### PR TITLE
[CORE-13902] ct: Sync ctp_stm before acquiring fence

### DIFF
--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -27,6 +27,8 @@
 
 namespace cloud_topics {
 
+static constexpr auto sync_timeout = 10s;
+
 namespace {
 cluster_epoch extract_epoch(model::record_batch&& batch) {
     vassert(
@@ -329,6 +331,10 @@ ss::future<iobuf> ctp_stm::take_raft_snapshot(model::offset snapshot_at) {
 }
 
 ss::future<cluster_epoch_fence> ctp_stm::fence_epoch(cluster_epoch e) {
+    if (!co_await sync(sync_timeout)) {
+        vlog(_log.warn, "ctp_stm::fence_epoch sync timeout");
+        throw std::runtime_error(fmt_with_ctx(fmt::format, "Sync timeout"));
+    }
     auto term = _raft->confirmed_term();
     auto max_seen_epoch = _state.get_max_seen_epoch();
     if (max_seen_epoch.has_value() && max_seen_epoch.value() == e) {


### PR DESCRIPTION
Currently, the `ctp_stm` is not invoking `sync` in the `fence_epoch` method. Because of that right after the leadership transfer the `fence_epoch` might return incorrect result.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details ahttps://github.com/redpanda-data/redpanda/pull/28282#topnd examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes: CORE-13902
Fixes: CORE-14470
Fixes: CORE-14366
Fixes: CORE-14365

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none