### PR TITLE
ct: Fix reactor stall in 'convert_to_placeholders'

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -65,26 +65,28 @@ static constexpr auto L0_replicate_default_timeout = 1s;
 
 // Utility function to convert array of extent_meta structs to
 // array of placeholder batches.
-static placeholder_batches_with_size convert_to_placeholders(
+static ss::future<placeholder_batches_with_size> convert_to_placeholders(
   const chunked_vector<cloud_topics::extent_meta>& extents,
   const chunked_vector<model::record_batch_header>& headers) {
     placeholder_batches_with_size result;
     result.batches.reserve(extents.size());
-    for (const auto& [extent, header] : std::views::zip(extents, headers)) {
-        vassert(
-          extent.base_offset() <= extent.last_offset(),
-          "Extent base offset {} is greater than committed offset {}",
-          extent.base_offset(),
-          extent.last_offset());
+    co_await ssx::async_for_each(
+      std::views::zip(extents, headers), [&result](const auto& pair) {
+          const auto& [extent, header] = pair;
+          vassert(
+            extent.base_offset() <= extent.last_offset(),
+            "Extent base offset {} is greater than committed offset {}",
+            extent.base_offset(),
+            extent.last_offset());
 
-        // Every extent maps to a single batch produced by the client
-        // and therefore we need to create a placeholder batch for it.
-        auto batch = encode_placeholder_batch(header, extent);
+          // Every extent maps to a single batch produced by the client
+          // and therefore we need to create a placeholder batch for it.
+          auto batch = encode_placeholder_batch(header, extent);
 
-        result.batches.push_back(std::move(batch));
-        result.extent_size += extent.byte_range_size;
-    }
-    return result;
+          result.batches.push_back(std::move(batch));
+          result.extent_size += extent.byte_range_size;
+      });
+    co_return result;
 }
 
 /// Get original record batch and prepare it for the record batch cache
@@ -568,7 +570,7 @@ ss::future<> bg_upload_and_replicate(
 
     chunked_vector<model::record_batch_header> headers;
     headers.push_back(header);
-    auto placeholders = convert_to_placeholders(
+    auto placeholders = co_await convert_to_placeholders(
       res.value(), std::move(headers));
 
     vassert(
@@ -690,7 +692,7 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
           kafka::make_error_code(kafka::error_code::request_timed_out));
     }
 
-    auto placeholders = convert_to_placeholders(res.value(), headers);
+    auto placeholders = co_await convert_to_placeholders(res.value(), headers);
 
     chunked_vector<model::record_batch> placeholder_batches;
     for (auto&& batch : placeholders.batches) {


### PR DESCRIPTION
The PR fixes reactor stall in the CT read path.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none