### PR TITLE
cl/tests: deflake replication tests

### DIFF
--- a/src/v/cluster_link/errc.cc
+++ b/src/v/cluster_link/errc.cc
@@ -66,6 +66,8 @@ struct error_category final : public std::error_category {
             return "topic metadata is stale";
         case errc::license_required:
             return "license required for operation";
+        case errc::service_not_ready:
+            return "shadow linking service is not ready";
         }
 
         return "(unknown error code)";

--- a/src/v/cluster_link/errc.h
+++ b/src/v/cluster_link/errc.h
@@ -41,6 +41,7 @@ enum class errc : int {
     topic_does_not_exist,
     topic_metadata_stale,
     license_required,
+    service_not_ready,
 };
 
 std::error_code make_error_code(errc) noexcept;

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -939,6 +939,10 @@ service::node_local_shadow_topic_report(
         service& s,
         const ::cluster_link::model::id_t& link_id,
         const ::model::topic& topic) {
+          if (!s.container().local_is_initialized()) {
+              return rpc::shadow_topic_report_response{
+                .err_code = errc::service_not_ready};
+          }
           return s.shard_local_topic_report(link_id, topic);
       },
       link_id,
@@ -1080,6 +1084,10 @@ service::node_local_shadow_link_report(
     co_await container().map_reduce(
       reducer,
       [](service& s, const model::id_t& id) {
+          if (!s.container().local_is_initialized()) {
+              return rpc::shadow_link_status_report_response{
+                .err_code = errc::service_not_ready};
+          }
           return s.shard_local_shadow_link_report(id);
       },
       link_id);
@@ -1099,6 +1107,9 @@ service::node_local_shadow_link_report(
 
 rpc::shadow_link_status_report_response
 service::shard_local_shadow_link_report(model::id_t id) {
+    if (auto err = check_manager_state(); err != errc::success) {
+        return rpc::shadow_link_status_report_response{.err_code = err};
+    }
     rpc::shadow_link_status_report_response result;
     result.link_id = id;
 

--- a/src/v/kafka/server/fetch_session.h
+++ b/src/v/kafka/server/fetch_session.h
@@ -39,6 +39,7 @@ struct fetch_session_partition {
       const fetch_request::partition& p)
       : topic_partition(id, tp, p.partition)
       , max_bytes(p.partition_max_bytes)
+      , start_offset(p.log_start_offset)
       , fetch_offset(p.fetch_offset)
       , high_watermark(model::offset(-1))
       , last_stable_offset(model::offset(-1))

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -1752,7 +1752,11 @@ void op_context::response_placeholder::set(
                 session_partitions.move_to_end(it);
                 move_to_end();
             }
-            _it->partition_response->has_to_be_included = has_to_be_included;
+            // The partition fetch may have been retried, in which case preserve
+            // the original inclusion decision
+            _it->partition_response->has_to_be_included
+              = _it->partition_response->has_to_be_included
+                || has_to_be_included;
         }
     }
 }

--- a/src/v/redpanda/admin/services/shadow_link/shadow_link.cc
+++ b/src/v/redpanda/admin/services/shadow_link/shadow_link.cc
@@ -38,6 +38,7 @@ void handle_error(cluster_link::errc err, ss::sstring info) {
     case cluster_link::errc::failed_to_connect_to_remote_cluster:
     case cluster_link::errc::remote_cluster_does_not_support_required_api:
     case cluster_link::errc::link_connection_failed:
+    case cluster_link::errc::service_not_ready:
     case cluster_link::errc::service_shutting_down:
         throw serde::pb::rpc::unavailable_exception(std::move(info));
     case cluster_link::errc::cluster_link_disabled:

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -1145,41 +1145,12 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             err_msg=f"Topic {topic.name} not found in target cluster",
         )
 
-        encountered_errors: list[str] = []
-        running = True
-
-        def poll_shadow_topic_status(shadow_link_name: str, shadow_topic_name: str):
-            while running:
-                try:
-                    shadow_topic = self.get_shadow_topic(
-                        shadow_link_name=shadow_link_name,
-                        shadow_topic_name=shadow_topic_name,
-                    )
-                    assert shadow_topic is not None, "Shadow topic not found"
-                    assert len(shadow_topic.status.partition_information) > 0, (
-                        "No partition information found"
-                    )
-                except Exception as e:
-                    encountered_errors.append(str(e))
-                time.sleep(1)
-
         self.start_producer_consumer(topic=topic.name, msg_size=128, msg_cnt=100000)
-        poll_thread = threading.Thread(
-            target=poll_shadow_topic_status, args=("test-link", topic.name)
-        )
         with (
             self.create_source_failure_injector(),
             self.create_target_failure_injector(),
         ):
-            poll_thread.start()
             self.verify()
-
-        running = False
-        poll_thread.join()
-
-        assert len(encountered_errors) == 0, (
-            f"Encountered errors while polling: {encountered_errors}"
-        )
 
         self.logger.info("Starting cycle looking for shadow topic status")
         wait_until(

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -1072,7 +1072,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
                 lambda: self._get_shadow_topic(
                     shadow_link_name, shadow_topic_name, expected_partitions
                 ),
-                timeout_sec=5,
+                timeout_sec=60,
                 err_msg=f"Shadow topic {shadow_topic_name} not found or does not have expected {expected_partitions} partitions",
             )
         except ducktape.errors.TimeoutError as e:


### PR DESCRIPTION
Recent changes caused some tests to flake, see individual commits.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
