### PR TITLE
ct: use context logger for level one reader

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -299,13 +299,13 @@ frontend::ntp_to_topic_id_partition(const model::ntp& ntp) const {
 }
 
 std::unique_ptr<model::record_batch_reader::impl>
-frontend::make_l0_reader(cloud_topic_log_reader_config& cfg) const {
+frontend::make_l0_reader(const cloud_topic_log_reader_config& cfg) const {
     return std::make_unique<level_zero_log_reader_impl>(
       cfg, _partition, _data_plane);
 }
 
 std::unique_ptr<model::record_batch_reader::impl>
-frontend::make_l1_reader(cloud_topic_log_reader_config& cfg) const {
+frontend::make_l1_reader(const cloud_topic_log_reader_config& cfg) const {
     auto ct_state = _partition->get_cloud_topics_state();
     auto l1_metastore = ct_state->local().get_l1_metastore();
     auto l1_io = ct_state->local().get_l1_io();

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -236,32 +236,29 @@ ss::future<storage::translating_reader> frontend::make_reader(
   std::optional<model::timeout_clock::time_point>) {
     vassert(_data_plane != nullptr, "cloud topics api not initialized");
 
-    auto ot_state = _partition->get_offset_translator_state();
-    auto lro = _ctp_stm_api->get_last_reconciled_offset();
-    if (lro > kafka::offset::min() && cfg.start_offset <= lro) {
-        // Read from L1 if some reconciliation has happened (lro > min) and the
-        // range overlaps L1.
-        vlog(
-          cd_log.debug,
-          "Start offset {} <= LRO {}: using L1 reader",
-          cfg.start_offset,
-          lro);
+    const auto lro = _ctp_stm_api->get_last_reconciled_offset();
 
-        auto impl = make_l1_reader(cfg);
-        co_return storage::translating_reader{
-          model::record_batch_reader(std::move(impl)), std::move(ot_state)};
-    }
+    const auto level_one = lro > kafka::offset::min()
+                           && cfg.start_offset <= lro;
 
     vlog(
       cd_log.debug,
-      "Start offset {} > LRO {}: using L0 reader",
+      "Building {} reader for {} from {} lro {}",
+      (level_one ? "L1" : "L0"),
+      _partition->ntp(),
       cfg.start_offset,
       lro);
 
-    auto impl = std::make_unique<level_zero_log_reader_impl>(
-      cfg, _partition, _data_plane);
+    auto impl = [&] {
+        if (level_one) {
+            return make_l1_reader(cfg);
+        }
+        return make_l0_reader(cfg);
+    }();
+
     co_return storage::translating_reader{
-      model::record_batch_reader(std::move(impl)), std::move(ot_state)};
+      model::record_batch_reader(std::move(impl)),
+      _partition->get_offset_translator_state()};
 }
 
 ss::future<std::vector<cluster::tx::tx_range>> frontend::aborted_transactions(
@@ -299,6 +296,12 @@ frontend::ntp_to_topic_id_partition(const model::ntp& ntp) const {
         return std::nullopt;
     }
     return model::topic_id_partition{*topic_cfg->tp_id, ntp.tp.partition};
+}
+
+std::unique_ptr<model::record_batch_reader::impl>
+frontend::make_l0_reader(cloud_topic_log_reader_config& cfg) const {
+    return std::make_unique<level_zero_log_reader_impl>(
+      cfg, _partition, _data_plane);
 }
 
 std::unique_ptr<model::record_batch_reader::impl>

--- a/src/v/cloud_topics/frontend/frontend.h
+++ b/src/v/cloud_topics/frontend/frontend.h
@@ -190,10 +190,10 @@ private:
     ntp_to_topic_id_partition(const model::ntp& ntp) const;
 
     std::unique_ptr<model::record_batch_reader::impl>
-    make_l0_reader(cloud_topic_log_reader_config& cfg) const;
+    make_l0_reader(const cloud_topic_log_reader_config& cfg) const;
 
     std::unique_ptr<model::record_batch_reader::impl>
-    make_l1_reader(cloud_topic_log_reader_config& cfg) const;
+    make_l1_reader(const cloud_topic_log_reader_config& cfg) const;
 
     ss::lw_shared_ptr<cluster::partition> _partition;
     data_plane_api* _data_plane;

--- a/src/v/cloud_topics/frontend/frontend.h
+++ b/src/v/cloud_topics/frontend/frontend.h
@@ -190,6 +190,9 @@ private:
     ntp_to_topic_id_partition(const model::ntp& ntp) const;
 
     std::unique_ptr<model::record_batch_reader::impl>
+    make_l0_reader(cloud_topic_log_reader_config& cfg) const;
+
+    std::unique_ptr<model::record_batch_reader::impl>
     make_l1_reader(cloud_topic_log_reader_config& cfg) const;
 
     ss::lw_shared_ptr<cluster::partition> _partition;

--- a/src/v/cloud_topics/level_one/frontend_reader/BUILD
+++ b/src/v/cloud_topics/level_one/frontend_reader/BUILD
@@ -21,6 +21,7 @@ redpanda_cc_library(
         "//src/v/config",
         "//src/v/model",
         "//src/v/model:timeout_clock",
+        "//src/v/utils:prefix_logger",
         "//src/v/utils:retry_chain_node",
         "@seastar",
     ],

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -47,7 +47,7 @@ level_one_log_reader_impl::level_one_log_reader_impl(
   , _next_offset(cfg.start_offset)
   , _metastore(metastore)
   , _io(io_interface)
-  , _log(cd_log, fmt::format("[{}/{}]", fmt::ptr(this), _ntp)) {
+  , _log(cd_log, fmt::format("[{}/{}/{}]", fmt::ptr(this), _ntp, _tidp)) {
     vlog(_log.debug, "New reader created {}", _config);
 }
 
@@ -105,20 +105,16 @@ ss::future<> level_one_log_reader_impl::fetch_metadata(
     if (_next_offset > _config.max_offset) {
         vlog(
           _log.debug,
-          "L1 reader next_offset {} > max_offset {} for {}: ending "
+          "L1 reader next_offset {} > max_offset {}: ending "
           "stream",
           _next_offset,
-          _config.max_offset,
-          _tidp);
+          _config.max_offset);
         _state = state::end_of_stream;
         co_return;
     }
 
     if (is_over_limit(0)) {
-        vlog(
-          _log.debug,
-          "L1 reader over byte budget for {}: ending stream",
-          _tidp);
+        vlog(_log.debug, "L1 reader over byte budget: ending stream");
         _state = state::end_of_stream;
         co_return;
     }
@@ -140,39 +136,31 @@ ss::future<> level_one_log_reader_impl::fetch_metadata(
         case l1::metastore::errc::out_of_range:
             vlog(
               _log.debug,
-              "No L1 objects found for {} at offset {} or later",
-              _tidp,
+              "No L1 objects found at offset {} or later",
               _next_offset);
             _state = state::end_of_stream;
             co_return;
         case l1::metastore::errc::missing_ntp:
-            vlog(_log.debug, "Partition {} not tracked in metastore", _tidp);
+            vlog(_log.debug, "Partition not tracked in metastore");
             _state = state::end_of_stream;
             co_return;
         default:
             vlog(
               _log.error,
-              "Failed to query metastore for {} offset {}: {}",
-              _tidp,
+              "Failed to query metastore offset {}: {}",
               _next_offset,
               response.error());
             _state = state::end_of_stream;
             throw std::runtime_error(
               fmt::format(
-                "Metastore query failed for {} offset {}: {}",
-                _tidp,
+                "Metastore query failed offset {}: {}",
                 _next_offset,
                 response.error()));
         }
     }
 
     auto& obj = response.value();
-    vlog(
-      _log.debug,
-      "Found L1 object {} for {} at offset {}",
-      obj.oid,
-      _tidp,
-      _next_offset);
+    vlog(_log.debug, "Found L1 object {} at offset {}", obj.oid, _next_offset);
 
     auto footer = co_await read_footer(
       obj.oid, obj.footer_pos, obj.object_size);
@@ -317,8 +305,7 @@ ss::future<> level_one_log_reader_impl::materialize_batches(
         // no data because of compaction.
         vlog(
           _log.debug,
-          "No data for {} in object {}: materializing 0 batches",
-          _tidp,
+          "No data in object {}: materializing 0 batches",
           _current_obj->oid);
         _state = state::materialized;
         co_return;
@@ -339,9 +326,8 @@ ss::future<> level_one_log_reader_impl::materialize_batches(
         auto ex = stream_fut.get_exception();
         vlog(
           _log.error,
-          "Exception opening stream for L1 object {} for {}: {}",
+          "Exception opening stream for L1 object {}: {}",
           _current_obj->oid,
-          _tidp,
           ex);
         _state = state::end_of_stream;
         std::rethrow_exception(ex);
@@ -350,16 +336,14 @@ ss::future<> level_one_log_reader_impl::materialize_batches(
     if (!stream_result.has_value()) {
         vlog(
           _log.error,
-          "Failed to open stream for L1 object {} for {}: {}",
+          "Failed to open stream for L1 object {}: {}",
           _current_obj->oid,
-          _tidp,
           std::to_underlying(stream_result.error()));
         _state = state::end_of_stream;
         throw std::runtime_error(
           fmt::format(
-            "Failed to open stream for L1 object {} for {}: {}",
+            "Failed to open stream for L1 object {}: {}",
             _current_obj->oid,
-            _tidp,
             std::to_underlying(stream_result.error())));
     }
 
@@ -369,9 +353,8 @@ ss::future<> level_one_log_reader_impl::materialize_batches(
         auto ex = read_fut.get_exception();
         vlog(
           _log.error,
-          "Exception reading L1 object {} for {}: {}",
+          "Exception reading L1 object {}: {}",
           _current_obj->oid,
-          _tidp,
           ex);
         co_await close_reader_safe(reader);
         _state = state::end_of_stream;
@@ -383,20 +366,15 @@ ss::future<> level_one_log_reader_impl::materialize_batches(
     // Note that it's possible to materialize zero batches.
     vlog(
       _log.debug,
-      "Materialized {} batches from L1 object {} for {}",
+      "Materialized {} batches from L1 object {}",
       _batches.size(),
-      _current_obj->oid,
-      _tidp);
+      _current_obj->oid);
     _state = state::materialized;
 }
 
 void level_one_log_reader_impl::consume_materialized_batches(
   chunked_circular_buffer<model::record_batch>* dest) {
-    vlog(
-      _log.debug,
-      "Consuming {} materialized batches for {}",
-      _batches.size(),
-      _tidp);
+    vlog(_log.debug, "Consuming {} materialized batches", _batches.size());
 
     dest->swap(_batches);
 

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -36,7 +36,7 @@ ss::future<> level_one_log_reader_impl::close_reader_safe(
 }
 
 level_one_log_reader_impl::level_one_log_reader_impl(
-  cloud_topic_log_reader_config& cfg,
+  const cloud_topic_log_reader_config& cfg,
   model::ntp ntp,
   model::topic_id_partition tidp,
   l1::metastore* metastore,

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -47,7 +47,9 @@ level_one_log_reader_impl::level_one_log_reader_impl(
   , _next_offset(cfg.start_offset)
   , _metastore(metastore)
   , _io(io_interface)
-  , _log(cd_log, fmt::format("[{}/{}]", fmt::ptr(this), _ntp)) {}
+  , _log(cd_log, fmt::format("[{}/{}]", fmt::ptr(this), _ntp)) {
+    vlog(_log.debug, "New reader created {}", _config);
+}
 
 ss::future<model::record_batch_reader::storage_t>
 level_one_log_reader_impl::do_load_slice(

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -105,11 +105,10 @@ ss::future<> level_one_log_reader_impl::fetch_metadata(
     if (_next_offset > _config.max_offset) {
         vlog(
           _log.debug,
-          "L1 reader next_offset {} > max_offset {} for {} ({}): ending "
+          "L1 reader next_offset {} > max_offset {} for {}: ending "
           "stream",
           _next_offset,
           _config.max_offset,
-          _ntp,
           _tidp);
         _state = state::end_of_stream;
         co_return;
@@ -118,8 +117,7 @@ ss::future<> level_one_log_reader_impl::fetch_metadata(
     if (is_over_limit(0)) {
         vlog(
           _log.debug,
-          "L1 reader over byte budget for {} ({}): ending stream",
-          _ntp,
+          "L1 reader over byte budget for {}: ending stream",
           _tidp);
         _state = state::end_of_stream;
         co_return;
@@ -142,33 +140,26 @@ ss::future<> level_one_log_reader_impl::fetch_metadata(
         case l1::metastore::errc::out_of_range:
             vlog(
               _log.debug,
-              "No L1 objects found for {} ({}) at offset {} or later",
-              _ntp,
+              "No L1 objects found for {} at offset {} or later",
               _tidp,
               _next_offset);
             _state = state::end_of_stream;
             co_return;
         case l1::metastore::errc::missing_ntp:
-            vlog(
-              _log.debug,
-              "Partition {} ({}) not tracked in metastore",
-              _ntp,
-              _tidp);
+            vlog(_log.debug, "Partition {} not tracked in metastore", _tidp);
             _state = state::end_of_stream;
             co_return;
         default:
             vlog(
               _log.error,
-              "Failed to query metastore for {} ({}) offset {}: {}",
-              _ntp,
+              "Failed to query metastore for {} offset {}: {}",
               _tidp,
               _next_offset,
               response.error());
             _state = state::end_of_stream;
             throw std::runtime_error(
               fmt::format(
-                "Metastore query failed for {} ({}) offset {}: {}",
-                _ntp,
+                "Metastore query failed for {} offset {}: {}",
                 _tidp,
                 _next_offset,
                 response.error()));
@@ -178,9 +169,8 @@ ss::future<> level_one_log_reader_impl::fetch_metadata(
     auto& obj = response.value();
     vlog(
       _log.debug,
-      "Found L1 object {} for {} ({}) at offset {}",
+      "Found L1 object {} for {} at offset {}",
       obj.oid,
-      _ntp,
       _tidp,
       _next_offset);
 
@@ -327,8 +317,7 @@ ss::future<> level_one_log_reader_impl::materialize_batches(
         // no data because of compaction.
         vlog(
           _log.debug,
-          "No data for {} ({}) in object {}: materializing 0 batches",
-          _ntp,
+          "No data for {} in object {}: materializing 0 batches",
           _tidp,
           _current_obj->oid);
         _state = state::materialized;
@@ -350,9 +339,8 @@ ss::future<> level_one_log_reader_impl::materialize_batches(
         auto ex = stream_fut.get_exception();
         vlog(
           _log.error,
-          "Exception opening stream for L1 object {} for {} ({}): {}",
+          "Exception opening stream for L1 object {} for {}: {}",
           _current_obj->oid,
-          _ntp,
           _tidp,
           ex);
         _state = state::end_of_stream;
@@ -362,17 +350,15 @@ ss::future<> level_one_log_reader_impl::materialize_batches(
     if (!stream_result.has_value()) {
         vlog(
           _log.error,
-          "Failed to open stream for L1 object {} for {} ({}): {}",
+          "Failed to open stream for L1 object {} for {}: {}",
           _current_obj->oid,
-          _ntp,
           _tidp,
           std::to_underlying(stream_result.error()));
         _state = state::end_of_stream;
         throw std::runtime_error(
           fmt::format(
-            "Failed to open stream for L1 object {} for {} ({}): {}",
+            "Failed to open stream for L1 object {} for {}: {}",
             _current_obj->oid,
-            _ntp,
             _tidp,
             std::to_underlying(stream_result.error())));
     }
@@ -383,9 +369,8 @@ ss::future<> level_one_log_reader_impl::materialize_batches(
         auto ex = read_fut.get_exception();
         vlog(
           _log.error,
-          "Exception reading L1 object {} for {} ({}): {}",
+          "Exception reading L1 object {} for {}: {}",
           _current_obj->oid,
-          _ntp,
           _tidp,
           ex);
         co_await close_reader_safe(reader);
@@ -398,10 +383,9 @@ ss::future<> level_one_log_reader_impl::materialize_batches(
     // Note that it's possible to materialize zero batches.
     vlog(
       _log.debug,
-      "Materialized {} batches from L1 object {} for {} ({})",
+      "Materialized {} batches from L1 object {} for {}",
       _batches.size(),
       _current_obj->oid,
-      _ntp,
       _tidp);
     _state = state::materialized;
 }
@@ -410,9 +394,8 @@ void level_one_log_reader_impl::consume_materialized_batches(
   chunked_circular_buffer<model::record_batch>* dest) {
     vlog(
       _log.debug,
-      "Consuming {} materialized batches for {} ({})",
+      "Consuming {} materialized batches for {}",
       _batches.size(),
-      _ntp,
       _tidp);
 
     dest->swap(_batches);

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -25,15 +25,13 @@
 
 namespace cloud_topics {
 
-static ss::future<>
-close_reader_safe(std::unique_ptr<l1::object_reader>& reader) {
+ss::future<> level_one_log_reader_impl::close_reader_safe(
+  std::unique_ptr<l1::object_reader>& reader) {
     try {
         co_await reader->close();
     } catch (const std::exception& e) {
         vlog(
-          cd_log.warn,
-          "Exception while closing L1 object reader: {}",
-          e.what());
+          _log.warn, "Exception while closing L1 object reader: {}", e.what());
     }
 }
 
@@ -48,7 +46,8 @@ level_one_log_reader_impl::level_one_log_reader_impl(
   , _tidp(tidp)
   , _next_offset(cfg.start_offset)
   , _metastore(metastore)
-  , _io(io_interface) {}
+  , _io(io_interface)
+  , _log(cd_log, fmt::format("[{}/{}]", fmt::ptr(this), _ntp)) {}
 
 ss::future<model::record_batch_reader::storage_t>
 level_one_log_reader_impl::do_load_slice(
@@ -103,7 +102,7 @@ ss::future<> level_one_log_reader_impl::fetch_metadata(
 
     if (_next_offset > _config.max_offset) {
         vlog(
-          cd_log.debug,
+          _log.debug,
           "L1 reader next_offset {} > max_offset {} for {} ({}): ending "
           "stream",
           _next_offset,
@@ -116,7 +115,7 @@ ss::future<> level_one_log_reader_impl::fetch_metadata(
 
     if (is_over_limit(0)) {
         vlog(
-          cd_log.debug,
+          _log.debug,
           "L1 reader over byte budget for {} ({}): ending stream",
           _ntp,
           _tidp);
@@ -140,7 +139,7 @@ ss::future<> level_one_log_reader_impl::fetch_metadata(
         switch (response.error()) {
         case l1::metastore::errc::out_of_range:
             vlog(
-              cd_log.debug,
+              _log.debug,
               "No L1 objects found for {} ({}) at offset {} or later",
               _ntp,
               _tidp,
@@ -149,7 +148,7 @@ ss::future<> level_one_log_reader_impl::fetch_metadata(
             co_return;
         case l1::metastore::errc::missing_ntp:
             vlog(
-              cd_log.debug,
+              _log.debug,
               "Partition {} ({}) not tracked in metastore",
               _ntp,
               _tidp);
@@ -157,7 +156,7 @@ ss::future<> level_one_log_reader_impl::fetch_metadata(
             co_return;
         default:
             vlog(
-              cd_log.error,
+              _log.error,
               "Failed to query metastore for {} ({}) offset {}: {}",
               _ntp,
               _tidp,
@@ -176,7 +175,7 @@ ss::future<> level_one_log_reader_impl::fetch_metadata(
 
     auto& obj = response.value();
     vlog(
-      cd_log.debug,
+      _log.debug,
       "Found L1 object {} for {} ({}) at offset {}",
       obj.oid,
       _ntp,
@@ -212,7 +211,7 @@ ss::future<l1::footer> level_one_log_reader_impl::read_footer(
     if (read_fut.failed()) {
         auto ex = read_fut.get_exception();
         vlog(
-          cd_log.error,
+          _log.error,
           "Exception opening stream for footer from object {} (pos {} object "
           "size {}): {}",
           oid,
@@ -225,7 +224,7 @@ ss::future<l1::footer> level_one_log_reader_impl::read_footer(
     auto read_result = read_fut.get();
     if (!read_result.has_value()) {
         vlog(
-          cd_log.error,
+          _log.error,
           "Failed to read footer from object {} (pos {} object size {}): {}",
           oid,
           extent.position,
@@ -246,7 +245,7 @@ ss::future<l1::footer> level_one_log_reader_impl::read_footer(
 
     if (!std::holds_alternative<l1::footer>(footer_result)) {
         vlog(
-          cd_log.error,
+          _log.error,
           "Failed to parse footer from object {} despite reading complete "
           "footer (pos {} object size {})",
           oid,
@@ -325,7 +324,7 @@ ss::future<> level_one_log_reader_impl::materialize_batches(
         // Perhaps this object spans offsets in the metastore but has
         // no data because of compaction.
         vlog(
-          cd_log.debug,
+          _log.debug,
           "No data for {} ({}) in object {}: materializing 0 batches",
           _ntp,
           _tidp,
@@ -348,7 +347,7 @@ ss::future<> level_one_log_reader_impl::materialize_batches(
     if (stream_fut.failed()) {
         auto ex = stream_fut.get_exception();
         vlog(
-          cd_log.error,
+          _log.error,
           "Exception opening stream for L1 object {} for {} ({}): {}",
           _current_obj->oid,
           _ntp,
@@ -360,7 +359,7 @@ ss::future<> level_one_log_reader_impl::materialize_batches(
     auto stream_result = stream_fut.get();
     if (!stream_result.has_value()) {
         vlog(
-          cd_log.error,
+          _log.error,
           "Failed to open stream for L1 object {} for {} ({}): {}",
           _current_obj->oid,
           _ntp,
@@ -381,7 +380,7 @@ ss::future<> level_one_log_reader_impl::materialize_batches(
     if (read_fut.failed()) {
         auto ex = read_fut.get_exception();
         vlog(
-          cd_log.error,
+          _log.error,
           "Exception reading L1 object {} for {} ({}): {}",
           _current_obj->oid,
           _ntp,
@@ -396,7 +395,7 @@ ss::future<> level_one_log_reader_impl::materialize_batches(
 
     // Note that it's possible to materialize zero batches.
     vlog(
-      cd_log.debug,
+      _log.debug,
       "Materialized {} batches from L1 object {} for {} ({})",
       _batches.size(),
       _current_obj->oid,
@@ -408,7 +407,7 @@ ss::future<> level_one_log_reader_impl::materialize_batches(
 void level_one_log_reader_impl::consume_materialized_batches(
   chunked_circular_buffer<model::record_batch>* dest) {
     vlog(
-      cd_log.debug,
+      _log.debug,
       "Consuming {} materialized batches for {} ({})",
       _batches.size(),
       _ntp,

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -151,11 +151,10 @@ ss::future<> level_one_log_reader_impl::fetch_metadata(
               _next_offset,
               response.error());
             _state = state::end_of_stream;
-            throw std::runtime_error(
-              fmt::format(
-                "Metastore query failed offset {}: {}",
-                _next_offset,
-                response.error()));
+            throw std::runtime_error(_log.format(
+              "Metastore query failed offset {}: {}",
+              _next_offset,
+              response.error()));
         }
     }
 
@@ -210,13 +209,12 @@ ss::future<l1::footer> level_one_log_reader_impl::read_footer(
           extent.position,
           object_size,
           std::to_underlying(read_result.error()));
-        throw std::runtime_error(
-          fmt::format(
-            "Failed to read footer from object {} (pos {} size {}): {}",
-            oid,
-            extent.position,
-            object_size,
-            std::to_underlying(read_result.error())));
+        throw std::runtime_error(_log.format(
+          "Failed to read footer from object {} (pos {} size {}): {}",
+          oid,
+          extent.position,
+          object_size,
+          std::to_underlying(read_result.error())));
     }
 
     // Parse the footer - we have the complete footer so this should succeed.
@@ -231,12 +229,11 @@ ss::future<l1::footer> level_one_log_reader_impl::read_footer(
           oid,
           extent.position,
           object_size);
-        throw std::runtime_error(
-          fmt::format(
-            "Failed to parse footer from object {} (pos {} size {})",
-            oid,
-            extent.position,
-            object_size));
+        throw std::runtime_error(_log.format(
+          "Failed to parse footer from object {} (pos {} size {})",
+          oid,
+          extent.position,
+          object_size));
     }
 
     co_return std::get<l1::footer>(std::move(footer_result));
@@ -340,11 +337,10 @@ ss::future<> level_one_log_reader_impl::materialize_batches(
           _current_obj->oid,
           std::to_underlying(stream_result.error()));
         _state = state::end_of_stream;
-        throw std::runtime_error(
-          fmt::format(
-            "Failed to open stream for L1 object {}: {}",
-            _current_obj->oid,
-            std::to_underlying(stream_result.error())));
+        throw std::runtime_error(_log.format(
+          "Failed to open stream for L1 object {}: {}",
+          _current_obj->oid,
+          std::to_underlying(stream_result.error())));
     }
 
     auto reader = l1::object_reader::create(std::move(stream_result).value());

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
@@ -62,7 +62,7 @@ namespace cloud_topics {
 class level_one_log_reader_impl : public model::record_batch_reader::impl {
 public:
     level_one_log_reader_impl(
-      cloud_topic_log_reader_config& cfg,
+      const cloud_topic_log_reader_config& cfg,
       model::ntp ntp,
       model::topic_id_partition tidp,
       l1::metastore* metastore,

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
@@ -15,6 +15,7 @@
 #include "cloud_topics/level_one/metastore/metastore.h"
 #include "cloud_topics/log_reader_config.h"
 #include "model/record_batch_reader.h"
+#include "utils/prefix_logger.h"
 
 namespace cloud_topics {
 
@@ -103,6 +104,8 @@ private:
 
     bool is_over_limit(size_t size) const;
 
+    ss::future<> close_reader_safe(std::unique_ptr<l1::object_reader>&);
+
     state _state{state::empty};
 
     // Current object being processed.
@@ -118,6 +121,7 @@ private:
     kafka::offset _next_offset;
     l1::metastore* _metastore;
     l1::io* _io;
+    prefix_logger _log;
 };
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -25,7 +25,7 @@
 namespace cloud_topics {
 
 level_zero_log_reader_impl::level_zero_log_reader_impl(
-  cloud_topic_log_reader_config& cfg,
+  const cloud_topic_log_reader_config& cfg,
   ss::lw_shared_ptr<cluster::partition> ctp,
   data_plane_api* ct_api)
   : _config(cfg)

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
@@ -68,7 +68,7 @@ back to 'empty' state.
 class level_zero_log_reader_impl : public model::record_batch_reader::impl {
 public:
     level_zero_log_reader_impl(
-      cloud_topic_log_reader_config& cfg,
+      const cloud_topic_log_reader_config& cfg,
       ss::lw_shared_ptr<cluster::partition> underlying,
       data_plane_api* ct_api);
 


### PR DESCRIPTION
Added context logging to the level one reader using prefix logger.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
