### PR TITLE
cloud_storage: move hydration units from cloud_io

### DIFF
--- a/src/v/cloud_io/io_resources.cc
+++ b/src/v/cloud_io/io_resources.cc
@@ -192,11 +192,7 @@ ss::future<std::optional<device_throughput>> get_storage_device_throughput() {
 } // namespace
 
 io_resources::io_resources(ss::scheduling_group sg)
-  : _max_concurrent_hydrations_per_shard(
-      config::shard_local_cfg()
-        .cloud_storage_max_concurrent_hydrations_per_shard.bind())
-  , _hydration_units(max_parallel_hydrations(), "cst_hydrations")
-  , _throughput_limit(
+  : _throughput_limit(
       // apply shard limit to downloads
       get_hard_throughput_limit().download_shard_throughput_limit,
       "ts-segment-downloads")
@@ -205,12 +201,6 @@ io_resources::io_resources(ss::scheduling_group sg)
   , _relative_throughput(
       config::shard_local_cfg().cloud_storage_throughput_limit_percent.bind())
   , _scheduling_group(sg) {
-    _max_concurrent_hydrations_per_shard.watch([this]() {
-        // The 'max_connections' parameter can't be changed without restarting
-        // redpanda.
-        _hydration_units.set_capacity(max_parallel_hydrations());
-    });
-
     auto reset_tp = [this] {
         ssx::spawn_with_gate(_gate, [this] { return update_throughput(); });
     };
@@ -224,7 +214,6 @@ io_resources::io_resources(ss::scheduling_group sg)
 ss::future<> io_resources::stop() {
     log.debug("Stopping cloud_io::io_resources...");
     _throughput_limit.shutdown();
-    _hydration_units.broken();
 
     co_await _gate.close();
     log.debug("Stopped cloud_io::io_resources...");
@@ -242,22 +231,6 @@ ss::future<> io_resources::start() {
 
 ss::scheduling_group io_resources::get_scheduling_group() const {
     return _scheduling_group;
-}
-
-size_t io_resources::max_parallel_hydrations() const {
-    auto max_connections
-      = config::shard_local_cfg().cloud_storage_max_connections();
-    auto n_readers = config::shard_local_cfg()
-                       .cloud_storage_max_partition_readers_per_shard();
-    if (n_readers) {
-        return std::min(
-          static_cast<unsigned>(max_connections), n_readers.value());
-    }
-    return max_connections / 2;
-}
-
-size_t io_resources::current_ongoing_hydrations() const {
-    return _hydration_units.outstanding();
 }
 
 ss::future<> io_resources::set_disk_max_bandwidth(size_t tput) {
@@ -300,11 +273,6 @@ void io_resources::set_net_max_bandwidth(size_t tput) {
           "Disabling cloud storage download throttling on this shard");
         _throttling_disabled = true;
     }
-}
-
-ss::future<ssx::semaphore_units> io_resources::get_hydration_units(size_t n) {
-    auto u = co_await _hydration_units.get_units(n);
-    co_return std::move(u);
 }
 
 ss::input_stream<char> io_resources::throttle_download(

--- a/src/v/cloud_io/io_resources.h
+++ b/src/v/cloud_io/io_resources.h
@@ -34,8 +34,6 @@ public:
     ss::future<> start();
     ss::future<> stop();
 
-    ss::future<ssx::semaphore_units> get_hydration_units(size_t n);
-
     /// Throttles the given stream such that calls to get on the resulting
     /// stream will wait some time if the underlying `_throughput_limit` is
     /// under stress.
@@ -50,11 +48,6 @@ public:
     ss::scheduling_group get_scheduling_group() const;
 
 private:
-    config::binding<std::optional<uint32_t>>
-      _max_concurrent_hydrations_per_shard;
-
-    size_t max_parallel_hydrations() const;
-
     /// Set bandwidth for tiered-storage scheduling_group
     ss::future<> set_disk_max_bandwidth(size_t tput);
 
@@ -66,8 +59,6 @@ private:
 
     /// Gate for background eviction
     ss::gate _gate;
-
-    adjustable_semaphore _hydration_units;
 
     token_bucket<> _throughput_limit;
     config::binding<std::optional<size_t>> _throughput_shard_limit_config;

--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -361,7 +361,7 @@ ss::future<download_result> remote::download_stream(
   transfer_details transfer_details,
   const try_consume_stream& cons_str,
   const std::string_view stream_label,
-  bool acquire_hydration_units,
+  [[maybe_unused]] bool acquire_hydration_units,
   std::optional<cloud_storage_clients::http_byte_range> byte_range,
   std::function<void(size_t)> throttle_metric_ms_cb) {
     const auto& path = transfer_details.key;
@@ -370,11 +370,6 @@ ss::future<download_result> remote::download_stream(
     auto guard = _gate.hold();
     retry_chain_node fib(&transfer_details.parent_rtc);
     retry_chain_logger ctxlog(log, fib);
-
-    ssx::semaphore_units hu;
-    if (acquire_hydration_units) {
-        hu = co_await _resources->get_hydration_units(1);
-    }
 
     auto fut = co_await [this, &fib, &transfer_details] {
         transfer_details.on_client_acquire();

--- a/src/v/cloud_storage/materialized_resources.cc
+++ b/src/v/cloud_storage/materialized_resources.cc
@@ -57,8 +57,12 @@ materialized_resources::materialized_resources()
       ss::make_shared<materialized_manifest_cache>(
         config::shard_local_cfg().cloud_storage_manifest_cache_size()))
   , _cache_carryover_bytes(
+      config::shard_local_cfg().cloud_storage_cache_trim_carryover_bytes.bind())
+
+  , _max_concurrent_hydrations_per_shard(
       config::shard_local_cfg()
-        .cloud_storage_cache_trim_carryover_bytes.bind()) {
+        .cloud_storage_max_concurrent_hydrations_per_shard.bind())
+  , _hydration_units(max_parallel_hydrations(), "cst_hydrations") {
     auto update_max_mem = [this]() {
         // Update memory capacity to accommodate new max number of segment
         // readers
@@ -124,6 +128,12 @@ materialized_resources::materialized_resources()
               _carryover_units.has_value() ? _carryover_units->count() : 0);
         });
     }
+
+    _max_concurrent_hydrations_per_shard.watch([this]() {
+        // The 'max_connections' parameter can't be changed without restarting
+        // redpanda.
+        _hydration_units.set_capacity(max_parallel_hydrations());
+    });
 }
 
 ts_read_path_probe& materialized_resources::get_read_path_probe() {
@@ -138,6 +148,8 @@ ss::future<> materialized_resources::stop() {
     _stm_timer.cancel();
 
     _mem_units.broken();
+
+    _hydration_units.broken();
 
     co_await _gate.close();
     cst_log.debug("Stopped materialized_segments...");
@@ -494,6 +506,28 @@ void materialized_resources::maybe_trim_segment(
             st.readers.pop_front();
         }
     }
+}
+
+ss::future<ssx::semaphore_units>
+materialized_resources::get_hydration_units(size_t n) {
+    auto u = co_await _hydration_units.get_units(n);
+    co_return std::move(u);
+}
+
+size_t materialized_resources::max_parallel_hydrations() const {
+    auto max_connections
+      = config::shard_local_cfg().cloud_storage_max_connections();
+    auto n_readers = config::shard_local_cfg()
+                       .cloud_storage_max_partition_readers_per_shard();
+    if (n_readers) {
+        return std::min(
+          static_cast<unsigned>(max_connections), n_readers.value());
+    }
+    return max_connections / 2;
+}
+
+size_t materialized_resources::current_ongoing_hydrations() const {
+    return _hydration_units.outstanding();
 }
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/materialized_resources.h
+++ b/src/v/cloud_storage/materialized_resources.h
@@ -65,6 +65,8 @@ public:
     ss::future<segment_reader_units>
     get_segment_reader_units(model::opt_abort_source_t as);
 
+    ss::future<ssx::semaphore_units> get_hydration_units(size_t n);
+
     ss::future<ssx::semaphore_units>
     get_partition_reader_units(model::opt_abort_source_t as);
 
@@ -87,6 +89,8 @@ private:
 
     /// How many remote_segment_batch_reader instances exist
     size_t current_segment_readers() const;
+
+    size_t max_parallel_hydrations() const;
 
     /// How many partition_record_batch_reader_impl instances exist
     size_t current_ongoing_hydrations() const;
@@ -154,6 +158,11 @@ private:
     config::binding<uint32_t> _cache_carryover_bytes;
     // Memory reserved for cache carryover mechanism
     std::optional<ssx::semaphore_units> _carryover_units;
+
+    config::binding<std::optional<uint32_t>>
+      _max_concurrent_hydrations_per_shard;
+
+    adjustable_semaphore _hydration_units;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -82,8 +82,7 @@ remote::remote(
       remote_metrics_disabled(
         static_cast<bool>(std::visit(
           [](auto&& cfg) { return cfg.disable_public_metrics; }, conf))),
-      *_materialized,
-      _io.local().resources()) {}
+      *_materialized) {}
 
 remote::remote(ss::sharded<cloud_io::remote>& io, const configuration& conf)
   : remote(io, conf.client_config) {}
@@ -391,34 +390,36 @@ ss::future<download_result> remote::download_stream(
   std::optional<cloud_storage_clients::http_byte_range> byte_range) {
     _as.check();
     auto holder = _gate.hold();
-    return io()
-      .download_stream(
-        {
-          // TODO: these metrics are for segments. Though this method appears to
-          // only be used for inventory downlaods.
-          .bucket = bucket,
-          .key = cloud_storage_clients::object_key{path()},
-          .parent_rtc = parent,
-          .success_cb = [this] { _probe.successful_download(); },
-          .success_size_cb =
-            [this](size_t sz) { _probe.register_download_size(sz); },
-          .failure_cb = [&metrics] { metrics.failed_download_metric(); },
-          .backoff_cb = [&metrics] { metrics.download_backoff_metric(); },
-          .client_acquire_cb = [this] { _probe.client_acquisition(); },
-          // TODO: pass type in as an argument.
-          .on_req_cb = make_notify_cb(
-            api_activity_type::segment_download, parent),
-          .measure_latency_cb =
-            [&metrics] { return metrics.download_latency_measurement(); },
-        },
-        cons_str,
-        stream_label,
-        false,
-        byte_range,
-        [this](size_t ms) {
-            _materialized->get_read_path_probe().download_throttled(ms);
-        })
-      .then([h = std::move(holder)](download_result r) { return r; });
+
+    ssx::semaphore_units hu;
+    hu = co_await materialized().get_hydration_units(1);
+
+    co_return co_await io().download_stream(
+      {
+        // TODO: these metrics are for segments. Though this method appears to
+        // only be used for inventory downlaods.
+        .bucket = bucket,
+        .key = cloud_storage_clients::object_key{path()},
+        .parent_rtc = parent,
+        .success_cb = [this] { _probe.successful_download(); },
+        .success_size_cb =
+          [this](size_t sz) { _probe.register_download_size(sz); },
+        .failure_cb = [&metrics] { metrics.failed_download_metric(); },
+        .backoff_cb = [&metrics] { metrics.download_backoff_metric(); },
+        .client_acquire_cb = [this] { _probe.client_acquisition(); },
+        // TODO: pass type in as an argument.
+        .on_req_cb = make_notify_cb(
+          api_activity_type::segment_download, parent),
+        .measure_latency_cb =
+          [&metrics] { return metrics.download_latency_measurement(); },
+      },
+      cons_str,
+      stream_label,
+      false,
+      byte_range,
+      [this](size_t ms) {
+          _materialized->get_read_path_probe().download_throttled(ms);
+      });
 }
 
 ss::future<download_result> remote::download_segment(

--- a/src/v/cloud_storage/remote_probe.cc
+++ b/src/v/cloud_storage/remote_probe.cc
@@ -10,7 +10,6 @@
 
 #include "cloud_storage/remote_probe.h"
 
-#include "cloud_io/io_resources.h"
 #include "cloud_storage/materialized_resources.h"
 #include "metrics/metrics.h"
 #include "metrics/prometheus_sanitize.h"
@@ -23,8 +22,7 @@ namespace cloud_storage {
 remote_probe::remote_probe(
   remote_metrics_disabled disabled,
   remote_metrics_disabled public_disabled,
-  materialized_resources& ms,
-  const cloud_io::io_resources& io) {
+  materialized_resources& ms) {
     namespace sm = ss::metrics;
 
     if (!disabled) {
@@ -216,7 +214,7 @@ remote_probe::remote_probe(
               .aggregate({sm::shard_label}),
             sm::make_gauge(
               "partition_readers",
-              [&io] { return io.current_ongoing_hydrations(); },
+              [&ms] { return ms.current_ongoing_hydrations(); },
               sm::description(
                 "Number of partition reader instances (number of current "
                 "fetch/timequery requests reading from tiered storage)"))

--- a/src/v/cloud_storage/remote_probe.h
+++ b/src/v/cloud_storage/remote_probe.h
@@ -11,10 +11,8 @@
 #pragma once
 
 #include "base/seastarx.h"
-#include "cloud_io/io_resources.h"
 #include "cloud_storage/types.h"
 #include "metrics/metrics.h"
-#include "model/fundamental.h"
 #include "utils/log_hist.h"
 
 #include <seastar/core/metrics_registration.hh>
@@ -33,8 +31,7 @@ public:
     explicit remote_probe(
       remote_metrics_disabled disabled,
       remote_metrics_disabled public_disabled,
-      materialized_resources&,
-      const cloud_io::io_resources&);
+      materialized_resources&);
     remote_probe(const remote_probe&) = delete;
     remote_probe& operator=(const remote_probe&) = delete;
     remote_probe(remote_probe&&) = delete;


### PR DESCRIPTION
Initial motivation is to remove dependency on cloud storage probe from cloud io as it seems unnecessary and makes some other refactoring I'm doing harder than it needs to be.

But there are additional factors. Hydrations are a cloud storage (tiered storage) concept. This is what configuration documentation tells us too. The metrics actually tells the same story: How many concurrent tiered storage segment downloads are in-flight.

This concept should not be present in cloud_io. I notice however that cloud topics also opted-into tracking its downloads as hydrations. This should not be done as it makes the configuration not serve its purpose anymore and also makes metrics confusing.

If we want to limit cluster wide tiered storage downloads a separate config should be introduced which also likely should be used in other calls like plain object downloads (i.e. not just download_stream call).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
