### PR TITLE
rptest: re-enable TLSMetricsTest.test_crc32c test.

### DIFF
--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -19,4 +19,3 @@ quick:
   - tests/workload_upgrade_runner_test.py # Excluded until CORE-13748 is fixed. 
   - tests/redpanda_oauth_test.py::RedpandaOIDCTlsTest # exclude until CORE-13761 is fixed
   - tests/redpanda_kerberos_test.py::RedpandaKerberosConfigTest # exclude until CORE-13787 is fixed
-  - tests/tls_metrics_test.py::TLSMetricsTest.test_crc32c # exclude until CORE-13788 is fixed


### PR DESCRIPTION
Re-enabling the test_crc32c test after CI infra has been updated.

https://redpandadata.atlassian.net/browse/CORE-13788

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
