### PR TITLE
tuner: Minor fixes to checkers

### DIFF
--- a/src/go/rpk/pkg/tuners/net_checkers.go
+++ b/src/go/rpk/pkg/tuners/net_checkers.go
@@ -83,33 +83,34 @@ func (f *netCheckersFactory) NewNicRxTxQueueCountChecker(
 		Warning,
 		true,
 		func() (interface{}, error) {
-			if !f.rnc.Tuners.GetAllowRxTxQueueTuner() {
-				zap.L().Sugar().Debugf("Skipping RX/TX Queue Tuner as it's disabled by configuration")
-				return true, nil
-			}
+			return isSet(nic, func(currentNic network.Nic) (bool, error) {
+				if !f.rnc.Tuners.GetAllowRxTxQueueTuner() {
+					zap.L().Sugar().Debugf("Skipping RX/TX Queue Tuner as it's disabled by configuration")
+					return true, nil
+				}
 
-			supportsIrqLowering, err := nic.SupportsRxTxQueueLowering()
-			if err != nil {
-				return false, err
-			}
-			if !supportsIrqLowering {
-				zap.L().Sugar().Debugf("Skipping RX/TX Queue Tuner as using an unknown driver")
-				return true, nil
-			}
+				supportsIrqLowering, err := currentNic.SupportsRxTxQueueLowering()
+				if err != nil {
+					return false, err
+				}
+				if !supportsIrqLowering {
+					zap.L().Sugar().Debugf("Skipping RX/TX Queue Tuner as using an unknown driver")
+					return true, nil
+				}
 
-			currentChannels, targetChannels, err := network.GetCurrentAndTargetChannels(nic, mode, cpuMask, f.cpuMasks, f.rnc, f.ethtool)
-			if err != nil {
-				return false, err
-			}
+				currentChannels, targetChannels, err := network.GetCurrentAndTargetChannels(currentNic, mode, cpuMask, f.cpuMasks, f.rnc, f.ethtool)
+				if err != nil {
+					return false, err
+				}
 
-			rxCheck := currentChannels.RxCount == targetChannels.RxCount
-			txCheck := currentChannels.TxCount == targetChannels.TxCount
-			combinedCheck := currentChannels.CombinedCount == targetChannels.CombinedCount
+				rxCheck := currentChannels.RxCount == targetChannels.RxCount
+				txCheck := currentChannels.TxCount == targetChannels.TxCount
+				combinedCheck := currentChannels.CombinedCount == targetChannels.CombinedCount
 
-			// We need all to be true because for the not in use one the check will always be true (0 == 0)
-			return rxCheck && txCheck && combinedCheck, nil
-		},
-	)
+				// We need all to be true because for the not in use one the check will always be true (0 == 0)
+				return rxCheck && txCheck && combinedCheck, nil
+			})
+		})
 }
 
 func (f *netCheckersFactory) NewNicRxTxQueueCountCheckers(

--- a/src/go/rpk/pkg/tuners/net_tuners.go
+++ b/src/go/rpk/pkg/tuners/net_tuners.go
@@ -430,7 +430,7 @@ func (f *netTunersFactory) NewInterruptConfigFileTuner(interfaces []string, mode
 				return false, err
 			}
 
-			if currentConfig != targetConfig {
+			if currentConfig.Cpusets == nil || *currentConfig.Cpusets != *targetConfig.Cpusets {
 				zap.L().Sugar().Debugf("Current config %+v is different than target %+v", currentConfig, targetConfig)
 				return false, nil
 			}


### PR DESCRIPTION
Fix two minor issues in the new checkers:
 - Support bonds in the RxTx queue lowering checker
 - Fix tuner state file always being rewritten

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none

