### PR TITLE
Joeonly nodewise fix

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1301,7 +1301,7 @@ ss::future<result<ss::stop_iteration>> controller_backend::reconcile_ntp_step(
 
         co_return co_await reconcile_partition_reconfiguration(
           std::move(partition),
-          *replicas_view.update,
+          *replicas_view.update, // the underlying hashmap is pointer stable
           replicas_view.revisions());
     }
 
@@ -1323,14 +1323,22 @@ controller_backend::reconcile_partition_reconfiguration(
           update.get_target_replicas());
         // other replicas replicated a configuration with a newer revision,
         // probably our topic_table is out of date? Anyway, there is nothing for
-        // us to do except to wait for a topic table update.
+        // us to do except to wait or a topic table update.
         co_return ss::stop_iteration::yes;
     }
 
     // Check if configuration is reconciled. If it is, try finishing the update.
 
+    // the update may be pointer stable, but dispatching_update_finished begins
+    // its deletion process. snap the value here s.t. the value is guaranteed to
+    // live to the end of the coroutine
+
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization) its safety
+    // necessary
+    const topic_table::in_progress_update snapped_update{update};
+
     auto update_ec = check_configuration_update(
-      _self, partition, update.get_resulting_replicas(), cmd_revision);
+      _self, partition, snapped_update.get_resulting_replicas(), cmd_revision);
     if (!update_ec) {
         auto leader = partition->get_leader_id();
         vlog(
@@ -1340,9 +1348,11 @@ controller_backend::reconcile_partition_reconfiguration(
           partition->ntp(),
           leader);
         if (can_finish_update(
-              leader, update.get_state(), update.get_resulting_replicas())) {
+              leader,
+              snapped_update.get_state(),
+              snapped_update.get_resulting_replicas())) {
             auto ec = co_await dispatch_update_finished(
-              partition->ntp(), update.get_resulting_replicas());
+              partition->ntp(), snapped_update.get_resulting_replicas());
             if (ec) {
                 co_return ec;
             } else {
@@ -1360,34 +1370,34 @@ controller_backend::reconcile_partition_reconfiguration(
     }
 
     // We need to dispatch the requested raft configuration update.
-    switch (update.get_state()) {
+    switch (snapped_update.get_state()) {
     case reconfiguration_state::in_progress:
         co_return co_await update_partition_replica_set(
           std::move(partition),
-          update.get_target_replicas(),
+          snapped_update.get_target_replicas(),
           replicas_revisions,
           cmd_revision,
-          update.get_reconfiguration_policy());
+          snapped_update.get_reconfiguration_policy());
     case reconfiguration_state::force_update:
         co_return co_await force_replica_set_update(
           std::move(partition),
-          update.get_previous_replicas(),
-          update.get_target_replicas(),
+          snapped_update.get_previous_replicas(),
+          snapped_update.get_target_replicas(),
           replicas_revisions,
           cmd_revision);
     case reconfiguration_state::cancelled:
         co_return co_await cancel_replica_set_update(
           std::move(partition),
-          update.get_previous_replicas(),
+          snapped_update.get_previous_replicas(),
           replicas_revisions,
-          update.get_target_replicas(),
+          snapped_update.get_target_replicas(),
           cmd_revision);
     case reconfiguration_state::force_cancelled:
         co_return co_await force_abort_replica_set_update(
           std::move(partition),
-          update.get_previous_replicas(),
+          snapped_update.get_previous_replicas(),
           replicas_revisions,
-          update.get_target_replicas(),
+          snapped_update.get_target_replicas(),
           cmd_revision);
     }
     __builtin_unreachable();

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -506,34 +506,48 @@ ss::future<> partition_balancer_backend::do_tick() {
       plan_data.reassignments, 32, [this](ntp_reassignment& reassignment) {
           _tick_in_progress->check();
           auto f = ss::make_ready_future<std::error_code>();
-          switch (reassignment.type) {
-          case regular:
-              f = _topics_frontend.move_partition_replicas(
-                reassignment.ntp,
-                reassignment.allocated.replicas(),
-                reassignment.reconfiguration_policy,
-                model::timeout_clock::now() + add_move_cmd_timeout,
-                _cur_term->id);
-              break;
-          case force:
-              f = _topics_frontend.force_update_partition_replicas(
-                reassignment.ntp,
-                reassignment.allocated.replicas(),
-                model::timeout_clock::now() + add_move_cmd_timeout);
-              break;
-          default:
-              vassert(
-                false,
-                "unexpected ntp reassignment type: {}",
-                reassignment.type);
-              break;
-          }
+
+          f = _topics_frontend.move_partition_replicas(
+            reassignment.ntp,
+            reassignment.allocated.replicas(),
+            reassignment.reconfiguration_policy,
+            model::timeout_clock::now() + add_move_cmd_timeout,
+            _cur_term->id);
           return std::move(f).then(
             [reassignment = std::move(reassignment)](auto errc) {
                 if (errc) {
                     vlog(
                       clusterlog.warn,
                       "submitting {} reassignment failed, error: {}",
+                      reassignment.ntp,
+                      errc.message());
+                }
+            });
+      });
+
+    co_await ss::max_concurrent_for_each(
+      plan_data.forced_reassignments,
+      32,
+      [this](forced_ntp_reassignment& reassignment) {
+          _tick_in_progress->check();
+          vlog(
+            clusterlog.info,
+            "executing force reassignment with ntp {} and offset: {}",
+            reassignment.ntp,
+            reassignment.bulk_force_offset);
+          return _topics_frontend
+            .force_update_partition_replicas(
+              reassignment.ntp,
+              reassignment.allocated.replicas(),
+              model::timeout_clock::now() + add_move_cmd_timeout,
+              _cur_term->id,
+              reassignment.bulk_force_offset)
+            .then([reassignment = std::move(reassignment)](auto errc) {
+                if (errc) {
+                    vlog(
+                      clusterlog.warn,
+                      "submitting {} forced reassignment failed, error: "
+                      "{}",
                       reassignment.ntp,
                       errc.message());
                 }
@@ -575,6 +589,15 @@ partition_balancer_overview_reply partition_balancer_backend::overview() const {
     ret.partitions_pending_force_recovery_count
       = _state.topics().partitions_to_force_recover().size();
     if (ret.partitions_pending_force_recovery_count > 0) {
+        for (auto& to_force : _state.topics().partitions_to_force_recover()) {
+            vlog(
+              clusterlog.info,
+              "248624 found partition to force recover: ntp {}, dead_nodes: "
+              "{}, assignment: {}",
+              to_force.first,
+              to_force.second.dead_nodes,
+              to_force.second.assignment);
+        }
         constexpr size_t max_partitions_to_include = 10;
         auto sample_size = std::min(
           ret.partitions_pending_force_recovery_count,

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -2102,6 +2102,11 @@ partition_balancer_planner::get_force_repair_actions(request_context& ctx) {
         co_return;
     }
 
+    vlog(
+      clusterlog.info,
+      "found {} force repair actions",
+      ctx.state().topics().partitions_to_force_recover().size());
+
     auto it = ctx.state().topics().partitions_to_force_recover_it_begin();
     while (it != ctx.state().topics().partitions_to_force_recover_it_end()) {
         if (!ctx.can_add_reassignment()) {
@@ -2110,14 +2115,29 @@ partition_balancer_planner::get_force_repair_actions(request_context& ctx) {
         co_await ctx.with_partition(it->first, [&](partition& part) {
             part.match_variant(
               [&](force_reassignable_partition& part) {
+                  vlog(
+                    clusterlog.info,
+                    "partition: {} is force reassignable",
+                    part.ntp());
                   part.force_move_dead_replicas(
                     ctx.config().max_disk_usage_ratio);
               },
-              [&](reassignable_partition&) {},
-              [&](moving_partition&) {
-                  // ignore, wait for it to be canceled / finished.
+              [&](reassignable_partition& part) {
+                  vlog(
+                    clusterlog.info,
+                    "partition: {} is only reassignable",
+                    part.ntp());
               },
-              [&](immutable_partition&) {});
+              [&](moving_partition& part) {
+                  vlog(clusterlog.info, "partition: {} is moving", part.ntp());
+              },
+              [&](immutable_partition& part) {
+                  vlog(
+                    clusterlog.info,
+                    "partition: {} is immutable because: {}",
+                    part.ntp(),
+                    static_cast<int>(part.reason()));
+              });
         });
         ++it;
     }

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -250,6 +250,11 @@ private:
         }
     };
 
+    struct force_reassignment {
+        allocated_partition allocated_partition;
+        model::offset bulk_force_offset;
+    };
+
     partition_balancer_planner& _parent;
     chunked_hash_map<model::ntp, partition_sizes> _ntp2sizes;
     chunked_hash_map<
@@ -259,7 +264,7 @@ private:
       model::topic_namespace_eq>
       _topic2node_counts;
     absl::node_hash_map<model::ntp, reassignment_info> _reassignments;
-    absl::node_hash_map<model::ntp, allocated_partition> _force_reassignments;
+    absl::node_hash_map<model::ntp, force_reassignment> _force_reassignments;
     size_t _failed_actions_count = 0;
     // we track missing partition size info separately as it requires force
     // refresh of health report
@@ -656,6 +661,8 @@ public:
 
     void force_move_dead_replicas(double max_disk_usage_ratio);
 
+    model::offset get_bulk_force_offset() { return _bulk_force_offset; }
+
 private:
     friend class request_context;
 
@@ -664,12 +671,14 @@ private:
       std::optional<request_context::partition_sizes> sizes,
       const partition_assignment& assignment,
       std::vector<model::node_id> nodes_to_remove,
-      request_context& ctx)
+      request_context& ctx,
+      model::offset bulk_force_offset)
       : _ntp(std::move(ntp))
       , _sizes(std::move(sizes))
       , _original_assignment(assignment)
       , _nodes_to_remove(nodes_to_remove.begin(), nodes_to_remove.end())
-      , _ctx(ctx) {}
+      , _ctx(ctx)
+      , _bulk_force_offset(bulk_force_offset) {}
 
     allocation_constraints
     get_allocation_constraints(double max_disk_usage_ratio) const;
@@ -679,6 +688,7 @@ private:
     const partition_assignment& _original_assignment;
     absl::flat_hash_set<model::node_id> _nodes_to_remove;
     request_context& _ctx;
+    model::offset _bulk_force_offset;
     result<allocated_partition> _reallocation = errc::allocation_error;
 };
 
@@ -957,44 +967,152 @@ auto partition_balancer_planner::request_context::do_with_partition(
   Visitor& visitor) {
     const auto& orig_replicas = assignment.replicas;
 
-    { // first thing to check, is this partition being forced
-      // check if the ntp is to be force reconfigured.
-        auto topic_md = _parent._state.topics().get_topic_metadata_ref(
+    // first thing to check, is this partition being forced
+    // check if the ntp is to be force reconfigured.
+    auto maybe_force_reconfig_partition = [&] -> std::optional<partition> {
+        // standard checks, does the original topic exist still, is there still
+        // a forced reconfiguration
+        auto maybe_topic_md = _parent._state.topics().get_topic_metadata_ref(
           model::topic_namespace_view{ntp});
         const auto& force_reconfigurable_partitions
           = _parent._state.topics().partitions_to_force_recover();
         auto force_it = force_reconfigurable_partitions.find(ntp);
-        if (topic_md && force_it != force_reconfigurable_partitions.end()) {
-            auto topic_revision = topic_md.value().get().get_revision();
-            const auto& entries = force_it->second;
-            auto it = std::find_if(
-              entries.begin(), entries.end(), [&](const auto& entry) {
-                  return entry.topic_revision == topic_revision
-                         && are_replica_sets_equal(
-                           entry.assignment, orig_replicas);
-              });
 
-            if (it != entries.end()) {
-                auto size_it = _ntp2sizes.find(ntp);
-                std::optional<request_context::partition_sizes> sizes;
-                if (size_it != _ntp2sizes.end()) {
-                    sizes = size_it->second;
-                }
-                partition part{force_reassignable_partition{
-                  ntp, sizes, assignment, it->dead_nodes, *this}};
+        if (!maybe_topic_md) {
+            // topic was deleted, exit
+            vlog(
+              clusterlog.info,
+              "248624 pbp tick ntp: {} exiting with not found in topic "
+              "metadata",
+              ntp);
+            return std::nullopt;
+        }
 
-                auto deferred = ss::defer([&] {
-                    auto& force_reassignable
-                      = std::get<force_reassignable_partition>(part._variant);
-                    if (force_reassignable._reallocation) {
-                        _force_reassignments.emplace(
-                          ntp,
-                          std::move(force_reassignable._reallocation.value()));
-                    }
-                });
-                return visitor(part);
+        if (force_it == force_reconfigurable_partitions.end()) {
+            // force_reconfiguration completed or cancelled
+            vlog(
+              clusterlog.info,
+              "248624 pbp tick ntp: {} exiting eith force reconfigure not "
+              "requested",
+              ntp);
+            return std::nullopt;
+        }
+        const auto& topic_md = maybe_topic_md->get();
+        const auto& force_entry = force_it->second;
+
+        if (topic_md.get_revision() != force_entry.topic_revision) {
+            // topic was deleted and recreated, this force entry no longer
+            // applies
+            vlog(
+              clusterlog.info,
+              "248624 pbp tick ntp: {} exiting with revision difference",
+              ntp);
+            return std::nullopt;
+        }
+
+        // now check if there is an ongoing force reconfiguration matching the
+        // requested one
+        const auto& ongoing_updates
+          = _parent._state.topics().updates_in_progress();
+
+        vassert(
+          force_entry.maybe_bulk_force_offset.has_value(),
+          "no force reconfiguration entry should ever be emplaced within "
+          "force_reconfigurable_partitions without a parent bulk force "
+          "reconfiguration offset");
+        model::offset requested_bulk_force_offset{
+          force_entry.maybe_bulk_force_offset.value()};
+
+        auto ongoing_update_it = ongoing_updates.find(ntp);
+        if (ongoing_update_it != ongoing_updates.end()) {
+            const auto& ongoing_update = ongoing_update_it->second;
+            const auto ongoing_update_revision
+              = ongoing_update.get_update_revision();
+
+            vlog(
+              clusterlog.info,
+              "248624 ntp tick ntp: {} requested_bulk_force_offset: {}, "
+              "ongoing_update_revision: {}, ongoing is forced?: {}",
+              ntp,
+              requested_bulk_force_offset,
+              ongoing_update_revision,
+              ongoing_update.get_state()
+                == reconfiguration_state::force_update);
+
+            if (
+              ongoing_update_revision
+                >= model::revision_id(requested_bulk_force_offset)
+              && ongoing_update.get_state()
+                   == reconfiguration_state::force_update) {
+                // the ongoing reconfiguration has a higher offset and is
+                // therefore a more recent intent to force reconfigure, do not
+                // override it
+                vlog(
+                  clusterlog.info,
+                  "248624 ntp: {} exiting because ongoing is same or greater "
+                  "intent",
+                  ntp);
+                return std::nullopt;
             }
         }
+
+        auto size_it = _ntp2sizes.find(ntp);
+        std::optional<request_context::partition_sizes> sizes;
+        if (size_it != _ntp2sizes.end()) {
+            sizes = size_it->second;
+        }
+        partition part{force_reassignable_partition{
+          ntp,
+          sizes,
+          assignment,
+          force_entry.dead_nodes,
+          *this,
+          requested_bulk_force_offset}};
+
+        vlog(
+          clusterlog.info,
+          "248624 exiting with force reassignment partition for ntp: {}",
+          ntp);
+
+        return part;
+    }();
+
+    if (maybe_force_reconfig_partition) {
+        auto& part = *maybe_force_reconfig_partition;
+        auto deferred
+          = ss::
+            defer(
+              [&] {
+                  auto& force_reassignable
+                    = std::get<force_reassignable_partition>(part._variant);
+                  vlog(
+                    clusterlog.info,
+                    "248624 pbp tick ntp: {} in deferred lambda",
+                    force_reassignable.ntp());
+                  if (force_reassignable._reallocation && (force_reassignable._reallocation.assume_value().replicas().size() > 0)) {
+                      vlog(
+                        clusterlog.info,
+                        "248624 pbp tick ntp: {} in deferred lambda, adding to "
+                        "map with replica size",
+                        force_reassignable.ntp(),
+                        force_reassignable._reallocation.assume_value()
+                          .replicas()
+                          .size());
+                      _force_reassignments.emplace(
+                        ntp,
+                        force_reassignment{
+                          .allocated_partition = std::move(
+                            force_reassignable._reallocation.value()),
+                          .bulk_force_offset
+                          = force_reassignable.get_bulk_force_offset()});
+                  }
+              });
+
+        vlog(
+          clusterlog.info,
+          "248624 running visitor for ntp: {}",
+          std::get<force_reassignable_partition>(part._variant).ntp());
+        return visitor(part);
     }
 
     const bool is_disabled = _parent._state.topics().is_disabled(ntp);
@@ -2112,6 +2230,15 @@ partition_balancer_planner::get_force_repair_actions(request_context& ctx) {
       "found {} force repair actions",
       ctx.state().topics().partitions_to_force_recover().size());
 
+    for (auto& force_repair_action :
+         ctx.state().topics().partitions_to_force_recover()) {
+        vlog(
+          clusterlog.info,
+          "248624 found force_repair_action ntp: {}, dead nodes: {}",
+          force_repair_action.first,
+          force_repair_action.second.dead_nodes);
+    }
+
     auto it = ctx.state().topics().partitions_to_force_recover_it_begin();
     while (it != ctx.state().topics().partitions_to_force_recover_it_end()) {
         if (!ctx.can_add_reassignment()) {
@@ -2122,7 +2249,7 @@ partition_balancer_planner::get_force_repair_actions(request_context& ctx) {
               [&](force_reassignable_partition& part) {
                   vlog(
                     clusterlog.info,
-                    "partition: {} is force reassignable",
+                    "248624 partition: {} is force reassignable",
                     part.ntp());
                   part.force_move_dead_replicas(
                     ctx.config().max_disk_usage_ratio);
@@ -2130,16 +2257,19 @@ partition_balancer_planner::get_force_repair_actions(request_context& ctx) {
               [&](reassignable_partition& part) {
                   vlog(
                     clusterlog.info,
-                    "partition: {} is only reassignable",
+                    "248624 partition: {} is only reassignable",
                     part.ntp());
               },
               [&](moving_partition& part) {
-                  vlog(clusterlog.info, "partition: {} is moving", part.ntp());
+                  vlog(
+                    clusterlog.info,
+                    "248624 partition: {} is moving",
+                    part.ntp());
               },
               [&](immutable_partition& part) {
                   vlog(
                     clusterlog.info,
-                    "partition: {} is immutable because: {}",
+                    "248624 partition: {} is immutable because: {}",
                     part.ntp(),
                     static_cast<int>(part.reason()));
               });
@@ -2156,17 +2286,24 @@ void partition_balancer_planner::request_context::collect_actions(
           ntp_reassignment{
             .ntp = ntp,
             .allocated = std::move(reallocated_meta.partition),
-            .reconfiguration_policy = reallocated_meta.reconfiguration_policy,
-            .type = ntp_reassignment_type::regular});
+            .reconfiguration_policy = reallocated_meta.reconfiguration_policy});
     }
 
+    result.forced_reassignments.reserve(_force_reassignments.size());
     for (auto& [ntp, reallocated] : _force_reassignments) {
-        result.reassignments.push_back(
-          ntp_reassignment{
-            .ntp = ntp,
-            .allocated = std::move(reallocated),
-            .type = ntp_reassignment_type::force});
+        forced_ntp_reassignment fnr(
+          ntp,
+          std::move(reallocated.allocated_partition),
+          reconfiguration_policy::full_local_retention,
+          reallocated.bulk_force_offset);
+        vlog(
+          clusterlog.info,
+          "248624 emplacing ntp {} bulk_force_offset: {}",
+          ntp,
+          reallocated.bulk_force_offset);
+        result.forced_reassignments.push_back(std::move(fnr));
     }
+    _force_reassignments.clear();
 
     result.failed_actions_count = _failed_actions_count;
 

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -955,8 +955,49 @@ auto partition_balancer_planner::request_context::do_with_partition(
   const model::ntp& ntp,
   const partition_assignment& assignment,
   Visitor& visitor) {
-    const bool is_disabled = _parent._state.topics().is_disabled(ntp);
     const auto& orig_replicas = assignment.replicas;
+
+    { // first thing to check, is this partition being forced
+      // check if the ntp is to be force reconfigured.
+        auto topic_md = _parent._state.topics().get_topic_metadata_ref(
+          model::topic_namespace_view{ntp});
+        const auto& force_reconfigurable_partitions
+          = _parent._state.topics().partitions_to_force_recover();
+        auto force_it = force_reconfigurable_partitions.find(ntp);
+        if (topic_md && force_it != force_reconfigurable_partitions.end()) {
+            auto topic_revision = topic_md.value().get().get_revision();
+            const auto& entries = force_it->second;
+            auto it = std::find_if(
+              entries.begin(), entries.end(), [&](const auto& entry) {
+                  return entry.topic_revision == topic_revision
+                         && are_replica_sets_equal(
+                           entry.assignment, orig_replicas);
+              });
+
+            if (it != entries.end()) {
+                auto size_it = _ntp2sizes.find(ntp);
+                std::optional<request_context::partition_sizes> sizes;
+                if (size_it != _ntp2sizes.end()) {
+                    sizes = size_it->second;
+                }
+                partition part{force_reassignable_partition{
+                  ntp, sizes, assignment, it->dead_nodes, *this}};
+
+                auto deferred = ss::defer([&] {
+                    auto& force_reassignable
+                      = std::get<force_reassignable_partition>(part._variant);
+                    if (force_reassignable._reallocation) {
+                        _force_reassignments.emplace(
+                          ntp,
+                          std::move(force_reassignable._reallocation.value()));
+                    }
+                });
+                return visitor(part);
+            }
+        }
+    }
+
+    const bool is_disabled = _parent._state.topics().is_disabled(ntp);
     auto in_progress_it = _parent._state.topics().updates_in_progress().find(
       ntp);
     if (in_progress_it != _parent._state.topics().updates_in_progress().end()) {
@@ -1021,42 +1062,6 @@ auto partition_balancer_planner::request_context::do_with_partition(
           *this}};
         return visitor(part);
     }
-
-    // check if the ntp is to be force reconfigured.
-    auto topic_md = _parent._state.topics().get_topic_metadata_ref(
-      model::topic_namespace_view{ntp});
-    const auto& force_reconfigurable_partitions
-      = _parent._state.topics().partitions_to_force_recover();
-    auto force_it = force_reconfigurable_partitions.find(ntp);
-    if (topic_md && force_it != force_reconfigurable_partitions.end()) {
-        auto topic_revision = topic_md.value().get().get_revision();
-        const auto& entries = force_it->second;
-        auto it = std::find_if(
-          entries.begin(), entries.end(), [&](const auto& entry) {
-              return entry.topic_revision == topic_revision
-                     && are_replica_sets_equal(entry.assignment, orig_replicas);
-          });
-
-        if (it != entries.end()) {
-            auto size_it = _ntp2sizes.find(ntp);
-            std::optional<request_context::partition_sizes> sizes;
-            if (size_it != _ntp2sizes.end()) {
-                sizes = size_it->second;
-            }
-            partition part{force_reassignable_partition{
-              ntp, sizes, assignment, it->dead_nodes, *this}};
-
-            auto deferred = ss::defer([&] {
-                auto& force_reassignable
-                  = std::get<force_reassignable_partition>(part._variant);
-                if (force_reassignable._reallocation) {
-                    _force_reassignments.emplace(
-                      ntp, std::move(force_reassignable._reallocation.value()));
-                }
-            });
-            return visitor(part);
-        }
-    };
 
     auto size_it = _ntp2sizes.find(ntp);
     if (size_it == _ntp2sizes.end()) {

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -29,7 +29,22 @@ struct ntp_reassignment {
     model::ntp ntp;
     allocated_partition allocated;
     reconfiguration_policy reconfiguration_policy;
-    ntp_reassignment_type type;
+
+    bool is_forced() { return false; }
+};
+
+struct forced_ntp_reassignment : public ntp_reassignment {
+    forced_ntp_reassignment(
+      model::ntp ntp,
+      ::cluster::allocated_partition allocated_partiton,
+      ::cluster::reconfiguration_policy reconfiguration_policy,
+      model::offset bulk_force_offset)
+      : ntp_reassignment(
+          std::move(ntp), std::move(allocated_partiton), reconfiguration_policy)
+      , bulk_force_offset{bulk_force_offset} {}
+
+    model::offset bulk_force_offset;
+    bool is_forced() { return true; }
 };
 
 struct planner_config {
@@ -83,6 +98,7 @@ public:
     struct plan_data {
         partition_balancer_violations violations;
         chunked_vector<ntp_reassignment> reassignments;
+        chunked_vector<forced_ntp_reassignment> forced_reassignments;
         chunked_vector<model::ntp> cancellations;
         chunked_hash_map<model::ntp, reallocation_failure_details>
           reallocation_failures;

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -28,6 +28,7 @@
 #include <seastar/coroutine/maybe_yield.hh>
 
 #include <algorithm>
+#include <memory>
 #include <optional>
 #include <span>
 #include <utility>
@@ -872,8 +873,18 @@ topic_table::apply(set_topic_partitions_disabled_cmd cmd, model::offset o) {
 ss::future<std::error_code>
 topic_table::apply(bulk_force_reconfiguration_cmd cmd, model::offset o) {
     _last_applied_revision_id = model::revision_id(o);
+
+    // set the bulk command controller offset for deduplication
+    auto& partitions_with_lost_majority
+      = cmd.value.user_approved_force_recovery_partitions;
+    std::ranges::for_each(
+      partitions_with_lost_majority, [o](ntp_with_majority_loss& lost_ntp) {
+          lost_ntp.maybe_bulk_force_offset = o;
+      });
+
     auto validation_ec = validate_force_reconfigurable_partitions(
       cmd.value.user_approved_force_recovery_partitions);
+
     if (validation_ec) {
         co_return validation_ec;
     }
@@ -893,6 +904,8 @@ std::error_code topic_table::validate_force_reconfigurable_partition(
     if (!topic_md || topic_md->get().get_revision() != entry.topic_revision) {
         return errc::topic_not_exists;
     }
+    /*
+    remove validation on equivalent sets
     const auto& current_assignment = get_partition_assignment(ntp);
     if (!current_assignment) {
         return errc::no_partition_assignments;
@@ -910,6 +923,7 @@ std::error_code topic_table::validate_force_reconfigurable_partition(
             return errc::partition_already_exists;
         }
     }
+    */
     return errc::success;
 }
 

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -154,6 +154,10 @@ ss::future<std::error_code> topic_table::do_local_delete(
     for (auto& [_, p_as] : tp->second.get_assignments()) {
         _partition_count--;
         auto ntp = model::ntp(nt.ns, nt.tp, p_as.id);
+        vlog(
+          clusterlog.info,
+          "248624 erasing in progress update for ntp: {}",
+          ntp);
         _updates_in_progress.erase(ntp);
         on_partition_deletion(ntp);
         _pending_ntp_deltas.emplace_back(
@@ -479,7 +483,7 @@ topic_table::apply(finish_moving_partition_replicas_cmd cmd, model::offset o) {
         co_return errc::topic_not_exists;
     }
 
-    // calculate deleta for backend
+    // calculate delta for backend
     auto current_assignment_it = tp->second.get_assignments().find(
       cmd.key.tp.partition);
 
@@ -491,6 +495,7 @@ topic_table::apply(finish_moving_partition_replicas_cmd cmd, model::offset o) {
         co_return errc::invalid_node_operation;
     }
     auto it = _updates_in_progress.find(cmd.key);
+
     if (it == _updates_in_progress.end()) {
         co_return errc::no_update_in_progress;
     }
@@ -499,7 +504,17 @@ topic_table::apply(finish_moving_partition_replicas_cmd cmd, model::offset o) {
     if (p_meta_it == tp->second.partitions.end()) {
         co_return errc::partition_not_exists;
     }
-    if (!is_cancelled_state(it->second.get_state())) {
+
+    // two valid forces may race to complete, in which case, the replica
+    // revisions will be wrong
+    // solution would likely be to plumb the intent offset through, and only
+    // remove in-progress updates when the revision from the given update has
+    // been found
+    //
+    // for now, we assume that the current update is the same as that which is
+    // being finished
+    auto& current_update = it->second;
+    if (!is_cancelled_state(current_update.get_state())) {
         // update went through and the cancellation didn't happen, we must
         // update replicas_revisions.
         p_meta_it->second.replicas_revisions = update_replicas_revisions(
@@ -509,11 +524,12 @@ topic_table::apply(finish_moving_partition_replicas_cmd cmd, model::offset o) {
     }
     p_meta_it->second.last_update_finished_revision = model::revision_id{o};
 
+    vlog(
+      clusterlog.info,
+      "248624 erasing in progress update for ntp: {}",
+      it->first);
     _updates_in_progress.erase(it);
-
-    _topics_map_revision++;
-
-    on_partition_move_finish(cmd.key, cmd.value);
+    ++_topics_map_revision;
 
     // notify backend about finished update
     _pending_ntp_deltas.emplace_back(
@@ -657,8 +673,12 @@ topic_table::apply(revert_cancel_partition_move_cmd cmd, model::offset o) {
     p_meta_it->second.last_update_finished_revision = model::revision_id{o};
 
     /// Since the update is already finished we drop in_progress state
-    _updates_in_progress.erase(in_progress_it);
 
+    vlog(
+      clusterlog.info,
+      "248624 erasing in progress update for ntp: {}",
+      in_progress_it->first);
+    _updates_in_progress.erase(in_progress_it);
     _topics_map_revision++;
 
     // notify backend about finished update
@@ -743,6 +763,15 @@ topic_table::apply(move_topic_replicas_cmd cmd, model::offset o) {
 ss::future<std::error_code>
 topic_table::apply(force_partition_reconfiguration_cmd cmd, model::offset o) {
     _last_applied_revision_id = model::revision_id(o);
+
+    vlog(
+      clusterlog.info,
+      " 248624 got force reconfiguration command for ntp: {}, with replicas: "
+      "{}, with bulk force offset: {}",
+      cmd.key,
+      cmd.value.replicas,
+      cmd.value.maybe_bulk_force_offset);
+
     // Check the topic exists.
     auto tp = _topics.find(model::topic_namespace_view(cmd.key));
     if (tp == _topics.end()) {
@@ -753,6 +782,8 @@ topic_table::apply(force_partition_reconfiguration_cmd cmd, model::offset o) {
       cmd.key.tp.partition);
 
     if (current_assignment_it == tp->second.get_assignments().end()) {
+        vlog(
+          clusterlog.info, "248624 partition does not exist ntp: {}", cmd.key);
         co_return errc::partition_not_exists;
     }
 
@@ -760,18 +791,102 @@ topic_table::apply(force_partition_reconfiguration_cmd cmd, model::offset o) {
         co_return errc::partition_disabled;
     }
 
+    // if the force reconfigure comes from a bulk force reconfigure, check that
+    // our intent has not been overridden by another force command
+    // this can happen in three cases:
+    //
+    // 1. another force command has exceeded the intent in
+    //    _partitions_to_force_reconfigure
+    // 2. another force command with excessive intent has completed and removed
+    //    the force configure request from _partitions_to_force_reconfigure
+    // 3. an in-progress force command with excessive intent is ongoing
+    //
+    // in all of these cases, the current command should be considered outdated
+    // and not be issued
+
+    // precondititon, this force reconfigure comes from a bulk command
+    if (cmd.value.maybe_bulk_force_offset) {
+        const auto command_bulk_force_offset
+          = cmd.value.maybe_bulk_force_offset.value();
+        const auto& force_it = _partitions_to_force_reconfigure.find(cmd.key);
+
+        // 2. the request has been removed
+        if (force_it == _partitions_to_force_reconfigure.end()) {
+            vlog(
+              clusterlog.info,
+              "248624 force reconfigure for ntp: {} with bulk force "
+              "reconfigure "
+              "offset: {} has been overridden by a more recent force command",
+              cmd.key,
+              command_bulk_force_offset);
+            co_return errc::concurrent_modification_error;
+        }
+
+        // 1. another command has exceeded the intent in the requests map
+        vassert(
+          force_it->second.maybe_bulk_force_offset,
+          "programmer error, map must always contain a bulk force offset");
+        auto requested_bulk_force_offset
+          = force_it->second.maybe_bulk_force_offset.value();
+        if (requested_bulk_force_offset > command_bulk_force_offset) {
+            vlog(
+              clusterlog.info,
+              "248624 force reconfigure for ntp: {} with bulk force "
+              "reconfigure "
+              "offset: {} has been overridden by a more recent force command "
+              "with offset: {}",
+              cmd.key,
+              command_bulk_force_offset,
+              requested_bulk_force_offset);
+            co_return errc::concurrent_modification_error;
+        }
+
+        // 3. there is an in-progress request that exceeds the intent of the
+        // current command
+        const auto& update_it = _updates_in_progress.find(cmd.key);
+        if (update_it != _updates_in_progress.end()) {
+            // the revision of the last command to
+            if (
+              update_it->second.get_update_revision()
+              >= model::revision_id{command_bulk_force_offset}) {
+                vlog(
+                  clusterlog.info,
+                  "248624 force reconfigure for ntp: {} with bulk force "
+                  "reconfigure "
+                  "offset: {} has been overridden by a more recent force "
+                  "command "
+                  "with offset: {}",
+                  cmd.key,
+                  command_bulk_force_offset,
+                  update_it->second.get_update_revision());
+                co_return errc::concurrent_modification_error;
+            }
+        }
+    }
+
     const auto& new_replicas = cmd.value.replicas;
-    auto update_revision = model::revision_id{o};
+    // the intent offset is the offset where the decision was made to perform
+    // this force reconfiguration
+    // for a bulk force reconfiguration, its the offset of the
+    //     bulk_force_reconfiguration command
+    // for a normal configuration, its the offset of the command itself
+    auto intent_offset = cmd.value.maybe_bulk_force_offset
+                           ? *cmd.value.maybe_bulk_force_offset
+                           : o;
+    auto update_revision = model::revision_id{intent_offset};
     auto& current_assignment = current_assignment_it->second;
 
     auto it = _updates_in_progress.find(cmd.key);
     if (it != _updates_in_progress.end()) {
+        vlog(clusterlog.info, "248624 overriding old move for ntp {}", cmd.key);
         // update in progress, amend it to update target replicas.
         it->second.force_set_state(
           new_replicas,
-          model::revision_id{o},
-          reconfiguration_policy::full_local_retention);
+          update_revision,
+          reconfiguration_policy::full_local_retention,
+          cmd.value.maybe_bulk_force_offset);
     } else {
+        vlog(clusterlog.info, "248624 new move for ntp: {}", cmd.key);
         _updates_in_progress.emplace(
           cmd.key,
           in_progress_update(
@@ -784,17 +899,40 @@ topic_table::apply(force_partition_reconfiguration_cmd cmd, model::offset o) {
              * reconfiguring partition.
              */
             reconfiguration_policy::full_local_retention,
-            &_probe));
+            &_probe,
+            cmd.value.maybe_bulk_force_offset));
     }
+
+    vassert(
+      _updates_in_progress.find(cmd.key) != _updates_in_progress.end(),
+      "what on earth");
     _topics_map_revision++;
 
     current_assignment.replicas = cmd.value.replicas;
+
+    vlog(
+      clusterlog.info,
+      "248624 successfully applied force reconfiguration for ntp: {}",
+      cmd.key);
+
+    // if a force reconfigure was accepted, whatever is in the map is either
+    // done or outdated, do this before the suspension point
+    auto force_it = _partitions_to_force_reconfigure.find(cmd.key);
+    if (force_it != _partitions_to_force_reconfigure.end()) {
+        vlog(
+          clusterlog.info,
+          "248624 erasing {} from partitions to force recover at end of apply",
+          cmd.key);
+        _partitions_to_force_reconfigure.erase(force_it);
+        ++_partitions_to_force_reconfigure_revision;
+    }
 
     _pending_ntp_deltas.emplace_back(
       std::move(cmd.key),
       current_assignment.group,
       update_revision,
       topic_table_ntp_delta_type::replicas_updated);
+
     co_await notify_waiters();
 
     co_return errc::success;
@@ -874,6 +1012,11 @@ ss::future<std::error_code>
 topic_table::apply(bulk_force_reconfiguration_cmd cmd, model::offset o) {
     _last_applied_revision_id = model::revision_id(o);
 
+    vlog(
+      clusterlog.info,
+      "248624 applying bulk force reconfiguration command at offset: {}",
+      o);
+
     // set the bulk command controller offset for deduplication
     auto& partitions_with_lost_majority
       = cmd.value.user_approved_force_recovery_partitions;
@@ -888,7 +1031,39 @@ topic_table::apply(bulk_force_reconfiguration_cmd cmd, model::offset o) {
     if (validation_ec) {
         co_return validation_ec;
     }
+
     for (auto& entry : cmd.value.user_approved_force_recovery_partitions) {
+        auto tp = _topics.find(model::topic_namespace_view(entry.ntp));
+        if (tp == _topics.end()) {
+            vlog(
+              clusterlog.info,
+              "248624 ntp: {} skipping on topic doesn't exist",
+              entry.ntp);
+            continue;
+        }
+
+        auto p_meta_it = tp->second.partitions.find(entry.ntp.tp.partition);
+        if (p_meta_it != tp->second.partitions.end()) {
+            if (
+              p_meta_it->second.last_update_finished_revision
+              >= model::revision_id(o)) {
+                vlog(
+                  clusterlog.info,
+                  "248624 skipping because the partition {} is already more up "
+                  "to date than the bulk force reconfiguration in question "
+                  "with "
+                  "current offset {}, found revision: {}",
+                  entry.ntp,
+                  o,
+                  p_meta_it->second.last_update_finished_revision);
+                continue;
+            }
+        } else {
+            vlog(
+              clusterlog.info,
+              "248624 ntp: {}skipping because partition does not exist",
+              entry.ntp);
+        }
         add_partition_to_force_reconfigure(std::move(entry));
     }
     co_return errc::success;
@@ -936,8 +1111,8 @@ std::error_code topic_table::validate_force_reconfigurable_partitions(
             result = error;
         }
         vlog(
-          clusterlog.debug,
-          "Processed force reconfiguration entry {}, result: {}",
+          clusterlog.info,
+          "248624 Processed force reconfiguration entry {}, result: {}",
           entry,
           error);
     }
@@ -1759,9 +1934,18 @@ ss::future<> topic_table::apply_snapshot(
 
 void topic_table::add_partition_to_force_reconfigure(
   ntp_with_majority_loss entry) {
+    vassert(
+      entry.maybe_bulk_force_offset.has_value(),
+      "all partitions added to partitions to force reconfigure must have bulk "
+      "offset set");
+
+    vlog(
+      clusterlog.info,
+      "248624 adding partition to force reconfigure with entry: {}",
+      entry.ntp);
     const auto& [it, _] = _partitions_to_force_reconfigure.try_emplace(
       entry.ntp);
-    it->second.push_back(std::move(entry));
+    it->second = entry;
     _partitions_to_force_reconfigure_revision++;
 }
 
@@ -2116,33 +2300,6 @@ size_t topic_table::get_node_partition_count(model::node_id id) const {
     return cnt;
 }
 
-void topic_table::on_partition_move_finish(
-  const model::ntp& ntp, const std::vector<model::broker_shard>& replicas) {
-    auto it = _partitions_to_force_reconfigure.find(ntp);
-    if (it == _partitions_to_force_reconfigure.end()) {
-        return;
-    }
-    auto& entries = it->second;
-    auto num_erased = std::erase_if(entries, [&replicas](const auto& entry) {
-        // check if the new replica set contains any dead nodes that were
-        // intended to be removed.
-        bool has_dead_nodes = std::any_of(
-          entry.dead_nodes.begin(),
-          entry.dead_nodes.end(),
-          [&replicas](const model::node_id& id) {
-              return contains_node(replicas, id);
-          });
-        return !has_dead_nodes;
-    });
-    if (num_erased > 0) {
-        _partitions_to_force_reconfigure_revision++;
-    }
-    if (entries.size() == 0) {
-        _partitions_to_force_reconfigure.erase(it);
-        _partitions_to_force_reconfigure_revision++;
-    }
-}
-
 void topic_table::on_partition_deletion(const model::ntp& ntp) {
     auto it = _partitions_to_force_reconfigure.find(ntp);
     if (it == _partitions_to_force_reconfigure.end()) {
@@ -2154,30 +2311,34 @@ void topic_table::on_partition_deletion(const model::ntp& ntp) {
         _partitions_to_force_reconfigure.erase(it);
         _partitions_to_force_reconfigure_revision++;
         vlog(
-          clusterlog.debug,
-          "marking force repair action as finished for partition: {} because "
+          clusterlog.info,
+          "248624 marking force repair action as finished for partition: {} "
+          "because "
           "the topic was deleted.",
           it->first);
         return;
     }
     // A newer version of the topic exists.
     // delete all entries for older revision of the topic.
-    auto& entries = it->second;
+    const auto& entry = it->second;
     auto new_topic_revision = topic_md.value().get().get_revision();
-    auto num_erased = std::erase_if(entries, [&](const auto& entry) {
-        return entry.topic_revision < new_topic_revision;
-    });
-    if (num_erased > 0) {
-        _partitions_to_force_reconfigure_revision++;
-    }
-    if (entries.size() == 0) {
+    if (entry.topic_revision <= new_topic_revision) {
         _partitions_to_force_reconfigure.erase(it);
         _partitions_to_force_reconfigure_revision++;
         vlog(
           clusterlog.debug,
-          "marking force repair action as finished for partition: {} because "
+          "248624 marking force repair action as finished for partition: {} "
+          "because "
           "the topic was deleted.",
           it->first);
+    } else {
+        vlog(
+          clusterlog.warn,
+          "a force repair action from the future was found. ntp: {}, current "
+          "revision: {}, forced repair revision: {}",
+          ntp,
+          new_topic_revision,
+          entry.topic_revision);
     }
 }
 

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -118,14 +118,16 @@ public:
           reconfiguration_state state,
           model::revision_id update_revision,
           reconfiguration_policy policy,
-          topic_table_probe* probe)
+          topic_table_probe* probe,
+          std::optional<model::offset> maybe_bulk_force_offset = std::nullopt)
           : _previous_replicas(std::move(previous_replicas))
           , _target_replicas(std::move(target_replicas))
           , _state(state)
           , _update_revision(update_revision)
           , _last_cmd_revision(update_revision)
           , _policy(policy)
-          , _probe(probe) {
+          , _probe(probe)
+          , _maybe_bulk_force_offset(maybe_bulk_force_offset) {
             if (_probe) {
                 _probe->handle_update(_previous_replicas, _target_replicas);
             }
@@ -163,7 +165,8 @@ public:
         void force_set_state(
           const replicas_t& new_replicas,
           model::revision_id rev,
-          reconfiguration_policy policy) {
+          reconfiguration_policy policy,
+          std::optional<model::offset> maybe_bulk_force_offset) {
             /**
              * a move from (A (prev) -> B (target)) -> C (force, new_replicas)
              * is redefined to
@@ -178,6 +181,7 @@ public:
             _last_cmd_revision = _update_revision = rev;
             _policy = policy;
             _state = reconfiguration_state::force_update;
+            _maybe_bulk_force_offset = maybe_bulk_force_offset;
         }
 
         const replicas_t& get_previous_replicas() const {
@@ -212,6 +216,10 @@ public:
                    || _state == reconfiguration_state::force_update;
         }
 
+        std::optional<model::offset> get_maybe_bulk_force_offset() const {
+            return _maybe_bulk_force_offset;
+        }
+
         friend std::ostream&
         operator<<(std::ostream&, const in_progress_update&);
 
@@ -224,6 +232,8 @@ public:
         reconfiguration_policy _policy;
         // _probe can be nullptr, in this case metrics are not updated.
         topic_table_probe* _probe;
+        // tracks the parent bulk_force_reconfiguration cmd if there was one
+        std::optional<model::offset> _maybe_bulk_force_offset;
     };
 
     struct partition_meta {
@@ -897,8 +907,6 @@ private:
       const force_recoverable_partitions_t&);
 
     void on_partition_deletion(const model::ntp&);
-    void on_partition_move_finish(
-      const model::ntp&, const std::vector<model::broker_shard>& replicas);
     std::error_code validate_force_reconfigurable_partition(
       const ntp_with_majority_loss&) const;
 

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -1348,7 +1348,15 @@ ss::future<std::error_code> topics_frontend::force_update_partition_replicas(
   model::ntp ntp,
   std::vector<model::broker_shard> new_replica_set,
   model::timeout_clock::time_point tout,
-  std::optional<model::term_id> term) {
+  std::optional<model::term_id> term,
+  std::optional<model::offset> maybe_bulk_force_offset) {
+    vlog(
+      clusterlog.info,
+      "248624 running force update partition replicas on ntp: {}, with "
+      "replicas : {}, bulk_force_offset: {}",
+      ntp,
+      new_replica_set,
+      maybe_bulk_force_offset);
     auto result = co_await stm_linearizable_barrier(tout);
     if (!result) {
         co_return result.error();
@@ -1358,7 +1366,13 @@ ss::future<std::error_code> topics_frontend::force_update_partition_replicas(
     }
     force_partition_reconfiguration_cmd cmd{
       std::move(ntp),
-      force_partition_reconfiguration_cmd_data{std::move(new_replica_set)}};
+      force_partition_reconfiguration_cmd_data{
+        std::move(new_replica_set), maybe_bulk_force_offset}};
+
+    vlog(
+      clusterlog.info,
+      "248624 confirm bulk_force_offset: {}",
+      cmd.value.maybe_bulk_force_offset);
 
     co_return co_await replicate_and_wait(
       _stm, _as, std::move(cmd), tout, term);
@@ -1421,6 +1435,12 @@ topics_frontend::force_recover_partitions_from_nodes(
     if (!result) {
         co_return result.error();
     }
+
+    vlog(
+      clusterlog.info,
+      "248624 got bulk force reconfiguration request with user approved "
+      "partitions {}",
+      user_approved_force_recovery_partitions);
     // check if the state of partitions to recover tallies with their
     // current state.
     const auto& topics = _topics.local();

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -113,7 +113,8 @@ public:
       model::ntp,
       std::vector<model::broker_shard>,
       model::timeout_clock::time_point,
-      std::optional<model::term_id> = std::nullopt);
+      std::optional<model::term_id> = std::nullopt,
+      std::optional<model::offset> maybe_bulk_force_offset = std::nullopt);
 
     /**
      * Given a list of defunct nodes, generates a list of ntps that lost

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1721,15 +1721,22 @@ struct cancel_moving_partition_replicas_cmd_data
 struct force_partition_reconfiguration_cmd_data
   : serde::envelope<
       force_partition_reconfiguration_cmd_data,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     force_partition_reconfiguration_cmd_data() noexcept = default;
-    explicit force_partition_reconfiguration_cmd_data(replicas_t replicas)
-      : replicas(std::move(replicas)) {}
+    explicit force_partition_reconfiguration_cmd_data(
+      replicas_t replicas,
+      std::optional<model::offset> maybe_bulk_force_offset = std::nullopt)
+      : replicas(std::move(replicas))
+      , maybe_bulk_force_offset(maybe_bulk_force_offset) {}
 
     replicas_t replicas;
 
-    auto serde_fields() { return std::tie(replicas); }
+    // used to correlate back to the spawning bulk_force_reconfiguration command
+    // if this force_partition_reconfiguration was spawned by one
+    std::optional<model::offset> maybe_bulk_force_offset;
+
+    auto serde_fields() { return std::tie(replicas, maybe_bulk_force_offset); }
 
     friend bool operator==(
       const force_partition_reconfiguration_cmd_data&,
@@ -2154,7 +2161,7 @@ struct bulk_force_reconfiguration_cmd_data
 };
 
 using force_recoverable_partitions_t
-  = absl::btree_map<model::ntp, std::vector<ntp_with_majority_loss>>;
+  = absl::btree_map<model::ntp, ntp_with_majority_loss>;
 
 struct reconciliation_state_reply
   : serde::envelope<

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2081,7 +2081,7 @@ struct reconciliation_state_request
 struct ntp_with_majority_loss
   : serde::envelope<
       ntp_with_majority_loss,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     ntp_with_majority_loss() = default;
     explicit ntp_with_majority_loss(
@@ -2093,10 +2093,21 @@ struct ntp_with_majority_loss
       , topic_revision(r)
       , assignment(std::move(replicas))
       , dead_nodes(std::move(dead_nodes)) {}
+
     model::ntp ntp;
+
+    // the version of the topic, used in case a topic is created, force
+    // reconfigured, deleted then recreated
+    // to prevent an old force reconfigure from applying to the new topic
     model::revision_id topic_revision;
     std::vector<model::broker_shard> assignment;
     std::vector<model::node_id> dead_nodes;
+
+    // Internal state tracking:
+    // A bulk force reconfiguration will add these to topic table.
+    // The controller offset will be used as an epoch to deduplicate
+    // different bulk force reconfigurations on the same ntp
+    std::optional<model::offset> maybe_bulk_force_offset;
 
     template<typename H>
     friend H AbslHashValue(H h, const ntp_with_majority_loss& s) {

--- a/tests/rptest/tests/partition_force_reconfiguration_test.py
+++ b/tests/rptest/tests/partition_force_reconfiguration_test.py
@@ -525,7 +525,7 @@ class NodeWiseRecoveryTest(RedpandaTest):
             *args,
             **kwargs,
         )
-        self.default_timeout_sec = 120
+        self.default_timeout_sec = 300
         self.rpk = RpkTool(self.redpanda)
         self.admin = Admin(self.redpanda, retries_amount=20, retry_codes=[503, 504])
 

--- a/tests/rptest/tests/partition_force_reconfiguration_test.py
+++ b/tests/rptest/tests/partition_force_reconfiguration_test.py
@@ -525,7 +525,7 @@ class NodeWiseRecoveryTest(RedpandaTest):
             *args,
             **kwargs,
         )
-        self.default_timeout_sec = 300
+        self.default_timeout_sec = 120
         self.rpk = RpkTool(self.redpanda)
         self.admin = Admin(self.redpanda, retries_amount=20, retry_codes=[503, 504])
 
@@ -636,7 +636,7 @@ class NodeWiseRecoveryTest(RedpandaTest):
     #
 
     @cluster(num_nodes=6)
-    @matrix(dead_node_count=[1, 2], ongoing_decommission=[True])
+    @matrix(dead_node_count=[1, 2], ongoing_decommission=[False])
     def test_node_wise_recovery(self, dead_node_count, ongoing_decommission):
         num_topics = 20
         # Create a mix of rf=1 and 3 topics.

--- a/tests/rptest/tests/partition_force_reconfiguration_test.py
+++ b/tests/rptest/tests/partition_force_reconfiguration_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 import random
 import time
+from enum import Enum
 from random import shuffle
 from threading import Condition, Thread
 
@@ -631,9 +632,12 @@ class NodeWiseRecoveryTest(RedpandaTest):
             retry_on_exc=True,
         )
 
+    # class NodeWiseRecoveryCase(str, Enum):
+    #
+
     @cluster(num_nodes=6)
-    @matrix(dead_node_count=[1, 2])
-    def test_node_wise_recovery(self, dead_node_count):
+    @matrix(dead_node_count=[1, 2], ongoing_decommission=[True])
+    def test_node_wise_recovery(self, dead_node_count, ongoing_decommission):
         num_topics = 20
         # Create a mix of rf=1 and 3 topics.
         topics = []
@@ -675,6 +679,14 @@ class NodeWiseRecoveryTest(RedpandaTest):
         initial_topic_hws = {
             t.name: self.get_topic_partition_high_watermarks(t.name) for t in topics
         }
+
+        if ongoing_decommission:
+            # jam recovery so the decommission is in progress at the time of forcing
+            self.redpanda.set_cluster_config(
+                {"raft_learner_recovery_rate": 1}, self.default_timeout_sec
+            )
+            for node_id in to_kill_node_ids:
+                admin.decommission_broker(node_id)
 
         self.logger.debug(f"Stopping nodes: {to_kill_node_ids}")
         self.redpanda.for_nodes(to_kill_nodes, self.redpanda.stop_node)
@@ -718,6 +730,12 @@ class NodeWiseRecoveryTest(RedpandaTest):
         self._rpk.force_partition_recovery(
             from_nodes=to_kill_node_ids, to_node=surviving_node
         )
+
+        if ongoing_decommission:
+            # unjam force recovery and transfers
+            self.redpanda.set_cluster_config(
+                {"raft_learner_recovery_rate": 1 << 30}, tolerate_stopped_nodes=True
+            )
 
         with ControllerLeadershipTransferInjector(self.redpanda) as transfers:
 


### PR DESCRIPTION
This is cached progress for getting node-wise recovery working with in-progress moves.

at the moment, the calculation for moves to execute does not include moves which may have stalled because of dead brokers.

In addition, the calculation for in-progress moves should guarantee that the move uses the same node set as the target as the existing move.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
