### PR TITLE
crash_tracker: print more context on failure

### DIFF
--- a/src/v/crash_tracker/prepared_writer.cc
+++ b/src/v/crash_tracker/prepared_writer.cc
@@ -111,7 +111,7 @@ crash_description* prepared_writer::fill() {
     return &_prepared_cd;
 }
 
-void prepared_writer::write() {
+bool prepared_writer::write() {
     auto before = state::filled;
     auto success = _state.compare_exchange_strong(before, state::written);
     vassert(
@@ -120,15 +120,7 @@ void prepared_writer::write() {
       "Unexpected state: {}",
       before);
 
-    if (try_write_crash()) {
-        constexpr static std::string_view success
-          = "Recorded crash reason to crash file.\n";
-        ss::print_safe(success.data(), success.size());
-    } else {
-        constexpr static std::string_view failure
-          = "Failed to record crash reason to crash file.\n";
-        ss::print_safe(failure.data(), failure.size());
-    }
+    return try_write_crash();
 }
 
 bool prepared_writer::try_write_crash() {

--- a/src/v/crash_tracker/prepared_writer.h
+++ b/src/v/crash_tracker/prepared_writer.h
@@ -53,7 +53,8 @@ public:
 
     /// Async-signal safe
     /// Must be called after a fill() that returned a non-null value
-    void write();
+    /// Returns true if writing the crash file succeeded
+    [[nodiscard]] bool write();
 
     /// Only to be used under testing situations.  Must be called _after_
     /// release()

--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -204,6 +204,20 @@ void print_skipping() {
     ss::print_safe(skipping.data(), skipping.size());
 }
 
+void print_write_outcome(bool success, std::string_view context) {
+    if (success) {
+        ss::print_safe("Recorded crash reason to crash file");
+
+    } else {
+        ss::print_safe("Failed to record crash reason to crash file");
+    }
+    ss::print_safe(" on shard ");
+    ss::print_decimal_safe(ss::this_shard_id());
+    ss::print_safe(" (");
+    ss::print_safe(context.data(), context.size());
+    ss::print_safe(")\n");
+}
+
 void record_message(crash_description& cd, std::string_view msg) {
     auto& format_buf = cd.crash_message;
     fmt::format_to_n(
@@ -228,25 +242,30 @@ void recorder::record_crash_sighandler(recorded_signo signo) {
 
     record_backtrace(cd);
 
+    auto print_ctx = std::string_view{"[unknown]"};
     switch (signo) {
     case recorded_signo::sigsegv: {
+        print_ctx = "SIGSEGV";
         cd.type = crash_type::segfault;
         record_message(cd, "Segmentation fault");
         break;
     }
     case recorded_signo::sigabrt: {
+        print_ctx = "SIGABRT";
         cd.type = crash_type::abort;
         record_message(cd, "Aborting");
         break;
     }
     case recorded_signo::sigill: {
+        print_ctx = "SIGILL";
         cd.type = crash_type::illegal_instruction;
         record_message(cd, "Illegal instruction");
         break;
     }
     }
 
-    _writer.write();
+    auto success = _writer.write();
+    print_write_outcome(success, print_ctx);
 }
 
 void recorder::record_crash_exception(std::exception_ptr eptr) {
@@ -282,7 +301,8 @@ void recorder::record_crash_exception(std::exception_ptr eptr) {
       "Failure during startup: {}",
       eptr);
 
-    _writer.write();
+    auto success = _writer.write();
+    print_write_outcome(success, "startup exception");
 }
 
 void recorder::record_crash_vassert(std::string_view msg) {
@@ -298,7 +318,8 @@ void recorder::record_crash_vassert(std::string_view msg) {
     cd.type = crash_type::assertion;
     record_message(cd, msg);
 
-    _writer.write();
+    auto success = _writer.write();
+    print_write_outcome(success, "vassert");
 }
 
 std::optional<recorder::oom_recorder> recorder::begin_oom_recording() {
@@ -322,7 +343,8 @@ std::optional<recorder::oom_recorder> recorder::begin_oom_recording() {
 void recorder::finish_oom_recording() {
     vassert(_oom_writer.has_value(), "No OOM recording in progress");
     _oom_writer.reset();
-    _writer.write();
+    auto success = _writer.write();
+    print_write_outcome(success, "OOM");
 }
 
 ss::future<bool> recorder::recorded_crash::is_uploaded() const {

--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -198,10 +198,16 @@ void record_backtrace(crash_description& cd) {
     });
 }
 
-void print_skipping() {
-    constexpr static std::string_view skipping
-      = "Skipping recording crash reason to crash file.\n";
-    ss::print_safe(skipping.data(), skipping.size());
+void print_skipping(std::string_view context) {
+    ss::print_safe("Skipping recording crash reason to crash file on shard ");
+    ss::print_decimal_safe(ss::this_shard_id());
+    ss::print_safe(" (");
+    ss::print_safe(context.data(), context.size());
+    ss::print_safe(")\n");
+}
+
+void print_skipping_already_consumed() {
+    print_skipping("the writer has already been consumed by another crash");
 }
 
 void print_write_outcome(bool success, std::string_view context) {
@@ -234,8 +240,7 @@ void record_message(crash_description& cd, std::string_view msg) {
 void recorder::record_crash_sighandler(recorded_signo signo) {
     auto* cd_opt = _writer.fill();
     if (!cd_opt) {
-        // The writer has already been consumed by another crash
-        print_skipping();
+        print_skipping_already_consumed();
         return;
     }
     auto& cd = *cd_opt;
@@ -279,14 +284,13 @@ void recorder::record_crash_exception(std::exception_ptr eptr) {
     if (!_writer.initialized()) {
         // We are unable to record any exceptions that happen before the writer
         // has been initialized
-        print_skipping();
+        print_skipping("the writer is not yet initialized");
         return;
     }
 
     auto* cd_opt = _writer.fill();
     if (!cd_opt) {
-        // The writer has already been consumed by another crash
-        print_skipping();
+        print_skipping_already_consumed();
         return;
     }
     auto& cd = *cd_opt;
@@ -308,8 +312,7 @@ void recorder::record_crash_exception(std::exception_ptr eptr) {
 void recorder::record_crash_vassert(std::string_view msg) {
     auto* cd_opt = _writer.fill();
     if (!cd_opt) {
-        // The writer has already been consumed by another crash
-        print_skipping();
+        print_skipping_already_consumed();
         return;
     }
     auto& cd = *cd_opt;

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -279,6 +279,7 @@ FAILURE_INJECTION_LOG_ALLOW_LIST = [
     ),
     re.compile("assert - Backtrace:"),
     re.compile("finject - .* flush called concurrently with other operations"),
+    re.compile("crash reason to crash file.*(vassert)"),
 ]
 
 # Log errors that are acceptable for tests that hit the OIDC endpoint but don't
@@ -4113,7 +4114,7 @@ class RedpandaService(Service, RedpandaServiceABC):
 
             crash_log = None
             for line in node.account.ssh_capture(
-                f"grep -e SEGV -e Segmentation\\ fault -e [Aa]ssert -e Sanitizer -e 'Aborting on shard' {RedpandaService.STDOUT_STDERR_CAPTURE} || true",
+                f"grep -e SEGV -e Segmentation\\ fault -e [Aa]ssert -e Sanitizer -e 'Aborting on shard' -e 'crash reason to crash file' {RedpandaService.STDOUT_STDERR_CAPTURE} || true",
                 timeout_sec=30,
             ):
                 if "SEGV" in line and any(

--- a/tests/rptest/tests/cluster_bootstrap_test.py
+++ b/tests/rptest/tests/cluster_bootstrap_test.py
@@ -18,6 +18,7 @@ from rptest.clients.rpk import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import RpkTool
 from rptest.services.redpanda_installer import RedpandaInstaller
+from rptest.services.utils import NodeCrash
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import expect_exception
 
@@ -61,8 +62,12 @@ class ClusterBootstrapNew(RedpandaTest):
         try:
             self.redpanda.start(omit_seeds_on_idx_one=True)
             assert False, "Should have been unable to start"
-        except ducktape.errors.TimeoutError:
-            # The cluster should be unable to start.
+        except NodeCrash as e:
+            # The cluster should be unable to start, and node 0 should shut down during startup
+            assert len(e.crashes) == 1, f"Unexpected crashes: {e.crashes}"
+            assert e.crashes[0][0] == self.redpanda.nodes[0], (
+                f"Unexpected crashes: {e.crashes}"
+            )
             pass
 
         for node in self.redpanda.nodes:

--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -20,6 +20,7 @@ from rptest.tests.redpanda_test import RedpandaTest
 CRASH_LOOP_LOG = [
     "Crash loop detected. Too many consecutive crashes.*",
     ".*Failure during startup: crash_tracker::crash_loop_limit_reached \(Crash loop detected, aborting startup.\).*",
+    ".*crash reason to crash file.*",
 ]
 
 SIGNAL_CRASH_LOG = [


### PR DESCRIPTION
Add more context into crash recording messages:
* [crash_tracker: record context of crash tracker write](https://github.com/redpanda-data/redpanda/commit/bbd13462a6a76b22b95a579349f8633d0e63a422)
* [crash_tracker: record context of write skipping](https://github.com/redpanda-data/redpanda/commit/aee8be1d90b1254da42ccb04b4030f0655b688c2)

Example:
```
Recorded crash reason to crash file on shard 0 (SIGILL)
```

Also detect the crash recording message as a `NodeCrash`-type failure in ducktape.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
