### PR TITLE
[CORE-14480] schema_registry/swagger: Fix type for version

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -888,6 +888,7 @@
           {
             "name": "version",
             "in": "path",
+            "description": "The schema version to retrieve. Use an integer for a specific version or 'latest' for the most recent version.",
             "required": true,
             "type": "string"
           },
@@ -956,6 +957,7 @@
           {
             "name": "version",
             "in": "path",
+            "description": "The schema version to delete. Use an integer for a specific version or 'latest' for the most recent version.",
             "required": true,
             "type": "string"
           },
@@ -1014,6 +1016,7 @@
           {
             "name": "version",
             "in": "path",
+            "description": "The schema version to retrieve. Use an integer for a specific version or 'latest' for the most recent version.",
             "required": true,
             "type": "string"
           },
@@ -1084,6 +1087,7 @@
           {
             "name": "version",
             "in": "path",
+            "description": "The schema version to check. Use an integer for a specific version or 'latest' for the most recent version.",
             "required": true,
             "type": "string"
           }
@@ -1139,6 +1143,7 @@
           {
             "name": "version",
             "in": "path",
+            "description": "The schema version to check. Use an integer for a specific version or 'latest' for the most recent version.",
             "required": true,
             "type": "string"
           }
@@ -1198,8 +1203,9 @@
           {
             "name": "version",
             "in": "path",
+            "description": "The schema version to check compatibility against. Use an integer for a specific version or 'latest' for the most recent version.",
             "required": true,
-            "type": "integer"
+            "type": "string"
           },
           {
             "name": "schema_def",

--- a/src/v/pandaproxy/api/api-doc/schema_registry_header.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_header.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Redpanda Schema Registry API",
-    "version": "1.1.1"
+    "version": "1.1.2"
   },
   "host": "{{Host}}",
   "basePath": "/",


### PR DESCRIPTION
Change `/compatibility/subjects/{subject}/versions/{version}` to a string so that it can accept `latest`.

Also add a description for `version`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x
- [x] v24.3.x

## Release Notes


### Bug Fixes

*  schema_registry/swagger: Fix type for `version` in GET `/compatibility/subjects/{subject}/versions/{version}`
