### PR TITLE
[v25.2.x] [CORE-14239] archival: Don't reset archiver probe until the gate is closed

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -1153,8 +1153,8 @@ ss::future<> ntp_archiver::stop() {
     _flush_cond.broken();
     _wakeup_event.broken();
 
-    _probe.reset();
     co_await _gate.close();
+    _probe.reset();
 }
 
 const model::ntp& ntp_archiver::get_ntp() const { return _ntp; }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28110 

NOTE: Skipped the second commit due to some code motion. Not part of the bug fix.

Closes #28112 