### PR TITLE
[CORE-13412] cluster_link: Add guards on the produce path

### DIFF
--- a/src/v/cluster_link/BUILD
+++ b/src/v/cluster_link/BUILD
@@ -200,6 +200,7 @@ redpanda_cc_library(
         ":security_migrator",
         ":source_topic_syncer",
         "//src/v/cluster_link/model",
+        "//src/v/config",
         "//src/v/kafka/data:partition_proxy",
         "//src/v/ssx:future_util",
     ],

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -15,6 +15,7 @@
 #include "cluster/controller.h"
 #include "cluster/health_monitor_frontend.h"
 #include "cluster/members_table.h"
+#include "cluster/metadata_cache.h"
 #include "cluster/partition_manager.h"
 #include "cluster_link/group_mirroring_task.h"
 #include "cluster_link/link.h"
@@ -377,8 +378,10 @@ class local_partition_sink : public replication::data_sink {
 public:
     static constexpr auto sync_timeout = 10s;
     explicit local_partition_sink(
-      ss::lw_shared_ptr<cluster::partition> partition)
+      ss::lw_shared_ptr<cluster::partition> partition,
+      const cluster::metadata_cache& md_cache)
       : _partition(std::move(partition))
+      , _metadata_cache{md_cache}
       , _stm(_partition->raft()
                ->stm_manager()
                ->get<kafka::write_at_offset_stm>()) {
@@ -427,6 +430,14 @@ public:
           !batches.empty(),
           "Cannot replicate empty batch vector {}",
           _partition->ntp());
+
+        if (_metadata_cache.should_reject_writes()) [[unlikely]] {
+            throw std::runtime_error{fmt::format(
+              "Replication rejected on {}. no disk space; free bytes less than "
+              "configurable threshold",
+              _partition->ntp())};
+        }
+
         chunked_vector<kafka::offset> expected_offsets;
         expected_offsets.reserve(batches.size());
         for (const auto& batch : batches) {
@@ -511,6 +522,7 @@ public:
 private:
     ss::gate _gate;
     ss::lw_shared_ptr<cluster::partition> _partition;
+    const cluster::metadata_cache& _metadata_cache;
     ss::shared_ptr<kafka::write_at_offset_stm> _stm;
     // set in start();
     std::optional<kafka::offset> _last_replicated_offset;
@@ -520,8 +532,10 @@ class local_partition_data_sink_factory
   : public replication::data_sink_factory {
 public:
     explicit local_partition_data_sink_factory(
-      ss::sharded<cluster::partition_manager>& pm)
-      : _partition_manager(pm) {}
+      ss::sharded<cluster::partition_manager>& pm,
+      ss::sharded<cluster::metadata_cache>& md_cache)
+      : _partition_manager(pm)
+      , _metadata_cache{md_cache} {}
 
     std::unique_ptr<replication::data_sink>
     make_sink(const ::model::ntp& ntp) final {
@@ -530,11 +544,13 @@ public:
             throw std::runtime_error(
               fmt::format("Partition not found: {} on this shard", ntp));
         }
-        return make_default_data_sink(std::move(partition));
+        return make_default_data_sink(
+          std::move(partition), _metadata_cache.local());
     }
 
 private:
     ss::sharded<cluster::partition_manager>& _partition_manager;
+    ss::sharded<cluster::metadata_cache>& _metadata_cache;
 };
 
 std::unique_ptr<replication::data_source> make_default_data_source(
@@ -543,9 +559,11 @@ std::unique_ptr<replication::data_source> make_default_data_source(
     return std::make_unique<remote_partition_source>(tp, consumer);
 }
 
-std::unique_ptr<replication::data_sink>
-make_default_data_sink(ss::lw_shared_ptr<cluster::partition> partition) {
-    return std::make_unique<local_partition_sink>(std::move(partition));
+std::unique_ptr<replication::data_sink> make_default_data_sink(
+  ss::lw_shared_ptr<cluster::partition> partition,
+  const cluster::metadata_cache& md_cache) {
+    return std::make_unique<local_partition_sink>(
+      std::move(partition), md_cache);
 }
 
 class default_link_config_provider
@@ -751,10 +769,12 @@ class default_link_factory : public link_factory {
 public:
     explicit default_link_factory(
       ss::sharded<cluster::partition_manager>* partition_manager,
-      ss::sharded<kafka::snc_quota_manager>* snc_quota_mgr)
+      ss::sharded<kafka::snc_quota_manager>* snc_quota_mgr,
+      ss::sharded<cluster::metadata_cache>* md_cache)
       : link_factory()
       , _partition_manager(partition_manager)
-      , _snc_quota_mgr(snc_quota_mgr) {}
+      , _snc_quota_mgr(snc_quota_mgr)
+      , _metadata_cache(md_cache) {}
 
     static constexpr auto link_reconciler_period = 5min;
     std::unique_ptr<link> create_link(
@@ -786,12 +806,13 @@ public:
               make_remote_consumer_configuration(config.connection),
               std::move(probe_cfg))),
           std::make_unique<local_partition_data_sink_factory>(
-            *_partition_manager));
+            *_partition_manager, *_metadata_cache));
     }
 
 private:
     ss::sharded<cluster::partition_manager>* _partition_manager;
     ss::sharded<kafka::snc_quota_manager>* _snc_quota_mgr;
+    ss::sharded<cluster::metadata_cache>* _metadata_cache;
 };
 
 class kafka_consumer_groups_router : public consumer_groups_router {
@@ -1074,7 +1095,7 @@ ss::future<> service::maybe_start_manager() {
       security_service::make_default(_security_fe),
       std::make_unique<link_registry_adapter>(&_plf->local(), this),
       std::make_unique<default_link_factory>(
-        _partition_manager, _snc_quota_mgr),
+        _partition_manager, _snc_quota_mgr, _metadata_cache),
       std::make_unique<cluster_factory>(),
       std::make_unique<kafka_consumer_groups_router>(_group_router),
       std::make_unique<health_monitor_based_partition_metadata_provider>(

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -29,6 +29,7 @@
 #include "cluster_link/security_migrator.h"
 #include "cluster_link/shadow_linking_rpc_service.h"
 #include "cluster_link/source_topic_syncer.h"
+#include "config/node_config.h"
 #include "kafka/client/direct_consumer/direct_consumer.h"
 #include "kafka/data/partition_proxy.h"
 #include "kafka/server/group_router.h"
@@ -435,6 +436,11 @@ public:
             throw std::runtime_error{fmt::format(
               "Replication rejected on {}. no disk space; free bytes less than "
               "configurable threshold",
+              _partition->ntp())};
+        }
+        if (config::node().recovery_mode_enabled()) [[unlikely]] {
+            throw std::runtime_error{fmt::format(
+              "Replication rejected on {}. Redpanda is in recovery mode",
               _partition->ntp())};
         }
 

--- a/src/v/cluster_link/service.h
+++ b/src/v/cluster_link/service.h
@@ -229,6 +229,7 @@ std::unique_ptr<replication::data_source> make_default_data_source(
   const ::model::topic_partition& tp,
   replication::mux_remote_consumer& consumer);
 
-std::unique_ptr<replication::data_sink>
-make_default_data_sink(ss::lw_shared_ptr<cluster::partition> partition);
+std::unique_ptr<replication::data_sink> make_default_data_sink(
+  ss::lw_shared_ptr<cluster::partition> partition,
+  const cluster::metadata_cache&);
 } // namespace cluster_link

--- a/src/v/cluster_link/tests/partition_replicator_fixture_tests.cc
+++ b/src/v/cluster_link/tests/partition_replicator_fixture_tests.cc
@@ -53,7 +53,8 @@ public:
           cluster_link::replication::tests::test_config_provider>();
         auto source = cluster_link::make_default_data_source(
           _source.tp, *_mux_consumer);
-        auto sink = cluster_link::make_default_data_sink(partition);
+        auto sink = cluster_link::make_default_data_sink(
+          partition, get_local_cache(model::node_id{0}));
         _replicator
           = std::make_unique<cluster_link::replication::partition_replicator>(
             _source,

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -64,6 +64,7 @@ from rptest.tests.cluster_linking_test_base import (
     ShadowLinkTestBase,
 )
 from rptest.clients.admin.proto.redpanda.core.admin.v2 import shadow_link_pb2
+from rptest.tests.full_disk_test import FDT_LOG_ALLOW_LIST
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import (
     bg_thread_cm,
@@ -72,9 +73,16 @@ from rptest.util import (
     wait_until,
     wait_until_result,
 )
+from rptest.utils.full_disk import FullDiskHelper
 from typing import Any, Callable, Optional
 from time import sleep
 import google.protobuf.duration_pb2
+
+FDT_CL_REPLICATION_REJECTION = [
+    re.compile(
+        ".*Error in fetch_and_replicate.*no disk space; free bytes less than configurable threshold\\)"
+    )
+]
 
 
 class MultiClusterTestBase(RedpandaTest):
@@ -1200,6 +1208,74 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
             lambda e: e.code == ConnectErrorCode.FAILED_PRECONDITION,
         ):
             self.create_link("link-to-incompatible-cluster")
+
+    @cluster(
+        num_nodes=6,
+        log_allow_list=FDT_LOG_ALLOW_LIST + FDT_CL_REPLICATION_REJECTION,
+    )
+    def test_produce_guards(self):
+        test_link = "test-link"
+        self.create_link(test_link)
+
+        topic = TopicSpec(name="test-topic", partition_count=3, replication_factor=1)
+        self.source_default_client().create_topic(topic)
+        self.target_cluster.service.wait_until(
+            lambda: self.topic_exists_in_target(topic.name),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"Topic {topic.name} not found in target cluster",
+        )
+
+        source_rpk = RpkTool(self.source_cluster.service)
+        target_rpk = RpkTool(self.target_cluster.service)
+
+        def verify_n_replications(n_expected_logs: int) -> bool:
+            desc = list(target_rpk.describe_topic(topic.name))
+            n_logs: int = 0
+            for partition in desc:
+                n_logs += partition.high_watermark
+            return n_logs == n_expected_logs
+
+        source_rpk.produce(topic.name, "key", "message1")
+
+        wait_until(
+            lambda: verify_n_replications(1),
+            timeout_sec=20,
+            backoff_sec=1,
+            err_msg=f"Failed to replicate shadow topic",
+        )
+
+        target_redpanda = self.target_cluster_service
+        target_full_disk = FullDiskHelper(self.logger, target_redpanda)
+        target_full_disk.trigger_low_space()
+        wait_until(
+            lambda: target_redpanda.search_log_all("ok -> degraded"),
+            timeout_sec=20,
+            backoff_sec=1,
+            err_msg=f"Failed to change to degraded state",
+        )
+
+        source_rpk.produce(topic.name, "key", "message2")
+        wait_until(
+            lambda: target_redpanda.search_log_any(
+                "Replication rejected on {kafka/test-topic/1}. no disk space;"
+            ),
+            timeout_sec=20,
+            backoff_sec=1,
+            err_msg=f"Sink replication should have been rejected",
+        )
+
+        assert verify_n_replications(1), (
+            "Sink replication was not rejected under degraded disk conditions"
+        )
+        target_full_disk.clear_low_space()
+
+        wait_until(
+            lambda: verify_n_replications(2),
+            timeout_sec=20,
+            backoff_sec=1,
+            err_msg=f"Failed to replicate shadow topic",
+        )
 
 
 class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):


### PR DESCRIPTION
Implements: [CORE-13412](https://redpandadata.atlassian.net/browse/CORE-13412)

Add checks for:
- degraded disk conditions
- node being in recovery mode

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-13412]: https://redpandadata.atlassian.net/browse/CORE-13412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ