### PR TITLE
iceberg: make timestamp types timezone aware

### DIFF
--- a/src/v/datalake/record_translator.cc
+++ b/src/v/datalake/record_translator.cc
@@ -86,7 +86,7 @@ std::unique_ptr<iceberg::struct_value> build_rp_struct(
     system_data->fields.emplace_back(iceberg::long_value(o));
     // NOTE: Kafka uses milliseconds, Iceberg uses microseconds.
     system_data->fields.emplace_back(
-      iceberg::timestamp_value(ts.value() * 1000));
+      iceberg::timestamptz_value(ts.value() * 1000));
 
     if (headers.empty()) {
         system_data->fields.emplace_back(std::nullopt);

--- a/src/v/datalake/table_definition.cc
+++ b/src/v/datalake/table_definition.cc
@@ -20,7 +20,7 @@ struct_type schemaless_struct_type() {
       nested_field::create(3, "offset", field_required::yes, long_type{}));
     system_fields.fields.emplace_back(
       nested_field::create(
-        4, "timestamp", field_required::yes, timestamp_type{}));
+        4, "timestamp", field_required::yes, timestamptz_type{}));
 
     struct_type headers_kv;
     headers_kv.fields.emplace_back(

--- a/src/v/iceberg/conversion/schema_avro.cc
+++ b/src/v/iceberg/conversion/schema_avro.cc
@@ -127,7 +127,7 @@ inner_field_type_from_avro(const avro::NodePtr& node, state& state) {
         if (
           lt == avro::LogicalType::TIMESTAMP_MILLIS
           || lt == avro::LogicalType::TIMESTAMP_MICROS) {
-            return iceberg::timestamp_type{};
+            return iceberg::timestamptz_type{};
         }
         return iceberg::long_type{};
     }

--- a/src/v/iceberg/conversion/schema_protobuf.cc
+++ b/src/v/iceberg/conversion/schema_protobuf.cc
@@ -157,7 +157,7 @@ field_outcome from_protobuf(
         // special case for handling google.protobuf.Timestamp
         if (
           msg_t->well_known_type() == pb::Descriptor::WELLKNOWNTYPE_TIMESTAMP) {
-            return success(fd, iceberg::timestamp_type{});
+            return success(fd, iceberg::timestamptz_type{});
         }
         // special case for handling google.protobuf.Struct, Value, and
         // ListValue - all serialize as JSON strings

--- a/src/v/iceberg/conversion/tests/iceberg_avro_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_avro_tests.cc
@@ -478,9 +478,9 @@ TEST(AvroSchema, TestLogicalTypes) {
     EXPECT_TRUE(field_matches(
       struct_t.fields[5], "long_time_micro", iceberg::time_type{}));
     EXPECT_TRUE(field_matches(
-      struct_t.fields[6], "long_ts_ms", iceberg::timestamp_type{}));
+      struct_t.fields[6], "long_ts_ms", iceberg::timestamptz_type{}));
     EXPECT_TRUE(field_matches(
-      struct_t.fields[7], "long_ts_micro", iceberg::timestamp_type{}));
+      struct_t.fields[7], "long_ts_micro", iceberg::timestamptz_type{}));
     // Duration logical type is not intrepreted in as a separate iceberg type
     EXPECT_TRUE(field_matches(
       struct_t.fields[8], "duration_fixed", iceberg::fixed_type{12}));
@@ -922,22 +922,22 @@ AssertionResult value_matches(
               });
         }
         if (datum.logicalType().type() == avro::LogicalType::TIMESTAMP_MILLIS) {
-            return primitive_equal<iceberg::timestamp_value>(
+            return primitive_equal<iceberg::timestamptz_value>(
               datum,
               value,
               [](
-                const iceberg::timestamp_value& current,
+                const iceberg::timestamptz_value& current,
                 const avro::GenericDatum& expected) {
                   ASSERT_VALUES_EQUAL(
                     current.val / 1000, expected.value<int64_t>());
               });
         }
         if (datum.logicalType().type() == avro::LogicalType::TIMESTAMP_MICROS) {
-            return primitive_equal<iceberg::timestamp_value>(
+            return primitive_equal<iceberg::timestamptz_value>(
               datum,
               value,
               [](
-                const iceberg::timestamp_value& current,
+                const iceberg::timestamptz_value& current,
                 const avro::GenericDatum& expected) {
                   ASSERT_VALUES_EQUAL(current.val, expected.value<int64_t>());
               });

--- a/src/v/iceberg/conversion/tests/iceberg_protobuf_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_protobuf_tests.cc
@@ -189,7 +189,7 @@ TEST_CORO(SchemaProtobuf, TestMessageWithTimestamp) {
     ASSERT_FALSE_CORO(result.has_error());
     auto field = std::move(result.value());
     EXPECT_THAT(
-      field.fields, ElementsAre(IsField(1, "timestamp", timestamp_type{})));
+      field.fields, ElementsAre(IsField(1, "timestamp", timestamptz_type{})));
 }
 
 TEST_CORO(SchemaProtobuf, TestMessageWithStruct) {
@@ -589,7 +589,8 @@ TEST(values_protobuf, TestTimestamp) {
 
     ASSERT_THAT(
       struct_v->fields,
-      ElementsAre(OptionalIcebergPrimitive<timestamp_value>(1743540027001635)));
+      ElementsAre(
+        OptionalIcebergPrimitive<timestamptz_value>(1743540027001635)));
 }
 
 TEST(values_protobuf, TestStruct) {

--- a/src/v/iceberg/conversion/values_avro.cc
+++ b/src/v/iceberg/conversion/values_avro.cc
@@ -69,11 +69,11 @@ struct primitive_visitor {
         if (node->logicalType().type() == avro::LogicalType::TIMESTAMP_MILLIS) {
             // times 1000 to convert from milliseconds to microseconds that
             // iceberg requires
-            return convert_primitive<int64_t, iceberg::timestamp_value>(
+            return convert_primitive<int64_t, iceberg::timestamptz_value>(
               v * 1000, avro::AVRO_LONG, node);
         }
         if (node->logicalType().type() == avro::LogicalType::TIMESTAMP_MICROS) {
-            return convert_primitive<int64_t, iceberg::timestamp_value>(
+            return convert_primitive<int64_t, iceberg::timestamptz_value>(
               v, avro::AVRO_LONG, node);
         }
         return convert_primitive<int64_t, iceberg::long_value>(

--- a/src/v/iceberg/conversion/values_protobuf.cc
+++ b/src/v/iceberg/conversion/values_protobuf.cc
@@ -241,7 +241,7 @@ convert_timestamp(std::unique_ptr<parsed::message> message) {
     if (it != message->fields.end()) {
         ts += absl::Nanoseconds(std::get<int32_t>(std::move(it->second)));
     }
-    co_return value_outcome{iceberg::timestamp_value{absl::ToUnixMicros(ts)}};
+    co_return value_outcome{iceberg::timestamptz_value{absl::ToUnixMicros(ts)}};
 }
 
 // Forward declaration for recursive calls

--- a/tests/rptest/tests/datalake/custom_partitioning_test.py
+++ b/tests/rptest/tests/datalake/custom_partitioning_test.py
@@ -674,7 +674,7 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
             expected_partitioning = [
                 ("# Partition Information", "", ""),
                 ("# col_name", "data_type", "comment"),
-                ("timestamp_us", "timestamp_ntz", None),
+                ("timestamp_us", "timestamp", None),
             ]
 
             assert describe_partitioning == expected_partitioning, (

--- a/tests/rptest/tests/datalake/databricks_test.py
+++ b/tests/rptest/tests/datalake/databricks_test.py
@@ -144,7 +144,7 @@ class DatabricksTest(RedpandaTest):
                 Row(col_name="# col_name", data_type="data_type", comment="comment"),
                 Row(
                     col_name="redpanda.timestamp",
-                    data_type="timestamp_ntz",
+                    data_type="timestamp",
                     comment=None,
                 ),
             ]
@@ -187,7 +187,7 @@ class DatabricksTest(RedpandaTest):
                     ),
                     Row(
                         col_name="redpanda.timestamp",
-                        data_type="timestamp_ntz",
+                        data_type="timestamp",
                         comment=None,
                     ),
                 ],
@@ -215,7 +215,7 @@ class DatabricksTest(RedpandaTest):
                     ),
                     Row(
                         col_name="redpanda.timestamp",
-                        data_type="timestamp_ntz",
+                        data_type="timestamp",
                         comment=None,
                     ),
                 ],

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -48,14 +48,14 @@ FieldTuple = tuple[str | None, ...]
 
 TRINO_RP_FIELD_TYPE: FieldTuple = (
     "redpanda",
-    "row(partition integer, offset bigint, timestamp timestamp(6), headers array(row(key varchar, value varbinary)), key varbinary, timestamp_type integer)",
+    "row(partition integer, offset bigint, timestamp timestamp(6) with time zone, headers array(row(key varchar, value varbinary)), key varbinary, timestamp_type integer)",
     "",
     "",
 )
 
 SPARK_RP_FIELD_TYPE: FieldTuple = (
     "redpanda",
-    "struct<partition:int,offset:bigint,timestamp:timestamp_ntz,headers:array<struct<key:string,value:binary>>,key:binary,timestamp_type:int>",
+    "struct<partition:int,offset:bigint,timestamp:timestamp,headers:array<struct<key:string,value:binary>>,key:binary,timestamp_type:int>",
     None,
 )
 

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -173,11 +173,11 @@ AVRO_SCHEMA_TEST_CASES = {
         record_generator=lambda t: {"number": int(t), "timestamp_us": int(t * 1000000)},
         expected_trino=[
             ("number", "bigint", "", ""),
-            ("timestamp_us", "timestamp(6)", "", ""),
+            ("timestamp_us", "timestamp(6) with time zone", "", ""),
         ],
         expected_spark=[
             ("number", "bigint", None),
-            ("timestamp_us", "timestamp_ntz", None),
+            ("timestamp_us", "timestamp", None),
             ("", "", ""),
             ("# Partitioning", "", ""),
             ("Part 0", "hours(redpanda.timestamp)", ""),
@@ -192,12 +192,12 @@ AVRO_SCHEMA_TEST_CASES = {
         },
         expected_trino=[
             ("number", "bigint", "", ""),
-            ("timestamp_us", "timestamp(6)", "", ""),
+            ("timestamp_us", "timestamp(6) with time zone", "", ""),
             ("suit", "bigint", "", ""),
         ],
         expected_spark=[
             ("number", "bigint", None),
-            ("timestamp_us", "timestamp_ntz", None),
+            ("timestamp_us", "timestamp", None),
             ("suit", "bigint", None),
             ("", "", ""),
             ("# Partitioning", "", ""),
@@ -213,12 +213,12 @@ AVRO_SCHEMA_TEST_CASES = {
         },
         expected_trino=[
             ("number", "bigint", "", ""),
-            ("timestamp_us", "timestamp(6)", "", ""),
+            ("timestamp_us", "timestamp(6) with time zone", "", ""),
             ("arr", "array(bigint)", "", ""),
         ],
         expected_spark=[
             ("number", "bigint", None),
-            ("timestamp_us", "timestamp_ntz", None),
+            ("timestamp_us", "timestamp", None),
             ("arr", "array<bigint>", None),
             ("", "", ""),
             ("# Partitioning", "", ""),
@@ -234,12 +234,12 @@ AVRO_SCHEMA_TEST_CASES = {
         },
         expected_trino=[
             ("number", "bigint", "", ""),
-            ("timestamp_us", "timestamp(6)", "", ""),
+            ("timestamp_us", "timestamp(6) with time zone", "", ""),
             ("kv", "map(varchar, bigint)", "", ""),
         ],
         expected_spark=[
             ("number", "bigint", None),
-            ("timestamp_us", "timestamp_ntz", None),
+            ("timestamp_us", "timestamp", None),
             ("kv", "map<string,bigint>", None),
             ("", "", ""),
             ("# Partitioning", "", ""),
@@ -255,12 +255,12 @@ AVRO_SCHEMA_TEST_CASES = {
         },
         expected_trino=[
             ("number", "bigint", "", ""),
-            ("timestamp_us", "timestamp(6)", "", ""),
+            ("timestamp_us", "timestamp(6) with time zone", "", ""),
             ("str_or_long", "row(string varchar, long bigint)", "", ""),
         ],
         expected_spark=[
             ("number", "bigint", None),
-            ("timestamp_us", "timestamp_ntz", None),
+            ("timestamp_us", "timestamp", None),
             ("str_or_long", "struct<string:string,long:bigint>", None),
             ("", "", ""),
             ("# Partitioning", "", ""),
@@ -276,12 +276,12 @@ AVRO_SCHEMA_TEST_CASES = {
         },
         expected_trino=[
             ("number", "bigint", "", ""),
-            ("timestamp_us", "timestamp(6)", "", ""),
+            ("timestamp_us", "timestamp(6) with time zone", "", ""),
             ("optional_long", "bigint", "", ""),
         ],
         expected_spark=[
             ("number", "bigint", None),
-            ("timestamp_us", "timestamp_ntz", None),
+            ("timestamp_us", "timestamp", None),
             ("optional_long", "bigint", None),
             ("", "", ""),
             ("# Partitioning", "", ""),


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


### Improvements

* BREAKING CHANGE: Iceberg: Make timestamp types timezone aware where relevant.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
