### PR TITLE
ct/tests: disable leader balancer in leader_epoch_test

### DIFF
--- a/src/v/cloud_topics/tests/leader_epoch_test.cc
+++ b/src/v/cloud_topics/tests/leader_epoch_test.cc
@@ -33,6 +33,7 @@ class LeaderEpochTest
   , public ::testing::Test {
 public:
     void SetUp() override {
+        cfg.get("enable_leader_balancer").set_value(false);
         cfg.get("cloud_topics_disable_reconciliation_loop").set_value(true);
         cfg.get("raft_heartbeat_interval_ms").set_value(50ms);
         cfg.get("raft_heartbeat_timeout_ms").set_value(500ms);


### PR DESCRIPTION
There was an instance where leadership stepped down mid-produce because of the leader balancer, causing the produce loop in the test to fail.

```
src/v/cloud_topics/tests/leader_epoch_test.cc:269: Failure
Value of: producer_error.has_value()
  Actual: true
Expected: false
Producer fiber failed with exception std::runtime_error (produce error: { error_code: not_leader_for_partition [6] }, message:{nullopt})
```

This disables the leader balancer entirely, since leadership is explicitly controlled in this test.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
