### PR TITLE
cl: Adjust logger levels in topic reconciler

### DIFF
--- a/src/v/cluster_link/topic_reconciler.cc
+++ b/src/v/cluster_link/topic_reconciler.cc
@@ -77,7 +77,9 @@ void topic_reconciler::trigger(model::id_t link_id) {
     ssx::spawn_with_gate(_gate, [this, link_id] {
         return execute(link_id).handle_exception(
           [](const std::exception_ptr& e) {
-              vlog(cllog.error, "Topic reconciler failed: {}", e);
+              auto level = ssx::is_shutdown_exception(e) ? ss::log_level::trace
+                                                         : ss::log_level::warn;
+              vlogl(cllog, level, "Topic reconciler failed: {}", e);
           });
     });
 }
@@ -171,7 +173,7 @@ ss::future<> topic_reconciler::maybe_update_existing_topic(
           ::model::timeout_clock::now() + update_timeout);
         if (res != ::cluster::cluster_link::errc::success) {
             vlog(
-              cllog.error,
+              cllog.warn,
               "Failed to mark mirror topic {} as failed: {}",
               topic,
               res);
@@ -199,7 +201,7 @@ ss::future<> topic_reconciler::maybe_update_existing_topic(
           ::model::timeout_clock::now() + update_timeout);
         if (res != cluster::errc::success) {
             vlog(
-              cllog.error,
+              cllog.warn,
               "Failed to set partition count on mirror topic {} to {}: {}",
               topic,
               mirror_topic_config.partition_count,
@@ -230,7 +232,7 @@ ss::future<> topic_reconciler::maybe_update_existing_topic(
     auto res = co_await _topic_creator->update_topic(
       std::move(update_cfg).value());
     if (res != cluster::errc::success) {
-        vlog(cllog.error, "Failed to update mirror topic {}: {}", topic, res);
+        vlog(cllog.warn, "Failed to update mirror topic {}: {}", topic, res);
     } else {
         vlog(
           cllog.trace,


### PR DESCRIPTION
The error levels are too high and are triggering failures in CI. As the errors being reported may be transitive in nature and are not reporting an overall fault in the system, dropping them to 'warn' is appropriate.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
