### PR TITLE
[CORE-13570] Deflake `test_timequery_with_local_gc`

### DIFF
--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -359,6 +359,11 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
         else:
             self.redpanda.add_extra_rp_conf({"log_segment_size": self.log_segment_size})
 
+        # `test_timequery_with_local_gc` attempts to set the `log_segment_size` lower than the minimum
+        # value of 1_MiB- disable bounded property checks to allow this.
+        self.redpanda.set_environment(
+            {"__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"}
+        )
         self.redpanda.start()
 
     def _do_test_timequery(
@@ -803,7 +808,7 @@ class TestReadReplicaTimeQuery(RedpandaTest):
             }
             rpk_rr_cluster.create_topic(self.topic_name, config=conf)
         except:
-            self.logger.warn(f"Failed to create a read-replica topic")
+            self.logger.warn("Failed to create a read-replica topic")
             return False
         return True
 

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -59,6 +59,8 @@ class BaseTimeQuery:
                 "redpanda.remote.read": "true",
                 "redpanda.remote.write": "true",
                 "retention.local.target.bytes": local_retention,
+                # See comment about disabling `retention.ms` below.
+                "retention.local.target.ms": -1,
             }.items():
                 self.client().alter_topic_config(topic.name, k, v)
             desc = self.client().describe_topic_configs(topic.name)


### PR DESCRIPTION
Fixes https://redpandadata.atlassian.net/issues/CORE-13570.

This test intended to disable local time-based retention, but did not consider the property `retention.local.target.ms` for a tiered storage enabled topic.

Previously, local retention would be enforced by broker time, but after PR https://github.com/redpanda-data/redpanda/pull/27383, the test became flakey due to the now "active" retention enforcement.

Set `retention.local-target.ms=-1` to disable time-based retention for tiered storage enabled topics for this test.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
