### PR TITLE
treewide: clean up is None checks (E711)

### DIFF
--- a/tests/rptest/chaos_tests/single_fault_test.py
+++ b/tests/rptest/chaos_tests/single_fault_test.py
@@ -172,7 +172,7 @@ class SingleFaultTestBase(RedpandaTest):
         for node in workload.nodes:
             workload.emit_event(node, "measure")
 
-        if fault == None:
+        if fault is None:
             if timings.no_fault_steady_s > 0:
                 self.logger.info(
                     f"wait for {timings.no_fault_steady_s} seconds "

--- a/tests/rptest/clients/admin/v2.py
+++ b/tests/rptest/clients/admin/v2.py
@@ -87,7 +87,7 @@ class Admin:
         protocol: Literal["json"] | Literal["proto"] = "json",
     ) -> None:
         self._rp = redpanda
-        if auth != None:
+        if auth is not None:
             self._headers = urllib3.util.make_headers(basic_auth=f"{auth[0]}:{auth[1]}")
         else:
             self._headers = {}

--- a/tests/rptest/clients/ping_pong.py
+++ b/tests/rptest/clients/ping_pong.py
@@ -43,11 +43,11 @@ class SyncProducer:
         )
         self.producer.flush(timeout_s)
         msg = self.last_msg
-        if msg == None:
+        if msg is None:
             raise KafkaException(KafkaError(KafkaError._MSG_TIMED_OUT))
-        if msg.error() != None:
+        if msg.error() is not None:
             raise KafkaException(msg.error())
-        assert msg.offset() != None
+        assert msg.offset() is not None
         return msg.offset()
 
 

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -899,10 +899,10 @@ class RpkTool:
             initialized = (
                 obj["LEADER"] >= 0
                 and obj["EPOCH"] >= -1
-                and obj["REPLICAS"] != None
-                and obj["LOG-START-OFFSET"] != None
+                and obj["REPLICAS"] is not None
+                and obj["LOG-START-OFFSET"] is not None
                 and obj["LOG-START-OFFSET"] >= 0
-                and obj["HIGH-WATERMARK"] != None
+                and obj["HIGH-WATERMARK"] is not None
                 and obj["HIGH-WATERMARK"] >= 0
             )
 

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -576,7 +576,7 @@ class Admin:
                 f'requesting "{namespace}/{topic}/{partition}" details from {host})'
             )
             meta = self._get_configuration(host, namespace, topic, partition)
-            if meta == None:
+            if meta is None:
                 return None
             if "replicas" not in meta:
                 self.redpanda.logger.debug("replicas are missing")
@@ -584,7 +584,7 @@ class Admin:
             if "status" not in meta:
                 self.redpanda.logger.debug("status is missing")
                 return None
-            if status == None:
+            if status is None:
                 status = meta["status"]
                 self.redpanda.logger.debug(f"get status:{status}")
             if status != meta["status"]:
@@ -601,7 +601,7 @@ class Admin:
                     f"get conflicting replicas:{read_replicas} from {host}"
                 )
                 return None
-            if replication != None:
+            if replication is not None:
                 if len(meta["replicas"]) != replication:
                     self.redpanda.logger.debug(
                         f"expected replication:{replication} got:{len(meta['replicas'])}"
@@ -645,7 +645,7 @@ class Admin:
 
         When the timeout is exhaust it throws TimeoutException
         """
-        if hosts == None:
+        if hosts is None:
             hosts = [n.account.hostname for n in self.redpanda.started_nodes()]
         hosts = list(hosts)
 
@@ -663,7 +663,7 @@ class Admin:
                     namespace=namespace,
                     replication=replication,
                 )
-                if info == None:
+                if info is None:
                     return False
                 return True, info
             except RequestException:
@@ -1420,7 +1420,7 @@ class Admin:
 
         #  check which node is current leader
 
-        if leader_id == None:
+        if leader_id is None:
             leader_id = self.await_stable_leader(
                 topic,
                 partition=partition,

--- a/tests/rptest/services/chaos/workloads/list_offsets/consistency.py
+++ b/tests/rptest/services/chaos/workloads/list_offsets/consistency.py
@@ -142,7 +142,7 @@ class LogPlayer:
                     found = False
                     for thread_id in self.last_write.keys():
                         write = self.last_write[thread_id]
-                        if write == None:
+                        if write is None:
                             continue
                         if write.key != key:
                             continue
@@ -225,7 +225,7 @@ class LogPlayer:
                 self.has_violation = True
             self.ok_writes[offset] = write
         elif self.curr_state[thread_id] in [State.ERROR, State.TIMEOUT]:
-            if thread_id in self.last_write and self.last_write[thread_id] != None:
+            if thread_id in self.last_write and self.last_write[thread_id] is not None:
                 write = self.last_write[thread_id]
                 self.last_write[thread_id] = None
                 write.offset = None
@@ -233,7 +233,7 @@ class LogPlayer:
                 self.err_writes[write.op] = write
 
     def is_violation(self, line):
-        if line == None:
+        if line is None:
             return False
         parts = line.rstrip().split("\t")
         if len(parts) < 3:
@@ -248,7 +248,7 @@ class LogPlayer:
         if parts[2] not in cmds:
             raise Exception(f'unknown cmd "{parts[2]}"')
 
-        if self.ts_us == None:
+        if self.ts_us is None:
             self.ts_us = int(parts[1])
         else:
             delta_us = int(parts[1])
@@ -268,7 +268,7 @@ class LogPlayer:
         thread_id = int(parts[0])
         if thread_id not in self.curr_state:
             self.curr_state[thread_id] = None
-        if self.curr_state[thread_id] == None:
+        if self.curr_state[thread_id] is None:
             if new_state != State.STARTED:
                 raise Exception(
                     f'first logged command of a new thread should be started, got: "{parts[2]}"'
@@ -304,7 +304,7 @@ def validate(workload_dir, workload_nodes, brokers_str, topic):
             ) as workload_file:
                 last_line = None
                 for line in workload_file:
-                    if last_line != None:
+                    if last_line is not None:
                         player.apply(last_line)
                     last_line = line
                 if player.is_violation(last_line):

--- a/tests/rptest/services/chaos/workloads/list_offsets/stat.py
+++ b/tests/rptest/services/chaos/workloads/list_offsets/stat.py
@@ -194,7 +194,7 @@ class LogPlayer:
         if parts[2] not in cmds:
             raise Exception(f'unknown cmd "{parts[2]}"')
 
-        if self.ts_us == None:
+        if self.ts_us is None:
             self.ts_us = int(parts[1])
             self.started_us = self.ts_us
         else:
@@ -222,7 +222,7 @@ class LogPlayer:
         thread_id = int(parts[0])
         if thread_id not in self.curr_state:
             self.curr_state[thread_id] = None
-        if self.curr_state[thread_id] == None:
+        if self.curr_state[thread_id] is None:
             if new_state != State.STARTED:
                 raise Exception(
                     f'first logged command of a new thread should be started, got: "{parts[2]}"'
@@ -276,7 +276,7 @@ def render_overview(title, workload_dir, stat):
             max_unavailability_ms = max(max_unavailability_ms, ts_ms - last_ok)
             last_ok = ts_ms
             duration_ms = max(duration_ms, ts_ms)
-            if min_latency_us == None:
+            if min_latency_us is None:
                 min_latency_us = latency_us
             min_latency_us = min(min_latency_us, latency_us)
             max_latency_us = max(max_latency_us, latency_us)
@@ -421,7 +421,7 @@ def collect(title, workload_dir, workload_nodes):
             with open(os.path.join(node_dir, "workload.log"), "r") as workload_file:
                 last_line = None
                 for line in workload_file:
-                    if last_line != None:
+                    if last_line is not None:
                         player.apply(last_line)
                     last_line = line
 

--- a/tests/rptest/services/chaos/workloads/retryable_consumer.py
+++ b/tests/rptest/services/chaos/workloads/retryable_consumer.py
@@ -42,7 +42,7 @@ class RetryableConsumer:
             if retries == 0:
                 raise Exception("Can't connect to the redpanda cluster")
             retries -= 1
-            if self.consumer != None:
+            if self.consumer is not None:
                 try:
                     self.consumer.close()
                 except:

--- a/tests/rptest/services/chaos/workloads/tx_subscribe/consistency.py
+++ b/tests/rptest/services/chaos/workloads/tx_subscribe/consistency.py
@@ -136,7 +136,7 @@ class LogPlayer:
                 logger.error(trace)
 
     def is_violation(self, line):
-        if line == None:
+        if line is None:
             return False
         parts = line.rstrip().split("\t")
         if len(parts) < 3:
@@ -153,7 +153,7 @@ class LogPlayer:
         if parts[2] not in cmds:
             raise Exception(f'unknown cmd "{parts[2]}"')
 
-        if self.ts_us == None:
+        if self.ts_us is None:
             self.ts_us = int(parts[1])
         else:
             delta_us = int(parts[1])
@@ -184,7 +184,7 @@ class LogPlayer:
             self.curr_state[thread_id] = None
             if self.thread_type[thread_id] not in threads:
                 raise Exception(f"unknown thread type: {parts[4]}")
-        if self.curr_state[thread_id] == None:
+        if self.curr_state[thread_id] is None:
             if new_state != State.STARTED:
                 raise Exception(
                     f'first logged command of a new thread should be started, got: "{parts[2]}"'
@@ -222,7 +222,7 @@ def validate(workload_dir, workload_nodes, fail_on_interruption=False):
             ) as workload_file:
                 last_line = None
                 for line in workload_file:
-                    if last_line != None:
+                    if last_line is not None:
                         player.apply(last_line)
                     last_line = line
                 if player.is_violation(last_line):

--- a/tests/rptest/services/chaos/workloads/tx_subscribe/stat.py
+++ b/tests/rptest/services/chaos/workloads/tx_subscribe/stat.py
@@ -240,7 +240,7 @@ class LogPlayer:
         if parts[2] not in cmds:
             raise Exception(f'unknown cmd "{parts[2]}"')
 
-        if self.ts_us == None:
+        if self.ts_us is None:
             self.ts_us = int(parts[1])
             self.started_us = self.ts_us
         else:
@@ -271,7 +271,7 @@ class LogPlayer:
             self.curr_state[thread_id] = None
             if self.thread_type[thread_id] not in threads:
                 raise Exception(f"unknown thread type: {parts[4]}")
-        if self.curr_state[thread_id] == None:
+        if self.curr_state[thread_id] is None:
             if new_state != State.STARTED:
                 raise Exception(
                     f'first logged command of a new thread should be started, got: "{parts[2]}"'
@@ -362,7 +362,7 @@ def render_overview(title, workload_dir, stat, source_partitions):
             max_unavailability_ms = max(max_unavailability_ms, ts_ms - last_ok)
             last_ok = ts_ms
             duration_ms = max(duration_ms, ts_ms)
-            if min_latency_us == None:
+            if min_latency_us is None:
                 min_latency_us = latency_us
             min_latency_us = min(min_latency_us, latency_us)
             max_latency_us = max(max_latency_us, latency_us)
@@ -544,7 +544,7 @@ def collect(title, workload_dir, workload_nodes, source_partitions):
             with open(os.path.join(node_dir, "workload.log"), "r") as workload_file:
                 last_line = None
                 for line in workload_file:
-                    if last_line != None:
+                    if last_line is not None:
                         player.apply(last_line)
                     last_line = line
 

--- a/tests/rptest/services/failure_injector.py
+++ b/tests/rptest/services/failure_injector.py
@@ -232,7 +232,7 @@ class FailureInjector(FailureInjectorBase):
         self.redpanda.signal_redpanda(node, signal=signal.SIGKILL, idempotent=True)
         timeout_sec = 10
         wait_until(
-            lambda: self.redpanda.redpanda_pid(node) == None,
+            lambda: self.redpanda.redpanda_pid(node) is None,
             timeout_sec=timeout_sec,
             err_msg="Redpanda failed to kill in %d seconds" % timeout_sec,
         )
@@ -331,7 +331,7 @@ class FailureInjector(FailureInjectorBase):
         self.redpanda.signal_redpanda(node, signal=signal.SIGTERM)
         timeout_sec = 30
         wait_until(
-            lambda: self.redpanda.redpanda_pid(node) == None,
+            lambda: self.redpanda.redpanda_pid(node) is None,
             timeout_sec=timeout_sec,
             err_msg="Redpanda failed to terminate in %d seconds" % timeout_sec,
         )
@@ -343,7 +343,7 @@ class FailureInjector(FailureInjectorBase):
     def _start(self, node):
         # make this idempotent
         pid = self.redpanda.redpanda_pid(node)
-        if pid == None:
+        if pid is None:
             self.redpanda.logger.info(f"starting redpanda on {node.account.hostname}")
             self.redpanda.start_redpanda(node)
         else:

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3624,7 +3624,7 @@ class RedpandaService(Service, RedpandaServiceABC):
 
             if expect_fail:
                 wait_until(
-                    lambda: self.redpanda_pid(node) == None,
+                    lambda: self.redpanda_pid(node) is None,
                     timeout_sec=timeout,
                     backoff_sec=0.2,
                     err_msg=f"Redpanda processes did not terminate on {node.name} during startup as expected in {timeout} sec",
@@ -3978,7 +3978,7 @@ class RedpandaService(Service, RedpandaServiceABC):
         The key must be equal to the current broker time expressed as unix epoch
         in seconds, and be within 1 hour.
         """
-        key = int(time.time()) if key == None else key
+        key = int(time.time()) if key is None else key
         self.set_cluster_config(
             dict(
                 enable_developmental_unrecoverable_data_corrupting_features=key,

--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -309,7 +309,7 @@ class RedpandaInstaller:
         # Verify that the installations on each node match.
         for node in nodes:
             vers = self._redpanda.get_version(node)
-            if initial_version == None:
+            if initial_version is None:
                 initial_version = vers
             assert initial_version == vers, (
                 f"Mismatch version {node.account.hostname} has {vers}, {nodes[0].account.hostname} has {initial_version}"

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -273,21 +273,21 @@ class AccessControlListTest(AccessControlListTestBase):
         # Run a few times for good health. The target condition
         # should be consistent
         for _ in range(repeat_check):
-            if pass_w_base_user != None:
+            if pass_w_base_user is not None:
                 wait_until(
                     check_base_user_perms,
                     timeout_sec=timeout_sec,
                     err_msg=f"base user: {err_msg}",
                 )
 
-            if pass_w_cluster_user != None:
+            if pass_w_cluster_user is not None:
                 wait_until(
                     check_cluster_user_perms,
                     timeout_sec=timeout_sec,
                     err_msg=f"cluster user: {err_msg}",
                 )
 
-            if pass_w_super_user != None:
+            if pass_w_super_user is not None:
                 wait_until(
                     check_super_user_perms,
                     timeout_sec=timeout_sec,
@@ -581,7 +581,7 @@ class AccessControlListTest(AccessControlListTestBase):
                 in cluster_cfg["kafka_mtls_principal_mapping_rules"]
             )
         else:
-            assert cluster_cfg["kafka_mtls_principal_mapping_rules"] == None
+            assert cluster_cfg["kafka_mtls_principal_mapping_rules"] is None
 
         self.check_permissions(
             pass_w_base_user=False,

--- a/tests/rptest/tests/admin_api_auth_test.py
+++ b/tests/rptest/tests/admin_api_auth_test.py
@@ -132,7 +132,7 @@ class AdminApiAuthTest(RedpandaTest):
 
         unauthed = AdminV2(self.redpanda)
         resp = unauthed.broker().call_list_brokers(broker_pb.ListBrokersRequest())
-        assert resp.error() != None, f"expected an error response, got {resp}"
+        assert resp.error() is not None, f"expected an error response, got {resp}"
         assert resp.error().code == ConnectErrorCode.PERMISSION_DENIED, (
             f"Expected unauthenticated admin v2 request to be denied, got: {resp.error()}"
         )
@@ -187,7 +187,7 @@ class AdminApiAuthTest(RedpandaTest):
                     metadata={"detail": "something"},
                 )
             )
-            assert resp.error() != None, "Expected an error in this RPC"
+            assert resp.error() is not None, "Expected an error in this RPC"
             err = resp.error()
             assert err.code == ConnectErrorCode.UNKNOWN, (
                 f"Expected UNKNOWN error code, got: {err}"

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -627,7 +627,7 @@ class ArchivalTest(RedpandaTest):
         self.admin.set_log_level(name="cluster", level="trace")
 
         # Verify assumptions
-        assert self.topics[0].cleanup_policy == None, (
+        assert self.topics[0].cleanup_policy is None, (
             "The compaction setting is assumed to be `delete` by default"
         )
         assert not self._archiver_restart_msg_seen(), (
@@ -655,7 +655,7 @@ class ArchivalTest(RedpandaTest):
         self.admin.set_log_level(name="cluster", level="trace")
 
         # Verify assumptions
-        assert self.topics[0].cleanup_policy == None, (
+        assert self.topics[0].cleanup_policy is None, (
             "The compaction setting is assumed to be `delete` by default"
         )
         assert not self._archiver_restart_msg_seen(), (

--- a/tests/rptest/tests/cluster_view_test.py
+++ b/tests/rptest/tests/cluster_view_test.py
@@ -65,7 +65,7 @@ class ClusterViewTest(EndToEndTest):
                         return False
                     if len(view["brokers"]) != 3:
                         return False
-                    if last == None:
+                    if last is None:
                         last = view
                         ids = set(
                             map(lambda broker: broker["node_id"], view["brokers"])

--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -96,7 +96,7 @@ class CrashLoopChecksTest(RedpandaTest):
         Wait for the redpanda process to terminate (e.g. after sending a crash signal)
         """
         wait_until(
-            lambda: self.redpanda.redpanda_pid(broker) == None,
+            lambda: self.redpanda.redpanda_pid(broker) is None,
             timeout_sec=timeout,
             backoff_sec=0.2,
             err_msg=f"Redpanda processes did not terminate on {broker.name} in {timeout} sec",

--- a/tests/rptest/tests/data_transforms_test.py
+++ b/tests/rptest/tests/data_transforms_test.py
@@ -950,7 +950,7 @@ class BaseDataTransformsLoggingTest(BaseDataTransformsTest):
             # we get a record.
             return record.offset == offset, record
 
-        if timeout != None:
+        if timeout is not None:
             return consume(timeout)[1]
 
         return wait_until_result(

--- a/tests/rptest/tests/group_membership_test.py
+++ b/tests/rptest/tests/group_membership_test.py
@@ -365,7 +365,7 @@ class GroupMetricsTest(RedpandaTest):
 
         # Wait until cluster starts producing metrics
         wait_until(
-            lambda: self.redpanda.metrics_sample("kafka_group_offset") != None,
+            lambda: self.redpanda.metrics_sample("kafka_group_offset") is not None,
             timeout_sec=30,
             backoff_sec=5,
         )

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -279,7 +279,7 @@ class PartitionBalancerService(EndToEndTest):
             self.make_available(wait_for_previous_node)
             self.logger.info(f"making {node.account.hostname} unavailable")
 
-            if failure_types == None:
+            if failure_types is None:
                 failure_types = [
                     FailureSpec.FAILURE_KILL,
                     FailureSpec.FAILURE_TERMINATE,

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -569,7 +569,7 @@ class RaftAvailabilityTest(RedpandaTest):
             follower = node
             break
 
-        assert follower != None
+        assert follower is not None
 
         with FailureInjector(self.redpanda) as fi:
             # isolate one of the followers

--- a/tests/rptest/tests/redpanda_oauth_test.py
+++ b/tests/rptest/tests/redpanda_oauth_test.py
@@ -486,7 +486,7 @@ class RedpandaOIDCTestMethods(RedpandaOIDCTestBase):
         consumer.subscribe([EXAMPLE_TOPIC])
         self.redpanda.logger.debug("consumer.subscribed")
         rec = consumer.poll(1.0)
-        assert rec == None
+        assert rec is None
 
         wait_until(has_group, timeout_sec=30, backoff_sec=1)
 

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -2054,7 +2054,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         )
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.json()["is_compatible"] == True
-        assert result_raw.json().get("messages", None) == None
+        assert result_raw.json().get("messages", None) is None
 
         self.logger.debug("Set subject config - BACKWARD")
         result_raw = self.sr_client.set_config_subject(
@@ -2068,7 +2068,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         )
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.json()["is_compatible"] == True
-        assert result_raw.json().get("messages", None) == None
+        assert result_raw.json().get("messages", None) is None
 
         self.logger.debug("Check compatibility backward, no default, verbose")
         result_raw = self.sr_client.post_compatibility_subject_version(
@@ -2083,7 +2083,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         )
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.json()["is_compatible"] == False
-        assert result_raw.json().get("messages", None) == None, (
+        assert result_raw.json().get("messages", None) is None, (
             f"Expected no messages, got {result_raw.json()['messages']}"
         )
 

--- a/tests/rptest/transactions/transaction_kafka_api_test.py
+++ b/tests/rptest/transactions/transaction_kafka_api_test.py
@@ -74,7 +74,7 @@ class TxKafkaApiTest(RedpandaTest):
             for partition in range(topic.partition_count):
                 txs_info = self.kafka_cli.describe_producers(topic.name, partition)
 
-                if expected_producers == None:
+                if expected_producers is None:
                     expected_producers = set(map(self.extract_producer, txs_info))
                     assert len(txs_info) == 2
 

--- a/tests/rptest/transactions/transactions_test.py
+++ b/tests/rptest/transactions/transactions_test.py
@@ -200,7 +200,7 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
             producer.begin_transaction()
 
             for record in records:
-                assert record.error() == None
+                assert record.error() is None
                 consumed_from_input_topic.append(record)
                 producer.produce(
                     self.output_t.name,
@@ -333,7 +333,7 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
         producer.begin_transaction()
 
         for record in records:
-            assert record.error() == None
+            assert record.error() is None
             producer.produce(self.output_t.name, record.value(), record.key())
 
         offsets = consumer1.position(consumer1.assignment())
@@ -400,7 +400,7 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
         producer.begin_transaction()
 
         for record in records:
-            assert record.error() == None
+            assert record.error() is None
             producer.produce(self.output_t.name, record.value(), record.key())
 
         offsets = consumer1.position(consumer1.assignment())

--- a/tests/rptest/transactions/tx_admin_api_test.py
+++ b/tests/rptest/transactions/tx_admin_api_test.py
@@ -80,7 +80,7 @@ class TxAdminTest(RedpandaTest):
             for partition in range(topic.partition_count):
                 txs_info = self.admin.get_transactions(topic.name, partition, "kafka")
                 assert "expired_transactions" not in txs_info
-                if expected_pids == None:
+                if expected_pids is None:
                     expected_pids = list(
                         map(self.extract_pid, txs_info["active_transactions"])
                     )

--- a/tests/rptest/transactions/tx_feature_flag_test.py
+++ b/tests/rptest/transactions/tx_feature_flag_test.py
@@ -68,4 +68,4 @@ class TxFeatureFlagTest(EndToEndTest):
 
         # make sure that all redpanda nodes are up and running
         for n in self.redpanda.nodes:
-            assert self.redpanda.redpanda_pid(n) != None
+            assert self.redpanda.redpanda_pid(n) is not None

--- a/tests/rptest/transactions/util.py
+++ b/tests/rptest/transactions/util.py
@@ -55,7 +55,7 @@ def try_transaction(
 
 class TransactionsMixin:
     def find_coordinator(self, txid, node=None):
-        if node == None:
+        if node is None:
             node = random.choice(self.redpanda.started_nodes())
 
         def find_tx_coordinator():
@@ -88,7 +88,7 @@ class TransactionsMixin:
         def consume_records():
             records = consumer.consume(max_records, timeout_s)
 
-            if (records != None) and (len(records) != 0):
+            if (records is not None) and (len(records) != 0):
                 return True, records
             else:
                 return False, records


### PR DESCRIPTION
This is the result of running:

ruff check --select E711 --fix --unsafe-fixes tests

It changes `foo == None` to `foo is None` and `foo != None` to `foo is not None`.

There is a small chance of this being unsafe if the type on the LHS overrides equality operators in a way that breaks identity semantics, but I checked each edit here and the LHS always seems like a relatively vanilla type that doesn't have this issue (known classes with this issues are
[listed here](https://github.com/astral-sh/ruff/issues/4560)).

See also: https://docs.astral.sh/ruff/rules/none-comparison/

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none
