### PR TITLE
CORE-13827 - Sync start offsets from source to shadow

### DIFF
--- a/src/v/cluster_link/BUILD
+++ b/src/v/cluster_link/BUILD
@@ -195,6 +195,7 @@ redpanda_cc_library(
         ":security_migrator",
         ":source_topic_syncer",
         "//src/v/cluster_link/model",
+        "//src/v/kafka/data:partition_proxy",
         "//src/v/ssx:future_util",
     ],
     visibility = ["//visibility:public"],

--- a/src/v/cluster_link/replication/BUILD
+++ b/src/v/cluster_link/replication/BUILD
@@ -71,6 +71,7 @@ redpanda_cc_library(
         "link_replication_mgr.h",
     ],
     implementation_deps = [
+        "//src/v/ssx:async_algorithm",
         "//src/v/ssx:future_util",
     ],
     visibility = ["//src/v/cluster_link:__subpackages__"],

--- a/src/v/cluster_link/replication/BUILD
+++ b/src/v/cluster_link/replication/BUILD
@@ -27,6 +27,7 @@ redpanda_cc_library(
     deps = [
         "//src/v/container:chunked_hash_map",
         "//src/v/container:chunked_vector",
+        "//src/v/kafka/protocol",
         "//src/v/model",
         "//src/v/raft",
         "//src/v/ssx:semaphore",

--- a/src/v/cluster_link/replication/deps.h
+++ b/src/v/cluster_link/replication/deps.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "container/chunked_vector.h"
+#include "kafka/protocol/errors.h"
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "model/timeout_clock.h"
@@ -49,6 +50,13 @@ public:
 
     // Returns the HWM of the partition
     virtual kafka::offset high_watermark() const = 0;
+
+    // Performs a prefix truncation on the sink partition
+    virtual ss::future<kafka::error_code> prefix_truncate(
+      kafka::offset truncation_offset, ss::lowres_clock::time_point deadline)
+      = 0;
+
+    virtual kafka::offset start_offset() = 0;
 };
 
 class data_sink_factory {

--- a/src/v/cluster_link/replication/link_replication_mgr.cc
+++ b/src/v/cluster_link/replication/link_replication_mgr.cc
@@ -12,6 +12,7 @@
 
 #include "base/units.h"
 #include "cluster_link/logger.h"
+#include "ssx/async_algorithm.h"
 #include "ssx/future-util.h"
 #include "utils/to_string.h"
 
@@ -40,6 +41,14 @@ ss::future<> link_replication_manager::start() {
                                                        : ss::log_level::error;
             vlogl(cllog, level, "reconciliation loop failed: {}", e);
         });
+    });
+    ssx::repeat_until_gate_closed(_gate, [this] {
+        return maybe_sync_start_offsets().handle_exception(
+          [](const std::exception_ptr& e) {
+              auto level = ssx::is_shutdown_exception(e) ? ss::log_level::trace
+                                                         : ss::log_level::warn;
+              vlogl(cllog, level, "Error in maybe_sync_start_offsets: {}", e);
+          });
     });
 }
 
@@ -278,4 +287,19 @@ void link_replication_manager::run_stop_actions() {
     _pending_stops.clear();
 }
 
+ss::future<> link_replication_manager::maybe_sync_start_offsets() {
+    auto h = _gate.hold();
+    ssx::async_counter cnt;
+    auto ntps = _replicators | std::views::keys
+                | std::ranges::to<chunked_vector<::model::ntp>>();
+    co_await ssx::async_for_each_counter(
+      cnt, std::move(ntps), [this](const ::model::ntp& ntp) {
+          auto it = _replicators.find(ntp);
+          if (it != _replicators.end()) {
+              it->second->maybe_synchronize_start_offset();
+          }
+      });
+
+    co_await ss::sleep_abortable(start_offset_synch_interval, _as);
+}
 } // namespace cluster_link::replication

--- a/src/v/cluster_link/replication/link_replication_mgr.h
+++ b/src/v/cluster_link/replication/link_replication_mgr.h
@@ -49,6 +49,8 @@ public:
     get_partition_offsets_report(const ::model::ntp&) const;
 
 private:
+    static constexpr auto start_offset_synch_interval = std::chrono::seconds{
+      30};
     ss::future<> do_start_replicator(::model::ntp, ::model::term_id);
     ss::future<>
       do_stop_replicator(::model::ntp, std::optional<::model::term_id>);
@@ -63,6 +65,7 @@ private:
     std::unique_ptr<link_configuration_provider> _config_provider;
     std::unique_ptr<data_source_factory> _source_factory;
     std::unique_ptr<data_sink_factory> _sink_factory;
+    ss::future<> maybe_sync_start_offsets();
     ssx::work_queue _queue;
     chunked_hash_map<::model::ntp, ::model::term_id> _pending_starts;
     chunked_hash_map<::model::ntp, std::optional<::model::term_id>>

--- a/src/v/cluster_link/replication/partition_replicator.cc
+++ b/src/v/cluster_link/replication/partition_replicator.cc
@@ -209,6 +209,7 @@ ss::future<> partition_replicator::fetch_and_replicate() {
         while (!_gate.is_closed() && !as.abort_requested()) {
             auto inflight_units = co_await ss::get_units(_max_requests, 1, as);
             auto data = co_await _source->fetch_next(as);
+            maybe_synchronize_start_offset();
             if (data.batches.empty()) {
                 continue;
             }
@@ -243,6 +244,82 @@ ss::future<> partition_replicator::fetch_and_replicate() {
         co_await ss::sleep_abortable(sleep_for, _as);
         _backoff_policy.next_backoff();
     }
+}
+
+void partition_replicator::maybe_synchronize_start_offset() {
+    auto shadow_partition_hwm = _sink->high_watermark();
+    auto shadow_partition_start_offset = _sink->start_offset();
+    auto source_offsets = _source->get_offsets();
+
+    if (_in_progress_truncate_offset.has_value()) {
+        vlog(
+          _log.trace,
+          "Truncation already in progress to offset {}",
+          _in_progress_truncate_offset.value());
+        return;
+    }
+
+    if (!source_offsets.has_value()) {
+        vlog(_log.debug, "Source partition not reporting offsets");
+        return;
+    }
+
+    auto source_start_offset = source_offsets->source_start_offset;
+
+    if (source_start_offset <= shadow_partition_start_offset) {
+        vlog(
+          _log.trace,
+          "Source and shadow partition start offsets are in sync: source: {}, "
+          "shadow: {}",
+          source_start_offset,
+          shadow_partition_start_offset);
+        return;
+    }
+
+    if (source_start_offset > shadow_partition_hwm) {
+        vlog(
+          _log.trace,
+          "Source start offset {} greater than shadow HWM {}, cannot truncate",
+          source_start_offset,
+          shadow_partition_hwm);
+        return;
+    }
+
+    _in_progress_truncate_offset = source_start_offset;
+
+    vlog(
+      _log.debug,
+      "Truncating shadow partition from {} -> {}",
+      shadow_partition_start_offset,
+      source_start_offset);
+
+    ssx::spawn_with_gate(_gate, [this, source_start_offset] {
+        return prefix_truncate(source_start_offset);
+    });
+}
+
+ss::future<> partition_replicator::prefix_truncate(kafka::offset o) {
+    static constexpr auto prefix_truncate_timeout = 5s;
+    auto prefix_f = co_await ss::coroutine::as_future(_sink->prefix_truncate(
+      o, ss::lowres_clock::now() + prefix_truncate_timeout));
+    _in_progress_truncate_offset = std::nullopt;
+    if (prefix_f.failed()) {
+        auto ex = prefix_f.get_exception();
+        auto level = ssx::is_shutdown_exception(ex) ? ss::log_level::debug
+                                                    : ss::log_level::warn;
+        vlogl(_log, level, "Exception during prefix truncation: {}", ex);
+        co_return;
+    }
+    auto ec = prefix_f.get();
+    // It is possible for another truncation to be queued up if it's higher than
+    // the offset we just truncated to.  Only reset if the in progress offset is
+    // less than or equal to this offset
+
+    if (ec != kafka::error_code::none) {
+        vlog(_log.warn, "Failed to truncate source partition to {}: {}", o, ec);
+        co_return;
+    }
+    vlog(_log.debug, "Successfully truncated shadow partition to {}", o);
 }
 
 } // namespace cluster_link::replication

--- a/src/v/cluster_link/replication/partition_replicator.h
+++ b/src/v/cluster_link/replication/partition_replicator.h
@@ -71,6 +71,8 @@ public:
 
     partition_offsets_report get_partition_offsets_report() const;
 
+    void maybe_synchronize_start_offset();
+
 private:
     struct replicate_ctx {
         ::model::offset begin;
@@ -87,6 +89,9 @@ private:
       ss::future<result<raft::replicate_result>>,
       ::model::offset begin,
       ::model::offset end) noexcept;
+    ss::future<> prefix_truncate(kafka::offset);
+
+private:
     ::model::ntp _ntp;
     ::model::term_id _term;
     link_configuration_provider& _config_provider;
@@ -101,6 +106,7 @@ private:
     ssx::semaphore _max_requests{
       max_in_flight_requests, "partition_replicator"};
     backoff_policy _backoff_policy;
+    std::optional<kafka::offset> _in_progress_truncate_offset{std::nullopt};
 };
 
 } // namespace cluster_link::replication

--- a/src/v/cluster_link/replication/tests/BUILD
+++ b/src/v/cluster_link/replication/tests/BUILD
@@ -8,6 +8,9 @@ redpanda_test_cc_library(
     hdrs = [
         "deps_test_impl.h",
     ],
+    implementation_deps = [
+        "//src/v/kafka/protocol",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/cluster_link/replication:deps",
@@ -28,6 +31,7 @@ redpanda_cc_gtest(
         ":deps_test_impl",
         "//src/v/base",
         "//src/v/cluster_link/replication:partition_replicator",
+        "//src/v/kafka/protocol",
         "//src/v/model/tests:random",
         "//src/v/random:generators",
         "//src/v/ssx:future_util",

--- a/src/v/cluster_link/replication/tests/deps_test_impl.cc
+++ b/src/v/cluster_link/replication/tests/deps_test_impl.cc
@@ -10,6 +10,7 @@
 
 #include "cluster_link/replication/tests/deps_test_impl.h"
 
+#include "kafka/protocol/errors.h"
 #include "model/tests/random_batch.h"
 #include "random/generators.h"
 
@@ -55,7 +56,24 @@ raft::replicate_stages accounting_sink::replicate(
 
 void accounting_sink::notify_replicator_failure(model::term_id) {}
 
-kafka::offset accounting_sink::high_watermark() const { return {}; }
+kafka::offset accounting_sink::high_watermark() const { return _last_offset; }
+
+ss::future<kafka::error_code> accounting_sink::prefix_truncate(
+  kafka::offset truncation_offset, ss::lowres_clock::time_point) {
+    if (truncation_offset <= start_offset()) {
+        co_return kafka::error_code::none;
+    }
+
+    if (truncation_offset > high_watermark()) {
+        co_return kafka::error_code::offset_out_of_range;
+    }
+
+    _start_offset = truncation_offset;
+
+    co_return kafka::error_code::none;
+}
+
+kafka::offset accounting_sink::start_offset() { return _start_offset; }
 
 ss::future<> random_data_source::start(kafka::offset offset) noexcept {
     _next = offset;

--- a/src/v/cluster_link/replication/tests/deps_test_impl.h
+++ b/src/v/cluster_link/replication/tests/deps_test_impl.h
@@ -34,9 +34,14 @@ public:
       ss::abort_source& as) override;
     void notify_replicator_failure(::model::term_id) override;
     kafka::offset high_watermark() const final;
+    ss::future<kafka::error_code> prefix_truncate(
+      kafka::offset truncation_offset,
+      ss::lowres_clock::time_point deadline) final;
+    kafka::offset start_offset() final;
 
 private:
     size_t _records_consumed;
+    kafka::offset _start_offset{0};
     kafka::offset _last_offset{};
     ss::gate _gate;
 };

--- a/src/v/cluster_link/replication/tests/link_replication_mgr_tests.cc
+++ b/src/v/cluster_link/replication/tests/link_replication_mgr_tests.cc
@@ -14,6 +14,8 @@
 #include "test_utils/randoms.h"
 #include "test_utils/test.h"
 
+#include <system_error>
+
 using namespace std::chrono_literals;
 
 namespace {
@@ -94,6 +96,13 @@ public:
     void notify_replicator_failure(model::term_id) final {}
 
     kafka::offset high_watermark() const final { return {}; }
+
+    ss::future<kafka::error_code>
+    prefix_truncate(kafka::offset, ss::lowres_clock::time_point) final {
+        co_return kafka::error_code::none;
+    }
+
+    kafka::offset start_offset() final { return {}; }
 
 private:
     ss::gate _gate;

--- a/src/v/cluster_link/replication/tests/partition_replicator_tests.cc
+++ b/src/v/cluster_link/replication/tests/partition_replicator_tests.cc
@@ -11,6 +11,7 @@
 #include "base/units.h"
 #include "cluster_link/replication/partition_replicator.h"
 #include "cluster_link/replication/tests/deps_test_impl.h"
+#include "kafka/protocol/errors.h"
 #include "model/tests/random_batch.h"
 #include "ssx/future-util.h"
 #include "test_utils/async.h"
@@ -19,6 +20,8 @@
 #include "utils/mutex.h"
 
 #include <seastar/core/sleep.hh>
+
+#include <system_error>
 
 using namespace std::chrono_literals;
 
@@ -140,12 +143,33 @@ public:
 
     void set_fail_replication(bool value) { _fail_replication = value; }
 
-    kafka::offset high_watermark() const final { return {}; }
+    kafka::offset high_watermark() const final {
+        return _last_replicated_offset;
+    }
+
+    ss::future<kafka::error_code> prefix_truncate(
+      kafka::offset truncation_offset, ss::lowres_clock::time_point) final {
+        if (truncation_offset <= start_offset()) {
+            // No-op, return early
+            co_return kafka::error_code::none;
+        }
+
+        if (truncation_offset > high_watermark()) {
+            co_return kafka::error_code::offset_out_of_range;
+        }
+
+        _start_offset = truncation_offset;
+
+        co_return kafka::error_code::none;
+    }
+
+    kafka::offset start_offset() final { return _start_offset; }
 
 private:
     model::ntp _ntp{"kafka", "test", model::partition_id(0)};
     mutex _replication_mu{"test_replication"};
     bool _fail_replication = false;
+    kafka::offset _start_offset{0};
     kafka::offset _last_replicated_offset;
 };
 

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -27,6 +27,7 @@
 #include "cluster_link/shadow_linking_rpc_service.h"
 #include "cluster_link/source_topic_syncer.h"
 #include "kafka/client/direct_consumer/direct_consumer.h"
+#include "kafka/data/partition_proxy.h"
 #include "kafka/server/group_router.h"
 #include "kafka/server/snc_quota_manager.h"
 #include "kafka/server/write_at_offset_stm.h"
@@ -490,6 +491,20 @@ public:
         _gate.check();
         return ::model::offset_cast(
           _partition->log()->from_log_offset(_partition->high_watermark()));
+    }
+
+    ss::future<kafka::error_code> prefix_truncate(
+      kafka::offset truncation_offset,
+      ss::lowres_clock::time_point deadline) final {
+        auto h = _gate.hold();
+        co_return co_await kafka::make_partition_proxy(_partition)
+          .prefix_truncate(kafka::offset_cast(truncation_offset), deadline);
+    }
+
+    kafka::offset start_offset() final {
+        _gate.check();
+        return ::model::offset_cast(
+          kafka::make_partition_proxy(_partition).start_offset());
     }
 
 private:

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -1389,6 +1389,127 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         consumer.start()
         consumer.wait_total_reads(count=9000, timeout_sec=60, backoff_sec=5)
 
+    def _maybe_failure_injector(self, with_failures: bool):
+        if with_failures:
+            return self.create_source_failure_injector()
+        else:
+            return self._nop_context_manager()
+
+    def _perform_auto_prefix_trimming(self, topic_name: str, partition_count: int):
+        self.start_producer_consumer(topic=topic_name, msg_size=128, msg_cnt=100000)
+        offsets = [1000, 1001, 1200, 1500, 2000, 2500]
+
+        def wait_for_records(rpk: RpkTool, offset: int, expected_partition_count: int):
+            num_parts = 0
+            for part in rpk.describe_topic("source-topic"):
+                num_parts += 1
+                if (part.high_watermark or 0) < offset:
+                    return False
+            return num_parts == expected_partition_count
+
+        partitions = list(range(partition_count))
+
+        for o in offsets:
+            self.source_cluster.service.wait_until(
+                lambda: wait_for_records(
+                    self.source_cluster_rpk,
+                    offset=o,
+                    expected_partition_count=partition_count,
+                ),
+                timeout_sec=30,
+                backoff_sec=1,
+                err_msg=f"Timed out waiting for {o} records in each partition",
+            )
+
+            self.logger.info(f"Trimming source topic prefixes to {o}")
+            self.source_cluster_rpk.trim_prefix(
+                topic="source-topic", partitions=partitions, offset=o
+            )
+
+            def wait_for_start_offset(
+                rpk: RpkTool, offset: int, expected_partition_count: int
+            ):
+                num_parts = 0
+                for part in rpk.describe_topic("source-topic"):
+                    num_parts += 1
+                    self.logger.info(
+                        f"Offset for source-topic/{part.id} is {part.start_offset}"
+                    )
+                    if (part.start_offset or 0) != offset:
+                        return False
+                return num_parts == expected_partition_count
+
+            self.source_cluster.service.wait_until(
+                lambda: wait_for_start_offset(
+                    self.source_cluster_rpk,
+                    offset=o,
+                    expected_partition_count=partition_count,
+                ),
+                timeout_sec=30,
+                backoff_sec=1,
+                err_msg=f"Timed out waiting for start offset to be {o} in each partition",
+            )
+
+            # Produce a single message to ensure cluster linking picks up the trim
+            for part in range(0, partition_count):
+                self.logger.info(f"Producing trim-trigger message to partition {part}")
+                self.source_cluster_rpk.produce(
+                    topic="source-topic",
+                    key="trim-trigger",
+                    msg="trim-trigger",
+                    partition=part,
+                )
+
+            self.logger.info(
+                f"Now waiting for target cluster to get to {o} starting offset"
+            )
+
+            self.target_cluster.service.wait_until(
+                lambda: wait_for_start_offset(
+                    self.target_cluster_rpk,
+                    offset=o,
+                    expected_partition_count=partition_count,
+                ),
+                timeout_sec=60,
+                backoff_sec=1,
+                err_msg=f"Timed out waiting for target to get start offset to be {o} in each partition",
+            )
+
+    @cluster(num_nodes=8)
+    @ignore(
+        with_failures=True,
+        source_cluster_spec=SecondaryClusterSpec(
+            ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
+        ),
+    )
+    @matrix(
+        with_failures=[True, False],
+        source_cluster_spec=[
+            SecondaryClusterSpec(ServiceType.REDPANDA),
+            SecondaryClusterSpec(
+                ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
+            ),
+        ],
+    )
+    def test_auto_prefix_trimming(self, with_failures, source_cluster_spec):
+        partition_count = 5
+        topic = TopicSpec(
+            name="source-topic", partition_count=partition_count, replication_factor=3
+        )
+
+        self.source_default_client().create_topic(topic)
+        self.create_link("test-link")
+
+        self.target_cluster.service.wait_until(
+            lambda: self.topic_exists_in_target(topic.name),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"Topic {topic.name} not found in target cluster",
+        )
+
+        with self._maybe_failure_injector(with_failures):
+            self._perform_auto_prefix_trimming(topic.name, partition_count)
+
 
 class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
     def create_source_consumer(self, topic, group_name="test_group", consumer_count=1):


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR implements automatic prefix-truncation based on updates to the source parititon's log start offset.  As that changes, the Shadow Link will automatically prefix-truncate the shadow partition.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
