### PR TITLE
rptest: change CloudStorageTypeAndUrlStyle to list

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -316,7 +316,10 @@ class MetricsEndpoint(Enum):
     PUBLIC_METRICS = "public_metrics"
 
 
-CloudStorageTypeAndUrlStyle = Tuple[CloudStorageType, Literal["virtual_host", "path"]]
+# for this type value[0] is CloudStorageType and value[1] is url style
+# but it needs to be a list rather than a tuple because injected parameters
+# must be "json compatible" which means no tuples
+CloudStorageTypeAndUrlStyle = list[CloudStorageType | Literal["virtual_host", "path"]]
 
 
 def prepare_allow_list(allow_list: LogAllowList) -> CompiledLogAllowList:
@@ -408,7 +411,7 @@ def get_cloud_storage_type_and_url_style() -> List[CloudStorageTypeAndUrlStyle]:
     """
 
     def get_style(t: CloudStorageType) -> List[CloudStorageTypeAndUrlStyle]:
-        return [(t, us) for us in get_cloud_storage_url_style(t)]
+        return [[t, us] for us in get_cloud_storage_url_style(t)]
 
     return [
         tus


### PR DESCRIPTION
This needs to be a list, not a tuple, because injected parameters must be JSON compatible.

I had inadvertently changed this to a tuple for better typing in an earlier commit, but set it back to list over a union of the types of the two elements, which may require some casting in the future at the call sites (when we further improve type safety), but that's fine.

See also [DEVPROD-3062](https://redpandadata.atlassian.net/browse/DEVPROD-3062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ).

Fixes CORE-14481.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none


[DEVPROD-3062]: https://redpandadata.atlassian.net/browse/DEVPROD-3062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ