### PR TITLE
tuner: Minor fixes to the net tuner

### DIFF
--- a/src/go/rpk/pkg/cli/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/redpanda/start.go
@@ -481,6 +481,8 @@ func readTunerConfigCpuset(fs afero.Fs, configFilePath string) (string, error) {
 		return "", err
 	}
 
+	// We allow an empty file to mean no cpuset. k8s will create an empty file
+	// when mounting in FileOrCreate mode and no file on the host exists.
 	if len(content) == 0 {
 		fmt.Println("Net tuner config file found but empty")
 		return "", nil

--- a/src/go/rpk/pkg/tuners/net_tuners.go
+++ b/src/go/rpk/pkg/tuners/net_tuners.go
@@ -315,6 +315,21 @@ func (f *netTunersFactory) getNetTunerConfig(nic network.Nic, mode irq.Mode, cpu
 	return config, nil
 }
 
+func maybeReadFile(fs afero.Fs, path string) ([]byte, error) {
+	exists, err := afero.Exists(fs, path)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, nil
+	}
+	content, err := afero.ReadFile(fs, path)
+	if err != nil {
+		return nil, err
+	}
+	return content, nil
+}
+
 func (f *netTunersFactory) NewInterruptConfigFileTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable {
 	// In the AllNicsSameMode we have already checked that the mode and
 	// config for all NICs is the same so we can just use the first non-virtual one.
@@ -355,9 +370,11 @@ func (f *netTunersFactory) NewInterruptConfigFileTuner(interfaces []string, mode
 				return NewTuneError(err)
 			}
 			if exists {
-				err := f.fs.Remove(statePath)
+				// Empty file to avoid rpk:start from using it
+				err = f.executor.Execute(
+					commands.NewWriteFileCmd(f.fs, statePath, ""))
 				if err != nil {
-					return NewTuneError(fmt.Errorf("failed to remove existing net tuner config file %s: %w", statePath, err))
+					return NewTuneError(fmt.Errorf("failed to empty existing net tuner config file %s: %w", statePath, err))
 				}
 			}
 
@@ -393,27 +410,22 @@ func (f *netTunersFactory) NewInterruptConfigFileTuner(interfaces []string, mode
 				statePath = f.statePath
 			}
 
-			exists, err := afero.Exists(f.fs, statePath)
+			data, err := maybeReadFile(f.fs, statePath)
 			if err != nil {
 				return false, err
 			}
 
-			if targetConfig.Cpusets.IrqMode != irq.Dedicated {
-				// If in MQ mode we still need to run the tuner such that it removes the file if it exists
-				return !exists, nil
+			if targetConfig.Cpusets.IrqMode == irq.Mq {
+				// If in MQ mode we still need to run the tuner such that it empties the file if it exists and is not empty
+				return len(data) == 0, nil
 			}
 
-			if !exists {
+			if len(data) == 0 {
 				return false, nil
 			}
 
-			content, err := afero.ReadFile(f.fs, statePath)
-			if err != nil {
-				return false, err
-			}
-
 			currentConfig := NodeTunerState{}
-			err = yaml.Unmarshal(content, &currentConfig)
+			err = yaml.Unmarshal(data, &currentConfig)
 			if err != nil {
 				return false, err
 			}

--- a/src/go/rpk/pkg/tuners/net_tuners.go
+++ b/src/go/rpk/pkg/tuners/net_tuners.go
@@ -316,14 +316,21 @@ func (f *netTunersFactory) getNetTunerConfig(nic network.Nic, mode irq.Mode, cpu
 }
 
 func (f *netTunersFactory) NewInterruptConfigFileTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable {
-	if len(interfaces) == 0 {
+	// In the AllNicsSameMode we have already checked that the mode and
+	// config for all NICs is the same so we can just use the first non-virtual one.
+	var nic network.Nic
+	for _, iface := range interfaces {
+		maybeNic := network.NewNic(f.fs, f.irqProcFile, f.irqDeviceInfo, f.ethtool, iface)
+		if maybeNic.IsHwInterface() || maybeNic.IsBondIface() {
+			nic = maybeNic
+			break
+		}
+	}
+
+	if nic == nil {
 		// No interfaces, nothing to do
 		return NewAggregatedTunable([]Tunable{})
 	}
-
-	// In the AllNicsSameMode we have already checked that the mode and
-	// config for all NICs is the same so we can just use the first here
-	nic := network.NewNic(f.fs, f.irqProcFile, f.irqDeviceInfo, f.ethtool, interfaces[0])
 
 	tunable := checkedTunable{}
 	tunable.tuneAction = func() TuneResult {

--- a/tests/rptest/tuner_integration_tests/net_tuner_test.py
+++ b/tests/rptest/tuner_integration_tests/net_tuner_test.py
@@ -207,13 +207,12 @@ class NetTunerTest(RedpandaTest):
                 assert line.endswith("true"), f"NIC check failed: {line}"
 
     def _test_tune_net_mq(self, expected_interrupt_setup: ExpectedInterruptSetup):
-        # Create an empty dummy file. This should be deleted by the tuner
-        self.redpanda.nodes[0].account.ssh(f"sudo touch {NET_TUNER_CONFIG_FILE_PATH}")
+        # Create a dummy file. This should be emptied by the tuner
+        self.redpanda.nodes[0].account.ssh(f"echo 123 > {NET_TUNER_CONFIG_FILE_PATH}")
         self.rpk.tune("net")
-        self.redpanda.nodes[0].account.ssh(f"test ! -e {NET_TUNER_CONFIG_FILE_PATH}")
+        self.redpanda.nodes[0].account.ssh(f"test ! -s {NET_TUNER_CONFIG_FILE_PATH}")
 
-        # Create it again. It should be ignored by rpk start as it's empty
-        self.redpanda.nodes[0].account.ssh(f"sudo touch {NET_TUNER_CONFIG_FILE_PATH}")
+        # rpk start should ignore the empty file
         self.start_rp()
 
         self._test_interrupt_config(self.node, self.rpk, expected_interrupt_setup)

--- a/tests/rptest/tuner_integration_tests/net_tuner_test.py
+++ b/tests/rptest/tuner_integration_tests/net_tuner_test.py
@@ -279,6 +279,24 @@ class AwsNetTunerTest(NetTunerTest):
         self._test_tune_net_mq(expected_interrupt_setup)
 
     @cluster(num_nodes=1)
+    def test_tune_net_dedicated_explicit_interfaces(self):
+        expected_interrupt_setup = self.ExpectedInterruptSetup(
+            interrupts_masks=["8"],
+            redpanda_cores={0, 1, 2},
+            rps_cpu_mask="7",
+            rps_cpu_flow_count=int(self.TARGET_RFS_TABLE_SIZE / 1),
+            rfs_table_size=self.TARGET_RFS_TABLE_SIZE,
+            rx_tx_queue_count=1,
+        )
+
+        # lo should be ignored
+        self._test_tune_net_dedicated_core(
+            expected_interrupt_setup,
+            4,
+            additional_tune_args=["--nic", "lo,ens5"],
+        )
+
+    @cluster(num_nodes=1)
     def test_tune_net_dedicated_1_core(self):
         expected_interrupt_setup = self.ExpectedInterruptSetup(
             interrupts_masks=["8"],


### PR DESCRIPTION
Two minor fixes:
 - Handle virtual interfaces in the config file tuner
 - Empty the net tuner config file in MQ (instead of deleting it)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none


