### PR TITLE
k/client: Hold gate when sending heartbeat from consumer

### DIFF
--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -113,28 +113,30 @@ void consumer::start() {
     vlog(_logger->info, "Consumer: {}: start", *this);
     _heartbeat_timer.set_callback([me{shared_from_this()}]() {
         vlog(me->_logger->trace, "Consumer: {}: timer cb", *me);
-        (void)me->heartbeat()
-          .handle_exception_type([me](const exception_base& e) {
-              vlog(
-                me->_logger->info,
-                "Consumer: {}: heartbeat failed: {}",
-                *me,
-                e.error);
-          })
-          .handle_exception_type([me](const ss::gate_closed_exception& e) {
-              vlog(
-                me->_logger->trace,
-                "Consumer: {}: heartbeat failed: {}",
-                *me,
-                e);
-          })
-          .handle_exception([me](const std::exception_ptr& e) {
-              vlog(
-                me->_logger->error,
-                "Consumer: {}: heartbeat failed: {}",
-                *me,
-                e);
-          });
+        return ssx::spawn_with_gate(me->_gate, [me]() {
+            return me->heartbeat()
+              .handle_exception_type([me](const exception_base& e) {
+                  vlog(
+                    me->_logger->info,
+                    "Consumer: {}: heartbeat failed: {}",
+                    *me,
+                    e.error);
+              })
+              .handle_exception_type([me](const ss::gate_closed_exception& e) {
+                  vlog(
+                    me->_logger->trace,
+                    "Consumer: {}: heartbeat failed: {}",
+                    *me,
+                    e);
+              })
+              .handle_exception([me](const std::exception_ptr& e) {
+                  vlog(
+                    me->_logger->error,
+                    "Consumer: {}: heartbeat failed: {}",
+                    *me,
+                    e);
+              });
+        });
     });
     _heartbeat_timer.rearm_periodic(_config.heartbeat_interval);
 }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Without holding a gate, the consumer may shutdown and the `kafka::client::client`, which holds the `prefix_logger` may be destructed while the `heartbeat` call is occurring causing a HUAF.

Fixes: CORE-14368

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
