### PR TITLE
CORE-13358 Client Monitoring: surface aborting and closing connections

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -219,9 +219,6 @@ ss::future<> connection_context::start() {
 }
 
 ss::future<> connection_context::stop() {
-    if (_hook && is_linked()) {
-        _hook.value().get().erase(_hook.value().get().iterator_to(*this));
-    }
     if (conn) {
         vlog(klog.trace, "stopping connection context for {}", conn->addr);
         conn->shutdown_input();
@@ -230,6 +227,10 @@ ss::future<> connection_context::stop() {
     co_await _as.request_abort_ex(ssx::connection_aborted_exception{});
     co_await _gate.close();
     co_await _as.stop();
+
+    if (_hook && is_linked()) {
+        _hook.value().get().erase(_hook.value().get().iterator_to(*this));
+    }
 
     if (conn) {
         vlog(klog.trace, "stopped connection context for {}", conn->addr);
@@ -375,7 +376,8 @@ connection_context::authorized_user<security::acl_cluster_name>(
 
 ss::future<> connection_context::revoke_credentials(std::string_view name) {
     if (
-      !_sasl.has_value() || !_sasl->has_mechanism()
+      !_as.local_is_initialized() || _as.abort_requested() || !_sasl.has_value()
+      || !_sasl->has_mechanism()
       || _sasl->mechanism().mechanism_name() != name) {
         return ss::now();
     }
@@ -841,9 +843,15 @@ proto::admin::kafka_connection connection_context::to_proto() const {
       config::node().node_id.value().value_or(model::unassigned_node_id));
     res.set_uid(ssx::sformat("{}", _attributes.connection_id));
     res.set_listener_name(ss::sstring{listener()});
-    res.set_state(
-      _as.abort_requested() ? kafka_connection_state::aborting
-                            : kafka_connection_state::open);
+    auto conn_state = [this]() {
+        if (!_as.local_is_initialized()) {
+            return kafka_connection_state::closed;
+        } else if (_as.abort_requested()) {
+            return kafka_connection_state::aborting;
+        }
+        return kafka_connection_state::open;
+    }();
+    res.set_state(conn_state);
     res.set_open_time(ss_sys_clock_to_absl(_attributes.open_time));
 
     auto src = proto::admin::source{};

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -170,6 +170,7 @@ parse_virtual_connection_id(const kafka::request_header& header) {
 connection_context::connection_context(
   std::optional<
     std::reference_wrapper<boost::intrusive::list<connection_context>>> hook,
+  std::optional<std::reference_wrapper<closed_connections_t>> closed_list,
   class server& s,
   ss::lw_shared_ptr<net::connection> conn,
   std::optional<security::sasl_server> sasl,
@@ -179,6 +180,7 @@ connection_context::connection_context(
   config::conversion_binding<std::vector<bool>, std::vector<ss::sstring>>
     kafka_throughput_controlled_api_keys) noexcept
   : _hook(hook)
+  , _closed_list(closed_list)
   , _server(s)
   , conn(conn)
   , _protocol_state()
@@ -218,6 +220,18 @@ ss::future<> connection_context::start() {
     }
 }
 
+namespace {
+constexpr static size_t closed_list_size_per_shard = 5;
+
+void push_limited(
+  closed_connections_t& queue, closed_connections_t::value_type&& value) {
+    if (queue.size() == closed_list_size_per_shard) {
+        queue.pop_front();
+    }
+    queue.push_back(std::move(value));
+}
+} // namespace
+
 ss::future<> connection_context::stop() {
     if (conn) {
         vlog(klog.trace, "stopping connection context for {}", conn->addr);
@@ -230,6 +244,10 @@ ss::future<> connection_context::stop() {
 
     if (_hook && is_linked()) {
         _hook.value().get().erase(_hook.value().get().iterator_to(*this));
+    }
+    if (_closed_list) {
+        push_limited(
+          _closed_list.value().get(), ss::make_lw_shared(to_closed_proto()));
     }
 
     if (conn) {
@@ -950,6 +968,13 @@ proto::admin::kafka_connection connection_context::to_proto() const {
     res.set_total_request_statistics(
       make_stats([](auto& attr) { return attr.total_stat; }));
 
+    return res;
+}
+
+proto::admin::kafka_connection connection_context::to_closed_proto() const {
+    auto res = to_proto();
+    res.set_state(proto::admin::kafka_connection_state::closed);
+    res.set_close_time(ss_sys_clock_to_absl(ss::lowres_system_clock::now()));
     return res;
 }
 

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -51,6 +51,9 @@ namespace kafka {
 
 using response_ptr = ss::foreign_ptr<std::unique_ptr<response>>;
 
+using closed_connections_t
+  = std::deque<ss::lw_shared_ptr<proto::admin::kafka_connection>>;
+
 class kafka_api_version_not_supported_exception : public std::runtime_error {
 public:
     explicit kafka_api_version_not_supported_exception(const std::string& m)
@@ -238,6 +241,7 @@ public:
     connection_context(
       std::optional<std::reference_wrapper<
         boost::intrusive::list<connection_context>>> hook,
+      std::optional<std::reference_wrapper<closed_connections_t>> closed_list,
       server& s,
       ss::lw_shared_ptr<net::connection> conn,
       std::optional<security::sasl_server> sasl,
@@ -381,6 +385,8 @@ private:
     // Returns handler specific connection override if available.
     std::optional<ss::scheduling_group>
       get_scheduling_group_override(api_key) const;
+
+    proto::admin::kafka_connection to_closed_proto() const;
 
     class ctx_log {
     public:
@@ -564,6 +570,7 @@ private:
     std::optional<
       std::reference_wrapper<boost::intrusive::list<connection_context>>>
       _hook;
+    std::optional<std::reference_wrapper<closed_connections_t>> _closed_list;
     class server& _server;
     ss::lw_shared_ptr<net::connection> conn;
 

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -256,6 +256,10 @@ server::list_connections() const {
            | std::ranges::to<ret_t>();
 }
 
+closed_connections_t server::list_closed_connections() const {
+    return _closed_connections;
+}
+
 void server::setup_metrics() {
     namespace sm = ss::metrics;
     if (config::shard_local_cfg().disable_metrics()) {
@@ -379,6 +383,7 @@ ss::future<> server::apply(ss::lw_shared_ptr<net::connection> conn) {
 
     auto ctx = ss::make_lw_shared<connection_context>(
       _connections,
+      _closed_connections,
       *this,
       conn,
       std::move(sasl),

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -264,6 +264,8 @@ public:
     chunked_vector<ss::lw_shared_ptr<const connection_context>>
     list_connections() const;
 
+    closed_connections_t list_closed_connections() const;
+
 private:
     void setup_metrics();
 
@@ -315,6 +317,7 @@ private:
     std::unique_ptr<replica_selector> _replica_selector;
     const std::unique_ptr<pandaproxy::schema_registry::api>& _schema_registry;
     boost::intrusive::list<connection_context> _connections;
+    closed_connections_t _closed_connections{};
 };
 
 } // namespace kafka

--- a/src/v/redpanda/admin/services/broker.cc
+++ b/src/v/redpanda/admin/services/broker.cc
@@ -105,10 +105,8 @@ ss::future<connection_gather_result> gather_connections(
     auto conn_ptrs = server.list_connections();
     co_await ss::coroutine::maybe_yield();
 
-    co_await ssx::async_for_each(
-      conn_ptrs, [&result, limit, &filter](const auto& conn_ptr) {
-          auto conn_proto = conn_ptr->to_proto();
-
+    auto process_conn =
+      [&result, limit, &filter](proto::admin::kafka_connection&& conn_proto) {
           bool matches_filter = filter(conn_proto);
 
           if (matches_filter) {
@@ -118,7 +116,17 @@ ss::future<connection_gather_result> gather_connections(
                   result.connections.emplace_back(std::move(conn_proto));
               }
           }
+      };
+
+    co_await ssx::async_for_each(
+      conn_ptrs, [&process_conn](const auto& conn_ptr) {
+          process_conn(conn_ptr->to_proto());
       });
+
+    const auto& closed_conns = server.list_closed_connections();
+    for (auto& elem : closed_conns) {
+        process_conn(std::move(*elem));
+    }
 
     co_return result;
 }

--- a/src/v/redpanda/tests/fixture.cc
+++ b/src/v/redpanda/tests/fixture.cc
@@ -796,6 +796,7 @@ conn_ptr redpanda_thread_fixture::make_connection_context(bool use_authz) {
     sasl.set_mechanism(std::make_unique<fake_sasl_mech>());
     return ss::make_lw_shared<kafka::connection_context>(
       std::nullopt,
+      std::nullopt,
       proto.local(),
       nullptr,
       std::move(sasl),

--- a/tests/rptest/tests/list_kafka_connections_test.py
+++ b/tests/rptest/tests/list_kafka_connections_test.py
@@ -142,6 +142,21 @@ class AdminV2ListKafkaConnectionsTest(RedpandaTest):
 
         self.consumer.stop()
 
+        self.logger.info(
+            "Test that closed connections can also be included in the response"
+        )
+        closed_conns_resp = admin_v2.broker().list_kafka_connections(
+            broker_pb.ListKafkaConnectionsRequest(
+                node_id=-1,
+                filter="state = KAFKA_CONNECTION_STATE_CLOSED",
+            )
+        )
+        self.logger.debug(f"Closed connections response: {closed_conns_resp}")
+        assert len(closed_conns_resp.connections) > 0
+        conn = closed_conns_resp.connections[0]
+        assert conn.state == kafka_connections_pb.KAFKA_CONNECTION_STATE_CLOSED
+        assert conn.close_time.ToDatetime() > datetime(year=2025, month=1, day=1)
+
 
 class AdminV2ListKafkaConnectionsLicenseTest(RedpandaTest):
     """


### PR DESCRIPTION
Include aborting and recently closed connections in the `ListKafkaConnections` endpoint. See the commit messages for implementation details.

It's difficult to generate "slow/stuck while aborting" connections for testing, so I have used this diff to manually test that they are correctly included in the response: https://gist.github.com/pgellert/cdd352215d58bff68df4f77846ccede0

Fixes https://redpandadata.atlassian.net/browse/CORE-13358

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
