### PR TITLE
[CORE-14389] Apply lower bound to L0 object epoch (GC)

### DIFF
--- a/src/v/cloud_topics/data_plane_api.h
+++ b/src/v/cloud_topics/data_plane_api.h
@@ -40,6 +40,7 @@ public:
     /// Write data batches and get back placeholder batches
     virtual ss::future<result<chunked_vector<extent_meta>>> write_and_debounce(
       model::ntp ntp,
+      cluster_epoch min_epoch,
       chunked_vector<model::record_batch> batches,
       model::timeout_clock::time_point deadline)
       = 0;

--- a/src/v/cloud_topics/data_plane_impl.cc
+++ b/src/v/cloud_topics/data_plane_impl.cc
@@ -103,10 +103,11 @@ public:
 
     ss::future<result<chunked_vector<extent_meta>>> write_and_debounce(
       model::ntp ntp,
+      cluster_epoch min_epoch,
       chunked_vector<model::record_batch> r,
       model::timeout_clock::time_point timeout) override {
         return _write_pipeline.local().write_and_debounce(
-          std::move(ntp), std::move(r), timeout);
+          std::move(ntp), min_epoch, std::move(r), timeout);
     }
 
     ss::future<result<chunked_vector<model::record_batch>>> materialize(

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -548,13 +548,30 @@ ss::future<> bg_upload_and_replicate(
         op->replicate_finished.set_value(raft::errc::timeout);
     });
 
+    /*
+     * L0 GC relies on a minimum epoch associated with each NTP for calculating
+     * the name of an L0 object. The minimum is based on the topic revision, but
+     * from the perspective of cloud topics this is largely an implementation
+     * detail. So here we go ahead and translate into a cluster_epoch type for
+     * the rest of its journey.
+     */
+    auto min_epoch = cluster_epoch(partition->get_topic_revision_id());
+    vassert(
+      min_epoch() > 0L,
+      "Unexpected invalid min epoch {} for {}",
+      min_epoch,
+      op->ntp);
+
     chunked_vector<model::record_batch> rb_copy;
     if (cache_enabled) {
         rb_copy = clone_batches(op->batches);
     }
     auto timeout = op->timeout == 0ms ? L0_upload_default_timeout : op->timeout;
     auto res = co_await api->write_and_debounce(
-      op->ntp, std::move(op->batches), model::timeout_clock::now() + timeout);
+      op->ntp,
+      min_epoch,
+      std::move(op->batches),
+      model::timeout_clock::now() + timeout);
 
     if (res.has_error()) {
         vlog(
@@ -680,9 +697,24 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
         rb_copy = clone_batches(batches);
     }
 
+    /*
+     * L0 GC relies on a minimum epoch associated with each NTP for calculating
+     * the name of an L0 object. The minimum is based on the topic revision, but
+     * from the perspective of cloud topics this is largely an implementation
+     * detail. So here we go ahead and translate into a cluster_epoch type for
+     * the rest of its journey.
+     */
+    auto min_epoch = cluster_epoch(_partition->get_topic_revision_id());
+    vassert(
+      min_epoch() > 0L,
+      "Unexpected invalid min epoch {} for {}",
+      min_epoch,
+      ntp());
+
     // Dataplane.
     auto res = co_await _data_plane->write_and_debounce(
       ntp(),
+      min_epoch,
       std::move(batches),
       model::timeout_clock::now()
         + opts.timeout.value_or(L0_replicate_default_timeout));

--- a/src/v/cloud_topics/frontend/tests/frontend_test.cc
+++ b/src/v/cloud_topics/frontend/tests/frontend_test.cc
@@ -43,6 +43,7 @@ public:
       ss::future<result<chunked_vector<extent_meta>>>,
       write_and_debounce,
       (model::ntp,
+       cluster_epoch,
        chunked_vector<model::record_batch>,
        model::timeout_clock::time_point),
       (override));
@@ -123,7 +124,7 @@ TEST_F(frontend_fixture, test_replicate_epoch) {
     cloud_topics::frontend frontend(std::move(partition), _data_plane.get());
 
     EXPECT_CALL(*_data_plane, cache_put(_, _)).Times(2);
-    EXPECT_CALL(*_data_plane, write_and_debounce(_, _, _))
+    EXPECT_CALL(*_data_plane, write_and_debounce(_, _, _, _))
       .WillOnce(Return(make_extent_fut(model::offset(0), cluster_epoch(0))))
       .WillOnce(Return(make_extent_fut(model::offset(1), cluster_epoch(1))))
       .WillOnce(Return(make_extent_fut(model::offset(2), cluster_epoch(0))));

--- a/src/v/cloud_topics/level_zero/batcher/aggregator.cc
+++ b/src/v/cloud_topics/level_zero/batcher/aggregator.cc
@@ -19,10 +19,6 @@
 namespace cloud_topics::l0 {
 
 template<class Clock>
-aggregator<Clock>::aggregator(object_id id)
-  : _id(id) {}
-
-template<class Clock>
 aggregator<Clock>::~aggregator() {
     ack_error(errc::timeout);
     if (!_staging.empty()) {
@@ -73,9 +69,9 @@ void make_ctp_placeholders(
 
 template<class Clock>
 chunked_vector<std::unique_ptr<extents_for_req<Clock>>>
-aggregator<Clock>::get_extents() {
+aggregator<Clock>::get_extents(object_id id) {
     prepared_extents<Clock> ctx{
-      .id = _id,
+      .id = id,
     };
     for (auto& [key, list] : _staging) {
         for (auto& req : list) {
@@ -101,17 +97,12 @@ iobuf aggregator<Clock>::get_stream() {
 }
 
 template<class Clock>
-object_id aggregator<Clock>::get_object_id() const noexcept {
-    return _id;
-}
-
-template<class Clock>
-iobuf aggregator<Clock>::prepare() {
+aggregator<Clock>::L0_object aggregator<Clock>::prepare(object_id id) {
     // Move data from staging to aggregated
-    _aggregated = get_extents();
+    _aggregated = get_extents(id);
     _staging.clear();
     // Produce input stream
-    return get_stream();
+    return {id, get_stream()};
 }
 
 template<class Clock>

--- a/src/v/cloud_topics/level_zero/batcher/aggregator.cc
+++ b/src/v/cloud_topics/level_zero/batcher/aggregator.cc
@@ -158,6 +158,7 @@ void aggregator<Clock>::add(l0::write_request<Clock>& req) {
     req._hook.unlink();
     it->second.push_back(req);
     _size_bytes += req.size_bytes();
+    _min_epoch = std::max(_min_epoch, req.min_epoch);
 }
 
 template<class Clock>

--- a/src/v/cloud_topics/level_zero/batcher/aggregator.h
+++ b/src/v/cloud_topics/level_zero/batcher/aggregator.h
@@ -36,7 +36,7 @@ struct extents_for_req {
 template<class Clock>
 class aggregator {
 public:
-    explicit aggregator(object_id id);
+    aggregator() = default;
     aggregator(const aggregator&) = delete;
     aggregator(aggregator&&) = delete;
     aggregator& operator=(const aggregator&) = delete;
@@ -61,9 +61,11 @@ public:
     cluster_epoch min_epoch() { return _min_epoch; }
 
     /// Prepare upload byte stream
-    iobuf prepare();
-
-    object_id get_object_id() const noexcept;
+    struct L0_object {
+        object_id id;
+        iobuf payload;
+    };
+    L0_object prepare(object_id);
 
     void ack();
     void ack_error(errc);
@@ -71,14 +73,13 @@ public:
 private:
     /// Generate placeholders.
     /// This method should be invoked before 'get_result'
-    chunked_vector<std::unique_ptr<extents_for_req<Clock>>> get_extents();
+    chunked_vector<std::unique_ptr<extents_for_req<Clock>>>
+      get_extents(object_id);
 
     /// Produce L0 object payload.
     /// The method messes up the state so it can only
     /// be called once.
     iobuf get_stream();
-
-    object_id _id;
 
     cluster_epoch _min_epoch;
 

--- a/src/v/cloud_topics/level_zero/batcher/aggregator.h
+++ b/src/v/cloud_topics/level_zero/batcher/aggregator.h
@@ -55,6 +55,11 @@ public:
     /// Estimate L0 object size
     size_t size_bytes() const noexcept;
 
+    /// Return the maximum min_epoch from all write requests that have been
+    /// added to the aggregator. This should be invoked after all of the
+    /// requests have been added.
+    cluster_epoch min_epoch() { return _min_epoch; }
+
     /// Prepare upload byte stream
     iobuf prepare();
 
@@ -74,6 +79,8 @@ private:
     iobuf get_stream();
 
     object_id _id;
+
+    cluster_epoch _min_epoch;
 
     /// Source data for the aggregator
     absl::btree_map<model::ntp, l0::write_request_list<Clock>> _staging;

--- a/src/v/cloud_topics/level_zero/batcher/batcher.cc
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.cc
@@ -179,17 +179,17 @@ ss::future<std::expected<std::monostate, errc>> batcher<Clock>::run_once(
             co_return std::unexpected(errc::failed_to_get_epoch);
         }
 
-        aggregator<Clock> aggregator{object_id::create(epoch_fut.get())};
+        aggregator<Clock> aggregator;
         while (!list.requests.empty()) {
             auto& wr = list.requests.back();
             wr._hook.unlink();
             aggregator.add(wr);
         }
         // TODO: skip waiting if list.completed is not true
-        auto payload = aggregator.prepare();
-        auto size_bytes = payload.size_bytes();
+        auto object = aggregator.prepare(object_id::create(epoch_fut.get()));
+        auto size_bytes = object.payload.size_bytes();
         auto result = co_await upload_object(
-          aggregator.get_object_id(), std::move(payload));
+          object.id, std::move(object.payload));
         if (!result) {
             // TODO: fix the error
             // NOTE: it should be possible to translate the

--- a/src/v/cloud_topics/level_zero/batcher/batcher.cc
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.cc
@@ -185,8 +185,17 @@ ss::future<std::expected<std::monostate, errc>> batcher<Clock>::run_once(
             wr._hook.unlink();
             aggregator.add(wr);
         }
+
+        /*
+         * L0 object is named using an epoch calculated as:
+         *
+         *    min_epoch = max(p.min_epoch() for all p in L0)
+         *    epoch = max(partition_epoch, cached_cluster_epoch)
+         */
+        auto object_epoch = std::max(aggregator.min_epoch(), epoch_fut.get());
+
         // TODO: skip waiting if list.completed is not true
-        auto object = aggregator.prepare(object_id::create(epoch_fut.get()));
+        auto object = aggregator.prepare(object_id::create(object_epoch));
         auto size_bytes = object.payload.size_bytes();
         auto result = co_await upload_object(
           object.id, std::move(object.payload));

--- a/src/v/cloud_topics/level_zero/batcher/tests/aggregator_test.cc
+++ b/src/v/cloud_topics/level_zero/batcher/tests/aggregator_test.cc
@@ -25,6 +25,8 @@
 
 using namespace std::chrono_literals;
 
+static cloud_topics::cluster_epoch min_epoch{3840};
+
 static ss::logger test_log("aggregator_test_log"); // NOLINT
 
 cloud_topics::l0::serialized_chunk get_random_serialized_chunk(
@@ -45,7 +47,7 @@ TEST(AggregatorTest, SingleRequestAck) {
     auto timeout = ss::manual_clock::now() + 10s;
     auto chunk = get_random_serialized_chunk(10, 10);
     cloud_topics::l0::write_request<ss::manual_clock> request(
-      model::controller_ntp, std::move(chunk), timeout);
+      model::controller_ntp, min_epoch, std::move(chunk), timeout);
     auto fut = request.response.get_future();
 
     // The aggregator produces single L0 object
@@ -69,7 +71,7 @@ TEST(AggregatorTest, SingleRequestDtorWithStagedRequest) {
     auto timeout = ss::manual_clock::now() + 10s;
     auto chunk = get_random_serialized_chunk(10, 10);
     cloud_topics::l0::write_request<ss::manual_clock> request(
-      model::controller_ntp, std::move(chunk), timeout);
+      model::controller_ntp, min_epoch, std::move(chunk), timeout);
     auto fut = request.response.get_future();
 
     {
@@ -89,7 +91,7 @@ TEST(AggregatorTest, SingleRequestDtorWithPreparedRequest) {
     auto timeout = ss::manual_clock::now() + 10s;
     auto chunk = get_random_serialized_chunk(10, 10);
     cloud_topics::l0::write_request<ss::manual_clock> request(
-      model::controller_ntp, std::move(chunk), timeout);
+      model::controller_ntp, min_epoch, std::move(chunk), timeout);
     auto fut = request.response.get_future();
 
     {
@@ -109,7 +111,10 @@ TEST(AggregatorTest, SingleRequestDtorWithLostRequestStaged) {
     // requests but one write request is destroyed before the aggregator.
     auto timeout = ss::manual_clock::now() + 10s;
     cloud_topics::l0::write_request<ss::manual_clock> request(
-      model::controller_ntp, get_random_serialized_chunk(10, 10), timeout);
+      model::controller_ntp,
+      min_epoch,
+      get_random_serialized_chunk(10, 10),
+      timeout);
     auto fut = request.response.get_future();
 
     {
@@ -121,6 +126,7 @@ TEST(AggregatorTest, SingleRequestDtorWithLostRequestStaged) {
             // is destroyed outside
             cloud_topics::l0::write_request<ss::manual_clock> tmp_request(
               model::controller_ntp,
+              min_epoch,
               get_random_serialized_chunk(10, 10),
               timeout);
             aggregator.add(tmp_request);
@@ -142,12 +148,15 @@ TEST(AggregatorTest, SingleRequestDtorWithLostRequestPrepared) {
     auto timeout = ss::manual_clock::now() + 10s;
     auto chunk = get_random_serialized_chunk(10, 10);
     cloud_topics::l0::write_request<ss::manual_clock> request(
-      model::controller_ntp, std::move(chunk), timeout);
+      model::controller_ntp, min_epoch, std::move(chunk), timeout);
     auto fut = request.response.get_future();
 
     {
         cloud_topics::l0::write_request<ss::manual_clock> tmp_request(
-          model::controller_ntp, get_random_serialized_chunk(10, 10), timeout);
+          model::controller_ntp,
+          min_epoch,
+          get_random_serialized_chunk(10, 10),
+          timeout);
         cloud_topics::l0::aggregator<ss::manual_clock> aggregator{
           cloud_topics::object_id::create(cloud_topics::cluster_epoch{0})};
         aggregator.add(request);
@@ -164,7 +173,7 @@ TEST(AggregatorTest, SingleRequestWithLostRequestPrepared) {
     auto timeout = ss::manual_clock::now() + 10s;
     auto chunk = get_random_serialized_chunk(10, 10);
     cloud_topics::l0::write_request<ss::manual_clock> request(
-      model::controller_ntp, std::move(chunk), timeout);
+      model::controller_ntp, min_epoch, std::move(chunk), timeout);
     auto fut = request.response.get_future();
 
     cloud_topics::l0::aggregator<ss::manual_clock> aggregator{
@@ -172,7 +181,10 @@ TEST(AggregatorTest, SingleRequestWithLostRequestPrepared) {
     aggregator.add(request);
     {
         cloud_topics::l0::write_request<ss::manual_clock> tmp_request(
-          model::controller_ntp, get_random_serialized_chunk(10, 10), timeout);
+          model::controller_ntp,
+          min_epoch,
+          get_random_serialized_chunk(10, 10),
+          timeout);
         aggregator.add(tmp_request);
     }
 

--- a/src/v/cloud_topics/level_zero/batcher/tests/aggregator_test.cc
+++ b/src/v/cloud_topics/level_zero/batcher/tests/aggregator_test.cc
@@ -29,6 +29,10 @@ static cloud_topics::cluster_epoch min_epoch{3840};
 
 static ss::logger test_log("aggregator_test_log"); // NOLINT
 
+auto make_oid(int epoch) {
+    return cloud_topics::object_id::create(cloud_topics::cluster_epoch{epoch});
+}
+
 cloud_topics::l0::serialized_chunk get_random_serialized_chunk(
   int num_batches, int num_records_per_batch) { // NOLINT
     chunked_vector<model::record_batch> batches;
@@ -51,15 +55,14 @@ TEST(AggregatorTest, SingleRequestAck) {
     auto fut = request.response.get_future();
 
     // The aggregator produces single L0 object
-    cloud_topics::l0::aggregator<ss::manual_clock> aggregator{
-      cloud_topics::object_id::create(cloud_topics::cluster_epoch{0})};
+    cloud_topics::l0::aggregator<ss::manual_clock> aggregator;
 
     aggregator.add(request);
-    auto dest = aggregator.prepare();
+    auto dest = aggregator.prepare(make_oid(0));
 
     aggregator.ack();
     ASSERT_TRUE(fut.available());
-    ASSERT_EQ(dest.size_bytes(), aggregator.size_bytes());
+    ASSERT_EQ(dest.payload.size_bytes(), aggregator.size_bytes());
 }
 
 TEST(AggregatorTest, SingleRequestDtorWithStagedRequest) {
@@ -75,8 +78,7 @@ TEST(AggregatorTest, SingleRequestDtorWithStagedRequest) {
     auto fut = request.response.get_future();
 
     {
-        cloud_topics::l0::aggregator<ss::manual_clock> aggregator{
-          cloud_topics::object_id::create(cloud_topics::cluster_epoch{0})};
+        cloud_topics::l0::aggregator<ss::manual_clock> aggregator;
         aggregator.add(request);
     }
     ASSERT_TRUE(fut.available());
@@ -95,10 +97,9 @@ TEST(AggregatorTest, SingleRequestDtorWithPreparedRequest) {
     auto fut = request.response.get_future();
 
     {
-        cloud_topics::l0::aggregator<ss::manual_clock> aggregator{
-          cloud_topics::object_id::create(cloud_topics::cluster_epoch{0})};
+        cloud_topics::l0::aggregator<ss::manual_clock> aggregator;
         aggregator.add(request);
-        std::ignore = aggregator.prepare();
+        std::ignore = aggregator.prepare(make_oid(0));
     }
     ASSERT_TRUE(fut.available());
     auto err = fut.get();
@@ -118,8 +119,7 @@ TEST(AggregatorTest, SingleRequestDtorWithLostRequestStaged) {
     auto fut = request.response.get_future();
 
     {
-        cloud_topics::l0::aggregator<ss::manual_clock> aggregator{
-          cloud_topics::object_id::create(cloud_topics::cluster_epoch{0})};
+        cloud_topics::l0::aggregator<ss::manual_clock> aggregator;
         aggregator.add(request);
         {
             // tmp_request is destroyed at the end of this block and aggregator
@@ -157,11 +157,10 @@ TEST(AggregatorTest, SingleRequestDtorWithLostRequestPrepared) {
           min_epoch,
           get_random_serialized_chunk(10, 10),
           timeout);
-        cloud_topics::l0::aggregator<ss::manual_clock> aggregator{
-          cloud_topics::object_id::create(cloud_topics::cluster_epoch{0})};
+        cloud_topics::l0::aggregator<ss::manual_clock> aggregator;
         aggregator.add(request);
         aggregator.add(tmp_request);
-        std::ignore = aggregator.prepare();
+        std::ignore = aggregator.prepare(make_oid(0));
     }
     ASSERT_TRUE(fut.available());
     auto err = fut.get();
@@ -176,8 +175,7 @@ TEST(AggregatorTest, SingleRequestWithLostRequestPrepared) {
       model::controller_ntp, min_epoch, std::move(chunk), timeout);
     auto fut = request.response.get_future();
 
-    cloud_topics::l0::aggregator<ss::manual_clock> aggregator{
-      cloud_topics::object_id::create(cloud_topics::cluster_epoch{0})};
+    cloud_topics::l0::aggregator<ss::manual_clock> aggregator;
     aggregator.add(request);
     {
         cloud_topics::l0::write_request<ss::manual_clock> tmp_request(
@@ -188,11 +186,11 @@ TEST(AggregatorTest, SingleRequestWithLostRequestPrepared) {
         aggregator.add(tmp_request);
     }
 
-    auto dest = aggregator.prepare();
+    auto dest = aggregator.prepare(make_oid(0));
 
     aggregator.ack();
     ASSERT_TRUE(fut.available());
-    ASSERT_LT(dest.size_bytes(), aggregator.size_bytes());
+    ASSERT_LT(dest.payload.size_bytes(), aggregator.size_bytes());
 }
 
 TEST(AggregatorTest, MinEpoch) {

--- a/src/v/cloud_topics/level_zero/batcher/tests/aggregator_test.cc
+++ b/src/v/cloud_topics/level_zero/batcher/tests/aggregator_test.cc
@@ -194,3 +194,31 @@ TEST(AggregatorTest, SingleRequestWithLostRequestPrepared) {
     ASSERT_TRUE(fut.available());
     ASSERT_LT(dest.size_bytes(), aggregator.size_bytes());
 }
+
+TEST(AggregatorTest, MinEpoch) {
+    auto timeout = ss::manual_clock::now() + 10s;
+
+    std::vector<
+      std::unique_ptr<cloud_topics::l0::write_request<ss::manual_clock>>>
+      requests;
+    auto make_request = [&](int min_epoch) {
+        auto chunk = get_random_serialized_chunk(10, 10);
+        requests.push_back(
+          std::make_unique<cloud_topics::l0::write_request<ss::manual_clock>>(
+            model::controller_ntp,
+            cloud_topics::cluster_epoch(min_epoch),
+            std::move(chunk),
+            timeout));
+    };
+
+    make_request(5);
+    make_request(10);
+    make_request(7);
+
+    cloud_topics::l0::aggregator<ss::manual_clock> aggregator;
+    for (auto& req : requests) {
+        aggregator.add(*req);
+    }
+
+    ASSERT_EQ(aggregator.min_epoch()(), 10);
+}

--- a/src/v/cloud_topics/level_zero/batcher/tests/batcher_test.cc
+++ b/src/v/cloud_topics/level_zero/batcher/tests/batcher_test.cc
@@ -47,6 +47,8 @@
 
 inline ss::logger test_log("aggregated_uploader_gtest");
 
+static cloud_topics::cluster_epoch min_epoch{3840};
+
 struct reader_with_content {
     chunked_vector<bytes> keys;
     chunked_vector<bytes> records;
@@ -158,7 +160,7 @@ TEST_CORO(batcher_test, single_write_request) {
     const auto timeout = 1s;
     auto deadline = ss::manual_clock::now() + timeout;
     auto fut = pipeline.write_and_debounce(
-      model::controller_ntp, std::move(reader), deadline);
+      model::controller_ntp, min_epoch, std::move(reader), deadline);
     // Make sure the write request is in the _pending list
     co_await sleep_until(
       10ms, [&] { return pipeline_accessor.write_requests_pending(1); });
@@ -228,11 +230,11 @@ TEST_CORO(batcher_test, many_write_requests) {
     std::vector<ss::future<result<chunked_vector<cloud_topics::extent_meta>>>>
       futures;
     futures.push_back(pipeline.write_and_debounce(
-      model::controller_ntp, std::move(reader1), deadline));
+      model::controller_ntp, min_epoch, std::move(reader1), deadline));
     futures.push_back(pipeline.write_and_debounce(
-      model::controller_ntp, std::move(reader2), deadline));
+      model::controller_ntp, min_epoch, std::move(reader2), deadline));
     futures.push_back(pipeline.write_and_debounce(
-      model::controller_ntp, std::move(reader3), deadline));
+      model::controller_ntp, min_epoch, std::move(reader3), deadline));
 
     // Make sure that all write requests are in the _pending list
     co_await sleep_until(
@@ -308,7 +310,7 @@ TEST_CORO(batcher_test, expired_write_request) {
     const auto timeout = 1s;
     auto deadline = ss::manual_clock::now() + timeout;
     auto expect_fail_fut = pipeline.write_and_debounce(
-      model::controller_ntp, std::move(timedout_batches), deadline);
+      model::controller_ntp, min_epoch, std::move(timedout_batches), deadline);
 
     // Let time pass to invalidate the first enqueued write request
     co_await sleep_until(
@@ -317,7 +319,7 @@ TEST_CORO(batcher_test, expired_write_request) {
 
     deadline = ss::manual_clock::now() + timeout;
     auto expect_pass_fut = pipeline.write_and_debounce(
-      model::controller_ntp, std::move(included_batches), deadline);
+      model::controller_ntp, min_epoch, std::move(included_batches), deadline);
 
     // Make sure that both write requests are pending
     co_await sleep_until(

--- a/src/v/cloud_topics/level_zero/pipeline/tests/event_filter_test.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/tests/event_filter_test.cc
@@ -29,6 +29,8 @@
 using namespace cloud_topics;
 using namespace std::chrono_literals;
 
+static cloud_topics::cluster_epoch min_epoch{3840};
+
 namespace cloud_topics::l0 {
 struct write_pipeline_accessor {
     // Returns true if the write request is in the `_pending` collection
@@ -101,6 +103,7 @@ TEST_CORO(EventFilterTest, filter_triggered_once) {
     auto sub = pipeline.subscribe(flt);
     auto write = pipeline.write_and_debounce(
       model::controller_ntp,
+      min_epoch,
       chunked_vector<model::record_batch>(
         std::from_range, std::move(batches) | std::views::as_rvalue),
       ss::lowres_clock::now() + 1s);
@@ -133,6 +136,7 @@ TEST_CORO(EventFilterTest, filter_has_memory) {
     auto stage = pipeline.register_write_pipeline_stage();
     auto write = pipeline.write_and_debounce(
       model::controller_ntp,
+      min_epoch,
       chunked_vector<model::record_batch>(
         std::from_range, std::move(batches) | std::views::as_rvalue),
       ss::lowres_clock::now() + 1s);
@@ -213,12 +217,14 @@ TEST_CORO(EventFilterTest, filter_min_write_bytes) {
     EXPECT_FALSE(sub.available());
     auto write1 = pipeline.write_and_debounce(
       model::controller_ntp,
+      min_epoch,
       chunked_vector<model::record_batch>::single(batch1.copy()),
       ss::lowres_clock::now() + 1s);
     co_await tests::drain_task_queue();
     EXPECT_FALSE(sub.available());
     auto write2 = pipeline.write_and_debounce(
       model::controller_ntp,
+      min_epoch,
       chunked_vector<model::record_batch>::single(batch2.copy()),
       ss::lowres_clock::now() + 1s);
     co_await tests::drain_task_queue();

--- a/src/v/cloud_topics/level_zero/pipeline/tests/pipeline_bench.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/tests/pipeline_bench.cc
@@ -26,6 +26,8 @@
 
 namespace ct = ::cloud_topics;
 
+static cloud_topics::cluster_epoch min_epoch{3840};
+
 struct read_pipeline_sink {
     explicit read_pipeline_sink(ct::l0::read_pipeline<>& p)
       : _my_stage(p.register_read_pipeline_stage())
@@ -116,6 +118,7 @@ PERF_TEST_C(write_pipeline_bench, propagation_latency) {
     perf_tests::do_not_optimize(
       co_await pipeline.write_and_debounce(
         model::controller_ntp,
+        min_epoch,
         {},
         ss::lowres_clock::now() + std::chrono::milliseconds(10)));
     perf_tests::stop_measuring_time();

--- a/src/v/cloud_topics/level_zero/pipeline/tests/write_pipeline_test.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/tests/write_pipeline_test.cc
@@ -31,6 +31,8 @@
 
 using namespace std::chrono_literals;
 
+static cloud_topics::cluster_epoch min_epoch{3840};
+
 namespace cloud_topics::l0 {
 struct write_pipeline_accessor {
     // Returns true if the write request is in the `_pending` collection
@@ -66,7 +68,8 @@ TEST_CORO(write_pipeline_test, single_write_request) {
     auto stage = pipeline.register_write_pipeline_stage();
 
     const auto timeout = ss::manual_clock::now() + 1s;
-    auto fut = pipeline.write_and_debounce(model::controller_ntp, {}, timeout);
+    auto fut = pipeline.write_and_debounce(
+      model::controller_ntp, min_epoch, {}, timeout);
 
     // Make sure the write request is in the _pending list
     co_await sleep_until(
@@ -95,7 +98,7 @@ TEST_CORO(batcher_test, expired_write_request) {
     static constexpr auto timeout = 1s;
     auto deadline = ss::manual_clock::now() + 1s;
     auto expect_fail_fut = pipeline.write_and_debounce(
-      model::controller_ntp, {}, deadline);
+      model::controller_ntp, min_epoch, {}, deadline);
 
     // Expire first request
     co_await sleep_until(
@@ -104,7 +107,7 @@ TEST_CORO(batcher_test, expired_write_request) {
 
     deadline = ss::manual_clock::now() + 1s;
     auto expect_pass_fut = pipeline.write_and_debounce(
-      model::controller_ntp, {}, deadline);
+      model::controller_ntp, min_epoch, {}, deadline);
 
     // Make sure that both write requests are pending
     co_await sleep_until(

--- a/src/v/cloud_topics/level_zero/pipeline/tests/write_request_test.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/tests/write_request_test.cc
@@ -17,9 +17,12 @@
 
 #include <chrono>
 
+static cloud_topics::cluster_epoch min_epoch{3840};
+
 TEST(WriteRequestTest, Expiration) {
     cloud_topics::l0::write_request<ss::manual_clock> req(
       model::kvstore_ntp(ss::shard_id(0)),
+      min_epoch,
       {},
       ss::manual_clock::now() + std::chrono::milliseconds(100));
     ASSERT_FALSE(req.has_expired());

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -67,7 +67,7 @@ template<class Clock>
 ss::future<result<chunked_vector<extent_meta>>>
 write_pipeline<Clock>::write_and_debounce(
   model::ntp ntp,
-  [[maybe_unused]] cluster_epoch min_epoch,
+  cluster_epoch min_epoch,
   chunked_vector<model::record_batch> batches,
   Clock::time_point timeout) {
     auto h = this->hold_gate();
@@ -99,7 +99,7 @@ write_pipeline<Clock>::write_and_debounce(
     auto d = ss::defer([this, sz] { _current_size -= sz; });
     auto stage = this->first_stage();
     l0::write_request<Clock> request(
-      std::move(ntp), std::move(data_chunk), timeout, stage);
+      std::move(ntp), min_epoch, std::move(data_chunk), timeout, stage);
     vlog(
       cd_log.trace,
       "write_pipeline.write_and_debounce, created write_request(size={}, "

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -67,6 +67,7 @@ template<class Clock>
 ss::future<result<chunked_vector<extent_meta>>>
 write_pipeline<Clock>::write_and_debounce(
   model::ntp ntp,
+  [[maybe_unused]] cluster_epoch min_epoch,
   chunked_vector<model::record_batch> batches,
   Clock::time_point timeout) {
     auto h = this->hold_gate();

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
@@ -52,8 +52,10 @@ public:
     ss::sstring pipeline_name() const { return "write_pipeline"; }
 
     /// Add write request to the pipeline
+    /// The revision id is the topic creation revision id for the ntp.
     ss::future<result<chunked_vector<extent_meta>>> write_and_debounce(
       model::ntp ntp,
+      cluster_epoch min_epoch,
       chunked_vector<model::record_batch> batches,
       Clock::time_point timeout);
 

--- a/src/v/cloud_topics/level_zero/pipeline/write_request.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_request.cc
@@ -19,10 +19,12 @@ namespace cloud_topics::l0 {
 template<class Clock>
 write_request<Clock>::write_request(
   model::ntp ntp,
+  cluster_epoch min_epoch,
   serialized_chunk chunk,
   timestamp_t timeout,
   pipeline_stage stage)
   : ntp(std::move(ntp))
+  , min_epoch(min_epoch)
   , data_chunk(std::move(chunk))
   , ingestion_time(Clock::now())
   , expiration_time(timeout)

--- a/src/v/cloud_topics/level_zero/pipeline/write_request.h
+++ b/src/v/cloud_topics/level_zero/pipeline/write_request.h
@@ -33,6 +33,8 @@ struct write_request : ss::weakly_referencable<write_request<Clock>> {
     using timestamp_t = Clock::time_point;
     /// Target NTP
     model::ntp ntp;
+    /// The minimum L0 GC epoch for this NTP
+    cluster_epoch min_epoch;
     /// Serialized record batches
     serialized_chunk data_chunk;
     /// Timestamp of the data ingestion
@@ -60,6 +62,7 @@ struct write_request : ss::weakly_referencable<write_request<Clock>> {
     /// The object can't be copied to another shard directly.
     write_request(
       model::ntp ntp,
+      cluster_epoch min_epoch,
       serialized_chunk chunk,
       timestamp_t timeout,
       pipeline_stage stage = unassigned_pipeline_stage);

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_bench.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_bench.cc
@@ -32,6 +32,8 @@
 
 using namespace std::chrono_literals;
 
+static cloud_topics::cluster_epoch min_epoch{3840};
+
 namespace cloud_topics {
 namespace l0 {
 struct write_request_balancer_accessor {
@@ -164,6 +166,7 @@ PERF_TEST_C(write_request_scheduler_bench, data_threshold) {
     perf_tests::do_not_optimize(
       co_await pipeline.local().write_and_debounce(
         model::controller_ntp,
+        min_epoch,
         std::move(batches),
         ss::lowres_clock::now() + std::chrono::milliseconds(10)));
     perf_tests::stop_measuring_time();
@@ -199,6 +202,7 @@ PERF_TEST_C(write_request_scheduler_bench, time_fallback) {
           return p
             .write_and_debounce(
               model::controller_ntp,
+              min_epoch,
               std::move(batches),
               ss::lowres_clock::now() + std::chrono::milliseconds(10))
             .discard_result();

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_test.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_test.cc
@@ -30,6 +30,8 @@
 
 inline ss::logger test_log("balancer_gtest");
 
+static cloud_topics::cluster_epoch min_epoch{3840};
+
 using namespace std::chrono_literals;
 
 namespace cloud_topics {
@@ -198,7 +200,10 @@ static ss::future<size_t> write_until_threshold(
 
         num_requests_sent++;
         wd.push_back(fix.pipeline.local().write_and_debounce(
-          test_ntp0, std::move(batches), ss::lowres_clock::now() + 10s));
+          test_ntp0,
+          min_epoch,
+          std::move(batches),
+          ss::lowres_clock::now() + 10s));
 
         vlog(
           test_log.info,
@@ -257,7 +262,7 @@ TEST_F_CORO(write_request_balancer_fixture, time_based_fallback_test) {
     }
 
     auto placeholders = co_await pipeline.local().write_and_debounce(
-      test_ntp0, std::move(batches), ss::lowres_clock::now() + 10s);
+      test_ntp0, min_epoch, std::move(batches), ss::lowres_clock::now() + 10s);
 
     // Check that number of upload requests matches expectation.
     // The current shard should receive the write request.
@@ -292,13 +297,16 @@ TEST_F_CORO(write_request_balancer_fixture, test_core_affinity) {
         }
         vlog(test_log.info, "Calling write_and_debounce on shard 1");
         return pipeline.local().write_and_debounce(
-          test_ntp0, std::move(batches), ss::lowres_clock::now() + 10s);
+          test_ntp0,
+          min_epoch,
+          std::move(batches),
+          ss::lowres_clock::now() + 10s);
     });
 
     auto batches = make_random_batches(num_batches_lo, batch_size);
     vlog(test_log.info, "Calling write_and_debounce on shard 0");
     auto s0_placeholders = co_await pipeline.local().write_and_debounce(
-      test_ntp0, std::move(batches), ss::lowres_clock::now() + 10s);
+      test_ntp0, min_epoch, std::move(batches), ss::lowres_clock::now() + 10s);
 
     auto s1_placeholders = co_await std::move(fut);
 
@@ -349,7 +357,7 @@ TEST_F_CORO(write_request_balancer_fixture, test_data_threshold_with_failover) {
         batches.push_back(std::move(b));
     }
     auto placeholders = co_await pipeline.local().write_and_debounce(
-      test_ntp0, std::move(batches), ss::lowres_clock::now() + 10s);
+      test_ntp0, min_epoch, std::move(batches), ss::lowres_clock::now() + 10s);
 
     // Produce on shard 1
     auto expected_num_requests1 = co_await ss::smp::submit_to(
@@ -406,7 +414,10 @@ TEST_F_CORO(
               vlog(test_log.info, "Calling write_and_debounce");
               // The failure is injected based on ntp
               return pipeline.write_and_debounce(
-                ntp, std::move(batches), ss::lowres_clock::now() + 10s);
+                ntp,
+                min_epoch,
+                std::move(batches),
+                ss::lowres_clock::now() + 10s);
           });
     };
 

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
@@ -336,6 +336,7 @@ write_request_scheduler::proxy_write_request(
     _probe.register_receive_xshard(req->size_bytes());
     write_request<> proxy(
       req->ntp,
+      req->min_epoch,
       shallow_copy(req->data_chunk),
       req->expiration_time,
       _stage.id());


### PR DESCRIPTION
Prior to this PR L0 objects were named using only the cached cluster epoch. However, per the RFC design, there are problems that can occur with this approach because it does not guarantee a lower bound (i.e. a cached epoch can be arbitrarily out of date). The fix is to apply a lower bound that the GC process can reason about, in this case it is the fixed topic creation revision ID which crucially is sequenced the same as the epoch address space (using controller offsets). This PR plumbs that into the CT and uses it to name L0 objects.

Fixes: https://redpandadata.atlassian.net/browse/CORE-13321
Fixes: https://redpandadata.atlassian.net/browse/CORE-14389

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
