### PR TITLE
`storage`: remove superfluous `compaction_placeholder` batches

### DIFF
--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -148,6 +148,18 @@ model::record_batch copy_data_segment_reducer::make_placeholder_batch(
 
 ss::future<std::optional<model::record_batch>>
 copy_data_segment_reducer::filter(model::record_batch batch) {
+    const auto is_last_batch_in_segment = batch.last_offset()
+                                          == _segment_last_offset;
+    // Compaction placeholder batches can actually be removed under one
+    // condition- that they are _not_ the last batch in a segment. This can
+    // happen if e.g. two segments containing placeholder batches are adjacently
+    // merged.
+    if (
+      (batch.header().type == model::record_batch_type::compaction_placeholder)
+      && !is_last_batch_in_segment) {
+        co_return std::nullopt;
+    }
+
     // do not filter non-removable batch types under any circumstances
     if (!compaction::is_filterable(batch.header().type)) {
         co_return std::move(batch);
@@ -166,8 +178,8 @@ copy_data_segment_reducer::filter(model::record_batch batch) {
       });
 
     if (
-      _compaction_placeholder_enabled
-      && batch.last_offset() == _segment_last_offset && offset_deltas.empty()) {
+      _compaction_placeholder_enabled && is_last_batch_in_segment
+      && offset_deltas.empty()) {
         // last batch in the segment has been compacted away.
         // This is most likely caused by aborted data batches getting compacted
         // away during self compaction of the segment if they are the last batch

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -2168,3 +2168,86 @@ TEST_F(CompactionFixtureTest, TestBatchCacheResetAfterAdjacentMerge) {
     auto after_merge = consume(reader_cfg);
     ASSERT_TRUE(after_merge.empty());
 }
+
+TEST_F(CompactionFixtureTest, SuperfluousPlaceholderRemoval) {
+    // Three segments, one record with the same key in each.
+    const int num_segments = 3;
+    generate_data(num_segments, 1, 1, 1).get();
+    ASSERT_EQ(log->segment_count(), num_segments + 1);
+
+    bool did_compact = do_sliding_window_compact(
+                         model::offset::max(), std::chrono::milliseconds{1})
+                         .get();
+    ASSERT_TRUE(did_compact);
+    auto rdr_cfg = storage::local_log_reader_config(
+      model::offset{0}, model::offset::max());
+
+    {
+        auto reader = log->make_reader(rdr_cfg).get();
+        auto batches = model::consume_reader_to_memory(
+                         std::move(reader), model::no_timeout)
+                         .get();
+        int num_placeholder_batches = 0;
+        for (const auto& batch : batches) {
+            num_placeholder_batches
+              += (batch.header().type == model::record_batch_type::compaction_placeholder);
+        }
+        // We have two placeholder batches in two segments which have been
+        // fully de-duplicated.
+        ASSERT_EQ(num_placeholder_batches, num_segments - 1);
+    }
+
+    auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
+    ss::abort_source never_abort;
+    compaction::compaction_config cfg(
+      model::offset::max(),
+      model::offset::max(),
+      std::nullopt,
+      std::nullopt,
+      never_abort);
+
+    // Merge the first two segments in the log.
+    test_local_cfg.get("log_compaction_merge_max_segments_per_range")
+      .set_value(std::make_optional<uint32_t>(2));
+    disk_log.adjacent_merge_compact(disk_log.segments().copy(), cfg).get();
+    ASSERT_EQ(disk_log.segment_count(), 3);
+
+    {
+        auto reader = log->make_reader(rdr_cfg).get();
+        auto batches = model::consume_reader_to_memory(
+                         std::move(reader), model::no_timeout)
+                         .get();
+        int num_placeholder_batches = 0;
+        for (const auto& batch : batches) {
+            num_placeholder_batches
+              += (batch.header().type == model::record_batch_type::compaction_placeholder);
+        }
+
+        // Expect that we filter out the un-needed placeholder batch in the
+        // adjacently merged segment created from the first two segments while
+        // maintaining the placeholder batch at the end of the segment.
+        ASSERT_EQ(num_placeholder_batches, 1);
+    }
+
+    // Merge the first two segments in the log, again.
+    disk_log.adjacent_merge_compact(disk_log.segments().copy(), cfg).get();
+    ASSERT_EQ(disk_log.segment_count(), 2);
+
+    {
+        auto reader = log->make_reader(rdr_cfg).get();
+        auto batches = model::consume_reader_to_memory(
+                         std::move(reader), model::no_timeout)
+                         .get();
+        int num_placeholder_batches = 0;
+        for (const auto& batch : batches) {
+            num_placeholder_batches
+              += (batch.header().type == model::record_batch_type::compaction_placeholder);
+        }
+
+        // We have merged together the 3 originally produced segments, which
+        // means there is a record entry in the last batch of the adjacently
+        // merged segment, and no compaction placeholder batches should exist in
+        // the log.
+        ASSERT_EQ(num_placeholder_batches, 0);
+    }
+}


### PR DESCRIPTION
Take two segments. Remove the last batch from both such that both segments contain placeholder batches, then adjacently merge the two segments.

The adjacently merged segment now has two compaction placeholder batches, of which only one is required to maintain offset boundaries.

Now compound this issue over many segments- we now have placeholder batch bloat, as these were previously unremovable batch types.

Add new logic to `copy_data_segment_reducer::filter()` which removes placeholder batches if they are not the last batch in a given `segment`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

