### PR TITLE
CORE-13365 Client Monitoring: rate limit and limit page size based on memory

### DIFF
--- a/proto/redpanda/core/admin/v2/cluster.proto
+++ b/proto/redpanda/core/admin/v2/cluster.proto
@@ -38,9 +38,13 @@ service ClusterService {
 // connections.
 message ListKafkaConnectionsRequest {
     // The maximum number of connections to return. If unspecified or 0, a
-    // default value may be applied. Note that paging is currently not fully
-    // supported, and this field only acts as a limit for the first page of data
-    // returned. Subsequent pages of data cannot be requested.
+    // default value may be applied. The server may return fewer connections
+    // than requested due to memory constraints; the limit is set to allow
+    // listing all connections for a single broker. Consider filtering by
+    // node_id to view connections for specific brokers. Note that paging is
+    // currently not fully supported, and this field only acts as a limit for
+    // the first page of data returned. Subsequent pages of data cannot be
+    // requested.
     int32 page_size = 1;
 
     // Filter expression to apply to the connection list.

--- a/src/v/redpanda/BUILD
+++ b/src/v/redpanda/BUILD
@@ -89,6 +89,7 @@ redpanda_cc_library(
         "//src/v/security/audit",
         "//src/v/ssx:abort_source",
         "//src/v/ssx:future_util",
+        "//src/v/ssx:semaphore",
         "//src/v/ssx:sharded_service_container",
         "//src/v/ssx:thread_worker",
         "//src/v/ssx:watchdog",

--- a/src/v/redpanda/admin/BUILD
+++ b/src/v/redpanda/admin/BUILD
@@ -233,9 +233,11 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/container:priority_queue",
         "//src/v/kafka/server",
+        "//src/v/random:generators",
         "//src/v/redpanda/admin/proxy:client",
         "//src/v/serde/protobuf:rpc",
         "//src/v/ssx:async_algorithm",
+        "//src/v/ssx:semaphore",
         "@seastar",
     ],
 )

--- a/src/v/redpanda/admin/kafka_connections_service.cc
+++ b/src/v/redpanda/admin/kafka_connections_service.cc
@@ -14,13 +14,16 @@
 #include "kafka/server/server.h"
 #include "proto/redpanda/core/admin/v2/cluster.proto.h"
 #include "proto/redpanda/core/admin/v2/kafka_connections.proto.h"
+#include "random/generators.h"
 #include "redpanda/admin/aip_filter.h"
 #include "redpanda/admin/aip_ordering.h"
 #include "redpanda/admin/kafka_connections_service_impl.h"
 #include "ssx/async_algorithm.h"
+#include "ssx/semaphore.h"
 
 #include <seastar/core/coroutine.hh>
 
+#include <chrono>
 #include <ranges>
 
 namespace proto {
@@ -95,6 +98,41 @@ ss::future<size_t> gather_all_shards(
 }
 
 } // namespace
+
+kafka_connections_service::kafka_connections_service(
+  ss::sharded<kafka::server>& kafka_server)
+  : _kafka_server(kafka_server) {
+    if (ss::this_shard_id() == rate_limiter_shard) {
+        constexpr static auto max_requests_in_flight = size_t{1};
+        _rate_limiter = std::make_unique<ssx::semaphore>(
+          max_requests_in_flight, "kafka_connections_service/rate_limiter");
+    }
+}
+
+ss::future<kafka_connections_service::remote_units>
+kafka_connections_service::rate_limit() {
+    co_return co_await container().invoke_on(
+      rate_limiter_shard,
+      [](kafka_connections_service& self) { return self.do_rate_limit(); });
+}
+
+ss::future<kafka_connections_service::remote_units>
+kafka_connections_service::do_rate_limit() {
+    vassert(
+      ss::this_shard_id() == rate_limiter_shard,
+      "do_rate_limit() must be called on shard {}",
+      rate_limiter_shard);
+    const auto timeout = std::chrono::milliseconds(
+      random_generators::get_int(3000, 5000));
+    try {
+        auto units = co_await ss::get_units(*_rate_limiter, 1, timeout);
+        co_return ss::make_foreign(
+          std::make_unique<ssx::semaphore_units>(std::move(units)));
+    } catch (const ss::semaphore_timed_out&) {
+        throw serde::pb::rpc::resource_exhausted_exception(
+          "Timeout acquiring rate limiter for list_kafka_connections");
+    }
+}
 
 ss::future<proto::admin::list_kafka_connections_response>
 kafka_connections_service::list_kafka_connections_local(

--- a/src/v/redpanda/admin/kafka_connections_service.cc
+++ b/src/v/redpanda/admin/kafka_connections_service.cc
@@ -36,6 +36,9 @@ namespace {
 
 using namespace admin::detail;
 
+// Estimated memory needed per kafka connection based on testing
+constexpr auto memory_per_connection = 3_KiB;
+
 ss::future<connection_gather_result> gather_connections(
   const kafka::server& server,
   const filter_predicate& filter,
@@ -109,8 +112,17 @@ kafka_connections_service::kafka_connections_service(
     }
 }
 
+ss::future<>
+kafka_connections_service::start(ssx::semaphore& admin_memory_semaphore) {
+    _admin_memory_semaphore = &admin_memory_semaphore;
+    _admin_memory_semaphore_max = admin_memory_semaphore.current();
+    co_return;
+}
+
 ss::future<kafka_connections_service::remote_units>
 kafka_connections_service::rate_limit() {
+    // TODO: this could be optimized later by reserving memory on-demand, while
+    // iterating through shards.
     co_return co_await container().invoke_on(
       rate_limiter_shard,
       [](kafka_connections_service& self) { return self.do_rate_limit(); });
@@ -131,6 +143,41 @@ kafka_connections_service::do_rate_limit() {
     } catch (const ss::semaphore_timed_out&) {
         throw serde::pb::rpc::resource_exhausted_exception(
           "Timeout acquiring rate limiter for list_kafka_connections");
+    }
+}
+
+ss::future<std::vector<kafka_connections_service::remote_units>>
+kafka_connections_service::memory_limit(size_t connection_count) {
+    co_return co_await container().map_reduce0(
+      [connection_count](kafka_connections_service& self) {
+          return self.do_memory_limit(connection_count);
+      },
+      std::vector<remote_units>{},
+      [](std::vector<remote_units> acc, remote_units&& units) {
+          acc.emplace_back(std::move(units));
+          return acc;
+      });
+}
+
+ss::future<kafka_connections_service::remote_units>
+kafka_connections_service::do_memory_limit(size_t connection_count) {
+    try {
+        vassert(
+          _admin_memory_semaphore != nullptr,
+          "Admin memory semaphore not initialized");
+        const auto timeout = std::chrono::milliseconds(
+          random_generators::get_int(3000, 5000));
+        auto units = co_await ss::get_units(
+          *_admin_memory_semaphore,
+          connection_count * memory_per_connection,
+          timeout);
+        co_return ss::make_foreign(
+          std::make_unique<ssx::semaphore_units>(std::move(units)));
+    } catch (const ss::semaphore_timed_out&) {
+        throw serde::pb::rpc::resource_exhausted_exception(
+          fmt::format(
+            "Timeout waiting for memory for list_kafka_connections. Consider "
+            "filtering for a single broker or reducing page_size."));
     }
 }
 
@@ -253,7 +300,16 @@ kafka_connections_service::list_kafka_connections_cluster_wide(
 
 size_t kafka_connections_service::get_effective_limit(size_t page_size) {
     constexpr size_t default_limit = 1000;
-    return page_size == 0 ? default_limit : page_size;
+    auto requested_page_size = page_size == 0 ? default_limit : page_size;
+
+    // Calculate maximum connections we can handle per request based on
+    // available memory
+    const auto max_connections_by_memory = _admin_memory_semaphore_max
+                                           / memory_per_connection;
+    const auto capped_page_size = std::min(
+      requested_page_size, max_connections_by_memory);
+
+    return capped_page_size;
 }
 
 } // namespace admin

--- a/src/v/redpanda/admin/kafka_connections_service.h
+++ b/src/v/redpanda/admin/kafka_connections_service.h
@@ -33,6 +33,8 @@ public:
 
     explicit kafka_connections_service(ss::sharded<kafka::server>&);
 
+    ss::future<> start(ssx::semaphore& admin_memory_semaphore);
+
     // List connections from all shards on this node
     ss::future<proto::admin::list_kafka_connections_response>
     list_kafka_connections_local(
@@ -45,15 +47,21 @@ public:
       const serde::pb::rpc::context& ctx,
       proto::admin::list_kafka_connections_request req);
 
-    static size_t get_effective_limit(size_t page_size);
+    size_t get_effective_limit(size_t page_size);
 
     ss::future<remote_units> rate_limit();
+
+    ss::future<std::vector<remote_units>> memory_limit(size_t connection_count);
 
 private:
     ss::future<remote_units> do_rate_limit();
 
+    ss::future<remote_units> do_memory_limit(size_t connection_count);
+
     ss::sharded<kafka::server>& _kafka_server;
     std::unique_ptr<ssx::semaphore> _rate_limiter{};
+    ssx::semaphore* _admin_memory_semaphore{};
+    size_t _admin_memory_semaphore_max{};
 };
 
 } // namespace admin

--- a/src/v/redpanda/admin/kafka_connections_service.h
+++ b/src/v/redpanda/admin/kafka_connections_service.h
@@ -15,18 +15,23 @@
 #include "kafka/server/fwd.h"
 #include "proto/redpanda/core/admin/v2/cluster.proto.h"
 #include "redpanda/admin/proxy/client.h"
+#include "ssx/semaphore.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>
 
 #include <cstddef>
+#include <memory>
 
 namespace admin {
 
-class kafka_connections_service {
+class kafka_connections_service
+  : public ss::peering_sharded_service<kafka_connections_service> {
 public:
-    explicit kafka_connections_service(ss::sharded<kafka::server>& kafka_server)
-      : _kafka_server(kafka_server) {}
+    using remote_units = ss::foreign_ptr<std::unique_ptr<ssx::semaphore_units>>;
+    constexpr static auto rate_limiter_shard = ss::shard_id{0};
+
+    explicit kafka_connections_service(ss::sharded<kafka::server>&);
 
     // List connections from all shards on this node
     ss::future<proto::admin::list_kafka_connections_response>
@@ -42,8 +47,13 @@ public:
 
     static size_t get_effective_limit(size_t page_size);
 
+    ss::future<remote_units> rate_limit();
+
 private:
+    ss::future<remote_units> do_rate_limit();
+
     ss::sharded<kafka::server>& _kafka_server;
+    std::unique_ptr<ssx::semaphore> _rate_limiter{};
 };
 
 } // namespace admin

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -342,7 +342,8 @@ admin_server::admin_server(
   , _debug_bundle_service(debug_bundle_service)
   , _kafka_connections_service(kafka_connections_service)
   , _default_blocked_reactor_notify(
-      ss::engine().get_blocked_reactor_notify_ms()) {
+      ss::engine().get_blocked_reactor_notify_ms())
+  , _memory_semaphore(_cfg.max_memory_usage_bytes, "admin/server-mem") {
     _server.set_content_streaming(true);
 }
 
@@ -549,6 +550,7 @@ ss::future<> admin_server::start() {
 
 ss::future<> admin_server::stop() {
     _blocked_reactor_notify_reset_timer.cancel();
+    _memory_semaphore.broken();
     co_await _server.stop();
     co_await _debug_bundle_file_handler.stop();
 }

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -56,6 +56,7 @@ struct admin_server_cfg {
     std::vector<config::endpoint_tls_config> endpoints_tls;
     ss::sstring admin_api_docs_dir;
     ss::scheduling_group sg;
+    size_t max_memory_usage_bytes;
 };
 
 enum class service_kind {
@@ -125,6 +126,8 @@ public:
     private:
         std::string _parameter_name;
     };
+
+    ssx::semaphore& memory_semaphore() noexcept { return _memory_semaphore; }
 
 private:
     enum class auth_level {
@@ -808,4 +811,5 @@ private:
     // Value before the temporary override
     std::chrono::milliseconds _default_blocked_reactor_notify;
     ss::timer<> _blocked_reactor_notify_reset_timer;
+    ssx::semaphore _memory_semaphore;
 };

--- a/src/v/redpanda/admin/services/BUILD
+++ b/src/v/redpanda/admin/services/BUILD
@@ -36,6 +36,7 @@ redpanda_cc_library(
         "//src/v/features",
         "//src/v/redpanda/admin:kafka_connections_service",
         "//src/v/redpanda/admin/proxy:client",
+        "//src/v/resource_mgmt:available_memory",
         "//src/v/serde/protobuf:rpc",
         "@seastar",
     ],

--- a/src/v/redpanda/admin/services/cluster.cc
+++ b/src/v/redpanda/admin/services/cluster.cc
@@ -48,6 +48,15 @@ cluster_service_impl::list_kafka_connections(
     utils::check_license(_feature_table.local());
 
     auto& kcs = _kafka_connections_service.local();
+
+    auto rate_units = std::optional<kafka_connections_service::remote_units>{};
+    if (!ctx.is_proxied()) {
+        // Only apply rate limiting on external requests to avoid deadlock on
+        // concurrent requests arriving at the same time through two different
+        // nodes.
+        rate_units = co_await kcs.rate_limit();
+    }
+
     auto resp = ctx.is_proxied()
                   ? co_await kcs.list_kafka_connections_local(std::move(req))
                   : co_await kcs.list_kafka_connections_cluster_wide(

--- a/src/v/redpanda/admin/services/cluster.cc
+++ b/src/v/redpanda/admin/services/cluster.cc
@@ -19,6 +19,8 @@
 
 #include <seastar/core/coroutine.hh>
 
+using namespace std::chrono_literals;
+
 namespace proto {
 using namespace proto::admin;
 } // namespace proto
@@ -56,6 +58,26 @@ cluster_service_impl::list_kafka_connections(
         // nodes.
         rate_units = co_await kcs.rate_limit();
     }
+
+    if (req.get_page_size() < 0) {
+        throw serde::pb::rpc::invalid_argument_exception(
+          "page_size must be non-negative");
+    }
+
+    const auto capped_page_size = kcs.get_effective_limit(req.get_page_size());
+
+    if (capped_page_size < static_cast<size_t>(req.get_page_size())) {
+        vlog(
+          brlog.debug,
+          "list_kafka_connections: reducing page_size from {} to {} due to "
+          "memory constraints",
+          req.get_page_size(),
+          capped_page_size);
+    }
+
+    req.set_page_size(static_cast<int32_t>(capped_page_size));
+
+    auto mem_units = co_await kcs.memory_limit(capped_page_size);
 
     auto resp = ctx.is_proxied()
                   ? co_await kcs.list_kafka_connections_local(std::move(req))

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1120,7 +1120,9 @@ admin_server_cfg_from_global_cfg(scheduling_groups& sgs) {
       .endpoints = config::node().admin(),
       .endpoints_tls = config::node().admin_api_tls(),
       .admin_api_docs_dir = config::node().admin_api_doc_dir(),
-      .sg = sgs.admin_sg()};
+      .sg = sgs.admin_sg(),
+      .max_memory_usage_bytes = memory_groups().admin_max_memory(),
+    };
 }
 
 void application::configure_admin_server(model::node_id node_id) {
@@ -3520,6 +3522,12 @@ void application::start_runtime_services(
     _debug_bundle_service.invoke_on_all(&debug_bundle::service::start).get();
 
     if (!config::node().admin().empty()) {
+        _kafka_connections_service
+          .invoke_on_all([this](admin::kafka_connections_service& kcs) {
+              return kcs.start(_admin.local().memory_semaphore());
+          })
+          .get();
+
         _admin.invoke_on_all(&admin_server::start).get();
     }
 

--- a/src/v/resource_mgmt/memory_groups.cc
+++ b/src/v/resource_mgmt/memory_groups.cc
@@ -42,13 +42,15 @@ struct memory_shares {
     constexpr static size_t rpc = 20;
     constexpr static size_t recovery = 10;
     constexpr static size_t tiered_storage = 10;
+    constexpr static size_t admin = 2;
     constexpr static size_t data_transforms = 10;
     constexpr static size_t datalake = 10;
     constexpr static size_t cloud_topics = 10;
 
     static size_t
     total_shares(bool with_wasm, bool with_datalake, bool with_cloud_topics) {
-        size_t total = chunk_cache + kafka + rpc + recovery + tiered_storage;
+        size_t total = chunk_cache + kafka + rpc + recovery + tiered_storage
+                       + admin;
         if (with_wasm) {
             total += data_transforms;
         }
@@ -117,6 +119,10 @@ size_t system_memory_groups::tiered_storage_max_memory() const {
     return subsystem_memory<memory_shares::tiered_storage>();
 }
 
+size_t system_memory_groups::admin_max_memory() const {
+    return subsystem_memory<memory_shares::admin>();
+}
+
 size_t system_memory_groups::data_transforms_max_memory() const {
     if (!_wasm_enabled) {
         return 0;
@@ -166,8 +172,8 @@ void system_memory_groups::log_memory_group_allocations(seastar::logger& log) {
       "Per shard memory group allocations: total memory: {}, "
       "total memory minus pre-share reservations: {}, chunk cache: {}, kafka: "
       "{}, rpc: {}, recovery: {}, "
-      "tiered storage: {}, data transforms: {}, compaction: {}, datalake: {}, "
-      "partitions: {}",
+      "tiered storage: {}, admin: {}, data transforms: {}, compaction: {}, "
+      "datalake: {}, partitions: {}",
       human::bytes(ss::memory::stats().total_memory()),
       human::bytes(total_memory()),
       human::bytes(chunk_cache_max_memory()),
@@ -175,6 +181,7 @@ void system_memory_groups::log_memory_group_allocations(seastar::logger& log) {
       human::bytes(rpc_total_memory()),
       human::bytes(recovery_max_memory()),
       human::bytes(tiered_storage_max_memory()),
+      human::bytes(admin_max_memory()),
       human::bytes(data_transforms_max_memory()),
       human::bytes(compaction_reserved_memory()),
       human::bytes(datalake_max_memory()),

--- a/src/v/resource_mgmt/memory_groups.h
+++ b/src/v/resource_mgmt/memory_groups.h
@@ -84,6 +84,9 @@ public:
     /// Max memory that both cloud storage uploads and read-path could use
     size_t tiered_storage_max_memory() const;
 
+    /// Max memory that the admin API subsystem should use
+    size_t admin_max_memory() const;
+
     /// Max memory that data transform subsystem should use.
     size_t data_transforms_max_memory() const;
 

--- a/src/v/resource_mgmt/tests/memory_groups_test.cc
+++ b/src/v/resource_mgmt/tests/memory_groups_test.cc
@@ -16,7 +16,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-static constexpr size_t total_shares_without_optionals = 85;
+static constexpr size_t total_shares_without_optionals = 87;
 static constexpr size_t total_wasm_shares = 10;
 static constexpr size_t total_datalake_shares = 10;
 static constexpr size_t total_cloud_topic_shares = 10;
@@ -88,6 +88,9 @@ TEST_P(MemoryGroupSharesTest, DividesSharesCorrectly) {
       groups.tiered_storage_max_memory(),
       IsApprox(total_available_memory * 10.0 / total_shares));
     EXPECT_THAT(
+      groups.admin_max_memory(),
+      IsApprox(total_available_memory * 2.0 / total_shares));
+    EXPECT_THAT(
       groups.recovery_max_memory(),
       IsApprox(total_available_memory * 10.0 / total_shares));
     EXPECT_THAT(
@@ -121,7 +124,7 @@ TEST_P(MemoryGroupSharesTest, DividesSharesCorrectly) {
       groups.data_transforms_max_memory() + groups.chunk_cache_max_memory()
         + groups.kafka_total_memory() + groups.recovery_max_memory()
         + groups.rpc_total_memory() + groups.tiered_storage_max_memory()
-        + groups.datalake_max_memory(),
+        + groups.admin_max_memory() + groups.datalake_max_memory(),
       total_available_memory);
 }
 

--- a/tests/rptest/tests/list_kafka_connections_test.py
+++ b/tests/rptest/tests/list_kafka_connections_test.py
@@ -73,8 +73,9 @@ class AdminV2ListKafkaConnectionsTest(RedpandaTest):
             self.redpanda,
             auth=(self.superuser.username, self.superuser.password),
         )
+        int32_max = 2_147_483_647
         req = cluster_pb.ListKafkaConnectionsRequest(
-            page_size=1000, order_by="source.port desc"
+            page_size=int32_max, order_by="source.port desc"
         )
 
         def valid_response() -> bool:


### PR DESCRIPTION
* [admin: rate limit ListKafkaConnections](https://github.com/redpanda-data/redpanda/pull/28251/commits/f437f59449b80c4f32bddc39f443157af9cb047c)
Rate limit the endpoint to 1 external cluster-wide request per broker.
Note that each cluster-wide request turns into 1 sub-request per broker,
so the rate limit allows up to num_brokers in flight requests on each
broker at the same time.

This rate limiting is to limit the CPU impact of the endpoint, a
separate memory semaphore is introduced in the next commit.

* [resource_mgmt: reserve memory for admin API](https://github.com/redpanda-data/redpanda/pull/28251/commits/9e1808edd8a35daa2ff6c60a1c77b452b1c5e5e2)
Reserve about ~2% (depending on which features are enabled) for the
admin API subsystem.

This is initially going to be used by the ListKafkaConnections endpoint,
but could be shared with other endpoints as well.

* [admin: limit ListKafkaConnections page_size to mem](https://github.com/redpanda-data/redpanda/pull/28251/commits/65c9acf8957d80080f75aa3e8411a978f141b8fc)
This endpoint uses approximately 3KiB x kafka_connection_count amount of
memory, which can get large in clusters with a large connection count.

Cap the page_size based on the available memory sempahores to the admin
API and reserve memory semaphores for it on all cores.

Fixes https://redpandadata.atlassian.net/browse/CORE-13365

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
