### PR TITLE
treewide: apply all ruff check safe fixes

### DIFF
--- a/tests/rptest/chaos_tests/single_fault_test.py
+++ b/tests/rptest/chaos_tests/single_fault_test.py
@@ -168,7 +168,7 @@ class SingleFaultTestBase(RedpandaTest):
             self.logger.info(f"warming up for {timings.warmup_s}s")
             sleep(timings.warmup_s)
 
-        self.logger.info(f"start measuring")
+        self.logger.info("start measuring")
         for node in workload.nodes:
             workload.emit_event(node, "measure")
 
@@ -339,7 +339,7 @@ class SingleTopicTest(SingleFaultTestBase):
                 target_id=random.choice(other_ids),
             )
 
-        self.logger.info(f"waiting for progress")
+        self.logger.info("waiting for progress")
 
         workload.wait_progress(timeout_sec=timings.wait_progress_timeout_s)
 
@@ -471,7 +471,7 @@ class TxSubscribeTest(SingleFaultTestBase):
             replica_ids=data_node_ids,
         )
 
-        self.logger.info(f"waiting for post-reconfigure progress")
+        self.logger.info("waiting for post-reconfigure progress")
         workload.wait_progress(timeout_sec=timings.wait_progress_timeout_s)
 
         self._transfer_leadership(
@@ -513,7 +513,7 @@ class TxSubscribeTest(SingleFaultTestBase):
                 target_id=data_node_ids[partition % len(data_node_ids)],
             )
 
-        self.logger.info(f"waiting for post-transfer progress")
+        self.logger.info("waiting for post-transfer progress")
         workload.wait_progress(timeout_sec=timings.wait_progress_timeout_s)
 
     @cluster(num_nodes=8)

--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -466,7 +466,7 @@ class KubectlTool:
 
         try:
             self._local_cmd(cmd)
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError:
             self._redpanda.logger.debug(f"Contents of {self.TELEPORT_DATA_DIR}:")
             subprocess.call(["ls", "-la", self.TELEPORT_DATA_DIR])
             self._redpanda.logger.debug(f"Contents of {self.TELEPORT_DEST_DIR}:")
@@ -516,7 +516,7 @@ class KubeNodeShell:
         # It is bad, but it works
         self.logger = self.kubectl._redpanda.logger
         self.namespace = namespace
-        self.current_context = self.kubectl.cmd(f"config current-context").strip()
+        self.current_context = self.kubectl.cmd("config current-context").strip()
         # Make sure that name is not longer that 63 chars
         # The Pod "gke-redpanda-co9uuq78jo-redpanda-6a66-fcfacc41-65mz-priviledged-shell" is invalid: metadata.labels:
         # Invalid value: "gke-redpanda-co9uuq78jo-redpanda-6a66-fcfacc41-65mz-priviledged-shell": must be no more than 63 characters

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1865,7 +1865,7 @@ class RpkTool:
                 except RpkException as e:
                     if e.returncode != 1:
                         raise e
-                    if not "NOT_COORDINATOR" in str(e):
+                    if "NOT_COORDINATOR" not in str(e):
                         e.parsed_output = parse_offset_delete_output(
                             e.stdout.splitlines()
                         )

--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -821,7 +821,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
 
         self.logger.info(f"Running for {wait_time}s after injected failure removed")
         time.sleep(wait_time)
-        self.logger.info(f"Waiting for the cluster to return to a healthy state")
+        self.logger.info("Waiting for the cluster to return to a healthy state")
         wait_until(self.redpanda.cluster_healthy(), timeout_sec=600, backoff_sec=1)
 
     def stage_stop_wait_start(self, forced_stop: bool, downtime: int):
@@ -902,14 +902,14 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
 
     def stage_block_s3(self):
         self.logger.info(
-            f"Getting the first 100 segments into the cloud for specific topic"
+            "Getting the first 100 segments into the cloud for specific topic"
         )
         wait_until(
             lambda: nodes_report_cloud_segments(self.redpanda, 100, self.topic),
             timeout_sec=600,
             backoff_sec=5,
         )
-        self.logger.info(f"Blocking S3 traffic for all nodes")
+        self.logger.info("Blocking S3 traffic for all nodes")
         self.last_num_errors = 0
 
         with cloudv2_object_store_blocked(self.redpanda, self.logger):
@@ -925,7 +925,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
 
         # make sure nothing is crashed
         wait_until(self.redpanda.cluster_healthy(), timeout_sec=60, backoff_sec=1)
-        self.logger.info(f"Waiting for S3 errors to cease")
+        self.logger.info("Waiting for S3 errors to cease")
         wait_until(
             lambda: self._cloud_storage_no_new_errors(self.redpanda, self.logger),
             timeout_sec=600,
@@ -1115,14 +1115,14 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         )
 
     def _disable_agent_services(self):
-        self.logger.debug(f"disabling agent services")
+        self.logger.debug("disabling agent services")
         # sudo systemctl disable --now redpanda-agent.service redpanda-agent-boot.service redpanda-agent-init.service
         self.redpanda.cloud_agent_ssh(
             ["sudo", "systemctl", "disable", "--now"] + self._agent_services
         )
 
     def _enable_agent_services(self):
-        self.logger.debug(f"enabling agent services")
+        self.logger.debug("enabling agent services")
         # sudo systemctl enable --now redpanda-agent.service redpanda-agent-boot.service redpanda-agent-init.service
         self.redpanda.cloud_agent_ssh(
             ["sudo", "systemctl", "enable", "--now"] + self._agent_services
@@ -1203,7 +1203,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         stage.
         """
 
-        self.logger.info(f"verify cluster > 3 nodes")
+        self.logger.info("verify cluster > 3 nodes")
         if self._num_brokers <= 3:
             self.logger.warning("need more than 3 nodes to run test")
             return
@@ -1447,7 +1447,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
 
             # Exhaust cloud cache with multiple consumers
             # reading at random offsets
-            self.logger.info(f"Starting thrashing consumers")
+            self.logger.info("Starting thrashing consumers")
             consumer = KgoVerifierRandomConsumer(
                 self.test_context,
                 self.redpanda,
@@ -1461,7 +1461,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
                 consumer.start(clean=False)
                 time.sleep(240)
             finally:
-                self.logger.info(f"Stopping thrashing consumers")
+                self.logger.info("Stopping thrashing consumers")
                 consumer.stop()
                 consumer.wait(timeout_sec=600)
 
@@ -1543,7 +1543,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         # them to consume ~10 messages before terminating them with
         # a SIGKILL.
 
-        self.logger.info(f"Starting stage_lots_of_failed_consumers")
+        self.logger.info("Starting stage_lots_of_failed_consumers")
         # Original value 10000
         consume_count = 5000
 
@@ -1658,7 +1658,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         # for a specific topic. Then it consumes from offsets known to not be in the
         # batch and verifies that these fetches occurred from disk and not the cache.
 
-        self.logger.info(f"Starting stage_consume_miss_cache")
+        self.logger.info("Starting stage_consume_miss_cache")
 
         # Get current offsets for topic. We'll use these for starting offsets
         # for consuming messages after we produce enough data to push them out
@@ -1745,7 +1745,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
             "vectorized_cluster_partition_under_replicated_replicas"
         )
         if sum(x.value for x in s.samples) == 0:
-            self.logger.info(f"No under-replicated replicas")
+            self.logger.info("No under-replicated replicas")
         else:
             self.logger.info(f"Under-replicated replicas: {s.samples}")
 
@@ -1850,7 +1850,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         # ensures that the S3 workload doesn't impact the performance of the
         # usual workload too greatly.
 
-        self.logger.info(f"Starting stage_tiered_storage_consuming")
+        self.logger.info("Starting stage_tiered_storage_consuming")
 
         segment_size = 128 * MiB  # 128 MiB
         consume_rate = 1 * GiB  # 1 GiB/s

--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -9,7 +9,7 @@
 
 import math
 from time import time
-from typing import Any, TypeVar
+from typing import Any
 
 from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
@@ -511,7 +511,7 @@ class OMBValidationTest(RedpandaCloudTest):
             assert metrics.clients_alive == producer_per_swarm_node, (
                 f"On {sname} bad clients_alive: {metrics.clients_alive} != {producer_per_swarm_node}"
             )
-            assert metrics.clients_stopped == 0, f"clients unexpectedly stopped"
+            assert metrics.clients_stopped == 0, "clients unexpectedly stopped"
 
             def in_range(name: str, value: float, nominal: float, max_range: float):
                 lb = nominal * (1 - max_range)

--- a/tests/rptest/remote_scripts/schema_registry_test_helper.py
+++ b/tests/rptest/remote_scripts/schema_registry_test_helper.py
@@ -162,7 +162,7 @@ class WriteWorker(threading.Thread):
 
         schema_ids = self.get_schema_ids()
         if len(set(schema_ids)) != len(schema_ids):
-            self._push_err(f"Schema IDs reused!")
+            self._push_err("Schema IDs reused!")
 
     def run(self):
         try:

--- a/tests/rptest/scale_tests/audit_log_test.py
+++ b/tests/rptest/scale_tests/audit_log_test.py
@@ -226,7 +226,7 @@ class AuditLogTest(RedpandaTest):
             return {name: avg_metric(mss.samples) for name, mss in results.items()}
 
         except TimeoutError as _:
-            self.redpanda.logger.warn(f"Timed out getting audit metrics")
+            self.redpanda.logger.warn("Timed out getting audit metrics")
 
         return {}
 

--- a/tests/rptest/scale_tests/large_controller_snapshot_test.py
+++ b/tests/rptest/scale_tests/large_controller_snapshot_test.py
@@ -117,7 +117,7 @@ class LargeControllerSnapshotTest(RedpandaTest):
             executor.map(create_users, user_names)
 
         # wait until everything is snapshotted
-        self.logger.info(f"waiting until all commands are snapshotted...")
+        self.logger.info("waiting until all commands are snapshotted...")
 
         controller_max_offset = max(
             admin.get_controller_status(n)["committed_index"] for n in seed_nodes
@@ -130,7 +130,7 @@ class LargeControllerSnapshotTest(RedpandaTest):
             )
 
         # add a node to the cluster
-        self.logger.info(f"adding a node to the cluster...")
+        self.logger.info("adding a node to the cluster...")
 
         # explicit clean step is needed because we are starting the node manually and not
         # using redpanda.start()
@@ -142,7 +142,7 @@ class LargeControllerSnapshotTest(RedpandaTest):
 
         # reboot the cluster to test that the cluster stabilizes after rebooting with high
         # partition count and a large controller snapshot
-        self.logger.info(f"rebooting the cluster...")
+        self.logger.info("rebooting the cluster...")
 
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=len(self.redpanda.nodes)
@@ -171,7 +171,7 @@ class LargeControllerSnapshotTest(RedpandaTest):
             assert actual == n_users + 1, f"unexpected number of users {actual}"
 
         # wait until rebalance on node addition is finished
-        self.logger.info(f"waiting until partitions are rebalanced to the new node...")
+        self.logger.info("waiting until partitions are rebalanced to the new node...")
 
         def rebalance_finished():
             in_progress = admin.list_reconfigurations(node=seed_nodes[0])

--- a/tests/rptest/scale_tests/large_messages_test.py
+++ b/tests/rptest/scale_tests/large_messages_test.py
@@ -415,12 +415,12 @@ class LargeMessagesTest(RedpandaTest):
             self.logger.info(f"Waiting for first message: {consumer}")
             still_running = consumer.await_first(
                 timeout_sec=120,
-                err_msg=f"client-swarm did not read any messages after 120s, check swarm logs",
+                err_msg="client-swarm did not read any messages after 120s, check swarm logs",
             )
 
             if not still_running:
                 # consumer finished, the others are probably finished too
-                self.logger.info(f"Consumer stopped, not waiting for any more")
+                self.logger.info("Consumer stopped, not waiting for any more")
                 break
 
         # Wait for all messages to be produced

--- a/tests/rptest/scale_tests/shard_placement_scale_test.py
+++ b/tests/rptest/scale_tests/shard_placement_scale_test.py
@@ -92,7 +92,7 @@ class ShardPlacementScaleTest(RedpandaTest):
             topology="ensemble",
         )
         self._benchmark.start()
-        self.logger.info(f"OMB started")
+        self.logger.info("OMB started")
 
     def omb_topics(self):
         rpk = RpkTool(self.redpanda)

--- a/tests/rptest/services/action_injector.py
+++ b/tests/rptest/services/action_injector.py
@@ -149,7 +149,7 @@ class ProcessKill(DisruptiveAction):
             self.redpanda.remove_from_started_nodes(node)
             return node
         else:
-            self.redpanda.logger.warn(f"no usable node")
+            self.redpanda.logger.warn("no usable node")
             return None
 
     def do_reverse_action(self):

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -579,10 +579,10 @@ class Admin:
             if meta == None:
                 return None
             if "replicas" not in meta:
-                self.redpanda.logger.debug(f"replicas are missing")
+                self.redpanda.logger.debug("replicas are missing")
                 return None
             if "status" not in meta:
-                self.redpanda.logger.debug(f"status is missing")
+                self.redpanda.logger.debug("status is missing")
                 return None
             if status == None:
                 status = meta["status"]
@@ -608,7 +608,7 @@ class Admin:
                     )
                     return None
             if meta["leader_id"] < 0:
-                self.redpanda.logger.debug(f"doesn't have leader")
+                self.redpanda.logger.debug("doesn't have leader")
                 return None
             if last_leader < 0:
                 last_leader = int(meta["leader_id"])
@@ -1080,7 +1080,7 @@ class Admin:
         """
         Trigger on demand partitions rebalancing
         """
-        path = f"partitions/rebalance"
+        path = "partitions/rebalance"
 
         return self._request("post", path, node=node)
 
@@ -1088,7 +1088,7 @@ class Admin:
         """
         Trigger core placement rebalancing for partitions in this node.
         """
-        path = f"partitions/rebalance_cores"
+        path = "partitions/rebalance_cores"
 
         return self._request("post", path, node=node)
 
@@ -1096,7 +1096,7 @@ class Admin:
         """
         List pending reconfigurations
         """
-        path = f"partitions/reconfigurations"
+        path = "partitions/reconfigurations"
 
         return self._request("get", path, node=node).json()
 
@@ -1269,7 +1269,7 @@ class Admin:
     ):
         self.redpanda.logger.debug(f"Creating user {username}:{password}:{algorithm}")
 
-        path = f"security/users"
+        path = "security/users"
 
         self._request(
             "POST",
@@ -1328,7 +1328,7 @@ class Admin:
         params = {}
         if filter is not None:
             params["filter"] = filter
-        return self._request("get", f"security/users/roles", params=params)
+        return self._request("get", "security/users/roles", params=params)
 
     def create_role(self, role: str):
         return self._request("post", "security/roles", json=dict(role=role))
@@ -1487,7 +1487,7 @@ class Admin:
             id = self.redpanda.node_id(node)
             self.redpanda.logger.info(f"Get leaders info on {node.name}/{id}")
         else:
-            self.redpanda.logger.info(f"Get leaders info on any node")
+            self.redpanda.logger.info("Get leaders info on any node")
 
         url = "debug/partition_leaders_table"
         return self._request("get", url, node=node).json()
@@ -1508,7 +1508,7 @@ class Admin:
         return self._request("GET", f"debug/peer_status/{peer_id}", node=node).json()
 
     def get_controller_status(self, node):
-        return self._request("GET", f"debug/controller_status", node=node).json()
+        return self._request("GET", "debug/controller_status", node=node).json()
 
     def get_cluster_uuid(self, node=None):
         try:
@@ -1671,7 +1671,7 @@ class Admin:
         return self._request("GET", path, node=node).json()
 
     def get_partitions_local_summary(self, node: ClusterNode):
-        path = f"partitions/local_summary"
+        path = "partitions/local_summary"
         return self._request("GET", path, node=node).json()
 
     def get_producers_state(self, namespace, topic, partition, node=None):
@@ -1804,7 +1804,7 @@ class Admin:
             req = f"cluster/partitions/{ns}/{topic}"
         else:
             assert ns is None
-            req = f"cluster/partitions"
+            req = "cluster/partitions"
 
         if disabled is not None:
             req += f"?disabled={disabled}"

--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -709,7 +709,7 @@ class AdminOperationsFuzzer:
         def validate_result():
             try:
                 return op.validate(self.operation_ctx)
-            except Exception as e:
+            except Exception:
                 self.redpanda.logger.debug(
                     f"Error validating operation {op_type}", exc_info=True
                 )

--- a/tests/rptest/services/apache_iceberg_catalog.py
+++ b/tests/rptest/services/apache_iceberg_catalog.py
@@ -32,7 +32,7 @@ class IcebergRESTCatalog(CatalogService):
     logs = {"iceberg_rest_logs": {"path": LOG_FILE, "collect_default": True}}
 
     DB_CATALOG_IMPL = "org.apache.iceberg.jdbc.JdbcCatalog"
-    DB_CATALOG_JDBC_URI_PREFIX = f"jdbc:sqlite:file:"
+    DB_CATALOG_JDBC_URI_PREFIX = "jdbc:sqlite:file:"
     DB_CATALOG_DB_USER = "user"
     DB_CATALOG_DB_PASS = "password"
 
@@ -240,8 +240,8 @@ class IcebergRESTCatalog(CatalogService):
             try:
                 node.account.ssh_output(check_cmd)
                 return True
-            except Exception as e:
-                self.logger.debug(f"Exception querying catalog", exc_info=True)
+            except Exception:
+                self.logger.debug("Exception querying catalog", exc_info=True)
             return False
 
         wait_until(
@@ -258,7 +258,7 @@ class IcebergRESTCatalog(CatalogService):
 
         def _stopped():
             out = node.account.ssh_output("jcmd").decode("utf-8")
-            return not (IcebergRESTCatalog.JAR in out)
+            return IcebergRESTCatalog.JAR not in out
 
         wait_until(
             _stopped,

--- a/tests/rptest/services/chaos/workloads/service_base.py
+++ b/tests/rptest/services/chaos/workloads/service_base.py
@@ -165,7 +165,7 @@ class WorkloadServiceBase(ABC, Service):
 
         try:
             self.stop_workload(nodes=[node])
-        except Exception as e:
+        except Exception:
             self.logger.warn(
                 f"{self.who_am_i()}: failed to stop workload on {node.name}"
             )

--- a/tests/rptest/services/chaos/workloads/tx_subscribe/stat.py
+++ b/tests/rptest/services/chaos/workloads/tx_subscribe/stat.py
@@ -582,7 +582,7 @@ def collect(title, workload_dir, workload_nodes, source_partitions):
         logger.info(f"total stats: {total_result}")
     else:
         total_result = {"result": Result.NODATA}
-        logger.info(f"not enough data to calculate total stats")
+        logger.info("not enough data to calculate total stats")
 
     ret["total"] = total_result
     ret["result"] = Result.more_severe(ret["result"], total_result["result"])

--- a/tests/rptest/services/client_swarm_base.py
+++ b/tests/rptest/services/client_swarm_base.py
@@ -97,7 +97,7 @@ class ClientSwarmBase(Service, ABC):
         )
 
     def is_metrics_available(self, node):
-        path = f"metrics/summary"
+        path = "metrics/summary"
         path = f"{path}?seconds=1"
         try:
             self._get(node, path)
@@ -168,7 +168,7 @@ class ClientSwarmBase(Service, ABC):
             return self.total_success + self.total_error
 
     def get_metrics_summary(self, seconds: int | None = None) -> MetricsSummary:
-        path = f"metrics/summary"
+        path = "metrics/summary"
         if seconds:
             path = f"{path}?seconds={seconds}"
 

--- a/tests/rptest/services/cloud_cluster_utils.py
+++ b/tests/rptest/services/cloud_cluster_utils.py
@@ -126,7 +126,7 @@ class CloudClusterUtils:
 
     # rpk_cloud_logout clears credentials
     def rpk_cloud_logout(self):
-        self.logger.debug(f"Clearing rpk login")
+        self.logger.debug("Clearing rpk login")
         cmd = self._get_rpk_cloud_cmd()
         cmd += ["logout", "--clear-credentials"]
         return self._exec(cmd)

--- a/tests/rptest/services/consumer_swarm.py
+++ b/tests/rptest/services/consumer_swarm.py
@@ -42,7 +42,7 @@ class ConsumerSwarm(ClientSwarmBase):
 
     def _additional_args(self):
         cmd = ""
-        cmd += f" consumers"
+        cmd += " consumers"
         cmd += f" --group {self._group}"
         cmd += f" --count {self._consumers}"
         cmd += f" --messages {self._records_per_consumer}"
@@ -74,14 +74,14 @@ class ConsumerSwarm(ClientSwarmBase):
                     )
                     self.check_passed = ms.total_success > 0
                     return self.check_passed
-                except RuntimeError as rt:
+                except RuntimeError:
                     # a common thing is that the swarm joins and then consumers immediately the
                     # requested number of messages between one poll and another, after which it
                     # stops, we don't treat this as a failure since though we do return False from
                     # this method to indicate the behavior
                     if self.checks_made > 0 and not self.swarm.is_alive():
                         self.swarm.logger.info(
-                            f"ConsumerSwarm await_first stopping wait after swarm stopped"
+                            "ConsumerSwarm await_first stopping wait after swarm stopped"
                         )
                         return True
                     raise

--- a/tests/rptest/services/failure_injector.py
+++ b/tests/rptest/services/failure_injector.py
@@ -116,7 +116,7 @@ class FailureInjectorBase:
                             # The stop timers may outlive the test, handle case
                             # where they run after we already had a heal_all call.
                             self.redpanda.logger.warn(
-                                f"Skipping failure stop action, already cleaned up?"
+                                "Skipping failure stop action, already cleaned up?"
                             )
                         else:
                             self._stop_func(spec.type)(spec.node)
@@ -267,7 +267,7 @@ class FailureInjector(FailureInjectorBase):
         tc_netem.tc_netem_delete(node)
 
     def _heal_all(self):
-        self.redpanda.logger.info(f"healing all network failures")
+        self.redpanda.logger.info("healing all network failures")
 
         actions = [
             lambda n: n.account.ssh("iptables -P INPUT ACCEPT"),
@@ -295,7 +295,7 @@ class FailureInjector(FailureInjectorBase):
         self.redpanda.logger.debug(f"after _heal_all _in_flight={self._in_flight}")
 
     def _continue_all(self):
-        self.redpanda.logger.info(f"continuing execution on all nodes")
+        self.redpanda.logger.info("continuing execution on all nodes")
         for n in self.redpanda.nodes:
             if self.redpanda.check_node(n):
                 self._continue(n)
@@ -308,7 +308,7 @@ class FailureInjector(FailureInjectorBase):
         self.redpanda.logger.debug(f"after _continue_all _in_flight={self._in_flight}")
 
     def _undo_all(self):
-        self.redpanda.logger.info(f"running scheduled undos earlier")
+        self.redpanda.logger.info("running scheduled undos earlier")
         self.redpanda.logger.debug(f"before _undo_all _in_flight={self._in_flight}")
         while self._in_flight:
             try:
@@ -395,7 +395,7 @@ class FailureInjectorCloud(FailureInjectorBase):
         )
 
     def _isolate(self, node):
-        self.redpanda.logger.info(f"isolating node with privilaged pod")
+        self.redpanda.logger.info("isolating node with privilaged pod")
         cmd = "apt update;apt install -y iptables;iptables -A OUTPUT -p tcp --destination-port 33145 -j DROP"
         self._kubectl.exec_privileged(cmd)
         cmd = "apt update;apt install -y iptables;iptables -A INPUT -p tcp --destination-port 33145 -j DROP"

--- a/tests/rptest/services/kerberos.py
+++ b/tests/rptest/services/kerberos.py
@@ -319,7 +319,7 @@ EOF
     def _configure_principal(
         self, krb5_conf_path: str, principal: str, dest: str, dest_node
     ):
-        if not "@" in principal:
+        if "@" not in principal:
             principal = f"{principal}@{self.realm}"
         self.logger.info(f"Adding principal {principal} to KDC")
         cmd = render_remote_kadmin_command(
@@ -432,7 +432,7 @@ class KrbClient(Service):
             f"rm -fr {self.redpanda.PERSISTENT_ROOT}/client.keytab /etc/krb5.keytab",
             allow_fail=True,
         )
-        node.account.ssh(f"rm -fr /tmp/*.krb5ccache", allow_fail=True)
+        node.account.ssh("rm -fr /tmp/*.krb5ccache", allow_fail=True)
 
     def add_primary(self, primary: str):
         self.logger.info(f"Adding primary {primary} to KrbClient {self.nodes[0].name}")
@@ -481,7 +481,7 @@ class KrbClient(Service):
         )
         try:
             res = self.nodes[0].account.ssh_output(
-                cmd=f"python3 /tmp/produce.py", allow_fail=False, combine_stderr=False
+                cmd="python3 /tmp/produce.py", allow_fail=False, combine_stderr=False
             )
             self.logger.debug(f"Produce request: {res}")
             return res
@@ -655,7 +655,7 @@ class ActiveDirectoryKdc:
         dest: str,
         dest_node,
     ):
-        if not "@" in principal:
+        if "@" not in principal:
             principal = f"{principal}@{self.realm}"
         src = rf"{user}.keytab.temp"
         cmd = f"ktpass -out {src} -mapuser {user} -princ {principal} -crypto ALL -pass * -ptype KRB5_NT_PRINCIPAL +DumpSalt"

--- a/tests/rptest/services/keycloak.py
+++ b/tests/rptest/services/keycloak.py
@@ -353,7 +353,7 @@ class KeycloakService(Service):
             self.stop_node(node)
 
         node.account.ssh(f"rm -rf {KC_LOG_FILE}")
-        node.account.ssh(f"rm -rf /opt/keycloak/data/*", allow_fail=False)
+        node.account.ssh("rm -rf /opt/keycloak/data/*", allow_fail=False)
         if self._remote_config_file is not None:
             node.account.ssh(f"rm {self._remote_config_file}")
 

--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -153,7 +153,7 @@ class KgoRepeaterService(Service):
             cmd += f" -rate-limit-bps={self.rate_limit_bps_per_node}"
 
         if self.use_transactions:
-            cmd += f" -use-transactions"
+            cmd += " -use-transactions"
 
             if self.transaction_abort_rate is not None:
                 cmd += f" -transaction-abort-rate={self.transaction_abort_rate}"

--- a/tests/rptest/services/nessie_catalog.py
+++ b/tests/rptest/services/nessie_catalog.py
@@ -128,8 +128,8 @@ class NessieCatalog(CatalogService):
         elif isinstance(self.credentials, cloud_storage.GCPInstanceMetadataCredentials):
             d_flags += "-Dnessie.catalog.service.gcs.default-options.auth-type=APPLICATION_DEFAULT"
         elif isinstance(self.credentials, cloud_storage.ABSSharedKeyCredentials):
-            d_flags += f"-Dnessie.catalog.service.adls.default-options.auth-type=STORAGE_SHARED_KEY "
-            d_flags += f"-Dnessie.catalog.service.adls.default-options.account=urn:nessie-secret:quarkus:my-secrets-default "
+            d_flags += "-Dnessie.catalog.service.adls.default-options.auth-type=STORAGE_SHARED_KEY "
+            d_flags += "-Dnessie.catalog.service.adls.default-options.account=urn:nessie-secret:quarkus:my-secrets-default "
             d_flags += f"-Dmy-secrets-default.name={self.credentials.account_name} "
             d_flags += f"-Dmy-secrets-default.secret={self.credentials.account_key} "
             d_flags += f"-Dnessie.catalog.service.adls.default-options.endpoint=https://{self.credentials.endpoint}/{self.cloud_storage_bucket}"

--- a/tests/rptest/services/ocsf_server.py
+++ b/tests/rptest/services/ocsf_server.py
@@ -129,7 +129,7 @@ class OcsfServer(Service):
             if node.account.alive(p):
                 return [p]
         except (RemoteCommandError, ValueError):
-            self.logger.warn(f"pid file not found for ocsf server")
+            self.logger.warn("pid file not found for ocsf server")
 
         return []
 

--- a/tests/rptest/services/producer_swarm.py
+++ b/tests/rptest/services/producer_swarm.py
@@ -61,13 +61,13 @@ class ProducerSwarm(ClientSwarmBase):
 
     def _additional_args(self) -> str:
         cmd = ""
-        cmd += f" producers "
+        cmd += " producers "
         cmd += f" --count {self._producers}"
         cmd += f" --messages {self._records_per_producer}"
         cmd += f" --timeout-ms {self._timeout_ms}"
 
         if self._compressible_payload:
-            cmd += f" --compressible-payload"
+            cmd += " --compressible-payload"
 
         if self._compression_type is not None:
             cmd += f" --compression-type={self._compression_type}"

--- a/tests/rptest/services/provider_clients/ec2_client.py
+++ b/tests/rptest/services/provider_clients/ec2_client.py
@@ -627,7 +627,7 @@ class EC2Client:
         def safe_clean(f, *args):
             try:
                 f(*args)
-            except Exception as e:
+            except Exception:
                 return False
 
         vpc_resource = self._ec2.Vpc(vpc_id)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -33,7 +33,6 @@ from logging import Logger
 from typing import (
     Any,
     Callable,
-    Generator,
     List,
     Literal,
     Mapping,

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -310,7 +310,7 @@ class CloudCluster:
             # Raise exception if client is not implemented yet
             if self.provider_cli is None and self.config.network != "public":
                 self._logger.error(
-                    f"Current provider does not yet support private networking"
+                    "Current provider does not yet support private networking"
                 )
                 raise RuntimeError(
                     "Private networking is not implemented "
@@ -627,7 +627,7 @@ class CloudCluster:
         token = b64.decode("utf-8")
         headers = {"Authorization": f"Basic {token}"}
         return self.rpcloud._http_get(
-            endpoint=f"/api/cloud/prometheus/public_metrics",
+            endpoint="/api/cloud/prometheus/public_metrics",
             base_url=base_url,
             override_headers=headers,
             text_response=True,
@@ -847,7 +847,7 @@ class CloudCluster:
             cluster = self._get_cluster(
                 self.current.cluster_id, is_serverless_cluster=is_serverless_cluster
             )
-        except Exception as e:
+        except Exception:
             return warn_and_return(
                 f"# Failed to get info for cluster with Id: '{self.current.cluster_id}'"
             )
@@ -862,7 +862,7 @@ class CloudCluster:
             return None
 
         # Check if panda-proxy is available
-        if not "url" in cluster["http_proxy"]:
+        if "url" not in cluster["http_proxy"]:
             return warn_and_return("Panda-Proxy listener is not available")
         else:
             _u = self.panda_proxy_url()
@@ -1692,7 +1692,7 @@ class CloudCluster:
             scopes = ["SCOPE_REDPANDA_CLUSTER"]
         response = self.public_api._http_post(
             base_url=dataplane_url,
-            endpoint=f"/v1/secrets",
+            endpoint="/v1/secrets",
             json={
                 "id": secret_id,
                 "scopes": scopes,

--- a/tests/rptest/services/redpanda_connect.py
+++ b/tests/rptest/services/redpanda_connect.py
@@ -135,7 +135,7 @@ logger:
         """
 
         def _finished():
-            streams = self._request("GET", f"streams").json()
+            streams = self._request("GET", "streams").json()
             return name not in streams or streams[name]["active"] == False
 
         if should_finish == False:
@@ -165,7 +165,7 @@ logger:
         """
 
         def _all_streams_finished():
-            streams = self._request("GET", f"streams").json()
+            streams = self._request("GET", "streams").json()
             return all(s["active"] == False for id, s in streams.items())
 
         wait_until(

--- a/tests/rptest/services/rolling_restarter.py
+++ b/tests/rptest/services/rolling_restarter.py
@@ -70,7 +70,7 @@ class RollingRestarter:
         # multiple nodes at a time.
         self.redpanda.logger.info(f"Rolling restart of nodes {[n.name for n in nodes]}")
         for node in nodes:
-            self.redpanda.logger.info(f"Waiting for cluster healthy")
+            self.redpanda.logger.info("Waiting for cluster healthy")
             controller_leader = wait_until_cluster_healthy(stop_timeout)
 
             # NOTE: callers may not want to use maintenance mode if the

--- a/tests/rptest/services/serde_client.py
+++ b/tests/rptest/services/serde_client.py
@@ -93,7 +93,7 @@ class SerdeClient(BackgroundThreadService):
             self._cmd_args += f" --compression-type {compression_type}"
 
         if self._serde_client_type == SerdeClientType.Golang:
-            self._cmd_args += f" --debug"
+            self._cmd_args += " --debug"
 
         if security_config is not None:
             security_string = json.dumps(security_config)

--- a/tests/rptest/services/spark_service.py
+++ b/tests/rptest/services/spark_service.py
@@ -140,8 +140,8 @@ class SparkService(Service, QueryEngineBase):
             try:
                 self.run_query_fetch_all("show databases")
                 return True
-            except Exception as e:
-                self.logger.debug(f"Exception querying spark server", exc_info=True)
+            except Exception:
+                self.logger.debug("Exception querying spark server", exc_info=True)
             return False
 
         wait_until(

--- a/tests/rptest/services/transform_verifier_service.py
+++ b/tests/rptest/services/transform_verifier_service.py
@@ -275,7 +275,7 @@ class TransformVerifierService(Service):
         # Attempt a graceful stop
         try:
             self._execute_cmd(node, "stop")
-        except Exception as e:
+        except Exception:
             self.logger.warn("unable to request /stop {self.who_am_i()}: {e}")
 
         try:
@@ -286,7 +286,7 @@ class TransformVerifierService(Service):
             )
             self._pid = None
             return
-        except TimeoutError as e:
+        except TimeoutError:
             self.logger.warn("gracefully stopping {self.who_am_i()} failed: {e}")
 
         # Gracefully stop did not work, try a hard kill

--- a/tests/rptest/services/trino_service.py
+++ b/tests/rptest/services/trino_service.py
@@ -97,8 +97,8 @@ iceberg.{{ catalog_type }}-catalog.uri={{ catalog_uri }}
             # https://trino.io/docs/current/object-storage/metastores.html#nessie-catalog
             extra_connector_conf = self.dict_to_conf(
                 {
-                    f"iceberg.nessie-catalog.default-warehouse-dir": self.default_warehouse_dir,
-                    f"iceberg.nessie-catalog.client-api-version": NessieCatalog.NESSIE_API_VERSION,
+                    "iceberg.nessie-catalog.default-warehouse-dir": self.default_warehouse_dir,
+                    "iceberg.nessie-catalog.client-api-version": NessieCatalog.NESSIE_API_VERSION,
                 }
             )
 
@@ -138,13 +138,13 @@ iceberg.{{ catalog_type }}-catalog.uri={{ catalog_uri }}
                 active_worker_count = len(active_workers) if active_workers else 0
 
                 if active_worker_count < 1:
-                    self.logger.debug(f"Trino initialized but has no active workers")
+                    self.logger.debug("Trino initialized but has no active workers")
                     return False
 
                 return True
             except Exception:
                 self.logger.debug(
-                    f"Exception during Trino readiness check", exc_info=True
+                    "Exception during Trino readiness check", exc_info=True
                 )
             return False
 

--- a/tests/rptest/services/utils.py
+++ b/tests/rptest/services/utils.py
@@ -266,7 +266,7 @@ class LogSearchCloud(LogSearch):
             tz = tz[0] if len(tz) > 0 else "+00:00"
             # Find all log files for target pod
             # Return type without capture is always str, so ignore type
-            logfiles = pod.nodeshell(f"find /var/log/pods -type f")  # type: ignore
+            logfiles = pod.nodeshell("find /var/log/pods -type f")  # type: ignore
             for logfile in logfiles:
                 if pod.name in logfile and "redpanda-configurator" not in logfile:  # type: ignore
                     self.logger.info(f"Inspecting '{logfile}'")

--- a/tests/rptest/services/verifiable_consumer.py
+++ b/tests/rptest/services/verifiable_consumer.py
@@ -591,7 +591,7 @@ class VerifiableConsumer(BackgroundThreadService):
                 # between the workers
                 fail_pre = False
                 for idx, s in self.global_state.items():
-                    if not tp in s.position_first:
+                    if tp not in s.position_first:
                         msg.append(
                             f"Start of consumed offset range "
                             f"not recorded for partiton {str(tp)}, worker "

--- a/tests/rptest/tests/admin_uuid_operations_test.py
+++ b/tests/rptest/tests/admin_uuid_operations_test.py
@@ -307,7 +307,7 @@ class AdminUUIDOperationsTest(RedpandaTest):
         self.logger.debug(f"Decommission ghost node [{ghost_node_id}]...")
         self._decommission(ghost_node_id)
 
-        self.logger.debug(f"...and wait for the cluster to become healthy.")
+        self.logger.debug("...and wait for the cluster to become healthy.")
         self.wait_until_cluster_healthy(timeout_sec=30)
 
         self.logger.debug("Check that all this state sticks across a rolling restart")
@@ -545,7 +545,7 @@ class AdminUUIDOperationsTest(RedpandaTest):
             )
 
         self.logger.debug(
-            f"Restart w/ the same config and confirm that current UUID mismatch prevents changes from taking effect"
+            "Restart w/ the same config and confirm that current UUID mismatch prevents changes from taking effect"
         )
         if mode == TestMode.CFG_OVERRIDE:
             self._restart_node(

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -287,7 +287,7 @@ class ArchivalTest(RedpandaTest):
 
             # All objects must belong to the topic we created (make sure we aren't searching on the wrong topic)
             if bucket_content.ignored_objects > 0:
-                raise RuntimeError(f"Unexpected objects in bucket")
+                raise RuntimeError("Unexpected objects in bucket")
 
         # Firewall is unblocked, segment uploads should proceed
         def data_uploaded():
@@ -295,7 +295,7 @@ class ArchivalTest(RedpandaTest):
             has_segments = bucket_content.segment_objects > 0
 
             if not has_segments:
-                self.logger.info(f"No segments yet")
+                self.logger.info("No segments yet")
                 return False
 
             has_segments_in_manifest = any(
@@ -628,7 +628,7 @@ class ArchivalTest(RedpandaTest):
 
         # Verify assumptions
         assert self.topics[0].cleanup_policy == None, (
-            f"The compaction setting is assumed to be `delete` by default"
+            "The compaction setting is assumed to be `delete` by default"
         )
         assert not self._archiver_restart_msg_seen(), (
             "There should be no archival restart message initially"
@@ -656,7 +656,7 @@ class ArchivalTest(RedpandaTest):
 
         # Verify assumptions
         assert self.topics[0].cleanup_policy == None, (
-            f"The compaction setting is assumed to be `delete` by default"
+            "The compaction setting is assumed to be `delete` by default"
         )
         assert not self._archiver_restart_msg_seen(), (
             "There should be no archival restart message initially"
@@ -671,7 +671,7 @@ class ArchivalTest(RedpandaTest):
         )
         time.sleep(10)
         assert not self._archiver_restart_msg_seen(), (
-            f"Unexpected archival restart when compacted config not changed"
+            "Unexpected archival restart when compacted config not changed"
         )
 
         self.redpanda.logger.debug(

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -703,7 +703,7 @@ class AuditLogTestBase(RedpandaTest):
                 self.next_offset_ingest = len(records)
                 new_records = [json.loads(msg["value"]) for msg in new_records]
                 self.logger.info(f"Ingested: {len(new_records)} records")
-                self.logger.debug(f"Ingested records:")
+                self.logger.debug("Ingested records:")
                 for rec in new_records:
                     self.logger.debug(f"{rec}")
                     self.ocsf_server.validate_schema(rec)
@@ -1021,7 +1021,7 @@ class AuditLogTestAdminApi(AuditLogTestBase):
                     timeout_sec=2,
                     backoff_sec=0.1,
                 )
-            except TimeoutError as e:
+            except TimeoutError:
                 return None
 
         public_metrics = [
@@ -1274,7 +1274,7 @@ class AuditLogTestKafkaApi(AuditLogTestBase):
                 1,
             ),
             RangeTestItem(
-                f"Attempt group offset delete",
+                "Attempt group offset delete",
                 lambda: self.execute_command_ignore_error(
                     partial(self.super_rpk.offset_delete, "fake", {topic_name: [0]})
                 ),
@@ -1313,7 +1313,7 @@ class AuditLogTestKafkaApi(AuditLogTestBase):
                 2,  # expect two, describe and delete
             ),
             AbsoluteTestItem(
-                f"Create ACL",
+                "Create ACL",
                 lambda: self.super_rpk.sasl_allow_principal(
                     principal="test",
                     operations=["all"],
@@ -1344,7 +1344,7 @@ class AuditLogTestKafkaApi(AuditLogTestBase):
                 1,
             ),
             AbsoluteTestItem(
-                f"Delete ACL",
+                "Delete ACL",
                 lambda: self.super_rpk.delete_principal(
                     principal="test",
                     operations=["all"],
@@ -1370,7 +1370,7 @@ class AuditLogTestKafkaApi(AuditLogTestBase):
                 1,
             ),
             AbsoluteTestItem(
-                f"Delete group test",
+                "Delete group test",
                 lambda: self.execute_command_ignore_error(
                     partial(self.super_rpk.group_delete, "test")
                 ),
@@ -1383,7 +1383,7 @@ class AuditLogTestKafkaApi(AuditLogTestBase):
                 1,
             ),
             AbsoluteTestItem(
-                f"Alter Partition Reassignments",
+                "Alter Partition Reassignments",
                 lambda: self.execute_command_ignore_error(
                     partial(
                         alter_partition_reassignments_with_kcl,
@@ -1400,7 +1400,7 @@ class AuditLogTestKafkaApi(AuditLogTestBase):
                 1,
             ),
             AbsoluteTestItem(
-                f"Alter Config (not-incremental)",
+                "Alter Config (not-incremental)",
                 lambda: self.execute_command_ignore_error(
                     partial(
                         alter_config_with_kcl,
@@ -1413,7 +1413,7 @@ class AuditLogTestKafkaApi(AuditLogTestBase):
                 1,
             ),
             AbsoluteTestItem(
-                f"Incremental Alter Config",
+                "Incremental Alter Config",
                 lambda: self.execute_command_ignore_error(
                     partial(
                         alter_config_with_kcl,
@@ -1430,7 +1430,7 @@ class AuditLogTestKafkaApi(AuditLogTestBase):
                 1,
             ),
             AbsoluteTestItem(
-                f"List ACLs (no item)",
+                "List ACLs (no item)",
                 lambda: self.super_rpk.acl_list(),
                 partial(self.api_match, "list_acls", self.kafka_rpc_service_name),
                 0,
@@ -2069,7 +2069,7 @@ class AuditLogTestInvalidConfigMTLS(AuditLogTestInvalidConfigBase):
             assert audit_transport_mode is AuditLogMode.RPC, (
                 f"Should not have created a topic in {audit_transport_mode=}"
             )
-        except RpkException as e:
+        except RpkException:
             pass
 
         # Error log should only appear in kclient mode

--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -389,7 +389,7 @@ class CloudRetentionTimelyGCTest(RedpandaTest):
         def check_cloud_log_size():
             s3_snapshot = BucketView(self.redpanda, topics=self.topics)
             if not s3_snapshot.is_ntp_in_manifest(self.topic, 0):
-                self.logger.debug(f"No manifest present yet")
+                self.logger.debug("No manifest present yet")
                 return
 
             if (
@@ -398,7 +398,7 @@ class CloudRetentionTimelyGCTest(RedpandaTest):
                 )
                 <= 0
             ):
-                self.logger.debug(f"Manifest not prefix-truncated yet")
+                self.logger.debug("Manifest not prefix-truncated yet")
                 return
 
             cloud_log_size = s3_snapshot.cloud_log_size_for_ntp(self.topic, 0).total(

--- a/tests/rptest/tests/cloud_storage_timing_stress_test.py
+++ b/tests/rptest/tests/cloud_storage_timing_stress_test.py
@@ -515,7 +515,7 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
                     f"Failed checks: {failure_count} ({failed}); Incomplete checks: {len(not_done)} ({incomplete})"
                 )
 
-            self.logger.info(f"All checks completed successfuly")
+            self.logger.info("All checks completed successfuly")
 
     @cluster(
         num_nodes=5,

--- a/tests/rptest/tests/cluster_bootstrap_test.py
+++ b/tests/rptest/tests/cluster_bootstrap_test.py
@@ -10,7 +10,6 @@
 import concurrent.futures
 import threading
 
-import ducktape.errors
 from ducktape.mark import matrix
 from requests.exceptions import ConnectionError
 

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -31,7 +31,6 @@ from rptest.clients.admin.proto.redpanda.core.admin.v2 import (
 from rptest.clients.kafka_cli_tools import KafkaCliToolsError
 from rptest.clients.rpk import RpkTool, RPKACLInput, RpkException
 from rptest.clients.types import TopicSpec
-from rptest.clients.default import DefaultClient
 from rptest.services.cluster import TestContext
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
@@ -63,12 +62,10 @@ from rptest.tests.cluster_linking_test_base import (
     ShadowLinkPreAllocTestBase,
     ShadowLinkTestBase,
 )
-from rptest.clients.admin.proto.redpanda.core.admin.v2 import shadow_link_pb2
 from rptest.tests.full_disk_test import FDT_LOG_ALLOW_LIST
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import (
     bg_thread_cm,
-    contextmanager,
     expect_exception,
     wait_until,
     wait_until_result,
@@ -1256,7 +1253,7 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
             lambda: verify_n_replications(1),
             timeout_sec=20,
             backoff_sec=1,
-            err_msg=f"Failed to replicate shadow topic",
+            err_msg="Failed to replicate shadow topic",
         )
 
         target_redpanda = self.target_cluster_service
@@ -1266,7 +1263,7 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
             lambda: target_redpanda.search_log_all("ok -> degraded"),
             timeout_sec=20,
             backoff_sec=1,
-            err_msg=f"Failed to change to degraded state",
+            err_msg="Failed to change to degraded state",
         )
 
         source_rpk.produce(topic.name, "key", "message2")
@@ -1276,7 +1273,7 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
             ),
             timeout_sec=20,
             backoff_sec=1,
-            err_msg=f"Sink replication should have been rejected",
+            err_msg="Sink replication should have been rejected",
         )
 
         assert verify_n_replications(1), (
@@ -1288,7 +1285,7 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
             lambda: verify_n_replications(2),
             timeout_sec=20,
             backoff_sec=1,
-            err_msg=f"Failed to replicate shadow topic",
+            err_msg="Failed to replicate shadow topic",
         )
 
 

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0
 
 from collections import defaultdict
-from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager
 import time
 import socket

--- a/tests/rptest/tests/cluster_metrics_test.py
+++ b/tests/rptest/tests/cluster_metrics_test.py
@@ -112,7 +112,7 @@ class ClusterMetricsTest(RedpandaTest):
                 timeout_sec=5,
                 backoff_sec=1,
             )
-        except TimeoutError as e:
+        except TimeoutError:
             # Timing out is the desirable outcome here as it means
             # that the value remained constant.
             return
@@ -135,7 +135,7 @@ class ClusterMetricsTest(RedpandaTest):
                 timeout_sec=2,
                 backoff_sec=0.1,
             )
-        except TimeoutError as e:
+        except TimeoutError:
             return None
 
     def _assert_cluster_metrics(self, node: ClusterNode, expect_metrics: bool):

--- a/tests/rptest/tests/compatibility/java_compression_test.py
+++ b/tests/rptest/tests/compatibility/java_compression_test.py
@@ -84,7 +84,7 @@ class JavaCompressionTest(EndToEndTest):
             if cur_messages_amount >= num_messages:
                 return
             if time() > deadline:
-                assert False, f"Failed to consume messages"
+                assert False, "Failed to consume messages"
 
     def get_compacted_segments(self):
         num_compacted_segments = self.redpanda.metric_sum(
@@ -226,5 +226,5 @@ class JavaCompressionTest(EndToEndTest):
             consumer_succeeds,
             timeout_sec=360,
             backoff_sec=5,
-            err_msg=f"Timed out waiting for consuming to succeed.",
+            err_msg="Timed out waiting for consuming to succeed.",
         )

--- a/tests/rptest/tests/connection_limits_test.py
+++ b/tests/rptest/tests/connection_limits_test.py
@@ -163,17 +163,17 @@ class ConnectionLimitsTest(RedpandaTest):
             }
         )
 
-        self.logger.info(f"Trying producer_a, should be blocked")
+        self.logger.info("Trying producer_a, should be blocked")
         with expect_exception(Exception, lambda e: "timeout" in str(e).lower()):
             producer_a.start()
             producer_a.wait()
 
-        self.logger.info(f"Tearing down producer_a")
+        self.logger.info("Tearing down producer_a")
         with expect_exception(Exception, lambda e: "timeout" in str(e).lower()):
             producer_a.stop()
         producer_a.free()
 
-        self.logger.info(f"Trying producer_b, should be OK")
+        self.logger.info("Trying producer_b, should be OK")
         producer_b.start()
         producer_b.wait()
         producer_b.free()

--- a/tests/rptest/tests/consumer_group_recovery_test.py
+++ b/tests/rptest/tests/consumer_group_recovery_test.py
@@ -208,7 +208,7 @@ class ConsumerOffsetsRecoveryTest(PreallocNodesTest):
     def run_workload_after_restore(self, groups, partition_count, topic):
         rpk = RpkTool(self.redpanda)
         group = next((k for k in groups.keys() if k.startswith("kgo-")), None)
-        assert group is not None, f"Missing kgo group in group description"
+        assert group is not None, "Missing kgo group in group description"
 
         tp_offsets = groups[group]
         for t, part, _ in tp_offsets:

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -538,7 +538,7 @@ class ConsumerGroupTest(RedpandaTest):
             try:
                 rpk_group = rpk.group_describe(group)
                 return rpk_group.members == 0 and rpk_group.state == "Dead"
-            except RpkException as e:
+            except RpkException:
                 # allow RPK to throw an exception as redpanda nodes were
                 # restarted and the request may require a retry
                 return False

--- a/tests/rptest/tests/controller_forced_reconfiguration_test.py
+++ b/tests/rptest/tests/controller_forced_reconfiguration_test.py
@@ -303,7 +303,7 @@ class ControllerForceReconfigurationTest(RedpandaTest):
             lambda: controller_available(),
             timeout_sec=recovery_timeout.timeout_s,
             backoff_sec=recovery_timeout.backoff_s,
-            err_msg=f"Controller never came back",
+            err_msg="Controller never came back",
         )
         self.redpanda.logger.debug("controller recovered")
 

--- a/tests/rptest/tests/controller_snapshot_test.py
+++ b/tests/rptest/tests/controller_snapshot_test.py
@@ -279,7 +279,7 @@ class ControllerSnapshotTest(RedpandaTest):
 
         check_and_save_node_ids(seed_nodes)
 
-        self.logger.info(f"seed nodes restarted successfully")
+        self.logger.info("seed nodes restarted successfully")
 
         self.redpanda.start(
             nodes=[joiner_node],

--- a/tests/rptest/tests/data_transforms_test.py
+++ b/tests/rptest/tests/data_transforms_test.py
@@ -173,7 +173,7 @@ class BaseDataTransformsTest(RedpandaTest):
             do_list,
             timeout_sec=30,
             backoff_sec=1,
-            err_msg=f"unable to list committed offsets",
+            err_msg="unable to list committed offsets",
             retry_on_exc=True,
         )
         return response
@@ -187,7 +187,7 @@ class BaseDataTransformsTest(RedpandaTest):
             do_gc,
             timeout_sec=30,
             backoff_sec=1,
-            err_msg=f"unable to gc committed offsets",
+            err_msg="unable to gc committed offsets",
             retry_on_exc=True,
         )
 
@@ -246,7 +246,7 @@ class BaseDataTransformsTest(RedpandaTest):
             do_deploy,
             timeout_sec=30,
             backoff_sec=5,
-            err_msg=f"unable to deploy invalid wasm transform",
+            err_msg="unable to deploy invalid wasm transform",
         )
 
 
@@ -323,7 +323,7 @@ class DataTransformsTest(BaseDataTransformsTest):
             all_offsets_committed,
             timeout_sec=30,
             backoff_sec=1,
-            err_msg=f"all offsets did not commit",
+            err_msg="all offsets did not commit",
             retry_on_exc=True,
         )
         self._delete_wasm(name="identity-xform")
@@ -341,7 +341,7 @@ class DataTransformsTest(BaseDataTransformsTest):
             all_offsets_removed,
             timeout_sec=30,
             backoff_sec=1,
-            err_msg=f"all offsets where not removed",
+            err_msg="all offsets where not removed",
             retry_on_exc=True,
         )
 
@@ -377,7 +377,7 @@ class DataTransformsTest(BaseDataTransformsTest):
             lambda: all_partitions_status("inactive"),
             timeout_sec=30,
             backoff_sec=1,
-            err_msg=f"some partitions didn't become inactive",
+            err_msg="some partitions didn't become inactive",
             retry_on_exc=True,
         )
 
@@ -395,7 +395,7 @@ class DataTransformsTest(BaseDataTransformsTest):
                 lambda: all_partitions_status("running"),
                 timeout_sec=30,
                 backoff_sec=1,
-                err_msg=f"some partitions didn't become active",
+                err_msg="some partitions didn't become active",
                 retry_on_exc=True,
             )
         else:  # NOTE: patching ENV is not yet implemented in rpk
@@ -416,7 +416,7 @@ class DataTransformsTest(BaseDataTransformsTest):
                 lambda: all_partitions_status("running") and env_is(env1),
                 timeout_sec=30,
                 backoff_sec=1,
-                err_msg=f"some partitions didn't come back",
+                err_msg="some partitions didn't come back",
                 retry_on_exc=True,
             )
 
@@ -1122,7 +1122,7 @@ class DataTransformsLoggingMetricsTest(BaseDataTransformsLoggingTest):
                 timeout_sec=2,
                 backoff_sec=0.1,
             )
-        except TimeoutError as e:
+        except TimeoutError:
             return None
 
     def unpack_samples(self, metric_samples):
@@ -1219,7 +1219,7 @@ class DataTransformsLoggingMetricsTest(BaseDataTransformsLoggingTest):
             lambda: get_total_events()[0] >= n_events_expected,
             timeout_sec=30,
             backoff_sec=5,
-            err_msg=f"never got all the events",
+            err_msg="never got all the events",
         )
 
         totals, dropped = get_total_events_per_xform()
@@ -1288,7 +1288,7 @@ class DataTransformsLoggingMetricsTest(BaseDataTransformsLoggingTest):
         it, ot = self.setup_identity_xform(
             input_topic,
             self.topics[1],
-            name=f"logger-xform",
+            name="logger-xform",
         )
 
         def get_buffer_usage() -> list[float]:
@@ -1327,7 +1327,7 @@ class DataTransformsLoggingMetricsTest(BaseDataTransformsLoggingTest):
                 lambda: any(bu > 1.0 for bu in get_buffer_usage()),
                 timeout_sec=10,
                 backoff_sec=1,
-                err_msg=f"buffers never filled up!",
+                err_msg="buffers never filled up!",
             )
 
         self.logger.debug(

--- a/tests/rptest/tests/datalake/admin_endpoint_test.py
+++ b/tests/rptest/tests/datalake/admin_endpoint_test.py
@@ -7,7 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from typing import Any
 
 from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
@@ -191,7 +190,7 @@ class DatalakeAdminEndpointTest(RedpandaTest):
                     response: admin_v2.datalake_pb.GetCoordinatorStateResponse = (
                         admin.datalake().get_coordinator_state(request)
                     )
-                except Exception as e:
+                except Exception:
                     return False
                 if topic not in response.state.topic_states:
                     return False

--- a/tests/rptest/tests/datalake/cluster_restore_test.py
+++ b/tests/rptest/tests/datalake/cluster_restore_test.py
@@ -526,7 +526,7 @@ class DatalakeClusterRestoreTest(RedpandaTest):
 
             structured_counts_snap_after = self.counts_per_table(dl, structured_tables)
             assert structured_counts_snap == structured_counts_snap_after, (
-                f"Expected no translation in structured main tables:\n"
+                "Expected no translation in structured main tables:\n"
                 "{structured_offsets_snap}\nvs\n{structured_offsets_snap_after}"
             )
 

--- a/tests/rptest/tests/datalake/datalake_usage_test.py
+++ b/tests/rptest/tests/datalake/datalake_usage_test.py
@@ -141,7 +141,7 @@ class IcebergUsageTest(RedpandaTest):
                 do_check,
                 timeout_sec=30,
                 backoff_sec=2,
-                err_msg=f"Timed out waiting for all usages to be empty",
+                err_msg="Timed out waiting for all usages to be empty",
             )
 
         def check_all_usages_atleast(

--- a/tests/rptest/tests/datalake/datalake_verifier.py
+++ b/tests/rptest/tests/datalake/datalake_verifier.py
@@ -154,10 +154,10 @@ class DatalakeVerifier:
     # to be called no more than once
     def go_offline(self, timeout=60):
         assert not self._offline_mode_requested.is_set()
-        self.logger.debug(f"offline mode requested")
+        self.logger.debug("offline mode requested")
         self._offline_mode_requested.set()
         assert self._consumer_stopped.wait(timeout)
-        self.logger.debug(f"consistent state reached")
+        self.logger.debug("consistent state reached")
         self._consumer_positions = self.update_and_get_fetch_positions()
         self.logger.debug(f"remembered {self._consumer_positions=}")
         self._partition_hwms = self.partition_hwms()
@@ -166,7 +166,7 @@ class DatalakeVerifier:
         with self._consumer_lock:
             self._consumer.close()
             self._consumer = None
-            self.logger.debug(f"offline mode established")
+            self.logger.debug("offline mode established")
             self._offline_mode_established = True
 
     def _consumed_till_hwm(self, update: bool):
@@ -370,7 +370,7 @@ class DatalakeVerifier:
                 assert len(self._errors) == 0, (
                     f"Topic {self.topic} validation errors: {self._errors}"
                 )
-            self.logger.debug(f"No errors around waiting")
+            self.logger.debug("No errors around waiting")
         except Exception as e:
             self.logger.error(f"Error around waiting: {e}")
             raise
@@ -395,7 +395,7 @@ class DatalakeVerifier:
             )
 
             assert len(self._expected_compacted_keys) == 0, (
-                f"Some keys which were compacted away were not seen later in the consumer's log"
+                "Some keys which were compacted away were not seen later in the consumer's log"
             )
         finally:
             if self._consumer:

--- a/tests/rptest/tests/datalake/delayed_translation_test.py
+++ b/tests/rptest/tests/datalake/delayed_translation_test.py
@@ -131,7 +131,7 @@ class DatalakeDelayedTranslationTest(RedpandaTest):
                 self.redpanda.all_up,
                 timeout_sec=60,
                 backoff_sec=1,
-                err_msg=f"Failed waiting for redpanda to become available",
+                err_msg="Failed waiting for redpanda to become available",
             )
 
             rpk = RpkTool(self.redpanda)

--- a/tests/rptest/tests/datalake/many_topics_test.py
+++ b/tests/rptest/tests/datalake/many_topics_test.py
@@ -108,7 +108,7 @@ class DatalakeManyTopicsTest(RedpandaTest):
             all_topics = self.create_topics(
                 1000 if self.redpanda.dedicated_nodes else 20
             )
-            self.logger.info(f"creating topics finished")
+            self.logger.info("creating topics finished")
 
             schema1 = """
 {
@@ -131,12 +131,12 @@ class DatalakeManyTopicsTest(RedpandaTest):
             self.produce_messages(
                 schema1, create_record1, topics=all_topics, msg_per_topic=100
             )
-            self.logger.info(f"producing finished")
+            self.logger.info("producing finished")
 
             def tables_created():
                 try:
                     return len(
-                        spark.run_query_fetch_all(f"show tables in redpanda")
+                        spark.run_query_fetch_all("show tables in redpanda")
                     ) >= len(all_topics)
                 except pyhive.exc.OperationalError:
                     # thrown if the namespace hasn't been created yet
@@ -144,7 +144,7 @@ class DatalakeManyTopicsTest(RedpandaTest):
 
             spark = dl.spark()
             self.redpanda.wait_until(tables_created, timeout_sec=180, backoff_sec=5)
-            self.logger.info(f"table creation finished")
+            self.logger.info("table creation finished")
 
             def all_translated(msg_per_topic):
                 for topic in random.sample(all_topics, 10):
@@ -161,7 +161,7 @@ class DatalakeManyTopicsTest(RedpandaTest):
                 backoff_sec=5,
                 err_msg="timed out waiting for first translation",
             )
-            self.logger.info(f"translation finished")
+            self.logger.info("translation finished")
 
             schema2 = """
 {
@@ -186,7 +186,7 @@ class DatalakeManyTopicsTest(RedpandaTest):
             self.produce_messages(
                 schema2, create_record2, topics=all_topics, msg_per_topic=100
             )
-            self.logger.info(f"producing with new schema finished")
+            self.logger.info("producing with new schema finished")
 
             self.redpanda.wait_until(
                 lambda: all_translated(200),
@@ -194,7 +194,7 @@ class DatalakeManyTopicsTest(RedpandaTest):
                 backoff_sec=5,
                 err_msg="timed out waiting for translation after schema change",
             )
-            self.logger.info(f"translation finished")
+            self.logger.info("translation finished")
 
             def all_updated_schema():
                 for topic in random.sample(all_topics, 10):
@@ -219,12 +219,12 @@ class DatalakeManyTopicsTest(RedpandaTest):
                     )
 
             execute_in_parallel(all_topics, set_property_for_batch)
-            self.logger.info(f"partition spec property changed")
+            self.logger.info("partition spec property changed")
 
             self.produce_messages(
                 schema2, create_record2, topics=all_topics, msg_per_topic=100
             )
-            self.logger.info(f"producing with new partition spec finished")
+            self.logger.info("producing with new partition spec finished")
 
             self.redpanda.wait_until(
                 lambda: all_translated(300),
@@ -232,7 +232,7 @@ class DatalakeManyTopicsTest(RedpandaTest):
                 backoff_sec=5,
                 err_msg="timed out waiting for translation after spec update",
             )
-            self.logger.info(f"translation finished")
+            self.logger.info("translation finished")
 
             def all_updated_spec():
                 for topic in random.sample(all_topics, 10):

--- a/tests/rptest/tests/datalake/mount_unmount_test.py
+++ b/tests/rptest/tests/datalake/mount_unmount_test.py
@@ -25,7 +25,6 @@ from rptest.tests.datalake.datalake_services import DatalakeServices
 from rptest.tests.datalake.datalake_verifier import DatalakeVerifier
 from rptest.tests.datalake.query_engine_base import QueryEngineType
 from rptest.tests.datalake.utils import supported_storage_types
-from rptest.tests.redpanda_test import RedpandaTest
 from rptest.utils.data_migrations import DataMigrationTestMixin
 from rptest.utils.mode_checks import skip_debug_mode
 from rptest.utils.rpcn_utils import counter_stream_config

--- a/tests/rptest/tests/datalake/nessie_catalog_smoke_test.py
+++ b/tests/rptest/tests/datalake/nessie_catalog_smoke_test.py
@@ -79,7 +79,7 @@ class NessieCatalogSmokeTest(RedpandaTest):
                 )
                 cursor.fetchall()
 
-                cursor.execute(f"SELECT * from redpanda.test")
+                cursor.execute("SELECT * from redpanda.test")
                 row = cursor.fetchall()
                 assert len(row) == 1
                 assert row == [(2024, "John", 60, "Wick")]

--- a/tests/rptest/tests/datalake/schemas/data_types.py
+++ b/tests/rptest/tests/datalake/schemas/data_types.py
@@ -32,15 +32,15 @@ class GenericDataType:
 
     @staticmethod
     def name() -> str:
-        raise NotImplementedError(f"Not implemented in GenericDataType base class")
+        raise NotImplementedError("Not implemented in GenericDataType base class")
 
     @staticmethod
     def to_avro() -> str:
-        raise NotImplementedError(f"Not implemented in GenericDataType base class")
+        raise NotImplementedError("Not implemented in GenericDataType base class")
 
     @staticmethod
     def to_proto() -> str:
-        raise NotImplementedError(f"Not implemented in GenericDataType base class")
+        raise NotImplementedError("Not implemented in GenericDataType base class")
 
 
 class GenericRecord(GenericDataType):

--- a/tests/rptest/tests/debug_bundle_test.py
+++ b/tests/rptest/tests/debug_bundle_test.py
@@ -209,14 +209,14 @@ class DebugBundleTestBase(RedpandaTest):
             kafka_file = [
                 entry for entry in zip_ref.namelist() if entry.endswith("kafka.json")
             ]
-            assert kafka_file, f"Expected to find kafka.json in the zip file"
+            assert kafka_file, "Expected to find kafka.json in the zip file"
             with zip_ref.open(kafka_file[0]) as f:
                 kafka_json = json.loads(f.read().decode("utf-8"))
                 self.logger.debug(f"kafka_json: {kafka_json}")
                 metadata_obj = [
                     entry for entry in kafka_json if entry["Name"] == "metadata"
                 ]
-                assert metadata_obj, f"Expected to find metadata object in kafka.json"
+                assert metadata_obj, "Expected to find metadata object in kafka.json"
                 if not expect_populated_topic_response:
                     assert metadata_obj[0]["Response"]["Topics"] is None, (
                         f"Expected to not find 'Topics' in kafka resonse: {metadata_obj[0]['Response']['Topics']}"
@@ -227,7 +227,7 @@ class DebugBundleTestBase(RedpandaTest):
                         f"Expected to find {topic_name} in metadata object {metadata_obj[0]['Response']['Topics']}"
                     )
                 else:
-                    assert not topic_name in metadata_obj[0]["Response"]["Topics"], (
+                    assert topic_name not in metadata_obj[0]["Response"]["Topics"], (
                         f"Expected not to find {topic_name} in metadata object {metadata_obj[0]['Response']['Topics']}"
                     )
 
@@ -324,7 +324,7 @@ class DebugBundleTest(DebugBundleTestBase):
             data_dir = self.admin.get_cluster_config(
                 node=node, key=self.debug_bundle_dir_config
             )[self.debug_bundle_dir_config]
-        except requests.HTTPError as e:
+        except requests.HTTPError:
             pass
 
         data_dir = (
@@ -574,12 +574,12 @@ class DebugBundleTest(DebugBundleTestBase):
 
         self._run_debug_bundle(job_id=job_id, node=node, config=params)
 
-        search_str = f"Starting RPK debug bundle:"
+        search_str = "Starting RPK debug bundle:"
         for k, v in env_variables.items():
             search_str += f" {k}={v}"
         search_str += f" {self.redpanda.find_path_to_rpk()} debug bundle"
         search_str += f" --output /var/lib/redpanda/data/debug-bundle/{str(job_id)}.zip"
-        search_str += f" --verbose"
+        search_str += " --verbose"
         search_str += (
             f" --controller-logs-size-limit {controller_logs_size_limit_bytes}B"
         )

--- a/tests/rptest/tests/delete_records_test.py
+++ b/tests/rptest/tests/delete_records_test.py
@@ -260,7 +260,7 @@ class DeleteRecordsTest(RedpandaTest, PartitionMovementMixin):
         def check_bound_end_fails(offset):
             return check_bound_end(offset, value_on_read=False)
 
-        assert truncate_offset <= high_watermark, f"Test malformed"
+        assert truncate_offset <= high_watermark, "Test malformed"
 
         if truncate_offset == high_watermark:
             # Assert no data at all can be read
@@ -470,9 +470,9 @@ class DeleteRecordsTest(RedpandaTest, PartitionMovementMixin):
                 backoff_sec=5,
                 err_msg=f"Failed while waiting on all segments below lwm: {low_watermark} to be removed",
             )
-        except ducktape.errors.TimeoutError as e:
+        except ducktape.errors.TimeoutError:
             self.redpanda.logger.info(
-                f"Timed out waiting for segments, ensure no orphaned segments exist nodes that didn't crash"
+                "Timed out waiting for segments, ensure no orphaned segments exist nodes that didn't crash"
             )
             snapshot = self.redpanda.storage(all_nodes=True).segments_by_node(
                 "kafka", TEST_TOPIC_NAME, 0

--- a/tests/rptest/tests/e2e_topic_recovery_test.py
+++ b/tests/rptest/tests/e2e_topic_recovery_test.py
@@ -101,7 +101,7 @@ class EndToEndTopicRecovery(RedpandaTest):
         """Stop all redpanda nodes"""
         for node in self.redpanda.nodes:
             self.logger.info(f"Node {node.account.hostname} will be stopped")
-            if not node is self._verifier_node:
+            if node is not self._verifier_node:
                 self.redpanda.stop_node(node)
         time.sleep(10)
 
@@ -109,7 +109,7 @@ class EndToEndTopicRecovery(RedpandaTest):
         """Start all redpanda nodes"""
         for node in self.redpanda.nodes:
             self.logger.info(f"Starting node {node.account.hostname}")
-            if not node is self._verifier_node:
+            if node is not self._verifier_node:
                 self.redpanda.start_node(node)
         time.sleep(10)
 
@@ -215,7 +215,7 @@ class EndToEndTopicRecovery(RedpandaTest):
             lambda: self._s3_has_all_data(num_messages),
             timeout_sec=600,
             backoff_sec=5,
-            err_msg=f"Not all data is uploaded to S3 bucket",
+            err_msg="Not all data is uploaded to S3 bucket",
         )
 
         # Wipe out the state on the nodes
@@ -307,7 +307,7 @@ class EndToEndTopicRecovery(RedpandaTest):
             lambda: self._s3_has_all_data(hwm),
             timeout_sec=600,
             backoff_sec=5,
-            err_msg=f"Not all data is uploaded to S3 bucket",
+            err_msg="Not all data is uploaded to S3 bucket",
         )
 
         # Keep services alive, so that log-capturing gets their logs at the end

--- a/tests/rptest/tests/internal_topic_protection_test.py
+++ b/tests/rptest/tests/internal_topic_protection_test.py
@@ -180,7 +180,7 @@ class InternalTopicProtectionTest(RedpandaTest):
             assert False, "Call to delete topic must fail"
         except Exception:
             self.redpanda.logger.info(
-                f"we were expecting delete_topic to fail", exc_info=True
+                "we were expecting delete_topic to fail", exc_info=True
             )
             pass
 

--- a/tests/rptest/tests/isolated_decommissioned_node_test.py
+++ b/tests/rptest/tests/isolated_decommissioned_node_test.py
@@ -13,7 +13,6 @@ from ducktape.utils.util import wait_until
 from rptest.clients.types import TopicSpec
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.util import firewall_blocked
-from rptest.clients.rpk import RpkTool
 from confluent_kafka import admin, Producer, KafkaException, Consumer
 from ducktape.mark import parametrize
 
@@ -21,16 +20,6 @@ import confluent_kafka as ck
 
 import time
 import uuid
-
-from confluent_kafka import Consumer, KafkaException, Producer, admin
-from ducktape.mark import parametrize
-from ducktape.utils.util import wait_until
-
-from rptest.clients.types import TopicSpec
-from rptest.services.admin import Admin
-from rptest.services.cluster import cluster
-from rptest.tests.prealloc_nodes import PreallocNodesTest
-from rptest.util import firewall_blocked
 
 
 def on_delivery(err, msg):

--- a/tests/rptest/tests/leaders_redirect_test.py
+++ b/tests/rptest/tests/leaders_redirect_test.py
@@ -100,7 +100,7 @@ class LeadersRedirectTest(RedpandaTest):
 
         Also verifies that original exact matching still works.
         """
-        path = f"security/users/cc-baxter"
+        path = "security/users/cc-baxter"
 
         def make_new_address(node, port, sub=""):
             return dict(address=f"{sub}{node.name}", port=port)

--- a/tests/rptest/tests/log_level_test.py
+++ b/tests/rptest/tests/log_level_test.py
@@ -285,7 +285,7 @@ class LogLevelTest(RedpandaTest):
         logger = "test\nlog"
 
         def check_log_for_invalid_parameter(val: str):
-            pattern = f"Parameter 'name' contained invalid control characters"
+            pattern = "Parameter 'name' contained invalid control characters"
             wait_until(lambda: self.redpanda.search_log_any(pattern), timeout_sec=5)
 
         try:

--- a/tests/rptest/tests/log_segment_ms_test.py
+++ b/tests/rptest/tests/log_segment_ms_test.py
@@ -156,7 +156,7 @@ class SegmentMsTest(RedpandaTest):
         producer.stop()
         stop_count = self._total_segments_count(topic)
         assert producer.num_acked == consumer.total_consumed(), (
-            f"failed to preserve the messages across segment rolling"
+            "failed to preserve the messages across segment rolling"
         )
 
         assert stop_count >= start_count
@@ -302,7 +302,7 @@ class SegmentMsTest(RedpandaTest):
         wait_until(
             lambda: self._total_segments_count(topic) > middle_count,
             timeout_sec=SERVER_HOUSEKEEPING_LOOP * 2,
-            err_msg=f"failed to roll a segment in a timely manner",
+            err_msg="failed to roll a segment in a timely manner",
         )
 
     @cluster(num_nodes=3)
@@ -341,7 +341,7 @@ class SegmentMsTest(RedpandaTest):
         wait_until(
             lambda: self._total_segments_count(topic) > start_count,
             timeout_sec=60,
-            err_msg=f"failed waiting for the segment to roll",
+            err_msg="failed waiting for the segment to roll",
         )
 
         self.client().alter_topic_config(
@@ -353,7 +353,7 @@ class SegmentMsTest(RedpandaTest):
         wait_until(
             lambda: self._total_segments_count(topic) <= 1,
             timeout_sec=60,
-            err_msg=f"failed waiting for retention policy",
+            err_msg="failed waiting for retention policy",
         )
 
         producer = VerifiableProducer(
@@ -367,7 +367,7 @@ class SegmentMsTest(RedpandaTest):
         wait_until(
             lambda: self._total_segments_count(topic) >= 2,
             timeout_sec=120,
-            err_msg=f"producer failed to produce enough messages to create 5 segments",
+            err_msg="producer failed to produce enough messages to create 5 segments",
         )
         producer.stop()
 
@@ -384,7 +384,7 @@ class SegmentMsTest(RedpandaTest):
         wait_until(
             lambda: consumer.total_consumed() >= 1000,
             timeout_sec=120,
-            err_msg=f"Failed to consume messages",
+            err_msg="Failed to consume messages",
         )
         consumer.stop()
 
@@ -425,7 +425,7 @@ class SegmentMsTest(RedpandaTest):
         wait_until(
             lambda: self._total_segments_count(topic) > start_count,
             timeout_sec=60,
-            err_msg=f"failed waiting for the segment to roll",
+            err_msg="failed waiting for the segment to roll",
         )
         group_id = "test-group"
 
@@ -447,7 +447,7 @@ class SegmentMsTest(RedpandaTest):
         wait_until(
             lambda: self._total_segments_count(topic) <= 1,
             timeout_sec=60,
-            err_msg=f"failed waiting for retention policy",
+            err_msg="failed waiting for retention policy",
         )
         consumer.stop()
 
@@ -462,7 +462,7 @@ class SegmentMsTest(RedpandaTest):
         wait_until(
             lambda: self._total_segments_count(topic) >= 2,
             timeout_sec=120,
-            err_msg=f"producer failed to produce enough messages to create 5 segments",
+            err_msg="producer failed to produce enough messages to create 5 segments",
         )
         producer.stop()
 

--- a/tests/rptest/tests/maintenance.py
+++ b/tests/rptest/tests/maintenance.py
@@ -99,7 +99,7 @@ class MaintenanceTestBase(RedpandaTest):
         # get status for this node via admin interface
         admin_status = self.admin.maintenance_status(node)
         self.logger.debug(
-            f"maintenance status from admin for {{node.name}}: {{admin_status}}"
+            "maintenance status from admin for {node.name}: {admin_status}"
         )
 
         # ensure that both agree on expected outcome

--- a/tests/rptest/tests/metrics_test.py
+++ b/tests/rptest/tests/metrics_test.py
@@ -45,7 +45,7 @@ class MetricsTest(Test):
         # We ignore those because:
         #  - seastar metrics so not affected by aggregate_metrics anyway
         #  - compaction io_queue class metrics can pop up after a delay so might make this flaky
-        return list(metric for metric in metrics if not "io_queue" in metric)
+        return list(metric for metric in metrics if "io_queue" not in metric)
 
     @cluster(num_nodes=3)
     @matrix(aggregate_metrics=[True, False])

--- a/tests/rptest/tests/node_pool_migration_test.py
+++ b/tests/rptest/tests/node_pool_migration_test.py
@@ -85,7 +85,7 @@ class NodePoolMigrationTestBase(PreallocNodesTest):
 
     def _create_workload_topic(self, cleanup_policy):
         spec = TopicSpec(
-            name=f"migration-test-workload",
+            name="migration-test-workload",
             partition_count=8,
             replication_factor=3,
             cleanup_policy=cleanup_policy,
@@ -405,7 +405,7 @@ class NodePoolMigrationTest(NodePoolMigrationTestBase):
 
             return all([min_expected <= v <= max_expected for v in r_per_node.values()])
 
-        wait_until(_all_nodes_balanced, 60, 1, f"Partitions are not balanced correctly")
+        wait_until(_all_nodes_balanced, 60, 1, "Partitions are not balanced correctly")
 
         def _quiescent_state():
             pb_status = self.admin.get_partition_balancer_status(
@@ -424,7 +424,7 @@ class NodePoolMigrationTest(NodePoolMigrationTestBase):
             _quiescent_state,
             120,
             1,
-            f"Cluster reached quiescent state (no partition movement)",
+            "Cluster reached quiescent state (no partition movement)",
             retry_on_exc=True,
         )
 
@@ -511,7 +511,7 @@ class DisableTieredStorageTest(NodePoolMigrationTestBase):
         self.admin.patch_cluster_config(upsert=cfg)
 
         spec = TopicSpec(
-            name=f"migration-test",
+            name="migration-test",
             partition_count=1,
             replication_factor=1,
             cleanup_policy="compact",

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -403,7 +403,7 @@ class PandaProxyEndpoints(RedpandaTest):
                 co_res_raw = c0.set_offsets(data=json.dumps(sco_req), auth=auth_tuple)
                 assert co_res_raw.status_code == requests.codes.no_content
 
-            self.logger.debug(f"Check consumer offsets")
+            self.logger.debug("Check consumer offsets")
             co_req = dict(
                 partitions=[dict(topic=topic_name, partition=p) for p in parts]
             )
@@ -509,12 +509,12 @@ class PandaProxyTestMethods(PandaProxyEndpoints):
         * Accept: "", "*.*", "application/vnd.kafka.v2+json"
 
         """
-        self.logger.debug(f"List topics with no accept header")
+        self.logger.debug("List topics with no accept header")
         result_raw = self._get_topics({"Content-Type": "application/vnd.kafka.v2+json"})
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.headers["Content-Type"] == "application/vnd.kafka.v2+json"
 
-        self.logger.debug(f"List topics with no content-type header")
+        self.logger.debug("List topics with no content-type header")
         result_raw = self._get_topics(
             {
                 "Accept": "application/vnd.kafka.v2+json",
@@ -523,17 +523,17 @@ class PandaProxyTestMethods(PandaProxyEndpoints):
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.headers["Content-Type"] == "application/vnd.kafka.v2+json"
 
-        self.logger.debug(f"List topics with generic accept header")
+        self.logger.debug("List topics with generic accept header")
         result_raw = self._get_topics({"Accept": "*/*"})
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.headers["Content-Type"] == "application/vnd.kafka.v2+json"
 
-        self.logger.debug(f"List topics with generic content-type header")
+        self.logger.debug("List topics with generic content-type header")
         result_raw = self._get_topics({"Content-Type": "*/*"})
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.headers["Content-Type"] == "application/vnd.kafka.v2+json"
 
-        self.logger.debug(f"List topics with invalid accept header")
+        self.logger.debug("List topics with invalid accept header")
         result_raw = self._get_topics({"Accept": "application/json"})
         assert result_raw.status_code == requests.codes.not_acceptable
         assert result_raw.headers["Content-Type"] == "application/json"
@@ -573,7 +573,7 @@ class PandaProxyTestMethods(PandaProxyEndpoints):
             ]
         }"""
 
-        self.logger.info(f"Producing with no accept header")
+        self.logger.info("Producing with no accept header")
         produce_result_raw = self._produce_topic(
             name, data, headers={"Content-Type": "application/vnd.kafka.binary.v2+json"}
         )
@@ -581,7 +581,7 @@ class PandaProxyTestMethods(PandaProxyEndpoints):
         produce_result = produce_result_raw.json()
         assert produce_result["offsets"][0]["error_code"] == 3  # topic not found
 
-        self.logger.info(f"Producing with unsupported accept header")
+        self.logger.info("Producing with unsupported accept header")
         produce_result_raw = self._produce_topic(
             name,
             data,
@@ -594,7 +594,7 @@ class PandaProxyTestMethods(PandaProxyEndpoints):
         produce_result = produce_result_raw.json()
         assert produce_result["error_code"] == requests.codes.not_acceptable
 
-        self.logger.info(f"Producing with no content-type header")
+        self.logger.info("Producing with no content-type header")
         produce_result_raw = self._produce_topic(
             name, data, headers={"Accept": "application/vnd.kafka.v2+json"}
         )
@@ -602,7 +602,7 @@ class PandaProxyTestMethods(PandaProxyEndpoints):
         produce_result = produce_result_raw.json()
         assert produce_result["error_code"] == requests.codes.unsupported_media_type
 
-        self.logger.info(f"Producing with unsupported content-type header")
+        self.logger.info("Producing with unsupported content-type header")
         produce_result_raw = self._produce_topic(
             name,
             data,
@@ -692,13 +692,13 @@ class PandaProxyTestMethods(PandaProxyEndpoints):
           * timeout
           * max_bytes
         """
-        self.logger.info(f"Consuming with empty topic param")
+        self.logger.info("Consuming with empty topic param")
         fetch_raw_result = self._fetch_topic("", 0)
         assert fetch_raw_result.status_code == requests.codes.bad_request
 
         name = create_topic_names(1)[0]
 
-        self.logger.info(f"Consuming with empty offset param")
+        self.logger.info("Consuming with empty offset param")
         fetch_raw_result = self._fetch_topic(name, 0, "")
         assert fetch_raw_result.status_code == requests.codes.bad_request
 
@@ -708,7 +708,7 @@ class PandaProxyTestMethods(PandaProxyEndpoints):
         fetch_result = fetch_raw_result.json()
         assert fetch_result["error_code"] == 40402
 
-        self.logger.info(f"Consuming with no content-type header")
+        self.logger.info("Consuming with no content-type header")
         fetch_raw_result = self._fetch_topic(
             name, 0, headers={"Accept": "application/vnd.kafka.binary.v2+json"}
         )
@@ -716,7 +716,7 @@ class PandaProxyTestMethods(PandaProxyEndpoints):
         fetch_result = fetch_raw_result.json()
         assert fetch_result["error_code"] == 40402
 
-        self.logger.info(f"Consuming with no accept header")
+        self.logger.info("Consuming with no accept header")
         fetch_raw_result = self._fetch_topic(
             name, 0, headers={"Content-Type": "application/vnd.kafka.v2+json"}
         )
@@ -724,7 +724,7 @@ class PandaProxyTestMethods(PandaProxyEndpoints):
         fetch_result = fetch_raw_result.json()
         assert fetch_result["error_code"] == requests.codes.not_acceptable
 
-        self.logger.info(f"Consuming with unsupported accept header")
+        self.logger.info("Consuming with unsupported accept header")
         fetch_raw_result = self._fetch_topic(
             name,
             0,
@@ -999,7 +999,7 @@ class PandaProxyTestMethods(PandaProxyEndpoints):
         co_req = dict(
             partitions=[dict(topic=t, partition=p) for t in topics for p in [0, 1, 2]]
         )
-        self.logger.info(f"Get consumer offsets")
+        self.logger.info("Get consumer offsets")
         co_res_raw = c0.get_offsets(data=json.dumps(co_req))
         assert co_res_raw.status_code == requests.codes.ok
         co_res = co_res_raw.json()
@@ -1008,11 +1008,11 @@ class PandaProxyTestMethods(PandaProxyEndpoints):
             assert co_res["offsets"][i]["offset"] == -1
 
         # Fetch from a consumer
-        self.logger.info(f"Consumer fetch")
+        self.logger.info("Consumer fetch")
         # 3 topics * 3 msg
         c0.fetch_n(3 * 3)
 
-        self.logger.info(f"Get consumer offsets")
+        self.logger.info("Get consumer offsets")
         co_res_raw = c0.get_offsets(data=json.dumps(co_req))
         assert co_res_raw.status_code == requests.codes.ok
         co_res = co_res_raw.json()
@@ -1026,11 +1026,11 @@ class PandaProxyTestMethods(PandaProxyEndpoints):
                 dict(topic=t, partition=p, offset=0) for t in topics for p in [0, 1, 2]
             ]
         )
-        self.logger.info(f"Set consumer offsets")
+        self.logger.info("Set consumer offsets")
         co_res_raw = c0.set_offsets(data=json.dumps(sco_req))
         assert co_res_raw.status_code == requests.codes.no_content
 
-        self.logger.info(f"Get consumer offsets")
+        self.logger.info("Get consumer offsets")
         co_res_raw = c0.get_offsets(data=json.dumps(co_req))
         assert co_res_raw.status_code == requests.codes.ok
         co_res = co_res_raw.json()
@@ -1083,7 +1083,7 @@ class PandaProxyTestMethods(PandaProxyEndpoints):
         assert sc_res.status_code == requests.codes.no_content
 
         # Fetch from a consumer
-        self.logger.info(f"Consumer fetch")
+        self.logger.info("Consumer fetch")
         # 3 topics * 3 msg
         c0.fetch_n(3 * 3)
 
@@ -1684,7 +1684,7 @@ class PandaProxyBasicAuthTest(PandaProxyEndpoints):
         assert sc_res.status_code == requests.codes.no_content
 
         # Fetch from a consumer
-        self.logger.info(f"Consumer fetch")
+        self.logger.info("Consumer fetch")
         cf_res = c0.fetch(auth=(self.username, self.password)).json()
         assert cf_res["error_code"] == 40101
 
@@ -1983,7 +1983,7 @@ class BasicAuthScaleTest(PandaProxyEndpoints):
             if task.result_raw.status_code != requests.codes.ok:
                 # Retry gate closed exceptions that bubble up to the user.
                 if res["error_code"] == 50003 and res["message"] == "gate closed":
-                    self.logger.debug(f"Gate closed exception, retrying ")
+                    self.logger.debug("Gate closed exception, retrying ")
                     retry_count += 1
                     print(f"Retry count {retry_count}")
                     result_raw = self._get_topics(
@@ -2219,7 +2219,7 @@ class PandaProxyConsumerGroupTest(PandaProxyEndpoints):
         assert sc_res.status_code == requests.codes.no_content
 
         # Attempt to read from topic
-        self.logger.info(f"Consumer fetch")
+        self.logger.info("Consumer fetch")
         cf_res = c0.fetch(headers=HTTP_CONSUMER_FETCH_JSON_V2_HEADERS)
         assert cf_res.status_code == requests.codes.ok, f"Status: {cf_res.status_code}"
         fetch_result = cf_res.json()
@@ -2334,7 +2334,7 @@ class PandaProxyCompressedBatchesTest(PandaProxyEndpoints):
         )
 
         # Confirm pandaproxy fetch
-        self.logger.info(f"Fetching compressed message via PandaProxy")
+        self.logger.info("Fetching compressed message via PandaProxy")
         fetch_result_raw = self._fetch_topic(self.topic, partition=target_partition)
         assert fetch_result_raw.status_code == requests.codes.ok, (
             f"Status: {fetch_result_raw.status_code}"
@@ -2373,7 +2373,7 @@ class PandaProxyCompressedBatchesTest(PandaProxyEndpoints):
 
         # Confirm pandaproxy consumer group fetch
         self.logger.info("Create a consumer group")
-        group_id = f"test-group"
+        group_id = "test-group"
         cc_res = self._create_consumer(group_id)
         assert cc_res.status_code == requests.codes.ok, f"Status: {cc_res.status_code}"
 
@@ -2387,7 +2387,7 @@ class PandaProxyCompressedBatchesTest(PandaProxyEndpoints):
         )
 
         # Attempt to read from topic
-        self.logger.info(f"Consumer fetch compressed record")
+        self.logger.info("Consumer fetch compressed record")
         cf_res = c0.fetch()
         assert cf_res.status_code == requests.codes.ok, f"Status: {cf_res.status_code}"
         result = cf_res.json()
@@ -2395,7 +2395,7 @@ class PandaProxyCompressedBatchesTest(PandaProxyEndpoints):
         assert len(result) == 1, "Unexpected output from Pandaproxy consumer fetch"
         item = result[0]
         assert item["topic"] == self.topic, (
-            f"Pandaproxy consumer fetch consumed the wrong topic"
+            "Pandaproxy consumer fetch consumed the wrong topic"
         )
         # Remove the b64 and bytes encodings
         value = base64.b64decode(item["value"]).decode()

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -207,7 +207,7 @@ class PartitionBalancerService(EndToEndTest):
             )
         else:
             node_id = None
-            self.logger.info(f"waiting for quiescent state")
+            self.logger.info("waiting for quiescent state")
 
         def predicate(status):
             return status["status"] == "ready" and (
@@ -397,7 +397,7 @@ class PartitionBalancerTest(PartitionBalancerService):
                     # but just for the partition movement to start and then
                     # move to the next node.
 
-                    self.logger.info(f"waiting for partition balancer to kick in")
+                    self.logger.info("waiting for partition balancer to kick in")
 
                     node_id = self.redpanda.idx(node)
 

--- a/tests/rptest/tests/partition_move_interruption_test.py
+++ b/tests/rptest/tests/partition_move_interruption_test.py
@@ -14,7 +14,7 @@ from rptest.tests.partition_movement import PartitionMovementMixin
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 
 from rptest.util import wait_for_recovery_throttle_rate
-from rptest.utils.mode_checks import cleanup_on_early_exit, skip_debug_mode
+from rptest.utils.mode_checks import skip_debug_mode
 
 NO_RECOVERY = "no_recovery"
 RESTART_RECOVERY = "restart_recovery"

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -183,7 +183,7 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         """
         Move partitions with data, but no active producers or consumers.
         """
-        self.logger.info(f"Starting redpanda...")
+        self.logger.info("Starting redpanda...")
         test_mixed_versions = num_to_upgrade > 0
         install_opts = InstallOptions(
             install_previous_version=test_mixed_versions, num_to_upgrade=num_to_upgrade
@@ -201,7 +201,7 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
                 )
                 topics.append(spec)
 
-        self.logger.info(f"Creating topics...")
+        self.logger.info("Creating topics...")
         for spec in topics:
             self.client().create_topic(spec)
 
@@ -219,7 +219,7 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
             self.logger.info(f"Finished producing to {spec}, waiting for producer...")
             producer.wait()
             producer.free()
-            self.logger.info(f"Producer stop complete.")
+            self.logger.info("Producer stop complete.")
 
         if test_mixed_versions:
             self.redpanda.set_feature_active("node_local_core_assignment", active=True)
@@ -259,11 +259,11 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
                         self.logger.info(f"message: {m}")
                     consumed = set([(m["key"], m["value"]) for m in consumer.messages])
 
-            self.logger.info(f"Stopping consumer...")
+            self.logger.info("Stopping consumer...")
             consumer.stop()
-            self.logger.info(f"Awaiting consumer...")
+            self.logger.info("Awaiting consumer...")
             consumer.wait()
-            self.logger.info(f"Freeing consumer...")
+            self.logger.info("Freeing consumer...")
             consumer.free()
 
             self.logger.info(f"Finished verifying records in {spec}")
@@ -520,7 +520,7 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
 
         # Create topic with enough data that inter-node movement
         # will take a while.
-        name = f"movetest"
+        name = "movetest"
         spec = TopicSpec(name=name, partition_count=1, replication_factor=3)
         self.client().create_topic(spec)
 
@@ -635,7 +635,7 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         self.logger.info(f"Finished producing to {topic}, waiting for producer...")
         producer.wait()
         producer.free()
-        self.logger.info(f"Producer stop complete.")
+        self.logger.info("Producer stop complete.")
 
         admin = Admin(self.redpanda)
         # get current assignments

--- a/tests/rptest/tests/partition_state_api_test.py
+++ b/tests/rptest/tests/partition_state_api_test.py
@@ -125,7 +125,7 @@ class PartitionStateAPItest(RedpandaTest):
 
         for s in controller_state:
             assert len(s["replicas"]) == 5
-            self.logger.debug(f"validating controller_state")
+            self.logger.debug("validating controller_state")
             leaders = list(
                 filter(lambda r: r["raft_state"]["is_elected_leader"], s["replicas"])
             )
@@ -228,7 +228,7 @@ class PartitionStateAPItest(RedpandaTest):
                     topic.name, 0, 1
                 )["current_leader_epoch"]
             except:
-                self.logger.debug(f"Failed to get current leader epoch", exc_info=True)
+                self.logger.debug("Failed to get current leader epoch", exc_info=True)
                 return -1
 
         def do_validate_offset_for_leader_epoch(epoch: int, expected_offset: int):

--- a/tests/rptest/tests/quota_management_test.py
+++ b/tests/rptest/tests/quota_management_test.py
@@ -612,5 +612,5 @@ Quota configs for client-id 'custom-producer' are producer_byte_rate=20480.0"""
             describe_shows_default,
             timeout_sec=30,
             retry_on_exc=True,
-            err_msg=f"Describe did not succeed in time",
+            err_msg="Describe did not succeed in time",
         )

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -79,7 +79,7 @@ class RaftAvailabilityTest(RedpandaTest):
             return condition(result[0][0])
 
         wait_until(
-            check, timeout_sec=timeout, backoff_sec=0.5, err_msg=f"No leader emerged!"
+            check, timeout_sec=timeout, backoff_sec=0.5, err_msg="No leader emerged!"
         )
 
         duration = time.time() - t1
@@ -126,7 +126,7 @@ class RaftAvailabilityTest(RedpandaTest):
         count = 0
         while True:
             count += 1
-            self.logger.info(f"Waiting for a leader")
+            self.logger.info("Waiting for a leader")
             leader_id = admin.await_stable_leader(
                 topic, partition=0, namespace=namespace, timeout_s=30, backoff_s=2
             )
@@ -326,7 +326,7 @@ class RaftAvailabilityTest(RedpandaTest):
             lambda: self._is_available() is True,
             timeout_sec=ELECTION_TIMEOUT * 2,
             backoff_sec=0.5,
-            err_msg=f"Cluster did not become available!",
+            err_msg="Cluster did not become available!",
         )
 
         new_leader, _ = self._wait_for_leader(

--- a/tests/rptest/tests/raft_recovery_test.py
+++ b/tests/rptest/tests/raft_recovery_test.py
@@ -96,7 +96,7 @@ class RaftRecoveryUpgradeTest(RedpandaTest):
         def wait_for_recovery_finished():
             _await_progress_in_all_partitions(rpk, topic)
             self._wait_for_underreplicated(self.redpanda.nodes, 0)
-            self.logger.info(f"recovery finished")
+            self.logger.info("recovery finished")
 
         producer = KgoVerifierProducer(
             self.test_context,

--- a/tests/rptest/tests/rbac_test.py
+++ b/tests/rptest/tests/rbac_test.py
@@ -216,7 +216,7 @@ class RBACTest(RBACTestBase):
                     filter=filter, principal=principal, principal_type=principal_type
                 ),
                 timeout_sec=10,
-                err_msg=f"Mismatch on filter result",
+                err_msg="Mismatch on filter result",
             )
 
         self.logger.debug(
@@ -352,7 +352,7 @@ class RBACTest(RBACTestBase):
             backoff_sec=1,
             retry_on_exc=True,
         )
-        assert res is not None, f"Failed to get members for newly created role"
+        assert res is not None, "Failed to get members for newly created role"
 
         assert res.status_code == 200, "Expected 200 (OK)"
         members = RoleMemberList.from_response(res)

--- a/tests/rptest/tests/redpanda_kerberos_test.py
+++ b/tests/rptest/tests/redpanda_kerberos_test.py
@@ -10,7 +10,6 @@
 import json
 import os
 import time
-from typing import Any
 
 from ducktape.cluster.remoteaccount import RemoteAccountSSHConfig, RemoteCommandError
 from ducktape.cluster.windows_remoteaccount import WindowsRemoteAccount
@@ -132,7 +131,7 @@ class RedpandaKerberosTest(RedpandaKerberosTestBase):
             sasl_mechanism=mechanism,
         )
 
-        client_user_principal = f"User:client"
+        client_user_principal = "User:client"
 
         # Create a topic that's visible to "client" iff acl = True
         super_rpk.create_topic("needs_acl")
@@ -296,7 +295,7 @@ class RedpandaKerberosRulesTesting(RedpandaKerberosTestBase):
             ),
             timeout_sec=5,
             backoff_sec=0.5,
-            err_msg=f"Did not receive expected set of topics",
+            err_msg="Did not receive expected set of topics",
         )
 
     def _have_expected_topics(self, req_principal, topics_set):
@@ -425,7 +424,7 @@ class RedpandaKerberosExternalActiveDirectoryTest(RedpandaKerberosTestBase):
     @env(ACTIVE_DIRECTORY_REALM=IsCIOrNotEmpty())
     @cluster(num_nodes=2)
     def test_metadata(self):
-        principal = f"client/localhost"
+        principal = "client/localhost"
         self.client.add_primary(primary=principal)
         metadata = self.client.metadata(principal)
         self.logger.info(f"metadata: {metadata}")
@@ -456,7 +455,7 @@ class GSSAPIReauthTest(RedpandaKerberosTestBase):
             sasl_mechanism=mechanism,
         )
 
-        client_user_principal = f"User:client"
+        client_user_principal = "User:client"
 
         # Create a topic that's visible to "client" iff acl = True
         super_rpk.create_topic(self.EXAMPLE_TOPIC)

--- a/tests/rptest/tests/rpk_connect_test.py
+++ b/tests/rptest/tests/rpk_connect_test.py
@@ -36,7 +36,7 @@ class RpkConnectTest(RedpandaTest):
             installed,
             timeout_sec=120,
             backoff_sec=2,
-            err_msg=f"could not find 'redpanda-connect' in plugin list after installing",
+            err_msg="could not find 'redpanda-connect' in plugin list after installing",
         )
 
     @cluster(num_nodes=1)

--- a/tests/rptest/tests/rpk_registry_test.py
+++ b/tests/rptest/tests/rpk_registry_test.py
@@ -538,7 +538,7 @@ message Test3 {
         bytes_from_string = bytes(
             raw_bytes_string.encode().decode("unicode-escape"), "utf-8"
         )
-        assert bytes_from_string[0] == 0, f"expected encoding to contain magic byte (0)"
+        assert bytes_from_string[0] == 0, "expected encoding to contain magic byte (0)"
 
         # Now we decode the same message:
         out = self._rpk.consume(test_topic, offset="2:3", use_schema_registry="value")

--- a/tests/rptest/tests/rpk_start_test.py
+++ b/tests/rptest/tests/rpk_start_test.py
@@ -250,7 +250,7 @@ class RpkRedpandaStartTest(RedpandaTest):
         )
 
         # This was the original issue:
-        assert not self.redpanda.search_log_any(f"\-\-abort-on-seastar-bad-alloc=true")
+        assert not self.redpanda.search_log_any("\-\-abort-on-seastar-bad-alloc=true")
 
     @cluster(num_nodes=3)
     def test_rpc_tls_start(self):

--- a/tests/rptest/tests/sasl_reauth_test.py
+++ b/tests/rptest/tests/sasl_reauth_test.py
@@ -47,7 +47,7 @@ def get_metrics_from_node(
         return wait_until_result(
             lambda: get_metrics_from_node_sync(patterns), timeout_sec=2, backoff_sec=0.1
         )
-    except TimeoutError as e:
+    except TimeoutError:
         return None
 
 

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -901,7 +901,7 @@ class SchemaRegistryRedpandaClient:
         return self.request("GET", "config", headers=headers, **kwargs)
 
     def set_config(self, data, headers=HTTP_POST_HEADERS, **kwargs):
-        return self.request("PUT", f"config", headers=headers, data=data, **kwargs)
+        return self.request("PUT", "config", headers=headers, data=data, **kwargs)
 
     def get_config_subject(
         self, subject, fallback=False, headers=HTTP_GET_HEADERS, **kwargs
@@ -961,7 +961,7 @@ class SchemaRegistryRedpandaClient:
         self, headers=HTTP_GET_HEADERS, tls_enabled: bool = False, **kwargs
     ):
         return self.request(
-            "GET", f"schemas/types", headers=headers, tls_enabled=tls_enabled, **kwargs
+            "GET", "schemas/types", headers=headers, tls_enabled=tls_enabled, **kwargs
         )
 
     def get_schemas_ids_id(self, id, format=None, headers=HTTP_GET_HEADERS, **kwargs):
@@ -1138,7 +1138,7 @@ class SchemaRegistryRedpandaClient:
         self, headers=HTTP_GET_HEADERS, tls_enabled: bool = False, **kwargs
     ):
         return self.request(
-            "GET", f"status/ready", headers=headers, tls_enabled=tls_enabled, **kwargs
+            "GET", "status/ready", headers=headers, tls_enabled=tls_enabled, **kwargs
         )
 
     def get_security_acls(self, **kwargs):
@@ -1338,11 +1338,11 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         """
         Verify the schema registry returns the supported types
         """
-        self.logger.debug(f"Request schema types with no accept header")
+        self.logger.debug("Request schema types with no accept header")
         result_raw = self.sr_client.get_schemas_types(headers={})
         assert result_raw.status_code == requests.codes.ok
 
-        self.logger.debug(f"Request schema types with defautl accept header")
+        self.logger.debug("Request schema types with defautl accept header")
         result_raw = self.sr_client.get_schemas_types()
         assert result_raw.status_code == requests.codes.ok
         result = result_raw.json()
@@ -1504,7 +1504,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
 
         topic = create_topic_names(1)[0]
 
-        self.logger.debug(f"Register a schema against a subject")
+        self.logger.debug("Register a schema against a subject")
         schema_1_data = json.dumps({"schema": schema1_def})
 
         self.logger.debug("Get empty subjects")
@@ -1587,7 +1587,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         assert result_raw.status_code == requests.codes.not_found
         result = result_raw.json()
         assert result["error_code"] == 40402
-        assert result["message"] == f"Version 2 not found."
+        assert result["message"] == "Version 2 not found."
 
         self.logger.debug("Get schema version 1 for subject key")
         result_raw = self.sr_client.get_subjects_subject_versions_version(
@@ -1762,7 +1762,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         assert result_raw.status_code == requests.codes.not_found
         result = result_raw.json()
         assert result["error_code"] == 40403
-        assert result["message"] == f"Schema not found"
+        assert result["message"] == "Schema not found"
 
         self.logger.info("Soft deleting the schema")
         result_raw = self.sr_client.delete_subject_version(
@@ -1813,7 +1813,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         assert result_raw.status_code == requests.codes.not_found
         result = result_raw.json()
         assert result["error_code"] == 40403
-        assert result["message"] == f"Schema not found"
+        assert result["message"] == "Schema not found"
 
     @cluster(num_nodes=3)
     def test_config(self):
@@ -1841,7 +1841,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         assert result_raw.json()["error_code"] == 40408
         assert (
             result_raw.json()["message"]
-            == f"Subject 'invalid_subject' does not have subject-level compatibility configured"
+            == "Subject 'invalid_subject' does not have subject-level compatibility configured"
         )
 
         schema_1_data = json.dumps({"schema": schema1_def})
@@ -1935,14 +1935,14 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         )
 
         self.logger.debug("DELETE on non-existant subject should 404")
-        result_raw = self.sr_client.delete_config_subject(subject=f"foo-key")
+        result_raw = self.sr_client.delete_config_subject(subject="foo-key")
         assert result_raw.status_code == requests.codes.not_found, (
             result_raw.status_code
         )
         assert result_raw.json()["error_code"] == 40401, (
             f"Wrong err code: {result_raw.json()}"
         )
-        assert result_raw.json()["message"] == f"Subject 'foo-key' not found.", (
+        assert result_raw.json()["message"] == "Subject 'foo-key' not found.", (
             f"{json.dumps(result_raw.json(), indent=1)}"
         )
 
@@ -1961,7 +1961,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             {"schema": dataset.schema_base, "schemaType": str(dataset.type)}
         )
 
-        self.logger.debug(f"Register a schema against a subject - not normalized")
+        self.logger.debug("Register a schema against a subject - not normalized")
         result_raw = self.sr_client.post_subjects_subject_versions(
             subject=f"{canonical_topic}-key", data=base_schema, normalize=False
         )
@@ -1972,7 +1972,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         )
         v1_id = result_raw.json()["id"]
 
-        self.logger.debug(f"Checking that the returned schema is canonical")
+        self.logger.debug("Checking that the returned schema is canonical")
         result_raw = self.sr_client.get_schemas_ids_id(id=v1_id)
         self.logger.debug(result_raw)
         self.logger.debug(result_raw.content)
@@ -1983,7 +1983,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             f"expected:\n{dataset.schema_canonical}\ngot:\n{result_raw.json()['schema']}"
         )
 
-        self.logger.debug(f"Register a schema against a subject - normalized")
+        self.logger.debug("Register a schema against a subject - normalized")
         result_raw = self.sr_client.post_subjects_subject_versions(
             subject=f"{normalize_topic}-key", data=base_schema, normalize=True
         )
@@ -1994,7 +1994,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         )
         v1_id = result_raw.json()["id"]
 
-        self.logger.debug(f"Checking that the returned schema is normalized")
+        self.logger.debug("Checking that the returned schema is normalized")
         result_raw = self.sr_client.get_schemas_ids_id(id=v1_id)
         self.logger.debug(result_raw)
         self.logger.debug(result_raw.content)
@@ -2017,7 +2017,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
 
         topic = create_topic_names(1)[0]
 
-        self.logger.debug(f"Register a schema against a subject")
+        self.logger.debug("Register a schema against a subject")
         schema_1_data = json.dumps(
             {"schema": dataset.schema_base, "schemaType": str(dataset.type)}
         )
@@ -2181,10 +2181,10 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
 
         messages = result_raw.json().get("messages", [])
         assert not any(schema1_def in m for m in messages), (
-            f"Expected schema 3 to be compared against schema 2 only (not schema 1)"
+            "Expected schema 3 to be compared against schema 2 only (not schema 1)"
         )
         assert any(schema2_def in m for m in messages), (
-            f"Expected schema 3 to be compared against schema 2 only (not schema 1)"
+            "Expected schema 3 to be compared against schema 2 only (not schema 1)"
         )
 
     @cluster(num_nodes=3)
@@ -2199,7 +2199,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
 
         topic = create_topic_names(1)[0]
 
-        self.logger.debug(f"Register a schema against a subject")
+        self.logger.debug("Register a schema against a subject")
         schema_data = json.dumps(
             {
                 "schema": validation_schemas[schemas[0]],
@@ -2264,7 +2264,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
 
         topic = create_topic_names(1)[0]
 
-        self.logger.debug(f"Register a schema against a subject")
+        self.logger.debug("Register a schema against a subject")
         schema_1_data = json.dumps({"schema": schema1_def})
         schema_2_data = json.dumps({"schema": schema2_def})
         schema_3_data = json.dumps({"schema": schema3_def})
@@ -2346,7 +2346,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
 
         topic = create_topic_names(1)[0]
 
-        self.logger.debug(f"Register a schema against a subject")
+        self.logger.debug("Register a schema against a subject")
         schema_1_data = json.dumps({"schema": schema1_def})
         schema_2_data = json.dumps({"schema": schema2_def})
         schema_3_data = json.dumps({"schema": schema3_def})
@@ -2604,14 +2604,14 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         assert result_raw.json()["id"] == 2
 
         result_raw = self.sr_client.request(
-            "GET", f"subjects/simple/versions/1/schema", headers=HTTP_GET_HEADERS
+            "GET", "subjects/simple/versions/1/schema", headers=HTTP_GET_HEADERS
         )
         self.logger.info(result_raw)
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.text.strip() == simple_proto_def.strip()
 
         result_raw = self.sr_client.request(
-            "GET", f"schemas/ids/1", headers=HTTP_GET_HEADERS
+            "GET", "schemas/ids/1", headers=HTTP_GET_HEADERS
         )
         self.logger.info(result_raw)
         assert result_raw.status_code == requests.codes.ok
@@ -2659,14 +2659,14 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         assert result_raw.json()["id"] == 1
 
         result_raw = self.sr_client.request(
-            "GET", f"subjects/simple/versions/1/schema", headers=HTTP_GET_HEADERS
+            "GET", "subjects/simple/versions/1/schema", headers=HTTP_GET_HEADERS
         )
         self.logger.info(result_raw)
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.text.strip() == json_number_schema_def.strip()
 
         result_raw = self.sr_client.request(
-            "GET", f"schemas/ids/1", headers=HTTP_GET_HEADERS
+            "GET", "schemas/ids/1", headers=HTTP_GET_HEADERS
         )
         self.logger.info(result_raw)
         assert result_raw.status_code == requests.codes.ok
@@ -3789,7 +3789,7 @@ class SchemaRegistryModeMutableTest(SchemaRegistryEndpoints):
             result_raw = self.sr_client.post_subjects_subject(subject=sub, data=schema2)
             assert result_raw.status_code == 404
             assert result_raw.json()["error_code"] == 40403
-            assert result_raw.json()["message"] == f"Schema not found"
+            assert result_raw.json()["message"] == "Schema not found"
 
         self.logger.info("Posting schema 2 as ro_subject key")
         result_raw = self.sr_client.post_subjects_subject_versions(
@@ -3975,7 +3975,7 @@ class SchemaRegistryModeMutableTest(SchemaRegistryEndpoints):
             self.assert_equal(result_raw.status_code, 200)
             self.assert_equal(result_raw.json()["mode"], "IMPORT")
         else:
-            self.logger.debug(f"Enable IMPORT mode globally")
+            self.logger.debug("Enable IMPORT mode globally")
             result_raw = self.sr_client.set_mode(data=json.dumps({"mode": "IMPORT"}))
             self.assert_equal(result_raw.status_code, 200)
             self.assert_equal(result_raw.json()["mode"], "IMPORT")
@@ -4063,7 +4063,7 @@ class SchemaRegistryModeMutableTest(SchemaRegistryEndpoints):
     def test_schema_id_smaller_than_one(self):
         sub = "test-subject-1"
 
-        self.logger.debug(f"Enable IMPORT mode to allow posting with specific ids")
+        self.logger.debug("Enable IMPORT mode to allow posting with specific ids")
         result_raw = self.sr_client.set_mode(data=json.dumps({"mode": "IMPORT"}))
         self.assert_equal(result_raw.status_code, 200)
         self.assert_equal(result_raw.json()["mode"], "IMPORT")
@@ -4100,7 +4100,7 @@ class SchemaRegistryModeMutableTest(SchemaRegistryEndpoints):
     def test_schema_id_exhausted(self):
         sub = "test-subject-1"
 
-        self.logger.debug(f"Enable IMPORT mode to allow posting specific versions")
+        self.logger.debug("Enable IMPORT mode to allow posting specific versions")
         result_raw = self.sr_client.set_mode(data=json.dumps({"mode": "IMPORT"}))
         self.assert_equal(result_raw.status_code, 200)
         self.assert_equal(result_raw.json()["mode"], "IMPORT")
@@ -4242,9 +4242,7 @@ class SchemaRegistryModeMutableTest(SchemaRegistryEndpoints):
             test_schemas_ids_id_subjects(id, expected_successful=True)
 
         # Test /subjects
-        result_raw = self.sr_client.request(
-            "GET", f"subjects", headers=HTTP_GET_HEADERS
-        )
+        result_raw = self.sr_client.request("GET", "subjects", headers=HTTP_GET_HEADERS)
         assert_request_code(result_raw, requests.codes.ok, "GET subjects")
 
         # All subjects should be present, regardless if their schemas are valid or not
@@ -4718,7 +4716,7 @@ class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
         result_raw = self.sr_client.get_schemas_types(auth=self.public_auth)
         assert result_raw.json()["error_code"] == 40101
 
-        self.logger.debug(f"Request schema types with default accept header")
+        self.logger.debug("Request schema types with default accept header")
         result_raw = self.sr_client.get_schemas_types(auth=self.super_auth)
         assert result_raw.status_code == requests.codes.ok
         result = result_raw.json()
@@ -5068,7 +5066,7 @@ class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
 
         topic = create_topic_names(1)[0]
 
-        self.logger.debug(f"Register a schema against a subject")
+        self.logger.debug("Register a schema against a subject")
         schema_1_data = json.dumps({"schema": schema1_def})
 
         self.logger.debug("Posting schema 1 as a subject key")
@@ -5107,7 +5105,7 @@ class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
 
         topic = create_topic_names(1)[0]
 
-        self.logger.debug(f"Register a schema against a subject")
+        self.logger.debug("Register a schema against a subject")
         schema_1_data = json.dumps({"schema": schema1_def})
 
         self.logger.debug("Posting schema 1 as a subject key")
@@ -5150,7 +5148,7 @@ class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
 
         topic = create_topic_names(1)[0]
 
-        self.logger.debug(f"Register a schema against a subject")
+        self.logger.debug("Register a schema against a subject")
         schema_1_data = json.dumps({"schema": schema1_def})
 
         self.logger.debug("Posting schema 1 as a subject key")
@@ -5241,7 +5239,7 @@ class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
 
         result_raw = self.sr_client.request(
             "GET",
-            f"subjects/simple/versions/1/schema",
+            "subjects/simple/versions/1/schema",
             headers=HTTP_GET_HEADERS,
             auth=self.super_auth,
         )
@@ -5250,7 +5248,7 @@ class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
         assert result_raw.text.strip() == simple_proto_def.strip()
 
         result_raw = self.sr_client.request(
-            "GET", f"schemas/ids/1", headers=HTTP_GET_HEADERS, auth=self.super_auth
+            "GET", "schemas/ids/1", headers=HTTP_GET_HEADERS, auth=self.super_auth
         )
         self.logger.info(result_raw)
         assert result_raw.status_code == requests.codes.ok
@@ -5274,7 +5272,7 @@ class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
     @cluster(num_nodes=3)
     def test_delete_subject_bug(self):
         topic = "foo"
-        self.logger.debug(f"Register a schema against a subject")
+        self.logger.debug("Register a schema against a subject")
         schema_1_data = json.dumps({"schema": schema1_def})
 
         self.logger.debug("Posting schema 1 as a subject key")
@@ -5284,7 +5282,7 @@ class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
         self.logger.debug(result_raw)
         assert result_raw.status_code == requests.codes.ok
 
-        self.logger.debug(f"Register a schema against a subject")
+        self.logger.debug("Register a schema against a subject")
         schema_2_data = json.dumps({"schema": schema2_def})
 
         self.logger.debug("Posting schema 2 as a subject key")
@@ -5358,7 +5356,7 @@ class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
         )
         assert result_raw.status_code == requests.codes.ok
 
-        self.logger.debug(f"Register a schema against a subject")
+        self.logger.debug("Register a schema against a subject")
         schema_1_data = json.dumps({"schema": schema1_def})
         schema_3_data = json.dumps({"schema": schema3_def})
 
@@ -7348,7 +7346,7 @@ class GetSchemasTypes(ACLTestEndpoint):
 
     @property
     def path(self) -> str:
-        return f"schemas/types"
+        return "schemas/types"
 
     def setup(self) -> None:
         pass
@@ -7368,7 +7366,7 @@ class GetStatusReady(ACLTestEndpoint):
 
     @property
     def path(self) -> str:
-        return f"status/ready"
+        return "status/ready"
 
     def setup(self) -> None:
         pass

--- a/tests/rptest/tests/scram_test.py
+++ b/tests/rptest/tests/scram_test.py
@@ -912,7 +912,7 @@ class InvalidNewUserStrings(BaseScramTest):
             username=username,
             algorithm="SCRAM-SHA-256",
             expected_status_code=400,
-            err_msg=f"Parameter 'username' contained invalid control characters",
+            err_msg="Parameter 'username' contained invalid control characters",
         )
 
         # Two ordinals (corresponding to ',' and '=') are explicitly excluded from SASL usernames
@@ -936,7 +936,7 @@ class InvalidNewUserStrings(BaseScramTest):
             username="test",
             algorithm=algorithm,
             expected_status_code=400,
-            err_msg=f"Parameter 'algorithm' contained invalid control characters",
+            err_msg="Parameter 'algorithm' contained invalid control characters",
         )
 
     @cluster(num_nodes=3)

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -311,7 +311,7 @@ class BucketScrubSelfTest(RedpandaTest):
         )
 
         # Initially a bucket scrub should pass
-        self.logger.info(f"Running baseline scrub")
+        self.logger.info("Running baseline scrub")
         self.redpanda.stop_and_scrub_object_storage()
         self.redpanda.for_nodes(
             self.redpanda.nodes,
@@ -340,7 +340,7 @@ class BucketScrubSelfTest(RedpandaTest):
             validate=True,
         )
 
-        self.logger.info(f"Running scrub that should discover issue")
+        self.logger.info("Running scrub that should discover issue")
         with expect_exception(RuntimeError, lambda e: "fatal" in str(e)):
             self.redpanda.stop_and_scrub_object_storage()
 

--- a/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
+++ b/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
@@ -161,7 +161,7 @@ class ShadowIndexingCompactedTopicTest(EndToEndTest):
             compacted_segments_uploaded,
             timeout_sec=180,
             backoff_sec=2,
-            err_msg=lambda: f"Compacted segments not uploaded",
+            err_msg=lambda: "Compacted segments not uploaded",
         )
 
         # check that the metric is increasing. the check needs to account for leadership changes (unlikely in this test),
@@ -330,7 +330,7 @@ class TSWithAlreadyCompactedTopic(EndToEndTest):
             compacted,
             timeout_sec=120,
             backoff_sec=2,
-            err_msg=f"Segments were not compacted well enough",
+            err_msg="Segments were not compacted well enough",
         )
 
         # enable TS for the topic

--- a/tests/rptest/tests/shard_placement_test.py
+++ b/tests/rptest/tests/shard_placement_test.py
@@ -321,7 +321,7 @@ class ShardPlacementTest(PreallocNodesTest):
         rpk.create_topic("quux", partitions=n_partitions, replicas=3)
 
         # check that shard counts are balanced
-        self.logger.info(f"added 2 nodes and a topic, checking shard map...")
+        self.logger.info("added 2 nodes and a topic, checking shard map...")
         map_after_join = self.wait_shard_map_stationary(joiner_nodes, admin)
         self.print_shard_stats(map_after_join)
         for joiner in joiner_nodes:

--- a/tests/rptest/tests/tiered_storage_model_test.py
+++ b/tests/rptest/tests/tiered_storage_model_test.py
@@ -131,7 +131,7 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
         # this code assumes that all offsets will be available
         # but this is not the case if retention or compaction (or both) is enabled
         if not fake_ts:
-            self.logger.info(f"Timequery check is disabled")
+            self.logger.info("Timequery check is disabled")
             return
         fake_ts_step = self.producer_config.get("fake_timestamp_step_ms", 1000)
         num_messages = self.producer_config.get("msg_count", 10000)

--- a/tests/rptest/tests/tls_metrics_test.py
+++ b/tests/rptest/tests/tls_metrics_test.py
@@ -162,7 +162,7 @@ class TLSMetricsTestBase(RedpandaTest):
                 timeout_sec=2,
                 backoff_sec=0.1,
             )
-        except TimeoutError as e:
+        except TimeoutError:
             return None
 
     def _unpack_samples(self, metric_samples):
@@ -346,7 +346,7 @@ class TLSMetricsTest(TLSMetricsTestBase):
 
         reloaded = check_crc()
 
-        assert original != reloaded, f"Checksums unexpectedly equal"
+        assert original != reloaded, "Checksums unexpectedly equal"
 
 
 class TLSMetricsTestChain(TLSMetricsTestBase):

--- a/tests/rptest/tests/workload_dummy.py
+++ b/tests/rptest/tests/workload_dummy.py
@@ -23,11 +23,11 @@ class DummyWorkload(PWorkload):
         self.ctx = ctx
 
     def get_earliest_applicable_release(self):
-        self.ctx.logger.info(f"returning None")
+        self.ctx.logger.info("returning None")
         return super().get_earliest_applicable_release()
 
     def get_latest_applicable_release(self):
-        self.ctx.logger.info(f"returning HEAD")
+        self.ctx.logger.info("returning HEAD")
         return super().get_latest_applicable_release()
 
     def begin(self):

--- a/tests/rptest/transactions/consumer_offsets_test.py
+++ b/tests/rptest/transactions/consumer_offsets_test.py
@@ -85,7 +85,7 @@ class VerifyConsumerOffsetsThruUpgrades(RedpandaTest):
             consumer_offsets_is_compactible,
             timeout_sec=30,
             backoff_sec=1,
-            err_msg=f"Timed out waiting for consumer offsets partition to be compactible",
+            err_msg="Timed out waiting for consumer offsets partition to be compactible",
         )
 
     @cluster(num_nodes=3)

--- a/tests/rptest/transactions/idempotency_test.py
+++ b/tests/rptest/transactions/idempotency_test.py
@@ -80,7 +80,7 @@ class IdempotentProducerRecoveryTest(RedpandaTest):
             do_wait,
             timeout_sec=20,
             backoff_sec=1,
-            err_msg=f"Not all producers were evicted in 20secs.",
+            err_msg="Not all producers were evicted in 20secs.",
             retry_on_exc=False,
         )
 

--- a/tests/rptest/transactions/transactions_test.py
+++ b/tests/rptest/transactions/transactions_test.py
@@ -504,7 +504,7 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
                 producer.init_transactions()
                 break
             except ck.cimpl.KafkaException as e:
-                self.redpanda.logger.debug(f"error on init_transactions", exc_info=True)
+                self.redpanda.logger.debug("error on init_transactions", exc_info=True)
                 kafka_error = e.args[0]
                 assert kafka_error.code() in [
                     ck.cimpl.KafkaError.NOT_COORDINATOR,

--- a/tests/rptest/transactions/tx_coordinator_migration_test.py
+++ b/tests/rptest/transactions/tx_coordinator_migration_test.py
@@ -111,7 +111,7 @@ class TxCoordinatorMigrationTest(RedpandaTest):
                 status = json.loads(admin.get_tx_manager_recovery_status(migrator).text)
                 self.logger.info(f"Migration status: {status}")
                 return status["required"] == False and status["in_progress"] == False
-            except Exception as e:
+            except Exception:
                 return False
 
         admin = Admin(self.redpanda, retries_amount=0)
@@ -258,7 +258,7 @@ class TxCoordinatorMigrationTest(RedpandaTest):
             used_partitions.add(p)
 
         assert len(new_mapping) == len(initial_mapping), (
-            f"All tx ids should be present after repartitioning"
+            "All tx ids should be present after repartitioning"
         )
 
         assert len(used_partitions) > self.initial_tx_manager_partitions

--- a/tests/rptest/transactions/verifiers/compacted_verifier.py
+++ b/tests/rptest/transactions/verifiers/compacted_verifier.py
@@ -112,7 +112,7 @@ class CompactedVerifier(Service):
 
     def start_node(self, node, timeout_sec=10):
         node.account.ssh(
-            f'bash /opt/remote/control/start.sh rw "java -cp /opt/verifiers/verifiers.jar io.vectorized.compaction.App"'
+            'bash /opt/remote/control/start.sh rw "java -cp /opt/verifiers/verifiers.jar io.vectorized.compaction.App"'
         )
         wait_until(
             lambda: self.is_alive(node),

--- a/tests/rptest/transactions/verifiers/consumer_offsets_verifier.py
+++ b/tests/rptest/transactions/verifiers/consumer_offsets_verifier.py
@@ -219,5 +219,5 @@ class ConsumerOffsetsVerifier:
             offsets_are_consistent,
             timeout_sec=30,
             backoff_sec=1,
-            err_msg=f"Timed out waiting group offsets to be consistent.",
+            err_msg="Timed out waiting group offsets to be consistent.",
         )

--- a/tests/rptest/transactions/verifiers/idempotency_load_generator.py
+++ b/tests/rptest/transactions/verifiers/idempotency_load_generator.py
@@ -55,7 +55,7 @@ class PausableIdempotentProducer(Service):
 
     def start_node(self, node, timeout_sec=10):
         node.account.ssh(
-            f'bash /opt/remote/control/start.sh pausable_idempotent_producer "java -cp /opt/verifiers/verifiers.jar io.vectorized.idempotency.App"'
+            'bash /opt/remote/control/start.sh pausable_idempotent_producer "java -cp /opt/verifiers/verifiers.jar io.vectorized.idempotency.App"'
         )
         wait_until(
             lambda: self.is_alive(node),

--- a/tests/rptest/utils/cluster_topology.py
+++ b/tests/rptest/utils/cluster_topology.py
@@ -79,7 +79,7 @@ class NodeQdisc:
                 "22",
                 "0xffff",
                 "flowid",
-                f"1:1",
+                "1:1",
             ]
         )
 
@@ -102,7 +102,7 @@ class NodeQdisc:
                 "22",
                 "0xffff",
                 "flowid",
-                f"1:1",
+                "1:1",
             ]
         )
 
@@ -314,7 +314,7 @@ class ClusterTopology:
         return []
 
     def _ip_address(self, node):
-        res = node.account.ssh_output(f"hostname -i")
+        res = node.account.ssh_output("hostname -i")
         return res.strip().decode("utf-8")
 
     def add_connection_spec(self, spec: TopologyConnectionSpec):

--- a/tests/rptest/utils/data_migrations.py
+++ b/tests/rptest/utils/data_migrations.py
@@ -83,7 +83,7 @@ class DataMigrationTestMixin(RedpandaTest):
             lambda: all(client.describe_topic(t).partitions == [] for t in topics),
             timeout_sec=90,
             backoff_sec=1,
-            err_msg=f"Failed waiting for partitions to disappear",
+            err_msg="Failed waiting for partitions to disappear",
         )
 
     def get_migration(self, id, node=None, redpanda: RedpandaService | None = None):

--- a/tests/rptest/utils/full_disk.py
+++ b/tests/rptest/utils/full_disk.py
@@ -41,7 +41,7 @@ class FullDiskHelper:
         self.redpanda.set_cluster_config(updates)
 
         # self.admin.patch_cluster_config(upsert=updates, remove=[])
-        self.logger.debug(f"Confirming new config values..")
+        self.logger.debug("Confirming new config values..")
         self._wait_for_node_config_value(self.CONF_MIN_FREE_BYTES, new_threshold)
 
     def trigger_low_space(self, node=None):

--- a/tests/rptest/utils/mode_checks.py
+++ b/tests/rptest/utils/mode_checks.py
@@ -31,7 +31,7 @@ def cleanup_on_early_exit(caller: Any):
         )
         hook()
 
-    caller.logger.debug(f"Cleaning up unused nodes.")
+    caller.logger.debug("Cleaning up unused nodes.")
 
     if test_context := getattr(caller, "test_context", None):
         test_context = rcast(TestContext, test_context)

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -571,7 +571,7 @@ def get_on_disk_size_per_ntp(chk):
             size = summary[1]
             tmp_size[ntp] += size
         for ntp, size in tmp_size.items():
-            if not ntp in size_bytes_per_ntp or size_bytes_per_ntp[ntp] < size:
+            if ntp not in size_bytes_per_ntp or size_bytes_per_ntp[ntp] < size:
                 size_bytes_per_ntp[ntp] = size
     return size_bytes_per_ntp
 
@@ -604,7 +604,7 @@ def get_expected_ntp_restored_size(
             tmp_partition_size[ntp] += size
             tmp_segments_sizes[ntp][segment.base_offset] = size
         for ntp, size in tmp_partition_size.items():
-            if not ntp in size_bytes_per_ntp or size_bytes_per_ntp[ntp] < size:
+            if ntp not in size_bytes_per_ntp or size_bytes_per_ntp[ntp] < size:
                 size_bytes_per_ntp[ntp] = size
                 segments_sizes_per_ntp[ntp] = tmp_segments_sizes[ntp]
         expected_restored_sizes = {}
@@ -1720,7 +1720,7 @@ class BucketView:
     def assert_segments_replaced(self, topic: str, partition: int):
         manifest_data = self.manifest_for_ntp(topic, partition)
         assert len(manifest_data.get("replaced", [])) > 0, (
-            f"No replaced segments after compacted segments uploaded"
+            "No replaced segments after compacted segments uploaded"
         )
 
     def assert_segments_deleted(self, topic: str, partition: int):

--- a/tests/typings/ducktape/mark/_mark.pyi
+++ b/tests/typings/ducktape/mark/_mark.pyi
@@ -1,6 +1,5 @@
 from typing import Any, Callable, ParamSpec, TypeVar
 from ducktape.errors import DucktapeError as DucktapeError
-from typing import Callable, TypeVar
 
 from rptest.services.cluster import Any
 

--- a/tools/type-checking/type-check-strictness.json
+++ b/tools/type-checking/type-check-strictness.json
@@ -26,7 +26,6 @@
         "rptest/redpanda_cloud_tests/cloudv2_object_store_blocked.py",
         "rptest/redpanda_cloud_tests/config_profile_verify_test.py",
         "rptest/redpanda_cloud_tests/observe_test.py",
-        "rptest/redpanda_cloud_tests/omb_validation_test.py",
         "rptest/remote_scripts/aws_iam_role_mock.py",
         "rptest/remote_scripts/compute_storage.py",
         "rptest/remote_scripts/schema_registry_test_helper.py",


### PR DESCRIPTION
This is just the result of `ruff check --fix tests`, which applies all safe fixes for ruff check issues. This fixes the issues in the following list with asterisks:

```
count   code    what
286     F541    [*] f-string-missing-placeholders
141     E712    [ ] true-false-comparison
 81     F841    [*] unused-variable
 72     E722    [ ] bare-except
 65     E711    [ ] none-comparison
 19     F811    [ ] redefined-while-unused
 17     E731    [ ] lambda-assignment
 12     F401    [*] unused-import
 10     E713    [*] not-in-test
 10     E721    [ ] type-comparison
  3     E402    [ ] module-import-not-at-top-of-file
  3     F821    [ ] undefined-name
  2     E714    [*] not-is-test
  1     F521    [ ] string-dot-format-invalid-format
```

This is a precursor to enabling ruff check as a pre-commit hook/and or CI check.

I did not exhaustively check all the changes, but I spot checked a bunch of them and they do what they say on the tin.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
