### PR TITLE
[UX-606] Cloud support on cluster connections list

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -10,8 +10,8 @@ require (
 	buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.10-20251022210436-bbacedafcd60.1
 	buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.10-20250904135917-9feeb2588236.1
 	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251031041656-b5652b54ce76.1
-	buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251027225853-643acf04839f.2
-	buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-20251027225853-643acf04839f.1
+	buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-00000000000000-6032d9405263.2
+	buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-00000000000000-6032d9405263.1
 	buf.build/gen/go/redpandadata/gatekeeper/connectrpc/go v1.19.1-20251022210437-a5dd600d04b6.2
 	buf.build/gen/go/redpandadata/gatekeeper/protocolbuffers/go v1.36.10-20251022210437-a5dd600d04b6.1
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -12,10 +12,10 @@ buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251031041656-b5652b54
 buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251031041656-b5652b54ce76.2/go.mod h1:DzxK2flGZATOVQYj2Yr2Vxgw6gA3S2O1gr1jxquVZBk=
 buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251031041656-b5652b54ce76.1 h1:sieB4fNFl0YhNthhlvByeBOtI67FNxlKjg3wNDbFm2U=
 buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251031041656-b5652b54ce76.1/go.mod h1:QenSPzqxZpyo9hHIpRzTetvDchelVDzimnmaggHKenc=
-buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251027225853-643acf04839f.2 h1:lleqpbHhE/SYEI/oeW2RVLZghkfhnAtIL1xk+ioTCos=
-buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251027225853-643acf04839f.2/go.mod h1:lhAYzpdAM94nEirXzLwymBud3CxFzmHGPTdMGSEM79U=
-buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-20251027225853-643acf04839f.1 h1:+QCxgPzEelsR15FWSky3nurPjPh7PfelmNZmgvD7nRA=
-buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-20251027225853-643acf04839f.1/go.mod h1:971HJnUM/0fTBc/LowaoI2ybuR8s+LLlQDpCkPxMwN8=
+buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-00000000000000-6032d9405263.2 h1:GrWApmnb66kg/di/eOCY3XeSqYSWUZEpLVQutZMSpQ4=
+buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-00000000000000-6032d9405263.2/go.mod h1:MDDsL64h613XunKObJwZ6yCKk4ousejC+y0NU+nmYp4=
+buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-00000000000000-6032d9405263.1 h1:qvvllwcFnR0fNCt3J+7NlblUK6dEV/xVZkv4KLHSgEc=
+buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-00000000000000-6032d9405263.1/go.mod h1:971HJnUM/0fTBc/LowaoI2ybuR8s+LLlQDpCkPxMwN8=
 buf.build/gen/go/redpandadata/gatekeeper/connectrpc/go v1.19.1-20251022210437-a5dd600d04b6.2 h1:TpeR1/FQQjGM6AjB3c/+AklMivMEsWNcJYZeipcmMGU=
 buf.build/gen/go/redpandadata/gatekeeper/connectrpc/go v1.19.1-20251022210437-a5dd600d04b6.2/go.mod h1:2PhIGolYdEsQckSpa7ZjVNWn+Z6BeLpSZBb20w1oWlw=
 buf.build/gen/go/redpandadata/gatekeeper/protocolbuffers/go v1.36.10-20251022210437-a5dd600d04b6.1 h1:buRXwBZNRhjymido98wvND0dtS3D/Ww5VmlDYwEKfvU=

--- a/src/go/rpk/pkg/cli/cluster/connections/connections_test.go
+++ b/src/go/rpk/pkg/cli/cluster/connections/connections_test.go
@@ -14,10 +14,64 @@ import (
 	"time"
 
 	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
+	dataplanev1 "buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go/redpanda/api/dataplane/v1"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var (
+	closeTime = "2025-10-23T01:02:05Z"
+	expected  = &Connection{
+		NodeID:             2,
+		ShardID:            4,
+		UID:                "36338ca5-86b7-4478-ad23-32d49cfaef61",
+		State:              "KAFKA_CONNECTION_STATE_OPEN",
+		OpenTime:           "2025-10-23T01:02:03Z",
+		CloseTime:          &closeTime,
+		ConnectionDuration: "2s",
+		TLSEnabled:         true,
+		IdleDuration:       "100ms",
+		ListenerName:       "external",
+		TransactionalID:    "trans-id",
+		Group: &GroupInfo{
+			ID:         "group-a",
+			MemberID:   "group-member",
+			InstanceID: "group-instance",
+		},
+		Authentication: &Authentication{
+			State:         "AUTHENTICATION_STATE_SUCCESS",
+			Mechanism:     "AUTHENTICATION_MECHANISM_MTLS",
+			UserPrincipal: "someone",
+		},
+		Client: &Client{
+			IP:              "4.2.2.1",
+			Port:            49722,
+			ID:              "a-unique-client-id",
+			SoftwareName:    "some-library",
+			SoftwareVersion: "v0.0.1",
+		},
+		APIVersions: []APIVersion{{API: dataplanev1.KafkaAPI_KAFKA_API_PRODUCE.String(), Version: 4}},
+		ActiveRequests: &ActiveRequests{
+			SampledRequests: []SampledRequest{
+				{API: dataplanev1.KafkaAPI_KAFKA_API_PRODUCE.String(), Duration: "40ms"},
+			},
+			HasMoreRequests: true,
+		},
+		RequestStatisticsAll: &RequestStatistics{
+			ProduceBytes:      10000,
+			FetchBytes:        2000,
+			RequestCount:      200,
+			ProduceBatchCount: 10,
+		},
+		RequestStatistics1m: &RequestStatistics{
+			ProduceBytes:      1000,
+			FetchBytes:        200,
+			RequestCount:      20,
+			ProduceBatchCount: 1,
+		},
+	}
 )
 
 func TestParseConnection(t *testing.T) {
@@ -27,7 +81,7 @@ func TestParseConnection(t *testing.T) {
 		Uid:       "36338ca5-86b7-4478-ad23-32d49cfaef61",
 		State:     adminv2.KafkaConnectionState_KAFKA_CONNECTION_STATE_OPEN,
 		OpenTime:  timestamppb.New(time.Date(2025, 10, 23, 1, 2, 3, 0, time.UTC)),
-		CloseTime: nil,
+		CloseTime: timestamppb.New(time.Date(2025, 10, 23, 1, 2, 5, 0, time.UTC)),
 		AuthenticationInfo: &adminv2.AuthenticationInfo{
 			State:         adminv2.AuthenticationState_AUTHENTICATION_STATE_SUCCESS,
 			Mechanism:     adminv2.AuthenticationMechanism_AUTHENTICATION_MECHANISM_MTLS,
@@ -47,7 +101,7 @@ func TestParseConnection(t *testing.T) {
 		GroupId:               "group-a",
 		GroupInstanceId:       "group-instance",
 		GroupMemberId:         "group-member",
-		ApiVersions:           map[int32]int32{0: 4, 9: 11},
+		ApiVersions:           map[int32]int32{0: 4},
 		IdleDuration:          durationpb.New(100 * time.Millisecond),
 		TransactionalId:       "trans-id",
 		InFlightRequests: &adminv2.InFlightRequests{
@@ -73,66 +127,58 @@ func TestParseConnection(t *testing.T) {
 		},
 	}
 
-	out := parseConnection(protoConn)
+	require.Equal(t, expected, parseConnection(protoConn))
+}
 
-	// Verify basic fields
-	require.Equal(t, int32(2), out.NodeID)
-	require.Equal(t, uint32(4), out.ShardID)
-	require.Equal(t, "36338ca5-86b7-4478-ad23-32d49cfaef61", out.UID)
-	require.Equal(t, "OPEN", out.State)
-	require.Equal(t, "2025-10-23T01:02:03Z", out.OpenTime)
-	require.Nil(t, out.CloseTime)
-	require.NotEmpty(t, out.ConnectionDuration)
-	require.True(t, out.TLSEnabled)
-	require.Equal(t, "group-a", out.GroupID)
-	require.Equal(t, "group-instance", out.GroupInstanceID)
-	require.Equal(t, "group-member", out.GroupMemberID)
-	require.Equal(t, "100ms", out.IdleDuration)
-	require.Equal(t, "external", out.ListenerName)
-	require.Equal(t, "trans-id", out.TransactionalID)
-
-	// Verify authentication
-	require.Equal(t, &Authentication{
-		State:         "SUCCESS",
-		Mechanism:     "MTLS",
-		UserPrincipal: "someone",
-	}, out.Authentication)
-
-	// Verify client
-	require.Equal(t, &Client{
-		IP:              "4.2.2.1",
-		Port:            49722,
-		ID:              "a-unique-client-id",
-		SoftwareName:    "some-library",
-		SoftwareVersion: "v0.0.1",
-	}, out.Client)
-
-	// Verify API versions (order-independent check)
-	require.ElementsMatch(t, []APIVersion{
-		{API: "PRODUCE", Version: 4},
-		{API: "OFFSET_FETCH", Version: 11},
-	}, out.APIVersions)
-
-	// Verify active requests
-	require.Equal(t, &ActiveRequests{
-		SampledRequests: []SampledRequest{
-			{API: "PRODUCE", Duration: "40ms"},
+func TestParseDataplaneConnection(t *testing.T) {
+	require.Equal(t, expected, parseDataplaneConnection(&dataplanev1.Connection{
+		NodeId:    2,
+		ShardId:   4,
+		Uid:       "36338ca5-86b7-4478-ad23-32d49cfaef61",
+		State:     adminv2.KafkaConnectionState_KAFKA_CONNECTION_STATE_OPEN,
+		OpenTime:  timestamppb.New(time.Date(2025, 10, 23, 1, 2, 3, 0, time.UTC)),
+		CloseTime: timestamppb.New(time.Date(2025, 10, 23, 1, 2, 5, 0, time.UTC)),
+		Authentication: &adminv2.AuthenticationInfo{
+			State:         adminv2.AuthenticationState_AUTHENTICATION_STATE_SUCCESS,
+			Mechanism:     adminv2.AuthenticationMechanism_AUTHENTICATION_MECHANISM_MTLS,
+			UserPrincipal: "someone",
 		},
-		HasMoreRequests: true,
-	}, out.ActiveRequests)
-
-	// Verify statistics
-	require.Equal(t, &RequestStatistics{
-		ProduceBytes:      10000,
-		FetchBytes:        2000,
-		RequestCount:      200,
-		ProduceBatchCount: 10,
-	}, out.RequestStatisticsAll)
-
-	require.Equal(t, &RequestStatistics{
-		ProduceBytes:      1000,
-		FetchBytes:        200,
-		RequestCount:      20,
-		ProduceBatchCount: 1,
-	}, out.RequestStatistics1m)
+		TlsEnabled:   true,
+		ListenerName: "external",
+		Client: &dataplanev1.ConnectionClient{
+			Ip:              "4.2.2.1",
+			Port:            49722,
+			Id:              "a-unique-client-id",
+			SoftwareName:    "some-library",
+			SoftwareVersion: "v0.0.1",
+		},
+		Group: &dataplanev1.GroupInfo{
+			Id:         "group-a",
+			InstanceId: "group-instance",
+			MemberId:   "group-member",
+		},
+		ApiVersions: []*dataplanev1.APIVersion{
+			{Api: dataplanev1.KafkaAPI_KAFKA_API_PRODUCE, Version: 4},
+		},
+		IdleDuration:    durationpb.New(100 * time.Millisecond),
+		TransactionalId: "trans-id",
+		ActiveRequests: &dataplanev1.ActiveRequests{
+			Requests: []*dataplanev1.ActiveRequests_Request{
+				{Api: dataplanev1.KafkaAPI_KAFKA_API_PRODUCE, Duration: durationpb.New(40 * time.Millisecond)},
+			},
+			HasMoreRequests: true,
+		},
+		RequestStatisticsAll: &adminv2.RequestStatistics{
+			ProduceBytes:      10000,
+			FetchBytes:        2000,
+			RequestCount:      200,
+			ProduceBatchCount: 10,
+		},
+		RequestStatistics_1M: &adminv2.RequestStatistics{
+			ProduceBytes:      1000,
+			FetchBytes:        200,
+			RequestCount:      20,
+			ProduceBatchCount: 1,
+		},
+	}))
 }

--- a/src/go/rpk/pkg/cli/cluster/connections/list.go
+++ b/src/go/rpk/pkg/cli/cluster/connections/list.go
@@ -18,11 +18,13 @@ import (
 	"time"
 
 	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
+	dataplanev1 "buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go/redpanda/api/dataplane/v1"
 	"connectrpc.com/connect"
 	"github.com/docker/go-units"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -51,10 +53,7 @@ var tableHeaders = []string{
 	"REQS/MIN",
 }
 
-func getConnectionDuration(conn *adminv2.KafkaConnection) string {
-	opened := conn.OpenTime.AsTime()
-	closed := conn.CloseTime.AsTime()
-
+func getConnectionDuration(opened time.Time, closed time.Time) string {
 	duration := closed.Sub(opened)
 	if opened.After(closed) {
 		duration = time.Since(opened)
@@ -186,43 +185,50 @@ List extended output for open connections in json format:
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 
 			// This doesn't support using the public API yet
-			config.CheckExitCloudAdmin(prof)
+			conns := []*Connection{}
 
-			cl, err := adminapi.NewClient(cmd.Context(), fs, prof)
-			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+			if prof.CloudCluster.IsServerless() {
+				out.Die("Serverless clusters aren't yet supported")
+			} else if prof.FromCloud {
+				cl, err := publicapi.DataplaneClientFromRpkProfile(prof)
+				out.MaybeDie(err, "unable to initialize cloud API client: %v", err)
 
-			// Build the filters based on the current flag set
-			filterClauses, err := filters.buildFilterClauses()
-			out.MaybeDie(err, "invalid filters: %v", err)
+				resp, err := cl.Monitoring.ListConnections(cmd.Context(), &connect.Request[dataplanev1.ListConnectionsRequest]{})
+				out.MaybeDie(err, "error listing connections: %v", err)
 
-			filterString := filterRaw
-			if len(filterClauses) > 0 {
-				filterString = strings.Join(filterClauses, " AND ")
-			}
+				for _, conn := range resp.Msg.Connections {
+					conns = append(conns, parseDataplaneConnection(conn))
+				}
+			} else {
+				cl, err := adminapi.NewClient(cmd.Context(), fs, prof)
+				out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			req := adminv2.ListKafkaConnectionsRequest{
-				Filter:   filterString,
-				OrderBy:  orderBy,
-				PageSize: limit,
-			}
+				// Build the filters based on the current flag set
+				filterClauses, err := filters.buildFilterClauses()
+				out.MaybeDie(err, "invalid filters: %v", err)
 
-			resp, err := cl.ClusterService().ListKafkaConnections(cmd.Context(), &connect.Request[adminv2.ListKafkaConnectionsRequest]{Msg: &req})
-			out.MaybeDie(err, "error listing connections: %v", err)
+				filterString := filterRaw
+				if len(filterClauses) > 0 {
+					filterString = strings.Join(filterClauses, " AND ")
+				}
 
-			conns := make([]*Connection, len(resp.Msg.Connections))
-			for i, conn := range resp.Msg.Connections {
-				conns[i] = parseConnection(conn)
+				req := adminv2.ListKafkaConnectionsRequest{
+					Filter:   filterString,
+					OrderBy:  orderBy,
+					PageSize: limit,
+				}
+
+				resp, err := cl.ClusterService().ListKafkaConnections(cmd.Context(), &connect.Request[adminv2.ListKafkaConnectionsRequest]{Msg: &req})
+				out.MaybeDie(err, "error listing connections: %v", err)
+
+				for _, conn := range resp.Msg.Connections {
+					conns = append(conns, parseConnection(conn))
+				}
 			}
 
 			if p.Formatter.IsText() {
 				fmt.Println(printConnectionListTable(conns))
 			} else {
-				// Convert from the core format to ours
-				conns := make([]*Connection, len(resp.Msg.Connections))
-				for i, conn := range resp.Msg.Connections {
-					conns[i] = parseConnection(conn)
-				}
-
 				_, _, output, err := p.Formatter.Format(conns)
 				out.MaybeDie(err, "unable to print in the required format %q: %v", p.Formatter.Kind, err)
 				out.Exit(output)

--- a/src/go/rpk/pkg/cli/cluster/connections/list_test.go
+++ b/src/go/rpk/pkg/cli/cluster/connections/list_test.go
@@ -13,25 +13,21 @@ import (
 	"testing"
 	"time"
 
-	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestGetConnectionDuration(t *testing.T) {
 	now := time.Now().UTC()
-	closed := timestamppb.New(now)
+	closed := timestamppb.New(now.Add(-5 * time.Second))
 	opened := timestamppb.New(now.Add(-10 * time.Second))
 
 	t.Run("open", func(t *testing.T) {
-		require.Equal(t, "10s", getConnectionDuration(&adminv2.KafkaConnection{OpenTime: opened}))
+		require.Equal(t, "10s", getConnectionDuration(opened.AsTime(), time.Time{}))
 	})
 
 	t.Run("closed", func(t *testing.T) {
-		require.Equal(t, "10s", getConnectionDuration(&adminv2.KafkaConnection{
-			OpenTime:  opened,
-			CloseTime: closed,
-		}))
+		require.Equal(t, "5s", getConnectionDuration(opened.AsTime(), closed.AsTime()))
 	})
 }
 
@@ -138,7 +134,7 @@ func TestConnectionsList(t *testing.T) {
 			UserPrincipal: "principal",
 		},
 		Client:             &Client{IP: "127.0.0.1", Port: 1234, ID: "client-id", SoftwareName: "client software name", SoftwareVersion: "v0.0.1"},
-		GroupID:            "group id",
+		Group:              &GroupInfo{ID: "group id"},
 		ConnectionDuration: "10s",
 		IdleDuration:       "100ms",
 		RequestStatisticsAll: &RequestStatistics{

--- a/src/go/rpk/pkg/cli/cluster/connections/types.go
+++ b/src/go/rpk/pkg/cli/cluster/connections/types.go
@@ -11,11 +11,17 @@
 package connections
 
 import (
-	"strings"
 	"time"
 
 	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
+	dataplanev1 "buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go/redpanda/api/dataplane/v1"
 )
+
+type GroupInfo struct {
+	ID         string `json:"id" yaml:"id"`
+	InstanceID string `json:"instance_id" yaml:"instance_id"`
+	MemberID   string `json:"member_id" yaml:"member_id"`
+}
 
 // Connection represents a Kafka connection with custom formatting for output.
 type Connection struct {
@@ -29,9 +35,7 @@ type Connection struct {
 	Authentication       *Authentication    `json:"authentication,omitempty" yaml:"authentication,omitempty"`
 	TLSEnabled           bool               `json:"tls_enabled" yaml:"tls_enabled"`
 	Client               *Client            `json:"client,omitempty" yaml:"client,omitempty"`
-	GroupID              string             `json:"group_id,omitempty" yaml:"group_id,omitempty"`
-	GroupInstanceID      string             `json:"group_instance_id,omitempty" yaml:"group_instance_id,omitempty"`
-	GroupMemberID        string             `json:"group_member_id,omitempty" yaml:"group_member_id,omitempty"`
+	Group                *GroupInfo         `json:"group" yaml:"group"`
 	ListenerName         string             `json:"listener_name,omitempty" yaml:"listener_name,omitempty"`
 	TransactionalID      string             `json:"transactional_id,omitempty" yaml:"transactional_id,omitempty"`
 	APIVersions          []APIVersion       `json:"api_versions" yaml:"api_versions"`
@@ -83,12 +87,78 @@ type RequestStatistics struct {
 	ProduceBatchCount uint64 `json:"produce_batch_count" yaml:"produce_batch_count"`
 }
 
+func parseDataplaneConnection(conn *dataplanev1.Connection) *Connection {
+	opened := conn.OpenTime.AsTime().Format(time.RFC3339)
+	closed := ""
+	if conn.CloseTime != nil {
+		closed = conn.CloseTime.AsTime().Format(time.RFC3339)
+	}
+
+	versions := make([]APIVersion, len(conn.ApiVersions))
+	for i, ver := range conn.ApiVersions {
+		versions[i] = APIVersion{API: ver.Api.String(), Version: ver.Version}
+	}
+
+	requests := make([]SampledRequest, len(conn.ActiveRequests.Requests))
+	for i, req := range conn.ActiveRequests.Requests {
+		requests[i] = SampledRequest{API: req.Api.String(), Duration: req.Duration.AsDuration().String()}
+	}
+
+	return &Connection{
+		NodeID:             conn.NodeId,
+		ShardID:            conn.ShardId,
+		UID:                conn.Uid,
+		OpenTime:           opened,
+		CloseTime:          &closed,
+		ConnectionDuration: getConnectionDuration(conn.OpenTime.AsTime(), conn.CloseTime.AsTime()),
+		IdleDuration:       conn.IdleDuration.AsDuration().String(),
+		State:              conn.State.String(),
+		TLSEnabled:         conn.TlsEnabled,
+		ListenerName:       conn.ListenerName,
+		TransactionalID:    conn.TransactionalId,
+		Authentication: &Authentication{
+			State:         conn.Authentication.State.String(),
+			Mechanism:     conn.Authentication.Mechanism.String(),
+			UserPrincipal: conn.Authentication.UserPrincipal,
+		},
+		APIVersions: versions,
+		Group: &GroupInfo{
+			ID:         conn.Group.Id,
+			MemberID:   conn.Group.MemberId,
+			InstanceID: conn.Group.InstanceId,
+		},
+		Client: &Client{
+			IP:              conn.Client.Ip,
+			Port:            conn.Client.Port,
+			ID:              conn.Client.Id,
+			SoftwareName:    conn.Client.SoftwareName,
+			SoftwareVersion: conn.Client.SoftwareVersion,
+		},
+		ActiveRequests: &ActiveRequests{
+			SampledRequests: requests,
+			HasMoreRequests: conn.ActiveRequests.HasMoreRequests,
+		},
+		RequestStatisticsAll: &RequestStatistics{
+			ProduceBytes:      conn.RequestStatisticsAll.ProduceBytes,
+			FetchBytes:        conn.RequestStatisticsAll.FetchBytes,
+			RequestCount:      conn.RequestStatisticsAll.RequestCount,
+			ProduceBatchCount: conn.RequestStatisticsAll.ProduceBatchCount,
+		},
+		RequestStatistics1m: &RequestStatistics{
+			ProduceBytes:      conn.RequestStatistics_1M.ProduceBytes,
+			FetchBytes:        conn.RequestStatistics_1M.FetchBytes,
+			RequestCount:      conn.RequestStatistics_1M.RequestCount,
+			ProduceBatchCount: conn.RequestStatistics_1M.ProduceBatchCount,
+		},
+	}
+}
+
 func parseConnection(conn *adminv2.KafkaConnection) *Connection {
 	c := &Connection{
 		NodeID:  conn.NodeId,
 		ShardID: conn.ShardId,
 		UID:     conn.Uid,
-		State:   strings.TrimPrefix(conn.State.String(), "KAFKA_CONNECTION_STATE_"),
+		State:   conn.State.String(),
 	}
 
 	// Add timestamps and duration
@@ -98,14 +168,14 @@ func parseConnection(conn *adminv2.KafkaConnection) *Connection {
 			closeTime := conn.CloseTime.AsTime().Format(time.RFC3339)
 			c.CloseTime = &closeTime
 		}
-		c.ConnectionDuration = getConnectionDuration(conn)
+		c.ConnectionDuration = getConnectionDuration(conn.OpenTime.AsTime(), conn.CloseTime.AsTime())
 	}
 
 	// Parse authentication info
 	if conn.AuthenticationInfo != nil {
 		c.Authentication = &Authentication{
-			State:         strings.TrimPrefix(conn.AuthenticationInfo.State.String(), "AUTHENTICATION_STATE_"),
-			Mechanism:     strings.TrimPrefix(conn.AuthenticationInfo.Mechanism.String(), "AUTHENTICATION_MECHANISM_"),
+			State:         conn.AuthenticationInfo.State.String(),
+			Mechanism:     conn.AuthenticationInfo.Mechanism.String(),
 			UserPrincipal: conn.AuthenticationInfo.UserPrincipal,
 		}
 	}
@@ -126,15 +196,17 @@ func parseConnection(conn *adminv2.KafkaConnection) *Connection {
 	}
 
 	// Parse group ID
-	c.GroupID = conn.GroupId
-	c.GroupInstanceID = conn.GroupInstanceId
-	c.GroupMemberID = conn.GroupMemberId
+	c.Group = &GroupInfo{
+		ID:         conn.GroupId,
+		InstanceID: conn.GroupInstanceId,
+		MemberID:   conn.GroupMemberId,
+	}
 
 	// Parse API versions
 	c.APIVersions = []APIVersion{}
 	for apiKey, version := range conn.ApiVersions {
 		c.APIVersions = append(c.APIVersions, APIVersion{
-			API:     formatAPIKey(apiKey),
+			API:     mapAPIKey(apiKey).String(),
 			Version: version,
 		})
 	}
@@ -154,7 +226,7 @@ func parseConnection(conn *adminv2.KafkaConnection) *Connection {
 			c.ActiveRequests.SampledRequests = make([]SampledRequest, len(conn.InFlightRequests.SampledInFlightRequests))
 			for i, req := range conn.InFlightRequests.SampledInFlightRequests {
 				c.ActiveRequests.SampledRequests[i] = SampledRequest{
-					API:      formatAPIKey(req.ApiKey),
+					API:      mapAPIKey(req.ApiKey).String(),
 					Duration: req.InFlightDuration.AsDuration().String(),
 				}
 			}
@@ -184,81 +256,35 @@ func parseConnection(conn *adminv2.KafkaConnection) *Connection {
 	return c
 }
 
-// formatAPIKey converts a Kafka API key to its string name.
-func formatAPIKey(apiKey int32) string {
+// mapAPIKey converts a Kafka API key to its enum value.
+func mapAPIKey(apiKey int32) dataplanev1.KafkaAPI {
 	// Kafka API keys: https://kafka.apache.org/protocol.html#protocol_api_keys
-	names := map[int32]string{
-		0:  "PRODUCE",
-		1:  "FETCH",
-		2:  "LIST_OFFSETS",
-		3:  "METADATA",
-		4:  "LEADER_AND_ISR",
-		5:  "STOP_REPLICA",
-		6:  "UPDATE_METADATA",
-		7:  "CONTROLLED_SHUTDOWN",
-		8:  "OFFSET_COMMIT",
-		9:  "OFFSET_FETCH",
-		10: "FIND_COORDINATOR",
-		11: "JOIN_GROUP",
-		12: "HEARTBEAT",
-		13: "LEAVE_GROUP",
-		14: "SYNC_GROUP",
-		15: "DESCRIBE_GROUPS",
-		16: "LIST_GROUPS",
-		17: "SASL_HANDSHAKE",
-		18: "API_VERSIONS",
-		19: "CREATE_TOPICS",
-		20: "DELETE_TOPICS",
-		21: "DELETE_RECORDS",
-		22: "INIT_PRODUCER_ID",
-		23: "OFFSET_FOR_LEADER_EPOCH",
-		24: "ADD_PARTITIONS_TO_TXN",
-		25: "ADD_OFFSETS_TO_TXN",
-		26: "END_TXN",
-		27: "WRITE_TXN_MARKERS",
-		28: "TXN_OFFSET_COMMIT",
-		29: "DESCRIBE_ACLS",
-		30: "CREATE_ACLS",
-		31: "DELETE_ACLS",
-		32: "DESCRIBE_CONFIGS",
-		33: "ALTER_CONFIGS",
-		34: "ALTER_REPLICA_LOG_DIRS",
-		35: "DESCRIBE_LOG_DIRS",
-		36: "SASL_AUTHENTICATE",
-		37: "CREATE_PARTITIONS",
-		38: "CREATE_DELEGATION_TOKEN",
-		39: "RENEW_DELEGATION_TOKEN",
-		40: "EXPIRE_DELEGATION_TOKEN",
-		41: "DESCRIBE_DELEGATION_TOKEN",
-		42: "DELETE_GROUPS",
-		43: "ELECT_LEADERS",
-		44: "INCREMENTAL_ALTER_CONFIGS",
-		45: "ALTER_PARTITION_REASSIGNMENTS",
-		46: "LIST_PARTITION_REASSIGNMENTS",
-		47: "OFFSET_DELETE",
-		48: "DESCRIBE_CLIENT_QUOTAS",
-		49: "ALTER_CLIENT_QUOTAS",
-		50: "DESCRIBE_USER_SCRAM_CREDENTIALS",
-		51: "ALTER_USER_SCRAM_CREDENTIALS",
-		52: "VOTE",
-		53: "BEGIN_QUORUM_EPOCH",
-		54: "END_QUORUM_EPOCH",
-		55: "DESCRIBE_QUORUM",
-		56: "ALTER_PARTITION",
-		57: "UPDATE_FEATURES",
-		58: "ENVELOPE",
-		59: "FETCH_SNAPSHOT",
-		60: "DESCRIBE_CLUSTER",
-		61: "DESCRIBE_PRODUCERS",
-		62: "BROKER_REGISTRATION",
-		63: "BROKER_HEARTBEAT",
-		64: "UNREGISTER_BROKER",
-		65: "DESCRIBE_TRANSACTIONS",
-		66: "LIST_TRANSACTIONS",
-		67: "ALLOCATE_PRODUCER_IDS",
+	vals := map[int32]dataplanev1.KafkaAPI{
+		0:  dataplanev1.KafkaAPI_KAFKA_API_PRODUCE,
+		1:  dataplanev1.KafkaAPI_KAFKA_API_FETCH,
+		2:  dataplanev1.KafkaAPI_KAFKA_API_OFFSETS,
+		3:  dataplanev1.KafkaAPI_KAFKA_API_METADATA,
+		4:  dataplanev1.KafkaAPI_KAFKA_API_LEADER_AND_ISR,
+		5:  dataplanev1.KafkaAPI_KAFKA_API_STOP_REPLICA,
+		6:  dataplanev1.KafkaAPI_KAFKA_API_UPDATE_METADATA,
+		7:  dataplanev1.KafkaAPI_KAFKA_API_CONTROLLED_SHUTDOWN,
+		8:  dataplanev1.KafkaAPI_KAFKA_API_OFFSET_COMMIT,
+		9:  dataplanev1.KafkaAPI_KAFKA_API_OFFSET_FETCH,
+		10: dataplanev1.KafkaAPI_KAFKA_API_GROUP_COORDINATOR,
+		11: dataplanev1.KafkaAPI_KAFKA_API_JOIN_GROUP,
+		12: dataplanev1.KafkaAPI_KAFKA_API_HEARTBEAT,
+		13: dataplanev1.KafkaAPI_KAFKA_API_LEAVE_GROUP,
+		14: dataplanev1.KafkaAPI_KAFKA_API_SYNC_GROUP,
+		15: dataplanev1.KafkaAPI_KAFKA_API_DESCRIBE_GROUPS,
+		16: dataplanev1.KafkaAPI_KAFKA_API_LIST_GROUPS,
+		17: dataplanev1.KafkaAPI_KAFKA_API_SASL_HANDSHAKE,
+		18: dataplanev1.KafkaAPI_KAFKA_API_API_VERSIONS,
+		19: dataplanev1.KafkaAPI_KAFKA_API_CREATE_TOPICS,
+		20: dataplanev1.KafkaAPI_KAFKA_API_DELETE_TOPICS,
 	}
-	if name, ok := names[apiKey]; ok {
-		return name
+
+	if val, ok := vals[apiKey]; ok {
+		return val
 	}
-	return "UNKNOWN"
+	return dataplanev1.KafkaAPI_KAFKA_API_UNSPECIFIED
 }

--- a/src/go/rpk/pkg/publicapi/dataplane.go
+++ b/src/go/rpk/pkg/publicapi/dataplane.go
@@ -37,6 +37,7 @@ type DataPlaneClientSet struct {
 	Quota         dataplanev1connect.QuotaServiceClient
 	Secret        dataplanev1connect.SecretServiceClient
 	Security      dataplanev1connect.SecurityServiceClient
+	Monitoring    dataplanev1connect.MonitoringServiceClient
 	KnowledgeBase dataplanev1alpha3connect.KnowledgeBaseServiceClient
 
 	m         sync.RWMutex
@@ -117,6 +118,7 @@ func NewDataPlaneClientSet(host, authToken string, opts ...connect.ClientOption)
 	dpCl.Quota = dataplanev1connect.NewQuotaServiceClient(httpCl, host, opts...)
 	dpCl.Secret = dataplanev1connect.NewSecretServiceClient(httpCl, host, opts...)
 	dpCl.Security = dataplanev1connect.NewSecurityServiceClient(httpCl, host, opts...)
+	dpCl.Monitoring = dataplanev1connect.NewMonitoringServiceClient(httpCl, host, opts...)
 	dpCl.KnowledgeBase = dataplanev1alpha3connect.NewKnowledgeBaseServiceClient(httpCl, host, opts...)
 
 	return dpCl, nil


### PR DESCRIPTION
This adds cloud (but not servlerless) support for the `rpk cluster connection list` command. It also rearranges output slightly by combining the `group` elements and uses protobuf enum values.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* Adds cloud support for `rpk cluster connections list`