### PR TITLE
Fix caching in python-type-check GHA

### DIFF
--- a/.github/workflows/type-check-python.yaml
+++ b/.github/workflows/type-check-python.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: docker/setup-buildx-action@v3
       - uses: docker/build-push-action@v6
         with:
-          context: "."
+          context: "tests"
           file: tools/type-checking/Dockerfile
           tags: redpanda-data/python-type-check
           cache-from: type=gha

--- a/.github/workflows/type-check-python.yaml
+++ b/.github/workflows/type-check-python.yaml
@@ -38,4 +38,4 @@ jobs:
           push: false
           load: true
       - name: Run type checking
-        run: tools/type-checking/type-check.sh ci --color=always
+        run: TC_SKIP_DOCKER_BUILD=1 tools/type-checking/type-check.sh ci --color=always

--- a/tools/type-checking/Dockerfile
+++ b/tools/type-checking/Dockerfile
@@ -22,7 +22,7 @@ FROM with-python AS build
 RUN apt-get update && \
     apt-get install --no-install-recommends -y python3-pip python3-dev git gcc && \
     rm -rf /var/lib/apt/lists/*
-COPY tests/setup.py /tmp/rptest-setup/
+COPY setup.py /tmp/rptest-setup/
 
 # install rptest and run pyright --version to prompt it to download its embedded nodejs
 RUN python3 -m pip install --no-cache-dir -e /tmp/rptest-setup
@@ -30,9 +30,11 @@ RUN python3 -m pip install --no-cache-dir -e /tmp/rptest-setup
 
 FROM with-python AS final
 
+# keep this in sync with tools/type-checking/requirements.txt
+ARG PYRIGHT_VERSION=pyright[nodejs]==1.1.406
+
 ###### install pyright
-COPY tools/type-checking/requirements.txt /tmp/pyright.txt
-RUN python3 -m pip install --no-cache-dir -r /tmp/pyright.txt
+RUN python3 -m pip install --no-cache-dir ${PYRIGHT_VERSION}
 
 # Copy-in *only* the parts of the python packages needed for type checking,
 # leaving the rest behind, which is a huge savings in final image size:

--- a/tools/type-checking/requirements.txt
+++ b/tools/type-checking/requirements.txt
@@ -1,2 +1,3 @@
 # requirements for type-checking
+# keep this in sync with PYRIGHT_VERSION in tools/type-checking/Dockerfile
 pyright[nodejs]==1.1.406

--- a/tools/type-checking/type-check.sh
+++ b/tools/type-checking/type-check.sh
@@ -25,7 +25,7 @@ tar -C "$ROOT_DIR" -cf - \
   tests/setup.py \
   tools/type-checking |
   docker build -t $tag -f "tools/type-checking/Dockerfile" \
-    ${TARGET:+--target=$TARGET} ${TC_DOCKER_ARGS---quiet} -
+    ${TARGET:+--target=$TARGET} ${TC_DOCKER_ARGS-} -
 
 # Run the container with the tests directory mounted
 # echo "Running type checker in Docker container..."

--- a/tools/type-checking/type-check.sh
+++ b/tools/type-checking/type-check.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-image_name=python-type-checking
+image_name=python-type-check
 tag=redpanda-data/$image_name
 
 # Get the directory containing this script
@@ -14,11 +14,14 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 TESTS_DIR="$ROOT_DIR/tests"
 TC_DIR="$ROOT_DIR/tools/type-checking"
 
-# Build the Docker image
-echo "Building Docker image $tag..."
-
-docker build -t $tag -f "tools/type-checking/Dockerfile" \
-  ${TARGET:+--target=$TARGET} ${TC_DOCKER_ARGS-} tests
+# Build the Docker image unless skipped
+if [[ ${TC_SKIP_DOCKER_BUILD:-0} != "0" ]]; then
+  echo "Skipping Docker build because TC_SKIP_DOCKER_BUILD=${TC_SKIP_DOCKER_BUILD}" >&2
+else
+  echo "Building Docker image $tag..."
+  docker build -t $tag -f "tools/type-checking/Dockerfile" \
+    ${TARGET:+--target=$TARGET} ${TC_DOCKER_ARGS-} tests
+fi
 
 # Run the container with the tests directory mounted
 # echo "Running type checker in Docker container..."

--- a/tools/type-checking/type-check.sh
+++ b/tools/type-checking/type-check.sh
@@ -17,15 +17,8 @@ TC_DIR="$ROOT_DIR/tools/type-checking"
 # Build the Docker image
 echo "Building Docker image $tag..."
 
-# Create a tar stream with only the files needed by the Dockerfile COPY commands
-# This is needed because we grab stuff from both tests/ and tools/ so the root
-# would need to be the parent (repo root) and we don't want to send the whole repo
-# context (this fails in practice too due to inaccessible files).
-tar -C "$ROOT_DIR" -cf - \
-  tests/setup.py \
-  tools/type-checking |
-  docker build -t $tag -f "tools/type-checking/Dockerfile" \
-    ${TARGET:+--target=$TARGET} ${TC_DOCKER_ARGS-} -
+docker build -t $tag -f "tools/type-checking/Dockerfile" \
+  ${TARGET:+--target=$TARGET} ${TC_DOCKER_ARGS-} tests
 
 # Run the container with the tests directory mounted
 # echo "Running type checker in Docker container..."


### PR DESCRIPTION
Fixes for caching in GHA.

I noticed that caching wasn't working for type checking script in GHA, so runs take 6-7 minutes (instead of ~2 minutes with caching). Some combination of these changes fixes it.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none
