### PR TITLE
`rptest`: transactional control batch testing follow-ups

### DIFF
--- a/src/v/cluster/producer_state.cc
+++ b/src/v/cluster/producer_state.cc
@@ -349,8 +349,10 @@ void producer_state::reset_with_new_epoch(model::producer_epoch new_epoch) {
       "Invalid epoch bump to {} for producer {}",
       new_epoch,
       *this);
+    // We remove `tx_fence` batches during compaction. It is a valid operation
+    // to update the epoch when not currently in an open transaction.
     vassert(
-      !_transaction_state,
+      !_transaction_state || !_transaction_state->is_in_progress(),
       "Invalid epoch bump to {} for a non idempotent producer: {}",
       new_epoch,
       *this);

--- a/tests/go/kgo-verifier/cmd/kgo-repeater/main.go
+++ b/tests/go/kgo-verifier/cmd/kgo-repeater/main.go
@@ -48,6 +48,7 @@ var (
 	rateLimitBps       = flag.Int("rate-limit-bps", -1, "Bytes/second throttle (global, will be split equally between workers)")
 
 	useTransactions      = flag.Bool("use-transactions", false, "Producer: use a transactional producer")
+	transactionTimeout   = flag.Duration("transaction-timeout-ms", 2*time.Minute, "Value to use for `transaction.timeout.ms` when producing with transactions.")
 	transactionAbortRate = flag.Float64("transaction-abort-rate", 0.0, "The probability that any given transaction should abort")
 	msgsPerTransaction   = flag.Uint("msgs-per-transaction", 1, "The number of messages that should be in a given transaction")
 
@@ -151,7 +152,7 @@ func main() {
 		// the many changes that would be needed to be made to the verifier program if
 		// it was refactored.
 		wConfig := worker.NewWorkerConfig(
-			name, *brokers, *trace, topicsList[0], *linger, *maxBufferedRecords, *useTransactions, *compressionType, *compressiblePayload, *username, *password, *enableTls)
+			name, *brokers, *trace, topicsList[0], *linger, *maxBufferedRecords, *useTransactions, *transactionTimeout, *compressionType, *compressiblePayload, *username, *password, *enableTls)
 		config := repeater.NewRepeaterConfig(wConfig, topicsList, *group, *keys, *payloadSize, dataInFlightPerWorker, rateLimitPerWorker, *tombstoneProbability)
 		lv := repeater.NewWorker(config)
 		if *useTransactions {

--- a/tests/go/kgo-verifier/cmd/kgo-verifier/main.go
+++ b/tests/go/kgo-verifier/cmd/kgo-verifier/main.go
@@ -66,6 +66,7 @@ var (
 	msgsPerProducerId   = flag.Int("msgs-per-producer-id", -1, "Number of messages produced before creating new Producer Client.  (used to generate many producer ids)")
 
 	useTransactions      = flag.Bool("use-transactions", false, "Use a transactional producer. Consumer with ReadComitted isolation level.")
+	transactionTimeout   = flag.Duration("transaction-timeout-ms", 2*time.Minute, "Value to use for `transaction.timeout.ms` when producing with transactions.")
 	transactionAbortRate = flag.Float64("transaction-abort-rate", 0.0, "The probability that any given transaction should abort")
 	msgsPerTransaction   = flag.Uint("msgs-per-transaction", 1, "The number of messages that should be in a given transaction")
 
@@ -94,6 +95,7 @@ func makeWorkerConfig() worker.WorkerConfig {
 		UseTls:                *enableTls,
 		Name:                  *name,
 		Transactions:          *useTransactions,
+		TransactionTimeout:    *transactionTimeout,
 		CompressionType:       *compressionType,
 		CompressiblePayload:   *compressiblePayload,
 		TolerateDataLoss:      *tolerateDataLoss,

--- a/tests/go/kgo-verifier/pkg/worker/verifier/producer_worker.go
+++ b/tests/go/kgo-verifier/pkg/worker/verifier/producer_worker.go
@@ -345,7 +345,6 @@ func (pw *ProducerWorker) produceInner(n int64) (int64, []BadOffset, error) {
 
 		opts = append(opts, []kgo.Opt{
 			kgo.TransactionalID(tid),
-			kgo.TransactionTimeout(2 * time.Minute),
 		}...)
 	}
 

--- a/tests/go/kgo-verifier/pkg/worker/worker.go
+++ b/tests/go/kgo-verifier/pkg/worker/worker.go
@@ -186,6 +186,7 @@ type WorkerConfig struct {
 	SaslPass           string
 	UseTls             bool
 	Transactions       bool
+	TransactionTimeout time.Duration
 
 	// A kafka `compression.type`, or `mixed` to use a random one for each worker (requires
 	// that you have multiple workers to be meaningful)
@@ -269,6 +270,7 @@ func (wc *WorkerConfig) MakeKgoOpts() []kgo.Opt {
 			// By default kgo reads uncommited records and unstable offsets
 			kgo.RequireStableFetchOffsets(),
 			kgo.FetchIsolationLevel(kgo.ReadCommitted()),
+			kgo.TransactionTimeout(wc.TransactionTimeout),
 		}...)
 	}
 
@@ -297,7 +299,7 @@ func (wc *WorkerConfig) MakeKgoOpts() []kgo.Opt {
 	return opts
 }
 
-func NewWorkerConfig(name string, brokers string, trace bool, topic string, linger time.Duration, maxBufferedRecords uint, transactions bool,
+func NewWorkerConfig(name string, brokers string, trace bool, topic string, linger time.Duration, maxBufferedRecords uint, transactions bool, transactionTimeout time.Duration,
 	compressionType string, commpressiblePayload bool, username string, password string, useTls bool) WorkerConfig {
 	return WorkerConfig{
 		Name:                name,
@@ -310,6 +312,7 @@ func NewWorkerConfig(name string, brokers string, trace bool, topic string, ling
 		SaslPass:            password,
 		UseTls:              useTls,
 		Transactions:        transactions,
+		TransactionTimeout:  transactionTimeout,
 		CompressionType:     compressionType,
 		CompressiblePayload: commpressiblePayload,
 	}

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -623,6 +623,7 @@ class KgoVerifierProducer(KgoVerifierService):
         fake_timestamp_ms=None,
         fake_timestamp_step_ms=None,
         use_transactions=False,
+        transaction_timeout_ms=None,
         transaction_abort_rate=None,
         msgs_per_transaction=None,
         rate_limit_bps=None,
@@ -656,6 +657,7 @@ class KgoVerifierProducer(KgoVerifierService):
         self._fake_timestamp_ms = fake_timestamp_ms
         self._fake_timestamp_step_ms = fake_timestamp_step_ms
         self._use_transactions = use_transactions
+        self._transaction_timeout_ms = transaction_timeout_ms
         self._transaction_abort_rate = transaction_abort_rate
         self._msgs_per_transaction = msgs_per_transaction
         self._rate_limit_bps = rate_limit_bps
@@ -787,6 +789,9 @@ class KgoVerifierProducer(KgoVerifierService):
 
         if self._use_transactions:
             cmd = cmd + " --use-transactions"
+
+            if self._transaction_timeout_ms is not None:
+                cmd += f" --transaction-timeout-ms {self._transaction_timeout_ms}ms"
 
             if self._msgs_per_transaction is not None:
                 cmd = cmd + f" --msgs-per-transaction {self._msgs_per_transaction}"

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -638,6 +638,7 @@ class KgoVerifierProducer(KgoVerifierService):
         tombstone_probability=0.0,
         validate_latest_values=False,
         client_name=None,
+        wait_for_acks=True,
     ):
         super(KgoVerifierProducer, self).__init__(
             context,
@@ -669,6 +670,7 @@ class KgoVerifierProducer(KgoVerifierService):
         self._tombstone_probability = tombstone_probability
         self._validate_latest_values = validate_latest_values
         self._client_name = client_name
+        self._wait_for_acks = wait_for_acks
 
     @property
     def produce_status(self) -> ProduceStatus:
@@ -685,10 +687,19 @@ class KgoVerifierProducer(KgoVerifierService):
 
         what = f"{self.who_am_i()} wait: awaiting message count"
         self.logger.debug(what)
+
+        def is_finished():
+            has_error = self.status_thread.errored
+            msg_count = (
+                self.produce_status.acked
+                if self._wait_for_acks
+                else self.produce_status.sent
+            )
+            return has_error or msg_count >= self._msg_count
+
         try:
             self._redpanda.wait_until(
-                lambda: self.status_thread.errored
-                or self.produce_status.acked >= self._msg_count,
+                is_finished,
                 timeout_sec=timeout_sec if timeout_sec is not None else 30,
                 backoff_sec=self._status_thread.INTERVAL,
                 err_msg=what,

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -21,7 +21,9 @@ from rptest.services.kgo_verifier_services import (
     KgoVerifierProducer,
     KgoVerifierSeqConsumer,
 )
-from rptest.services.redpanda_installer import RedpandaVersionLine
+from rptest.services.redpanda_installer import (
+    RedpandaVersionLine,
+)
 from rptest.services.redpanda import MetricsEndpoint
 from rptest.tests.partition_movement import PartitionMovementMixin
 from rptest.tests.prealloc_nodes import PreallocNodesTest
@@ -794,8 +796,6 @@ class LogCompactionTxRemovalUpgradeTest(LogCompactionTxRemovalTestBase):
         self.initial_version: RedpandaVersionLine = (25, 1)
         # Version before tx removal was added to compaction.
         self.may_have_tx_batch_version: RedpandaVersionLine = (25, 2)
-        # Version in which tx batch removal was added to compaction.
-        self.tx_removal_version: RedpandaVersionLine = (25, 3)
 
     def setUp(self):
         self.redpanda._installer.install(self.redpanda.nodes, self.initial_version)
@@ -826,8 +826,11 @@ class LogCompactionTxRemovalUpgradeTest(LogCompactionTxRemovalTestBase):
         # Produce more transactional data.
         self.produce(test_case)
 
-        # Upgrade to `tx_removal` version.
-        self.upgrade_to_version(self.tx_removal_version)
+        # Upgrade to `HEAD`.
+        for version in self.redpanda._installer.upgrade_path_to_head(
+            self.may_have_tx_batch_version
+        ):
+            self.upgrade_to_version(version)
 
         # Perform rest of test
         self.do_test_tx_control_batch_removal(test_case_name, test_case)

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -711,21 +711,22 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
         for node in self.redpanda.nodes:
             num_control_batches = 0
             num_fence_batches = 0
-            records_and_batches = viewer.read_kafka_records(node, self.topic_spec.name)
-            for record_or_batch in records_and_batches:
-                if "expanded_attrs" not in record_or_batch:
-                    continue
-                if record_or_batch["expanded_attrs"]["control_batch"]:
-                    num_control_batches += 1
-                if record_or_batch["type_name"] == "tx_fence":
-                    num_fence_batches += 1
+            partitions = viewer.read_kafka_records(node, self.topic_spec.name)
+            for partition in partitions:
+                for record_or_batch in partition:
+                    if "expanded_attrs" not in record_or_batch:
+                        continue
+                    if record_or_batch["expanded_attrs"]["control_batch"]:
+                        num_control_batches += 1
+                    if record_or_batch["type_name"] == "tx_fence":
+                        num_fence_batches += 1
 
-            assert num_control_batches == 0, (
-                f"expected 0 control batches (abort/commit batches), saw {num_control_batches} on node {node.name()}"
-            )
-            assert num_fence_batches == 0, (
-                f"expected 0 tx_fence batches, saw {num_fence_batches}  on node {node.name()}"
-            )
+                assert num_control_batches == 0, (
+                    f"expected 0 control batches (abort/commit batches), saw {num_control_batches} on node {node.name}"
+                )
+                assert num_fence_batches == 0, (
+                    f"expected 0 tx_fence batches, saw {num_fence_batches}  on node {node.name}"
+                )
 
     def do_test_tx_control_batch_removal(self, test_case_name, test_case):
         self.logger.info(
@@ -737,7 +738,6 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
 
         # Restart the redpanda broker to roll segments
         self.redpanda.restart_nodes(self.redpanda.nodes)
-
 
         self.wait_for_sliding_window_compaction()
 

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -232,6 +232,22 @@ class LogCompactionTestBase(PartitionMovementMixin):
             else float(dirty_segment_bytes) / float(closed_segment_bytes)
         )
 
+    def wait_for_sliding_window_compaction(self):
+        self.prev_sliding_window_rounds = None
+
+        def compaction_has_completed():
+            new_sliding_window_rounds = self.get_complete_sliding_window_rounds()
+            res = self.prev_sliding_window_rounds == new_sliding_window_rounds
+            self.prev_sliding_window_rounds = new_sliding_window_rounds
+            return res
+
+        wait_until(
+            compaction_has_completed,
+            timeout_sec=120,
+            backoff_sec=self.extra_rp_conf["log_compaction_interval_ms"] / 1000 * 4,
+            err_msg="Compaction did not stabilize.",
+        )
+
 
 class LogCompactionTest(LogCompactionTestBase, PreallocNodesTest):
     def __init__(self, test_context):
@@ -476,21 +492,7 @@ class LogCompactionSchedulingTest(LogCompactionTestBase, PreallocNodesTest):
         self.produce_and_consume()
 
         # At this point, the min.cleanable.dirty.ratio is 1.0
-        self.prev_sliding_window_rounds = -1
-
-        def compaction_has_completed():
-            new_sliding_window_rounds = self.get_complete_sliding_window_rounds()
-
-            res = self.prev_sliding_window_rounds == new_sliding_window_rounds
-            self.prev_sliding_window_rounds = new_sliding_window_rounds
-            return res
-
-        wait_until(
-            compaction_has_completed,
-            timeout_sec=120,
-            backoff_sec=self.extra_rp_conf["log_compaction_interval_ms"] / 1000 * 4,
-            err_msg="Compaction did not stabilize.",
-        )
+        self.wait_for_sliding_window_compaction()
 
         # We may race with a segment roll which won't be compacted (due to high min.cleanable.dirty.ratio),
         # so we cannot assert dirty_segment_bytes == 0 here.
@@ -525,12 +527,7 @@ class LogCompactionSchedulingTest(LogCompactionTestBase, PreallocNodesTest):
         # see the rolled segment compacted along with the rest of the log
         self.set_min_cleanable_dirty_ratio(0.0)
 
-        wait_until(
-            compaction_has_completed,
-            timeout_sec=120,
-            backoff_sec=self.extra_rp_conf["log_compaction_interval_ms"] / 1000 * 4,
-            err_msg="Compaction did not stabilize.",
-        )
+        self.wait_for_sliding_window_compaction()
 
         def no_dirty_bytes():
             return all(
@@ -741,21 +738,8 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
         # Restart the redpanda broker to roll segments
         self.redpanda.restart_nodes(self.redpanda.nodes)
 
-        self.prev_sliding_window_rounds = -1
 
-        def compaction_has_completed():
-            new_sliding_window_rounds = self.get_complete_sliding_window_rounds()
-
-            res = self.prev_sliding_window_rounds == new_sliding_window_rounds
-            self.prev_sliding_window_rounds = new_sliding_window_rounds
-            return res
-
-        wait_until(
-            compaction_has_completed,
-            timeout_sec=120,
-            backoff_sec=self.extra_rp_conf["log_compaction_interval_ms"] / 1000 * 4,
-            err_msg="Compaction did not stabilize.",
-        )
+        self.wait_for_sliding_window_compaction()
 
         self.stop_partition_movement()
 

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -679,6 +679,7 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
             "log_segment_size": 2 * 1024**2,  # 2 MiB
             "compacted_log_segment_size": 1024**2,  # 1 MiB
         }
+        self.transaction_timeout_ms = 2000
 
         super().__init__(
             test_context=test_context,
@@ -694,12 +695,16 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
             context=self.test_context,
             redpanda=self.redpanda,
             topic=self.topic_spec.name,
-            use_transactions=True,
             msg_size=test_case.msg_size,
             msg_count=test_case.msg_count,
+            use_transactions=True,
+            transaction_timeout_ms=self.transaction_timeout_ms,
             transaction_abort_rate=test_case.abort_rate,
             msgs_per_transaction=test_case.msgs_per_transaction,
             custom_node=self.preallocated_nodes,
+            tolerate_failed_produce=True,
+            tolerate_data_loss=True,
+            wait_for_acks=False,
         )
 
         producer.start()
@@ -738,6 +743,9 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
 
         # Restart the redpanda broker to roll segments
         self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        # Sleep in order to allow any open transaction to be closed.
+        time.sleep(2 * self.transaction_timeout_ms / 1000)
 
         self.wait_for_sliding_window_compaction()
 

--- a/tests/rptest/transactions/tx_upgrade_test.py
+++ b/tests/rptest/transactions/tx_upgrade_test.py
@@ -292,7 +292,7 @@ class TxUpgradeRevertTest(RedpandaTest):
                                 id, state, partitions, sequence=sequence
                             )
                         sequence += 1
-            except Exception as e:
+            except Exception:
                 self.failed = True
                 self.dump_debug_transaction_state()
                 self.redpanda.logger.error(

--- a/tests/rptest/transactions/tx_upgrade_test.py
+++ b/tests/rptest/transactions/tx_upgrade_test.py
@@ -23,33 +23,33 @@ from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, RedpandaService
-from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_versions
+from rptest.services.redpanda_installer import (
+    RedpandaInstaller,
+    RedpandaVersionLine,
+    RedpandaVersionTriple,
+    wait_for_num_versions,
+    ver_string,
+)
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.utils.mode_checks import skip_debug_mode
 
 
-class TxUpgradeTest(RedpandaTest):
+class TxUpgradeTestBase(RedpandaTest):
     """
     Basic test verifying if mapping between transaction coordinator and transaction_id is preserved across the upgrades
     """
 
-    def __init__(self, test_context):
-        super(TxUpgradeTest, self).__init__(test_context=test_context, num_brokers=3)
-        self.installer = self.redpanda._installer
+    def __init__(self, test_context, extra_rp_conf={}):
+        super(TxUpgradeTestBase, self).__init__(
+            test_context=test_context, num_brokers=3, extra_rp_conf=extra_rp_conf
+        )
         self.partition_count = 10
         self.msg_sent = 0
         self.producers_count = 100
+        self.installer = self.redpanda._installer
 
     def setUp(self):
-        self.old_version = self.installer.highest_from_prior_feature_version(
-            RedpandaInstaller.HEAD
-        )
-
-        self.old_version_str = (
-            f"v{self.old_version[0]}.{self.old_version[1]}.{self.old_version[2]}"
-        )
-        self.installer.install(self.redpanda.nodes, self.old_version)
-        super(TxUpgradeTest, self).setUp()
+        super(TxUpgradeTestBase, self).setUp()
 
     def _tx_id(self, idx):
         return f"test-producer-{idx}"
@@ -87,6 +87,24 @@ class TxUpgradeTest(RedpandaTest):
             mapping[self._tx_id(idx)] = f"{c['ntp']['topic']}/{c['ntp']['partition']}"
 
         return mapping
+
+
+class TxUpgradeTest(TxUpgradeTestBase):
+    """
+    Basic test verifying if mapping between transaction coordinator and transaction_id is preserved across the upgrades
+    """
+
+    def __init__(self, test_context):
+        super(TxUpgradeTest, self).__init__(test_context=test_context)
+
+    def setUp(self):
+        self.old_version = self.installer.highest_from_prior_feature_version(
+            RedpandaInstaller.HEAD
+        )
+
+        self.old_version_str = ver_string(self.old_version)
+        self.installer.install(self.redpanda.nodes, self.old_version)
+        super(TxUpgradeTest, self).setUp()
 
     @skip_debug_mode
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)

--- a/tests/rptest/transactions/tx_upgrade_test.py
+++ b/tests/rptest/transactions/tx_upgrade_test.py
@@ -18,11 +18,16 @@ import confluent_kafka as ck
 from ducktape.errors import TimeoutError
 from ducktape.utils.util import wait_until
 
+from rptest.clients.offline_log_viewer import OfflineLogViewer
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, RedpandaService
+from rptest.services.redpanda import (
+    RESTART_LOG_ALLOW_LIST,
+    RedpandaService,
+    MetricsEndpoint,
+)
 from rptest.services.redpanda_installer import (
     RedpandaInstaller,
     RedpandaVersionLine,
@@ -46,6 +51,7 @@ class TxUpgradeTestBase(RedpandaTest):
         self.partition_count = 10
         self.msg_sent = 0
         self.producers_count = 100
+        self.transaction_timeout_ms = 10000
         self.installer = self.redpanda._installer
 
     def setUp(self):
@@ -64,6 +70,7 @@ class TxUpgradeTestBase(RedpandaTest):
                 {
                     "bootstrap.servers": self.redpanda.brokers(),
                     "transactional.id": self._tx_id(i),
+                    "transaction.timeout.ms": self.transaction_timeout_ms,
                 }
             )
             producer.init_transactions()
@@ -140,6 +147,132 @@ class TxUpgradeTest(TxUpgradeTestBase):
         assert self._get_tx_id_mapping() == initial_mapping, (
             "Mapping changed after full upgrade"
         )
+
+
+class TxUpgradeCompactionTest(TxUpgradeTestBase):
+    """
+    Test validating interaction between compaction and transactions during rolling-restart upgrades (including mixed-version node cluster interaction)
+    """
+
+    def __init__(self, test_context):
+        self.extra_rp_conf = {
+            "log_compaction_interval_ms": 4000,
+            "log_segment_size": 2 * 1024**2,  # 2 MiB
+            "compacted_log_segment_size": 1024**2,  # 1 MiB
+        }
+
+        super(TxUpgradeCompactionTest, self).__init__(
+            test_context=test_context, extra_rp_conf=self.extra_rp_conf
+        )
+
+        self.transaction_timeout_ms = 2000
+
+    def setUp(self):
+        # Version before `may_have_transactional_batches` was added.
+        self.initial_version: RedpandaVersionTriple = self.installer.latest_for_line(
+            RedpandaVersionLine((25, 1))
+        )[0]
+        self.installer.install(self.redpanda.nodes, self.initial_version)
+        super(TxUpgradeCompactionTest, self).setUp()
+
+    def get_complete_sliding_window_rounds(self):
+        return self.redpanda.metric_sum(
+            metric_name="vectorized_storage_log_complete_sliding_window_rounds_total",
+            metrics_endpoint=MetricsEndpoint.METRICS,
+            topic=self.topic_spec.name,
+        )
+
+    def wait_for_sliding_window_compaction(self):
+        self.prev_sliding_window_rounds = None
+
+        def compaction_has_completed():
+            new_sliding_window_rounds = self.get_complete_sliding_window_rounds()
+            res = self.prev_sliding_window_rounds == new_sliding_window_rounds
+            self.prev_sliding_window_rounds = new_sliding_window_rounds
+            return res
+
+        wait_until(
+            compaction_has_completed,
+            timeout_sec=120,
+            backoff_sec=self.extra_rp_conf["log_compaction_interval_ms"] / 1000 * 4,
+            err_msg="Compaction did not stabilize.",
+        )
+
+    def check_tx_batches(self):
+        viewer = OfflineLogViewer(self.redpanda)
+        for node in self.redpanda.nodes:
+            num_control_batches = 0
+            num_fence_batches = 0
+            partitions = viewer.read_kafka_records(node, self.topic_spec.name)
+            for partition in partitions:
+                for record_or_batch in partition:
+                    if "expanded_attrs" not in record_or_batch:
+                        continue
+                    if record_or_batch["expanded_attrs"]["control_batch"]:
+                        num_control_batches += 1
+                    if record_or_batch["type_name"] == "tx_fence":
+                        num_fence_batches += 1
+
+            assert num_control_batches == 0, (
+                f"expected 0 control batches (abort/commit batches), saw {num_control_batches} on node {node.name}"
+            )
+            assert num_fence_batches == 0, (
+                f"expected 0 tx_fence batches, saw {num_fence_batches}  on node {node.name}"
+            )
+
+    @skip_debug_mode
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def upgrade_with_compaction_test(self):
+        self.topic_spec = TopicSpec(
+            partition_count=self.partition_count,
+            delete_retention_ms=3000,
+            cleanup_policy=TopicSpec.CLEANUP_COMPACT,
+            min_cleanable_dirty_ratio=0.0,
+        )
+        self.client().create_topic(self.topic_spec)
+
+        prev_version_str = ver_string(self.initial_version)
+        unique_versions = wait_for_num_versions(self.redpanda, 1)
+        assert prev_version_str in unique_versions, unique_versions
+
+        for new_version in self.installer.upgrade_path_to_head(self.initial_version):
+            self._populate_tx_coordinator(topic=self.topic_spec.name)
+            initial_mapping = self._get_tx_id_mapping()
+            self.logger.info(f"Initial mapping {initial_mapping}")
+
+            first_node = self.redpanda.nodes[0]
+
+            self.installer.install(self.redpanda.nodes, new_version)
+
+            # Upgrade & restart one node to the new version.
+            self.redpanda.restart_nodes([first_node])
+            unique_versions = wait_for_num_versions(self.redpanda, 2)
+            assert prev_version_str in unique_versions, unique_versions
+            assert self._get_tx_id_mapping() == initial_mapping, (
+                "Mapping changed after upgrading one of the nodes"
+            )
+
+            # verify if txs are handled correctly with mixed versions
+            self._populate_tx_coordinator(topic=self.topic_spec.name)
+
+            # Only once we upgrade the rest of the nodes do we converge on the new
+            # version.
+            self.redpanda.restart_nodes(self.redpanda.nodes)
+            unique_versions = wait_for_num_versions(self.redpanda, 1)
+            assert prev_version_str not in unique_versions, unique_versions
+            assert self._get_tx_id_mapping() == initial_mapping, (
+                "Mapping changed after full upgrade"
+            )
+            prev_version_str = ver_string(new_version)
+
+        # One last round of producing
+        self._populate_tx_coordinator(topic=self.topic_spec.name)
+
+        # Restart the redpanda broker to roll segments
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        self.wait_for_sliding_window_compaction()
+        self.check_tx_batches()
 
 
 class TxUpgradeRevertTest(RedpandaTest):

--- a/tools/offline_log_viewer/viewer.py
+++ b/tools/offline_log_viewer/viewer.py
@@ -62,12 +62,16 @@ class OfflineLogViewer:
     def build_store(self):
         return Store(self._config.path)
 
-    def stream_json(self, data: Any, wrap_with_gen: bool = True) -> None:
+    def stream_json(
+        self, data: Any, wrap_with_gen: bool = True, print_delimiter=False
+    ) -> None:
         iter_json = json.JSONEncoder(indent=2).iterencode(
             SerializableGenerator(data) if wrap_with_gen else data
         )
         for j in iter_json:
             sys.stdout.write(j)
+        if print_delimiter:
+            sys.stdout.write(",")
         sys.stdout.flush()
 
     def print_kv_store(self):
@@ -110,15 +114,22 @@ class OfflineLogViewer:
 
     def print_kafka(self, headers_only: bool = False):
         store = self.build_store()
+        output_ntps = []
         for ntp in store.ntps:
             if ntp.nspace in ["kafka", "kafka_internal"]:
                 if self._config.topic and ntp.topic != self._config.topic:
                     continue
                 if self._should_skip_partition(ntp.partition):
                     continue
-                logger.info(f"topic: {ntp.topic}, partition: {ntp.partition}")
-                log = KafkaLog(ntp, headers_only=headers_only)
-                self.stream_json(log)
+                output_ntps.append(ntp)
+        len_ntps = len(output_ntps)
+        sys.stdout.write("[")
+        for i, ntp in enumerate(output_ntps):
+            logger.info(f"topic: {ntp.topic}, partition: {ntp.partition}")
+            log = KafkaLog(ntp, headers_only=headers_only)
+            print_delimiter = i != len_ntps - 1
+            self.stream_json(log, print_delimiter=print_delimiter)
+        sys.stdout.write("]")
 
     def print_groups(self):
         store = self.build_store()


### PR DESCRIPTION
Sequel to https://github.com/redpanda-data/redpanda/pull/28205.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
