### PR TITLE
dt/redpanda: tolerate nodes not running with FI

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -4137,8 +4137,11 @@ class RedpandaService(Service, RedpandaServiceABC):
         if not crashes:
             # Even if there is no assertion or segfault, look for unexpectedly
             # not-running processes
-            for node in self._started:
-                if not self.redpanda_pid(node):
+            unexpected_not_running = [
+                node for node in self._started if not self.redpanda_pid(node)
+            ]
+            if len(unexpected_not_running) > self.tolerate_not_running:
+                for node in unexpected_not_running:
                     crashes.append((node, "Redpanda process unexpectedly stopped"))
 
         if crashes:


### PR DESCRIPTION
If FailureInjection is running while the `raise_on_crash` method is called, allow up to `self.tolerate_not_running` number of nodes not running.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
