### PR TITLE
tuner: Handle ssh timeouts in tuner tests

### DIFF
--- a/tests/rptest/clients/rpk_remote.py
+++ b/tests/rptest/clients/rpk_remote.py
@@ -63,12 +63,19 @@ class RpkRemoteTool:
     def cluster_config_lint(self):
         return self._execute([self._rpk_binary(), "cluster", "config", "lint"])
 
-    def tune(self, tuner: str, extra_args: list[str] = [], verbose: bool = True) -> str:
+    def tune(
+        self,
+        tuner: str,
+        extra_args: list[str] = [],
+        verbose: bool = True,
+        timeout: int = 30,
+    ) -> str:
         verbose_args: list[str] = []
         if verbose:
             verbose_args = ["-v"]
         return self._execute(
-            [self._rpk_binary(), "redpanda", "tune", tuner] + verbose_args + extra_args
+            [self._rpk_binary(), "redpanda", "tune", tuner] + verbose_args + extra_args,
+            timeout=timeout,
         )
 
     def check(self) -> str:

--- a/tests/rptest/tuner_integration_tests/net_tuner_test.py
+++ b/tests/rptest/tuner_integration_tests/net_tuner_test.py
@@ -216,6 +216,16 @@ class NetTunerTest(RedpandaTest):
             if line.startswith(f"NIC {self.interface_name}"):
                 assert line.endswith("true"), f"NIC check failed: {line}"
 
+    def _fix_ssh_connection(self):
+        # RX/TX queue lowering can "break" the ssh connection on GCP. The
+        # command will have succeeded anyway so such ignore and continue.
+        # Close the ssh client to force a reconnect otherwise the next
+        # command will timeout/fail again
+        self.node.account.ssh_client.close()
+        self.logger.debug(
+            "Tuner command timed out (likely due to GCP connection dropping), continuing"
+        )
+
     def _test_tune_net_mq(self, expected_interrupt_setup: ExpectedInterruptSetup):
         # Create a dummy file. This should be emptied by the tuner
         self.redpanda.nodes[0].account.ssh(f"echo 123 > {NET_TUNER_CONFIG_FILE_PATH}")
@@ -242,7 +252,12 @@ class NetTunerTest(RedpandaTest):
         if not rps_rfs:
             self.rpk.config_set("rpk.allow_rps_rfs_tuner", "false")
 
-        self.rpk.tune("net", ["--mode", "dedicated"] + additional_tune_args)
+        try:
+            self.rpk.tune(
+                "net", ["--mode", "dedicated"] + additional_tune_args, timeout=2
+            )
+        except TimeoutError:
+            self._fix_ssh_connection()
 
         self.start_rp(additional_args=additional_start_args)
 
@@ -259,9 +274,15 @@ class NetTunerTest(RedpandaTest):
 
         self.rpk.config_set("rpk.allow_dedicated_interrupt_mode", "true")
 
-        # In this test also confirm that the net tuner config file mode is set correctly
-        # Tune with very restrictive umask
-        self.node.account.ssh("umask 077 && rpk redpanda tune net -v")
+        try:
+            # In this test also confirm that the net tuner config file mode is set correctly
+            # Tune with very restrictive umask
+            self.node.account.ssh_output(
+                "umask 077 && rpk redpanda tune net -v", timeout_sec=2
+            )
+        except TimeoutError:
+            self._fix_ssh_connection()
+
         # And then confirm the redpanda user can read it
         self.node.account.ssh(
             f"sudo -u redpanda bash -c 'test -r {NET_TUNER_CONFIG_FILE_PATH}'"


### PR DESCRIPTION
We were seeing test failures in GCP because of the tuner ssh commands
timing out.

This seems very reproducible now presumably after my changes to speed up
the tuner.

After investigation it seems that this is caused by RX/TX queue count
lowering which apparently seems to somehow kill the SSH connection and
leaves it in bad state.

This doesn't seem to happen on AWS but only on GCP.

A workaround seems to be to disable verbose logging. However that is
very important to debug any other failures and hence we'd rather keep it
on.

This change instead adds a two second timeout to the ssh commands (the
tuner should run in lower XXXms) which we just ignore and just wait for.
The tuner command still succeeds and tunes correctly without issues and
we check that after the timeout.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none

