### PR TITLE
rpk: fix admin host index selection

### DIFF
--- a/src/go/rpk/pkg/adminapi/admin.go
+++ b/src/go/rpk/pkg/adminapi/admin.go
@@ -117,7 +117,7 @@ func NewHostClient(fs afero.Fs, p *config.RpkProfile, host string) (*rpadmin.Adm
 		if i < 0 || i >= len(addrs) {
 			return nil, fmt.Errorf("admin host %d is out of allowed range [0, %d)", i, len(addrs))
 		}
-		addrs = []string{addrs[0]}
+		addrs = []string{addrs[i]}
 	} else {
 		addrs = []string{host} // trust input is hostname (validate below)
 	}


### PR DESCRIPTION
The code was incorrectly using `addrs[0]` instead of `addrs[i]` when selecting a specific host by index, which meant the index parameter was being validated but not actually used.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes

* rpk: Fix host selection when using `--host <index in address config>`. Previously it would always choose the first address.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
