### PR TITLE
[CORE-14466] ts: Fix spillover race

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -3028,7 +3028,7 @@ ss::future<> ntp_archiver::apply_spillover() {
         auto fo = manifest().begin()->base_offset;
         if (fo != so.value()) {
             vlog(
-              _rtclog.error,
+              _rtclog.warn,
               "Spillover invariant violated: manifest start_offset {}, first "
               "segment base_offset {}",
               so.value(),

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -2774,6 +2774,9 @@ ss::future<> ntp_archiver::apply_archive_retention() {
           _rtclog.warn,
           "Failed to replicate archive truncation command: {}",
           error.message());
+
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format, "Failed to apply archive retention: {}", error));
     } else {
         vlog(
           _rtclog.info,

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -2986,6 +2986,10 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
               _rtclog.info,
               "Failed to clean up metadata after garbage collection: {}",
               error);
+            throw std::runtime_error(fmt_with_ctx(
+              fmt::format,
+              "Failed to clean up metadata after archive GC: {}",
+              error));
         } else {
             std::ignore = co_await _remote.delete_objects(
               get_bucket_name(), manifests_to_remove, fib);
@@ -3439,6 +3443,9 @@ ss::future<> ntp_archiver::garbage_collect() {
               _rtclog.info,
               "Failed to clean up metadata after garbage collection: {}",
               error);
+
+            throw std::runtime_error(fmt_with_ctx(
+              fmt::format, "Failed to clean up metadata after GC: {}", error));
         }
     } else {
         vlog(


### PR DESCRIPTION
This PR
* Downgrades error to warning.
* Interrupts housekeeping in case if replication of the archival STM command times out. This is needed to prevent certain race conditions from happening (when the replication times out but the command is replicated and then applied asynchronously).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none