### PR TITLE
rpk: bump Shadow Link protos 

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -320,6 +320,7 @@ use_repo(
     "io_k8s_api",
     "io_k8s_apimachinery",
     "io_k8s_client_go",
+    "org_golang_google_genproto_googleapis_api",
     "org_golang_google_genproto_googleapis_rpc",
     "org_golang_google_protobuf",
     "org_golang_x_exp",

--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -9,7 +9,7 @@ require (
 	buf.build/gen/go/redpandadata/cloud/connectrpc/go v1.19.1-20251022210436-bbacedafcd60.2
 	buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.10-20251022210436-bbacedafcd60.1
 	buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.10-20250904135917-9feeb2588236.1
-	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251021160320-d44d783528c8.1
+	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251025023032-d04cd59f0958.1
 	buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250819145731-621dc775ffe4.1
 	buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.7-20250819145731-621dc775ffe4.1
 	buf.build/gen/go/redpandadata/gatekeeper/connectrpc/go v1.18.1-20250813192242-efcc93bcd794.1
@@ -73,6 +73,7 @@ require (
 	golang.org/x/sync v0.17.0
 	golang.org/x/sys v0.37.0
 	golang.org/x/term v0.36.0
+	google.golang.org/genproto/googleapis/api v0.0.0-20251020155222-88f65dc88635
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251014184007-4626949a642f
 	google.golang.org/protobuf v1.36.10
 	gopkg.in/yaml.v2 v2.4.0
@@ -166,7 +167,6 @@ require (
 	golang.org/x/time v0.9.0 // indirect
 	golang.org/x/tools v0.37.0 // indirect
 	google.golang.org/genproto v0.0.0-20250409194420-de1ac958c67a // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20251020155222-88f65dc88635 // indirect
 	google.golang.org/grpc v1.73.0 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -10,8 +10,8 @@ buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.10-20250904135917-
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.10-20250904135917-9feeb2588236.1/go.mod h1:EhA16a3hhvTg9rzQ69ch2mJ2ppasEGJFy8ViCc8PYUE=
 buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251021160320-d44d783528c8.2 h1:1Lt/PN3/ZJ9TiGIfmoQI1r1K2l3UQmHGpQ3pgxuwDxc=
 buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251021160320-d44d783528c8.2/go.mod h1:3kUjX0N7isNP+EIkTWWht2ATgy8f4/+0feYvn65UgCs=
-buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251021160320-d44d783528c8.1 h1:Ynt6p41TwmjUyG7H3jgXKoS+g7cC7ZED/zkOpzOgr/Y=
-buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251021160320-d44d783528c8.1/go.mod h1:QenSPzqxZpyo9hHIpRzTetvDchelVDzimnmaggHKenc=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251025023032-d04cd59f0958.1 h1:30O0ky3rUXnI8Ya8DUKxYXo9+Bs36e/hrpRqjfaqw10=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251025023032-d04cd59f0958.1/go.mod h1:QenSPzqxZpyo9hHIpRzTetvDchelVDzimnmaggHKenc=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250819145731-621dc775ffe4.1 h1:CiTv2Rme+0H/2IQpyZFK8SQYRWgRWEvFNxZIfDMYOQQ=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250819145731-621dc775ffe4.1/go.mod h1:HJnvbiwx2qZN8HcD30Dijm5Aamjcrk/8/ffTOFrF5Go=
 buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.7-20250819145731-621dc775ffe4.1 h1:31r1Sv/BoVyGzzBfBHcUcyQJz/+4i/fr8wc7gQVihEM=

--- a/src/go/rpk/pkg/cli/shadow/BUILD
+++ b/src/go/rpk/pkg/cli/shadow/BUILD
@@ -23,27 +23,33 @@ go_library(
         "//src/go/rpk/pkg/os",
         "//src/go/rpk/pkg/out",
         "@build_buf_gen_go_redpandadata_core_protocolbuffers_go//redpanda/core/admin/v2:admin",
-        "@build_buf_gen_go_redpandadata_core_protocolbuffers_go//redpanda/core/common",
+        "@build_buf_gen_go_redpandadata_core_protocolbuffers_go//redpanda/core/common/v1:common",
         "@com_connectrpc_connect//:connect",
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@org_golang_google_protobuf//types/known/durationpb",
+        "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )
 
 go_test(
     name = "shadow_test",
     srcs = [
+        "create_test.go",
         "mapper_test.go",
         "types_test.go",
     ],
     embed = [":shadow"],
     deps = [
         "@build_buf_gen_go_redpandadata_core_protocolbuffers_go//redpanda/core/admin/v2:admin",
-        "@build_buf_gen_go_redpandadata_core_protocolbuffers_go//redpanda/core/common",
+        "@build_buf_gen_go_redpandadata_core_protocolbuffers_go//redpanda/core/common/v1:common",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",
+        "@org_golang_google_genproto_googleapis_api//annotations",
+        "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//reflect/protoreflect",
+        "@org_golang_google_protobuf//types/descriptorpb",
         "@org_golang_google_protobuf//types/known/durationpb",
     ],
 )

--- a/src/go/rpk/pkg/cli/shadow/config.go
+++ b/src/go/rpk/pkg/cli/shadow/config.go
@@ -77,16 +77,20 @@ func generateSampleConfig() *ShadowLinkConfig {
 		ClientOptions: &ShadowLinkClientOptions{
 			BootstrapServers: []string{"localhost:9092", "localhost:19092"},
 			SourceClusterID:  "optional-source-cluster-id",
-			TLSSettings: &TLSFileSettings{
-				Enabled:  true,
-				CAPath:   "/path/to/ca.crt",
-				KeyPath:  "/path/to/optional/client.key",
-				CertPath: "/path/to/optional/client.crt",
+			TLSSettings: &TLSSettings{
+				Enabled: true,
+				TLSFileSettings: &TLSFileSettings{
+					CAPath:   "/path/to/ca.crt",
+					KeyPath:  "/path/to/optional/client.key",
+					CertPath: "/path/to/optional/client.crt",
+				},
 			},
-			AuthenticationConfiguration: &ScramConfig{
-				Username:       "username",
-				Password:       "password",
-				ScramMechanism: ScramMechanismScramSha256,
+			AuthenticationConfiguration: &AuthenticationConfiguration{
+				ScramConfiguration: &ScramConfiguration{
+					Username:       "username",
+					Password:       "password",
+					ScramMechanism: ScramMechanismScramSha256,
+				},
 			},
 			MetadataMaxAgeMs:       10000,
 			ConnectionTimeoutMs:    1000,
@@ -112,6 +116,7 @@ func generateSampleConfig() *ShadowLinkConfig {
 				},
 			},
 			SyncedShadowTopicProperties: []string{"retention.ms", "segment.ms"},
+			StartAtEarliest:             &StartAtEarliest{},
 		},
 		ConsumerOffsetSyncOptions: &ConsumerOffsetSyncOptions{
 			Interval: 30 * time.Second,
@@ -142,6 +147,9 @@ func generateSampleConfig() *ShadowLinkConfig {
 					},
 				},
 			},
+		},
+		SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
+			ShadowSchemaRegistryTopic: &ShadowSchemaRegistryTopic{},
 		},
 	}
 }

--- a/src/go/rpk/pkg/cli/shadow/create.go
+++ b/src/go/rpk/pkg/cli/shadow/create.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 
 	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
-
 	"connectrpc.com/connect"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -116,6 +115,24 @@ func validateParsedShadowLinkConfig(slCfg *ShadowLinkConfig) error {
 	}
 	if len(slCfg.ClientOptions.BootstrapServers) == 0 {
 		return fmt.Errorf("at least one bootstrap server is required")
+	}
+	if tls := slCfg.ClientOptions.TLSSettings; tls != nil && tls.TLSFileSettings != nil && tls.TLSPEMSettings != nil {
+		return fmt.Errorf("only one of TLS file settings or PEM settings can be provided")
+	}
+	if ts := slCfg.TopicMetadataSyncOptions; ts != nil {
+		var count int
+		if ts.StartAtLatest != nil {
+			count++
+		}
+		if ts.StartAtEarliest != nil {
+			count++
+		}
+		if ts.StartAtTimestamp != nil {
+			count++
+		}
+		if count > 1 {
+			return fmt.Errorf("only one of start_at_latest, start_at_earliest, or start_at_timestamp can be provided")
+		}
 	}
 	return nil
 }

--- a/src/go/rpk/pkg/cli/shadow/create_test.go
+++ b/src/go/rpk/pkg/cli/shadow/create_test.go
@@ -1,0 +1,233 @@
+package shadow
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateParsedShadowLinkConfig(t *testing.T) {
+	date := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		config      *ShadowLinkConfig
+		expectedErr string
+	}{
+		{
+			name:        "nil config",
+			config:      nil,
+			expectedErr: "provided configuration file generated an empty configuration",
+		},
+		{
+			name: "empty name",
+			config: &ShadowLinkConfig{
+				Name: "",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+			},
+			expectedErr: "the Shadow Link name is required",
+		},
+		{
+			name: "no bootstrap servers",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{},
+				},
+			},
+			expectedErr: "at least one bootstrap server is required",
+		},
+		{
+			name: "nil client options with bootstrap servers",
+			config: &ShadowLinkConfig{
+				Name:          "test-link",
+				ClientOptions: &ShadowLinkClientOptions{},
+			},
+			expectedErr: "at least one bootstrap server is required",
+		},
+		{
+			name: "both TLS file and PEM settings",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+					TLSSettings: &TLSSettings{
+						TLSFileSettings: &TLSFileSettings{
+							CAPath: "/path/to/ca",
+						},
+						TLSPEMSettings: &TLSPEMSettings{
+							CA: "pem-content",
+						},
+					},
+				},
+			},
+			expectedErr: "only one of TLS file settings or PEM settings can be provided",
+		},
+		{
+			name: "multiple StartAt options - latest and earliest",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+				TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
+					StartAtLatest:   &StartAtLatest{},
+					StartAtEarliest: &StartAtEarliest{},
+				},
+			},
+			expectedErr: "only one of start_at_latest, start_at_earliest, or start_at_timestamp can be provided",
+		},
+		{
+			name: "multiple StartAt options - earliest and timestamp",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+				TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
+					StartAtEarliest:  &StartAtEarliest{},
+					StartAtTimestamp: &date,
+				},
+			},
+			expectedErr: "only one of start_at_latest, start_at_earliest, or start_at_timestamp can be provided",
+		},
+		{
+			name: "multiple StartAt options - latest and timestamp",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+				TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
+					StartAtLatest:    &StartAtLatest{},
+					StartAtTimestamp: &date,
+				},
+			},
+			expectedErr: "only one of start_at_latest, start_at_earliest, or start_at_timestamp can be provided",
+		},
+		{
+			name: "all three StartAt options",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+				TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
+					StartAtLatest:    &StartAtLatest{},
+					StartAtEarliest:  &StartAtEarliest{},
+					StartAtTimestamp: &date,
+				},
+			},
+			expectedErr: "only one of start_at_latest, start_at_earliest, or start_at_timestamp can be provided",
+		},
+		{
+			name: "valid config - minimal",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+			},
+		},
+		{
+			name: "valid config - with TLS file settings only",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+					TLSSettings: &TLSSettings{
+						TLSFileSettings: &TLSFileSettings{
+							CAPath: "/path/to/ca",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "valid config - with TLS PEM settings only",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+					TLSSettings: &TLSSettings{
+						TLSPEMSettings: &TLSPEMSettings{
+							CA: "pem-content",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "valid config - with StartAtLatest",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+				TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
+					StartAtLatest: &StartAtLatest{},
+				},
+			},
+		},
+		{
+			name: "valid config - with StartAtEarliest",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+				TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
+					StartAtEarliest: &StartAtEarliest{},
+				},
+			},
+		},
+		{
+			name: "valid config - with StartAtTimestamp",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+				TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
+					StartAtTimestamp: &date,
+				},
+			},
+		},
+		{
+			name: "valid config - with multiple bootstrap servers",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092", "broker2:9092", "broker3:9092"},
+				},
+			},
+		},
+		{
+			name: "valid config - TopicMetadataSyncOptions without StartAt fields",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+				},
+				TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
+					Interval: 45 * time.Second,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateParsedShadowLinkConfig(tt.config)
+			if tt.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedErr)
+			}
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/shadow/describe.go
+++ b/src/go/rpk/pkg/cli/shadow/describe.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
-	"buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/common"
+	corecommonv1 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/common/v1"
 	"connectrpc.com/connect"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -198,13 +198,13 @@ func printClient(opts *adminv2.ShadowLinkClientOptions) {
 	tw.Print(strings.Repeat("-", 21), "")
 
 	// Print client config table
-	tw.Print("metadata_max_age_ms", opts.GetMetadataMaxAgeMs())
-	tw.Print("connection_timeout_ms", opts.GetConnectionTimeoutMs())
-	tw.Print("retry_backoff_ms", opts.GetRetryBackoffMs())
-	tw.Print("fetch_wait_max_ms", opts.GetFetchWaitMaxMs())
-	tw.Print("fetch_min_bytes", opts.GetFetchMinBytes())
-	tw.Print("fetch_max_bytes", opts.GetFetchMaxBytes())
-	tw.Print("fetch_partition_max_bytes", opts.GetFetchPartitionMaxBytes())
+	tw.Print("metadata_max_age_ms", opts.GetEffectiveMetadataMaxAgeMs())
+	tw.Print("connection_timeout_ms", opts.GetEffectiveConnectionTimeoutMs())
+	tw.Print("retry_backoff_ms", opts.GetEffectiveRetryBackoffMs())
+	tw.Print("fetch_wait_max_ms", opts.GetEffectiveFetchWaitMaxMs())
+	tw.Print("fetch_min_bytes", opts.GetEffectiveFetchMinBytes())
+	tw.Print("fetch_max_bytes", opts.GetEffectiveFetchMaxBytes())
+	tw.Print("fetch_partition_max_bytes", opts.GetEffectiveFetchPartitionMaxBytes())
 }
 
 func printTopicSync(opts *adminv2.TopicMetadataSyncOptions) {
@@ -215,8 +215,20 @@ func printTopicSync(opts *adminv2.TopicMetadataSyncOptions) {
 		return
 	}
 
-	tw.Print("INTERVAL", opts.GetInterval().AsDuration().String())
-
+	tw.Print("INTERVAL", opts.GetEffectiveInterval().AsDuration().String())
+	if opts.HasStartOffset() {
+		var startOffset string
+		if opts.GetStartAtEarliest() != nil {
+			startOffset = "EARLIEST"
+		}
+		if opts.GetStartAtLatest() != nil {
+			startOffset = "LATEST"
+		}
+		if opts.GetStartAtTimestamp() != nil {
+			startOffset = opts.GetStartAtTimestamp().AsTime().String()
+		}
+		tw.Print("START OFFSET", startOffset)
+	}
 	if len(opts.GetAutoCreateShadowTopicFilters()) > 0 {
 		tw.Print("FILTERS:", "")
 		for _, filter := range opts.GetAutoCreateShadowTopicFilters() {
@@ -241,10 +253,7 @@ func printConsumerOffsetSync(opts *adminv2.ConsumerOffsetSyncOptions) {
 	}
 
 	tw.Print("ENABLED", opts.GetEnabled())
-	if !opts.GetEnabled() {
-		return
-	}
-	tw.Print("INTERVAL", opts.GetInterval().AsDuration().String())
+	tw.Print("INTERVAL", opts.GetEffectiveInterval().AsDuration().String())
 
 	if len(opts.GetGroupFilters()) > 0 {
 		tw.Print("GROUP FILTERS:", "")
@@ -263,20 +272,18 @@ func printSecuritySync(opts *adminv2.SecuritySettingsSyncOptions) {
 	}
 
 	tw.Print("ENABLED", opts.GetEnabled())
-	if !opts.GetEnabled() {
-		return
-	}
-	tw.Print("INTERVAL", opts.GetInterval().AsDuration().String())
+	tw.Print("INTERVAL", opts.GetEffectiveInterval().AsDuration().String())
 
 	if len(opts.GetAclFilters()) > 0 {
 		tw.Print("ACL FILTERS:")
 		tw.Flush()
-		aclTw := out.NewTable("RESOURCE", "PATTERN", "NAME", "OPERATION", "PERMISSION")
+		aclTw := out.NewTable("", "RESOURCE", "PATTERN", "NAME", "OPERATION", "PERMISSION")
 		defer aclTw.Flush()
 		for _, filter := range opts.GetAclFilters() {
 			resource := filter.GetResourceFilter()
 			access := filter.GetAccessFilter()
 			aclTw.Print(
+				"",
 				formatACLResource(resource.GetResourceType()),
 				formatACLPattern(resource.GetPatternType()),
 				resource.GetName(),
@@ -320,18 +327,18 @@ func formatPatternType(pt adminv2.PatternType) string {
 	}
 }
 
-func formatACLResource(r common.ACLResource) string {
+func formatACLResource(r corecommonv1.ACLResource) string {
 	return strings.ToUpper(strings.TrimPrefix(r.String(), "ACL_RESOURCE_"))
 }
 
-func formatACLPattern(p common.ACLPattern) string {
+func formatACLPattern(p corecommonv1.ACLPattern) string {
 	return strings.ToUpper(strings.TrimPrefix(p.String(), "ACL_PATTERN_"))
 }
 
-func formatACLOperation(o common.ACLOperation) string {
+func formatACLOperation(o corecommonv1.ACLOperation) string {
 	return strings.ToUpper(strings.TrimPrefix(o.String(), "ACL_OPERATION_"))
 }
 
-func formatACLPermissionType(p common.ACLPermissionType) string {
+func formatACLPermissionType(p corecommonv1.ACLPermissionType) string {
 	return strings.ToUpper(strings.TrimPrefix(p.String(), "ACL_PERMISSION_TYPE_"))
 }

--- a/src/go/rpk/pkg/cli/shadow/mapper.go
+++ b/src/go/rpk/pkg/cli/shadow/mapper.go
@@ -11,8 +11,9 @@ package shadow
 
 import (
 	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
-	"buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/common"
+	corecommonv1 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/common/v1"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func shadowLinkConfigToProto(slCfg *ShadowLinkConfig) *adminv2.ShadowLink {
@@ -30,6 +31,7 @@ func shadowLinkConfigToProto(slCfg *ShadowLinkConfig) *adminv2.ShadowLink {
 		TopicMetadataSyncOptions:  mapTopicMetadataSyncOptions(slCfg.TopicMetadataSyncOptions),
 		ConsumerOffsetSyncOptions: mapConsumerOffsetSyncOptions(slCfg.ConsumerOffsetSyncOptions),
 		SecuritySyncOptions:       mapSecuritySyncOptions(slCfg.SecuritySyncOptions),
+		SchemaRegistrySyncOptions: mapSchemaRegistrySyncOptions(slCfg.SchemaRegistrySyncOptions),
 	}
 	return shadowLink
 }
@@ -63,29 +65,29 @@ func mapClientOptions(opts *ShadowLinkClientOptions) *adminv2.ShadowLinkClientOp
 	return pbOpts
 }
 
-func mapTLSSettings(tls TLSSettings) *adminv2.TLSSettings {
+func mapTLSSettings(tls *TLSSettings) *corecommonv1.TLSSettings {
 	if tls == nil {
 		return nil
 	}
 
-	pbTLS := &adminv2.TLSSettings{}
-
-	switch t := tls.(type) {
-	case *TLSFileSettings:
-		pbTLS.Enabled = t.Enabled
-		pbTLS.DoNotSetSniHostname = t.DoNotSetSniHostname
-		pbTLS.TlsSettings = &adminv2.TLSSettings_TlsFileSettings{
-			TlsFileSettings: &adminv2.TLSFileSettings{
+	pbTLS := &corecommonv1.TLSSettings{
+		Enabled:             tls.Enabled,
+		DoNotSetSniHostname: tls.DoNotSetSniHostname,
+	}
+	switch {
+	case tls.TLSFileSettings != nil:
+		t := tls.TLSFileSettings
+		pbTLS.TlsSettings = &corecommonv1.TLSSettings_TlsFileSettings{
+			TlsFileSettings: &corecommonv1.TLSFileSettings{
 				CaPath:   t.CAPath,
 				KeyPath:  t.KeyPath,
 				CertPath: t.CertPath,
 			},
 		}
-	case *TLSPEMSettings:
-		pbTLS.Enabled = t.Enabled
-		pbTLS.DoNotSetSniHostname = t.DoNotSetSniHostname
-		pbTLS.TlsSettings = &adminv2.TLSSettings_TlsPemSettings{
-			TlsPemSettings: &adminv2.TLSPEMSettings{
+	case tls.TLSPEMSettings != nil:
+		t := tls.TLSPEMSettings
+		pbTLS.TlsSettings = &corecommonv1.TLSSettings_TlsPemSettings{
+			TlsPemSettings: &corecommonv1.TLSPEMSettings{
 				Ca:   t.CA,
 				Key:  t.Key,
 				Cert: t.Cert,
@@ -97,14 +99,14 @@ func mapTLSSettings(tls TLSSettings) *adminv2.TLSSettings {
 	return pbTLS
 }
 
-func mapAuthenticationConfiguration(auth AuthenticationConfiguration) *adminv2.AuthenticationConfiguration {
+func mapAuthenticationConfiguration(auth *AuthenticationConfiguration) *adminv2.AuthenticationConfiguration {
 	if auth == nil {
 		return nil
 	}
 
 	pbAuth := &adminv2.AuthenticationConfiguration{}
 
-	if a, ok := auth.(*ScramConfig); ok {
+	if a := auth.ScramConfiguration; a != nil {
 		pbAuth.Authentication = &adminv2.AuthenticationConfiguration_ScramConfiguration{
 			ScramConfiguration: &adminv2.ScramConfig{
 				Username:       a.Username,
@@ -147,6 +149,21 @@ func mapTopicMetadataSyncOptions(opts *TopicMetadataSyncOptions) *adminv2.TopicM
 		pbOpts.AutoCreateShadowTopicFilters = append(pbOpts.AutoCreateShadowTopicFilters, mapNameFilter(filter))
 	}
 
+	// Handle start_offset oneof - only one can be set
+	if opts.StartAtEarliest != nil {
+		pbOpts.StartOffset = &adminv2.TopicMetadataSyncOptions_StartAtEarliest{
+			StartAtEarliest: &adminv2.TopicMetadataSyncOptions_EarliestOffset{},
+		}
+	} else if opts.StartAtLatest != nil {
+		pbOpts.StartOffset = &adminv2.TopicMetadataSyncOptions_StartAtLatest{
+			StartAtLatest: &adminv2.TopicMetadataSyncOptions_LatestOffset{},
+		}
+	} else if opts.StartAtTimestamp != nil {
+		pbOpts.StartOffset = &adminv2.TopicMetadataSyncOptions_StartAtTimestamp{
+			StartAtTimestamp: timestamppb.New(*opts.StartAtTimestamp),
+		}
+	}
+
 	return pbOpts
 }
 
@@ -185,6 +202,25 @@ func mapSecuritySyncOptions(opts *SecuritySettingsSyncOptions) *adminv2.Security
 
 	for _, filter := range opts.ACLFilters {
 		pbOpts.AclFilters = append(pbOpts.AclFilters, mapACLFilter(filter))
+	}
+
+	return pbOpts
+}
+
+func mapSchemaRegistrySyncOptions(opts *SchemaRegistrySyncOptions) *adminv2.SchemaRegistrySyncOptions {
+	if opts == nil {
+		return nil
+	}
+
+	pbOpts := &adminv2.SchemaRegistrySyncOptions{}
+
+	// Handle schema_registry_shadowing_mode oneof
+	// If the struct has the ShadowSchemaRegistryTopic field populated,
+	// we set the oneof
+	if opts.ShadowSchemaRegistryTopic != nil {
+		pbOpts.SchemaRegistryShadowingMode = &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryTopic_{
+			ShadowSchemaRegistryTopic: &adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryTopic{},
+		}
 	}
 
 	return pbOpts
@@ -260,83 +296,83 @@ func mapFilterType(ft FilterType) adminv2.FilterType {
 	}
 }
 
-func mapACLResource(resource ACLResource) common.ACLResource {
+func mapACLResource(resource ACLResource) corecommonv1.ACLResource {
 	switch resource {
 	case ACLResourceAny:
-		return common.ACLResource_ACL_RESOURCE_ANY
+		return corecommonv1.ACLResource_ACL_RESOURCE_ANY
 	case ACLResourceCluster:
-		return common.ACLResource_ACL_RESOURCE_CLUSTER
+		return corecommonv1.ACLResource_ACL_RESOURCE_CLUSTER
 	case ACLResourceGroup:
-		return common.ACLResource_ACL_RESOURCE_GROUP
+		return corecommonv1.ACLResource_ACL_RESOURCE_GROUP
 	case ACLResourceTopic:
-		return common.ACLResource_ACL_RESOURCE_TOPIC
+		return corecommonv1.ACLResource_ACL_RESOURCE_TOPIC
 	case ACLResourceTXNID:
-		return common.ACLResource_ACL_RESOURCE_TXN_ID
+		return corecommonv1.ACLResource_ACL_RESOURCE_TXN_ID
 	case ACLResourceSRSubject:
-		return common.ACLResource_ACL_RESOURCE_SR_SUBJECT
+		return corecommonv1.ACLResource_ACL_RESOURCE_SR_SUBJECT
 	case ACLResourceSRRegistry:
-		return common.ACLResource_ACL_RESOURCE_SR_REGISTRY
+		return corecommonv1.ACLResource_ACL_RESOURCE_SR_REGISTRY
 	case ACLResourceSRAny:
-		return common.ACLResource_ACL_RESOURCE_SR_ANY
+		return corecommonv1.ACLResource_ACL_RESOURCE_SR_ANY
 	default:
-		return common.ACLResource_ACL_RESOURCE_UNSPECIFIED
+		return corecommonv1.ACLResource_ACL_RESOURCE_UNSPECIFIED
 	}
 }
 
-func mapACLPattern(pattern ACLPattern) common.ACLPattern {
+func mapACLPattern(pattern ACLPattern) corecommonv1.ACLPattern {
 	switch pattern {
 	case ACLPatternAny:
-		return common.ACLPattern_ACL_PATTERN_ANY
+		return corecommonv1.ACLPattern_ACL_PATTERN_ANY
 	case ACLPatternLiteral:
-		return common.ACLPattern_ACL_PATTERN_LITERAL
+		return corecommonv1.ACLPattern_ACL_PATTERN_LITERAL
 	case ACLPatternPrefixed:
-		return common.ACLPattern_ACL_PATTERN_PREFIXED
+		return corecommonv1.ACLPattern_ACL_PATTERN_PREFIXED
 	case ACLPatternMatch:
-		return common.ACLPattern_ACL_PATTERN_MATCH
+		return corecommonv1.ACLPattern_ACL_PATTERN_MATCH
 	default:
-		return common.ACLPattern_ACL_PATTERN_UNSPECIFIED
+		return corecommonv1.ACLPattern_ACL_PATTERN_UNSPECIFIED
 	}
 }
 
-func mapACLOperation(operation ACLOperation) common.ACLOperation {
+func mapACLOperation(operation ACLOperation) corecommonv1.ACLOperation {
 	switch operation {
 	case ACLOperationAny:
-		return common.ACLOperation_ACL_OPERATION_ANY
+		return corecommonv1.ACLOperation_ACL_OPERATION_ANY
 	case ACLOperationRead:
-		return common.ACLOperation_ACL_OPERATION_READ
+		return corecommonv1.ACLOperation_ACL_OPERATION_READ
 	case ACLOperationWrite:
-		return common.ACLOperation_ACL_OPERATION_WRITE
+		return corecommonv1.ACLOperation_ACL_OPERATION_WRITE
 	case ACLOperationCreate:
-		return common.ACLOperation_ACL_OPERATION_CREATE
+		return corecommonv1.ACLOperation_ACL_OPERATION_CREATE
 	case ACLOperationRemove:
-		return common.ACLOperation_ACL_OPERATION_REMOVE
+		return corecommonv1.ACLOperation_ACL_OPERATION_REMOVE
 	case ACLOperationAlter:
-		return common.ACLOperation_ACL_OPERATION_ALTER
+		return corecommonv1.ACLOperation_ACL_OPERATION_ALTER
 	case ACLOperationDescribe:
-		return common.ACLOperation_ACL_OPERATION_DESCRIBE
+		return corecommonv1.ACLOperation_ACL_OPERATION_DESCRIBE
 	case ACLOperationClusterAction:
-		return common.ACLOperation_ACL_OPERATION_CLUSTER_ACTION
+		return corecommonv1.ACLOperation_ACL_OPERATION_CLUSTER_ACTION
 	case ACLOperationDescribeConfigs:
-		return common.ACLOperation_ACL_OPERATION_DESCRIBE_CONFIGS
+		return corecommonv1.ACLOperation_ACL_OPERATION_DESCRIBE_CONFIGS
 	case ACLOperationAlterConfigs:
-		return common.ACLOperation_ACL_OPERATION_ALTER_CONFIGS
+		return corecommonv1.ACLOperation_ACL_OPERATION_ALTER_CONFIGS
 	case ACLOperationIdempotentWrite:
-		return common.ACLOperation_ACL_OPERATION_IDEMPOTENT_WRITE
+		return corecommonv1.ACLOperation_ACL_OPERATION_IDEMPOTENT_WRITE
 	default:
-		return common.ACLOperation_ACL_OPERATION_UNSPECIFIED
+		return corecommonv1.ACLOperation_ACL_OPERATION_UNSPECIFIED
 	}
 }
 
-func mapACLPermissionType(permType ACLPermissionType) common.ACLPermissionType {
+func mapACLPermissionType(permType ACLPermissionType) corecommonv1.ACLPermissionType {
 	switch permType {
 	case ACLPermissionTypeAny:
-		return common.ACLPermissionType_ACL_PERMISSION_TYPE_ANY
+		return corecommonv1.ACLPermissionType_ACL_PERMISSION_TYPE_ANY
 	case ACLPermissionTypeAllow:
-		return common.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW
+		return corecommonv1.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW
 	case ACLPermissionTypeDeny:
-		return common.ACLPermissionType_ACL_PERMISSION_TYPE_DENY
+		return corecommonv1.ACLPermissionType_ACL_PERMISSION_TYPE_DENY
 	default:
-		return common.ACLPermissionType_ACL_PERMISSION_TYPE_UNSPECIFIED
+		return corecommonv1.ACLPermissionType_ACL_PERMISSION_TYPE_UNSPECIFIED
 	}
 }
 
@@ -355,6 +391,7 @@ func shadowLinkToConfig(sl *adminv2.ShadowLink) *ShadowLinkConfig {
 		cfg.TopicMetadataSyncOptions = adminTopicMetadataSyncToCfg(sl.GetConfigurations().GetTopicMetadataSyncOptions())
 		cfg.ConsumerOffsetSyncOptions = adminConsumerOffsetSyncToCfg(sl.GetConfigurations().GetConsumerOffsetSyncOptions())
 		cfg.SecuritySyncOptions = adminSecuritySyncToCfg(sl.GetConfigurations().GetSecuritySyncOptions())
+		cfg.SchemaRegistrySyncOptions = adminSchemaRegistrySyncToCfg(sl.GetConfigurations().GetSchemaRegistrySyncOptions())
 	}
 
 	return cfg
@@ -388,40 +425,40 @@ func adminClientOptsToCfg(opts *adminv2.ShadowLinkClientOptions) *ShadowLinkClie
 	return cfg
 }
 
-func adminTLSToCfg(tls *adminv2.TLSSettings) TLSSettings {
+func adminTLSToCfg(tls *corecommonv1.TLSSettings) *TLSSettings {
 	if tls == nil {
 		return nil
 	}
+	tlsSettings := &TLSSettings{
+		Enabled:             tls.GetEnabled(),
+		DoNotSetSniHostname: tls.GetDoNotSetSniHostname(),
+	}
 
 	switch t := tls.GetTlsSettings().(type) {
-	case *adminv2.TLSSettings_TlsFileSettings:
+	case *corecommonv1.TLSSettings_TlsFileSettings:
 		if t.TlsFileSettings == nil {
-			return nil
+			return tlsSettings
 		}
-		return &TLSFileSettings{
-			Enabled:             tls.GetEnabled(),
-			DoNotSetSniHostname: tls.GetDoNotSetSniHostname(),
-			CAPath:              t.TlsFileSettings.GetCaPath(),
-			KeyPath:             t.TlsFileSettings.GetKeyPath(),
-			CertPath:            t.TlsFileSettings.GetCertPath(),
+		tlsSettings.TLSFileSettings = &TLSFileSettings{
+			CAPath:   t.TlsFileSettings.GetCaPath(),
+			KeyPath:  t.TlsFileSettings.GetKeyPath(),
+			CertPath: t.TlsFileSettings.GetCertPath(),
 		}
-	case *adminv2.TLSSettings_TlsPemSettings:
+	case *corecommonv1.TLSSettings_TlsPemSettings:
 		if t.TlsPemSettings == nil {
-			return nil
+			return tlsSettings
 		}
-		return &TLSPEMSettings{
-			Enabled:             tls.GetEnabled(),
-			DoNotSetSniHostname: tls.GetDoNotSetSniHostname(),
-			CA:                  t.TlsPemSettings.GetCa(),
-			Key:                 t.TlsPemSettings.GetKey(),
-			Cert:                t.TlsPemSettings.GetCert(),
+		tlsSettings.TLSPEMSettings = &TLSPEMSettings{
+			CA:   t.TlsPemSettings.GetCa(),
+			Key:  t.TlsPemSettings.GetKey(),
+			Cert: t.TlsPemSettings.GetCert(),
 		}
 	}
 
-	return nil
+	return tlsSettings
 }
 
-func adminAuthToCfg(auth *adminv2.AuthenticationConfiguration) AuthenticationConfiguration {
+func adminAuthToCfg(auth *adminv2.AuthenticationConfiguration) *AuthenticationConfiguration {
 	if auth == nil {
 		return nil
 	}
@@ -430,10 +467,12 @@ func adminAuthToCfg(auth *adminv2.AuthenticationConfiguration) AuthenticationCon
 		if a.ScramConfiguration == nil {
 			return nil
 		}
-		return &ScramConfig{
-			Username:       a.ScramConfiguration.GetUsername(),
-			Password:       a.ScramConfiguration.GetPassword(),
-			ScramMechanism: adminScramMechanismToCfg(a.ScramConfiguration.GetScramMechanism()),
+		return &AuthenticationConfiguration{
+			ScramConfiguration: &ScramConfiguration{
+				Username:       a.ScramConfiguration.GetUsername(),
+				Password:       a.ScramConfiguration.GetPassword(),
+				ScramMechanism: adminScramMechanismToCfg(a.ScramConfiguration.GetScramMechanism()),
+			},
 		}
 	}
 
@@ -467,6 +506,19 @@ func adminTopicMetadataSyncToCfg(opts *adminv2.TopicMetadataSyncOptions) *TopicM
 
 	for _, filter := range opts.GetAutoCreateShadowTopicFilters() {
 		cfg.AutoCreateShadowTopicFilters = append(cfg.AutoCreateShadowTopicFilters, adminMapFilterToCfg(filter))
+	}
+
+	// Handle start_offset oneof
+	switch startOffset := opts.GetStartOffset().(type) {
+	case *adminv2.TopicMetadataSyncOptions_StartAtEarliest:
+		cfg.StartAtEarliest = &StartAtEarliest{}
+	case *adminv2.TopicMetadataSyncOptions_StartAtLatest:
+		cfg.StartAtLatest = &StartAtLatest{}
+	case *adminv2.TopicMetadataSyncOptions_StartAtTimestamp:
+		if startOffset.StartAtTimestamp != nil {
+			t := startOffset.StartAtTimestamp.AsTime()
+			cfg.StartAtTimestamp = &t
+		}
 	}
 
 	return cfg
@@ -507,6 +559,21 @@ func adminSecuritySyncToCfg(opts *adminv2.SecuritySettingsSyncOptions) *Security
 
 	for _, filter := range opts.GetAclFilters() {
 		cfg.ACLFilters = append(cfg.ACLFilters, adminACLFilterToCfg(filter))
+	}
+
+	return cfg
+}
+
+func adminSchemaRegistrySyncToCfg(opts *adminv2.SchemaRegistrySyncOptions) *SchemaRegistrySyncOptions {
+	if opts == nil {
+		return nil
+	}
+
+	cfg := &SchemaRegistrySyncOptions{}
+
+	// Handle schema_registry_shadowing_mode oneof
+	if _, ok := opts.GetSchemaRegistryShadowingMode().(*adminv2.SchemaRegistrySyncOptions_ShadowSchemaRegistryTopic_); ok {
+		cfg.ShadowSchemaRegistryTopic = &ShadowSchemaRegistryTopic{}
 	}
 
 	return cfg
@@ -582,80 +649,80 @@ func adminFilterTypeToCfg(ft adminv2.FilterType) FilterType {
 	}
 }
 
-func adminACLResourceToCfg(resource common.ACLResource) ACLResource {
+func adminACLResourceToCfg(resource corecommonv1.ACLResource) ACLResource {
 	switch resource {
-	case common.ACLResource_ACL_RESOURCE_ANY:
+	case corecommonv1.ACLResource_ACL_RESOURCE_ANY:
 		return ACLResourceAny
-	case common.ACLResource_ACL_RESOURCE_CLUSTER:
+	case corecommonv1.ACLResource_ACL_RESOURCE_CLUSTER:
 		return ACLResourceCluster
-	case common.ACLResource_ACL_RESOURCE_GROUP:
+	case corecommonv1.ACLResource_ACL_RESOURCE_GROUP:
 		return ACLResourceGroup
-	case common.ACLResource_ACL_RESOURCE_TOPIC:
+	case corecommonv1.ACLResource_ACL_RESOURCE_TOPIC:
 		return ACLResourceTopic
-	case common.ACLResource_ACL_RESOURCE_TXN_ID:
+	case corecommonv1.ACLResource_ACL_RESOURCE_TXN_ID:
 		return ACLResourceTXNID
-	case common.ACLResource_ACL_RESOURCE_SR_SUBJECT:
+	case corecommonv1.ACLResource_ACL_RESOURCE_SR_SUBJECT:
 		return ACLResourceSRSubject
-	case common.ACLResource_ACL_RESOURCE_SR_REGISTRY:
+	case corecommonv1.ACLResource_ACL_RESOURCE_SR_REGISTRY:
 		return ACLResourceSRRegistry
-	case common.ACLResource_ACL_RESOURCE_SR_ANY:
+	case corecommonv1.ACLResource_ACL_RESOURCE_SR_ANY:
 		return ACLResourceSRAny
 	default:
 		return ""
 	}
 }
 
-func adminACLPatternToCfg(pattern common.ACLPattern) ACLPattern {
+func adminACLPatternToCfg(pattern corecommonv1.ACLPattern) ACLPattern {
 	switch pattern {
-	case common.ACLPattern_ACL_PATTERN_ANY:
+	case corecommonv1.ACLPattern_ACL_PATTERN_ANY:
 		return ACLPatternAny
-	case common.ACLPattern_ACL_PATTERN_LITERAL:
+	case corecommonv1.ACLPattern_ACL_PATTERN_LITERAL:
 		return ACLPatternLiteral
-	case common.ACLPattern_ACL_PATTERN_PREFIXED:
+	case corecommonv1.ACLPattern_ACL_PATTERN_PREFIXED:
 		return ACLPatternPrefixed
-	case common.ACLPattern_ACL_PATTERN_MATCH:
+	case corecommonv1.ACLPattern_ACL_PATTERN_MATCH:
 		return ACLPatternMatch
 	default:
 		return ""
 	}
 }
 
-func adminACLOperationToCfg(operation common.ACLOperation) ACLOperation {
+func adminACLOperationToCfg(operation corecommonv1.ACLOperation) ACLOperation {
 	switch operation {
-	case common.ACLOperation_ACL_OPERATION_ANY:
+	case corecommonv1.ACLOperation_ACL_OPERATION_ANY:
 		return ACLOperationAny
-	case common.ACLOperation_ACL_OPERATION_READ:
+	case corecommonv1.ACLOperation_ACL_OPERATION_READ:
 		return ACLOperationRead
-	case common.ACLOperation_ACL_OPERATION_WRITE:
+	case corecommonv1.ACLOperation_ACL_OPERATION_WRITE:
 		return ACLOperationWrite
-	case common.ACLOperation_ACL_OPERATION_CREATE:
+	case corecommonv1.ACLOperation_ACL_OPERATION_CREATE:
 		return ACLOperationCreate
-	case common.ACLOperation_ACL_OPERATION_REMOVE:
+	case corecommonv1.ACLOperation_ACL_OPERATION_REMOVE:
 		return ACLOperationRemove
-	case common.ACLOperation_ACL_OPERATION_ALTER:
+	case corecommonv1.ACLOperation_ACL_OPERATION_ALTER:
 		return ACLOperationAlter
-	case common.ACLOperation_ACL_OPERATION_DESCRIBE:
+	case corecommonv1.ACLOperation_ACL_OPERATION_DESCRIBE:
 		return ACLOperationDescribe
-	case common.ACLOperation_ACL_OPERATION_CLUSTER_ACTION:
+	case corecommonv1.ACLOperation_ACL_OPERATION_CLUSTER_ACTION:
 		return ACLOperationClusterAction
-	case common.ACLOperation_ACL_OPERATION_DESCRIBE_CONFIGS:
+	case corecommonv1.ACLOperation_ACL_OPERATION_DESCRIBE_CONFIGS:
 		return ACLOperationDescribeConfigs
-	case common.ACLOperation_ACL_OPERATION_ALTER_CONFIGS:
+	case corecommonv1.ACLOperation_ACL_OPERATION_ALTER_CONFIGS:
 		return ACLOperationAlterConfigs
-	case common.ACLOperation_ACL_OPERATION_IDEMPOTENT_WRITE:
+	case corecommonv1.ACLOperation_ACL_OPERATION_IDEMPOTENT_WRITE:
 		return ACLOperationIdempotentWrite
 	default:
 		return ""
 	}
 }
 
-func adminPermissionTypeToCfg(permType common.ACLPermissionType) ACLPermissionType {
+func adminPermissionTypeToCfg(permType corecommonv1.ACLPermissionType) ACLPermissionType {
 	switch permType {
-	case common.ACLPermissionType_ACL_PERMISSION_TYPE_ANY:
+	case corecommonv1.ACLPermissionType_ACL_PERMISSION_TYPE_ANY:
 		return ACLPermissionTypeAny
-	case common.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW:
+	case corecommonv1.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW:
 		return ACLPermissionTypeAllow
-	case common.ACLPermissionType_ACL_PERMISSION_TYPE_DENY:
+	case corecommonv1.ACLPermissionType_ACL_PERMISSION_TYPE_DENY:
 		return ACLPermissionTypeDeny
 	default:
 		return ""

--- a/src/go/rpk/pkg/cli/shadow/mapper_test.go
+++ b/src/go/rpk/pkg/cli/shadow/mapper_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
-	"buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/common"
+	corecommonv1 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/common/v1"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
@@ -90,21 +90,23 @@ func TestMapClientOptions(t *testing.T) {
 			name: "with file-based TLS",
 			opts: &ShadowLinkClientOptions{
 				BootstrapServers: []string{"localhost:9092"},
-				TLSSettings: &TLSFileSettings{
+				TLSSettings: &TLSSettings{
 					Enabled:             true,
 					DoNotSetSniHostname: true,
-					CAPath:              "/ca.crt",
-					KeyPath:             "/key.pem",
-					CertPath:            "/cert.pem",
+					TLSFileSettings: &TLSFileSettings{
+						CAPath:   "/ca.crt",
+						KeyPath:  "/key.pem",
+						CertPath: "/cert.pem",
+					},
 				},
 			},
 			want: &adminv2.ShadowLinkClientOptions{
 				BootstrapServers: []string{"localhost:9092"},
-				TlsSettings: &adminv2.TLSSettings{
+				TlsSettings: &corecommonv1.TLSSettings{
 					Enabled:             true,
 					DoNotSetSniHostname: true,
-					TlsSettings: &adminv2.TLSSettings_TlsFileSettings{
-						TlsFileSettings: &adminv2.TLSFileSettings{
+					TlsSettings: &corecommonv1.TLSSettings_TlsFileSettings{
+						TlsFileSettings: &corecommonv1.TLSFileSettings{
 							CaPath:   "/ca.crt",
 							KeyPath:  "/key.pem",
 							CertPath: "/cert.pem",
@@ -117,21 +119,23 @@ func TestMapClientOptions(t *testing.T) {
 			name: "with PEM-based TLS",
 			opts: &ShadowLinkClientOptions{
 				BootstrapServers: []string{"localhost:9092"},
-				TLSSettings: &TLSPEMSettings{
+				TLSSettings: &TLSSettings{
 					Enabled:             true,
 					DoNotSetSniHostname: true,
-					CA:                  "ca-content",
-					Key:                 "key-content",
-					Cert:                "cert-content",
+					TLSPEMSettings: &TLSPEMSettings{
+						CA:   "ca-content",
+						Key:  "key-content",
+						Cert: "cert-content",
+					},
 				},
 			},
 			want: &adminv2.ShadowLinkClientOptions{
 				BootstrapServers: []string{"localhost:9092"},
-				TlsSettings: &adminv2.TLSSettings{
+				TlsSettings: &corecommonv1.TLSSettings{
 					Enabled:             true,
 					DoNotSetSniHostname: true,
-					TlsSettings: &adminv2.TLSSettings_TlsPemSettings{
-						TlsPemSettings: &adminv2.TLSPEMSettings{
+					TlsSettings: &corecommonv1.TLSSettings_TlsPemSettings{
+						TlsPemSettings: &corecommonv1.TLSPEMSettings{
 							Ca:   "ca-content",
 							Key:  "key-content",
 							Cert: "cert-content",
@@ -144,10 +148,12 @@ func TestMapClientOptions(t *testing.T) {
 			name: "with SCRAM authentication",
 			opts: &ShadowLinkClientOptions{
 				BootstrapServers: []string{"localhost:9092"},
-				AuthenticationConfiguration: &ScramConfig{
-					Username:       "user",
-					Password:       "pass",
-					ScramMechanism: ScramMechanismScramSha512,
+				AuthenticationConfiguration: &AuthenticationConfiguration{
+					ScramConfiguration: &ScramConfiguration{
+						Username:       "user",
+						Password:       "pass",
+						ScramMechanism: ScramMechanismScramSha512,
+					},
 				},
 			},
 			want: &adminv2.ShadowLinkClientOptions{
@@ -176,8 +182,8 @@ func TestMapClientOptions(t *testing.T) {
 func TestMapTLSSettings(t *testing.T) {
 	tests := []struct {
 		name string
-		tls  TLSSettings
-		want *adminv2.TLSSettings
+		tls  *TLSSettings
+		want *corecommonv1.TLSSettings
 	}{
 		{
 			name: "nil TLS returns nil",
@@ -186,16 +192,18 @@ func TestMapTLSSettings(t *testing.T) {
 		},
 		{
 			name: "file-based TLS settings",
-			tls: &TLSFileSettings{
-				Enabled:  true,
-				CAPath:   "/path/to/ca",
-				KeyPath:  "/path/to/key",
-				CertPath: "/path/to/cert",
-			},
-			want: &adminv2.TLSSettings{
+			tls: &TLSSettings{
 				Enabled: true,
-				TlsSettings: &adminv2.TLSSettings_TlsFileSettings{
-					TlsFileSettings: &adminv2.TLSFileSettings{
+				TLSFileSettings: &TLSFileSettings{
+					CAPath:   "/path/to/ca",
+					KeyPath:  "/path/to/key",
+					CertPath: "/path/to/cert",
+				},
+			},
+			want: &corecommonv1.TLSSettings{
+				Enabled: true,
+				TlsSettings: &corecommonv1.TLSSettings_TlsFileSettings{
+					TlsFileSettings: &corecommonv1.TLSFileSettings{
 						CaPath:   "/path/to/ca",
 						KeyPath:  "/path/to/key",
 						CertPath: "/path/to/cert",
@@ -205,16 +213,18 @@ func TestMapTLSSettings(t *testing.T) {
 		},
 		{
 			name: "PEM-based TLS settings",
-			tls: &TLSPEMSettings{
+			tls: &TLSSettings{
 				Enabled: false,
-				CA:      "ca-pem",
-				Key:     "key-pem",
-				Cert:    "cert-pem",
+				TLSPEMSettings: &TLSPEMSettings{
+					CA:   "ca-pem",
+					Key:  "key-pem",
+					Cert: "cert-pem",
+				},
 			},
-			want: &adminv2.TLSSettings{
+			want: &corecommonv1.TLSSettings{
 				Enabled: false,
-				TlsSettings: &adminv2.TLSSettings_TlsPemSettings{
-					TlsPemSettings: &adminv2.TLSPEMSettings{
+				TlsSettings: &corecommonv1.TLSSettings_TlsPemSettings{
+					TlsPemSettings: &corecommonv1.TLSPEMSettings{
 						Ca:   "ca-pem",
 						Key:  "key-pem",
 						Cert: "cert-pem",
@@ -235,7 +245,7 @@ func TestMapTLSSettings(t *testing.T) {
 func TestMapAuthenticationConfiguration(t *testing.T) {
 	tests := []struct {
 		name string
-		auth AuthenticationConfiguration
+		auth *AuthenticationConfiguration
 		want *adminv2.AuthenticationConfiguration
 	}{
 		{
@@ -245,10 +255,12 @@ func TestMapAuthenticationConfiguration(t *testing.T) {
 		},
 		{
 			name: "SCRAM-SHA-256 configuration",
-			auth: &ScramConfig{
-				Username:       "alice",
-				Password:       "secret",
-				ScramMechanism: ScramMechanismScramSha256,
+			auth: &AuthenticationConfiguration{
+				ScramConfiguration: &ScramConfiguration{
+					Username:       "alice",
+					Password:       "secret",
+					ScramMechanism: ScramMechanismScramSha256,
+				},
 			},
 			want: &adminv2.AuthenticationConfiguration{
 				Authentication: &adminv2.AuthenticationConfiguration_ScramConfiguration{
@@ -262,10 +274,12 @@ func TestMapAuthenticationConfiguration(t *testing.T) {
 		},
 		{
 			name: "SCRAM-SHA-512 configuration",
-			auth: &ScramConfig{
-				Username:       "bob",
-				Password:       "password",
-				ScramMechanism: ScramMechanismScramSha512,
+			auth: &AuthenticationConfiguration{
+				ScramConfiguration: &ScramConfiguration{
+					Username:       "bob",
+					Password:       "password",
+					ScramMechanism: ScramMechanismScramSha512,
+				},
 			},
 			want: &adminv2.AuthenticationConfiguration{
 				Authentication: &adminv2.AuthenticationConfiguration_ScramConfiguration{
@@ -432,14 +446,14 @@ func TestMapSecuritySyncOptions(t *testing.T) {
 				AclFilters: []*adminv2.ACLFilter{
 					{
 						ResourceFilter: &adminv2.ACLResourceFilter{
-							ResourceType: common.ACLResource_ACL_RESOURCE_TOPIC,
-							PatternType:  common.ACLPattern_ACL_PATTERN_LITERAL,
+							ResourceType: corecommonv1.ACLResource_ACL_RESOURCE_TOPIC,
+							PatternType:  corecommonv1.ACLPattern_ACL_PATTERN_LITERAL,
 							Name:         "sensitive-topic",
 						},
 						AccessFilter: &adminv2.ACLAccessFilter{
 							Principal:      "User:admin",
-							Operation:      common.ACLOperation_ACL_OPERATION_WRITE,
-							PermissionType: common.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW,
+							Operation:      corecommonv1.ACLOperation_ACL_OPERATION_WRITE,
+							PermissionType: corecommonv1.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW,
 							Host:           "192.168.1.1",
 						},
 					},
@@ -531,14 +545,14 @@ func TestMapACLFilter(t *testing.T) {
 			},
 			want: &adminv2.ACLFilter{
 				ResourceFilter: &adminv2.ACLResourceFilter{
-					ResourceType: common.ACLResource_ACL_RESOURCE_GROUP,
-					PatternType:  common.ACLPattern_ACL_PATTERN_PREFIXED,
+					ResourceType: corecommonv1.ACLResource_ACL_RESOURCE_GROUP,
+					PatternType:  corecommonv1.ACLPattern_ACL_PATTERN_PREFIXED,
 					Name:         "consumer-",
 				},
 				AccessFilter: &adminv2.ACLAccessFilter{
 					Principal:      "User:consumer",
-					Operation:      common.ACLOperation_ACL_OPERATION_READ,
-					PermissionType: common.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW,
+					Operation:      corecommonv1.ACLOperation_ACL_OPERATION_READ,
+					PermissionType: corecommonv1.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW,
 					Host:           "*",
 				},
 			},
@@ -626,10 +640,10 @@ func TestAdminClientOptsToCfg(t *testing.T) {
 			name: "with file-based TLS",
 			opts: &adminv2.ShadowLinkClientOptions{
 				BootstrapServers: []string{"localhost:9092"},
-				TlsSettings: &adminv2.TLSSettings{
+				TlsSettings: &corecommonv1.TLSSettings{
 					Enabled: true,
-					TlsSettings: &adminv2.TLSSettings_TlsFileSettings{
-						TlsFileSettings: &adminv2.TLSFileSettings{
+					TlsSettings: &corecommonv1.TLSSettings_TlsFileSettings{
+						TlsFileSettings: &corecommonv1.TLSFileSettings{
 							CaPath:   "/ca.crt",
 							KeyPath:  "/key.pem",
 							CertPath: "/cert.pem",
@@ -639,11 +653,13 @@ func TestAdminClientOptsToCfg(t *testing.T) {
 			},
 			want: &ShadowLinkClientOptions{
 				BootstrapServers: []string{"localhost:9092"},
-				TLSSettings: &TLSFileSettings{
-					Enabled:  true,
-					CAPath:   "/ca.crt",
-					KeyPath:  "/key.pem",
-					CertPath: "/cert.pem",
+				TLSSettings: &TLSSettings{
+					Enabled: true,
+					TLSFileSettings: &TLSFileSettings{
+						CAPath:   "/ca.crt",
+						KeyPath:  "/key.pem",
+						CertPath: "/cert.pem",
+					},
 				},
 			},
 		},
@@ -651,10 +667,10 @@ func TestAdminClientOptsToCfg(t *testing.T) {
 			name: "with PEM-based TLS",
 			opts: &adminv2.ShadowLinkClientOptions{
 				BootstrapServers: []string{"localhost:9092"},
-				TlsSettings: &adminv2.TLSSettings{
+				TlsSettings: &corecommonv1.TLSSettings{
 					Enabled: true,
-					TlsSettings: &adminv2.TLSSettings_TlsPemSettings{
-						TlsPemSettings: &adminv2.TLSPEMSettings{
+					TlsSettings: &corecommonv1.TLSSettings_TlsPemSettings{
+						TlsPemSettings: &corecommonv1.TLSPEMSettings{
 							Ca:   "ca-content",
 							Key:  "key-content",
 							Cert: "cert-content",
@@ -664,11 +680,13 @@ func TestAdminClientOptsToCfg(t *testing.T) {
 			},
 			want: &ShadowLinkClientOptions{
 				BootstrapServers: []string{"localhost:9092"},
-				TLSSettings: &TLSPEMSettings{
+				TLSSettings: &TLSSettings{
 					Enabled: true,
-					CA:      "ca-content",
-					Key:     "key-content",
-					Cert:    "cert-content",
+					TLSPEMSettings: &TLSPEMSettings{
+						CA:   "ca-content",
+						Key:  "key-content",
+						Cert: "cert-content",
+					},
 				},
 			},
 		},
@@ -688,10 +706,12 @@ func TestAdminClientOptsToCfg(t *testing.T) {
 			},
 			want: &ShadowLinkClientOptions{
 				BootstrapServers: []string{"localhost:9092"},
-				AuthenticationConfiguration: &ScramConfig{
-					Username:       "user",
-					Password:       "pass",
-					ScramMechanism: ScramMechanismScramSha512,
+				AuthenticationConfiguration: &AuthenticationConfiguration{
+					ScramConfiguration: &ScramConfiguration{
+						Username:       "user",
+						Password:       "pass",
+						ScramMechanism: ScramMechanismScramSha512,
+					},
 				},
 			},
 		},
@@ -708,8 +728,8 @@ func TestAdminClientOptsToCfg(t *testing.T) {
 func TestAdminTLSToCfg(t *testing.T) {
 	tests := []struct {
 		name string
-		tls  *adminv2.TLSSettings
-		want TLSSettings
+		tls  *corecommonv1.TLSSettings
+		want *TLSSettings
 	}{
 		{
 			name: "nil TLS returns nil",
@@ -718,61 +738,45 @@ func TestAdminTLSToCfg(t *testing.T) {
 		},
 		{
 			name: "file-based TLS settings",
-			tls: &adminv2.TLSSettings{
+			tls: &corecommonv1.TLSSettings{
 				Enabled: true,
-				TlsSettings: &adminv2.TLSSettings_TlsFileSettings{
-					TlsFileSettings: &adminv2.TLSFileSettings{
+				TlsSettings: &corecommonv1.TLSSettings_TlsFileSettings{
+					TlsFileSettings: &corecommonv1.TLSFileSettings{
 						CaPath:   "/path/to/ca",
 						KeyPath:  "/path/to/key",
 						CertPath: "/path/to/cert",
 					},
 				},
 			},
-			want: &TLSFileSettings{
-				Enabled:  true,
-				CAPath:   "/path/to/ca",
-				KeyPath:  "/path/to/key",
-				CertPath: "/path/to/cert",
+			want: &TLSSettings{
+				Enabled: true,
+				TLSFileSettings: &TLSFileSettings{
+					CAPath:   "/path/to/ca",
+					KeyPath:  "/path/to/key",
+					CertPath: "/path/to/cert",
+				},
 			},
 		},
 		{
 			name: "PEM-based TLS settings",
-			tls: &adminv2.TLSSettings{
+			tls: &corecommonv1.TLSSettings{
 				Enabled: false,
-				TlsSettings: &adminv2.TLSSettings_TlsPemSettings{
-					TlsPemSettings: &adminv2.TLSPEMSettings{
+				TlsSettings: &corecommonv1.TLSSettings_TlsPemSettings{
+					TlsPemSettings: &corecommonv1.TLSPEMSettings{
 						Ca:   "ca-pem",
 						Key:  "key-pem",
 						Cert: "cert-pem",
 					},
 				},
 			},
-			want: &TLSPEMSettings{
+			want: &TLSSettings{
 				Enabled: false,
-				CA:      "ca-pem",
-				Key:     "key-pem",
-				Cert:    "cert-pem",
-			},
-		},
-		{
-			name: "nil file settings returns nil",
-			tls: &adminv2.TLSSettings{
-				Enabled: true,
-				TlsSettings: &adminv2.TLSSettings_TlsFileSettings{
-					TlsFileSettings: nil,
+				TLSPEMSettings: &TLSPEMSettings{
+					CA:   "ca-pem",
+					Key:  "key-pem",
+					Cert: "cert-pem",
 				},
 			},
-			want: nil,
-		},
-		{
-			name: "nil PEM settings returns nil",
-			tls: &adminv2.TLSSettings{
-				Enabled: true,
-				TlsSettings: &adminv2.TLSSettings_TlsPemSettings{
-					TlsPemSettings: nil,
-				},
-			},
-			want: nil,
 		},
 	}
 
@@ -788,7 +792,7 @@ func TestAdminAuthToCfg(t *testing.T) {
 	tests := []struct {
 		name string
 		auth *adminv2.AuthenticationConfiguration
-		want AuthenticationConfiguration
+		want *AuthenticationConfiguration
 	}{
 		{
 			name: "nil auth returns nil",
@@ -806,10 +810,12 @@ func TestAdminAuthToCfg(t *testing.T) {
 					},
 				},
 			},
-			want: &ScramConfig{
-				Username:       "alice",
-				Password:       "secret",
-				ScramMechanism: ScramMechanismScramSha256,
+			want: &AuthenticationConfiguration{
+				ScramConfiguration: &ScramConfiguration{
+					Username:       "alice",
+					Password:       "secret",
+					ScramMechanism: ScramMechanismScramSha256,
+				},
 			},
 		},
 		{
@@ -823,10 +829,12 @@ func TestAdminAuthToCfg(t *testing.T) {
 					},
 				},
 			},
-			want: &ScramConfig{
-				Username:       "bob",
-				Password:       "password",
-				ScramMechanism: ScramMechanismScramSha512,
+			want: &AuthenticationConfiguration{
+				ScramConfiguration: &ScramConfiguration{
+					Username:       "bob",
+					Password:       "password",
+					ScramMechanism: ScramMechanismScramSha512,
+				},
 			},
 		},
 		{
@@ -978,14 +986,14 @@ func TestAdminSecuritySyncToCfg(t *testing.T) {
 				AclFilters: []*adminv2.ACLFilter{
 					{
 						ResourceFilter: &adminv2.ACLResourceFilter{
-							ResourceType: common.ACLResource_ACL_RESOURCE_TOPIC,
-							PatternType:  common.ACLPattern_ACL_PATTERN_LITERAL,
+							ResourceType: corecommonv1.ACLResource_ACL_RESOURCE_TOPIC,
+							PatternType:  corecommonv1.ACLPattern_ACL_PATTERN_LITERAL,
 							Name:         "sensitive-topic",
 						},
 						AccessFilter: &adminv2.ACLAccessFilter{
 							Principal:      "User:admin",
-							Operation:      common.ACLOperation_ACL_OPERATION_WRITE,
-							PermissionType: common.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW,
+							Operation:      corecommonv1.ACLOperation_ACL_OPERATION_WRITE,
+							PermissionType: corecommonv1.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW,
 							Host:           "192.168.1.1",
 						},
 					},
@@ -1083,14 +1091,14 @@ func TestAdminACLFilterToCfg(t *testing.T) {
 			name: "complete ACL filter",
 			filter: &adminv2.ACLFilter{
 				ResourceFilter: &adminv2.ACLResourceFilter{
-					ResourceType: common.ACLResource_ACL_RESOURCE_GROUP,
-					PatternType:  common.ACLPattern_ACL_PATTERN_PREFIXED,
+					ResourceType: corecommonv1.ACLResource_ACL_RESOURCE_GROUP,
+					PatternType:  corecommonv1.ACLPattern_ACL_PATTERN_PREFIXED,
 					Name:         "consumer-",
 				},
 				AccessFilter: &adminv2.ACLAccessFilter{
 					Principal:      "User:consumer",
-					Operation:      common.ACLOperation_ACL_OPERATION_READ,
-					PermissionType: common.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW,
+					Operation:      corecommonv1.ACLOperation_ACL_OPERATION_READ,
+					PermissionType: corecommonv1.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW,
 					Host:           "*",
 				},
 			},
@@ -1134,18 +1142,25 @@ func TestRoundTrip(t *testing.T) {
 			FetchMinBytes:          2048,
 			FetchMaxBytes:          20971520,
 			FetchPartitionMaxBytes: 512,
-			TLSSettings: &TLSFileSettings{
+			TLSSettings: &TLSSettings{
 				Enabled:             true,
 				DoNotSetSniHostname: true,
-				CAPath:              "/etc/ssl/certs/ca-bundle.pem",
-				KeyPath:             "/etc/ssl/private/client-key.pem",
-				CertPath:            "/etc/ssl/certs/client-cert.pem",
+				TLSFileSettings: &TLSFileSettings{
+					CAPath:   "/etc/ssl/certs/ca-bundle.pem",
+					KeyPath:  "/etc/ssl/private/client-key.pem",
+					CertPath: "/etc/ssl/certs/client-cert.pem",
+				},
 			},
-			AuthenticationConfiguration: &ScramConfig{
-				Username:       "shadow-replication-user",
-				Password:       "super-secure-password-123",
-				ScramMechanism: ScramMechanismScramSha512,
+			AuthenticationConfiguration: &AuthenticationConfiguration{
+				ScramConfiguration: &ScramConfiguration{
+					Username:       "shadow-replication-user",
+					Password:       "super-secure-password-123",
+					ScramMechanism: ScramMechanismScramSha512,
+				},
 			},
+		},
+		SchemaRegistrySyncOptions: &SchemaRegistrySyncOptions{
+			ShadowSchemaRegistryTopic: &ShadowSchemaRegistryTopic{},
 		},
 		TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
 			Interval: 45 * time.Second,
@@ -1178,7 +1193,8 @@ func TestRoundTrip(t *testing.T) {
 				"cleanup.policy",
 				"min.compaction.lag.ms",
 			},
-			ExcludeDefault: false,
+			ExcludeDefault:  false,
+			StartAtEarliest: &StartAtEarliest{},
 		},
 		ConsumerOffsetSyncOptions: &ConsumerOffsetSyncOptions{
 			Enabled:  true,
@@ -1274,21 +1290,21 @@ func TestAdminFilterTypeToCfg_UnknownValue(t *testing.T) {
 }
 
 func TestAdminACLResourceToCfg_UnknownValue(t *testing.T) {
-	result := adminACLResourceToCfg(common.ACLResource_ACL_RESOURCE_UNSPECIFIED)
+	result := adminACLResourceToCfg(corecommonv1.ACLResource_ACL_RESOURCE_UNSPECIFIED)
 	require.Equal(t, ACLResource(""), result, "unspecified ACL resource should return empty string")
 }
 
 func TestAdminACLPatternToCfg_UnknownValue(t *testing.T) {
-	result := adminACLPatternToCfg(common.ACLPattern_ACL_PATTERN_UNSPECIFIED)
+	result := adminACLPatternToCfg(corecommonv1.ACLPattern_ACL_PATTERN_UNSPECIFIED)
 	require.Equal(t, ACLPattern(""), result, "unspecified ACL pattern should return empty string")
 }
 
 func TestAdminACLOperationToCfg_UnknownValue(t *testing.T) {
-	result := adminACLOperationToCfg(common.ACLOperation_ACL_OPERATION_UNSPECIFIED)
+	result := adminACLOperationToCfg(corecommonv1.ACLOperation_ACL_OPERATION_UNSPECIFIED)
 	require.Equal(t, ACLOperation(""), result, "unspecified ACL operation should return empty string")
 }
 
 func TestAdminPermissionTypeToCfg_UnknownValue(t *testing.T) {
-	result := adminPermissionTypeToCfg(common.ACLPermissionType_ACL_PERMISSION_TYPE_UNSPECIFIED)
+	result := adminPermissionTypeToCfg(corecommonv1.ACLPermissionType_ACL_PERMISSION_TYPE_UNSPECIFIED)
 	require.Equal(t, ACLPermissionType(""), result, "unspecified permission type should return empty string")
 }

--- a/src/go/rpk/pkg/cli/shadow/types.go
+++ b/src/go/rpk/pkg/cli/shadow/types.go
@@ -10,8 +10,6 @@
 package shadow
 
 import (
-	"encoding/json"
-	"errors"
 	"time"
 )
 
@@ -26,6 +24,8 @@ type ShadowLinkConfig struct {
 	ConsumerOffsetSyncOptions *ConsumerOffsetSyncOptions `json:"consumer_offset_sync_options,omitempty" yaml:"consumer_offset_sync_options,omitempty"`
 	// Security settings sync options
 	SecuritySyncOptions *SecuritySettingsSyncOptions `json:"security_sync_options,omitempty" yaml:"security_sync_options,omitempty"`
+	// Schema Registry sync options
+	SchemaRegistrySyncOptions *SchemaRegistrySyncOptions `json:"schema_registry_sync_options,omitempty" yaml:"schema_registry_sync_options,omitempty"`
 }
 
 type ShadowLinkClientOptions struct {
@@ -37,9 +37,9 @@ type ShadowLinkClientOptions struct {
 	// message
 	SourceClusterID string `json:"source_cluster_id,omitempty" yaml:"source_cluster_id,omitempty"`
 	// TLS settings
-	TLSSettings TLSSettings `json:"tls_settings,omitempty" yaml:"tls_settings,omitempty"`
+	TLSSettings *TLSSettings `json:"tls_settings,omitempty" yaml:"tls_settings,omitempty"`
 	// Authentication settings
-	AuthenticationConfiguration AuthenticationConfiguration `json:"authentication_configuration,omitempty" yaml:"authentication_configuration,omitempty"`
+	AuthenticationConfiguration *AuthenticationConfiguration `json:"authentication_configuration,omitempty" yaml:"authentication_configuration,omitempty"`
 	// Max metadata age
 	// If 0 is provided, defaults to 10 seconds
 	MetadataMaxAgeMs int32 `json:"metadata_max_age_ms,omitempty" yaml:"metadata_max_age_ms,omitempty"`
@@ -63,22 +63,19 @@ type ShadowLinkClientOptions struct {
 	FetchPartitionMaxBytes int32 `json:"fetch_partition_max_bytes,omitempty" yaml:"fetch_partition_max_bytes,omitempty"`
 }
 
-const (
-	tlsSettingsTypeTLSFileSettings = "TLSFileSettings"
-	tlsSettingsTypeTLSPEMSettings  = "TLSPEMSettings"
-)
-
-// TLSSettings is an interface for TLS configuration, supporting file paths or
+// TLSSettings is the union for TLS configuration, supporting file paths or
 // PEM content.
-type TLSSettings interface {
-	tlsSettingType() string
-}
-
-type TLSFileSettings struct {
+type TLSSettings struct {
 	// Whether or not TLS is enabled
 	Enabled bool `json:"enabled" yaml:"enabled"`
 	// If true, the SNI hostname will not be provided when TLS is used
 	DoNotSetSniHostname bool `json:"do_not_set_sni_hostname,omitempty" yaml:"do_not_set_sni_hostname,omitempty"`
+	// One of the following must be provided:
+	TLSFileSettings *TLSFileSettings `json:"tls_file_settings,omitempty" yaml:"tls_file_settings,omitempty"`
+	TLSPEMSettings  *TLSPEMSettings  `json:"tls_pem_settings,omitempty" yaml:"tls_pem_settings,omitempty"`
+}
+
+type TLSFileSettings struct {
 	// Path to the CA
 	CAPath string `json:"ca_path,omitempty" yaml:"ca_path,omitempty"`
 	// Key and Cert are optional but if one is provided, then both must be
@@ -88,15 +85,7 @@ type TLSFileSettings struct {
 	CertPath string `json:"cert_path,omitempty" yaml:"cert_path,omitempty"`
 }
 
-func (*TLSFileSettings) tlsSettingType() string {
-	return tlsSettingsTypeTLSFileSettings
-}
-
 type TLSPEMSettings struct {
-	// Whether or not TLS is enabled
-	Enabled bool `json:"enabled" yaml:"enabled"`
-	// If true, the SNI hostname will not be provided when TLS is used
-	DoNotSetSniHostname bool `json:"do_not_set_sni_hostname,omitempty" yaml:"do_not_set_sni_hostname,omitempty"`
 	// The CA
 	CA string `json:"ca,omitempty" yaml:"ca,omitempty"`
 	// Key and Cert are optional but if one is provided, then both must be
@@ -106,14 +95,19 @@ type TLSPEMSettings struct {
 	Cert string `json:"cert,omitempty" yaml:"cert,omitempty"`
 }
 
-func (*TLSPEMSettings) tlsSettingType() string {
-	return tlsSettingsTypeTLSPEMSettings
+// AuthenticationConfiguration is the union for authentication configurations.
+type AuthenticationConfiguration struct {
+	ScramConfiguration *ScramConfiguration `json:"scram_configuration,omitempty" yaml:"scram_configuration,omitempty"`
 }
 
-const authenticationTypeScram = "SCRAM"
-
-type AuthenticationConfiguration interface {
-	authenticationType() string
+// ScramConfiguration is an authentication configuration using SCRAM.
+type ScramConfiguration struct {
+	// SCRAM username
+	Username string `json:"username,omitempty" yaml:"username,omitempty"`
+	// Password
+	Password string `json:"password,omitempty" yaml:"password,omitempty"`
+	// The SCRAM mechanism to use
+	ScramMechanism ScramMechanism `json:"scram_mechanism,omitempty" yaml:"scram_mechanism,omitempty"`
 }
 
 // ScramMechanism are valid SCRAM mechanisms.
@@ -125,20 +119,6 @@ const (
 	// ScramMechanismScramSha512 represents SCRAM-SHA-512.
 	ScramMechanismScramSha512 ScramMechanism = "SCRAM-SHA-512"
 )
-
-// ScramConfig is an authentication configuration using SCRAM.
-type ScramConfig struct {
-	// SCRAM username
-	Username string `json:"username,omitempty" yaml:"username,omitempty"`
-	// Password
-	Password string `json:"password,omitempty" yaml:"password,omitempty"`
-	// The SCRAM mechanism to use
-	ScramMechanism ScramMechanism `json:"scram_mechanism,omitempty" yaml:"scram_mechanism,omitempty"`
-}
-
-func (*ScramConfig) authenticationType() string {
-	return authenticationTypeScram
-}
 
 type TopicMetadataSyncOptions struct {
 	// How often to sync metadata
@@ -162,7 +142,20 @@ type TopicMetadataSyncOptions struct {
 	// If this is true, then only the properties listed in
 	// `synced_shadow_topic_properties` will be synced.
 	ExcludeDefault bool `json:"exclude_default,omitempty" yaml:"exclude_default,omitempty"`
+	// One Of the following must be selected
+	//
+	// - StartAtEarliest: Start syncing from the earliest offset
+	// - StartAtLatest: Start syncing from the latest offset
+	// - StartAtTimestamp: Start syncing from a specific timestamp
+	StartAtEarliest  *StartAtEarliest `json:"start_at_earliest,omitempty" yaml:"start_at_earliest,omitempty"`
+	StartAtLatest    *StartAtLatest   `json:"start_at_latest,omitempty" yaml:"start_at_latest,omitempty"`
+	StartAtTimestamp *time.Time       `json:"start_at_timestamp,omitempty" yaml:"start_at_timestamp,omitempty"`
 }
+
+type (
+	StartAtEarliest struct{}
+	StartAtLatest   struct{}
+)
 
 type ConsumerOffsetSyncOptions struct {
 	// Sync interval
@@ -183,6 +176,25 @@ type SecuritySettingsSyncOptions struct {
 	// ACL filters
 	ACLFilters []*ACLFilter `json:"acl_filters,omitempty" yaml:"acl_filters,omitempty"`
 }
+
+type SchemaRegistrySyncOptions struct {
+	// Shadow the entire source cluster's Schema Registry byte-for-byte.
+	// If set, the Shadow Link will attempt to add the `_schemas`
+	// topic to the list of Shadow Topics as long as:
+	// 1. The `_schemas` topic exists on the source cluster
+	// 2. The `_schemas` topic does not exist on the shadow cluster, or it is
+	// empty.
+	// If either of the above conditions are _not_ met, then the `_schemas`
+	// topic will _not_ be shadowed by this cluster. Unsetting this flag will
+	// _not_ remove the `_schemas` topic from shadowing if it has already been
+	// added.  Once made a shadow topic, the
+	// `_schemas` topic will be replicated byte-for-byte.  To stop shadowing the
+	// `_schemas` topic, unset this field, then either fail-over the topic or
+	// delete it.
+	ShadowSchemaRegistryTopic *ShadowSchemaRegistryTopic `json:"shadow_schema_registry_topic,omitempty" yaml:"shadow_schema_registry_topic,omitempty"`
+}
+
+type ShadowSchemaRegistryTopic struct{}
 
 type NameFilter struct {
 	// Literal or prefix
@@ -303,203 +315,3 @@ const (
 	ACLPermissionTypeAllow ACLPermissionType = "ALLOW"
 	ACLPermissionTypeDeny  ACLPermissionType = "DENY"
 )
-
-// checkRawTLSConfig checks the raw map for TLS config and determines if it's
-// file-based or PEM-based. It also performs validation to ensure that the
-// config is valid.
-func checkRawTLSConfig(raw map[string]any) (hasCA, hasCAPath bool, err error) {
-	var isEnabled bool
-	if val, hasEnabled := raw["enabled"]; hasEnabled {
-		if enabledVal, ok := val.(bool); ok {
-			isEnabled = enabledVal
-		}
-	}
-	// Determine type based on presence of fields; ca_path is mandatory for
-	// file-based and ca is mandatory for PEM-based.
-	_, hasCa := raw["ca"]
-	_, hasCaPath := raw["ca_path"]
-	if hasCaPath && hasCa {
-		return false, false, errors.New("both ca_path and ca are set; only one of these can be set")
-	}
-	if !hasCaPath && !hasCa && !isEnabled {
-		return false, false, errors.New("unrecognized 'tls_settings' neither ca_path nor ca are set; one of these must be set")
-	}
-	return hasCa, hasCaPath, nil
-}
-
-// tlsSettingsWrapper is used for YAML unmarshaling of TLSSettings interface.
-type tlsSettingsWrapper struct {
-	TLSSettings
-}
-
-// UnmarshalYAML implements custom YAML unmarshaling for TLSSettings interface.
-func (w *tlsSettingsWrapper) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var raw map[string]interface{}
-	if err := unmarshal(&raw); err != nil {
-		return err
-	}
-
-	_, hasCAPath, err := checkRawTLSConfig(raw)
-	if err != nil {
-		return err
-	}
-
-	if hasCAPath {
-		var fileSettings TLSFileSettings
-		if err := unmarshal(&fileSettings); err != nil {
-			return err
-		}
-		w.TLSSettings = &fileSettings
-		return nil
-	}
-
-	var pemSettings TLSPEMSettings
-	if err := unmarshal(&pemSettings); err != nil {
-		return err
-	}
-	w.TLSSettings = &pemSettings
-	return nil
-}
-
-// authConfigWrapper is used for YAML unmarshaling of AuthenticationConfiguration interface.
-type authConfigWrapper struct {
-	AuthenticationConfiguration
-}
-
-// UnmarshalYAML implements custom YAML unmarshaling for AuthenticationConfiguration interface.
-func (w *authConfigWrapper) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	// For now we only have SCRAM authentication, so we can unmarshal directly
-	var scramConfig ScramConfig
-	if err := unmarshal(&scramConfig); err != nil {
-		return err
-	}
-	w.AuthenticationConfiguration = &scramConfig
-	return nil
-}
-
-// UnmarshalYAML implements custom YAML unmarshaling for ShadowLinkClientOptions.
-func (s *ShadowLinkClientOptions) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	// Create an auxiliary struct with all fields explicitly defined
-	aux := &struct {
-		BootstrapServers            []string            `yaml:"bootstrap_servers"`
-		ClientID                    string              `yaml:"client_id"`
-		SourceClusterID             string              `yaml:"source_cluster_id"`
-		TLSSettings                 *tlsSettingsWrapper `yaml:"tls_settings"`
-		AuthenticationConfiguration *authConfigWrapper  `yaml:"authentication_configuration"`
-		MetadataMaxAgeMs            int32               `yaml:"metadata_max_age_ms"`
-		ConnectionTimeoutMs         int32               `yaml:"connection_timeout_ms"`
-		RetryBackoffMs              int32               `yaml:"retry_backoff_ms"`
-		FetchWaitMaxMs              int32               `yaml:"fetch_wait_max_ms"`
-		FetchMinBytes               int32               `yaml:"fetch_min_bytes"`
-		FetchMaxBytes               int32               `yaml:"fetch_max_bytes"`
-		FetchPartitionMaxBytes      int32               `yaml:"fetch_partition_max_bytes"`
-	}{}
-
-	if err := unmarshal(aux); err != nil {
-		return err
-	}
-
-	// Copy all the regular fields
-	s.BootstrapServers = aux.BootstrapServers
-	s.SourceClusterID = aux.SourceClusterID
-	s.MetadataMaxAgeMs = aux.MetadataMaxAgeMs
-	s.ConnectionTimeoutMs = aux.ConnectionTimeoutMs
-	s.RetryBackoffMs = aux.RetryBackoffMs
-	s.FetchWaitMaxMs = aux.FetchWaitMaxMs
-	s.FetchMinBytes = aux.FetchMinBytes
-	s.FetchMaxBytes = aux.FetchMaxBytes
-	s.FetchPartitionMaxBytes = aux.FetchPartitionMaxBytes
-
-	// Extract the interface values from the wrappers
-	if aux.TLSSettings != nil {
-		s.TLSSettings = aux.TLSSettings.TLSSettings
-	}
-	if aux.AuthenticationConfiguration != nil {
-		s.AuthenticationConfiguration = aux.AuthenticationConfiguration.AuthenticationConfiguration
-	}
-
-	return nil
-}
-
-// UnmarshalJSON implements custom JSON unmarshaling for TLSSettings interface.
-func (w *tlsSettingsWrapper) UnmarshalJSON(data []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-
-	_, hasCAPath, err := checkRawTLSConfig(raw)
-	if err != nil {
-		return err
-	}
-	if hasCAPath {
-		var fileSettings TLSFileSettings
-		if err := json.Unmarshal(data, &fileSettings); err != nil {
-			return err
-		}
-		w.TLSSettings = &fileSettings
-		return nil
-	}
-
-	var pemSettings TLSPEMSettings
-	if err := json.Unmarshal(data, &pemSettings); err != nil {
-		return err
-	}
-	w.TLSSettings = &pemSettings
-	return nil
-}
-
-// UnmarshalJSON implements custom JSON unmarshaling for AuthenticationConfiguration interface.
-func (w *authConfigWrapper) UnmarshalJSON(data []byte) error {
-	// For now we only have SCRAM authentication, so we can unmarshal directly
-	var scramConfig ScramConfig
-	if err := json.Unmarshal(data, &scramConfig); err != nil {
-		return err
-	}
-	w.AuthenticationConfiguration = &scramConfig
-	return nil
-}
-
-// UnmarshalJSON implements custom JSON unmarshaling for ShadowLinkClientOptions.
-func (s *ShadowLinkClientOptions) UnmarshalJSON(data []byte) error {
-	// Create an auxiliary struct with all fields explicitly defined
-	aux := &struct {
-		BootstrapServers            []string            `json:"bootstrap_servers"`
-		ClientID                    string              `json:"client_id"`
-		SourceClusterID             string              `json:"source_cluster_id"`
-		TLSSettings                 *tlsSettingsWrapper `json:"tls_settings"`
-		AuthenticationConfiguration *authConfigWrapper  `json:"authentication_configuration"`
-		MetadataMaxAgeMs            int32               `json:"metadata_max_age_ms"`
-		ConnectionTimeoutMs         int32               `json:"connection_timeout_ms"`
-		RetryBackoffMs              int32               `json:"retry_backoff_ms"`
-		FetchWaitMaxMs              int32               `json:"fetch_wait_max_ms"`
-		FetchMinBytes               int32               `json:"fetch_min_bytes"`
-		FetchMaxBytes               int32               `json:"fetch_max_bytes"`
-		FetchPartitionMaxBytes      int32               `json:"fetch_partition_max_bytes"`
-	}{}
-
-	if err := json.Unmarshal(data, aux); err != nil {
-		return err
-	}
-
-	// Copy all the regular fields
-	s.BootstrapServers = aux.BootstrapServers
-	s.SourceClusterID = aux.SourceClusterID
-	s.MetadataMaxAgeMs = aux.MetadataMaxAgeMs
-	s.ConnectionTimeoutMs = aux.ConnectionTimeoutMs
-	s.RetryBackoffMs = aux.RetryBackoffMs
-	s.FetchWaitMaxMs = aux.FetchWaitMaxMs
-	s.FetchMinBytes = aux.FetchMinBytes
-	s.FetchMaxBytes = aux.FetchMaxBytes
-	s.FetchPartitionMaxBytes = aux.FetchPartitionMaxBytes
-
-	// Extract the interface values from the wrappers
-	if aux.TLSSettings != nil {
-		s.TLSSettings = aux.TLSSettings.TLSSettings
-	}
-	if aux.AuthenticationConfiguration != nil {
-		s.AuthenticationConfiguration = aux.AuthenticationConfiguration.AuthenticationConfiguration
-	}
-
-	return nil
-}

--- a/src/go/rpk/pkg/cli/shadow/types_test.go
+++ b/src/go/rpk/pkg/cli/shadow/types_test.go
@@ -14,13 +14,17 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
-
 	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
 	"gopkg.in/yaml.v2"
 )
 
@@ -29,7 +33,6 @@ func TestShadowLinkConfigUnmarshalYAML(t *testing.T) {
 		name     string
 		yamlData string
 		want     ShadowLinkConfig
-		wantErr  bool
 	}{
 		{
 			name: "complete config with file-based TLS",
@@ -42,13 +45,15 @@ client_options:
   source_cluster_id: "source-123"
   tls_settings:
     enabled: true
-    ca_path: "/path/to/ca.crt"
-    key_path: "/path/to/key.pem"
-    cert_path: "/path/to/cert.pem"
+    tls_file_settings:
+      ca_path: "/path/to/ca.crt"
+      key_path: "/path/to/key.pem"
+      cert_path: "/path/to/cert.pem"
   authentication_configuration:
-    username: "testuser"
-    password: "testpass"
-    scram_mechanism: "SCRAM-SHA-256"
+    scram_configuration:
+      username: "testuser"
+      password: "testpass"
+      scram_mechanism: "SCRAM-SHA-256"
   metadata_max_age_ms: 10000
   connection_timeout_ms: 1000
 topic_metadata_sync_options:
@@ -75,16 +80,20 @@ security_sync_options:
 				ClientOptions: &ShadowLinkClientOptions{
 					BootstrapServers: []string{"broker1:9092", "broker2:9092"},
 					SourceClusterID:  "source-123",
-					TLSSettings: &TLSFileSettings{
-						Enabled:  true,
-						CAPath:   "/path/to/ca.crt",
-						KeyPath:  "/path/to/key.pem",
-						CertPath: "/path/to/cert.pem",
+					TLSSettings: &TLSSettings{
+						Enabled: true,
+						TLSFileSettings: &TLSFileSettings{
+							CAPath:   "/path/to/ca.crt",
+							KeyPath:  "/path/to/key.pem",
+							CertPath: "/path/to/cert.pem",
+						},
 					},
-					AuthenticationConfiguration: &ScramConfig{
-						Username:       "testuser",
-						Password:       "testpass",
-						ScramMechanism: "SCRAM-SHA-256",
+					AuthenticationConfiguration: &AuthenticationConfiguration{
+						ScramConfiguration: &ScramConfiguration{
+							Username:       "testuser",
+							Password:       "testpass",
+							ScramMechanism: "SCRAM-SHA-256",
+						},
 					},
 					MetadataMaxAgeMs:    10000,
 					ConnectionTimeoutMs: 1000,
@@ -127,37 +136,45 @@ client_options:
     - "broker1:9092"
   tls_settings:
     enabled: true
-    ca: |
-      -----BEGIN CERTIFICATE-----
-      test-ca-content
-      -----END CERTIFICATE-----
-    key: |
-      -----BEGIN PRIVATE KEY-----
-      test-key-content
-      -----END PRIVATE KEY-----
-    cert: |
-      -----BEGIN CERTIFICATE-----
-      test-cert-content
-      -----END CERTIFICATE-----
+    do_not_set_sni_hostname: true
+    tls_pem_settings:
+      ca: |
+        -----BEGIN CERTIFICATE-----
+        test-ca-content
+        -----END CERTIFICATE-----
+      key: |
+        -----BEGIN PRIVATE KEY-----
+        test-key-content
+        -----END PRIVATE KEY-----
+      cert: |
+        -----BEGIN CERTIFICATE-----
+        test-cert-content
+        -----END CERTIFICATE-----
   authentication_configuration:
-    username: "pemuser"
-    password: "pempass"
-    scram_mechanism: "SCRAM-SHA-512"
+    scram_configuration:
+      username: "pemuser"
+      password: "pempass"
+      scram_mechanism: "SCRAM-SHA-512"
 `,
 			want: ShadowLinkConfig{
 				Name: "pem-test",
 				ClientOptions: &ShadowLinkClientOptions{
 					BootstrapServers: []string{"broker1:9092"},
-					TLSSettings: &TLSPEMSettings{
-						Enabled: true,
-						CA:      "-----BEGIN CERTIFICATE-----\ntest-ca-content\n-----END CERTIFICATE-----\n",
-						Key:     "-----BEGIN PRIVATE KEY-----\ntest-key-content\n-----END PRIVATE KEY-----\n",
-						Cert:    "-----BEGIN CERTIFICATE-----\ntest-cert-content\n-----END CERTIFICATE-----\n",
+					TLSSettings: &TLSSettings{
+						Enabled:             true,
+						DoNotSetSniHostname: true,
+						TLSPEMSettings: &TLSPEMSettings{
+							CA:   "-----BEGIN CERTIFICATE-----\ntest-ca-content\n-----END CERTIFICATE-----\n",
+							Key:  "-----BEGIN PRIVATE KEY-----\ntest-key-content\n-----END PRIVATE KEY-----\n",
+							Cert: "-----BEGIN CERTIFICATE-----\ntest-cert-content\n-----END CERTIFICATE-----\n",
+						},
 					},
-					AuthenticationConfiguration: &ScramConfig{
-						Username:       "pemuser",
-						Password:       "pempass",
-						ScramMechanism: "SCRAM-SHA-512",
+					AuthenticationConfiguration: &AuthenticationConfiguration{
+						ScramConfiguration: &ScramConfiguration{
+							Username:       "pemuser",
+							Password:       "pempass",
+							ScramMechanism: "SCRAM-SHA-512",
+						},
 					},
 				},
 			},
@@ -177,170 +194,14 @@ client_options:
 				},
 			},
 		},
-		{
-			name: "invalid TLS - both ca_path and ca",
-			yamlData: `
-name: "invalid-tls"
-client_options:
-  bootstrap_servers:
-    - "broker1:9092"
-  tls_settings:
-    ca_path: "/path/to/ca.crt"
-    ca: "cert-content"
-`,
-			wantErr: true,
-		},
-		{
-			name: "invalid TLS - neither ca_path nor ca",
-			yamlData: `
-name: "invalid-tls2"
-client_options:
-  bootstrap_servers:
-    - "broker1:9092"
-  tls_settings:
-    key_path: "/path/to/key.pem"
-`,
-			wantErr: true,
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var got ShadowLinkConfig
 			err := yaml.Unmarshal([]byte(tt.yamlData), &got)
-
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func TestTLSSettingsUnmarshalYAML(t *testing.T) {
-	tests := []struct {
-		name     string
-		yamlData string
-		want     TLSSettings
-		wantErr  bool
-	}{
-		{
-			name:     "just enabled TLS",
-			yamlData: "enabled: true",
-			want: &TLSPEMSettings{
-				Enabled: true,
-			},
-		},
-		{
-			name: "file-based TLS settings",
-			yamlData: `
-ca_path: "/path/to/ca.crt"
-key_path: "/path/to/key.pem"
-cert_path: "/path/to/cert.pem"
-`,
-			want: &TLSFileSettings{
-				CAPath:   "/path/to/ca.crt",
-				KeyPath:  "/path/to/key.pem",
-				CertPath: "/path/to/cert.pem",
-			},
-		},
-		{
-			name: "PEM-based TLS settings",
-			yamlData: `
-ca: "ca-content"
-key: "key-content"
-cert: "cert-content"
-`,
-			want: &TLSPEMSettings{
-				CA:   "ca-content",
-				Key:  "key-content",
-				Cert: "cert-content",
-			},
-		},
-		{
-			name: "error - both ca_path and ca",
-			yamlData: `
-ca_path: "/path/to/ca.crt"
-ca: "ca-content"
-`,
-			wantErr: true,
-		},
-		{
-			name: "error - neither ca_path nor ca (enabled is false)",
-			yamlData: `
-enabled: false
-key_path: "/path/to/key.pem"
-`,
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var wrapper tlsSettingsWrapper
-			err := yaml.Unmarshal([]byte(tt.yamlData), &wrapper)
-
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-			require.Equal(t, tt.want, wrapper.TLSSettings)
-		})
-	}
-}
-
-func TestAuthenticationConfigurationUnmarshalYAML(t *testing.T) {
-	tests := []struct {
-		name     string
-		yamlData string
-		want     AuthenticationConfiguration
-		wantErr  bool
-	}{
-		{
-			name: "SCRAM authentication",
-			yamlData: `
-username: "testuser"
-password: "testpass"
-scram_mechanism: "SCRAM-SHA-256"
-`,
-			want: &ScramConfig{
-				Username:       "testuser",
-				Password:       "testpass",
-				ScramMechanism: "SCRAM-SHA-256",
-			},
-		},
-		{
-			name: "SCRAM SHA-512",
-			yamlData: `
-username: "testuser2"
-password: "testpass2"
-scram_mechanism: "SCRAM-SHA-512"
-`,
-			want: &ScramConfig{
-				Username:       "testuser2",
-				Password:       "testpass2",
-				ScramMechanism: "SCRAM-SHA-512",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var wrapper authConfigWrapper
-			err := yaml.Unmarshal([]byte(tt.yamlData), &wrapper)
-
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-			require.Equal(t, tt.want, wrapper.AuthenticationConfiguration)
 		})
 	}
 }
@@ -350,7 +211,6 @@ func TestShadowLinkConfigUnmarshalJSON(t *testing.T) {
 		name     string
 		jsonData string
 		want     ShadowLinkConfig
-		wantErr  bool
 	}{
 		{
 			name: "complete config with file-based TLS",
@@ -361,14 +221,18 @@ func TestShadowLinkConfigUnmarshalJSON(t *testing.T) {
 					"source_cluster_id": "source-123",
 					"tls_settings": {
 						"enabled": false,
-						"ca_path": "/path/to/ca.crt",
-						"key_path": "/path/to/key.pem",
-						"cert_path": "/path/to/cert.pem"
+						"tls_file_settings": {
+							"ca_path": "/path/to/ca.crt",
+							"key_path": "/path/to/key.pem",
+							"cert_path": "/path/to/cert.pem"
+						}
 					},
 					"authentication_configuration": {
-						"username": "testuser",
-						"password": "testpass",
-						"scram_mechanism": "SCRAM-SHA-256"
+						"scram_configuration": {
+							"username": "testuser",
+							"password": "testpass",
+							"scram_mechanism": "SCRAM-SHA-256"
+						}
 					},
 					"metadata_max_age_ms": 10000,
 					"connection_timeout_ms": 1000
@@ -402,16 +266,20 @@ func TestShadowLinkConfigUnmarshalJSON(t *testing.T) {
 				ClientOptions: &ShadowLinkClientOptions{
 					BootstrapServers: []string{"broker1:9092", "broker2:9092"},
 					SourceClusterID:  "source-123",
-					TLSSettings: &TLSFileSettings{
-						Enabled:  false,
-						CAPath:   "/path/to/ca.crt",
-						KeyPath:  "/path/to/key.pem",
-						CertPath: "/path/to/cert.pem",
+					TLSSettings: &TLSSettings{
+						TLSFileSettings: &TLSFileSettings{
+							CAPath:   "/path/to/ca.crt",
+							KeyPath:  "/path/to/key.pem",
+							CertPath: "/path/to/cert.pem",
+						},
+						Enabled: false,
 					},
-					AuthenticationConfiguration: &ScramConfig{
-						Username:       "testuser",
-						Password:       "testpass",
-						ScramMechanism: "SCRAM-SHA-256",
+					AuthenticationConfiguration: &AuthenticationConfiguration{
+						ScramConfiguration: &ScramConfiguration{
+							Username:       "testuser",
+							Password:       "testpass",
+							ScramMechanism: "SCRAM-SHA-256",
+						},
 					},
 					MetadataMaxAgeMs:    10000,
 					ConnectionTimeoutMs: 1000,
@@ -452,14 +320,18 @@ func TestShadowLinkConfigUnmarshalJSON(t *testing.T) {
 				"client_options": {
 					"bootstrap_servers": ["broker1:9092"],
 					"tls_settings": {
-						"ca": "-----BEGIN CERTIFICATE-----\ntest-ca-content\n-----END CERTIFICATE-----\n",
-						"key": "-----BEGIN PRIVATE KEY-----\ntest-key-content\n-----END PRIVATE KEY-----\n",
-						"cert": "-----BEGIN CERTIFICATE-----\ntest-cert-content\n-----END CERTIFICATE-----\n"
+						"tls_pem_settings": {
+							"ca": "-----BEGIN CERTIFICATE-----\ntest-ca-content\n-----END CERTIFICATE-----\n",
+							"key": "-----BEGIN PRIVATE KEY-----\ntest-key-content\n-----END PRIVATE KEY-----\n",
+							"cert": "-----BEGIN CERTIFICATE-----\ntest-cert-content\n-----END CERTIFICATE-----\n"
+						}
 					},
 					"authentication_configuration": {
-						"username": "pemuser",
-						"password": "pempass",
-						"scram_mechanism": "SCRAM-SHA-512"
+						"scram_configuration": {
+							"username": "pemuser",
+							"password": "pempass",
+							"scram_mechanism": "SCRAM-SHA-512"
+						}
 					}
 				}
 			}`,
@@ -467,15 +339,19 @@ func TestShadowLinkConfigUnmarshalJSON(t *testing.T) {
 				Name: "pem-test",
 				ClientOptions: &ShadowLinkClientOptions{
 					BootstrapServers: []string{"broker1:9092"},
-					TLSSettings: &TLSPEMSettings{
-						CA:   "-----BEGIN CERTIFICATE-----\ntest-ca-content\n-----END CERTIFICATE-----\n",
-						Key:  "-----BEGIN PRIVATE KEY-----\ntest-key-content\n-----END PRIVATE KEY-----\n",
-						Cert: "-----BEGIN CERTIFICATE-----\ntest-cert-content\n-----END CERTIFICATE-----\n",
+					TLSSettings: &TLSSettings{
+						TLSPEMSettings: &TLSPEMSettings{
+							CA:   "-----BEGIN CERTIFICATE-----\ntest-ca-content\n-----END CERTIFICATE-----\n",
+							Key:  "-----BEGIN PRIVATE KEY-----\ntest-key-content\n-----END PRIVATE KEY-----\n",
+							Cert: "-----BEGIN CERTIFICATE-----\ntest-cert-content\n-----END CERTIFICATE-----\n",
+						},
 					},
-					AuthenticationConfiguration: &ScramConfig{
-						Username:       "pemuser",
-						Password:       "pempass",
-						ScramMechanism: "SCRAM-SHA-512",
+					AuthenticationConfiguration: &AuthenticationConfiguration{
+						ScramConfiguration: &ScramConfiguration{
+							Username:       "pemuser",
+							Password:       "pempass",
+							ScramMechanism: "SCRAM-SHA-512",
+						},
 					},
 				},
 			},
@@ -495,256 +371,53 @@ func TestShadowLinkConfigUnmarshalJSON(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "invalid TLS - both ca_path and ca",
-			jsonData: `{
-				"name": "invalid-tls",
-				"client_options": {
-					"bootstrap_servers": ["broker1:9092"],
-					"tls_settings": {
-						"ca_path": "/path/to/ca.crt",
-						"ca": "cert-content"
-					}
-				}
-			}`,
-			wantErr: true,
-		},
-		{
-			name: "invalid TLS - neither ca_path nor ca",
-			jsonData: `{
-				"name": "invalid-tls2",
-				"client_options": {
-					"bootstrap_servers": ["broker1:9092"],
-					"tls_settings": {
-						"key_path": "/path/to/key.pem"
-					}
-				}
-			}`,
-			wantErr: true,
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var got ShadowLinkConfig
 			err := json.Unmarshal([]byte(tt.jsonData), &got)
-
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestTLSSettingsUnmarshalJSON(t *testing.T) {
-	tests := []struct {
-		name     string
-		jsonData string
-		want     TLSSettings
-		wantErr  bool
-	}{
-		{
-			name:     "just enabled TLS",
-			jsonData: `{"enabled": true}`,
-			want: &TLSPEMSettings{
-				Enabled: true,
-			},
-		},
-		{
-			name: "file-based TLS settings",
-			jsonData: `{
-				"enabled": true,
-				"ca_path": "/path/to/ca.crt",
-				"key_path": "/path/to/key.pem",
-				"cert_path": "/path/to/cert.pem"
-			}`,
-			want: &TLSFileSettings{
-				Enabled:  true,
-				CAPath:   "/path/to/ca.crt",
-				KeyPath:  "/path/to/key.pem",
-				CertPath: "/path/to/cert.pem",
-			},
-		},
-		{
-			name: "PEM-based TLS settings",
-			jsonData: `{
-				"enabled": false,
-				"ca": "ca-content",
-				"key": "key-content",
-				"cert": "cert-content"
-			}`,
-			want: &TLSPEMSettings{
-				Enabled: false,
-				CA:      "ca-content",
-				Key:     "key-content",
-				Cert:    "cert-content",
-			},
-		},
-		{
-			name: "error - both ca_path and ca",
-			jsonData: `{
-				"ca_path": "/path/to/ca.crt",
-				"ca": "ca-content"
-			}`,
-			wantErr: true,
-		},
-		{
-			name: "error - neither ca_path nor ca and enabled is false",
-			jsonData: `{
-				"enabled": false,
-				"key_path": "/path/to/key.pem"
-			}`,
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var wrapper tlsSettingsWrapper
-			err := json.Unmarshal([]byte(tt.jsonData), &wrapper)
-
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-			require.Equal(t, tt.want, wrapper.TLSSettings)
-		})
-	}
-}
-
-func TestAuthenticationConfigurationUnmarshalJSON(t *testing.T) {
-	tests := []struct {
-		name     string
-		jsonData string
-		want     AuthenticationConfiguration
-		wantErr  bool
-	}{
-		{
-			name: "SCRAM authentication",
-			jsonData: `{
-				"username": "testuser",
-				"password": "testpass",
-				"scram_mechanism": "SCRAM-SHA-256"
-			}`,
-			want: &ScramConfig{
-				Username:       "testuser",
-				Password:       "testpass",
-				ScramMechanism: "SCRAM-SHA-256",
-			},
-		},
-		{
-			name: "SCRAM SHA-512",
-			jsonData: `{
-				"username": "testuser2",
-				"password": "testpass2",
-				"scram_mechanism": "SCRAM-SHA-512"
-			}`,
-			want: &ScramConfig{
-				Username:       "testuser2",
-				Password:       "testpass2",
-				ScramMechanism: "SCRAM-SHA-512",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var wrapper authConfigWrapper
-			err := json.Unmarshal([]byte(tt.jsonData), &wrapper)
-
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-			require.Equal(t, tt.want, wrapper.AuthenticationConfiguration)
-		})
-	}
-}
-
-// TestShadowLinkConfigChanges validates that ShadowLinkConfig stays in sync
-// with the protobuf-generated adminv2.ShadowLinkConfigurations structure.
-func TestShadowLinkConfigChanges(t *testing.T) {
+// TestShadowLinkConfigDrift validates that ShadowLinkConfig stays in sync with
+// the protobuf-generated adminv2.ShadowLinkConfigurations.
+func TestShadowLinkConfigDrift(t *testing.T) {
+	// This is the list of fields that we _know_ are represented differently.
 	excludedPatterns := []*regexp.Regexp{
-		// OUTPUT_ONLY fields, we don't care about them in our configuration.
-		// We do an exact match.
-		regexp.MustCompile(`^client_options\.client_id$`),
 		// Intervals are represented as time.Duration but in protobuf they are
 		// durationpb.Duration which has an underlying struct with exported
 		// fields.
 		regexp.MustCompile(`^.*\.interval$`),
-		// Filter types are enums in protobuf, but strings in our config.
+		// Enums in protobuf but string in our config.
 		regexp.MustCompile(`_filters\..*_type$`),
-		// Special-case exclusion for exactly this one field which is also an
-		// enum.
+		regexp.MustCompile(`^.*\.scram_configuration.scram_mechanism$`),
 		regexp.MustCompile(`^security_sync_options\.acl_filters\.access_filter\.operation$`),
-		// A one-of type in protobuf, represented as an interface{} in Go.
-		regexp.MustCompile(`client_options.tls_settings.enabled$`),
-		regexp.MustCompile(`client_options.tls_settings.do_not_set_sni_hostname$`),
+		// one of: start_at_timestamp is a oneof field in protobuf but is a
+		// duration. In proto, it is parsed as a struct containing a timestamp
+		// field, but in the resulting JSON it is represented as a timestamp,
+		// not a struct.
+		regexp.MustCompile(`^topic_metadata_sync_options\.start_at_timestamp$`),
 	}
 
-	var walk func(v reflect.Type, parentName string, m map[string]string)
-	walk = func(v reflect.Type, parentName string, m map[string]string) {
-		for i := 0; i < v.NumField(); i++ {
-			field := v.Field(i)
-			if field.IsExported() {
-				fullName := strings.Split(field.Tag.Get("json"), ",")[0]
-				if parentName != "" && fullName != "" {
-					fullName = parentName + "." + fullName
-				}
+	// Use protoreflect to walk the protobuf message.
+	protoConfigMap := make(map[string]string)
+	msgDesc := new(adminv2.ShadowLinkConfigurations).ProtoReflect().Descriptor()
+	walkProtoMessage(msgDesc, "", protoConfigMap, excludedPatterns)
 
-				// This is to avoid repetition on oneof types in protobuf which are represented as
-				// structs with no exported fields. And to exclude OUTPUT_ONLY fields which are
-				// still present in the struct but don't matter for our config comparison.
-				if excluded := isExcluded(fullName, excludedPatterns); fullName == "" || excluded {
-					continue
-				}
-				typ := field.Type
-				if typ.Kind() == reflect.Pointer {
-					typ = typ.Elem()
-				}
-
-				m[fullName] = normalizeKindString(field.Type)
-
-				// Recurse into structs and slices of structs/pointers to structs.
-				if typ.Kind() == reflect.Struct {
-					walk(typ, fullName, m)
-				}
-				if typ.Kind() == reflect.Slice {
-					elem := typ.Elem()
-					if elem.Kind() != reflect.Pointer && elem.Kind() != reflect.Struct {
-						// No need to recurse into slices of primitives.
-						continue
-					}
-					if elem.Kind() == reflect.Pointer {
-						elem = elem.Elem()
-					}
-					walk(elem, fullName, m)
-				}
-			}
-		}
-	}
-
-	// It's a flat map of field:type
-	adminConfigMap := make(map[string]string)
-	adminType := reflect.TypeOf(adminv2.ShadowLinkConfigurations{})
-	walk(adminType, "", adminConfigMap)
-
+	// Use regular reflection to walk the Go struct.
 	shadowConfigMap := make(map[string]string)
 	shadowConfigType := reflect.TypeOf(ShadowLinkConfig{})
-	walk(shadowConfigType, "", shadowConfigMap)
+	walkType(shadowConfigType, "", shadowConfigMap, excludedPatterns)
 
-	for k, v := range adminConfigMap {
+	// Compare the two maps
+	for k, v := range protoConfigMap {
 		sv, ok := shadowConfigMap[k]
 		if !ok {
-			t.Errorf("Missing field: %q is missing in ShadowLinkConfig; was the proto updated? is it OUTPUT_ONLY?", k)
+			t.Errorf("Missing field: %q is missing in ShadowLinkConfig; was the proto updated?", k)
 			continue
 		}
 		if sv != v {
@@ -754,16 +427,19 @@ func TestShadowLinkConfigChanges(t *testing.T) {
 	}
 }
 
-// This is our opinionated normalization of type strings to avoid false
-// positives and deal with some differences in representation between protobuf
-// and our selected Go types.
+// isExcluded checks if a field matches any of the excluded patterns.
+func isExcluded(field string, excludedPatterns []*regexp.Regexp) bool {
+	for _, re := range excludedPatterns {
+		if re.MatchString(field) {
+			return true
+		}
+	}
+	return false
+}
+
 func normalizeKindString(t reflect.Type) string {
 	var kString string
 	switch k := t.Kind(); k {
-	case reflect.Interface:
-		// Opinionated: we use an interface to represent a union type
-		// (oneof in protobuf), while protobuf generates a struct.
-		return "struct"
 	case reflect.Pointer:
 		kString = normalizeKindString(t.Elem())
 	case reflect.Slice, reflect.Array:
@@ -776,12 +452,132 @@ func normalizeKindString(t reflect.Type) string {
 	return kString
 }
 
-// isExcluded checks if a field matches any of the excluded patterns.
-func isExcluded(field string, excludedPatterns []*regexp.Regexp) bool {
-	for _, re := range excludedPatterns {
-		if re.MatchString(field) {
-			return true
+// protoKindToString converts a protoreflect.Kind to a type string to match
+// our normalized type strings.
+func protoKindToString(kind protoreflect.Kind) string {
+	switch kind {
+	case protoreflect.BoolKind:
+		return "bool"
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind:
+		return "int32"
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+		return "int64"
+	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
+		return "uint32"
+	case protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+		return "uint64"
+	case protoreflect.FloatKind:
+		return "float32"
+	case protoreflect.DoubleKind:
+		return "float64"
+	case protoreflect.StringKind:
+		return "string"
+	case protoreflect.BytesKind:
+		return "[]uint8"
+	case protoreflect.EnumKind:
+		return "int32"
+	case protoreflect.MessageKind:
+		return "struct"
+	default:
+		return "unknown"
+	}
+}
+
+func walkType(v reflect.Type, parentName string, m map[string]string, excludedPatterns []*regexp.Regexp) {
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		if field.IsExported() {
+			fullName := strings.Split(field.Tag.Get("json"), ",")[0]
+			if parentName != "" && fullName != "" {
+				fullName = parentName + "." + fullName
+			}
+
+			// This is to avoid repetition on oneof types in protobuf which are represented as
+			// structs with no exported fields. And to exclude OUTPUT_ONLY fields which are
+			// still present in the struct but don't matter for our config comparison.
+			if excluded := isExcluded(fullName, excludedPatterns); fullName == "" || excluded {
+				continue
+			}
+			typ := field.Type
+			if typ.Kind() == reflect.Pointer {
+				typ = typ.Elem()
+			}
+
+			m[fullName] = normalizeKindString(field.Type)
+
+			// Recurse into structs and slices of structs/pointers to structs.
+			if typ.Kind() == reflect.Struct {
+				walkType(typ, fullName, m, excludedPatterns)
+			}
+			if typ.Kind() == reflect.Slice {
+				elem := typ.Elem()
+				if elem.Kind() != reflect.Pointer && elem.Kind() != reflect.Struct {
+					// No need to recurse into slices of primitives.
+					continue
+				}
+				if elem.Kind() == reflect.Pointer {
+					elem = elem.Elem()
+				}
+				walkType(elem, fullName, m, excludedPatterns)
+			}
 		}
 	}
-	return false
+}
+
+// protoFieldToTypeString converts a protoreflect.FieldDescriptor to a normalized type string
+// that is compatible with the output from normalizeKindString.
+func protoFieldToTypeString(fd protoreflect.FieldDescriptor) string {
+	if fd.IsList() {
+		// Repeated field (slice)
+		return fmt.Sprintf("[]%s", protoKindToString(fd.Kind()))
+	}
+	return protoKindToString(fd.Kind())
+}
+
+// walkProtoMessage walks a protobuf message descriptor using protoreflect and builds
+// a map of field paths to type strings, similar to the walk function but using
+// protoreflect API instead of regular reflection.
+func walkProtoMessage(md protoreflect.MessageDescriptor, parentName string, m map[string]string, excludedPatterns []*regexp.Regexp) {
+	fields := md.Fields()
+	for i := 0; i < fields.Len(); i++ {
+		field := fields.Get(i)
+		if isFieldOutputOnly(field) {
+			continue
+		}
+
+		// Get the proto field name (snake_case) to match the Go struct json tags
+		fieldName := string(field.Name())
+		fullName := fieldName
+		if parentName != "" {
+			fullName = parentName + "." + fieldName
+		}
+
+		// Check if this field should be excluded
+		if isExcluded(fullName, excludedPatterns) {
+			continue
+		}
+
+		// Get the type string for this field
+		typeStr := protoFieldToTypeString(field)
+		m[fullName] = typeStr
+
+		// Recurse into message types
+		if field.Kind() == protoreflect.MessageKind {
+			msgDesc := field.Message()
+			walkProtoMessage(msgDesc, fullName, m, excludedPatterns)
+		}
+	}
+}
+
+func isFieldOutputOnly(field protoreflect.FieldDescriptor) bool {
+	f, ok := field.Options().(*descriptorpb.FieldOptions)
+	if !ok {
+		return false
+	}
+	e := proto.GetExtension(f, annotations.E_FieldBehavior)
+	fb, ok := e.([]annotations.FieldBehavior)
+	if !ok {
+		return false
+	}
+	return slices.Contains(fb, annotations.FieldBehavior_OUTPUT_ONLY)
 }

--- a/src/go/rpk/pkg/cli/shadow/update.go
+++ b/src/go/rpk/pkg/cli/shadow/update.go
@@ -58,6 +58,9 @@ you must delete and recreate it.
 			updatedCfg, err := rpkos.EditTmpYAMLFile(fs, originalCfg)
 			out.MaybeDie(err, "unable to edit Shadow Link configuration: %v", err)
 
+			err = validateParsedShadowLinkConfig(updatedCfg)
+			out.MaybeDie(err, "invalid Shadow Link configuration: %v", err)
+
 			if updatedCfg.Name != originalCfg.Name {
 				out.Die("Shadow Link name cannot be changed; if you need to rename, please delete and recreate the shadow link")
 			}
@@ -86,7 +89,7 @@ func addRedactedPasswordString(cfg *ShadowLinkConfig, link *adminv2.ShadowLink) 
 	if !isPassSet {
 		return
 	}
-	if auth, ok := cfg.ClientOptions.AuthenticationConfiguration.(*ScramConfig); ok && auth != nil {
-		auth.Password = "<redacted>"
+	if auth := cfg.ClientOptions.AuthenticationConfiguration; auth != nil && auth.ScramConfiguration != nil {
+		auth.ScramConfiguration.Password = "<redacted>"
 	}
 }


### PR DESCRIPTION
This PR adds support for:

- OneOf configurations for Start Offsets in the topic sync.
- Schema Registry Sync Options
- Now TLS_CONFIG and SCRAM_CONFIGURATION will have children fields instead of rpk guessing which type it is (this is to bring rpk config closer to the proto definition).

On top of that it includes the following changes:
- Now our config drift test uses protoreflect and autodetects OUTPUT_ONLY fields.
- Migrated the core package used for TLS config to the new commonv1 package (recently moved in core).
- Add the new fields to the output of `describe`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

