### PR TITLE
Coordinated compaction fixups

### DIFF
--- a/src/v/raft/compaction_coordinator.cc
+++ b/src/v/raft/compaction_coordinator.cc
@@ -263,6 +263,10 @@ void compaction_coordinator::on_local_mcco_update(model::offset new_mcco) {
         }
     }
     if (new_mcco < _local_mcco) {
+        // This may happen when a cleanly compacted segment is merged with the
+        // following one which is not cleanly compacted. Log only tracks clean
+        // compaction per segment, but compaction coordinator will retain
+        // earlier info about it gathered when segment were more granular.
         vlog(
           _logger.debug,
           "attempted to move local max cleanly compacted offset backwards from "
@@ -388,8 +392,20 @@ void compaction_coordinator::update_mtro(model::offset new_mtro) {
         return;
     }
     if (new_mtro < _mtro) [[unlikely]] {
+        // A follower with an empty log has MCCO of 0. Similarly, a follower
+        // with a log much shorter than the leader may have MCCO less than the
+        // group's MTRO. Low MCCO reported by such followers earlier may
+        // contribute to lowering the group's MTRO below existing value.
+        //
+        // It is intentionally ignored, as semantically MTRO remains the same:
+        // when such a follower catches up, its log will be filled with already
+        // cleanly compacted data, as, by definition of MTRO, all replicas have
+        // their logs cleanly compacted up to it.
+        //
+        // Later, when the follower receives MTRO from the leader, the follower
+        // will update its MCCO to at least match the group's MTRO.
         vlog(
-          _logger.error,
+          _logger.debug,
           "attempted to move max tombstone remove offset backwards from {} to "
           "{}",
           _mtro,

--- a/src/v/raft/compaction_coordinator.cc
+++ b/src/v/raft/compaction_coordinator.cc
@@ -180,8 +180,10 @@ void compaction_coordinator::collect_mcco_from_all_members() {
     update_local_mcco();
     for (auto& [node_id, fstat] : _fstats) {
         ssx::background = fstat.mcco_getter->submit(
-          [this, holder = _raft_bg.hold(), node_id](ss::abort_source& op_as) {
-              return get_and_process_compaction_mcco(node_id, op_as);
+          [this, holder = _raft_bg.hold(), node_id](
+            ss::abort_source& op_as) mutable {
+              return get_and_process_compaction_mcco(node_id, op_as)
+                .finally([holder = std::move(holder)] {});
           });
     }
     arm_timer_if_needed(false);
@@ -280,7 +282,7 @@ void compaction_coordinator::send_mtro_to_followers() {
     for (const auto& [node_id, fstat] : _fstats) {
         ssx::background = fstat.mtro_sender->submit(
           [this, holder = _raft_bg.hold(), node_id](
-            ss::abort_source& op_as) -> ss::future<> {
+            ss::abort_source& op_as) mutable -> ss::future<> {
               // MTRO may get recalculated a few times triggered by MCCO
               // arriving from multiple nodes. However, we cannot wait for all
               // MCCOs to arrive as some of them may come very late e.g. due to
@@ -295,6 +297,7 @@ void compaction_coordinator::send_mtro_to_followers() {
                       },
                       op_as);
                 })
+                .finally([holder = std::move(holder)] {})
                 .discard_result();
           });
     }

--- a/src/v/raft/compaction_coordinator.h
+++ b/src/v/raft/compaction_coordinator.h
@@ -36,6 +36,16 @@ using namespace std::chrono_literals;
  *
  * MCCO and MTRO are not inclusive, i.e. denote first non-cleanly-compacted and
  * first non-tombstone-removable offsets respectively.
+ *
+ * MCCO of a replica log is defined as an offset where all data below it are
+ * cleanly compacted. MCCO may be above the log's dirty offset if the data
+ * replica receives in future is guaranteed to be cleanly compacted up to this
+ * offset.
+ *
+ * MTRO is defined as an offset where all data below it are cleanly compacted on
+ * all replicas. This makes MTRO never go back, as once data has been cleanly
+ * compacted on all replicas there's no uncompacted data for the same offset
+ * range.
  */
 
 class compaction_coordinator {

--- a/src/v/raft/tests/raft_fixture_base.cc
+++ b/src/v/raft/tests/raft_fixture_base.cc
@@ -316,8 +316,8 @@ ss::future<result<RespT>> in_memory_test_protocol::dispatch(
     auto& node_channel = *it->second;
 
     if (!node_channel.is_valid()) {
-        co_await node_channel.stop();
-        _channels.erase(id);
+        auto extracted_channel = _channels.extract(it);
+        co_await extracted_channel.mapped()->stop();
         co_return errc::group_not_exists;
     }
 


### PR DESCRIPTION
Coordinated compaction bugfixes:
1) hold raft gate in functions submitted to single-fiber executors until their futures are resolved
2) eliminate a race condition in raft_fixture

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
