### PR TITLE
Block tests that have non-jsonable params (and fix existing ones)

### DIFF
--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -9,6 +9,7 @@
 
 import dataclasses
 import functools
+import json
 import time
 from dataclasses import dataclass
 from typing import Any, Callable, Protocol
@@ -221,6 +222,40 @@ def cluster(
 
         return extra_results
 
+    @staticmethod
+    def _check_injected_args_roundtrip(args: Any):
+        """Check that the injected args roundtrip through a JSON encode/decode, if
+        they do not, the test cannot be correctly parameterized on the command line."""
+
+        # In ducktape, "injected args", i.e. those passes with @matrix or
+        # @parametrize, annotations, should always use "json roundtrip-able"
+        # types, otherwise they cannot be re-invoked on the command line (or
+        # using a test suite file), as DT can only parse JSON arguments. Among
+        # other things, this means that PT retry will always fail to re-invoke
+        # test during retry and these tests will simply fail if they fail in their
+        # initial invocation.
+        #
+        # This means that you can only use types that are JSON de/serializable, such
+        # as: str, int, float, bool, None, list, dict.  You should not use any
+        # user defined types, or tuples, sets, enums, etc, as these do no roundtrip
+        # correctly. As a workaround, for tuples pass lists, for sets pass lists,
+        # and for any more complicated type, you can just pass a string identifier
+        # and look up the real type inside the test from a dict[str, MyComplexType].
+
+        try:
+            roundtripped = json.loads(json.dumps(args))
+        except Exception as e:
+            raise ValueError(
+                "Injected args cannot be serialized to JSON "
+                f"or do not roundtrip correctly: {args}"
+            ) from e
+
+        if roundtripped != args:
+            raise RuntimeError(  # see source (here) line for details
+                "Injected args do not roundtrip through JSON: "
+                f"original={args}, roundtripped={roundtripped}"
+            )
+
     def cluster_use_metadata_adder(f: Callable[..., Any]):
         Mark.mark(f, ClusterUseMetadata(**kwargs))
 
@@ -229,6 +264,9 @@ def cluster(
             # This decorator will only work on test classes that have a RedpandaService,
             # such as RedpandaTest subclasses
             assert hasattr(self, "redpanda")
+            assert hasattr(self, "test_context")
+
+            _check_injected_args_roundtrip(self.test_context.injected_args)
 
             # some checks only make sense on "vanilla" Redpanda nodes, i.e., those created on
             # VMs or docker containers inside a ducktape node, where we have ssh access, for

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -2022,24 +2022,24 @@ class ClusterConfigIcebergTest(RedpandaTest):
         )
 
 
-"""
-PropertyAliasData:
-    primary_name: str  # this is the primary name in the current version of redpanda
-    aliased_name: str  # this is the legacy name, retained as an alias for backward compat
-    redpanda_version: RedpandaVersionLine  # this is the first version to use primary_name
-    test_values: list[Any, Any, Any]  # values for this property to run the tests
-    expect_restart: bool # setting property will ask for a restart
-"""
-PropertyAliasData = namedtuple(
-    "PropertyAliasData",
-    [
-        "primary_name",
-        "aliased_name",
-        "redpanda_version",
-        "test_values",
-        "expect_restart",
-    ],
-)
+class PropertyAliasData(NamedTuple):
+    """Data structure for property alias testing configuration."""
+
+    primary_name: str
+    """The primary name in the current version of redpanda."""
+
+    aliased_name: str
+    """The legacy name, retained as an alias for backward compat."""
+
+    redpanda_version: tuple[int, int]
+    """The first version to use primary_name."""
+
+    test_values: tuple[Any, Any, Any]
+    """Values for this property to run the tests."""
+
+    expect_restart: bool
+    """Setting property will ask for a restart."""
+
 
 cloud_storage_graceful_transfer_timeout = PropertyAliasData(
     primary_name="cloud_storage_graceful_transfer_timeout_ms",
@@ -2065,6 +2065,13 @@ data_transforms_per_core_memory_reservation = PropertyAliasData(
     expect_restart=True,
 )
 
+# Mapping from identifier string to PropertyAliasData for use in @matrix annotations
+PROPERTY_ALIAS_SETS: dict[str, PropertyAliasData] = {
+    "cloud_storage_graceful_transfer_timeout": cloud_storage_graceful_transfer_timeout,
+    "log_retention_ms": log_retention_ms,
+    "data_transforms_per_core_memory_reservation": data_transforms_per_core_memory_reservation,
+}
+
 
 class ClusterConfigAliasTest(RedpandaTest, ClusterConfigHelpersMixin):
     def __init__(self, *args, **kwargs):
@@ -2079,13 +2086,14 @@ class ClusterConfigAliasTest(RedpandaTest, ClusterConfigHelpersMixin):
 
     @cluster(num_nodes=3)
     @matrix(
-        prop_set=[
-            cloud_storage_graceful_transfer_timeout,
-            log_retention_ms,
-            data_transforms_per_core_memory_reservation,
+        prop_set_name=[
+            "cloud_storage_graceful_transfer_timeout",
+            "log_retention_ms",
+            "data_transforms_per_core_memory_reservation",
         ]
     )
-    def test_aliasing(self, prop_set: PropertyAliasData):
+    def test_aliasing(self, prop_set_name: str):
+        prop_set = PROPERTY_ALIAS_SETS[prop_set_name]
         """
         Validate that configuration property aliases enable the various means
         of setting a property to accept the old name (alias) as well as the new one.
@@ -2142,9 +2150,10 @@ class ClusterConfigAliasTest(RedpandaTest, ClusterConfigHelpersMixin):
     @cluster(num_nodes=3)
     @matrix(
         wipe_cache=[False, True],
-        prop_set=[cloud_storage_graceful_transfer_timeout, log_retention_ms],
+        prop_set_name=["cloud_storage_graceful_transfer_timeout", "log_retention_ms"],
     )
-    def test_aliasing_with_upgrade(self, wipe_cache: bool, prop_set: PropertyAliasData):
+    def test_aliasing_with_upgrade(self, wipe_cache: bool, prop_set_name: str):
+        prop_set = PROPERTY_ALIAS_SETS[prop_set_name]
         """
         Validate that a property written under an alias in a previous release
         is read correctly after upgrade.

--- a/tests/rptest/tests/control_character_flag_test.py
+++ b/tests/rptest/tests/control_character_flag_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 import time
+from typing import cast
 
 import requests.exceptions
 from ducktape.mark import parametrize
@@ -75,14 +76,18 @@ class ControlCharacterPermittedAfterUpgrade(ControlCharacterPermittedBase):
         )
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
-    @parametrize(initial_version=(22, 2, 9))
-    @parametrize(initial_version=(22, 3, 11))
-    @parametrize(initial_version=(23, 1, 1))
-    def test_upgrade_from_pre_v23_2(self, initial_version):
+    @parametrize(initial_version_as_list=[22, 2, 9])
+    @parametrize(initial_version_as_list=[22, 3, 11])
+    @parametrize(initial_version_as_list=[23, 1, 1])
+    def test_upgrade_from_pre_v23_2(self, initial_version_as_list: list[int]):
         """
         Validate that when upgrading from pre v23.2 that the flag is
         honored
         """
+
+        # work-around for rule that params must roundtrip through json
+        initial_version = cast(tuple[int, int, int], tuple(initial_version_as_list))
+
         self._validate_pre_upgrade(initial_version)
 
         # Creates a user with invalid control characters
@@ -143,13 +148,16 @@ class ControlCharacterNag(ControlCharacterPermittedBase):
     # before v24.2, dns query to s3 endpoint do not include the bucketname, which is required for AWS S3 fips endpoints
     @skip_fips_mode
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
-    @parametrize(initial_version=(22, 2, 9))
-    @parametrize(initial_version=(22, 3, 11))
-    @parametrize(initial_version=(23, 1, 1))
-    def test_validate_nag_message(self, initial_version):
+    @parametrize(initial_version_as_list=[22, 2, 9])
+    @parametrize(initial_version_as_list=[22, 3, 11])
+    @parametrize(initial_version_as_list=[23, 1, 1])
+    def test_validate_nag_message(self, initial_version_as_list: list[int]):
         """
         Validates that the nag message is present after upgrading a cluster
         """
+        # work-around for rule that params must roundtrip through json
+        initial_version = cast(tuple[int, int, int], tuple(initial_version_as_list))
+
         self._validate_pre_upgrade(initial_version)
 
         # Nag shouldn't be in logs

--- a/tests/rptest/tests/log_level_test.py
+++ b/tests/rptest/tests/log_level_test.py
@@ -114,9 +114,9 @@ class LogLevelTest(RedpandaTest):
             )
 
     @cluster(num_nodes=1)
-    @parametrize(loggers=("admin_api_server", "raft"))
-    @parametrize(loggers=("raft", "admin_api_server"))
-    def test_log_level_multiple_expiry(self, loggers=tuple[str, str]):
+    @parametrize(loggers=["admin_api_server", "raft"])
+    @parametrize(loggers=["raft", "admin_api_server"])
+    def test_log_level_multiple_expiry(self, loggers: list[str]):
         """
         Check that more than one logger can be in a modified level and be expired correctly
         see https://redpandadata.atlassian.net/browse/CORE-96

--- a/tests/rptest/tests/offset_retention_test.py
+++ b/tests/rptest/tests/offset_retention_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 import time
 from functools import partial
+from typing import cast
 
 from ducktape.mark import parametrize
 from ducktape.utils.util import wait_until
@@ -198,9 +199,9 @@ class OffsetRetentionDisabledAfterUpgrade(RedpandaTest):
         return not offsets_exist(True)
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
-    @parametrize(initial_version=(22, 2, 9))
-    @parametrize(initial_version=(22, 3, 11))
-    def test_upgrade_from_pre_v23(self, initial_version):
+    @parametrize(initial_version_as_list=[22, 2, 9])
+    @parametrize(initial_version_as_list=[22, 3, 11])
+    def test_upgrade_from_pre_v23(self, initial_version_as_list: list[int]):
         """
         1. test that retention feature doesn't work on legacy version
         2. upgrade cluster and test that feature still doesn't work
@@ -208,6 +209,9 @@ class OffsetRetentionDisabledAfterUpgrade(RedpandaTest):
         4. test that retention works properly
         """
         period = 30
+
+        # work-around for rule that params must roundtrip through json
+        initial_version = cast(tuple[int, int, int], tuple(initial_version_as_list))
 
         # in old cluster offset retention should not be active
         self._validate_pre_upgrade(initial_version)

--- a/tests/rptest/tests/redpanda_kerberos_test.py
+++ b/tests/rptest/tests/redpanda_kerberos_test.py
@@ -241,9 +241,8 @@ class RedpandaKerberosRulesTesting(RedpandaKerberosTestBase):
     @parametrize(
         rules=["RULE:[1:$1test$0](client.*)", "DEFAULT"],
         kerberos_principal="client",
-        rp_user=f"clienttest{REALM}",
         expected_topics=["restricted", "always_visible"],
-        acl=[("restricted", f"clienttest{REALM}"), ("always_visible", "*")],
+        acl=[["restricted", f"clienttest{REALM}"], ["always_visible", "*"]],
     )
     @parametrize(
         rules=[
@@ -252,17 +251,15 @@ class RedpandaKerberosRulesTesting(RedpandaKerberosTestBase):
             "DEFAULT",
         ],
         kerberos_principal="client",
-        rp_user="TESTGOODREDPANDA",
         expected_topics=["restricted", "always_visible"],
-        acl=[("restricted", "TESTGOODREDPANDA"), ("always_visible", "*")],
+        acl=[["restricted", "TESTGOODREDPANDA"], ["always_visible", "*"]],
     )
     def test_kerberos_mapping_rules(
         self,
         rules: list[str],
         kerberos_principal: str,
-        rp_user: str,
         expected_topics: list[str],
-        acl: list[tuple[str, str]],
+        acl: list[list[str]],
     ):
         self.client.add_primary(primary=kerberos_principal)
 

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -2228,11 +2228,11 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         )
 
     @cluster(num_nodes=3)
-    @parametrize(schemas=("avro", "avro_incompat", "AVRO"))
-    @parametrize(schemas=("proto3", "proto3_incompat", "PROTOBUF"))
-    @parametrize(schemas=("proto2", "proto2_incompat", "PROTOBUF"))
-    @parametrize(schemas=("json", "json_incompat", "JSON"))
-    def test_compatibility_messages(self, schemas):
+    @parametrize(schemas=["avro", "avro_incompat", "AVRO"])
+    @parametrize(schemas=["proto3", "proto3_incompat", "PROTOBUF"])
+    @parametrize(schemas=["proto2", "proto2_incompat", "PROTOBUF"])
+    @parametrize(schemas=["json", "json_incompat", "JSON"])
+    def test_compatibility_messages(self, schemas: list[str]):
         """
         Verify compatibility messages
         """


### PR DESCRIPTION
In ducktape, "injected args", i.e. those passed with @matrix or
@parametrize, annotations, should always use "json roundtrip-able"
types, otherwise they cannot be re-invoked on the command line (or
using a test suite file), as DT can only parse JSON arguments. Among
other things, this means that PT retry will always fail to re-invoke
test during retry and these tests will simply fail if they fail in their
initial invocation.

This means that you can only use types that are JSON de/serializable,
such as: str, int, float, bool, None, list, dict.  You should not use
any user defined types, or tuples, sets, enums, etc, as these do no
roundtrip correctly.

This change modifies tests which don't follow these rules. Most are
just swaps of tuple for list, often not requiring any test changes. In
one case (for redpanda version), we map back to tuple inside the test
since downstream functions want tuples.

For one test, we had NamedTuple instances being passed in @matrix, so
we use string identifiers instead of PropertyAliasData instances, and
then do a dict lookup in the test to recover the original object.

Also, if a test is non-jsonable (see previous commit for details), block it
from running by throwing an error in the @cluster decorator. We do the
check by literally checking if it roundtrips through json.

We try to add a detailed description of what is going on as well as
the details of the input and output objects which failed to roundtrip
to help the user.

Fixes [CORE-14572].

xref: https://redpandadata.slack.com/archives/C06H3S140NM/p1761836294875129

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none


[CORE-14572]: https://redpandadata.atlassian.net/browse/CORE-14572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ