### PR TITLE
cl/replication_mgr: rework replicator start/stop dispatch

### DIFF
--- a/src/v/cluster_link/replication/link_replication_mgr.cc
+++ b/src/v/cluster_link/replication/link_replication_mgr.cc
@@ -30,14 +30,6 @@ link_replication_manager::link_replication_manager(
   , _config_provider(std::move(config_provider))
   , _source_factory(std::move(source_factory))
   , _sink_factory(std::move(sink_factory))
-  , _queue(
-      _sg,
-      [](const std::exception_ptr& ex) {
-          vlog(
-            cllog.error,
-            "unexpected error in processing notifications: {}",
-            ex);
-      })
   , _cfg_probe{std::move(cfg_probe)}
   , _link_data_probe{nullptr} {}
 
@@ -65,19 +57,19 @@ ss::future<> link_replication_manager::stop() {
     vlog(cllog.trace, "Stopping link replication manager");
     // to avoid further submissions to the queue.
     _as.request_abort();
-    _pending_changes_cv.broken();
+    _pending_cv.broken();
     auto gate_f = _gate.close();
-    // no new replicators can be added / removed past this point.
-    chunked_vector<ss::future<>> stop_futures;
-    stop_futures.reserve(_replicators.size());
-    // stop any pending replicators
+    // no new replicators can be added after gate is closed
     for (auto& [_, replicator] : _replicators) {
-        stop_futures.push_back(replicator->stop());
+        replicator->initiate_shutdown();
     }
-    co_await _queue.shutdown();
-    co_await ss::when_all_succeed(stop_futures.begin(), stop_futures.end());
-    _replicators.clear();
     co_await std::move(gate_f);
+    vlog(cllog.debug, "Gate closed");
+    // wait for all replicators to stop
+    for (auto& [ntp, replicator] : _replicators) {
+        vlog(cllog.debug, "Stopping replicator for {}", ntp);
+        co_await replicator->stop();
+    }
     co_await _source_factory->stop();
     unset_data_probe();
     vlog(cllog.trace, "Link replication manager stopped");
@@ -98,32 +90,57 @@ void link_replication_manager::unset_data_probe() {
     }
 }
 
-ss::future<> link_replication_manager::do_start_replicator(
-  model::ntp ntp, model::term_id term) {
-    if (_as.abort_requested()) {
-        co_return;
+std::ostream&
+operator<<(std::ostream& os, link_replication_manager::op_type op) {
+    switch (op) {
+    case link_replication_manager::op_type::start:
+        return os << "start";
+    case link_replication_manager::op_type::stop:
+        return os << "stop";
+    default:
+        return os << "unknown";
     }
-    auto holder = _gate.hold();
-    vlog(cllog.debug, "Starting replicator for {}", ntp);
-    auto it = _replicators.find(ntp);
-    vassert(
-      it == _replicators.end(),
-      "Replicator for {} already exists, an instance should be stopped before "
-      "starting a new one",
-      ntp);
-    auto source = _source_factory->make_source(ntp);
-    auto sink = _sink_factory->make_sink(ntp);
-    auto replicator = std::make_unique<partition_replicator>(
+}
+
+fmt::iterator
+link_replication_manager::ntp_target_state::format_to(fmt::iterator out) const {
+    return fmt::format_to(out, "{{op={}, term: {}}}", op, term);
+}
+
+bool link_replication_manager::ntp_target_state::merge(
+  const ::model::ntp& ntp, ntp_target_state new_desired) {
+    // The incoming state can be merged if it is of higher or equal term.
+    // For example a stop request from term 5 can override a start request
+    // from term 4 or a start request from term 5.
+    // If the term is not specified in the incoming request (eg: can only happen
+    // if the replica is getting managed out of shard), we accept the change as
+    // is. Similarly if the current desired state does not have a term, we
+    // accept the incoming change as is assuming it is coming from a higher
+    // term. In theory this allows sequence like (start(t=4) -> stop(t=null) ->
+    // start(t=4)) but this is not possible in practice as raft guarantees
+    // monotoncity of terms when assuming leadership. Even if such a sequence
+    // happens, we process it and start a replicator in an incorrect term which
+    // will fail to replicate and stop itself.
+    auto can_merge = !new_desired.term || !term || new_desired.term >= term;
+    if (!can_merge) {
+        vlog(
+          cllog.debug,
+          "Ignoring attempt to change desired state for {} from {} to {} as "
+          "it has a lower term",
+          ntp,
+          *this,
+          new_desired);
+        return false;
+    }
+    vlog(
+      cllog.debug,
+      "Merging desired state for {} from {} to {}",
       ntp,
-      term,
-      *_config_provider,
-      std::move(source),
-      std::move(sink),
-      _sg,
-      _cfg_probe,
-      _link_data_probe);
-    auto [r_it, _] = _replicators.emplace(ntp, std::move(replicator));
-    co_await r_it->second->start();
+      *this,
+      new_desired);
+    op = new_desired.op;
+    term = new_desired.term;
+    return true;
 }
 
 void link_replication_manager::start_replicator(
@@ -131,63 +148,10 @@ void link_replication_manager::start_replicator(
     if (_gate.is_closed()) {
         return;
     }
-
-    // If we are starting replication, check to see if there is a pending stop.
-    // If one exists and its term is higher than ours, then do not enqueue the
-    // start action, otherwise remove the stop action
-    auto stop_it = _pending_stops.find(ntp);
-    if (stop_it != _pending_stops.end()) {
-        if (stop_it->second.has_value() && term <= *stop_it->second) {
-            vlog(
-              cllog.debug,
-              "Not enqueueing start action for {} at term {}, a stop is "
-              "pending with term {}",
-              ntp,
-              term,
-              stop_it->second);
-            return;
-        }
-    }
-
-    // Now check if there are any pending starts.  If there are, replace the
-    // start only if the term is higher
-    auto start_it = _pending_starts.find(ntp);
-    if (start_it != _pending_starts.end()) {
-        if (term <= start_it->second) {
-            vlog(
-              cllog.debug,
-              "Not enqueueing start action for {} at term {}, a start is "
-              "pending with term {}",
-              ntp,
-              term,
-              start_it->second);
-            return;
-        }
-    }
-    vlog(cllog.debug, "Enqueueing start action for {} at term {}", ntp, term);
-    _pending_starts.insert_or_assign(ntp, term);
-    _pending_changes_cv.signal();
-}
-
-ss::future<> link_replication_manager::do_stop_replicator(
-  model::ntp ntp, std::optional<model::term_id> term) {
-    if (_as.abort_requested()) {
-        co_return;
-    }
-    auto holder = _gate.hold();
-    vlog(cllog.debug, "Stopping replicator for {}", ntp);
-    auto it = _replicators.find(ntp);
-    if (it == _replicators.end() || (term && (*term < it->second->term()))) {
-        vlog(
-          cllog.trace,
-          "No replicator found for {} at term {}, skipping stop",
-          ntp,
-          term);
-        co_return;
-    }
-    auto replicator = std::move(it->second);
-    _replicators.erase(it);
-    co_await replicator->stop();
+    vlog(cllog.debug, "Enqueuing start action for {} term {}", ntp, term);
+    auto& rec_state = _pending[ntp];
+    rec_state.set_desired(ntp, {.op = op_type::start, .term = term});
+    _pending_cv.signal();
 }
 
 void link_replication_manager::stop_replicator(
@@ -195,42 +159,30 @@ void link_replication_manager::stop_replicator(
     if (_gate.is_closed()) {
         return;
     }
-
-    // If we are stopping replication, we need to check if there are any pending
-    // starting or stopping operations.  If there are pending starts and the
-    // term is higher or not present, enqueue the stop and remove the start
-    auto start_it = _pending_starts.find(ntp);
-    if (start_it != _pending_starts.end()) {
-        if (term.has_value() && *term < start_it->second) {
-            vlog(
-              cllog.debug,
-              "Not enqueueing stop action for {} at term {}",
-              ntp,
-              term);
-            return;
-        }
-        vlog(cllog.debug, "Removing pending start action for {}", ntp);
-        _pending_starts.erase(start_it);
-    }
-
-    auto stop_it = _pending_stops.find(ntp);
-    if (stop_it != _pending_stops.end()) {
-        if (
-          term.has_value() && stop_it->second.has_value()
-          && *term <= *stop_it->second) {
-            vlog(
-              cllog.debug,
-              "Not enqueueing stop action for {} at term {}, a stop is "
-              "pending with term {}",
-              ntp,
-              term,
-              stop_it->second);
-            return;
+    vlog(cllog.debug, "Enqueuing stop action for {} term {}", ntp, term);
+    auto& rec_state = _pending[ntp];
+    auto result = rec_state.set_desired(
+      ntp, {.op = op_type::stop, .term = term});
+    if (result) {
+        vlog(
+          cllog.debug,
+          "Desired state for {} set to stop with term {}, initiating shutdown",
+          ntp,
+          term);
+        auto it = _replicators.find(ntp);
+        if (it != _replicators.end()) {
+            // signal the replicator to stop. We do this to preempt any
+            // replicator that is stuck in start() attempting to connect to
+            // source. Not doing so will cause shutdown to wait for the full
+            // start() timeout.
+            // Also any future start requests from a higher or equal term merged
+            // into the stop state will cause the reconciler to restart the
+            // replicator (ensuring it is not in a half stopped state). Hence
+            // this is safe to do. See @reconcile_ntp_once.
+            it->second->initiate_shutdown();
         }
     }
-    vlog(cllog.debug, "Enqueuing stop action for {} at term {}", ntp, term);
-    _pending_stops.insert_or_assign(ntp, term);
-    _pending_changes_cv.signal();
+    _pending_cv.signal();
 }
 
 void link_replication_manager::stop_replicators(
@@ -266,55 +218,161 @@ link_replication_manager::get_partition_offsets_report(
     return it->second->get_partition_offsets_report();
 }
 
-bool link_replication_manager::has_pending_actions() {
-    return !_pending_starts.empty() || !_pending_stops.empty();
+bool link_replication_manager::can_reconcile_now() {
+    auto has_pending_actions = std::ranges::any_of(
+      _pending, [](const auto& pair) {
+          const auto& [_, rec_state] = pair;
+          return rec_state.needs_reconciliation()
+                 || rec_state.reconciliation_complete();
+      });
+    vlog(
+      cllog.debug,
+      "Checking for pending actions: {}, available units: {}",
+      has_pending_actions ? "found" : "none found",
+      _max_reconciliations.available_units());
+    return has_pending_actions && _max_reconciliations.available_units() > 0;
 }
 
 ss::future<> link_replication_manager::reconcile() {
-    co_await _pending_changes_cv.wait([this] { return has_pending_actions(); });
+    co_await _pending_cv.wait([this] { return can_reconcile_now(); });
     if (_gate.is_closed()) {
         co_return;
     }
-    run_stop_actions();
-    run_start_actions();
+    vlog(
+      cllog.debug,
+      "Starting reconciliation loop, pending actions: {}",
+      _pending.size());
+    // cleanup completed reconciliations
+    for (auto it = _pending.begin(); it != _pending.end();) {
+        if (it->second.reconciliation_complete()) {
+            it = _pending.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    // launch new reconciliations
+    for (auto& [ntp, rec_state] : _pending) {
+        if (!rec_state.needs_reconciliation()) {
+            continue;
+        }
+        auto units = ss::try_get_units(_max_reconciliations, 1);
+        if (!units) {
+            // try when available.
+            co_return;
+        }
+        ssx::spawn_with_gate(
+          _gate, [this, ntp, u = std::move(units.value())]() mutable {
+              return reconcile_ntp_once(std::move(ntp), std::move(u));
+          });
+    }
 }
 
-void link_replication_manager::run_start_actions() {
-    for (auto& [ntp, term] : _pending_starts) {
-        vlog(cllog.trace, "Starting {} term {}", ntp, term);
-        _queue.submit([this, ntp = std::move(ntp), term]() mutable {
-            return do_start_replicator(ntp, term).handle_exception(
-              [ntp = std::move(ntp),
-               term](const std::exception_ptr& e) mutable {
-                  vlog(
-                    cllog.warn,
-                    "Failed to start replicator for {} at term {}: {}",
-                    ntp,
-                    term,
-                    e);
-              });
-        });
+ss::future<> link_replication_manager::reconcile_ntp_once(
+  ::model::ntp ntp, ssx::semaphore_units units) {
+    auto it = _pending.find(ntp);
+    if (it == _pending.end()) {
+        co_return;
     }
-    _pending_starts.clear();
-}
-
-void link_replication_manager::run_stop_actions() {
-    for (auto& [ntp, term] : _pending_stops) {
-        vlog(cllog.trace, "Stopping {} term {}", ntp, term);
-        _queue.submit([this, ntp = std::move(ntp), term]() mutable {
-            return do_stop_replicator(ntp, term).handle_exception(
-              [ntp = std::move(ntp),
-               term](const std::exception_ptr& e) mutable {
-                  vlog(
-                    cllog.error,
-                    "Failed to stop replicator for {} at term {}: {}",
-                    ntp,
-                    term,
-                    e);
-              });
-        });
+    auto& state = it->second;
+    vlog(cllog.debug, "Reconciling ntp {} to state: {}", ntp, state.desired);
+    vassert(
+      state.needs_reconciliation(),
+      "Attempting to reconcile ntp {} which is already in progress",
+      ntp);
+    // mark it in progress
+    // this is the target state for this iteration of reconciliation
+    state.in_progress = std::exchange(state.desired, std::nullopt);
+    auto target_state = state.in_progress.value();
+    auto replicator_it = _replicators.find(ntp);
+    auto has_running_replicator = replicator_it != _replicators.end();
+    if (has_running_replicator) {
+        // check if it needs to be stopped first
+        auto replicator_term = replicator_it->second->term();
+        auto needs_stop = false;
+        switch (target_state.op) {
+        case op_type::start:
+            // if there is a start from higher term, we need to restart
+            // so stop if first.
+            needs_stop = target_state.term
+                         && (replicator_term < *target_state.term);
+            break;
+        case op_type::stop:
+            // If the stop is from higher or equal term, we need to stop
+            needs_stop = !target_state.term
+                         || (replicator_term <= *target_state.term);
+            break;
+        }
+        // If the shutdown has already been initiated it is possible that a stop
+        // request got merged with a start request. In that case we need to stop
+        // the replicator first before starting it again below.
+        needs_stop = needs_stop || replicator_it->second->shutdown_initiated();
+        if (needs_stop) {
+            auto stop_it = _replicators.extract(replicator_it);
+            try {
+                co_await stop_it.second->stop();
+            } catch (const std::exception& e) {
+                vlog(
+                  cllog.warn,
+                  "Error stopping replicator for {}: {}, moving on",
+                  ntp,
+                  e);
+            }
+            has_running_replicator = false;
+        }
     }
-    _pending_stops.clear();
+    // Check if we need to start a replicator
+    if (
+      !has_running_replicator && target_state.op == op_type::start
+      && !_gate.is_closed()) {
+        vassert(
+          !_replicators.contains(ntp), "Replicator for {} already exists", ntp);
+        vassert(
+          target_state.term.has_value(),
+          "Cannot start replicator for {} without a term",
+          ntp);
+        auto term = target_state.term.value();
+        auto source = _source_factory->make_source(ntp);
+        auto sink = _sink_factory->make_sink(ntp);
+        auto replicator = std::make_unique<partition_replicator>(
+          ntp,
+          term,
+          *_config_provider,
+          std::move(source),
+          std::move(sink),
+          _sg,
+          _cfg_probe,
+          _link_data_probe);
+        auto [r_it, _] = _replicators.emplace(ntp, std::move(replicator));
+        try {
+            co_await r_it->second->start();
+        } catch (const std::exception& e) {
+            vlog(cllog.warn, "Error starting replicator for {}: {}", ntp, e);
+            auto r_it = _replicators.find(ntp);
+            if (r_it != _replicators.end()) {
+                // this initiates a step down and a subsequent stop
+                r_it->second->notify_sink_on_failure(term);
+            }
+        }
+    }
+    it = _pending.find(ntp);
+    // State should not have been removed during reconciliation
+    vassert(it != _pending.end(), "Pending state for {} missing", ntp);
+    // Only place that can modify in_progress is this function
+    vassert(
+      it->second.in_progress == target_state,
+      "In-progress state for {} changed during reconciliation, expected {}, "
+      "got {}",
+      ntp,
+      target_state,
+      it->second.in_progress);
+    it->second.in_progress.reset();
+    units.return_all();
+    _pending_cv.signal();
+    vlog(
+      cllog.debug,
+      "Completed reconciliation for ntp {} to state: {}",
+      ntp,
+      target_state);
 }
 
 ss::future<> link_replication_manager::maybe_sync_start_offsets() {

--- a/src/v/cluster_link/replication/link_replication_mgr.h
+++ b/src/v/cluster_link/replication/link_replication_mgr.h
@@ -60,23 +60,63 @@ private:
     ss::future<> do_start_replicator(::model::ntp, ::model::term_id);
     ss::future<>
       do_stop_replicator(::model::ntp, std::optional<::model::term_id>);
-    bool has_pending_actions();
+    bool can_reconcile_now();
     ss::future<> reconcile();
+    ss::future<> reconcile_ntp_once(::model::ntp ntp, ssx::semaphore_units);
 
-    void run_start_actions();
-    void run_stop_actions();
+    // Allowed operations on a replicator
+    enum class op_type : uint8_t { start, stop };
+    friend std::ostream& operator<<(std::ostream& os, op_type);
+    struct ntp_target_state {
+        op_type op;
+        std::optional<::model::term_id> term;
+        fmt::iterator format_to(fmt::iterator) const;
+        // merges new_desired into this. Returns true if successful, false if
+        // new_desired is stale and rejected.
+        bool merge(const ::model::ntp&, ntp_target_state new_desired);
+        bool operator==(const ntp_target_state& other) const = default;
+    };
 
-private:
+    struct ntp_reconciliation_state {
+        //  Only set when a reconciliation is in progress and is set
+        // to the state being reconciled to.
+        std::optional<ntp_target_state> in_progress;
+        // Desired state to reconcile to. This is updated when new requests
+        // appear. If there is a desired state already, we attempt to merge the
+        // new desired state into the existing one if possible.
+        std::optional<ntp_target_state> desired;
+
+        // Sets the desired state. Returns true if successful, false if the
+        // new desired state is stale and rejected.
+        bool
+        set_desired(const ::model::ntp& ntp, ntp_target_state new_desired) {
+            if (desired) {
+                return desired->merge(ntp, new_desired);
+            }
+            desired = new_desired;
+            return true;
+        }
+
+        // Returns true if reconciliation is needed.
+        bool needs_reconciliation() const { return desired && !in_progress; }
+        bool reconciliation_complete() const {
+            return !desired && !in_progress;
+        }
+    };
+
+    // List of pending reconciliations. Each ntp maintains a desired target
+    // state to reconcile to, and an in-progress state if a reconciliation is
+    // ongoing. Multiple desired state updates can be merged while a
+    // reconciliation is in progress.
+    chunked_hash_map<::model::ntp, ntp_reconciliation_state> _pending;
+    ss::condition_variable _pending_cv;
+    ssx::semaphore _max_reconciliations{32, "link-replicator-mgr"};
+
     ss::scheduling_group _sg;
     std::unique_ptr<link_configuration_provider> _config_provider;
     std::unique_ptr<data_source_factory> _source_factory;
     std::unique_ptr<data_sink_factory> _sink_factory;
     ss::future<> maybe_sync_start_offsets();
-    ssx::work_queue _queue;
-    chunked_hash_map<::model::ntp, ::model::term_id> _pending_starts;
-    chunked_hash_map<::model::ntp, std::optional<::model::term_id>>
-      _pending_stops;
-    ss::condition_variable _pending_changes_cv;
     chunked_hash_map<::model::ntp, std::unique_ptr<partition_replicator>>
       _replicators;
     std::optional<replication_probe::configuration> _cfg_probe;

--- a/src/v/cluster_link/replication/partition_replicator.cc
+++ b/src/v/cluster_link/replication/partition_replicator.cc
@@ -69,7 +69,7 @@ ss::future<> partition_replicator::start() {
         vlog(_log.debug, "Resuming replication from offset {}", start_offset);
     }
     co_await _source->start(start_offset);
-    ssx::repeat_until_gate_closed(_gate, [this] {
+    ssx::repeat_until_gate_closed_or_aborted(_gate, _as, [this] {
         return fetch_and_replicate().handle_exception(
           [this](const std::exception_ptr& e) {
               auto log_level = ssx::is_shutdown_exception(e)
@@ -249,6 +249,7 @@ bool partition_replicator::shutdown_initiated() noexcept {
 }
 
 ss::future<> partition_replicator::fetch_and_replicate() {
+    _as.check();
     _gate.check();
     // abort source for this iteration of fetch_and_replicate
     ss::abort_source as;

--- a/src/v/cluster_link/replication/partition_replicator.cc
+++ b/src/v/cluster_link/replication/partition_replicator.cc
@@ -83,7 +83,7 @@ ss::future<> partition_replicator::start() {
 ss::future<> partition_replicator::stop() {
     co_await ss::coroutine::switch_to(_scheduling_group);
     vlog(_log.trace, "Stopping replicator");
-    _as.request_abort();
+    initiate_shutdown();
     // closing the gate first ensures all the units are returned to the
     // semaphores before the source is stopped.
     co_await _gate.close();
@@ -241,6 +241,11 @@ kafka::offset partition_replicator::get_partition_lag() const {
 
     auto hwm = _sink->high_watermark();
     return lso - hwm;
+}
+
+void partition_replicator::initiate_shutdown() noexcept { _as.request_abort(); }
+bool partition_replicator::shutdown_initiated() noexcept {
+    return _as.abort_requested();
 }
 
 ss::future<> partition_replicator::fetch_and_replicate() {

--- a/src/v/cluster_link/replication/partition_replicator.h
+++ b/src/v/cluster_link/replication/partition_replicator.h
@@ -81,6 +81,9 @@ public:
 
     kafka::offset get_partition_lag() const;
 
+    void initiate_shutdown() noexcept;
+    bool shutdown_initiated() noexcept;
+
 private:
     struct replicate_ctx {
         ::model::offset begin;


### PR DESCRIPTION
Refactor how the replication_mgr handles start and stop notifications for
replicators.

Previously, all partition notifications on a shard were processed through a
single queue which caused the following issues.

 * Head-of-line blocking: starting a replicator may involve querying the
   source cluster for offsets (with retries), potentially blocking all
   subsequent notifications.
 * Duplicate work: multiple notifications for the same replicator (e.g.
   start -> stop -> start) were processed independently instead of being
   collapsed into a single effective target state.
 * Concurrency issues: under some conditions, multiple replicators could
   start in the same term, triggering assertion failures in RNOT.

This commit introduces a per-ntp reconciler (with a cap on concurrent
fibers). All in-flight requests for a given replicator are merged into a
single target state (either started or stopped coupled with a term) and
the reconciler drives the actual state toward that target, eliminating
redundant work and preventing blocking.

Fixes: CORE-14449
Fixes: CORE-14450


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
