### PR TITLE
tuner: Refactor net tuner 

### DIFF
--- a/src/go/rpk/pkg/tuners/net_checkers.go
+++ b/src/go/rpk/pkg/tuners/net_checkers.go
@@ -398,30 +398,7 @@ func (f *netCheckersFactory) NewSynBacklogChecker() Checker {
 func isSet(
 	nic network.Nic, hwCheckFunction func(network.Nic) (bool, error),
 ) (bool, error) {
-	// Some HW interfaces might still be bond interfaces like hv_netvsc
-	if nic.IsBondIface() {
-		zap.L().Sugar().Debugf("'%s' is bond interface", nic.Name())
-		slaves, err := nic.Slaves()
-		if err != nil {
-			return false, err
-		}
-		for _, slave := range slaves {
-			isSet, err := isSet(slave, hwCheckFunction)
-			if err != nil {
-				return false, err
-			}
-			if !isSet {
-				return false, nil
-			}
-		}
-
-		return true, nil
-	}
-	if nic.IsHwInterface() {
-		zap.L().Sugar().Debugf("'%s' is HW interface", nic.Name())
-		return hwCheckFunction(nic)
-	}
-	return true, nil
+	return hwCheckFunction(nic)
 }
 
 func (*netCheckersFactory) forInterfaces(

--- a/src/go/rpk/pkg/tuners/net_checkers.go
+++ b/src/go/rpk/pkg/tuners/net_checkers.go
@@ -26,18 +26,18 @@ import (
 )
 
 type NetCheckersFactory interface {
-	NewNicRxTxQueueCountCheckers(interfaces []string, mode irq.Mode, cpuMask string) []Checker
+	NewNicRxTxQueueCountCheckers(interfaces []network.Nic, mode irq.Mode, cpuMask string) []Checker
 	NewNicRxTxQueueCountChecker(nic network.Nic, mode irq.Mode, cpuMask string) Checker
-	NewNicIRQBalanceChecker(interfaces []string) Checker
-	NewNicIRQAffinityCheckers(interfaces []string, mode irq.Mode, mask string) []Checker
+	NewNicIRQBalanceChecker(interfaces []network.Nic) Checker
+	NewNicIRQAffinityCheckers(interfaces []network.Nic, mode irq.Mode, mask string) []Checker
 	NewNicIRQAffinityChecker(nic network.Nic, mode irq.Mode, mask string) Checker
-	NewNicRpsSetCheckers(interfaces []string, mode irq.Mode, mask string) []Checker
+	NewNicRpsSetCheckers(interfaces []network.Nic, mode irq.Mode, mask string) []Checker
 	NewNicRpsSetChecker(nic network.Nic, mode irq.Mode, mask string) Checker
-	NewNicRfsCheckers(interfaces []string, mode irq.Mode, mask string) []Checker
+	NewNicRfsCheckers(interfaces []network.Nic, mode irq.Mode, mask string) []Checker
 	NewNicRfsChecker(nic network.Nic, mode irq.Mode, mask string) Checker
-	NewNicNTupleCheckers(interfaces []string) []Checker
+	NewNicNTupleCheckers(interfaces []network.Nic) []Checker
 	NewNicNTupleChecker(nic network.Nic) Checker
-	NewNicXpsCheckers(interfaces []string) []Checker
+	NewNicXpsCheckers(interfaces []network.Nic) []Checker
 	NewNicXpsChecker(nic network.Nic) Checker
 	NewRfsTableSizeChecker() Checker
 	NewListenBacklogChecker() Checker
@@ -114,16 +114,16 @@ func (f *netCheckersFactory) NewNicRxTxQueueCountChecker(
 }
 
 func (f *netCheckersFactory) NewNicRxTxQueueCountCheckers(
-	interfaces []string, mode irq.Mode, cpuMask string,
+	interfaces []network.Nic, mode irq.Mode, cpuMask string,
 ) []Checker {
-	return f.forNonVirtualInterfaces(interfaces,
+	return f.forInterfaces(interfaces,
 		func(nic network.Nic) Checker {
 			return f.NewNicRxTxQueueCountChecker(nic, mode, cpuMask)
 		})
 }
 
 func (f *netCheckersFactory) NewNicIRQBalanceChecker(
-	interfaces []string,
+	interfaces []network.Nic,
 ) Checker {
 	return NewEqualityChecker(
 		NicIRQBalanceChecker,
@@ -132,8 +132,7 @@ func (f *netCheckersFactory) NewNicIRQBalanceChecker(
 		true,
 		func() (interface{}, error) {
 			var IRQs []int
-			for _, ifaceName := range interfaces {
-				nic := network.NewNic(f.fs, f.irqProcFile, f.irqDeviceInfo, f.ethtool, ifaceName)
+			for _, nic := range interfaces {
 				nicIRQs, err := network.CollectIRQs(nic)
 				if err != nil {
 					return false, err
@@ -179,18 +178,18 @@ func (f *netCheckersFactory) NewNicIRQAffinityChecker(
 }
 
 func (f *netCheckersFactory) NewNicIRQAffinityCheckers(
-	interfaces []string, mode irq.Mode, cpuMask string,
+	interfaces []network.Nic, mode irq.Mode, cpuMask string,
 ) []Checker {
-	return f.forNonVirtualInterfaces(interfaces,
+	return f.forInterfaces(interfaces,
 		func(nic network.Nic) Checker {
 			return f.NewNicIRQAffinityChecker(nic, mode, cpuMask)
 		})
 }
 
 func (f *netCheckersFactory) NewNicRpsSetCheckers(
-	interfaces []string, mode irq.Mode, cpuMask string,
+	interfaces []network.Nic, mode irq.Mode, cpuMask string,
 ) []Checker {
-	return f.forNonVirtualInterfaces(
+	return f.forInterfaces(
 		interfaces,
 		func(nic network.Nic) Checker {
 			return f.NewNicRpsSetChecker(nic, mode, cpuMask)
@@ -234,8 +233,8 @@ func (f *netCheckersFactory) NewNicRpsSetChecker(
 	)
 }
 
-func (f *netCheckersFactory) NewNicRfsCheckers(interfaces []string, mode irq.Mode, cpuMask string) []Checker {
-	return f.forNonVirtualInterfaces(interfaces,
+func (f *netCheckersFactory) NewNicRfsCheckers(interfaces []network.Nic, mode irq.Mode, cpuMask string) []Checker {
+	return f.forInterfaces(interfaces,
 		func(nic network.Nic) Checker {
 			return f.NewNicRfsChecker(nic, mode, cpuMask)
 		})
@@ -273,9 +272,9 @@ func (f *netCheckersFactory) NewNicRfsChecker(nic network.Nic, mode irq.Mode, cp
 }
 
 func (f *netCheckersFactory) NewNicNTupleCheckers(
-	interfaces []string,
+	interfaces []network.Nic,
 ) []Checker {
-	return f.forNonVirtualInterfaces(interfaces, f.NewNicNTupleChecker)
+	return f.forInterfaces(interfaces, f.NewNicNTupleChecker)
 }
 
 func (*netCheckersFactory) NewNicNTupleChecker(nic network.Nic) Checker {
@@ -299,8 +298,8 @@ func (*netCheckersFactory) NewNicNTupleChecker(nic network.Nic) Checker {
 	)
 }
 
-func (f *netCheckersFactory) NewNicXpsCheckers(interfaces []string) []Checker {
-	return f.forNonVirtualInterfaces(interfaces, f.NewNicXpsChecker)
+func (f *netCheckersFactory) NewNicXpsCheckers(interfaces []network.Nic) []Checker {
+	return f.forInterfaces(interfaces, f.NewNicXpsChecker)
 }
 
 func (f *netCheckersFactory) NewNicXpsChecker(nic network.Nic) Checker {
@@ -425,17 +424,12 @@ func isSet(
 	return true, nil
 }
 
-func (f *netCheckersFactory) forNonVirtualInterfaces(
-	interfaces []string, checkerFactory func(network.Nic) Checker,
+func (*netCheckersFactory) forInterfaces(
+	interfaces []network.Nic, checkerFactory func(network.Nic) Checker,
 ) []Checker {
 	var chkrs []Checker
 	for _, iface := range interfaces {
-		nic := network.NewNic(f.fs, f.irqProcFile, f.irqDeviceInfo, f.ethtool, iface)
-		if !nic.IsHwInterface() && !nic.IsBondIface() {
-			zap.L().Sugar().Debugf("Skipping '%s' virtual interface", nic.Name())
-			continue
-		}
-		chkrs = append(chkrs, checkerFactory(nic))
+		chkrs = append(chkrs, checkerFactory(iface))
 	}
 	return chkrs
 }

--- a/src/go/rpk/pkg/tuners/net_checkers.go
+++ b/src/go/rpk/pkg/tuners/net_checkers.go
@@ -26,15 +26,15 @@ import (
 )
 
 type NetCheckersFactory interface {
-	NewNicRxTxQueueCountCheckers(interfaces []network.Nic, mode irq.Mode, cpuMask string) []Checker
-	NewNicRxTxQueueCountChecker(nic network.Nic, mode irq.Mode, cpuMask string) Checker
+	NewNicRxTxQueueCountCheckers(interfaces []network.Nic, effectiveConfig network.EffectiveNicConfig) []Checker
+	NewNicRxTxQueueCountChecker(nic network.Nic, effectiveConfig network.EffectiveNicConfig) Checker
 	NewNicIRQBalanceChecker(interfaces []network.Nic) Checker
-	NewNicIRQAffinityCheckers(interfaces []network.Nic, mode irq.Mode, mask string) []Checker
-	NewNicIRQAffinityChecker(nic network.Nic, mode irq.Mode, mask string) Checker
-	NewNicRpsSetCheckers(interfaces []network.Nic, mode irq.Mode, mask string) []Checker
-	NewNicRpsSetChecker(nic network.Nic, mode irq.Mode, mask string) Checker
-	NewNicRfsCheckers(interfaces []network.Nic, mode irq.Mode, mask string) []Checker
-	NewNicRfsChecker(nic network.Nic, mode irq.Mode, mask string) Checker
+	NewNicIRQAffinityCheckers(interfaces []network.Nic, effectiveConfig network.EffectiveNicConfig) []Checker
+	NewNicIRQAffinityChecker(nic network.Nic, effectiveConfig network.EffectiveNicConfig) Checker
+	NewNicRpsSetCheckers(interfaces []network.Nic, effectiveConfig network.EffectiveNicConfig) []Checker
+	NewNicRpsSetChecker(nic network.Nic, effectiveConfig network.EffectiveNicConfig) Checker
+	NewNicRfsCheckers(interfaces []network.Nic, effectiveConfig network.EffectiveNicConfig) []Checker
+	NewNicRfsChecker(nic network.Nic, effectiveConfig network.EffectiveNicConfig) Checker
 	NewNicNTupleCheckers(interfaces []network.Nic) []Checker
 	NewNicNTupleChecker(nic network.Nic) Checker
 	NewNicXpsCheckers(interfaces []network.Nic) []Checker
@@ -75,7 +75,7 @@ func NewNetCheckersFactory(
 }
 
 func (f *netCheckersFactory) NewNicRxTxQueueCountChecker(
-	nic network.Nic, mode irq.Mode, cpuMask string,
+	nic network.Nic, effectiveConfig network.EffectiveNicConfig,
 ) Checker {
 	return NewEqualityChecker(
 		NicRxTxQueueCountChecker,
@@ -98,7 +98,7 @@ func (f *netCheckersFactory) NewNicRxTxQueueCountChecker(
 					return true, nil
 				}
 
-				currentChannels, targetChannels, err := network.GetCurrentAndTargetChannels(currentNic, mode, cpuMask, f.cpuMasks, f.rnc, f.ethtool)
+				currentChannels, targetChannels, err := network.GetCurrentAndTargetChannels(currentNic, effectiveConfig, f.ethtool)
 				if err != nil {
 					return false, err
 				}
@@ -114,11 +114,11 @@ func (f *netCheckersFactory) NewNicRxTxQueueCountChecker(
 }
 
 func (f *netCheckersFactory) NewNicRxTxQueueCountCheckers(
-	interfaces []network.Nic, mode irq.Mode, cpuMask string,
+	interfaces []network.Nic, effectiveConfig network.EffectiveNicConfig,
 ) []Checker {
 	return f.forInterfaces(interfaces,
 		func(nic network.Nic) Checker {
-			return f.NewNicRxTxQueueCountChecker(nic, mode, cpuMask)
+			return f.NewNicRxTxQueueCountChecker(nic, effectiveConfig)
 		})
 }
 
@@ -145,7 +145,7 @@ func (f *netCheckersFactory) NewNicIRQBalanceChecker(
 }
 
 func (f *netCheckersFactory) NewNicIRQAffinityChecker(
-	nic network.Nic, mode irq.Mode, cpuMask string,
+	nic network.Nic, effectiveConfig network.EffectiveNicConfig,
 ) Checker {
 	return NewEqualityChecker(
 		NicIRQsAffinitChecker,
@@ -155,7 +155,7 @@ func (f *netCheckersFactory) NewNicIRQAffinityChecker(
 		func() (interface{}, error) {
 			return isSet(nic, func(currentNic network.Nic) (bool, error) {
 				dist, err := network.GetHwInterfaceIRQsDistribution(
-					currentNic, mode, cpuMask, f.cpuMasks, f.rnc)
+					currentNic, effectiveConfig, f.cpuMasks)
 				if err != nil {
 					return false, err
 				}
@@ -178,26 +178,26 @@ func (f *netCheckersFactory) NewNicIRQAffinityChecker(
 }
 
 func (f *netCheckersFactory) NewNicIRQAffinityCheckers(
-	interfaces []network.Nic, mode irq.Mode, cpuMask string,
+	interfaces []network.Nic, effectiveConfig network.EffectiveNicConfig,
 ) []Checker {
 	return f.forInterfaces(interfaces,
 		func(nic network.Nic) Checker {
-			return f.NewNicIRQAffinityChecker(nic, mode, cpuMask)
+			return f.NewNicIRQAffinityChecker(nic, effectiveConfig)
 		})
 }
 
 func (f *netCheckersFactory) NewNicRpsSetCheckers(
-	interfaces []network.Nic, mode irq.Mode, cpuMask string,
+	interfaces []network.Nic, effectiveConfig network.EffectiveNicConfig,
 ) []Checker {
 	return f.forInterfaces(
 		interfaces,
 		func(nic network.Nic) Checker {
-			return f.NewNicRpsSetChecker(nic, mode, cpuMask)
+			return f.NewNicRpsSetChecker(nic, effectiveConfig)
 		})
 }
 
 func (f *netCheckersFactory) NewNicRpsSetChecker(
-	nic network.Nic, mode irq.Mode, cpuMask string,
+	nic network.Nic, effectiveConfig network.EffectiveNicConfig,
 ) Checker {
 	return NewEqualityChecker(
 		NicRpsChecker,
@@ -210,7 +210,7 @@ func (f *netCheckersFactory) NewNicRpsSetChecker(
 				if err != nil {
 					return false, err
 				}
-				rfsMask, err := network.GetRpsCPUMask(currentNic, mode, cpuMask, f.cpuMasks, f.rnc)
+				rfsMask, err := network.GetRpsCPUMask(currentNic, effectiveConfig, f.rnc)
 				if err != nil {
 					return false, err
 				}
@@ -233,14 +233,14 @@ func (f *netCheckersFactory) NewNicRpsSetChecker(
 	)
 }
 
-func (f *netCheckersFactory) NewNicRfsCheckers(interfaces []network.Nic, mode irq.Mode, cpuMask string) []Checker {
+func (f *netCheckersFactory) NewNicRfsCheckers(interfaces []network.Nic, effectiveConfig network.EffectiveNicConfig) []Checker {
 	return f.forInterfaces(interfaces,
 		func(nic network.Nic) Checker {
-			return f.NewNicRfsChecker(nic, mode, cpuMask)
+			return f.NewNicRfsChecker(nic, effectiveConfig)
 		})
 }
 
-func (f *netCheckersFactory) NewNicRfsChecker(nic network.Nic, mode irq.Mode, cpuMask string) Checker {
+func (f *netCheckersFactory) NewNicRfsChecker(nic network.Nic, effectiveConfig network.EffectiveNicConfig) Checker {
 	return NewEqualityChecker(
 		NicRfsChecker,
 		fmt.Sprintf("NIC %s RFS set", nic.Name()),
@@ -252,7 +252,7 @@ func (f *netCheckersFactory) NewNicRfsChecker(nic network.Nic, mode irq.Mode, cp
 				if err != nil {
 					return false, err
 				}
-				queueLimit, err := network.OneRPSQueueLimit(limits, currentNic, mode, cpuMask, f.cpuMasks, f.rnc)
+				queueLimit, err := network.OneRPSQueueLimit(limits, currentNic, effectiveConfig, f.rnc)
 				if err != nil {
 					return false, err
 				}

--- a/src/go/rpk/pkg/tuners/net_tuners.go
+++ b/src/go/rpk/pkg/tuners/net_tuners.go
@@ -46,6 +46,28 @@ type netTunable struct {
 	cpuMask    string
 }
 
+func (n *netTunable) checkAllNicsSameMode(nics []network.Nic) (*network.EffectiveNicConfig, error) {
+	var currentEffectiveConfig *network.EffectiveNicConfig
+
+	for _, iface := range nics {
+		effectiveConfig, err := network.GetEffectiveNicConfig(iface, n.mode, n.cpuMask, n.f.cpuMasks, n.f.rnc)
+		if err != nil {
+			return nil, err
+		}
+
+		zap.L().Sugar().Debugf("interface %s: effective config: %v", iface.Name(), effectiveConfig)
+		if currentEffectiveConfig == nil {
+			currentEffectiveConfig = &effectiveConfig
+		} else {
+			if *currentEffectiveConfig != effectiveConfig {
+				return nil, fmt.Errorf("interfaces %s has different effective configuration than the rest: %v vs %v",
+					iface.Name(), *currentEffectiveConfig, effectiveConfig)
+			}
+		}
+	}
+	return currentEffectiveConfig, nil
+}
+
 func (n *netTunable) CheckIfSupported() (bool, string) {
 	if !n.f.cpuMasks.IsSupported() {
 		return false, "Tuner is not supported as 'hwloc' is not installed"
@@ -66,8 +88,12 @@ func (n *netTunable) Tune() TuneResult {
 		return NewAggregatedTunable(genericTuners).Tune()
 	}
 
+	_, err := n.checkAllNicsSameMode(nics)
+	if err != nil {
+		return NewTuneError(err)
+	}
+
 	nicTuners := []Tunable{
-		n.f.NewAllNicsSameModeTuner(nics, n.mode, n.cpuMask),
 		// RX/TX queue count tuner should always be first in order as others will re-read queue counts
 		n.f.NewRxTxQueueCountTuner(nics, n.mode, n.cpuMask),
 		n.f.NewNICsBalanceServiceTuner(nics),
@@ -159,47 +185,6 @@ func NewNetTunersFactory(
 		checkersFactory: NewNetCheckersFactory(
 			fs, rnc, irqProcFile, irqDeviceInfo, ethtool, balanceService, cpuMasks),
 	}
-}
-
-type NicsEqualTunable struct {
-	f          *netTunersFactory
-	interfaces []network.Nic
-	mode       irq.Mode
-	cpuMask    string
-}
-
-func (*NicsEqualTunable) CheckIfSupported() (bool, string) {
-	return true, ""
-}
-
-func (net *NicsEqualTunable) Tune() TuneResult {
-	var currentEffectiveConfig *network.EffectiveNicConfig
-
-	for _, iface := range net.interfaces {
-		effectiveConfig, err := network.GetEffectiveNicConfig(iface, net.mode, net.cpuMask, net.f.cpuMasks, net.f.rnc)
-		if err != nil {
-			return NewTuneError(err)
-		}
-
-		zap.L().Sugar().Debugf("interface %s: effective config: %v", iface.Name(), effectiveConfig)
-		if currentEffectiveConfig == nil {
-			currentEffectiveConfig = &effectiveConfig
-		} else {
-			if *currentEffectiveConfig != effectiveConfig {
-				return NewTuneError(fmt.Errorf("interfaces %s has different effective configuration than the rest: %v vs %v",
-					iface.Name(), *currentEffectiveConfig, effectiveConfig))
-			}
-		}
-	}
-	return NewTuneResult(false)
-}
-
-// This is a meta tuner that checks that all given NICs use the same mode and IRQ masks.
-// It's really only needed like this because of the way the different subtuners are implemented.
-// Once we rewrite everything to be a single function this can just be at the top and won't be a separate "tuner".
-func (f *netTunersFactory) NewAllNicsSameModeTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable {
-	tuneable := NicsEqualTunable{f: f, interfaces: interfaces, mode: mode, cpuMask: cpuMask}
-	return &tuneable
 }
 
 func (f *netTunersFactory) NewRxTxQueueCountTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable {

--- a/src/go/rpk/pkg/tuners/net_tuners.go
+++ b/src/go/rpk/pkg/tuners/net_tuners.go
@@ -628,26 +628,5 @@ func (f *netTunersFactory) tuneInterfaces(
 func tuneInterface(
 	nic network.Nic, tuneAction func(network.Nic) TuneResult,
 ) TuneResult {
-	// Need to check bond interface first as some HW interfaces might also be bonds
-	if nic.IsBondIface() {
-		slaves, err := nic.Slaves()
-		if err != nil {
-			return NewTuneError(err)
-		}
-		var res TuneResult
-		for _, slave := range slaves {
-			res = tuneInterface(slave, tuneAction)
-			if res.IsFailed() {
-				return res
-			}
-		}
-		// return the last
-		return res
-	}
-
-	if nic.IsHwInterface() {
-		return tuneAction(nic)
-	}
-
-	return NewTuneResult(false)
+	return tuneAction(nic)
 }

--- a/src/go/rpk/pkg/tuners/net_tuners.go
+++ b/src/go/rpk/pkg/tuners/net_tuners.go
@@ -88,20 +88,22 @@ func (n *netTunable) Tune() TuneResult {
 		return NewAggregatedTunable(genericTuners).Tune()
 	}
 
-	_, err := n.checkAllNicsSameMode(nics)
+	effectiveConfig, err := n.checkAllNicsSameMode(nics)
 	if err != nil {
 		return NewTuneError(err)
 	}
 
+	zap.L().Sugar().Debugf("Using effective config: %v", *effectiveConfig)
+
 	nicTuners := []Tunable{
 		// RX/TX queue count tuner should always be first in order as others will re-read queue counts
-		n.f.NewRxTxQueueCountTuner(nics, n.mode, n.cpuMask),
+		n.f.NewRxTxQueueCountTuner(nics, *effectiveConfig),
 		n.f.NewNICsBalanceServiceTuner(nics),
-		n.f.NewNICsIRQsAffinityTuner(nics, n.mode, n.cpuMask),
+		n.f.NewNICsIRQsAffinityTuner(nics, *effectiveConfig),
 		// Write out net tuner interrupt config once we have successfully tuned IRQ config
-		n.f.NewInterruptConfigFileTuner(nics, n.mode, n.cpuMask),
-		n.f.NewNICsRpsTuner(nics, n.mode, n.cpuMask),
-		n.f.NewNICsRfsTuner(nics, n.mode, n.cpuMask),
+		n.f.NewInterruptConfigFileTuner(*effectiveConfig),
+		n.f.NewNICsRpsTuner(nics, *effectiveConfig),
+		n.f.NewNICsRfsTuner(nics, *effectiveConfig),
 		n.f.NewNICsNTupleTuner(nics),
 		n.f.NewNICsXpsTuner(nics),
 	}
@@ -131,13 +133,12 @@ func NewNetTuner(
 }
 
 type NetTunersFactory interface {
-	NewAllNicsSameModeTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable
-	NewRxTxQueueCountTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable
+	NewRxTxQueueCountTuner(interfaces []network.Nic, effectiveConfig network.EffectiveNicConfig) Tunable
 	NewNICsBalanceServiceTuner(interfaces []network.Nic) Tunable
-	NewNICsIRQsAffinityTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable
-	NewInterruptConfigFileTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable
-	NewNICsRpsTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable
-	NewNICsRfsTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable
+	NewNICsIRQsAffinityTuner(interfaces []network.Nic, effectiveConfig network.EffectiveNicConfig) Tunable
+	NewInterruptConfigFileTuner(effectiveConfig network.EffectiveNicConfig) Tunable
+	NewNICsRpsTuner(interfaces []network.Nic, effectiveConfig network.EffectiveNicConfig) Tunable
+	NewNICsRfsTuner(interfaces []network.Nic, effectiveConfig network.EffectiveNicConfig) Tunable
 	NewNICsNTupleTuner(interfaces []network.Nic) Tunable
 	NewNICsXpsTuner(interfaces []network.Nic) Tunable
 	NewRfsTableSizeTuner() Tunable
@@ -187,11 +188,11 @@ func NewNetTunersFactory(
 	}
 }
 
-func (f *netTunersFactory) NewRxTxQueueCountTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable {
+func (f *netTunersFactory) NewRxTxQueueCountTuner(interfaces []network.Nic, effectiveConfig network.EffectiveNicConfig) Tunable {
 	return f.tuneInterfaces(
 		interfaces,
 		func(nic network.Nic) Checker {
-			return f.checkersFactory.NewNicRxTxQueueCountChecker(nic, mode, cpuMask)
+			return f.checkersFactory.NewNicRxTxQueueCountChecker(nic, effectiveConfig)
 		},
 		func(nic network.Nic) TuneResult {
 			zap.L().Sugar().Debugf(out.WithLogBanner("Tuning '%s' queue counts", nic.Name()))
@@ -209,7 +210,7 @@ func (f *netTunersFactory) NewRxTxQueueCountTuner(interfaces []network.Nic, mode
 				return NewTuneResult(false)
 			}
 
-			_, targetChannels, err := network.GetCurrentAndTargetChannels(nic, mode, cpuMask, f.cpuMasks, f.rnc, f.ethtool)
+			_, targetChannels, err := network.GetCurrentAndTargetChannels(nic, effectiveConfig, f.ethtool)
 			if err != nil {
 				return NewTuneError(err)
 			}
@@ -253,16 +254,16 @@ func (f *netTunersFactory) NewNICsBalanceServiceTuner(
 }
 
 func (f *netTunersFactory) NewNICsIRQsAffinityTuner(
-	interfaces []network.Nic, mode irq.Mode, cpuMask string,
+	interfaces []network.Nic, effectiveConfig network.EffectiveNicConfig,
 ) Tunable {
 	return f.tuneInterfaces(
 		interfaces,
 		func(nic network.Nic) Checker {
-			return f.checkersFactory.NewNicIRQAffinityChecker(nic, mode, cpuMask)
+			return f.checkersFactory.NewNicIRQAffinityChecker(nic, effectiveConfig)
 		},
 		func(nic network.Nic) TuneResult {
 			zap.L().Sugar().Debugf(out.WithLogBanner("Tuning '%s' IRQs affinity", nic.Name()))
-			dist, err := network.GetHwInterfaceIRQsDistribution(nic, mode, cpuMask, f.cpuMasks, f.rnc)
+			dist, err := network.GetHwInterfaceIRQsDistribution(nic, effectiveConfig, f.cpuMasks)
 			if err != nil {
 				return NewTuneError(err)
 			}
@@ -272,12 +273,7 @@ func (f *netTunersFactory) NewNICsIRQsAffinityTuner(
 	)
 }
 
-func (f *netTunersFactory) getNetTunerConfig(nic network.Nic, mode irq.Mode, cpuMask string) (NodeTunerState, error) {
-	networkConfig, err := network.GetEffectiveNicConfig(nic, mode, cpuMask, f.cpuMasks, f.rnc)
-	if err != nil {
-		return NodeTunerState{}, err
-	}
-
+func (f *netTunersFactory) getNetTunerConfig(networkConfig network.EffectiveNicConfig) (NodeTunerState, error) {
 	// All the below transformations we could also do in rpk:start but we just
 	// do them here to avoid having to invoke hwloc again then.
 
@@ -285,15 +281,7 @@ func (f *netTunersFactory) getNetTunerConfig(nic network.Nic, mode irq.Mode, cpu
 	if err != nil {
 		return NodeTunerState{}, err
 	}
-	redpandaSize, err := f.cpuMasks.GetNumberOfPUs(networkConfig.ComputationsCPUMask)
-	if err != nil {
-		return NodeTunerState{}, err
-	}
 	irqCpusetListForm, err := f.cpuMasks.MaskToListFormat(networkConfig.IRQCPUMask)
-	if err != nil {
-		return NodeTunerState{}, err
-	}
-	irqSize, err := f.cpuMasks.GetNumberOfPUs(networkConfig.IRQCPUMask)
 	if err != nil {
 		return NodeTunerState{}, err
 	}
@@ -302,9 +290,9 @@ func (f *netTunersFactory) getNetTunerConfig(nic network.Nic, mode irq.Mode, cpu
 		Cpusets: &CpusetConfig{
 			IrqMode:            networkConfig.Mode,
 			RedpandaCpuset:     redpandaCpusetListForm,
-			RedpandaCpusetSize: int(redpandaSize),
+			RedpandaCpusetSize: networkConfig.ComputationsCPUMaskSize,
 			IrqCpuset:          irqCpusetListForm,
-			IrqCpusetSize:      int(irqSize),
+			IrqCpusetSize:      networkConfig.IRQCPUMaskSize,
 		},
 	}
 	return config, nil
@@ -325,15 +313,12 @@ func maybeReadFile(fs afero.Fs, path string) ([]byte, error) {
 	return content, nil
 }
 
-func (f *netTunersFactory) NewInterruptConfigFileTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable {
-	// We have already checked they are all the same so just use the first one
-	nic := interfaces[0]
-
+func (f *netTunersFactory) NewInterruptConfigFileTuner(effectiveConfig network.EffectiveNicConfig) Tunable {
 	tunable := checkedTunable{}
 	tunable.tuneAction = func() TuneResult {
 		zap.L().Sugar().Debugf(out.WithLogBanner("Creating tuner config file"))
 
-		config, err := f.getNetTunerConfig(nic, mode, cpuMask)
+		config, err := f.getNetTunerConfig(effectiveConfig)
 		if err != nil {
 			return NewTuneError(err)
 		}
@@ -382,7 +367,7 @@ func (f *netTunersFactory) NewInterruptConfigFileTuner(interfaces []network.Nic,
 		Warning,
 		true,
 		func() (interface{}, error) {
-			targetConfig, err := f.getNetTunerConfig(nic, mode, cpuMask)
+			targetConfig, err := f.getNetTunerConfig(effectiveConfig)
 			if err != nil {
 				return false, err
 			}
@@ -427,12 +412,12 @@ func (f *netTunersFactory) NewInterruptConfigFileTuner(interfaces []network.Nic,
 }
 
 func (f *netTunersFactory) NewNICsRpsTuner(
-	interfaces []network.Nic, mode irq.Mode, cpuMask string,
+	interfaces []network.Nic, effectiveConfig network.EffectiveNicConfig,
 ) Tunable {
 	return f.tuneInterfaces(
 		interfaces,
 		func(nic network.Nic) Checker {
-			return f.checkersFactory.NewNicRpsSetChecker(nic, mode, cpuMask)
+			return f.checkersFactory.NewNicRpsSetChecker(nic, effectiveConfig)
 		},
 		func(nic network.Nic) TuneResult {
 			zap.L().Sugar().Debugf(out.WithLogBanner("Tuning '%s' RPS", nic.Name()))
@@ -440,7 +425,7 @@ func (f *netTunersFactory) NewNICsRpsTuner(
 			if err != nil {
 				return NewTuneError(err)
 			}
-			rpsMask, err := network.GetRpsCPUMask(nic, mode, cpuMask, f.cpuMasks, f.rnc)
+			rpsMask, err := network.GetRpsCPUMask(nic, effectiveConfig, f.rnc)
 			if err != nil {
 				return NewTuneError(err)
 			}
@@ -455,11 +440,11 @@ func (f *netTunersFactory) NewNICsRpsTuner(
 	)
 }
 
-func (f *netTunersFactory) NewNICsRfsTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable {
+func (f *netTunersFactory) NewNICsRfsTuner(interfaces []network.Nic, effectiveConfig network.EffectiveNicConfig) Tunable {
 	return f.tuneInterfaces(
 		interfaces,
 		func(nic network.Nic) Checker {
-			return f.checkersFactory.NewNicRfsChecker(nic, mode, cpuMask)
+			return f.checkersFactory.NewNicRfsChecker(nic, effectiveConfig)
 		},
 		func(nic network.Nic) TuneResult {
 			zap.L().Sugar().Debugf(out.WithLogBanner("Tuning '%s' RFS", nic.Name()))
@@ -467,7 +452,7 @@ func (f *netTunersFactory) NewNICsRfsTuner(interfaces []network.Nic, mode irq.Mo
 			if err != nil {
 				return NewTuneError(err)
 			}
-			queueLimit, err := network.OneRPSQueueLimit(limits, nic, mode, cpuMask, f.cpuMasks, f.rnc)
+			queueLimit, err := network.OneRPSQueueLimit(limits, nic, effectiveConfig, f.rnc)
 			if err != nil {
 				return NewTuneError(err)
 			}

--- a/src/go/rpk/pkg/tuners/net_tuners.go
+++ b/src/go/rpk/pkg/tuners/net_tuners.go
@@ -39,6 +39,50 @@ type NodeTunerState struct {
 	Cpusets *CpusetConfig `yaml:"cpusets,omitempty" json:"cpusets"`
 }
 
+type netTunable struct {
+	f          *netTunersFactory
+	interfaces []string
+	mode       irq.Mode
+	cpuMask    string
+}
+
+func (n *netTunable) CheckIfSupported() (bool, string) {
+	if !n.f.cpuMasks.IsSupported() {
+		return false, "Tuner is not supported as 'hwloc' is not installed"
+	}
+	return true, ""
+}
+
+func (n *netTunable) Tune() TuneResult {
+	genericTuners := []Tunable{
+		n.f.NewRfsTableSizeTuner(),
+		n.f.NewListenBacklogTuner(),
+		n.f.NewSynBacklogTuner(),
+	}
+
+	nics := network.MapInterfaces(n.interfaces, n.f.fs, n.f.irqProcFile, n.f.irqDeviceInfo, n.f.ethtool)
+	if len(nics) == 0 {
+		zap.L().Sugar().Debugf("No physical or bond interfaces to tune, only running generic network tuners")
+		return NewAggregatedTunable(genericTuners).Tune()
+	}
+
+	nicTuners := []Tunable{
+		n.f.NewAllNicsSameModeTuner(nics, n.mode, n.cpuMask),
+		// RX/TX queue count tuner should always be first in order as others will re-read queue counts
+		n.f.NewRxTxQueueCountTuner(nics, n.mode, n.cpuMask),
+		n.f.NewNICsBalanceServiceTuner(nics),
+		n.f.NewNICsIRQsAffinityTuner(nics, n.mode, n.cpuMask),
+		// Write out net tuner interrupt config once we have successfully tuned IRQ config
+		n.f.NewInterruptConfigFileTuner(nics, n.mode, n.cpuMask),
+		n.f.NewNICsRpsTuner(nics, n.mode, n.cpuMask),
+		n.f.NewNICsRfsTuner(nics, n.mode, n.cpuMask),
+		n.f.NewNICsNTupleTuner(nics),
+		n.f.NewNICsXpsTuner(nics),
+	}
+
+	return NewAggregatedTunable(append(nicTuners, genericTuners...)).Tune()
+}
+
 func NewNetTuner(
 	mode irq.Mode,
 	rnc config.RpkNodeConfig,
@@ -56,35 +100,20 @@ func NewNetTuner(
 ) Tunable {
 	factory := NewNetTunersFactory(
 		fs, rnc, irqProcFile, irqDeviceInfo, ethtool, irqBalanceService, cpuMasks, executor, proc, statePath)
-	return NewAggregatedTunable(
-		[]Tunable{
-			factory.NewAllNicsSameModeTuner(interfaces, mode, cpuMask),
-			// RX/TX queue count tuner should always be first in order as others will re-read queue counts
-			factory.NewRxTxQueueCountTuner(interfaces, mode, cpuMask),
-			factory.NewNICsBalanceServiceTuner(interfaces),
-			factory.NewNICsIRQsAffinityTuner(interfaces, mode, cpuMask),
-			// Write out net tuner interrupt config once we have successfully tuned IRQ config
-			factory.NewInterruptConfigFileTuner(interfaces, mode, cpuMask),
-			factory.NewNICsRpsTuner(interfaces, mode, cpuMask),
-			factory.NewNICsRfsTuner(interfaces, mode, cpuMask),
-			factory.NewNICsNTupleTuner(interfaces),
-			factory.NewNICsXpsTuner(interfaces),
-			factory.NewRfsTableSizeTuner(),
-			factory.NewListenBacklogTuner(),
-			factory.NewSynBacklogTuner(),
-		})
+
+	return &netTunable{f: factory.(*netTunersFactory), interfaces: interfaces, mode: mode, cpuMask: cpuMask}
 }
 
 type NetTunersFactory interface {
-	NewAllNicsSameModeTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable
-	NewRxTxQueueCountTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable
-	NewNICsBalanceServiceTuner(interfaces []string) Tunable
-	NewNICsIRQsAffinityTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable
-	NewInterruptConfigFileTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable
-	NewNICsRpsTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable
-	NewNICsRfsTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable
-	NewNICsNTupleTuner(interfaces []string) Tunable
-	NewNICsXpsTuner(interfaces []string) Tunable
+	NewAllNicsSameModeTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable
+	NewRxTxQueueCountTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable
+	NewNICsBalanceServiceTuner(interfaces []network.Nic) Tunable
+	NewNICsIRQsAffinityTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable
+	NewInterruptConfigFileTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable
+	NewNICsRpsTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable
+	NewNICsRfsTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable
+	NewNICsNTupleTuner(interfaces []network.Nic) Tunable
+	NewNICsXpsTuner(interfaces []network.Nic) Tunable
 	NewRfsTableSizeTuner() Tunable
 	NewListenBacklogTuner() Tunable
 	NewSynBacklogTuner() Tunable
@@ -134,7 +163,7 @@ func NewNetTunersFactory(
 
 type NicsEqualTunable struct {
 	f          *netTunersFactory
-	interfaces []string
+	interfaces []network.Nic
 	mode       irq.Mode
 	cpuMask    string
 }
@@ -147,24 +176,18 @@ func (net *NicsEqualTunable) Tune() TuneResult {
 	var currentEffectiveConfig *network.EffectiveNicConfig
 
 	for _, iface := range net.interfaces {
-		nic := network.NewNic(net.f.fs, net.f.irqProcFile, net.f.irqDeviceInfo, net.f.ethtool, iface)
-		if !nic.IsHwInterface() && !nic.IsBondIface() {
-			zap.L().Sugar().Debugf("Skipping tuning of '%s' virtual interface", nic.Name())
-			continue
-		}
-
-		effectiveConfig, err := network.GetEffectiveNicConfig(nic, net.mode, net.cpuMask, net.f.cpuMasks, net.f.rnc)
+		effectiveConfig, err := network.GetEffectiveNicConfig(iface, net.mode, net.cpuMask, net.f.cpuMasks, net.f.rnc)
 		if err != nil {
 			return NewTuneError(err)
 		}
 
-		zap.L().Sugar().Debugf("interface %s: effective config: %v", nic.Name(), effectiveConfig)
+		zap.L().Sugar().Debugf("interface %s: effective config: %v", iface.Name(), effectiveConfig)
 		if currentEffectiveConfig == nil {
 			currentEffectiveConfig = &effectiveConfig
 		} else {
 			if *currentEffectiveConfig != effectiveConfig {
 				return NewTuneError(fmt.Errorf("interfaces %s has different effective configuration than the rest: %v vs %v",
-					nic.Name(), *currentEffectiveConfig, effectiveConfig))
+					iface.Name(), *currentEffectiveConfig, effectiveConfig))
 			}
 		}
 	}
@@ -174,13 +197,13 @@ func (net *NicsEqualTunable) Tune() TuneResult {
 // This is a meta tuner that checks that all given NICs use the same mode and IRQ masks.
 // It's really only needed like this because of the way the different subtuners are implemented.
 // Once we rewrite everything to be a single function this can just be at the top and won't be a separate "tuner".
-func (f *netTunersFactory) NewAllNicsSameModeTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable {
+func (f *netTunersFactory) NewAllNicsSameModeTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable {
 	tuneable := NicsEqualTunable{f: f, interfaces: interfaces, mode: mode, cpuMask: cpuMask}
 	return &tuneable
 }
 
-func (f *netTunersFactory) NewRxTxQueueCountTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable {
-	return f.tuneNonVirtualInterfaces(
+func (f *netTunersFactory) NewRxTxQueueCountTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable {
+	return f.tuneInterfaces(
 		interfaces,
 		func(nic network.Nic) Checker {
 			return f.checkersFactory.NewNicRxTxQueueCountChecker(nic, mode, cpuMask)
@@ -213,24 +236,17 @@ func (f *netTunersFactory) NewRxTxQueueCountTuner(interfaces []string, mode irq.
 
 			return NewTuneResult(false)
 		},
-		func() (bool, string) {
-			if !f.cpuMasks.IsSupported() {
-				return false, "Tuner is not supported as 'hwloc' is not installed"
-			}
-			return true, ""
-		},
 	)
 }
 
 func (f *netTunersFactory) NewNICsBalanceServiceTuner(
-	interfaces []string,
+	interfaces []network.Nic,
 ) Tunable {
 	return NewCheckedTunable(
 		f.checkersFactory.NewNicIRQBalanceChecker(interfaces),
 		func() TuneResult {
 			var IRQs []int
-			for _, ifaceName := range interfaces {
-				nic := network.NewNic(f.fs, f.irqProcFile, f.irqDeviceInfo, f.ethtool, ifaceName)
+			for _, nic := range interfaces {
 				nicIRQs, err := network.CollectIRQs(nic)
 				if err != nil {
 					return NewTuneError(err)
@@ -252,9 +268,9 @@ func (f *netTunersFactory) NewNICsBalanceServiceTuner(
 }
 
 func (f *netTunersFactory) NewNICsIRQsAffinityTuner(
-	interfaces []string, mode irq.Mode, cpuMask string,
+	interfaces []network.Nic, mode irq.Mode, cpuMask string,
 ) Tunable {
-	return f.tuneNonVirtualInterfaces(
+	return f.tuneInterfaces(
 		interfaces,
 		func(nic network.Nic) Checker {
 			return f.checkersFactory.NewNicIRQAffinityChecker(nic, mode, cpuMask)
@@ -267,12 +283,6 @@ func (f *netTunersFactory) NewNICsIRQsAffinityTuner(
 			}
 			f.cpuMasks.DistributeIRQs(dist)
 			return NewTuneResult(false)
-		},
-		func() (bool, string) {
-			if !f.cpuMasks.IsSupported() {
-				return false, "Tuner is not supported as 'hwloc' is not installed"
-			}
-			return true, ""
 		},
 	)
 }
@@ -330,22 +340,9 @@ func maybeReadFile(fs afero.Fs, path string) ([]byte, error) {
 	return content, nil
 }
 
-func (f *netTunersFactory) NewInterruptConfigFileTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable {
-	// In the AllNicsSameMode we have already checked that the mode and
-	// config for all NICs is the same so we can just use the first non-virtual one.
-	var nic network.Nic
-	for _, iface := range interfaces {
-		maybeNic := network.NewNic(f.fs, f.irqProcFile, f.irqDeviceInfo, f.ethtool, iface)
-		if maybeNic.IsHwInterface() || maybeNic.IsBondIface() {
-			nic = maybeNic
-			break
-		}
-	}
-
-	if nic == nil {
-		// No interfaces, nothing to do
-		return NewAggregatedTunable([]Tunable{})
-	}
+func (f *netTunersFactory) NewInterruptConfigFileTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable {
+	// We have already checked they are all the same so just use the first one
+	nic := interfaces[0]
 
 	tunable := checkedTunable{}
 	tunable.tuneAction = func() TuneResult {
@@ -445,9 +442,9 @@ func (f *netTunersFactory) NewInterruptConfigFileTuner(interfaces []string, mode
 }
 
 func (f *netTunersFactory) NewNICsRpsTuner(
-	interfaces []string, mode irq.Mode, cpuMask string,
+	interfaces []network.Nic, mode irq.Mode, cpuMask string,
 ) Tunable {
-	return f.tuneNonVirtualInterfaces(
+	return f.tuneInterfaces(
 		interfaces,
 		func(nic network.Nic) Checker {
 			return f.checkersFactory.NewNicRpsSetChecker(nic, mode, cpuMask)
@@ -470,17 +467,11 @@ func (f *netTunersFactory) NewNICsRpsTuner(
 			}
 			return NewTuneResult(false)
 		},
-		func() (bool, string) {
-			if !f.cpuMasks.IsSupported() {
-				return false, "Tuner is not supported as 'hwloc' is not installed"
-			}
-			return true, ""
-		},
 	)
 }
 
-func (f *netTunersFactory) NewNICsRfsTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable {
-	return f.tuneNonVirtualInterfaces(
+func (f *netTunersFactory) NewNICsRfsTuner(interfaces []network.Nic, mode irq.Mode, cpuMask string) Tunable {
+	return f.tuneInterfaces(
 		interfaces,
 		func(nic network.Nic) Checker {
 			return f.checkersFactory.NewNicRfsChecker(nic, mode, cpuMask)
@@ -503,17 +494,11 @@ func (f *netTunersFactory) NewNICsRfsTuner(interfaces []string, mode irq.Mode, c
 			}
 			return NewTuneResult(false)
 		},
-		func() (bool, string) {
-			if !f.cpuMasks.IsSupported() {
-				return false, "Tuner is not supported as 'hwloc' is not installed"
-			}
-			return true, ""
-		},
 	)
 }
 
-func (f *netTunersFactory) NewNICsNTupleTuner(interfaces []string) Tunable {
-	return f.tuneNonVirtualInterfaces(
+func (f *netTunersFactory) NewNICsNTupleTuner(interfaces []network.Nic) Tunable {
+	return f.tuneInterfaces(
 		interfaces,
 		func(nic network.Nic) Checker {
 			return f.checkersFactory.NewNicNTupleChecker(nic)
@@ -528,14 +513,11 @@ func (f *netTunersFactory) NewNICsNTupleTuner(interfaces []string) Tunable {
 			}
 			return NewTuneResult(false)
 		},
-		func() (bool, string) {
-			return true, ""
-		},
 	)
 }
 
-func (f *netTunersFactory) NewNICsXpsTuner(interfaces []string) Tunable {
-	return f.tuneNonVirtualInterfaces(
+func (f *netTunersFactory) NewNICsXpsTuner(interfaces []network.Nic) Tunable {
+	return f.tuneInterfaces(
 		interfaces,
 		func(nic network.Nic) Checker {
 			return f.checkersFactory.NewNicXpsChecker(nic)
@@ -557,9 +539,6 @@ func (f *netTunersFactory) NewNICsXpsTuner(interfaces []string) Tunable {
 				}
 			}
 			return NewTuneResult(false)
-		},
-		func() (bool, string) {
-			return true, ""
 		},
 	)
 }
@@ -625,25 +604,21 @@ func (f *netTunersFactory) writeIntToFile(file string, value int) error {
 		commands.NewWriteFileCmd(f.fs, file, fmt.Sprint(value)))
 }
 
-func (f *netTunersFactory) tuneNonVirtualInterfaces(
-	interfaces []string,
+func (f *netTunersFactory) tuneInterfaces(
+	interfaces []network.Nic,
 	checkerCreator func(network.Nic) Checker,
 	tuneAction func(network.Nic) TuneResult,
-	supportedAction func() (bool, string),
 ) Tunable {
 	var tunables []Tunable
 	for _, iface := range interfaces {
-		nic := network.NewNic(f.fs, f.irqProcFile, f.irqDeviceInfo, f.ethtool, iface)
-		if !nic.IsHwInterface() && !nic.IsBondIface() {
-			zap.L().Sugar().Debugf("Skipping tuning of '%s' virtual interface", nic.Name())
-			continue
-		}
 		tunables = append(tunables, NewCheckedTunable(
-			checkerCreator(nic),
+			checkerCreator(iface),
 			func() TuneResult {
-				return tuneInterface(nic, tuneAction)
+				return tuneInterface(iface, tuneAction)
 			},
-			supportedAction,
+			func() (bool, string) {
+				return true, ""
+			},
 			f.executor.IsLazy(),
 		))
 	}

--- a/src/go/rpk/pkg/tuners/network/nic.go
+++ b/src/go/rpk/pkg/tuners/network/nic.go
@@ -63,7 +63,7 @@ func IrqInfosToIDs(irqs []IrqInfo) []int {
 type Nic interface {
 	IsHwInterface() bool
 	IsBondIface() bool
-	Slaves() ([]Nic, error)
+	Slaves() []Nic
 	GetIRQs() ([]IrqInfo, error)
 	GetMaxRxQueueCount() (int, error)
 	GetRxQueueCount() (int, error)
@@ -83,6 +83,7 @@ type nic struct {
 	irqDeviceInfo irq.DeviceInfo
 	ethtool       ethtool.EthtoolWrapper
 	name          string
+	slaves        []Nic
 }
 
 func NewNic(
@@ -98,6 +99,7 @@ func NewNic(
 		irqDeviceInfo: irqDeviceInfo,
 		irqProcFile:   irqProcFile,
 		ethtool:       ethtool,
+		slaves:        getslaves(fs, irqProcFile, irqDeviceInfo, ethtool, name),
 	}
 }
 
@@ -122,23 +124,28 @@ func getLowerNames(fs afero.Fs, nicName string) []string {
 }
 
 func (n *nic) IsBondIface() bool {
-	zap.L().Sugar().Debugf("Checking if '%s' is bond interface", n.name)
-	lowers := getLowerNames(n.fs, n.name)
-	return len(lowers) > 0
+	return len(n.slaves) > 0
 }
 
-func (n *nic) Slaves() ([]Nic, error) {
+func getslaves(fs afero.Fs, irqProcFile irq.ProcFile,
+	irqDeviceInfo irq.DeviceInfo,
+	ethtool ethtool.EthtoolWrapper,
+	name string,
+) []Nic {
 	slaves := []Nic{}
 
-	if n.IsBondIface() {
-		zap.L().Sugar().Debugf("Reading slaves of '%s'", n.name)
-		slaveNames := getLowerNames(n.fs, n.name)
+	zap.L().Sugar().Debugf("Reading slaves of '%s'", name)
+	slaveNames := getLowerNames(fs, name)
 
-		for _, name := range slaveNames {
-			slaves = append(slaves, NewNic(n.fs, n.irqProcFile, n.irqDeviceInfo, n.ethtool, name))
-		}
+	for _, name := range slaveNames {
+		slaves = append(slaves, NewNic(fs, irqProcFile, irqDeviceInfo, ethtool, name))
 	}
-	return slaves, nil
+
+	return slaves
+}
+
+func (n *nic) Slaves() []Nic {
+	return n.slaves
 }
 
 func (n *nic) IsHwInterface() bool {

--- a/src/go/rpk/pkg/tuners/network/nic_test.go
+++ b/src/go/rpk/pkg/tuners/network/nic_test.go
@@ -14,6 +14,7 @@ package network
 import (
 	"fmt"
 	"math"
+	"sort"
 	"testing"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/tuners/ethtool"
@@ -62,8 +63,9 @@ func Test_nic_IsBondIface(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	procFile := &procFileMock{}
 	deviceInfo := &deviceInfoMock{}
-	nic := NewNic(fs, procFile, deviceInfo, &ethtoolMock{}, "test0")
 	afero.WriteFile(fs, "/sys/class/net/test0/lower_ens5", []byte{}, 0o644)
+	fs.MkdirAll("/sys/class/net/ens5/device", 0o755)
+	nic := NewNic(fs, procFile, deviceInfo, &ethtoolMock{}, "test0")
 	// when
 	bond := nic.IsBondIface()
 	// then
@@ -75,14 +77,16 @@ func Test_nic_Slaves_ReturnAllSlavesOfAnInterface(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	procFile := &procFileMock{}
 	deviceInfo := &deviceInfoMock{}
-	nic := NewNic(fs, procFile, deviceInfo, &ethtoolMock{}, "test0")
 	afero.WriteFile(fs, "/sys/class/net/test0/lower_sl0", []byte{}, 0o644)
 	afero.WriteFile(fs, "/sys/class/net/test0/lower_sl1", []byte{}, 0o644)
 	afero.WriteFile(fs, "/sys/class/net/test0/lower_sl2", []byte{}, 0o644)
+	fs.MkdirAll("/sys/class/net/sl0/device", 0o755)
+	fs.MkdirAll("/sys/class/net/sl1/device", 0o755)
+	fs.MkdirAll("/sys/class/net/sl2/device", 0o755)
+	nic := NewNic(fs, procFile, deviceInfo, &ethtoolMock{}, "test0")
 	// when
-	slaves, err := nic.Slaves()
+	slaves := nic.Slaves()
 	// then
-	require.NoError(t, err)
 	require.Len(t, slaves, 3)
 	require.Equal(t, slaves[0].Name(), "sl0")
 	require.Equal(t, slaves[1].Name(), "sl1")
@@ -94,13 +98,34 @@ func Test_nic_Slaves_ReturnEmptyForNotBondInterface(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	procFile := &procFileMock{}
 	deviceInfo := &deviceInfoMock{}
-	nic := NewNic(fs, procFile, deviceInfo, &ethtoolMock{}, "test0")
 	fs.MkdirAll("/sys/class/net/test0/device", 0o755)
+	nic := NewNic(fs, procFile, deviceInfo, &ethtoolMock{}, "test0")
 	// when
-	slaves, err := nic.Slaves()
+	slaves := nic.Slaves()
 	// then
-	require.NoError(t, err)
 	require.Empty(t, slaves)
+}
+
+func Test_mapInterfaces(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	procFile := &procFileMock{}
+	deviceInfo := &deviceInfoMock{}
+
+	afero.WriteFile(fs, "/sys/class/net/test0/lower_sl0", []byte{}, 0o644)
+	afero.WriteFile(fs, "/sys/class/net/test0/lower_sl1", []byte{}, 0o644)
+	fs.MkdirAll("/sys/class/net/sl0/device", 0o755)
+	fs.MkdirAll("/sys/class/net/sl1/device", 0o755)
+
+	// One child is passed explicitly, shouldn't exist twice in the output
+	interfaces := []string{"test0", "sl1"}
+	nics := MapInterfaces(interfaces, fs, procFile, deviceInfo, &ethtoolMock{})
+	sort.Slice(nics, func(i, j int) bool {
+		return nics[i].Name() < nics[j].Name()
+	})
+
+	require.Equal(t, 2, len(nics))
+	require.Equal(t, "sl0", nics[0].Name())
+	require.Equal(t, "sl1", nics[1].Name())
 }
 
 type IrqInfoRes struct {

--- a/src/go/rpk/pkg/tuners/network/nics.go
+++ b/src/go/rpk/pkg/tuners/network/nics.go
@@ -158,49 +158,26 @@ func canDefaultToDedicatedMode(numOfPUs int, cpuMask string, cpuMasks irq.CPUMas
 func GetDefaultMode(
 	nic Nic, cpuMask string, cpuMasks irq.CPUMasks, rnc config.RpkNodeConfig,
 ) (irq.Mode, error) {
-	if nic.IsHwInterface() {
-		numOfPUs, err := cpuMasks.GetNumberOfPUs(cpuMask)
-		if err != nil {
-			return "", err
-		}
-
-		canDoDedicated, err := canDefaultToDedicatedMode(int(numOfPUs), cpuMask, cpuMasks, rnc)
-		if err != nil {
-			return "", err
-		}
-		var mode irq.Mode
-		if numOfPUs >= uint(rnc.Tuners.GetCoresPerDedicatedInterruptCore()) && rnc.Tuners.GetAllowDedicatedInterruptMode() && canDoDedicated {
-			mode = irq.Dedicated
-		} else {
-			mode = irq.Mq
-		}
-
-		zap.L().Sugar().Debugf("Using '%s' mode for '%s': '%d' PUs",
-			mode, nic.Name(), numOfPUs)
-
-		return mode, nil
+	numOfPUs, err := cpuMasks.GetNumberOfPUs(cpuMask)
+	if err != nil {
+		return "", err
 	}
 
-	if nic.IsBondIface() {
-		defaultMode := irq.Mq
-		slaves, err := nic.Slaves()
-		if err != nil {
-			return "", err
-		}
-		for _, slave := range slaves {
-			slaveDefaultMode, err := GetDefaultMode(slave, cpuMask, cpuMasks, rnc)
-			if err != nil {
-				return "", err
-			}
-			if slaveDefaultMode == irq.Sq {
-				defaultMode = irq.Sq
-			} else if slaveDefaultMode == irq.SqSplit && defaultMode == irq.Mq {
-				defaultMode = irq.SqSplit
-			}
-		}
-		return defaultMode, nil
+	canDoDedicated, err := canDefaultToDedicatedMode(int(numOfPUs), cpuMask, cpuMasks, rnc)
+	if err != nil {
+		return "", err
 	}
-	return "", fmt.Errorf("virtual device %s is not supported", nic.Name())
+	var mode irq.Mode
+	if numOfPUs >= uint(rnc.Tuners.GetCoresPerDedicatedInterruptCore()) && rnc.Tuners.GetAllowDedicatedInterruptMode() && canDoDedicated {
+		mode = irq.Dedicated
+	} else {
+		mode = irq.Mq
+	}
+
+	zap.L().Sugar().Debugf("Using '%s' mode for '%s': '%d' PUs",
+		mode, nic.Name(), numOfPUs)
+
+	return mode, nil
 }
 
 func checkDedicatedCompatibleConfig(cpuMask string, cpuMasks irq.CPUMasks, rnc config.RpkNodeConfig) error {
@@ -482,26 +459,11 @@ func GetCurrentAndTargetChannels(
 
 func CollectIRQs(nic Nic) ([]int, error) {
 	var IRQs []int
-	if nic.IsHwInterface() {
-		nicIRQs, err := nic.GetIRQs()
-		if err != nil {
-			return nil, err
-		}
-		IRQs = append(IRQs, IrqInfosToIDs(nicIRQs)...)
+	nicIRQs, err := nic.GetIRQs()
+	if err != nil {
+		return nil, err
 	}
-	if nic.IsBondIface() {
-		slaves, err := nic.Slaves()
-		if err != nil {
-			return nil, err
-		}
-		for _, slave := range slaves {
-			slaveIRQs, err := CollectIRQs(slave)
-			if err != nil {
-				return nil, err
-			}
-			IRQs = append(IRQs, slaveIRQs...)
-		}
-	}
+	IRQs = append(IRQs, IrqInfosToIDs(nicIRQs)...)
 	return IRQs, nil
 }
 
@@ -545,7 +507,14 @@ func checkNic(nic Nic, nicMap map[string]Nic) {
 		return
 	}
 
-	nicMap[nic.Name()] = nic
+	// unroll bond slaves here such that we don't have to deal with later everywhere
+	if nic.IsBondIface() {
+		for _, slave := range nic.Slaves() {
+			checkNic(slave, nicMap)
+		}
+	} else {
+		nicMap[nic.Name()] = nic
+	}
 }
 
 func MapInterfaces(interfaces []string, fs afero.Fs,

--- a/src/go/rpk/pkg/tuners/network/nics.go
+++ b/src/go/rpk/pkg/tuners/network/nics.go
@@ -366,7 +366,7 @@ func GetHwInterfaceIRQsDistribution(
 	if err != nil {
 		return nil, err
 	}
-	zap.L().Sugar().Debugf("Distributing rest of '%s' IRQs\n", nic.Name())
+	zap.L().Sugar().Debugf("Distributing rest of '%s' IRQs", nic.Name())
 	restIRQsDistribution, err := cpuMasks.GetIRQsDistributionMasks(
 		IrqInfosToIDs(allIRQs[irqCutOffIndex:]), effectiveConfig.IRQCPUMask)
 	if err != nil {

--- a/src/go/rpk/pkg/tuners/network/nics.go
+++ b/src/go/rpk/pkg/tuners/network/nics.go
@@ -20,6 +20,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/tuners/ethtool"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/tuners/irq"
 	et "github.com/safchain/ethtool"
+	"github.com/spf13/afero"
 	"go.uber.org/zap"
 )
 
@@ -533,4 +534,35 @@ func OneRPSQueueLimit(limits []string, nic Nic, mode irq.Mode, cpuMask string, c
 		return 0, nil
 	}
 	return RfsTableSize / len(limits), nil
+}
+
+func checkNic(nic Nic, nicMap map[string]Nic) {
+	if _, exists := nicMap[nic.Name()]; exists {
+		return
+	}
+	if !nic.IsHwInterface() && !nic.IsBondIface() {
+		zap.L().Sugar().Debugf("Skipping tuning of '%s' virtual interface", nic.Name())
+		return
+	}
+
+	nicMap[nic.Name()] = nic
+}
+
+func MapInterfaces(interfaces []string, fs afero.Fs,
+	irqProcFile irq.ProcFile,
+	irqDeviceInfo irq.DeviceInfo,
+	ethtool ethtool.EthtoolWrapper,
+) []Nic {
+	nics := make(map[string]Nic)
+
+	for _, iface := range interfaces {
+		nic := NewNic(fs, irqProcFile, irqDeviceInfo, ethtool, iface)
+		checkNic(nic, nics)
+	}
+
+	var nicsList []Nic
+	for _, nic := range nics {
+		nicsList = append(nicsList, nic)
+	}
+	return nicsList
 }

--- a/src/go/rpk/pkg/tuners/network/nics.go
+++ b/src/go/rpk/pkg/tuners/network/nics.go
@@ -25,9 +25,11 @@ import (
 )
 
 type EffectiveNicConfig struct {
-	Mode                irq.Mode
-	ComputationsCPUMask string
-	IRQCPUMask          string
+	Mode                    irq.Mode
+	ComputationsCPUMask     string
+	ComputationsCPUMaskSize int
+	IRQCPUMask              string
+	IRQCPUMaskSize          int
 }
 
 func GetEffectiveNicConfig(
@@ -48,11 +50,21 @@ func GetEffectiveNicConfig(
 	if err != nil {
 		return EffectiveNicConfig{}, err
 	}
+	irqPUs, err := cpuMasks.GetNumberOfPUs(effectiveConfig.IRQCPUMask)
+	if err != nil {
+		return EffectiveNicConfig{}, err
+	}
+	effectiveConfig.IRQCPUMaskSize = int(irqPUs)
 
 	effectiveConfig.ComputationsCPUMask, err = cpuMasks.CPUMaskForComputations(effectiveConfig.Mode, effectiveCPUMask, rnc)
 	if err != nil {
 		return EffectiveNicConfig{}, err
 	}
+	computationPUs, err := cpuMasks.GetNumberOfPUs(effectiveConfig.ComputationsCPUMask)
+	if err != nil {
+		return EffectiveNicConfig{}, err
+	}
+	effectiveConfig.ComputationsCPUMaskSize = int(computationPUs)
 
 	return effectiveConfig, nil
 }
@@ -225,68 +237,34 @@ func getEffectiveMode(mode irq.Mode, nic Nic, effectiveCPUMask string, cpuMasks 
 }
 
 func GetRpsCPUMask(
-	nic Nic, mode irq.Mode, cpuMask string, cpuMasks irq.CPUMasks, rnc config.RpkNodeConfig,
+	nic Nic, effectiveConfig EffectiveNicConfig, rnc config.RpkNodeConfig,
 ) (string, error) {
 	if !rnc.Tuners.GetAllowRpsRfsTuner() {
 		return "0x0", nil
-	}
-
-	effectiveCPUMask, err := cpuMasks.BaseCPUMask(cpuMask)
-	if err != nil {
-		return "", err
-	}
-
-	effectiveMode, err := getEffectiveMode(mode, nic, effectiveCPUMask, cpuMasks, rnc)
-	if err != nil {
-		return "", err
 	}
 
 	queueCount, err := nic.GetRxQueueCount()
 	if err != nil {
 		return "", err
 	}
-	puCount, err := cpuMasks.GetNumberOfPUs(effectiveCPUMask)
-	if err != nil {
-		return "", err
-	}
 
 	// In MQ mode, with at least one hardware RX queue per core just disable RPS as it adds no benefit.
-	if queueCount >= int(puCount) && effectiveMode == irq.Mq {
+	if queueCount >= effectiveConfig.ComputationsCPUMaskSize && effectiveConfig.Mode == irq.Mq {
 		return "0x0", nil
 	}
 
-	computationsCPUMask, err := cpuMasks.CPUMaskForComputations(
-		effectiveMode, effectiveCPUMask, rnc)
-	if err != nil {
-		return "", err
-	}
-	return computationsCPUMask, nil
+	return effectiveConfig.ComputationsCPUMask, nil
 }
 
 func GetHwInterfaceIRQsDistribution(
-	nic Nic, mode irq.Mode, cpuMask string, cpuMasks irq.CPUMasks, rnc config.RpkNodeConfig,
+	nic Nic, effectiveConfig EffectiveNicConfig, cpuMasks irq.CPUMasks,
 ) (map[int]string, error) {
-	effectiveCPUMask, err := cpuMasks.BaseCPUMask(cpuMask)
-	if err != nil {
-		return nil, err
-	}
-
-	effectiveMode, err := getEffectiveMode(mode, nic, effectiveCPUMask, cpuMasks, rnc)
-	if err != nil {
-		return nil, err
-	}
-
 	maxRxQueues, err := nic.GetMaxRxQueueCount()
 	if err != nil {
 		return nil, err
 	}
 
 	allIRQs, err := nic.GetIRQs()
-	if err != nil {
-		return nil, err
-	}
-
-	irqCPUMask, err := cpuMasks.CPUMaskForIRQs(effectiveMode, effectiveCPUMask, rnc)
 	if err != nil {
 		return nil, err
 	}
@@ -364,10 +342,10 @@ func GetHwInterfaceIRQsDistribution(
 	// There is an exception to the above where if we are on a driver that has broken
 	// "RSS queue" behaviour (it announces more queues than actually support RSS).
 
-	if (effectiveMode == irq.Mq || !supportsIrqLowering) && maxRxQueues >= len(allIRQs) {
+	if (effectiveConfig.Mode == irq.Mq || !supportsIrqLowering) && maxRxQueues >= len(allIRQs) {
 		zap.L().Sugar().Debugf("Calculating distribution '%s' IRQs (not limiting by RX queues)", nic.Name())
 		IRQsDistribution, err := cpuMasks.GetIRQsDistributionMasks(
-			IrqInfosToIDs(allIRQs), irqCPUMask)
+			IrqInfosToIDs(allIRQs), effectiveConfig.IRQCPUMask)
 		if err != nil {
 			return nil, err
 		}
@@ -384,13 +362,13 @@ func GetHwInterfaceIRQsDistribution(
 
 	zap.L().Sugar().Debugf("Distributing '%s' IRQs handling Rx/Tx queues", nic.Name())
 	IRQsDistribution, err := cpuMasks.GetIRQsDistributionMasks(
-		IrqInfosToIDs(allIRQs[0:irqCutOffIndex]), irqCPUMask)
+		IrqInfosToIDs(allIRQs[0:irqCutOffIndex]), effectiveConfig.IRQCPUMask)
 	if err != nil {
 		return nil, err
 	}
 	zap.L().Sugar().Debugf("Distributing rest of '%s' IRQs\n", nic.Name())
 	restIRQsDistribution, err := cpuMasks.GetIRQsDistributionMasks(
-		IrqInfosToIDs(allIRQs[irqCutOffIndex:]), irqCPUMask)
+		IrqInfosToIDs(allIRQs[irqCutOffIndex:]), effectiveConfig.IRQCPUMask)
 	if err != nil {
 		return nil, err
 	}
@@ -416,41 +394,18 @@ func getIrqCutOffIndex(allIRQs []IrqInfo, rxQueues int) int {
 // Returns the current ethtool channel config and the target (possibly lowered) channel config as required by the RX channel tuner.
 func GetCurrentAndTargetChannels(
 	nic Nic,
-	mode irq.Mode,
-	cpuMask string,
-	cpuMasks irq.CPUMasks,
-	rnc config.RpkNodeConfig,
+	effectiveConfig EffectiveNicConfig,
 	ethtool ethtool.EthtoolWrapper,
 ) (currentChannels et.Channels, targetChannels et.Channels, err error) {
-	effectiveCPUMask, err := cpuMasks.BaseCPUMask(cpuMask)
-	if err != nil {
-		return et.Channels{}, et.Channels{}, err
-	}
-
-	effectiveMode, err := getEffectiveMode(mode, nic, effectiveCPUMask, cpuMasks, rnc)
-	if err != nil {
-		return et.Channels{}, et.Channels{}, err
-	}
-
-	irqMask, err := cpuMasks.CPUMaskForIRQs(effectiveMode, effectiveCPUMask, rnc)
-	if err != nil {
-		return et.Channels{}, et.Channels{}, err
-	}
-
-	puCount, err := cpuMasks.GetNumberOfPUs(irqMask)
-	if err != nil {
-		return et.Channels{}, et.Channels{}, err
-	}
-
 	currentChannels, err = ethtool.GetChannels(nic.Name())
 	if err != nil {
 		return et.Channels{}, et.Channels{}, err
 	}
 
 	targetChannels = currentChannels
-	targetChannels.RxCount = min(currentChannels.MaxRx, uint32(puCount))
-	targetChannels.TxCount = min(currentChannels.MaxTx, uint32(puCount))
-	targetChannels.CombinedCount = min(currentChannels.MaxCombined, uint32(puCount))
+	targetChannels.RxCount = min(currentChannels.MaxRx, uint32(effectiveConfig.IRQCPUMaskSize))
+	targetChannels.TxCount = min(currentChannels.MaxTx, uint32(effectiveConfig.IRQCPUMaskSize))
+	targetChannels.CombinedCount = min(currentChannels.MaxCombined, uint32(effectiveConfig.IRQCPUMaskSize))
 
 	zap.L().Sugar().Debugf("Got current channels for '%s': %+v, target channels: %+v", nic.Name(), currentChannels, targetChannels)
 
@@ -467,29 +422,14 @@ func CollectIRQs(nic Nic) ([]int, error) {
 	return IRQs, nil
 }
 
-func OneRPSQueueLimit(limits []string, nic Nic, mode irq.Mode, cpuMask string, cpuMasks irq.CPUMasks, rnc config.RpkNodeConfig) (int, error) {
-	effectiveCPUMask, err := cpuMasks.BaseCPUMask(cpuMask)
-	if err != nil {
-		return 0, err
-	}
-
-	effectiveMode, err := getEffectiveMode(mode, nic, effectiveCPUMask, cpuMasks, rnc)
-	if err != nil {
-		return 0, err
-	}
-
+func OneRPSQueueLimit(limits []string, nic Nic, effectiveConfig EffectiveNicConfig, rnc config.RpkNodeConfig) (int, error) {
 	queueCount, err := nic.GetRxQueueCount()
 	if err != nil {
 		return 0, err
 	}
 
-	puCount, err := cpuMasks.GetNumberOfPUs(effectiveCPUMask)
-	if err != nil {
-		return 0, err
-	}
-
 	// In MQ mode, with at least one hardware RX queue per core just disable RFS as it adds no benefit.
-	if queueCount >= int(puCount) && effectiveMode == irq.Mq {
+	if queueCount >= effectiveConfig.ComputationsCPUMaskSize && effectiveConfig.Mode == irq.Mq {
 		return 0, nil
 	}
 	if !rnc.Tuners.GetAllowRpsRfsTuner() {

--- a/src/go/rpk/pkg/tuners/redpanda_checkers.go
+++ b/src/go/rpk/pkg/tuners/redpanda_checkers.go
@@ -29,6 +29,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/tuners/executors"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/tuners/hwloc"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/tuners/irq"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/tuners/network"
 	"github.com/spf13/afero"
 )
 
@@ -234,6 +235,7 @@ func RedpandaCheckers(
 	}
 	netCheckersFactory := NewNetCheckersFactory(
 		fs, y.Rpk, irqProcFile, irqDeviceInfo, ethtool, balanceService, cpuMasks)
+	nics := network.MapInterfaces(interfaces, fs, irqProcFile, irqDeviceInfo, ethtool)
 	checkers := map[CheckerID][]Checker{
 		ConfigFileChecker:             {NewConfigChecker(y)},
 		IoConfigFileChecker:           {NewIOConfigFileExistanceChecker(fs, ioConfigFile)},
@@ -252,12 +254,12 @@ func RedpandaCheckers(
 		SynBacklogChecker:             {netCheckersFactory.NewSynBacklogChecker()},
 		ListenBacklogChecker:          {netCheckersFactory.NewListenBacklogChecker()},
 		RfsTableEntriesChecker:        {netCheckersFactory.NewRfsTableSizeChecker()},
-		NicRxTxQueueCountChecker:      netCheckersFactory.NewNicRxTxQueueCountCheckers(interfaces, irq.Default, "all"),
-		NicIRQBalanceChecker:          {netCheckersFactory.NewNicIRQBalanceChecker(interfaces)},
-		NicIRQsAffinitChecker:         netCheckersFactory.NewNicIRQAffinityCheckers(interfaces, irq.Default, "all"),
-		NicRpsChecker:                 netCheckersFactory.NewNicRpsSetCheckers(interfaces, irq.Default, "all"),
-		NicRfsChecker:                 netCheckersFactory.NewNicRfsCheckers(interfaces, irq.Default, "all"),
-		NicXpsChecker:                 netCheckersFactory.NewNicXpsCheckers(interfaces),
+		NicRxTxQueueCountChecker:      netCheckersFactory.NewNicRxTxQueueCountCheckers(nics, irq.Default, "all"),
+		NicIRQBalanceChecker:          {netCheckersFactory.NewNicIRQBalanceChecker(nics)},
+		NicIRQsAffinitChecker:         netCheckersFactory.NewNicIRQAffinityCheckers(nics, irq.Default, "all"),
+		NicRpsChecker:                 netCheckersFactory.NewNicRpsSetCheckers(nics, irq.Default, "all"),
+		NicRfsChecker:                 netCheckersFactory.NewNicRfsCheckers(nics, irq.Default, "all"),
+		NicXpsChecker:                 netCheckersFactory.NewNicXpsCheckers(nics),
 		MaxAIOEvents:                  {NewMaxAIOEventsChecker(fs)},
 		ClockSource:                   {NewClockSourceChecker(fs)},
 		Swappiness:                    {NewSwappinessChecker(fs)},

--- a/src/go/rpk/pkg/tuners/redpanda_checkers.go
+++ b/src/go/rpk/pkg/tuners/redpanda_checkers.go
@@ -236,6 +236,15 @@ func RedpandaCheckers(
 	netCheckersFactory := NewNetCheckersFactory(
 		fs, y.Rpk, irqProcFile, irqDeviceInfo, ethtool, balanceService, cpuMasks)
 	nics := network.MapInterfaces(interfaces, fs, irqProcFile, irqDeviceInfo, ethtool)
+	effectiveConfig := network.EffectiveNicConfig{}
+	if len(nics) > 0 {
+		// just use the first nic for now.
+		// TODO: Unify net checkers below to match how the tuner actually works
+		effectiveConfig, err = network.GetEffectiveNicConfig(nics[0], irq.Default, "all", cpuMasks, y.Rpk)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get effective NIC config for checker setup: %w", err)
+		}
+	}
 	checkers := map[CheckerID][]Checker{
 		ConfigFileChecker:             {NewConfigChecker(y)},
 		IoConfigFileChecker:           {NewIOConfigFileExistanceChecker(fs, ioConfigFile)},
@@ -254,11 +263,11 @@ func RedpandaCheckers(
 		SynBacklogChecker:             {netCheckersFactory.NewSynBacklogChecker()},
 		ListenBacklogChecker:          {netCheckersFactory.NewListenBacklogChecker()},
 		RfsTableEntriesChecker:        {netCheckersFactory.NewRfsTableSizeChecker()},
-		NicRxTxQueueCountChecker:      netCheckersFactory.NewNicRxTxQueueCountCheckers(nics, irq.Default, "all"),
+		NicRxTxQueueCountChecker:      netCheckersFactory.NewNicRxTxQueueCountCheckers(nics, effectiveConfig),
 		NicIRQBalanceChecker:          {netCheckersFactory.NewNicIRQBalanceChecker(nics)},
-		NicIRQsAffinitChecker:         netCheckersFactory.NewNicIRQAffinityCheckers(nics, irq.Default, "all"),
-		NicRpsChecker:                 netCheckersFactory.NewNicRpsSetCheckers(nics, irq.Default, "all"),
-		NicRfsChecker:                 netCheckersFactory.NewNicRfsCheckers(nics, irq.Default, "all"),
+		NicIRQsAffinitChecker:         netCheckersFactory.NewNicIRQAffinityCheckers(nics, effectiveConfig),
+		NicRpsChecker:                 netCheckersFactory.NewNicRpsSetCheckers(nics, effectiveConfig),
+		NicRfsChecker:                 netCheckersFactory.NewNicRfsCheckers(nics, effectiveConfig),
 		NicXpsChecker:                 netCheckersFactory.NewNicXpsCheckers(nics),
 		MaxAIOEvents:                  {NewMaxAIOEventsChecker(fs)},
 		ClockSource:                   {NewClockSourceChecker(fs)},


### PR DESCRIPTION
This patch series refactors the net tuner a bit to avoid repeated invocations of the basic support tools like hwloc etc.

This simplifies the code, reduces log spam and makes the tuner run faster:

Compare runtimes before and after:

Before:

```
ubuntu@ip-172-31-2-234:~$ time sudo rpk redpanda tune net --mode dedicated
TUNER         APPLIED        ENABLED        SUPPORTED
net  true  true  true

real    0m0.990s
```

After:

```
ubuntu@ip-172-31-2-234:~$ time sudo rpk redpanda tune net --mode dedicated
TUNER         APPLIED        ENABLED        SUPPORTED
net  true  true  true

real    0m0.264s
```

and log levels:

Before:

```
ubuntu@ip-172-31-2-234:~$ wc -l /tmp/ded_master
351 /tmp/ded_master
```

After:

```
ubuntu@ip-172-31-2-234:~$ wc -l /tmp/ded_fast
159 /tmp/ded_fast
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none

