### PR TITLE
Introduce pre-commit (pre-commit hooks)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,6 +268,9 @@ tests/java/iceberg-rest-catalog/.gradle
 #asdf tool version file
 .tool-versions
 
+# pre-commit local config
+.pre-commit-local.yaml
+
 # Ruff (python formatter)
 .ruff_cache
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,45 @@
+# Pre-commit hooks for Redpanda project
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+
+default_language_version:
+  python: python3
+
+repos:
+  # Python formatting and linting
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.10
+    hooks:
+      # we can't enable this one yet because we aren't ruff-check clean
+      # - id: ruff-check
+      #   args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+
+  # Shell script formatting
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.12.0-2
+    hooks:
+      - id: shfmt
+        # args should be kept in sync with vtools/taskfiles/lint.yml
+        # except that we add -d to provide some feedback about the error
+        args: ['-i', '2', '-ci', '-s', '-w', '-d']
+
+  # Local hooks
+  - repo: local
+    hooks:
+        # runs python type checking (same as task rp:type-check) but only in
+        # manual mode for now as it's too slow for pre-commit for now
+      - id: python-type-check
+        name: Python type checking (pyright)
+        entry: env TC_DOCKER_ARGS=--quiet tools/type-checking/type-check.sh pre-commit
+        language: system
+        stages: [manual]
+        files: '(tests/rptest/.*\.py$)|(tools/type-checking/.*)'
+
+      - id: clang-format
+        name: C++ formatting (clang-format)
+        entry: ./tools/clang-format -i
+        language: script
+        types_or: [c++, c]
+        files: '\.(cc|h)$'
+

--- a/tools/type-checking/type-check.py
+++ b/tools/type-checking/type-check.py
@@ -77,7 +77,9 @@ class TypeCheck:
 
         self._config: Path = self._tests_root / args.config
         self.pyright: Path = args.pyright_path
-        self._input_files: str | None = args.input_files or None
+        self._input_files: list[str] | None = (
+            args.input_files if args.input_files else None
+        )
         self._force_level: Level | None = (
             Level(args.force_level) if args.force_level else None
         )
@@ -276,7 +278,7 @@ class TypeCheck:
 
         return not failed
 
-    def promotion_check(self):
+    def promotion_check(self, always_update: bool = False):
         """Check if files can be promoted to stricter levels than their current assignment."""
 
         # Group files by their current level for efficient batch testing
@@ -307,9 +309,9 @@ class TypeCheck:
             print("No files can be promoted to stricter levels.")
 
         # Update strictness file if requested and there are promotable files
-        if self._args.update:
+        if (self._args.update or always_update) and promotable_files:
             self._update_strictness_file(promotable_files)
-            return True
+            return self._args.update
         else:
             is_sorted = self._check_strictness_file_sorted()
             return is_sorted and not promotable_files
@@ -522,6 +524,51 @@ class TypeCheck:
     def check_sorted(self):
         self._check_strictness_file_sorted()
 
+    def pre_commit(self):
+        """Run the promotion-check and check commands on changed files only.
+
+        This is intended to be used as a pre-commit hook to catch type checking issues
+        before they are committed.
+        """
+
+        # this is basically the same as ci, but we pre-process the
+        # input files to remove tests/ since things should be relative
+        # to tests/ not the repo-root
+
+        self._input_files = [
+            p.removeprefix("tests/")
+            for p in self._args.input_files
+            if p.startswith("tests/")
+        ]
+
+        # type-check
+        file_count = self.input_file_count()
+        if self.check():
+            print(f"Type check passed on {file_count} files")
+        else:
+            print(f"{self.info} run this command locally to reproduce:")
+            print("pre-commit run --hook-stage=manual python-type-check")
+            # fail eagerly since the considerations are different than CI:
+            # favor fast feedback as user will run again anyway
+            return False
+
+        if self.promotion_check(always_update=True):
+            print(f"Promotion check passed on {file_count} files")
+        else:
+            print(
+                f"{self.info}The updated type-check-strictness.json should be in your working tree now, run:"
+            )
+            print("git add tools/type-checking/type-check-strictness.json")
+            print("to add it to your stage and try again.")
+            return False
+
+        return True
+
+    def input_file_count(self) -> int:
+        """Return the number of input files that will be processed."""
+        strictness_map = self._get_input_files()
+        return sum(len(files) for files in strictness_map.values())
+
     def _update_strictness_file(
         self, promotable_files: list[tuple[Path, Level, Level]]
     ):
@@ -604,15 +651,20 @@ class TypeCheck:
 
     def _get_input_files(self):
         """Return a map of strictness level to a list of files which are in that level."""
-        input_files = self._input_files or "rptest/**/*.py"
-        if (abs_input := Path(self._tests_root / input_files)).is_file():
-            self.vprint(f"treating {input_files} as a file")
-            files = [abs_input]
-        else:
-            self.vprint(f"treating {input_files} as a glob")
-            files = list(self._tests_root.glob(input_files))
+        input_patterns = self._input_files if self._input_files else ["rptest/**/*.py"]
+
+        files: list[Path] = []
+        for pattern in input_patterns:
+            if (abs_input := Path(self._tests_root / pattern)).is_file():
+                self.vprint(f"treating {pattern} as a file")
+                files.append(abs_input)
+            else:
+                self.vprint(f"treating {pattern} as a glob")
+                matched = list(self._tests_root.glob(pattern))
+                files.extend(matched)
+
         if not files:
-            raise RuntimeError(f"No files matched input glob: {input_files}")
+            raise RuntimeError(f"No files matched input patterns: {input_patterns}")
 
         # If force level is specified, put all files at that level
         if self._force_level is not None:
@@ -706,7 +758,7 @@ class TypeCheck:
             raise
 
 
-CMDS = ["check", "promotion-check", "fruit", "ci", "check-sorted"]
+CMDS = ["check", "promotion-check", "fruit", "ci", "check-sorted", "pre-commit"]
 
 COMMAND_DOC = """Commands:\nmissing-check: Find files and directories which are not included in the pyrightconfig.json
 check: Run the type checker on the input set and print any errors to stdout
@@ -724,6 +776,7 @@ def main():
     )
 
     p.add_argument("command", type=str, help="Command to run", choices=CMDS)
+
     p.add_argument(
         "--tests-root",
         type=Path,
@@ -743,8 +796,6 @@ def main():
         help="Path to (or bare name of) pyright",
         default="pyright",
     )
-
-    p.add_argument("--input-files", help="Path (glob) to input file(s)", type=str)
 
     p.add_argument(
         "--force-level",
@@ -787,6 +838,14 @@ def main():
         type=int,
         default=10,
         help="Number of files to show per target level when using 'fruit' command (default: 10)",
+    )
+
+    p.add_argument(
+        "input_files",
+        nargs="*",
+        help="Path/globs to input file(s)",
+        type=str,
+        default=None,
     )
 
     args = p.parse_args()

--- a/tools/type-checking/type-check.py
+++ b/tools/type-checking/type-check.py
@@ -556,7 +556,7 @@ class TypeCheck:
             print(f"Promotion check passed on {file_count} files")
         else:
             print(
-                f"{self.info}The updated type-check-strictness.json should be in your working tree now, run:"
+                f"{self.info} The updated type-check-strictness.json should be in your working tree now, run:"
             )
             print("git add tools/type-checking/type-check-strictness.json")
             print("to add it to your stage and try again.")


### PR DESCRIPTION
Pre-commit hooks config. This alone does nothing as you have to install it first, which is part of the [vtools change](github.com/redpanda-data/vtools/pull/3975).

Doc: https://redpandadata.atlassian.net/wiki/spaces/CORE/pages/1430028303/Pre-commit+git+commit+hooks

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
