### PR TITLE
treewide: ruff E721: type checks

### DIFF
--- a/tests/rptest/tests/data_transforms_test.py
+++ b/tests/rptest/tests/data_transforms_test.py
@@ -845,7 +845,7 @@ class LogRecord:
             return (
                 self.key == other.key
                 and self.value_type == other.value_type
-                and type(self.value) == type(other.value)
+                and type(self.value) is type(other.value)
             )
 
     EXPECTED_ATTRS = [

--- a/tests/rptest/tests/metrics_reporter_test.py
+++ b/tests/rptest/tests/metrics_reporter_test.py
@@ -167,7 +167,7 @@ class MetricsReporterTest(RedpandaTest):
         # the source of the value is sound, so assert on presence instead.
         assert "has_enterprise_features" in last
         assert "enterprise_features" in last
-        assert type(last["enterprise_features"]) == list
+        assert type(last["enterprise_features"]) is list
         assert "hostname" in last
         assert "domainname" in last
         assert "fqdns" in last

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -1617,7 +1617,7 @@ class PandaProxyBasicAuthTest(PandaProxyEndpoints):
             ]
         }
 
-        if offset_value is not None and type(offset_value) == int:
+        if offset_value is not None and type(offset_value) is int:
             for p in offset_data["partitions"]:
                 p["offset"] = offset_value
 

--- a/tests/rptest/tests/partition_reassignments_test.py
+++ b/tests/rptest/tests/partition_reassignments_test.py
@@ -72,7 +72,7 @@ def check_execute_reassign_partitions(
 
     # Then a json structure
     current_assignment = json.loads(lines.pop().strip())
-    assert type(current_assignment) == type({}), "Expected JSON object"
+    assert type(current_assignment) is type({}), "Expected JSON object"
 
     # Then another exact string
     assert len(lines.pop()) == 0
@@ -387,7 +387,7 @@ class PartitionReassignmentsTest(RedpandaTest):
         all_node_idx_set = set(all_node_idx)
         for res in responses:
             assert res.topic in all_topic_names
-            assert type(res.partition) == int
+            assert type(res.partition) is int
             assert res.partition in all_partition_idx
             assert set(res.replicas).issubset(all_node_idx_set)
             assert set(res.adding_replicas).issubset(all_node_idx_set)
@@ -403,7 +403,7 @@ class PartitionReassignmentsTest(RedpandaTest):
 
             for res in responses:
                 assert res.topic in all_topic_names
-                assert type(res.partition) == int
+                assert type(res.partition) is int
                 assert res.partition in all_partition_idx
                 assert set(res.replicas).issubset(all_node_idx_set)
 

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1435,7 +1435,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             if result_raw.status_code != requests.codes.ok:
                 return False
             res_subjects = result_raw.json()
-            if type(res_subjects) != type([]):
+            if type(res_subjects) is not type([]):
                 return False
             subjects.sort()
             return res_subjects == subjects and res_subjects == sorted(res_subjects)
@@ -3030,7 +3030,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             assert result_raw.status_code == requests.codes.ok
             res_subjects = result_raw.json()
             self.logger.debug(res_subjects)
-            assert type(res_subjects) == type([])
+            assert type(res_subjects) is type([])
             res_subjects.sort()
             subjects.sort()
             assert res_subjects == subjects
@@ -3042,7 +3042,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             assert result_raw.status_code == requests.codes.ok
             res_versions = result_raw.json()
             self.logger.debug(res_versions)
-            assert type(res_versions) == type([])
+            assert type(res_versions) is type([])
             assert res_versions == subject_versions
 
         # Given the subject, list of schemas, list of versions, and list of ids,
@@ -3064,7 +3064,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 assert result_raw.status_code == requests.codes.ok
                 res = result_raw.json()
                 self.logger.debug(res)
-                assert type(res) == type({})
+                assert type(res) is type({})
                 assert "subject" in res
                 assert "version" in res
                 assert "id" in res


### PR DESCRIPTION
Replace all use of '== type(...)' with 'is type(...)' for type checks.

This preserves the existing semantics. Arguably, some of these can be replaced with isinstance() checks, but that is more likely to change the semantics and I don't see any compelling reason to do so for these limited cases.

Basically we silence the lint with the least invasive change.

Docs on this rule: https://docs.astral.sh/ruff/rules/type-comparison/

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none
