### PR TITLE
Add cluster connections list

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.65.0
 	github.com/redpanda-data/common-go/proto v0.0.0-20250820120127-9b518fca5ecf
-	github.com/redpanda-data/common-go/rpadmin v0.1.17-0.20251020144719-b6a2aa280c0b
+	github.com/redpanda-data/common-go/rpadmin v0.1.17-0.20251027222924-1d7bc6181411
 	github.com/redpanda-data/common-go/rpsr v0.1.2
 	github.com/redpanda-data/protoc-gen-go-mcp v0.0.0-20250812151819-7e5d5fef8241
 	github.com/rs/xid v1.6.0
@@ -73,7 +73,7 @@ require (
 	golang.org/x/sync v0.17.0
 	golang.org/x/sys v0.37.0
 	golang.org/x/term v0.36.0
-	google.golang.org/genproto/googleapis/api v0.0.0-20251020155222-88f65dc88635
+	google.golang.org/genproto/googleapis/api v0.0.0-20251022142026-3a174f9686a8
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251014184007-4626949a642f
 	google.golang.org/protobuf v1.36.10
 	gopkg.in/yaml.v2 v2.4.0
@@ -86,7 +86,7 @@ require (
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.10-20250912141014-52f32327d4b0.1 // indirect
 	buf.build/gen/go/grpc-ecosystem/grpc-gateway/protocolbuffers/go v1.36.10-20221127060915-a1ecdc58eccd.1 // indirect
-	buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251021160320-d44d783528c8.2 // indirect
+	buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251025023032-d04cd59f0958.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/BurntSushi/toml v1.1.0 // indirect
 	github.com/Microsoft/go-winio v0.4.14 // indirect

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -8,8 +8,8 @@ buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.10-20251022210436-b
 buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.10-20251022210436-bbacedafcd60.1/go.mod h1:LUiEZ+N+YdoSrXkiPjXMLIrGZA/rQ891zrqwzXeNzgw=
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.10-20250904135917-9feeb2588236.1 h1:vjdv8if8q5whtYaE6tfbhoX80qWi/pnguP4RAxEaMaU=
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.10-20250904135917-9feeb2588236.1/go.mod h1:EhA16a3hhvTg9rzQ69ch2mJ2ppasEGJFy8ViCc8PYUE=
-buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251021160320-d44d783528c8.2 h1:1Lt/PN3/ZJ9TiGIfmoQI1r1K2l3UQmHGpQ3pgxuwDxc=
-buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251021160320-d44d783528c8.2/go.mod h1:3kUjX0N7isNP+EIkTWWht2ATgy8f4/+0feYvn65UgCs=
+buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251025023032-d04cd59f0958.2 h1:QzDn+n2TYwzHL6JkkvBJBQZUQFqLqPs06zw+iEb/L3w=
+buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251025023032-d04cd59f0958.2/go.mod h1:jL3Gxe+SdWs6ZE0R53U16T08XGFDksf/YWKzAK1BZ88=
 buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251025023032-d04cd59f0958.1 h1:30O0ky3rUXnI8Ya8DUKxYXo9+Bs36e/hrpRqjfaqw10=
 buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251025023032-d04cd59f0958.1/go.mod h1:QenSPzqxZpyo9hHIpRzTetvDchelVDzimnmaggHKenc=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250819145731-621dc775ffe4.1 h1:CiTv2Rme+0H/2IQpyZFK8SQYRWgRWEvFNxZIfDMYOQQ=
@@ -251,8 +251,8 @@ github.com/redpanda-data/common-go/net v0.1.0 h1:JnJioRJuL961r1QXiJQ1tW9+yEaJfu8
 github.com/redpanda-data/common-go/net v0.1.0/go.mod h1:iOdNkjxM7a1T8F3cYHTaKIPFCHzzp/ia6TN+Z+7Tt5w=
 github.com/redpanda-data/common-go/proto v0.0.0-20250820120127-9b518fca5ecf h1:Oe0Sc3+/37Xgdpze7klkWyvB6eAt/nuUhrn93Rd4ESA=
 github.com/redpanda-data/common-go/proto v0.0.0-20250820120127-9b518fca5ecf/go.mod h1:GMoRcdMz6CIpr+8vKrSJvr8fJDlojETRV45BD6A0DvU=
-github.com/redpanda-data/common-go/rpadmin v0.1.17-0.20251020144719-b6a2aa280c0b h1:1IYchooFCXdUog5fu+ytG/Rnk0/B9amqMhGvs+1mxZw=
-github.com/redpanda-data/common-go/rpadmin v0.1.17-0.20251020144719-b6a2aa280c0b/go.mod h1:cmQgsLSFmrrt/9Ztu+zKz8+t+iGTvWVyyBz9nKiimts=
+github.com/redpanda-data/common-go/rpadmin v0.1.17-0.20251027222924-1d7bc6181411 h1:3EGG99swdunHH173yRBneKs0bb1vD+ci6igg9NUCTTM=
+github.com/redpanda-data/common-go/rpadmin v0.1.17-0.20251027222924-1d7bc6181411/go.mod h1:PJIPruemuTspD26BeFt96sxw4Q+xqMZhlDonDMxs6iU=
 github.com/redpanda-data/common-go/rpsr v0.1.2 h1:DThUeyfBH8fkL9WoP1sEbRhT2NVV22zmsTpcCtzfusQ=
 github.com/redpanda-data/common-go/rpsr v0.1.2/go.mod h1:2j2416onosg5FKaKz52NooRE+q/9EJqQn0kyTcTXWHc=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525 h1:vskZrV6q8W8flL0Ud23AJUYAd8ZgTadO45+loFnG2G0=
@@ -448,8 +448,8 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/genproto v0.0.0-20250409194420-de1ac958c67a h1:AoyioNVZR+nS6zbvnvW5rjQdeQu7/BWwIT7YI8Gq5wU=
 google.golang.org/genproto v0.0.0-20250409194420-de1ac958c67a/go.mod h1:qD4k1RhYfNmRjqaHJxKLG/HRtqbXVclhjop2mPlxGwA=
-google.golang.org/genproto/googleapis/api v0.0.0-20251020155222-88f65dc88635 h1:1wvBeYv+A2zfEbxROscJl69OP0m74S8wGEO+Syat26o=
-google.golang.org/genproto/googleapis/api v0.0.0-20251020155222-88f65dc88635/go.mod h1:fDMmzKV90WSg1NbozdqrE64fkuTv6mlq2zxo9ad+3yo=
+google.golang.org/genproto/googleapis/api v0.0.0-20251022142026-3a174f9686a8 h1:mepRgnBZa07I4TRuomDE4sTIYieg/osKmzIf4USdWS4=
+google.golang.org/genproto/googleapis/api v0.0.0-20251022142026-3a174f9686a8/go.mod h1:fDMmzKV90WSg1NbozdqrE64fkuTv6mlq2zxo9ad+3yo=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251014184007-4626949a642f h1:1FTH6cpXFsENbPR5Bu8NQddPSaUUE6NA2XdZdDSAJK4=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251014184007-4626949a642f/go.mod h1:7i2o+ce6H/6BluujYR+kqX3GKH+dChPTQU19wjRPiGk=
 google.golang.org/grpc v1.73.0 h1:VIWSmpI2MegBtTuFt5/JWy2oXxtjJ/e89Z70ImfD2ok=

--- a/src/go/rpk/pkg/cli/cluster/BUILD
+++ b/src/go/rpk/pkg/cli/cluster/BUILD
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//src/go/rpk/pkg/adminapi",
         "//src/go/rpk/pkg/cli/cluster/config",
+        "//src/go/rpk/pkg/cli/cluster/connections",
         "//src/go/rpk/pkg/cli/cluster/license",
         "//src/go/rpk/pkg/cli/cluster/maintenance",
         "//src/go/rpk/pkg/cli/cluster/partitions",

--- a/src/go/rpk/pkg/cli/cluster/cluster.go
+++ b/src/go/rpk/pkg/cli/cluster/cluster.go
@@ -11,6 +11,7 @@ package cluster
 
 import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster/connections"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster/license"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster/maintenance"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster/partitions"
@@ -49,6 +50,7 @@ func NewCommand(fs afero.Fs, p *pkgconfig.Params) *cobra.Command {
 		storage.NewCommand(fs, p),
 		txn.NewCommand(fs, p),
 		quotas.NewCommand(fs, p),
+		connections.NewCommand(fs, p),
 		offsets,
 	)
 

--- a/src/go/rpk/pkg/cli/cluster/connections/BUILD
+++ b/src/go/rpk/pkg/cli/cluster/connections/BUILD
@@ -1,0 +1,37 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "connections",
+    srcs = [
+        "connections.go",
+        "list.go",
+        "types.go",
+    ],
+    importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster/connections",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/go/rpk/pkg/adminapi",
+        "//src/go/rpk/pkg/config",
+        "//src/go/rpk/pkg/out",
+        "@build_buf_gen_go_redpandadata_core_protocolbuffers_go//redpanda/core/admin/v2:admin",
+        "@com_connectrpc_connect//:connect",
+        "@com_github_docker_go_units//:go-units",
+        "@com_github_spf13_afero//:afero",
+        "@com_github_spf13_cobra//:cobra",
+    ],
+)
+
+go_test(
+    name = "connections_test",
+    srcs = [
+        "connections_test.go",
+        "list_test.go",
+    ],
+    embed = [":connections"],
+    deps = [
+        "@build_buf_gen_go_redpandadata_core_protocolbuffers_go//redpanda/core/admin/v2:admin",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//types/known/durationpb",
+        "@org_golang_google_protobuf//types/known/timestamppb",
+    ],
+)

--- a/src/go/rpk/pkg/cli/cluster/connections/connections.go
+++ b/src/go/rpk/pkg/cli/cluster/connections/connections.go
@@ -1,0 +1,29 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Package connections deals with listing current connections in the cluster
+package connections
+
+import (
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "connections",
+		Aliases: []string{"connection"},
+		Short:   "Manage and monitor cluster connections",
+		Long:    `Manage and monitor cluster connections.`,
+	}
+
+	cmd.AddCommand(newConnectionList(fs, p))
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cluster/connections/connections_test.go
+++ b/src/go/rpk/pkg/cli/cluster/connections/connections_test.go
@@ -1,0 +1,138 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package connections
+
+import (
+	"testing"
+	"time"
+
+	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestParseConnection(t *testing.T) {
+	protoConn := &adminv2.KafkaConnection{
+		NodeId:    2,
+		ShardId:   4,
+		Uid:       "36338ca5-86b7-4478-ad23-32d49cfaef61",
+		State:     adminv2.KafkaConnectionState_KAFKA_CONNECTION_STATE_OPEN,
+		OpenTime:  timestamppb.New(time.Date(2025, 10, 23, 1, 2, 3, 0, time.UTC)),
+		CloseTime: nil,
+		AuthenticationInfo: &adminv2.AuthenticationInfo{
+			State:         adminv2.AuthenticationState_AUTHENTICATION_STATE_SUCCESS,
+			Mechanism:     adminv2.AuthenticationMechanism_AUTHENTICATION_MECHANISM_MTLS,
+			UserPrincipal: "someone",
+		},
+		TlsInfo: &adminv2.TLSInfo{
+			Enabled: true,
+		},
+		ListenerName: "external",
+		Source: &adminv2.Source{
+			IpAddress: "4.2.2.1",
+			Port:      49722,
+		},
+		ClientId:              "a-unique-client-id",
+		ClientSoftwareName:    "some-library",
+		ClientSoftwareVersion: "v0.0.1",
+		GroupId:               "group-a",
+		GroupInstanceId:       "group-instance",
+		GroupMemberId:         "group-member",
+		ApiVersions:           map[int32]int32{0: 4, 9: 11},
+		IdleDuration:          durationpb.New(100 * time.Millisecond),
+		TransactionalId:       "trans-id",
+		InFlightRequests: &adminv2.InFlightRequests{
+			SampledInFlightRequests: []*adminv2.InFlightRequests_Request{
+				{
+					ApiKey:           0, // PRODUCE
+					InFlightDuration: durationpb.New(40 * time.Millisecond),
+				},
+			},
+			HasMoreRequests: true,
+		},
+		TotalRequestStatistics: &adminv2.RequestStatistics{
+			ProduceBytes:      10000,
+			FetchBytes:        2000,
+			RequestCount:      200,
+			ProduceBatchCount: 10,
+		},
+		RecentRequestStatistics: &adminv2.RequestStatistics{
+			ProduceBytes:      1000,
+			FetchBytes:        200,
+			RequestCount:      20,
+			ProduceBatchCount: 1,
+		},
+	}
+
+	out := parseConnection(protoConn)
+
+	// Verify basic fields
+	require.Equal(t, int32(2), out.NodeID)
+	require.Equal(t, uint32(4), out.ShardID)
+	require.Equal(t, "36338ca5-86b7-4478-ad23-32d49cfaef61", out.UID)
+	require.Equal(t, "OPEN", out.State)
+	require.Equal(t, "2025-10-23T01:02:03Z", out.OpenTime)
+	require.Nil(t, out.CloseTime)
+	require.NotEmpty(t, out.ConnectionDuration)
+	require.True(t, out.TLSEnabled)
+	require.Equal(t, "group-a", out.GroupID)
+	require.Equal(t, "group-instance", out.GroupInstanceID)
+	require.Equal(t, "group-member", out.GroupMemberID)
+	require.Equal(t, "100ms", out.IdleDuration)
+	require.Equal(t, "external", out.ListenerName)
+	require.Equal(t, "trans-id", out.TransactionalID)
+
+	// Verify authentication
+	require.Equal(t, &Authentication{
+		State:         "SUCCESS",
+		Mechanism:     "MTLS",
+		UserPrincipal: "someone",
+	}, out.Authentication)
+
+	// Verify client
+	require.Equal(t, &Client{
+		IP:              "4.2.2.1",
+		Port:            49722,
+		ID:              "a-unique-client-id",
+		SoftwareName:    "some-library",
+		SoftwareVersion: "v0.0.1",
+	}, out.Client)
+
+	// Verify API versions (order-independent check)
+	require.ElementsMatch(t, []APIVersion{
+		{API: "PRODUCE", Version: 4},
+		{API: "OFFSET_FETCH", Version: 11},
+	}, out.APIVersions)
+
+	// Verify active requests
+	require.Equal(t, &ActiveRequests{
+		SampledRequests: []SampledRequest{
+			{API: "PRODUCE", Duration: "40ms"},
+		},
+		HasMoreRequests: true,
+	}, out.ActiveRequests)
+
+	// Verify statistics
+	require.Equal(t, &RequestStatistics{
+		ProduceBytes:      10000,
+		FetchBytes:        2000,
+		RequestCount:      200,
+		ProduceBatchCount: 10,
+	}, out.RequestStatisticsAll)
+
+	require.Equal(t, &RequestStatistics{
+		ProduceBytes:      1000,
+		FetchBytes:        200,
+		RequestCount:      20,
+		ProduceBatchCount: 1,
+	}, out.RequestStatistics1m)
+}

--- a/src/go/rpk/pkg/cli/cluster/connections/list.go
+++ b/src/go/rpk/pkg/cli/cluster/connections/list.go
@@ -1,0 +1,263 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Package connections deals with listing current connections in the cluster
+package connections
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
+	"connectrpc.com/connect"
+	"github.com/docker/go-units"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+const defaultPageSize = 20
+
+var errInvalidStateFilter = errors.New("invalid state filter")
+
+var stateOptionMap = map[string]adminv2.KafkaConnectionState{
+	"OPEN":   adminv2.KafkaConnectionState_KAFKA_CONNECTION_STATE_OPEN,
+	"CLOSED": adminv2.KafkaConnectionState_KAFKA_CONNECTION_STATE_CLOSED,
+}
+
+var tableHeaders = []string{
+	"UID",
+	"STATE",
+	"USER",
+	"CLIENT-ID",
+	"IP:PORT",
+	"NODE",
+	"SHARD",
+	"OPEN-TIME",
+	"IDLE",
+	"PROD-TPUT/SEC",
+	"FETCH-TPUT/SEC",
+	"REQS/MIN",
+}
+
+func getConnectionDuration(conn *adminv2.KafkaConnection) string {
+	opened := conn.OpenTime.AsTime()
+	closed := conn.CloseTime.AsTime()
+
+	duration := closed.Sub(opened)
+	if opened.After(closed) {
+		duration = time.Since(opened)
+	}
+
+	return duration.Round(time.Second).String()
+}
+
+func writeConnectionRow(w *out.TabWriter, conn *Connection) {
+	userString := conn.Authentication.UserPrincipal
+	if conn.Authentication.State != "SUCCESS" {
+		userString = "UNAUTHENTICATED"
+	}
+
+	w.Print(
+		conn.UID,
+		conn.State,
+		userString,
+		conn.Client.ID,
+		fmt.Sprintf("%s:%d", conn.Client.IP, conn.Client.Port),
+		conn.NodeID,
+		conn.ShardID,
+		conn.ConnectionDuration,
+		conn.IdleDuration,
+		units.HumanSize(float64(conn.RequestStatistics1m.ProduceBytes/60)),
+		units.HumanSize(float64(conn.RequestStatistics1m.FetchBytes/60)),
+		conn.RequestStatistics1m.RequestCount,
+	)
+}
+
+func printConnectionListTable(connections []*Connection) string {
+	if len(connections) <= 0 {
+		return "No open connections found."
+	}
+
+	var buf bytes.Buffer
+	writer := out.NewTableTo(&buf, tableHeaders...)
+
+	for _, conn := range connections {
+		writeConnectionRow(writer, conn)
+	}
+
+	writer.Flush()
+	return buf.String()
+}
+
+type flagFilters struct {
+	state                 string
+	ipAddress             string
+	clientID              string
+	clientSoftwareName    string
+	clientSoftwareVersion string
+	groupID               string
+	idleMs                int64
+	user                  string
+}
+
+func (f *flagFilters) buildFilterClauses() ([]string, error) {
+	clauses := []string{}
+
+	if f.state != "" {
+		val, ok := stateOptionMap[f.state]
+		if !ok {
+			return nil, fmt.Errorf("%w: %s", errInvalidStateFilter, f.state)
+		}
+		clauses = append(clauses, fmt.Sprintf("state = %s", val.String()))
+	}
+
+	// We have a series of string options we need to map to the upstream API filters
+	for key, val := range map[string]string{
+		"source.ip_address":                  f.ipAddress,
+		"client_id":                          f.clientID,
+		"client_software_name":               f.clientSoftwareName,
+		"client_software_version":            f.clientSoftwareVersion,
+		"group_id":                           f.groupID,
+		"authentication_info.user_principal": f.user,
+	} {
+		if val != "" {
+			clauses = append(clauses, fmt.Sprintf("%s = %q", key, val))
+		}
+	}
+
+	if f.idleMs > 0 {
+		clauses = append(clauses, fmt.Sprintf("idle_duration > %dms", f.idleMs))
+	}
+	return clauses, nil
+}
+
+func newConnectionList(fs afero.Fs, p *config.Params) *cobra.Command {
+	var filters flagFilters
+	var filterRaw string
+	var orderBy string
+	var limit int32
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Display statistics about current kafka connections",
+		Long: `Display statistics about current kafka connections.
+
+This command displays a table of active and recently closed connections within the cluster.
+
+Use filtering and sorting to identify the connections of the client applications that you are interested in. See --help for the list of filtering arguments and sorting arguments.
+
+In addition to the filtering shorthand cli arguments (e.g.; --client-id, --state), you can also use the --filter-raw and --order-by arguments that take string expressions. To understand the syntax of these arguments, refer to the admin API docs of the filter and order-by fields of the ListKafkaConnections endpoint: https://docs.redpanda.com/api/doc/admin/version/11f41833-5783-4f1a-ad64-5957267abd52/operation/operation-redpanda-core-admin-v2-clusterservice-listkafkaconnections
+
+By default only a subset of the per-connection data is printed. To see all of the available data, use --format=json.`,
+		Example: `
+List connections ordered by their recent produce throughput:
+	rpk cluster connections list --order-by="recent_request_statistics.produce_bytes desc"
+
+List connections ordered by their recent fetch throughput:
+	rpk cluster connections list --order-by="recent_request_statistics.fetch_bytes desc"
+
+List connections ordered by the time that they've been idle:
+	rpk cluster connections list --order-by="idle_duration desc"
+
+List connections ordered by those that have made the least requests:
+	rpk cluster connections list --order-by="total_request_statistics.request_count asc"
+
+List extended output for open connections in json format:
+	rpk cluster connections list --format=json --state="OPEN"`,
+		Args: cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, _ []string) {
+			if h, ok := p.Formatter.Help([]Connection{}); ok {
+				out.Exit(h)
+			}
+
+			prof, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "rpk unable to load config: %v", err)
+
+			// This doesn't support using the public API yet
+			config.CheckExitCloudAdmin(prof)
+
+			cl, err := adminapi.NewClient(cmd.Context(), fs, prof)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			// Build the filters based on the current flag set
+			filterClauses, err := filters.buildFilterClauses()
+			out.MaybeDie(err, "invalid filters: %v", err)
+
+			filterString := filterRaw
+			if len(filterClauses) > 0 {
+				filterString = strings.Join(filterClauses, " AND ")
+			}
+
+			req := adminv2.ListKafkaConnectionsRequest{
+				Filter:   filterString,
+				OrderBy:  orderBy,
+				PageSize: limit,
+			}
+
+			resp, err := cl.ClusterService().ListKafkaConnections(cmd.Context(), &connect.Request[adminv2.ListKafkaConnectionsRequest]{Msg: &req})
+			out.MaybeDie(err, "error listing connections: %v", err)
+
+			conns := make([]*Connection, len(resp.Msg.Connections))
+			for i, conn := range resp.Msg.Connections {
+				conns[i] = parseConnection(conn)
+			}
+
+			if p.Formatter.IsText() {
+				fmt.Println(printConnectionListTable(conns))
+			} else {
+				// Convert from the core format to ours
+				conns := make([]*Connection, len(resp.Msg.Connections))
+				for i, conn := range resp.Msg.Connections {
+					conns[i] = parseConnection(conn)
+				}
+
+				_, _, output, err := p.Formatter.Format(conns)
+				out.MaybeDie(err, "unable to print in the required format %q: %v", p.Formatter.Kind, err)
+				out.Exit(output)
+			}
+		},
+	}
+
+	// Set filtering flags
+	fset := cmd.Flags()
+	fset.StringVarP(&filters.state, "state", "s", "", "Filter results by state (OPEN, CLOSED)")
+	fset.StringVar(&filters.ipAddress, "ip-address", "", "Filter results by the client ip address")
+	fset.StringVar(&filters.clientID, "client-id", "", "Filter results by the client ID")
+	fset.StringVar(&filters.clientSoftwareName, "client-software-name", "", "Filter results by the client software name")
+	fset.StringVar(&filters.clientSoftwareVersion, "client-software-version", "", "Filter results by the client software version")
+	fset.StringVarP(&filters.groupID, "group-id", "g", "", "Filter by client group ID")
+	fset.Int64VarP(&filters.idleMs, "idle-ms", "i", 0, "Show connections idle for more than i milliseconds")
+	fset.StringVarP(&filters.user, "user", "u", "", "Filter results by a specific user principal")
+	fset.StringVar(&filterRaw, "filter-raw", "", "Filter connections based on a raw query (overrides other filters)")
+
+	// TODO: add guardrails and define a proper field mapping
+	fset.StringVar(&orderBy, "order-by", "", "Order the results by their values. See Examples above")
+
+	// TODO: establish a limit
+	fset.Int32Var(&limit, "limit", defaultPageSize, "Limit how many records can be returned")
+
+	// Ensure --filters-raw can't be used with the other filters
+	cmd.MarkFlagsMutuallyExclusive("filter-raw", "state")
+	cmd.MarkFlagsMutuallyExclusive("filter-raw", "ip-address")
+	cmd.MarkFlagsMutuallyExclusive("filter-raw", "client-id")
+	cmd.MarkFlagsMutuallyExclusive("filter-raw", "client-software-name")
+	cmd.MarkFlagsMutuallyExclusive("filter-raw", "client-software-version")
+	cmd.MarkFlagsMutuallyExclusive("filter-raw", "group-id")
+	cmd.MarkFlagsMutuallyExclusive("filter-raw", "idle-ms")
+	cmd.MarkFlagsMutuallyExclusive("filter-raw", "user")
+
+	p.InstallFormatFlag(cmd)
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cluster/connections/list_test.go
+++ b/src/go/rpk/pkg/cli/cluster/connections/list_test.go
@@ -1,0 +1,178 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+package connections
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestGetConnectionDuration(t *testing.T) {
+	now := time.Now().UTC()
+	closed := timestamppb.New(now)
+	opened := timestamppb.New(now.Add(-10 * time.Second))
+
+	t.Run("open", func(t *testing.T) {
+		require.Equal(t, "10s", getConnectionDuration(&adminv2.KafkaConnection{OpenTime: opened}))
+	})
+
+	t.Run("closed", func(t *testing.T) {
+		require.Equal(t, "10s", getConnectionDuration(&adminv2.KafkaConnection{
+			OpenTime:  opened,
+			CloseTime: closed,
+		}))
+	})
+}
+
+func TestBuildFilterClauses(t *testing.T) {
+	// Make sure we correctly build a set of filters based on the flags we're given
+	cases := []struct {
+		name     string
+		filters  *flagFilters
+		expected []string
+		err      error
+	}{
+		{
+			name:     "state",
+			filters:  &flagFilters{state: "OPEN"},
+			expected: []string{"state = KAFKA_CONNECTION_STATE_OPEN"},
+		},
+		{
+			name:    "invalid state",
+			filters: &flagFilters{state: "FANCY"},
+			err:     errInvalidStateFilter,
+		},
+		{
+			name: "normal options",
+			filters: &flagFilters{
+				ipAddress: "127.0.0.1",
+				clientID:  "clientid", clientSoftwareName: "softwarename",
+				clientSoftwareVersion: "softwareversion",
+				groupID:               "groupid",
+				user:                  "principal",
+			},
+			expected: []string{
+				`source.ip_address = "127.0.0.1"`,
+				`client_id = "clientid"`,
+				`client_software_name = "softwarename"`,
+				`client_software_version = "softwareversion"`,
+				`group_id = "groupid"`,
+				`authentication_info.user_principal = "principal"`,
+			},
+		},
+		{
+			name:     "idle",
+			filters:  &flagFilters{idleMs: 2000},
+			expected: []string{"idle_duration > 2000ms"},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := tt.filters.buildFilterClauses()
+			if tt.err != nil {
+				require.ErrorIs(t, err, tt.err, "expected error")
+			} else {
+				require.ElementsMatch(t, tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestUserDisplay(t *testing.T) {
+	t.Run("logged in", func(t *testing.T) {
+		output := printConnectionListTable([]*Connection{
+			{
+				Client:              &Client{},
+				RequestStatistics1m: &RequestStatistics{},
+				Authentication: &Authentication{
+					State:         "SUCCESS",
+					UserPrincipal: "theuser",
+				},
+			},
+		})
+
+		require.Contains(t, strings.Split(output, "\n")[1], "theuser")
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		output := printConnectionListTable([]*Connection{
+			{
+				Client:              &Client{},
+				RequestStatistics1m: &RequestStatistics{},
+				Authentication: &Authentication{
+					State: "UNAUTHENTICATED",
+				},
+			},
+		})
+
+		require.Contains(t, strings.Split(output, "\n")[1], "UNAUTHENTICATED")
+	})
+}
+
+func TestConnectionsList(t *testing.T) {
+	t.Run("empty response", func(t *testing.T) {
+		display := printConnectionListTable([]*Connection{})
+		require.Equal(t, "No open connections found.", display)
+	})
+
+	openConn := Connection{
+		NodeID:  1,
+		ShardID: 2,
+		UID:     "uid",
+		State:   "OPEN",
+		Authentication: &Authentication{
+			State:         "SUCCESS",
+			Mechanism:     "MTLS",
+			UserPrincipal: "principal",
+		},
+		Client:             &Client{IP: "127.0.0.1", Port: 1234, ID: "client-id", SoftwareName: "client software name", SoftwareVersion: "v0.0.1"},
+		GroupID:            "group id",
+		ConnectionDuration: "10s",
+		IdleDuration:       "100ms",
+		RequestStatisticsAll: &RequestStatistics{
+			ProduceBytes:      1_000_000,
+			FetchBytes:        900_000,
+			RequestCount:      1000,
+			ProduceBatchCount: 2000,
+		},
+		RequestStatistics1m: &RequestStatistics{
+			ProduceBytes:      120_000,
+			FetchBytes:        60_000,
+			RequestCount:      100,
+			ProduceBatchCount: 200,
+		},
+	}
+
+	display := printConnectionListTable([]*Connection{&openConn})
+
+	// Fetch the first line and make sure it has the required headers in it in the right order
+	parts := strings.Split(display, "\n")
+
+	require.Equal(t, tableHeaders, strings.Fields(parts[0]))
+	require.Equal(t, []string{
+		"uid",            // UID
+		"OPEN",           // STATE
+		"principal",      // USER
+		"client-id",      // CLIENT-ID
+		"127.0.0.1:1234", // IP:PORT
+		"1",              // NODE
+		"2",              // SHARD
+		"10s",            // OPEN-TIME
+		"100ms",          // IDLE
+		"2kB",            // PROD-TPUT (120_000B / 60s)
+		"1kB",            // FETCH-TPUT (60_000B / 60s)
+		"100",            // REQS/MIN
+	}, strings.Fields(parts[1]))
+}

--- a/src/go/rpk/pkg/cli/cluster/connections/types.go
+++ b/src/go/rpk/pkg/cli/cluster/connections/types.go
@@ -1,0 +1,264 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Package connections deals with listing current connections in the cluster
+package connections
+
+import (
+	"strings"
+	"time"
+
+	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
+)
+
+// Connection represents a Kafka connection with custom formatting for output.
+type Connection struct {
+	NodeID               int32              `json:"node_id" yaml:"node_id"`
+	ShardID              uint32             `json:"shard_id" yaml:"shard_id"`
+	UID                  string             `json:"uid" yaml:"uid"`
+	State                string             `json:"state" yaml:"state"`
+	OpenTime             string             `json:"open_time" yaml:"open_time"`
+	CloseTime            *string            `json:"close_time" yaml:"close_time"`
+	ConnectionDuration   string             `json:"connection_duration" yaml:"connection_duration"`
+	Authentication       *Authentication    `json:"authentication,omitempty" yaml:"authentication,omitempty"`
+	TLSEnabled           bool               `json:"tls_enabled" yaml:"tls_enabled"`
+	Client               *Client            `json:"client,omitempty" yaml:"client,omitempty"`
+	GroupID              string             `json:"group_id,omitempty" yaml:"group_id,omitempty"`
+	GroupInstanceID      string             `json:"group_instance_id,omitempty" yaml:"group_instance_id,omitempty"`
+	GroupMemberID        string             `json:"group_member_id,omitempty" yaml:"group_member_id,omitempty"`
+	ListenerName         string             `json:"listener_name,omitempty" yaml:"listener_name,omitempty"`
+	TransactionalID      string             `json:"transactional_id,omitempty" yaml:"transactional_id,omitempty"`
+	APIVersions          []APIVersion       `json:"api_versions" yaml:"api_versions"`
+	IdleDuration         string             `json:"idle_duration,omitempty" yaml:"idle_duration,omitempty"`
+	ActiveRequests       *ActiveRequests    `json:"active_requests,omitempty" yaml:"active_requests,omitempty"`
+	RequestStatisticsAll *RequestStatistics `json:"request_statistics_all,omitempty" yaml:"request_statistics_all,omitempty"`
+	RequestStatistics1m  *RequestStatistics `json:"request_statistics_1m,omitempty" yaml:"request_statistics_1m,omitempty"`
+}
+
+// Authentication holds authentication information.
+type Authentication struct {
+	State         string `json:"state" yaml:"state"`
+	Mechanism     string `json:"mechanism" yaml:"mechanism"`
+	UserPrincipal string `json:"user_principal,omitempty" yaml:"user_principal,omitempty"`
+}
+
+// Client holds client connection information.
+type Client struct {
+	IP              string `json:"ip,omitempty" yaml:"ip,omitempty"`
+	Port            uint32 `json:"port,omitempty" yaml:"port,omitempty"`
+	ID              string `json:"id,omitempty" yaml:"id,omitempty"`
+	SoftwareName    string `json:"software_name,omitempty" yaml:"software_name,omitempty"`
+	SoftwareVersion string `json:"software_version,omitempty" yaml:"software_version,omitempty"`
+}
+
+// APIVersion represents a Kafka API and its version.
+type APIVersion struct {
+	API     string `json:"api" yaml:"api"`
+	Version int32  `json:"version" yaml:"version"`
+}
+
+// ActiveRequests holds information about in-flight requests.
+type ActiveRequests struct {
+	SampledRequests []SampledRequest `json:"sampled_requests" yaml:"sampled_requests"`
+	HasMoreRequests bool             `json:"has_more_requests" yaml:"has_more_requests"`
+}
+
+// SampledRequest represents a single in-flight request.
+type SampledRequest struct {
+	API      string `json:"api" yaml:"api"`
+	Duration string `json:"duration" yaml:"duration"`
+}
+
+// RequestStatistics holds aggregated request statistics.
+type RequestStatistics struct {
+	ProduceBytes      uint64 `json:"produce_bytes" yaml:"produce_bytes"`
+	FetchBytes        uint64 `json:"fetch_bytes" yaml:"fetch_bytes"`
+	RequestCount      uint64 `json:"request_count" yaml:"request_count"`
+	ProduceBatchCount uint64 `json:"produce_batch_count" yaml:"produce_batch_count"`
+}
+
+func parseConnection(conn *adminv2.KafkaConnection) *Connection {
+	c := &Connection{
+		NodeID:  conn.NodeId,
+		ShardID: conn.ShardId,
+		UID:     conn.Uid,
+		State:   strings.TrimPrefix(conn.State.String(), "KAFKA_CONNECTION_STATE_"),
+	}
+
+	// Add timestamps and duration
+	if conn.OpenTime != nil {
+		c.OpenTime = conn.OpenTime.AsTime().Format(time.RFC3339)
+		if conn.CloseTime != nil {
+			closeTime := conn.CloseTime.AsTime().Format(time.RFC3339)
+			c.CloseTime = &closeTime
+		}
+		c.ConnectionDuration = getConnectionDuration(conn)
+	}
+
+	// Parse authentication info
+	if conn.AuthenticationInfo != nil {
+		c.Authentication = &Authentication{
+			State:         strings.TrimPrefix(conn.AuthenticationInfo.State.String(), "AUTHENTICATION_STATE_"),
+			Mechanism:     strings.TrimPrefix(conn.AuthenticationInfo.Mechanism.String(), "AUTHENTICATION_MECHANISM_"),
+			UserPrincipal: conn.AuthenticationInfo.UserPrincipal,
+		}
+	}
+
+	c.TLSEnabled = conn.TlsInfo.Enabled
+
+	// Parse client info
+	if conn.Source != nil || conn.ClientId != "" || conn.ClientSoftwareName != "" || conn.ClientSoftwareVersion != "" {
+		c.Client = &Client{
+			ID:              conn.ClientId,
+			SoftwareName:    conn.ClientSoftwareName,
+			SoftwareVersion: conn.ClientSoftwareVersion,
+		}
+		if conn.Source != nil {
+			c.Client.IP = conn.Source.IpAddress
+			c.Client.Port = conn.Source.Port
+		}
+	}
+
+	// Parse group ID
+	c.GroupID = conn.GroupId
+	c.GroupInstanceID = conn.GroupInstanceId
+	c.GroupMemberID = conn.GroupMemberId
+
+	// Parse API versions
+	c.APIVersions = []APIVersion{}
+	for apiKey, version := range conn.ApiVersions {
+		c.APIVersions = append(c.APIVersions, APIVersion{
+			API:     formatAPIKey(apiKey),
+			Version: version,
+		})
+	}
+
+	c.IdleDuration = conn.IdleDuration.AsDuration().String()
+	c.ListenerName = conn.ListenerName
+	c.TransactionalID = conn.TransactionalId
+
+	// Parse in-flight requests
+	c.ActiveRequests = &ActiveRequests{
+		SampledRequests: []SampledRequest{},
+		HasMoreRequests: conn.InFlightRequests.HasMoreRequests,
+	}
+
+	if conn.InFlightRequests != nil {
+		if len(conn.InFlightRequests.SampledInFlightRequests) > 0 {
+			c.ActiveRequests.SampledRequests = make([]SampledRequest, len(conn.InFlightRequests.SampledInFlightRequests))
+			for i, req := range conn.InFlightRequests.SampledInFlightRequests {
+				c.ActiveRequests.SampledRequests[i] = SampledRequest{
+					API:      formatAPIKey(req.ApiKey),
+					Duration: req.InFlightDuration.AsDuration().String(),
+				}
+			}
+		}
+	}
+
+	// Parse total statistics
+	if conn.TotalRequestStatistics != nil {
+		c.RequestStatisticsAll = &RequestStatistics{
+			ProduceBytes:      conn.TotalRequestStatistics.ProduceBytes,
+			FetchBytes:        conn.TotalRequestStatistics.FetchBytes,
+			RequestCount:      conn.TotalRequestStatistics.RequestCount,
+			ProduceBatchCount: conn.TotalRequestStatistics.ProduceBatchCount,
+		}
+	}
+
+	// Parse recent statistics
+	if conn.RecentRequestStatistics != nil {
+		c.RequestStatistics1m = &RequestStatistics{
+			ProduceBytes:      conn.RecentRequestStatistics.ProduceBytes,
+			FetchBytes:        conn.RecentRequestStatistics.FetchBytes,
+			RequestCount:      conn.RecentRequestStatistics.RequestCount,
+			ProduceBatchCount: conn.RecentRequestStatistics.ProduceBatchCount,
+		}
+	}
+
+	return c
+}
+
+// formatAPIKey converts a Kafka API key to its string name.
+func formatAPIKey(apiKey int32) string {
+	// Kafka API keys: https://kafka.apache.org/protocol.html#protocol_api_keys
+	names := map[int32]string{
+		0:  "PRODUCE",
+		1:  "FETCH",
+		2:  "LIST_OFFSETS",
+		3:  "METADATA",
+		4:  "LEADER_AND_ISR",
+		5:  "STOP_REPLICA",
+		6:  "UPDATE_METADATA",
+		7:  "CONTROLLED_SHUTDOWN",
+		8:  "OFFSET_COMMIT",
+		9:  "OFFSET_FETCH",
+		10: "FIND_COORDINATOR",
+		11: "JOIN_GROUP",
+		12: "HEARTBEAT",
+		13: "LEAVE_GROUP",
+		14: "SYNC_GROUP",
+		15: "DESCRIBE_GROUPS",
+		16: "LIST_GROUPS",
+		17: "SASL_HANDSHAKE",
+		18: "API_VERSIONS",
+		19: "CREATE_TOPICS",
+		20: "DELETE_TOPICS",
+		21: "DELETE_RECORDS",
+		22: "INIT_PRODUCER_ID",
+		23: "OFFSET_FOR_LEADER_EPOCH",
+		24: "ADD_PARTITIONS_TO_TXN",
+		25: "ADD_OFFSETS_TO_TXN",
+		26: "END_TXN",
+		27: "WRITE_TXN_MARKERS",
+		28: "TXN_OFFSET_COMMIT",
+		29: "DESCRIBE_ACLS",
+		30: "CREATE_ACLS",
+		31: "DELETE_ACLS",
+		32: "DESCRIBE_CONFIGS",
+		33: "ALTER_CONFIGS",
+		34: "ALTER_REPLICA_LOG_DIRS",
+		35: "DESCRIBE_LOG_DIRS",
+		36: "SASL_AUTHENTICATE",
+		37: "CREATE_PARTITIONS",
+		38: "CREATE_DELEGATION_TOKEN",
+		39: "RENEW_DELEGATION_TOKEN",
+		40: "EXPIRE_DELEGATION_TOKEN",
+		41: "DESCRIBE_DELEGATION_TOKEN",
+		42: "DELETE_GROUPS",
+		43: "ELECT_LEADERS",
+		44: "INCREMENTAL_ALTER_CONFIGS",
+		45: "ALTER_PARTITION_REASSIGNMENTS",
+		46: "LIST_PARTITION_REASSIGNMENTS",
+		47: "OFFSET_DELETE",
+		48: "DESCRIBE_CLIENT_QUOTAS",
+		49: "ALTER_CLIENT_QUOTAS",
+		50: "DESCRIBE_USER_SCRAM_CREDENTIALS",
+		51: "ALTER_USER_SCRAM_CREDENTIALS",
+		52: "VOTE",
+		53: "BEGIN_QUORUM_EPOCH",
+		54: "END_QUORUM_EPOCH",
+		55: "DESCRIBE_QUORUM",
+		56: "ALTER_PARTITION",
+		57: "UPDATE_FEATURES",
+		58: "ENVELOPE",
+		59: "FETCH_SNAPSHOT",
+		60: "DESCRIBE_CLUSTER",
+		61: "DESCRIBE_PRODUCERS",
+		62: "BROKER_REGISTRATION",
+		63: "BROKER_HEARTBEAT",
+		64: "UNREGISTER_BROKER",
+		65: "DESCRIBE_TRANSACTIONS",
+		66: "LIST_TRANSACTIONS",
+		67: "ALLOCATE_PRODUCER_IDS",
+	}
+	if name, ok := names[apiKey]; ok {
+		return name
+	}
+	return "UNKNOWN"
+}


### PR DESCRIPTION
This adds a basic `cluster connections list` command that uses the adminv2 API to list open and recently closed client connections inside th cluster.

## Example output

`rpk cluster connection list --help`
```
Display statistics about current kafka connections.

This command displays a table of active and recently closed connections within the cluster.

Use filtering and sorting to identify the connections of the client applications that you are interested in. See --help for the list of filtering arguments and sorting arguments.

In addition to the filtering shorthand cli arguments (e.g.; --client-id, --state), you can also use the --filter-raw and --order-by arguments that take a string expression for filtering. To understand the syntax of these arguments, refer to the admin API docs of the filter and order-by fields of the ListKafkaConnections endpoint: https://docs.redpanda.com/api/doc/admin/v2/operation/operation-redpanda-core-admin-v2-clusterservice-listkafkaconnections

By default only a subset of the per-connection data is printed. To see all of the available data, use --format=json.

Usage:
  rpk cluster connections list [flags]

Examples:

List connections ordered by their recent produce throughput:
	rpk cluster connections list --order-by="recent_request_statistics.produce_bytes desc"

List connections ordered by their recent fetch throughput:
	rpk cluster connections list --order-by="recent_request_statistics.fetch_bytes desc"

List connections ordered by the time that they've been idle:
	rpk cluster connections list --order-by="idle_duration desc"

List connections ordered by those that have made the least requests:
	rpk cluster connections list --order-by="total_request_statistics.request_count asc"

List extended output for open connections in json format:
	rpk cluster connections list --format=json --state="OPEN"

Flags:
      --client-id string                 Filter results by the client ID
      --client-software-name string      Filter results by the client software name
      --client-software-version string   Filter results by the client software version
      --filter-raw string                Filter connections based on a raw query (overrides other filters)
      --format string                    Output format (json,yaml,text,wide,help) (default "text")
  -g, --group-id string                  Filter by client group ID
  -h, --help                             Help for list
  -i, --idle-ms int                      Show connections idle for more than i milliseconds
      --ip-address string                Filter results by the client ip address
      --limit int32                      Limit how many records can be returned (default 20)
      --order-by string                  Order the results by their values. See Examples above
  -s, --state string                     Filter results by state (OPEN, CLOSED)
  -u, --user string                      Filter results by a specific user principal

Global Flags:
      --config string            Redpanda or rpk config file; default search paths are "/Users/graham.smith/Library/Application Support/rpk/rpk.yaml", $PWD/redpanda.yaml, and /etc/redpanda/redpanda.yaml
  -X, --config-opt stringArray   Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail
      --profile string           rpk profile to use
  -v, --verbose                  Enable verbose logging

```

`rpk cluster connection list`
```
UID                                   STATE   USER             CLIENT-ID         IP:PORT           NODE  SHARD  OPEN-TIME  IDLE           PROD-TPUT/SEC  FETCH-TPUT/SEC  REQS/MIN
dcb11d6f-2760-489c-b0da-7159a320ba2c  OPEN    UNAUTHENTICATED  rpk               172.24.1.1:59830  2     0      1h32m4s    0s             0B             0B              12
48987ed9-537d-48b7-897f-2b0506f5a42b  OPEN    UNAUTHENTICATED  rpk               172.24.1.1:59834  2     0      1h32m3s    0s             0B             0B              12
ddb5f731-4a77-4c92-821f-eea41338076c  CLOSED  UNAUTHENTICATED  redpanda-console  172.24.1.5:43416  2     0      40s        39.996088954s  0B             0B              1
008ce0bd-59e0-47c6-8f3c-e3ceb8313ed8  CLOSED  UNAUTHENTICATED  redpanda-console  172.24.1.5:60592  2     0      40s        39.997238898s  0B             0B              1
3e243f78-b9c8-412e-b228-fd02ebc297a5  CLOSED  UNAUTHENTICATED  rpk               172.24.1.1:38256  2     0      40s        39.998215761s  0B             0B              1
b0796b09-d8d6-4953-ab71-96b6eceea8e1  CLOSED  UNAUTHENTICATED  rpk               172.24.1.1:39822  2     0      40s        40.001789052s  0B             0B              1
f8d86923-b54a-45b2-a918-10718e68117c  CLOSED  UNAUTHENTICATED  redpanda-console  172.24.1.5:43376  2     0      40s        40.00347736s   0B             0B              1
6ad9e31a-4ffb-4912-b43b-c302e04659d8  CLOSED  UNAUTHENTICATED  rpk               172.24.1.1:38246  2     1      40s        39.997179883s  0B             0B              1
8f015563-54e6-4088-84a3-de6e719a4e35  CLOSED  UNAUTHENTICATED  rpk               172.24.1.1:39936  2     1      40s        39.998671695s  0B             0B              1
...
```

`rpk cluster connection list --client-id=rpk --order-by "state, open_time asc"`
```
UID                                   STATE   USER             CLIENT-ID  IP:PORT           NODE  SHARD  OPEN-TIME  IDLE           PROD-TPUT/SEC  FETCH-TPUT/SEC  REQS/MIN
5d801ca6-e7b4-4ef7-98f6-0d1b40e29e07  OPEN    UNAUTHENTICATED  rpk        172.24.1.1:55278  0     0      1h33m13s   462.798031ms   0B             0B              33
2510ffad-f4f2-49db-bf9e-7ef3295edd45  OPEN    UNAUTHENTICATED  rpk        172.24.1.1:38488  1     1      1h33m9s    0s             0B             0B              11
23d5a95e-34c6-49e9-a17d-3e8f1233050c  OPEN    UNAUTHENTICATED  rpk        172.24.1.1:55318  0     1      1h33m9s    0s             0B             163B            59
dcb11d6f-2760-489c-b0da-7159a320ba2c  OPEN    UNAUTHENTICATED  rpk        172.24.1.1:59830  2     0      1h33m9s    0s             0B             0B              11
69712100-b6c8-465c-9c74-a1f651e0ada9  OPEN    UNAUTHENTICATED  rpk        172.24.1.1:55332  0     1      1h33m9s    462.619368ms   0B             0B              21
48987ed9-537d-48b7-897f-2b0506f5a42b  OPEN    UNAUTHENTICATED  rpk        172.24.1.1:59834  2     0      1h33m9s    0s             0B             0B              12
37000ff9-da71-4aac-b7ce-1c9fef4e1f0e  OPEN    UNAUTHENTICATED  rpk        172.24.1.1:38496  1     0      1h33m9s    0s             0B             0B              12
7ebab7f3-e731-4560-bff6-b08b99efc59b  OPEN    UNAUTHENTICATED  rpk        172.24.1.1:55334  0     0      1h33m9s    0s             0B             0B              13
...
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Features

* Added a beta `cluster connections list` command