### PR TITLE
[DEVPROD-3496] dt: expand testing around cluster linking lifecycle

### DIFF
--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -2131,6 +2131,31 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             err_msg="Compaction state is not consistent between clusters",
         )
 
+    @cluster(num_nodes=9)
+    def test_with_restart(self):
+        self.create_link("test-link")
+
+        def restart_nodes(service):
+            for n in service.nodes:
+                service.restart_nodes([n])
+                time.sleep(5)
+
+        topic_1 = TopicSpec(
+            name="source-topic-1", partition_count=3, replication_factor=1
+        )
+        self.source_default_client().create_topic(topic_1)
+        self.start_producer_consumer(topic=topic_1.name, msg_size=128, msg_cnt=100000)
+        restart_nodes(self.target_cluster_service)
+        self.verify()
+
+        topic_2 = TopicSpec(
+            name="source-topic-2", partition_count=3, replication_factor=1
+        )
+        self.source_default_client().create_topic(topic_2)
+        self.start_producer_consumer(topic=topic_2.name, msg_size=128, msg_cnt=100000)
+        restart_nodes(self.source_cluster_service)
+        self.verify()
+
 
 class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
     def create_source_consumer(

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -188,6 +188,9 @@ class MultiClusterKafkaTest(MultiClusterTestBase):
 
 
 class ShadowLinkBasicTests(ShadowLinkTestBase):
+    def _expect_connect_error(self, expected_code: ConnectErrorCode):
+        return expect_exception(ConnectError, lambda e: e.code == expected_code)
+
     def _topics_are_present_in_target_cluster(self, topics):
         target_rpk = RpkTool(self.target_cluster.service)
         topics_in_target = {t for t in target_rpk.list_topics()}
@@ -314,13 +317,9 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
             f"Expected shadow link name to be 'test-link', got {got_link.name}"
         )
 
-        try:
+        # Retrieving a non-existent link should fail
+        with self._expect_connect_error(ConnectErrorCode.NOT_FOUND):
             self.get_link(name="non-existent-link")
-            assert False, "Should not have gotten a non-existent link"
-        except ConnectError as e:
-            assert e.code == ConnectErrorCode.NOT_FOUND, (
-                f"Expected NOT_FOUND error code, got {e.code}"
-            )
 
         task_statuses = got_link.status.task_statuses
         self.logger.info(f"Shadow link task_statuses: {task_statuses}")
@@ -411,25 +410,14 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
             f"Expected shadow link name to be 'test-link', got {shadow_link.name}"
         )
 
-        # Now attempt to create a second one with the same name
-        try:
+        # Attempting to create a second one with the same name should fail
+        with self._expect_connect_error(ConnectErrorCode.ALREADY_EXISTS):
             self.create_link("test-link")
-            assert False, (
-                "Should not have been able to create a second link with the same name"
-            )
-        except ConnectError as e:
-            assert e.code == ConnectErrorCode.ALREADY_EXISTS, (
-                f"Expected {ConnectErrorCode.ALREADY_EXISTS}, got {e.code}"
-            )
 
-        # Now create a second one with a different name
-        try:
+        # Attempting to create a second link should fail.
+        # Only one link is supported per cluster
+        with self._expect_connect_error(ConnectErrorCode.RESOURCE_EXHAUSTED):
             self.create_link("test-link-2")
-            assert False, "Should not have been able to create a second link"
-        except ConnectError as e:
-            assert e.code == ConnectErrorCode.RESOURCE_EXHAUSTED, (
-                f"Expected {ConnectErrorCode.RESOURCE_EXHAUSTED}, got {e.code}"
-            )
 
     @cluster(num_nodes=6)
     def test_topic_creation_in_target_cluster(self):
@@ -479,9 +467,7 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
                 shadow_link_name="test-link", shadow_topic_name=t.name
             )
 
-        with expect_exception(
-            ConnectError, lambda e: e.code == ConnectErrorCode.NOT_FOUND
-        ):
+        with self._expect_connect_error(ConnectErrorCode.NOT_FOUND):
             self.get_shadow_topic(
                 shadow_link_name="test-link", shadow_topic_name="non-existent-topic"
             )
@@ -792,9 +778,7 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
         # Now verify that we can delete the link when force=True
         self.delete_link(test_link, force=True)
 
-        with expect_exception(
-            ConnectError, lambda e: e.code == ConnectErrorCode.NOT_FOUND
-        ):
+        with self._expect_connect_error(ConnectErrorCode.NOT_FOUND):
             self.get_link(test_link)
 
     @cluster(num_nodes=6)
@@ -1250,10 +1234,7 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
             :
         ] = bad_bootstrap_servers
 
-        with expect_exception(
-            ConnectError,
-            lambda e: e.code == ConnectErrorCode.FAILED_PRECONDITION,
-        ):
+        with self._expect_connect_error(ConnectErrorCode.FAILED_PRECONDITION):
             self.create_link_with_request(req=bad_link_request)
 
         # Test invalid TLS settings, source cluster has no TLS
@@ -1268,10 +1249,7 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
                 ),
             )
         )
-        with expect_exception(
-            ConnectError,
-            lambda e: e.code == ConnectErrorCode.FAILED_PRECONDITION,
-        ):
+        with self._expect_connect_error(ConnectErrorCode.FAILED_PRECONDITION):
             self.create_link_with_request(req=bad_link_request)
 
         # Kill one broker on the source cluster to simulate partial connectivity
@@ -1295,10 +1273,7 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
         rp._installer.install(rp.nodes, (25, 1))
         rp.for_nodes(rp.nodes, lambda node: rp.stop_node(node))
         rp.start(rp.nodes, clean_nodes=True)
-        with expect_exception(
-            ConnectError,
-            lambda e: e.code == ConnectErrorCode.FAILED_PRECONDITION,
-        ):
+        with self._expect_connect_error(ConnectErrorCode.FAILED_PRECONDITION):
             self.create_link("link-to-incompatible-cluster")
 
     @cluster(

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -308,13 +308,28 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
 
         links = self.list_links()
         assert len(links) == 1, f"Expected exactly one shadow link, got {len(links)}"
-        assert links[0].name == "test-link", (
-            f"Expected shadow link name to be 'test-link', got {links[0].name}"
+
+        test_link = links[0]
+        assert test_link.name == "test-link", (
+            f"Expected shadow link name to be 'test-link', got {test_link.name}"
         )
+
+        active = shadow_link_pb2.ShadowLinkState.SHADOW_LINK_STATE_ACTIVE
+        link_state = test_link.status.state
+        assert link_state == active, (
+            f"Expected shadow link state to be '{active}', got {link_state}"
+        )
+
+        link_uid = test_link.uid
+        assert link_uid, f"Expected some uid for shadow link"
 
         got_link = self.get_link(name="test-link")
         assert got_link.name == "test-link", (
             f"Expected shadow link name to be 'test-link', got {got_link.name}"
+        )
+
+        assert got_link.uid == link_uid, (
+            f"Expected shadow link uid to be '{link_uid}', got {got_link.uid}"
         )
 
         # Retrieving a non-existent link should fail

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -1454,6 +1454,72 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
             self._execute_task_pausing(num_topics=num_topics)
 
 
+class ShadowLinkingAuthzTests(ShadowLinkTestBase):
+    SUPERUSER_ERROR = "[permission_denied] Forbidden (superuser role required)"
+
+    def expect_superuser_error(self):
+        return expect_exception(
+            ConnectError,
+            lambda e: str(e) == self.SUPERUSER_ERROR,
+        )
+
+    @cluster(num_nodes=6)
+    def test_shadow_link_admin_api_authz(self):
+        topic = TopicSpec(name="source-topic", partition_count=3, replication_factor=1)
+        self.source_default_client().create_topic(topic)
+
+        link_name = "test-link"
+
+        shadow_link = self.create_link(link_name)
+        links = self.list_links()
+        assert len(links) == 1, (
+            f"Expected exactly one shadow link, got {len(links)}. Setup failed"
+        )
+
+        self.target_cluster.service.wait_until(
+            lambda: self.topic_exists_in_target(topic.name),
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg=f"Topic {topic.name} not found in target cluster",
+        )
+
+        self.target_cluster_service.set_cluster_config(
+            values={"admin_api_require_auth": True}
+        )
+
+        # Verify that an unauthorised user can't access any of the sl api
+        with self.expect_superuser_error():
+            self.create_link(link_name)
+
+        with self.expect_superuser_error():
+            self.list_links()
+
+        with self.expect_superuser_error():
+            self.get_link(link_name)
+
+        with self.expect_superuser_error():
+            self.update_link(shadow_link)
+
+        with self.expect_superuser_error():
+            self.failover_link(link_name)
+
+        with self.expect_superuser_error():
+            self.get_shadow_topic(link_name, topic.name)
+
+        with self.expect_superuser_error():
+            self.list_shadow_topics(link_name)
+
+        with self.expect_superuser_error():
+            self.delete_link(link_name)
+
+        # And a spot check that a superuser can actually use them
+        with self.superuser_access():
+            links = self.list_links()
+            assert len(links) == 1, (
+                f"Expected exactly one shadow link, got {len(links)}."
+            )
+
+
 class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
     def _get_shadow_topic(
         self,

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager, nullcontext
 import time
 import socket
 import random
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import google.protobuf.duration_pb2
 import google.protobuf.field_mask_pb2
@@ -53,6 +53,7 @@ from rptest.util import (
     contextmanager,
 )
 from rptest.utils.node_operations import FailureInjectorBackgroundThread
+from urllib3.exceptions import ProtocolError
 
 
 SOURCE_CLUSTER_SPEC = "source_cluster_spec"
@@ -389,6 +390,23 @@ class ClusterLinkingProgressVerifier:
         return (True, None)
 
 
+# Will retry to send the request if there was a connection aborted
+# error, after a short backoff period
+def retry_request(func: Callable[..., Any]) -> Any:
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return func(*args, **kwargs)
+        except ProtocolError as e:
+            if "Connection aborted" not in str(e):
+                raise
+            self = args[0]
+            self.logger.debug(f"Received {e} while executing {str(func)}. Retrying...")
+            time.sleep(0.1)
+            return func(*args, **kwargs)
+
+    return wrapper
+
+
 class ShadowLinkTestBase(PreallocNodesTest):
     """
     Base class for Shadow Link tests. This base is responsible
@@ -614,6 +632,7 @@ class ShadowLinkTestBase(PreallocNodesTest):
         req = self.create_default_link_request(link_name=link_name, *args, **kwargs)
         return self.create_link_with_request(req=req)
 
+    @retry_request
     def create_link_with_request(
         self, req: shadow_link_pb2.CreateShadowLinkRequest
     ) -> shadow_link_pb2.ShadowLink:
@@ -627,27 +646,32 @@ class ShadowLinkTestBase(PreallocNodesTest):
         )
         return self.delete_link_with_request(req=req)
 
+    @retry_request
     def failover_link(self, name: str) -> shadow_link_pb2.ShadowLink:
         req = shadow_link_pb2.FailOverRequest(name=name)
         return self.service_client.fail_over(req=req).shadow_link
 
+    @retry_request
     def failover_link_topic(
         self, link_name: str, topic: str
     ) -> shadow_link_pb2.ShadowLink:
         req = shadow_link_pb2.FailOverRequest(name=link_name, shadow_topic_name=topic)
         return self.service_client.fail_over(req=req).shadow_link
 
+    @retry_request
     def delete_link_with_request(
         self, req: shadow_link_pb2.DeleteShadowLinkRequest
     ) -> shadow_link_pb2.DeleteShadowLinkResponse:
         return self.service_client.delete_shadow_link(req=req)
 
+    @retry_request
     def list_links(self) -> list[shadow_link_pb2.ShadowLink]:
         resp = self.service_client.list_shadow_links(
             req=shadow_link_pb2.ListShadowLinksRequest()
         )
         return resp.shadow_links
 
+    @retry_request
     def update_link(
         self,
         shadow_link: shadow_link_pb2.ShadowLink,
@@ -661,12 +685,14 @@ class ShadowLinkTestBase(PreallocNodesTest):
 
         return resp.shadow_link
 
+    @retry_request
     def get_link(self, name: str) -> shadow_link_pb2.ShadowLink:
         resp = self.service_client.get_shadow_link(
             req=shadow_link_pb2.GetShadowLinkRequest(name=name)
         )
         return resp.shadow_link
 
+    @retry_request
     def get_shadow_topic(
         self, shadow_link_name: str, shadow_topic_name: str
     ) -> shadow_link_pb2.ShadowTopic:
@@ -677,6 +703,7 @@ class ShadowLinkTestBase(PreallocNodesTest):
         )
         return resp.shadow_topic
 
+    @retry_request
     def list_shadow_topics(
         self, shadow_link_name: str
     ) -> list[shadow_link_pb2.ShadowTopic]:

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -863,6 +863,22 @@ class ShadowLinkTestBase(PreallocNodesTest):
         finally:
             fi.stop()
 
+    @contextmanager
+    def superuser_access(self):
+        self.admin_v2 = AdminV2(
+            self.target_cluster_service,
+            auth=(
+                self.redpanda.SUPERUSER_CREDENTIALS.username,
+                self.redpanda.SUPERUSER_CREDENTIALS.password,
+            ),
+        )
+        self.service_client = self.admin_v2.shadow_link()
+        try:
+            yield
+        finally:
+            self.admin_v2 = AdminV2(self.target_cluster_service)
+            self.service_client = self.admin_v2.shadow_link()
+
 
 class ShadowLinkPreAllocTestBase(ShadowLinkTestBase):
     """

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -620,7 +620,7 @@ class ShadowLinkTestBase(PreallocNodesTest):
         return self.service_client.create_shadow_link(req=req).shadow_link
 
     def delete_link(
-        self, link_name: str, force: bool = False, *args, **kwargs
+        self, link_name: str, force: bool = False, *args: Any, **kwargs: Any
     ) -> shadow_link_pb2.DeleteShadowLinkResponse:
         req = self.delete_link_request(
             link_name=link_name, force=force, *args, **kwargs


### PR DESCRIPTION
Fixes: [DEVPROD-3496](https://redpandadata.atlassian.net/browse/DEVPROD-3496)

As title says.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[DEVPROD-3496]: https://redpandadata.atlassian.net/browse/DEVPROD-3496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ