### PR TITLE
ct: Respect read timeout in cloud topics

### DIFF
--- a/src/v/cloud_topics/level_zero/frontend_reader/BUILD
+++ b/src/v/cloud_topics/level_zero/frontend_reader/BUILD
@@ -17,6 +17,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics:data_plane_api",
         "//src/v/cloud_topics:log_reader_config",
         "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics:types",
         "//src/v/cloud_topics/level_zero/stm:placeholder",
         "//src/v/cluster",
         "//src/v/config",

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -10,6 +10,7 @@
 #include "cloud_topics/level_zero/frontend_reader/level_zero_reader.h"
 
 #include "cloud_topics/data_plane_api.h"
+#include "cloud_topics/errc.h"
 #include "cloud_topics/level_zero/stm/placeholder.h"
 #include "cloud_topics/logger.h"
 #include "cluster/partition.h"
@@ -343,6 +344,16 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
         auto mat_res = co_await _ct_api->materialize(
           _ctp->ntp(), materialize_bytes, std::move(to_materialize), deadline);
         if (mat_res.has_error()) {
+            if (mat_res.error() == errc::shutting_down) {
+                vlog(_log.debug, "Materialize aborted due to shutdown");
+                _current = state::end_of_stream_state;
+                throw ss::abort_requested_exception();
+            }
+            if (mat_res.error() == errc::timeout) {
+                vlog(_log.debug, "Materialize aborted due to timeout");
+                _current = state::end_of_stream_state;
+                co_return;
+            }
             throw std::runtime_error(
               fmt::format(
                 "Failed to materialize batches from the cloud storage: {}",

--- a/src/v/cloud_topics/level_zero/pipeline/read_request.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/read_request.cc
@@ -33,9 +33,7 @@ read_request<Clock>::read_request(
   , rtc(
       expiration_time,
       std::chrono::milliseconds(100),
-      // NOTE: we're not retrying the downloads. The retries are happening when
-      // the cache element is 'in-progress'.
-      retry_strategy::polling,
+      retry_strategy::backoff,
       root_rtc)
   , rtc_logger(
       cd_log, rtc, ssx::sformat("ct:read_request[{}]", this->ntp.path())) {

--- a/src/v/cloud_topics/level_zero/reader/fetch_request_handler.cc
+++ b/src/v/cloud_topics/level_zero/reader/fetch_request_handler.cc
@@ -125,7 +125,24 @@ ss::future<> fetch_handler::process_single_request(l0::read_request<>* req) {
             co_return;
         }
 
-        auto data = std::move(extent.get());
+        auto res = extent.get();
+        if (res.has_error()) {
+            vlog(
+              req->rtc_logger.warn,
+              "Failed to materialize placeholders, error: {} ({})",
+              res.error(),
+              res.error().message());
+            std::error_code ec = res.error();
+            if (ec.category() == error_category()) {
+                req->set_value(static_cast<errc>(res.error().value()));
+            } else {
+                req->set_value(errc::unexpected_failure);
+            }
+            auto_dispose.cancel();
+            co_return;
+        }
+
+        auto data = std::move(res.value());
         if (data.empty()) {
             vlog(req->rtc_logger.debug, "Empty response");
         }

--- a/src/v/cloud_topics/level_zero/reader/materialized_extent.cc
+++ b/src/v/cloud_topics/level_zero/reader/materialized_extent.cc
@@ -143,10 +143,6 @@ ss::future<result<bool>> materialize(
     // 2. download object from S3
     auto cache_file_name = std::filesystem::path(
       object_path_factory::level_zero_path(ext->meta.id));
-    // TODO: replace this with proper object name
-    // currently this value is used as both cloud storage name
-    // and cache name. This shouldn't necessary be the case in the
-    // future.
 
     std::optional<cloud_io::cache_element_status> status = std::nullopt;
     basic_retry_chain_node<> is_cached_rtc(retry_strategy::backoff, rtc);

--- a/src/v/cloud_topics/level_zero/reader/materialized_extent_reader.cc
+++ b/src/v/cloud_topics/level_zero/reader/materialized_extent_reader.cc
@@ -63,7 +63,8 @@ ss::future<result<chunked_vector<materialized_extent>>> materialize_sorted_run(
 
 } // namespace
 
-ss::future<chunked_vector<model::record_batch>> materialize_placeholders(
+ss::future<result<chunked_vector<model::record_batch>>>
+materialize_placeholders(
   cloud_storage_clients::bucket_name bucket,
   chunked_vector<extent_meta> query,
   cloud_io::remote_api<ss::lowres_clock>& api,
@@ -77,7 +78,7 @@ ss::future<chunked_vector<model::record_batch>> materialize_placeholders(
           logger.warn,
           "Failed to materialize sorted run: {}",
           extents.error().message());
-        throw std::system_error(extents.error());
+        co_return extents.error();
     }
 
     chunked_vector<model::record_batch> results;

--- a/src/v/cloud_topics/level_zero/reader/materialized_extent_reader.h
+++ b/src/v/cloud_topics/level_zero/reader/materialized_extent_reader.h
@@ -32,7 +32,8 @@ namespace cloud_topics::l0 {
 /// \param cache is a cloud storage cache instance
 /// \param rtc is a retry chain node to use
 /// \param rtc_logger is a logger that should track the progress
-ss::future<chunked_vector<model::record_batch>> materialize_placeholders(
+ss::future<result<chunked_vector<model::record_batch>>>
+materialize_placeholders(
   cloud_storage_clients::bucket_name bucket,
   chunked_vector<extent_meta> query,
   cloud_io::remote_api<ss::lowres_clock>& api,

--- a/src/v/cloud_topics/level_zero/reader/tests/fetch_handler_test.cc
+++ b/src/v/cloud_topics/level_zero/reader/tests/fetch_handler_test.cc
@@ -81,3 +81,41 @@ TEST_F_CORO(materialized_extent_fixture, l0_fetch_handler_test) {
     co_await l0_fetch_handler.stop();
     vlog(test_log.debug, "Stopped fetch handler");
 }
+
+TEST_F_CORO(materialized_extent_fixture, l0_fetch_handler_timeout) {
+    const int num_batches = 1;
+    co_await add_random_batches(num_batches);
+    std::queue<injected_failure> failures;
+    failures.push({.cloud_get = injected_cloud_get_failure::return_timeout});
+    produce_placeholders(false, 1, failures);
+
+    auto ntp = model::controller_ntp;
+
+    auto underlying = convert_placeholders(make_underlying());
+
+    cloud_topics::l0::read_pipeline<> pipeline;
+
+    cloud_topics::l0::fetch_handler l0_fetch_handler(
+      pipeline.register_read_pipeline_stage(),
+      cloud_storage_clients::bucket_name("foo"),
+      &remote,
+      &cache);
+
+    vlog(test_log.debug, "Starting L0 fetch handler");
+
+    co_await l0_fetch_handler.start();
+
+    vlog(test_log.debug, "Make reader");
+    auto reader = co_await pipeline.make_reader(
+      ntp,
+      {.output_size_estimate = 1_MiB, .meta = std::move(underlying)},
+      ss::lowres_clock::now() + 1s);
+
+    ASSERT_FALSE_CORO(reader.has_value());
+    ASSERT_TRUE_CORO(reader.error() == cloud_topics::errc::timeout);
+
+    vlog(test_log.debug, "Stopping pipeline");
+    co_await pipeline.stop();
+    co_await l0_fetch_handler.stop();
+    vlog(test_log.debug, "Stopped fetch handler");
+}

--- a/src/v/cloud_topics/level_zero/reader/tests/materialized_extent_reader_test.cc
+++ b/src/v/cloud_topics/level_zero/reader/tests/materialized_extent_reader_test.cc
@@ -9,6 +9,7 @@
  */
 
 #include "base/vlog.h"
+#include "cloud_topics/errc.h"
 #include "cloud_topics/level_zero/reader/materialized_extent_reader.h"
 #include "cloud_topics/level_zero/reader/tests/materialized_extent_fixture.h"
 #include "container/chunked_vector.h"
@@ -55,8 +56,8 @@ TEST_F_CORO(materialized_extent_fixture, full_scan_test) {
       cache,
       rtc,
       logger);
-    ASSERT_EQ_CORO(actual.size(), expected.size());
-    ASSERT_TRUE_CORO(actual == expected);
+    ASSERT_EQ_CORO(actual.value().size(), expected.size());
+    ASSERT_TRUE_CORO(actual.value() == expected);
 }
 
 // Same as 'full_scan_test' but the range can be arbitrary
@@ -105,10 +106,37 @@ ss::future<> test_aggregated_log_partial_scan(
       rtc,
       logger);
 
-    ASSERT_EQ_CORO(actual.size(), expected_view.size());
-    ASSERT_TRUE_CORO(actual == expected_view);
+    ASSERT_EQ_CORO(actual.value().size(), expected_view.size());
+    ASSERT_TRUE_CORO(actual.value() == expected_view);
 }
 
 TEST_F_CORO(materialized_extent_fixture, scan_range) {
     co_await test_aggregated_log_partial_scan(this, 10, 0, 0);
+}
+
+TEST_F_CORO(materialized_extent_fixture, timeout_test) {
+    // The test validates that the error is properly propagated
+    // from the materialize_placeholders function.
+    const int num_batches = 1;
+    co_await add_random_batches(num_batches);
+
+    std::queue<injected_failure> failures;
+    failures.push({.cloud_get = injected_cloud_get_failure::return_timeout});
+    produce_placeholders(false, 1, failures);
+
+    auto underlying = convert_placeholders(make_underlying());
+    ss::abort_source as;
+    retry_chain_node rtc(as, 1s, 100ms);
+    retry_chain_logger logger(test_log, rtc, "materialized_extent_reader_test");
+
+    auto actual = co_await cloud_topics::l0::materialize_placeholders(
+      cloud_storage_clients::bucket_name("test-bucket-name"),
+      std::move(underlying),
+      remote,
+      cache,
+      rtc,
+      logger);
+
+    ASSERT_TRUE_CORO(actual.has_error());
+    ASSERT_TRUE_CORO(actual.error() == cloud_topics::errc::timeout);
 }


### PR DESCRIPTION
Various changes to handle read timeout better.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none