### PR TITLE
[CORE-14511] [CORE-14518] dt/cluster_linking: Wait for topic and partitions

### DIFF
--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -949,7 +949,7 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
         shadow_link = self.create_link("test-link")
 
         self.target_cluster.service.wait_until(
-            lambda: self.topic_exists_in_target(topic.name),
+            lambda: self.topic_partitions_exists_in_target(topic),
             timeout_sec=30,
             backoff_sec=1,
             err_msg=f"Topic {topic.name} not found in target cluster",
@@ -1049,7 +1049,7 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
         shadow_link = self.create_link("test-link")
 
         self.target_cluster.service.wait_until(
-            lambda: self.topic_exists_in_target(topic.name),
+            lambda: self.topic_partitions_exists_in_target(topic),
             timeout_sec=30,
             backoff_sec=1,
             err_msg=f"Topic {topic.name} not found in target cluster",
@@ -1229,7 +1229,7 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
         topic = TopicSpec(name="test-topic", partition_count=3, replication_factor=1)
         self.source_default_client().create_topic(topic)
         self.target_cluster.service.wait_until(
-            lambda: self.topic_exists_in_target(topic.name),
+            lambda: self.topic_partitions_exists_in_target(topic),
             timeout_sec=30,
             backoff_sec=1,
             err_msg=f"Topic {topic.name} not found in target cluster",
@@ -1357,7 +1357,7 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
                 f"Verifying that topic {topic_name} IS created in target cluster"
             )
             self.target_cluster.service.wait_until(
-                lambda: self.topic_exists_in_target(topic_name),
+                lambda: self.topic_partitions_exists_in_target(topic),
                 timeout_sec=10,
                 backoff_sec=1,
             )
@@ -1459,7 +1459,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         self.create_link("test-link")
 
         self.target_cluster.service.wait_until(
-            lambda: self.topic_exists_in_target(topic.name),
+            lambda: self.topic_partitions_exists_in_target(topic),
             timeout_sec=30,
             backoff_sec=1,
             err_msg=f"Topic {topic.name} not found in target cluster",
@@ -1497,7 +1497,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         self.create_link("test-link")
 
         self.target_cluster.service.wait_until(
-            lambda: self.topic_exists_in_target(topic.name),
+            lambda: self.topic_partitions_exists_in_target(topic),
             timeout_sec=30,
             backoff_sec=1,
             err_msg=f"Topic {topic.name} not found in target cluster",
@@ -1537,7 +1537,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         shadow_link = self.create_link("test-link")
 
         self.target_cluster.service.wait_until(
-            lambda: self.topic_exists_in_target(topic.name),
+            lambda: self.topic_partitions_exists_in_target(topic),
             timeout_sec=30,
             backoff_sec=1,
             err_msg=f"Topic {topic.name} not found in target cluster",
@@ -1587,7 +1587,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         self.create_link("test-link")
 
         self.target_cluster.service.wait_until(
-            lambda: self.topic_exists_in_target(topic.name),
+            lambda: self.topic_partitions_exists_in_target(topic),
             timeout_sec=30,
             backoff_sec=1,
             err_msg=f"Topic {topic.name} not found in target cluster",
@@ -1616,7 +1616,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         )
         self.create_link("test-link")
         self.target_cluster.service.wait_until(
-            lambda: self.topic_exists_in_target(topic.name),
+            lambda: self.topic_partitions_exists_in_target(topic),
             timeout_sec=30,
             backoff_sec=1,
             err_msg=f"Topic {topic.name} not found in target cluster",
@@ -1745,7 +1745,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         self.create_link("test-link")
 
         self.target_cluster.service.wait_until(
-            lambda: self.topic_exists_in_target(topic.name),
+            lambda: self.topic_partitions_exists_in_target(topic),
             timeout_sec=30,
             backoff_sec=1,
             err_msg=f"Topic {topic.name} not found in target cluster",
@@ -1780,7 +1780,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         self.create_link("test-link")
 
         self.target_cluster.service.wait_until(
-            lambda: self.topic_exists_in_target(topic.name),
+            lambda: self.topic_partitions_exists_in_target(topic),
             timeout_sec=30,
             backoff_sec=1,
             err_msg=f"Topic {topic.name} not found in target cluster",
@@ -2378,7 +2378,7 @@ class ShadowLinkTopicFailoverTests(ShadowLinkPreAllocTestBase):
         # Wait for topics to be created in the target cluster
         for t in all_topics:
             self.target_cluster.service.wait_until(
-                lambda: self.topic_exists_in_target(t.name),
+                lambda: self.topic_partitions_exists_in_target(t),
                 timeout_sec=60,
                 backoff_sec=1,
                 err_msg=f"Topic {t.name} not found in target cluster",
@@ -2492,7 +2492,7 @@ class ShadowLinkTopicFailoverTests(ShadowLinkPreAllocTestBase):
 
         for t in topics:
             self.target_cluster.service.wait_until(
-                lambda: self.topic_exists_in_target(t.name),
+                lambda: self.topic_partitions_exists_in_target(t),
                 timeout_sec=60,
                 backoff_sec=1,
                 err_msg=f"Topic {t.name} not found in target cluster",
@@ -2596,19 +2596,17 @@ class ShadowLinkUpdateBrokersTests(ShadowLinkPreAllocTestBase):
         self.source_cluster_rpk.create_topic(old_source_topic)
         self.other_source_cluster_rpk.create_topic(new_source_topic)
 
-        def topic_exists_in_target(topic: str):
-            topics = self.target_cluster_rpk.list_topics()
-            return topic in topics
-
         self.target_cluster.service.wait_until(
-            lambda: topic_exists_in_target(new_source_topic),
+            lambda: self.topic_exists_in_target(
+                new_source_topic, 1, self.target_cluster_rpk
+            ),
             timeout_sec=30,
             backoff_sec=1,
             err_msg=f"Topic {new_source_topic} not found in target cluster",
         )
-        assert not topic_exists_in_target(old_source_topic), (
-            f"Topic {old_source_topic} should not be visible to the target cluster"
-        )
+        assert not self.topic_exists_in_target(
+            old_source_topic, None, self.target_cluster_rpk
+        ), f"Topic {old_source_topic} should not be visible to the target cluster"
 
 
 class ShadowLinkingMetricsTests(ShadowLinkPreAllocTestBase):
@@ -2848,7 +2846,7 @@ class ShadowLinkingMetricsTests(ShadowLinkPreAllocTestBase):
         )
         self.source_default_client().create_topic(topic_3)
         self.target_cluster.service.wait_until(
-            lambda: self.topic_exists_in_target(topic_3.name),
+            lambda: self.topic_partitions_exists_in_target(topic_3),
             timeout_sec=30,
             backoff_sec=1,
             err_msg=f"Topic {topic_3.name} not found in target cluster",
@@ -3064,7 +3062,7 @@ class ShadowLinkCustomStartOffsetSelectionTests(ShadowLinkPreAllocTestBase):
             self.create_link_with_request(req=req)
 
             self.target_cluster.service.wait_until(
-                lambda: self.topic_exists_in_target(topic.name, 1),
+                lambda: self.topic_partitions_exists_in_target(topic),
                 timeout_sec=30,
                 backoff_sec=1,
                 err_msg=f"Topic {topic.name} not found in target cluster",

--- a/tests/rptest/tests/cluster_linking_omb_test.py
+++ b/tests/rptest/tests/cluster_linking_omb_test.py
@@ -40,7 +40,7 @@ class ClusterLinkingOMBTest(ShadowLinkTestBase):
             replicas=3,
         )
         self.target_cluster.service.wait_until(
-            lambda: self.topic_exists_in_target(topic_name),
+            lambda: self.topic_exists_in_target(topic_name, topic_partitions),
             timeout_sec=30,
             backoff_sec=1,
             err_msg=f"Topic {topic_name} not found in target cluster",

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -672,6 +672,15 @@ class ShadowLinkTestBase(PreallocNodesTest):
         topics = RpkTool(self.source_cluster_service).list_topics()
         return topic in topics
 
+    def topic_partitions_exists_in_target(
+        self,
+        topic: TopicSpec,
+        rpk: Optional[RpkTool] = None,
+    ) -> bool:
+        return self.topic_exists_in_target(
+            topic=topic.name, partition_count=topic.partition_count, rpk=rpk
+        )
+
     def topic_exists_in_target(
         self,
         topic: str,

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -156,7 +156,7 @@ class ClusterLinkingProgressVerifier:
             custom_node=self.preallocated_nodes,
             **self.producer_properties,
         )
-        self.producer.start(clean=False)
+        self.producer.start(clean=True)
         self.producer.wait_for_acks(10, 40, 1)
         readers = 8
 

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -29,6 +29,7 @@ from rptest.clients.admin.proto.redpanda.core.common.v1 import acl_pb2
 from rptest.clients.admin.v2 import Admin as AdminV2
 from rptest.clients.default import DefaultClient
 from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import TestContext
 from rptest.services.kgo_verifier_services import (
@@ -674,7 +675,7 @@ class ShadowLinkTestBase(PreallocNodesTest):
     def topic_exists_in_target(
         self,
         topic: str,
-        partition_count: int | None = None,
+        partition_count: Optional[int] = None,
         rpk: Optional[RpkTool] = None,
     ) -> bool:
         rpk = rpk or RpkTool(self.target_cluster.service)
@@ -684,9 +685,7 @@ class ShadowLinkTestBase(PreallocNodesTest):
         if partition_count is None:
             return topic_exists
 
-        partitions = [
-            p for p in RpkTool(self.target_cluster.service).describe_topic(topic)
-        ]
+        partitions = list(rpk.describe_topic(topic))
         return topic_exists and len(partitions) == partition_count
 
     def wait_for_topic_status(


### PR DESCRIPTION
If the topic is going to be produced to, wait for the partitions, too.

For example, this avoids the KgoVerifier warning:
```
"More partitions in valid_offsets file than in topic!"
```

E.g.: https://ci-artifacts.dev.vectorized.cloud/production-devprod/redpanda/75412/019a3a6a-4e02-4342-9b24-7ecdaa64c418/vbuild/ducktape/results/2025-10-31--001/report.html

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
