### PR TITLE
datalake: make all `redpanda` fields optional + upgrade test for v25.3 breaking changes

### DIFF
--- a/src/v/datalake/catalog_schema_manager.cc
+++ b/src/v/datalake/catalog_schema_manager.cc
@@ -254,8 +254,11 @@ catalog_schema_manager::ensure_table_schema(
             if (merge_res.has_error()) {
                 vlog(
                   datalake_log.warn,
-                  "Failed to merge record schema with table schema {}: {}",
+                  "Failed to merge record schema with table schema {} (writer: "
+                  "{}, current: {}): {}",
                   table_id,
+                  writer_struct_type,
+                  current_schema->schema_struct,
                   merge_res.error());
                 co_return errc::not_supported;
             }

--- a/src/v/datalake/table_definition.cc
+++ b/src/v/datalake/table_definition.cc
@@ -15,9 +15,9 @@ struct_type schemaless_struct_type() {
     using namespace iceberg;
     struct_type system_fields;
     system_fields.fields.emplace_back(
-      nested_field::create(2, "partition", field_required::yes, int_type{}));
+      nested_field::create(2, "partition", field_required::no, int_type{}));
     system_fields.fields.emplace_back(
-      nested_field::create(3, "offset", field_required::yes, long_type{}));
+      nested_field::create(3, "offset", field_required::no, long_type{}));
     system_fields.fields.emplace_back(
       nested_field::create(
         4, "timestamp", field_required::no, timestamptz_type{}));
@@ -44,7 +44,7 @@ struct_type schemaless_struct_type() {
       nested_field::create(
         1,
         ss::sstring{rp_struct_name},
-        field_required::yes,
+        field_required::no,
         std::move(system_fields)));
 
     return res;

--- a/src/v/datalake/table_definition.cc
+++ b/src/v/datalake/table_definition.cc
@@ -20,7 +20,7 @@ struct_type schemaless_struct_type() {
       nested_field::create(3, "offset", field_required::yes, long_type{}));
     system_fields.fields.emplace_back(
       nested_field::create(
-        4, "timestamp", field_required::yes, timestamptz_type{}));
+        4, "timestamp", field_required::no, timestamptz_type{}));
 
     struct_type headers_kv;
     headers_kv.fields.emplace_back(
@@ -32,7 +32,7 @@ struct_type schemaless_struct_type() {
         5,
         "headers",
         field_required::no,
-        list_type::create(6, field_required::yes, std::move(headers_kv))));
+        list_type::create(6, field_required::no, std::move(headers_kv))));
 
     system_fields.fields.emplace_back(
       nested_field::create(9, "key", field_required::no, binary_type{}));

--- a/tests/rptest/tests/datalake/datalake_upgrade_test.py
+++ b/tests/rptest/tests/datalake/datalake_upgrade_test.py
@@ -7,19 +7,33 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+from enum import Enum
 import json
 
 from ducktape.mark import matrix
+from ducktape.utils.util import wait_until
 
+from rptest.clients.admin import v2 as admin_v2
+from rptest.clients.rpk import RpkTool
 from rptest.services.cluster import cluster
+from rptest.services.catalog_service import CatalogType
+from rptest.services.spark_service import SparkService
 from rptest.services.redpanda import SISettings
 from rptest.services.redpanda_installer import RedpandaVersionTriple
-from rptest.tests.datalake.catalog_service_factory import filesystem_catalog_type
 from rptest.tests.datalake.datalake_services import DatalakeServices
 from rptest.tests.datalake.query_engine_base import QueryEngineType
 from rptest.tests.datalake.utils import supported_storage_types
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.utils.mode_checks import skip_debug_mode
+
+
+class MigrationType25_3(str, Enum):
+    RENAME_COLUMNS = "rename_columns"
+    RECREATE_TABLE = "recreate_table"
+    # Alternatives:
+    # - drop columns
+    # - drop table
+    # - rename table
 
 
 class DatalakeUpgradeTest(RedpandaTest):
@@ -35,42 +49,159 @@ class DatalakeUpgradeTest(RedpandaTest):
         )
         self.test_ctx = test_context
         self.topic_name = "upgrade_topic"
+        self.topic_partition_count = 10
 
         # Initial version that supported Iceberg.
         self.initial_version: RedpandaVersionTriple = (24, 3, 1)
         self.min_version_with_lag_support: RedpandaVersionTriple = (25, 1, 1)
-        # NOTE: v25.3 introduces some changes that break table compatibility
-        # across the upgrade, so we'll stop upgrading at 25.2 for now.
-        # TODO: Implement post-25.3 table migration as an integration test
-        self.max_version: RedpandaVersionTriple = (25, 2, 1)
+        self.min_version_25_3_with_new_schemas: RedpandaVersionTriple = (25, 3, 0)
 
     def setUp(self):
         self.redpanda._installer.install(self.redpanda.nodes, self.initial_version)
+
+    def pre_25_3_migration(self) -> None:
+        """
+        Redpanda v25.3 includes changes that break table compatibility. There
+        are manual steps that need to be run.
+        1. Before upgrading to v25.3, disable Iceberg on all Iceberg topics.
+        2. Upgrade to v25.3.
+        3. Query the GetCoordinatorState endpoint to see if there are any
+           remaining pending entries in the coordinator for the given topic.
+        4. Run queries to make the existing table conformant with the breaking
+           changes:
+           - redpanda.timestamp column (was timestamp, is now timestamptz)
+           - redpanda.headers.key column (was binary, is now string)
+           - Avro optionals (two-field union of [null, <FIELD>]) (was struct,
+             is now an optional FIELD)
+           - Avro union (union field names are now the type names)
+           - Avro enums (was integer, is now string)
+           - Protobuf enums (was integer, is now string)
+        5. Reenable Iceberg on all Iceberg topics.
+        """
+        self.logger.info("Running pre-25.3 migration steps")
+        rpk = RpkTool(self.redpanda)
+
+        # Disabling Iceberg before upgrading (and restarting) ensures that post
+        # upgrade, no additional state will be sent to the coordinator while we
+        # update our tables.
+        rpk.alter_topic_config(self.topic_name, "redpanda.iceberg.mode", "disabled")
+
+    def post_25_3_migration(
+        self, migration_type: MigrationType25_3, spark: SparkService
+    ) -> None:
+        self.logger.info("Running post-25.3 migration steps")
+
+        def no_pending_coordinator_state():
+            topic = self.topic_name
+            admin: admin_v2.Admin = admin_v2.Admin(self.redpanda)
+            request = admin_v2.datalake_pb.GetCoordinatorStateRequest()
+            try:
+                response: admin_v2.datalake_pb.GetCoordinatorStateResponse = (
+                    admin.datalake().get_coordinator_state(request)
+                )
+            except Exception as e:
+                self.logger.debug(f"Exception while hitting endpoint: {e}")
+                return False
+
+            if topic not in response.state.topic_states:
+                self.logger.debug(f"Topic {topic} not found")
+                return False
+
+            t_state = response.state.topic_states[topic]
+            self.logger.debug(f"{topic}: {t_state}")
+            if len(t_state.partition_states) != self.topic_partition_count:
+                return False
+
+            for _, p_state in t_state.partition_states.items():
+                if len(p_state.pending_entries) > 0:
+                    return False
+            return True
+
+        wait_until(no_pending_coordinator_state, timeout_sec=60, backoff_sec=1)
+
+        match migration_type:
+            case MigrationType25_3.RENAME_COLUMNS:
+                # Rename the affected columns. This means that the query engine
+                # will need to know about the renamed fields.
+                with spark.run_query(f"""
+                    ALTER TABLE redpanda.{self.topic_name}
+                    RENAME COLUMN redpanda.timestamp TO timestamp_v1
+                    """) as cursor:
+                    cursor.close()
+
+                with spark.run_query(f"""
+                    ALTER TABLE redpanda.{self.topic_name}
+                    RENAME COLUMN redpanda.headers TO headers_v1
+                    """) as cursor:
+                    cursor.close()
+
+            case MigrationType25_3.RECREATE_TABLE:
+                # Replace the table. This means that the query engines will be
+                # able to use the existing table/columns with no modifications.
+                with spark.run_query(f"""
+                    REPLACE TABLE redpanda.{self.topic_name}
+                    USING iceberg
+                    AS SELECT
+                    STRUCT(
+                        redpanda.partition,
+                        redpanda.offset,
+                        CAST(redpanda.timestamp AS TIMESTAMP) AS timestamp,
+                        TRANSFORM(redpanda.headers,
+                          header -> STRUCT(
+                            CAST(header.key AS STRING) AS key,
+                            header.value)
+                          ) AS headers,
+                        redpanda.key
+                        ) AS redpanda,
+                    value
+                    FROM redpanda.{self.topic_name}
+                    """) as cursor:
+                    cursor.close()
+
+        rpk = RpkTool(self.redpanda)
+        rpk.alter_topic_config(self.topic_name, "redpanda.iceberg.mode", "key_value")
 
     @cluster(num_nodes=6)
     @skip_debug_mode
     @matrix(
         cloud_storage_type=supported_storage_types(),
         query_engine=[QueryEngineType.SPARK],
+        migration_type=[
+            MigrationType25_3.RECREATE_TABLE,
+            MigrationType25_3.RENAME_COLUMNS,
+        ],
     )
-    def test_upload_through_upgrade(self, cloud_storage_type, query_engine):
+    def test_upload_through_upgrade(
+        self, cloud_storage_type, query_engine, migration_type: MigrationType25_3
+    ):
         """
         Test that Iceberg translation can progress through different versions
         of Redpanda (e.g. ensuring that data format changes or additional
         Iceberg fields don't block progress).
         """
-        versions = self.load_version_range(self.initial_version, self.max_version)
+        versions = self.load_version_range(self.initial_version)
         lag_set = self.initial_version >= self.min_version_with_lag_support
+        migrated_schemas_25_3 = (
+            self.initial_version >= self.min_version_25_3_with_new_schemas
+        )
+
+        last_version_with_legacy_schemas = (
+            self.redpanda._installer.highest_from_prior_feature_version(
+                self.min_version_25_3_with_new_schemas
+            )
+        )
 
         total_count = 0
         with DatalakeServices(
             self.test_ctx,
             redpanda=self.redpanda,
-            catalog_type=filesystem_catalog_type(),
+            catalog_type=CatalogType.REST_JDBC,
             include_query_engines=[query_engine],
         ) as dl:
             dl.create_iceberg_enabled_topic(
-                self.topic_name, partitions=10, target_lag_ms=10000
+                self.topic_name,
+                partitions=self.topic_partition_count,
+                target_lag_ms=10000,
             )
 
             def run_workload():
@@ -90,7 +221,17 @@ class DatalakeUpgradeTest(RedpandaTest):
                     # to first version with the support
                     self.redpanda.set_cluster_config({"iceberg_target_lag_ms": 10000})
                     lag_set = True
+                if (
+                    not migrated_schemas_25_3
+                    and v >= self.min_version_25_3_with_new_schemas
+                ):
+                    self.post_25_3_migration(migration_type, dl.spark())
+                    migrated_schemas_25_3 = True
+
                 run_workload()
+
+                if v == last_version_with_legacy_schemas:
+                    self.pre_25_3_migration()
 
             # Run some spot checks to ensure that the data is readable.
             result = dl.spark().run_query_fetch_one(f"""
@@ -101,10 +242,15 @@ class DatalakeUpgradeTest(RedpandaTest):
                                                     """)
             assert result[0] == 10, f"Expected 10 rows, got {result[0]}"
 
+            additional_where = ""
+            if migration_type == MigrationType25_3.RENAME_COLUMNS:
+                additional_where = "OR redpanda.timestamp_v1 >= '2025-01-01 00:00:00'"
+
             result = dl.spark().run_query_fetch_one(f"""
                                                     SELECT count(*)
                                                     FROM redpanda.{self.topic_name}
                                                     WHERE redpanda.timestamp >= '2025-01-01 00:00:00'
+                                                    {additional_where}
                                                     """)
             assert result[0] == total_count, (
                 f"Expected {total_count} rows, got {result[0]}"
@@ -146,12 +292,80 @@ class DatalakeUpgradeTest(RedpandaTest):
                 assert rows
 
                 # Fetch all rows to make sure the underlying query engine does
-                # not fail internally but it should be enough to check a single
-                # row from the result set.
-                assert json.loads(rows[0][0]).keys() == {
+                # not fail internally.
+                expected_keys_pre_25_3 = {
                     "partition",
                     "offset",
                     "timestamp",
                     "headers",
                     "key",
-                }, f"Unexpected JSON keys: {json.loads(rows[0][0]).keys()}"
+                }
+                if migration_type == MigrationType25_3.RENAME_COLUMNS:
+                    # Row written pre-25.3 will use the old, renamed column.
+                    expected_keys_pre_25_3.remove("timestamp")
+                    expected_keys_pre_25_3.remove("headers")
+                    expected_keys_pre_25_3.add("timestamp_v1")
+                    expected_keys_pre_25_3.add("headers_v1")
+
+                # Note, individual rows only include either the pre-25.3
+                # fields or post-25.3 fields, unlike the table schema which
+                # contains both.
+                expected_keys = {
+                    "partition",
+                    "offset",
+                    "timestamp",
+                    "headers",
+                    "key",
+                    "timestamp_type",
+                }
+
+                for row in rows:
+                    row_keys = json.loads(row[0]).keys()
+                    assert (
+                        row_keys == expected_keys_pre_25_3 or row_keys == expected_keys
+                    ), f"Unexpected JSON keys: {row_keys}"
+
+                # The table schema will have both the pre-25.3 _and_ post-25.3
+                # fields.
+                expected_struct_str = ""
+                match migration_type:
+                    case MigrationType25_3.RENAME_COLUMNS:
+                        expected_struct_str = (
+                            "struct<"
+                            "partition:int,"
+                            "offset:bigint,"
+                            "timestamp_v1:timestamp_ntz,"
+                            "headers_v1:array<struct<key:binary,value:binary>>,"
+                            "key:binary,"
+                            "timestamp:timestamp,"
+                            "headers:array<struct<key:string,value:binary>>,"
+                            "timestamp_type:int>"
+                        )
+                    case MigrationType25_3.RECREATE_TABLE:
+                        expected_struct_str = (
+                            "struct<"
+                            "partition:int,"
+                            "offset:bigint,"
+                            "timestamp:timestamp,"
+                            "headers:array<struct<key:string,value:binary>>,"
+                            "key:binary,"
+                            "timestamp_type:int>"
+                        )
+
+                spark_expected_out = [
+                    (
+                        "redpanda",
+                        expected_struct_str,
+                        None,
+                    ),
+                    ("value", "binary", None),
+                    ("", "", ""),
+                    ("# Partitioning", "", ""),
+                    ("Part 0", "hours(redpanda.timestamp)", ""),
+                ]
+                spark_describe_out = dl.spark().run_query_fetch_all(
+                    f"describe redpanda.{self.topic_name}"
+                )
+                assert spark_describe_out == spark_expected_out, (
+                    f"\n{spark_describe_out}\nvs\n{spark_expected_out}"
+                )


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
All Iceberg topics will break (end up DLQing data) when upgrading to v25.3 because the Iceberg topics' table schemas will have type changes for `redpanda.timestamp` and `redpanda.headers` that aren't seamless Iceberg schema changes. This will require some manual intervention to the table, either by removing/renaming these columns, recreating the table, or something similar.

This PR makes all `redpanda` fields optional so that it's easier to upgrade to v25.3 by renaming `redpanda` columns. Otherwise, renaming/removing the `redpanda` columns will result in subsequent Iceberg translation failures because it's not allowed to add a required field to a table.

This PR also adds a test for this, as a form of documenting the manual upgrade steps required. Testing for the data-specific breakages (i.e. the Avro/Protobuf-specific breakages) is left as future work.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* Tables created by Iceberg Topics will have all fields of the `redpanda` system struct be optional. Existing tables will be updated as well.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
