### PR TITLE
force partition movement first, ask questions later

### DIFF
--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -955,8 +955,49 @@ auto partition_balancer_planner::request_context::do_with_partition(
   const model::ntp& ntp,
   const partition_assignment& assignment,
   Visitor& visitor) {
-    const bool is_disabled = _parent._state.topics().is_disabled(ntp);
     const auto& orig_replicas = assignment.replicas;
+
+    { // first thing to check, is this partition being forced
+      // check if the ntp is to be force reconfigured.
+        auto topic_md = _parent._state.topics().get_topic_metadata_ref(
+          model::topic_namespace_view{ntp});
+        const auto& force_reconfigurable_partitions
+          = _parent._state.topics().partitions_to_force_recover();
+        auto force_it = force_reconfigurable_partitions.find(ntp);
+        if (topic_md && force_it != force_reconfigurable_partitions.end()) {
+            auto topic_revision = topic_md.value().get().get_revision();
+            const auto& entries = force_it->second;
+            auto it = std::find_if(
+              entries.begin(), entries.end(), [&](const auto& entry) {
+                  return entry.topic_revision == topic_revision
+                         && are_replica_sets_equal(
+                           entry.assignment, orig_replicas);
+              });
+
+            if (it != entries.end()) {
+                auto size_it = _ntp2sizes.find(ntp);
+                std::optional<request_context::partition_sizes> sizes;
+                if (size_it != _ntp2sizes.end()) {
+                    sizes = size_it->second;
+                }
+                partition part{force_reassignable_partition{
+                  ntp, sizes, assignment, it->dead_nodes, *this}};
+
+                auto deferred = ss::defer([&] {
+                    auto& force_reassignable
+                      = std::get<force_reassignable_partition>(part._variant);
+                    if (force_reassignable._reallocation) {
+                        _force_reassignments.emplace(
+                          ntp,
+                          std::move(force_reassignable._reallocation.value()));
+                    }
+                });
+                return visitor(part);
+            }
+        }
+    }
+
+    const bool is_disabled = _parent._state.topics().is_disabled(ntp);
     auto in_progress_it = _parent._state.topics().updates_in_progress().find(
       ntp);
     if (in_progress_it != _parent._state.topics().updates_in_progress().end()) {
@@ -1021,42 +1062,6 @@ auto partition_balancer_planner::request_context::do_with_partition(
           *this}};
         return visitor(part);
     }
-
-    // check if the ntp is to be force reconfigured.
-    auto topic_md = _parent._state.topics().get_topic_metadata_ref(
-      model::topic_namespace_view{ntp});
-    const auto& force_reconfigurable_partitions
-      = _parent._state.topics().partitions_to_force_recover();
-    auto force_it = force_reconfigurable_partitions.find(ntp);
-    if (topic_md && force_it != force_reconfigurable_partitions.end()) {
-        auto topic_revision = topic_md.value().get().get_revision();
-        const auto& entries = force_it->second;
-        auto it = std::find_if(
-          entries.begin(), entries.end(), [&](const auto& entry) {
-              return entry.topic_revision == topic_revision
-                     && are_replica_sets_equal(entry.assignment, orig_replicas);
-          });
-
-        if (it != entries.end()) {
-            auto size_it = _ntp2sizes.find(ntp);
-            std::optional<request_context::partition_sizes> sizes;
-            if (size_it != _ntp2sizes.end()) {
-                sizes = size_it->second;
-            }
-            partition part{force_reassignable_partition{
-              ntp, sizes, assignment, it->dead_nodes, *this}};
-
-            auto deferred = ss::defer([&] {
-                auto& force_reassignable
-                  = std::get<force_reassignable_partition>(part._variant);
-                if (force_reassignable._reallocation) {
-                    _force_reassignments.emplace(
-                      ntp, std::move(force_reassignable._reallocation.value()));
-                }
-            });
-            return visitor(part);
-        }
-    };
 
     auto size_it = _ntp2sizes.find(ntp);
     if (size_it == _ntp2sizes.end()) {


### PR DESCRIPTION
There are exit clauses in do_with_partition that result in forced movement not being forced. Namely if a partitiong is 'moving' it will never be forced.

This commit swaps the order of checks such that the first thing checked is forced partition movement.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [x] v24.3.x

## Release Notes
### Improvements
* forced partitions movements will always force

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
