### PR TITLE
CORE-14496 Use app_signal abort source in cluster/controller startup

### DIFF
--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -175,17 +175,31 @@ ss::future<std::error_code> replicate_and_wait(
   std::optional<model::term_id> term = std::nullopt) {
     return stm.invoke_on(
       controller_stm_shard,
-      [cmd = std::forward<Cmd>(cmd), term, &as = as, timeout](
+      [cmd = std::forward<Cmd>(cmd), term, &as, timeout](
         controller_stm& stm) mutable {
-          if (!stm.throttle<Cmd>()) {
-              return ss::make_ready_future<std::error_code>(
-                errc::throttling_quota_exceeded);
-          }
-
-          auto b = serde_serialize_cmd(std::forward<Cmd>(cmd));
-          return stm.replicate_and_wait(
-            std::move(b), timeout, as.local(), term);
+          return do_replicate_and_wait(
+            stm, as.local(), std::forward<Cmd>(cmd), timeout, term);
       });
+}
+
+template<typename Cmd>
+ss::future<std::error_code> do_replicate_and_wait(
+  controller_stm& stm,
+  ss::abort_source& as,
+  Cmd&& cmd,
+  model::timeout_clock::time_point timeout,
+  std::optional<model::term_id> term = std::nullopt) {
+    vassert(
+      ss::this_shard_id() == controller_stm_shard,
+      "do_replicate_and_wait must be called on controller_stm_shard");
+
+    if (!stm.throttle<Cmd>()) {
+        return ss::make_ready_future<std::error_code>(
+          errc::throttling_quota_exceeded);
+    }
+
+    auto b = serde_serialize_cmd(std::forward<Cmd>(cmd));
+    return stm.replicate_and_wait(std::move(b), timeout, as, term);
 }
 
 custom_assignable_topic_configuration_vector

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -250,11 +250,6 @@ ss::future<> controller::start(
   std::chrono::milliseconds application_start_time,
   ss::sharded<std::unique_ptr<cluster::data_migrations::group_proxy>>&
     data_migrations_group_proxy) {
-    // Abort all background activity if start() is asked to abort mid-way.
-    auto shard0_as_sub = shard0_as.subscribe([this](const auto&) noexcept {
-        return _as.invoke_on_all(&ss::abort_source::request_abort);
-    });
-
     /**
      * Switch to cluster scheduling group to ensure that all the controller
      * services are started within that scheduling group.

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -641,7 +641,7 @@ ss::future<> controller::start(
     /// print the RF minimum warning
     _tp_frontend.local().print_rf_warning_message();
 
-    co_await cluster_creation_hook(discovery);
+    co_await cluster_creation_hook(discovery, shard0_as);
     {
         auto u = co_await _stm.local().lock_apply();
         // start shard_balancer before controller_backend so that it bootstraps
@@ -995,7 +995,8 @@ ss::future<> controller::stop() {
     co_await _as.stop();
 }
 
-ss::future<> controller::create_cluster(bootstrap_cluster_cmd_data cmd_data) {
+ss::future<> controller::create_cluster(
+  bootstrap_cluster_cmd_data cmd_data, ss::abort_source& as) {
     vassert(
       ss::this_shard_id() == controller_stm_shard,
       "Cluster can only be created from controller_stm_shard");
@@ -1012,7 +1013,7 @@ ss::future<> controller::create_cluster(bootstrap_cluster_cmd_data cmd_data) {
         // really just a wait for the consensus object to finish writing its
         // last_voted_for from its self-vote.
         while (!_storage.local().get_cluster_uuid() && !_raft0->is_leader()) {
-            co_await ss::sleep_abortable(100ms, _as.local());
+            co_await ss::sleep_abortable(100ms, as);
         }
         if (_storage.local().get_cluster_uuid()) {
             // Cluster has been created by other seed node and replicated here
@@ -1029,7 +1030,7 @@ ss::future<> controller::create_cluster(bootstrap_cluster_cmd_data cmd_data) {
           bucket_opt.has_value()
           && config::shard_local_cfg()
                .cloud_storage_attempt_cluster_restore_on_bootstrap.value()) {
-            retry_chain_node retry_node(_as.local(), 300s, 5s);
+            retry_chain_node retry_node(as, 300s, 5s);
             auto res
               = co_await cloud_metadata::download_highest_manifest_in_bucket(
                 _cloud_storage_api.local(),
@@ -1063,16 +1064,16 @@ ss::future<> controller::create_cluster(bootstrap_cluster_cmd_data cmd_data) {
                       "retrying: {}",
                       err);
                     co_await ss::sleep_abortable(
-                      retry_jitter.next_duration(), _as.local());
+                      retry_jitter.next_duration(), as);
                     continue;
                 }
             }
         }
 
         vlog(clusterlog.info, "Creating cluster UUID {}", cmd_data.uuid);
-        const std::error_code errc = co_await replicate_and_wait(
-          _stm,
-          _as,
+        const std::error_code errc = co_await do_replicate_and_wait(
+          _stm.local(),
+          _as.local(),
           bootstrap_cluster_cmd{0, cmd_data},
           model::timeout_clock::now() + 30s,
           std::nullopt);
@@ -1089,7 +1090,7 @@ ss::future<> controller::create_cluster(bootstrap_cluster_cmd_data cmd_data) {
             co_return;
         }
 
-        co_await ss::sleep_abortable(retry_jitter.next_duration(), _as.local());
+        co_await ss::sleep_abortable(retry_jitter.next_duration(), as);
         vlog(
           clusterlog.trace,
           "Will retry to create cluster UUID {}",
@@ -1102,7 +1103,8 @@ ss::future<> controller::create_cluster(bootstrap_cluster_cmd_data cmd_data) {
  * after it has been created, before anything else has been written
  * to it, and before we have started communicating with peers.
  */
-ss::future<> controller::cluster_creation_hook(cluster_discovery& discovery) {
+ss::future<> controller::cluster_creation_hook(
+  cluster_discovery& discovery, ss::abort_source& as) {
     if (co_await discovery.is_cluster_founder()) {
         // Full cluster bootstrap
         bootstrap_cluster_cmd_data cmd_data;
@@ -1113,7 +1115,7 @@ ss::future<> controller::cluster_creation_hook(cluster_discovery& discovery) {
         cmd_data.founding_version
           = features::feature_table::get_latest_logical_version();
         cmd_data.initial_nodes = discovery.founding_brokers();
-        co_return co_await create_cluster(std::move(cmd_data));
+        co_return co_await create_cluster(std::move(cmd_data), as);
     }
 
     if (_storage.local().get_cluster_uuid()) {
@@ -1131,7 +1133,7 @@ ss::future<> controller::cluster_creation_hook(cluster_discovery& discovery) {
     bootstrap_cluster_cmd_data cmd_data;
     cmd_data.uuid = model::cluster_uuid(uuid_t::create());
     ssx::background
-      = create_cluster(std::move(cmd_data))
+      = create_cluster(std::move(cmd_data), _as.local())
           .handle_exception([](const std::exception_ptr e) {
               vlog(clusterlog.warn, "Error creating cluster UUID. {}", e);
           });

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -304,9 +304,11 @@ private:
      * Create a \c bootstrap_cluster_cmd, replicate-and-wait it to the current
      * quorum, retry infinitely if replicate-and-wait fails.
      */
-    ss::future<> create_cluster(bootstrap_cluster_cmd_data cmd_data);
+    ss::future<>
+    create_cluster(bootstrap_cluster_cmd_data cmd_data, ss::abort_source& as);
 
-    ss::future<> cluster_creation_hook(cluster_discovery& discovery);
+    ss::future<>
+    cluster_creation_hook(cluster_discovery& discovery, ss::abort_source& as);
 
     std::optional<cloud_storage_clients::bucket_name> get_configured_bucket();
 


### PR DESCRIPTION
This reverts commit de128aad307f30e02c896fd4eabafd30a555e49e as it led to race conditions between shutdown and startup, as well as to potential use-after-free:

- Race condition reintroduced by the commit reverted is described in 1f06ff2c7a546608d9adbbc185307749995d0e45: we should always abort controller_stm before controller to avoid repeated apply attempts on stopping controller.
- Also, in the reverted commit, the function used as a `ss::abort_source::subscribe` argument returns a `ss::future`, which is never awaited. No gate is held, so it may be completed when `this` is dangling.

It also passes shard 0 abort source to the boostrapping process in controller, so that Redpanda can be stopped while starting if stuck e.g. in the loop in `controller::create_cluster` when repeatedly failing `cloud_metadata::download_highest_manifest_in_bucket`.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
