### PR TITLE
[CORE-14461] Shadow Linking: Update ID allocator with max incoming producer ID on replicate

### DIFF
--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -196,6 +196,11 @@ public:
         return _instances[id]->app.metadata_cache.local();
     }
 
+    cluster::id_allocator_frontend&
+    get_local_id_allocator_frontend(model::node_id id) {
+        return _instances[id]->app.id_allocator_frontend.local();
+    }
+
     ss::sharded<cluster::partition_manager>&
     get_partition_manager(model::node_id id) {
         return _instances[id]->app.partition_manager;

--- a/src/v/cluster_link/replication/deps.h
+++ b/src/v/cluster_link/replication/deps.h
@@ -56,6 +56,14 @@ public:
       = 0;
 
     virtual kafka::offset start_offset() = 0;
+
+    // If needed, push the highest seen producer ID into id_allocator. This
+    // helps avoid false-positive idempotency errors, e.g. if, after failing
+    // over, a new producer on the target cluster were assigned an ID already
+    // used on the source cluster. We can avoid this by always making sure the
+    // next ID persisted to the allocator is ahead of the highest producer ID
+    // we've seen from a source cluster batch.
+    virtual ss::future<> maybe_sync_pid() = 0;
 };
 
 class data_sink_factory {

--- a/src/v/cluster_link/replication/partition_replicator.cc
+++ b/src/v/cluster_link/replication/partition_replicator.cc
@@ -199,6 +199,7 @@ ss::future<> partition_replicator::replicate_and_wait(
             .finally(
               [inflight = std::move(inflight), data = std::move(data)]() {});
       });
+    co_await _sink->maybe_sync_pid();
 }
 
 partition_offsets_report

--- a/src/v/cluster_link/replication/tests/deps_test_impl.h
+++ b/src/v/cluster_link/replication/tests/deps_test_impl.h
@@ -38,6 +38,7 @@ public:
       kafka::offset truncation_offset,
       ss::lowres_clock::time_point deadline) final;
     kafka::offset start_offset() final;
+    ss::future<> maybe_sync_pid() final { return ss::now(); }
 
 private:
     size_t _records_consumed;

--- a/src/v/cluster_link/replication/tests/link_replication_mgr_tests.cc
+++ b/src/v/cluster_link/replication/tests/link_replication_mgr_tests.cc
@@ -105,6 +105,8 @@ public:
 
     kafka::offset start_offset() final { return {}; }
 
+    ss::future<> maybe_sync_pid() final { return ss::now(); }
+
 private:
     ss::gate _gate;
 };

--- a/src/v/cluster_link/replication/tests/partition_replicator_tests.cc
+++ b/src/v/cluster_link/replication/tests/partition_replicator_tests.cc
@@ -171,6 +171,8 @@ public:
 
     kafka::offset start_offset() final { return _start_offset; }
 
+    ss::future<> maybe_sync_pid() final { return ss::now(); }
+
 private:
     model::ntp _ntp{"kafka", "test", model::partition_id(0)};
     mutex _replication_mu{"test_replication"};

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -531,15 +531,53 @@ public:
           kafka::make_partition_proxy(_partition).start_offset());
     }
 
+    ss::future<> maybe_sync_pid() final {
+        // each time we sync the producer ID, advanced it by some fixed amount
+        // greater than one to minimize the number of reset queries.
+        constexpr ::model::producer_id::type pid_sync_increment{1000};
+        constexpr auto timeout = 10s;
+        auto h = _gate.hold();
+        if (
+          _highest_seen_pid
+          < _last_synced_pid.value_or(::model::producer_id{0})) {
+            co_return;
+        }
+        auto next_pid = _highest_seen_pid + pid_sync_increment;
+        vlog(cllog.debug, "Setting next producer ID to {}", next_pid);
+        auto res_f = co_await ss::coroutine::as_future(
+          _id_allocator_frontend.reset_next_id(next_pid, timeout));
+
+        if (res_f.failed()) {
+            auto eptr = res_f.get_exception();
+            vlog(
+              cllog.warn,
+              "Failed to set next producer ID to {}: {}",
+              next_pid,
+              eptr);
+            co_return;
+        }
+
+        if (auto ec = res_f.get().ec; ec != cluster::errc::success) {
+            vlog(
+              cllog.warn,
+              "Failed to set next producer ID to {}: {}",
+              next_pid,
+              ec);
+            co_return;
+        }
+        _last_synced_pid = next_pid;
+    }
+
 private:
     ss::gate _gate;
     ss::lw_shared_ptr<cluster::partition> _partition;
     const cluster::metadata_cache& _metadata_cache;
-    [[maybe_unused]] cluster::id_allocator_frontend& _id_allocator_frontend;
+    cluster::id_allocator_frontend& _id_allocator_frontend;
     ss::shared_ptr<kafka::write_at_offset_stm> _stm;
     // set in start();
     std::optional<kafka::offset> _last_replicated_offset;
     ::model::producer_id _highest_seen_pid{::model::no_producer_id};
+    std::optional<::model::producer_id> _last_synced_pid;
 };
 
 class local_partition_data_sink_factory

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -450,6 +450,9 @@ public:
         chunked_vector<kafka::offset> expected_offsets;
         expected_offsets.reserve(batches.size());
         for (const auto& batch : batches) {
+            _highest_seen_pid = std::max(
+              _highest_seen_pid,
+              ::model::producer_id{batch.header().producer_id});
             expected_offsets.push_back(
               ::model::offset_cast(batch.base_offset()));
         }
@@ -536,6 +539,7 @@ private:
     ss::shared_ptr<kafka::write_at_offset_stm> _stm;
     // set in start();
     std::optional<kafka::offset> _last_replicated_offset;
+    ::model::producer_id _highest_seen_pid{::model::no_producer_id};
 };
 
 class local_partition_data_sink_factory

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -14,6 +14,7 @@
 #include "cluster/cluster_link/frontend.h"
 #include "cluster/controller.h"
 #include "cluster/health_monitor_frontend.h"
+#include "cluster/id_allocator_frontend.h"
 #include "cluster/members_table.h"
 #include "cluster/metadata_cache.h"
 #include "cluster/partition_manager.h"
@@ -380,9 +381,11 @@ public:
     static constexpr auto sync_timeout = 10s;
     explicit local_partition_sink(
       ss::lw_shared_ptr<cluster::partition> partition,
-      const cluster::metadata_cache& md_cache)
+      const cluster::metadata_cache& md_cache,
+      cluster::id_allocator_frontend& id_alloc)
       : _partition(std::move(partition))
       , _metadata_cache{md_cache}
+      , _id_allocator_frontend(id_alloc)
       , _stm(_partition->raft()
                ->stm_manager()
                ->get<kafka::write_at_offset_stm>()) {
@@ -529,6 +532,7 @@ private:
     ss::gate _gate;
     ss::lw_shared_ptr<cluster::partition> _partition;
     const cluster::metadata_cache& _metadata_cache;
+    [[maybe_unused]] cluster::id_allocator_frontend& _id_allocator_frontend;
     ss::shared_ptr<kafka::write_at_offset_stm> _stm;
     // set in start();
     std::optional<kafka::offset> _last_replicated_offset;
@@ -539,9 +543,11 @@ class local_partition_data_sink_factory
 public:
     explicit local_partition_data_sink_factory(
       ss::sharded<cluster::partition_manager>& pm,
-      ss::sharded<cluster::metadata_cache>& md_cache)
+      ss::sharded<cluster::metadata_cache>& md_cache,
+      ss::sharded<cluster::id_allocator_frontend>& id_alloc)
       : _partition_manager(pm)
-      , _metadata_cache{md_cache} {}
+      , _metadata_cache{md_cache}
+      , _id_allocator_frontend(id_alloc) {}
 
     std::unique_ptr<replication::data_sink>
     make_sink(const ::model::ntp& ntp) final {
@@ -551,12 +557,15 @@ public:
               fmt::format("Partition not found: {} on this shard", ntp));
         }
         return make_default_data_sink(
-          std::move(partition), _metadata_cache.local());
+          std::move(partition),
+          _metadata_cache.local(),
+          _id_allocator_frontend.local());
     }
 
 private:
     ss::sharded<cluster::partition_manager>& _partition_manager;
     ss::sharded<cluster::metadata_cache>& _metadata_cache;
+    ss::sharded<cluster::id_allocator_frontend>& _id_allocator_frontend;
 };
 
 std::unique_ptr<replication::data_source> make_default_data_source(
@@ -567,9 +576,10 @@ std::unique_ptr<replication::data_source> make_default_data_source(
 
 std::unique_ptr<replication::data_sink> make_default_data_sink(
   ss::lw_shared_ptr<cluster::partition> partition,
-  const cluster::metadata_cache& md_cache) {
+  const cluster::metadata_cache& md_cache,
+  cluster::id_allocator_frontend& id_allocator) {
     return std::make_unique<local_partition_sink>(
-      std::move(partition), md_cache);
+      std::move(partition), md_cache, id_allocator);
 }
 
 class default_link_config_provider
@@ -776,11 +786,13 @@ public:
     explicit default_link_factory(
       ss::sharded<cluster::partition_manager>* partition_manager,
       ss::sharded<kafka::snc_quota_manager>* snc_quota_mgr,
-      ss::sharded<cluster::metadata_cache>* md_cache)
+      ss::sharded<cluster::metadata_cache>* md_cache,
+      ss::sharded<cluster::id_allocator_frontend>* id_alloc)
       : link_factory()
       , _partition_manager(partition_manager)
       , _snc_quota_mgr(snc_quota_mgr)
-      , _metadata_cache(md_cache) {}
+      , _metadata_cache(md_cache)
+      , _id_allocator_frontend(id_alloc) {}
 
     static constexpr auto link_reconciler_period = 5min;
     std::unique_ptr<link> create_link(
@@ -812,13 +824,14 @@ public:
               make_remote_consumer_configuration(config.connection),
               std::move(probe_cfg))),
           std::make_unique<local_partition_data_sink_factory>(
-            *_partition_manager, *_metadata_cache));
+            *_partition_manager, *_metadata_cache, *_id_allocator_frontend));
     }
 
 private:
     ss::sharded<cluster::partition_manager>* _partition_manager;
     ss::sharded<kafka::snc_quota_manager>* _snc_quota_mgr;
     ss::sharded<cluster::metadata_cache>* _metadata_cache;
+    ss::sharded<cluster::id_allocator_frontend>* _id_allocator_frontend;
 };
 
 class kafka_consumer_groups_router : public consumer_groups_router {
@@ -905,6 +918,7 @@ service::service(
   ss::sharded<cluster::health_monitor_frontend>* hm_frontend,
   ss::sharded<cluster::security_frontend>* security_fe,
   ss::sharded<kafka::data::rpc::client>* kafka_data_rpc_client,
+  ss::sharded<cluster::id_allocator_frontend>* id_alloc,
   ss::smp_service_group smp_group,
   ss::scheduling_group scheduling_group)
   : _self(self)
@@ -922,6 +936,7 @@ service::service(
   , _hm_frontend(hm_frontend)
   , _security_fe(security_fe)
   , _kafka_data_rpc_client(kafka_data_rpc_client)
+  , _id_allocator_frontend(id_alloc)
   , _smp_group(smp_group)
   , _scheduling_group(scheduling_group)
   , _queue(_scheduling_group, [](const std::exception_ptr& ex) {
@@ -1101,7 +1116,10 @@ ss::future<> service::maybe_start_manager() {
       security_service::make_default(_security_fe),
       std::make_unique<link_registry_adapter>(&_plf->local(), this),
       std::make_unique<default_link_factory>(
-        _partition_manager, _snc_quota_mgr, _metadata_cache),
+        _partition_manager,
+        _snc_quota_mgr,
+        _metadata_cache,
+        _id_allocator_frontend),
       std::make_unique<cluster_factory>(),
       std::make_unique<kafka_consumer_groups_router>(_group_router),
       std::make_unique<health_monitor_based_partition_metadata_provider>(

--- a/src/v/cluster_link/service.h
+++ b/src/v/cluster_link/service.h
@@ -56,6 +56,7 @@ public:
       ss::sharded<cluster::health_monitor_frontend>* hm_frontend,
       ss::sharded<cluster::security_frontend>* security_fe,
       ss::sharded<kafka::data::rpc::client>* kafka_data_rpc_client,
+      ss::sharded<cluster::id_allocator_frontend>* id_alloc,
       ss::smp_service_group smp_group,
       ss::scheduling_group scheduling_group);
 
@@ -214,6 +215,7 @@ private:
     ss::sharded<cluster::health_monitor_frontend>* _hm_frontend;
     ss::sharded<cluster::security_frontend>* _security_fe;
     ss::sharded<kafka::data::rpc::client>* _kafka_data_rpc_client;
+    ss::sharded<cluster::id_allocator_frontend>* _id_allocator_frontend;
     ss::smp_service_group _smp_group;
     ss::scheduling_group _scheduling_group;
     std::unique_ptr<manager> _manager;
@@ -231,5 +233,6 @@ std::unique_ptr<replication::data_source> make_default_data_source(
 
 std::unique_ptr<replication::data_sink> make_default_data_sink(
   ss::lw_shared_ptr<cluster::partition> partition,
-  const cluster::metadata_cache&);
+  const cluster::metadata_cache&,
+  cluster::id_allocator_frontend&);
 } // namespace cluster_link

--- a/src/v/cluster_link/tests/partition_replicator_fixture_tests.cc
+++ b/src/v/cluster_link/tests/partition_replicator_fixture_tests.cc
@@ -54,7 +54,9 @@ public:
         auto source = cluster_link::make_default_data_source(
           _source.tp, *_mux_consumer);
         auto sink = cluster_link::make_default_data_sink(
-          partition, get_local_cache(model::node_id{0}));
+          partition,
+          get_local_cache(model::node_id{0}),
+          get_local_id_allocator_frontend(model::node_id{0}));
         _replicator
           = std::make_unique<cluster_link::replication::partition_replicator>(
             _source,

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1568,6 +1568,7 @@ void application::wire_up_runtime_services(
       &controller->get_health_monitor(),
       &controller->get_security_frontend(),
       &_kafka_data_rpc_client,
+      &id_allocator_frontend,
       smp_service_groups.cluster_link_smp_sg(),
       sched_groups.cluster_linking_sg())
       .get();

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -45,6 +45,7 @@ from rptest.services.multi_cluster_services import (
     SecondaryClusterArgs,
     SecondaryClusterSpec,
     ServiceType,
+    Service as MultiService,
 )
 from rptest.services.redpanda import (
     MetricSamples,
@@ -2137,6 +2138,68 @@ class ShadowLinkTopicFailoverTests(ShadowLinkPreAllocTestBase):
 
         self._produce_to_topics(
             topics, self.target_cluster.service, expect_failures=False
+        )
+
+    @cluster(num_nodes=7)
+    def test_producer_ids_failover(self):
+        self.create_link("test-link")
+        num_messages = 2
+        topic = TopicSpec(name="test-topic", partition_count=1, replication_factor=3)
+        self.source_default_client().create_topic(topic)
+
+        def produce(n: int, redpanda: MultiService):
+            KgoVerifierProducer.oneshot(
+                self.test_context,
+                redpanda,
+                topic.name,
+                128,
+                n,
+                timeout_sec=30,
+            )
+
+        def consume(n: int, offset: str = "start") -> list[int]:
+            try:
+                raw = self.target_cluster_rpk.consume(
+                    topic=topic.name,
+                    n=n,
+                    partition=0,
+                    timeout=5,
+                    offset=offset,
+                    format="%o,",
+                )
+                return [int(o) for o in raw.split(",")[0:-1]]
+            except Exception as e:
+                return []
+
+        produce(n=num_messages, redpanda=self.source_cluster.service)
+
+        self.target_cluster_service.wait_until(
+            lambda: self.topic_exists_in_target(topic.name),
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg=f"Topic {topic.name} not found in target cluster",
+        )
+
+        wait_until(
+            lambda: consume(1, offset=f"{num_messages - 1}") == [num_messages - 1],
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"First messages never appeared: {consume(num_messages)}",
+        )
+
+        self.failover_link(name="test-link")
+        self.wait_for_link_failover(link="test-link")
+
+        second_round = 2
+
+        produce(n=second_round, redpanda=self.target_cluster.service)
+
+        wait_until(
+            lambda: consume(second_round, offset=f"{num_messages}")
+            == list(range(num_messages, num_messages + second_round)),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"Second Messages never appeared: {consume(num_messages)}",
         )
 
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR:
- Plumbs id_allocator_frontend into local_partition_sink
- Adds some code to track the highest producer ID seen, per sink
- Adds code to update the next ID in id_allocator to highest_seen + largeN while replicating batches
   - if and only if the highest producer ID in the replication operation exceeds the highest pid seen/synced

The idea here is to address situations where, post-failover, a producer on the target cluster could get assigned an ID that had already been used on the source cluster, previously. The result in that case could be an effectively false-positive idempotency error. Producers on the target cluster should be assigned IDs strictly greater than any gleaned from batches incoming over the shadow link.

TODO:
- [x] fill out comments
- [ ] fixture test (WIP)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
