### PR TITLE
tuner: Add well-known io-props for m8gd

### DIFF
--- a/src/go/rpk/pkg/tuners/iotune/data.go
+++ b/src/go/rpk/pkg/tuners/iotune/data.go
@@ -302,6 +302,44 @@ func precompiledData() map[string]map[string]map[string]io {
 				"default": {"", 4 * 269588, 4 * 1263357056, 4 * 134608, 4 * 604995968, true},
 			},
 
+			// m8gd values are taken from direct measurement with iotune except
+			// where noted.
+			"m8gd.large": {
+				"default": {"", 33638, 224 * 1024 * 1024, 16836, 109 * 1024 * 1024, true},
+			},
+
+			"m8gd.xlarge": {
+				"default": {"", 67274, 450 * 1024 * 1024, 33676, 215 * 1024 * 1024, true},
+			},
+
+			"m8gd.2xlarge": {
+				"default": {"", 134550, 904 * 1024 * 1024, 67358, 431 * 1024 * 1024, true},
+			},
+
+			"m8gd.4xlarge": {
+				"default": {"", 269588, 1821 * 1024 * 1024, 134608, 865 * 1024 * 1024, true},
+			},
+
+			// These disks aren't 100% full-duplex (more like 50% full
+			// duplex or so). Nevertheless we still mark them as full duplex.
+			// Otherwise we let too much perf go to waste compared to running
+			// without io-properties.
+			"m8gd.8xlarge": {
+				"default": {"", 541806, 3699 * 1024 * 1024, 268818, 1743 * 1024 * 1024, true},
+			},
+
+			// Read IOPS values are upscaled because default iotune struggles to
+			// reach full RIOPS with default settings (needs either lowered smp
+			// or increased iodepth) but I was too lazy to implement that but
+			// have confirmed that we can reach those numbers otherwise.
+			"m8gd.12xlarge": {
+				"default": {"", 3 * 269588, 5465 * 1024 * 1024, 402765, 2596 * 1024 * 1024, true},
+			},
+
+			"m8gd.16xlarge": {
+				"default": {"", 4 * 269588, 7398 * 1024 * 1024, 540197, 3590 * 1024 * 1024, true},
+			},
+
 			// m6id values are copied from m7gd as they should have the same
 			// disks and behave the same from tests.
 			"m6id.large": {


### PR DESCRIPTION
Adds well known io-properties for m8gd up to 16xl

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none


