### PR TITLE
cl/tests: deflake test_starting_offset

### DIFF
--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -2475,8 +2475,11 @@ class ShadowLinkCustomStartOffsetSelectionTests(ShadowLinkPreAllocTestBase):
     earliest_offset = "earliest"
     latest_offset = "latest"
     timequery_offset = "timestamp"
+    max_records = 10000
 
     def setup_starting_offset(self, topic: TopicSpec) -> tuple[float, float]:
+        initial = 1000
+        assert self.max_records > initial
         self.source_default_client().create_topic(topic)
         start_time = time.time()
         KgoVerifierProducer.oneshot(
@@ -2484,7 +2487,7 @@ class ShadowLinkCustomStartOffsetSelectionTests(ShadowLinkPreAllocTestBase):
             self.source_cluster.service,
             topic="source-topic",
             msg_size=4 * 1024,
-            msg_count=1000,
+            msg_count=initial,
             custom_node=self.preallocated_nodes,
         )
         # We produce in 2 phases so a batch cleanly ends at offset 999
@@ -2498,7 +2501,7 @@ class ShadowLinkCustomStartOffsetSelectionTests(ShadowLinkPreAllocTestBase):
             self.source_cluster.service,
             topic="source-topic",
             msg_size=4 * 1024,
-            msg_count=39000,
+            msg_count=self.max_records - initial,
             custom_node=self.preallocated_nodes,
         )
         end_time = time.time()
@@ -2732,6 +2735,22 @@ class ShadowLinkCustomStartOffsetSelectionTests(ShadowLinkPreAllocTestBase):
                 self.source_cluster_rpk, source_offset_to_fetch
             )
             self.logger.info(f"Source cluster offsets: {source_offsets}")
+
+            def do_wait_for_hwm():
+                partition_info = list(
+                    self.target_cluster_rpk.describe_topic(topic.name)
+                )
+                for p in partition_info:
+                    if p.id == 0:
+                        return p.high_watermark >= self.max_records
+
+            self.target_cluster_service.wait_until(
+                do_wait_for_hwm,
+                timeout_sec=60,
+                backoff_sec=2,
+                err_msg="Timed out waiting for hwm to catchup on target",
+                retry_on_exc=True,
+            )
 
             # If testing for earliest or latest offset, use "start", else
             # use the timequery value.  The batch fetched from the source at


### PR DESCRIPTION
The issue is that if we do not wait for data to be replicated, the consumer that probes for offset sees a missing offset (-1) in list_offset responds and tries fetching from ts=-1 (latest_offset) and that resolves to an incorrect offset (lso at the time of request).

The fix is to wait for hwm to advance (data is replicated) before it queries for a timestamp.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
