### PR TITLE
Controller forced reconfiguration: pare down

### DIFF
--- a/proto/redpanda/core/admin/internal/v1/breakglass.proto
+++ b/proto/redpanda/core/admin/internal/v1/breakglass.proto
@@ -25,13 +25,12 @@ option (redpanda.core.pbgen.cpp_namespace) = "proto::admin::internal";
 // extraordinary circumstances.
 //
 service BreakglassService {
-    // Forcibly recovers a cluster when the majority of nodes are lost.
-    // This operation is dangerous by design and will likely result in data
-    // loss.
-    // 1. Removes dead nodes from the controller group until a new leader
-    //    can be chosen.
-    // 2. Force reconfigures all partitions off of dead nodes.
-    // 3. Decommission & remove the dead nodes from the cluster.
+    // Forcibly recovers a cluster's controller when the majority of nodes
+    // are lost.
+    //
+    // This RPC will remove dead nodes from raft0 until a new controller
+    // leader is elected, at which point the cluster may be recovered
+    // with existing rpcs (nodewise-recovery, decommission brokers).
     //
     // Requirements:
     // 1. All surviving brokers must be booted into recovery mode.

--- a/src/v/cluster/controller_forced_reconfiguration_manager.cc
+++ b/src/v/cluster/controller_forced_reconfiguration_manager.cc
@@ -133,9 +133,6 @@ controller_forced_reconfiguration_manager::calculation_reconfiguration_group(
 ss::future<cluster::error_info> controller_forced_reconfiguration_manager::
   initialize_controller_forced_reconfiguration(
     std::vector<model::node_id> dead_nodes, uint16_t surviving_node_count) {
-    // constant
-    const auto timeout = std::chrono::minutes{15};
-
     vlog(
       clusterlog.info,
       "invocation of controller_forced_reconfiguration with dead_nodes: {}, "
@@ -282,71 +279,6 @@ ss::future<cluster::error_info> controller_forced_reconfiguration_manager::
           leader);
     }
 
-    { // step 3 force all partitions out of failed brokers
-        vlog(clusterlog.info, "starting all partition force recovery");
-        auto maybe_quorum_loss_partitions
-          = co_await controller.get_topics_frontend()
-              .local()
-              .partitions_with_lost_majority(dead_nodes);
-        if (!maybe_quorum_loss_partitions) {
-            co_return cluster::error_info{
-              .err = maybe_quorum_loss_partitions.error(),
-              .message
-              = "failed to gather list of partitions with quorum loss"};
-        }
-        auto& quorum_loss_partitions = maybe_quorum_loss_partitions.value();
-
-        // todo find reasonable timeout
-        auto ec = co_await controller.get_topics_frontend()
-                    .local()
-                    .force_recover_partitions_from_nodes(
-                      dead_nodes,
-                      std::move(quorum_loss_partitions),
-                      ss::lowres_clock::now() + timeout);
-
-        if (ec) {
-            co_return cluster::error_info{
-              .err = ec,
-              .message
-              = "controller force reconfiguration failed on force recovering "
-                "partitions"};
-        }
-        vlog(clusterlog.info, "finished all partition force recovery");
-    }
-
-    // we succeed the CFR even if some nodes fail to decommission or remove
-    std::vector<model::node_id> failed_to_decom_nodes{};
-    std::error_code last_decom_error{};
-    { // step 4 decommission and remove all dead brokers
-        vlog(clusterlog.info, "starting dead node decommission");
-        for (const auto dead_node : dead_nodes) {
-            const auto ec = co_await controller.get_members_frontend()
-                              .local()
-                              .decommission_node(dead_node);
-            if (ec) {
-                last_decom_error = ec;
-                failed_to_decom_nodes.emplace_back(dead_node);
-                vlog(
-                  clusterlog.warn,
-                  "controller force reconfiguration failed to "
-                  "decommission "
-                  "node: {}, with error: {}",
-                  dead_node,
-                  ec);
-                continue;
-            }
-        }
-        vlog(clusterlog.info, "finished dead node decommission");
-
-        if (!failed_to_decom_nodes.empty()) {
-            co_return cluster::error_info{
-              .err = last_decom_error,
-              .message = fmt::format(
-                "leader exiting, failed to decomission nodes: {}. If survivors "
-                "nodes are stable, decommission these brokers normally",
-                failed_to_decom_nodes)};
-        }
-    }
     co_return cluster::error_info{
       .err = cluster::errc::success,
       .message = "leader exiting successful controller forced recovery"};

--- a/src/v/cluster/controller_forced_reconfiguration_manager.h
+++ b/src/v/cluster/controller_forced_reconfiguration_manager.h
@@ -70,8 +70,6 @@ public:
      *     0. validation of the above requirements
      *     1. force reconfiguration of the raft0 group to exclude dead_nodes
      *     2. poll for a newly elected controller leader
-     *     3. force reconfigure all partitions with quorum loss off dead_nodes
-     *     4. decommission and remove all dead nodes
      * This operation is volatile until completion of step 2
      *     - successful leader election will replicate a configuration batch
      *     - on successful replication, the reduced raft0 group is persistent

--- a/src/v/cluster/tests/BUILD
+++ b/src/v/cluster/tests/BUILD
@@ -1306,6 +1306,7 @@ redpanda_cc_gtest(
         "//src/v/model",
         "//src/v/raft:fundamental",
         "//src/v/random:generators",
+        "//src/v/redpanda/tests:fixture",
         "//src/v/security",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",

--- a/src/v/cluster/tests/controller_forced_reconfiguration_test.cc
+++ b/src/v/cluster/tests/controller_forced_reconfiguration_test.cc
@@ -48,6 +48,16 @@ constexpr auto small_wait = 3s;
 constexpr auto medium_wait = 15s;
 constexpr auto large_wait = 120s;
 
+namespace { // smoke tests
+static const auto default_topic = topic_config{
+  .name = model::topic{"test-topic"},
+  .partition_count = 3,
+  .replication_factor = 3};
+
+constexpr raft::vnode to_vnode(int node_id) {
+    return raft::vnode{model::node_id{node_id}, model::revision_id{0}};
+}
+
 template<typename T>
 auto typed_range(int begin, T end) {
     return std::views::iota(static_cast<T>(begin), end);
@@ -513,19 +523,34 @@ class SizedCFRFixture : public CFRFixture {
 public:
     SizedCFRFixture() noexcept
       : CFRFixture(Size) {}
+
+    void do_smoke_test() {
+        // set up
+        setup_topic(default_topic);
+        move_partition_onto_dying_nodes(default_topic);
+
+        // disaster
+        induce_controller_loss();
+        toggle_recovery_mode(true);
+        check_no_controller_leader();
+
+        // recovery
+        force_recover_cluster();
+        check_controller_leader();
+        restore_node_number();
+        check_controller_leader();
+        toggle_recovery_mode(false);
+        check_controller_leader();
+        execute_nodewise_recovery();
+        decommission_dead_nodes();
+
+        // check recovery succeeded
+        wait_for_leader_restoration(default_topic);
+        check_final_replica_locations();
+    }
 };
 
 } // namespace
-
-namespace { // smoke tests
-static const auto default_topic = topic_config{
-  .name = model::topic{"test-topic"},
-  .partition_count = 3,
-  .replication_factor = 3};
-
-constexpr raft::vnode to_vnode(int node_id) {
-    return raft::vnode{model::node_id{node_id}, model::revision_id{0}};
-}
 
 TEST(CalculateRaftGroup, TwoSuvivors) {
     std::vector<raft::vnode> voter_config = {
@@ -542,6 +567,33 @@ TEST(CalculateRaftGroup, TwoSuvivors) {
     auto result_config = std::move(maybe_result_config).value();
 
     std::vector<raft::vnode> expected = {to_vnode(3), to_vnode(4), to_vnode(0)};
+
+    ASSERT_EQ(result_config.size(), expected.size());
+    for (const auto& result_node : result_config) {
+        ASSERT_TRUE(std::ranges::find(expected, result_node) != expected.end());
+    }
+}
+
+TEST(CalculateRaftGroup, EvenClusterSize) {
+    std::vector<raft::vnode> voter_config = {
+      to_vnode(0),
+      to_vnode(1),
+      to_vnode(2),
+      to_vnode(3),
+      to_vnode(4),
+      to_vnode(5)};
+
+    std::vector<model::node_id> dead_nodes = {
+      model::node_id{0}, model::node_id{1}, model::node_id{2}};
+
+    auto maybe_result_config
+      = cluster::controller_forced_reconfiguration_manager::
+        calculation_reconfiguration_group(dead_nodes, voter_config, 2);
+    ASSERT_TRUE(maybe_result_config.has_value());
+
+    auto result_config = std::move(maybe_result_config).value();
+
+    std::vector<raft::vnode> expected = {to_vnode(3), to_vnode(4), to_vnode(5)};
 
     ASSERT_EQ(result_config.size(), expected.size());
     for (const auto& result_node : result_config) {
@@ -586,55 +638,12 @@ TEST(CalculateRaftGroup, NotEnoughNodes) {
 }
 
 using CFRFixture5 = SizedCFRFixture<5>;
-TEST_F(CFRFixture5, Smoke5) {
-    // set up
-    setup_topic(default_topic);
-    move_partition_onto_dying_nodes(default_topic);
-
-    // disaster
-    induce_controller_loss();
-    toggle_recovery_mode(true);
-    check_no_controller_leader();
-
-    // recovery
-    force_recover_cluster();
-    check_controller_leader();
-    restore_node_number();
-    check_controller_leader();
-    toggle_recovery_mode(false);
-    check_controller_leader();
-    execute_nodewise_recovery();
-    decommission_dead_nodes();
-
-    // check recovery succeeded
-    wait_for_leader_restoration(default_topic);
-    check_final_replica_locations();
-}
+TEST_F(CFRFixture5, Smoke5) { do_smoke_test(); }
 
 using CFRFixture3 = SizedCFRFixture<3>;
-TEST_F(CFRFixture3, Smoke3) {
-    // set up
-    setup_topic(default_topic);
-    move_partition_onto_dying_nodes(default_topic);
+TEST_F(CFRFixture3, Smoke3) { do_smoke_test(); }
 
-    // disaster
-    induce_controller_loss();
-    toggle_recovery_mode(true);
-    check_no_controller_leader();
-
-    // recovery
-    force_recover_cluster();
-    check_controller_leader();
-    restore_node_number();
-    check_controller_leader();
-    toggle_recovery_mode(false);
-    check_controller_leader();
-    execute_nodewise_recovery();
-    decommission_dead_nodes();
-
-    // check recovery succeeded
-    wait_for_leader_restoration(default_topic);
-    check_final_replica_locations();
-}
+using CFRFixture4 = SizedCFRFixture<4>;
+TEST_F(CFRFixture4, Smoke4) { do_smoke_test(); }
 
 } // namespace

--- a/src/v/cluster/tests/controller_forced_reconfiguration_test.cc
+++ b/src/v/cluster/tests/controller_forced_reconfiguration_test.cc
@@ -9,14 +9,18 @@
 
 #include "base/vassert.h"
 #include "cluster/controller_forced_reconfiguration_manager.h"
+#include "cluster/errc.h"
+#include "cluster/members_frontend.h"
 #include "cluster/tests/cluster_test_fixture.h"
 #include "config/configuration.h"
 #include "gtest/gtest.h"
 #include "model/fundamental.h"
+#include "model/metadata.h"
 #include "model/namespace.h"
 #include "raft/fundamental.h"
-#include "test_utils/test.h"
+#include "redpanda/tests/fixture.h"
 
+#include <algorithm>
 #include <exception>
 
 namespace {
@@ -125,21 +129,23 @@ public:
         }
     }
 
-    // kill the majority of the cluster nodes starting at 0
-    // for a cluster of size 5, will kill 0, 1, and 2
-    void induce_controller_loss() {
-        scope_logger sl{"induce controller loss"};
-
+    std::vector<model::node_id> get_nodes_to_kill() {
         // cluster size of 5 -> kill [0,3)
         uint16_t kill_up_to_exclusive = _cluster_size / 2 + 1;
-
         std::vector<model::node_id> nodes_to_kill{};
         nodes_to_kill.reserve(kill_up_to_exclusive);
         for (const auto node_number : typed_range(0, kill_up_to_exclusive)) {
             nodes_to_kill.emplace_back(node_number);
         }
+        return nodes_to_kill;
+    }
 
-        batch_kill_nodes(nodes_to_kill);
+    // kill the majority of the cluster nodes starting at 0
+    // for a cluster of size 5, will kill 0, 1, and 2
+    void induce_controller_loss() {
+        scope_logger sl{"induce controller loss"};
+
+        batch_kill_nodes(get_nodes_to_kill());
     }
 
     // snap the dead nodes to a vector
@@ -328,10 +334,150 @@ public:
         }
     }
 
+    // this assumes that the controller is alive, dont use this to poll or
+    // otherwise
+    redpanda_thread_fixture* safe_get_controller_rp() {
+        // get controller from living nodes
+        auto living_nodes = get_living_nodes();
+        wait_for_controller_leadership(living_nodes.front()).get();
+        auto* app = get_node_application(living_nodes.front());
+        auto maybe_controller_leader
+          = app->controller->get_partition_leaders().local().get_leader(
+            model::controller_ntp);
+        vassert(
+          maybe_controller_leader.has_value(),
+          "failed to get controller leader");
+
+        auto controller_leader = *maybe_controller_leader;
+        auto controller_rp = instance(controller_leader);
+
+        vassert(
+          controller_rp != nullptr,
+          "controller leader instance should not be nullptr");
+
+        return controller_rp;
+    }
+
+    // put one partition of the topic as much as possible onto the dead nodes
+    void move_partition_onto_dying_nodes(const topic_config& topic_config) {
+        auto to_move_ntp = model::ntp{
+          model::kafka_namespace, topic_config.name, model::partition_id{0}};
+
+        scope_logger sl{
+          fmt::format("move partition onto dying nodes {}", to_move_ntp)};
+
+        auto* controller_rp = safe_get_controller_rp();
+
+        // use topic table to request the move
+        auto& topics_frontend
+          = controller_rp->app.controller->get_topics_frontend().local();
+
+        std::vector<model::broker_shard> to_kill_broker_shards{
+          std::from_range,
+          std::ranges::views::transform(
+            get_nodes_to_kill(),
+            [](model::node_id node_id) -> model::broker_shard {
+                return model::broker_shard{.node_id = node_id, .shard = 0};
+            })};
+
+        // request the move
+        auto move_err
+          = topics_frontend
+              .move_partition_replicas(
+                to_move_ntp,
+                to_kill_broker_shards,
+                cluster::reconfiguration_policy::full_local_retention,
+                ss::lowres_clock::now() + medium_wait)
+              .get();
+        ASSERT_FALSE(move_err)
+          << "failed to move partition with error_code " << move_err;
+
+        // spin until theres no move in progress
+        auto& topics_table
+          = controller_rp->app.controller->get_topics_state().local();
+        wait_for(medium_wait, [&topics_table, to_move_ntp] {
+            return !topics_table.is_update_in_progress(to_move_ntp);
+        });
+    }
+
+    // execute nodewise recovery, wait for completion
+    void execute_nodewise_recovery() {
+        scope_logger sl{"nodewise recovery"};
+        auto* controller_rp = safe_get_controller_rp();
+
+        auto& topic_frontend
+          = controller_rp->app.controller->get_topics_frontend().local();
+        auto maybe_pwlm = topic_frontend
+                            .partitions_with_lost_majority(get_dead_nodes())
+                            .get();
+        ASSERT_TRUE(maybe_pwlm.has_value())
+          << "get partitions_with_lost_majority failed with error: "
+          << maybe_pwlm.error().message();
+
+        auto pwlm = std::move(maybe_pwlm).assume_value();
+
+        for (const auto& entry : pwlm) {
+            vlog(
+              _logger.info, "executing nodewise recovery on entry: {}", entry);
+        }
+
+        auto force_error = topic_frontend
+                             .force_recover_partitions_from_nodes(
+                               get_dead_nodes(),
+                               std::move(pwlm),
+                               ss::lowres_clock::now() + large_wait)
+                             .get();
+
+        ASSERT_FALSE(force_error)
+          << "failed to execute force recovery with error "
+          << force_error.message();
+
+        auto& topic_table
+          = controller_rp->app.controller->get_topics_state().local();
+
+        wait_for(large_wait, [&topic_table] {
+            return topic_table.updates_in_progress().size() == 0;
+        });
+    }
+
+    void decommission_dead_nodes() {
+        scope_logger sl{"decommission dead nodes"};
+
+        auto* controller_rp = safe_get_controller_rp();
+
+        auto& members_frontend
+          = controller_rp->app.controller->get_members_frontend().local();
+
+        for (auto dead_node : get_dead_nodes()) {
+            auto decom_err
+              = members_frontend.decommission_node(dead_node).get();
+            ASSERT_FALSE(decom_err) << "failed to decommission node "
+                                    << dead_node << " with error " << decom_err;
+        }
+
+        auto& members_table
+          = controller_rp->app.controller->get_members_table().local();
+
+        wait_for(large_wait, [&members_table, dead_nodes = get_dead_nodes()] {
+            for (const auto dead_node : dead_nodes) {
+                auto dead_meta = members_table.get_node_metadata(dead_node);
+                if (dead_meta) {
+                    vlog(
+                      _logger.info,
+                      "still has metadata for dead node: {}",
+                      dead_node);
+                    return false;
+                }
+            }
+            vlog(_logger.info, "successfully removed dead_nodes");
+            return true;
+        });
+    }
+
     void check_final_replica_locations() {
-        // given a cluster size of N, check that [0, floor(N/2)] are actually
-        // gone (killed to lose quorum)
-        // and that [ceil(N/2), N + ceil(N/2)] are alive
+        // given a cluster size of N, check that all nodes
+        // [0, floor(N/2)] are actually gone (killed to lose quorum)
+        // and that [floor(N/2) + 1, N + floor(N/2) + 1] are alive
         auto nodes = this->instance_ids();
 
         ASSERT_EQ(nodes.size(), _cluster_size);
@@ -441,55 +587,53 @@ TEST(CalculateRaftGroup, NotEnoughNodes) {
 
 using CFRFixture5 = SizedCFRFixture<5>;
 TEST_F(CFRFixture5, Smoke5) {
+    // set up
     setup_topic(default_topic);
+    move_partition_onto_dying_nodes(default_topic);
 
+    // disaster
     induce_controller_loss();
-
     toggle_recovery_mode(true);
-
     check_no_controller_leader();
 
+    // recovery
     force_recover_cluster();
-
     check_controller_leader();
-
     restore_node_number();
-
     check_controller_leader();
-
     toggle_recovery_mode(false);
-
     check_controller_leader();
+    execute_nodewise_recovery();
+    decommission_dead_nodes();
 
+    // check recovery succeeded
     wait_for_leader_restoration(default_topic);
-
     check_final_replica_locations();
 }
 
 using CFRFixture3 = SizedCFRFixture<3>;
 TEST_F(CFRFixture3, Smoke3) {
+    // set up
     setup_topic(default_topic);
+    move_partition_onto_dying_nodes(default_topic);
 
+    // disaster
     induce_controller_loss();
-
     toggle_recovery_mode(true);
-
     check_no_controller_leader();
 
+    // recovery
     force_recover_cluster();
-
     check_controller_leader();
-
     restore_node_number();
-
     check_controller_leader();
-
     toggle_recovery_mode(false);
-
     check_controller_leader();
+    execute_nodewise_recovery();
+    decommission_dead_nodes();
 
+    // check recovery succeeded
     wait_for_leader_restoration(default_topic);
-
     check_final_replica_locations();
 }
 

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -17,7 +17,7 @@ import time
 import typing
 from collections import namedtuple
 from dataclasses import dataclass, field
-from typing import Any, Iterator, Literal, overload
+from typing import Any, Iterator, Literal, Optional, overload
 
 from ducktape.cluster.cluster import ClusterNode
 from ducktape.errors import TimeoutError
@@ -2351,7 +2351,9 @@ class RpkTool:
 
         return json.loads(out) if output_format == "json" else out
 
-    def force_partition_recovery(self, from_nodes, to_node=None):
+    def force_partition_recovery(
+        self, from_nodes: list[int], to_node: Optional[ClusterNode] = None
+    ):
         cmd = [
             self._rpk_binary(),
             "cluster",

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1501,7 +1501,9 @@ class Admin:
         path = f"cloud_storage/sync_local_state/{topic}/{partition}"
         return self._request("post", path, node=node)
 
-    def get_partition_balancer_status(self, node=None, **kwargs):
+    def get_partition_balancer_status(
+        self, node: Optional[ClusterNode] = None, **kwargs: Any
+    ) -> Any:
         return self._request(
             "GET", "cluster/partition_balancer/status", node=node, **kwargs
         ).json()

--- a/tests/rptest/tests/controller_forced_reconfiguration_test.py
+++ b/tests/rptest/tests/controller_forced_reconfiguration_test.py
@@ -15,6 +15,7 @@ from ducktape.cluster.cluster import ClusterNode
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 
+from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import PartitionDetails, Replica
 from rptest.services.cluster import cluster
@@ -221,6 +222,19 @@ class ControllerForceReconfigurationTest(RedpandaTest):
                         f"dead node: {killed_node_id} still in configuration"
                     )
 
+    def _wait_for_no_reconfigurations(self):
+        def no_pending_force_reconfigurations():
+            status = self.redpanda._admin.get_partition_balancer_status()
+            return status["partitions_pending_force_recovery_count"] == 0
+
+        wait_until(
+            no_pending_force_reconfigurations,
+            timeout_sec=120,
+            backoff_sec=3,
+            err_msg="reported force recovery count is non zero",
+            retry_on_exc=True,
+        )
+
     @cluster(num_nodes=6)
     def test_smoke_cfr(self):
         """
@@ -317,6 +331,21 @@ class ControllerForceReconfigurationTest(RedpandaTest):
             recovery_mode_enabled=False,
         )
 
+        self.logger.debug(f"recovering from: {killed_node_ids}")
+        self._rpk = RpkTool(self.redpanda)
+
+        # issue a node wise recovery
+        self._rpk.force_partition_recovery(
+            from_nodes=killed_node_ids, to_node=designated_survivor
+        )
+
+        self._wait_for_no_reconfigurations()
+
+        for dead_node_id in killed_node_ids:
+            self.redpanda._admin.decommission_broker(dead_node_id, designated_survivor)
+
+        self._check_topic_recovered(topic, cluster_size, killed_node_ids)
+
         KgoVerifierProducer.oneshot(  # type: ignore
             self.test_context,
             self.redpanda,
@@ -324,5 +353,3 @@ class ControllerForceReconfigurationTest(RedpandaTest):
             msg_size=10000,
             msg_count=1000,
         )
-
-        self._check_topic_recovered(topic, cluster_size, killed_node_ids)


### PR DESCRIPTION
Node-wise recovery today does not support force moving partitions which are already moving.

As a result, the existing implementation of controller forced recovery would often trigger partition moves from the brokers to be decommissioned before the force_moves from node-wise recovery were attempted.

The longterm resolution is to make node-wise recovery override existing moves.

For now, though, CFR is substantially more reliable if the operators execute node-wise recovery and then decommission.

This PR pares back controller forced recovery to only execute the raft0 update and wait for a leader, alongside the relevant test updates per the new expected operator workflow.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
### Bug Fixes
* makes CFR cleanup manual to avoid nodewise recovery race
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
