### PR TITLE
[CORE-10237] Implement metrics for shadow link

### DIFF
--- a/src/v/cluster_link/BUILD
+++ b/src/v/cluster_link/BUILD
@@ -208,6 +208,7 @@ redpanda_cc_library(
         "//src/v/cluster/utils:partition_change_notifier_api",
         "//src/v/cluster_link/replication:deps",
         "//src/v/cluster_link/replication:mux_remote_consumer",
+        "//src/v/cluster_link/replication:types",
         "//src/v/kafka/client/direct_consumer",
         "//src/v/kafka/data/rpc",
         "//src/v/kafka/server",

--- a/src/v/cluster_link/BUILD
+++ b/src/v/cluster_link/BUILD
@@ -86,6 +86,7 @@ redpanda_cc_library(
         "//src/v/cluster_link/model",
         "//src/v/cluster_link/replication:deps",
         "//src/v/cluster_link/replication:link_replication_mgr",
+        "//src/v/cluster_link/replication:partition_replicator",
         "//src/v/cluster_link/replication:types",
         "//src/v/container:chunked_vector",
         "//src/v/kafka/client:cluster",

--- a/src/v/cluster_link/BUILD
+++ b/src/v/cluster_link/BUILD
@@ -56,6 +56,7 @@ redpanda_cc_library(
     srcs = [
         "deps.cc",
         "link.cc",
+        "link_probe.cc",
         "link_status_reconciler.cc",
         "manager.cc",
         "task.cc",
@@ -64,6 +65,7 @@ redpanda_cc_library(
     hdrs = [
         "deps.h",
         "link.h",
+        "link_probe.h",
         "link_status_reconciler.h",
         "manager.h",
         "task.h",
@@ -84,9 +86,11 @@ redpanda_cc_library(
         "//src/v/cluster_link/model",
         "//src/v/cluster_link/replication:deps",
         "//src/v/cluster_link/replication:link_replication_mgr",
+        "//src/v/cluster_link/replication:types",
         "//src/v/container:chunked_vector",
         "//src/v/kafka/client:cluster",
         "//src/v/kafka/data/rpc",
+        "//src/v/metrics",
         "//src/v/model",
         "//src/v/ssx:future_util",
         "//src/v/ssx:work_queue",

--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -12,9 +12,11 @@
 #include "cluster_link/link.h"
 
 #include "cluster_link/deps.h"
+#include "cluster_link/link_probe.h"
 #include "cluster_link/logger.h"
 #include "cluster_link/manager.h"
 #include "cluster_link/model/types.h"
+#include "cluster_link/replication/replication_probe.h"
 #include "cluster_link/utils.h"
 #include "model/fundamental.h"
 #include "model/namespace.h"
@@ -89,15 +91,24 @@ link::link(
       _manager->scheduling_group(),
       std::move(config_provider),
       std::move(data_source_factory),
-      std::move(data_sink_factory))
-  , _task_reconciler_interval(task_reconciler_interval) {}
+      std::move(data_sink_factory),
+      replication::replication_probe::configuration{
+        .group_name = _config.name,
+        .labels = {link_probe::shadow_link_name(_config.name)}})
+  , _task_reconciler_interval(task_reconciler_interval)
+  , _probe{} {}
+
+link::~link() noexcept = default;
 
 ss::future<> link::start() {
     vlog(
       cllog.info, "Starting cluster link {} ({})", _config.name, _config.uuid);
+
     // Allow exception to propagate to the caller
+    _probe = std::make_unique<link_probe>(*this);
+
     co_await _cluster_connection->start();
-    co_await _replication_mgr.start();
+    co_await _replication_mgr.start(_probe->get_link_data());
     co_await run_task_reconciler();
     _task_reconciler.set_callback([this] {
         ssx::spawn_with_gate(_gate, [this] {
@@ -149,6 +160,8 @@ ss::future<> link::stop() noexcept {
     } catch (const std::exception& e) {
         vlog(cllog.warn, "Error shutting down cluster connection: {}", e);
     }
+
+    _probe.reset(nullptr);
 
     vlog(cllog.info, "Stopped link {} ({})", _config.name, _config.uuid);
 }
@@ -285,6 +298,9 @@ ss::future<> link::handle_on_leadership_change(
             _replication_mgr.stop_replicator(ntp, term);
         }
     }
+
+    _probe->handle_on_leadership_change(ntp, is_ntp_leader);
+
     // todo: add debouncing here so that we do not trigger multiple
     // reconciliation loops at once.
     co_await run_task_reconciler();

--- a/src/v/cluster_link/link.h
+++ b/src/v/cluster_link/link.h
@@ -23,6 +23,9 @@
 #include "utils/notification_list.h"
 
 namespace cluster_link {
+
+class link_probe;
+
 /**
  * @brief The link class represents a link between two clusters
  */
@@ -42,7 +45,7 @@ public:
     link(link&&) = delete;
     link& operator=(const link&) = delete;
     link& operator=(link&&) = delete;
-    virtual ~link() = default;
+    virtual ~link() noexcept;
 
     virtual ss::future<> start();
     virtual ss::future<> stop() noexcept;
@@ -146,6 +149,7 @@ private:
     ss::lowres_clock::duration _task_reconciler_interval;
     mutex _task_reconciler_mutex{"cluster_link::link::task_reconciler"};
     ss::timer<ss::lowres_clock> _task_reconciler;
+    std::unique_ptr<link_probe> _probe;
     ss::gate _gate;
     ss::abort_source _as;
 };

--- a/src/v/cluster_link/link_probe.cc
+++ b/src/v/cluster_link/link_probe.cc
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cluster_link/link_probe.h"
+
+#include "cluster_link/replication/types.h"
+#include "model/namespace.h"
+
+#include <seastar/core/metrics.hh>
+
+#include <ranges>
+
+namespace sm = ss::metrics;
+
+namespace cluster_link {
+
+link_probe::link_probe(link& link)
+  : _link(link)
+  , _fetch_data{ss::make_lw_shared<replication::link_data_probe>()}
+  , _public_counter_metrics()
+  , _public_status_metrics() {
+    if (_link.partition_manager().is_current_shard_leader(
+          ::model::controller_ntp)) {
+        setup_status_metrics();
+    }
+
+    setup_counter_metrics();
+}
+
+void link_probe::handle_on_leadership_change(
+  const ::model::ntp& ntp, ntp_leader is_ntp_leader) {
+    if (ntp != ::model::controller_ntp) {
+        return;
+    }
+
+    if (is_ntp_leader) {
+        setup_status_metrics();
+    } else {
+        reset_status_metrics();
+    }
+}
+
+int link_probe::count_topics(const model::mirror_topic_status status) const {
+    if (!_link.partition_manager().is_current_shard_leader(
+          ::model::controller_ntp)) {
+        return 0;
+    }
+
+    auto mirror_topics = _link.get_mirror_topics_for_link();
+    if (!mirror_topics.has_value()) {
+        return 0;
+    }
+
+    auto to_status = std::views::transform(
+      &model::mirror_topic_metadata::status);
+    auto topic_statuses = mirror_topics.value() | std::views::values
+                          | to_status;
+    return std::ranges::count(topic_statuses, status);
+}
+
+void link_probe::setup_counter_metrics() {
+    if (config::shard_local_cfg().disable_public_metrics()) {
+        return;
+    }
+
+    const auto sl_name = shadow_link_name(_link.get_config().name);
+
+    _public_counter_metrics.add_group(
+      shadow_link_group,
+      {
+        sm::make_total_bytes(
+          "total_records_fetched",
+          [this] { return _fetch_data->total_fetched.n_records; },
+          sm::description("Total number of records fetched by the replicator"),
+          {sl_name})
+          .aggregate({sm::shard_label}),
+        sm::make_total_bytes(
+          "total_records_written",
+          [this] { return _fetch_data->total_written.n_records; },
+          sm::description("Total number of records written by the replicator"),
+          {sl_name})
+          .aggregate({sm::shard_label}),
+        sm::make_total_bytes(
+          "total_bytes_fetched",
+          [this] { return _fetch_data->total_fetched.n_bytes; },
+          sm::description("Total number of bytes fetched by the replicator"),
+          {sl_name})
+          .aggregate({sm::shard_label}),
+        sm::make_total_bytes(
+          "total_bytes_written",
+          [this] { return _fetch_data->total_written.n_bytes; },
+          sm::description("Total number of bytes written by the replicator"),
+          {sl_name})
+          .aggregate({sm::shard_label}),
+      });
+}
+
+void link_probe::setup_status_metrics() {
+    if (_public_status_metrics.has_value()) {
+        return;
+    }
+
+    if (config::shard_local_cfg().disable_public_metrics()) {
+        return;
+    }
+
+    const auto sl_name = shadow_link_name(_link.get_config().name);
+
+    // topics per mirror_topic_status
+    auto status_to_metric = std::views::transform(
+      [this, &sl_name](const model::mirror_topic_status status) {
+          auto status_label = sm::label_instance(
+            "status", to_string_view(status));
+          return sm::make_gauge(
+                   "shadow_topic_state",
+                   [this, status] { return count_topics(status); },
+                   sm::description(
+                     "Number of shadow topics in the respective state"),
+                   {sl_name, status_label})
+            .aggregate({sm::shard_label});
+      });
+    constexpr auto statuses = std::to_array({
+      model::mirror_topic_status::active,
+      model::mirror_topic_status::failed,
+      model::mirror_topic_status::paused,
+      model::mirror_topic_status::failing_over,
+      model::mirror_topic_status::failed_over,
+      model::mirror_topic_status::promoting,
+      model::mirror_topic_status::promoted,
+    });
+
+    std::vector<sm::metric_definition> defs;
+    defs.reserve(statuses.size());
+
+    std::ranges::copy(statuses | status_to_metric, std::back_inserter(defs));
+
+    _public_status_metrics.emplace().add_group(
+      shadow_link_group, std::move(defs));
+}
+
+} // namespace cluster_link

--- a/src/v/cluster_link/link_probe.h
+++ b/src/v/cluster_link/link_probe.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cluster_link/link.h"
+#include "cluster_link/replication/types.h"
+#include "metrics/metrics.h"
+
+namespace cluster_link {
+class link_probe {
+public:
+    link_probe(link& link);
+    link_probe(const link_probe&) = delete;
+    link_probe& operator=(const link_probe&) = delete;
+    link_probe(link_probe&&) = delete;
+    link_probe& operator=(link_probe&&) = delete;
+    ~link_probe() = default;
+
+    void setup_counter_metrics();
+    void setup_status_metrics();
+    void reset_status_metrics() { _public_status_metrics.reset(); }
+
+    void handle_on_leadership_change(
+      const ::model::ntp& ntp, ntp_leader is_ntp_leader);
+
+    replication::link_data_probe_ptr get_link_data() { return _fetch_data; }
+
+    static inline const ss::sstring shadow_link_group{"shadow_link"};
+    static inline const ss::metrics::label shadow_link_name{"shadow_link_name"};
+
+private:
+    int count_topics(const model::mirror_topic_status) const;
+
+    link& _link;
+
+    replication::link_data_probe_ptr _fetch_data;
+
+    // These metrics are defined on every shard
+    metrics::public_metric_groups _public_counter_metrics;
+
+    // These metrics are only defined on the controller leader
+    std::optional<metrics::public_metric_groups> _public_status_metrics;
+};
+} // namespace cluster_link

--- a/src/v/cluster_link/replication/BUILD
+++ b/src/v/cluster_link/replication/BUILD
@@ -41,9 +41,11 @@ redpanda_cc_library(
     name = "partition_replicator",
     srcs = [
         "partition_replicator.cc",
+        "replication_probe.cc",
     ],
     hdrs = [
         "partition_replicator.h",
+        "replication_probe.h",
     ],
     visibility = [
         "__subpackages__",
@@ -53,7 +55,9 @@ redpanda_cc_library(
         ":deps",
         ":types",
         "//src/v/cluster_link:logger",
+        "//src/v/config",
         "//src/v/container:chunked_vector",
+        "//src/v/metrics",
         "//src/v/model",
         "//src/v/ssx:future_util",
         "//src/v/ssx:semaphore",

--- a/src/v/cluster_link/replication/BUILD
+++ b/src/v/cluster_link/replication/BUILD
@@ -11,7 +11,9 @@ redpanda_cc_library(
     visibility = ["//src/v/cluster_link:__subpackages__"],
     deps = [
         "//src/v/base",
+        "//src/v/container:chunked_vector",
         "//src/v/model",
+        "//src/v/ssx:semaphore",
     ],
 )
 
@@ -25,6 +27,7 @@ redpanda_cc_library(
     ],
     visibility = ["//src/v/cluster_link:__subpackages__"],
     deps = [
+        ":types",
         "//src/v/container:chunked_hash_map",
         "//src/v/container:chunked_vector",
         "//src/v/kafka/protocol",
@@ -98,9 +101,9 @@ redpanda_cc_library(
     ],
     visibility = ["__subpackages__"],
     deps = [
+        ":types",
         "//src/v/container:chunked_vector",
         "//src/v/model",
-        "//src/v/ssx:semaphore",
         "@seastar",
     ],
 )

--- a/src/v/cluster_link/replication/BUILD
+++ b/src/v/cluster_link/replication/BUILD
@@ -85,6 +85,7 @@ redpanda_cc_library(
     deps = [
         ":deps",
         ":partition_replicator",
+        ":types",
         "//src/v/base",
         "//src/v/cluster_link:logger",
         "//src/v/container:chunked_hash_map",

--- a/src/v/cluster_link/replication/deps.h
+++ b/src/v/cluster_link/replication/deps.h
@@ -9,13 +9,12 @@
  */
 #pragma once
 
+#include "cluster_link/replication/types.h"
 #include "container/chunked_vector.h"
 #include "kafka/protocol/errors.h"
 #include "model/fundamental.h"
-#include "model/record.h"
 #include "model/timeout_clock.h"
 #include "raft/replicate.h"
-#include "ssx/semaphore.h"
 
 namespace cluster_link::replication {
 
@@ -89,15 +88,10 @@ public:
      */
     virtual ss::future<> reset(kafka::offset) = 0;
 
-    struct data {
-        chunked_vector<::model::record_batch> batches;
-        ssx::semaphore_units units;
-    };
-
     /**
      * Fetches some data, if any.
      */
-    virtual ss::future<data> fetch_next(ss::abort_source&) = 0;
+    virtual ss::future<fetch_data> fetch_next(ss::abort_source&) = 0;
 
     /// \brief Returns the source partitions offsets (HWM and LSO)
     virtual std::optional<source_partition_offsets_report> get_offsets() = 0;

--- a/src/v/cluster_link/replication/link_replication_mgr.cc
+++ b/src/v/cluster_link/replication/link_replication_mgr.cc
@@ -24,16 +24,25 @@ link_replication_manager::link_replication_manager(
   ss::scheduling_group sg,
   std::unique_ptr<link_configuration_provider> config_provider,
   std::unique_ptr<data_source_factory> source_factory,
-  std::unique_ptr<data_sink_factory> sink_factory)
+  std::unique_ptr<data_sink_factory> sink_factory,
+  std::optional<replication_probe::configuration> cfg_probe)
   : _sg(sg)
   , _config_provider(std::move(config_provider))
   , _source_factory(std::move(source_factory))
   , _sink_factory(std::move(sink_factory))
-  , _queue(_sg, [](const std::exception_ptr& ex) {
-      vlog(cllog.error, "unexpected error in processing notifications: {}", ex);
-  }) {}
+  , _queue(
+      _sg,
+      [](const std::exception_ptr& ex) {
+          vlog(
+            cllog.error,
+            "unexpected error in processing notifications: {}",
+            ex);
+      })
+  , _cfg_probe{std::move(cfg_probe)}
+  , _link_data_probe{nullptr} {}
 
-ss::future<> link_replication_manager::start() {
+ss::future<> link_replication_manager::start(link_data_probe_ptr ldp) {
+    set_data_probe(std::move(ldp));
     co_await _source_factory->start();
     ssx::repeat_until_gate_closed(_gate, [this] {
         return reconcile().handle_exception([](const std::exception_ptr& e) {
@@ -70,7 +79,23 @@ ss::future<> link_replication_manager::stop() {
     _replicators.clear();
     co_await std::move(gate_f);
     co_await _source_factory->stop();
+    unset_data_probe();
     vlog(cllog.trace, "Link replication manager stopped");
+}
+
+void link_replication_manager::set_data_probe(link_data_probe_ptr ldp) {
+    _link_data_probe = ldp;
+
+    for (auto& replicator : _replicators | std::views::values) {
+        replicator->set_data_probe(ldp);
+    }
+}
+
+void link_replication_manager::unset_data_probe() {
+    _link_data_probe = nullptr;
+    for (auto& replicator : _replicators | std::views::values) {
+        replicator->unset_data_probe();
+    }
 }
 
 ss::future<> link_replication_manager::do_start_replicator(
@@ -89,7 +114,14 @@ ss::future<> link_replication_manager::do_start_replicator(
     auto source = _source_factory->make_source(ntp);
     auto sink = _sink_factory->make_sink(ntp);
     auto replicator = std::make_unique<partition_replicator>(
-      ntp, term, *_config_provider, std::move(source), std::move(sink), _sg);
+      ntp,
+      term,
+      *_config_provider,
+      std::move(source),
+      std::move(sink),
+      _sg,
+      _cfg_probe,
+      _link_data_probe);
     auto [r_it, _] = _replicators.emplace(ntp, std::move(replicator));
     co_await r_it->second->start();
 }

--- a/src/v/cluster_link/replication/link_replication_mgr.h
+++ b/src/v/cluster_link/replication/link_replication_mgr.h
@@ -11,6 +11,8 @@
 #pragma once
 
 #include "cluster_link/replication/partition_replicator.h"
+#include "cluster_link/replication/replication_probe.h"
+#include "cluster_link/replication/types.h"
 #include "container/chunked_hash_map.h"
 #include "ssx/work_queue.h"
 
@@ -27,9 +29,10 @@ public:
       ss::scheduling_group,
       std::unique_ptr<link_configuration_provider> config_provider,
       std::unique_ptr<data_source_factory> source_factory,
-      std::unique_ptr<data_sink_factory> sink_factory);
+      std::unique_ptr<data_sink_factory> sink_factory,
+      std::optional<replication_probe::configuration> cfg_probe = std::nullopt);
 
-    ss::future<> start();
+    ss::future<> start(link_data_probe_ptr data_probe = nullptr);
 
     ss::future<> stop();
 
@@ -47,6 +50,9 @@ public:
 
     std::optional<partition_offsets_report>
     get_partition_offsets_report(const ::model::ntp&) const;
+
+    void set_data_probe(link_data_probe_ptr);
+    void unset_data_probe();
 
 private:
     static constexpr auto start_offset_synch_interval = std::chrono::seconds{
@@ -73,6 +79,8 @@ private:
     ss::condition_variable _pending_changes_cv;
     chunked_hash_map<::model::ntp, std::unique_ptr<partition_replicator>>
       _replicators;
+    std::optional<replication_probe::configuration> _cfg_probe;
+    link_data_probe_ptr _link_data_probe;
     ss::gate _gate;
     ss::abort_source _as;
 };

--- a/src/v/cluster_link/replication/mux_remote_consumer.cc
+++ b/src/v/cluster_link/replication/mux_remote_consumer.cc
@@ -12,6 +12,7 @@
 
 #include "cluster_link/logger.h"
 #include "config/configuration.h"
+#include "kafka/client/direct_consumer/direct_consumer.h"
 #include "ssx/future-util.h"
 
 namespace cluster_link::replication {
@@ -19,11 +20,14 @@ namespace cluster_link::replication {
 mux_remote_consumer::mux_remote_consumer(
   kafka::client::cluster& cluster,
   kafka::snc_quota_manager& snc_quota_mgr,
-  mux_remote_consumer::configuration consumer_configuration)
+  mux_remote_consumer::configuration consumer_configuration,
+  std::optional<kafka::client::direct_consumer_probe::configuration> probe_cfg)
   : _client_id(std::move(consumer_configuration.client_id))
   , _consumer(
       std::make_unique<kafka::client::direct_consumer>(
-        cluster, consumer_configuration.direct_consumer_configuration))
+        cluster,
+        consumer_configuration.direct_consumer_configuration,
+        std::move(probe_cfg)))
   , _snc_quota_mgr(snc_quota_mgr)
   , _partition_max_buffered(consumer_configuration.partition_max_buffered)
   , _fetch_max_wait(consumer_configuration.fetch_max_wait)

--- a/src/v/cluster_link/replication/mux_remote_consumer.cc
+++ b/src/v/cluster_link/replication/mux_remote_consumer.cc
@@ -113,8 +113,7 @@ mux_remote_consumer::result mux_remote_consumer::reset(
     return {};
 }
 
-ss::future<
-  std::expected<partition_data_queue::fetch_data, mux_remote_consumer::errc>>
+ss::future<std::expected<fetch_data, mux_remote_consumer::errc>>
 mux_remote_consumer::fetch(
   const model::topic_partition& tp, ss::abort_source& as) {
     auto holder = _gate.hold();

--- a/src/v/cluster_link/replication/mux_remote_consumer.h
+++ b/src/v/cluster_link/replication/mux_remote_consumer.h
@@ -60,7 +60,10 @@ public:
     mux_remote_consumer(
       kafka::client::cluster& cluster,
       kafka::snc_quota_manager& snc_quota_mgr,
-      configuration consumer_configuration);
+      configuration consumer_configuration,
+      std::optional<kafka::client::direct_consumer_probe::configuration>
+        probe_cfg
+      = std::nullopt);
 
     ss::future<> start();
     ss::future<> stop() noexcept;

--- a/src/v/cluster_link/replication/mux_remote_consumer.h
+++ b/src/v/cluster_link/replication/mux_remote_consumer.h
@@ -12,6 +12,7 @@
 
 #include "base/format_to.h"
 #include "cluster_link/replication/partition_data_queue.h"
+#include "cluster_link/replication/types.h"
 #include "container/chunked_hash_map.h"
 #include "kafka/client/direct_consumer/api_types.h"
 #include "kafka/client/direct_consumer/direct_consumer.h"
@@ -81,7 +82,7 @@ public:
      * are add() and reset() (atleast once). add() adds the partition to the
      * consumer and reset() sets the initial offset for fetching.
      */
-    ss::future<std::expected<partition_data_queue::fetch_data, errc>>
+    ss::future<std::expected<fetch_data, errc>>
     fetch(const ::model::topic_partition&, ss::abort_source&);
     /**
      * Update the configuration of the consumer.

--- a/src/v/cluster_link/replication/partition_data_queue.cc
+++ b/src/v/cluster_link/replication/partition_data_queue.cc
@@ -84,8 +84,7 @@ bool partition_data_queue::enqueue(
     return _sem.available_units() > 0;
 }
 
-ss::future<partition_data_queue::fetch_data>
-partition_data_queue::fetch(ss::abort_source& as) {
+ss::future<fetch_data> partition_data_queue::fetch(ss::abort_source& as) {
     auto holder = _gate.hold();
     if (_waiter) {
         throw std::runtime_error("Only one fetch can be in progress at a time");

--- a/src/v/cluster_link/replication/partition_data_queue.h
+++ b/src/v/cluster_link/replication/partition_data_queue.h
@@ -10,9 +10,8 @@
 
 #pragma once
 
+#include "cluster_link/replication/types.h"
 #include "container/chunked_vector.h"
-#include "model/record.h"
-#include "ssx/semaphore.h"
 
 #include <seastar/core/gate.hh>
 
@@ -35,10 +34,6 @@ namespace cluster_link::replication {
 class partition_data_queue {
 public:
     explicit partition_data_queue(size_t max_buffered_bytes);
-    struct fetch_data {
-        chunked_vector<::model::record_batch> batches;
-        ssx::semaphore_units units;
-    };
     ss::future<> stop() noexcept;
     // note: enqueue never fails, it will oversubscribe memory but the return
     // value is a hint to the caller to not enqueue more until the queue is

--- a/src/v/cluster_link/replication/partition_replicator.cc
+++ b/src/v/cluster_link/replication/partition_replicator.cc
@@ -11,6 +11,7 @@
 #include "cluster_link/replication/partition_replicator.h"
 
 #include "cluster_link/logger.h"
+#include "cluster_link/replication/replication_probe.h"
 #include "ssx/future-util.h"
 
 #include <seastar/coroutine/switch_to.hh>
@@ -28,7 +29,8 @@ partition_replicator::partition_replicator(
   link_configuration_provider& config_provider,
   std::unique_ptr<data_source> source,
   std::unique_ptr<data_sink> sink,
-  ss::scheduling_group scheduling_group)
+  ss::scheduling_group scheduling_group,
+  std::optional<replication_probe::configuration> cfg)
   : _ntp(ntp)
   , _term(term)
   , _config_provider(config_provider)
@@ -38,7 +40,12 @@ partition_replicator::partition_replicator(
   , _scheduling_group(scheduling_group)
   , _backoff_policy(
       make_exponential_backoff_policy<ss::lowres_clock>(
-        base_backoff, max_backoff)) {}
+        base_backoff, max_backoff))
+  , _probe{} {
+    if (cfg.has_value()) {
+        _probe.emplace(std::move(cfg.value()), ntp, *this);
+    }
+}
 
 ss::future<> partition_replicator::start() {
     co_await ss::coroutine::switch_to(_scheduling_group);
@@ -131,6 +138,7 @@ ss::future<> partition_replicator::replicate_and_wait(
   replicate_ctx ctx, ss::gate& gate, ss::abort_source& as) {
     static constexpr auto large_timeout
       = std::chrono::duration_cast<model::timeout_clock::duration>(5min);
+
     auto stages = _sink->replicate(
       std::move(ctx.fdata.batches), large_timeout, as);
     auto enqueue_f = co_await ss::coroutine::as_future(

--- a/src/v/cluster_link/replication/partition_replicator.cc
+++ b/src/v/cluster_link/replication/partition_replicator.cc
@@ -30,7 +30,8 @@ partition_replicator::partition_replicator(
   std::unique_ptr<data_source> source,
   std::unique_ptr<data_sink> sink,
   ss::scheduling_group scheduling_group,
-  std::optional<replication_probe::configuration> cfg)
+  std::optional<replication_probe::configuration> cfg,
+  link_data_probe_ptr ldp)
   : _ntp(ntp)
   , _term(term)
   , _config_provider(config_provider)
@@ -41,7 +42,8 @@ partition_replicator::partition_replicator(
   , _backoff_policy(
       make_exponential_backoff_policy<ss::lowres_clock>(
         base_backoff, max_backoff))
-  , _probe{} {
+  , _probe{}
+  , _link_data_probe{std::move(ldp)} {
     if (cfg.has_value()) {
         _probe.emplace(std::move(cfg.value()), ntp, *this);
     }
@@ -139,6 +141,11 @@ ss::future<> partition_replicator::replicate_and_wait(
     static constexpr auto large_timeout
       = std::chrono::duration_cast<model::timeout_clock::duration>(5min);
 
+    auto probe_update = fetch_counters::from_fetch_data(ctx.fdata);
+    if (_link_data_probe) {
+        _link_data_probe->add_fetched(probe_update);
+    }
+
     auto stages = _sink->replicate(
       std::move(ctx.fdata.batches), large_timeout, as);
     auto enqueue_f = co_await ss::coroutine::as_future(
@@ -177,11 +184,16 @@ ss::future<> partition_replicator::replicate_and_wait(
        end = ctx.end,
        inflight = std::move(ctx.inflight_units),
        data = std::move(ctx.fdata.units),
-       &as]() mutable {
+       &as,
+       probe_update]() mutable {
           return handle_replication_result(std::move(f), begin, end)
-            .then([&as](bool success) {
+            .then([this, &as, probe_update](bool success) {
                 if (!success) {
                     as.request_abort();
+                    return;
+                }
+                if (_link_data_probe) {
+                    _link_data_probe->add_written(probe_update);
                 }
             })
             .finally(
@@ -207,6 +219,12 @@ partition_replicator::get_partition_offsets_report() const {
       .shadow_hwm = sink_info,
     };
 }
+
+void partition_replicator::set_data_probe(link_data_probe_ptr ldp) {
+    _link_data_probe = std::move(ldp);
+}
+
+void partition_replicator::unset_data_probe() { _link_data_probe = nullptr; }
 
 kafka::offset partition_replicator::get_partition_lag() const {
     constexpr kafka::offset invalid{-1};

--- a/src/v/cluster_link/replication/partition_replicator.cc
+++ b/src/v/cluster_link/replication/partition_replicator.cc
@@ -131,7 +131,8 @@ ss::future<> partition_replicator::replicate_and_wait(
   replicate_ctx ctx, ss::gate& gate, ss::abort_source& as) {
     static constexpr auto large_timeout
       = std::chrono::duration_cast<model::timeout_clock::duration>(5min);
-    auto stages = _sink->replicate(std::move(ctx.batches), large_timeout, as);
+    auto stages = _sink->replicate(
+      std::move(ctx.fdata.batches), large_timeout, as);
     auto enqueue_f = co_await ss::coroutine::as_future(
       std::move(stages.request_enqueued));
     std::exception_ptr eptr = nullptr;
@@ -167,7 +168,7 @@ ss::future<> partition_replicator::replicate_and_wait(
        begin = ctx.begin,
        end = ctx.end,
        inflight = std::move(ctx.inflight_units),
-       data = std::move(ctx.data_units),
+       data = std::move(ctx.fdata.units),
        &as]() mutable {
           return handle_replication_result(std::move(f), begin, end)
             .then([&as](bool success) {
@@ -214,11 +215,13 @@ ss::future<> partition_replicator::fetch_and_replicate() {
                 continue;
             }
             co_await replicate_and_wait(
-              {.begin = data.batches.front().base_offset(),
-               .end = data.batches.back().last_offset(),
-               .batches = std::move(data.batches),
-               .inflight_units = std::move(inflight_units),
-               .data_units = std::move(data.units)},
+              {
+                .begin = data.batches.front().base_offset(),
+                .end = data.batches.back().last_offset(),
+                .fdata
+                = {.batches = std::move(data.batches), .units = std::move(data.units)},
+                .inflight_units = std::move(inflight_units),
+              },
               gate,
               as);
         }

--- a/src/v/cluster_link/replication/partition_replicator.cc
+++ b/src/v/cluster_link/replication/partition_replicator.cc
@@ -200,6 +200,23 @@ partition_replicator::get_partition_offsets_report() const {
     };
 }
 
+kafka::offset partition_replicator::get_partition_lag() const {
+    constexpr kafka::offset invalid{-1};
+
+    auto source_info = _source->get_offsets();
+    if (!source_info.has_value()) {
+        return invalid;
+    }
+
+    auto lso = source_info->source_lso;
+    if (lso == kafka::offset{-1}) {
+        return invalid;
+    }
+
+    auto hwm = _sink->high_watermark();
+    return lso - hwm;
+}
+
 ss::future<> partition_replicator::fetch_and_replicate() {
     _gate.check();
     // abort source for this iteration of fetch_and_replicate

--- a/src/v/cluster_link/replication/partition_replicator.h
+++ b/src/v/cluster_link/replication/partition_replicator.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "cluster_link/replication/deps.h"
+#include "cluster_link/replication/replication_probe.h"
 #include "cluster_link/replication/types.h"
 #include "ssx/semaphore.h"
 #include "utils/prefix_logger.h"
@@ -61,7 +62,8 @@ public:
       link_configuration_provider& config_provider,
       std::unique_ptr<data_source> source,
       std::unique_ptr<data_sink> sink,
-      ss::scheduling_group sg = ss::default_scheduling_group());
+      ss::scheduling_group sg = ss::default_scheduling_group(),
+      std::optional<replication_probe::configuration> cfg = std::nullopt);
     ss::future<> start();
     ss::future<> stop();
 
@@ -108,6 +110,7 @@ private:
       max_in_flight_requests, "partition_replicator"};
     backoff_policy _backoff_policy;
     std::optional<kafka::offset> _in_progress_truncate_offset{std::nullopt};
+    std::optional<replication_probe> _probe;
 };
 
 } // namespace cluster_link::replication

--- a/src/v/cluster_link/replication/partition_replicator.h
+++ b/src/v/cluster_link/replication/partition_replicator.h
@@ -63,7 +63,8 @@ public:
       std::unique_ptr<data_source> source,
       std::unique_ptr<data_sink> sink,
       ss::scheduling_group sg = ss::default_scheduling_group(),
-      std::optional<replication_probe::configuration> cfg = std::nullopt);
+      std::optional<replication_probe::configuration> cfg = std::nullopt,
+      link_data_probe_ptr ldp = nullptr);
     ss::future<> start();
     ss::future<> stop();
 
@@ -74,6 +75,9 @@ public:
     partition_offsets_report get_partition_offsets_report() const;
 
     void maybe_synchronize_start_offset();
+
+    void set_data_probe(link_data_probe_ptr);
+    void unset_data_probe();
 
     kafka::offset get_partition_lag() const;
 
@@ -111,6 +115,7 @@ private:
     backoff_policy _backoff_policy;
     std::optional<kafka::offset> _in_progress_truncate_offset{std::nullopt};
     std::optional<replication_probe> _probe;
+    link_data_probe_ptr _link_data_probe;
 };
 
 } // namespace cluster_link::replication

--- a/src/v/cluster_link/replication/partition_replicator.h
+++ b/src/v/cluster_link/replication/partition_replicator.h
@@ -77,9 +77,8 @@ private:
     struct replicate_ctx {
         ::model::offset begin;
         ::model::offset end;
-        chunked_vector<::model::record_batch> batches;
+        fetch_data fdata;
         ssx::semaphore_units inflight_units;
-        ssx::semaphore_units data_units;
     };
     ss::future<> fetch_and_replicate();
     ss::future<>

--- a/src/v/cluster_link/replication/partition_replicator.h
+++ b/src/v/cluster_link/replication/partition_replicator.h
@@ -73,6 +73,8 @@ public:
 
     void maybe_synchronize_start_offset();
 
+    kafka::offset get_partition_lag() const;
+
 private:
     struct replicate_ctx {
         ::model::offset begin;

--- a/src/v/cluster_link/replication/replication_probe.cc
+++ b/src/v/cluster_link/replication/replication_probe.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cluster_link/replication/replication_probe.h"
+
+#include "cluster_link/replication/partition_replicator.h"
+#include "config/configuration.h"
+
+#include <seastar/core/metrics.hh>
+
+namespace cluster_link::replication {
+
+replication_probe::replication_probe(
+  configuration config, ::model::ntp ntp, partition_replicator& pr)
+  : _partition_replicator{pr}
+  , _public_metrics{} {
+    setup_metrics(std::move(config), ntp);
+}
+
+void replication_probe::setup_metrics(configuration config, ::model::ntp ntp) {
+    namespace sm = ss::metrics;
+
+    if (config::shard_local_cfg().disable_public_metrics()) {
+        return;
+    }
+
+    auto topic_label = metrics::make_namespaced_label("topic");
+    auto partition_label = metrics::make_namespaced_label("partition");
+
+    std::vector<sm::label_instance> labels = {
+      topic_label(ntp.tp.topic()),
+      partition_label(ntp.tp.partition()),
+    };
+    std::ranges::copy(config.labels, std::back_inserter(labels));
+
+    std::vector<sm::label> total_counters_agg = {topic_label, partition_label};
+
+    _public_metrics.add_group(
+      config.group_name,
+      {
+        sm::make_gauge(
+          "shadow_lag",
+          [this] { return _partition_replicator.get_partition_lag(); },
+          sm::description(
+            "Lag of the shadow partition against the source partition"),
+          labels)
+          .aggregate({sm::shard_label}),
+      });
+}
+
+} // namespace cluster_link::replication

--- a/src/v/cluster_link/replication/replication_probe.h
+++ b/src/v/cluster_link/replication/replication_probe.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "metrics/metrics.h"
+#include "model/fundamental.h"
+
+namespace cluster_link::replication {
+
+class partition_replicator;
+
+class replication_probe {
+public:
+    struct configuration {
+        ss::sstring group_name;
+        std::vector<ss::metrics::label_instance> labels;
+    };
+
+    explicit replication_probe(
+      configuration, ::model::ntp, partition_replicator&);
+    replication_probe(const replication_probe&) = delete;
+    replication_probe& operator=(const replication_probe&) = delete;
+    replication_probe(replication_probe&&) = delete;
+    replication_probe& operator=(replication_probe&&) = delete;
+    ~replication_probe() = default;
+
+    void setup_metrics(configuration, ::model::ntp);
+
+private:
+    partition_replicator& _partition_replicator;
+
+    metrics::public_metric_groups _public_metrics;
+};
+} // namespace cluster_link::replication

--- a/src/v/cluster_link/replication/tests/BUILD
+++ b/src/v/cluster_link/replication/tests/BUILD
@@ -15,6 +15,7 @@ redpanda_test_cc_library(
     deps = [
         "//src/v/cluster_link/replication:deps",
         "//src/v/cluster_link/replication:link_replication_mgr",
+        "//src/v/cluster_link/replication:types",
         "//src/v/model/tests:random",
         "//src/v/random:generators",
         "@seastar",
@@ -31,6 +32,7 @@ redpanda_cc_gtest(
         ":deps_test_impl",
         "//src/v/base",
         "//src/v/cluster_link/replication:partition_replicator",
+        "//src/v/cluster_link/replication:types",
         "//src/v/kafka/protocol",
         "//src/v/model/tests:random",
         "//src/v/random:generators",
@@ -51,6 +53,7 @@ redpanda_cc_gtest(
     deps = [
         "//src/v/base",
         "//src/v/cluster_link/replication:link_replication_mgr",
+        "//src/v/cluster_link/replication:types",
         "//src/v/model/tests:random",
         "//src/v/random:generators",
         "//src/v/test_utils:gtest",
@@ -68,6 +71,7 @@ redpanda_cc_gtest(
     deps = [
         "//src/v/base",
         "//src/v/cluster_link/replication:partition_data_queue",
+        "//src/v/cluster_link/replication:types",
         "//src/v/model/tests:random",
         "//src/v/random:generators",
         "//src/v/test_utils:gtest",

--- a/src/v/cluster_link/replication/tests/BUILD
+++ b/src/v/cluster_link/replication/tests/BUILD
@@ -34,6 +34,7 @@ redpanda_cc_gtest(
         "//src/v/cluster_link/replication:partition_replicator",
         "//src/v/cluster_link/replication:types",
         "//src/v/kafka/protocol",
+        "//src/v/model",
         "//src/v/model/tests:random",
         "//src/v/random:generators",
         "//src/v/ssx:future_util",

--- a/src/v/cluster_link/replication/tests/deps_test_impl.cc
+++ b/src/v/cluster_link/replication/tests/deps_test_impl.cc
@@ -85,8 +85,7 @@ ss::future<> random_data_source::reset(kafka::offset offset) {
     _next = offset;
     return ss::now();
 }
-ss::future<data_source::data>
-random_data_source::fetch_next(ss::abort_source& as) {
+ss::future<fetch_data> random_data_source::fetch_next(ss::abort_source& as) {
     auto holder = _gate.hold();
     auto batch = ::model::test::make_random_batch(
       kafka::offset_cast(_next), 5, true, model::record_batch_type::raft_data);
@@ -94,7 +93,7 @@ random_data_source::fetch_next(ss::abort_source& as) {
     batches.push_back(std::move(batch));
     co_await ss::sleep_abortable(
       std::chrono::milliseconds{random_generators::get_int(1, 3)}, as);
-    co_return data_source::data{std::move(batches), ssx::semaphore_units{}};
+    co_return fetch_data{std::move(batches), ssx::semaphore_units{}};
 }
 
 std::optional<data_source::source_partition_offsets_report>

--- a/src/v/cluster_link/replication/tests/deps_test_impl.h
+++ b/src/v/cluster_link/replication/tests/deps_test_impl.h
@@ -11,7 +11,7 @@
 #pragma once
 
 #include "cluster_link/replication/deps.h"
-#include "cluster_link/replication/link_replication_mgr.h"
+#include "cluster_link/replication/types.h"
 
 #include <seastar/core/gate.hh>
 
@@ -51,7 +51,7 @@ public:
     ss::future<> start(kafka::offset) noexcept override;
     ss::future<> stop() noexcept override;
     ss::future<> reset(kafka::offset) override;
-    ss::future<data_source::data> fetch_next(ss::abort_source&) override;
+    ss::future<fetch_data> fetch_next(ss::abort_source&) override;
     std::optional<source_partition_offsets_report> get_offsets() final;
 
 private:

--- a/src/v/cluster_link/replication/tests/link_replication_mgr_tests.cc
+++ b/src/v/cluster_link/replication/tests/link_replication_mgr_tests.cc
@@ -9,6 +9,7 @@
  */
 
 #include "cluster_link/replication/link_replication_mgr.h"
+#include "cluster_link/replication/types.h"
 #include "model/tests/random_batch.h"
 #include "random/generators.h"
 #include "test_utils/randoms.h"
@@ -45,14 +46,14 @@ public:
         return ss::make_ready_future<>();
     }
     ss::future<> stop() noexcept override { return _gate.close(); }
-    ss::future<data_source::data> fetch_next(ss::abort_source& as) override {
+    ss::future<fetch_data> fetch_next(ss::abort_source& as) override {
         auto holder = _gate.hold();
         co_await ss::sleep_abortable(sleep_for(), as);
         auto batch = model::test::make_random_batch(
           model::offset{0}, 5, true, model::record_batch_type::raft_data);
         chunked_vector<model::record_batch> batches;
         batches.push_back(std::move(batch));
-        co_return data_source::data{std::move(batches), ssx::semaphore_units{}};
+        co_return fetch_data{std::move(batches), ssx::semaphore_units{}};
     }
     std::optional<data_source::source_partition_offsets_report>
     get_offsets() final {

--- a/src/v/cluster_link/replication/tests/partition_data_queue_tests.cc
+++ b/src/v/cluster_link/replication/tests/partition_data_queue_tests.cc
@@ -10,6 +10,7 @@
  */
 
 #include "cluster_link/replication/partition_data_queue.h"
+#include "cluster_link/replication/types.h"
 #include "model/tests/random_batch.h"
 #include "test_utils/test.h"
 
@@ -54,21 +55,19 @@ TEST_F_CORO(PartitionDataQueueTest, testWaiterBehavior) {
     auto fetch_future = _queue->fetch(as);
     ASSERT_FALSE_CORO(fetch_future.available());
     co_await enqueue_some_data();
-    co_await std::move(fetch_future)
-      .then([this](partition_data_queue::fetch_data data) {
-          ASSERT_FALSE(data.batches.empty());
-          ASSERT_TRUE(_queue->empty());
-      });
+    co_await std::move(fetch_future).then([this](fetch_data data) {
+        ASSERT_FALSE(data.batches.empty());
+        ASSERT_TRUE(_queue->empty());
+    });
 
     // enqueue before waiter
     co_await enqueue_some_data();
     ASSERT_FALSE_CORO(_queue->empty());
     fetch_future = _queue->fetch(as);
-    co_await std::move(fetch_future)
-      .then([this](partition_data_queue::fetch_data data) {
-          ASSERT_FALSE(data.batches.empty());
-          ASSERT_TRUE(_queue->empty());
-      });
+    co_await std::move(fetch_future).then([this](fetch_data data) {
+        ASSERT_FALSE(data.batches.empty());
+        ASSERT_TRUE(_queue->empty());
+    });
     // double waiter should throw
     fetch_future = _queue->fetch(as);
     EXPECT_THROW(co_await _queue->fetch(as), std::runtime_error);

--- a/src/v/cluster_link/replication/tests/partition_replicator_tests.cc
+++ b/src/v/cluster_link/replication/tests/partition_replicator_tests.cc
@@ -11,6 +11,7 @@
 #include "base/units.h"
 #include "cluster_link/replication/partition_replicator.h"
 #include "cluster_link/replication/tests/deps_test_impl.h"
+#include "cluster_link/replication/types.h"
 #include "kafka/protocol/errors.h"
 #include "model/tests/random_batch.h"
 #include "ssx/future-util.h"
@@ -49,7 +50,7 @@ public:
     int num_resets() const { return _num_resets; }
     int num_fetches() const { return _num_fetches; }
 
-    ss::future<data_source::data> fetch_next(ss::abort_source& as) final {
+    ss::future<fetch_data> fetch_next(ss::abort_source& as) final {
         _num_fetches++;
         auto holder = _gate.hold();
         while (_data.batches.empty()) {
@@ -90,7 +91,7 @@ private:
     kafka::offset _next_to_consume;
     int _num_fetches = 0;
     int _num_resets = 0;
-    data _data;
+    fetch_data _data;
     ss::gate _gate;
     ssx::semaphore _max_memory{5_MiB, "test_data_source"};
 };

--- a/src/v/cluster_link/replication/tests/partition_replicator_tests.cc
+++ b/src/v/cluster_link/replication/tests/partition_replicator_tests.cc
@@ -13,6 +13,7 @@
 #include "cluster_link/replication/tests/deps_test_impl.h"
 #include "cluster_link/replication/types.h"
 #include "kafka/protocol/errors.h"
+#include "model/fundamental.h"
 #include "model/tests/random_batch.h"
 #include "ssx/future-util.h"
 #include "test_utils/async.h"
@@ -83,7 +84,11 @@ public:
 
     std::optional<data_source::source_partition_offsets_report>
     get_offsets() final {
-        return std::nullopt;
+        source_partition_offsets_report ret;
+        ret.source_start_offset = _start_offset.value_or(kafka::offset{-1});
+        ret.source_hwm = _next_to_consume;
+        ret.source_lso = _next_to_consume;
+        return ret;
     }
 
 private:
@@ -145,7 +150,7 @@ public:
     void set_fail_replication(bool value) { _fail_replication = value; }
 
     kafka::offset high_watermark() const final {
-        return _last_replicated_offset;
+        return kafka::next_offset(_last_replicated_offset);
     }
 
     ss::future<kafka::error_code> prefix_truncate(
@@ -263,6 +268,22 @@ TEST_F_CORO(PartitionReplicatorFixture, TestMemoryExhaustion) {
       3s, [&] { return _source->available_memory() == 5_MiB; });
     RPTEST_REQUIRE_EVENTUALLY_CORO(
       3s, [&] { return _source->num_fetches() > num_fetches; });
+}
+
+TEST_F_CORO(PartitionReplicatorFixture, ShadowPartitionLag) {
+    co_await push_data();
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      5s, [&] { return _sink->last_replicated_offset() == kafka::offset(9); });
+
+    auto units = co_await _sink->block_replication();
+    co_await push_data();
+    RPTEST_REQUIRE_EQ_CORO(_replicator->get_partition_lag(), kafka::offset(10));
+    co_await push_data();
+    RPTEST_REQUIRE_EQ_CORO(_replicator->get_partition_lag(), kafka::offset(20));
+
+    units.return_all();
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      3s, [&] { return _replicator->get_partition_lag() == kafka::offset{0}; });
 }
 
 } // namespace cluster_link::replication

--- a/src/v/cluster_link/replication/types.cc
+++ b/src/v/cluster_link/replication/types.cc
@@ -10,6 +10,10 @@
 
 #include "cluster_link/replication/types.h"
 
+#include <algorithm>
+#include <functional>
+#include <ranges>
+
 namespace cluster_link::replication {
 fmt::iterator partition_offsets_report::format_to(fmt::iterator it) const {
     return fmt::format_to(
@@ -21,5 +25,15 @@ fmt::iterator partition_offsets_report::format_to(fmt::iterator it) const {
       std::chrono::duration_cast<std::chrono::milliseconds>(
         update_time.time_since_epoch()),
       shadow_hwm);
+}
+
+fetch_counters fetch_counters::from_fetch_data(const fetch_data& data) {
+    fetch_counters ret;
+    ret.n_bytes = data.units.count();
+    ret.n_records = std::ranges::fold_left(
+      data.batches | std::views::transform(&model::record_batch::record_count),
+      int64_t{},
+      std::plus<int64_t>{});
+    return ret;
 }
 } // namespace cluster_link::replication

--- a/src/v/cluster_link/replication/types.h
+++ b/src/v/cluster_link/replication/types.h
@@ -11,7 +11,10 @@
 #pragma once
 
 #include "base/format_to.h"
+#include "container/chunked_vector.h"
 #include "model/fundamental.h"
+#include "model/record.h"
+#include "ssx/semaphore.h"
 
 namespace cluster_link::replication {
 struct partition_offsets_report {
@@ -23,4 +26,10 @@ struct partition_offsets_report {
 
     fmt::iterator format_to(fmt::iterator) const;
 };
+
+struct fetch_data {
+    chunked_vector<::model::record_batch> batches;
+    ssx::semaphore_units units;
+};
+
 } // namespace cluster_link::replication

--- a/src/v/cluster_link/replication/types.h
+++ b/src/v/cluster_link/replication/types.h
@@ -16,6 +16,8 @@
 #include "model/record.h"
 #include "ssx/semaphore.h"
 
+#include <cstdio>
+
 namespace cluster_link::replication {
 struct partition_offsets_report {
     kafka::offset source_start_offset{-1};
@@ -32,4 +34,27 @@ struct fetch_data {
     ssx::semaphore_units units;
 };
 
+struct fetch_counters {
+    size_t n_bytes{};
+    size_t n_records{};
+
+    static fetch_counters from_fetch_data(const fetch_data& data);
+
+    fetch_counters& operator+=(const fetch_counters& rhs) {
+        n_bytes += rhs.n_bytes;
+        n_records += rhs.n_records;
+        return *this;
+    }
+};
+
+struct link_data_probe {
+    fetch_counters total_fetched;
+    fetch_counters total_written;
+
+    void add_fetched(const fetch_counters& fc) { total_fetched += fc; }
+
+    void add_written(const fetch_counters& fc) { total_written += fc; }
+};
+
+using link_data_probe_ptr = ss::lw_shared_ptr<link_data_probe>;
 } // namespace cluster_link::replication

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -18,6 +18,7 @@
 #include "cluster/partition_manager.h"
 #include "cluster_link/group_mirroring_task.h"
 #include "cluster_link/link.h"
+#include "cluster_link/link_probe.h"
 #include "cluster_link/logger.h"
 #include "cluster_link/manager.h"
 #include "cluster_link/model/types.h"
@@ -764,6 +765,9 @@ public:
       std::unique_ptr<kafka::client::cluster> cluster_connection) override {
         auto client_id = config.connection.client_id;
         auto cluster = cluster_connection.get();
+        kafka::client::direct_consumer_probe::configuration probe_cfg{
+          .group_name = link_probe::shadow_link_group,
+          .labels = {link_probe::shadow_link_name(config.name)}};
         return std::make_unique<link>(
           self,
           link_id,
@@ -779,7 +783,8 @@ public:
             std::make_unique<replication::mux_remote_consumer>(
               *cluster_connection,
               _snc_quota_mgr->local(),
-              make_remote_consumer_configuration(config.connection))),
+              make_remote_consumer_configuration(config.connection),
+              std::move(probe_cfg))),
           std::make_unique<local_partition_data_sink_factory>(
             *_partition_manager));
     }

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -23,6 +23,7 @@
 #include "cluster_link/model/types.h"
 #include "cluster_link/replication/deps.h"
 #include "cluster_link/replication/mux_remote_consumer.h"
+#include "cluster_link/replication/types.h"
 #include "cluster_link/security_migrator.h"
 #include "cluster_link/shadow_linking_rpc_service.h"
 #include "cluster_link/source_topic_syncer.h"
@@ -288,8 +289,7 @@ public:
         return ss::now();
     }
 
-    ss::future<replication::data_source::data>
-    fetch_next(ss::abort_source& as) final {
+    ss::future<replication::fetch_data> fetch_next(ss::abort_source& as) final {
         auto holder = _gate.hold();
         auto result = co_await _consumer.fetch(_tp, as);
         if (!result.has_value()) [[unlikely]] {
@@ -306,7 +306,7 @@ public:
                 err));
         }
         auto [batches, units] = std::move(*result);
-        co_return data_source::data{
+        co_return replication::fetch_data{
           .batches = std::move(batches), .units = std::move(units)};
     }
 

--- a/src/v/kafka/client/direct_consumer/BUILD
+++ b/src/v/kafka/client/direct_consumer/BUILD
@@ -5,17 +5,20 @@ redpanda_cc_library(
     srcs = [
         "data_queue.cc",
         "direct_consumer.cc",
+        "direct_consumer_probe.cc",
         "fetcher.cc",
     ],
     hdrs = [
         "api_types.h",
         "data_queue.h",
         "direct_consumer.h",
+        "direct_consumer_probe.h",
         "fetcher.h",
     ],
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",
+        "//src/v/config",
         "//src/v/container:chunked_hash_map",
         "//src/v/container:chunked_vector",
         "//src/v/container:intrusive",
@@ -29,6 +32,7 @@ redpanda_cc_library(
         "//src/v/kafka/protocol:list_offset",
         "//src/v/kafka/protocol:metadata",
         "//src/v/kafka/protocol/schemata:fetch_response",
+        "//src/v/metrics",
         "//src/v/model",
         "//src/v/ssx:async_algorithm",
         "//src/v/ssx:future_util",

--- a/src/v/kafka/client/direct_consumer/direct_consumer.cc
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.cc
@@ -20,12 +20,20 @@
 
 namespace kafka::client {
 
-direct_consumer::direct_consumer(cluster& cluster, configuration cfg)
+direct_consumer::direct_consumer(
+  cluster& cluster,
+  configuration cfg,
+  std::optional<direct_consumer_probe::configuration> probe_cfg)
   : _cluster(&cluster)
   , _config(cfg)
   , _fetched_data_queue(
       std::make_unique<data_queue>(
-        cfg.max_buffered_bytes, cfg.max_buffered_elements)) {}
+        cfg.max_buffered_bytes, cfg.max_buffered_elements))
+  , _probe{} {
+    if (probe_cfg.has_value()) {
+        _probe.emplace(std::move(probe_cfg.value()));
+    }
+}
 
 ss::future<fetches>
 direct_consumer::fetch_next(std::chrono::milliseconds timeout) {

--- a/src/v/kafka/client/direct_consumer/direct_consumer.h
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.h
@@ -13,6 +13,7 @@
 #include "container/chunked_hash_map.h"
 #include "kafka/client/cluster.h"
 #include "kafka/client/direct_consumer/api_types.h"
+#include "kafka/client/direct_consumer/direct_consumer_probe.h"
 #include "model/fundamental.h"
 
 namespace kafka {
@@ -67,7 +68,11 @@ public:
         friend std::ostream& operator<<(std::ostream&, const configuration&);
     };
 
-    direct_consumer(cluster& cluster, configuration cfg);
+    direct_consumer(
+      cluster& cluster,
+      configuration cfg,
+      std::optional<direct_consumer_probe::configuration> probe_cfg
+      = std::nullopt);
 
     ~direct_consumer();
     /**
@@ -127,6 +132,19 @@ public:
     std::optional<source_partition_offsets>
     get_source_offsets(model::topic_partition_view tp) const;
 
+    /**
+     *  Executes a functor on the probe, if available.
+     */
+    template<typename Fn>
+    requires std::invocable<Fn, direct_consumer_probe&>
+    void with_probe(Fn fn) {
+        if (!_probe) {
+            return;
+        }
+
+        fn(_probe.value());
+    }
+
 private:
     struct subscription {
         subscription(
@@ -184,6 +202,8 @@ private:
      * Stale fetches need to be dropped.
      */
     subscription_epoch epoch{0};
+
+    std::optional<direct_consumer_probe> _probe;
 
     cluster::callback_id _metadata_callback_id;
     bool _started = false;

--- a/src/v/kafka/client/direct_consumer/direct_consumer_probe.cc
+++ b/src/v/kafka/client/direct_consumer/direct_consumer_probe.cc
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/client/direct_consumer/direct_consumer_probe.h"
+
+#include "config/configuration.h"
+
+#include <seastar/core/metrics.hh>
+
+namespace kafka {
+namespace client {
+
+direct_consumer_probe::direct_consumer_probe(configuration config)
+  : n_fetch_errors{}
+  , _public_metrics{} {
+    setup_metrics(std::move(config));
+}
+
+void direct_consumer_probe::setup_metrics(configuration config) {
+    namespace sm = ss::metrics;
+
+    if (config::shard_local_cfg().disable_public_metrics()) {
+        return;
+    }
+
+    // client metrics
+    auto client_metrics = std::to_array({
+      sm::make_counter(
+        "client_errors",
+        [this] { return n_fetch_errors; },
+        sm::description("Number of errors seen by the client"),
+        config.labels),
+    });
+
+    std::vector<sm::metric_definition> defs;
+    defs.reserve(client_metrics.size());
+    std::ranges::copy(
+      client_metrics | std::views::as_rvalue, std::back_inserter(defs));
+
+    _public_metrics.add_group(config.group_name, std::move(defs));
+}
+
+} // namespace client
+} // namespace kafka

--- a/src/v/kafka/client/direct_consumer/direct_consumer_probe.h
+++ b/src/v/kafka/client/direct_consumer/direct_consumer_probe.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "metrics/metrics.h"
+
+namespace kafka {
+namespace client {
+
+struct direct_consumer_probe {
+    struct configuration {
+        ss::sstring group_name;
+        std::vector<ss::metrics::label_instance> labels;
+    };
+
+    explicit direct_consumer_probe(configuration);
+    direct_consumer_probe(const direct_consumer_probe&) = delete;
+    direct_consumer_probe& operator=(const direct_consumer_probe&) = delete;
+    direct_consumer_probe(direct_consumer_probe&&) = delete;
+    direct_consumer_probe& operator=(direct_consumer_probe&&) = delete;
+    ~direct_consumer_probe() = default;
+
+    void setup_metrics(configuration);
+
+    size_t n_fetch_errors;
+
+private:
+    metrics::public_metric_groups _public_metrics;
+};
+
+} // namespace client
+} // namespace kafka

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -271,6 +271,11 @@ reader_to_chunked_vector(kafka::batch_reader reader) {
       model::make_record_batch_reader<kafka::batch_reader>(std::move(reader)),
       model::no_timeout);
 }
+
+void increment_fetch_errors(direct_consumer_probe& probe) {
+    ++probe.n_fetch_errors;
+}
+
 } // namespace
 
 bool fetcher::maybe_update_fetch_offset(
@@ -430,6 +435,7 @@ fetcher::process_fetch_response(
   const topic_partition_map<epoch_set>& epochs,
   const chunked_vector<partitions_to_process>& partitions) {
     if (resp.data.error_code != kafka::error_code::none) {
+        _parent->with_probe(increment_fetch_errors);
         co_return resp.data.error_code;
     }
 
@@ -496,6 +502,7 @@ fetcher::process_fetch_response(
               = maybe_epoch_set.value().subscription_epoch;
 
             if (part_response.error_code != kafka::error_code::none) {
+                _parent->with_probe(increment_fetch_errors);
                 if (
                   part_response.error_code
                   == kafka::error_code::offset_out_of_range) {
@@ -747,6 +754,7 @@ ss::future<kafka::error_code> fetcher::maybe_initialise_fetch_offsets(
     for (auto& response_topic : list_offsets_response.value()) {
         for (auto& response_partition : response_topic.offsets) {
             if (response_partition.error_code != kafka::error_code::none) {
+                _parent->with_probe(increment_fetch_errors);
                 if (is_retriable_error(response_partition.error_code)) {
                     vlog(
                       logger().debug,

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -2263,6 +2263,14 @@ class ShadowLinkingMetricsTests(ShadowLinkPreAllocTestBase):
                     total_value += s.value
             return total_value > 0
 
+        def check_metric_exists(
+            node_samples: list[dict[str, MetricSamples]], metric_name: str
+        ) -> bool:
+            for samples in node_samples:
+                if metric_name not in samples:
+                    return False
+            return True
+
         def active_shadow_topics_1(samples: list[dict[str, MetricSamples]]):
             return check_shadow_topic_states(samples, 1)
 
@@ -2295,6 +2303,9 @@ class ShadowLinkingMetricsTests(ShadowLinkPreAllocTestBase):
         ) -> bool:
             return check_value_positive(node_samples, "shadow_lag")
 
+        def check_client_errors(node_samples: list[dict[str, MetricSamples]]) -> bool:
+            return check_metric_exists(node_samples, "client_errors")
+
         target_nodes = self.target_cluster.service.nodes
 
         metric_validators = [
@@ -2304,6 +2315,7 @@ class ShadowLinkingMetricsTests(ShadowLinkPreAllocTestBase):
             ("total_bytes_fetched", check_bytes_fetched),
             ("total_bytes_written", check_bytes_written),
             ("shadow_lag", check_shadow_lag_zero),
+            ("client_errors", check_client_errors),
         ]
         for metric_name, validator in metric_validators:
             self.logger.debug(f"Validating values of metric: {metric_name}")
@@ -2328,6 +2340,7 @@ class ShadowLinkingMetricsTests(ShadowLinkPreAllocTestBase):
             ("total_bytes_fetched", check_bytes_fetched),
             ("total_bytes_written", check_bytes_written),
             ("shadow_lag", check_shadow_lag_zero),
+            ("client_errors", check_client_errors),
         ]
         for metric_name, validator in metric_validators:
             self.logger.debug(f"Validating values of metric: {metric_name}")

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -17,6 +17,7 @@ import threading
 import time
 import json
 
+from ducktape.cluster.cluster import ClusterNode
 from ducktape.cluster.cluster_spec import ClusterSpec
 from connectrpc.errors import ConnectError, ConnectErrorCode
 from contextlib import nullcontext
@@ -47,6 +48,8 @@ from rptest.services.multi_cluster_services import (
     ServiceType,
 )
 from rptest.services.redpanda import (
+    MetricSamples,
+    MetricsEndpoint,
     RedpandaService,
     SchemaRegistryConfig,
     SecurityConfig,
@@ -69,7 +72,7 @@ from rptest.util import (
     wait_until,
     wait_until_result,
 )
-from typing import Any
+from typing import Any, Callable, Optional
 from time import sleep
 import google.protobuf.duration_pb2
 
@@ -2145,6 +2148,238 @@ class ShadowLinkUpdateBrokersTests(ShadowLinkPreAllocTestBase):
         assert not topic_exists_in_target(old_source_topic), (
             f"Topic {old_source_topic} should not be visible to the target cluster"
         )
+
+
+class ShadowLinkingMetricsTests(ShadowLinkPreAllocTestBase):
+    def _get_metrics_for_node(
+        self,
+        node: ClusterNode,
+        patterns: list[str],
+    ) -> Optional[dict[str, MetricSamples]]:
+        def get_metrics_from_node_sync(patterns: list[str]):
+            samples = self.redpanda.metrics_samples(
+                patterns, [node], MetricsEndpoint.PUBLIC_METRICS
+            )
+            success = set(samples.keys()) == set(patterns)
+            return success, samples
+
+        try:
+            samples = wait_until_result(
+                lambda: get_metrics_from_node_sync(patterns),
+                timeout_sec=2,
+                backoff_sec=0.1,
+            )
+            return samples
+        except ducktape.errors.TimeoutError:
+            return None
+
+    def _get_metrics_for_nodes(
+        self,
+        nodes: list[ClusterNode],
+        patterns: list[str],
+    ) -> Optional[list[dict[str, MetricSamples]]]:
+        metrics: list[dict[str, MetricSamples]] = []
+        for n in nodes:
+            node_metrics = self._get_metrics_for_node(n, patterns)
+
+            if node_metrics is None:
+                continue
+            metrics.append(node_metrics)
+        return metrics
+
+    def _validate_metrics(
+        self,
+        nodes: list[ClusterNode],
+        patterns: list[str],
+        validator: Callable[[list[dict[str, MetricSamples]]], bool],
+    ):
+        metrics = self._get_metrics_for_nodes(nodes, patterns)
+        if metrics is None:
+            return False
+        return validator(metrics)
+
+    @cluster(num_nodes=10)
+    def test_link_metrics(self):
+        topic_1 = TopicSpec(
+            name="test-topic-1", partition_count=3, replication_factor=1
+        )
+        self.source_default_client().create_topic(topic_1)
+        self.create_link("test-link")
+
+        self.start_producer_consumer(topic=topic_1.name, msg_size=128, msg_cnt=1000)
+        self.verify()
+
+        def check_shadow_topic_states(
+            node_samples: list[dict[str, MetricSamples]], n_active: int
+        ) -> bool:
+            sts = "shadow_topic_state"
+            other_statuses = [
+                "failed",
+                "paused",
+                "failing_over",
+                "failed_over",
+                "promoting",
+                "promoted",
+            ]
+
+            if not node_samples:
+                return False
+
+            by_status: dict[str, int] = {}
+            for samples in node_samples:
+                if sts not in samples:
+                    continue
+                for s in samples[sts].samples:
+                    status = s.labels["status"]
+                    if status not in by_status:
+                        by_status[status] = 0
+                    by_status[status] += int(s.value)
+            return by_status["active"] == n_active and all(
+                [by_status[s] == 0 for s in other_statuses]
+            )
+
+        def check_total_value(
+            node_samples: list[dict[str, MetricSamples]],
+            metric_name: str,
+            expected_total: int,
+        ) -> bool:
+            total_records = 0
+            for samples in node_samples:
+                if metric_name not in samples:
+                    return False
+                for s in samples[metric_name].samples:
+                    total_records += s.value
+            return total_records == expected_total
+
+        # This function only checks that the result is greater than zero. i.e. something has been returned by this metric
+        def check_value_positive(
+            node_samples: list[dict[str, MetricSamples]], metric_name: str
+        ) -> bool:
+            total_value = 0
+            for samples in node_samples:
+                if metric_name not in samples:
+                    return False
+                for s in samples[metric_name].samples:
+                    total_value += s.value
+            return total_value > 0
+
+        def active_shadow_topics_1(samples: list[dict[str, MetricSamples]]):
+            return check_shadow_topic_states(samples, 1)
+
+        def active_shadow_topics_2(samples: list[dict[str, MetricSamples]]):
+            return check_shadow_topic_states(samples, 2)
+
+        def check_records_fetched_1000(samples: list[dict[str, MetricSamples]]):
+            return check_total_value(samples, "total_records_fetched", 1000)
+
+        def check_records_fetched_2500(samples: list[dict[str, MetricSamples]]):
+            return check_total_value(samples, "total_records_fetched", 2500)
+
+        def check_records_written_1000(samples: list[dict[str, MetricSamples]]):
+            return check_total_value(samples, "total_records_written", 1000)
+
+        def check_records_written_2500(samples: list[dict[str, MetricSamples]]):
+            return check_total_value(samples, "total_records_written", 2500)
+
+        def check_bytes_fetched(samples: list[dict[str, MetricSamples]]):
+            return check_value_positive(samples, "total_bytes_fetched")
+
+        def check_bytes_written(samples: list[dict[str, MetricSamples]]):
+            return check_value_positive(samples, "total_bytes_written")
+
+        def check_shadow_lag_zero(node_samples: list[dict[str, MetricSamples]]) -> bool:
+            return check_total_value(node_samples, "shadow_lag", 0)
+
+        def check_shadow_lag_positive(
+            node_samples: list[dict[str, MetricSamples]],
+        ) -> bool:
+            return check_value_positive(node_samples, "shadow_lag")
+
+        target_nodes = self.target_cluster.service.nodes
+
+        metric_validators = [
+            ("shadow_topic_state", active_shadow_topics_1),
+            ("total_records_fetched", check_records_fetched_1000),
+            ("total_records_written", check_records_written_1000),
+            ("total_bytes_fetched", check_bytes_fetched),
+            ("total_bytes_written", check_bytes_written),
+            ("shadow_lag", check_shadow_lag_zero),
+        ]
+        for metric_name, validator in metric_validators:
+            self.logger.debug(f"Validating values of metric: {metric_name}")
+            wait_until(
+                lambda: self._validate_metrics(target_nodes, [metric_name], validator),
+                timeout_sec=10,
+                backoff_sec=1,
+                err_msg=f"Failed to get the expected metrics value for metric {metric_name}",
+            )
+
+        topic_2 = TopicSpec(
+            name="test-topic-2", partition_count=3, replication_factor=1
+        )
+        self.source_default_client().create_topic(topic_2)
+        self.start_producer_consumer(topic=topic_2.name, msg_size=128, msg_cnt=1500)
+        self.verify()
+
+        metric_validators = [
+            ("shadow_topic_state", active_shadow_topics_2),
+            ("total_records_fetched", check_records_fetched_2500),
+            ("total_records_written", check_records_written_2500),
+            ("total_bytes_fetched", check_bytes_fetched),
+            ("total_bytes_written", check_bytes_written),
+            ("shadow_lag", check_shadow_lag_zero),
+        ]
+        for metric_name, validator in metric_validators:
+            self.logger.debug(f"Validating values of metric: {metric_name}")
+            wait_until(
+                lambda: self._validate_metrics(target_nodes, [metric_name], validator),
+                timeout_sec=10,
+                backoff_sec=1,
+                err_msg=f"Failed to get the expected metrics value for metric {metric_name}",
+            )
+
+        topic_3 = TopicSpec(
+            name="test-topic-3", partition_count=1, replication_factor=3
+        )
+        self.source_default_client().create_topic(topic_3)
+        self.target_cluster.service.wait_until(
+            lambda: self.topic_exists_in_target(topic_3.name),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"Topic {topic_3.name} not found in target cluster",
+        )
+
+        self.start_producer_consumer(
+            topic=topic_3.name,
+            msg_size=128,
+            msg_cnt=100000,
+            use_transactions=True,
+            msgs_per_transaction=10000,
+        )
+        metric_validators = [
+            ("shadow_lag", check_shadow_lag_positive),
+        ]
+        for metric_name, validator in metric_validators:
+            self.logger.debug(f"Validating values of metric: {metric_name}")
+            wait_until(
+                lambda: self._validate_metrics(target_nodes, [metric_name], validator),
+                timeout_sec=30,
+                backoff_sec=1,
+                err_msg=f"Failed to get the expected metrics value for metric {metric_name}",
+            )
+        self.verify()
+
+        metric_validators = [
+            ("shadow_lag", check_shadow_lag_zero),
+        ]
+        for metric_name, validator in metric_validators:
+            self.logger.debug(f"Validating values of metric: {metric_name}")
+            wait_until(
+                lambda: self._validate_metrics(target_nodes, [metric_name], validator),
+                timeout_sec=30,
+                backoff_sec=1,
+                err_msg=f"Failed to get the expected metrics value for metric {metric_name}",
+            )
 
 
 class ShadowLinkCustomStartOffsetSelectionTests(ShadowLinkPreAllocTestBase):

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -790,6 +790,7 @@ class ShadowLinkPreAllocTestBase(ShadowLinkTestBase):
         msg_size: int = 128,
         msg_cnt: int = 10000,
         use_transactions: bool = False,
+        msgs_per_transaction: int | None = None,
         transaction_abort_rate: float = 0.3,
     ):
         self.verifier = ClusterLinkingProgressVerifier(
@@ -802,7 +803,10 @@ class ShadowLinkPreAllocTestBase(ShadowLinkTestBase):
             msg_count=msg_cnt,
             msg_size=msg_size,
             use_transactions=use_transactions,
-            producer_properties={"transaction_abort_rate": transaction_abort_rate},
+            producer_properties={
+                "transaction_abort_rate": transaction_abort_rate,
+                "msgs_per_transaction": msgs_per_transaction,
+            },
             timeout_sec=180,
         )
         self.verifier.start()


### PR DESCRIPTION
Implements: [CORE-10237](https://redpandadata.atlassian.net/browse/CORE-10237)

| Metric | Type | Description | Labels | Aggregation labels |
| -- | -- | -- | -- | -- |
| `redpanda_shadow_link_total_records_fetched` | count | Total number of records fetched by the replicator | `shadow_link_name`, `shard` |
| `redpanda_shadow_link_total_records_written` | count | Total number of records written by the replicator | `shadow_link_name`, `shard` |
| `redpanda_shadow_link_total_bytes_fetched` | count | Total number of bytes fetched by the replicator | `shadow_link_name`, `shard` |
| `redpanda_shadow_link_total_bytes_written` | count | Total number of bytes written by the replicator | `shadow_link_name`, `shard` |
| `redpanda_shadow_link_shadow_topic_state` | gauge | Number of shadow topics in the respective state | `shadow_link_name` | `shard` |
| `redpanda_shadow_link_client_errors` | count | Number of errors seen by the client |`shadow_link_name`, `shard` |
| `redpanda_shadow_link_shadow_lag` | gauge | Lag of the shadow partition against the source partition |`shadow_link_name`, `topic`, `partition` | `shard` |


</div>


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-10237]: https://redpandadata.atlassian.net/browse/CORE-10237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ