### PR TITLE
tx: update max_transactions description

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -972,17 +972,26 @@ configuration::configuration()
       *this,
       "transactional_id_expiration_ms",
       "Expiration time of producer IDs. Measured starting from the time of the "
-      "last write until now for a given ID.",
+      "last write until now for a given ID. Producer IDs are automatically "
+      "removed from memory when they expire, which helps manage memory usage. "
+      "However, this natural cleanup may not be sufficient for workloads with "
+      "high producer churn rates. For applications with long-running "
+      "transactions, ensure this value accommodates your typical transaction "
+      "lifetime to avoid premature producer ID expiration.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       10080min)
   , max_concurrent_producer_ids(
       *this,
       "max_concurrent_producer_ids",
-      "Maximum number of the active producers sessions. When the threshold is "
-      "passed, Redpanda terminates old sessions. When an idle producer "
-      "corresponding to the terminated session wakes up and produces, its "
-      "message batches are rejected, and an out of order sequence error is "
-      "emitted. Consumers don't affect this setting.",
+      "Maximum number of active producer sessions per shard. Each shard "
+      "tracks producer IDs using an LRU (Least Recently Used) eviction "
+      "policy. When the configured limit is exceeded, the least recently "
+      "used producer IDs are evicted from the cache. IMPORTANT: The default "
+      "value is unlimited, which can lead to unbounded memory growth and "
+      "out-of-memory (OOM) crashes in production environments with heavy "
+      "producer usage, especially when using transactions or idempotent "
+      "producers. It is strongly recommended to set a reasonable limit in "
+      "production deployments.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::numeric_limits<uint64_t>::max(),
       {.min = 1})


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Update description of `max_concurrent_producer_ids` and `transactional_id_expiration_ms`

to match docs at 
https://github.com/redpanda-data/docs/pull/1425

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* Improve description of `max_concurrent_producer_ids` and `transactional_id_expiration_ms` with details to prevent OOM scenarios.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
