### PR TITLE
[CORE-14239] archival: Don't reset archiver probe until the gate is closed

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -583,7 +583,7 @@ ss::future<> ntp_archiver::upload_until_abort() {
         vlog(_rtclog.warn, "Skipping upload loop start");
         co_return;
     }
-    if (!_probe) {
+    if (!_probe.has_value()) {
         initialize_probe();
     }
 
@@ -682,7 +682,7 @@ ss::future<> ntp_archiver::upload_until_abort() {
                   "anomalies",
                   sync_timeout.count(),
                   _start_term);
-                auto hold = _probe->register_archiver_on_hold(true);
+                auto hold = _probe.value().register_archiver_on_hold(true);
                 co_await ss::sleep_abortable(sync_timeout, _as);
                 continue;
             } else {
@@ -770,7 +770,7 @@ ss::future<> ntp_archiver::sync_manifest_until_abort() {
         vlog(_rtclog.warn, "Skipping read replica sync loop start");
         co_return;
     }
-    if (!_probe) {
+    if (!_probe.has_value()) {
         initialize_probe();
     }
 
@@ -1080,7 +1080,8 @@ ss::future<> ntp_archiver::upload_until_term_change_legacy() {
         bool uploads_paused
           = !config::shard_local_cfg().cloud_storage_enable_segment_uploads();
         std::optional<batch_result> result;
-        auto track_paused = _probe->register_archiver_on_hold(uploads_paused);
+        auto track_paused = _probe.value().register_archiver_on_hold(
+          uploads_paused);
         if (!uploads_paused) {
             result = co_await upload_next_candidates(emit_rw_fence());
         }
@@ -1522,7 +1523,7 @@ ss::future<cloud_storage::upload_result> ntp_archiver::upload_manifest(
 
     // now that manifest() is updated in cloud, updated the
     // compacted_away_cloud_bytes metric
-    _probe->compacted_replaced_bytes(
+    _probe.value().compacted_replaced_bytes(
       _parent.archival_meta_stm()->get_compacted_replaced_bytes());
 
     if (result == cloud_storage::upload_result::success) {
@@ -2046,7 +2047,8 @@ ntp_archiver::schedule_uploads(std::vector<upload_context> loop_contexts) {
 
         // this metric is only relevant for non compacted uploads.
         if (ctx.upload_kind == segment_upload_kind::non_compacted) {
-            _probe->upload_lag(ctx.end_offset_exclusive - ctx.start_offset);
+            _probe.value().upload_lag(
+              ctx.end_offset_exclusive - ctx.start_offset);
         }
 
         std::exception_ptr ep;
@@ -2230,7 +2232,7 @@ ntp_archiver::wait_uploads_complete(
               "{} can be added",
               segment_results.size(),
               num_accepted);
-            _probe->gap_detected(
+            _probe.value().gap_detected(
               model::offset(
                 static_cast<int64_t>(segment_results.size() - num_accepted)));
         }
@@ -2274,8 +2276,8 @@ ntp_archiver::wait_uploads_complete(
         }
 
         if (segment_kind == segment_upload_kind::non_compacted) {
-            _probe->uploaded(*upload.delta);
-            _probe->uploaded_bytes(upload.meta->size_bytes);
+            _probe.value().uploaded(*upload.delta);
+            _probe.value().uploaded_bytes(upload.meta->size_bytes);
 
             model::offset expected_base_offset;
             if (manifest().get_last_offset() < model::offset{0}) {
@@ -2990,7 +2992,7 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
         }
     }
 
-    _probe->segments_deleted(
+    _probe.value().segments_deleted(
       static_cast<int64_t>(
         all_deletes_succeeded ? segments_to_remove_count : 0));
     vlog(
@@ -3426,7 +3428,7 @@ ss::future<> ntp_archiver::garbage_collect() {
           "retry on the next housekeeping run.");
     }
 
-    _probe->segments_deleted(
+    _probe.value().segments_deleted(
       static_cast<int64_t>(all_deletes_succeeded ? to_remove.size() : 0));
     vlog(
       _rtclog.debug,

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -1315,8 +1315,8 @@ ss::future<> ntp_archiver::stop() {
     _flush_cond.broken();
     _wakeup_event.broken();
 
-    _probe.reset();
     co_await _gate.close();
+    _probe.reset();
 }
 
 const model::ntp& ntp_archiver::get_ntp() const { return _ntp; }


### PR DESCRIPTION
In a previous commit [1] we reset the per-ntp probe in archiver::stop. However the probe reset was incorrectly sequenced before gate closure, so there could be background fibers still running and trying to access the probe.

Close the gate first, then reset the probe.

[1]: https://github.com/redpanda-data/redpanda/commit/f305476d44c4270956d9b4ad3b18ea0847532b6e

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [x] v24.3.x

## Release Notes

### Bug Fixes

* Correct a sequencing error in tiered storage archiver teardown that could cause unchecked optional access.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
