### PR TITLE
`misc`: debug test fixes

### DIFF
--- a/src/v/cloud_storage/tests/BUILD
+++ b/src/v/cloud_storage/tests/BUILD
@@ -630,7 +630,7 @@ redpanda_cc_gtest(
 
 redpanda_cc_btest(
     name = "delete_records_e2e_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "delete_records_e2e_test.cc",
     ],

--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -285,7 +285,7 @@ TEST_P(EndToEndFixture, TestProduceConsumeFromCloud) {
 }
 
 TEST_P(EndToEndFixture, TestProduceConsumeFromCloudWithSpillover) {
-#ifndef _NDEBUG
+#ifdef NDEBUG
     test_local_cfg.get("cloud_storage_disable_upload_loop_for_tests")
       .set_value(true);
     test_local_cfg.get("cloud_storage_spillover_manifest_size")

--- a/src/v/cloud_storage/tests/delete_records_e2e_test.cc
+++ b/src/v/cloud_storage/tests/delete_records_e2e_test.cc
@@ -67,7 +67,11 @@ class delete_records_e2e_fixture
   , public redpanda_thread_fixture
   , public enable_cloud_storage_fixture {
 public:
+#ifdef NDEBUG
     static constexpr auto segs_per_spill = 10;
+#else
+    static constexpr auto segs_per_spill = 2;
+#endif
     delete_records_e2e_fixture()
       : redpanda_thread_fixture(
           redpanda_thread_fixture::init_cloud_storage_tag{},
@@ -351,14 +355,20 @@ FIXTURE_TEST(test_delete_from_archive_consume, delete_records_e2e_fixture) {
 // DeleteRecords request lands in local storage.
 FIXTURE_TEST(
   test_delete_from_local_storage_truncation, delete_records_e2e_fixture) {
+    static constexpr size_t records_per_seg = 5;
+    static constexpr size_t num_segments = segs_per_spill * 4;
+    static constexpr size_t additional_local_segments = segs_per_spill;
+
+    static constexpr size_t expected_records
+      = (num_segments + additional_local_segments) * records_per_seg;
+
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
     auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
-    size_t records_per_seg = 5;
     BOOST_REQUIRE_GE(
-      250,
+      expected_records,
       gen.batches_per_segment(records_per_seg)
-        .num_segments(40)
-        .additional_local_segments(10)
+        .num_segments(num_segments)
+        .additional_local_segments(additional_local_segments)
         .produce()
         .get());
     BOOST_REQUIRE(archiver->sync_for_tests().get());
@@ -371,7 +381,7 @@ FIXTURE_TEST(
     kafka_delete_records_transport deleter(make_kafka_client().get());
     deleter.start().get();
     auto deferred_d_close = ss::defer([&deleter] { deleter.stop().get(); });
-    auto new_start_offset = kafka::offset(245);
+    auto new_start_offset = kafka::offset(expected_records - 5);
     BOOST_REQUIRE_EQUAL(
       new_start_offset,
       model::offset_cast(deleter
@@ -393,7 +403,7 @@ FIXTURE_TEST(
     BOOST_REQUIRE_EQUAL(
       stm_manifest.get_archive_clean_offset(), model::offset{});
     BOOST_REQUIRE(stm_manifest.get_spillover_map().empty());
-    BOOST_REQUIRE_EQUAL(10, archiver->manifest().size());
+    BOOST_REQUIRE_EQUAL(segs_per_spill, archiver->manifest().size());
     BOOST_REQUIRE_EQUAL(stm_start_before, stm_manifest.get_start_offset());
     BOOST_REQUIRE_NE(
       stm_manifest.get_start_kafka_offset_override(), kafka::offset{});
@@ -438,7 +448,8 @@ FIXTURE_TEST(
       archiver->upload_manifest("test").get());
     BOOST_REQUIRE(stm_manifest.get_start_kafka_offset().has_value());
     BOOST_REQUIRE_EQUAL(
-      stm_manifest.get_start_kafka_offset().value(), kafka::offset(200));
+      stm_manifest.get_start_kafka_offset().value(),
+      kafka::offset(num_segments * records_per_seg));
 
     // When truncating the STM, we should still honor the requested start.
     archiver->housekeeping().get();
@@ -446,24 +457,31 @@ FIXTURE_TEST(
     BOOST_REQUIRE_EQUAL(
       stm_manifest.get_start_kafka_offset().value(), new_start_offset);
     BOOST_REQUIRE_EQUAL(
-      stm_manifest.get_start_kafka_offset_override(), kafka::offset(245));
+      stm_manifest.get_start_kafka_offset_override(),
+      kafka::offset(expected_records - records_per_seg));
 
     auto size_above_override = segment_bytes_above_offset(
-      stm_manifest, kafka::offset(245));
+      stm_manifest, kafka::offset(expected_records - records_per_seg));
     check_truncate_removes_override(size_above_override);
 }
 
 // Test that truncation is applied to cloud storage as expected when a
 // DeleteRecords request lands in the STM manifest.
 FIXTURE_TEST(test_delete_from_stm_truncation, delete_records_e2e_fixture) {
+    static constexpr size_t records_per_seg = 5;
+    static constexpr size_t num_segments = segs_per_spill * 4;
+    static constexpr size_t additional_local_segments = segs_per_spill;
+
+    static constexpr size_t expected_records
+      = (num_segments + additional_local_segments) * records_per_seg;
+
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
     auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
-    size_t records_per_seg = 5;
     BOOST_REQUIRE_GE(
-      250,
+      expected_records,
       gen.batches_per_segment(records_per_seg)
-        .num_segments(40)
-        .additional_local_segments(10)
+        .num_segments(num_segments)
+        .additional_local_segments(additional_local_segments)
         .produce()
         .get());
     BOOST_REQUIRE(archiver->sync_for_tests().get());
@@ -488,7 +506,7 @@ FIXTURE_TEST(test_delete_from_stm_truncation, delete_records_e2e_fixture) {
     // The first housekeeping will cleanup the archive.
     BOOST_REQUIRE(archiver->sync_for_tests().get());
     archiver->housekeeping().get();
-    BOOST_REQUIRE_EQUAL(10, archiver->manifest().size());
+    BOOST_REQUIRE_EQUAL(segs_per_spill, archiver->manifest().size());
     BOOST_REQUIRE_EQUAL(
       stm_manifest.get_archive_start_offset(), model::offset{});
     BOOST_REQUIRE_EQUAL(
@@ -526,14 +544,20 @@ FIXTURE_TEST(test_delete_from_stm_truncation, delete_records_e2e_fixture) {
 // Test that truncation is applied to cloud storage as expected when a
 // DeleteRecords request lands in the archive.
 FIXTURE_TEST(test_delete_from_archive_truncation, delete_records_e2e_fixture) {
+    static constexpr size_t records_per_seg = 5;
+    static constexpr size_t num_segments = segs_per_spill * 4;
+    static constexpr size_t additional_local_segments = segs_per_spill;
+
+    static constexpr size_t expected_records
+      = (num_segments + additional_local_segments) * records_per_seg;
+
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
     auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
-    size_t records_per_seg = 5;
     BOOST_REQUIRE_GE(
-      250,
+      expected_records,
       gen.batches_per_segment(records_per_seg)
-        .num_segments(40)
-        .additional_local_segments(10)
+        .num_segments(num_segments)
+        .additional_local_segments(additional_local_segments)
         .produce()
         .get());
     BOOST_REQUIRE(archiver->sync_for_tests().get());

--- a/src/v/kafka/server/tests/group_tx_compaction_test.cc
+++ b/src/v/kafka/server/tests/group_tx_compaction_test.cc
@@ -473,22 +473,32 @@ TEST_P_CORO(
     co_await run_workload(GetParam(), this, consumer_offsets_log());
 }
 
+#ifdef NDEBUG
+static constexpr size_t num_groups = 100;
+static constexpr size_t num_tx_per_group = 50;
+static constexpr size_t num_rolls = 30;
+#else
+static constexpr size_t num_groups = 10;
+static constexpr size_t num_tx_per_group = 5;
+static constexpr size_t num_rolls = 3;
+#endif
+
 INSTANTIATE_TEST_SUITE_P(
   group_tx_combinations,
   group_tx_random_workload_fixture,
   testing::Values(
     workload_parameters{
-      .num_groups = 100,
-      .num_tx_per_group = 50,
-      .num_rolls = 30,
+      .num_groups = num_groups,
+      .num_tx_per_group = num_tx_per_group,
+      .num_rolls = num_rolls,
       .tx_workload_type = workload_parameters::commit_only},
     workload_parameters{
-      .num_groups = 100,
-      .num_tx_per_group = 50,
-      .num_rolls = 30,
+      .num_groups = num_groups,
+      .num_tx_per_group = num_tx_per_group,
+      .num_rolls = num_rolls,
       .tx_workload_type = workload_parameters::abort_only},
     workload_parameters{
-      .num_groups = 100,
-      .num_tx_per_group = 50,
-      .num_rolls = 30,
+      .num_groups = num_groups,
+      .num_tx_per_group = num_tx_per_group,
+      .num_rolls = num_rolls,
       .tx_workload_type = workload_parameters::mixed}));

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -1089,8 +1089,13 @@ INSTANTIATE_TEST_SUITE_P(
 
 struct TombstonesRandomArgs {
     static TombstonesRandomArgs create() {
+#ifdef NDEBUG
         static constexpr size_t max_segments = 100;
         static constexpr size_t max_records = 1000;
+#else
+        static constexpr size_t max_segments = 10;
+        static constexpr size_t max_records = 100;
+#endif
         static constexpr size_t max_cardinality = max_records;
         static constexpr size_t max_batches_per_segment = 5;
         return TombstonesRandomArgs{


### PR DESCRIPTION
Fixes for a variety of tests that were timing out in `DEBUG` mode due to volume of data produced.

Relevant slack thread: https://redpandadata.slack.com/archives/C06H3S140NM/p1759934777504819?thread_ts=1756247039.219359&cid=C06H3S140NM

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
