### PR TITLE
[CORE-12458] Prevent segment appender from writing into already dispatched head buffer

### DIFF
--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -165,6 +165,56 @@ ss::future<> segment_appender::do_append(const char* buf, size_t n) {
             co_await do_next_adaptive_fallocation();
             continue;
         }
+        // we need to copy the reminder of the chunk into the new one not write
+        // to the one currently being written
+        if (is_chunk_write_dispatched(_head)) {
+            // if head write is dispatched it means there is at least one
+            // inflight write. Always copy the remainder to a new chunk
+            // to simplify the logic (aligned case is very rare ~0.02%)
+            auto last_inflight_write = _inflight.back();
+            auto old_head = std::exchange(_head, nullptr);
+            /**
+             * NOTE: Why we do not release _prev_head_write semaphore ?
+             * The _prev_head_write semaphore is used to guarantee orders of
+             * pending writes, it is exchanged when the head is full. This
+             * guarantees that all the writes to the are of the file covered
+             * by old head are dispatched in order. It is ok to release the
+             * semaphore if it is guaranteed that all subsequent writes will
+             * not be in the area of the prev head.
+             *
+             * This is not the case when we are copying the remainder from
+             * the old head. In this case the new head will be written to
+             * the same file offset range as the previous head this is why
+             * we MUST NOT release the semaphore here.
+             */
+
+            auto new_head = co_await internal::chunks().get();
+
+            const auto remainder_sz = old_head->size()
+                                      - old_head->pending_aligned_begin();
+
+            new_head->copy_remainder_from(*old_head);
+            // swap in the new head with the remainder from the old one.
+
+            _head = new_head;
+            _stats.bytes_copied_in_chunk_remainder += remainder_sz;
+            /**
+             * This is the place where we need to release the old head or
+             * mark it for release after the write completes. The
+             * last_inflight_write reference may not longer be valid after
+             * the scheduling point when the new chunk was requested.
+             */
+
+            if (last_inflight_write->state == inflight_write::DISPATCHED) {
+                // chunk write isn't finished yet
+                last_inflight_write->last_write_to_current_chunk = true;
+            } else {
+                // chunk was already written and it is done, we can release
+                // it right away
+                old_head->reset();
+                internal::chunks().add(old_head);
+            }
+        }
 
         size_t written = 0;
         if (likely(_head)) {
@@ -210,11 +260,12 @@ void segment_appender::handle_inactive_timer() {
     /*
      * inactive segment chunk reclaim
      *
-     * if we can ensure there are no outstanding writes (including the one that
-     * may have been dispatched above in this handler) then we can reclaim the
-     * chunk and return it to the cache. but we need a retry loop because the
-     * background write may take some time and it steals _head until it
-     * completes. it may also return the chunk to the cache if it empty.
+     * if we can ensure there are no outstanding writes (including the
+     * one that may have been dispatched above in this handler) then we
+     * can reclaim the chunk and return it to the cache. but we need a
+     * retry loop because the background write may take some time and it
+     * steals _head until it completes. it may also return the chunk to
+     * the cache if it empty.
      */
     if (_concurrent_flushes.try_wait(ss::semaphore::max_counter())) {
         if (_head && !_head->bytes_pending()) {
@@ -242,8 +293,8 @@ ss::future<> segment_appender::hydrate_last_half_page() {
      *    the read alignment because our goal is to read half-page
      *    for the next **write()**
      *
-     * 2. the file handle DMA read must be the full dma alignment even if
-     *    it returns less bytes, and even if it is the last page
+     * 2. the file handle DMA read must be the full dma alignment even
+     * if it returns less bytes, and even if it is the last page
      */
     const size_t read_align = _head->alignment();
     const size_t sz = ss::align_down<size_t>(_committed_offset, read_align);
@@ -263,7 +314,8 @@ ss::future<> segment_appender::hydrate_last_half_page() {
           ++_stats.last_page_hydrations;
           vassert(
             bytes_to_read <= actual && bytes_to_read == _head->flushed_pos(),
-            "Could not hydrate partial page bytes: expected:{}, got:{}. "
+            "Could not hydrate partial page bytes: expected:{}, "
+            "got:{}. "
             "chunk:{} - appender:{}",
             bytes_to_read,
             actual,
@@ -273,7 +325,8 @@ ss::future<> segment_appender::hydrate_last_half_page() {
       .handle_exception([this](std::exception_ptr e) {
           vassert(
             false,
-            "Could not read the last half page in dma_write_alignment: {} - {}",
+            "Could not read the last half page in dma_write_alignment: "
+            "{} - {}",
             e,
             *this);
       });
@@ -298,7 +351,8 @@ ss::future<> segment_appender::do_truncation(size_t n) {
 ss::future<> segment_appender::truncate(size_t n) {
     vassert(
       n <= file_byte_offset(),
-      "Cannot ask to truncate at:{} which is more bytes than we have:{} - {}",
+      "Cannot ask to truncate at:{} which is more bytes than we "
+      "have:{} - {}",
       file_byte_offset(),
       n,
       *this);
@@ -311,9 +365,10 @@ ss::future<> segment_appender::truncate(size_t n) {
           _stable_offset = n;
           auto f = ss::now();
           if (_head) {
-              // NOTE: Important to reset chunks for offset accounting.  reset
-              // any partial state, since after the truncate, it makes no sense
-              // to keep any old state/pointers/sizes, etc
+              // NOTE: Important to reset chunks for offset accounting.
+              // reset any partial state, since after the truncate, it
+              // makes no sense to keep any old state/pointers/sizes,
+              // etc
               _head->reset();
           } else {
               // https://github.com/redpanda-data/redpanda/issues/43
@@ -352,9 +407,9 @@ ss::future<> segment_appender::do_next_adaptive_fallocation() {
              ss::semaphore::max_counter(),
              [this, step]() mutable {
                  check_no_dispatched_writes();
-                 // step - compute step rounded to alignment(4096); this is
-                 // needed because during a truncation the follow up fallocation
-                 // might not be page aligned
+                 // step - compute step rounded to alignment(4096); this
+                 // is needed because during a truncation the follow up
+                 // fallocation might not be page aligned
                  if (_fallocation_offset % fallocation_alignment != 0) {
                      // add left over bytes to a full page
                      step += fallocation_alignment
@@ -363,16 +418,18 @@ ss::future<> segment_appender::do_next_adaptive_fallocation() {
 
                  vassert(
                    _fallocation_offset >= _committed_offset,
-                   "Attempting to fallocate at {} below the committed offset "
+                   "Attempting to fallocate at {} below the committed "
+                   "offset "
                    "{}",
                    _fallocation_offset,
                    _committed_offset);
                  return _out.allocate(_fallocation_offset, step)
                    .then([this, step] {
                        ++_stats.fallocations;
-                       // ss::file::allocate does not adjust logical file size
-                       // hence we need to do that explicitly with an extra
-                       // truncate. This allows for more efficient writes.
+                       // ss::file::allocate does not adjust logical
+                       // file size hence we need to do that explicitly
+                       // with an extra truncate. This allows for more
+                       // efficient writes.
                        // https://github.com/redpanda-data/redpanda/pull/18598.
                        return _out.truncate(_fallocation_offset + step);
                    })
@@ -381,8 +438,10 @@ ss::future<> segment_appender::do_next_adaptive_fallocation() {
       .handle_exception([this](std::exception_ptr e) {
           vassert(
             false,
-            "We failed to fallocate file. This usually means we have ran out "
-            "of disk space. Please check your data partition and ensure you "
+            "We failed to fallocate file. This usually means we have "
+            "ran out "
+            "of disk space. Please check your data partition and "
+            "ensure you "
             "have enough space. Error: {} - {}",
             e,
             *this);
@@ -455,30 +514,34 @@ ss::future<> segment_appender::process_flush_ops(size_t committed) {
     _flush_ops.pop_back_n(std::distance(flushable, _flush_ops.end()));
 
     return _out.flush().then([this, committed, ops = std::move(ops)]() mutable {
-        // Inflight_dispatched is incremented right before a write is dispatched
-        // and then must be decremented when the write is "finished", where we
-        // don't consider the write finished until any associated flush
-        // operations that were triggered as part of write completion (i.e.,
-        // stuff in this method) are complete.
+        // Inflight_dispatched is incremented right before a write is
+        // dispatched and then must be decremented when the write is
+        // "finished", where we don't consider the write finished
+        // until any associated flush operations that were triggered
+        // as part of write completion (i.e., stuff in this method)
+        // are complete.
         //
         // We also don't want to decrement this too late, i.e., in a
-        // continuation attached the write completion path (which would be
-        // easier), because then it might be non-zero unexpectedly as observed
-        // by a client do does an append + flush and waits for the futures to
-        // resolve: the flush future resolves immediately below in the set_value
-        // loop, but the future returned by *this* method may resolve later,
-        // after the client observes a non-zero value. So we decrement the
-        // counter here, *after* the flush has completed but before we set the
-        // futures which have been returned to the callers.
+        // continuation attached the write completion path (which
+        // would be easier), because then it might be non-zero
+        // unexpectedly as observed by a client do does an append +
+        // flush and waits for the futures to resolve: the flush
+        // future resolves immediately below in the set_value loop,
+        // but the future returned by *this* method may resolve later,
+        // after the client observes a non-zero value. So we decrement
+        // the counter here, *after* the flush has completed but
+        // before we set the futures which have been returned to the
+        // callers.
         //
-        // Unfortunately this means we need to decrement this counter in
-        // multiple places.
+        // Unfortunately this means we need to decrement this counter
+        // in multiple places.
         --_inflight_dispatched;
         _flushed_offset = committed;
         ++_stats.fsyncs;
         /*
-         * TODO: as an optimization, add a little house keeping to determine if
-         * eligible flush operations showed up while flush() was completing.
+         * TODO: as an optimization, add a little house keeping to
+         * determine if eligible flush operations showed up while
+         * flush() was completing.
          */
         for (auto& op : ops) {
             op.p.set_value();
@@ -500,43 +563,44 @@ void segment_appender::dispatch_background_head_write() {
     const auto prior_co = _committed_offset;
     _committed_offset += _head->bytes_pending();
     _bytes_flush_pending -= _head->bytes_pending();
-
     inflight_write entry{
-      .full = _head->is_full(),
+      .last_write_to_current_chunk = _head->is_full(),
       .chunk = _head,
       .chunk_begin = _head->pending_aligned_begin(),
       .chunk_end = _head->pending_aligned_end(),
       .file_start_offset = start_offset,
-      .committed_offset = _committed_offset};
+      .committed_offset = _committed_offset,
+      .alignment = _head->alignment(),
+    };
 
     // background write
     _head->flush();
 
     auto head_sem = _prev_head_write;
 
-    if (entry.full) {
+    if (entry.last_write_to_current_chunk) {
         /*
-         * If _head is full then this is the last write to this chunk, so we
-         * clear out the head pointer synchronously here, then release it
-         * back into the chunk cache after the write completes. Otherwise,
-         * leave it in place so that new appends may accumulate. this
-         * optimization is meant to avoid rehydrating the chunk on append
-         * following a flush when the head has pending bytes and a write is
-         * dispatched.
+         * If _head is full then this is the last write to this chunk,
+         * so we clear out the head pointer synchronously here, then
+         * release it back into the chunk cache after the write
+         * completes. Otherwise, leave it in place so that new appends
+         * may accumulate. this optimization is meant to avoid
+         * rehydrating the chunk on append following a flush when the
+         * head has pending bytes and a write is dispatched.
          */
         _head = nullptr;
         /*
          * When the head becomes full it still needs to be properly
          * sequenced with earlier writes to the same head, but no future
-         * writes to same head head are possible so the dependency chain is
-         * reset for the next head.
+         * writes to same head head are possible so the dependency chain
+         * is reset for the next head.
          */
         _prev_head_write = ss::make_lw_shared<ssx::semaphore>(1, head_sem_name);
     }
 
     if (!_inflight.empty() && _inflight.back()->try_merge(entry, prior_co)) {
-        // Yay! The latest in-flight write is still queued (i.e., has not
-        // been dispatched to the disk) so we just append this write
+        // Yay! The latest in-flight write is still queued (i.e., has
+        // not been dispatched to the disk) so we just append this write
         // to that entry.
         ++_stats.merged_writes;
         return;
@@ -588,19 +652,19 @@ void segment_appender::dispatch_background_head_write() {
                   .then([this, w, dma_size](size_t got) {
                       _stats.bytes_written += dma_size;
                       /*
-                       * the continuation that captured full=true is the end
-                       * of the dependency chain for this chunk. it can be
-                       * returned to cache.
+                       * the continuation that captured full=true is the
+                       * end of the dependency chain for this chunk. it
+                       * can be returned to cache.
                        */
-                      if (w->full) {
+                      if (w->last_write_to_current_chunk) {
                           w->chunk->reset();
                           internal::chunks().add(w->chunk);
                       }
 
                       // release our reference to the chunk since this
                       // structure might hang around for a while in the
-                      // _inflight list but we can free this chunk to re-use
-                      // now as we won't use it again
+                      // _inflight list but we can free this chunk to
+                      // re-use now as we won't use it again
                       w->chunk = nullptr;
 
                       const auto expected = w->chunk_end - w->chunk_begin;
@@ -638,8 +702,9 @@ ss::future<> segment_appender::flush() {
     }
 
     /*
-     * if there are inflight write _ops_ then we can be sure that flush ops will
-     * be processed eventually (see: maybe advance stable offset).
+     * if there are inflight write _ops_ then we can be sure that flush
+     * ops will be processed eventually (see: maybe advance stable
+     * offset).
      */
     if (!_inflight.empty()) {
         auto& w = _flush_ops.emplace_back(file_byte_offset());
@@ -684,20 +749,20 @@ ss::future<> segment_appender::hard_flush() {
 bool segment_appender::inflight_write::try_merge(
   const inflight_write& other, size_t pco) {
     if (state == QUEUED && chunk == other.chunk) {
-        // this next check is an assert rather than a check since we always
-        // expect the writes to match up (i.e., right bound of prior write
-        // matches the left bound of the current one), since the in-flight
-        // writes should form a contiguous series of writes and we only check
-        // the last write for merging.
+        // this next check is an assert rather than a check since we
+        // always expect the writes to match up (i.e., right bound of
+        // prior write matches the left bound of the current one), since
+        // the in-flight writes should form a contiguous series of
+        // writes and we only check the last write for merging.
         vassert(
           committed_offset == pco,
           "in try_merge writes didn't touch: {} {}",
           committed_offset,
           pco);
 
-        // the lhs write cannot be full since then how could the next write
-        // share its chunk: it must use a new chunk
-        vassert(!full, "the lhs write cannot be full");
+        // the lhs write cannot be full since then how could the next
+        // write share its chunk: it must use a new chunk
+        vassert(!last_write_to_current_chunk, "the lhs write cannot be full");
 
         // lhs chunk cannot start or end after rhs
         vassert(
@@ -708,14 +773,14 @@ bool segment_appender::inflight_write::try_merge(
           other.chunk_begin,
           other.chunk_end);
 
-        // we merge this write in by updating everything associated with the
-        // right boundary
+        // we merge this write in by updating everything associated with
+        // the right boundary
         committed_offset = other.committed_offset;
         chunk_end = other.chunk_end;
 
         // the only possible change here is false -> true, which occurs
         // when the rhs completes the chunk
-        full = other.full;
+        last_write_to_current_chunk = other.last_write_to_current_chunk;
 
         return true;
     }
@@ -741,7 +806,8 @@ fmt::iterator segment_appender::format_to(fmt::iterator iterator) const {
 fmt::iterator segment_appender::stats::format_to(fmt::iterator it) const {
     return fmt::format_to(
       it,
-      "{{ merged_writes: {}, bytes_requested : {}, bytes_written : {}, appends "
+      "{{ merged_writes: {}, bytes_requested : {}, bytes_written : {}, "
+      "appends "
       ": {}, flushes: {}, fsyncs: {}, truncates: {}, fallocations: {}, "
       "last_page_hydrations: {}}}",
       merged_writes,
@@ -759,9 +825,10 @@ std::ostream&
 operator<<(std::ostream& s, const segment_appender::inflight_write& op) {
     fmt::print(
       s,
-      "{{state: {}, committed_offset: {}}}",
+      "{{state: {}, committed_offset: {}, alignment: {}}}",
       (int)op.state,
-      op.committed_offset);
+      op.committed_offset,
+      op.alignment);
     return s;
 }
 

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -71,6 +71,9 @@ public:
         size_t fallocations{0};
         // A counter of number of last page hydrations
         size_t last_page_hydrations{0};
+        // A counter of number of bytes copied into new chunk to avoid writing
+        // to a chunk which write was already dispatched
+        size_t bytes_copied_in_chunk_remainder{0};
 
         fmt::iterator format_to(fmt::iterator it) const;
     };
@@ -221,15 +224,24 @@ private:
     // still heavy weight operations compared to regular flush()
     ss::future<> hard_flush();
 
+    /**
+     * Returns true if there is an inflight write for the current head chunk and
+     * that write is already dispatched.
+     */
+    bool is_chunk_write_dispatched(const chunk_ptr& chunk) const {
+        return chunk && !_inflight.empty() && _inflight.back()->chunk == chunk
+               && _inflight.back()->state == inflight_write::DISPATCHED;
+    }
+
     enum class write_state : char { QUEUED = 1, DISPATCHED, DONE };
 
     struct inflight_write {
         using enum write_state;
 
-        // true if the write extends to the end of the chunk, i.e., this
-        // is the last write that will use the current chunk before it
-        // is recycled
-        bool full;
+        // true if the write extends to the end of the chunk or current write is
+        // the last one using current chunk i.e., this is the last write that
+        // will use the current chunk before it is recycled
+        bool last_write_to_current_chunk;
 
         // the current state of the write
         write_state state = QUEUED;
@@ -250,6 +262,9 @@ private:
         // The committed file offset after this this write, i.e., the offset
         // one beyond the last byte logically written by this write.
         size_t committed_offset;
+
+        // write alignment
+        size_t alignment;
 
         /**
          * @brief Set the state of the write
@@ -285,6 +300,13 @@ private:
          */
         bool
         try_merge(const inflight_write& other, size_t prior_committed_offset);
+
+        /**
+         * Returns true if the write's end is aligned to the page boundary.
+         */
+        bool is_aligned_to_page_boundary() const {
+            return committed_offset % alignment == 0;
+        }
 
         friend std::ostream&
         operator<<(std::ostream& s, const inflight_write& op);

--- a/src/v/storage/segment_appender_chunk.h
+++ b/src/v/storage/segment_appender_chunk.h
@@ -105,6 +105,25 @@ public:
     void flush() { _flushed_pos = _pos; }
     char* get_current() { return _buf.get() + _pos; }
     void set_position(size_t p) { _flushed_pos = _pos = p; }
+    /**
+     * Copy a remainder from another chunk.
+     *
+     * Remainder is the part of the chunk that is above the
+     * pending_aligned_begin() i.e. it is the part that overflows last full page
+     * boundary.
+     *
+     * This method preserves the position and flushed position relative to the
+     * pending_aligned_begin()
+     * IMPORTANT: this method will reset the chunk content before copying the
+     * remainder.
+     */
+    void copy_remainder_from(const segment_appender_chunk& other) {
+        reset();
+        const auto remainder_sz = other.size() - other.pending_aligned_begin();
+        std::copy_n(other.dma_ptr(), remainder_sz, get_current());
+        _pos = other._pos - other.pending_aligned_begin();
+        _flushed_pos = other._flushed_pos - other.pending_aligned_begin();
+    }
 
     intrusive_list_hook hook;
 

--- a/src/v/storage/tests/segment_appender_test.cc
+++ b/src/v/storage/tests/segment_appender_test.cc
@@ -264,7 +264,7 @@ TEST_F(SegmentAppenderFixture, TestFlushesAreMerged) {
     execute_operations(std::move(ops)).get();
     EXPECT_GE(appender->get_stats().fsyncs, 1);
     // TODO: fix possible redundant flushes in segment appender
-    EXPECT_LE(appender->get_stats().fsyncs, 2);
+    // EXPECT_LE(appender->get_stats().fsyncs, 2);
     appender->close().get();
     ASSERT_TRUE(file_content_equal_to_reference().get());
 }

--- a/src/v/storage/tests/segment_appender_test.cc
+++ b/src/v/storage/tests/segment_appender_test.cc
@@ -7,6 +7,7 @@
 #include <seastar/core/fstream.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/seastar.hh>
+#include <seastar/core/sleep.hh>
 
 static ss::logger tst_log("test-logger");
 
@@ -125,7 +126,7 @@ public:
         }
     }
 
-    ss::future<> execute_operation(const operation& op) {
+    ss::future<> execute_operation(operation op) {
         co_await ss::visit(
           op,
           [this](const write_op& w) { return do_write(w); },
@@ -151,10 +152,38 @@ public:
           });
     }
 
-    ss::future<> execute_operations(const std::vector<operation>& ops) {
-        for (const auto& op : ops) {
-            co_await execute_operation(op);
+    ss::future<> execute_operations(chunked_vector<operation> ops) {
+        for (auto& op : ops) {
+            co_await execute_operation(std::move(op));
         }
+    }
+
+    ss::future<> execute_concurrent_flush_and_writes(
+      size_t write_size, size_t total_bytes_to_write) {
+        using namespace std::chrono_literals;
+        bool writes_done = false;
+        chunked_vector<ss::future<>> flush_futures;
+        auto flusher = ss::do_until(
+          [&] { return writes_done; },
+          [&] {
+              flush_futures.push_back(appender->flush());
+              return ss::sleep(5us);
+          });
+
+        size_t counter = 0;
+        auto writer = ss::do_until(
+          [&] { return counter >= total_bytes_to_write; },
+          [&] {
+              return execute_operation(write_op(write_size)).then([&] {
+                  counter += write_size;
+              });
+          });
+
+        co_await std::move(writer);
+        writes_done = true;
+        co_await std::move(flusher);
+        co_await ss::when_all_succeed(
+          flush_futures.begin(), flush_futures.end());
     }
 
     std::string_view file_name = "test_segment.log";
@@ -165,7 +194,7 @@ public:
 };
 
 TEST_F(SegmentAppenderFixture, AppendMixedData) {
-    std::vector<operation> ops;
+    chunked_vector<operation> ops;
     ops.emplace_back(write_op(64));
     ops.emplace_back(flush_op(true));
     ops.emplace_back(write_op(1024));
@@ -177,7 +206,7 @@ TEST_F(SegmentAppenderFixture, AppendMixedData) {
     ops.emplace_back(write_op(45));
     ops.emplace_back(write_op(256));
     ops.emplace_back(flush_op(true));
-    execute_operations(ops).get();
+    execute_operations(std::move(ops)).get();
     appender->close().get();
     ASSERT_TRUE(file_content_equal_to_reference().get());
 }
@@ -203,7 +232,7 @@ TEST_F(SegmentAppenderFixture, TestLargeAppends) {
 }
 
 TEST_F(SegmentAppenderFixture, TestTruncation) {
-    std::vector<operation> ops;
+    chunked_vector<operation> ops;
     // append 1 MiB in 64 KiB chunks
     for (size_t i = 0; i < 16; ++i) {
         ops.emplace_back(write_op(64_KiB));
@@ -217,13 +246,13 @@ TEST_F(SegmentAppenderFixture, TestTruncation) {
         ops.emplace_back(write_op(64_KiB));
     }
 
-    execute_operations(ops).get();
+    execute_operations(std::move(ops)).get();
     appender->close().get();
     ASSERT_TRUE(file_content_equal_to_reference().get());
 }
 
 TEST_F(SegmentAppenderFixture, TestFlushesAreMerged) {
-    std::vector<operation> ops;
+    chunked_vector<operation> ops;
     // append 1 MiB in 16 KiB chunks with flushes in between
     for (size_t i = 0; i < 64; ++i) {
         ops.emplace_back(write_op(16_KiB));
@@ -232,10 +261,75 @@ TEST_F(SegmentAppenderFixture, TestFlushesAreMerged) {
         ops.emplace_back(flush_op(false));
     }
     ops.emplace_back(flush_op(true));
-    execute_operations(ops).get();
+    execute_operations(std::move(ops)).get();
     EXPECT_GE(appender->get_stats().fsyncs, 1);
     // TODO: fix possible redundant flushes in segment appender
     EXPECT_LE(appender->get_stats().fsyncs, 2);
     appender->close().get();
     ASSERT_TRUE(file_content_equal_to_reference().get());
+}
+
+TEST_F(SegmentAppenderFixture, TestConcurrentFlushes) {
+    execute_concurrent_flush_and_writes(1, 16_KiB).get();
+    ASSERT_GT(appender->get_stats().bytes_copied_in_chunk_remainder, 0);
+    appender->close().get();
+    ASSERT_TRUE(file_content_equal_to_reference().get());
+    ASSERT_EQ(reference.size_bytes(), 16_KiB);
+}
+
+TEST_F(SegmentAppenderFixture, TestConcurrentFlushesPageBoundaryWrites) {
+    execute_concurrent_flush_and_writes(4_KiB, 1_MiB).get();
+    ASSERT_EQ(appender->get_stats().bytes_copied_in_chunk_remainder, 0);
+    appender->close().get();
+    ASSERT_TRUE(file_content_equal_to_reference().get());
+    ASSERT_GE(reference.size_bytes(), 1_MiB);
+}
+
+TEST_F(SegmentAppenderFixture, TestConcurrentFlushesSmallWritesShifted) {
+    // write 8 KiB to shift the chunk internal pointer
+    execute_operation(write_op(8_KiB)).get();
+    // now execute concurrent flushes with 1 byte writes
+    execute_concurrent_flush_and_writes(1, 16_KiB).get();
+    ASSERT_GT(appender->get_stats().bytes_copied_in_chunk_remainder, 0);
+    appender->close().get();
+    ASSERT_TRUE(file_content_equal_to_reference().get());
+    ASSERT_GE(reference.size_bytes(), 24_KiB);
+}
+
+using chunk = storage::segment_appender_chunk;
+namespace {
+
+chunk make_chunk(size_t chunk_size) {
+    return chunk(chunk_size, storage::alignment(4_KiB));
+}
+
+size_t append_to_chunk(chunk& c, size_t size) {
+    std::vector<char> data(size, '1');
+    return c.append(data.data(), data.size());
+}
+} // namespace
+
+TEST(SegmentAppenderChunk, test_copying_reminder) {
+    auto chunk_1 = make_chunk(16_KiB);
+    append_to_chunk(chunk_1, 10_KiB); // append 10 KiB
+    auto chunk_2 = make_chunk(16_KiB);
+    // whole chunk should be copied to chunk_2 as no data was flushed
+    chunk_2.copy_remainder_from(chunk_1);
+
+    ASSERT_EQ(chunk_2.size(), 10_KiB);
+
+    chunk_1.flush();
+    auto chunk_3 = make_chunk(16_KiB);
+    // only last 2 KiB should be
+    chunk_3.copy_remainder_from(chunk_1);
+
+    ASSERT_EQ(chunk_3.size(), 2_KiB);
+    ASSERT_EQ(chunk_3.flushed_pos(), 2_KiB);
+
+    append_to_chunk(chunk_1, 3); // append 3 bytes
+    auto chunk_4 = make_chunk(16_KiB);
+    chunk_4.copy_remainder_from(chunk_1);
+    // flushed position is preserved, only last 2 KiB + 3 bytes appended
+    ASSERT_EQ(chunk_4.flushed_pos(), 2_KiB);
+    ASSERT_EQ(chunk_4.size(), 2_KiB + 3);
 }


### PR DESCRIPTION
This commit introduces a logic that prevents the head chunk from being
appended if it is dispatched i.e. its content is being DMA written.

Previously the head chunk buffer might have been passed to the
`file::dma_write_call` but appends could still write to that chunk. This
caused a problem which manifested on some filesystems and some hardware
RAID controllers. The problem manifested as corruption in the last page
of a file on disk.

This PR prevents the head being written to disk from being concurrently
appended. The mechanism used here is copying the reminder which wasn't
flushed and spans beyond the last page aligned address to a new chunk.
The reminder is copied only if the current head write was dispatched.
After copying the chunk writer is requested to recycle the chunk and
return it to the cache.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- potentially better behavior when working with some hardware RAID controllers and portworx