### PR TITLE
ct: l1 reader refactor

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -249,12 +249,7 @@ ss::future<storage::translating_reader> frontend::make_reader(
       cfg.start_offset,
       lro);
 
-    auto impl = [&] {
-        if (level_one) {
-            return make_l1_reader(cfg);
-        }
-        return make_l0_reader(cfg);
-    }();
+    auto impl = level_one ? make_l1_reader(cfg) : make_l0_reader(cfg);
 
     co_return storage::translating_reader{
       model::record_batch_reader(std::move(impl)),

--- a/src/v/cloud_topics/level_one/common/object.cc
+++ b/src/v/cloud_topics/level_one/common/object.cc
@@ -192,7 +192,7 @@ ss::future<> footer::serde_async_write(iobuf& buf) const {
 }
 
 footer::seek_result footer::file_position_before_kafka_offset(
-  const model::topic_id_partition& tidp, kafka::offset target) {
+  const model::topic_id_partition& tidp, kafka::offset target) const {
     auto [it, end] = partitions.equal_range(tidp);
     auto min_partition_after_target = end;
     for (; it != end; ++it) {

--- a/src/v/cloud_topics/level_one/common/object.h
+++ b/src/v/cloud_topics/level_one/common/object.h
@@ -180,7 +180,7 @@ struct footer
     // while a search for offsets 25 or 40 would yield batch[2]. Searching for
     // offset 50 would yield `npos`.
     seek_result file_position_before_kafka_offset(
-      const model::topic_id_partition&, kafka::offset);
+      const model::topic_id_partition&, kafka::offset) const;
 
     // Return the file position of the latest record batch that has a
     // max_timestamp at or before the given timestamp. If the timestamp is

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -80,7 +80,11 @@ level_one_log_reader_impl::do_load_slice(
             if (_state == state::end_of_stream) {
                 break;
             }
-            _batches = co_await materialize_batches(deadline);
+            vassert(
+              _current_obj.has_value(),
+              "Expected to have current object in ready state");
+            _batches = co_await materialize_batches_from_object_offset(
+              _current_obj.value(), _next_offset, deadline);
             _state = state::materialized;
             [[fallthrough]];
         case state::materialized:
@@ -293,7 +297,9 @@ level_one_log_reader_impl::read_batches(l1::object_reader& reader) {
 }
 
 ss::future<chunked_circular_buffer<model::record_batch>>
-level_one_log_reader_impl::materialize_batches(
+level_one_log_reader_impl::materialize_batches_from_object_offset(
+  const current_object& object,
+  kafka::offset offset,
   model::timeout_clock::time_point /*deadline*/) {
     // Could be EOS because there are no more objects, but
     // there should never be materialized batches remaining.
@@ -306,25 +312,20 @@ level_one_log_reader_impl::materialize_batches(
       "Invalid state to materialize batches: {}",
       std::to_underlying(_state));
 
-    // I wish I had ADTs to enforce these invariants...
-    vassert(
-      _current_obj.has_value(),
-      "Expected to have current object in ready state");
-
-    auto seek_res = _current_obj->footer.file_position_before_kafka_offset(
-      _tidp, _next_offset);
+    auto seek_res = object.footer.file_position_before_kafka_offset(
+      _tidp, offset);
     if (seek_res == l1::footer::npos) {
         // Perhaps this object spans offsets in the metastore but has
         // no data because of compaction.
         vlog(
           _log.debug,
           "No data in object {}: materializing 0 batches",
-          _current_obj->oid);
+          object.oid);
         co_return chunked_circular_buffer<model::record_batch>{};
     }
 
     l1::object_extent extent{
-      .id = _current_obj->oid,
+      .id = object.oid,
       .position = seek_res.file_position,
       .size = seek_res.length,
     };
@@ -339,7 +340,7 @@ level_one_log_reader_impl::materialize_batches(
         vlog(
           _log.error,
           "Exception opening stream for L1 object {}: {}",
-          _current_obj->oid,
+          object.oid,
           ex);
         std::rethrow_exception(ex);
     }
@@ -348,11 +349,11 @@ level_one_log_reader_impl::materialize_batches(
         vlog(
           _log.error,
           "Failed to open stream for L1 object {}: {}",
-          _current_obj->oid,
+          object.oid,
           std::to_underlying(stream_result.error()));
         throw std::runtime_error(_log.format(
           "Failed to open stream for L1 object {}: {}",
-          _current_obj->oid,
+          object.oid,
           std::to_underlying(stream_result.error())));
     }
 
@@ -360,11 +361,7 @@ level_one_log_reader_impl::materialize_batches(
     auto read_fut = co_await ss::coroutine::as_future(read_batches(*reader));
     if (read_fut.failed()) {
         auto ex = read_fut.get_exception();
-        vlog(
-          _log.error,
-          "Exception reading L1 object {}: {}",
-          _current_obj->oid,
-          ex);
+        vlog(_log.error, "Exception reading L1 object {}: {}", object.oid, ex);
         co_await close_reader_safe(reader);
         std::rethrow_exception(ex);
     }
@@ -376,7 +373,7 @@ level_one_log_reader_impl::materialize_batches(
       _log.debug,
       "Materialized {} batches from L1 object {}",
       _batches.size(),
-      _current_obj->oid);
+      object.oid);
 
     co_return read_fut.get();
 }

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -77,7 +77,7 @@ level_one_log_reader_impl::do_load_slice(
         }
             [[fallthrough]];
         case state::ready:
-            co_await materialize_batches(deadline);
+            _batches = co_await materialize_batches(deadline);
             [[fallthrough]];
         case state::materialized:
         case state::end_of_stream:
@@ -250,8 +250,10 @@ ss::future<l1::footer> level_one_log_reader_impl::read_footer(
     co_return std::get<l1::footer>(std::move(footer_result));
 }
 
-ss::future<>
+ss::future<chunked_circular_buffer<model::record_batch>>
 level_one_log_reader_impl::read_batches(l1::object_reader& reader) {
+    chunked_circular_buffer<model::record_batch> batches;
+
     while (true) {
         auto result = co_await reader.read_next();
 
@@ -276,15 +278,18 @@ level_one_log_reader_impl::read_batches(l1::object_reader& reader) {
             _config.bytes_consumed += batch_size;
 
             // If we make it past all that, emit the batch.
-            _batches.push_back(std::move(batch));
+            batches.push_back(std::move(batch));
         } else {
             // End of data.
             break;
         }
     }
+
+    co_return batches;
 }
 
-ss::future<> level_one_log_reader_impl::materialize_batches(
+ss::future<chunked_circular_buffer<model::record_batch>>
+level_one_log_reader_impl::materialize_batches(
   model::timeout_clock::time_point /*deadline*/) {
     // Could be EOS because there are no more objects, but
     // there should never be materialized batches remaining.
@@ -293,7 +298,7 @@ ss::future<> level_one_log_reader_impl::materialize_batches(
       "Materialize batches called with batches already materialized");
 
     if (_state == state::end_of_stream) {
-        co_return;
+        co_return chunked_circular_buffer<model::record_batch>{};
     }
 
     vassert(
@@ -316,7 +321,7 @@ ss::future<> level_one_log_reader_impl::materialize_batches(
           "No data in object {}: materializing 0 batches",
           _current_obj->oid);
         _state = state::materialized;
-        co_return;
+        co_return chunked_circular_buffer<model::record_batch>{};
     }
 
     l1::object_extent extent{
@@ -376,7 +381,9 @@ ss::future<> level_one_log_reader_impl::materialize_batches(
       "Materialized {} batches from L1 object {}",
       _batches.size(),
       _current_obj->oid);
+
     _state = state::materialized;
+    co_return read_fut.get();
 }
 
 void level_one_log_reader_impl::consume_materialized_batches(

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -57,7 +57,8 @@ level_one_log_reader_impl::do_load_slice(
     // reaches end-of-stream.
     switch (_state) {
     case state::empty:
-        _current_obj = co_await fetch_metadata(deadline);
+        _current_obj = co_await lookup_object_for_offset(
+          _next_offset, deadline);
         [[fallthrough]];
     case state::ready:
         co_await materialize_batches(deadline);
@@ -89,8 +90,8 @@ level_one_log_reader_impl::do_load_slice(
 }
 
 ss::future<std::optional<level_one_log_reader_impl::current_object>>
-level_one_log_reader_impl::fetch_metadata(
-  model::timeout_clock::time_point /*deadline*/) {
+level_one_log_reader_impl::lookup_object_for_offset(
+  kafka::offset offset, model::timeout_clock::time_point /*deadline*/) {
     vassert(
       _state == state::empty,
       "Invalid state for metadata fetch: {}",
@@ -100,12 +101,12 @@ level_one_log_reader_impl::fetch_metadata(
       !_current_obj.has_value(),
       "Empty state should not have a current object");
 
-    if (_next_offset > _config.max_offset) {
+    if (offset > _config.max_offset) {
         vlog(
           _log.debug,
           "L1 reader next_offset {} > max_offset {}: ending "
           "stream",
-          _next_offset,
+          offset,
           _config.max_offset);
         _state = state::end_of_stream;
         co_return std::nullopt;
@@ -123,19 +124,17 @@ level_one_log_reader_impl::fetch_metadata(
                            : &default_abort_source;
     retry_chain_node rtc = l1::make_default_metastore_rtc(*abort_source);
     auto response = co_await l1::retry_metastore_op(
-      [this]()
-        -> ss::future<
-          std::expected<l1::metastore::object_response, l1::metastore::errc>> {
-          return _metastore->get_first_ge(_tidp, _next_offset);
+      [this, offset]
+      -> ss::future<
+        std::expected<l1::metastore::object_response, l1::metastore::errc>> {
+          return _metastore->get_first_ge(_tidp, offset);
       },
       rtc);
     if (!response.has_value()) {
         switch (response.error()) {
         case l1::metastore::errc::out_of_range:
             vlog(
-              _log.debug,
-              "No L1 objects found at offset {} or later",
-              _next_offset);
+              _log.debug, "No L1 objects found at offset {} or later", offset);
             _state = state::end_of_stream;
             co_return std::nullopt;
         case l1::metastore::errc::missing_ntp:
@@ -146,18 +145,18 @@ level_one_log_reader_impl::fetch_metadata(
             vlog(
               _log.error,
               "Failed to query metastore offset {}: {}",
-              _next_offset,
+              offset,
               response.error());
             _state = state::end_of_stream;
             throw std::runtime_error(_log.format(
               "Metastore query failed offset {}: {}",
-              _next_offset,
+              offset,
               response.error()));
         }
     }
 
     auto& obj = response.value();
-    vlog(_log.debug, "Found L1 object {} at offset {}", obj.oid, _next_offset);
+    vlog(_log.debug, "Found L1 object {} at offset {}", obj.oid, offset);
 
     auto footer = co_await read_footer(
       obj.oid, obj.footer_pos, obj.object_size);

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -57,7 +57,7 @@ level_one_log_reader_impl::do_load_slice(
     // reaches end-of-stream.
     switch (_state) {
     case state::empty:
-        co_await fetch_metadata(deadline);
+        _current_obj = co_await fetch_metadata(deadline);
         [[fallthrough]];
     case state::ready:
         co_await materialize_batches(deadline);
@@ -88,7 +88,8 @@ level_one_log_reader_impl::do_load_slice(
     co_return res;
 }
 
-ss::future<> level_one_log_reader_impl::fetch_metadata(
+ss::future<std::optional<level_one_log_reader_impl::current_object>>
+level_one_log_reader_impl::fetch_metadata(
   model::timeout_clock::time_point /*deadline*/) {
     vassert(
       _state == state::empty,
@@ -107,13 +108,13 @@ ss::future<> level_one_log_reader_impl::fetch_metadata(
           _next_offset,
           _config.max_offset);
         _state = state::end_of_stream;
-        co_return;
+        co_return std::nullopt;
     }
 
     if (is_over_limit(0)) {
         vlog(_log.debug, "L1 reader over byte budget: ending stream");
         _state = state::end_of_stream;
-        co_return;
+        co_return std::nullopt;
     }
 
     ss::abort_source default_abort_source;
@@ -136,11 +137,11 @@ ss::future<> level_one_log_reader_impl::fetch_metadata(
               "No L1 objects found at offset {} or later",
               _next_offset);
             _state = state::end_of_stream;
-            co_return;
+            co_return std::nullopt;
         case l1::metastore::errc::missing_ntp:
             vlog(_log.debug, "Partition not tracked in metastore");
             _state = state::end_of_stream;
-            co_return;
+            co_return std::nullopt;
         default:
             vlog(
               _log.error,
@@ -160,12 +161,13 @@ ss::future<> level_one_log_reader_impl::fetch_metadata(
 
     auto footer = co_await read_footer(
       obj.oid, obj.footer_pos, obj.object_size);
-    _current_obj = current_object{
+
+    _state = state::ready;
+    co_return current_object{
       .oid = obj.oid,
       .footer = std::move(footer),
       .last_offset = obj.last_offset,
     };
-    _state = state::ready;
 }
 
 ss::future<l1::footer> level_one_log_reader_impl::read_footer(

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -56,9 +56,15 @@ level_one_log_reader_impl::do_load_slice(
     // First switch: ensure batches are materialized or the reader
     // reaches end-of-stream.
     switch (_state) {
-    case state::empty:
-        _current_obj = co_await lookup_object_for_offset(
-          _next_offset, deadline);
+    case state::empty: {
+        auto obj = co_await lookup_object_for_offset(_next_offset, deadline);
+        if (obj.has_value()) {
+            _state = state::ready;
+          _current_obj = std::move(obj.value());
+        } else {
+            _state = state::end_of_stream;
+        }
+    }
         [[fallthrough]];
     case state::ready:
         co_await materialize_batches(deadline);
@@ -108,13 +114,11 @@ level_one_log_reader_impl::lookup_object_for_offset(
           "stream",
           offset,
           _config.max_offset);
-        _state = state::end_of_stream;
         co_return std::nullopt;
     }
 
     if (is_over_limit(0)) {
         vlog(_log.debug, "L1 reader over byte budget: ending stream");
-        _state = state::end_of_stream;
         co_return std::nullopt;
     }
 
@@ -135,12 +139,12 @@ level_one_log_reader_impl::lookup_object_for_offset(
         case l1::metastore::errc::out_of_range:
             vlog(
               _log.debug, "No L1 objects found at offset {} or later", offset);
-            _state = state::end_of_stream;
             co_return std::nullopt;
+
         case l1::metastore::errc::missing_ntp:
             vlog(_log.debug, "Partition not tracked in metastore");
-            _state = state::end_of_stream;
             co_return std::nullopt;
+
         default:
             vlog(
               _log.error,
@@ -161,7 +165,6 @@ level_one_log_reader_impl::lookup_object_for_offset(
     auto footer = co_await read_footer(
       obj.oid, obj.footer_pos, obj.object_size);
 
-    _state = state::ready;
     co_return current_object{
       .oid = obj.oid,
       .footer = std::move(footer),

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -9,10 +9,8 @@
  */
 #include "cloud_topics/level_one/frontend_reader/level_one_reader.h"
 
-#include "bytes/iostream.h"
 #include "cloud_topics/level_one/metastore/retry.h"
 #include "cloud_topics/logger.h"
-#include "config/configuration.h"
 #include "model/fundamental.h"
 #include "model/timeout_clock.h"
 #include "utils/retry_chain_node.h"
@@ -20,7 +18,6 @@
 #include <seastar/coroutine/as_future.hh>
 
 #include <exception>
-#include <iterator>
 #include <utility>
 
 namespace cloud_topics {

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -48,9 +48,18 @@ level_one_log_reader_impl::level_one_log_reader_impl(
     vlog(_log.debug, "New reader created {}", _config);
 }
 
+/*
+ * Error handling
+ * ==============
+ *
+ * Exceptions should not be used unless you intend for the exception to be
+ * propogated back to the user of a model::record_batch_reader. In this case an
+ * exception that carries a string message can be useful for debugging.
+ */
 ss::future<model::record_batch_reader::storage_t>
 level_one_log_reader_impl::do_load_slice(
   model::timeout_clock::time_point deadline) {
+    try {
     chunked_circular_buffer<model::record_batch> res;
 
     // First switch: ensure batches are materialized or the reader
@@ -93,6 +102,12 @@ level_one_log_reader_impl::do_load_slice(
         break;
     }
     co_return res;
+    } catch (...) {
+        vlog(
+          _log.error, "Reader caught exception: {}", std::current_exception());
+        _state = state::end_of_stream;
+        throw;
+    }
 }
 
 ss::future<std::optional<level_one_log_reader_impl::current_object>>
@@ -146,12 +161,6 @@ level_one_log_reader_impl::lookup_object_for_offset(
             co_return std::nullopt;
 
         default:
-            vlog(
-              _log.error,
-              "Failed to query metastore offset {}: {}",
-              offset,
-              response.error());
-            _state = state::end_of_stream;
             throw std::runtime_error(_log.format(
               "Metastore query failed offset {}: {}",
               offset,

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -60,48 +60,49 @@ ss::future<model::record_batch_reader::storage_t>
 level_one_log_reader_impl::do_load_slice(
   model::timeout_clock::time_point deadline) {
     try {
-    chunked_circular_buffer<model::record_batch> res;
+        chunked_circular_buffer<model::record_batch> res;
 
-    // First switch: ensure batches are materialized or the reader
-    // reaches end-of-stream.
-    switch (_state) {
-    case state::empty: {
-        auto obj = co_await lookup_object_for_offset(_next_offset, deadline);
-        if (obj.has_value()) {
-            _state = state::ready;
-          _current_obj = std::move(obj.value());
-        } else {
-            _state = state::end_of_stream;
+        // First switch: ensure batches are materialized or the reader
+        // reaches end-of-stream.
+        switch (_state) {
+        case state::empty: {
+            auto obj = co_await lookup_object_for_offset(
+              _next_offset, deadline);
+            if (obj.has_value()) {
+                _state = state::ready;
+                _current_obj = std::move(obj.value());
+            } else {
+                _state = state::end_of_stream;
+            }
         }
-    }
-        [[fallthrough]];
-    case state::ready:
-        co_await materialize_batches(deadline);
-        [[fallthrough]];
-    case state::materialized:
-    case state::end_of_stream:
-        // Handled in the next switch statement.
-        break;
-    }
+            [[fallthrough]];
+        case state::ready:
+            co_await materialize_batches(deadline);
+            [[fallthrough]];
+        case state::materialized:
+        case state::end_of_stream:
+            // Handled in the next switch statement.
+            break;
+        }
 
-    // Second switch: enforces that the reader has materialized batches
-    // or reached end-of-stream.
-    switch (_state) {
-    case state::empty:
-    case state::ready:
-        vassert(
-          false,
-          "Invalid reader state after materialization for {} ({}): got {}",
-          _ntp,
-          _tidp,
-          std::to_underlying(_state));
-    case state::materialized:
-        consume_materialized_batches(&res);
-        [[fallthrough]];
-    case state::end_of_stream:
-        break;
-    }
-    co_return res;
+        // Second switch: enforces that the reader has materialized batches
+        // or reached end-of-stream.
+        switch (_state) {
+        case state::empty:
+        case state::ready:
+            vassert(
+              false,
+              "Invalid reader state after materialization for {} ({}): got {}",
+              _ntp,
+              _tidp,
+              std::to_underlying(_state));
+        case state::materialized:
+            consume_materialized_batches(&res);
+            [[fallthrough]];
+        case state::end_of_stream:
+            break;
+        }
+        co_return res;
     } catch (...) {
         vlog(
           _log.error, "Reader caught exception: {}", std::current_exception());

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -60,8 +60,6 @@ ss::future<model::record_batch_reader::storage_t>
 level_one_log_reader_impl::do_load_slice(
   model::timeout_clock::time_point deadline) {
     try {
-        chunked_circular_buffer<model::record_batch> res;
-
         // First switch: ensure batches are materialized or the reader
         // reaches end-of-stream.
         switch (_state) {
@@ -105,12 +103,13 @@ level_one_log_reader_impl::do_load_slice(
               _tidp,
               std::to_underlying(_state));
         case state::materialized:
-            consume_materialized_batches(&res);
+            _state = state::empty;
+            co_return consume_materialized_batches();
             [[fallthrough]];
         case state::end_of_stream:
-            break;
+            co_return chunked_circular_buffer<model::record_batch>{};
         }
-        co_return res;
+
     } catch (...) {
         vlog(
           _log.error, "Reader caught exception: {}", std::current_exception());
@@ -378,27 +377,28 @@ level_one_log_reader_impl::materialize_batches_from_object_offset(
     co_return read_fut.get();
 }
 
-void level_one_log_reader_impl::consume_materialized_batches(
-  chunked_circular_buffer<model::record_batch>* dest) {
+chunked_circular_buffer<model::record_batch>
+level_one_log_reader_impl::consume_materialized_batches() {
     vlog(_log.debug, "Consuming {} materialized batches", _batches.size());
 
-    dest->swap(_batches);
+    auto batches = std::exchange(_batches, {});
 
     // Increment the next offset for the next metastore query.
     // The offset is always incremented so the reader makes
     // progress even if the offset range in the object is
     // smaller than the metastore's metadata about the offset
     // range covered by the object (because of, e.g. compaction).
-    auto last_offset = dest->empty()
+    auto last_offset = batches.empty()
                          ? _current_obj
                              .transform(
                                [](const auto& obj) { return obj.last_offset; })
                              .value_or(_next_offset)
-                         : model::offset_cast(dest->back().last_offset());
+                         : model::offset_cast(batches.back().last_offset());
     _next_offset = kafka::next_offset(last_offset);
 
     _current_obj.reset();
-    _state = state::empty;
+
+    return batches;
 }
 
 void level_one_log_reader_impl::print(std::ostream& o) {

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -77,7 +77,11 @@ level_one_log_reader_impl::do_load_slice(
         }
             [[fallthrough]];
         case state::ready:
+            if (_state == state::end_of_stream) {
+                break;
+            }
             _batches = co_await materialize_batches(deadline);
+            _state = state::materialized;
             [[fallthrough]];
         case state::materialized:
         case state::end_of_stream:
@@ -297,10 +301,6 @@ level_one_log_reader_impl::materialize_batches(
       _batches.empty(),
       "Materialize batches called with batches already materialized");
 
-    if (_state == state::end_of_stream) {
-        co_return chunked_circular_buffer<model::record_batch>{};
-    }
-
     vassert(
       _state == state::ready,
       "Invalid state to materialize batches: {}",
@@ -320,7 +320,6 @@ level_one_log_reader_impl::materialize_batches(
           _log.debug,
           "No data in object {}: materializing 0 batches",
           _current_obj->oid);
-        _state = state::materialized;
         co_return chunked_circular_buffer<model::record_batch>{};
     }
 
@@ -342,7 +341,6 @@ level_one_log_reader_impl::materialize_batches(
           "Exception opening stream for L1 object {}: {}",
           _current_obj->oid,
           ex);
-        _state = state::end_of_stream;
         std::rethrow_exception(ex);
     }
     auto stream_result = stream_fut.get();
@@ -352,7 +350,6 @@ level_one_log_reader_impl::materialize_batches(
           "Failed to open stream for L1 object {}: {}",
           _current_obj->oid,
           std::to_underlying(stream_result.error()));
-        _state = state::end_of_stream;
         throw std::runtime_error(_log.format(
           "Failed to open stream for L1 object {}: {}",
           _current_obj->oid,
@@ -369,7 +366,6 @@ level_one_log_reader_impl::materialize_batches(
           _current_obj->oid,
           ex);
         co_await close_reader_safe(reader);
-        _state = state::end_of_stream;
         std::rethrow_exception(ex);
     }
 
@@ -382,7 +378,6 @@ level_one_log_reader_impl::materialize_batches(
       _batches.size(),
       _current_obj->oid);
 
-    _state = state::materialized;
     co_return read_fut.get();
 }
 

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
@@ -90,8 +90,12 @@ private:
         kafka::offset last_offset;
     };
 
-    ss::future<std::optional<current_object>>
-    fetch_metadata(model::timeout_clock::time_point deadline);
+    /*
+     * Contacts the L1 metastore to retrieve metadata for an L1 object that
+     * contains the target offset.
+     */
+    ss::future<std::optional<current_object>> lookup_object_for_offset(
+      kafka::offset, model::timeout_clock::time_point deadline);
 
     ss::future<> materialize_batches(model::timeout_clock::time_point deadline);
 

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
@@ -90,7 +90,8 @@ private:
         kafka::offset last_offset;
     };
 
-    ss::future<> fetch_metadata(model::timeout_clock::time_point deadline);
+    ss::future<std::optional<current_object>>
+    fetch_metadata(model::timeout_clock::time_point deadline);
 
     ss::future<> materialize_batches(model::timeout_clock::time_point deadline);
 

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
@@ -97,15 +97,23 @@ private:
     ss::future<std::optional<current_object>> lookup_object_for_offset(
       kafka::offset, model::timeout_clock::time_point deadline);
 
-    ss::future<> materialize_batches(model::timeout_clock::time_point deadline);
+    ss::future<chunked_circular_buffer<model::record_batch>>
+    materialize_batches(model::timeout_clock::time_point deadline);
+
+    /*
+     * Return batches from the reader's current position until the next
+     * partition or the end of the object is reached. The set of batches
+     * returned may further be limited by restrictions (e.g. byte limit)
+     * imposed by the reader configuration.
+     */
+    ss::future<chunked_circular_buffer<model::record_batch>>
+    read_batches(l1::object_reader& reader);
 
     void consume_materialized_batches(
       chunked_circular_buffer<model::record_batch>* dest);
 
     ss::future<l1::footer>
     read_footer(l1::object_id oid, size_t footer_pos, size_t object_size);
-
-    ss::future<> read_batches(l1::object_reader& reader);
 
     bool is_over_limit(size_t size) const;
 

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
@@ -97,8 +97,14 @@ private:
     ss::future<std::optional<current_object>> lookup_object_for_offset(
       kafka::offset, model::timeout_clock::time_point deadline);
 
+    /*
+     * Materialize batches from the L1 object starting from the given offset.
+     */
     ss::future<chunked_circular_buffer<model::record_batch>>
-    materialize_batches(model::timeout_clock::time_point deadline);
+    materialize_batches_from_object_offset(
+      const current_object&,
+      kafka::offset,
+      model::timeout_clock::time_point deadline);
 
     /*
      * Return batches from the reader's current position until the next

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
@@ -115,8 +115,12 @@ private:
     ss::future<chunked_circular_buffer<model::record_batch>>
     read_batches(l1::object_reader& reader);
 
-    void consume_materialized_batches(
-      chunked_circular_buffer<model::record_batch>* dest);
+    /*
+     * Prepare the result set to return to the record batch reader and configure
+     * the reader for the next request to load slice which will be the next
+     * offset that should be fetched.
+     */
+    chunked_circular_buffer<model::record_batch> consume_materialized_batches();
 
     ss::future<l1::footer>
     read_footer(l1::object_id oid, size_t footer_pos, size_t object_size);


### PR DESCRIPTION
This is a pure refactor of the L1 reader and should not result in functional changes.

The goal of the refactor is to prepare the reader for the next set of updates which will further consolidate the state transitions and centralize key reader logic in one place. That PR will also address the bug in CORE-13950.

This refactor does the following:

1. Makes the helper functions in the reader functional so that they are easier to compose and reuse. This is in contrast to the monolithic design where the helpers all operate on shared reader state.
2. Renames helpers to be more descriptive about their function
3. Consolidates state changes at the top-level of the reader instead of sprinkling the state changes around all the helper functions.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
