### PR TITLE
Fixing fetch for serverless cluster

### DIFF
--- a/src/go/rpk/pkg/cli/profile/create.go
+++ b/src/go/rpk/pkg/cli/profile/create.go
@@ -770,15 +770,20 @@ func PromptCloudClusterProfile(ctx context.Context, yAuth *config.RpkCloudAuth, 
 		}
 		o = fromCloudCluster(yAuth, rg, c)
 	} else {
-		rg := findResourceGroupByID(rgs, selected.sc.GetResourceGroupId())
-		if rg == nil {
-			return CloudClusterOutputs{}, fmt.Errorf("unable to find resource group %q", selected.sc.GetResourceGroupId())
-		}
-		usePrivate, err := isPrivateNetwork(selected.sc, serverlessNetworking)
+		// Fetch full cluster details to get NetworkingConfig
+		sc, err := cl.ServerlessClusterForID(ctx, selected.sc.Id)
 		if err != nil {
 			return CloudClusterOutputs{}, err
 		}
-		o = fromVirtualCluster(yAuth, rg, selected.sc, usePrivate)
+		rg := findResourceGroupByID(rgs, sc.GetResourceGroupId())
+		if rg == nil {
+			return CloudClusterOutputs{}, fmt.Errorf("unable to find resource group %q", sc.GetResourceGroupId())
+		}
+		usePrivate, err := isPrivateNetwork(sc, serverlessNetworking)
+		if err != nil {
+			return CloudClusterOutputs{}, err
+		}
+		o = fromVirtualCluster(yAuth, rg, sc, usePrivate)
 	}
 	o.Profile.Description = fmt.Sprintf("%s %q", org.Name, selected.name)
 	return o, nil


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

Fix for serverless cluster not populating network config

### Bug Fixes

This PR fixes a bug in the serverless cluster profile creation flow where the NetworkingConfig field was not being properly populated. The issue occurred because the cluster list endpoint returns a lightweight cluster object that lacks the full networking configuration details needed to determine whether private networking should be used.

Key changes:

Added a call to ServerlessClusterForID to fetch the complete cluster details before checking networking configuration
Updated all downstream references to use the fully-fetched cluster object instead of the list result


