### PR TITLE
shadow_link: check reachability of source cluster before creating link

### DIFF
--- a/src/v/cluster_link/errc.cc
+++ b/src/v/cluster_link/errc.cc
@@ -68,6 +68,16 @@ struct error_category final : public std::error_category {
             return "license required for operation";
         case errc::service_not_ready:
             return "shadow linking service is not ready";
+        case errc::link_unsupported_api_version:
+            return "unsupported API version on remote cluster";
+        case cluster_link::errc::link_cluster_unreachable:
+            return "unable to reach link cluster, no broker is reachable.";
+        case errc::link_broker_unreachable:
+            return "unable to reach link broker";
+        case errc::link_broker_verification_failed:
+            return "link broker verification failed";
+        case errc::link_verification_unknown_error:
+            return "link verification unknown error";
         }
 
         return "(unknown error code)";

--- a/src/v/cluster_link/errc.h
+++ b/src/v/cluster_link/errc.h
@@ -42,6 +42,11 @@ enum class errc : int {
     topic_metadata_stale,
     license_required,
     service_not_ready,
+    link_unsupported_api_version,
+    link_cluster_unreachable,
+    link_broker_unreachable,
+    link_broker_verification_failed,
+    link_verification_unknown_error,
 };
 
 std::error_code make_error_code(errc) noexcept;

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -157,6 +157,192 @@ ss::future<> manager::stop() {
     vlog(cllog.info, "Cluster link manager stopped");
 }
 
+ss::future<err_info> manager::broker_preflight_check(
+  ::model::node_id node_id, kafka::client::cluster& cluster) {
+    static constexpr auto min_version_with_topic_id_support
+      = kafka::api_version(10);
+    static constexpr std::array<
+      std::tuple<kafka::api_key, kafka::api_version, kafka::api_version>,
+      7>
+      apis_to_check{
+        {{kafka::offset_fetch_api::key,
+          kafka::offset_fetch_api::min_valid,
+          // clamped as needed by group_mirroring_task
+          kafka::api_version(7)},
+         {kafka::list_groups_api::key,
+          kafka::list_groups_api::min_valid,
+          kafka::list_groups_api::max_valid},
+         {kafka::find_coordinator_api::key,
+          kafka::find_coordinator_api::min_valid,
+          kafka::find_coordinator_api::max_valid},
+         {kafka::describe_acls_api::key,
+          kafka::describe_acls_api::min_valid,
+          kafka::describe_acls_api::max_valid},
+         {kafka::list_offsets_api::key,
+          kafka::list_offsets_api::min_valid,
+          kafka::list_offsets_api::max_valid},
+         {kafka::describe_configs_api::key,
+          kafka::describe_configs_api::min_valid,
+          kafka::describe_configs_api::max_valid},
+         {kafka::metadata_api::key,
+          min_version_with_topic_id_support,
+          kafka::metadata_api::max_valid}}};
+    vlog(cllog.trace, "Performing preflight check on broker {}", node_id);
+    try {
+        chunked_vector<ss::sstring> unsupported_api_errors;
+        unsupported_api_errors.reserve(apis_to_check.size());
+        for (const auto& [api_key, min_version, max_version] : apis_to_check) {
+            auto versions = co_await cluster.supported_api_versions(
+              node_id, api_key);
+            if (!versions) {
+                vlog(
+                  cllog.warn,
+                  "Broker {} does not support required API {}",
+                  node_id,
+                  api_key);
+                unsupported_api_errors.push_back(
+                  fmt::format("{}: unsupported", api_key));
+                continue;
+            }
+            // Check if the broker's supported version range overlaps with the
+            // required range
+            if (versions->max < min_version || versions->min > max_version) {
+                vlog(
+                  cllog.warn,
+                  "Broker {} does not support required version range for "
+                  "API {}: supported [{}, {}], required [{}, {}]",
+                  node_id,
+                  api_key,
+                  versions->min,
+                  versions->max,
+                  min_version,
+                  max_version);
+                unsupported_api_errors.push_back(
+                  fmt::format(
+                    "{}: supported [{}, {}], required [{}, {}]",
+                    api_key,
+                    versions->min,
+                    versions->max,
+                    min_version,
+                    max_version));
+            }
+        }
+        if (!unsupported_api_errors.empty()) {
+            co_return err_info(
+              errc::link_unsupported_api_version,
+              fmt::format(
+                "Broker {} does not support required APIs: [{}]",
+                node_id,
+                fmt::join(unsupported_api_errors, ", ")));
+        }
+    } catch (const kafka::client::broker_error& e) {
+        vlog(
+          cllog.warn,
+          "Broker {} preflight check failed - {}",
+          node_id,
+          e.what());
+        co_return err_info(
+          errc::link_broker_unreachable,
+          fmt::format(
+            "Broker {} preflight check failed - {}", node_id, e.what()));
+    } catch (...) {
+        vlog(
+          cllog.warn,
+          "Broker {} preflight check failed - {}",
+          node_id,
+          std::current_exception());
+        co_return err_info(
+          errc::link_broker_verification_failed,
+          fmt::format(
+            "Broker {} preflight check failed - {}",
+            node_id,
+            std::current_exception()));
+    }
+    vlog(
+      cllog.trace,
+      "Performed preflight check on broker {} successfully",
+      node_id);
+    co_return err_info{errc::success};
+}
+
+ss::future<err_info> manager::link_preflight_checks(const model::metadata& md) {
+    auto cluster = _cluster_factory->create_cluster(md);
+    err_info return_error{errc::success};
+    auto stop_and_ignore = [&cluster, &md]() {
+        return cluster->stop().handle_exception([&md](std::exception_ptr ex) {
+            vlog(
+              cllog.warn,
+              "[Ignoring] Error stopping cluster after preflight check for "
+              "link '{}' - {}",
+              md.name,
+              ex);
+        });
+    };
+    try {
+        co_await cluster->start();
+        co_await cluster->request_metadata_update();
+        if (!cluster->is_connected()) {
+            vlog(
+              cllog.warn,
+              "Cluster link '{}' preflight check failed - unable to connect to "
+              "cluster",
+              md.name);
+            co_await stop_and_ignore();
+            co_return err_info(
+              errc::link_cluster_unreachable,
+              fmt::format(
+                "Cluster link '{}' preflight check failed - unable to connect "
+                "to cluster",
+                md.name));
+        }
+        // there is at least one broker.
+        const auto& brokers = cluster->get_brokers();
+        auto reported_brokers = brokers.get_broker_ids();
+        auto num_reported_brokers = reported_brokers.size();
+        chunked_vector<ss::sstring> broker_errors;
+        broker_errors.reserve(brokers.size());
+        co_await ss::max_concurrent_for_each(
+          std::move(reported_brokers),
+          10,
+          [this, &cluster, &broker_errors](::model::node_id id) mutable {
+              return broker_preflight_check(id, *cluster)
+                .then([&broker_errors](err_info err) mutable {
+                    // Handle any incompatible API versions or unexpected
+                    // errors.
+                    if (err.code() != errc::success) {
+                        broker_errors.push_back(std::move(err.message()));
+                    }
+                });
+          });
+        // Here it is possible that we may be missing some brokers
+        // (if they are dead), we just deal with whatever responses
+        // we have.
+        // We consider it a failure if none of the brokers succeeded
+        // in the preflight check. This is a loose check but should be
+        // sufficient to catch misconfigurations.
+        if (broker_errors.size() == num_reported_brokers) {
+            return_error = err_info(
+              errc::link_broker_verification_failed,
+              fmt::format("[{}]", fmt::join(broker_errors, ", ")));
+        }
+    } catch (const std::exception& e) {
+        vlog(
+          cllog.warn,
+          "Cluster link '{}' preflight check failed - {}",
+          md.name,
+          e.what());
+        return_error = {
+          errc::link_cluster_unreachable,
+          fmt::format(
+            "Cluster link '{}' unreachable, preflight check "
+            "failed - {}",
+            md.name,
+            e.what())};
+    }
+    co_await stop_and_ignore();
+    co_return return_error;
+}
+
 ss::future<cl_result<model::metadata>>
 manager::upsert_cluster_link(model::metadata md) {
     static constexpr auto wait_for_link_creation_timeout = 30s;
@@ -164,6 +350,11 @@ manager::upsert_cluster_link(model::metadata md) {
     auto name = md.name;
     vlog(cllog.info, "Attempting to create cluster link named '{}'", md.name);
     vlog(cllog.trace, "Cluster link metadata: {}", md);
+    auto preflight_err = co_await link_preflight_checks(md);
+    if (preflight_err.code() != errc::success) {
+        co_return preflight_err;
+    }
+
     const auto needs_consumer_offsets_topic
       = md.configuration.consumer_groups_mirroring_cfg.is_enabled;
     auto ec = co_await _registry->upsert_link(

--- a/src/v/cluster_link/manager.h
+++ b/src/v/cluster_link/manager.h
@@ -205,6 +205,9 @@ private:
     ss::future<> link_task_reconciler();
     ss::future<> on_controller_leadership(::model::term_id);
     ss::future<> on_controller_stepdown();
+    ss::future<err_info>
+    broker_preflight_check(::model::node_id, kafka::client::cluster&);
+    ss::future<err_info> link_preflight_checks(const model::metadata& md);
 
 private:
     ::model::node_id _self;

--- a/src/v/redpanda/admin/proxy/client.cc
+++ b/src/v/redpanda/admin/proxy/client.cc
@@ -79,7 +79,7 @@ ss::future<iobuf> client::send(
                           [req = std::move(req)](
                             proxy_client_protocol client) mutable {
                               return client.proxy_rpc(
-                                std::move(req), rpc::client_opts(1s));
+                                std::move(req), rpc::client_opts(rpc_timeout));
                           });
         if (!result) {
             vlog(

--- a/src/v/redpanda/admin/services/shadow_link/shadow_link.cc
+++ b/src/v/redpanda/admin/services/shadow_link/shadow_link.cc
@@ -44,6 +44,11 @@ void handle_error(cluster_link::errc err, ss::sstring info) {
     case cluster_link::errc::cluster_link_disabled:
     case cluster_link::errc::link_has_active_shadow_topics:
     case cluster_link::errc::license_required:
+    case cluster_link::errc::link_unsupported_api_version:
+    case cluster_link::errc::link_cluster_unreachable:
+    case cluster_link::errc::link_broker_unreachable:
+    case cluster_link::errc::link_broker_verification_failed:
+    case cluster_link::errc::link_verification_unknown_error:
         throw serde::pb::rpc::failed_precondition_exception(std::move(info));
     case cluster_link::errc::link_id_not_found:
         throw serde::pb::rpc::not_found_exception(std::move(info));

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -46,7 +46,11 @@ from rptest.services.multi_cluster_services import (
     SecondaryClusterSpec,
     ServiceType,
 )
-from rptest.services.redpanda import SchemaRegistryConfig, SecurityConfig
+from rptest.services.redpanda import (
+    RedpandaService,
+    SchemaRegistryConfig,
+    SecurityConfig,
+)
 from rptest.services.tls import TLSCertManager
 from rptest.tests.cluster_linking_test_base import (
     DEFAULT_SYNCED_TOPIC_PROPERTIES,
@@ -56,6 +60,7 @@ from rptest.tests.cluster_linking_test_base import (
     ShadowLinkPreAllocTestBase,
     ShadowLinkTestBase,
 )
+from rptest.clients.admin.proto.redpanda.core.admin.v2 import shadow_link_pb2
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import (
     bg_thread_cm,
@@ -1115,6 +1120,83 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
                 lambda e: e.code == ConnectErrorCode.INVALID_ARGUMENT,
             ):
                 self.update_link(shadow_link, update_mask)
+
+    @cluster(num_nodes=6)
+    @matrix(
+        source_cluster_spec=[
+            SecondaryClusterSpec(ServiceType.REDPANDA),
+            SecondaryClusterSpec(
+                ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
+            ),
+        ],
+    )
+    def test_link_creation_checks(self, source_cluster_spec):
+        """
+        Checks that preflight checks during link creation work as expected. Particularly
+        creating links where the remote cluster is not reachable due to connectivity issues
+        or incorrect configurations.
+        """
+        # Test incorrect bootstrap servers
+        bad_bootstrap_servers = [
+            "non.existent.server:9092",
+            "one.more.bad:9092",
+            "localhost:1234",
+        ]
+        bad_link_request = self.create_default_link_request("bad-link")
+        bad_link_request.shadow_link.configurations.client_options.bootstrap_servers[
+            :
+        ] = bad_bootstrap_servers
+
+        with expect_exception(
+            ConnectError,
+            lambda e: e.code == ConnectErrorCode.FAILED_PRECONDITION,
+        ):
+            self.create_link_with_request(req=bad_link_request)
+
+        # Test invalid TLS settings, source cluster has no TLS
+        bad_link_request = self.create_default_link_request("bad-link-tls")
+        bad_link_request.shadow_link.configurations.client_options.tls_settings.CopyFrom(
+            shadow_link_pb2.TLSSettings(
+                enabled=True,
+                tls_file_settings=shadow_link_pb2.TLSFileSettings(
+                    ca_path=self.redpanda.TLS_CA_CRT_FILE,
+                    key_path=self.redpanda.TLS_SERVER_KEY_FILE,
+                    cert_path=self.redpanda.TLS_SERVER_CRT_FILE,
+                ),
+            )
+        )
+        with expect_exception(
+            ConnectError,
+            lambda e: e.code == ConnectErrorCode.FAILED_PRECONDITION,
+        ):
+            self.create_link_with_request(req=bad_link_request)
+
+        # Kill one broker on the source cluster to simulate partial connectivity
+        # during preflight checks
+        node_to_stop = self.source_cluster._service.get_node(idx=1)
+        self.source_cluster._service.stop_node(node_to_stop)
+        self.create_link("link-with-partial-connectivity")
+
+    @cluster(num_nodes=6)
+    def test_link_creation_incompatible_api(self):
+        """
+        Tests that link creation fails when the source cluster has an incompatible
+        kafka API support.
+        """
+        # Downgrade the source cluster to a version that does not support
+        # v10 of metadata request used for cluster linking
+        assert isinstance(self.source_cluster.service, RedpandaService), (
+            "Invalid source cluster service type"
+        )
+        rp = self.source_cluster.service
+        rp._installer.install(rp.nodes, (25, 1))
+        rp.for_nodes(rp.nodes, lambda node: rp.stop_node(node))
+        rp.start(rp.nodes, clean_nodes=True)
+        with expect_exception(
+            ConnectError,
+            lambda e: e.code == ConnectErrorCode.FAILED_PRECONDITION,
+        ):
+            self.create_link("link-to-incompatible-cluster")
 
 
 class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):


### PR DESCRIPTION
Currently the link is created first and tasks may silently error in the background if there are connection issues. This commits adds some preflight checks that the remote cluster is reachable and the available brokers have compatible kafka API versions.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
