### PR TITLE
treewide: remove bare excepts (E722)

### DIFF
--- a/tests/rp_cloud_cleanup.py
+++ b/tests/rp_cloud_cleanup.py
@@ -456,7 +456,7 @@ class CloudCleanup:
                 r = self.provider.get_vpc_by_id(vpc["VpcId"])
                 if r["State"] == "deleted":
                     break
-            except:
+            except Exception:
                 break
             time.sleep(10)
         elapsed = time.time() - start

--- a/tests/rptest/archival/s3_client.py
+++ b/tests/rptest/archival/s3_client.py
@@ -287,7 +287,7 @@ class S3Client:
                                 Bucket=name,
                                 Delete={"Objects": [{"Key": k} for k in key_list]},
                             )
-                    except:
+                    except Exception:
                         self.logger.exception(
                             f"empty_bucket: delete request failed for keys {key_list[0]}..{key_list[-1]}"
                         )

--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -534,7 +534,7 @@ class KubeNodeShell:
         try:
             _out = self.kubectl.cmd(f"get pods -A | grep {self.pod_name}")
             return len(_out) > 0
-        except:
+        except Exception:
             # Above command fails only when pod is not found
             return False
 

--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -389,7 +389,7 @@ class OMBValidationTest(RedpandaCloudTest):
         swarm_topic_name = "swarm_topic"
         try:
             self.rpk.delete_topic(swarm_topic_name)
-        except:
+        except Exception:
             # Ignore the exception that is thrown if the topic doesn't exist.
             pass
 

--- a/tests/rptest/remote_scripts/compute_storage.py
+++ b/tests/rptest/remote_scripts/compute_storage.py
@@ -257,7 +257,7 @@ def read_compaction_footer(file_path):
         )
         res["crc"] = unpacked_footer[3]
         res["version"] = unpacked_footer[4]
-    except:
+    except Exception:
         footer_v2 = footer[:]
         unpacked_footer = struct.unpack(FOOTER_V2, footer_v2)
         res["size"] = unpacked_footer[0]

--- a/tests/rptest/scale_tests/many_topics_test.py
+++ b/tests/rptest/scale_tests/many_topics_test.py
@@ -1519,7 +1519,7 @@ class ManyTopicsTest(RedpandaTest):
             try:
                 self.redpanda.validate_controller_log()
                 return True
-            except:
+            except Exception:
                 return False
 
         # If the test exits right after this the controll log size  on disk

--- a/tests/rptest/services/chaos/workloads/list_offsets/stat.py
+++ b/tests/rptest/services/chaos/workloads/list_offsets/stat.py
@@ -327,7 +327,7 @@ def render_overview(title, workload_dir, stat):
                 "max/s": max_throughput,
             },
         }
-    except:
+    except Exception:
         e, v = sys.exc_info()[:2]
         trace = traceback.format_exc()
         logger.debug(v)
@@ -359,7 +359,7 @@ def render_availability(title, workload_dir, stat):
             gnuplot_file.write(jinja2.Template(AVAILABILITY).render(title=title))
 
         gnuplot(availability_gnuplot_path, _cwd=workload_dir)
-    except:
+    except Exception:
         e, v = sys.exc_info()[:2]
         trace = traceback.format_exc()
         logger.debug(v)
@@ -394,7 +394,7 @@ def render_percentiles(title, workload_dir, stat):
             )
 
         gnuplot(percentiles_gnuplot_path, _cwd=workload_dir)
-    except:
+    except Exception:
         e, v = sys.exc_info()[:2]
         trace = traceback.format_exc()
         logger.debug(v)

--- a/tests/rptest/services/chaos/workloads/retryable_consumer.py
+++ b/tests/rptest/services/chaos/workloads/retryable_consumer.py
@@ -45,7 +45,7 @@ class RetryableConsumer:
             if self.consumer != None:
                 try:
                     self.consumer.close()
-                except:
+                except Exception:
                     pass
             self.logger.debug(f"Attempting to init a consumer using {self.brokers}")
             self.consumer = Consumer(config)

--- a/tests/rptest/services/chaos/workloads/service_base.py
+++ b/tests/rptest/services/chaos/workloads/service_base.py
@@ -271,7 +271,7 @@ class WorkloadServiceBase(ABC, Service):
 
         try:
             stats = self.collect_stats()
-        except:
+        except Exception:
             self.logger.warn(
                 f"{self.who_am_i()}: failed to collect workload stats", exc_info=True
             )

--- a/tests/rptest/services/chaos/workloads/tx_subscribe/consistency.py
+++ b/tests/rptest/services/chaos/workloads/tx_subscribe/consistency.py
@@ -128,7 +128,7 @@ class LogPlayer:
                     int(parts[6]),
                     int(parts[7]),
                 )
-            except:
+            except Exception:
                 self.has_violation = True
                 e, v = sys.exc_info()[:2]
                 trace = traceback.format_exc()

--- a/tests/rptest/services/chaos/workloads/tx_subscribe/stat.py
+++ b/tests/rptest/services/chaos/workloads/tx_subscribe/stat.py
@@ -126,7 +126,7 @@ set parametric
 
 plot 'throughput.log' using ($1/1000):2 title "throughput - all (per 1s)" with line lt rgb "black"{% for throughput in throughput_plots %},\\
      '{{throughput.file}}' using ($1/1000):2 title "{{throughput.title}}" with line lt rgb "{{throughput.color}}"{% endfor %}
-     
+
 
 unset multiplot
 """
@@ -447,7 +447,7 @@ def render_overview(title, workload_dir, stat, source_partitions):
             },
         }
 
-    except:
+    except Exception:
         e, v = sys.exc_info()[:2]
         trace = traceback.format_exc()
         logger.debug(v)
@@ -482,7 +482,7 @@ def render_availability(title, workload_dir, stat):
             gnuplot_file.write(jinja2.Template(AVAILABILITY).render(title=title))
 
         gnuplot(availability_gnuplot_path, _cwd=workload_dir)
-    except:
+    except Exception:
         e, v = sys.exc_info()[:2]
         trace = traceback.format_exc()
         logger.debug(v)
@@ -517,7 +517,7 @@ def render_percentiles(title, workload_dir, stat):
             )
 
         gnuplot(percentiles_gnuplot_path, _cwd=workload_dir)
-    except:
+    except Exception:
         e, v = sys.exc_info()[:2]
         trace = traceback.format_exc()
         logger.debug(v)

--- a/tests/rptest/services/client_swarm_base.py
+++ b/tests/rptest/services/client_swarm_base.py
@@ -102,7 +102,7 @@ class ClientSwarmBase(Service, ABC):
         try:
             self._get(node, path)
             return True
-        except:
+        except Exception:
             return False
 
     def is_alive(self) -> bool:

--- a/tests/rptest/services/kaf_consumer.py
+++ b/tests/rptest/services/kaf_consumer.py
@@ -58,7 +58,7 @@ class KafConsumer(BackgroundThreadService):
                     offset = int(m.group("offset"))
                     self.offset[partition] = offset
                     partition = None
-        except:
+        except Exception:
             if self._stopping.is_set():
                 # Expect a non-zero exit code when killing during teardown
                 pass

--- a/tests/rptest/services/kafka_cli_consumer.py
+++ b/tests/rptest/services/kafka_cli_consumer.py
@@ -92,7 +92,7 @@ class KafkaCliConsumer(BackgroundThreadService):
                     with self._lock:
                         self._message_cnt += 1
                         self._last_consumed = time.time()
-        except:
+        except Exception:
             if self._stopping.is_set():
                 # Expect a non-zero exit code when killing during teardown
                 pass
@@ -127,7 +127,7 @@ class KafkaCliConsumer(BackgroundThreadService):
 
         try:
             wait_until(lambda: self._done is None or self._done == True, timeout_sec=10)
-        except:
+        except Exception:
             self.logger.warn(
                 f"{self._instance_name} running on {node.name} failed to stop gracefully"
             )

--- a/tests/rptest/services/kcat_consumer.py
+++ b/tests/rptest/services/kcat_consumer.py
@@ -224,7 +224,7 @@ class KcatConsumer(BackgroundThreadService):
                 finally:
                     stderr_reader.join()
 
-        except:
+        except Exception:
             if self._stopping.is_set():
                 # Expect a non-zero exit code when killing during teardown
                 pass

--- a/tests/rptest/services/keycloak.py
+++ b/tests/rptest/services/keycloak.py
@@ -71,7 +71,7 @@ class KeycloakConfigWriter:
     def write(self, node):
         try:
             node.account.mkdirs(self._dest_dir)
-        except:
+        except Exception:
             pass
         dest_f = os.path.join(self._dest_dir, KC_CFG)
         with tempfile.NamedTemporaryFile(mode="w") as f:

--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -224,7 +224,7 @@ class KgoRepeaterService(Service):
                     r = requests.get(self._remote_url(node, "status"), timeout=10)
                     self.logger.debug(f"kgo-repeater status on node {node.name}:")
                     self.logger.debug(json.dumps(r.json(), indent=2))
-                except:
+                except Exception:
                     self.logger.exception(
                         f"Error getting pre-stop status on {node.name}"
                     )
@@ -331,7 +331,7 @@ class KgoRepeaterService(Service):
             self.redpanda.wait_until(
                 group_ready, timeout_sec=120, backoff_sec=10, err_msg=what
             )
-        except:
+        except Exception:
             # On failure, dump stacks on all workers in case there is an apparent client bug to investigate
             for node in self.nodes:
                 try:

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3407,7 +3407,7 @@ class RedpandaService(Service, RedpandaServiceABC):
         cur_ver: RedpandaVersionTriple | None = None
         try:
             cur_ver = self.get_version_int_tuple(node)
-        except:  # noqa
+        except Exception:  # noqa
             pass
 
         cmd = (
@@ -4186,7 +4186,7 @@ class RedpandaService(Service, RedpandaServiceABC):
 
         try:
             self._cloud_storage_diagnostics()
-        except:
+        except Exception:
             # We are running during test teardown, so do log the exception
             # instead of propagating: this was a best effort thing
             self.logger.exception("Failed to gather cloud storage diagnostics")

--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -179,7 +179,7 @@ class RedpandaInstaller:
             try:
                 for line in ssh_out_per_node[node]:
                     captured_output.append(line)
-            except:
+            except Exception:
                 logger.error(f"Command failed: {captured_output}")
                 raise
 
@@ -383,7 +383,7 @@ class RedpandaInstaller:
                 releases_resp.raise_for_status()
                 try:
                     releases_json = releases_resp.json()
-                except:
+                except Exception:
                     self._redpanda.logger.error(releases_resp.text)
                     raise
 

--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -286,7 +286,7 @@ class CloudRetentionTest(PreallocNodesTest):
             for partition in range(0, num_partitions):
                 try:
                     manifest = s3_snapshot.manifest_for_ntp(self.topic_name, partition)
-                except:
+                except Exception:
                     self.logger.info(f"Partition {partition} has no uploaded manifest")
                     return False
 

--- a/tests/rptest/tests/cluster_bootstrap_test.py
+++ b/tests/rptest/tests/cluster_bootstrap_test.py
@@ -160,7 +160,7 @@ class ClusterBootstrapFiveNodes(RedpandaTest):
                     topic = TopicSpec(partition_count=1, replication_factor=3)
                     rpk.create_topic(topic.name, partitions=1, replicas=3)
                     rpk.group_describe("test_group")
-                except:
+                except Exception:
                     pass
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:

--- a/tests/rptest/tests/compatibility/java_compression_test.py
+++ b/tests/rptest/tests/compatibility/java_compression_test.py
@@ -219,7 +219,7 @@ class JavaCompressionTest(EndToEndTest):
             try:
                 self.consume()
                 return True
-            except:
+            except Exception:
                 return False
 
         wait_until(

--- a/tests/rptest/tests/connection_rate_limit_test.py
+++ b/tests/rptest/tests/connection_rate_limit_test.py
@@ -60,7 +60,7 @@ class ConnectionRateLimitTest(PreallocNodesTest):
     def stop_consumer(self, consumer):
         try:
             consumer.stop()
-        except:
+        except Exception:
             # Should ignore exception form kaf_consumer
             pass
         consumer.free()

--- a/tests/rptest/tests/cpu_stress_injection_test.py
+++ b/tests/rptest/tests/cpu_stress_injection_test.py
@@ -21,7 +21,7 @@ def stop_stress(admin: Admin, node: ClusterNode):
     """
     try:
         admin.stress_fiber_stop(node)
-    except:
+    except Exception:
         return False
     return True
 
@@ -51,7 +51,7 @@ class CpuStressInjectionTest(RedpandaTest):
                 min_ms_per_scheduling_point=30,
                 max_ms_per_scheduling_point=300,
             )
-        except:
+        except Exception:
             # Ignore errors, since the HTTP endpoint may be stalled behind a
             # fiber.
             pass
@@ -76,7 +76,7 @@ class CpuStressInjectionTest(RedpandaTest):
                 min_spins_per_scheduling_point=1000,
                 max_spins_per_scheduling_point=100000,
             )
-        except:
+        except Exception:
             # Ignore errors, since the HTTP endpoint may be stalled behind a
             # fiber.
             pass
@@ -104,7 +104,7 @@ class CpuStressInjectionTest(RedpandaTest):
                 max_ms_per_scheduling_point=10,
             )
             assert False, "Expected failure: require ms min < max"
-        except:
+        except Exception:
             pass
 
         try:
@@ -115,7 +115,7 @@ class CpuStressInjectionTest(RedpandaTest):
                 max_spins_per_scheduling_point=10,
             )
             assert False, "Expected failure: require spins min < max"
-        except:
+        except Exception:
             pass
 
         try:
@@ -126,7 +126,7 @@ class CpuStressInjectionTest(RedpandaTest):
                 max_ms_per_scheduling_point=1000,
             )
             assert False, "Expected failure: require both ms min/max be set"
-        except:
+        except Exception:
             pass
 
         try:
@@ -137,7 +137,7 @@ class CpuStressInjectionTest(RedpandaTest):
                 max_spins_per_scheduling_point=1000,
             )
             assert False, "Expected failure: require both spins min/max be set"
-        except:
+        except Exception:
             pass
 
         try:
@@ -150,6 +150,6 @@ class CpuStressInjectionTest(RedpandaTest):
                 max_spins_per_scheduling_point=1000,
             )
             assert False, "Expected failure: require either spins or ms set"
-        except:
+        except Exception:
             pass
         assert not self.has_started_stress()

--- a/tests/rptest/tests/crl_test.py
+++ b/tests/rptest/tests/crl_test.py
@@ -319,5 +319,5 @@ class CertificateRevocationTest(RedpandaTest):
         )
         try:
             self.rpk.list_schemas()
-        except:
+        except Exception:
             pass

--- a/tests/rptest/tests/datalake/batching_test.py
+++ b/tests/rptest/tests/datalake/batching_test.py
@@ -101,7 +101,7 @@ class DatalakeBatchingTest(RedpandaTest):
                         else file_size < batch_file_size
                     )
                     return file_count >= min_file_count and file_size_checks_out
-                except:
+                except Exception:
                     return False
 
             wait_until(

--- a/tests/rptest/tests/datalake/coordinator_retention_test.py
+++ b/tests/rptest/tests/datalake/coordinator_retention_test.py
@@ -59,7 +59,7 @@ class CoordinatorRetentionTest(RedpandaTest):
                 len(replica_last_snapshot_offsets) == 3
                 and replica_last_snapshot_offsets.count(True) == 1
             )
-        except:
+        except Exception:
             self.redpanda.logger.debug(
                 "Exception querying snapshot states", exc_info=True
             )

--- a/tests/rptest/tests/datalake/schemas/schema_generator.py
+++ b/tests/rptest/tests/datalake/schemas/schema_generator.py
@@ -141,10 +141,10 @@ class SchemaGenerator:
             if isinstance(obj, str):
                 try:
                     return int(obj)
-                except:
+                except Exception:
                     try:
                         return float(obj)
-                    except:
+                    except Exception:
                         return obj
             elif isinstance(obj, dict):
                 return {k: fix_types(v) for k, v in obj.items()}

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -1645,7 +1645,7 @@ class ShadowIndexingTrafficShapingTest(PreallocNodesTest):
             s3_service_dest = ":443"
             try:
                 s3_service_dest = socket.gethostbyname(s3_service_ep)
-            except:
+            except Exception:
                 pass
 
             self.rp_qdisc = NodeQdisc(

--- a/tests/rptest/tests/idempotency_stress_test.py
+++ b/tests/rptest/tests/idempotency_stress_test.py
@@ -162,7 +162,7 @@ class IdempotencyStressTest(PreallocNodesTest):
                         f"Producer {i} should not start as it would exceed the total number of allowed producers"
                     )
                 producers.append(producer)
-            except:
+            except Exception:
                 pass
 
         for p in producers:

--- a/tests/rptest/tests/isolated_decommissioned_node_test.py
+++ b/tests/rptest/tests/isolated_decommissioned_node_test.py
@@ -129,7 +129,7 @@ class IsolatedDecommissionedNodeTest(PreallocNodesTest):
                     namespace="kafka", topic=str(topic), partition=0
                 )
                 return True
-            except:
+            except Exception:
                 return False
 
         wait_until(

--- a/tests/rptest/tests/offset_for_leader_epoch_archival_test.py
+++ b/tests/rptest/tests/offset_for_leader_epoch_archival_test.py
@@ -76,7 +76,7 @@ class OffsetForLeaderEpochArchivalTest(RedpandaTest):
                     cfgs[TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES][0]
                 )
                 return retention == OffsetForLeaderEpochArchivalTest.local_retention
-            except:
+            except Exception:
                 return False
 
         wait_until(alter_and_verify, 15, 0.5)
@@ -217,7 +217,7 @@ class OffsetForLeaderEpochArchivalTest(RedpandaTest):
                     topic.name, "retention.local.target.bytes", 0x1000
                 )
                 return True
-            except:
+            except Exception:
                 return False
 
         wait_until(

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -338,7 +338,7 @@ class PartitionBalancerTest(PartitionBalancerService):
                 def node_removed():
                     try:
                         brokers = self.redpanda._admin.get_brokers()
-                    except:
+                    except Exception:
                         return False
                     return not any(b["node_id"] == old_node_id for b in brokers)
 

--- a/tests/rptest/tests/partition_force_reconfiguration_test.py
+++ b/tests/rptest/tests/partition_force_reconfiguration_test.py
@@ -252,7 +252,7 @@ class PartitionForceReconfigurationTest(EndToEndTest, PartitionMovementMixin):
                     )
                     > 0
                 )
-            except:
+            except Exception:
                 return False
 
         self.redpanda.wait_until(
@@ -458,7 +458,7 @@ class PartitionForceReconfigurationTest(EndToEndTest, PartitionMovementMixin):
                     if len(partitions) == 0:
                         return -1
                     return partitions[0].end_offset
-                except:
+                except Exception:
                     return -1
 
             wait_until(

--- a/tests/rptest/tests/partition_move_interruption_test.py
+++ b/tests/rptest/tests/partition_move_interruption_test.py
@@ -617,7 +617,7 @@ class PartitionMoveInterruption(PartitionMovementMixin, PreallocNodesTest):
             if should_cancel:
                 try:
                     admin.cancel_partition_move(topic, partition)
-                except:
+                except Exception:
                     pass
 
             self._throttle_recovery(10000000)

--- a/tests/rptest/tests/partition_state_api_test.py
+++ b/tests/rptest/tests/partition_state_api_test.py
@@ -227,7 +227,7 @@ class PartitionStateAPItest(RedpandaTest):
                 return self.redpanda._admin.get_offset_for_leader_epoch(
                     topic.name, 0, 1
                 )["current_leader_epoch"]
-            except:
+            except Exception:
                 self.logger.debug("Failed to get current leader epoch", exc_info=True)
                 return -1
 
@@ -242,7 +242,7 @@ class PartitionStateAPItest(RedpandaTest):
                         output["end_offset"] == expected_offset
                         and output["current_leader_epoch"] == epoch
                     )
-                except:
+                except Exception:
                     self.logger.debug(
                         f"Failed to get offset for leader epoch for node {node}",
                         exc_info=True,

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -102,7 +102,7 @@ class RaftAvailabilityTest(RedpandaTest):
         try:
             # Should fail
             self.ping_pong().ping_pong(timeout_s)
-        except:
+        except Exception:
             return False
         else:
             return True
@@ -111,7 +111,7 @@ class RaftAvailabilityTest(RedpandaTest):
         try:
             # Should fail
             self.ping_pong().ping_pong()
-        except:
+        except Exception:
             self.logger.exception("Cluster is unavailable as expected")
         else:
             assert False, "ping_pong should not have worked "

--- a/tests/rptest/tests/read_distribution_test.py
+++ b/tests/rptest/tests/read_distribution_test.py
@@ -86,7 +86,7 @@ class ReadDistributionTest(RedpandaTest):
             try:
                 topic_read_dist[int(float(le))] = int(v - prev)
                 prev = v
-            except:
+            except Exception:
                 continue
 
         first_bucket_lower_bound = 4

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -491,7 +491,7 @@ class TestReadReplicaService(EndToEndTest):
             try:
                 res = admin.get_partitions(topic, partition)
                 return True, res
-            except:
+            except Exception:
                 return False, None
 
         res = wait_until_result(try_get_partitions, timeout_sec=30, backoff_sec=1)

--- a/tests/rptest/tests/tiered_storage_model_test.py
+++ b/tests/rptest/tests/tiered_storage_model_test.py
@@ -186,7 +186,7 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
             try:
                 self.logger.info(f"Running validator {validator.name()}")
                 validator.run(self)
-            except:
+            except Exception:
                 self.logger.error("Failed to run validator", exc_info=True)
 
         self._bg_loop(invoke, validator.name(), lambda: random.uniform(0.5, 1.5))
@@ -224,7 +224,7 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
                 self.private_metrics = res
                 self.logger.info(f"Private metrics {res}")
             time.sleep(2)
-        except:
+        except Exception:
             self.logger.error("Failed to pull metrics", exc_info=True)
             time.sleep(2)
         finally:
@@ -245,7 +245,7 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
                 f"Bucket view updated, {self.bucket_view.segment_objects} segments scanned"
             )
             time.sleep(10)
-        except:
+        except Exception:
             self.logger.error("Failed to scan bucket", exc_info=True)
             time.sleep(20)
         finally:
@@ -271,7 +271,7 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
                                 v.on_match(node.name, line)
                     if self.stop_flag:
                         return
-            except:
+            except Exception:
                 self.logger.error("Failed to grep logs", exc_info=True)
             finally:
                 self.logger.info("tail -f on {node.name} stopping")

--- a/tests/rptest/tests/timely_shutdown_test.py
+++ b/tests/rptest/tests/timely_shutdown_test.py
@@ -60,7 +60,7 @@ class ShutdownTest(EndToEndTest):
                         )
                     ),
                 )
-            except:
+            except Exception:
                 return False
 
         self.redpanda.start()

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -382,7 +382,7 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
                         ntp=NTP(ns="kafka", topic="tqtopic", partition=0)
                     )
                     return res is not None and len(res) > 0
-                except:
+                except Exception:
                     return False
 
             wait_until(
@@ -807,7 +807,7 @@ class TestReadReplicaTimeQuery(RedpandaTest):
                 "redpanda.remote.readreplica": self.si_settings.cloud_storage_bucket,
             }
             rpk_rr_cluster.create_topic(self.topic_name, config=conf)
-        except:
+        except Exception:
             self.logger.warn("Failed to create a read-replica topic")
             return False
         return True
@@ -857,12 +857,12 @@ class TestReadReplicaTimeQuery(RedpandaTest):
             try:
                 record = kcat_src.consume_one(self.topic_name, 0, offset_src)
                 self.logger.info(f"src cluster record at {offset_src}: {record}")
-            except:
+            except Exception:
                 pass
             try:
                 record = kcat_rr.consume_one(self.topic_name, 0, offset_rr)
                 self.logger.info(f"rr cluster record at {offset_rr}: {record}")
-            except:
+            except Exception:
                 pass
         assert matches, f"Expected offset {offset_src}, got {offset_rr}"
 

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -847,7 +847,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         view = BucketView(self.redpanda)
         try:
             marker = view.get_lifecycle_marker(NT("kafka", topic_name))
-        except:
+        except Exception:
             # FIXME: very broad exception catching because cloud storage clients
             # may use diverse exceptions for missing objects
             pass
@@ -1060,7 +1060,7 @@ class TopicDeleteStressTest(RedpandaTest):
 
             try:
                 producer.stop()
-            except:
+            except Exception:
                 # Should ignore exception form rpk
                 pass
             producer.free()

--- a/tests/rptest/tests/topic_limits_test.py
+++ b/tests/rptest/tests/topic_limits_test.py
@@ -35,7 +35,7 @@ class TopicLimitsTest(RedpandaTest):
             for t in topics:
                 try:
                     self.client().create_topic(t)
-                except:
+                except Exception:
                     failed_attempts += 1
             return failed_attempts
 
@@ -86,7 +86,7 @@ class TopicLimitsTest(RedpandaTest):
                         f"auto_created_topic_{current_topic_id}", 1, 1024
                     )
                     current_topic_id += 1
-                except:
+                except Exception:
                     pass
 
         topic_limit = 5

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -517,7 +517,7 @@ class AdminApiBasedRestore(FastCheck):
         def wait_for_topic():
             try:
                 return self._kafka_tools.describe_topic_config(self.topics[0].name)
-            except:
+            except Exception:
                 return None
 
         topic_config = wait_until_result(wait_for_topic, timeout_sec=60)

--- a/tests/rptest/tests/workload_upgrade_runner_test.py
+++ b/tests/rptest/tests/workload_upgrade_runner_test.py
@@ -128,7 +128,7 @@ class WorkloadAdapter(PWorkload):
             try:
                 # attempt at cleanup anyway
                 self.workload.end()
-            except:
+            except Exception:
                 pass
             return None
 

--- a/tests/rptest/transactions/verifiers/compacted_verifier.py
+++ b/tests/rptest/transactions/verifiers/compacted_verifier.py
@@ -258,7 +258,7 @@ class CompactedVerifier(Service):
                 raise
             except ConsistencyViolationException:
                 raise
-            except:
+            except Exception:
                 self._redpanda.logger.debug(
                     "Got error on fetching info, retrying?!", exc_info=True
                 )

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -526,7 +526,7 @@ def wait_for_recovery_throttle_rate(redpanda, new_rate: int):
                     current_rate >= min_expected_rate
                     and current_rate <= max_expected_rate
                 )
-            except:
+            except Exception:
                 redpanda.logger.debug(
                     f"Error getting throttle rate for {node}", exc_info=True
                 )


### PR DESCRIPTION
Change all bare `except:` statements to catch `Exception` instead, except where the exception is being unconditionally re-raised.

This makes `ruff check --select E722` pass cleanly, but specifically for DT this is important as Type II test timeouts will get a TestTimeoutError injected into the test, which inherits from BaseException and would be caught by a bare except, but not by except Exception. We don't want to catch this and eat them as it will prevent this forced termination from working correctly. This is the same general reasoning as to why one should not catch BaseException (or use `except:`) in the first place.

Cases which unconditionally re-raise the exception are left as bare excepts, since arguably here you want the logging or cleanup they do. These are also not flagged by ruff.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

