### PR TITLE
Iceberg: Type names for Avro union structs

### DIFF
--- a/src/v/iceberg/conversion/BUILD
+++ b/src/v/iceberg/conversion/BUILD
@@ -39,7 +39,9 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/iceberg:datatypes",
+        "//src/v/ssx:sformat",
         "@avro",
+        "@seastar",
     ],
 )
 

--- a/src/v/iceberg/conversion/avro_utils.cc
+++ b/src/v/iceberg/conversion/avro_utils.cc
@@ -10,6 +10,10 @@
 
 #include "iceberg/conversion/avro_utils.h"
 
+#include "ssx/sformat.h"
+
+#include <seastar/util/variant_utils.hh>
+
 #include <avro/Schema.hh>
 
 namespace iceberg {
@@ -31,5 +35,62 @@ std::optional<avro::NodePtr> maybe_flatten_union(const avro::NodePtr& node) {
     }
 
     return std::nullopt;
+}
+
+struct branch_label_primitive_type_visitor {
+    explicit branch_label_primitive_type_visitor(const avro::NodePtr& branch)
+      : branch(branch) {}
+
+    ss::sstring operator()(const iceberg::fixed_type&) {
+        return branch->name().simpleName();
+    }
+
+    ss::sstring operator()(const iceberg::long_type&) {
+        if (branch->type() == avro::AVRO_ENUM) {
+            return branch->name().simpleName();
+        }
+        return ssx::sformat("{}", branch->type());
+    }
+
+    ss::sstring operator()(const iceberg::decimal_type&) {
+        if (branch->type() == avro::AVRO_FIXED) {
+            return branch->name().simpleName();
+        }
+        return ssx::sformat("{}", branch->type());
+    }
+
+    ss::sstring operator()(const auto&) {
+        return ssx::sformat("{}", branch->type());
+    }
+
+    const avro::NodePtr& branch;
+};
+
+struct branch_label_visitor {
+    explicit branch_label_visitor(const avro::NodePtr& branch)
+      : branch(branch) {}
+
+    ss::sstring operator()(const iceberg::primitive_type& pt) {
+        return ss::visit(pt, branch_label_primitive_type_visitor{branch});
+    }
+
+    ss::sstring operator()(const iceberg::struct_type&) {
+        return branch->name().simpleName();
+    }
+
+    ss::sstring operator()(const iceberg::list_type&) {
+        return ss::sstring{"array"};
+    }
+
+    ss::sstring operator()(const iceberg::map_type&) {
+        return ss::sstring{"map"};
+    }
+
+    const avro::NodePtr& branch;
+};
+
+ss::sstring union_branch_label(
+  const avro::NodePtr& branch, const iceberg::field_type& branch_type) {
+    return ss::visit(branch_type, branch_label_visitor{branch});
 }
 } // namespace iceberg

--- a/src/v/iceberg/conversion/avro_utils.h
+++ b/src/v/iceberg/conversion/avro_utils.h
@@ -29,4 +29,23 @@ namespace iceberg {
  * optional".
  */
 std::optional<avro::NodePtr> maybe_flatten_union(const avro::NodePtr&);
+
+/**
+ * Take an Avro node and the corresponding Iceberg field type and produce a
+ * label based on the JSON encoding for unions laid out in the Avro spec.
+ *
+ * See https://avro.apache.org/docs/1.12.0/specification/#json-encoding
+ *
+ * Treatment of logical types is somewhat subtle. Since the mapping from logical
+ * types to Avro base types to iceberg field types is not 1:1, propagating
+ * logical type names into union branch struct fields can introduce ambiguity.
+ * Additionally, named types may collide w/ logical type names (i.e. there is no
+ * rule against it). To avoid dealing with collisions, we map branches w/
+ * logical type info to struct fields w/ the base type name.
+ *
+ * For example a {"type": "int", "logicalType": "time-millis"} maps to 'int'
+ * rather than 'time'.
+ */
+ss::sstring union_branch_label(
+  const avro::NodePtr& branch, const iceberg::field_type& branch_type);
 } // namespace iceberg

--- a/src/v/iceberg/conversion/schema_avro.cc
+++ b/src/v/iceberg/conversion/schema_avro.cc
@@ -221,9 +221,10 @@ inner_field_type_from_avro(const avro::NodePtr& node, state& state) {
                 ret.fields.push_back(
                   iceberg::nested_field::create(
                     placeholder_field_id,
-                    // union struct fields name are represented as
-                    // <union_name>_<leaf_idx>
-                    fmt::format("union_opt_{}", i),
+                    // union struct branch names are represented as in Avro JSON
+                    // encoding. See spec for detail:
+                    // https://avro.apache.org/docs/1.12.0/specification/#json-encoding
+                    union_branch_label(leaf, field.value()),
                     // union struct fields are not required
                     iceberg::field_required::no,
                     std::move(field.value())));

--- a/src/v/iceberg/conversion/schema_avro.h
+++ b/src/v/iceberg/conversion/schema_avro.h
@@ -26,8 +26,9 @@ namespace iceberg {
  *  - do not support recursive types
  *
  *  - avro unions are 'flattened' as a structure with optional fields out of
- *    which only one or none are present (i case ther is a field with null type)
- *    - excepting unions of the form ["null", <some_type>] or [<some_type>,
+ *    which only one or none is present (in case there is a field with null
+ *    type)
+ *    - except unions of the form ["null", <some_type>] or [<some_type>,
  *      "null"] which are treated as a bare, optional field of <some_type>.
  *
  *  - all fields are required by default (avro always sets a default in binary

--- a/src/v/iceberg/conversion/tests/iceberg_avro_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_avro_tests.cc
@@ -1269,3 +1269,163 @@ INSTANTIATE_TEST_SUITE_P(
       .schema = R"J({"type": "long"})J",
       .expected = std::nullopt,
     }));
+
+struct branch_label_test_case {
+    std::string_view schema;
+    std::vector<std::string_view> labels;
+};
+
+struct BranchLabelTest : ::testing::TestWithParam<branch_label_test_case> {};
+
+namespace {
+MATCHER_P(AvroTypeIs, type, fmt::format("avro type is {}", type)) {
+    return arg != nullptr && arg->type() == type;
+}
+} // namespace
+
+TEST_P(BranchLabelTest, UnionBranchLabelsTest) {
+    auto [schema, expected] = GetParam();
+
+    auto root = load_json_schema(schema);
+    ASSERT_THAT(root, AvroTypeIs(avro::AVRO_UNION));
+    ASSERT_THAT(expected, SizeIs(root->leaves()));
+
+    auto s_type = iceberg::type_to_iceberg(root);
+    ASSERT_TRUE(s_type.has_value());
+    ASSERT_THAT(s_type.value().fields, SizeIs(1));
+
+    ASSERT_TRUE(
+      std::holds_alternative<iceberg::struct_type>(
+        s_type.value().fields[0]->type));
+
+    const auto& u_type = std::get<iceberg::struct_type>(
+      s_type.value().fields[0]->type);
+
+    ASSERT_EQ(u_type.fields.size(), root->leaves());
+
+    for (auto i : std::views::iota(0UL, root->leaves())) {
+        auto label = iceberg::union_branch_label(
+          root->leafAt(i), u_type.fields[i]->type);
+        ASSERT_THAT(label, Eq(expected[i]));
+    }
+}
+
+using btc = branch_label_test_case;
+INSTANTIATE_TEST_SUITE_P(
+  UnionBranchLabelsTest,
+  BranchLabelTest,
+  Values(
+    btc{
+      .schema = R"J([ "long", "int" ])J",
+      .labels = {"long", "int"},
+    },
+    btc{
+      .schema = R"J([ "long", {"type": "map", "values": "int" } ])J",
+      .labels = {"long", "map"},
+    },
+    btc{
+      .schema = R"J([ "long", {"type": "array", "items": "int" } ])J",
+      .labels = {"long", "array"},
+    },
+    btc{
+      .schema
+      = R"J([ {"type": "record", "name": "Struct", "fields": [{"name": "a", "type": "int"}]}, "long" ])J",
+      .labels = {"Struct", "long"},
+    },
+    btc{
+      .schema
+      = R"J([ {"type": "enum", "name": "Enum", "symbols": ["FOO", "BAR"]}, "long" ])J",
+      .labels = {"Enum", "long"},
+    },
+    btc{
+      .schema
+      = R"J([ {"type": "fixed", "name": "Hash", "size": 16}, "long" ])J",
+      .labels = {"Hash", "long"},
+    },
+    btc{
+      .schema = R"J([ {"type": "string", "logicalType": "uuid"}, "long" ])J",
+      .labels = {"string", "long"},
+    },
+    btc{
+      .schema
+      = R"J([ {"type": "bytes", "logicalType": "decimal", "precision": 10, "scale": 2}, "long" ])J",
+      .labels = {"bytes", "long"},
+    },
+    btc{
+      .schema = R"J([ {"type": "int", "logicalType": "date"}, "long" ])J",
+      .labels = {"int", "long"},
+    },
+    btc{
+      .schema
+      = R"J([ {"type": "int", "logicalType": "time-millis"}, "long" ])J",
+      .labels = {"int", "long"},
+    },
+    btc{
+      .schema
+      = R"J([ {"type": "long", "logicalType": "time-micros"}, "string" ])J",
+      .labels = {"long", "string"},
+    },
+    btc{
+      .schema
+      = R"J([ {"type": "long", "logicalType": "timestamp-millis"}, "string" ])J",
+      .labels = {"long", "string"},
+    },
+    btc{
+      .schema
+      = R"J([ {"type": "long", "logicalType": "timestamp-micros"}, "string" ])J",
+      .labels = {"long", "string"},
+    },
+    btc{
+      .schema
+      = R"J([ {"type": "fixed", "name": "FixedDecimal", "size": 16, "logicalType": "decimal", "precision": 10, "scale": 2}, "long" ])J",
+      .labels = {"FixedDecimal", "long"},
+    }));
+
+TEST(AvroSchema, TestSymbolicUnionBranch) {
+    std::string_view schema = R"J(
+{
+    "type": "record",
+    "name": "Root",
+    "fields": [
+        {
+            "name": "rec",
+            "type": {
+                "type": "record",
+                "name": "Record",
+                "fields": [ {"name": "f1", "type": "int"} ]
+            }
+        },
+        {
+            "name": "union",
+            "type": [ "Record", "long"]
+        }
+    ]
+})J";
+
+    auto root = load_json_schema(schema);
+    ASSERT_THAT(root, AvroTypeIs(avro::AVRO_RECORD));
+    ASSERT_EQ(root->leaves(), 2);
+    ASSERT_THAT(root->leafAt(1), AvroTypeIs(avro::AVRO_UNION));
+
+    auto type = iceberg::type_to_iceberg(root);
+    ASSERT_TRUE(type.has_value());
+    ASSERT_THAT(type.value().fields, SizeIs(2));
+
+    ASSERT_TRUE(
+      std::holds_alternative<iceberg::struct_type>(
+        type.value().fields[1]->type));
+
+    const auto& u_type = std::get<iceberg::struct_type>(
+      type.value().fields[1]->type);
+    ASSERT_THAT(u_type.fields, SizeIs(2));
+    const auto& u_node = root->leafAt(1);
+    ASSERT_EQ(u_node->leaves(), 2);
+
+    auto expected = std::array{"Record", "long"};
+    ASSERT_THAT(
+      iceberg::union_branch_label(u_node->leafAt(0), u_type.fields[0]->type),
+      Eq(expected.at(0)));
+    ASSERT_THAT(
+      iceberg::union_branch_label(u_node->leafAt(1), u_type.fields[1]->type),
+      Eq(expected.at(1)));
+}

--- a/src/v/iceberg/conversion/tests/iceberg_avro_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_avro_tests.cc
@@ -92,13 +92,13 @@ TEST(AvroSchema, TestNonRecordSchema) {
     iceberg::struct_type union_st;
     union_st.fields.push_back(
       iceberg::nested_field::create(
-        0, "union_opt_0", iceberg::field_required::no, iceberg::int_type{}));
+        0, "int", iceberg::field_required::no, iceberg::int_type{}));
     union_st.fields.push_back(
       iceberg::nested_field::create(
-        0, "union_opt_1", iceberg::field_required::no, iceberg::long_type{}));
+        0, "long", iceberg::field_required::no, iceberg::long_type{}));
     union_st.fields.push_back(
       iceberg::nested_field::create(
-        0, "union_opt_2", iceberg::field_required::no, iceberg::float_type{}));
+        0, "float", iceberg::field_required::no, iceberg::float_type{}));
 
     tl_type_expectations.emplace_back("root", tl_union, std::move(union_st));
 
@@ -314,7 +314,7 @@ TEST(AvroSchema, TestRecordType) {
     union_struct.fields.push_back(
       iceberg::nested_field::create(
         0,
-        "union_opt_1",
+        "map",
         iceberg::field_required::no,
         iceberg::map_type::create(
           0,
@@ -324,7 +324,7 @@ TEST(AvroSchema, TestRecordType) {
           iceberg::int_type{})));
     union_struct.fields.push_back(
       iceberg::nested_field::create(
-        0, "union_opt_2", iceberg::field_required::no, iceberg::float_type{}));
+        0, "float", iceberg::field_required::no, iceberg::float_type{}));
 
     ASSERT_TRUE(
       field_matches(struct_t.fields[6], "myunion", std::move(union_struct)));

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -255,12 +255,12 @@ AVRO_SCHEMA_TEST_CASES = {
         expected_trino=[
             ("number", "bigint", "", ""),
             ("timestamp_us", "timestamp(6)", "", ""),
-            ("str_or_long", "row(union_opt_0 varchar, union_opt_1 bigint)", "", ""),
+            ("str_or_long", "row(string varchar, long bigint)", "", ""),
         ],
         expected_spark=[
             ("number", "bigint", None),
             ("timestamp_us", "timestamp_ntz", None),
-            ("str_or_long", "struct<union_opt_0:string,union_opt_1:bigint>", None),
+            ("str_or_long", "struct<string:string,long:bigint>", None),
             ("", "", ""),
             ("# Partitioning", "", ""),
             ("Part 0", "hours(redpanda.timestamp)", ""),


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

PR updates Avro union translation such that filelds take the name of their type rather than `union_opt_X` as before.

The type-to-name translation works as described in https://avro.apache.org/docs/1.12.0/specification/#json-encoding

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* (Iceberg) Struct fields corresponding to Avro union branches are given names matching their type rather than `union_opt_X`.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
