### PR TITLE
ducktape: Speedup metric gathering on shutdown

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1336,7 +1336,7 @@ class RedpandaServiceABC(ABC, RedpandaServiceConstants):
         )
 
     def _extract_samples(
-        self, metrics: Generator[Metric, Any, None], sample_pattern: str, node: Any
+        self, metrics: list[Metric], sample_pattern: str, node: Any
     ) -> list[MetricSample]:
         """Extract metrics samples given a sample pattern. Embed the node in which it came from."""
         found_sample = None
@@ -1363,7 +1363,7 @@ class RedpandaServiceABC(ABC, RedpandaServiceConstants):
     @abstractmethod
     def metrics(
         self, node, metrics_endpoint: MetricsEndpoint = MetricsEndpoint.METRICS
-    ) -> Generator[Metric, Any, None]:
+    ) -> list[Metric]:
         """Implement this method to parse the prometheus text format metric from a given node."""
         pass
 
@@ -1438,8 +1438,8 @@ class RedpandaServiceABC(ABC, RedpandaServiceConstants):
         sample_values_per_pattern = {pattern: [] for pattern in sample_patterns}
 
         for n in ns:
+            metrics = self.metrics(n, metrics_endpoint)
             for pattern in sample_patterns:
-                metrics = self.metrics(n, metrics_endpoint)
                 sample_values_per_pattern[pattern] += self._extract_samples(
                     metrics, pattern, n
                 )
@@ -2022,7 +2022,7 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
             text = self.kubectl.exec(
                 f"curl -f -s -S {p}://localhost:9644/metrics", node.name
             )
-        return text_string_to_metric_families(text)
+        return list(text_string_to_metric_families(text))
 
     def metrics_sample(
         self,
@@ -4164,7 +4164,7 @@ class RedpandaService(Service, RedpandaServiceABC):
     ):
         """Parse the prometheus text format metric from a given node."""
         text = self.raw_metrics(node, metrics_endpoint)
-        return text_string_to_metric_families(text)
+        return list(text_string_to_metric_families(text))
 
     def cloud_storage_diagnostics(self):
         """
@@ -4511,41 +4511,32 @@ class RedpandaService(Service, RedpandaServiceABC):
         if node not in self._started:
             return
 
-        def _metrics_sum(name: str) -> int:
-            samples = self.metrics_sample(name, [node])
-            if samples is None:
-                return 0
-            return int(sum(s.value for s in samples.samples))
+        metrics = {
+            "vectorized_io_queue_total_read_bytes_total": "disk_bytes_read",
+            "vectorized_io_queue_total_write_bytes_total": "disk_bytes_written",
+            "vectorized_storage_log_batches_read": "batches_read",
+            "vectorized_storage_log_batches_written": "batches_written",
+            "vectorized_internal_rpc_sent_bytes": "internal_rpc_bytes_sent",
+            "vectorized_internal_rpc_received_bytes": "internal_rpc_bytes_recv",
+            "vectorized_cloud_client_total_uploads": "cloud_storage_puts",
+            "vectorized_cloud_client_total_downloads": "cloud_storage_gets",
+        }
 
         try:
-            self._usage_stats.disk_bytes_read += _metrics_sum(
-                "vectorized_io_queue_total_read_bytes_total"
+            metric_samples = self.metrics_samples(
+                list(metrics.keys()),
+                [node],
             )
 
-            self._usage_stats.disk_bytes_written += _metrics_sum(
-                "vectorized_io_queue_total_write_bytes_total"
-            )
-            self._usage_stats.batches_read += _metrics_sum(
-                "vectorized_storage_log_batches_read"
-            )
-
-            self._usage_stats.batches_written += _metrics_sum(
-                "vectorized_storage_log_batches_written"
-            )
-            self._usage_stats.internal_rpc_bytes_sent += _metrics_sum(
-                "vectorized_internal_rpc_sent_bytes"
-            )
-            self._usage_stats.internal_rpc_bytes_recv += _metrics_sum(
-                "vectorized_internal_rpc_received_bytes"
-            )
-            self._usage_stats.cloud_storage_puts += _metrics_sum(
-                "vectorized_cloud_client_total_uploads"
-            )
-            self._usage_stats.cloud_storage_gets += _metrics_sum(
-                "vectorized_cloud_client_total_downloads"
-            )
+            for key, ms in metric_samples.items():
+                current = getattr(self._usage_stats, metrics[key])
+                setattr(
+                    self._usage_stats,
+                    metrics[key],
+                    current + int(sum(s.value for s in ms.samples)),
+                )
         except Exception as e:
-            self.logger.warning(f"Cannot check metrics - {e}")
+            self.logger.warning(f"Cannot check metrics on shutdown - {e}")
 
     def stop_node(
         self,


### PR DESCRIPTION
When running a basic DT self test we see that "shutdown" is fairly slow:

```
[INFO  - 2025-10-24 14:09:12,672 - redpanda - stop - lineno:4487]: RedpandaService-0-138017904872800: stopping service
[DEBUG - 2025-10-24 14:09:15,199 - remoteaccount - _log - lineno:186]: root@redpanda-0: Running ssh command: pgrep --list-full --exact redpanda
```

On Azure in `RedpandaServiceSelfTest.test_start` we see a total run time of:

```
run time:         6.869 seconds
```

Looking into it we see that this is because when scraping metrics we query the metrics endpoint N times. This is quite slow as each attempt takes in the region of XXX milliseconds.

Improving the metrics scraping code to only scrape once we get the following improvement:

```
[INFO  - 2025-10-24 14:07:23,215 - redpanda - stop - lineno:4487]: RedpandaService-0-135056967880080: stopping service
[DEBUG - 2025-10-24 14:07:23,654 - remoteaccount - _log - lineno:186]: root@redpanda-0: Running ssh command: pgrep --list-full --exact redpanda
```

```
run time:         4.775 seconds
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none


