### PR TITLE
ct/l1: Bump up file input buffering options

### DIFF
--- a/src/v/cloud_topics/level_one/common/BUILD
+++ b/src/v/cloud_topics/level_one/common/BUILD
@@ -100,6 +100,7 @@ redpanda_cc_library(
         "//src/v/cloud_io:remote",
         "//src/v/cloud_storage_clients",
         "//src/v/cloud_topics:logger",
+        "//src/v/config",
         "//src/v/model",
         "@seastar",
     ],

--- a/src/v/cloud_topics/level_one/common/file_io.cc
+++ b/src/v/cloud_topics/level_one/common/file_io.cc
@@ -17,6 +17,7 @@
 #include "cloud_topics/level_one/common/object_id.h"
 #include "cloud_topics/level_one/common/object_utils.h"
 #include "cloud_topics/logger.h"
+#include "config/configuration.h"
 
 #include <seastar/core/file.hh>
 #include <seastar/core/fstream.hh>
@@ -40,18 +41,28 @@ public:
           _path.native(),
           ss::open_flags::rw | ss::open_flags::truncate
             | ss::open_flags::create);
+        ss::file_output_stream_options options{};
+        // The read buffer size also makes sense as the write buffer here
+        // (default 128KiB).
+        options.buffer_size
+          = config::shard_local_cfg().storage_read_buffer_size();
+        // Defaults to 1, which is reasonable for write-behind as well.
+        options.write_behind
+          = config::shard_local_cfg().storage_read_readahead_count();
         co_return co_await ss::make_file_output_stream(
-          std::move(file),
-          ss::file_output_stream_options{
-            .buffer_size = 128_KiB,
-            .write_behind = 2,
-          });
+          std::move(file), std::move(options));
     }
     ss::future<> remove() override { return ss::remove_file(_path.native()); }
     ss::future<ss::input_stream<char>> input_stream() override {
         auto file = co_await ss::open_file_dma(
           _path.native(), ss::open_flags::ro);
-        co_return ss::make_file_input_stream(std::move(file));
+        ss::file_input_stream_options options{};
+        options.buffer_size
+          = config::shard_local_cfg().storage_read_buffer_size();
+        options.read_ahead
+          = config::shard_local_cfg().storage_read_readahead_count();
+        co_return ss::make_file_input_stream(
+          std::move(file), std::move(options));
     }
 
 private:


### PR DESCRIPTION
Experimentally, uploads of L1 staging objects to S3 were slow (~10s for 64MiB). Using these options reduces upload time to ~1s for 64MiB, which is about the same as `aws s3 cp`ing a 64MiB file from the same machine.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
