### PR TITLE
dt: Handle out-of-order /proc/interrupts in GCP tests

### DIFF
--- a/tests/rptest/tuner_integration_tests/net_tuner_test.py
+++ b/tests/rptest/tuner_integration_tests/net_tuner_test.py
@@ -91,13 +91,15 @@ class NetTunerTest(RedpandaTest):
     def parse_matching_interrupt_num_from_interrupt_file(
         interrupt_file: str, matcher: str
     ) -> list[int]:
-        ret: list[int] = []
         pattern = re.compile(matcher)
+        irqs: list[tuple[int, str]] = []
         for line in interrupt_file.split("\n"):
-            if pattern.search(line):
-                ret.append(int(line.split(":")[0]))
+            match = pattern.search(line)
+            if match:
+                id = int(line.split(":")[0])
+                irqs.append((id, match.group()))
 
-        return ret
+        return [id for id, _ in sorted(irqs, key=lambda x: x[1])]
 
     def _test_irq_balance(self):
         # test irqbalance
@@ -401,7 +403,7 @@ class GcpNetTunerTest(NetTunerTest):
         return interface.startswith("ens")
 
     def get_interrupt_match(self) -> str:
-        return "virtio1-(input|output)"
+        return "\\d+-edge\\s+virtio1-(input|output)"
 
     def _test_irq_balance(self):
         # no irq-balance on GCP ubu images


### PR DESCRIPTION
We saw GCP CDT net tuner tests flake because of a peculiar /proc/interrupts:

```
28:  ...     PCI-MSIX-0000:00:05.0   8-edge      virtio1-output.3
29:  ...     PCI-MSIX-0000:00:05.0   0-edge      virtio1-config
30:  ...     PCI-MSIX-0000:00:05.0   1-edge      virtio1-input.0
31:  ...     PCI-MSIX-0000:00:05.0   2-edge      virtio1-output.0
32:  ...     PCI-MSIX-0000:00:05.0   3-edge      virtio1-input.1
33:  ...     PCI-MSIX-0000:00:05.0   4-edge      virtio1-output.1
34:  ...     PCI-MSIX-0000:00:05.0   5-edge      virtio1-input.2
35:  ...     PCI-MSIX-0000:00:05.0   6-edge      virtio1-output.2
36:  ...     PCI-MSIX-0000:00:05.0   7-edge      virtio1-input.3
```

Note how the the last output queue somehow has a lower IRQ id than the others.  The expectations rely on this list to be ordered. Hence, change the test such that it orders the list based on the matcher. Also adjust the GCP regex such that we get the required ordering.

The tuner already does this right based on the queue index functions which also use regexes.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
