### PR TITLE
rpk shadow: add support for updating

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.65.0
 	github.com/redpanda-data/common-go/proto v0.0.0-20250820120127-9b518fca5ecf
-	github.com/redpanda-data/common-go/rpadmin v0.1.17-0.20251001175055-902a29f7fa07
+	github.com/redpanda-data/common-go/rpadmin v0.1.17-0.20251014175421-41be4739ddaa
 	github.com/redpanda-data/common-go/rpsr v0.1.2
 	github.com/redpanda-data/protoc-gen-go-mcp v0.0.0-20250812151819-7e5d5fef8241
 	github.com/rs/xid v1.6.0
@@ -73,7 +73,7 @@ require (
 	golang.org/x/sync v0.16.0
 	golang.org/x/sys v0.35.0
 	golang.org/x/term v0.34.0
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250922171735-9219d122eba9
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20251007200510-49b9836ed3ff
 	google.golang.org/protobuf v1.36.10
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -166,7 +166,7 @@ require (
 	golang.org/x/time v0.9.0 // indirect
 	golang.org/x/tools v0.36.0 // indirect
 	google.golang.org/genproto v0.0.0-20250409194420-de1ac958c67a // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20251002232023-7c0ddcbb5797 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20251014184007-4626949a642f // indirect
 	google.golang.org/grpc v1.73.0 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -251,8 +251,8 @@ github.com/redpanda-data/common-go/net v0.1.0 h1:JnJioRJuL961r1QXiJQ1tW9+yEaJfu8
 github.com/redpanda-data/common-go/net v0.1.0/go.mod h1:iOdNkjxM7a1T8F3cYHTaKIPFCHzzp/ia6TN+Z+7Tt5w=
 github.com/redpanda-data/common-go/proto v0.0.0-20250820120127-9b518fca5ecf h1:Oe0Sc3+/37Xgdpze7klkWyvB6eAt/nuUhrn93Rd4ESA=
 github.com/redpanda-data/common-go/proto v0.0.0-20250820120127-9b518fca5ecf/go.mod h1:GMoRcdMz6CIpr+8vKrSJvr8fJDlojETRV45BD6A0DvU=
-github.com/redpanda-data/common-go/rpadmin v0.1.17-0.20251001175055-902a29f7fa07 h1:k/+Hy9oRYvcJZsny5THNefxylUe9OjwhPD4F1+nAhqQ=
-github.com/redpanda-data/common-go/rpadmin v0.1.17-0.20251001175055-902a29f7fa07/go.mod h1:9l5bznk8s0JnwnbvC70pQMaLERhqlTrpOzxhv3tF8J4=
+github.com/redpanda-data/common-go/rpadmin v0.1.17-0.20251014175421-41be4739ddaa h1:WjYobfeDbXDMk9vtWE9duGJpHBB5vTqg5ByEeyGv2cM=
+github.com/redpanda-data/common-go/rpadmin v0.1.17-0.20251014175421-41be4739ddaa/go.mod h1:GXYT3f4rjuPgPmzGdtlBWULI82GEd6mA8fr05SM5s3I=
 github.com/redpanda-data/common-go/rpsr v0.1.2 h1:DThUeyfBH8fkL9WoP1sEbRhT2NVV22zmsTpcCtzfusQ=
 github.com/redpanda-data/common-go/rpsr v0.1.2/go.mod h1:2j2416onosg5FKaKz52NooRE+q/9EJqQn0kyTcTXWHc=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525 h1:vskZrV6q8W8flL0Ud23AJUYAd8ZgTadO45+loFnG2G0=
@@ -448,10 +448,10 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/genproto v0.0.0-20250409194420-de1ac958c67a h1:AoyioNVZR+nS6zbvnvW5rjQdeQu7/BWwIT7YI8Gq5wU=
 google.golang.org/genproto v0.0.0-20250409194420-de1ac958c67a/go.mod h1:qD4k1RhYfNmRjqaHJxKLG/HRtqbXVclhjop2mPlxGwA=
-google.golang.org/genproto/googleapis/api v0.0.0-20251002232023-7c0ddcbb5797 h1:D/zZ8knc/wLq9imidPFpHsGuRUYTCWWCwemZ2dxACGs=
-google.golang.org/genproto/googleapis/api v0.0.0-20251002232023-7c0ddcbb5797/go.mod h1:NnuHhy+bxcg30o7FnVAZbXsPHUDQ9qKWAQKCD7VxFtk=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20250922171735-9219d122eba9 h1:V1jCN2HBa8sySkR5vLcCSqJSTMv093Rw9EJefhQGP7M=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20250922171735-9219d122eba9/go.mod h1:HSkG/KdJWusxU1F6CNrwNDjBMgisKxGnc5dAZfT0mjQ=
+google.golang.org/genproto/googleapis/api v0.0.0-20251014184007-4626949a642f h1:OiFuztEyBivVKDvguQJYWq1yDcfAHIID/FVrPR4oiI0=
+google.golang.org/genproto/googleapis/api v0.0.0-20251014184007-4626949a642f/go.mod h1:kprOiu9Tr0JYyD6DORrc4Hfyk3RFXqkQ3ctHEum3ZbM=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20251007200510-49b9836ed3ff h1:A90eA31Wq6HOMIQlLfzFwzqGKBTuaVztYu/g8sn+8Zc=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20251007200510-49b9836ed3ff/go.mod h1:7i2o+ce6H/6BluujYR+kqX3GKH+dChPTQU19wjRPiGk=
 google.golang.org/grpc v1.73.0 h1:VIWSmpI2MegBtTuFt5/JWy2oXxtjJ/e89Z70ImfD2ok=
 google.golang.org/grpc v1.73.0/go.mod h1:50sbHOUqWoCQGI8V2HQLJM0B+LMlIUjNSZmow7EVBQc=
 google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=

--- a/src/go/rpk/pkg/cli/shadow/BUILD
+++ b/src/go/rpk/pkg/cli/shadow/BUILD
@@ -13,6 +13,7 @@ go_library(
         "shadow.go",
         "status.go",
         "types.go",
+        "update.go",
     ],
     importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/shadow",
     visibility = ["//visibility:public"],

--- a/src/go/rpk/pkg/cli/shadow/create.go
+++ b/src/go/rpk/pkg/cli/shadow/create.go
@@ -12,6 +12,8 @@ package shadow
 import (
 	"fmt"
 
+	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
+
 	"connectrpc.com/connect"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -65,9 +67,10 @@ skip the confirmation prompt.
 				}
 			}
 			fmt.Println()
-			createReq := shadowLinkConfigToCreateReq(slCfg)
 
-			link, err := cl.ShadowLinkService().CreateShadowLink(cmd.Context(), connect.NewRequest(createReq))
+			link, err := cl.ShadowLinkService().CreateShadowLink(cmd.Context(), connect.NewRequest(&adminv2.CreateShadowLinkRequest{
+				ShadowLink: shadowLinkConfigToProto(slCfg),
+			}))
 			out.MaybeDie(err, "unable to create shadow link: %v", err)
 
 			fmt.Printf("Successfully created shadow link %q with ID %q. To query the status, run:\n  'rpk shadow status %[1]v'\n", link.Msg.GetShadowLink().GetName(), link.Msg.GetShadowLink().GetUid())

--- a/src/go/rpk/pkg/cli/shadow/mapper.go
+++ b/src/go/rpk/pkg/cli/shadow/mapper.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-func shadowLinkConfigToCreateReq(slCfg *ShadowLinkConfig) *adminv2.CreateShadowLinkRequest {
+func shadowLinkConfigToProto(slCfg *ShadowLinkConfig) *adminv2.ShadowLink {
 	if slCfg == nil {
 		return nil
 	}
@@ -31,10 +31,7 @@ func shadowLinkConfigToCreateReq(slCfg *ShadowLinkConfig) *adminv2.CreateShadowL
 		ConsumerOffsetSyncOptions: mapConsumerOffsetSyncOptions(slCfg.ConsumerOffsetSyncOptions),
 		SecuritySyncOptions:       mapSecuritySyncOptions(slCfg.SecuritySyncOptions),
 	}
-
-	return &adminv2.CreateShadowLinkRequest{
-		ShadowLink: shadowLink,
-	}
+	return shadowLink
 }
 
 func mapClientOptions(opts *ShadowLinkClientOptions) *adminv2.ShadowLinkClientOptions {
@@ -337,5 +334,324 @@ func mapACLPermissionType(permType ACLPermissionType) common.ACLPermissionType {
 		return common.ACLPermissionType_ACL_PERMISSION_TYPE_DENY
 	default:
 		return common.ACLPermissionType_ACL_PERMISSION_TYPE_UNSPECIFIED
+	}
+}
+
+func shadowLinkToConfig(sl *adminv2.ShadowLink) *ShadowLinkConfig {
+	if sl == nil {
+		return nil
+	}
+
+	cfg := &ShadowLinkConfig{
+		Name: sl.Name,
+		// uid and status are output-only fields, not included in config
+	}
+
+	if sl.GetConfigurations() != nil {
+		cfg.ClientOptions = adminClientOptsToCfg(sl.GetConfigurations().GetClientOptions())
+		cfg.TopicMetadataSyncOptions = adminTopicMetadataSyncToCfg(sl.GetConfigurations().GetTopicMetadataSyncOptions())
+		cfg.ConsumerOffsetSyncOptions = adminConsumerOffsetSyncToCfg(sl.GetConfigurations().GetConsumerOffsetSyncOptions())
+		cfg.SecuritySyncOptions = adminSecuritySyncToCfg(sl.GetConfigurations().GetSecuritySyncOptions())
+	}
+
+	return cfg
+}
+
+func adminClientOptsToCfg(opts *adminv2.ShadowLinkClientOptions) *ShadowLinkClientOptions {
+	if opts == nil {
+		return nil
+	}
+
+	cfg := &ShadowLinkClientOptions{
+		BootstrapServers:    opts.GetBootstrapServers(),
+		SourceClusterID:     opts.GetSourceClusterId(),
+		MetadataMaxAgeMs:    opts.GetMetadataMaxAgeMs(),
+		ConnectionTimeoutMs: opts.GetConnectionTimeoutMs(),
+		RetryBackoffMs:      opts.GetRetryBackoffMs(),
+		FetchWaitMaxMs:      opts.GetFetchWaitMaxMs(),
+		FetchMinBytes:       opts.GetFetchMinBytes(),
+		FetchMaxBytes:       opts.GetFetchMaxBytes(),
+	}
+
+	if opts.GetTlsSettings() != nil {
+		cfg.TLSSettings = adminTLSToCfg(opts.GetTlsSettings())
+	}
+
+	if opts.GetAuthenticationConfiguration() != nil {
+		cfg.AuthenticationConfiguration = adminAuthToCfg(opts.GetAuthenticationConfiguration())
+	}
+
+	return cfg
+}
+
+func adminTLSToCfg(tls *adminv2.TLSSettings) TLSSettings {
+	if tls == nil {
+		return nil
+	}
+
+	switch t := tls.GetTlsSettings().(type) {
+	case *adminv2.TLSSettings_TlsFileSettings:
+		if t.TlsFileSettings == nil {
+			return nil
+		}
+		return &TLSFileSettings{
+			Enabled:  tls.GetEnabled(),
+			CAPath:   t.TlsFileSettings.GetCaPath(),
+			KeyPath:  t.TlsFileSettings.GetKeyPath(),
+			CertPath: t.TlsFileSettings.GetCertPath(),
+		}
+	case *adminv2.TLSSettings_TlsPemSettings:
+		if t.TlsPemSettings == nil {
+			return nil
+		}
+		return &TLSPEMSettings{
+			Enabled: tls.GetEnabled(),
+			CA:      t.TlsPemSettings.GetCa(),
+			Key:     t.TlsPemSettings.GetKey(),
+			Cert:    t.TlsPemSettings.GetCert(),
+		}
+	}
+
+	return nil
+}
+
+func adminAuthToCfg(auth *adminv2.AuthenticationConfiguration) AuthenticationConfiguration {
+	if auth == nil {
+		return nil
+	}
+
+	if a, ok := auth.GetAuthentication().(*adminv2.AuthenticationConfiguration_ScramConfiguration); ok {
+		if a.ScramConfiguration == nil {
+			return nil
+		}
+		return &ScramConfig{
+			Username:       a.ScramConfiguration.GetUsername(),
+			Password:       a.ScramConfiguration.GetPassword(),
+			ScramMechanism: adminScramMechanismToCfg(a.ScramConfiguration.GetScramMechanism()),
+		}
+	}
+
+	return nil
+}
+
+func adminScramMechanismToCfg(m adminv2.ScramMechanism) ScramMechanism {
+	switch m {
+	case adminv2.ScramMechanism_SCRAM_MECHANISM_SCRAM_SHA_256:
+		return ScramMechanismScramSha256
+	case adminv2.ScramMechanism_SCRAM_MECHANISM_SCRAM_SHA_512:
+		return ScramMechanismScramSha512
+	default:
+		return ""
+	}
+}
+
+func adminTopicMetadataSyncToCfg(opts *adminv2.TopicMetadataSyncOptions) *TopicMetadataSyncOptions {
+	if opts == nil {
+		return nil
+	}
+
+	cfg := &TopicMetadataSyncOptions{
+		SyncedShadowTopicProperties: opts.GetSyncedShadowTopicProperties(),
+		ExcludeDefault:              opts.GetExcludeDefault(),
+	}
+
+	if opts.GetInterval() != nil {
+		cfg.Interval = opts.GetInterval().AsDuration()
+	}
+
+	for _, filter := range opts.GetAutoCreateShadowTopicFilters() {
+		cfg.AutoCreateShadowTopicFilters = append(cfg.AutoCreateShadowTopicFilters, adminMapFilterToCfg(filter))
+	}
+
+	return cfg
+}
+
+func adminConsumerOffsetSyncToCfg(opts *adminv2.ConsumerOffsetSyncOptions) *ConsumerOffsetSyncOptions {
+	if opts == nil {
+		return nil
+	}
+
+	cfg := &ConsumerOffsetSyncOptions{
+		Enabled: opts.GetEnabled(),
+	}
+
+	if opts.GetInterval() != nil {
+		cfg.Interval = opts.GetInterval().AsDuration()
+	}
+
+	for _, filter := range opts.GetGroupFilters() {
+		cfg.GroupFilters = append(cfg.GroupFilters, adminMapFilterToCfg(filter))
+	}
+
+	return cfg
+}
+
+func adminSecuritySyncToCfg(opts *adminv2.SecuritySettingsSyncOptions) *SecuritySettingsSyncOptions {
+	if opts == nil {
+		return nil
+	}
+
+	cfg := &SecuritySettingsSyncOptions{
+		Enabled: opts.GetEnabled(),
+	}
+
+	if opts.GetInterval() != nil {
+		cfg.Interval = opts.GetInterval().AsDuration()
+	}
+
+	for _, filter := range opts.GetAclFilters() {
+		cfg.ACLFilters = append(cfg.ACLFilters, adminACLFilterToCfg(filter))
+	}
+
+	return cfg
+}
+
+func adminMapFilterToCfg(filter *adminv2.NameFilter) *NameFilter {
+	if filter == nil {
+		return nil
+	}
+
+	return &NameFilter{
+		PatternType: adminPatternTypeToCfg(filter.GetPatternType()),
+		FilterType:  adminFilterTypeToCfg(filter.GetFilterType()),
+		Name:        filter.GetName(),
+	}
+}
+
+func adminACLFilterToCfg(filter *adminv2.ACLFilter) *ACLFilter {
+	if filter == nil {
+		return nil
+	}
+
+	return &ACLFilter{
+		ResourceFilter: adminACLResourceFilterToCfg(filter.GetResourceFilter()),
+		AccessFilter:   adminACLAccessFilterToCfg(filter.GetAccessFilter()),
+	}
+}
+
+func adminACLResourceFilterToCfg(filter *adminv2.ACLResourceFilter) *ACLResourceFilter {
+	if filter == nil {
+		return nil
+	}
+
+	return &ACLResourceFilter{
+		ResourceType: adminACLResourceToCfg(filter.GetResourceType()),
+		PatternType:  adminACLPatternToCfg(filter.GetPatternType()),
+		Name:         filter.GetName(),
+	}
+}
+
+func adminACLAccessFilterToCfg(filter *adminv2.ACLAccessFilter) *ACLAccessFilter {
+	if filter == nil {
+		return nil
+	}
+
+	return &ACLAccessFilter{
+		Principal:      filter.GetPrincipal(),
+		Operation:      adminACLOperationToCfg(filter.GetOperation()),
+		PermissionType: adminPermissionTypeToCfg(filter.GetPermissionType()),
+		Host:           filter.GetHost(),
+	}
+}
+
+func adminPatternTypeToCfg(pt adminv2.PatternType) PatternType {
+	switch pt {
+	case adminv2.PatternType_PATTERN_TYPE_LITERAL:
+		return PatternTypeLiteral
+	case adminv2.PatternType_PATTERN_TYPE_PREFIX:
+		return PatternTypePrefix
+	default:
+		return ""
+	}
+}
+
+func adminFilterTypeToCfg(ft adminv2.FilterType) FilterType {
+	switch ft {
+	case adminv2.FilterType_FILTER_TYPE_INCLUDE:
+		return FilterTypeInclude
+	case adminv2.FilterType_FILTER_TYPE_EXCLUDE:
+		return FilterTypeExclude
+	default:
+		return ""
+	}
+}
+
+func adminACLResourceToCfg(resource common.ACLResource) ACLResource {
+	switch resource {
+	case common.ACLResource_ACL_RESOURCE_ANY:
+		return ACLResourceAny
+	case common.ACLResource_ACL_RESOURCE_CLUSTER:
+		return ACLResourceCluster
+	case common.ACLResource_ACL_RESOURCE_GROUP:
+		return ACLResourceGroup
+	case common.ACLResource_ACL_RESOURCE_TOPIC:
+		return ACLResourceTopic
+	case common.ACLResource_ACL_RESOURCE_TXN_ID:
+		return ACLResourceTXNID
+	case common.ACLResource_ACL_RESOURCE_SR_SUBJECT:
+		return ACLResourceSRSubject
+	case common.ACLResource_ACL_RESOURCE_SR_REGISTRY:
+		return ACLResourceSRRegistry
+	case common.ACLResource_ACL_RESOURCE_SR_ANY:
+		return ACLResourceSRAny
+	default:
+		return ""
+	}
+}
+
+func adminACLPatternToCfg(pattern common.ACLPattern) ACLPattern {
+	switch pattern {
+	case common.ACLPattern_ACL_PATTERN_ANY:
+		return ACLPatternAny
+	case common.ACLPattern_ACL_PATTERN_LITERAL:
+		return ACLPatternLiteral
+	case common.ACLPattern_ACL_PATTERN_PREFIXED:
+		return ACLPatternPrefixed
+	case common.ACLPattern_ACL_PATTERN_MATCH:
+		return ACLPatternMatch
+	default:
+		return ""
+	}
+}
+
+func adminACLOperationToCfg(operation common.ACLOperation) ACLOperation {
+	switch operation {
+	case common.ACLOperation_ACL_OPERATION_ANY:
+		return ACLOperationAny
+	case common.ACLOperation_ACL_OPERATION_READ:
+		return ACLOperationRead
+	case common.ACLOperation_ACL_OPERATION_WRITE:
+		return ACLOperationWrite
+	case common.ACLOperation_ACL_OPERATION_CREATE:
+		return ACLOperationCreate
+	case common.ACLOperation_ACL_OPERATION_REMOVE:
+		return ACLOperationRemove
+	case common.ACLOperation_ACL_OPERATION_ALTER:
+		return ACLOperationAlter
+	case common.ACLOperation_ACL_OPERATION_DESCRIBE:
+		return ACLOperationDescribe
+	case common.ACLOperation_ACL_OPERATION_CLUSTER_ACTION:
+		return ACLOperationClusterAction
+	case common.ACLOperation_ACL_OPERATION_DESCRIBE_CONFIGS:
+		return ACLOperationDescribeConfigs
+	case common.ACLOperation_ACL_OPERATION_ALTER_CONFIGS:
+		return ACLOperationAlterConfigs
+	case common.ACLOperation_ACL_OPERATION_IDEMPOTENT_WRITE:
+		return ACLOperationIdempotentWrite
+	default:
+		return ""
+	}
+}
+
+func adminPermissionTypeToCfg(permType common.ACLPermissionType) ACLPermissionType {
+	switch permType {
+	case common.ACLPermissionType_ACL_PERMISSION_TYPE_ANY:
+		return ACLPermissionTypeAny
+	case common.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW:
+		return ACLPermissionTypeAllow
+	case common.ACLPermissionType_ACL_PERMISSION_TYPE_DENY:
+		return ACLPermissionTypeDeny
+	default:
+		return ""
 	}
 }

--- a/src/go/rpk/pkg/cli/shadow/mapper_test.go
+++ b/src/go/rpk/pkg/cli/shadow/mapper_test.go
@@ -19,11 +19,11 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-func TestShadowLinkConfigToCreateReq(t *testing.T) {
+func TestShadowLinkConfigToAdmin(t *testing.T) {
 	tests := []struct {
 		name string
 		cfg  *ShadowLinkConfig
-		want *adminv2.CreateShadowLinkRequest
+		want *adminv2.ShadowLink
 	}{
 		{
 			name: "nil config returns nil",
@@ -35,165 +35,16 @@ func TestShadowLinkConfigToCreateReq(t *testing.T) {
 			cfg: &ShadowLinkConfig{
 				Name: "test-link",
 			},
-			want: &adminv2.CreateShadowLinkRequest{
-				ShadowLink: &adminv2.ShadowLink{
-					Name:           "test-link",
-					Configurations: &adminv2.ShadowLinkConfigurations{},
-				},
-			},
-		},
-		{
-			name: "complete config with all options",
-			cfg: &ShadowLinkConfig{
-				Name: "complete-link",
-				ClientOptions: &ShadowLinkClientOptions{
-					BootstrapServers:    []string{"broker1:9092", "broker2:9092"},
-					SourceClusterID:     "cluster-123",
-					MetadataMaxAgeMs:    10000,
-					ConnectionTimeoutMs: 1000,
-					RetryBackoffMs:      100,
-					FetchWaitMaxMs:      500,
-					FetchMinBytes:       1,
-					FetchMaxBytes:       1048576,
-					TLSSettings: &TLSFileSettings{
-						Enabled:  true,
-						CAPath:   "/path/to/ca.crt",
-						KeyPath:  "/path/to/key.pem",
-						CertPath: "/path/to/cert.pem",
-					},
-					AuthenticationConfiguration: &ScramConfig{
-						Username:       "testuser",
-						Password:       "testpass",
-						ScramMechanism: ScramMechanismScramSha256,
-					},
-				},
-				TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
-					Interval: 30 * time.Second,
-					AutoCreateShadowTopicFilters: []*NameFilter{
-						{
-							PatternType: PatternTypeLiteral,
-							FilterType:  FilterTypeInclude,
-							Name:        "test-topic",
-						},
-					},
-					SyncedShadowTopicProperties: []string{"retention.ms"},
-					ExcludeDefault:              true,
-				},
-				ConsumerOffsetSyncOptions: &ConsumerOffsetSyncOptions{
-					Enabled:  true,
-					Interval: 30 * time.Second,
-					GroupFilters: []*NameFilter{
-						{
-							PatternType: PatternTypePrefix,
-							FilterType:  FilterTypeExclude,
-							Name:        "test-",
-						},
-					},
-				},
-				SecuritySyncOptions: &SecuritySettingsSyncOptions{
-					Enabled:  true,
-					Interval: 30 * time.Second,
-					ACLFilters: []*ACLFilter{
-						{
-							ResourceFilter: &ACLResourceFilter{
-								ResourceType: ACLResourceTopic,
-								PatternType:  ACLPatternLiteral,
-								Name:         "secure-topic",
-							},
-							AccessFilter: &ACLAccessFilter{
-								Principal:      "User:alice",
-								Operation:      ACLOperationRead,
-								PermissionType: ACLPermissionTypeAllow,
-								Host:           "*",
-							},
-						},
-					},
-				},
-			},
-			want: &adminv2.CreateShadowLinkRequest{
-				ShadowLink: &adminv2.ShadowLink{
-					Name: "complete-link",
-					Configurations: &adminv2.ShadowLinkConfigurations{
-						ClientOptions: &adminv2.ShadowLinkClientOptions{
-							BootstrapServers:    []string{"broker1:9092", "broker2:9092"},
-							SourceClusterId:     "cluster-123",
-							MetadataMaxAgeMs:    10000,
-							ConnectionTimeoutMs: 1000,
-							RetryBackoffMs:      100,
-							FetchWaitMaxMs:      500,
-							FetchMinBytes:       1,
-							FetchMaxBytes:       1048576,
-							TlsSettings: &adminv2.TLSSettings{
-								Enabled: true,
-								TlsSettings: &adminv2.TLSSettings_TlsFileSettings{
-									TlsFileSettings: &adminv2.TLSFileSettings{
-										CaPath:   "/path/to/ca.crt",
-										KeyPath:  "/path/to/key.pem",
-										CertPath: "/path/to/cert.pem",
-									},
-								},
-							},
-							AuthenticationConfiguration: &adminv2.AuthenticationConfiguration{
-								Authentication: &adminv2.AuthenticationConfiguration_ScramConfiguration{
-									ScramConfiguration: &adminv2.ScramConfig{
-										Username:       "testuser",
-										Password:       "testpass",
-										ScramMechanism: adminv2.ScramMechanism_SCRAM_MECHANISM_SCRAM_SHA_256,
-									},
-								},
-							},
-						},
-						TopicMetadataSyncOptions: &adminv2.TopicMetadataSyncOptions{
-							Interval: durationpb.New(30 * time.Second),
-							AutoCreateShadowTopicFilters: []*adminv2.NameFilter{
-								{
-									PatternType: adminv2.PatternType_PATTERN_TYPE_LITERAL,
-									FilterType:  adminv2.FilterType_FILTER_TYPE_INCLUDE,
-									Name:        "test-topic",
-								},
-							},
-							SyncedShadowTopicProperties: []string{"retention.ms"},
-							ExcludeDefault:              true,
-						},
-						ConsumerOffsetSyncOptions: &adminv2.ConsumerOffsetSyncOptions{
-							Enabled:  true,
-							Interval: durationpb.New(30 * time.Second),
-							GroupFilters: []*adminv2.NameFilter{
-								{
-									PatternType: adminv2.PatternType_PATTERN_TYPE_PREFIX,
-									FilterType:  adminv2.FilterType_FILTER_TYPE_EXCLUDE,
-									Name:        "test-",
-								},
-							},
-						},
-						SecuritySyncOptions: &adminv2.SecuritySettingsSyncOptions{
-							Enabled:  true,
-							Interval: durationpb.New(30 * time.Second),
-							AclFilters: []*adminv2.ACLFilter{
-								{
-									ResourceFilter: &adminv2.ACLResourceFilter{
-										ResourceType: common.ACLResource_ACL_RESOURCE_TOPIC,
-										PatternType:  common.ACLPattern_ACL_PATTERN_LITERAL,
-										Name:         "secure-topic",
-									},
-									AccessFilter: &adminv2.ACLAccessFilter{
-										Principal:      "User:alice",
-										Operation:      common.ACLOperation_ACL_OPERATION_READ,
-										PermissionType: common.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW,
-										Host:           "*",
-									},
-								},
-							},
-						},
-					},
-				},
+			want: &adminv2.ShadowLink{
+				Name:           "test-link",
+				Configurations: &adminv2.ShadowLinkConfigurations{},
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := shadowLinkConfigToCreateReq(tt.cfg)
+			got := shadowLinkConfigToProto(tt.cfg)
 			require.Equal(t, tt.want, got)
 		})
 	}
@@ -430,37 +281,6 @@ func TestMapAuthenticationConfiguration(t *testing.T) {
 	}
 }
 
-func TestMapScramMechanism(t *testing.T) {
-	tests := []struct {
-		name string
-		mech ScramMechanism
-		want adminv2.ScramMechanism
-	}{
-		{
-			name: "SCRAM-SHA-256",
-			mech: ScramMechanismScramSha256,
-			want: adminv2.ScramMechanism_SCRAM_MECHANISM_SCRAM_SHA_256,
-		},
-		{
-			name: "SCRAM-SHA-512",
-			mech: ScramMechanismScramSha512,
-			want: adminv2.ScramMechanism_SCRAM_MECHANISM_SCRAM_SHA_512,
-		},
-		{
-			name: "unknown mechanism",
-			mech: ScramMechanism("unknown"),
-			want: adminv2.ScramMechanism_SCRAM_MECHANISM_UNSPECIFIED,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := mapScramMechanism(tt.mech)
-			require.Equal(t, tt.want, got)
-		})
-	}
-}
-
 func TestMapTopicMetadataSyncOptions(t *testing.T) {
 	tests := []struct {
 		name string
@@ -480,7 +300,7 @@ func TestMapTopicMetadataSyncOptions(t *testing.T) {
 			want: &adminv2.TopicMetadataSyncOptions{},
 		},
 		{
-			name: "complete options",
+			name: "with filters and properties",
 			opts: &TopicMetadataSyncOptions{
 				Interval: 60 * time.Second,
 				AutoCreateShadowTopicFilters: []*NameFilter{
@@ -727,158 +547,738 @@ func TestMapACLFilter(t *testing.T) {
 	}
 }
 
-func TestMapPatternType(t *testing.T) {
+// Reverse mapping tests (admin proto -> config)
+
+func TestShadowLinkToConfig(t *testing.T) {
 	tests := []struct {
 		name string
-		pt   PatternType
-		want adminv2.PatternType
+		sl   *adminv2.ShadowLink
+		want *ShadowLinkConfig
 	}{
 		{
-			name: "literal pattern",
-			pt:   PatternTypeLiteral,
-			want: adminv2.PatternType_PATTERN_TYPE_LITERAL,
+			name: "nil shadow link returns nil",
+			sl:   nil,
+			want: nil,
 		},
 		{
-			name: "prefix pattern",
-			pt:   PatternTypePrefix,
-			want: adminv2.PatternType_PATTERN_TYPE_PREFIX,
-		},
-		{
-			name: "unknown pattern",
-			pt:   PatternType("unknown"),
-			want: adminv2.PatternType_PATTERN_TYPE_UNSPECIFIED,
+			name: "minimal shadow link",
+			sl: &adminv2.ShadowLink{
+				Name:           "test-link",
+				Configurations: nil,
+			},
+			want: &ShadowLinkConfig{
+				Name: "test-link",
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := mapPatternType(tt.pt)
+			got := shadowLinkToConfig(tt.sl)
 			require.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestMapFilterType(t *testing.T) {
+func TestAdminClientOptsToCfg(t *testing.T) {
 	tests := []struct {
 		name string
-		ft   FilterType
-		want adminv2.FilterType
+		opts *adminv2.ShadowLinkClientOptions
+		want *ShadowLinkClientOptions
 	}{
 		{
-			name: "include filter",
-			ft:   FilterTypeInclude,
-			want: adminv2.FilterType_FILTER_TYPE_INCLUDE,
+			name: "nil options returns nil",
+			opts: nil,
+			want: nil,
 		},
 		{
-			name: "exclude filter",
-			ft:   FilterTypeExclude,
-			want: adminv2.FilterType_FILTER_TYPE_EXCLUDE,
+			name: "basic options without TLS or auth",
+			opts: &adminv2.ShadowLinkClientOptions{
+				BootstrapServers:    []string{"localhost:9092"},
+				SourceClusterId:     "test-cluster",
+				MetadataMaxAgeMs:    5000,
+				ConnectionTimeoutMs: 2000,
+				RetryBackoffMs:      200,
+				FetchWaitMaxMs:      1000,
+				FetchMinBytes:       10,
+				FetchMaxBytes:       2097152,
+			},
+			want: &ShadowLinkClientOptions{
+				BootstrapServers:    []string{"localhost:9092"},
+				SourceClusterID:     "test-cluster",
+				MetadataMaxAgeMs:    5000,
+				ConnectionTimeoutMs: 2000,
+				RetryBackoffMs:      200,
+				FetchWaitMaxMs:      1000,
+				FetchMinBytes:       10,
+				FetchMaxBytes:       2097152,
+			},
 		},
 		{
-			name: "unknown filter",
-			ft:   FilterType("unknown"),
-			want: adminv2.FilterType_FILTER_TYPE_UNSPECIFIED,
+			name: "with file-based TLS",
+			opts: &adminv2.ShadowLinkClientOptions{
+				BootstrapServers: []string{"localhost:9092"},
+				TlsSettings: &adminv2.TLSSettings{
+					Enabled: true,
+					TlsSettings: &adminv2.TLSSettings_TlsFileSettings{
+						TlsFileSettings: &adminv2.TLSFileSettings{
+							CaPath:   "/ca.crt",
+							KeyPath:  "/key.pem",
+							CertPath: "/cert.pem",
+						},
+					},
+				},
+			},
+			want: &ShadowLinkClientOptions{
+				BootstrapServers: []string{"localhost:9092"},
+				TLSSettings: &TLSFileSettings{
+					Enabled:  true,
+					CAPath:   "/ca.crt",
+					KeyPath:  "/key.pem",
+					CertPath: "/cert.pem",
+				},
+			},
+		},
+		{
+			name: "with PEM-based TLS",
+			opts: &adminv2.ShadowLinkClientOptions{
+				BootstrapServers: []string{"localhost:9092"},
+				TlsSettings: &adminv2.TLSSettings{
+					Enabled: true,
+					TlsSettings: &adminv2.TLSSettings_TlsPemSettings{
+						TlsPemSettings: &adminv2.TLSPEMSettings{
+							Ca:   "ca-content",
+							Key:  "key-content",
+							Cert: "cert-content",
+						},
+					},
+				},
+			},
+			want: &ShadowLinkClientOptions{
+				BootstrapServers: []string{"localhost:9092"},
+				TLSSettings: &TLSPEMSettings{
+					Enabled: true,
+					CA:      "ca-content",
+					Key:     "key-content",
+					Cert:    "cert-content",
+				},
+			},
+		},
+		{
+			name: "with SCRAM authentication",
+			opts: &adminv2.ShadowLinkClientOptions{
+				BootstrapServers: []string{"localhost:9092"},
+				AuthenticationConfiguration: &adminv2.AuthenticationConfiguration{
+					Authentication: &adminv2.AuthenticationConfiguration_ScramConfiguration{
+						ScramConfiguration: &adminv2.ScramConfig{
+							Username:       "user",
+							Password:       "pass",
+							ScramMechanism: adminv2.ScramMechanism_SCRAM_MECHANISM_SCRAM_SHA_512,
+						},
+					},
+				},
+			},
+			want: &ShadowLinkClientOptions{
+				BootstrapServers: []string{"localhost:9092"},
+				AuthenticationConfiguration: &ScramConfig{
+					Username:       "user",
+					Password:       "pass",
+					ScramMechanism: ScramMechanismScramSha512,
+				},
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := mapFilterType(tt.ft)
+			got := adminClientOptsToCfg(tt.opts)
 			require.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestMapACLResource(t *testing.T) {
+func TestAdminTLSToCfg(t *testing.T) {
 	tests := []struct {
-		name     string
-		resource ACLResource
-		want     common.ACLResource
+		name string
+		tls  *adminv2.TLSSettings
+		want TLSSettings
 	}{
-		{name: "any", resource: ACLResourceAny, want: common.ACLResource_ACL_RESOURCE_ANY},
-		{name: "cluster", resource: ACLResourceCluster, want: common.ACLResource_ACL_RESOURCE_CLUSTER},
-		{name: "group", resource: ACLResourceGroup, want: common.ACLResource_ACL_RESOURCE_GROUP},
-		{name: "topic", resource: ACLResourceTopic, want: common.ACLResource_ACL_RESOURCE_TOPIC},
-		{name: "txn_id", resource: ACLResourceTXNID, want: common.ACLResource_ACL_RESOURCE_TXN_ID},
-		{name: "sr_subject", resource: ACLResourceSRSubject, want: common.ACLResource_ACL_RESOURCE_SR_SUBJECT},
-		{name: "sr_registry", resource: ACLResourceSRRegistry, want: common.ACLResource_ACL_RESOURCE_SR_REGISTRY},
-		{name: "sr_any", resource: ACLResourceSRAny, want: common.ACLResource_ACL_RESOURCE_SR_ANY},
-		{name: "unknown", resource: ACLResource("unknown"), want: common.ACLResource_ACL_RESOURCE_UNSPECIFIED},
+		{
+			name: "nil TLS returns nil",
+			tls:  nil,
+			want: nil,
+		},
+		{
+			name: "file-based TLS settings",
+			tls: &adminv2.TLSSettings{
+				Enabled: true,
+				TlsSettings: &adminv2.TLSSettings_TlsFileSettings{
+					TlsFileSettings: &adminv2.TLSFileSettings{
+						CaPath:   "/path/to/ca",
+						KeyPath:  "/path/to/key",
+						CertPath: "/path/to/cert",
+					},
+				},
+			},
+			want: &TLSFileSettings{
+				Enabled:  true,
+				CAPath:   "/path/to/ca",
+				KeyPath:  "/path/to/key",
+				CertPath: "/path/to/cert",
+			},
+		},
+		{
+			name: "PEM-based TLS settings",
+			tls: &adminv2.TLSSettings{
+				Enabled: false,
+				TlsSettings: &adminv2.TLSSettings_TlsPemSettings{
+					TlsPemSettings: &adminv2.TLSPEMSettings{
+						Ca:   "ca-pem",
+						Key:  "key-pem",
+						Cert: "cert-pem",
+					},
+				},
+			},
+			want: &TLSPEMSettings{
+				Enabled: false,
+				CA:      "ca-pem",
+				Key:     "key-pem",
+				Cert:    "cert-pem",
+			},
+		},
+		{
+			name: "nil file settings returns nil",
+			tls: &adminv2.TLSSettings{
+				Enabled: true,
+				TlsSettings: &adminv2.TLSSettings_TlsFileSettings{
+					TlsFileSettings: nil,
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "nil PEM settings returns nil",
+			tls: &adminv2.TLSSettings{
+				Enabled: true,
+				TlsSettings: &adminv2.TLSSettings_TlsPemSettings{
+					TlsPemSettings: nil,
+				},
+			},
+			want: nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := mapACLResource(tt.resource)
+			got := adminTLSToCfg(tt.tls)
 			require.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestMapACLPattern(t *testing.T) {
+func TestAdminAuthToCfg(t *testing.T) {
 	tests := []struct {
-		name    string
-		pattern ACLPattern
-		want    common.ACLPattern
+		name string
+		auth *adminv2.AuthenticationConfiguration
+		want AuthenticationConfiguration
 	}{
-		{name: "any", pattern: ACLPatternAny, want: common.ACLPattern_ACL_PATTERN_ANY},
-		{name: "literal", pattern: ACLPatternLiteral, want: common.ACLPattern_ACL_PATTERN_LITERAL},
-		{name: "prefixed", pattern: ACLPatternPrefixed, want: common.ACLPattern_ACL_PATTERN_PREFIXED},
-		{name: "match", pattern: ACLPatternMatch, want: common.ACLPattern_ACL_PATTERN_MATCH},
-		{name: "unknown", pattern: ACLPattern("unknown"), want: common.ACLPattern_ACL_PATTERN_UNSPECIFIED},
+		{
+			name: "nil auth returns nil",
+			auth: nil,
+			want: nil,
+		},
+		{
+			name: "SCRAM-SHA-256 configuration",
+			auth: &adminv2.AuthenticationConfiguration{
+				Authentication: &adminv2.AuthenticationConfiguration_ScramConfiguration{
+					ScramConfiguration: &adminv2.ScramConfig{
+						Username:       "alice",
+						Password:       "secret",
+						ScramMechanism: adminv2.ScramMechanism_SCRAM_MECHANISM_SCRAM_SHA_256,
+					},
+				},
+			},
+			want: &ScramConfig{
+				Username:       "alice",
+				Password:       "secret",
+				ScramMechanism: ScramMechanismScramSha256,
+			},
+		},
+		{
+			name: "SCRAM-SHA-512 configuration",
+			auth: &adminv2.AuthenticationConfiguration{
+				Authentication: &adminv2.AuthenticationConfiguration_ScramConfiguration{
+					ScramConfiguration: &adminv2.ScramConfig{
+						Username:       "bob",
+						Password:       "password",
+						ScramMechanism: adminv2.ScramMechanism_SCRAM_MECHANISM_SCRAM_SHA_512,
+					},
+				},
+			},
+			want: &ScramConfig{
+				Username:       "bob",
+				Password:       "password",
+				ScramMechanism: ScramMechanismScramSha512,
+			},
+		},
+		{
+			name: "nil SCRAM configuration returns nil",
+			auth: &adminv2.AuthenticationConfiguration{
+				Authentication: &adminv2.AuthenticationConfiguration_ScramConfiguration{
+					ScramConfiguration: nil,
+				},
+			},
+			want: nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := mapACLPattern(tt.pattern)
+			got := adminAuthToCfg(tt.auth)
 			require.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestMapACLOperation(t *testing.T) {
+func TestAdminTopicMetadataSyncToCfg(t *testing.T) {
 	tests := []struct {
-		name      string
-		operation ACLOperation
-		want      common.ACLOperation
+		name string
+		opts *adminv2.TopicMetadataSyncOptions
+		want *TopicMetadataSyncOptions
 	}{
-		{name: "any", operation: ACLOperationAny, want: common.ACLOperation_ACL_OPERATION_ANY},
-		{name: "read", operation: ACLOperationRead, want: common.ACLOperation_ACL_OPERATION_READ},
-		{name: "write", operation: ACLOperationWrite, want: common.ACLOperation_ACL_OPERATION_WRITE},
-		{name: "create", operation: ACLOperationCreate, want: common.ACLOperation_ACL_OPERATION_CREATE},
-		{name: "remove", operation: ACLOperationRemove, want: common.ACLOperation_ACL_OPERATION_REMOVE},
-		{name: "alter", operation: ACLOperationAlter, want: common.ACLOperation_ACL_OPERATION_ALTER},
-		{name: "describe", operation: ACLOperationDescribe, want: common.ACLOperation_ACL_OPERATION_DESCRIBE},
-		{name: "cluster_action", operation: ACLOperationClusterAction, want: common.ACLOperation_ACL_OPERATION_CLUSTER_ACTION},
-		{name: "describe_configs", operation: ACLOperationDescribeConfigs, want: common.ACLOperation_ACL_OPERATION_DESCRIBE_CONFIGS},
-		{name: "alter_configs", operation: ACLOperationAlterConfigs, want: common.ACLOperation_ACL_OPERATION_ALTER_CONFIGS},
-		{name: "idempotent_write", operation: ACLOperationIdempotentWrite, want: common.ACLOperation_ACL_OPERATION_IDEMPOTENT_WRITE},
-		{name: "unknown", operation: ACLOperation("unknown"), want: common.ACLOperation_ACL_OPERATION_UNSPECIFIED},
+		{
+			name: "nil options returns nil",
+			opts: nil,
+			want: nil,
+		},
+		{
+			name: "options with nil interval",
+			opts: &adminv2.TopicMetadataSyncOptions{
+				Interval: nil,
+			},
+			want: &TopicMetadataSyncOptions{
+				Interval: 0,
+			},
+		},
+		{
+			name: "with filters and properties",
+			opts: &adminv2.TopicMetadataSyncOptions{
+				Interval: durationpb.New(60 * time.Second),
+				AutoCreateShadowTopicFilters: []*adminv2.NameFilter{
+					{PatternType: adminv2.PatternType_PATTERN_TYPE_LITERAL, FilterType: adminv2.FilterType_FILTER_TYPE_INCLUDE, Name: "topic1"},
+					{PatternType: adminv2.PatternType_PATTERN_TYPE_PREFIX, FilterType: adminv2.FilterType_FILTER_TYPE_EXCLUDE, Name: "test-"},
+				},
+				SyncedShadowTopicProperties: []string{"retention.ms", "compression.type"},
+				ExcludeDefault:              true,
+			},
+			want: &TopicMetadataSyncOptions{
+				Interval: 60 * time.Second,
+				AutoCreateShadowTopicFilters: []*NameFilter{
+					{PatternType: PatternTypeLiteral, FilterType: FilterTypeInclude, Name: "topic1"},
+					{PatternType: PatternTypePrefix, FilterType: FilterTypeExclude, Name: "test-"},
+				},
+				SyncedShadowTopicProperties: []string{"retention.ms", "compression.type"},
+				ExcludeDefault:              true,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := mapACLOperation(tt.operation)
+			got := adminTopicMetadataSyncToCfg(tt.opts)
 			require.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestMapACLPermissionType(t *testing.T) {
+func TestAdminConsumerOffsetSyncToCfg(t *testing.T) {
 	tests := []struct {
-		name     string
-		permType ACLPermissionType
-		want     common.ACLPermissionType
+		name string
+		opts *adminv2.ConsumerOffsetSyncOptions
+		want *ConsumerOffsetSyncOptions
 	}{
-		{name: "any", permType: ACLPermissionTypeAny, want: common.ACLPermissionType_ACL_PERMISSION_TYPE_ANY},
-		{name: "allow", permType: ACLPermissionTypeAllow, want: common.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW},
-		{name: "deny", permType: ACLPermissionTypeDeny, want: common.ACLPermissionType_ACL_PERMISSION_TYPE_DENY},
-		{name: "unknown", permType: ACLPermissionType("unknown"), want: common.ACLPermissionType_ACL_PERMISSION_TYPE_UNSPECIFIED},
+		{
+			name: "nil options returns nil",
+			opts: nil,
+			want: nil,
+		},
+		{
+			name: "disabled with nil interval",
+			opts: &adminv2.ConsumerOffsetSyncOptions{
+				Enabled:  false,
+				Interval: nil,
+			},
+			want: &ConsumerOffsetSyncOptions{
+				Enabled:  false,
+				Interval: 0,
+			},
+		},
+		{
+			name: "enabled with filters",
+			opts: &adminv2.ConsumerOffsetSyncOptions{
+				Enabled:  true,
+				Interval: durationpb.New(45 * time.Second),
+				GroupFilters: []*adminv2.NameFilter{
+					{PatternType: adminv2.PatternType_PATTERN_TYPE_LITERAL, FilterType: adminv2.FilterType_FILTER_TYPE_INCLUDE, Name: "*"},
+				},
+			},
+			want: &ConsumerOffsetSyncOptions{
+				Enabled:  true,
+				Interval: 45 * time.Second,
+				GroupFilters: []*NameFilter{
+					{PatternType: PatternTypeLiteral, FilterType: FilterTypeInclude, Name: "*"},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := mapACLPermissionType(tt.permType)
+			got := adminConsumerOffsetSyncToCfg(tt.opts)
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestAdminSecuritySyncToCfg(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *adminv2.SecuritySettingsSyncOptions
+		want *SecuritySettingsSyncOptions
+	}{
+		{
+			name: "nil options returns nil",
+			opts: nil,
+			want: nil,
+		},
+		{
+			name: "disabled with no filters",
+			opts: &adminv2.SecuritySettingsSyncOptions{
+				Enabled:  false,
+				Interval: nil,
+			},
+			want: &SecuritySettingsSyncOptions{
+				Enabled:  false,
+				Interval: 0,
+			},
+		},
+		{
+			name: "enabled with ACL filters",
+			opts: &adminv2.SecuritySettingsSyncOptions{
+				Enabled:  true,
+				Interval: durationpb.New(120 * time.Second),
+				AclFilters: []*adminv2.ACLFilter{
+					{
+						ResourceFilter: &adminv2.ACLResourceFilter{
+							ResourceType: common.ACLResource_ACL_RESOURCE_TOPIC,
+							PatternType:  common.ACLPattern_ACL_PATTERN_LITERAL,
+							Name:         "sensitive-topic",
+						},
+						AccessFilter: &adminv2.ACLAccessFilter{
+							Principal:      "User:admin",
+							Operation:      common.ACLOperation_ACL_OPERATION_WRITE,
+							PermissionType: common.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW,
+							Host:           "192.168.1.1",
+						},
+					},
+				},
+			},
+			want: &SecuritySettingsSyncOptions{
+				Enabled:  true,
+				Interval: 120 * time.Second,
+				ACLFilters: []*ACLFilter{
+					{
+						ResourceFilter: &ACLResourceFilter{
+							ResourceType: ACLResourceTopic,
+							PatternType:  ACLPatternLiteral,
+							Name:         "sensitive-topic",
+						},
+						AccessFilter: &ACLAccessFilter{
+							Principal:      "User:admin",
+							Operation:      ACLOperationWrite,
+							PermissionType: ACLPermissionTypeAllow,
+							Host:           "192.168.1.1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := adminSecuritySyncToCfg(tt.opts)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAdminMapFilterToCfg(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter *adminv2.NameFilter
+		want   *NameFilter
+	}{
+		{
+			name:   "nil filter returns nil",
+			filter: nil,
+			want:   nil,
+		},
+		{
+			name: "literal include filter",
+			filter: &adminv2.NameFilter{
+				PatternType: adminv2.PatternType_PATTERN_TYPE_LITERAL,
+				FilterType:  adminv2.FilterType_FILTER_TYPE_INCLUDE,
+				Name:        "my-topic",
+			},
+			want: &NameFilter{
+				PatternType: PatternTypeLiteral,
+				FilterType:  FilterTypeInclude,
+				Name:        "my-topic",
+			},
+		},
+		{
+			name: "prefix exclude filter",
+			filter: &adminv2.NameFilter{
+				PatternType: adminv2.PatternType_PATTERN_TYPE_PREFIX,
+				FilterType:  adminv2.FilterType_FILTER_TYPE_EXCLUDE,
+				Name:        "internal-",
+			},
+			want: &NameFilter{
+				PatternType: PatternTypePrefix,
+				FilterType:  FilterTypeExclude,
+				Name:        "internal-",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := adminMapFilterToCfg(tt.filter)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAdminACLFilterToCfg(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter *adminv2.ACLFilter
+		want   *ACLFilter
+	}{
+		{
+			name:   "nil filter returns nil",
+			filter: nil,
+			want:   nil,
+		},
+		{
+			name: "complete ACL filter",
+			filter: &adminv2.ACLFilter{
+				ResourceFilter: &adminv2.ACLResourceFilter{
+					ResourceType: common.ACLResource_ACL_RESOURCE_GROUP,
+					PatternType:  common.ACLPattern_ACL_PATTERN_PREFIXED,
+					Name:         "consumer-",
+				},
+				AccessFilter: &adminv2.ACLAccessFilter{
+					Principal:      "User:consumer",
+					Operation:      common.ACLOperation_ACL_OPERATION_READ,
+					PermissionType: common.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW,
+					Host:           "*",
+				},
+			},
+			want: &ACLFilter{
+				ResourceFilter: &ACLResourceFilter{
+					ResourceType: ACLResourceGroup,
+					PatternType:  ACLPatternPrefixed,
+					Name:         "consumer-",
+				},
+				AccessFilter: &ACLAccessFilter{
+					Principal:      "User:consumer",
+					Operation:      ACLOperationRead,
+					PermissionType: ACLPermissionTypeAllow,
+					Host:           "*",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := adminACLFilterToCfg(tt.filter)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// Round-trip test: config -> proto -> config
+// This comprehensive test validates the entire bidirectional mapping chain works correctly
+func TestRoundTrip(t *testing.T) {
+	// Create a fully populated config with all possible options
+	originalConfig := &ShadowLinkConfig{
+		Name: "complete-round-trip-link",
+		ClientOptions: &ShadowLinkClientOptions{
+			BootstrapServers:    []string{"broker1:9092", "broker2:9092", "broker3:9092"},
+			SourceClusterID:     "prod-cluster-xyz",
+			MetadataMaxAgeMs:    15000,
+			ConnectionTimeoutMs: 3000,
+			RetryBackoffMs:      250,
+			FetchWaitMaxMs:      750,
+			FetchMinBytes:       2048,
+			FetchMaxBytes:       20971520,
+			TLSSettings: &TLSFileSettings{
+				Enabled:  true,
+				CAPath:   "/etc/ssl/certs/ca-bundle.pem",
+				KeyPath:  "/etc/ssl/private/client-key.pem",
+				CertPath: "/etc/ssl/certs/client-cert.pem",
+			},
+			AuthenticationConfiguration: &ScramConfig{
+				Username:       "shadow-replication-user",
+				Password:       "super-secure-password-123",
+				ScramMechanism: ScramMechanismScramSha512,
+			},
+		},
+		TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
+			Interval: 45 * time.Second,
+			AutoCreateShadowTopicFilters: []*NameFilter{
+				{
+					PatternType: PatternTypeLiteral,
+					FilterType:  FilterTypeInclude,
+					Name:        "orders",
+				},
+				{
+					PatternType: PatternTypeLiteral,
+					FilterType:  FilterTypeInclude,
+					Name:        "payments",
+				},
+				{
+					PatternType: PatternTypePrefix,
+					FilterType:  FilterTypeExclude,
+					Name:        "internal-",
+				},
+				{
+					PatternType: PatternTypePrefix,
+					FilterType:  FilterTypeExclude,
+					Name:        "_",
+				},
+			},
+			SyncedShadowTopicProperties: []string{
+				"retention.ms",
+				"retention.bytes",
+				"compression.type",
+				"cleanup.policy",
+				"min.compaction.lag.ms",
+			},
+			ExcludeDefault: false,
+		},
+		ConsumerOffsetSyncOptions: &ConsumerOffsetSyncOptions{
+			Enabled:  true,
+			Interval: 90 * time.Second,
+			GroupFilters: []*NameFilter{
+				{
+					PatternType: PatternTypePrefix,
+					FilterType:  FilterTypeInclude,
+					Name:        "prod-",
+				},
+				{
+					PatternType: PatternTypeLiteral,
+					FilterType:  FilterTypeExclude,
+					Name:        "test-group",
+				},
+			},
+		},
+		SecuritySyncOptions: &SecuritySettingsSyncOptions{
+			Enabled:  true,
+			Interval: 120 * time.Second,
+			ACLFilters: []*ACLFilter{
+				{
+					ResourceFilter: &ACLResourceFilter{
+						ResourceType: ACLResourceTopic,
+						PatternType:  ACLPatternLiteral,
+						Name:         "sensitive-topic",
+					},
+					AccessFilter: &ACLAccessFilter{
+						Principal:      "User:admin",
+						Operation:      ACLOperationRead,
+						PermissionType: ACLPermissionTypeAllow,
+						Host:           "*",
+					},
+				},
+				{
+					ResourceFilter: &ACLResourceFilter{
+						ResourceType: ACLResourceGroup,
+						PatternType:  ACLPatternPrefixed,
+						Name:         "consumer-",
+					},
+					AccessFilter: &ACLAccessFilter{
+						Principal:      "User:service-account",
+						Operation:      ACLOperationWrite,
+						PermissionType: ACLPermissionTypeDeny,
+						Host:           "192.168.1.100",
+					},
+				},
+				{
+					ResourceFilter: &ACLResourceFilter{
+						ResourceType: ACLResourceCluster,
+						PatternType:  ACLPatternLiteral,
+						Name:         "kafka-cluster",
+					},
+					AccessFilter: &ACLAccessFilter{
+						Principal:      "User:cluster-admin",
+						Operation:      ACLOperationClusterAction,
+						PermissionType: ACLPermissionTypeAllow,
+						Host:           "*",
+					},
+				},
+			},
+		},
+	}
+
+	// Step 1: Convert config to proto (config -> proto)
+	adminShadowLink := shadowLinkConfigToProto(originalConfig)
+	require.NotNil(t, adminShadowLink, "shadow link should not be nil")
+
+	// Step 2: Convert proto back to config (proto -> config)
+	roundTripConfig := shadowLinkToConfig(adminShadowLink)
+	require.NotNil(t, roundTripConfig, "round-trip config should not be nil")
+
+	// Step 3: Verify the round-trip config matches the original
+	require.Equal(t, originalConfig, roundTripConfig, "round-trip config should exactly match original config")
+}
+
+// Test reverse enum mapping functions return empty string for
+// unknown/unspecified values. These tests validate fallback behavior.
+// The round-trip test above covers known values.
+func TestAdminScramMechanismToCfg_UnknownValue(t *testing.T) {
+	result := adminScramMechanismToCfg(adminv2.ScramMechanism_SCRAM_MECHANISM_UNSPECIFIED)
+	require.Equal(t, ScramMechanism(""), result, "unspecified SCRAM mechanism should return empty string")
+}
+
+func TestAdminPatternTypeToCfg_UnknownValue(t *testing.T) {
+	result := adminPatternTypeToCfg(adminv2.PatternType_PATTERN_TYPE_UNSPECIFIED)
+	require.Equal(t, PatternType(""), result, "unspecified pattern type should return empty string")
+}
+
+func TestAdminFilterTypeToCfg_UnknownValue(t *testing.T) {
+	result := adminFilterTypeToCfg(adminv2.FilterType_FILTER_TYPE_UNSPECIFIED)
+	require.Equal(t, FilterType(""), result, "unspecified filter type should return empty string")
+}
+
+func TestAdminACLResourceToCfg_UnknownValue(t *testing.T) {
+	result := adminACLResourceToCfg(common.ACLResource_ACL_RESOURCE_UNSPECIFIED)
+	require.Equal(t, ACLResource(""), result, "unspecified ACL resource should return empty string")
+}
+
+func TestAdminACLPatternToCfg_UnknownValue(t *testing.T) {
+	result := adminACLPatternToCfg(common.ACLPattern_ACL_PATTERN_UNSPECIFIED)
+	require.Equal(t, ACLPattern(""), result, "unspecified ACL pattern should return empty string")
+}
+
+func TestAdminACLOperationToCfg_UnknownValue(t *testing.T) {
+	result := adminACLOperationToCfg(common.ACLOperation_ACL_OPERATION_UNSPECIFIED)
+	require.Equal(t, ACLOperation(""), result, "unspecified ACL operation should return empty string")
+}
+
+func TestAdminPermissionTypeToCfg_UnknownValue(t *testing.T) {
+	result := adminPermissionTypeToCfg(common.ACLPermissionType_ACL_PERMISSION_TYPE_UNSPECIFIED)
+	require.Equal(t, ACLPermissionType(""), result, "unspecified permission type should return empty string")
 }

--- a/src/go/rpk/pkg/cli/shadow/shadow.go
+++ b/src/go/rpk/pkg/cli/shadow/shadow.go
@@ -29,6 +29,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		newDescribeCommand(fs, p),
 		newStatusCommand(fs, p),
 		newListCommand(fs, p),
+		newUpdateCommand(fs, p),
 	)
 	p.InstallAdminFlags(cmd)
 	p.InstallSASLFlags(cmd)

--- a/src/go/rpk/pkg/cli/shadow/types.go
+++ b/src/go/rpk/pkg/cli/shadow/types.go
@@ -17,7 +17,7 @@ import (
 
 type ShadowLinkConfig struct {
 	// Name is the name of the shadow link
-	Name string
+	Name string `json:"name" yaml:"name"`
 	// Configuration for the internal kafka client
 	ClientOptions *ShadowLinkClientOptions `json:"client_options,omitempty" yaml:"client_options,omitempty"`
 	// Topic metadata sync options

--- a/src/go/rpk/pkg/cli/shadow/update.go
+++ b/src/go/rpk/pkg/cli/shadow/update.go
@@ -1,0 +1,78 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package shadow
+
+import (
+	"fmt"
+	"reflect"
+
+	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
+	"connectrpc.com/connect"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/os"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newUpdateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update [LINK_NAME]",
+		Short: "Update a Shadow Link",
+		Long: `Update a Shadow Link
+
+This command opens your default editor to modify the Shadow Link configuration.
+Only the fields that are changed will be updated on the server.
+
+The Shadow Link name cannot be changed. If you need to rename a Shadow Link,
+you must delete and recreate it.
+`,
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			prof, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "unable to load rpk config: %v", err)
+			config.CheckExitCloudAdmin(prof)
+
+			cl, err := adminapi.NewClient(cmd.Context(), fs, prof)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			linkName := args[0]
+			link, err := cl.ShadowLinkService().GetShadowLink(cmd.Context(), connect.NewRequest(&adminv2.GetShadowLinkRequest{
+				Name: linkName,
+			}))
+			out.MaybeDie(err, "unable to get Redpanda Shadow Link information: %v", err)
+
+			originalCfg := shadowLinkToConfig(link.Msg.GetShadowLink())
+
+			// Open editor to modify the configuration.
+			updatedCfg, err := rpkos.EditTmpYAMLFile(fs, originalCfg)
+			out.MaybeDie(err, "unable to edit Shadow Link configuration: %v", err)
+
+			if updatedCfg.Name != originalCfg.Name {
+				out.Die("Shadow Link name cannot be changed; if you need to rename, please delete and recreate the shadow link")
+			}
+
+			if reflect.DeepEqual(originalCfg, updatedCfg) {
+				out.Exit("No changes detected")
+			}
+
+			// No field mask used: we update all fields that are set in the
+			// ShadowLink message.
+			_, err = cl.ShadowLinkService().UpdateShadowLink(cmd.Context(), connect.NewRequest(&adminv2.UpdateShadowLinkRequest{
+				ShadowLink: shadowLinkConfigToProto(updatedCfg),
+			}))
+			out.MaybeDie(err, "unable to update Shadow Link: %v", err)
+
+			fmt.Printf("Successfully updated shadow link %q.\n", linkName)
+		},
+	}
+	return cmd
+}


### PR DESCRIPTION
This command will open a YAML file containing a
configuration file, on close, we will readback
and update what changed.

This PR also cleans up the mapper test with a new round-trip test that I found more valuable, so I'm deleting what's repeated in the old tests.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none

