### PR TITLE
Reduce max_message_bytes from 1GB to 100MB in quota test

### DIFF
--- a/tests/rptest/tests/cluster_quota_test.py
+++ b/tests/rptest/tests/cluster_quota_test.py
@@ -32,7 +32,7 @@ from rptest.services.redpanda import (
 )
 from rptest.tests.redpanda_test import RedpandaTest
 
-GB = 1_000_000_000
+MiB = 1024 * 1024
 
 
 class ExpectedMetric(NamedTuple):
@@ -144,7 +144,7 @@ class ClusterRateQuotaTest(RedpandaTest):
     Ducktape tests for rate quota
     """
 
-    topics = (TopicSpec(replication_factor=1, max_message_bytes=1 * GB),)
+    topics = (TopicSpec(replication_factor=1, max_message_bytes=100 * MiB),)
 
     def __init__(self, *args, **kwargs):
         # Note: the quotas apply based on the full size of the request (for
@@ -550,12 +550,12 @@ class ClusterRateQuotaTest(RedpandaTest):
         # Create two producers sharing a client.id
         producer1 = self.make_producer(
             "shared_client_id",
-            max_request_size=1 * GB,
+            max_request_size=100 * MiB,
             max_in_flight_requests_per_connection=1,
         )
         producer2 = self.make_producer(
             "shared_client_id",
-            max_request_size=1 * GB,
+            max_request_size=100 * MiB,
             max_in_flight_requests_per_connection=1,
         )
         consumer = self.make_consumer("shared_client_id")


### PR DESCRIPTION
1GB exceeds the 100MiB default max request size for Redpanda and therefore isn't a valid configuration in CI ducktape tests currently.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
