### PR TITLE
rpk: set default language for app generate

### DIFF
--- a/src/go/rpk/pkg/cli/generate/app.go
+++ b/src/go/rpk/pkg/cli/generate/app.go
@@ -137,7 +137,7 @@ func newAppCmd(fs afero.Fs, p *config.Params) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&langFlag, "language", "l", "", "The language you want the code sample to be generated with")
+	cmd.Flags().StringVarP(&langFlag, "language", "l", "go", "The language you want the code sample to be generated with. Available language: `go`.")
 	cmd.Flags().StringVarP(&outPath, "output", "o", "", "The path where the app will be written")
 	cmd.Flags().StringVar(&saslCred, "new-sasl-credentials", "", "If provided, rpk will generate and use these credentials (<user>:<password>)")
 	cmd.Flags().BoolVar(&noUser, "no-user", false, "Generates the sample app without SASL user")
@@ -362,7 +362,7 @@ By default, this will run interactively, prompting you to select a language and
 a user with which to create your application. To use this without interactivity,
 specify how you would like your application to be created using flags.
 
-The --language option allows you to specify the language. There is no default.
+The --language option allows you to specify the language. The default is 'go'. Available language: 'go'.
 
 The --new-sasl-credentials <user>:<password> allows you to generate a new SASL
 user with admin ACLs. If you don't want to use your current profile user nor

--- a/src/go/rpk/pkg/cli/generate/app.go
+++ b/src/go/rpk/pkg/cli/generate/app.go
@@ -137,7 +137,7 @@ func newAppCmd(fs afero.Fs, p *config.Params) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&langFlag, "language", "l", "go", "The language you want the code sample to be generated with. Available language: `go`.")
+	cmd.Flags().StringVarP(&langFlag, "language", "l", "go", "The language you want the code sample to be generated with. Available language: 'go'")
 	cmd.Flags().StringVarP(&outPath, "output", "o", "", "The path where the app will be written")
 	cmd.Flags().StringVar(&saslCred, "new-sasl-credentials", "", "If provided, rpk will generate and use these credentials (<user>:<password>)")
 	cmd.Flags().BoolVar(&noUser, "no-user", false, "Generates the sample app without SASL user")


### PR DESCRIPTION
Set the default language for rpk generate app to `go` since it's the only one available today. 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* On rpk generate app, set `go` as the default language. 


