### PR TITLE
CORE-13987 Client Monitoring: integrate sorting into ListKafkaConnections

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -862,9 +862,7 @@ proto::admin::kafka_connection connection_context::to_proto() const {
     res.set_uid(ssx::sformat("{}", _attributes.connection_id));
     res.set_listener_name(ss::sstring{listener()});
     auto conn_state = [this]() {
-        if (!_as.local_is_initialized()) {
-            return kafka_connection_state::closed;
-        } else if (_as.abort_requested()) {
+        if (!_as.local_is_initialized() || _as.abort_requested()) {
             return kafka_connection_state::aborting;
         }
         return kafka_connection_state::open;

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -52,7 +52,7 @@ namespace kafka {
 using response_ptr = ss::foreign_ptr<std::unique_ptr<response>>;
 
 using closed_connections_t
-  = std::deque<ss::lw_shared_ptr<proto::admin::kafka_connection>>;
+  = std::deque<ss::lw_shared_ptr<const proto::admin::kafka_connection>>;
 
 class kafka_api_version_not_supported_exception : public std::runtime_error {
 public:

--- a/src/v/redpanda/admin/services/BUILD
+++ b/src/v/redpanda/admin/services/BUILD
@@ -8,9 +8,11 @@ redpanda_cc_library(
     hdrs = ["broker.h"],
     deps = [
         "//proto/redpanda/core/admin/v2:broker_redpanda_proto",
+        "//src/v/container:priority_queue",
         "//src/v/features",
         "//src/v/kafka/server",
         "//src/v/redpanda/admin:aip_filter",
+        "//src/v/redpanda/admin:aip_ordering",
         "//src/v/redpanda/admin/proxy:client",
         "//src/v/serde/protobuf:rpc",
         "//src/v/ssx:async_algorithm",

--- a/src/v/redpanda/admin/services/broker.cc
+++ b/src/v/redpanda/admin/services/broker.cc
@@ -93,30 +93,57 @@ proto::admin::broker broker_service_impl::self_broker() const {
 
 namespace {
 
+struct connection_collector {
+    virtual ~connection_collector() = default;
+    virtual void add(proto::kafka_connection conn) = 0;
+    virtual chunked_vector<proto::kafka_connection> extract() && = 0;
+    virtual size_t size() const = 0;
+};
+
+class unordered_collector : public connection_collector {
+    chunked_vector<proto::kafka_connection> _connections;
+    size_t _limit;
+
+public:
+    explicit unordered_collector(size_t limit)
+      : _limit(limit) {}
+
+    void add(proto::kafka_connection conn) final {
+        if (_connections.size() < _limit) {
+            _connections.emplace_back(std::move(conn));
+        }
+    }
+
+    chunked_vector<proto::kafka_connection> extract() && final {
+        return std::move(_connections);
+    }
+
+    size_t size() const final { return _connections.size(); }
+};
+
 struct connection_gather_result {
     chunked_vector<proto::kafka_connection> connections;
     size_t total_matching_count;
 };
 
 ss::future<connection_gather_result> gather_connections(
-  const kafka::server& server, size_t limit, const filter_predicate& filter) {
+  const kafka::server& server,
+  const filter_predicate& filter,
+  ss::shared_ptr<connection_collector> collector) {
     auto result = connection_gather_result{};
 
     auto conn_ptrs = server.list_connections();
     co_await ss::coroutine::maybe_yield();
 
-    auto process_conn =
-      [&result, limit, &filter](proto::admin::kafka_connection&& conn_proto) {
-          bool matches_filter = filter(conn_proto);
+    auto process_conn = [&result, &collector, &filter](
+                          proto::admin::kafka_connection&& conn_proto) {
+        bool matches_filter = filter(conn_proto);
 
-          if (matches_filter) {
-              result.total_matching_count++;
-
-              if (result.connections.size() < limit) {
-                  result.connections.emplace_back(std::move(conn_proto));
-              }
-          }
-      };
+        if (matches_filter) {
+            result.total_matching_count++;
+            collector->add(std::move(conn_proto));
+        }
+    };
 
     co_await ssx::async_for_each(
       conn_ptrs, [&process_conn](const auto& conn_ptr) {
@@ -130,7 +157,37 @@ ss::future<connection_gather_result> gather_connections(
         process_conn(std::move(elem_copy));
     }
 
+    result.connections = std::move(*collector).extract();
     co_return result;
+}
+
+ss::future<size_t> gather_all_shards(
+  ss::sharded<kafka::server>& kafka_server,
+  const filter_predicate& filter,
+  const auto& make_local_collector,
+  connection_collector& global_collector) {
+    size_t total_matching_connections = 0;
+
+    for (ss::shard_id shard = 0; shard < ss::smp::count; ++shard) {
+        auto accumulated_count = global_collector.size();
+        auto shard_result = co_await kafka_server.invoke_on(
+          shard,
+          [accumulated_count, &filter, &make_local_collector](
+            kafka::server& server) {
+              return gather_connections(
+                server, filter, make_local_collector(accumulated_count));
+          });
+
+        total_matching_connections += shard_result.total_matching_count;
+
+        for (auto& conn : shard_result.connections) {
+            global_collector.add(std::move(conn));
+        }
+
+        co_await ss::coroutine::maybe_yield();
+    }
+
+    co_return total_matching_connections;
 }
 
 void check_license(const features::feature_table& ft) {
@@ -175,30 +232,17 @@ broker_service_impl::list_kafka_connections(
       req.get_filter());
     auto filter = aip_filter_parser::create_aip_filter(std::move(filter_cfg));
 
-    // Iterate across shards sequentially to bound memory usage while
-    // calculating total size
-    auto result_connections = chunked_vector<proto::kafka_connection>{};
-    auto total_matching_connections = size_t{0};
+    auto global_collector = unordered_collector{limit};
 
-    for (ss::shard_id shard = 0; shard < ss::smp::count; ++shard) {
-        // Get connections from this shard with the remaining limit
-        auto remaining_limit = limit - result_connections.size();
-        auto shard_result = co_await _kafka_server.invoke_on(
-          shard,
-          [remaining_limit, &filter](
-            kafka::server& server) -> ss::future<connection_gather_result> {
-              return gather_connections(server, remaining_limit, filter);
-          });
+    auto make_local_collector = [limit](size_t accumulated_count) {
+        return ss::make_shared<unordered_collector>(limit - accumulated_count);
+    };
 
-        total_matching_connections += shard_result.total_matching_count;
-        std::ranges::move(
-          shard_result.connections, std::back_inserter(result_connections));
+    auto total_matching_connections = co_await gather_all_shards(
+      _kafka_server, filter, make_local_collector, global_collector);
 
-        co_await ss::coroutine::maybe_yield();
-    }
-
+    resp.set_connections(std::move(global_collector).extract());
     resp.set_total_size(total_matching_connections);
-    resp.set_connections(std::move(result_connections));
 
     vlog(
       brlog.trace,

--- a/src/v/redpanda/admin/services/broker.cc
+++ b/src/v/redpanda/admin/services/broker.cc
@@ -123,9 +123,11 @@ ss::future<connection_gather_result> gather_connections(
           process_conn(conn_ptr->to_proto());
       });
 
-    const auto& closed_conns = server.list_closed_connections();
+    auto closed_conns = server.list_closed_connections();
     for (auto& elem : closed_conns) {
-        process_conn(std::move(*elem));
+        auto elem_copy = co_await proto::admin::kafka_connection::from_proto(
+          co_await elem->to_proto());
+        process_conn(std::move(elem_copy));
     }
 
     co_return result;

--- a/src/v/redpanda/admin/services/broker.cc
+++ b/src/v/redpanda/admin/services/broker.cc
@@ -11,11 +11,13 @@
 
 #include "redpanda/admin/services/broker.h"
 
+#include "container/priority_queue.h"
 #include "features/feature_table.h"
 #include "kafka/server/connection_context.h"
 #include "kafka/server/server.h"
 #include "proto/redpanda/core/admin/v2/kafka_connections.proto.h"
 #include "redpanda/admin/aip_filter.h"
+#include "redpanda/admin/aip_ordering.h"
 #include "serde/protobuf/rpc.h"
 #include "ssx/async_algorithm.h"
 #include "version/version.h"
@@ -119,6 +121,31 @@ public:
     }
 
     size_t size() const final { return _connections.size(); }
+};
+
+template<typename Comparator>
+class ordered_collector : public connection_collector {
+    // Invert the order here to get the min-k instead of the max-k
+    chunked_bounded_priority_queue<
+      proto::kafka_connection,
+      detail::invert_comparator<Comparator>>
+      _pq;
+
+public:
+    ordered_collector(size_t limit, Comparator comp)
+      : _pq(limit, detail::invert_comparator<Comparator>(std::move(comp))) {}
+
+    void add(proto::kafka_connection conn) final { _pq.push(std::move(conn)); }
+
+    chunked_vector<proto::kafka_connection> extract() && final {
+        return std::move(_pq).extract_heap();
+    }
+
+    size_t size() const final { return _pq.size(); }
+
+    ss::future<chunked_vector<proto::kafka_connection>> extract_sorted() && {
+        return std::move(_pq).async_extract_sorted();
+    }
 };
 
 struct connection_gather_result {
@@ -232,17 +259,39 @@ broker_service_impl::list_kafka_connections(
       req.get_filter());
     auto filter = aip_filter_parser::create_aip_filter(std::move(filter_cfg));
 
-    auto global_collector = unordered_collector{limit};
+    if (req.get_order_by().empty()) {
+        auto global_collector = unordered_collector{limit};
 
-    auto make_local_collector = [limit](size_t accumulated_count) {
-        return ss::make_shared<unordered_collector>(limit - accumulated_count);
-    };
+        auto make_local_collector = [limit](size_t accumulated_count) {
+            return ss::make_shared<unordered_collector>(
+              limit - accumulated_count);
+        };
 
-    auto total_matching_connections = co_await gather_all_shards(
-      _kafka_server, filter, make_local_collector, global_collector);
+        auto total_matching_connections = co_await gather_all_shards(
+          _kafka_server, filter, make_local_collector, global_collector);
 
-    resp.set_connections(std::move(global_collector).extract());
-    resp.set_total_size(total_matching_connections);
+        resp.set_connections(std::move(global_collector).extract());
+        resp.set_total_size(total_matching_connections);
+    } else {
+        auto ordering_conf
+          = make_ordering_config<proto::admin::kafka_connection>(
+            req.get_order_by());
+        auto comp = sort_order::parse(ordering_conf);
+
+        auto global_collector = ordered_collector{limit, comp};
+
+        auto make_local_collector = [limit, &comp](size_t) {
+            return ss::make_shared<ordered_collector<decltype(comp)>>(
+              limit, comp);
+        };
+
+        auto total_matching_connections = co_await gather_all_shards(
+          _kafka_server, filter, make_local_collector, global_collector);
+
+        resp.set_connections(
+          co_await std::move(global_collector).extract_sorted());
+        resp.set_total_size(total_matching_connections);
+    }
 
     vlog(
       brlog.trace,

--- a/tests/rptest/tests/list_kafka_connections_test.py
+++ b/tests/rptest/tests/list_kafka_connections_test.py
@@ -90,33 +90,34 @@ class AdminV2ListKafkaConnectionsTest(RedpandaTest):
             # Sanity check the response
             assert len(resp.connections) > 0
 
-            # Find the connection used for consumer group requests
+            # Find the connection used for franz-go consumer group requests
             # Note: this is different from the connection used for fetch requests
-            conn: kafka_connections_pb.KafkaConnection = next(
-                filter(lambda conn: conn.group_id == self.test_group, resp.connections)
-            )
-
-            assert conn.node_id == node_id
-            assert conn.state == kafka_connections_pb.KAFKA_CONNECTION_STATE_OPEN
-            assert conn.open_time.ToDatetime() > datetime(year=2025, month=1, day=1)
-            assert len(conn.source.ip_address) > 0
-            assert conn.source.port != 0
-            assert (
-                conn.authentication_info.state
+            matching_conns = [
+                conn
+                for conn in resp.connections
+                if conn.group_id == self.test_group
+                and conn.node_id == node_id
+                and conn.state == kafka_connections_pb.KAFKA_CONNECTION_STATE_OPEN
+                and conn.open_time.ToDatetime() > datetime(year=2025, month=1, day=1)
+                and len(conn.source.ip_address) > 0
+                and conn.source.port != 0
+                and conn.authentication_info.state
                 == kafka_connections_pb.AUTHENTICATION_STATE_SUCCESS
-            )
-            assert (
-                conn.authentication_info.mechanism
+                and conn.authentication_info.mechanism
                 == kafka_connections_pb.AUTHENTICATION_MECHANISM_SASL_SCRAM
+                and conn.authentication_info.user_principal == self.superuser.username
+                and not conn.tls_info.enabled
+                and conn.client_id == "rpk"
+                and conn.client_software_name == "kgo"
+                and len(conn.client_software_version) > 0
+                and len(conn.group_member_id) > 0
+                and len(conn.api_versions) > 0
+                and conn.total_request_statistics.request_count > 0
+            ]
+
+            assert matching_conns, (
+                f"No connection in response matched expected criteria for group_id={self.test_group}"
             )
-            assert conn.authentication_info.user_principal == self.superuser.username
-            assert not conn.tls_info.enabled
-            assert conn.client_id == "rpk"
-            assert conn.client_software_name == "kgo"
-            assert len(conn.client_software_version) > 0
-            assert len(conn.group_member_id) > 0
-            assert len(conn.api_versions) > 0
-            assert conn.total_request_statistics.request_count > 0
 
             return True
 

--- a/tests/rptest/tests/list_kafka_connections_test.py
+++ b/tests/rptest/tests/list_kafka_connections_test.py
@@ -75,8 +75,7 @@ class AdminV2ListKafkaConnectionsTest(RedpandaTest):
         )
         node_id = self.redpanda.node_id(self.redpanda.nodes[0])
         req = broker_pb.ListKafkaConnectionsRequest(
-            node_id=node_id,
-            page_size=10,
+            node_id=node_id, page_size=10, order_by="source.port desc"
         )
 
         def valid_response() -> bool:
@@ -88,7 +87,10 @@ class AdminV2ListKafkaConnectionsTest(RedpandaTest):
             self.logger.debug(f"ListKafkaConnectionsResponse: {resp}")
 
             # Sanity check the response
-            assert len(resp.connections) > 0
+            assert len(resp.connections) >= 2
+
+            # Check the ordering is correct
+            assert resp.connections[0].source.port >= resp.connections[1].source.port
 
             # Find the connection used for franz-go consumer group requests
             # Note: this is different from the connection used for fetch requests


### PR DESCRIPTION
Implement the `order_by` field of the request on the `ListKafkaConnections` by integrating it using `aip_ordering` and `chunked_bounded_priority_queue`.

See the commit messages for implementation details.

Fixes https://redpandadata.atlassian.net/browse/CORE-13987

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
