### PR TITLE
pbgen: fix field mask apply to oneof message variant

### DIFF
--- a/bazel/pbgen/main.go
+++ b/bazel/pbgen/main.go
@@ -982,6 +982,13 @@ func (g *implGenerator) generateMessageFieldMaskApplyHelper(msg protoreflect.Mes
 					w.Println("}")
 					w.Println("self_field->apply_field_path_from(path, update_field);")
 				} else if msg := field.Message(); msg != nil && !isWellKnownType(msg) {
+					if field.ContainingOneof() != nil {
+						w.Printf("if (!self->has_%s()) {\n", field.Name())
+						w.Indent()
+						w.Printf("self->set_%s({});\n", field.Name())
+						w.Dedent()
+						w.Println("}")
+					}
 					w.Printf("self->get_%s().apply_field_path_from(path, &update->get_%s());\n", field.Name(), field.Name())
 				} else {
 					w.Printf("self->set_%s(std::move(update->get_%s()));\n", field.Name(), field.Name())
@@ -992,6 +999,7 @@ func (g *implGenerator) generateMessageFieldMaskApplyHelper(msg protoreflect.Mes
 				w.Indent()
 				w.Printf("if (update->has_%s()) {\n", field.Name())
 				w.Indent()
+
 				printApplyFn()
 				w.Dedent()
 				w.Println("} else {")

--- a/src/v/serde/protobuf/tests/field_mask_test.cc
+++ b/src/v/serde/protobuf/tests/field_mask_test.cc
@@ -315,4 +315,46 @@ INSTANTIATE_TEST_SUITE_P(
       .expected = R"(
         {"recursiveMessage":null}
       )",
+    },
+    merge_test_case{
+      .name = "OneofMatch",
+      .input = R"({"oneofUint32": 1})",
+      .update = R"({"oneofUint32": 3})",
+      .mask = R"({"mask": "oneofUint32"})",
+      .expected = R"({"oneofUint32": 3})",
+    },
+    merge_test_case{
+      .name = "OneofMismatch",
+      .input = R"({"oneofUint32": 1})",
+      .update = R"({"oneofBool": true})",
+      .mask = R"({"mask": "oneofBool"})",
+      .expected = R"({"oneofBool": true})",
+    },
+    merge_test_case{
+      .name = "OneofMismatchFromMessage",
+      .input = R"({"oneofNestedMessage": {"a":4}})",
+      .update = R"({"oneofBool": true})",
+      .mask = R"({"mask": "oneofBool"})",
+      .expected = R"({"oneofBool": true})",
+    },
+    merge_test_case{
+      .name = "OneofMismatchToMessage",
+      .input = R"({"oneofBool": true})",
+      .update = R"({"oneofNestedMessage": {"a":5}})",
+      .mask = R"({"mask": "oneofNestedMessage"})",
+      .expected = R"({"oneofNestedMessage": {"a":5}})",
+    },
+    merge_test_case{
+      .name = "OneofMismatchToMessageField",
+      .input = R"({"oneofBool": true})",
+      .update = R"({"oneofNestedMessage": {"a":5}})",
+      .mask = R"({"mask": "oneofNestedMessage.a"})",
+      .expected = R"({"oneofNestedMessage": {"a":5}})",
+    },
+    merge_test_case{
+      .name = "OneofMismatchUnset",
+      .input = R"({"oneofUint32": 1})",
+      .update = R"({"oneofBool": true})",
+      .mask = R"({"mask": "oneofUint32"})",
+      .expected = R"({"oneofUint32": 0})",
     }));

--- a/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.cc
+++ b/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.cc
@@ -5016,6 +5016,9 @@ void test_all_types_edition2023::apply_field_path_from(std::span<const ss::sstri
     }},
     {"oneof_nested_message", []([[maybe_unused]] auto path, auto* self, auto* update) {
       if (update->has_oneof_nested_message()) {
+        if (!self->has_oneof_nested_message()) {
+          self->set_oneof_nested_message({});
+        }
         self->get_oneof_nested_message().apply_field_path_from(path, &update->get_oneof_nested_message());
       } else {
         self->set_oneof_nested_message({});


### PR DESCRIPTION
In the case where we apply a field mask to a message type, we need to
check that the message type existing before applying the field mask. If
it doesn't exist, then create the default message first to have the
changes applied.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
