### PR TITLE
[CORE-13983] Support Avro "optionals" as flat iceberg type/value

### DIFF
--- a/src/v/iceberg/conversion/BUILD
+++ b/src/v/iceberg/conversion/BUILD
@@ -51,6 +51,9 @@ redpanda_cc_library(
     hdrs = [
         "schema_avro.h",
     ],
+    implementation_deps = [
+        ":avro_utils",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         ":conversion_outcome",
@@ -100,6 +103,7 @@ redpanda_cc_library(
     srcs = ["values_avro.cc"],
     hdrs = ["values_avro.h"],
     implementation_deps = [
+        ":avro_utils",
         "//src/v/bytes:iobuf",
         "//src/v/bytes:iobuf_parser",
         "//src/v/iceberg:avro_decimal",

--- a/src/v/iceberg/conversion/BUILD
+++ b/src/v/iceberg/conversion/BUILD
@@ -29,6 +29,21 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "avro_utils",
+    srcs = [
+        "avro_utils.cc",
+    ],
+    hdrs = [
+        "avro_utils.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/iceberg:datatypes",
+        "@avro",
+    ],
+)
+
+redpanda_cc_library(
     name = "schema_avro",
     srcs = [
         "schema_avro.cc",

--- a/src/v/iceberg/conversion/avro_utils.cc
+++ b/src/v/iceberg/conversion/avro_utils.cc
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "iceberg/conversion/avro_utils.h"
+
+#include <avro/Schema.hh>
+
+namespace iceberg {
+std::optional<avro::NodePtr> maybe_flatten_union(const avro::NodePtr& node) {
+    if (node->type() != avro::AVRO_UNION || node->leaves() != 2) {
+        return std::nullopt;
+    }
+
+    // NOTE: Avro union branches must be unique by definition
+
+    auto b0 = node->leafAt(0);
+    auto b1 = node->leafAt(1);
+
+    if (b0->type() == avro::AVRO_NULL) {
+        return b1;
+    }
+    if (b1->type() == avro::AVRO_NULL) {
+        return b0;
+    }
+
+    return std::nullopt;
+}
+} // namespace iceberg

--- a/src/v/iceberg/conversion/avro_utils.h
+++ b/src/v/iceberg/conversion/avro_utils.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "iceberg/datatypes.h"
+
+#include <avro/Node.hh>
+
+#include <optional>
+
+namespace iceberg {
+/**
+ * Since the Avro specification doesn't include a way to express optional
+ * fields, users commonly use a UNION typed field with one or two  alternates
+ * NULL and the other of the desired type.
+ *
+ * This is a helper function to detect that pattern during record schema
+ * conversion.
+ *
+ * returns the non-NULL leaf, if present, which can then be converted to a
+ * redpanda-native field type. nullopt indicates "the node does not contain an
+ * optional".
+ */
+std::optional<avro::NodePtr> maybe_flatten_union(const avro::NodePtr&);
+} // namespace iceberg

--- a/src/v/iceberg/conversion/schema_avro.cc
+++ b/src/v/iceberg/conversion/schema_avro.cc
@@ -9,6 +9,8 @@
  */
 #include "iceberg/conversion/schema_avro.h"
 
+#include "iceberg/conversion/avro_utils.h"
+
 #include <seastar/util/defer.hh>
 #include <seastar/util/log.hh>
 
@@ -45,12 +47,20 @@ struct_from_avro_record(const avro::NodePtr& node, state& state) {
         }
 
         auto field = std::move(result.value());
+        // Incidentally, all columns are forced nullable when we push the
+        // resulting schema into the table. This is an implementation detail on
+        // our side to simplify schema evolution, so we may as well detect the
+        // Avro optional pattern and set any such field optional as a matter of
+        // course.
+        auto required = iceberg::maybe_flatten_union(leaf).has_value()
+                          ? iceberg::field_required::no
+                          : iceberg::field_required::yes;
         if (field.has_value()) {
             ret.fields.push_back(
               iceberg::nested_field::create(
                 placeholder_field_id,
                 node->nameAt(i),
-                iceberg::field_required::yes,
+                required,
                 std::move(field.value())));
         }
     }
@@ -195,6 +205,9 @@ inner_field_type_from_avro(const avro::NodePtr& node, state& state) {
     case avro::AVRO_UNION: {
         // Avro union is flattened as a struct with fields that are not
         // required, only one of the fields will be present at a time.
+        if (auto opt = iceberg::maybe_flatten_union(node); opt.has_value()) {
+            return field_type_from_avro(opt.value(), state);
+        }
         iceberg::struct_type ret;
         ret.fields.reserve(node->leaves());
         for (size_t i = 0; i < node->leaves(); ++i) {

--- a/src/v/iceberg/conversion/schema_avro.h
+++ b/src/v/iceberg/conversion/schema_avro.h
@@ -27,6 +27,8 @@ namespace iceberg {
  *
  *  - avro unions are 'flattened' as a structure with optional fields out of
  *    which only one or none are present (i case ther is a field with null type)
+ *    - excepting unions of the form ["null", <some_type>] or [<some_type>,
+ *      "null"] which are treated as a bare, optional field of <some_type>.
  *
  *  - all fields are required by default (avro always sets a default in binary
  *    representation)

--- a/src/v/iceberg/conversion/tests/BUILD
+++ b/src/v/iceberg/conversion/tests/BUILD
@@ -89,6 +89,7 @@ redpanda_cc_gtest(
         "//src/v/bytes:iobuf_parser",
         "//src/v/iceberg:avro_decimal",
         "//src/v/iceberg:datatypes",
+        "//src/v/iceberg/conversion:avro_utils",
         "//src/v/iceberg/conversion:schema_avro",
         "//src/v/iceberg/conversion:values_avro",
         "//src/v/serde/avro/tests:data_generator",

--- a/src/v/iceberg/conversion/tests/iceberg_avro_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_avro_tests.cc
@@ -34,6 +34,7 @@ static constexpr auto tl_array = R"J({ "type" : "array", "items" : "int" })J";
 
 static constexpr auto tl_map = R"J({"type": "map","values": {"type":"int"}})J";
 static constexpr auto tl_union = R"J([ "int" , "long" , "float" ])J";
+static constexpr auto tl_optional = R"J([ "null", "long" ])J";
 avro::NodePtr load_json_schema(std::string_view sch) {
     return avro::compileJsonSchemaFromString(std::string(sch)).root();
 }
@@ -100,6 +101,9 @@ TEST(AvroSchema, TestNonRecordSchema) {
         0, "union_opt_2", iceberg::field_required::no, iceberg::float_type{}));
 
     tl_type_expectations.emplace_back("root", tl_union, std::move(union_st));
+
+    tl_type_expectations.emplace_back(
+      "root", tl_optional, iceberg::long_type{});
 
     for (auto& [name, schema, type] : tl_type_expectations) {
         auto root = load_json_schema(schema);
@@ -191,7 +195,7 @@ constexpr auto big_record = R"J(
             ]
         },
         {
-            "name": "anotherunion",
+            "name": "optional_bytes",
             "type": [
                 "bytes",
                 "null"
@@ -324,14 +328,9 @@ TEST(AvroSchema, TestRecordType) {
 
     ASSERT_TRUE(
       field_matches(struct_t.fields[6], "myunion", std::move(union_struct)));
-    iceberg::struct_type another_union_struct;
-
-    another_union_struct.fields.push_back(
-      iceberg::nested_field::create(
-        0, "union_opt_0", iceberg::field_required::no, iceberg::binary_type{}));
 
     ASSERT_TRUE(field_matches(
-      struct_t.fields[7], "anotherunion", std::move(another_union_struct)));
+      struct_t.fields[7], "optional_bytes", iceberg::binary_type{}));
 
     ASSERT_TRUE(
       field_matches(struct_t.fields[8], "mybool", iceberg::boolean_type{}));
@@ -757,14 +756,19 @@ AssertionResult primitive_equal(
 }
 
 AssertionResult value_matches(
-  const avro::GenericDatum& datum, const iceberg::value& value, bool is_union);
+  const avro::GenericDatum& datum,
+  const iceberg::value& value,
+  bool is_union,
+  const iceberg::field_type& iceberg_schema);
 
 AssertionResult value_matches(
   const avro::GenericDatum& datum,
   const std::optional<iceberg::value>& optional_val,
-  bool is_union) {
+  bool is_union,
+  const iceberg::field_type& iceberg_schema) {
     if (optional_val) {
-        return value_matches(datum, optional_val.value(), is_union);
+        return value_matches(
+          datum, optional_val.value(), is_union, iceberg_schema);
     }
     if (datum.type() != avro::AVRO_NULL) {
         return AssertionFailure() << "Empty optional must be represented as "
@@ -791,8 +795,13 @@ std::vector<uint8_t> decimal_to_vector(absl::int128 decimal) {
  * Check if avro generic datum matches iceberg value
  */
 AssertionResult value_matches(
-  const avro::GenericDatum& datum, const iceberg::value& value, bool is_union) {
-    if (is_union) {
+  const avro::GenericDatum& datum,
+  const iceberg::value& value,
+  bool is_union,
+  const iceberg::field_type& iceberg_schema) {
+    if (
+      is_union
+      && std::holds_alternative<iceberg::struct_type>(iceberg_schema)) {
         if (!std::holds_alternative<std::unique_ptr<iceberg::struct_value>>(
               value)) {
             return AssertionFailure() << fmt::format(
@@ -801,6 +810,7 @@ AssertionResult value_matches(
 
         auto& struct_v = std::get<std::unique_ptr<iceberg::struct_value>>(
           value);
+        auto& struct_s = std::get<iceberg::struct_type>(iceberg_schema);
         if (datum.type() == avro::AVRO_NULL) {
             auto all_empty = std::ranges::all_of(
               struct_v->fields,
@@ -819,7 +829,8 @@ AssertionResult value_matches(
           struct_v->fields, [](const std::optional<iceberg::value>& field) {
               return field.has_value();
           });
-        return value_matches(datum, *field, false);
+        auto i = std::distance(struct_v->fields.begin(), field);
+        return value_matches(datum, *field, false, struct_s.fields[i]->type);
     }
     switch (datum.type()) {
     case avro::AVRO_STRING:
@@ -977,6 +988,7 @@ AssertionResult value_matches(
         }
         auto& record_v = std::get<std::unique_ptr<iceberg::struct_value>>(
           value);
+        auto& record_s = std::get<iceberg::struct_type>(iceberg_schema);
         // since the nulls are skipped in iceberg schema the field count in
         // record_value is always greater than or equal to the field count in
         // avro record
@@ -996,7 +1008,8 @@ AssertionResult value_matches(
             auto r = value_matches(
               avro_field,
               record_v->fields.at(i - null_count),
-              avro_field.isUnion());
+              avro_field.isUnion(),
+              record_s.fields[i - null_count]->type);
             if (!r) {
                 return AssertionFailure() << "Record field value mismatch at "
                                           << i << " - " << r.message();
@@ -1034,6 +1047,7 @@ AssertionResult value_matches(
                    << fmt::format("Expected value {} to be a list", value);
         }
         auto& list = std::get<std::unique_ptr<iceberg::list_value>>(value);
+        auto& list_s = std::get<iceberg::list_type>(iceberg_schema);
         if (avro_array.value().size() != list->elements.size()) {
             return AssertionFailure() << fmt::format(
                      "Array size mismatch {} != {}",
@@ -1044,7 +1058,8 @@ AssertionResult value_matches(
             auto r = value_matches(
               avro_array.value()[i],
               list->elements[i],
-              avro_array.value()[i].isUnion());
+              avro_array.value()[i].isUnion(),
+              list_s.element_field->type);
             if (!r) {
                 return AssertionFailure()
                        << "Array element mismatch - " << r.message();
@@ -1061,6 +1076,7 @@ AssertionResult value_matches(
                    << fmt::format("Expected value {} to be a map", value);
         }
         auto& map_v = std::get<std::unique_ptr<iceberg::map_value>>(value);
+        auto& map_s = std::get<iceberg::map_type>(iceberg_schema);
         if (avro_map.value().size() != map_v->kvs.size()) {
             return AssertionFailure() << fmt::format(
                      "Map size mismatch {} != {}",
@@ -1089,7 +1105,10 @@ AssertionResult value_matches(
               parser.read_string(key_value.val.size_bytes()), avro_kv.first);
 
             auto r = value_matches(
-              avro_kv.second, kv.val, avro_kv.second.isUnion());
+              avro_kv.second,
+              kv.val,
+              avro_kv.second.isUnion(),
+              map_s.value_field->type);
             if (!r) {
                 return AssertionFailure()
                        << "Map value mismatch - " << r.message();
@@ -1150,6 +1169,7 @@ std::unordered_map<std::string_view, std::string_view> test_cases{
   {"tl_array", tl_array},
   {"tl_map", tl_map},
   {"tl_union", tl_union},
+  {"tl_optional", tl_optional},
   {"big_record", big_record},
   {"logical_types", logical_types}};
 
@@ -1158,8 +1178,8 @@ TEST_P(AvroValueTest, RoundtripTest) {
     for (int i = 0; i < 100; ++i) {
         auto [value_result, schema_result, datum] = prepare_avro_test(
           test_cases[test_case_key]);
-        ASSERT_TRUE(value_result.has_value());
-        ASSERT_TRUE(schema_result.has_value());
+        ASSERT_TRUE(value_result.has_value()) << value_result.error().what();
+        ASSERT_TRUE(schema_result.has_value()) << schema_result.error().what();
         auto& iceberg_value = value_result.value();
         auto& iceberg_schema = schema_result.value();
 
@@ -1173,11 +1193,16 @@ TEST_P(AvroValueTest, RoundtripTest) {
             auto& struct_value
               = std::get<std::unique_ptr<iceberg::struct_value>>(iceberg_value);
 
+            auto& struct_schema = std::get<iceberg::struct_type>(
+              iceberg_schema);
             ASSERT_TRUE(value_matches(
-              datum, struct_value->fields[0].value(), datum.isUnion()));
+              datum,
+              struct_value->fields[0],
+              datum.isUnion(),
+              struct_schema.fields[0]->type));
         } else {
-            ASSERT_TRUE(
-              value_matches(datum, value_result.value(), datum.isUnion()));
+            ASSERT_TRUE(value_matches(
+              datum, value_result.value(), datum.isUnion(), iceberg_schema));
         }
     }
 }
@@ -1193,6 +1218,7 @@ INSTANTIATE_TEST_SUITE_P(
     "tl_array",
     "tl_map",
     "tl_union",
+    "tl_optional",
     "big_record",
     "logical_types"));
 

--- a/src/v/iceberg/conversion/tests/iceberg_avro_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_avro_tests.cc
@@ -10,6 +10,7 @@
 #include "bytes/iobuf_parser.h"
 #include "gtest/gtest.h"
 #include "iceberg/avro_decimal.h"
+#include "iceberg/conversion/avro_utils.h"
 #include "iceberg/conversion/schema_avro.h"
 #include "iceberg/conversion/values_avro.h"
 #include "iceberg/datatypes.h"
@@ -1194,3 +1195,51 @@ INSTANTIATE_TEST_SUITE_P(
     "tl_union",
     "big_record",
     "logical_types"));
+
+struct maybe_optional_test_case {
+    std::string_view schema;
+    std::optional<avro::Type> expected;
+};
+
+struct MaybeOptionalTest
+  : ::testing::TestWithParam<maybe_optional_test_case> {};
+
+TEST_P(MaybeOptionalTest, DetectOptionalTest) {
+    auto [schema, expected] = GetParam();
+
+    auto root = load_json_schema(schema);
+    ASSERT_NE(root, nullptr);
+
+    auto opt = iceberg::maybe_flatten_union(root);
+    if (!expected.has_value()) {
+        ASSERT_FALSE(opt.has_value());
+    } else {
+        ASSERT_EQ(opt.value()->type(), expected);
+    }
+}
+
+using tc = maybe_optional_test_case;
+INSTANTIATE_TEST_SUITE_P(
+  DetectOptionalTest,
+  MaybeOptionalTest,
+  Values(
+    tc{
+      .schema = R"J([ "null", {"type": "array", "items": "int" } ])J",
+      .expected = avro::AVRO_ARRAY,
+    },
+    tc{
+      .schema = R"J([ "long", "null" ])J",
+      .expected = avro::AVRO_LONG,
+    },
+    tc{
+      .schema = R"J([ "long", "int" ])J",
+      .expected = std::nullopt,
+    },
+    tc{
+      .schema = R"J([ "long", "int", "null" ])J",
+      .expected = std::nullopt,
+    },
+    tc{
+      .schema = R"J({"type": "long"})J",
+      .expected = std::nullopt,
+    }));

--- a/src/v/iceberg/conversion/values_avro.cc
+++ b/src/v/iceberg/conversion/values_avro.cc
@@ -12,6 +12,7 @@
 
 #include "bytes/iobuf_parser.h"
 #include "iceberg/avro_decimal.h"
+#include "iceberg/conversion/avro_utils.h"
 #include "serde/avro/parser.h"
 
 #include <seastar/core/coroutine.hh>
@@ -188,7 +189,17 @@ struct parsed_msg_visitor {
     ss::future<optional_value_outcome>
     operator()(serde::avro::parsed::avro_union v) {
         // union is represented as a struct with all possible types but only one
-        // present
+        // present. if the union follows the "optional" pattern, flatten the
+        // taken branch into either an instance of the non-null alternative or
+        // nullopt
+        if (auto opt = iceberg::maybe_flatten_union(node); opt.has_value()) {
+            if (node->leafAt(v.branch) == opt.value()) {
+                co_return co_await avro_parsed_to_value(
+                  std::move(v.message), opt.value());
+            }
+            co_return std::nullopt;
+        }
+
         auto ret = std::make_unique<iceberg::struct_value>();
         ret->fields.reserve(node->leaves());
         for (size_t i = 0; i < node->leaves(); ++i) {

--- a/src/v/iceberg/conversion/values_avro.cc
+++ b/src/v/iceberg/conversion/values_avro.cc
@@ -21,7 +21,7 @@ namespace iceberg {
 
 namespace {
 
-ss::future<value_outcome> avro_parsed_to_value(
+ss::future<optional_value_outcome> avro_parsed_to_value(
   std::unique_ptr<serde::avro::parsed::message> parsed_msg, avro::NodePtr node);
 
 template<typename T, typename ValueT>
@@ -125,7 +125,8 @@ struct primitive_visitor {
 };
 
 struct parsed_msg_visitor {
-    ss::future<value_outcome> operator()(serde::avro::parsed::record record) {
+    ss::future<optional_value_outcome>
+    operator()(serde::avro::parsed::record record) {
         auto ret = std::make_unique<iceberg::struct_value>();
         ret->fields.reserve(node->leaves());
         for (size_t i = 0; i < node->leaves(); ++i) {
@@ -142,7 +143,8 @@ struct parsed_msg_visitor {
         }
         co_return ret;
     }
-    ss::future<value_outcome> operator()(serde::avro::parsed::map parsed_map) {
+    ss::future<optional_value_outcome>
+    operator()(serde::avro::parsed::map parsed_map) {
         auto ret = std::make_unique<iceberg::map_value>();
         ret->kvs.reserve(parsed_map.entries.size());
         const auto key_node = node->leafAt(0);
@@ -169,7 +171,7 @@ struct parsed_msg_visitor {
         }
         co_return ret;
     }
-    ss::future<value_outcome> operator()(serde::avro::parsed::list v) {
+    ss::future<optional_value_outcome> operator()(serde::avro::parsed::list v) {
         auto ret = std::make_unique<iceberg::list_value>();
         ret->elements.reserve(v.elements.size());
         auto element_node = node->leafAt(0);
@@ -183,7 +185,8 @@ struct parsed_msg_visitor {
         }
         co_return ret;
     }
-    ss::future<value_outcome> operator()(serde::avro::parsed::avro_union v) {
+    ss::future<optional_value_outcome>
+    operator()(serde::avro::parsed::avro_union v) {
         // union is represented as a struct with all possible types but only one
         // present
         auto ret = std::make_unique<iceberg::struct_value>();
@@ -211,13 +214,14 @@ struct parsed_msg_visitor {
         }
         co_return ret;
     }
-    ss::future<value_outcome> operator()(serde::avro::parsed::primitive v) {
+    ss::future<optional_value_outcome>
+    operator()(serde::avro::parsed::primitive v) {
         co_return std::visit(primitive_visitor{node}, std::move(v));
     }
     avro::NodePtr node;
 };
 
-ss::future<value_outcome> avro_parsed_to_value(
+ss::future<optional_value_outcome> avro_parsed_to_value(
   std::unique_ptr<serde::avro::parsed::message> parsed_msg,
   avro::NodePtr node) {
     if (node->type() == avro::AVRO_NULL) {
@@ -265,8 +269,16 @@ deserialize_avro(iobuf buffer, avro::ValidSchema schema) {
             ret->fields.push_back(std::move(root_field.value()));
             co_return ret;
         }
-        co_return co_await avro_parsed_to_value(
+        auto res = co_await avro_parsed_to_value(
           std::move(parsed), schema.root());
+        if (res.has_error()) {
+            co_return res.error();
+        }
+        auto val = std::move(res).value();
+        if (!val.has_value()) {
+            throw std::runtime_error("Avro root record was unexpectedly null");
+        }
+        co_return value_outcome{std::move(val).value()};
     } catch (...) {
         co_return value_outcome{value_conversion_exception(
           fmt::format(

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -276,12 +276,12 @@ AVRO_SCHEMA_TEST_CASES = {
         expected_trino=[
             ("number", "bigint", "", ""),
             ("timestamp_us", "timestamp(6)", "", ""),
-            ("optional_long", "row(union_opt_1 bigint)", "", ""),
+            ("optional_long", "bigint", "", ""),
         ],
         expected_spark=[
             ("number", "bigint", None),
             ("timestamp_us", "timestamp_ntz", None),
-            ("optional_long", "struct<union_opt_1:bigint>", None),
+            ("optional_long", "bigint", None),
             ("", "", ""),
             ("# Partitioning", "", ""),
             ("Part 0", "hours(redpanda.timestamp)", ""),


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR updates avro -> iceberg translation to treat certain union-typed fields and values as "optional". That is, if an Avro field is:

- UNION typed
- Has exactly 2 branches
- One branch is NULL
- The other branch is non-NULL

Previously we would translate this as `struct<union_opt_0:?non-NULL-type>`. After this change it becomes `?non-NULL-type`. We also need to detect this during value translation. Both changes are included in the PR.

TODO:
- [x] fix ducktape

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* Avro unions following the "optional" pattern are treated as flat values with no enclosing struct.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
