### PR TITLE
[v25.2.x] rpk: Remove deprecated cmd from help text

### DIFF
--- a/src/go/rpk/pkg/cli/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/redpanda/config.go
@@ -42,8 +42,8 @@ func NewConfigCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 func set(fs afero.Fs, p *config.Params) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "set [KEY] [VALUE]",
-		Short: "Set configuration values, such as the redpanda node ID or the list of seed servers",
-		Long: `Set configuration values, such as the redpanda node ID or the list of seed servers
+		Short: "Set node configuration values",
+		Long: `Set node configuration values, such as the list of seed servers or the ports that various APIs listen on
 
 This command modifies the redpanda.yaml you have locally on disk. The first
 argument is the key within the yaml representing a property / field that you


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28040
