### PR TITLE
ruff E402, F821, F521

### DIFF
--- a/tests/rptest/services/kcat_consumer.py
+++ b/tests/rptest/services/kcat_consumer.py
@@ -272,7 +272,7 @@ class KcatConsumer(BackgroundThreadService):
                     partition = int(m.group("partition"))
                     if m.group("topic") != self._topic:
                         self._redpanda.logger.warning(
-                            "{}Topic reported by kcat ({}}) is different from the requested ({}). Line: {}".format(
+                            "{}Topic reported by kcat ({}) is different from the requested ({}). Line: {}".format(
                                 self._caption,
                                 m.group("topic"),
                                 self._topic,

--- a/tests/rptest/services/multi_cluster_services.py
+++ b/tests/rptest/services/multi_cluster_services.py
@@ -216,7 +216,7 @@ class MultiClusterServices:
 
     def setUp(self):
         assert len(self.primary.service.started_nodes()) == 0, (
-            f"{str(c)}: MultiClusterServices expects to start itself"
+            "MultiClusterServices expects to start itself"
         )
 
         # TODO: extra configs?

--- a/tests/rptest/tests/basic_kafka_compat_test.py
+++ b/tests/rptest/tests/basic_kafka_compat_test.py
@@ -24,8 +24,9 @@ from rptest.services.kafka import KafkaServiceAdapter
 from rptest.services.redpanda import RedpandaService, ValidationMode
 from rptest.tests.end_to_end import EndToEndTest
 
-KAFKA_VERSION = kafkatest.version.KafkaVersion("3.7.0")
 from rptest.services.redpanda_types import RedpandaServiceForClients
+
+KAFKA_VERSION = kafkatest.version.KafkaVersion("3.7.0")
 
 T = TypeVar("T")
 

--- a/tests/rptest/tests/connection_virtualizing_test.py
+++ b/tests/rptest/tests/connection_virtualizing_test.py
@@ -24,6 +24,9 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import wait_until
 from rptest.utils.xid_utils import random_xid_string
 
+import kafka.errors as Errors
+from kafka.protocol.types import Int32
+
 
 @dataclass
 class PartitionInfo:
@@ -121,10 +124,6 @@ class MpxMockClient:
 
     def close(self):
         self.client.close()
-
-
-import kafka.errors as Errors
-from kafka.protocol.types import Int32
 
 
 def no_validation_process_response(self, read_buffer):

--- a/tests/typings/ducktape/cluster/node_container.pyi
+++ b/tests/typings/ducktape/cluster/node_container.pyi
@@ -1,6 +1,9 @@
 from collections.abc import Generator
 
 from _typeshed import Incomplete
+from typing import Iterator
+
+from ducktape.cluster.cluster import ClusterNode
 
 class NodeNotPresentError(Exception): ...
 class InsufficientResourcesError(Exception): ...


### PR DESCRIPTION
Fixing the remaining ruff check errors (other than E712), which are

- Move imports to top of file (E402)
- Fix undefined names (these were all just bugs)
- Fix format string braces (again just a bug)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

