### PR TITLE
tuner: Add support Azure mana

### DIFF
--- a/src/go/rpk/pkg/tuners/network/nic.go
+++ b/src/go/rpk/pkg/tuners/network/nic.go
@@ -166,6 +166,7 @@ var supportedDrivers = []driverSupport{
 		return func(irq IrqInfo) int { return gvnicIrqToQueueIdx(irq, numIRQs) }
 	}},
 	{"mlx5_core", func(_ int) func(IrqInfo) int { return azureHyperVIrqToQueueIdx }},
+	{"mana", func(_ int) func(IrqInfo) int { return azureManaIrqToQueueIdx }},
 }
 
 func getQueueIndexFunc(driverName string, numIRQs int) func(IrqInfo) int {
@@ -211,7 +212,7 @@ func (n *nic) GetIRQs() ([]IrqInfo, error) {
 		return nil, err
 	}
 
-	fastPathIRQsPattern := regexp.MustCompile(`-TxRx-|-fp-|virtio\d+-(input|output)|ntfy-block|gve-ntfy-blk|mlx5_comp\d+|-Tx-Rx-|mlx\d+-\d+@`)
+	fastPathIRQsPattern := regexp.MustCompile(`-TxRx-|-fp-|virtio\d+-(input|output)|ntfy-block|gve-ntfy-blk|mlx5_comp\d+|mana_q|-Tx-Rx-|mlx\d+-\d+@`)
 	var fastPathIRQNums []int
 	for _, irq := range IRQNums {
 		if fastPathIRQsPattern.MatchString(procFileLines[irq]) {
@@ -292,6 +293,16 @@ func azureHyperVIrqToQueueIdx(irq IrqInfo) int {
 	// Below will only pattern match on Azure but that's fine
 	hyperVPattern := regexp.MustCompile(`mlx5_comp(\d+)@`)
 	match := hyperVPattern.FindStringSubmatch(irq.ProcLine)
+	if len(match) == 2 {
+		idx, _ := strconv.Atoi(match[1])
+		return idx
+	}
+	return MaxInt
+}
+
+func azureManaIrqToQueueIdx(irq IrqInfo) int {
+	manaPattern := regexp.MustCompile(`mana_q(\d+)@`)
+	match := manaPattern.FindStringSubmatch(irq.ProcLine)
 	if len(match) == 2 {
 		idx, _ := strconv.Atoi(match[1])
 		return idx

--- a/src/go/rpk/pkg/tuners/network/nic_test.go
+++ b/src/go/rpk/pkg/tuners/network/nic_test.go
@@ -386,6 +386,36 @@ func Test_nic_GetIRQs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "azure mana",
+			driverName: "mana",
+			irqProcFile: &procFileMock{
+				getIRQProcFileLinesMap: func() (map[int]string, error) {
+					return map[int]string{
+						32: "32:        189  Hyper-V PCIe MSI 2147483648-edge      mana_hwc@pci:7870:00:00.0",
+						33: "33:       5282  Hyper-V PCIe MSI 2147483649-edge      mana_q0@pci:7870:00:00.0",
+						34: "34:       1627  Hyper-V PCIe MSI 2147483650-edge      mana_q1@pci:7870:00:00.0",
+					}, nil
+				},
+			},
+			irqDeviceInfo: &deviceInfoMock{
+				getIRQs: func(string, string) ([]int, error) {
+					return []int{32, 33, 34}, nil
+				},
+			},
+			want: []IrqInfoRes{
+				{
+					Num:        33,
+					ProcLine:   "33:       5282  Hyper-V PCIe MSI 2147483649-edge      mana_q0@pci:7870:00:00.0",
+					QueueIndex: 0,
+				},
+				{
+					Num:        34,
+					ProcLine:   "34:       1627  Hyper-V PCIe MSI 2147483650-edge      mana_q1@pci:7870:00:00.0",
+					QueueIndex: 1,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -697,6 +727,26 @@ func Test_azureHyperVIrqToQueueIdx(t *testing.T) {
 			Num:       33,
 			ProcLine:  "33:       1465        806  Hyper-V PCIe MSI 2701534461952-edge      mlx5_async0@pci:4ea0:00:02.0",
 			indexFunc: azureHyperVIrqToQueueIdx,
+		}
+		require.Equal(t, math.MaxInt64, irq.QueueIndex())
+	}
+}
+
+func test_azureManaIrqToQueueIdx(t *testing.T) {
+	{
+		irq := IrqInfo{
+			Num:       34,
+			ProcLine:  "33:       5282  Hyper-V PCIe MSI 2147483649-edge      mana_q0@pci:7870:00:00.0",
+			indexFunc: azureManaIrqToQueueIdx,
+		}
+		require.Equal(t, 0, irq.QueueIndex())
+	}
+
+	{
+		irq := IrqInfo{
+			Num:       33,
+			ProcLine:  "32:        189  Hyper-V PCIe MSI 2147483648-edge      mana_hwc@pci:7870:00:00.0",
+			indexFunc: azureManaIrqToQueueIdx,
 		}
 		require.Equal(t, math.MaxInt64, irq.QueueIndex())
 	}


### PR DESCRIPTION
Newer Azure instances use custom MS `mana` NICs and drivers instead of mellanox ones.

Add support for that.

Can't use this in CDT yet as we are still running on older instance types there.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none
