### PR TITLE
tuner: support Azure and bonding fixes

### DIFF
--- a/src/go/rpk/pkg/tuners/irq/device_info.go
+++ b/src/go/rpk/pkg/tuners/irq/device_info.go
@@ -49,9 +49,9 @@ func (e EmptyMSIRQError) Error() string {
 }
 
 func (deviceInfo *deviceInfo) GetIRQs(
-	irqConfigDir string, xenDeviceName string,
+	irqConfigDir string, deviceName string,
 ) ([]int, error) {
-	zap.L().Sugar().Debugf("Reading IRQs of '%s', with deviceInfo name pattern '%s'", irqConfigDir, xenDeviceName)
+	zap.L().Sugar().Debugf("Reading IRQs of '%s', with deviceInfo name pattern '%s'", irqConfigDir, deviceName)
 	msiIRQsDirName := path.Join(irqConfigDir, "msi_irqs")
 	var irqs []int
 	if exists, _ := afero.Exists(deviceInfo.fs, msiIRQsDirName); exists {
@@ -92,6 +92,7 @@ func (deviceInfo *deviceInfo) GetIRQs(
 				return nil, err
 			}
 			modAlias := lines[0]
+			zap.L().Sugar().Debugf("Found modalias with name %s", modAlias)
 			irqProcFileLines, err := deviceInfo.procFile.GetIRQProcFileLinesMap()
 			if err != nil {
 				return nil, err
@@ -105,11 +106,11 @@ func (deviceInfo *deviceInfo) GetIRQs(
 							deviceInfo.getIRQsForLinesMatching(name, irqProcFileLines)...)
 					}
 				}
+			} else if strings.Contains(modAlias, "xen:") {
+				zap.L().Sugar().Debugf("Reading '%s' device IRQs from /proc/interrupts", irqConfigDir)
+				irqs = deviceInfo.getIRQsForLinesMatching(deviceName, irqProcFileLines)
 			} else {
-				if strings.Contains(modAlias, "xen:") {
-					zap.L().Sugar().Debugf("Reading '%s' device IRQs from /proc/interrupts", irqConfigDir)
-					irqs = deviceInfo.getIRQsForLinesMatching(xenDeviceName, irqProcFileLines)
-				}
+				zap.L().Sugar().Debugf("No modalias support for %s", modAlias)
 			}
 		}
 	}

--- a/src/go/rpk/pkg/tuners/net_checkers.go
+++ b/src/go/rpk/pkg/tuners/net_checkers.go
@@ -211,7 +211,7 @@ func (f *netCheckersFactory) NewNicRpsSetChecker(
 				if err != nil {
 					return false, err
 				}
-				rfsMask, err := network.GetRpsCPUMask(nic, mode, cpuMask, f.cpuMasks, f.rnc)
+				rfsMask, err := network.GetRpsCPUMask(currentNic, mode, cpuMask, f.cpuMasks, f.rnc)
 				if err != nil {
 					return false, err
 				}
@@ -253,7 +253,7 @@ func (f *netCheckersFactory) NewNicRfsChecker(nic network.Nic, mode irq.Mode, cp
 				if err != nil {
 					return false, err
 				}
-				queueLimit, err := network.OneRPSQueueLimit(limits, nic, mode, cpuMask, f.cpuMasks, f.rnc)
+				queueLimit, err := network.OneRPSQueueLimit(limits, currentNic, mode, cpuMask, f.cpuMasks, f.rnc)
 				if err != nil {
 					return false, err
 				}

--- a/src/go/rpk/pkg/tuners/net_checkers.go
+++ b/src/go/rpk/pkg/tuners/net_checkers.go
@@ -399,10 +399,7 @@ func (f *netCheckersFactory) NewSynBacklogChecker() Checker {
 func isSet(
 	nic network.Nic, hwCheckFunction func(network.Nic) (bool, error),
 ) (bool, error) {
-	if nic.IsHwInterface() {
-		zap.L().Sugar().Debugf("'%s' is HW interface", nic.Name())
-		return hwCheckFunction(nic)
-	}
+	// Some HW interfaces might still be bond interfaces like hv_netvsc
 	if nic.IsBondIface() {
 		zap.L().Sugar().Debugf("'%s' is bond interface", nic.Name())
 		slaves, err := nic.Slaves()
@@ -418,6 +415,12 @@ func isSet(
 				return false, nil
 			}
 		}
+
+		return true, nil
+	}
+	if nic.IsHwInterface() {
+		zap.L().Sugar().Debugf("'%s' is HW interface", nic.Name())
+		return hwCheckFunction(nic)
 	}
 	return true, nil
 }

--- a/src/go/rpk/pkg/tuners/net_tuners.go
+++ b/src/go/rpk/pkg/tuners/net_tuners.go
@@ -659,9 +659,15 @@ func tuneInterface(
 		if err != nil {
 			return NewTuneError(err)
 		}
+		var res TuneResult
 		for _, slave := range slaves {
-			return tuneInterface(slave, tuneAction)
+			res = tuneInterface(slave, tuneAction)
+			if res.IsFailed() {
+				return res
+			}
 		}
+		// return the last
+		return res
 	}
 
 	if nic.IsHwInterface() {

--- a/src/go/rpk/pkg/tuners/net_tuners.go
+++ b/src/go/rpk/pkg/tuners/net_tuners.go
@@ -653,10 +653,7 @@ func (f *netTunersFactory) tuneNonVirtualInterfaces(
 func tuneInterface(
 	nic network.Nic, tuneAction func(network.Nic) TuneResult,
 ) TuneResult {
-	if nic.IsHwInterface() {
-		return tuneAction(nic)
-	}
-
+	// Need to check bond interface first as some HW interfaces might also be bonds
 	if nic.IsBondIface() {
 		slaves, err := nic.Slaves()
 		if err != nil {
@@ -665,6 +662,10 @@ func tuneInterface(
 		for _, slave := range slaves {
 			return tuneInterface(slave, tuneAction)
 		}
+	}
+
+	if nic.IsHwInterface() {
+		return tuneAction(nic)
 	}
 
 	return NewTuneResult(false)

--- a/src/go/rpk/pkg/tuners/network/nic.go
+++ b/src/go/rpk/pkg/tuners/network/nic.go
@@ -105,34 +105,34 @@ func (n *nic) Name() string {
 	return n.name
 }
 
-func (n *nic) IsBondIface() bool {
-	zap.L().Sugar().Debugf("Checking if '%s' is bond interface", n.name)
-	if exists, _ := afero.Exists(n.fs, "/sys/class/net/bond_masters"); !exists {
-		return false
-	}
-	lines, _ := utils.ReadFileLines(n.fs, "/sys/class/net/bond_masters")
-	for _, line := range lines {
-		if strings.Contains(line, n.name) {
-			zap.L().Sugar().Debugf("'%s' is bond interface", n.name)
-			return true
+// We use the existence of lower_* files in /sys/class/net/<nic>/ to determine
+// if the NIC is a bond or something bond-like like VLAN interfaces or hyper-v
+// NICs.
+func getLowerNames(fs afero.Fs, nicName string) []string {
+	nicDir := fmt.Sprintf("/sys/class/net/%s", nicName)
+	files := utils.ListFilesInPath(fs, nicDir)
+
+	lowers := []string{}
+	for _, file := range files {
+		if after, ok := strings.CutPrefix(file, "lower_"); ok {
+			lowers = append(lowers, after)
 		}
 	}
-	return false
+	return lowers
+}
+
+func (n *nic) IsBondIface() bool {
+	zap.L().Sugar().Debugf("Checking if '%s' is bond interface", n.name)
+	lowers := getLowerNames(n.fs, n.name)
+	return len(lowers) > 0
 }
 
 func (n *nic) Slaves() ([]Nic, error) {
 	slaves := []Nic{}
+
 	if n.IsBondIface() {
-		var slaveNames []string
 		zap.L().Sugar().Debugf("Reading slaves of '%s'", n.name)
-		lines, err := utils.ReadFileLines(n.fs,
-			fmt.Sprintf("/sys/class/net/%s/bond/slaves", n.name))
-		if err != nil {
-			return nil, err
-		}
-		for _, line := range lines {
-			slaveNames = append(slaveNames, strings.Split(line, " ")...)
-		}
+		slaveNames := getLowerNames(n.fs, n.name)
 
 		for _, name := range slaveNames {
 			slaves = append(slaves, NewNic(n.fs, n.irqProcFile, n.irqDeviceInfo, n.ethtool, name))

--- a/src/go/rpk/pkg/tuners/network/nic.go
+++ b/src/go/rpk/pkg/tuners/network/nic.go
@@ -158,6 +158,7 @@ var supportedDrivers = []driverSupport{
 	{"gve", func(numIRQs int) func(IrqInfo) int {
 		return func(irq IrqInfo) int { return gvnicIrqToQueueIdx(irq, numIRQs) }
 	}},
+	{"mlx5_core", func(_ int) func(IrqInfo) int { return azureHyperVIrqToQueueIdx }},
 }
 
 func getQueueIndexFunc(driverName string, numIRQs int) func(IrqInfo) int {
@@ -203,7 +204,7 @@ func (n *nic) GetIRQs() ([]IrqInfo, error) {
 		return nil, err
 	}
 
-	fastPathIRQsPattern := regexp.MustCompile(`-TxRx-|-fp-|virtio\d+-(input|output)|ntfy-block|gve-ntfy-blk|-Tx-Rx-|mlx\d+-\d+@`)
+	fastPathIRQsPattern := regexp.MustCompile(`-TxRx-|-fp-|virtio\d+-(input|output)|ntfy-block|gve-ntfy-blk|mlx5_comp\d+|-Tx-Rx-|mlx\d+-\d+@`)
 	var fastPathIRQNums []int
 	for _, irq := range IRQNums {
 		if fastPathIRQsPattern.MatchString(procFileLines[irq]) {
@@ -276,6 +277,17 @@ func gvnicIrqToQueueIdx(irq IrqInfo, numIRQs int) int {
 		// https://github.com/torvalds/linux/blob/v6.17/drivers/net/ethernet/google/gve/gve.h#L1082-L1094
 		// TX is the lower half, RX the upper half of the IRQs
 		return idx % (numIRQs / 2)
+	}
+	return MaxInt
+}
+
+func azureHyperVIrqToQueueIdx(irq IrqInfo) int {
+	// Below will only pattern match on Azure but that's fine
+	hyperVPattern := regexp.MustCompile(`mlx5_comp(\d+)@`)
+	match := hyperVPattern.FindStringSubmatch(irq.ProcLine)
+	if len(match) == 2 {
+		idx, _ := strconv.Atoi(match[1])
+		return idx
 	}
 	return MaxInt
 }

--- a/src/go/rpk/pkg/tuners/network/nic_test.go
+++ b/src/go/rpk/pkg/tuners/network/nic_test.go
@@ -63,7 +63,7 @@ func Test_nic_IsBondIface(t *testing.T) {
 	procFile := &procFileMock{}
 	deviceInfo := &deviceInfoMock{}
 	nic := NewNic(fs, procFile, deviceInfo, &ethtoolMock{}, "test0")
-	afero.WriteFile(fs, "/sys/class/net/bond_masters", []byte(fmt.Sprintln("test0")), 0o644)
+	afero.WriteFile(fs, "/sys/class/net/test0/lower_ens5", []byte{}, 0o644)
 	// when
 	bond := nic.IsBondIface()
 	// then
@@ -76,8 +76,9 @@ func Test_nic_Slaves_ReturnAllSlavesOfAnInterface(t *testing.T) {
 	procFile := &procFileMock{}
 	deviceInfo := &deviceInfoMock{}
 	nic := NewNic(fs, procFile, deviceInfo, &ethtoolMock{}, "test0")
-	afero.WriteFile(fs, "/sys/class/net/bond_masters", []byte(fmt.Sprintln("test0")), 0o644)
-	afero.WriteFile(fs, "/sys/class/net/test0/bond/slaves", []byte("sl0\nsl1\nsl2"), 0o644)
+	afero.WriteFile(fs, "/sys/class/net/test0/lower_sl0", []byte{}, 0o644)
+	afero.WriteFile(fs, "/sys/class/net/test0/lower_sl1", []byte{}, 0o644)
+	afero.WriteFile(fs, "/sys/class/net/test0/lower_sl2", []byte{}, 0o644)
 	// when
 	slaves, err := nic.Slaves()
 	// then
@@ -94,6 +95,7 @@ func Test_nic_Slaves_ReturnEmptyForNotBondInterface(t *testing.T) {
 	procFile := &procFileMock{}
 	deviceInfo := &deviceInfoMock{}
 	nic := NewNic(fs, procFile, deviceInfo, &ethtoolMock{}, "test0")
+	fs.MkdirAll("/sys/class/net/test0/device", 0o755)
 	// when
 	slaves, err := nic.Slaves()
 	// then

--- a/src/go/rpk/pkg/tuners/network/nic_test.go
+++ b/src/go/rpk/pkg/tuners/network/nic_test.go
@@ -331,6 +331,36 @@ func Test_nic_GetIRQs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "mlx5_core",
+			driverName: "mlx5_core",
+			irqProcFile: &procFileMock{
+				getIRQProcFileLinesMap: func() (map[int]string, error) {
+					return map[int]string{
+						33: "33:       1465        806  Hyper-V PCIe MSI 2701534461952-edge      mlx5_async0@pci:4ea0:00:02.0",
+						34: "34:        154       9690  Hyper-V PCIe MSI 2701534461953-edge      mlx5_comp0@pci:4ea0:00:02.0",
+						35: "35:          0         43  Hyper-V PCIe MSI 2701534461954-edge      mlx5_comp1@pci:4ea0:00:02.0",
+					}, nil
+				},
+			},
+			irqDeviceInfo: &deviceInfoMock{
+				getIRQs: func(string, string) ([]int, error) {
+					return []int{33, 34, 35}, nil
+				},
+			},
+			want: []IrqInfoRes{
+				{
+					Num:        34,
+					ProcLine:   "34:        154       9690  Hyper-V PCIe MSI 2701534461953-edge      mlx5_comp0@pci:4ea0:00:02.0",
+					QueueIndex: 0,
+				},
+				{
+					Num:        35,
+					ProcLine:   "35:          0         43  Hyper-V PCIe MSI 2701534461954-edge      mlx5_comp1@pci:4ea0:00:02.0",
+					QueueIndex: 1,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -622,6 +652,26 @@ func Test_gvnicIrqToQueueIdx(t *testing.T) {
 			Num:       26,
 			ProcLine:  "26:        134          0   ITS-MSI   0 Edge      eth%d-mgmnt",
 			indexFunc: func(irq IrqInfo) int { return gvnicIrqToQueueIdx(irq, 4) },
+		}
+		require.Equal(t, math.MaxInt64, irq.QueueIndex())
+	}
+}
+
+func Test_azureHyperVIrqToQueueIdx(t *testing.T) {
+	{
+		irq := IrqInfo{
+			Num:       34,
+			ProcLine:  "34:        154       9690  Hyper-V PCIe MSI 2701534461953-edge      mlx5_comp0@pci:4ea0:00:02.0",
+			indexFunc: azureHyperVIrqToQueueIdx,
+		}
+		require.Equal(t, 0, irq.QueueIndex())
+	}
+
+	{
+		irq := IrqInfo{
+			Num:       33,
+			ProcLine:  "33:       1465        806  Hyper-V PCIe MSI 2701534461952-edge      mlx5_async0@pci:4ea0:00:02.0",
+			indexFunc: azureHyperVIrqToQueueIdx,
 		}
 		require.Equal(t, math.MaxInt64, irq.QueueIndex())
 	}

--- a/tests/rptest/test_suite_azure.yml
+++ b/tests/rptest/test_suite_azure.yml
@@ -2,6 +2,7 @@ azure:
   included:
     - tests
     - transactions
+    - tuner_integration_tests/net_tuner_test.py::AzureNetTunerTest
 
   excluded:
     - tests/librdkafka_test.py # normally disabled

--- a/tests/rptest/tuner_integration_tests/net_tuner_test.py
+++ b/tests/rptest/tuner_integration_tests/net_tuner_test.py
@@ -16,8 +16,6 @@ from rptest.clients.rpk_remote import RpkRemoteTool
 import dataclasses
 import re
 
-# only works with --max-parallel 1
-
 CORE_COUNT = 4
 NET_TUNER_CONFIG_FILE_PATH = "/var/run/redpanda_node_tuner_state.yaml"
 
@@ -28,6 +26,9 @@ class NetTunerTest(RedpandaTest):
     def __init__(self, ctx: TestContext):
         super().__init__(test_context=ctx)
 
+    def interface_matcher(self, interface: str) -> bool:
+        return False
+
     def setUp(self):
         # Skip starting redpanda, so that test can explicitly start it with rpk
         self.node = self.redpanda.nodes[0]
@@ -35,6 +36,7 @@ class NetTunerTest(RedpandaTest):
         self.rpk = RpkRemoteTool(self.redpanda, self.node)
         self.rpk.mode_set("production")
 
+        self.interface_name = ""
         interfaces = (
             self.redpanda.nodes[0]
             .account.ssh_output("ls /sys/class/net")
@@ -42,11 +44,14 @@ class NetTunerTest(RedpandaTest):
             .strip()
             .split("\n")
         )
-        assert len(interfaces) == 2, f"Unexpected amount of interfaces: {interfaces}"
         for interface in interfaces:
-            if interface != "lo":
+            if self.interface_matcher(interface):
                 self.interface_name = interface
                 break
+
+        assert self.interface_name != "", (
+            f"No interface matched - interfaces: {interfaces}"
+        )
 
         self.logger.info(f"Found interface {self.interface_name}")
 
@@ -267,6 +272,9 @@ class NetTunerTest(RedpandaTest):
 
 # Targets CORE_COUNT core machines
 class AwsNetTunerTest(NetTunerTest):
+    def interface_matcher(self, interface: str) -> bool:
+        return interface.startswith("ens")
+
     def get_basic_dedicated_expected(self) -> NetTunerTest.ExpectedInterruptSetup:
         return self.ExpectedInterruptSetup(
             interrupts_masks=["8"],
@@ -389,6 +397,9 @@ class AwsNetTunerTest(NetTunerTest):
 
 # Targets CORE_COUNT core virtio (this is what our current ansible targets) machines
 class GcpNetTunerTest(NetTunerTest):
+    def interface_matcher(self, interface: str) -> bool:
+        return interface.startswith("ens")
+
     def get_interrupt_match(self) -> str:
         return "virtio1-(input|output)"
 
@@ -460,3 +471,64 @@ class GcpNetTunerTest(NetTunerTest):
         )
 
         self._test_tune_net_dedicated_core(expected_interrupt_setup, 2)
+
+
+# Targets 8 core machines (Standard_L8s_v3)
+class AzureNetTunerTest(NetTunerTest):
+    def interface_matcher(self, interface: str) -> bool:
+        return interface.startswith("enP")
+
+    def get_interrupt_match(self) -> str:
+        return "mlx5_comp\\d+"
+
+    @cluster(num_nodes=1)
+    def test_tune_net_mq(self):
+        expected_interrupt_setup = self.ExpectedInterruptSetup(
+            interrupts_masks=["01", "02", "04", "08", "10", "20", "40", "80"],
+            redpanda_cores={0, 1, 2, 3, 4, 5, 6, 7},
+            rps_cpu_mask="00",
+            rps_cpu_flow_count=0,
+            rfs_table_size=self.TARGET_RFS_TABLE_SIZE,
+            rx_tx_queue_count=8,
+        )
+
+        self._test_tune_net_mq(expected_interrupt_setup)
+
+    @cluster(num_nodes=1)
+    def test_tune_net_dedicated_1_core(self):
+        expected_interrupt_setup = self.ExpectedInterruptSetup(
+            interrupts_masks=["80", "80", "80", "80", "80", "80", "80", "80"],
+            redpanda_cores={0, 1, 2, 3, 4, 5, 6},
+            rps_cpu_mask="7f",
+            rps_cpu_flow_count=int(self.TARGET_RFS_TABLE_SIZE / 1),
+            rfs_table_size=self.TARGET_RFS_TABLE_SIZE,
+            rx_tx_queue_count=1,
+        )
+
+        self._test_tune_net_dedicated_core(expected_interrupt_setup, 8)
+
+    @cluster(num_nodes=1)
+    def test_tune_net_dedicated_1_core_no_rps_rfs(self):
+        expected_interrupt_setup = self.ExpectedInterruptSetup(
+            interrupts_masks=["80", "80", "80", "80", "80", "80", "80", "80"],
+            redpanda_cores={0, 1, 2, 3, 4, 5, 6},
+            rps_cpu_mask="00",
+            rps_cpu_flow_count=0,
+            rfs_table_size=self.TARGET_RFS_TABLE_SIZE,
+            rx_tx_queue_count=1,
+        )
+
+        self._test_tune_net_dedicated_core(expected_interrupt_setup, 8, False)
+
+    @cluster(num_nodes=1)
+    def test_tune_net_dedicated_2_cores(self):
+        expected_interrupt_setup = self.ExpectedInterruptSetup(
+            interrupts_masks=["08", "80", "08", "08", "08", "80", "80", "80"],
+            redpanda_cores={0, 1, 2, 4, 5, 6},
+            rps_cpu_mask="77",
+            rps_cpu_flow_count=int(self.TARGET_RFS_TABLE_SIZE / 2),
+            rfs_table_size=self.TARGET_RFS_TABLE_SIZE,
+            rx_tx_queue_count=2,
+        )
+
+        self._test_tune_net_dedicated_core(expected_interrupt_setup, 4)


### PR DESCRIPTION
Multiple patches to:
 - Improve bonding support (it was partially broken where it would only ever tune the first slave of a bond)
 - Add support for Azure which relies on bonding support to work

Note we don't have a good bonding integration test as it requires adding two additional NICs which I first need to check it doesn't break the rest of CDT in peculiar ways. I'll need to look into doing this later and manually verified this on AWS for now. The Azure support at least partially tests the bonding paths though it wouldn't have caught the bug mentioned above. 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
