### PR TITLE
Client Monitoring: minor improvements to ducktape tests

### DIFF
--- a/tests/rptest/tests/list_kafka_connections_test.py
+++ b/tests/rptest/tests/list_kafka_connections_test.py
@@ -74,7 +74,7 @@ class AdminV2ListKafkaConnectionsTest(RedpandaTest):
             auth=(self.superuser.username, self.superuser.password),
         )
         req = cluster_pb.ListKafkaConnectionsRequest(
-            page_size=10, order_by="source.port desc"
+            page_size=1000, order_by="source.port desc"
         )
 
         def valid_response() -> bool:

--- a/tests/rptest/tests/list_kafka_connections_test.py
+++ b/tests/rptest/tests/list_kafka_connections_test.py
@@ -156,6 +156,77 @@ class AdminV2ListKafkaConnectionsTest(RedpandaTest):
         assert conn.state == kafka_connections_pb.KAFKA_CONNECTION_STATE_CLOSED
         assert conn.close_time.ToDatetime() > datetime(year=2025, month=1, day=1)
 
+    @cluster(num_nodes=4)
+    def test_list_kafka_connections_page_size(self):
+        self.logger.debug("Start a consumer to open some kafka connections")
+        self.consumer.start()
+
+        admin_v2 = AdminV2(
+            self.redpanda,
+            auth=(self.superuser.username, self.superuser.password),
+        )
+
+        for order_by in ["", "source.port asc"]:
+            self.logger.info(f"Testing with order_by='{order_by}'")
+
+            def validate():
+                self.logger.debug(
+                    f"Sending request with page_size=3 and order_by='{order_by}'"
+                )
+                first_req = cluster_pb.ListKafkaConnectionsRequest(
+                    page_size=3, order_by=order_by
+                )
+
+                first_resp = admin_v2.cluster().list_kafka_connections(first_req)
+                self.logger.debug(f"First response: {first_resp}")
+                assert len(first_resp.connections) == 3
+
+                self.logger.debug(
+                    f"Sending request with page_size=1000 and order_by='{order_by}'"
+                )
+                second_req = cluster_pb.ListKafkaConnectionsRequest(
+                    page_size=1000, order_by=order_by
+                )
+                second_resp = admin_v2.cluster().list_kafka_connections(second_req)
+                self.logger.debug(f"Second response: {second_resp}")
+                assert len(second_resp.connections) > 3
+
+                def is_ascending_order(
+                    resp: cluster_pb.ListKafkaConnectionsResponse,
+                ) -> bool:
+                    for i in range(len(resp.connections) - 1):
+                        if (
+                            resp.connections[i].source.port
+                            > resp.connections[i + 1].source.port
+                        ):
+                            return False
+                    return True
+
+                # Validate consistency between limited and full responses
+                assert first_resp.total_size == second_resp.total_size
+
+                if order_by:
+                    assert is_ascending_order(first_resp)
+                    assert is_ascending_order(second_resp)
+
+                    for i in range(len(first_resp.connections)):
+                        assert (
+                            first_resp.connections[i].source.port
+                            == second_resp.connections[i].source.port
+                        )
+
+                return True
+
+            # Retry to avoid flakiness due to connection changes between the two requests
+            wait_until(
+                validate,
+                timeout_sec=30,
+                retry_on_exc=True,
+                err_msg="Pagination validation failed",
+            )
+
+        self.consumer.stop()
+
 
 class AdminV2ListKafkaConnectionsLicenseTest(RedpandaTest):
     """


### PR DESCRIPTION
* [dt: increase page_size in list_kafka_connections](https://github.com/redpanda-data/redpanda/commit/302477d7389f56d054a12df41cea9630a1884d27): The test was flaky because we could have >10 kafka connections in the cluster, and so it was possible for the target connection (the one with the consumer group name) to be omitted from the results due to the page size.

* [dt: improve ordering and page_size coverage in LKC](https://github.com/redpanda-data/redpanda/commit/42f100a7921dd42df0a7be6b21252ccfe768bc38): Add a more comprehensive test for checking that the page_size and the order_by fields of the ListKafkaConnections endpoint are respected.

There was a bug in one of my earlier PRs that @BenPope noticed. This new test would catch that automatically.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
