### PR TITLE
[CORE-13364] admin: Add a scale test for ListKafkaConnections

### DIFF
--- a/src/v/redpanda/admin/BUILD
+++ b/src/v/redpanda/admin/BUILD
@@ -201,6 +201,21 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "kafka_connections_service_impl",
+    hdrs = [
+        "kafka_connections_service_impl.h",
+    ],
+    visibility = ["//src/v/redpanda/admin:__subpackages__"],
+    deps = [
+        "//proto/redpanda/core/admin/v2:kafka_connections_redpanda_proto",
+        "//src/v/base",
+        "//src/v/container:priority_queue",
+        "//src/v/ssx:async_algorithm",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "kafka_connections_service",
     srcs = [
         "kafka_connections_service.cc",
@@ -212,6 +227,7 @@ redpanda_cc_library(
     deps = [
         ":aip_filter",
         ":aip_ordering",
+        ":kafka_connections_service_impl",
         "//proto/redpanda/core/admin/v2:cluster_redpanda_proto",
         "//proto/redpanda/core/admin/v2:kafka_connections_redpanda_proto",
         "//src/v/base",

--- a/src/v/redpanda/admin/kafka_connections_service.cc
+++ b/src/v/redpanda/admin/kafka_connections_service.cc
@@ -11,12 +11,12 @@
 
 #include "redpanda/admin/kafka_connections_service.h"
 
-#include "container/priority_queue.h"
 #include "kafka/server/server.h"
 #include "proto/redpanda/core/admin/v2/cluster.proto.h"
 #include "proto/redpanda/core/admin/v2/kafka_connections.proto.h"
 #include "redpanda/admin/aip_filter.h"
 #include "redpanda/admin/aip_ordering.h"
+#include "redpanda/admin/kafka_connections_service_impl.h"
 #include "ssx/async_algorithm.h"
 
 #include <seastar/core/coroutine.hh>
@@ -30,98 +30,8 @@ using namespace proto::admin;
 namespace admin {
 
 namespace {
-struct connection_collector {
-    virtual ~connection_collector() = default;
-    virtual void add(proto::admin::kafka_connection conn) = 0;
-    virtual ss::future<>
-    add_all(chunked_vector<proto::admin::kafka_connection> conns) = 0;
-    virtual chunked_vector<proto::admin::kafka_connection>
-    extract_unordered() && = 0;
-    virtual ss::future<chunked_vector<proto::admin::kafka_connection>>
-    extract() && = 0;
-    virtual size_t size() const = 0;
-};
 
-class unordered_collector : public connection_collector {
-    chunked_vector<proto::admin::kafka_connection> _connections;
-    size_t _limit;
-
-public:
-    explicit unordered_collector(size_t limit)
-      : _limit(limit) {}
-
-    void add(proto::admin::kafka_connection conn) final {
-        if (_connections.size() < _limit) {
-            _connections.emplace_back(std::move(conn));
-        }
-    }
-
-    ss::future<>
-    add_all(chunked_vector<proto::admin::kafka_connection> conns) final {
-        auto to_add_count = std::min(
-          conns.size(), _limit - _connections.size());
-        auto insert_range = std::ranges::subrange(
-          conns.begin(), conns.begin() + to_add_count);
-        _connections.reserve(_connections.size() + insert_range.size());
-        co_await ssx::async_for_each(insert_range, [this](auto& conn) {
-            _connections.emplace_back(std::move(conn));
-        });
-    }
-
-    chunked_vector<proto::admin::kafka_connection> extract_unordered()
-      && final {
-        return std::move(_connections);
-    }
-
-    ss::future<chunked_vector<proto::admin::kafka_connection>> extract()
-      && final {
-        co_return std::move(_connections);
-    };
-
-    size_t size() const final { return _connections.size(); }
-};
-
-template<typename Comparator>
-class ordered_collector : public connection_collector {
-    // Invert the order here to get the min-k instead of the max-k
-    chunked_bounded_priority_queue<
-      proto::admin::kafka_connection,
-      detail::invert_comparator<Comparator>>
-      _pq;
-
-public:
-    ordered_collector(size_t limit, Comparator comp)
-      : _pq(limit, detail::invert_comparator<Comparator>(std::move(comp))) {}
-
-    void add(proto::admin::kafka_connection conn) final {
-        _pq.push(std::move(conn));
-    }
-
-    ss::future<>
-    add_all(chunked_vector<proto::admin::kafka_connection> conns) final {
-        co_await _pq.async_push_range(std::move(conns));
-    }
-
-    chunked_vector<proto::admin::kafka_connection> extract_unordered()
-      && final {
-        return std::move(_pq).extract_heap();
-    }
-
-    ss::future<chunked_vector<proto::admin::kafka_connection>> extract()
-      && final {
-        return std::move(_pq).async_extract_sorted();
-    }
-
-    size_t size() const final { return _pq.size(); }
-};
-
-using make_local_collector_t
-  = ss::noncopyable_function<std::unique_ptr<connection_collector>(size_t)>;
-
-struct connection_gather_result {
-    chunked_vector<proto::admin::kafka_connection> connections;
-    size_t total_matching_count;
-};
+using namespace admin::detail;
 
 ss::future<connection_gather_result> gather_connections(
   const kafka::server& server,

--- a/src/v/redpanda/admin/kafka_connections_service_impl.h
+++ b/src/v/redpanda/admin/kafka_connections_service_impl.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "container/priority_queue.h"
+#include "proto/redpanda/core/admin/v2/kafka_connections.proto.h"
+#include "ssx/async_algorithm.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/sharded.hh>
+
+#include <cstddef>
+
+namespace admin::detail {
+
+struct connection_collector {
+    virtual ~connection_collector() = default;
+    virtual void add(proto::admin::kafka_connection conn) = 0;
+    virtual ss::future<>
+    add_all(chunked_vector<proto::admin::kafka_connection> conns) = 0;
+    virtual chunked_vector<proto::admin::kafka_connection>
+    extract_unordered() && = 0;
+    virtual ss::future<chunked_vector<proto::admin::kafka_connection>>
+    extract() && = 0;
+    virtual size_t size() const = 0;
+};
+
+class unordered_collector : public connection_collector {
+    chunked_vector<proto::admin::kafka_connection> _connections;
+    size_t _limit;
+
+public:
+    explicit unordered_collector(size_t limit)
+      : _limit(limit) {}
+
+    void add(proto::admin::kafka_connection conn) final {
+        if (_connections.size() < _limit) {
+            _connections.emplace_back(std::move(conn));
+        }
+    }
+
+    ss::future<>
+    add_all(chunked_vector<proto::admin::kafka_connection> conns) final {
+        auto to_add_count = std::min(
+          conns.size(), _limit - _connections.size());
+        auto insert_range = std::ranges::subrange(
+          conns.begin(), conns.begin() + to_add_count);
+        _connections.reserve(_connections.size() + insert_range.size());
+        co_await ssx::async_for_each(insert_range, [this](auto& conn) {
+            _connections.emplace_back(std::move(conn));
+        });
+    }
+
+    chunked_vector<proto::admin::kafka_connection> extract_unordered()
+      && final {
+        return std::move(_connections);
+    }
+
+    ss::future<chunked_vector<proto::admin::kafka_connection>> extract()
+      && final {
+        co_return std::move(_connections);
+    };
+
+    size_t size() const final { return _connections.size(); }
+};
+
+template<typename Comparator>
+class ordered_collector : public connection_collector {
+    // Invert the order here to get the min-k instead of the max-k
+    chunked_bounded_priority_queue<
+      proto::admin::kafka_connection,
+      ::detail::invert_comparator<Comparator>>
+      _pq;
+
+public:
+    ordered_collector(size_t limit, Comparator comp)
+      : _pq(limit, ::detail::invert_comparator<Comparator>(std::move(comp))) {}
+
+    void add(proto::admin::kafka_connection conn) final {
+        _pq.push(std::move(conn));
+    }
+
+    ss::future<>
+    add_all(chunked_vector<proto::admin::kafka_connection> conns) final {
+        co_await _pq.async_push_range(std::move(conns));
+    }
+
+    chunked_vector<proto::admin::kafka_connection> extract_unordered()
+      && final {
+        return std::move(_pq).extract_heap();
+    }
+
+    ss::future<chunked_vector<proto::admin::kafka_connection>> extract()
+      && final {
+        return std::move(_pq).async_extract_sorted();
+    }
+
+    size_t size() const final { return _pq.size(); }
+};
+
+using make_local_collector_t
+  = ss::noncopyable_function<std::unique_ptr<connection_collector>(size_t)>;
+
+struct connection_gather_result {
+    chunked_vector<proto::admin::kafka_connection> connections;
+    size_t total_matching_count;
+};
+
+} // namespace admin::detail

--- a/src/v/redpanda/admin/tests/BUILD
+++ b/src/v/redpanda/admin/tests/BUILD
@@ -1,5 +1,5 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("//bazel:test.bzl", "redpanda_cc_gtest", "redpanda_test_cc_library")
+load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_gtest", "redpanda_test_cc_library")
 load("//bazel/pbgen:pbgen.bzl", "redpanda_proto_library")
 
 proto_library(
@@ -61,5 +61,28 @@ redpanda_cc_gtest(
         "@abseil-cpp//absl/time",
         "@fmt",
         "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_bench(
+    name = "list_kafka_connections_rpbench",
+    timeout = "long",
+    srcs = [
+        "list_kafka_connections_bench.cc",
+    ],
+    deps = [
+        "//proto/redpanda/core/admin/v2:cluster_redpanda_proto",
+        "//proto/redpanda/core/admin/v2:kafka_connections_redpanda_proto",
+        "//src/v/container:chunked_vector",
+        "//src/v/kafka/protocol",
+        "//src/v/random:generators",
+        "//src/v/redpanda/admin:aip_ordering",
+        "//src/v/redpanda/admin:kafka_connections_service_impl",
+        "//src/v/ssx:async_algorithm",
+        "//src/v/ssx:async_clear",
+        "//src/v/ssx:async_merge_top_k",
+        "@boost//:uuid",
+        "@seastar",
+        "@seastar//:benchmark",
     ],
 )

--- a/src/v/redpanda/admin/tests/list_kafka_connections_bench.cc
+++ b/src/v/redpanda/admin/tests/list_kafka_connections_bench.cc
@@ -1,0 +1,307 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "container/chunked_vector.h"
+#include "kafka/protocol/types.h"
+#include "proto/redpanda/core/admin/v2/cluster.proto.h"
+#include "proto/redpanda/core/admin/v2/kafka_connections.proto.h"
+#include "random/generators.h"
+#include "redpanda/admin/aip_ordering.h"
+#include "redpanda/admin/kafka_connections_service_impl.h"
+
+#include <seastar/net/inet_address.hh>
+#include <seastar/testing/perf_tests.hh>
+#include <seastar/util/defer.hh>
+
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <ranges>
+
+struct ListKafkaConnectionsTest {
+    using value_type = proto::admin::kafka_connection;
+
+    struct random_connection_data {
+        int32_t node_id;
+        int32_t shard_id;
+        ss::sstring uid;
+        proto::admin::kafka_connection_state state;
+        absl::Time open_time;
+        proto::admin::authentication_state auth_state;
+        proto::admin::authentication_mechanism auth_mechanism;
+        ss::sstring user_principal;
+        ss::sstring listener_name;
+        bool tls_enabled;
+        ss::sstring ip_address;
+        uint16_t port;
+        ss::sstring client_id;
+        ss::sstring client_software_name;
+        ss::sstring client_software_version;
+        std::optional<ss::sstring> group_id;
+        std::optional<kafka::member_id> group_member_id;
+
+        random_connection_data()
+          : node_id(random_generators::get_int<int32_t>(8))
+          , shard_id(random_generators::get_int<int32_t>(8))
+          , uid(ssx::sformat("{}", uuid_t::create()))
+          , state(
+              static_cast<proto::admin::kafka_connection_state>(
+                random_generators::get_int<int32_t>(0, 3)))
+          , open_time(absl::Time(absl::Now()))
+          , auth_state(
+              static_cast<proto::admin::authentication_state>(
+                random_generators::get_int<int32_t>(0, 3)))
+          , auth_mechanism(
+              static_cast<proto::admin::authentication_mechanism>(
+                random_generators::get_int<int32_t>(0, 4)))
+          , user_principal(random_generators::gen_alphanum_max_distinct(16))
+          , listener_name("kafka")
+          , tls_enabled(random_generators::get_int<int32_t>(0, 1) == 1)
+          , ip_address(ssx::sformat("{}", ss::net::inet_address{}))
+          , port(random_generators::get_int<uint16_t>(1024, 65535))
+          , client_id(random_generators::gen_alphanum_max_distinct(16))
+          , client_software_name(
+              random_generators::gen_alphanum_max_distinct(4))
+          , client_software_version(
+              random_generators::gen_alphanum_max_distinct(4)) {
+            if (random_generators::get_int<int32_t>(0, 1) == 1) {
+                group_id = random_generators::gen_alphanum_max_distinct(64);
+                boost::uuids::uuid uuid = boost::uuids::random_generator()();
+                group_member_id = kafka::member_id(
+                  ssx::sformat("{}-{}", client_id, to_string(uuid)));
+            }
+        }
+
+        auto to_proto() const {
+            proto::admin::kafka_connection conn;
+            conn.set_node_id(node_id);
+            conn.set_shard_id(shard_id);
+            conn.set_uid(ss::sstring{uid});
+            conn.set_state(state);
+            conn.set_open_time(absl::Time{open_time});
+            proto::admin::authentication_info auth_info;
+            auth_info.set_state(auth_state);
+            auth_info.set_mechanism(auth_mechanism);
+            auth_info.set_user_principal(ss::sstring{user_principal});
+            conn.set_authentication_info(std::move(auth_info));
+            conn.set_listener_name(ss::sstring{listener_name});
+            proto::admin::tls_info tls_info;
+            tls_info.set_enabled(tls_enabled);
+            conn.set_tls_info(std::move(tls_info));
+            proto::admin::source src;
+            src.set_ip_address(ss::sstring{ip_address});
+            src.set_port(port);
+            conn.set_source(std::move(src));
+            conn.set_client_id(ss::sstring{client_id});
+            conn.set_client_software_name(ss::sstring{client_software_name});
+            conn.set_client_software_version(
+              ss::sstring{client_software_version});
+            if (group_id.has_value()) {
+                conn.set_group_id(ss::sstring{group_id.value()});
+            }
+            if (group_member_id.has_value()) {
+                conn.set_group_member_id(ss::sstring{group_member_id.value()});
+            }
+            return conn;
+        }
+    };
+
+    static auto make_random_data(size_t size) {
+        return chunked_vector<random_connection_data>(
+          std::from_range,
+          std::views::iota(size_t{0}, size) | std::views::transform([](auto) {
+              return random_connection_data{};
+          }));
+    }
+
+    static auto
+    make_test_proto(const chunked_vector<random_connection_data>& data) {
+        return chunked_vector<value_type>(
+          std::from_range,
+          data | std::views::transform(&random_connection_data::to_proto));
+    }
+
+    using serde_fun = ss::future<iobuf> (
+      proto::admin::list_kafka_connections_response::*)() const;
+
+    static constexpr serde_fun to_proto
+      = &proto::admin::list_kafka_connections_response::to_proto;
+    static constexpr serde_fun to_json
+      = &proto::admin::list_kafka_connections_response::to_json;
+
+    template<typename Fn>
+    constexpr auto measure(bool measure, Fn&& fn) {
+        if (measure) {
+            perf_tests::start_measuring_time();
+        }
+        return ss::futurize_invoke(std::forward<Fn>(fn)).finally([measure]() {
+            if (measure) {
+                perf_tests::stop_measuring_time();
+            }
+        });
+    }
+
+    ss::future<> run_test_impl(
+      bool ordered,
+      bool measure_to_proto,
+      bool measure_insert,
+      bool measure_extract,
+      std::optional<serde_fun> serialize,
+      size_t size,
+      size_t limit) {
+        auto random_data = make_random_data(size);
+
+        std::unique_ptr<admin::detail::connection_collector> collector;
+        if (ordered) {
+            auto cmp = admin::sort_order::parse(
+              admin::make_ordering_config<proto::admin::kafka_connection>(
+                "uid"));
+            collector = std::make_unique<
+              ::admin::detail::ordered_collector<decltype(cmp)>>(limit, cmp);
+        } else {
+            collector = std::make_unique<::admin::detail::unordered_collector>(
+              limit);
+        }
+
+        constexpr auto end = [](auto obj) { perf_tests::do_not_optimize(obj); };
+
+        auto test_data = co_await measure(
+          measure_to_proto, [&]() { return make_test_proto(random_data); });
+        if (!measure_insert && !measure_extract && !serialize) {
+            co_return end(test_data.size());
+        }
+
+        co_await measure(measure_insert, [&]() {
+            return collector->add_all(std::move(test_data));
+        });
+        if (!measure_extract && !serialize) {
+            co_return end(collector->size());
+        }
+
+        auto result = co_await measure(
+          measure_extract, [&]() { return std::move(*collector).extract(); });
+        if (!serialize) {
+            co_return end(result.size());
+        }
+
+        proto::admin::list_kafka_connections_response resp;
+        resp.set_connections(std::move(result));
+        auto buf = co_await measure(
+          serialize.has_value(), [&]() { return (resp.*serialize.value())(); });
+
+        end(buf.size_bytes());
+    }
+};
+
+constexpr size_t c1 = 100;
+constexpr size_t k10 = 10000;
+constexpr size_t k100 = 100000;
+constexpr size_t k250 = 250000;
+
+/// Unordered Collect and Insert are both O(n)
+PERF_TEST_F(ListKafkaConnectionsTest, CollectProto100k) {
+    return run_test_impl(false, true, false, false, std::nullopt, k100, k100);
+}
+PERF_TEST_F(ListKafkaConnectionsTest, CollectProto250k) {
+    return run_test_impl(false, true, false, false, std::nullopt, k250, k250);
+}
+
+// Combine insert and extract, since extract is just a std::move()
+PERF_TEST_F(ListKafkaConnectionsTest, UnorderedInsertExtract100k) {
+    return run_test_impl(false, false, true, true, std::nullopt, k100, k100);
+}
+PERF_TEST_F(ListKafkaConnectionsTest, UnorderedInsertExtract250k) {
+    return run_test_impl(false, false, true, true, std::nullopt, k250, k250);
+}
+
+// Ordered Insert and Extract are both O(n log n)
+PERF_TEST_F(ListKafkaConnectionsTest, OrderedInsert10k) {
+    return run_test_impl(true, false, true, false, std::nullopt, k10, k10);
+}
+PERF_TEST_F(ListKafkaConnectionsTest, OrderedInsert100k) {
+    return run_test_impl(true, false, true, false, std::nullopt, k100, k100);
+}
+PERF_TEST_F(ListKafkaConnectionsTest, OrderedInsert250k) {
+    return run_test_impl(true, false, true, false, std::nullopt, k250, k250);
+}
+PERF_TEST_F(ListKafkaConnectionsTest, OrderedExtract10k) {
+    return run_test_impl(true, false, false, true, std::nullopt, k10, k10);
+}
+PERF_TEST_F(ListKafkaConnectionsTest, OrderedExtract100k) {
+    return run_test_impl(true, false, false, true, std::nullopt, k100, k100);
+}
+PERF_TEST_F(ListKafkaConnectionsTest, OrderedExtract250k) {
+    return run_test_impl(true, false, false, true, std::nullopt, k250, k250);
+}
+
+// ToProto and ToJson should both be O(n)
+PERF_TEST_F(ListKafkaConnectionsTest, ToProto10k) {
+    return run_test_impl(false, false, false, false, to_proto, k10, k10);
+}
+PERF_TEST_F(ListKafkaConnectionsTest, ToProto100k) {
+    return run_test_impl(false, false, false, false, to_proto, k100, k100);
+}
+PERF_TEST_F(ListKafkaConnectionsTest, ToJson10k) {
+    return run_test_impl(false, false, false, false, to_json, k10, k10);
+}
+PERF_TEST_F(ListKafkaConnectionsTest, ToJson100k) {
+    return run_test_impl(false, false, false, false, to_json, k100, k100);
+}
+
+// Test select 100 from 100k
+PERF_TEST_F(ListKafkaConnectionsTest, UnorderedInsertProto100of100k) {
+    return run_test_impl(false, false, true, false, std::nullopt, k100, c1);
+}
+PERF_TEST_F(ListKafkaConnectionsTest, OrderedInsertProto100of100k) {
+    return run_test_impl(true, false, true, false, std::nullopt, k100, c1);
+}
+
+// E2E Unordered is O(n)
+PERF_TEST_F(ListKafkaConnectionsTest, E2EUnorderedProto10k) {
+    return run_test_impl(false, true, true, true, to_proto, k10, k10);
+}
+PERF_TEST_F(ListKafkaConnectionsTest, E2EUnorderedProto100k) {
+    return run_test_impl(false, true, true, true, to_proto, k100, k100);
+}
+PERF_TEST_F(ListKafkaConnectionsTest, E2EUnorderedJson10k) {
+    return run_test_impl(false, true, true, true, to_json, k10, k10);
+}
+PERF_TEST_F(ListKafkaConnectionsTest, E2EUnorderedJson100k) {
+    return run_test_impl(false, true, true, true, to_json, k100, k100);
+}
+
+// E2E Ordered tests are harder to quantify
+PERF_TEST_F(ListKafkaConnectionsTest, E2EOrderedProto10k) {
+    return run_test_impl(true, true, true, true, to_proto, k10, k10);
+}
+PERF_TEST_F(ListKafkaConnectionsTest, E2EOrderedProto100k) {
+    return run_test_impl(true, true, true, true, to_proto, k100, k100);
+}
+PERF_TEST_F(ListKafkaConnectionsTest, E2EOrderedJson10k) {
+    return run_test_impl(true, true, true, true, to_json, k10, k10);
+}
+PERF_TEST_F(ListKafkaConnectionsTest, E2EOrderedJson100k) {
+    return run_test_impl(true, true, true, true, to_json, k100, k100);
+}
+
+// E2E tests with limit
+PERF_TEST_F(ListKafkaConnectionsTest, E2EUnorderedProto100of100k) {
+    return run_test_impl(false, true, true, true, to_proto, k100, c1);
+}
+PERF_TEST_F(ListKafkaConnectionsTest, E2EOrderedProto100of100k) {
+    return run_test_impl(true, true, true, true, to_proto, k100, c1);
+}
+PERF_TEST_F(ListKafkaConnectionsTest, E2EUnorderedJson100of100k) {
+    return run_test_impl(false, true, true, true, to_json, k100, c1);
+}
+PERF_TEST_F(ListKafkaConnectionsTest, E2EOrderedJson100of100k) {
+    return run_test_impl(true, true, true, true, to_json, k100, c1);
+}

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1580,6 +1580,21 @@ class RpkTool:
         output = self._execute(cmd)
         return list(filter(None, map(parse, output.splitlines())))
 
+    def cluster_connections_list(self, limit: int, filter_raw=None, order_by=None):
+        cmd = [
+            self._rpk_binary(),
+            "-X",
+            f"brokers={self._admin_host()}",
+            "cluster",
+            "connections",
+            "list",
+            "--format=json",
+            f"--limit={limit}",
+        ]
+        cmd += [f"--filter-raw={filter_raw}"] if filter_raw else []
+        cmd += [f"--order-by={order_by}"] if order_by else []
+        return self._execute(cmd)
+
     def _tls_settings(self):
         flags = []
         if self._tls_cert is not None:

--- a/tests/rptest/scale_tests/list_kafka_connections_scale_test.py
+++ b/tests/rptest/scale_tests/list_kafka_connections_scale_test.py
@@ -1,0 +1,177 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import json
+import time
+
+from typing import Any
+
+from ducktape.mark import parametrize
+from ducktape.tests.test import TestContext
+
+from rptest.clients.admin.v2 import Admin as AdminV2
+from rptest.clients.admin.v2 import cluster_pb
+from rptest.clients.rpk import RpkTool
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.services.consumer_swarm import ConsumerSwarm
+from rptest.services.redpanda import SecurityConfig
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.util import wait_until
+
+
+class AdminV2ListKafkaConnectionsScaleTest(RedpandaTest):
+    """
+    Tests the scaling of AdminV2 ListKafkaConnections endpoint for many connections.
+    """
+
+    test_topic: str = "test-list-connections"
+    test_group_base: str = "test-cg-group-"
+    test_group_max: str = "test-cg-group."
+
+    def __init__(self, test_ctx: TestContext, *args: Any, **kwargs: Any):
+        security = SecurityConfig()
+        security.enable_sasl = True
+
+        assert test_ctx.injected_args is not None
+        consumers_per_group = int(test_ctx.injected_args["consumers_per_group"])
+        group_count = int(test_ctx.injected_args["group_count"])
+
+        client_count = consumers_per_group * group_count
+
+        super().__init__(
+            test_ctx,
+            *args,
+            security=security,
+            num_brokers=3,
+            extra_rp_conf={
+                "kafka_connection_rate_limit": 10000,
+                "kafka_connections_max": 2 * client_count + 2048,
+                "kafka_connections_max_per_ip": 2 * client_count + 2048,
+            },
+            **kwargs,
+        )
+        self.superuser = self.redpanda.SUPERUSER_CREDENTIALS
+        self.superuser_admin = Admin(
+            self.redpanda, auth=(self.superuser.username, self.superuser.password)
+        )
+
+        self.consumers: list[ConsumerSwarm] = []
+        for i in range(group_count):
+            consumer = ConsumerSwarm(
+                context=test_ctx,
+                redpanda=self.redpanda,
+                topic=self.test_topic,
+                group=f"{self.test_group_base}{i}",
+                consumers=consumers_per_group,
+                records_per_consumer=1,
+                properties={
+                    "security.protocol": "SASL_PLAINTEXT",
+                    "sasl.mechanism": self.superuser.mechanism,
+                    "sasl.username": self.superuser.username,
+                    "sasl.password": self.superuser.password,
+                },
+                unique_topics=False,
+                unique_groups=True,
+                topics_per_client=1,
+            )
+            self.consumers.append(consumer)
+
+        self.super_rpk = RpkTool(
+            self.redpanda,
+            username=self.superuser.username,
+            password=self.superuser.password,
+            sasl_mechanism=self.superuser.algorithm,
+        )
+
+    def setUp(self):
+        super().setUp()
+
+        self.super_rpk.create_topic(self.test_topic)
+
+    @cluster(num_nodes=7)
+    @parametrize(consumers_per_group=2500, group_count=4, ordered=False)
+    @parametrize(consumers_per_group=2500, group_count=4, ordered=True)
+    def test_list_kafka_connections_scale(
+        self, consumers_per_group: int, group_count: int, ordered: bool
+    ):
+        """
+        Tests the AdminV2 list_connections endpoint at scale
+        """
+
+        client_count = consumers_per_group * group_count
+
+        for swarm_client in self.consumers:
+            self.logger.info(f"Starting swarm client on node {swarm_client}")
+            swarm_client.start()
+
+        self.logger.info("Waiting for consumer swarm to become ready")
+
+        def consumers_alive() -> bool:
+            alive = 0
+            for c in self.consumers:
+                alive += c.get_metrics_summary().clients_alive
+
+            self.logger.debug(f"{alive} consumers alive so far")
+            return alive >= client_count
+
+        wait_until(
+            consumers_alive,
+            timeout_sec=30 + client_count // 20,
+            retry_on_exc=True,
+            err_msg="Did not observe expected number of alive consumers",
+        )
+
+        self.logger.info("All consumers alive, proceed to list kafka connections")
+
+        conn_filter = (
+            f"state = KAFKA_CONNECTION_STATE_OPEN "
+            f'AND group_id > "{self.test_group_base}" '
+            f'AND group_id < "{self.test_group_max}" '
+            f'AND group_member_id != ""'
+        )
+        conn_order_by = "group_id asc, group_member_id asc" if ordered else None
+
+        def valid_response() -> bool:
+            start = time.perf_counter()
+            raw_resp = self.super_rpk.cluster_connections_list(
+                limit=client_count + 1,
+                filter_raw=conn_filter,
+                order_by=conn_order_by,
+            )
+            duration = time.perf_counter() - start
+
+            resp = json.loads(raw_resp)
+
+            matching_conns = [
+                conn for conn in resp if len(conn.get("group_member_id", "")) > 0
+            ]
+            non_matching = [conn for conn in resp if conn not in matching_conns]
+
+            succeeded = len(matching_conns) == client_count and len(non_matching) == 0
+            if succeeded:
+                self.logger.info(
+                    f"Successfully listed all {client_count} expected connections in {duration:.2f}s"
+                )
+            else:
+                self.logger.debug(f"Found {len(matching_conns)} of {client_count}")
+                if len(non_matching) > 0:
+                    self.logger.debug(f"Non-matching connections: {non_matching}")
+            return succeeded
+
+        wait_until(
+            valid_response,
+            timeout_sec=60,
+            retry_on_exc=True,
+            err_msg="Did not observe a valid ListKafkaConnectionsResponse",
+        )
+
+        for swarm_client in self.consumers:
+            self.logger.info(f"Stopping swarm client on node {swarm_client}")
+            swarm_client.stop()

--- a/tools/type-checking/type-check-strictness.json
+++ b/tools/type-checking/type-check-strictness.json
@@ -34,6 +34,7 @@
         "rptest/scale_tests/ht_partition_movement_test.py",
         "rptest/scale_tests/large_controller_snapshot_test.py",
         "rptest/scale_tests/large_messages_test.py",
+        "rptest/scale_tests/list_kafka_connections_scale_test.py",
         "rptest/scale_tests/log_storage_target_size_test.py",
         "rptest/scale_tests/many_clients_test.py",
         "rptest/scale_tests/partition_balancer_scale_test.py",


### PR DESCRIPTION
* Add a scale test of 10000 consumers across many groups.
* Add a benchmark:

```
ListKafkaConnectionsTest.CollectProto100k                        5    13.781ms    76.531us    13.705ms    14.203ms 1000469.800       0.000 178249093.1  75169253.2
ListKafkaConnectionsTest.CollectProto250k                        2    34.756ms   372.677us    34.257ms    43.658ms 2501158.000       0.000 445639345.2 196148938.8
ListKafkaConnectionsTest.UnorderedInsertExtract100k              5     9.337ms   277.948us     9.028ms    10.132ms  200796.000      13.560  67508290.2  50832862.5
ListKafkaConnectionsTest.UnorderedInsertExtract250k              2    23.533ms   292.763us    23.240ms    24.140ms  501969.000      31.100 168758142.4 128303692.6
ListKafkaConnectionsTest.OrderedInsert10k                       46     2.656ms   201.230us     2.422ms     3.194ms  135620.800       7.996  37673676.0  14411238.5
ListKafkaConnectionsTest.OrderedInsert100k                       5    37.106ms   565.834us    36.313ms    38.040ms 1359486.200      69.200 377839668.0 200662008.1
ListKafkaConnectionsTest.OrderedInsert250k                       2    93.537ms   303.527us    91.483ms    93.841ms 3399565.000     170.300 944830310.9 503646360.4
ListKafkaConnectionsTest.OrderedExtract10k                      28    10.217ms   199.791us     9.952ms    10.692ms  546589.314      23.414 160864658.7  54632298.4
ListKafkaConnectionsTest.OrderedExtract100k                      3   202.626ms   417.978us   196.329ms   205.021ms 6798893.067     406.667 2008655124.0 1091604280.9
ListKafkaConnectionsTest.OrderedExtract250k                      1   649.845ms     5.973ms   643.872ms   693.044ms 18294883.600    1324.000 5411307332.0 3587524143.4
ListKafkaConnectionsTest.ToProto10k                             39     5.769ms    13.281us     5.747ms     5.799ms  220072.000      23.462 125429038.8  30730835.5
ListKafkaConnectionsTest.ToProto100k                             4    61.049ms   835.368us    59.606ms    62.204ms 2200517.200     239.250 1254310351.1 323518758.4
ListKafkaConnectionsTest.ToJson10k                              22    26.352ms   105.037us    26.229ms    26.468ms  280186.000     105.727 456151590.1 140718130.8
ListKafkaConnectionsTest.ToJson100k                              3   265.074ms   469.551us   264.474ms   265.544ms 2801650.667    1055.667 4561772366.7 1412622467.7
ListKafkaConnectionsTest.UnorderedInsertProto100of100k           6     5.691ms    20.413us     5.659ms     6.281ms     204.000       0.000  61350747.5  31311410.8
ListKafkaConnectionsTest.OrderedInsertProto100of100k             5    20.093ms   239.787us    19.840ms    21.954ms  431978.400      31.120 155769734.6 110934282.3
ListKafkaConnectionsTest.E2EUnorderedProto10k                   38     7.854ms    39.901us     7.701ms     7.932ms  340210.547      26.889 149964546.3  41871378.8
ListKafkaConnectionsTest.E2EUnorderedProto100k                   4    83.534ms   233.196us    82.061ms    83.933ms 3401772.300     248.750 1500028417.0 443883801.9
ListKafkaConnectionsTest.E2EUnorderedJson10k                    21    28.894ms    61.803us    28.716ms    29.028ms  400308.114     110.476 480687347.9 154071789.9
ListKafkaConnectionsTest.E2EUnorderedJson100k                    3   290.131ms   351.367us   288.762ms   292.523ms 4002851.667    1073.000 4807471054.8 1548414865.1
ListKafkaConnectionsTest.E2EOrderedProto10k                     25    20.858ms   145.508us    20.482ms    21.205ms 1002342.928      57.856 341769348.9 111351247.2
ListKafkaConnectionsTest.E2EOrderedProto100k                     2   341.600ms     2.084ms   333.316ms   344.391ms 11357941.000     797.500 3818749405.2 1841880691.2
ListKafkaConnectionsTest.E2EOrderedJson10k                      16    41.903ms   164.827us    41.666ms    42.206ms 1062604.300     142.050 672536096.0 224024166.7
ListKafkaConnectionsTest.E2EOrderedJson100k                      2   558.536ms     5.947ms   551.798ms   566.316ms 11958270.600    1667.700 7125728506.1 2999548876.7
ListKafkaConnectionsTest.E2EUnorderedProto100of100k              5    20.173ms   125.258us    19.809ms    20.298ms 1002891.000       0.600 240834246.5 108531102.9
ListKafkaConnectionsTest.E2EOrderedProto100of100k                5    36.553ms   469.725us    35.823ms    37.999ms 1437420.840      34.320 336054884.2 199054218.1
ListKafkaConnectionsTest.E2EUnorderedJson100of100k               5    21.770ms   417.547us    20.445ms    22.661ms 1003497.520       2.120 244150566.0 117065849.3
ListKafkaConnectionsTest.E2EOrderedJson100of100k                 5    37.656ms     1.197ms    35.681ms    39.333ms 1437906.560      35.840 339330154.2 204563851.0
```
Notes:
* For collection, ordered is about 3x unordered, for insertion.
* When accounting for insert and extract, ordered is much slower (18x for 100k connections), dominated by the `sort_heap`.
* Serialization to json is 4x slower than proto (449-165) / (233-165)

Allocations (probably an underestimate due to not all fields being added) due to `make_data()` (a proxy for `connection_context::to_proto()`) are, per connection:
* 10
* 1.4KiB

Serialization to iobuf increases that further, since both the proto and the serialized form are held in memory at the same time.
Proto: 1KiB
Json 2.5KiB


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

