### PR TITLE
container_rpbench: fix sort benchmark

### DIFF
--- a/src/v/container/tests/vector_bench.cc
+++ b/src/v/container/tests/vector_bench.cc
@@ -16,12 +16,26 @@
 #include <seastar/testing/perf_tests.hh>
 
 #include <algorithm>
+#include <concepts>
 #include <iterator>
 #include <vector>
 
 template<typename Vector, size_t Size>
 struct VectorBenchTest {
     using value_type = typename Vector::value_type;
+
+    const value_type val = make_value();
+    const Vector filled = make_filled();
+
+    // copy overloads copy a T either via ctor (this one)
+    auto copy(const std::copy_constructible auto& t) { return t; }
+
+    // or a .copy method (this one)
+    template<typename T>
+    requires requires(const T& t) { t.copy(); }
+    auto copy(const T& t) {
+        return t.copy();
+    }
 
     static auto make_value() {
         return ::make_value<typename Vector::value_type>();
@@ -33,8 +47,6 @@ struct VectorBenchTest {
         return v;
     }
 
-    value_type val = make_value();
-    Vector filled = make_filled();
     std::vector<size_t> indexes = [] {
         random_generators::rng rng{0};
         std::vector<size_t> indexes;
@@ -46,13 +58,15 @@ struct VectorBenchTest {
 
     [[gnu::noinline]]
     void run_sort_test() {
-        std::sort(filled.begin(), filled.end());
+        auto v = copy(filled);
+        std::sort(v.begin(), v.end());
     }
 
     [[gnu::noinline]]
     void run_fifo_test() {
         Vector v;
         for (size_t i = 0; i < Size; ++i) {
+            // NOLINTNEXTLINE(performance-inefficient-vector-operation)
             v.push_back(val);
         }
         perf_tests::do_not_optimize(v);


### PR DESCRIPTION
I had inadvertently made this test much more trivial while I was reducing the variance, by repeatedly sorting the same container in the fixture. This also affects later tests as they use the same container.

Make the fixture vector `const` to avoid bugs like this in the future.

Bench results before:

```
test                                                    iterations      median         mad         min         max      allocs       tasks        inst      cycles
VectorBenchTest_std_vector_int64_t_64.Sort                14849418    66.973ns     0.214ns    66.393ns    67.464ns       0.000       0.000      1212.0       266.4
VectorBenchTest_chunked_vector_int64_t_64.Sort             7364195   135.479ns     0.124ns   135.355ns   136.785ns       0.000       0.000      2837.0       538.9
VectorBenchTest_std_vector_sstring_64.Sort                 2958513   338.396ns     0.257ns   338.013ns   339.558ns       0.000       0.000      6015.0      1346.5
VectorBenchTest_chunked_vector_sstring_64.Sort             2318030   429.021ns     0.289ns   428.588ns   429.998ns       0.000       0.000      8042.0      1706.1
VectorBenchTest_std_vector_large_struct_64.Sort             772271     1.286us     1.094ns     1.283us     1.287us       0.000       0.000     22385.0      5108.2
VectorBenchTest_chunked_vector_large_struct_64.Sort         684590     1.501us     3.367ns     1.479us     1.505us       0.000       0.000     24682.0      5882.9
VectorBenchTest_std_vector_int64_t_10000.Sort               165052     6.061us    12.786ns     6.048us     6.165us       0.000       0.000    160249.0     24136.1
VectorBenchTest_chunked_vector_int64_t_10000.Sort            55581    17.627us   170.435ns    17.456us    18.874us       0.000       0.000    420217.0     70792.9
VectorBenchTest_std_vector_sstring_10000.Sort                19512    51.973us    74.135ns    50.970us    52.047us       0.000       0.000    910447.1    203423.4
VectorBenchTest_chunked_vector_sstring_10000.Sort            14995    67.895us   165.359ns    66.829us    68.060us       0.000       0.000   1220578.1    266261.1
VectorBenchTest_std_vector_large_struct_10000.Sort            4736   211.695us   286.851ns   211.408us   215.719us       0.000       0.000   3439599.3    840875.4
VectorBenchTest_chunked_vector_large_struct_10000.Sort        4192   243.542us   307.349ns   243.181us   245.455us       0.000       0.000   3792890.3    967465.9
VectorBenchTest_std_vector_int64_t_1048576.Sort               1559   642.799us     1.275us   641.524us   645.581us       0.000       0.000  16777465.9   2555913.2
VectorBenchTest_chunked_vector_int64_t_1048576.Sort            544     1.844ms     1.430us     1.841ms     1.847ms       0.000       0.000  44040411.6   7327058.4
```

Bench results after:

```
test                                                    iterations      median         mad         min         max      allocs       tasks        inst      cycles
VectorBenchTest_std_vector_int64_t_64.Sort                13269196    75.593ns     0.219ns    75.175ns    75.827ns       1.000       0.000      1394.0       300.5
VectorBenchTest_chunked_vector_int64_t_64.Sort             6617760   151.008ns     0.068ns   150.911ns   151.309ns       2.000       0.000      3169.0       600.6
VectorBenchTest_std_vector_sstring_64.Sort                 1371982   708.962ns     0.518ns   708.444ns   728.763ns      65.000       0.000     13763.0      2835.3
VectorBenchTest_chunked_vector_sstring_64.Sort             1188044   827.197ns     5.353ns   816.435ns   841.001ns      66.000       0.000     15931.0      3268.1
VectorBenchTest_std_vector_large_struct_64.Sort             441714     2.325us     1.101ns     2.324us     2.389us     129.000       0.000     43083.0      9200.7
VectorBenchTest_chunked_vector_large_struct_64.Sort         414201     2.417us     0.622ns     2.417us     2.483us     130.000       0.000     45440.0      9665.0
VectorBenchTest_std_vector_int64_t_10000.Sort               133910     7.465us     1.766ns     7.459us     7.615us       1.000       0.000    160602.0     29811.8
VectorBenchTest_chunked_vector_int64_t_10000.Sort            53282    18.767us    15.142ns    18.752us    18.952us       2.000       0.000    420720.0     74702.2
VectorBenchTest_std_vector_sstring_10000.Sort                 5744   174.292us    23.710ns   174.268us   174.478us   10001.000       0.000   2457679.2    693534.9
VectorBenchTest_chunked_vector_sstring_10000.Sort             5374   185.886us    89.334ns   185.680us   185.975us   10003.000       0.000   2768447.6    739234.2
VectorBenchTest_std_vector_large_struct_10000.Sort            1816   548.172us   845.626ns   547.203us   551.620us   20001.000       0.000   7391913.8   2181090.7
VectorBenchTest_chunked_vector_large_struct_10000.Sort        1750   575.482us   786.441ns   574.069us   578.705us   20011.000       0.000   7733825.1   2288388.7
VectorBenchTest_std_vector_int64_t_1048576.Sort                962     1.064ms     6.820us     1.054ms     1.077ms       1.000       0.000  16777810.5   4223159.9
VectorBenchTest_chunked_vector_int64_t_1048576.Sort            442     2.341ms     6.122us     2.310ms     2.401ms      65.000       0.000  44067886.3   9315832.2
```


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
