### PR TITLE
treewide: ruff E731: do not assign a lambda

### DIFF
--- a/tests/rptest/scale_tests/log_storage_target_size_test.py
+++ b/tests/rptest/scale_tests/log_storage_target_size_test.py
@@ -143,7 +143,9 @@ class LogStorageTargetSizeTest(RedpandaTest):
 
         # helper: bytes to MBs / human readable
         def hmb(bs):
-            convert = lambda b: round(b / (1024 * 1024), 1)
+            def convert(b):
+                return round(b / (1024 * 1024), 1)
+
             if isinstance(bs, int):
                 return convert(bs)
             return [convert(b) for b in bs]

--- a/tests/rptest/services/openmessaging_benchmark_configs.py
+++ b/tests/rptest/services/openmessaging_benchmark_configs.py
@@ -114,7 +114,9 @@ class OMBSampleConfigurations:
         assert len(validator) > 0, "At least one metric should be validated"
 
         results: list[str] = []
-        kv_str = lambda k, v: f"Metric {k}, value {v}, "
+
+        def kv_str(k, v):
+            return f"Metric {k}, value {v}, "
 
         for key in validator.keys():
             assert key in metrics, f"Missing requested validator key {key} in metrics"

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -760,7 +760,10 @@ class AuditLogTestBase(RedpandaTest):
 
         Matched records
         """
-        stop_cond = lambda records: valid_check_fn(self.aggregate_count(records))
+
+        def stop_cond(records):
+            return valid_check_fn(self.aggregate_count(records))
+
         return self.read_all_from_audit_log(filter_fn=filter_fn, stop_cond=stop_cond)
 
 
@@ -961,7 +964,9 @@ class AuditLogTestAdminApi(AuditLogTestBase):
         def number_of_records_matching(filter_by, n_expected):
             filter_fn = partial(is_api_match, filter_by)
 
-            stop_cond = lambda records: self.aggregate_count(records) >= n_expected
+            def stop_cond(records):
+                return self.aggregate_count(records) >= n_expected
+
             records = self.read_all_from_audit_log(filter_fn, stop_cond)
             assert self.aggregate_count(records) == n_expected, (
                 f"Expected: {n_expected}, Actual: {self.aggregate_count(records)}"
@@ -977,7 +982,10 @@ class AuditLogTestAdminApi(AuditLogTestBase):
             "cluster/health_overview": self.admin.get_cluster_health_overview,
         }
         api_keys = api_calls.keys()
-        call_apis = lambda: [fn() for fn in api_calls.values()]
+
+        def call_apis():
+            return [fn() for fn in api_calls.values()]
+
         self.logger.debug("Starting 500 api calls with management enabled")
         for _ in range(0, 500):
             call_apis()

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -665,10 +665,13 @@ class DataMigrationsApiTest(DataMigrationTestMixin):
             in_migr_id = self.admin.mount_topics([in_topic]).json()["id"]
             self.wait_partitions_appear([topic])
             self.wait_migration_disappear(in_migr_id)
-            expected_msg_predicate = lambda msg: {
-                "key": msg.key(),
-                "value": msg.value(),
-            } == make_msg(i)
+
+            def expected_msg_predicate(msg):
+                return {
+                    "key": msg.key(),
+                    "value": msg.value(),
+                } == make_msg(i)
+
             self.assure_exactly_one_message(topic.name, expected_msg_predicate)
             self.client().delete_topic(topic.name)
 

--- a/tests/rptest/tests/full_disk_test.py
+++ b/tests/rptest/tests/full_disk_test.py
@@ -306,7 +306,10 @@ class FullDiskReclaimTest(RedpandaTest):
         4. Trigger a low disk space alert
         5. Observe that data is reclaimed from disk
         """
-        nbytes = lambda mb: mb * 2**20
+
+        def nbytes(mb):
+            return mb * 2**20
+
         node = self.redpanda.nodes[0]
 
         produce_size = 3 * self.partition_count * self.log_segment_size

--- a/tests/rptest/tests/internal_topic_protection_test.py
+++ b/tests/rptest/tests/internal_topic_protection_test.py
@@ -9,6 +9,7 @@
 
 import subprocess
 import time
+from typing import Any, Callable
 
 from ducktape.mark import parametrize
 from ducktape.utils.util import wait_until
@@ -108,14 +109,22 @@ class InternalTopicProtectionTest(RedpandaTest):
 
             return partition[0].high_watermark
 
+        produce_fn: Callable[[str, str], Any] | None = None
+
         if client_type == "rpk":
-            produce_fn = lambda topic, msg: self.rpk.produce(
-                topic, "key", msg, timeout=30
-            )
+
+            def produce_fn_rpk(topic: str, msg: str):
+                return self.rpk.produce(topic, "key", msg, timeout=30)
+
+            produce_fn = produce_fn_rpk
             failure_exception_type = RpkException
 
         elif client_type == "kafka_tools":
-            produce_fn = lambda topic, msg: self.kafka_cat.produce_one(topic, msg)
+
+            def produce_fn_kt(topic: str, msg: str):
+                return self.kafka_cat.produce_one(topic, msg)
+
+            produce_fn = produce_fn_kt
             failure_exception_type = subprocess.CalledProcessError
 
         else:

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -1422,7 +1422,9 @@ class NodeDecommissionSpaceManagementTest(RedpandaTest):
 
         # helper: bytes to MBs / human readable
         def hmb(bs):
-            convert = lambda b: round(b / (1024 * 1024), 1)
+            def convert(b):
+                return round(b / (1024 * 1024), 1)
+
             if isinstance(bs, int):
                 return convert(bs)
             return [convert(b) for b in bs]

--- a/tests/rptest/tests/partition_movement.py
+++ b/tests/rptest/tests/partition_movement.py
@@ -35,7 +35,10 @@ class PartitionMovementMixin:
         limitation in redpanda raft implementation.
         """
         replication_factor = len(assignments)
-        node_ids = lambda x: set([a["node_id"] for a in x])
+
+        def node_ids(x):
+            return set([a["node_id"] for a in x])
+
         orig_node_ids = node_ids(assignments)
 
         assert replication_factor >= 1

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -72,7 +72,9 @@ class RaftAvailabilityTest(RedpandaTest):
         result = {}
 
         if condition is None:
-            condition = lambda x: x is not None
+
+            def condition(x):
+                return x is not None
 
         def check():
             result[0] = self._get_leader()

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -464,7 +464,9 @@ class TestReadReplicaService(EndToEndTest):
         self.start_consumer()
 
         # Assert zero bytes written for at least 20 seconds.
-        total_bytes = lambda: self._bucket_usage().total_bytes
+        def total_bytes():
+            return self._bucket_usage().total_bytes
+
         assert self.redpanda and self.redpanda.logger
         er = ExpectRate(total_bytes, self.redpanda.logger)
         zero_growth = RateTarget(

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -833,9 +833,12 @@ class TopicRecoveryTest(RedpandaTest):
         num_nodes = len(self.redpanda.nodes)
         queue = Queue(num_nodes)
         for node in self.redpanda.nodes:
-            checksummer = lambda: queue.put(
-                NodeChecksums(node, self._get_data_log_segment_checksums(node))
-            )
+
+            def checksummer():
+                queue.put(
+                    NodeChecksums(node, self._get_data_log_segment_checksums(node))
+                )
+
             Thread(target=checksummer, daemon=True).start()
             self.logger.debug(f"Started checksum thread for {node.account.hostname}..")
         for i in range(num_nodes):

--- a/tests/rptest/tests/workload_upgrade_runner_test.py
+++ b/tests/rptest/tests/workload_upgrade_runner_test.py
@@ -244,11 +244,13 @@ class RedpandaUpgradeTest(PreallocNodesTest):
             if not partial_update
             else "partial progress check done"
         )
-        progress_lambda = (
-            lambda w, v_param: w.on_cluster_upgraded(v_param)
-            if not partial_update
-            else w.on_partial_cluster_upgrade(v_param)
-        )
+
+        def progress_lambda(w, v_param):
+            return (
+                w.on_cluster_upgraded(v_param)
+                if not partial_update
+                else w.on_partial_cluster_upgrade(v_param)
+            )
 
         while len(to_check_list) > 0:
             start_time = time.time()

--- a/tests/rptest/utils/expect_rate.py
+++ b/tests/rptest/utils/expect_rate.py
@@ -67,7 +67,10 @@ class ExpectRate:
 
     def expect_rate(self, target: RateTarget) -> None:
         sample_interval_ms = 1000
-        ts = lambda x: x.timestamp
+
+        def ts(x):
+            return x.timestamp
+
         total_msec = 0
         interval_start = -1
         samples: list[CounterMeasurement] = []

--- a/tests/rptest/utils/full_disk.py
+++ b/tests/rptest/utils/full_disk.py
@@ -17,7 +17,8 @@ class FullDiskHelper:
 
     # TODO factor out similar code in cluster_config_test.py
     def _wait_for_node_config_value(self, key: str, value: int) -> None:
-        _get = lambda k: self.admin.get_cluster_config()[k]
+        def _get(k):
+            return self.admin.get_cluster_config()[k]
 
         def match(key: str, val: int) -> bool:
             v = _get(key)


### PR DESCRIPTION
Do not assign a lambda expression, use a definition instead.

Ran: ruff check --select E731 --fix --unsafe-fixes tests

Details about the rule:
https://docs.astral.sh/ruff/rules/lambda-assignment/

Technically this is an unsafe fix, but the unsafeness is very obscure as far as I can tell (the doc doesn't even mention the unsafeness), e.g. if someone introspected the specific type of the function object or its string representation.

I didn't exhaustively check each case but I looked at a few and there is nothing like that and it seems unlikely to me (and likely to fail loudly if it happens).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
