### PR TITLE
[CORE-13776] Handle `rpk.describe_group` racing with `__consumer_offsets` creation

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -682,8 +682,12 @@ class RpkTool:
     @overload
     def list_topics(self, detailed: Literal[True]) -> list[list[str]]: ...
 
-    def list_topics(self, detailed: bool = False) -> list[str | list[str]]:
+    def list_topics(
+        self, detailed: bool = False, internal: bool = False
+    ) -> list[str | list[str]]:
         cmd = ["list"]
+        if internal:
+            cmd.append("-i")
 
         output = self._run_topic(cmd)
         if "No topics found." in output:

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -29,7 +29,7 @@ from rptest.services.redpanda_types import (
     KafkaClientSecurity,
     check_username_password,
 )
-from rptest.util import wait_until_result
+from rptest.util import wait_until, wait_until_result
 
 DEFAULT_TIMEOUT = 30
 
@@ -1028,14 +1028,14 @@ class RpkTool:
             assert m is not None, f"Field string '{string}' does not match the pattern"
             return m["value"]
 
-        def try_describe_group(group):
+        def describe_group(group):
             if summary:
                 cmd = ["describe", "-s", group]
             else:
                 cmd = ["describe", group]
 
             try:
-                out = self._run_group(cmd)
+                return self._run_group(cmd)
             except RpkException as e:
                 if "COORDINATOR_NOT_AVAILABLE" in e.msg + e.stderr:
                     # Transient, return None to retry
@@ -1054,6 +1054,40 @@ class RpkTool:
                 else:
                     raise
 
+        def try_describe_group(group):
+            try:
+                out = describe_group(group)
+                if out is not None:
+                    return parse_describe_group(out)
+                return None
+            except:
+                # rpk will not print out the COORDINATOR-PARTITION field for
+                # parsing when __consumer_offsets topic hasn't been created yet.
+                # instead of trying to be fancy and adapt to such output, we
+                # wait for it to be created and try again. NOTE: in the context
+                # in which this wait has been added we see that the topic is
+                # created as a side effect of rpk running find_coordinator. this
+                # behavior might be specific to the test prompting this change.
+                # if you see a similar parsing problem (see git blame for
+                # details) in the future, another option would be to explicitly
+                # poke redpanda in a way so as to create the consumer offsets
+                # topic by running a command where the consumer offsets topic is
+                # created as a side effect.
+                self._redpanda.logger.debug(
+                    "Waiting for __consumer_offsets topic to exist"
+                )
+                wait_until(
+                    lambda: "__consumer_offsets" in self.list_topics(internal=True),
+                    timeout_sec=10,
+                    backoff_sec=1,
+                    err_msg="__consumer_offsets topic not created",
+                )
+                out = describe_group(group)
+                if out is not None:
+                    return parse_describe_group(out)
+                return None
+
+        def parse_describe_group(out):
             lines = out.splitlines()
             group_name = parse_field("GROUP", lines[0])
             coordinator_node = parse_field("COORDINATOR-NODE", lines[1])


### PR DESCRIPTION

```
Module:      rptest.tests.log_segment_ms_test
Class:       SegmentMsTest
Method:      test_segment_rolling_with_retention_consumer
Nodes (used/allocated): 4/4

  File "/root/tests/rptest/clients/rpk.py", line 1047, in try_describe_group
    coordinator_partition = parse_field("COORDINATOR-PARTITION", lines[2])
  File "/root/tests/rptest/clients/rpk.py", line 1015, in parse_field
    assert m is not None, f"Field string '{string}' does not match the pattern"
AssertionError: Field string 'STATE             Dead' does not match the pattern
```

Here is normal output from rpk when parsing

```
[INFO  - 2025-11-19 02:33:29,103 - rpk - try_describe_group - lineno:1056]: 
GROUP                  test-group
COORDINATOR-NODE       1
COORDINATOR-PARTITION  __consumer_offsets/8
STATE                  Empty
BALANCER               
MEMBERS                0
TOTAL-LAG              0
```

Here it is when we see this exception

```
[DEBUG - 2025-11-17 06:56:35,198 - rpk - _execute - lineno:1482]: 
GROUP             test-group
COORDINATOR-NODE  1
STATE             Dead
BALANCER          
MEMBERS           0
TOTAL-LAG         0
```

Indeed, that is the case in rpk

```
	if partitionCount > 0 {
		// We do calculate the partition ID for the group with the following
		// hash-based algorithm, which is Redpanda specific at least at 25.1.x, https://github.com/redpanda-data/redpanda/blob/v25.1.1/src/v/kafka/server/coordinator_ntp_mapper.h#L50-L60
		// Apache Kafka does use a different algorithm, https://github.com/apache/kafka/blob/4.0.0/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala#L192
		hash := xxhash.Sum64String(group.Group)
		partitionID := jump.Hash(hash, int32(partitionCount))
		fmt.Fprintf(tw, "COORDINATOR-PARTITION\t__consumer_offsets/%d\n", partitionID)
	}
```

So presumably rpk is conditionally logging the coordinator partition field.

We can see this in the logs

```
A) here is where rpk describe is begin called by ducktape. one of the very first things that it does is checks how many partitions the consumer offsets topic has.

[DEBUG - 2025-11-17 06:56:34,631 - rpk - _execute - lineno:1455]: Executing command: ['/var/lib/buildkite-agent/builds/redpanda-bk-agent-v6-core-m5d12xlarge-xfs-partitions-i-0e274305d11b8b15c-1/redpanda/redpanda/vbuild/redpanda_installs/ci/bin/rpk', 'group', '-X', 'brokers=docker-rp-16:9092', 'describe', 'test-group', '-X', 'globals.request_timeout_overhead=30s', '-v']

B) here is that metadata call about 50ms later

TRACE 2025-11-17 06:56:34,684 [shard 0:kafk] kafka - handler.h:81 - [client_id: {rpk}] handling metadata v12 request {topics={[{topic_id=AAAAAAAAAAAAAAAAAAAAAA== name={__consumer_offsets}}]} allow_auto_topic_creation=false include_cluster_authorized_operations=false include_topic_authorized_operations=false}
DEBUG 2025-11-17 06:56:34,684 [shard 0:kafk] kafka - request_context.h:238 -
[192.168.215.28:51426] sending 3:metadata for {rpk}, response
{throttle_time_ms=0ms brokers={node_id=1 host=docker-rp-16 port=9092
rack={nullopt}} cluster_id={redpanda.21650b5b-9fbf-43ac-88ae-05ee7363042a}
controller_id=1 topics={error_code={ error_code: unknown_topic_or_partition [3]
} name={__consumer_offsets} topic_id=AAAAAAAAAAAAAAAAAAAAAA== is_internal=false
partitions= topic_authorized_operations=-2147483648}
cluster_authorized_operations=-2147483648}

C) above we see that the topic doesn't exist. rpk will handle this later by using partition count = 0 which alters the output causing the parsing issue.

D) then we see that the consumer offsets topic is created a second or so later.

TRACE 2025-11-17 06:56:34,685 [shard 1:kafk] kafka - requests.cc:96 - [192.168.215.28:51432] processing name:find_coordinator, key:10, version:4 for rpk, mem_units: 8056, ctx_size: 14
TRACE 2025-11-17 06:56:34,685 [shard 1:kafk] kafka - handler.h:81 - [client_id: {rpk}] handling find_coordinator v4 request {key= key_type={group} coordinator_keys=[test-group]}


TRACE 2025-11-17 06:56:34,686 [shard 1:kafk] kafka - group_initializer.cc:37 - can't find consumer group topic, creating
TRACE 2025-11-17 06:56:34,686 [shard 1:kafk] cluster - topics_frontend.cc:1208 - Auto create topics [{ topic: {kafka/__consumer_offsets}, partition_count: 16, replication_factor: 1, is_migrated: true, topic_id: {nullopt}, properties: { compression: {nullopt}, 
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none


[CORE-13776]: https://redpandadata.atlassian.net/browse/CORE-13776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ