### PR TITLE
Iceberg: Avro: Translate enums as string_type

### DIFF
--- a/src/v/iceberg/conversion/avro_utils.cc
+++ b/src/v/iceberg/conversion/avro_utils.cc
@@ -45,7 +45,7 @@ struct branch_label_primitive_type_visitor {
         return branch->name().simpleName();
     }
 
-    ss::sstring operator()(const iceberg::long_type&) {
+    ss::sstring operator()(const iceberg::string_type&) {
         if (branch->type() == avro::AVRO_ENUM) {
             return branch->name().simpleName();
         }

--- a/src/v/iceberg/conversion/schema_avro.cc
+++ b/src/v/iceberg/conversion/schema_avro.cc
@@ -148,7 +148,7 @@ inner_field_type_from_avro(const avro::NodePtr& node, state& state) {
           std::move(struct_result.value()));
     }
     case avro::AVRO_ENUM:
-        return iceberg::long_type{};
+        return iceberg::string_type{};
     case avro::AVRO_ARRAY: {
         if (node->leaves() != 1) {
             return conversion_exception(

--- a/src/v/iceberg/conversion/tests/iceberg_avro_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_avro_tests.cc
@@ -306,7 +306,7 @@ TEST(AvroSchema, TestRecordType) {
         0, iceberg::field_required::yes, iceberg::double_type{})));
 
     ASSERT_TRUE(
-      field_matches(struct_t.fields[5], "myenum", iceberg::long_type{}));
+      field_matches(struct_t.fields[5], "myenum", iceberg::string_type{}));
 
     iceberg::struct_type union_struct;
     // starts from union_1 as the union_0 is null type which is not represented
@@ -1025,17 +1025,17 @@ AssertionResult value_matches(
         }
 
         auto& actual_primitive = std::get<iceberg::primitive_value>(value);
-        if (!std::holds_alternative<iceberg::long_value>(actual_primitive)) {
+        if (!std::holds_alternative<iceberg::string_value>(actual_primitive)) {
             return AssertionFailure() << fmt::format(
-                     "Expected value {} to be of type iceberg::long_value",
+                     "Expected value {} to be of type iceberg::string_value",
                      value);
         }
-        auto& value = std::get<iceberg::long_value>(actual_primitive);
-        if (value.val != static_cast<int64_t>(generic_enum.value())) {
+        auto& value = std::get<iceberg::string_value>(actual_primitive);
+        if (value.val != iobuf::from(generic_enum.symbol())) {
             return AssertionFailure() << fmt::format(
                      "Expected value {} to be equal to {}",
                      value,
-                     generic_enum.value());
+                     generic_enum.symbol());
         }
         return AssertionSuccess();
     }

--- a/src/v/iceberg/conversion/values_avro.cc
+++ b/src/v/iceberg/conversion/values_avro.cc
@@ -59,8 +59,9 @@ struct primitive_visitor {
     }
     ret_t operator()(int64_t v) {
         if (node->type() == avro::AVRO_ENUM) {
-            return convert_primitive<int64_t, iceberg::long_value>(
-              v, avro::AVRO_ENUM, node);
+            iobuf buf = iobuf::from(node->nameAt(v));
+            return convert_primitive<iobuf, iceberg::string_value>(
+              std::move(buf), avro::AVRO_ENUM, node);
         }
         if (node->logicalType().type() == avro::LogicalType::TIME_MICROS) {
             return convert_primitive<int64_t, iceberg::time_value>(

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -193,12 +193,12 @@ AVRO_SCHEMA_TEST_CASES = {
         expected_trino=[
             ("number", "bigint", "", ""),
             ("timestamp_us", "timestamp(6) with time zone", "", ""),
-            ("suit", "bigint", "", ""),
+            ("suit", "varchar", "", ""),
         ],
         expected_spark=[
             ("number", "bigint", None),
             ("timestamp_us", "timestamp", None),
-            ("suit", "bigint", None),
+            ("suit", "string", None),
             ("", "", ""),
             ("# Partitioning", "", ""),
             ("Part 0", "hours(redpanda.timestamp)", ""),


### PR DESCRIPTION
We recently changed this for protobuf, we should change it here too to match.

This is yet another table-breaking change.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* Iceberg: Avro enums will be translated as strings (previously long ints)

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
