### PR TITLE
tuner: Raise aio-max-nr to 10M

### DIFF
--- a/src/go/rpk/pkg/tuners/aio.go
+++ b/src/go/rpk/pkg/tuners/aio.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	maxAIOEvents     = 1048576
+	maxAIOEvents     = 10_000_137
 	maxAIOEventsFile = "/proc/sys/fs/aio-max-nr"
 )
 

--- a/src/go/rpk/pkg/tuners/aio_test.go
+++ b/src/go/rpk/pkg/tuners/aio_test.go
@@ -56,7 +56,7 @@ func TestMaxAIOEventsCheck(t *testing.T) {
 			before: func(fs afero.Fs) error {
 				_, err := utils.WriteBytes(
 					fs,
-					[]byte("1048576"),
+					[]byte("10000137"),
 					maxAIOEventsFile,
 				)
 				return err
@@ -67,13 +67,13 @@ func TestMaxAIOEventsCheck(t *testing.T) {
 			before: func(fs afero.Fs) error {
 				_, err := utils.WriteBytes(
 					fs,
-					[]byte("1048575"),
+					[]byte("10000136"),
 					maxAIOEventsFile,
 				)
 				return err
 			},
 			expectChange: true,
-			expected:     1048576,
+			expected:     10000137,
 		},
 		{
 			name:           "it should fail if the file is missing",


### PR DESCRIPTION
Raise the aio target to 10M.

At the seastar default `max_networking_io_control_blocks` of 10k the
current 1M value only allows using ~95 shards. We are already seeing
--smp=64 deployments so bump this for some future proofing.

I am also not aware of any reason not to have this that high.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none

