### PR TITLE
[CORE-13743] rptest: enable cloud topics in partition_movement_test

### DIFF
--- a/tests/rptest/test_suite_cloud_topics.yml
+++ b/tests/rptest/test_suite_cloud_topics.yml
@@ -12,4 +12,5 @@ cloud_topics:
     - tests/cloud_topics/
     - tests/follower_fetching_test.py
     - tests/nodes_decommissioning_test.py
+    - tests/partition_movement_test.py
     - tests/random_node_operations_smoke_test.py

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -11,8 +11,10 @@ import copy
 import random
 import signal
 import time
+from typing import Any
 
 import requests
+from ducktape.cluster.cluster_spec import ClusterSpec
 from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
 
@@ -24,10 +26,12 @@ from rptest.services.cluster import cluster
 from rptest.services.honey_badger import HoneyBadger
 from rptest.services.kaf_producer import KafProducer
 from rptest.services.redpanda import (
+    CLOUD_TOPICS_CONFIG_STR,
     PREV_VERSION_LOG_ALLOW_LIST,
     RESTART_LOG_ALLOW_LIST,
     SISettings,
     get_cloud_storage_type,
+    make_redpanda_service,
 )
 from rptest.services.redpanda_installer import InstallOptions, RedpandaInstaller
 from rptest.services.rpk_consumer import RpkConsumer
@@ -990,23 +994,48 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
     @skip_fips_mode
     @skip_debug_mode  # rolling restarts require more reliable recovery that a slow debug mode cluster can provide
     @cluster(num_nodes=5, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
-    @matrix(num_to_upgrade=[0, 2], cloud_storage_type=get_cloud_storage_type())
-    def test_shadow_indexing(self, num_to_upgrade, cloud_storage_type):
+    @matrix(
+        num_to_upgrade=[0, 2],
+        cloud_storage_type=get_cloud_storage_type(),
+        with_cloud_topics=[True, False],
+    )
+    def test_shadow_indexing(
+        self, num_to_upgrade, cloud_storage_type, with_cloud_topics: bool
+    ):
         """
         Test interaction between the shadow indexing and the partition movement.
         Partition movement generate partitions with different revision-ids and the
         archival/shadow-indexing subsystem is using revision to generate unique object
         keys inside the remote storage.
         """
+        test_mixed_versions: bool = num_to_upgrade > 0
+        if test_mixed_versions and with_cloud_topics:
+            # Upgrades not supported with cloud topics yet.
+            # Avoid the "Test requested 5 nodes, used only 0" error.
+            self.logger.warn("skipping test, upgrades with cloud topics not supported")
+            self.redpanda = make_redpanda_service(self.test_context, 0)
+            self.test_context.cluster.alloc(ClusterSpec.simple_linux(5))
+            return
+        extra_rp_conf: dict = {}
+        if with_cloud_topics:
+            extra_rp_conf = {CLOUD_TOPICS_CONFIG_STR: True}
+
         throughput, records, moves, partitions = self._get_scale_params()
-
-        test_mixed_versions = num_to_upgrade > 0
         install_opts = InstallOptions(install_previous_version=test_mixed_versions)
-        self.start_redpanda(num_nodes=3, install_opts=install_opts)
+        self.start_redpanda(
+            num_nodes=3, install_opts=install_opts, extra_rp_conf=extra_rp_conf
+        )
 
-        spec = TopicSpec(name="topic", partition_count=partitions, replication_factor=3)
-        self.client().create_topic(spec)
-        self.topic = spec.name
+        self.topic = "topic"
+        config = dict[str, Any]()
+        if with_cloud_topics:
+            config[TopicSpec.PROPERTY_CLOUD_TOPIC_ENABLE] = "true"
+        self.rpk_client().create_topic(
+            self.topic,
+            partitions=partitions,
+            replicas=3,
+            config=config,
+        )
         self.start_producer(1, throughput=throughput)
         self.start_consumer(1)
         self.await_startup()
@@ -1035,22 +1064,47 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
     @cluster(num_nodes=5, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
     @skip_debug_mode  # rolling restarts require more reliable recovery that a slow debug mode cluster can provide
     # Redpandas before v23.1 did not have support for ABS.
-    @matrix(num_to_upgrade=[0, 2], cloud_storage_type=get_cloud_storage_type())
-    def test_cross_shard(self, num_to_upgrade, cloud_storage_type):
+    @matrix(
+        num_to_upgrade=[0, 2],
+        cloud_storage_type=get_cloud_storage_type(),
+        with_cloud_topics=[True, False],
+    )
+    def test_cross_shard(
+        self, num_to_upgrade, cloud_storage_type, with_cloud_topics: bool
+    ):
         """
         Test interaction between the shadow indexing and the partition movement.
         Move partitions with SI enabled between shards.
         """
+        test_mixed_versions: bool = num_to_upgrade > 0
+        if test_mixed_versions and with_cloud_topics:
+            # Upgrades not supported with cloud topics yet.
+            # Avoid the "Test requested 5 nodes, used only 0" error.
+            self.logger.warn("skipping test, upgrades with cloud topics not supported")
+            self.redpanda = make_redpanda_service(self.test_context, 0)
+            self.test_context.cluster.alloc(ClusterSpec.simple_linux(5))
+            return
+        extra_rp_conf: dict = {}
+        if with_cloud_topics:
+            extra_rp_conf = {CLOUD_TOPICS_CONFIG_STR: True}
 
         throughput, records, moves, partitions = self._get_scale_params()
 
-        test_mixed_versions = num_to_upgrade > 0
         install_opts = InstallOptions(install_previous_version=test_mixed_versions)
-        self.start_redpanda(num_nodes=3, install_opts=install_opts)
+        self.start_redpanda(
+            num_nodes=3, install_opts=install_opts, extra_rp_conf=extra_rp_conf
+        )
 
-        spec = TopicSpec(name="topic", partition_count=partitions, replication_factor=3)
-        self.client().create_topic(spec)
-        self.topic = spec.name
+        self.topic = "topic"
+        config = dict[str, Any]()
+        if with_cloud_topics:
+            config[TopicSpec.PROPERTY_CLOUD_TOPIC_ENABLE] = "true"
+        self.rpk_client().create_topic(
+            self.topic,
+            partitions=partitions,
+            replicas=3,
+            config=config,
+        )
         self.start_producer(1, throughput=throughput)
         self.start_consumer(1)
         self.await_startup()


### PR DESCRIPTION
Enables cloud topics in the SIPartitionMovementTests. These seemed like low hanging fruit since they're already configured to use tiered storage.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
