### PR TITLE
container/priority_queue: Improve benchmark

### DIFF
--- a/src/v/container/tests/priority_queue_bench.cc
+++ b/src/v/container/tests/priority_queue_bench.cc
@@ -46,85 +46,147 @@ struct PriorityQueueBenchTest {
     }
 
     static auto make_test_data() {
-        chunked_vector<value_type> vec;
-        vec.reserve(Size);
-        for (size_t j = 0; j < Size; ++j) {
-            vec.emplace_back(make_random_value());
-        }
-        return vec;
+        static const auto data = []() {
+            chunked_vector<value_type> vec;
+            vec.reserve(Size);
+            for (size_t j = 0; j < Size; ++j) {
+                vec.emplace_back(make_random_value());
+            }
+            return vec;
+        }();
+        return data.copy();
     }
-
-    chunked_vector<value_type> test_data = make_test_data();
 
     PriorityQueue make_filled() {
         PriorityQueue pq;
-        for (auto val : test_data) {
-            pq.push(val);
-        }
-        return pq;
-    }
-
-    PriorityQueue make_range_filled() {
-        PriorityQueue pq;
-        pq.push_range(test_data);
+        pq.push_range(make_test_data());
         return pq;
     }
 
     [[gnu::noinline]]
     void run_push_test() {
-        PriorityQueue pq = make_filled();
+        auto test_data = make_test_data();
+        PriorityQueue pq;
+        perf_tests::start_measuring_time();
+        for (const auto& val : test_data) {
+            pq.push(val);
+        }
+        perf_tests::stop_measuring_time();
+        perf_tests::do_not_optimize(pq);
+    }
+
+    [[gnu::noinline]]
+    void run_push_rvalue_test() {
+        auto test_data = make_test_data();
+        PriorityQueue pq;
+        perf_tests::start_measuring_time();
+        for (auto& val : std::move(test_data)) {
+            pq.push(std::move(val));
+        }
+        perf_tests::stop_measuring_time();
         perf_tests::do_not_optimize(pq);
     }
 
     [[gnu::noinline]]
     void run_push_range_test() {
-        PriorityQueue pq = make_range_filled();
+        auto test_data = make_test_data();
+        PriorityQueue pq;
+        perf_tests::start_measuring_time();
+        pq.push_range(test_data);
+        perf_tests::stop_measuring_time();
         perf_tests::do_not_optimize(pq);
     }
 
-    PriorityQueue filled_pop = make_range_filled();
+    [[gnu::noinline]]
+    void run_push_rvalue_range_test() {
+        auto test_data = make_test_data();
+        PriorityQueue pq;
+        perf_tests::start_measuring_time();
+        pq.push_range(std::move(test_data));
+        perf_tests::stop_measuring_time();
+        perf_tests::do_not_optimize(pq);
+    }
+
+    [[gnu::noinline]]
+    ss::future<> run_async_push_rvalue_range_test() {
+        auto test_data = make_test_data();
+        PriorityQueue pq;
+        perf_tests::start_measuring_time();
+        co_await pq.async_push_range(std::move(test_data));
+        perf_tests::stop_measuring_time();
+        perf_tests::do_not_optimize(pq);
+    }
 
     [[gnu::noinline]]
     void run_pop_test() {
-        while (!filled_pop.empty()) {
-            if constexpr (!std::is_void_v<decltype(filled_pop.pop())>) {
+        PriorityQueue pq = make_filled();
+        perf_tests::start_measuring_time();
+        while (!pq.empty()) {
+            if constexpr (!std::is_void_v<decltype(pq.pop())>) {
                 // bounded_priority_queue::pop() returns a value
-                auto x = filled_pop.pop();
+                auto x = pq.pop();
                 perf_tests::do_not_optimize(x);
             } else {
                 // std::priority_queue::pop() returns void
-                auto x = filled_pop.top();
-                filled_pop.pop();
+                auto x = pq.top();
+                pq.pop();
                 perf_tests::do_not_optimize(x);
             }
         }
+        perf_tests::stop_measuring_time();
     }
-
-    PriorityQueue filled_extract_sorted = make_range_filled();
 
     [[gnu::noinline]]
     void run_extract_sorted_test() {
-        auto x = std::move(filled_extract_sorted).extract_sorted();
+        PriorityQueue pq = make_filled();
+        perf_tests::start_measuring_time();
+        auto x = std::move(pq).extract_sorted();
+        perf_tests::stop_measuring_time();
         perf_tests::do_not_optimize(x);
     }
-
-    PriorityQueue filled_async_extract_sorted = make_range_filled();
 
     [[gnu::noinline]]
     ss::future<> run_async_extract_sorted_test() {
-        auto x = co_await std::move(filled_async_extract_sorted)
-                   .async_extract_sorted()
-                   .get();
+        PriorityQueue pq;
+        co_await pq.async_push_range(make_test_data());
+        perf_tests::start_measuring_time();
+        auto x = co_await std::move(pq).async_extract_sorted();
+        perf_tests::stop_measuring_time();
         perf_tests::do_not_optimize(x);
     }
 
-    PriorityQueue filled_sort_extract_sorted = make_range_filled();
-
     [[gnu::noinline]]
     void run_sort_extract_heap_test() {
-        auto x = std::move(filled_sort_extract_sorted).extract_heap();
+        PriorityQueue pq = make_filled();
+        perf_tests::start_measuring_time();
+        auto x = std::move(pq).extract_heap();
         std::ranges::sort(x);
+        perf_tests::stop_measuring_time();
         perf_tests::do_not_optimize(x);
+    }
+};
+
+template<typename PriorityQueue, size_t InputSize, size_t Cap>
+struct BoundedPriorityQueueBenchTest
+  : PriorityQueueBenchTest<PriorityQueue, InputSize> {
+    [[gnu::noinline]]
+    void run_push_rvalue_range_test() {
+        auto test_data = this->make_test_data();
+        PriorityQueue pq{Cap};
+        perf_tests::start_measuring_time();
+        pq.push_range(std::move(test_data));
+        perf_tests::stop_measuring_time();
+        perf_tests::do_not_optimize(pq);
+    }
+
+    [[gnu::noinline]]
+    ss::future<> run_async_push_rvalue_range_test() {
+        auto test_data = this->make_test_data();
+        PriorityQueue pq{Cap};
+        perf_tests::start_measuring_time();
+        co_await pq.async_push_range(std::move(test_data));
+        perf_tests::stop_measuring_time();
+        perf_tests::do_not_optimize(pq);
     }
 };
 
@@ -145,50 +207,95 @@ struct PriorityQueueBenchTest {
         run_pop_test();                                                        \
     }
 
-#define BOUNDED_PRIORITY_QUEUE_PERF_TEST(container, element, size)             \
-    class BoundedPriorityQueueBenchTest_##container##_##element##_##size       \
+#define PRIORITY_QUEUE_MOVE_TEST(container, element, size)                     \
+    class PriorityQueueRValueBenchTest_##container##_##element##_##size        \
       : public PriorityQueueBenchTest<container<element>, size> {};            \
     PERF_TEST_F(                                                               \
-      BoundedPriorityQueueBenchTest_##container##_##element##_##size, Push) {  \
-        run_push_test();                                                       \
+      PriorityQueueRValueBenchTest_##container##_##element##_##size, Push) {   \
+        run_push_rvalue_test();                                                \
     }                                                                          \
     PERF_TEST_F(                                                               \
-      BoundedPriorityQueueBenchTest_##container##_##element##_##size,          \
+      PriorityQueueRValueBenchTest_##container##_##element##_##size,           \
       PushRange) {                                                             \
-        run_push_range_test();                                                 \
+        run_push_rvalue_range_test();                                          \
     }                                                                          \
     PERF_TEST_F(                                                               \
-      BoundedPriorityQueueBenchTest_##container##_##element##_##size,          \
+      PriorityQueueRValueBenchTest_##container##_##element##_##size,           \
+      AsyncPushRange) {                                                        \
+        return run_async_push_rvalue_range_test();                             \
+    }
+
+#define PRIORITY_QUEUE_SORT_TEST(container, element, size)                     \
+    class PriorityQueueSortBenchTest_##container##_##element##_##size          \
+      : public PriorityQueueBenchTest<container<element>, size> {};            \
+    PERF_TEST_F(                                                               \
+      PriorityQueueSortBenchTest_##container##_##element##_##size,             \
       ExtractSorted) {                                                         \
         run_extract_sorted_test();                                             \
     }                                                                          \
     PERF_TEST_F(                                                               \
-      BoundedPriorityQueueBenchTest_##container##_##element##_##size,          \
+      PriorityQueueSortBenchTest_##container##_##element##_##size,             \
       SortExtractHeap) {                                                       \
         run_sort_extract_heap_test();                                          \
+    }                                                                          \
+    PERF_TEST_F(                                                               \
+      PriorityQueueSortBenchTest_##container##_##element##_##size,             \
+      AsyncExtractSorted) {                                                    \
+        return run_async_extract_sorted_test();                                \
+    }
+
+#define BOUNDED_PRIORITY_QUEUE_PERF_TEST(                                                \
+  container, element, input_size, capacity)                                              \
+    class                                                                                \
+      BoundedPriorityQueueBenchTest_##container##_##element##_##input_size##_##          \
+      capacity                                                                           \
+      : public BoundedPriorityQueueBenchTest<                                            \
+          container<element>,                                                            \
+          input_size,                                                                    \
+          capacity> {};                                                                  \
+    PERF_TEST_F(                                                                         \
+      BoundedPriorityQueueBenchTest_##container##_##element##_##input_size##_##capacity, \
+      PushRange) {                                                                       \
+        run_push_rvalue_range_test();                                                    \
+    }                                                                                    \
+    PERF_TEST_F(                                                                         \
+      BoundedPriorityQueueBenchTest_##container##_##element##_##input_size##_##capacity, \
+      AsyncPushRange) {                                                                  \
+        return run_async_push_rvalue_range_test();                                       \
     }
 // NOLINTEND(*-macro-*)
 
 template<typename T>
-using std_priority_queue = std::priority_queue<T>;
+using std_pq = std::priority_queue<T>;
+template<typename T>
+using our_pq = priority_queue<T>;
+template<typename T>
+using bounded_pq = bounded_priority_queue<T>;
 
-PRIORITY_QUEUE_PERF_TEST(std_priority_queue, int64_t, 64)
-PRIORITY_QUEUE_PERF_TEST(priority_queue, int64_t, 64)
+PRIORITY_QUEUE_PERF_TEST(std_pq, int64_t, 64)
+PRIORITY_QUEUE_PERF_TEST(our_pq, int64_t, 64)
 
-PRIORITY_QUEUE_PERF_TEST(std_priority_queue, int64_t, 1024)
-PRIORITY_QUEUE_PERF_TEST(priority_queue, int64_t, 1024)
+PRIORITY_QUEUE_PERF_TEST(std_pq, int64_t, 1024)
+PRIORITY_QUEUE_PERF_TEST(our_pq, int64_t, 1024)
 
-PRIORITY_QUEUE_PERF_TEST(std_priority_queue, sstring, 1024)
-PRIORITY_QUEUE_PERF_TEST(priority_queue, sstring, 1024)
+PRIORITY_QUEUE_PERF_TEST(std_pq, sstring, 1024)
+PRIORITY_QUEUE_PERF_TEST(our_pq, sstring, 1024)
 
-PRIORITY_QUEUE_PERF_TEST(std_priority_queue, large_struct, 1024)
-PRIORITY_QUEUE_PERF_TEST(priority_queue, large_struct, 1024)
+PRIORITY_QUEUE_PERF_TEST(std_pq, large_struct, 1024)
+PRIORITY_QUEUE_PERF_TEST(our_pq, large_struct, 1024)
 
-PRIORITY_QUEUE_PERF_TEST(std_priority_queue, int64_t, 1048576)
-PRIORITY_QUEUE_PERF_TEST(priority_queue, int64_t, 1048576)
+PRIORITY_QUEUE_PERF_TEST(std_pq, int64_t, 1048576)
+PRIORITY_QUEUE_PERF_TEST(our_pq, int64_t, 1048576)
 
-// BOUNDED_PRIORITY_QUEUE_PERF_TEST(priority_queue, int64_t, 64)
-BOUNDED_PRIORITY_QUEUE_PERF_TEST(priority_queue, int64_t, 1024)
-BOUNDED_PRIORITY_QUEUE_PERF_TEST(priority_queue, sstring, 1024)
-BOUNDED_PRIORITY_QUEUE_PERF_TEST(priority_queue, large_struct, 1024)
-BOUNDED_PRIORITY_QUEUE_PERF_TEST(priority_queue, int64_t, 1048576)
+PRIORITY_QUEUE_MOVE_TEST(our_pq, sstring, 1024)
+
+PRIORITY_QUEUE_SORT_TEST(our_pq, int64_t, 64)
+PRIORITY_QUEUE_SORT_TEST(our_pq, int64_t, 1024)
+PRIORITY_QUEUE_SORT_TEST(our_pq, int64_t, 1048576)
+
+// small
+BOUNDED_PRIORITY_QUEUE_PERF_TEST(bounded_pq, int64_t, 1024, 1024)
+// reduce
+BOUNDED_PRIORITY_QUEUE_PERF_TEST(bounded_pq, int64_t, 1048576, 1024)
+// large
+BOUNDED_PRIORITY_QUEUE_PERF_TEST(bounded_pq, int64_t, 1048576, 1048576)


### PR DESCRIPTION
Several Improvements:
* Use a copy of the data for each run (the fixture isn't new for each run)
* Test move semantics
* Test sorting strategies
* Test `bounded_priority_queue`

```
test                                                                             iterations      median         mad         min         max      allocs       tasks        inst      cycles
PriorityQueueBenchTest_std_pq_int64_t_64.Push                                        454611     1.138us     2.519ns     1.125us     1.157us       7.000       0.000      3848.0       955.7
PriorityQueueBenchTest_std_pq_int64_t_64.PushRange                                   467286     1.114us    10.287ns     1.103us     1.133us       1.000       0.000      2443.0       786.8
PriorityQueueBenchTest_std_pq_int64_t_64.Pop                                         395972     1.416us     0.334ns     1.413us     1.416us       0.000       0.000      6725.0      2481.0
PriorityQueueBenchTest_our_pq_int64_t_64.Push                                        459250     1.123us     3.750ns     1.117us     1.127us       7.000       0.000      3848.0       942.4
PriorityQueueBenchTest_our_pq_int64_t_64.PushRange                                   465423     1.092us     1.541ns     1.091us     1.121us       1.000       0.000      2767.0       810.7
PriorityQueueBenchTest_our_pq_int64_t_64.Pop                                         395358     1.415us     3.141ns     1.412us     1.428us       0.000       0.000      6788.0      2498.3
PriorityQueueBenchTest_std_pq_int64_t_1024.Push                                      272314     2.534us     8.722ns     2.525us     2.546us      11.000       0.000     46122.0      8540.6
PriorityQueueBenchTest_std_pq_int64_t_1024.PushRange                                 294805     2.276us     2.488ns     2.273us     2.311us       1.000       0.000     34426.0      7216.3
PriorityQueueBenchTest_std_pq_int64_t_1024.Pop                                        74622    11.036us    17.763ns    11.008us    11.252us       0.000       0.000    174333.0     54856.0
PriorityQueueBenchTest_our_pq_int64_t_1024.Push                                      274542     2.493us     6.709ns     2.486us     2.647us      11.000       0.000     46122.0      8441.5
PriorityQueueBenchTest_our_pq_int64_t_1024.PushRange                                 288080     2.345us     6.063ns     2.339us     2.431us       1.000       0.000     39550.0      7613.3
PriorityQueueBenchTest_our_pq_int64_t_1024.Pop                                        73924    11.163us     5.425ns    11.150us    11.238us       0.000       0.000    175356.0     55213.9
PriorityQueueBenchTest_std_pq_sstring_1024.Push                                       34307    16.494us    58.223ns    16.436us    17.501us    1035.000       0.000    260074.3     84112.2
PriorityQueueBenchTest_std_pq_sstring_1024.PushRange                                  42413    11.140us     9.952ns    11.116us    11.162us    1025.000       0.000    210731.3     54140.7
PriorityQueueBenchTest_std_pq_sstring_1024.Pop                                        17937    35.156us   213.293ns    34.847us    35.658us    1024.000       0.000    818481.8    182439.9
PriorityQueueBenchTest_our_pq_sstring_1024.Push                                       34513    16.541us    11.340ns    16.525us    16.552us    1035.000       0.000    259972.4     83283.1
PriorityQueueBenchTest_our_pq_sstring_1024.PushRange                                  41337    11.559us     7.575ns    11.551us    11.902us    1025.000       0.000    216830.0     56692.9
PriorityQueueBenchTest_our_pq_sstring_1024.Pop                                        21810    32.759us   105.896ns    32.594us    32.890us       0.000       0.000    709128.1    169303.0
PriorityQueueBenchTest_std_pq_large_struct_1024.Push                                  16467    31.519us    20.275ns    31.499us    31.751us    2059.000       0.000    633088.1    162140.5
PriorityQueueBenchTest_std_pq_large_struct_1024.PushRange                             19605    24.039us   216.737ns    23.822us    24.364us    2049.000       0.000    498715.5    122386.6
PriorityQueueBenchTest_std_pq_large_struct_1024.Pop                                    7070    94.679us     1.075us    92.639us    95.754us    2048.000       0.000   1820658.7    496647.6
PriorityQueueBenchTest_our_pq_large_struct_1024.Push                                  16635    31.786us    42.321ns    31.744us    32.328us    2059.000       0.000    633104.3    164120.9
PriorityQueueBenchTest_our_pq_large_struct_1024.PushRange                             19515    23.840us    81.821ns    23.759us    24.613us    2049.000       0.000    502741.5    121723.4
PriorityQueueBenchTest_our_pq_large_struct_1024.Pop                                    9136    81.267us   771.512ns    80.496us    85.104us       0.000       0.000   1550506.0    434378.3
PriorityQueueBenchTest_std_pq_int64_t_1048576.Push                                      138     6.874ms    13.861us     6.860ms     6.944ms      21.000       0.000  46346699.9  37560337.1
PriorityQueueBenchTest_std_pq_int64_t_1048576.PushRange                                 343     2.670ms     7.414us     2.656ms     2.683ms       1.000       0.000  35141480.7  14453510.6
PriorityQueueBenchTest_std_pq_int64_t_1048576.Pop                                        17    57.067ms   205.575us    56.718ms    57.496ms       0.000       0.000 366942174.9 311489085.8
PriorityQueueBenchTest_our_pq_int64_t_1048576.Push                                      140     6.767ms    30.061us     6.718ms     6.888ms      21.000       0.000  46346692.8  37001980.1
PriorityQueueBenchTest_our_pq_int64_t_1048576.PushRange                                 336     2.740ms     3.974us     2.729ms     2.744ms       1.000       0.000  40384401.8  14792657.8
PriorityQueueBenchTest_our_pq_int64_t_1048576.Pop                                        17    56.727ms   256.767us    56.470ms    60.984ms       0.000       0.000 367990748.2 314350803.9
PriorityQueueRValueBenchTest_our_pq_sstring_1024.Push                                 51504     9.149us   131.241ns     9.006us     9.300us      11.000       0.000    182499.0     43758.1
PriorityQueueRValueBenchTest_our_pq_sstring_1024.PushRange                            58450     7.675us     6.914ns     7.667us     7.919us       1.000       0.000    139170.0     36182.7
PriorityQueueRValueBenchTest_our_pq_sstring_1024.AsyncPushRange                       53283     8.892us    19.681ns     8.872us     8.943us       3.000       0.112    172740.8     42302.7
PriorityQueueSortBenchTest_our_pq_int64_t_64.ExtractSorted                           393156     1.417us     2.323ns     1.415us     1.421us       0.000       0.000      6467.0      2601.8
PriorityQueueSortBenchTest_our_pq_int64_t_64.SortExtractHeap                         416846     1.273us     0.823ns     1.270us     1.276us       0.000       0.000      6773.0      1759.0
PriorityQueueSortBenchTest_our_pq_int64_t_64.AsyncExtractSorted                      384249     1.445us     0.244ns     1.445us     1.448us       3.000       0.009      8918.5      2658.8
PriorityQueueSortBenchTest_our_pq_int64_t_1024.ExtractSorted                          74832    10.869us    11.995ns    10.857us    10.913us       0.000       0.000    170227.0     54358.4
PriorityQueueSortBenchTest_our_pq_int64_t_1024.SortExtractHeap                       116458     6.128us     0.129ns     6.125us     6.131us       0.000       0.000    124274.0     28190.4
PriorityQueueSortBenchTest_our_pq_int64_t_1024.AsyncExtractSorted                     68158    12.020us     9.607ns    12.010us    12.066us       3.000       0.096    194879.9     60148.7
PriorityQueueSortBenchTest_our_pq_int64_t_1048576.ExtractSorted                          17    55.881ms   661.404us    55.219ms    57.114ms       0.000       0.000 362747849.7 309193787.2
PriorityQueueSortBenchTest_our_pq_int64_t_1048576.SortExtractHeap                        51    16.675ms    59.455us    16.607ms    17.822ms       0.000       0.000 254471503.3  91996563.6
PriorityQueueSortBenchTest_our_pq_int64_t_1048576.AsyncExtractSorted                     16    56.523ms    82.858us    56.440ms    56.843ms       3.000     116.225 405829678.7 310612812.4
BoundedPriorityQueueBenchTest_bounded_pq_int64_t_1024_1024.PushRange                 271537     2.541us     5.508ns     2.529us     2.547us       1.000       0.000     53220.0      8704.7
BoundedPriorityQueueBenchTest_bounded_pq_int64_t_1024_1024.AsyncPushRange            256392     2.734us     2.578ns     2.730us     2.741us       3.000       0.023     61629.9      9605.1
BoundedPriorityQueueBenchTest_bounded_pq_int64_t_1048576_1024.PushRange                1120   743.057us   785.135ns   740.797us   746.614us       1.000       0.000  22511546.3   4009947.3
BoundedPriorityQueueBenchTest_bounded_pq_int64_t_1048576_1024.AsyncPushRange            906   943.178us   113.600ns   943.065us   957.145us       3.001       4.171  27141068.6   5083545.9
BoundedPriorityQueueBenchTest_bounded_pq_int64_t_1048576_1048576.PushRange              145     6.675ms    11.928us     6.658ms     6.696ms       1.000       0.000  54651366.9  36433759.8
BoundedPriorityQueueBenchTest_bounded_pq_int64_t_1048576_1048576.AsyncPushRange         130     7.526ms    15.545us     7.511ms     7.569ms       3.008      17.415  63826540.7  40895559.5
```

Notes:
* It performs on par with `std::priority_queue`.
* With move semantics and `reserve`, it's almost allocation free.
* Asynchronous operations are quite close to synchronous.
* `sort_heap` (used in `ExtractSorted`) does not perform as well as `std::sort` (used in `SortExtractHeap`), but is much easier to make asynchronous.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

