### PR TITLE
ct/reconciler: fine grained stats on reconciler speed

### DIFF
--- a/src/v/cloud_topics/reconciler/BUILD
+++ b/src/v/cloud_topics/reconciler/BUILD
@@ -11,6 +11,7 @@ redpanda_cc_library(
         "reconciliation_consumer.h",
     ],
     deps = [
+        ":reconciler_probe",
         "//src/v/base",
         "//src/v/cloud_topics/level_one/common:object",
         "//src/v/model",

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -504,8 +504,6 @@ reconciler::add_source_to_object(
       src->ntp(),
       src->last_reconciled_offset());
 
-    reconciliation_consumer consumer(
-      ctx.builder.get(), src->topic_id_partition());
     std::optional<consumer_metadata> metadata;
     try {
         auto reader = co_await src->make_reader(
@@ -513,8 +511,8 @@ reconciler::add_source_to_object(
             .max_bytes = ctx.size_budget,
             .as = &_as,
           });
-        metadata = co_await std::move(reader).consume(
-          std::move(consumer), model::no_timeout);
+        metadata = co_await build_from_reader(
+          src->topic_id_partition(), std::move(reader), ctx.builder.get());
     } catch (...) {
         co_return std::unexpected(reconcile_error(
           "unable to consume from L0 partition: {}", std::current_exception()));

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -512,7 +512,10 @@ reconciler::add_source_to_object(
             .as = &_as,
           });
         metadata = co_await build_from_reader(
-          src->topic_id_partition(), std::move(reader), ctx.builder.get());
+          src->topic_id_partition(),
+          std::move(reader),
+          ctx.builder.get(),
+          &_probe);
     } catch (...) {
         co_return std::unexpected(reconcile_error(
           "unable to consume from L0 partition: {}", std::current_exception()));

--- a/src/v/cloud_topics/reconciler/reconciler_probe.cc
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.cc
@@ -78,6 +78,16 @@ void reconciler_probe::setup_metrics() {
 
         // Histograms.
         sm::make_histogram(
+          "l0_read_duration_seconds",
+          [this] { return _l0_read_duration.internal_histogram_logform(); },
+          sm::description("Duration reading from L0")),
+        sm::make_histogram(
+          "object_build_duration_seconds",
+          [this] {
+              return _object_build_duration.internal_histogram_logform();
+          },
+          sm::description("Duration building L1 objects")),
+        sm::make_histogram(
           "object_upload_duration_seconds",
           [this] {
               return _object_upload_duration.internal_histogram_logform();

--- a/src/v/cloud_topics/reconciler/reconciler_probe.h
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.h
@@ -55,6 +55,13 @@ public:
         _sources_per_object.record(count);
     }
 
+    std::unique_ptr<hist_t::measurement> measure_l0_read_duration() {
+        return _l0_read_duration.auto_measure();
+    }
+    std::unique_ptr<hist_t::measurement> measure_object_build_duration() {
+        return _object_build_duration.auto_measure();
+    }
+
     std::unique_ptr<hist_t::measurement> measure_object_upload_duration() {
         return _object_upload_duration.auto_measure();
     }
@@ -93,6 +100,8 @@ private:
     uint64_t _offset_corrections{0};
 
     // Histograms.
+    hist_t _l0_read_duration;
+    hist_t _object_build_duration;
     hist_t _object_upload_duration;
     hist_t _metastore_add_objects_duration;
     hist_t _object_size_bytes;

--- a/src/v/cloud_topics/reconciler/reconciliation_consumer.cc
+++ b/src/v/cloud_topics/reconciler/reconciliation_consumer.cc
@@ -16,47 +16,33 @@
 
 namespace cloud_topics::reconciler {
 
-reconciliation_consumer::reconciliation_consumer(
-  l1::object_builder* builder, model::topic_id_partition tidp)
-  : _builder(builder)
-  , _tidp(tidp)
-  , _metadata{
-      .base_offset = kafka::offset::min(),
-      .last_offset = kafka::offset::min(),
-      .last_timestamp = model::timestamp::min(),
-      .batch_count = 0} {}
-
-ss::future<ss::stop_iteration>
-reconciliation_consumer::operator()(model::record_batch batch) {
-    if (_metadata.base_offset == kafka::offset::min()) {
-        _metadata.base_offset = model::offset_cast(batch.base_offset());
-        co_await _builder->start_partition(_tidp);
+ss::future<std::optional<consumer_metadata>> build_from_reader(
+  model::topic_id_partition tidp,
+  model::record_batch_reader reader,
+  l1::object_builder* builder) {
+    auto gen = std::move(reader).slice_generator(model::no_timeout);
+    co_await builder->start_partition(tidp);
+    consumer_metadata metadata;
+    while (auto batches = co_await gen()) {
+        for (auto& batch : *batches) {
+            if (metadata.base_offset == kafka::offset::min()) {
+                metadata.base_offset = model::offset_cast(batch.base_offset());
+            }
+            metadata.last_timestamp = std::max(
+              batch.header().max_timestamp, metadata.last_timestamp);
+            metadata.last_offset = model::offset_cast(batch.last_offset());
+            if (!metadata.terms.contains(batch.term())) {
+                metadata.terms.insert(
+                  std::make_pair(
+                    batch.term(), model::offset_cast(batch.base_offset())));
+            }
+            ++metadata.batch_count;
+            co_await builder->add_batch(std::move(batch));
+        }
     }
-
-    // NOTE: Only data batches here. It's safe to use timestamps without
-    //       checking the batch type.
-    _metadata.last_timestamp = std::max(
-      batch.header().max_timestamp, _metadata.last_timestamp);
-    _metadata.last_offset = model::offset_cast(batch.last_offset());
-
-    if (!_metadata.terms.contains(batch.term())) {
-        _metadata.terms.insert(
-          std::make_pair(
-            batch.term(), model::offset_cast(batch.base_offset())));
-    }
-
-    ++_metadata.batch_count;
-
-    co_await _builder->add_batch(std::move(batch));
-
-    co_return ss::stop_iteration::no;
-}
-
-std::optional<consumer_metadata> reconciliation_consumer::end_of_stream() {
-    if (_metadata.base_offset != kafka::offset::min()) {
-        return _metadata;
-    }
-    return std::nullopt;
+    co_return metadata.batch_count == 0
+      ? std::nullopt
+      : std::make_optional(std::move(metadata));
 }
 
 } // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/reconciliation_consumer.cc
+++ b/src/v/cloud_topics/reconciler/reconciliation_consumer.cc
@@ -10,8 +10,6 @@
 
 #include "cloud_topics/reconciler/reconciliation_consumer.h"
 
-#include "model/timestamp.h"
-
 #include <seastar/core/coroutine.hh>
 
 namespace cloud_topics::reconciler {
@@ -19,11 +17,17 @@ namespace cloud_topics::reconciler {
 ss::future<std::optional<consumer_metadata>> build_from_reader(
   model::topic_id_partition tidp,
   model::record_batch_reader reader,
-  l1::object_builder* builder) {
+  l1::object_builder* builder,
+  reconciler_probe* probe) {
     auto gen = std::move(reader).slice_generator(model::no_timeout);
+    auto build_duration = probe->measure_object_build_duration();
     co_await builder->start_partition(tidp);
+    build_duration->stop();
+    auto read_duration = probe->measure_l0_read_duration();
     consumer_metadata metadata;
     while (auto batches = co_await gen()) {
+        read_duration->stop();
+        build_duration->start();
         for (auto& batch : *batches) {
             if (metadata.base_offset == kafka::offset::min()) {
                 metadata.base_offset = model::offset_cast(batch.base_offset());
@@ -39,6 +43,8 @@ ss::future<std::optional<consumer_metadata>> build_from_reader(
             ++metadata.batch_count;
             co_await builder->add_batch(std::move(batch));
         }
+        build_duration->stop();
+        read_duration->start();
     }
     co_return metadata.batch_count == 0
       ? std::nullopt

--- a/src/v/cloud_topics/reconciler/reconciliation_consumer.h
+++ b/src/v/cloud_topics/reconciler/reconciliation_consumer.h
@@ -13,12 +13,10 @@
 #include "absl/container/btree_map.h"
 #include "cloud_topics/level_one/common/object.h"
 #include "model/fundamental.h"
-#include "model/record.h"
+#include "model/record_batch_reader.h"
 #include "model/timestamp.h"
 
 #include <seastar/core/future.hh>
-
-#include <optional>
 
 namespace cloud_topics::reconciler {
 
@@ -35,18 +33,9 @@ struct consumer_metadata {
 /// Consumes record batches from a reader and writes them to an L1 object.
 /// Produces metadata about the consumed range including offsets, timestamps,
 /// and term transitions.
-class reconciliation_consumer {
-public:
-    reconciliation_consumer(
-      l1::object_builder* builder, model::topic_id_partition tidp);
-
-    ss::future<ss::stop_iteration> operator()(model::record_batch);
-    std::optional<consumer_metadata> end_of_stream();
-
-private:
-    l1::object_builder* _builder;
-    model::topic_id_partition _tidp;
-    consumer_metadata _metadata;
-};
+ss::future<std::optional<consumer_metadata>> build_from_reader(
+  model::topic_id_partition tidp,
+  model::record_batch_reader,
+  l1::object_builder* builder);
 
 } // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/reconciliation_consumer.h
+++ b/src/v/cloud_topics/reconciler/reconciliation_consumer.h
@@ -12,6 +12,7 @@
 
 #include "absl/container/btree_map.h"
 #include "cloud_topics/level_one/common/object.h"
+#include "cloud_topics/reconciler/reconciler_probe.h"
 #include "model/fundamental.h"
 #include "model/record_batch_reader.h"
 #include "model/timestamp.h"
@@ -34,8 +35,9 @@ struct consumer_metadata {
 /// Produces metadata about the consumed range including offsets, timestamps,
 /// and term transitions.
 ss::future<std::optional<consumer_metadata>> build_from_reader(
-  model::topic_id_partition tidp,
+  model::topic_id_partition,
   model::record_batch_reader,
-  l1::object_builder* builder);
+  l1::object_builder*,
+  reconciler_probe*);
 
 } // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/tests/BUILD
+++ b/src/v/cloud_topics/reconciler/tests/BUILD
@@ -24,6 +24,7 @@ redpanda_cc_gtest(
     deps = [
         "//src/v/bytes:iostream",
         "//src/v/cloud_topics/level_one/common:object",
+        "//src/v/cloud_topics/reconciler:reconciler_probe",
         "//src/v/cloud_topics/reconciler:reconciliation_consumer",
         "//src/v/model",
         "//src/v/storage:record_batch_builder",

--- a/src/v/cloud_topics/reconciler/tests/reconciliation_consumer_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciliation_consumer_test.cc
@@ -10,7 +10,6 @@
 #include "bytes/iostream.h"
 #include "cloud_topics/level_one/common/object.h"
 #include "cloud_topics/reconciler/reconciliation_consumer.h"
-#include "model/namespace.h"
 #include "model/record_batch_reader.h"
 #include "storage/record_batch_builder.h"
 #include "test_utils/random_bytes.h"
@@ -19,7 +18,7 @@
 
 #include <gtest/gtest.h>
 
-using consumer = cloud_topics::reconciler::reconciliation_consumer;
+const auto build_from_reader = cloud_topics::reconciler::build_from_reader;
 using namespace cloud_topics::l1;
 
 model::record_batch_reader make_reader(
@@ -47,9 +46,8 @@ TEST(ReconciliationConsumerTest, EmptyReader) {
 
     model::topic_id_partition tidp{
       model::topic_id(uuid_t::create()), model::partition_id(0)};
-    consumer c(builder.get(), tidp);
     auto metadata
-      = std::move(reader).consume(std::move(c), model::no_timeout).get();
+      = build_from_reader(tidp, std::move(reader), builder.get()).get();
     ASSERT_FALSE(metadata.has_value());
 }
 
@@ -69,9 +67,8 @@ TEST(ReconciliationConsumerTest, BuildObject) {
     // Consumer 1: Partition 0 of topic1, offset range 100-109.
     {
         auto reader1 = make_reader(100, 50, 2, 5);
-        consumer c1(builder.get(), tidp1);
         auto metadata1
-          = std::move(reader1).consume(std::move(c1), model::no_timeout).get();
+          = build_from_reader(tidp1, std::move(reader1), builder.get()).get();
         ASSERT_TRUE(metadata1.has_value());
         ASSERT_EQ(metadata1->base_offset(), 100);
         ASSERT_EQ(metadata1->last_offset(), 109);
@@ -80,9 +77,8 @@ TEST(ReconciliationConsumerTest, BuildObject) {
     // Consumer 2: Partition 1 of topic1, offset range 200-204.
     {
         auto reader2 = make_reader(200, 75, 1, 5);
-        consumer c2(builder.get(), tidp2);
         auto metadata2
-          = std::move(reader2).consume(std::move(c2), model::no_timeout).get();
+          = build_from_reader(tidp2, std::move(reader2), builder.get()).get();
         ASSERT_TRUE(metadata2.has_value());
         ASSERT_EQ(metadata2->base_offset(), 200);
         ASSERT_EQ(metadata2->last_offset(), 204);
@@ -91,9 +87,8 @@ TEST(ReconciliationConsumerTest, BuildObject) {
     // Consumer 3: Partition 0 of topic2, offset range 300-311.
     {
         auto reader3 = make_reader(300, 25, 3, 4);
-        consumer c3(builder.get(), tidp3);
         auto metadata3
-          = std::move(reader3).consume(std::move(c3), model::no_timeout).get();
+          = build_from_reader(tidp3, std::move(reader3), builder.get()).get();
         ASSERT_TRUE(metadata3.has_value());
         ASSERT_EQ(metadata3->base_offset(), 300);
         ASSERT_EQ(metadata3->last_offset(), 311);

--- a/src/v/cloud_topics/reconciler/tests/reconciliation_consumer_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciliation_consumer_test.cc
@@ -9,6 +9,7 @@
  */
 #include "bytes/iostream.h"
 #include "cloud_topics/level_one/common/object.h"
+#include "cloud_topics/reconciler/reconciler_probe.h"
 #include "cloud_topics/reconciler/reconciliation_consumer.h"
 #include "model/record_batch_reader.h"
 #include "storage/record_batch_builder.h"
@@ -37,6 +38,7 @@ model::record_batch_reader make_reader(
 }
 
 TEST(ReconciliationConsumerTest, EmptyReader) {
+    cloud_topics::reconciler::reconciler_probe probe;
     // Test that reading no batches produces no metadata.
     auto reader = model::make_empty_record_batch_reader();
     iobuf output;
@@ -47,7 +49,7 @@ TEST(ReconciliationConsumerTest, EmptyReader) {
     model::topic_id_partition tidp{
       model::topic_id(uuid_t::create()), model::partition_id(0)};
     auto metadata
-      = build_from_reader(tidp, std::move(reader), builder.get()).get();
+      = build_from_reader(tidp, std::move(reader), builder.get(), &probe).get();
     ASSERT_FALSE(metadata.has_value());
 }
 
@@ -58,6 +60,7 @@ TEST(ReconciliationConsumerTest, BuildObject) {
       make_iobuf_ref_output_stream(output), object_builder::options{});
     auto _ = ss::defer([&builder] { builder->close().get(); });
 
+    cloud_topics::reconciler::reconciler_probe probe;
     auto topic1 = model::topic_id(uuid_t::create());
     auto topic2 = model::topic_id(uuid_t::create());
     model::topic_id_partition tidp1{topic1, model::partition_id(0)};
@@ -67,8 +70,9 @@ TEST(ReconciliationConsumerTest, BuildObject) {
     // Consumer 1: Partition 0 of topic1, offset range 100-109.
     {
         auto reader1 = make_reader(100, 50, 2, 5);
-        auto metadata1
-          = build_from_reader(tidp1, std::move(reader1), builder.get()).get();
+        auto metadata1 = build_from_reader(
+                           tidp1, std::move(reader1), builder.get(), &probe)
+                           .get();
         ASSERT_TRUE(metadata1.has_value());
         ASSERT_EQ(metadata1->base_offset(), 100);
         ASSERT_EQ(metadata1->last_offset(), 109);
@@ -77,8 +81,9 @@ TEST(ReconciliationConsumerTest, BuildObject) {
     // Consumer 2: Partition 1 of topic1, offset range 200-204.
     {
         auto reader2 = make_reader(200, 75, 1, 5);
-        auto metadata2
-          = build_from_reader(tidp2, std::move(reader2), builder.get()).get();
+        auto metadata2 = build_from_reader(
+                           tidp2, std::move(reader2), builder.get(), &probe)
+                           .get();
         ASSERT_TRUE(metadata2.has_value());
         ASSERT_EQ(metadata2->base_offset(), 200);
         ASSERT_EQ(metadata2->last_offset(), 204);
@@ -87,8 +92,9 @@ TEST(ReconciliationConsumerTest, BuildObject) {
     // Consumer 3: Partition 0 of topic2, offset range 300-311.
     {
         auto reader3 = make_reader(300, 25, 3, 4);
-        auto metadata3
-          = build_from_reader(tidp3, std::move(reader3), builder.get()).get();
+        auto metadata3 = build_from_reader(
+                           tidp3, std::move(reader3), builder.get(), &probe)
+                           .get();
         ASSERT_TRUE(metadata3.has_value());
         ASSERT_EQ(metadata3->base_offset(), 300);
         ASSERT_EQ(metadata3->last_offset(), 311);

--- a/src/v/model/record_batch_reader.h
+++ b/src/v/model/record_batch_reader.h
@@ -116,17 +116,34 @@ public:
         static seastar::coroutine::experimental::generator<model::record_batch>
         generator(
           std::unique_ptr<impl> impl, timeout_clock::time_point timeout) {
+            auto gen = slice_generator(std::move(impl), timeout);
+            while (auto slice = co_await gen()) {
+                for (auto& batch : *slice) {
+                    co_yield std::move(batch);
+                }
+            }
+        }
+
+        static seastar::coroutine::experimental::generator<data_t>
+        slice_generator(
+          std::unique_ptr<impl> impl, timeout_clock::time_point timeout) {
             std::exception_ptr eptr;
             try {
-                while (true) {
-                    if (!impl->is_slice_empty()) {
-                        co_yield impl->pop_batch();
-                        continue;
-                    }
-                    if (impl->is_end_of_stream()) {
-                        break;
-                    }
-                    co_await impl->load_slice(timeout);
+                while (!impl->is_end_of_stream()) {
+                    co_yield ss::visit(
+                      co_await impl->do_load_slice(timeout),
+                      [](data_t&& d) { return std::move(d); },
+                      [](foreign_data_t d) {
+                          // Make a copy for the cross-shard case, this is dead
+                          // code anyways now that iobuf uses an atomic
+                          // ref-count and we've removed the foreign data
+                          // readers.
+                          data_t copy;
+                          for (auto& batch : *d.buffer) {
+                              copy.push_back(batch.copy());
+                          }
+                          return copy;
+                      });
                 }
             } catch (...) {
                 eptr = std::current_exception();
@@ -333,7 +350,7 @@ public:
     /*
      * Create a coroutine generator from the reader.
      *
-     *    auto gen = std::move(reader).generator();
+     *    auto gen = std::move(reader).generator(model::no_timeout);
      *    while (std::optional<model::record_batch> batch = co_await gen()) {
      *        ...
      *    }
@@ -343,6 +360,23 @@ public:
     seastar::coroutine::experimental::generator<model::record_batch>
     generator(timeout_clock::time_point timeout) && {
         return impl::generator(std::move(_impl), timeout);
+    }
+
+    /*
+     * Create a coroutine generator from the reader of chunks of batches.
+     *
+     *    auto gen = std::move(reader).slice_generator(model::no_timeout);
+     *    while (auto batches = co_await gen()) {
+     *        for (const model::record_batch& batch : *batches) {
+     *            ...
+     *        }
+     *    }
+     *
+     * When end of stream is reached std::nullopt will be returned.
+     */
+    seastar::coroutine::experimental::generator<data_t>
+    slice_generator(timeout_clock::time_point timeout) && {
+        return impl::slice_generator(std::move(_impl), timeout);
     }
 
     std::unique_ptr<impl> release() && { return std::move(_impl); }

--- a/src/v/model/tests/record_batch_reader_gtest.cc
+++ b/src/v/model/tests/record_batch_reader_gtest.cc
@@ -7,9 +7,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "gmock/gmock.h"
 #include "model/record_batch_reader.h"
 #include "model/tests/random_batch.h"
 #include "test_utils/test.h"
+
+#include <gtest/gtest-matchers.h>
 
 template<typename... Offsets>
 chunked_circular_buffer<model::record_batch> make_batches(Offsets... o) {
@@ -35,25 +38,41 @@ TEST_CORO(RecordBatchReaderGenerator, EmptyReader) {
     while (auto batch = co_await gen()) {
         ASSERT_TRUE_CORO(false) << "No batches expected";
     }
+    auto slice_gen = model::make_empty_record_batch_reader().slice_generator(
+      model::no_timeout);
+    while (auto batch = co_await slice_gen()) {
+        ASSERT_TRUE_CORO(false) << "No batches expected";
+    }
 }
 
 TEST_CORO(RecordBatchReaderGenerator, SmallSetMemory) {
     auto batches = make_batches(1, 2, 3, 4);
     auto r0 = make_memory_record_batch_reader(copy_batches(batches));
-    auto r1 = make_memory_record_batch_reader(std::move(batches));
+    auto r1 = make_memory_record_batch_reader(copy_batches(batches));
+    auto r2 = make_memory_record_batch_reader(copy_batches(batches));
 
     auto r0_materialized = co_await model::consume_reader_to_chunked_vector(
       std::move(r0), model::no_timeout);
 
     chunked_vector<model::record_batch> r1_materialized;
-    auto gen = std::move(r1).generator(model::no_timeout);
-    while (auto batch = co_await gen()) {
+    auto gen1 = std::move(r1).generator(model::no_timeout);
+    while (auto batch = co_await gen1()) {
         r1_materialized.push_back(std::move(batch.value()));
+    }
+
+    chunked_vector<model::record_batch> r2_materialized;
+    auto gen2 = std::move(r2).slice_generator(model::no_timeout);
+    while (auto batches = co_await gen2()) {
+        for (auto& batch : batches.value()) {
+            r2_materialized.push_back(std::move(batch));
+        }
     }
 
     ASSERT_EQ_CORO(r0_materialized.size(), 4);
     ASSERT_EQ_CORO(r1_materialized.size(), r0_materialized.size());
+    ASSERT_EQ_CORO(r2_materialized.size(), r0_materialized.size());
     for (int i = 0; i < 4; ++i) {
         ASSERT_EQ_CORO(r1_materialized[i], r0_materialized[i]);
+        ASSERT_EQ_CORO(r2_materialized[i], r0_materialized[i]);
     }
 }


### PR DESCRIPTION
- **model: add slice generator**
- **ct/reconciler: use generators to read from L0**
- **ct/reconciler: measure reconciler build vs read speed**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
