### PR TITLE
ct: Disable unsupported state machines in cloud topics

### DIFF
--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -1725,7 +1725,8 @@ bool archival_metadata_stm_factory::is_applicable_for(
   const storage::ntp_config& ntp_cfg) const {
     return _cloud_storage_enabled && _cloud_storage_api.local_is_initialized()
            && ntp_cfg.ntp().tp.topic != model::kafka_consumer_offsets_topic
-           && ntp_cfg.ntp().ns == model::kafka_namespace;
+           && ntp_cfg.ntp().ns == model::kafka_namespace
+           && ntp_cfg.cloud_topic_enabled() == false;
 }
 
 void archival_metadata_stm_factory::create(

--- a/src/v/kafka/server/write_at_offset_stm.cc
+++ b/src/v/kafka/server/write_at_offset_stm.cc
@@ -384,6 +384,9 @@ write_at_offset_stm_factory::write_at_offset_stm_factory(
 
 bool write_at_offset_stm_factory::is_applicable_for(
   const storage::ntp_config& cfg) const {
+    if (cfg.cloud_topic_enabled()) {
+        return false;
+    }
     return model::is_shadow_link_enabled(cfg.ntp());
 }
 


### PR DESCRIPTION
The `write_at_offset` and `archival_metadata_stm` state machines shouldn't be used with CT at the moment.
The archival STM should never be used and for `write_at_offset_stm` we could(should) potentially add support in the future.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none