### PR TITLE
[CORE-14483] ct: Split big L0 read requests to improve concurrency

### DIFF
--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -132,6 +132,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_zero/cluster_services_impl",
         "//src/v/cloud_topics/level_zero/pipeline:read_pipeline",
         "//src/v/cloud_topics/level_zero/pipeline:write_pipeline",
+        "//src/v/cloud_topics/level_zero/read_fanout",
         "//src/v/cloud_topics/level_zero/reader:fetch_handler",
         "//src/v/cloud_topics/level_zero/write_request_scheduler",
         "//src/v/model",

--- a/src/v/cloud_topics/data_plane_impl.cc
+++ b/src/v/cloud_topics/data_plane_impl.cc
@@ -19,6 +19,7 @@
 #include "cloud_topics/level_zero/cluster_services_impl/cluster_services.h"
 #include "cloud_topics/level_zero/pipeline/read_pipeline.h"
 #include "cloud_topics/level_zero/pipeline/write_pipeline.h"
+#include "cloud_topics/level_zero/read_fanout/read_fanout.h"
 #include "cloud_topics/level_zero/reader/fetch_request_handler.h"
 #include "cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.h"
 #include "model/fundamental.h"
@@ -68,6 +69,11 @@ public:
         co_await construct_service(_read_pipeline);
 
         co_await construct_service(
+          _read_fanout, ss::sharded_parameter([this] {
+              return _read_pipeline.local().register_read_pipeline_stage();
+          }));
+
+        co_await construct_service(
           _fetch_handler,
           ss::sharded_parameter([this] {
               return _read_pipeline.local().register_read_pipeline_stage();
@@ -86,6 +92,7 @@ public:
         co_await _write_req_scheduler.invoke_on_all(
           [](auto& s) { return s.start(); });
         co_await _batcher.invoke_on_all([](auto& s) { return s.start(); });
+        co_await _read_fanout.invoke_on_all([](auto& s) { return s.start(); });
         co_await _fetch_handler.invoke_on_all(
           [](auto& s) { return s.start(); });
         co_await _batch_cache.invoke_on_all([](auto& s) { return s.start(); });
@@ -147,6 +154,7 @@ private:
     ss::sharded<l0::batcher<>> _batcher;
     // Read path
     ss::sharded<l0::read_pipeline<>> _read_pipeline;
+    ss::sharded<l0::read_fanout> _read_fanout;
     ss::sharded<l0::fetch_handler> _fetch_handler;
     // Batch cache
     ss::sharded<batch_cache> _batch_cache;

--- a/src/v/cloud_topics/level_zero/pipeline/BUILD
+++ b/src/v/cloud_topics/level_zero/pipeline/BUILD
@@ -5,6 +5,8 @@ package(default_visibility = [
     "//src/v/cloud_topics:__pkg__",
     "//src/v/cloud_topics/level_zero/batcher:__pkg__",
     "//src/v/cloud_topics/level_zero/batcher/tests:__pkg__",
+    "//src/v/cloud_topics/level_zero/read_fanout:__pkg__",
+    "//src/v/cloud_topics/level_zero/read_fanout/tests:__pkg__",
     "//src/v/cloud_topics/level_zero/reader:__pkg__",
     "//src/v/cloud_topics/level_zero/reader/tests:__pkg__",
     "//src/v/cloud_topics/level_zero/write_request_scheduler:__pkg__",

--- a/src/v/cloud_topics/level_zero/pipeline/read_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/read_pipeline.cc
@@ -45,6 +45,12 @@ size_t get_cloud_topics_l0_read_path_memory() {
 } // namespace
 
 template<class Clock>
+void read_pipeline<Clock>::stage::push_next_stage(
+  read_request<Clock>& r, bool signal) {
+    _parent->reenqueue(r, signal);
+}
+
+template<class Clock>
 read_pipeline<Clock>::read_pipeline()
   : _mem_quota(get_cloud_topics_l0_read_path_memory(), "read-pipeline")
   // TODO: use config parameter
@@ -124,7 +130,6 @@ ss::future<result<dataplane_query_result>> read_pipeline<Clock>::make_reader(
         err_fallback.cancel();
         co_return errc::shutting_down;
     }
-
     auto res = co_await std::move(fut);
     if (res.has_error()) {
         if (res.error() == errc::timeout) {
@@ -212,6 +217,32 @@ void read_pipeline<Clock>::register_pipeline_error(errc e) {
         // potentially throttle the read path.
         _breaker.register_error();
         break;
+    }
+}
+
+template<class Clock>
+void read_pipeline<Clock>::reenqueue(read_request<Clock>& r, bool signal) {
+    if (r._hook.is_linked()) {
+        r._hook.unlink();
+    }
+    if (r.has_expired()) {
+        vlog(r.rtc_logger.debug, "Read request has expired");
+        r.set_value(errc::timeout);
+    } else {
+        auto next = this->next_stage(r.stage);
+        vlog(
+          r.rtc_logger.debug,
+          "Read request is returned, stage will be propagated from {} to {} {}",
+          r.stage,
+          next,
+          signal ? "with signal" : "without signal");
+        // Move all re-enqueued requests to the next stage automatically
+        // and notify the corresponding event filter.
+        r.stage = next;
+        this->get_pending().push_back(r);
+        if (signal) {
+            this->signal(r.stage);
+        }
     }
 }
 

--- a/src/v/cloud_topics/level_zero/pipeline/read_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/read_pipeline.h
@@ -58,7 +58,11 @@ public:
     public:
         explicit stage(pipeline_stage ps, read_pipeline<Clock>* parent)
           : _ps(ps)
-          , _parent(parent) {}
+          , _parent(parent)
+          , _logger(
+              cd_log,
+              parent->get_root_rtc(),
+              ssx::sformat("ct:read_pipeline[{}]", ps)) {}
 
         explicit operator pipeline_stage() const { return _ps; }
 
@@ -96,9 +100,19 @@ public:
             _parent->register_pipeline_error(e);
         }
 
+        /// Return read request back into the pipeline.
+        /// The read request advances to the next stage of the
+        /// pipeline.
+        /// \param r Read request to reenqueue
+        /// \param signal If true signal the next stage that new read request
+        void push_next_stage(read_request<Clock>& r, bool signal = true);
+
+        basic_retry_chain_logger<Clock>& logger() noexcept { return _logger; }
+
     private:
         pipeline_stage _ps;
         read_pipeline<Clock>* _parent;
+        basic_retry_chain_logger<Clock> _logger;
     };
 
     /// Register new pipeline stage
@@ -121,6 +135,15 @@ private:
 
     /// Register read-path errors
     void register_pipeline_error(errc);
+
+    /// Return read request which was already been in the pipeline
+    /// before back into the pipeline.
+    /// The method allows to reenqueue requests returned by get_read_requests
+    /// method.
+    /// \param req Read request to reenqueue
+    /// \param signal If true signal the next stage that new read request is
+    /// available
+    void reenqueue(read_request<Clock>& req, bool signal = true);
 
     // Total size of all fetch requests (estimated using max_bytes)
     size_t _current_size{0};

--- a/src/v/cloud_topics/level_zero/pipeline/read_request.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/read_request.cc
@@ -41,7 +41,7 @@ read_request<Clock>::read_request(
       cd_log, rtc, ssx::sformat("ct:read_request[{}]", this->ntp.path())) {
     vlog(
       rtc_logger.debug,
-      "read_request created, timeout: {}ms",
+      "read_request created, timeout: {}",
       std::chrono::duration_cast<std::chrono::milliseconds>(rtc.get_timeout()));
 }
 

--- a/src/v/cloud_topics/level_zero/read_fanout/BUILD
+++ b/src/v/cloud_topics/level_zero/read_fanout/BUILD
@@ -1,0 +1,32 @@
+load("//bazel:build.bzl", "redpanda_cc_library")
+
+package(default_visibility = [
+    "//src/v/cloud_topics:__pkg__",
+    "//src/v/cloud_topics/level_zero/read_fanout:__pkg__",
+    "//src/v/cloud_topics/level_zero/read_fanout/tests:__pkg__",
+])
+
+redpanda_cc_library(
+    name = "read_fanout",
+    srcs = [
+        "read_fanout.cc",
+    ],
+    hdrs = [
+        "read_fanout.h",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes",
+        "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics:types",
+        "//src/v/cloud_topics/level_zero/pipeline:event_filter",
+        "//src/v/cloud_topics/level_zero/pipeline:read_pipeline",
+        "//src/v/cloud_topics/level_zero/pipeline:read_request",
+        "//src/v/container:chunked_vector",
+        "//src/v/model",
+        "//src/v/ssx:future_util",
+        "//src/v/storage",
+        "//src/v/utils:retry_chain_node",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_zero/read_fanout/read_fanout.cc
+++ b/src/v/cloud_topics/level_zero/read_fanout/read_fanout.cc
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "cloud_topics/level_zero/read_fanout/read_fanout.h"
+
+#include "cloud_topics/level_zero/pipeline/read_request.h"
+#include "container/chunked_vector.h"
+#include "ssx/future-util.h"
+
+namespace cloud_topics::l0 {
+
+constexpr size_t max_bytes_per_iter = 10_MiB;
+
+read_fanout::read_fanout(l0::read_pipeline<>::stage s)
+  : _pipeline_stage(s) {}
+
+ss::future<> read_fanout::start() {
+    ssx::spawn_with_gate(_gate, [this] { return bg_process(); });
+    return ss::now();
+}
+ss::future<> read_fanout::stop() { co_await _gate.close(); }
+
+ss::future<> read_fanout::bg_process() {
+    auto holder = _gate.hold();
+    while (!_pipeline_stage.stopped()) {
+        auto fut = co_await ss::coroutine::as_future(
+          _pipeline_stage.pull_fetch_requests(max_bytes_per_iter));
+
+        if (fut.failed()) {
+            auto e = fut.get_exception();
+            if (ssx::is_shutdown_exception(e)) {
+                vlog(
+                  _pipeline_stage.logger().debug,
+                  "Read fanout stopping due to shutdown");
+                co_return;
+            }
+            vlog(
+              _pipeline_stage.logger().error,
+              "Read fanout failed to pull requests: {}",
+              e);
+            continue;
+        }
+        auto fut_res = std::move(fut).get();
+        if (fut_res.has_error()) {
+            auto err = fut_res.error();
+            if (err == errc::shutting_down) {
+                vlog(
+                  _pipeline_stage.logger().debug,
+                  "Read fanout stopping due to shutdown");
+                co_return;
+            }
+            vlog(
+              _pipeline_stage.logger().error,
+              "Read fanout received error pulling requests: {}",
+              fut_res.error());
+            continue;
+        }
+        auto to_process = std::move(fut_res.value());
+        auto queue = std::move(to_process.requests);
+        while (!queue.empty()) {
+            auto req = &queue.front();
+            queue.pop_front();
+            // It's safe to spawn fiber per request because the memory usage
+            // is limited by the read pipeline memory quota.
+            ssx::spawn_with_gate(_gate, [this, req]() mutable {
+                return process_single_request(req);
+            });
+        }
+    }
+}
+
+read_fanout::stats read_fanout::get_stats() const noexcept { return _stats; }
+
+ss::future<> read_fanout::process_single_request(l0::read_request<>* req) {
+    try {
+        _stats.requests_in++;
+        if (req->query.meta.size() <= 1) {
+            // Fast path
+            _stats.requests_out++;
+            _pipeline_stage.push_next_stage(*req);
+            co_return;
+        }
+
+        const chunked_vector<extent_meta>& metadata = req->query.meta;
+        using ret_future_t = ss::future<checked<dataplane_query_result, errc>>;
+        chunked_vector<ret_future_t> futures;
+        std::optional<dataplane_query> curr_query;
+        curr_query.emplace();
+        auto timeout = req->expiration_time;
+        for (const auto& meta : metadata) {
+            if (
+              curr_query->meta.empty()
+              || curr_query->meta.back().id == meta.id) {
+                curr_query->output_size_estimate += meta.byte_range_size();
+                curr_query->meta.push_back(meta);
+                continue;
+            }
+            vassert(
+              !curr_query->meta.empty(), "extent list shouldn't be empty");
+
+            auto proxy = ss::make_lw_shared<l0::read_request<>>(
+              req->ntp,
+              std::move(curr_query.value()),
+              timeout,
+              &_pipeline_stage.get_root_rtc(),
+              req->stage);
+
+            auto fut = proxy->response.get_future().finally([proxy] {});
+
+            // start proxy request
+            _pipeline_stage.push_next_stage(*proxy);
+
+            futures.emplace_back(std::move(fut));
+            curr_query.emplace();
+            curr_query->output_size_estimate = meta.byte_range_size();
+            curr_query->meta.push_back(meta);
+        }
+        if (!curr_query->meta.empty()) {
+            auto proxy = ss::make_lw_shared<l0::read_request<>>(
+              req->ntp,
+              std::move(curr_query.value()),
+              timeout,
+              &_pipeline_stage.get_root_rtc(),
+              req->stage);
+            auto fut = proxy->response.get_future().finally([proxy] {});
+            // start proxy request
+            _pipeline_stage.push_next_stage(*proxy);
+            futures.push_back(std::move(fut));
+        }
+        auto fut_res = co_await ss::when_all(futures.begin(), futures.end());
+
+        // First process all exception, propagate the first one to the source
+        // request Then process error codes, if there are any errors propagate
+        // it. If there are multiple errors the shutdown error gets priority,
+        // otherwise the first error code is propagated.
+        std::exception_ptr first_exception;
+        for (auto& fut : fut_res) {
+            if (fut.failed()) {
+                auto err = fut.get_exception();
+                vlog(
+                  req->rtc_logger.warn,
+                  "Materialize operation failed: {}",
+                  err);
+                if (!first_exception) {
+                    first_exception = err;
+                }
+            }
+        }
+        if (first_exception) {
+            vlog(
+              req->rtc_logger.warn,
+              "Materialize operation failed, propagating exception {}",
+              first_exception);
+            _stats.requests_fail += fut_res.size();
+            req->set_value(errc::unexpected_failure);
+            co_return;
+        }
+        chunked_vector<model::record_batch> results;
+        for (auto& fut : fut_res) {
+            auto res = fut.get();
+            if (res.has_error()) {
+                vlog(
+                  req->rtc_logger.warn,
+                  "Materialize operation returned error: {}",
+                  res.error());
+                _stats.requests_fail += fut_res.size();
+                req->set_value(res.error());
+                co_return;
+            }
+            std::move(
+              res.value().results.begin(),
+              res.value().results.end(),
+              std::back_inserter(results));
+        }
+        vlog(
+          req->rtc_logger.debug,
+          "Materialize operation succeeded, {} batches materialized",
+          results.size());
+
+        _stats.requests_out += fut_res.size();
+        req->set_value(dataplane_query_result{.results = std::move(results)});
+    } catch (...) {
+        auto ex = std::current_exception();
+        if (ssx::is_shutdown_exception(ex)) {
+            vlog(
+              req->rtc_logger.debug,
+              "Read fanout stopping processing due to shutdown");
+            req->set_value(errc::shutting_down);
+            co_return;
+        }
+        vlog(
+          req->rtc_logger.error, "Unexpected exception in read fanout: {}", ex);
+        req->set_value(errc::unexpected_failure);
+    }
+}
+
+} // namespace cloud_topics::l0

--- a/src/v/cloud_topics/level_zero/read_fanout/read_fanout.h
+++ b/src/v/cloud_topics/level_zero/read_fanout/read_fanout.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_topics/level_zero/pipeline/read_pipeline.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/lowres_clock.hh>
+
+namespace cloud_topics::l0 {
+
+/// Read fanout stage coverts vectorized read requests into multiple
+/// parallel requests. The client is allowed to send wide read requests
+/// that target multiple extents that may be stored in different L0
+/// objects. The read fanout stage splits the requests into multiple
+/// smaller requests that are then processed in parallel by the
+/// fetch request handler stage. The fetch handler can't run individual
+/// requests in parallel due to its own limitations. This stage allows
+/// to regain some parallelism.
+///
+/// For requests that target single extent the stage simply forwards
+/// them to the next stage without any modifications.
+class read_fanout {
+public:
+    explicit read_fanout(l0::read_pipeline<>::stage);
+
+    struct stats {
+        size_t requests_in{0};
+        size_t requests_out{0};
+        size_t requests_fail{0};
+    };
+
+    ss::future<> start();
+    ss::future<> stop();
+
+    stats get_stats() const noexcept;
+
+private:
+    ss::future<> bg_process();
+
+    ss::future<> process_single_request(l0::read_request<>* req);
+
+    ss::gate _gate;
+    l0::read_pipeline<>::stage _pipeline_stage;
+    stats _stats;
+};
+} // namespace cloud_topics::l0

--- a/src/v/cloud_topics/level_zero/read_fanout/tests/BUILD
+++ b/src/v/cloud_topics/level_zero/read_fanout/tests/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_gtest")
+load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_gtest")
 
 redpanda_cc_gtest(
     name = "read_fanout_test",
@@ -21,5 +21,29 @@ redpanda_cc_gtest(
         "//src/v/utils:uuid",
         "@googletest//:gtest",
         "@seastar",
+    ],
+)
+
+redpanda_cc_bench(
+    name = "read_fanout_rpbench",
+    timeout = "short",
+    srcs = [
+        "read_fanout_bench.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/base",
+        "//src/v/cloud_topics/level_zero/pipeline:event_filter",
+        "//src/v/cloud_topics/level_zero/pipeline:pipeline_stage",
+        "//src/v/cloud_topics/level_zero/pipeline:read_pipeline",
+        "//src/v/cloud_topics/level_zero/pipeline:read_request",
+        "//src/v/cloud_topics/level_zero/read_fanout",
+        "//src/v/config",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/ssx:future_util",
+        "//src/v/test_utils:scoped_config",
+        "@seastar",
+        "@seastar//:benchmark",
     ],
 )

--- a/src/v/cloud_topics/level_zero/read_fanout/tests/BUILD
+++ b/src/v/cloud_topics/level_zero/read_fanout/tests/BUILD
@@ -1,0 +1,25 @@
+load("//bazel:test.bzl", "redpanda_cc_gtest")
+
+redpanda_cc_gtest(
+    name = "read_fanout_test",
+    timeout = "short",
+    srcs = [
+        "read_fanout_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/cloud_topics:types",
+        "//src/v/cloud_topics/level_zero/pipeline:event_filter",
+        "//src/v/cloud_topics/level_zero/pipeline:pipeline_stage",
+        "//src/v/cloud_topics/level_zero/pipeline:read_pipeline",
+        "//src/v/cloud_topics/level_zero/pipeline:read_request",
+        "//src/v/cloud_topics/level_zero/read_fanout",
+        "//src/v/config",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:uuid",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_zero/read_fanout/tests/read_fanout_bench.cc
+++ b/src/v/cloud_topics/level_zero/read_fanout/tests/read_fanout_bench.cc
@@ -1,0 +1,277 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cloud_topics/level_zero/pipeline/event_filter.h"
+#include "cloud_topics/level_zero/pipeline/pipeline_stage.h"
+#include "cloud_topics/level_zero/read_fanout/read_fanout.h"
+#include "config/configuration.h"
+#include "model/fundamental.h"
+#include "model/namespace.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "model/tests/random_batch.h"
+#include "ssx/future-util.h"
+#include "test_utils/scoped_config.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/manual_clock.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/coroutine/as_future.hh>
+#include <seastar/testing/perf_tests.hh>
+
+#include <chrono>
+#include <cstddef>
+#include <exception>
+#include <limits>
+
+using namespace std::chrono_literals;
+namespace cloud_topics {
+
+/// The handler simulates L0 object downloads
+/// by injecting sleeps.
+struct fetch_handler {
+    explicit fetch_handler(l0::read_pipeline<>& p, int concurrency)
+      : stage(p.register_read_pipeline_stage())
+      , _con(concurrency) {
+        // Use same batch to reply to all materialization requests
+        // to avoid regenerating it during the run.
+        _batch = model::test::make_random_batch(
+          model::test::record_batch_spec{
+            .offset = model::offset(0),
+            .allow_compression = false,
+            .count = 1,
+            .records = 1,
+            .record_sizes = std::vector<size_t>{4096},
+          });
+    }
+
+    ss::future<> start(std::chrono::milliseconds d) {
+        _download_latency = d;
+        ssx::background = bg_run();
+        return ss::now();
+    }
+
+    ss::future<> stop() { co_await _gate.close(); }
+
+    ss::future<> bg_run() {
+        auto h = _gate.hold();
+        while (!stage.stopped()) {
+            auto result = co_await stage.pull_fetch_requests(
+              std::numeric_limits<size_t>::max());
+
+            if (result.has_error()) {
+                // Expected during shutdown
+                co_return;
+            }
+
+            for (auto& r : result.value().requests) {
+                // Process every request concurrently because this is what
+                // real fetch handler does.
+                ssx::spawn_with_gate(
+                  _gate, [this, &r] { return process_single_request(&r); });
+            }
+        }
+    }
+
+    ss::future<> process_single_request(l0::read_request<>* req) {
+        auto auto_dispose = ss::defer(
+          [req] { req->set_value(errc::unexpected_failure); });
+
+        auto meta = std::move(req->query.meta);
+        chunked_vector<model::record_batch> data;
+        for (auto& m : meta) {
+            std::ignore = m;
+            data.push_back(_batch->copy());
+            // Simulate download
+            if (_download_latency != 0ms) {
+                auto u = co_await ss::get_units(_con, 1);
+                co_await ss::sleep(_download_latency);
+            }
+        }
+
+        auto_dispose.cancel();
+
+        req->set_value(l0::dataplane_query_result{.results = std::move(data)});
+    }
+
+    std::optional<model::record_batch> _batch;
+    l0::read_pipeline<>::stage stage;
+    ss::gate _gate;
+    std::chrono::milliseconds _download_latency;
+    // Semaphore used to simulate connection pool.
+    // Up to 20 connections are allowed to run concurrently.
+    // This mirrors the default in Redpanda.
+    ss::semaphore _con;
+};
+} // namespace cloud_topics
+
+using namespace cloud_topics;
+
+class read_fanout_bench {
+public:
+    /// Start benchmark fixture.
+    /// \param enable_fanout enables or disables read fanout
+    /// \param concurrency defines max number of concurrent downloads
+    /// \param dl_lat is a latency of the simulated object download
+    ss::future<> start(
+      bool enable_fanout, int concurrency, std::chrono::milliseconds dl_lat) {
+        co_await pipeline.start();
+
+        if (enable_fanout) {
+            co_await fanout.start(ss::sharded_parameter([this] {
+                return pipeline.local().register_read_pipeline_stage();
+            }));
+
+            co_await fanout.invoke_on_all([](auto& f) { return f.start(); });
+        }
+
+        co_await sink.start(
+          ss::sharded_parameter([this] { return std::ref(pipeline.local()); }),
+          concurrency);
+
+        co_await sink.invoke_on_all(
+          [dl_lat](auto& sink) { return sink.start(dl_lat); });
+    }
+
+    ss::future<> stop() {
+        co_await pipeline.stop();
+        co_await sink.stop();
+        if (fanout.local_is_initialized()) {
+            co_await fanout.stop();
+        }
+    }
+
+    /// Build one big vectorized query and then run it
+    ss::future<> vectorized_test_run(int num_requests) {
+        l0::dataplane_query query;
+        query.output_size_estimate = 1_KiB;
+        for (int i = 0; i < num_requests; i++) {
+            query.meta.push_back(
+              extent_meta{
+                .id = object_id{.name = uuid_t::create()},
+                .byte_range_size = byte_range_size_t{1_KiB}});
+        }
+
+        perf_tests::start_measuring_time();
+
+        perf_tests::do_not_optimize(
+          co_await pipeline.local().make_reader(
+            model::controller_ntp,
+            std::move(query),
+            ss::lowres_clock::now() + std::chrono::seconds(10)));
+
+        perf_tests::stop_measuring_time();
+    }
+
+    /// Run requests one after another serially
+    ss::future<> serialized_test_run(int num_requests) {
+        std::vector<ss::future<>> fut;
+        for (int i = 0; i < num_requests; i++) {
+            l0::dataplane_query query;
+            query.output_size_estimate = 1_KiB;
+            query.meta.push_back(
+              extent_meta{
+                .id = object_id{.name = uuid_t::create()},
+                .byte_range_size = byte_range_size_t{1_KiB}});
+
+            fut.push_back(
+              pipeline.local()
+                .make_reader(
+                  model::controller_ntp,
+                  std::move(query),
+                  ss::lowres_clock::now() + std::chrono::seconds(10))
+                .discard_result());
+        }
+
+        perf_tests::start_measuring_time();
+
+        // The pipeline should run all requests concurrently.
+        co_await ss::when_all_succeed(fut.begin(), fut.end());
+
+        perf_tests::stop_measuring_time();
+    }
+
+    ss::sharded<cloud_topics::l0::read_pipeline<>> pipeline;
+    ss::sharded<cloud_topics::l0::read_fanout> fanout;
+    ss::sharded<cloud_topics::fetch_handler> sink;
+};
+
+PERF_TEST_C(read_fanout_bench, baseline) {
+    // This is a baseline. It shows best performance that we can get.
+    // Caching is not taken into account by the test.
+    // The download latency is set to 50ms. The concurrency
+    // is not limited.
+    co_await start(false, 1000, 50ms);
+
+    co_await serialized_test_run(100);
+
+    co_await stop();
+}
+
+PERF_TEST_C(read_fanout_bench, serialized) {
+    // This is supposed to be very slow.
+    // A single vectorized read is issued. All downloads inside
+    // it are going to be serialized because read_fanout component
+    // is not added to the pipeline.
+    co_await start(false, 100, 50ms);
+
+    co_await vectorized_test_run(100);
+
+    co_await stop();
+}
+
+PERF_TEST_C(read_fanout_bench, concurrent) {
+    // This is supposed to match the baseline.
+    // One big vectorized request will be issued but
+    // the read_fanout component will scatter it into multiple
+    // small requests that can run concurrently.
+    co_await start(true, 100, 50ms);
+
+    co_await vectorized_test_run(100);
+
+    co_await stop();
+}
+
+PERF_TEST_C(read_fanout_bench, bypass) {
+    // This should be as fast as baseline. The requests
+    // could be executed concurrently, but we're adding one more
+    // step (read_fanout) which should just bypass all requests
+    // without adding latency.
+    co_await start(true, 1000, 50ms);
+
+    co_await serialized_test_run(100);
+
+    co_await stop();
+}
+
+PERF_TEST_C(read_fanout_bench, baseline_noop) {
+    // Run 100 requests serially without simulating the download
+    // latency. This measures the roundtrip latency.
+    co_await start(false, 1000, 0ms);
+    co_await serialized_test_run(100);
+    co_await stop();
+}
+
+PERF_TEST_C(read_fanout_bench, serialized_noop) {
+    // Same but with read_fanout in the pipeline.
+    co_await start(true, 1000, 0ms);
+    co_await serialized_test_run(100);
+    co_await stop();
+}
+
+PERF_TEST_C(read_fanout_bench, vectorized_noop) {
+    // Run single vectorized request that touches 100 objects.
+    // The latency should be similar to the baseline.
+    co_await start(true, 1000, 0ms);
+    co_await vectorized_test_run(100);
+    co_await stop();
+}

--- a/src/v/cloud_topics/level_zero/read_fanout/tests/read_fanout_test.cc
+++ b/src/v/cloud_topics/level_zero/read_fanout/tests/read_fanout_test.cc
@@ -1,0 +1,264 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cloud_topics/level_zero/pipeline/event_filter.h"
+#include "cloud_topics/level_zero/pipeline/pipeline_stage.h"
+#include "cloud_topics/level_zero/read_fanout/read_fanout.h"
+#include "cloud_topics/types.h"
+#include "config/configuration.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "model/tests/random_batch.h"
+#include "test_utils/test.h"
+#include "utils/uuid.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/manual_clock.hh>
+#include <seastar/coroutine/as_future.hh>
+
+#include <chrono>
+#include <exception>
+#include <limits>
+
+using namespace std::chrono_literals;
+
+static ss::logger test_log("L0_read_fanout_test");
+
+namespace cloud_topics {
+
+// Special object id that triggers failure
+static auto id_to_fail = object_id{
+  .epoch = cluster_epoch{0},
+  .name = uuid_t::create(),
+};
+
+struct fake_fetch_handler {
+    explicit fake_fetch_handler(l0::read_pipeline<>& p)
+      : stage(p.register_read_pipeline_stage()) {
+        vlog(stage.logger().info, "fake fetch handler created");
+    }
+
+    ss::future<> start() {
+        ssx::background = bg_run();
+        return ss::now();
+    }
+
+    ss::future<> stop() {
+        vlog(stage.logger().info, "fake fetch handler stop");
+        co_await _gate.close();
+    }
+
+    ss::future<> bg_run() {
+        auto h = _gate.hold();
+        while (!stage.stopped()) {
+            vlog(stage.logger().debug, "fake_fetch_handler subscribe");
+
+            auto result = co_await stage.pull_fetch_requests(
+              std::numeric_limits<size_t>::max());
+
+            if (result.has_error()) {
+                // Expected during shutdown
+                co_return;
+            }
+
+            vlog(
+              stage.logger().debug,
+              "fake_fetch_handler got {} requests",
+              result.value().requests.size());
+
+            for (auto& r : result.value().requests) {
+                // The expectation is that all extents in this request
+                // will share the same object id.
+                object_id id = r.query.meta.front().id;
+                chunked_vector<model::record_batch> batches;
+                for (size_t i = 0; i < r.query.meta.size(); i++) {
+                    if (r.query.meta.at(i).id != id) {
+                        throw std::runtime_error(
+                          "request targets more than one object");
+                    }
+                    model::test::record_batch_spec spec{};
+                    spec.offset = _next_offset;
+                    spec.count = 1;
+                    spec.records = 1;
+                    auto rb = model::test::make_random_batch(spec);
+                    batches.push_back(std::move(rb));
+                    _next_offset = model::next_offset(_next_offset);
+                }
+                if (id_to_fail == id) {
+                    // The failure was injected
+                    r.set_value(errc::timeout);
+                } else {
+                    r.set_value({{std::move(batches)}});
+                }
+            }
+        }
+    }
+
+    model::offset _next_offset{0};
+    l0::read_pipeline<>::stage stage;
+    ss::gate _gate;
+};
+
+} // namespace cloud_topics
+
+using namespace cloud_topics;
+
+class read_fanout_fixture : public seastar_test {
+public:
+    ss::future<> start() {
+        co_await pipeline.start();
+
+        co_await fanout.start(ss::sharded_parameter([this] {
+            return pipeline.local().register_read_pipeline_stage();
+        }));
+
+        co_await fanout.invoke_on_all(
+          [](l0::read_fanout& s) { return s.start(); });
+
+        co_await fetch_handler.start(
+          ss::sharded_parameter([this] { return std::ref(pipeline.local()); }));
+
+        co_await fetch_handler.invoke_on_all(
+          [](fake_fetch_handler& handler) { return handler.start(); });
+    }
+
+    ss::future<> stop() {
+        co_await pipeline.invoke_on_all([](auto& s) { return s.shutdown(); });
+        co_await fetch_handler.stop();
+        co_await fanout.stop();
+        co_await pipeline.stop();
+    }
+
+    ss::sharded<l0::read_pipeline<>> pipeline;
+    ss::sharded<l0::read_fanout> fanout;
+    ss::sharded<fake_fetch_handler> fetch_handler;
+};
+
+static const model::topic_namespace
+  test_topic(model::kafka_namespace, model::topic("tapioca"));
+
+static const model::ntp
+  test_ntp0(test_topic.ns, test_topic.tp, model::partition_id(0));
+
+static const model::ntp
+  test_ntp1(test_topic.ns, test_topic.tp, model::partition_id(1));
+
+TEST_F_CORO(read_fanout_fixture, test_bypass) {
+    // Check that the read request is bypassed when it has single extent
+    co_await start();
+    l0::dataplane_query query;
+    query.output_size_estimate = 1_MiB;
+    query.meta.push_back(
+      extent_meta{.byte_range_size = byte_range_size_t{1_MiB}});
+    auto result = co_await pipeline.local().make_reader(
+      test_ntp0, std::move(query), ss::lowres_clock::now() + 10s);
+    ASSERT_FALSE_CORO(result.has_error());
+    ASSERT_EQ_CORO(result.value().results.size(), 1);
+    ASSERT_EQ_CORO(
+      result.value().results.front().header().base_offset, model::offset{0});
+    auto [in, out, fail] = this->fanout.local().get_stats();
+    ASSERT_EQ_CORO(in, out);
+    ASSERT_EQ_CORO(in, 1);
+    ASSERT_EQ_CORO(fail, 0);
+    co_await stop();
+}
+
+TEST_F_CORO(read_fanout_fixture, test_scatter_gather) {
+    // Check that the read request that targets several objects
+    // is split into several smaller ones. Check that number of
+    // requests matches number of objects.
+    co_await start();
+
+    auto obj1_uuid = uuid_t::create();
+    auto obj2_uuid = uuid_t::create();
+    auto obj3_uuid = uuid_t::create();
+
+    l0::dataplane_query query;
+    query.output_size_estimate = 4_MiB;
+    // Obj1, one extent
+    query.meta.push_back(
+      extent_meta{
+        .id = object_id{.epoch = cluster_epoch{0}, .name = obj1_uuid},
+        .byte_range_size = byte_range_size_t{1_MiB}});
+    // Obj2, two extents
+    query.meta.push_back(
+      extent_meta{
+        .id = object_id{.epoch = cluster_epoch{0}, .name = obj2_uuid},
+        .byte_range_size = byte_range_size_t{1_MiB}});
+    query.meta.push_back(
+      extent_meta{
+        .id = object_id{.epoch = cluster_epoch{0}, .name = obj2_uuid},
+        .byte_range_size = byte_range_size_t{1_MiB}});
+    // Obj3, one extent
+    query.meta.push_back(
+      extent_meta{
+        .id = object_id{.epoch = cluster_epoch{0}, .name = obj3_uuid},
+        .byte_range_size = byte_range_size_t{1_MiB}});
+
+    auto result = co_await pipeline.local().make_reader(
+      test_ntp0, std::move(query), ss::lowres_clock::now() + 10s);
+
+    ASSERT_FALSE_CORO(result.has_error());
+    ASSERT_EQ_CORO(result.value().results.size(), 4);
+    ASSERT_EQ_CORO(
+      result.value().results.front().header().base_offset, model::offset{0});
+    ASSERT_EQ_CORO(
+      result.value().results.back().header().base_offset, model::offset{3});
+
+    auto [in, out, fail] = this->fanout.local().get_stats();
+    ASSERT_NE_CORO(in, out);
+    ASSERT_EQ_CORO(in, 1);
+    ASSERT_EQ_CORO(out, 3);
+    ASSERT_EQ_CORO(fail, 0);
+    co_await stop();
+}
+
+TEST_F_CORO(read_fanout_fixture, test_failure) {
+    // Check that the read request only fails as a whole.
+    // No partial failures are allowed for now.
+    co_await start();
+
+    auto obj1_uuid = uuid_t::create();
+    auto obj2_uuid = uuid_t::create();
+
+    l0::dataplane_query query;
+    query.output_size_estimate = 3_MiB;
+
+    // Obj1, one extent
+    query.meta.push_back(
+      extent_meta{
+        .id = object_id{.epoch = cluster_epoch{0}, .name = obj1_uuid},
+        .byte_range_size = byte_range_size_t{1_MiB}});
+
+    // Obj2, two extents (one injects failure)
+    query.meta.push_back(
+      extent_meta{
+        .id = object_id{.epoch = cluster_epoch{0}, .name = obj2_uuid},
+        .byte_range_size = byte_range_size_t{1_MiB}});
+    query.meta.push_back(
+      extent_meta{
+        .id = id_to_fail, .byte_range_size = byte_range_size_t{1_MiB}});
+
+    auto result = co_await pipeline.local().make_reader(
+      test_ntp0, std::move(query), ss::lowres_clock::now() + 10s);
+
+    ASSERT_TRUE_CORO(result.has_error());
+
+    auto [in, out, fail] = this->fanout.local().get_stats();
+    ASSERT_NE_CORO(in, out);
+    ASSERT_EQ_CORO(in, 1);
+    ASSERT_EQ_CORO(out, 0);
+    // Shows number of failed proxy requests
+    ASSERT_EQ_CORO(fail, 3);
+    co_await stop();
+}


### PR DESCRIPTION
Previously, the read pipeline contained only the `fetch_request_handler`.
This component was responsible for:
* Fetching all data needed for a particular read request.
* Constructing record batches.
* Acknowledging the read request.

While `fetch_request_handler` could process multiple read requests concurrently, it fetched objects within a single request sequentially.

This sequential fetching became a performance bottleneck when a single read request referenced multiple L0 objects—the latencies from each fetch stacked on top of each other, degrading performance.


### New Component: read_fanout

To address this, a new pipeline component called `read_fanout` has been introduced.
It sits before the fetch_request_handler and optimizes how read requests are handled.

`read_fanout` logic:
* If a read request references only one object:
   - Forward the request directly to fetch_request_handler.
* If a read request is vectorized (spans multiple L0 objects):
  - Split it into smaller sub-requests (each referencing one L0 object).
  - Push these sub-requests down the pipeline in parallel.
  - Collect all results and propagate them back to the original request.

This effectively implements a fan-out read pattern — multiple smaller requests are dispatched concurrently instead of one large sequential request.

```
                         ┌──────────────────────┐
                         │   Original Request   │
                         └──────────┬───────────┘
                                    │
                                    ▼
                         ┌──────────────────────┐
                         │     read_fanout      │
                         └──────────┬───────────┘
                                    │
                     ┌──────────────┴──────────────┐
                     │                             │
                     ▼                             ▼
        ┌─────────────────────┐          ┌─────────────────────┐
        │ Sub-request A       │          │ Sub-request B       │
        └──────────┬──────────┘          └──────────┬──────────┘
                   │                                │
                   ▼                                ▼
      ┌───────────────────────┐          ┌───────────────────────┐
      │ fetch_request_handler │          │ fetch_request_handler │
      └───────────────────────┘          └───────────────────────┘

```

From the caller’s perspective, this process is transparent — they still receive a single response. Note that the original request can not fail partially. If one of the sub-requests failed the error will be propagated to the source.


### Why not implement it elsewhere?

1. Why this is not implemented in L0 reader?
   - This is possible but it will complicate the API. The caller of the data layer API will have to keep in mind that certain requests are not running concurrently and will have bad latency.
2. Why this is not implemented in `fetch_request_handler`?
    - This is also possible but it will complicate the handler (it will have to do the same thing or it will have to deduplicate and debounce read requests internally somehow). 
    - The `read_fanaout` will come handy when the parallel fetch will be implemented. Wide read requests don't play well with parallel fetching either.

### Benchmark Results

Benchmarks show that:
* With read_fanout, performance of “bad” (wide) read patterns matches that of “good” (narrow) ones.
* The system achieves the best possible concurrency regardless of how the reads are structured.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none