### PR TITLE
Track average batch size in fetch metadata cache

### DIFF
--- a/src/v/kafka/protocol/batch_consumer.h
+++ b/src/v/kafka/protocol/batch_consumer.h
@@ -29,6 +29,7 @@ public:
     struct result {
         iobuf data;
         uint32_t record_count;
+        uint32_t batch_count;
         model::offset base_offset;
         model::offset last_offset;
         model::timestamp first_timestamp;
@@ -69,6 +70,7 @@ public:
         }
         _last_offset = batch.last_offset();
         record_count_ += batch.record_count();
+        batch_count_++;
         write_batch(std::move(batch));
         return ss::make_ready_future<ss::stop_iteration>(
           ss::stop_iteration::no);
@@ -78,6 +80,7 @@ public:
         return result{
           .data = std::move(_buf),
           .record_count = record_count_,
+          .batch_count = batch_count_,
           .base_offset = _base_offset,
           .last_offset = _last_offset,
           .first_timestamp = _first_timestamp,
@@ -98,6 +101,7 @@ private:
     model::timestamp _first_timestamp;
     std::optional<model::offset> _first_tx_batch_offset;
     uint32_t record_count_ = 0;
+    uint32_t batch_count_ = 0;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/fetch_memory_units.cc
+++ b/src/v/kafka/server/fetch_memory_units.cc
@@ -11,6 +11,7 @@
 
 #include "kafka/server/fetch_memory_units.h"
 
+#include "kafka/protocol/logger.h"
 #include "ssx/future-util.h"
 
 #include <seastar/core/reactor.hh>
@@ -24,6 +25,7 @@ fetch_memory_units_manager::fetch_memory_units_manager(
   local_instance_fn&& local_fn)
   : _kafka_units(kafka_units)
   , _fetch_units(fetch_units)
+  , _max_fetch_units(fetch_units.current())
   , _release_units_timer([this] { release_all_units_to_semaphore(); })
   , _local_instance_fn(std::move(local_fn)) {
     _release_units_timer.arm_periodic(max_release_period);
@@ -65,30 +67,69 @@ fetch_memory_units_manager::units::~units() noexcept {
 }
 
 fetch_memory_units fetch_memory_units_manager::allocate_memory_units(
-  size_t max_units, const size_t min_units, const bool require_min_units) {
+  const model::ktp& ktp,
+  size_t max_bytes,
+  size_t max_batch_size,
+  const size_t avg_batch_size,
+  const bool require_max_batch_size) {
     vassert(!_gate.is_closed(), "fetch_memory_units_manager is stopped");
+
+    static constexpr auto rate = 5min;
+
+    if (max_bytes > _max_fetch_units) {
+        thread_local static ss::logger::rate_limit rate_limit(rate);
+        klog.log(
+          ss::log_level::debug,
+          rate_limit,
+          "{}: max_bytes({}) exceeds available fetch memory ({}). Consider "
+          "reducing `max.partition.fetch.bytes` on the consumers. Setting "
+          "max_bytes to available fetch memory.",
+          ktp,
+          max_bytes,
+          _max_fetch_units);
+        max_bytes = _max_fetch_units;
+    }
+
+    if (max_batch_size > _max_fetch_units) {
+        thread_local static ss::logger::rate_limit rate_limit(rate);
+        klog.log(
+          ss::log_level::error,
+          rate_limit,
+          "{}: max_batch_size({}) exceeds available fetch memory ({}). "
+          "Consider reducing `message.max.bytes` for the topic. Setting "
+          "max_batch_size to available fetch memory.",
+          ktp,
+          max_batch_size,
+          _max_fetch_units);
+        max_batch_size = _max_fetch_units;
+    }
 
     const size_t available_units = std::min(
       _kafka_units.current(), _fetch_units.current());
-    // Note that it's not currently enforced that max_units >= min_units. Hence
-    // we set max_units to the larger of the two here to ensure that is the
+
+    // There is no relation enforced for \ref max_bytes and \ref max_batch_size.
+    // Normally max_bytes >= max_batch_size, however, that is not always the
     // case.
-    max_units = std::max(max_units, min_units);
+    const auto max_units = std::max(max_bytes, max_batch_size);
 
     size_t units_to_alloc = 0;
-    if (require_min_units) {
-        // if \ref require_min_units is true then we must read at least \ref
-        // min_units. So allocate at least that many even if it causes the
-        // semaphores to become negative.
+    if (require_max_batch_size) {
+        // If \ref require_max_batch_size is true then we must read at least
+        // \ref max_batch_size. Even if that means the memory semaphores result
+        // in negative units.
         units_to_alloc = std::max(
-          min_units, std::min(max_units, available_units));
-    } else if (available_units >= min_units) {
-        // only reserve memory if we have space for at least \ref min_units,
-        // otherwise allocate none.
+          max_batch_size, std::min(max_units, available_units));
+    } else if (available_units >= avg_batch_size) {
+        // Only reserve memory if we have space for at least \ref
+        // avg_batch_size, otherwise allocate none.
         units_to_alloc = std::min(available_units, max_units);
     }
 
     return {allocate_units(units_to_alloc), _local_instance_fn};
+}
+
+fetch_memory_units fetch_memory_units_manager::zero_units() {
+    return {allocate_units(0), _local_instance_fn};
 }
 
 void fetch_memory_units_manager::release_units_to_manager(units&& u) {

--- a/src/v/kafka/server/fetch_memory_units.h
+++ b/src/v/kafka/server/fetch_memory_units.h
@@ -12,6 +12,7 @@
 #include "base/seastarx.h"
 #include "base/units.h"
 #include "container/chunked_hash_map.h"
+#include "model/ktp.h"
 #include "ssx/semaphore.h"
 
 #include <seastar/core/gate.hh>
@@ -65,7 +66,15 @@ public:
      * memory_fetch_sem.
      */
     fetch_memory_units allocate_memory_units(
-      size_t max_units, const size_t min_units, const bool require_min_units);
+      const model::ktp& ktp,
+      size_t max_bytes,
+      size_t max_batch_size,
+      const size_t avg_batch_size,
+      const bool require_max_batch_size);
+
+    /** Returns a fetch_memory_units object with zero units.
+     */
+    fetch_memory_units zero_units();
 
 private:
     friend fetch_memory_units;
@@ -104,6 +113,7 @@ private:
     ss::gate _gate;
     ssx::semaphore& _kafka_units;
     ssx::semaphore& _fetch_units;
+    size_t _max_fetch_units;
 
     ss::timer<> _release_units_timer;
     // Collected units are aggregated together by shard in order to ensure there

--- a/src/v/kafka/server/fetch_metadata_cache.h
+++ b/src/v/kafka/server/fetch_metadata_cache.h
@@ -29,6 +29,7 @@ struct partition_metadata {
     model::offset high_watermark;
     model::offset last_stable_offset;
     size_t avg_bytes_per_offset;
+    size_t avg_bytes_per_batch;
 };
 
 using namespace std::chrono_literals;
@@ -53,25 +54,40 @@ public:
       model::offset hw,
       model::offset lso,
       size_t offset_count,
+      size_t batch_count,
       size_t total_size_bytes) {
         auto& e = _cache[ktp];
         e.reset_ts();
-        if (offset_count > 0) {
-            if (e.bytes_per_offset.has_samples()) {
-                auto avg_bytes_per_offset = static_cast<double>(
-                  e.bytes_per_offset.get());
-                auto bytes_per_offset = static_cast<double>(total_size_bytes)
-                                        / static_cast<double>(offset_count);
-                auto abs_err = std::abs(
-                  bytes_per_offset - avg_bytes_per_offset);
-                const auto epsilon = 1e-6; // prevent division by zero
-                auto re = abs_err / (bytes_per_offset + epsilon);
-                _error.update(re, e.timestamp);
-            }
 
+        auto rel_err = [](size_t sum, size_t count, auto& mov_avg) {
+            if (mov_avg.has_samples()) {
+                auto actual = static_cast<double>(sum)
+                              / static_cast<double>(count);
+                auto avg = static_cast<double>(mov_avg.get());
+                auto abs_err = std::abs(actual - avg);
+                const auto epsilon = 1e-6; // prevent division by zero
+                auto re = abs_err / (actual + epsilon);
+                return re;
+            }
+            return 0.0;
+        };
+
+        if (offset_count > 0) {
+            auto bytes_per_offset_error = rel_err(
+              total_size_bytes, offset_count, e.bytes_per_offset);
+            _bytes_per_offset_error.update(bytes_per_offset_error, e.timestamp);
             e.bytes_per_offset.update(
               total_size_bytes, e.timestamp, offset_count);
         }
+
+        if (batch_count > 0) {
+            auto bytes_per_batch_error = rel_err(
+              total_size_bytes, batch_count, e.bytes_per_batch);
+            _bytes_per_batch_error.update(bytes_per_batch_error, e.timestamp);
+            e.bytes_per_batch.update(
+              total_size_bytes, e.timestamp, batch_count);
+        }
+
         e.md = {
           .start_offset = start_offset,
           .high_watermark = hw,
@@ -79,6 +95,9 @@ public:
           .avg_bytes_per_offset = e.bytes_per_offset.has_samples()
                                     ? e.bytes_per_offset.get()
                                     : 0,
+          .avg_bytes_per_batch = e.bytes_per_batch.has_samples()
+                                   ? e.bytes_per_batch.get()
+                                   : 0,
         };
     }
 
@@ -103,10 +122,23 @@ public:
         _metrics.add_group(
           prometheus_sanitize::metrics_name("kafka:fetch_metadata_cache"),
           {sm::make_gauge(
-            "error",
-            [this] { return _error.has_samples() ? _error.get() : 0.0; },
-            sm::description(
-              "A moving average of the relative error for bytes per offset."))},
+             "bytes_per_offset_error",
+             [this] {
+                 return _bytes_per_offset_error.has_samples()
+                          ? _bytes_per_offset_error.get()
+                          : 0.0;
+             },
+             sm::description(
+               "A moving average of the relative error for bytes per offset.")),
+           sm::make_gauge(
+             "bytes_per_batch_error",
+             [this] {
+                 return _bytes_per_batch_error.has_samples()
+                          ? _bytes_per_batch_error.get()
+                          : 0.0;
+             },
+             sm::description(
+               "A moving average of the relative error for bytes per batch."))},
           {},
           {sm::shard_label});
     }
@@ -118,14 +150,16 @@ private:
       = timed_moving_average<double, ss::lowres_clock>;
 
     constexpr static std::chrono::seconds eviction_timeout{60};
-    constexpr static auto bytes_per_offset_window{1h};
-    constexpr static auto bytes_per_offset_resolution{20min};
+    constexpr static auto moving_avg_window{1h};
+    constexpr static auto moving_avg_resolution{20min};
 
     struct entry {
         partition_metadata md;
         ss::lowres_clock::time_point timestamp;
         entry_sliding_window_t bytes_per_offset{
-          bytes_per_offset_window, bytes_per_offset_resolution};
+          moving_avg_window, moving_avg_resolution};
+        entry_sliding_window_t bytes_per_batch{
+          moving_avg_window, moving_avg_resolution};
 
         void reset_ts() { timestamp = ss::lowres_clock::now(); }
     };
@@ -139,8 +173,10 @@ private:
 
     chunked_hash_map<model::ktp_with_hash, entry> _cache;
     ss::timer<> _eviction_timer;
-    error_sliding_window_t _error{
-      bytes_per_offset_window, bytes_per_offset_resolution};
+    error_sliding_window_t _bytes_per_offset_error{
+      moving_avg_window, moving_avg_resolution};
+    error_sliding_window_t _bytes_per_batch_error{
+      moving_avg_window, moving_avg_resolution};
     metrics::internal_metric_groups _metrics;
 };
 } // namespace kafka

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -220,22 +220,20 @@ static ss::future<read_result> do_read_from_ntp(
   const bool obligatory_batch_read,
   fetch_memory_units_manager& units_mgr) {
     // control available memory
-    fetch_memory_units memory_units = [&] {
-        if (!ntp_config.cfg.skip_read) {
-            auto memory_units = units_mgr.allocate_memory_units(
-              ntp_config.cfg.max_bytes,
-              ntp_config.cfg.max_batch_size,
-              obligatory_batch_read);
-            if (!memory_units.has_units()) {
-                ntp_config.cfg.skip_read = true;
-            } else if (ntp_config.cfg.max_bytes > memory_units.num_units()) {
-                ntp_config.cfg.max_bytes = memory_units.num_units();
-            }
-            return memory_units;
-        } else {
-            return units_mgr.allocate_memory_units(0, 0, false);
+    auto memory_units = units_mgr.zero_units();
+    if (!ntp_config.cfg.skip_read) {
+        memory_units = units_mgr.allocate_memory_units(
+          ntp_config.ktp(),
+          ntp_config.cfg.max_bytes,
+          ntp_config.cfg.max_batch_size,
+          ntp_config.cfg.avg_batch_size,
+          obligatory_batch_read);
+        if (!memory_units.has_units()) {
+            ntp_config.cfg.skip_read = true;
+        } else if (ntp_config.cfg.max_bytes > memory_units.num_units()) {
+            ntp_config.cfg.max_bytes = memory_units.num_units();
         }
-    }();
+    }
 
     /*
      * lookup the ntp's partition

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -136,6 +136,7 @@ static ss::future<read_result> read_from_partition(
     std::vector<cluster::tx::tx_range> aborted_transactions;
     std::optional<std::chrono::milliseconds> delta_from_tip_ms;
     model::offset data_base_offset, data_last_offset;
+    size_t batch_count = 0;
 
     try {
         auto result = co_await rdr.reader.consume(
@@ -143,6 +144,7 @@ static ss::future<read_result> read_from_partition(
         data = std::make_unique<iobuf>(std::move(result.data));
         data_base_offset = result.base_offset;
         data_last_offset = result.last_offset;
+        batch_count = result.batch_count;
         part.probe().add_records_fetched(result.record_count);
         part.probe().add_bytes_fetched(data->size_bytes());
         if (!part.is_leader() && config.read_from_follower) {
@@ -198,6 +200,7 @@ static ss::future<read_result> read_from_partition(
       start_o,
       data_base_offset,
       data_last_offset,
+      batch_count,
       hw,
       lso,
       delta_from_tip_ms,
@@ -400,6 +403,7 @@ static void fill_fetch_responses(
           res.high_watermark,
           res.last_stable_offset,
           res.offset_count(),
+          res.batch_count,
           res.data_size_bytes());
         /**
          * Over response budget, we will just waste this read, it will cause
@@ -1319,6 +1323,10 @@ class simple_fetch_planner final : public fetch_planner::impl {
                   auto fetch_md = octx.rctx.get_fetch_metadata_cache().get(ktp);
                   auto max_bytes = std::min(
                     bytes_left_in_plan, size_t(fp.max_bytes));
+                  auto avg_batch_size
+                    = fetch_md && (fetch_md->avg_bytes_per_batch > 0)
+                        ? fetch_md->avg_bytes_per_batch
+                        : 1_MiB;
                   /**
                    * If the fetch offest is less than the hwm for the partition
                    * then we try to estimate the number of bytes that can be
@@ -1346,6 +1354,7 @@ class simple_fetch_planner final : public fetch_planner::impl {
                       .max_offset = model::model_limits<model::offset>::max(),
                       .max_bytes = max_bytes,
                       .max_batch_size = max_batch_size,
+                      .avg_batch_size = avg_batch_size,
                       .timeout = octx.deadline.value_or(model::no_timeout),
                       .current_leader_epoch = fp.current_leader_epoch,
                       .isolation_level = octx.request.data.isolation_level,

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -215,6 +215,7 @@ struct fetch_config {
     model::offset max_offset;
     size_t max_bytes;
     size_t max_batch_size;
+    size_t avg_batch_size;
     model::timeout_clock::time_point timeout;
     kafka::leader_epoch current_leader_epoch;
     model::isolation_level isolation_level;
@@ -300,6 +301,7 @@ struct read_result {
       model::offset start_offset,
       model::offset data_base_offset,
       model::offset data_last_offset,
+      size_t batch_count,
       model::offset hw,
       model::offset lso,
       std::optional<std::chrono::milliseconds> delta,
@@ -308,6 +310,7 @@ struct read_result {
       , start_offset(start_offset)
       , data_base_offset(data_base_offset)
       , data_last_offset(data_last_offset)
+      , batch_count(batch_count)
       , high_watermark(hw)
       , last_stable_offset(lso)
       , delta_from_tip_ms(delta)
@@ -346,6 +349,7 @@ struct read_result {
     model::offset start_offset;
     model::offset data_base_offset;
     model::offset data_last_offset;
+    size_t batch_count{0};
     model::offset high_watermark;
     model::offset last_stable_offset;
     std::optional<std::chrono::milliseconds> delta_from_tip_ms;

--- a/src/v/kafka/server/tests/fetch_memory_units_test.cc
+++ b/src/v/kafka/server/tests/fetch_memory_units_test.cc
@@ -39,8 +39,8 @@ void set_units(ssx::semaphore& sem, size_t target_units) {
 class fetch_memory_units_test_fixture : public seastar_test {
 public:
     ss::future<> SetUpAsync() override {
-        co_await _kafka_sem.start(0, ss::sstring("kafka_sem"));
-        co_await _fetch_sem.start(0, ss::sstring("fetch_sem"));
+        co_await _kafka_sem.start(100_MiB, ss::sstring("kafka_sem"));
+        co_await _fetch_sem.start(50_MiB, ss::sstring("fetch_sem"));
         co_await _manager.start(
           ss::sharded_parameter(
             [this] { return std::reference_wrapper(_kafka_sem.local()); }),
@@ -115,7 +115,8 @@ TEST_F_CORO(fetch_memory_units_test_fixture, test_cross_shard_free) {
     };
     auto get_remote_units = [&](size_t n) {
         return sharded_manager().invoke_on(other_shard_id, [n](auto& mgr) {
-            return std::make_optional(mgr.allocate_memory_units(n, n, false));
+            return std::make_optional(
+              mgr.allocate_memory_units(model::ktp{}, n, n, n, false));
         });
     };
 
@@ -154,7 +155,7 @@ TEST_F_CORO(fetch_memory_units_test_fixture, test_adjust_units) {
     co_await set_kafka_units(10);
     co_await set_fetch_units(10);
 
-    auto units = mgr.allocate_memory_units(10, 10, false);
+    auto units = mgr.allocate_memory_units(model::ktp{}, 10, 10, 10, false);
     EXPECT_EQ(units.num_units(), 10);
     units.adjust_units(5);
     EXPECT_EQ(units.num_units(), 5);
@@ -173,7 +174,11 @@ TEST_F_CORO(fetch_memory_units_test_fixture, test_allocate_memory_units) {
     const auto test_case =
       [&mgr](size_t max_bytes, bool obligatory_batch_read) -> size_t {
         auto mu = mgr.allocate_memory_units(
-          max_bytes, batch_size, obligatory_batch_read);
+          model::ktp{},
+          max_bytes,
+          batch_size,
+          batch_size,
+          obligatory_batch_read);
         return mu.num_units();
     };
 

--- a/src/v/kafka/server/tests/fetch_metadata_cache_test.cc
+++ b/src/v/kafka/server/tests/fetch_metadata_cache_test.cc
@@ -25,7 +25,7 @@ TEST_CORO(fetch_metadata_cache_tests, test_avg_bytes_per_offset) {
       model::topic{"test_topic"}, model::partition_id{1}};
 
     mdc.insert_or_assign(
-      ktp, model::offset(0), model::offset(10), model::offset(10), 0, 0);
+      ktp, model::offset(0), model::offset(10), model::offset(10), 0, 0, 0);
     auto res = mdc.get(ktp).value();
     EXPECT_EQ(res.avg_bytes_per_offset, 0);
     EXPECT_EQ(mdc.size(), 1);
@@ -36,13 +36,16 @@ TEST_CORO(fetch_metadata_cache_tests, test_avg_bytes_per_offset) {
       model::offset(15),
       model::offset(15),
       5,
+      1,
       5 * 1_MiB);
     res = mdc.get(ktp).value();
     EXPECT_EQ(res.avg_bytes_per_offset, 1_MiB);
+    EXPECT_EQ(res.avg_bytes_per_batch, 5_MiB);
 
     mdc.insert_or_assign(
-      ktp, model::offset(0), model::offset(15), model::offset(15), 1, 2_MiB);
+      ktp, model::offset(0), model::offset(15), model::offset(15), 1, 1, 2_MiB);
     res = mdc.get(ktp).value();
     EXPECT_GE(res.avg_bytes_per_offset, 1_MiB);
+    EXPECT_LT(res.avg_bytes_per_batch, 5_MiB);
     co_return;
 }

--- a/src/v/kafka/server/tests/fetch_plan_bench.cc
+++ b/src/v/kafka/server/tests/fetch_plan_bench.cc
@@ -190,6 +190,7 @@ struct fetch_plan : redpanda_thread_fixture {
                   model::offset(100),
                   model::offset(100),
                   0,
+                  0,
                   0);
             }
         }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Separated from https://github.com/redpanda-data/redpanda/pull/28037 . This allows for more accurate estimates of the minimum amount of memory we'd need to read a batch. Especially in cases where the max batch size for a topic is set to a larger than used number. 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
