### PR TITLE
rpk shadow: docs and improved error handling

### DIFF
--- a/src/go/rpk/pkg/cli/shadow/BUILD
+++ b/src/go/rpk/pkg/cli/shadow/BUILD
@@ -7,6 +7,7 @@ go_library(
         "create.go",
         "delete.go",
         "describe.go",
+        "errors.go",
         "failover.go",
         "list.go",
         "mapper.go",

--- a/src/go/rpk/pkg/cli/shadow/config.go
+++ b/src/go/rpk/pkg/cli/shadow/config.go
@@ -39,15 +39,24 @@ func newGenerateCommand(fs afero.Fs, _ *config.Params) *cobra.Command {
 		Use:   "generate",
 		Args:  cobra.NoArgs,
 		Short: "Generate a Redpanda Shadow Link configuration file",
-		Long: `Generate a Redpanda Shadow Link configuration file
+		Long: `Generate a configuration file for creating a Shadow Link.
 
-By default, the command prints a sample configuration file to standard output.
-Use the --output flag to specify a file path to save the configuration file.
+This command creates a sample configuration file with placeholder values that
+you customize for your environment. 
 
-It generates a configuration file with placeholder values that you need to fill
-in with actual connection details and settings for your Shadow Link. You may
-also create a configuration file from an existing rpk profile or from a Redpanda
-configuration file.
+By default, this command prints the configuration to standard output. Use the
+--output flag to save the configuration to a file.
+
+After you generate the configuration file, update the placeholder values with
+your actual connection details and settings. Then use 'rpk shadow create' to
+create the Shadow Link.
+`,
+		Example: `
+Generate a configuration file and print it to standard output:
+  rpk shadow config generate
+
+Save the configuration file to a specific location:
+  rpk shadow config generate -o shadow-link.yaml
 `,
 		Run: func(_ *cobra.Command, _ []string) {
 			// TODO: support generating from an rpk profile or Redpanda config file.

--- a/src/go/rpk/pkg/cli/shadow/create.go
+++ b/src/go/rpk/pkg/cli/shadow/create.go
@@ -70,7 +70,7 @@ skip the confirmation prompt.
 			link, err := cl.ShadowLinkService().CreateShadowLink(cmd.Context(), connect.NewRequest(&adminv2.CreateShadowLinkRequest{
 				ShadowLink: shadowLinkConfigToProto(slCfg),
 			}))
-			out.MaybeDie(err, "unable to create shadow link: %v", err)
+			out.MaybeDie(err, "unable to create shadow link: %v", handleConnectError(err, "create", slCfg.Name))
 
 			fmt.Printf("Successfully created shadow link %q with ID %q. To query the status, run:\n  'rpk shadow status %[1]v'\n", link.Msg.GetShadowLink().GetName(), link.Msg.GetShadowLink().GetUid())
 		},

--- a/src/go/rpk/pkg/cli/shadow/create.go
+++ b/src/go/rpk/pkg/cli/shadow/create.go
@@ -31,15 +31,25 @@ func newCreateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Use:   "create",
 		Args:  cobra.NoArgs,
 		Short: "Create a Redpanda Shadow Link",
-		Long: `Create a Shadow Link
+		Long: `Create a Redpanda Shadow Link.
 
-Create a Shadow Link using a configuration file. The configuration file defines
-the connection details and settings for the Shadow Link. For details on the
-configuration file format, see:
-  rpk shadow config --help
+This command creates a Shadow Link using a configuration file that defines the
+connection details and synchronization settings.
 
-The command prompts for confirmation by default. Use the --no-confirm flag to
-skip the confirmation prompt.
+Before you create a Shadow Link, generate a configuration file with 'rpk shadow
+config generate' and update it with your source cluster details. The command
+prompts you to confirm the creation. Use the --no-confirm flag to skip the
+confirmation prompt.
+
+After you create the Shadow Link, use 'rpk shadow status' to monitor the
+replication progress.
+`,
+		Example: `
+Create a Shadow Link using a configuration file:
+  rpk shadow create --config-file shadow-link.yaml
+
+Create a Shadow Link without confirmation prompt:
+  rpk shadow create -c shadow-link.yaml --no-confirm
 `,
 		Run: func(cmd *cobra.Command, _ []string) {
 			p, err := p.LoadVirtualProfile(fs)

--- a/src/go/rpk/pkg/cli/shadow/delete.go
+++ b/src/go/rpk/pkg/cli/shadow/delete.go
@@ -30,18 +30,29 @@ func newDeleteCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Use:   "delete [LINK_NAME]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Delete a Redpanda Shadow Link",
-		Long: `Delete a Redpanda Shadow Link
+		Long: `Delete a Redpanda Shadow Link.
 
-Delete a Shadow Link by name. You cannot delete Shadow Links that have active
-Shadow topics. Run the failover command first to deactivate topics before 
-deletion.
+This command deletes a Shadow Link by name. By default, you cannot delete a
+Shadow Link that has active shadow topics. Use 'rpk shadow failover' first to
+deactivate topics before deletion, or use the --force flag to delete the Shadow
+Link and failover all its active shadow topics.
 
-The command prompts for confirmation by default. Use the --no-confirm flag to
-skip the confirmation prompt.
+The command prompts you to confirm the deletion. Use the --no-confirm flag to
+skip the confirmation prompt. The --force flag automatically disables the
+confirmation prompt.
 
-Use the -f/--force flag to delete a Shadow Link even if it has active Shadow
-topics. Effectively has the same result as Failing Over all topics + deleting
-the Shadow Link. This flag also disables the confirmation prompt.
+WARNING: Deleting a Shadow Link with --force permanently removes all shadow
+topics and stops replication. This operation cannot be undone.
+`,
+		Example: `
+Delete a Shadow Link:
+  rpk shadow delete my-shadow-link
+
+Delete a Shadow Link without confirmation:
+  rpk shadow delete my-shadow-link --no-confirm
+
+Force delete a Shadow Link with active shadow topics:
+  rpk shadow delete my-shadow-link --force
 `,
 		Run: func(cmd *cobra.Command, args []string) {
 			p, err := p.LoadVirtualProfile(fs)

--- a/src/go/rpk/pkg/cli/shadow/delete.go
+++ b/src/go/rpk/pkg/cli/shadow/delete.go
@@ -55,7 +55,7 @@ the Shadow Link. This flag also disables the confirmation prompt.
 			link, err := cl.ShadowLinkService().GetShadowLink(cmd.Context(), connect.NewRequest(&adminv2.GetShadowLinkRequest{
 				Name: linkName,
 			}))
-			out.MaybeDie(err, "unable to get Redpanda Shadow Link information: %v", err)
+			out.MaybeDie(err, "unable to get Redpanda Shadow Link information: %v", handleConnectError(err, "get", linkName))
 
 			printShadowLinkInfo(link.Msg.GetShadowLink())
 			if !noConfirm && !forceDelete {
@@ -70,7 +70,7 @@ the Shadow Link. This flag also disables the confirmation prompt.
 				Name:  linkName,
 				Force: forceDelete,
 			}))
-			out.MaybeDie(err, "unable to delete Redpanda Shadow Link %q: %v", linkName, err)
+			out.MaybeDie(err, "unable to delete Redpanda Shadow Link %q: %v", linkName, handleConnectError(err, "delete", linkName))
 
 			fmt.Printf("Shadow Link %q deleted successfully\n", linkName)
 		},

--- a/src/go/rpk/pkg/cli/shadow/describe.go
+++ b/src/go/rpk/pkg/cli/shadow/describe.go
@@ -30,6 +30,29 @@ func newDescribeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Use:   "describe [LINK_NAME]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Describe a Redpanda Shadow Link",
+		Long: `Describe a Redpanda Shadow Link.
+
+This command shows the Shadow Link configuration, including connection settings,
+synchronization options, and filters. Use the flags to display specific sections
+or all sections of the configuration.
+
+By default, the command displays the overview and client configuration sections.
+Use the flags to display additional sections such as topic synchronization,
+consumer offset synchronization, and security synchronization settings.
+`,
+		Example: `
+Describe a Shadow Link with default sections (overview and client):
+  rpk shadow describe my-shadow-link
+
+Display all configuration sections:
+  rpk shadow describe my-shadow-link --print-all
+
+Display specific sections:
+  rpk shadow describe my-shadow-link --print-overview --print-topic
+
+Display only the client configuration:
+  rpk shadow describe my-shadow-link -c
+`,
 		Run: func(cmd *cobra.Command, args []string) {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "unable to load rpk config: %v", err)

--- a/src/go/rpk/pkg/cli/shadow/describe.go
+++ b/src/go/rpk/pkg/cli/shadow/describe.go
@@ -10,7 +10,6 @@
 package shadow
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -45,12 +44,7 @@ func newDescribeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			link, err := cl.ShadowLinkService().GetShadowLink(cmd.Context(), connect.NewRequest(&adminv2.GetShadowLinkRequest{
 				Name: linkName,
 			}))
-			if err != nil {
-				if ce := new(connect.Error); errors.As(err, &ce) && ce.Code() == connect.CodeNotFound {
-					out.Die("shadow link %q not found; use 'rpk shadow list' to list all available shadow links", linkName)
-				}
-				out.Die("unable to get Redpanda Shadow Link %q: %v", linkName, err)
-			}
+			out.MaybeDie(err, "unable to get Redpanda Shadow Link %q: %v", linkName, handleConnectError(err, "get", linkName))
 
 			printShadowLinkDescription(link.Msg.GetShadowLink(), opts)
 		},

--- a/src/go/rpk/pkg/cli/shadow/errors.go
+++ b/src/go/rpk/pkg/cli/shadow/errors.go
@@ -1,0 +1,57 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package shadow
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"connectrpc.com/connect"
+)
+
+// handleConnectError transforms Connect API errors into user-friendly error
+// messages. It returns the original error if no transformation is needed, or a
+// new error with a more helpful message for known error codes.
+//
+// The function handles:
+//   - NotFound (404): Suggests running 'rpk shadow list' to see available links.
+//   - PermissionDenied: Provides guidance about permissions, preserving role requirements.
+//
+// Parameters:
+//   - err: The Connect error to handle.
+//   - operation: The operation being performed (e.g., "delete", "create").
+//   - linkName: The name of the shadow link (optional).
+func handleConnectError(err error, operation, linkName string) error {
+	if err == nil {
+		return nil
+	}
+	var ce *connect.Error
+	if errors.As(err, &ce) {
+		switch ce.Code() {
+		case connect.CodeNotFound:
+			if linkName != "" {
+				return fmt.Errorf("shadow link %q not found; to get all active shadow links run 'rpk shadow list'", linkName)
+			}
+			return fmt.Errorf("shadow link not found; to get all active shadow links run 'rpk shadow list'")
+
+		case connect.CodePermissionDenied:
+			msg := fmt.Sprintf("permission denied: you don't have access to %s shadow links", operation)
+			// Preserve role requirement information from the original error
+			if strings.Contains(ce.Message(), "superuser role required") {
+				msg += " (superuser role required). Use a superuser account by updating your rpk profile (see 'rpk profile set --help')" // TODO: update once we have Cloud support.
+			} else {
+				msg += "; check your roles and permissions using 'rpk security' commands"
+			}
+			return fmt.Errorf("%s", msg)
+		}
+	}
+	return err
+}

--- a/src/go/rpk/pkg/cli/shadow/failover.go
+++ b/src/go/rpk/pkg/cli/shadow/failover.go
@@ -48,7 +48,7 @@ func newFailoverCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				sl, err := cl.ShadowLinkService().GetShadowLink(cmd.Context(), connect.NewRequest(&adminv2.GetShadowLinkRequest{
 					Name: linkName,
 				}))
-				out.MaybeDie(err, "unable to get Redpanda Shadow Link %q: %v", linkName, err)
+				out.MaybeDie(err, "unable to get Redpanda Shadow Link %q: %v", linkName, handleConnectError(err, "get", linkName))
 				printOverview(sl.Msg.GetShadowLink())
 				var confirmed bool
 				if all {
@@ -65,7 +65,7 @@ func newFailoverCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				Name:            linkName,
 				ShadowTopicName: topic,
 			}))
-			out.MaybeDie(err, "unable to failover Shadow Link: %v", err)
+			out.MaybeDie(err, "unable to failover Shadow Link: %v", handleConnectError(err, "failover", linkName))
 
 			fmt.Printf(`Successfully initiated the Fail Over for Shadow Link %q. To check the status, run:
   rpk shadow status %[1]s

--- a/src/go/rpk/pkg/cli/shadow/failover.go
+++ b/src/go/rpk/pkg/cli/shadow/failover.go
@@ -31,7 +31,34 @@ func newFailoverCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Use:   "failover [LINK_NAME]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Failover a Redpanda Shadow Link",
-		Long:  `Failover a Redpanda Shadow Link or a specific topic`,
+		Long: `Failover a Redpanda Shadow Link.
+
+This command performs a failover operation for a Shadow Link. Failover converts
+shadow topics into regular topics on the destination cluster, allowing producers
+and consumers to interact with them directly. After failover, the Shadow Link
+stops replicating data from the source cluster.
+
+Use the --all flag to failover all shadow topics associated with the Shadow
+Link, or use the --topic flag to failover a specific topic. You must specify
+either --all or --topic.
+
+The command prompts you to confirm the failover operation. Use the --no-confirm
+flag to skip the confirmation prompt.
+
+WARNING: Failover is a critical operation. After failover, shadow topics become
+regular topics and replication stops. Ensure your applications are ready to
+connect to the destination cluster before performing a failover.
+`,
+		Example: `
+Failover all topics for a Shadow Link:
+  rpk shadow failover my-shadow-link --all
+
+Failover a specific topic:
+  rpk shadow failover my-shadow-link --topic my-topic
+
+Failover without confirmation:
+  rpk shadow failover my-shadow-link --all --no-confirm
+`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if !all && topic == "" {
 				out.Die("either --all or --topic must be provided")
@@ -74,7 +101,7 @@ func newFailoverCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt")
-	cmd.Flags().BoolVar(&all, "all", false, "Failover all shadow links")
+	cmd.Flags().BoolVar(&all, "all", false, "Failover all shadow topics associated with the Shadow Link")
 	cmd.Flags().StringVar(&topic, "topic", "", "Specific topic to failover. If --all is not set, at least a topic must be provided")
 
 	cmd.MarkFlagsMutuallyExclusive("all", "topic")

--- a/src/go/rpk/pkg/cli/shadow/list.go
+++ b/src/go/rpk/pkg/cli/shadow/list.go
@@ -26,7 +26,16 @@ func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Use:   "list",
 		Args:  cobra.NoArgs,
 		Short: "List Redpanda Shadow Links",
-		Long:  `List Redpanda Shadow Links`, // TODO: add more details.
+		Long: `List Redpanda Shadow Links.
+
+This command lists all Shadow Links on the shadow cluster, showing their
+names, unique identifiers, and current states. Use this command to get an
+overview of all configured Shadow Links and their operational status.
+`,
+		Example: `
+List all Shadow Links:
+  rpk shadow list
+`,
 		Run: func(cmd *cobra.Command, _ []string) {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "unable to load rpk config: %v", err)

--- a/src/go/rpk/pkg/cli/shadow/list.go
+++ b/src/go/rpk/pkg/cli/shadow/list.go
@@ -36,7 +36,7 @@ func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			link, err := cl.ShadowLinkService().ListShadowLinks(cmd.Context(), connect.NewRequest(&adminv2.ListShadowLinksRequest{}))
-			out.MaybeDie(err, "unable to list Redpanda Shadow Links: %v", err)
+			out.MaybeDie(err, "unable to list Redpanda Shadow Links: %v", handleConnectError(err, "list", ""))
 
 			tw := out.NewTable("NAME", "UID", "STATE")
 			defer tw.Flush()

--- a/src/go/rpk/pkg/cli/shadow/shadow.go
+++ b/src/go/rpk/pkg/cli/shadow/shadow.go
@@ -20,6 +20,14 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Use:   "shadow",
 		Args:  cobra.NoArgs,
 		Short: "Manage Redpanda Shadow Links",
+		Long: `Manage Redpanda Shadow Links.
+
+Shadowing is Redpanda’s enterprise-grade disaster recovery solution that
+establishes asynchronous, offset-preserving replication between two distinct
+Redpanda clusters. A cluster is able to create a dedicated client that
+continuously replicates source cluster data, including offsets, timestamps, and
+cluster metadata.
+`,
 	}
 	cmd.AddCommand(
 		newShadowConfigCommand(fs, p),

--- a/src/go/rpk/pkg/cli/shadow/status.go
+++ b/src/go/rpk/pkg/cli/shadow/status.go
@@ -35,7 +35,23 @@ func newStatusCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Use:   "status [LINK_NAME]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Get the status of a Redpanda Shadow Link",
-		Long:  `Get the status of a Redpanda Shadow Link`, // TODO: add more details once we have a wider response.
+		Long: `Get the status of a Redpanda Shadow Link.
+
+This command shows the current status of a Shadow Link, including the overall
+state, task statuses, and per-topic replication progress. Use this command to
+monitor replication health and track how closely shadow topics follow the source
+cluster.
+
+By default, the command displays all status sections. Use the flags to display
+specific sections such as overview, task status, or topic status.
+`,
+		Example: `
+Display the status of a Shadow Link:
+  rpk shadow status my-shadow-link
+
+Display specific sections:
+  rpk shadow status my-shadow-link --print-overview --print-topic
+`,
 		Run: func(cmd *cobra.Command, args []string) {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "unable to load rpk config: %v", err)

--- a/src/go/rpk/pkg/cli/shadow/status.go
+++ b/src/go/rpk/pkg/cli/shadow/status.go
@@ -48,8 +48,7 @@ func newStatusCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			link, err := cl.ShadowLinkService().GetShadowLink(cmd.Context(), connect.NewRequest(&adminv2.GetShadowLinkRequest{
 				Name: linkName,
 			}))
-			// TODO: handle NotFound error and print a friendly message.
-			out.MaybeDie(err, "unable to get Redpanda Shadow Link status %q: %v", linkName, err)
+			out.MaybeDie(err, "unable to get Redpanda Shadow Link status %q: %v", linkName, handleConnectError(err, "get", linkName))
 
 			opts.defaultOrAll()
 			printShadowLinkStatus(link.Msg.GetShadowLink(), opts)

--- a/src/go/rpk/pkg/cli/shadow/update.go
+++ b/src/go/rpk/pkg/cli/shadow/update.go
@@ -48,7 +48,7 @@ you must delete and recreate it.
 			link, err := cl.ShadowLinkService().GetShadowLink(cmd.Context(), connect.NewRequest(&adminv2.GetShadowLinkRequest{
 				Name: linkName,
 			}))
-			out.MaybeDie(err, "unable to get Redpanda Shadow Link information: %v", err)
+			out.MaybeDie(err, "unable to get Redpanda Shadow Link information: %v", handleConnectError(err, "get", linkName))
 
 			shadowLink := link.Msg.GetShadowLink()
 			originalCfg := shadowLinkToConfig(shadowLink)
@@ -74,7 +74,7 @@ you must delete and recreate it.
 			_, err = cl.ShadowLinkService().UpdateShadowLink(cmd.Context(), connect.NewRequest(&adminv2.UpdateShadowLinkRequest{
 				ShadowLink: shadowLinkConfigToProto(updatedCfg),
 			}))
-			out.MaybeDie(err, "unable to update Shadow Link: %v", err)
+			out.MaybeDie(err, "unable to update Shadow Link: %v", handleConnectError(err, "update", linkName))
 
 			fmt.Printf("Successfully updated shadow link %q.\n", linkName)
 		},

--- a/src/go/rpk/pkg/cli/shadow/update.go
+++ b/src/go/rpk/pkg/cli/shadow/update.go
@@ -27,13 +27,21 @@ func newUpdateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update [LINK_NAME]",
 		Short: "Update a Shadow Link",
-		Long: `Update a Shadow Link
+		Long: `Update a Shadow Link.
 
-This command opens your default editor to modify the Shadow Link configuration.
-Only the fields that are changed will be updated on the server.
+This command opens your default editor with the current Shadow Link
+configuration. Update the fields you want to change, save the file, and close
+the editor. The command applies only the changed fields to the Shadow Link.
 
-The Shadow Link name cannot be changed. If you need to rename a Shadow Link,
-you must delete and recreate it.
+You cannot change the Shadow Link name. If you need to rename a Shadow Link,
+delete it and create a new one with the desired name.
+
+The editor respects your EDITOR environment variable. If EDITOR is not set, the
+command uses 'vi' on Unix-like systems.
+`,
+		Example: `
+Update a Shadow Link configuration:
+  rpk shadow update my-shadow-link
 `,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
This commit introduces long texts for all rpk shadow commands as well as hints on common errors.

### **Examples:**
**Unauthorized**:
```
unable to list Redpanda Shadow Links: permission_denied: request POST http://0.0.0.0:29644/redpanda.core.admin.v2.ShadowLinkService/ListShadowLinks failed: Forbidden, Forbidden (superuser role required)
```
Now
```
unable to list Redpanda Shadow Links: permission denied: you don't have access to list shadow links (superuser role required). Use a superuser account by updating your rpk profile (see 'rpk profile set --help')
```

**Not Found**
```
unable to get Redpanda Shadow Link "foo": not_found: request POST http://0.0.0.0:29644/redpanda.core.admin.v2.ShadowLinkService/GetShadowLink failed: Not Found, Failed to find cluster link with name 'foo'
````
Now
```
unable to get Redpanda Shadow Link "foo": shadow link "foo" not found; to get all active shadow links run 'rpk shadow list'
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none

