### PR TITLE
[CORE-14333] cluster: fix unmanage notifications for kafka_internal_namespace

### DIFF
--- a/src/v/cluster/utils/partition_change_notifier_impl.cc
+++ b/src/v/cluster/utils/partition_change_notifier_impl.cc
@@ -110,7 +110,8 @@ partition_change_notifier_impl::register_partition_notifications(
       = _partition_mgr.local().register_unmanage_notification(
         model::kafka_internal_namespace,
         [this, id](model::topic_partition_view tp) mutable {
-            model::ntp ntp{model::kafka_namespace, tp.topic, tp.partition};
+            model::ntp ntp{
+              model::kafka_internal_namespace, tp.topic, tp.partition};
             do_notify_call_back(
               notification_type::partition_replica_unassigned,
               id,


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This caused a UAF in the L1 garbage collector slept for 5 minutes, and
during that time, the underlying Raft group was unmanaged. Since the
notification was for the wrong NTP, we ended up not stopping the domain
manager.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
