### PR TITLE
cl/replication_mgr: fix start/stop sequence

### DIFF
--- a/src/v/cluster_link/replication/link_replication_mgr.cc
+++ b/src/v/cluster_link/replication/link_replication_mgr.cc
@@ -147,8 +147,6 @@ void link_replication_manager::start_replicator(
               stop_it->second);
             return;
         }
-        vlog(cllog.debug, "Removing pending stop action for {}", ntp);
-        _pending_stops.erase(stop_it);
     }
 
     // Now check if there are any pending starts.  If there are, replace the

--- a/src/v/cluster_link/replication/tests/link_replication_mgr_tests.cc
+++ b/src/v/cluster_link/replication/tests/link_replication_mgr_tests.cc
@@ -182,4 +182,37 @@ TEST_F_CORO(LinkReplicationMgrFixture, TestFuzzStartStop) {
     co_await ss::when_all_succeed(std::move(add_f), std::move(remove_f));
 }
 
+TEST_F_CORO(LinkReplicationMgrFixture, TestStartStopBackToBack) {
+    model::term_id term{0};
+    // set to term if replicator is started
+    std::optional<model::term_id> started_term{};
+    model::ntp ntp{"kafka", "partition", model::partition_id{0}};
+
+    auto maybe_start_replicator = [this, &started_term, &ntp, &term]() {
+        if (!started_term) {
+            started_term = term++;
+            _mgr->start_replicator(ntp, started_term.value());
+        }
+        return tests::random_bool() ? ss::now() : ss::sleep(sleep_for());
+    };
+
+    auto maybe_stop_replicator = [this, &started_term, &ntp]() {
+        if (started_term) {
+            _mgr->stop_replicator(
+              ntp, std::exchange(started_term, std::nullopt));
+        }
+        return tests::random_bool() ? ss::now() : ss::sleep(sleep_for());
+    };
+
+    auto end_time = ss::lowres_clock::now() + 10s;
+    auto start_f = ss::do_until(
+      [&] { return end_time < ss::lowres_clock::now(); },
+      [&]() { return maybe_start_replicator(); });
+    auto stop_f = ss::do_until(
+      [&] { return end_time < ss::lowres_clock::now(); },
+      [&]() { return maybe_stop_replicator(); });
+
+    co_await ss::when_all_succeed(std::move(start_f), std::move(stop_f));
+};
+
 } // namespace cluster_link::replication


### PR DESCRIPTION
Regression from https://github.com/redpanda-data/redpanda/commit/7595b5fd33439ec709b090901cd0c0244c81c00e

The following sequence would result in an incorrect double start.

Leadership dropped and regained on the same replica.

term - 2 - stop
term - 3 - start

Current implementation removes stop in favor of start which is incorrect. Instead we stop the exiting replicatr and then start a new one in term 3.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
