### PR TITLE
[CORE-13950] Fix L1 reader gap skipping

### DIFF
--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -103,7 +103,7 @@ level_one_log_reader_impl::do_load_slice(
     }
 }
 
-ss::future<std::optional<level_one_log_reader_impl::current_object>>
+ss::future<std::optional<level_one_log_reader_impl::object_info>>
 level_one_log_reader_impl::lookup_object_for_offset(
   kafka::offset offset, model::timeout_clock::time_point /*deadline*/) {
     if (offset > _config.max_offset) {
@@ -153,7 +153,7 @@ level_one_log_reader_impl::lookup_object_for_offset(
     auto footer = co_await read_footer(
       obj.oid, obj.footer_pos, obj.object_size);
 
-    co_return current_object{
+    co_return object_info{
       .oid = obj.oid,
       .footer = std::move(footer),
       .last_offset = obj.last_offset,
@@ -268,7 +268,7 @@ level_one_log_reader_impl::read_batches(l1::object_reader& reader) {
 
 ss::future<chunked_circular_buffer<model::record_batch>>
 level_one_log_reader_impl::materialize_batches_from_object_offset(
-  const current_object& object,
+  const object_info& object,
   kafka::offset offset,
   model::timeout_clock::time_point /*deadline*/) {
     auto seek_res = object.footer.file_position_before_kafka_offset(

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -60,60 +60,45 @@ ss::future<model::record_batch_reader::storage_t>
 level_one_log_reader_impl::do_load_slice(
   model::timeout_clock::time_point deadline) {
     try {
-        // First switch: ensure batches are materialized or the reader
-        // reaches end-of-stream.
-        switch (_state) {
-        case state::empty: {
-            auto obj = co_await lookup_object_for_offset(
-              _next_offset, deadline);
-            if (obj.has_value()) {
-                _state = state::ready;
-                _current_obj = std::move(obj.value());
-            } else {
-                _state = state::end_of_stream;
-            }
-        }
-            [[fallthrough]];
-        case state::ready:
-            if (_state == state::end_of_stream) {
-                break;
-            }
-            vassert(
-              _current_obj.has_value(),
-              "Expected to have current object in ready state");
-            _batches = co_await materialize_batches_from_object_offset(
-              _current_obj.value(), _next_offset, deadline);
-            _state = state::materialized;
-            [[fallthrough]];
-        case state::materialized:
-        case state::end_of_stream:
-            // Handled in the next switch statement.
-            break;
+        auto object = co_await lookup_object_for_offset(_next_offset, deadline);
+        if (!object.has_value()) {
+            set_end_of_stream();
+            co_return model::record_batch_reader::storage_t{};
         }
 
-        // Second switch: enforces that the reader has materialized batches
-        // or reached end-of-stream.
-        switch (_state) {
-        case state::empty:
-        case state::ready:
-            vassert(
-              false,
-              "Invalid reader state after materialization for {} ({}): got {}",
-              _ntp,
-              _tidp,
-              std::to_underlying(_state));
-        case state::materialized:
-            _state = state::empty;
-            co_return consume_materialized_batches();
-            [[fallthrough]];
-        case state::end_of_stream:
-            co_return chunked_circular_buffer<model::record_batch>{};
+        auto batches = co_await materialize_batches_from_object_offset(
+          object.value(), _next_offset, deadline);
+
+        /*
+         * When EOS is reached this reader is done. So we don't need to worry
+         * about what is in batches. If it's empty, the reader will yield no
+         * batches. Otherwise the batches will be consumed but we don't need to
+         * worry about incrementing the next offset.
+         */
+        if (is_end_of_stream()) {
+            co_return batches;
         }
+
+        // Increment the next offset for the next metastore query.
+        // The offset is always incremented so the reader makes
+        // progress even if the offset range in the object is
+        // smaller than the metastore's metadata about the offset
+        // range covered by the object (because of, e.g. compaction).
+        auto last_offset = batches.empty()
+                             ? object
+                                 .transform([](const auto& obj) {
+                                     return obj.last_offset;
+                                 })
+                                 .value_or(_next_offset)
+                             : model::offset_cast(batches.back().last_offset());
+        _next_offset = kafka::next_offset(last_offset);
+
+        co_return batches;
 
     } catch (...) {
         vlog(
           _log.error, "Reader caught exception: {}", std::current_exception());
-        _state = state::end_of_stream;
+        set_end_of_stream();
         throw;
     }
 }
@@ -121,15 +106,6 @@ level_one_log_reader_impl::do_load_slice(
 ss::future<std::optional<level_one_log_reader_impl::current_object>>
 level_one_log_reader_impl::lookup_object_for_offset(
   kafka::offset offset, model::timeout_clock::time_point /*deadline*/) {
-    vassert(
-      _state == state::empty,
-      "Invalid state for metadata fetch: {}",
-      std::to_underlying(_state));
-
-    vassert(
-      !_current_obj.has_value(),
-      "Empty state should not have a current object");
-
     if (offset > _config.max_offset) {
         vlog(
           _log.debug,
@@ -137,11 +113,6 @@ level_one_log_reader_impl::lookup_object_for_offset(
           "stream",
           offset,
           _config.max_offset);
-        co_return std::nullopt;
-    }
-
-    if (is_over_limit(0)) {
-        vlog(_log.debug, "L1 reader over byte budget: ending stream");
         co_return std::nullopt;
     }
 
@@ -277,15 +248,15 @@ level_one_log_reader_impl::read_batches(l1::object_reader& reader) {
                 break;
             }
 
-            // Check if adding this batch would exceed our byte limit.
-            size_t batch_size = batch.size_bytes();
+            auto batch_size = batch.size_bytes();
             if (is_over_limit(batch_size)) {
+                set_end_of_stream();
                 break;
             }
             _config.bytes_consumed += batch_size;
 
-            // If we make it past all that, emit the batch.
             batches.push_back(std::move(batch));
+
         } else {
             // End of data.
             break;
@@ -300,17 +271,6 @@ level_one_log_reader_impl::materialize_batches_from_object_offset(
   const current_object& object,
   kafka::offset offset,
   model::timeout_clock::time_point /*deadline*/) {
-    // Could be EOS because there are no more objects, but
-    // there should never be materialized batches remaining.
-    vassert(
-      _batches.empty(),
-      "Materialize batches called with batches already materialized");
-
-    vassert(
-      _state == state::ready,
-      "Invalid state to materialize batches: {}",
-      std::to_underlying(_state));
-
     auto seek_res = object.footer.file_position_before_kafka_offset(
       _tidp, offset);
     if (seek_res == l1::footer::npos) {
@@ -367,46 +327,26 @@ level_one_log_reader_impl::materialize_batches_from_object_offset(
 
     co_await close_reader_safe(reader);
 
+    auto batches = read_fut.get();
+
     // Note that it's possible to materialize zero batches.
     vlog(
       _log.debug,
       "Materialized {} batches from L1 object {}",
-      _batches.size(),
+      batches.size(),
       object.oid);
 
-    co_return read_fut.get();
-}
-
-chunked_circular_buffer<model::record_batch>
-level_one_log_reader_impl::consume_materialized_batches() {
-    vlog(_log.debug, "Consuming {} materialized batches", _batches.size());
-
-    auto batches = std::exchange(_batches, {});
-
-    // Increment the next offset for the next metastore query.
-    // The offset is always incremented so the reader makes
-    // progress even if the offset range in the object is
-    // smaller than the metastore's metadata about the offset
-    // range covered by the object (because of, e.g. compaction).
-    auto last_offset = batches.empty()
-                         ? _current_obj
-                             .transform(
-                               [](const auto& obj) { return obj.last_offset; })
-                             .value_or(_next_offset)
-                         : model::offset_cast(batches.back().last_offset());
-    _next_offset = kafka::next_offset(last_offset);
-
-    _current_obj.reset();
-
-    return batches;
+    co_return batches;
 }
 
 void level_one_log_reader_impl::print(std::ostream& o) {
     o << "level_one_cloud_topics_reader";
 }
 
+void level_one_log_reader_impl::set_end_of_stream() { _end_of_stream = true; }
+
 bool level_one_log_reader_impl::is_end_of_stream() const {
-    return _state == state::end_of_stream;
+    return _end_of_stream;
 }
 
 bool level_one_log_reader_impl::is_over_limit(size_t size) const {

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -22,10 +22,10 @@
 
 namespace cloud_topics {
 
-ss::future<> level_one_log_reader_impl::close_reader_safe(
-  std::unique_ptr<l1::object_reader>& reader) {
+ss::future<>
+level_one_log_reader_impl::close_reader_safe(l1::object_reader& reader) {
     try {
-        co_await reader->close();
+        co_await reader.close();
     } catch (const std::exception& e) {
         vlog(
           _log.warn, "Exception while closing L1 object reader: {}", e.what());
@@ -318,11 +318,11 @@ level_one_log_reader_impl::materialize_batches_from_object_offset(
     if (read_fut.failed()) {
         auto ex = read_fut.get_exception();
         vlog(_log.error, "Exception reading L1 object {}: {}", object.oid, ex);
-        co_await close_reader_safe(reader);
+        co_await close_reader_safe(*reader);
         std::rethrow_exception(ex);
     }
 
-    co_await close_reader_safe(reader);
+    co_await close_reader_safe(*reader);
 
     auto batches = read_fut.get();
 

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -79,19 +79,16 @@ level_one_log_reader_impl::do_load_slice(
             co_return batches;
         }
 
-        // Increment the next offset for the next metastore query.
-        // The offset is always incremented so the reader makes
-        // progress even if the offset range in the object is
-        // smaller than the metastore's metadata about the offset
-        // range covered by the object (because of, e.g. compaction).
-        auto last_offset = batches.empty()
-                             ? object
-                                 .transform([](const auto& obj) {
-                                     return obj.last_offset;
-                                 })
-                                 .value_or(_next_offset)
-                             : model::offset_cast(batches.back().last_offset());
-        _next_offset = kafka::next_offset(last_offset);
+        /*
+         * If we didn't read any batches, then start again past the end of the
+         * object. Otherwise start again after the range that was read.
+         */
+        if (batches.empty()) {
+            _next_offset = kafka::next_offset(object.value().last_offset);
+        } else {
+            _next_offset = kafka::next_offset(
+              model::offset_cast(batches.back().last_offset()));
+        }
 
         co_return batches;
 

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -253,7 +253,7 @@ level_one_log_reader_impl::read_batches(l1::object_reader& reader) {
             }
 
             auto batch_size = batch.size_bytes();
-            if (is_over_limit(batch_size)) {
+            if (is_over_limit_with_bytes(batch_size)) {
                 set_end_of_stream();
                 break;
             }
@@ -353,7 +353,7 @@ bool level_one_log_reader_impl::is_end_of_stream() const {
     return _end_of_stream;
 }
 
-bool level_one_log_reader_impl::is_over_limit(size_t size) const {
+bool level_one_log_reader_impl::is_over_limit_with_bytes(size_t size) const {
     return (_config.strict_max_bytes || _config.bytes_consumed > 0)
            && (_config.bytes_consumed + size) > _config.max_bytes;
 }

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -73,6 +73,17 @@ ss::future<model::record_batch_reader::storage_t>
 level_one_log_reader_impl::read_some(
   model::timeout_clock::time_point deadline) {
     while (true) {
+        if (_next_offset > _config.max_offset) {
+            vlog(
+              _log.debug,
+              "L1 reader next_offset {} > max_offset {}: ending "
+              "stream",
+              _next_offset,
+              _config.max_offset);
+            set_end_of_stream();
+            co_return model::record_batch_reader::storage_t{};
+        }
+
         auto object = co_await lookup_object_for_offset(_next_offset, deadline);
         if (!object.has_value()) {
             set_end_of_stream();
@@ -109,16 +120,6 @@ level_one_log_reader_impl::read_some(
 ss::future<std::optional<level_one_log_reader_impl::object_info>>
 level_one_log_reader_impl::lookup_object_for_offset(
   kafka::offset offset, model::timeout_clock::time_point /*deadline*/) {
-    if (offset > _config.max_offset) {
-        vlog(
-          _log.debug,
-          "L1 reader next_offset {} > max_offset {}: ending "
-          "stream",
-          offset,
-          _config.max_offset);
-        co_return std::nullopt;
-    }
-
     ss::abort_source default_abort_source;
     auto* abort_source = _config.abort_source
                            ? &_config.abort_source.value().get()

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -60,6 +60,19 @@ ss::future<model::record_batch_reader::storage_t>
 level_one_log_reader_impl::do_load_slice(
   model::timeout_clock::time_point deadline) {
     try {
+        return read_some(deadline);
+    } catch (...) {
+        vlog(
+          _log.error, "Reader caught exception: {}", std::current_exception());
+        set_end_of_stream();
+        throw;
+    }
+}
+
+ss::future<model::record_batch_reader::storage_t>
+level_one_log_reader_impl::read_some(
+  model::timeout_clock::time_point deadline) {
+    while (true) {
         auto object = co_await lookup_object_for_offset(_next_offset, deadline);
         if (!object.has_value()) {
             set_end_of_stream();
@@ -88,15 +101,8 @@ level_one_log_reader_impl::do_load_slice(
         } else {
             _next_offset = kafka::next_offset(
               model::offset_cast(batches.back().last_offset()));
+            co_return batches;
         }
-
-        co_return batches;
-
-    } catch (...) {
-        vlog(
-          _log.error, "Reader caught exception: {}", std::current_exception());
-        set_end_of_stream();
-        throw;
     }
 }
 

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
@@ -76,8 +76,7 @@ public:
     void print(std::ostream& o) final;
 
 private:
-    // Represents the current L1 object being read.
-    struct current_object {
+    struct object_info {
         l1::object_id oid;
         l1::footer footer;
         kafka::offset last_offset;
@@ -87,7 +86,7 @@ private:
      * Contacts the L1 metastore to retrieve metadata for an L1 object that
      * contains the target offset.
      */
-    ss::future<std::optional<current_object>> lookup_object_for_offset(
+    ss::future<std::optional<object_info>> lookup_object_for_offset(
       kafka::offset, model::timeout_clock::time_point deadline);
 
     /*
@@ -95,7 +94,7 @@ private:
      */
     ss::future<chunked_circular_buffer<model::record_batch>>
     materialize_batches_from_object_offset(
-      const current_object&,
+      const object_info&,
       kafka::offset,
       model::timeout_clock::time_point deadline);
 

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
@@ -76,13 +76,6 @@ public:
     void print(std::ostream& o) final;
 
 private:
-    enum class state {
-        empty,
-        ready,
-        materialized,
-        end_of_stream,
-    };
-
     // Represents the current L1 object being read.
     struct current_object {
         l1::object_id oid;
@@ -115,13 +108,6 @@ private:
     ss::future<chunked_circular_buffer<model::record_batch>>
     read_batches(l1::object_reader& reader);
 
-    /*
-     * Prepare the result set to return to the record batch reader and configure
-     * the reader for the next request to load slice which will be the next
-     * offset that should be fetched.
-     */
-    chunked_circular_buffer<model::record_batch> consume_materialized_batches();
-
     ss::future<l1::footer>
     read_footer(l1::object_id oid, size_t footer_pos, size_t object_size);
 
@@ -129,14 +115,8 @@ private:
 
     ss::future<> close_reader_safe(std::unique_ptr<l1::object_reader>&);
 
-    state _state{state::empty};
-
-    // Current object being processed.
-    // Present in ready and materialized states, empty in empty state.
-    std::optional<current_object> _current_obj;
-
-    // Materialized batches ready to be consumed.
-    chunked_circular_buffer<model::record_batch> _batches;
+    void set_end_of_stream();
+    bool _end_of_stream{false};
 
     cloud_topic_log_reader_config _config;
     model::ntp _ntp;

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
@@ -112,7 +112,7 @@ private:
 
     bool is_over_limit(size_t size) const;
 
-    ss::future<> close_reader_safe(std::unique_ptr<l1::object_reader>&);
+    ss::future<> close_reader_safe(l1::object_reader&);
 
     void set_end_of_stream();
     bool _end_of_stream{false};

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
@@ -117,7 +117,11 @@ private:
     ss::future<model::record_batch_reader::storage_t>
       read_some(model::timeout_clock::time_point);
 
-    bool is_over_limit(size_t size) const;
+    /*
+     * Returns true if accepting the given number of bytes would cause the
+     * reader to exceed its configured bytes limit.
+     */
+    bool is_over_limit_with_bytes(size_t size) const;
 
     ss::future<> close_reader_safe(l1::object_reader&);
 

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
@@ -110,6 +110,13 @@ private:
     ss::future<l1::footer>
     read_footer(l1::object_id oid, size_t footer_pos, size_t object_size);
 
+    /*
+     * Returns batches starting at next offset. It will continue to advance next
+     * offset until batches are read or end-of-stream is reached.
+     */
+    ss::future<model::record_batch_reader::storage_t>
+      read_some(model::timeout_clock::time_point);
+
     bool is_over_limit(size_t size) const;
 
     ss::future<> close_reader_safe(l1::object_reader&);

--- a/src/v/cloud_topics/level_one/frontend_reader/tests/reader_test.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/tests/reader_test.cc
@@ -471,3 +471,108 @@ TEST_F(l1_reader_test, max_bytes_zero_behavior) {
         EXPECT_TRUE(result.empty());
     }
 }
+
+TEST_F(l1_reader_test, read_offset_range_multiple_objects2) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+
+    /*
+     * Populate test with 50 L1 objects. Each batch will contain 10 records.
+     */
+    auto source_batches = model::test::make_random_batches(
+                            model::offset{0}, 50, false, std::nullopt, 10)
+                            .get();
+
+    /*
+     * After the source batches, add a bunch of batches that are
+     * predictably smaller than the ones created above (1 record vs 10 records).
+     * We add a bunch because we need one of these smaller batches to land as
+     * the first batch in an L1 object.
+     */
+    {
+        auto small_batches = model::test::make_random_batches(
+                               source_batches.back().last_offset()
+                                 + model::offset{1},
+                               100,
+                               false,
+                               std::nullopt,
+                               1)
+                               .get();
+        for (auto& batch : small_batches) {
+            source_batches.push_back(std::move(batch));
+        }
+    }
+
+    // Populate all the the l1 objects from the 50 batches
+    for (int i = 0; i < 15; ++i) {
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, slice(source_batches, i * 10, 10));
+        make_l1_objects(tidp_batches);
+    }
+
+    /*
+     * Calculate max_bytes for the reader used in the next phase of the test.
+     * What we want is a value that will be rejected by the speculative size
+     * check in reader::read_batches, but not be rejected by the size check in
+     * reader::fetch_metadata.
+     *
+     * When this condition is encountered the reader will bump the next offset
+     * (read_batches returns 0 batches because byte limit has been exceeded),
+     * but the higher level reader won't observe byte limits exceeded and
+     * transition to end-of-stream state because the speculative byte limit
+     * exceeded doesn't bump consumed bytes (or do anything else that causes the
+     * reader to enter end-of-stream state).
+     *
+     * So the reader will keep going. If it happens to encounter a small enough
+     * batch, one that is small enough be accepted by the speculative limit
+     * check, then the batch will be read and cause the reader to return a batch
+     * that skips offsets / creates a gap to the reader. The only time gaps are
+     * allowed is when there are true gaps, such as those caused by compaction.
+     *
+     * NOTE: the bug that exists further requires that the small batch that ends
+     * up being accepted is the first batch in an L1 object because
+     * reader::read_batches will stop reading from an object as soon as
+     * speculative byte limit is exceeeded, thus the errant acceptance needs to
+     * be the first batch.
+     */
+    size_t max_bytes = 0;
+    {
+        auto batches = model::consume_reader_to_memory(
+                         make_reader(ntp, tidp), model::no_timeout)
+                         .get();
+        ASSERT_EQ(batches.size(), 150);
+
+        auto expected_offset = batches.front().base_offset();
+        for (const auto& batch : batches) {
+            ASSERT_EQ(batch.base_offset(), expected_offset);
+            expected_offset += model::offset(batch.record_count() - 1);
+            ASSERT_EQ(batch.last_offset(), expected_offset);
+            expected_offset += 1;
+        }
+
+        // accumulated size of the first three batches
+        max_bytes += batches[0].size_bytes();
+        max_bytes += batches[1].size_bytes();
+        max_bytes += batches[2].size_bytes();
+
+        // add in enough extra allowance for one of the smaller batches so that
+        // when the reader will accept it speculatively.
+        max_bytes += batches[100].size_bytes() + 1;
+    }
+
+    auto batches
+      = model::consume_reader_to_memory(
+          make_reader(
+            ntp, tidp, kafka::offset{0}, kafka::offset::max(), max_bytes),
+          model::no_timeout)
+          .get();
+
+    EXPECT_EQ(batches.size(), 3);
+
+    auto expected_offset = batches.front().base_offset();
+    for (const auto& batch : batches) {
+        EXPECT_EQ(batch.base_offset(), expected_offset);
+        expected_offset += model::offset(batch.record_count() - 1);
+        EXPECT_EQ(batch.last_offset(), expected_offset);
+        expected_offset += 1;
+    }
+}

--- a/tests/rptest/test_suite_cloud_topics.yml
+++ b/tests/rptest/test_suite_cloud_topics.yml
@@ -1,0 +1,15 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+cloud_topics:
+  included:
+    - tests/cloud_topics/
+    - tests/follower_fetching_test.py
+    - tests/nodes_decommissioning_test.py
+    - tests/random_node_operations_smoke_test.py

--- a/tests/rptest/tests/random_node_operations_smoke_test.py
+++ b/tests/rptest/tests/random_node_operations_smoke_test.py
@@ -286,7 +286,6 @@ class RandomNodeOperationsBase(PreallocNodesTest):
             self.redpanda.set_cluster_config(
                 values={
                     "cloud_topics_enabled": True,
-                    "cloud_topics_disable_reconciliation_loop": True,
                 }
             )
             self.redpanda.restart_nodes(


### PR DESCRIPTION
* Fixes the L1 reader gap skipping issue
* Removes all of the explicit states from the L1 reader. Now the state machine is implicit in the structure of the main reader coroutine.
* Reenables reconciler in RNOT tests
* Adds a test_suite_cloud_topics.yml to quickly run cloud topics enabled tests

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
