### PR TITLE
iobuf: optimize comparison more

### DIFF
--- a/src/v/bytes/details/io_fragment.h
+++ b/src/v/bytes/details/io_fragment.h
@@ -107,6 +107,8 @@ public:
     char* get_current() { return _buf.get_write() + _used_bytes; }
     char* get_write() { return _buf.get_write(); }
 
+    explicit operator std::string_view() const { return {get(), size()}; }
+
 private:
     friend class io_fragment_list;
 
@@ -235,7 +237,14 @@ public:
         return _head == nullptr;
     }
 
+    bool is_single_fragment() const { return !empty() && _head == _tail; }
+
     io_fragment& front() {
+        check_consistency();
+        return *_head;
+    }
+
+    const io_fragment& front() const {
         check_consistency();
         return *_head;
     }

--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -106,8 +106,12 @@ bool iobuf::operator==(const iobuf& o) const {
     if (_size != o._size) {
         return false;
     }
-    // We know these have the same amount of bytes in them, but they might be
-    // chunked differently.
+    if (_frags.is_single_fragment() && o._frags.is_single_fragment()) {
+        return std::string_view{_frags.front()}
+               == std::string_view{o._frags.front()};
+    }
+    // We know these have the same amount of bytes in them, but they might
+    // be chunked differently.
     auto o_it = o.cbegin();
     auto other_next_view = [&o, &o_it] -> std::string_view {
         while (o_it != o.cend() && o_it->is_empty()) {
@@ -143,6 +147,23 @@ bool iobuf::operator<(const iobuf& o) const {
 }
 
 std::strong_ordering iobuf::operator<=>(const iobuf& o) const {
+    if (_frags.is_single_fragment() && o._frags.is_single_fragment()) {
+        std::string_view lhs{_frags.front()};
+        std::string_view rhs{o._frags.front()};
+        auto n = std::min(lhs.size(), rhs.size());
+        constexpr size_t max_byte_for_byte_size = 32;
+        if (n > max_byte_for_byte_size) {
+            return lhs <=> rhs;
+        }
+        for (size_t i = 0; i < n; ++i) {
+            auto cmp = lhs[i] <=> rhs[i];
+            if (cmp != std::strong_ordering::equal) {
+                return cmp;
+            }
+        }
+        return lhs.size() <=> rhs.size();
+    }
+
     auto o_it = o.cbegin();
     auto other_next_view = [&o, &o_it] -> std::string_view {
         while (o_it != o.cend() && o_it->is_empty()) {
@@ -151,16 +172,16 @@ std::strong_ordering iobuf::operator<=>(const iobuf& o) const {
         if (o_it == o.cend()) {
             return {};
         }
-        std::string_view s{o_it->get(), o_it->size()};
+        std::string_view s{*o_it};
         ++o_it;
         return s;
     };
     std::string_view rhs = other_next_view();
     for (const auto& frag : *this) {
-        std::string_view lhs{frag.get(), frag.size()};
+        std::string_view lhs{frag};
         while (!lhs.empty()) {
             auto n = std::min(lhs.size(), rhs.size());
-            auto cmp = lhs.substr(0, n) <=> rhs.substr(0, n);
+            auto cmp = std::memcmp(lhs.data(), rhs.data(), n) <=> 0;
             if (cmp != std::strong_ordering::equal) {
                 return cmp;
             }
@@ -186,8 +207,9 @@ bool iobuf::operator==(std::string_view o) const {
     auto in = iobuf::iterator_consumer(cbegin(), cend());
     std::ignore = in.consume(
       size_bytes(), [&are_equal, &o, &n](const char* src, size_t fg_sz) {
-          /// Both strings are equiv in total size, so its safe to assume the
-          /// next chunk to compare is the remaining to cmp or the fragment size
+          /// Both strings are equiv in total size, so its safe to assume
+          /// the next chunk to compare is the remaining to cmp or the
+          /// fragment size
           const auto size = std::min((o.size() - n), fg_sz);
           std::string_view a_view(src, size);
           std::string_view b_view(o.data() + n, size);

--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -18,6 +18,7 @@
 #include <seastar/core/future-util.hh>
 #include <seastar/core/smp.hh>
 
+#include <algorithm>
 #include <compare>
 #include <cstddef>
 #include <iostream>
@@ -106,9 +107,16 @@ bool iobuf::operator==(const iobuf& o) const {
     if (_size != o._size) {
         return false;
     }
-    if (_frags.is_single_fragment() && o._frags.is_single_fragment()) {
-        return std::string_view{_frags.front()}
-               == std::string_view{o._frags.front()};
+    if (!_frags.empty() && !o._frags.empty()) {
+        std::string_view lhs{_frags.front()};
+        std::string_view rhs{o._frags.front()};
+        constexpr static size_t max_byte_for_byte_cmp = 4;
+        auto n = std::min({lhs.size(), rhs.size(), max_byte_for_byte_cmp});
+        for (size_t i = 0; i < n; ++i) {
+            if (lhs[i] != rhs[i]) {
+                return false;
+            }
+        }
     }
     // We know these have the same amount of bytes in them, but they might
     // be chunked differently.
@@ -147,23 +155,22 @@ bool iobuf::operator<(const iobuf& o) const {
 }
 
 std::strong_ordering iobuf::operator<=>(const iobuf& o) const {
-    if (_frags.is_single_fragment() && o._frags.is_single_fragment()) {
+    // Always check the first few bytes using byte for byte comparison,
+    // this allows the case of relatively randomized data to be done quickly
+    // but we still preserve the chunked checks that are faster if there is
+    // a matching prefix.
+    if (!_frags.empty() && !o._frags.empty()) {
         std::string_view lhs{_frags.front()};
         std::string_view rhs{o._frags.front()};
-        auto n = std::min(lhs.size(), rhs.size());
-        constexpr size_t max_byte_for_byte_size = 32;
-        if (n > max_byte_for_byte_size) {
-            return lhs <=> rhs;
-        }
+        constexpr static size_t max_byte_for_byte_cmp = 4;
+        auto n = std::min({lhs.size(), rhs.size(), max_byte_for_byte_cmp});
         for (size_t i = 0; i < n; ++i) {
             auto cmp = lhs[i] <=> rhs[i];
             if (cmp != std::strong_ordering::equal) {
                 return cmp;
             }
         }
-        return lhs.size() <=> rhs.size();
     }
-
     auto o_it = o.cbegin();
     auto other_next_view = [&o, &o_it] -> std::string_view {
         while (o_it != o.cend() && o_it->is_empty()) {

--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -184,20 +184,22 @@ std::strong_ordering iobuf::operator<=>(const iobuf& o) const {
         return s;
     };
     std::string_view rhs = other_next_view();
-    for (const auto& frag : *this) {
-        std::string_view lhs{frag};
-        while (!lhs.empty()) {
-            auto n = std::min(lhs.size(), rhs.size());
-            auto cmp = std::memcmp(lhs.data(), rhs.data(), n) <=> 0;
-            if (cmp != std::strong_ordering::equal) {
-                return cmp;
-            }
-            lhs.remove_prefix(n);
-            rhs.remove_prefix(n);
-            if (rhs.empty()) {
-                rhs = other_next_view();
-                if (o_it == o.cend()) {
-                    break;
+    if (!rhs.empty()) { // This prevents UB by using memcmp with nullptr
+        for (const auto& frag : *this) {
+            std::string_view lhs{frag};
+            while (!lhs.empty()) {
+                auto n = std::min(lhs.size(), rhs.size());
+                auto cmp = std::memcmp(lhs.data(), rhs.data(), n) <=> 0;
+                if (cmp != std::strong_ordering::equal) {
+                    return cmp;
+                }
+                lhs.remove_prefix(n);
+                rhs.remove_prefix(n);
+                if (rhs.empty()) {
+                    rhs = other_next_view();
+                    if (o_it == o.cend()) {
+                        break;
+                    }
                 }
             }
         }

--- a/src/v/bytes/tests/iobuf_bench.cc
+++ b/src/v/bytes/tests/iobuf_bench.cc
@@ -49,12 +49,11 @@ size_t move_bench() {
     return inner_iters * 2;
 }
 
-template<size_t Size, typename cmp_fn>
+template<size_t Size, typename cmp_fn, bool same>
 size_t cmp_bench() {
     iobuf a = make_iobuf(Size);
-    iobuf a_shared = a.share();
     iobuf a_copy = a.copy();
-    iobuf b = make_iobuf(Size, /*reverse=*/true);
+    iobuf b = make_iobuf(Size, !same);
     iobuf b_copy;
     for (const auto& frag : b) {
         for (char c : std::string_view(frag.get(), frag.size())) {
@@ -63,14 +62,11 @@ size_t cmp_bench() {
     }
     perf_tests::start_measuring_time();
     for (auto i = inner_iters; i--;) {
-        perf_tests::do_not_optimize(cmp_fn{}(a, a_shared));
-        perf_tests::do_not_optimize(cmp_fn{}(a, a_copy));
         perf_tests::do_not_optimize(cmp_fn{}(a, b));
         perf_tests::do_not_optimize(cmp_fn{}(a_copy, b_copy));
-        perf_tests::do_not_optimize(cmp_fn{}(b_copy, b));
     }
     perf_tests::stop_measuring_time();
-    return inner_iters * 5;
+    return inner_iters * 2;
 }
 
 // This microbench mocks common pattern in Redpanda where smaller iobufs will be
@@ -98,21 +94,55 @@ size_t append_bench() {
 }
 } // namespace
 
+// clang-format off
+PERF_TEST(iobuf, cmp_bench_0000) { return cmp_bench<   0, std::less<>, false>(); }
+PERF_TEST(iobuf, cmp_bench_0001) { return cmp_bench<   1, std::less<>, false>(); }
+PERF_TEST(iobuf, cmp_bench_0002) { return cmp_bench<   2, std::less<>, false>(); }
+PERF_TEST(iobuf, cmp_bench_0003) { return cmp_bench<   3, std::less<>, false>(); }
+PERF_TEST(iobuf, cmp_bench_0004) { return cmp_bench<   4, std::less<>, false>(); }
+PERF_TEST(iobuf, cmp_bench_0016) { return cmp_bench<  16, std::less<>, false>(); }
+PERF_TEST(iobuf, cmp_bench_0064) { return cmp_bench<  64, std::less<>, false>(); }
+PERF_TEST(iobuf, cmp_bench_0128) { return cmp_bench< 128, std::less<>, false>(); }
+PERF_TEST(iobuf, cmp_bench_0256) { return cmp_bench< 256, std::less<>, false>(); }
+PERF_TEST(iobuf, cmp_bench_0512) { return cmp_bench< 512, std::less<>, false>(); }
+PERF_TEST(iobuf, cmp_bench_1024) { return cmp_bench<1024, std::less<>, false>(); }
+PERF_TEST(iobuf, cmp_bench_2048) { return cmp_bench<2048, std::less<>, false>(); }
+PERF_TEST(iobuf, cmp_bench_0000_same) { return cmp_bench<   0, std::less<>, true>(); }
+PERF_TEST(iobuf, cmp_bench_0001_same) { return cmp_bench<   1, std::less<>, true>(); }
+PERF_TEST(iobuf, cmp_bench_0002_same) { return cmp_bench<   2, std::less<>, true>(); }
+PERF_TEST(iobuf, cmp_bench_0003_same) { return cmp_bench<   3, std::less<>, true>(); }
+PERF_TEST(iobuf, cmp_bench_0004_same) { return cmp_bench<   4, std::less<>, true>(); }
+PERF_TEST(iobuf, cmp_bench_0016_same) { return cmp_bench<  16, std::less<>, true>(); }
+PERF_TEST(iobuf, cmp_bench_0064_same) { return cmp_bench<  64, std::less<>, true>(); }
+PERF_TEST(iobuf, cmp_bench_0128_same) { return cmp_bench< 128, std::less<>, true>(); }
+PERF_TEST(iobuf, cmp_bench_0256_same) { return cmp_bench< 256, std::less<>, true>(); }
+PERF_TEST(iobuf, cmp_bench_0512_same) { return cmp_bench< 512, std::less<>, true>(); }
+PERF_TEST(iobuf, cmp_bench_1024_same) { return cmp_bench<1024, std::less<>, true>(); }
+PERF_TEST(iobuf, cmp_bench_2048_same) { return cmp_bench<2048, std::less<>, true>(); }
+// clang-format on
+
 PERF_TEST(iobuf, move_bench_small) { return move_bench<71>(); }
 PERF_TEST(iobuf, move_bench_medium) { return move_bench<300_KiB>(); }
 PERF_TEST(iobuf, move_bench_large) { return move_bench<965_KiB>(); }
 
-PERF_TEST(iobuf, eq_bench_small) { return cmp_bench<71, std::equal_to<>>(); }
+PERF_TEST(iobuf, eq_bench_small) {
+    return cmp_bench<71, std::equal_to<>, false>();
+}
+PERF_TEST(iobuf, eq_bench_small_same) {
+    return cmp_bench<71, std::equal_to<>, true>();
+}
 PERF_TEST(iobuf, eq_bench_medium) {
-    return cmp_bench<300_KiB, std::equal_to<>>();
+    return cmp_bench<300_KiB, std::equal_to<>, false>();
+}
+PERF_TEST(iobuf, eq_bench_medium_same) {
+    return cmp_bench<300_KiB, std::equal_to<>, true>();
 }
 PERF_TEST(iobuf, eq_bench_large) {
-    return cmp_bench<965_KiB, std::equal_to<>>();
+    return cmp_bench<965_KiB, std::equal_to<>, false>();
 }
-
-PERF_TEST(iobuf, cmp_bench_small) { return cmp_bench<71, std::less<>>(); }
-PERF_TEST(iobuf, cmp_bench_medium) { return cmp_bench<300_KiB, std::less<>>(); }
-PERF_TEST(iobuf, cmp_bench_large) { return cmp_bench<965_KiB, std::less<>>(); }
+PERF_TEST(iobuf, eq_bench_large_same) {
+    return cmp_bench<965_KiB, std::equal_to<>, true>();
+}
 
 PERF_TEST(iobuf, append_bench_small) { return append_bench<1'000, 4>(); }
 PERF_TEST(iobuf, append_bench_medium) { return append_bench<1'000, 40_KiB>(); }

--- a/src/v/bytes/tests/iobuf_tests.cc
+++ b/src/v/bytes/tests/iobuf_tests.cc
@@ -97,6 +97,8 @@ SEASTAR_THREAD_TEST_CASE(test_cmp_str_view) {
     BOOST_CHECK_EQUAL(true, multiple_frags > "cat");
     BOOST_CHECK_EQUAL(
       std::strong_ordering::equal, (multiple_frags.share(0, 3) <=> "cat"));
+    BOOST_CHECK_LT(iobuf::from(""), iobuf::from("cat"));
+    BOOST_CHECK_GT(iobuf::from("cat"), iobuf::from(""));
 }
 
 SEASTAR_THREAD_TEST_CASE(test_appended_data_is_retained) {


### PR DESCRIPTION
Turns out if the first byte is different memcmp is slower than a byte
for byte comparison. So what we do is optimize small iobufs and change
how we do the comparison, instead we check. This is a tradeoff we can
see in the bench for the best/worse case of how many bytes we compare


## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
