### PR TITLE
dt: capture the crash_reports dir on redpanda nodes

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2380,6 +2380,7 @@ class RedpandaService(Service, RedpandaServiceABC):
     PERSISTENT_ROOT = "/var/lib/redpanda"
     TRIM_LOGS_KEY = "trim_logs"
     DATA_DIR = os.path.join(PERSISTENT_ROOT, "data")
+    CRASH_REPORTS = os.path.join(DATA_DIR, "crash_reports")
     NODE_CONFIG_FILE = "/etc/redpanda/redpanda.yaml"
     RPK_CONFIG_FILE = "/root/.config/rpk/rpk.yaml"
     CLUSTER_BOOTSTRAP_CONFIG_FILE = "/etc/redpanda/.bootstrap.yaml"
@@ -2459,6 +2460,7 @@ class RedpandaService(Service, RedpandaServiceABC):
         },
         "executable": {"path": EXECUTABLE_SAVE_PATH, "collect_default": False},
         "backtraces": {"path": BACKTRACE_CAPTURE, "collect_default": True},
+        "crash_reports": {"path": CRASH_REPORTS, "collect_default": True},
     }
 
     # Thread name of shards to be used with redpanda_tid()


### PR DESCRIPTION
The crash_reports directory contains information about why the redpanda node crashed. In some cases we have seen ducktape failures where there is a log line stating that the crash has been successfully recorded, yet the stderr logs do not contain the stacktrace. In this case, capturing the crash_reports directory should give us a way to see the cause of the crash.

I've manually tested that we now capture the crash reports when the redpanda node crashes:
```
% ls --tree ./vbuild/ducktape/results/latest/AdminV2ListKafkaConnectionsLicenseTest/test_without_license/2/
./vbuild/ducktape/results/latest/AdminV2ListKafkaConnectionsLicenseTest/test_without_license/2
├── RedpandaService-0-139813533531632
│  └── docker-rp-3
│     ├── crash_reports
│     │  └── 1760714366772_1385.crash
│     ├── redpanda.log
│     └── redpanda_backtrace.log
├── report.json
├── report.txt
├── test_log.debug
└── test_log.info
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
