### PR TITLE
[CORE-14303] CI Failured: Redpanda Failed to stop ShadowLinkingRandomOpsTest.test_node_operations

### DIFF
--- a/src/v/cluster_link/replication/mux_remote_consumer.cc
+++ b/src/v/cluster_link/replication/mux_remote_consumer.cc
@@ -55,6 +55,7 @@ ss::future<> mux_remote_consumer::start() {
 }
 
 ss::future<> mux_remote_consumer::stop() noexcept {
+    vlog(cllog.trace, "Stopping mux remote consumer");
     _cv.broken();
     auto f = _gate.close();
     co_await _consumer->stop();
@@ -63,6 +64,7 @@ ss::future<> mux_remote_consumer::stop() noexcept {
     co_await ss::max_concurrent_for_each(
       _partitions, concurrent_stops, [](auto& p) { return p.second->stop(); });
     _partitions.clear();
+    vlog(cllog.trace, "mux remote consumer stopped");
 }
 
 mux_remote_consumer::result mux_remote_consumer::add(

--- a/src/v/kafka/client/direct_consumer/direct_consumer.cc
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.cc
@@ -259,6 +259,7 @@ ss::future<> direct_consumer::start() {
 }
 
 ss::future<> direct_consumer::stop() {
+    vlog(_cluster->logger().trace, "Stopping direct consumer");
     _cluster->unregister_metadata_cb(_metadata_callback_id);
     _fetched_data_queue->stop();
 
@@ -267,6 +268,8 @@ ss::future<> direct_consumer::stop() {
 
     co_await ss::parallel_for_each(
       _broker_fetchers, [](auto& pair) { return pair.second->stop(); });
+    _broker_fetchers.clear();
+    vlog(_cluster->logger().trace, "Direct consumer stopped");
 }
 
 ss::future<>

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -133,7 +133,9 @@ ss::future<> fetcher::stop() {
     _as.request_abort();
     _state_lock.broken();
     _partitions_updated.broken();
-    return _gate.close();
+    return _gate.close().then([logger = logger(), id = _id] {
+        vlog(logger.debug, "[broker: {}] fetcher stopped", id);
+    });
 }
 
 ss::future<fetcher::partitions_with_epoch> fetcher::collect_partitions() {


### PR DESCRIPTION
I traced the code and this no longer looks possible.

Given how common the failure was between 21st and 24th, and we haven't seen this since, this looks fixed.

There was an unmatched `Link replication manager stopped` 

The code has since been reworked in: https://github.com/redpanda-data/redpanda/pull/28083

Improve logging a little.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
