### PR TITLE
ct/l1/io: bump up writer buffer options

### DIFF
--- a/src/v/cloud_topics/level_one/common/file_io.cc
+++ b/src/v/cloud_topics/level_one/common/file_io.cc
@@ -40,7 +40,12 @@ public:
           _path.native(),
           ss::open_flags::rw | ss::open_flags::truncate
             | ss::open_flags::create);
-        co_return co_await ss::make_file_output_stream(std::move(file));
+        co_return co_await ss::make_file_output_stream(
+          std::move(file),
+          ss::file_output_stream_options{
+            .buffer_size = 128_KiB,
+            .write_behind = 2,
+          });
     }
     ss::future<> remove() override { return ss::remove_file(_path.native()); }
     ss::future<ss::input_stream<char>> input_stream() override {


### PR DESCRIPTION

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
