### PR TITLE
CORE-14334 [v25.1.x] dt: capture the crash_reports dir on redpanda nodes

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1411,6 +1411,7 @@ class RedpandaServiceBase(RedpandaServiceABC, Service):
     PERSISTENT_ROOT = "/var/lib/redpanda"
     TRIM_LOGS_KEY = "trim_logs"
     DATA_DIR = os.path.join(PERSISTENT_ROOT, "data")
+    CRASH_REPORTS = os.path.join(DATA_DIR, "crash_reports")
     NODE_CONFIG_FILE = "/etc/redpanda/redpanda.yaml"
     RPK_CONFIG_FILE = "/root/.config/rpk/rpk.yaml"
     CLUSTER_BOOTSTRAP_CONFIG_FILE = "/etc/redpanda/.bootstrap.yaml"
@@ -1485,6 +1486,7 @@ class RedpandaServiceBase(RedpandaServiceABC, Service):
         },
         "executable": {"path": EXECUTABLE_SAVE_PATH, "collect_default": False},
         "backtraces": {"path": BACKTRACE_CAPTURE, "collect_default": True},
+        "crash_reports": {"path": CRASH_REPORTS, "collect_default": True},
     }
 
     # Thread name of shards to be used with redpanda_tid()


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28099 
Fixes https://github.com/redpanda-data/redpanda/issues/28162
Fixes https://redpandadata.atlassian.net/browse/CORE-14334