### PR TITLE
dt: Allow for describe_topic_configs to fail

### DIFF
--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -1027,7 +1027,21 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
             max_compaction_lag_ms=topic_properties["max.compaction.lag.ms"],
         )
         self.source_default_client().create_topic(topic)
-        source_topic = self.source_cluster_rpk.describe_topic_configs(topic.name)
+
+        def get_source_topic_properties() -> tuple[bool, dict[str, tuple[str, str]]]:
+            try:
+                return True, self.source_cluster_rpk.describe_topic_configs(topic.name)
+            except RpkException as e:
+                self.logger.debug(f"Failed to get topic configs for {topic.name}: {e}")
+                return False, {}
+
+        source_topic = wait_until_result(
+            get_source_topic_properties,
+            timeout_sec=10,
+            backoff_sec=1,
+            err_msg=f"Topic {topic.name} not found in source cluster",
+            retry_on_exc=True,
+        )
 
         def validate_topic_properties(properties_to_check: dict[str, tuple[str, str]]):
             for key, val in topic_properties.items():


### PR DESCRIPTION
Sometimes after immediately creating a topic, the topic may not appear to be present on the cluster so describing the topic properties will fail.  This change addresses this flakiness by retrying getting the topic properties.

Todo:
- [ ] Rerun that test a bunch

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
