### PR TITLE
DEVPROD-3498 Cluster Linking: implement data replication ducktape tests

### DIFF
--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -523,7 +523,7 @@ class ValidatorStatus:
         invalid_reads: int,
         offset_gaps: int,
         out_of_scope_invalid_reads: int,
-        max_offsets_consumed: Optional[int],
+        max_offsets_consumed: Dict[int, int],
         lost_offsets: Dict[str, int],
         tombstones_consumed: int,
     ):
@@ -550,7 +550,7 @@ class ValidatorStatus:
         self.name = ""
 
         # Clear other fields we aren't interested in, to avoid confusion.
-        self.max_offsets_consumed = None
+        self.max_offsets_consumed = {}
         self.lost_offsets = {}
 
         self.valid_reads += rhs.valid_reads

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -1950,6 +1950,131 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         )
         self.verify()
 
+    @cluster(num_nodes=8)
+    def test_replication_with_compaction(self):
+        self.logger.info(
+            "Create a topic with compaction settings set but without compaction and tombstone removal enabled"
+        )
+        topic = TopicSpec(
+            name="compacted-topic",
+            partition_count=1,
+            replication_factor=3,
+            segment_bytes=1024 * 1024,
+            max_compaction_lag_ms=1000,
+            min_cleanable_dirty_ratio=0.0,
+        )
+        self.source_default_client().create_topic(topic)
+
+        req = self.create_default_link_request("test-link")
+        req.shadow_link.configurations.topic_metadata_sync_options.synced_shadow_topic_properties.extend(
+            ["segment.bytes", "min.cleanable.dirty.ratio"]
+        )
+        self.create_link_with_request(req=req)
+
+        self.logger.info("Replicate some data with compactable keys and tombstones")
+        self.target_cluster.service.wait_until(
+            lambda: self.topic_exists_in_target(topic.name),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"Topic {topic.name} not found in target cluster",
+        )
+
+        self.start_producer_consumer(
+            topic=topic.name,
+            msg_size=128,
+            msg_cnt=10000,
+            producer_properties={
+                "key_set_cardinality": 600,
+                "tombstone_probability": 0.4,
+            },
+        )
+        self.verify()
+
+        def get_compaction_progress(
+            rpk: RpkTool = self.target_cluster_rpk,
+        ) -> tuple[int, int]:
+            keys: list[str] = []
+            tombstones = 0
+            for line in rpk.consume(
+                topic=topic.name,
+                offset=":end",
+                format="%k,%v\n",
+            ).splitlines():
+                key, value = line.split(",", maxsplit=1)
+                keys += [key]
+                if value == "":
+                    tombstones += 1
+
+            self.logger.info(
+                f"Data read from target topic: {len(keys)=}, {keys[:5]=}, {tombstones=}"
+            )
+            return len(keys), tombstones
+
+        self.logger.info("Verifying that replicated records can be compacted")
+        pre_compaction_keys, _ = get_compaction_progress()
+        self.source_default_client().alter_topic_configs(
+            topic.name,
+            {"cleanup.policy": "compact"},
+        )
+
+        def compaction_made_progress():
+            post_compaction_keys, _ = get_compaction_progress()
+            self.logger.info(
+                f"Compaction progress check: {pre_compaction_keys=}, {post_compaction_keys=}"
+            )
+            return post_compaction_keys < pre_compaction_keys
+
+        wait_until(
+            compaction_made_progress,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Target topic compaction did not make progress",
+        )
+
+        self.logger.info("Verifying that replicated tombstones can be removed")
+        _, pre_tombstone_removal_tombstones = get_compaction_progress()
+        self.source_default_client().alter_topic_configs(
+            topic.name,
+            {"delete.retention.ms": "1000"},
+        )
+
+        def tombstone_removal_made_progress():
+            _, post_tombstone_removal_tombstones = get_compaction_progress()
+            self.logger.info(
+                f"Tombstone removal progress check: {pre_tombstone_removal_tombstones=}, {post_tombstone_removal_tombstones=}"
+            )
+            return post_tombstone_removal_tombstones < pre_tombstone_removal_tombstones
+
+        wait_until(
+            tombstone_removal_made_progress,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Target topic tombstone removal did not make progress",
+        )
+
+        self.logger.info(
+            "Verifying that compaction state is consistent on both clusters"
+        )
+
+        def compaction_states_consistent():
+            source_keys, source_tombstones = get_compaction_progress(
+                self.source_cluster_rpk
+            )
+            target_keys, target_tombstones = get_compaction_progress(
+                self.target_cluster_rpk
+            )
+            self.logger.info(
+                f"Compaction state check: {source_keys=}, {target_keys=}, {source_tombstones=}, {target_tombstones=}"
+            )
+            return source_keys == target_keys and source_tombstones == target_tombstones
+
+        wait_until(
+            compaction_states_consistent,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Compaction state is not consistent between clusters",
+        )
+
 
 class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
     def create_source_consumer(

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -1921,6 +1921,35 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             f"Timestamps don't match {expected_timestamps=} vs {consumed=}"
         )
 
+    @cluster(num_nodes=8)
+    def test_replication_with_large_msgs(self):
+        msg_size = 2 * 1024 * 1024
+        max_bytes = 10 * msg_size
+        topic = TopicSpec(
+            name="source-topic",
+            partition_count=1,
+            replication_factor=3,
+            max_message_bytes=max_bytes,
+        )
+
+        self.source_default_client().create_topic(topic)
+        self.create_link("test-link")
+
+        self.target_cluster.service.wait_until(
+            lambda: self.topic_exists_in_target(topic.name),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"Topic {topic.name} not found in target cluster",
+        )
+
+        self.start_producer_consumer(
+            topic=topic.name,
+            msg_size=msg_size,
+            msg_cnt=20,
+            producer_properties={"batch_max_bytes": max_bytes},
+        )
+        self.verify()
+
 
 class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
     def create_source_consumer(

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -1677,7 +1677,11 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         )
 
         self.start_producer_consumer(
-            topic=topic.name, msg_size=128, msg_cnt=10000, use_transactions=True
+            topic=topic.name,
+            msg_size=128,
+            msg_cnt=10000,
+            use_transactions=True,
+            producer_properties={"transaction_abort_rate": "0.3"},
         )
         self.verify()
 
@@ -1874,8 +1878,10 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             topic=topic.name,
             msg_size=128,
             msg_cnt=msg_cnt,
-            fake_timestamp_ms=base_ts,
-            producer_rate_limit_bps=1024,
+            producer_properties={
+                "fake_timestamp_ms": base_ts,
+                "rate_limit_bps": 1024,
+            },
         )
         self.verify()
 
@@ -3002,7 +3008,10 @@ class ShadowLinkingMetricsTests(ShadowLinkPreAllocTestBase):
             msg_size=128,
             msg_cnt=100000,
             use_transactions=True,
-            msgs_per_transaction=10000,
+            producer_properties={
+                "msgs_per_transaction": "10000",
+                "transaction_abort_rate": "0.3",
+            },
         )
         validate_metrics(
             timeout_sec=30,

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -120,6 +120,7 @@ class ClusterLinkingProgressVerifier:
         preallocated_nodes: list,
         logger,
         use_transactions: bool = False,
+        use_compaction: bool = False,
         msg_count: int = 40000,
         msg_size: int = 4 * 1024,
         timeout_sec: int = 600,
@@ -137,6 +138,7 @@ class ClusterLinkingProgressVerifier:
         self.preallocated_nodes = preallocated_nodes
         self.logger = logger
         self.use_transactions = use_transactions
+        self.use_compaction = use_compaction
 
         self.msg_count = msg_count
         self.msg_size = msg_size
@@ -204,19 +206,37 @@ class ClusterLinkingProgressVerifier:
             - self.producer.produce_status.aborted_transaction_messages
         )
 
-    def source_consumer_finished(self):
-        return self.producer_finished() and (
-            self.source_consumer.consumer_status.validator.total_reads
-            >= self.expected_read_messages()
+    def max_offsets_match(
+        self, consumer: KgoVerifierConsumerGroupConsumer, producer: KgoVerifierProducer
+    ) -> bool:
+        return (
+            consumer.consumer_status.validator.max_offsets_consumed
+            == producer.produce_status.max_offsets_produced
         )
 
+    def source_consumer_finished(self):
+        if not self.producer_finished():
+            return False
+        elif self.use_compaction:
+            return self.max_offsets_match(self.source_consumer, self.producer)
+        else:
+            return (
+                self.source_consumer.consumer_status.validator.total_reads
+                >= self.expected_read_messages()
+            )
+
     def target_consumer_finished(self):
-        if not self.validate_number_of_messages_on_target:
+        if not self.producer_finished():
+            return False
+        elif not self.validate_number_of_messages_on_target:
             return True
-        return self.producer_finished() and (
-            self.target_consumer.consumer_status.validator.total_reads
-            >= self.expected_read_messages()
-        )
+        elif self.use_compaction:
+            return self.max_offsets_match(self.target_consumer, self.producer)
+        else:
+            return (
+                self.target_consumer.consumer_status.validator.total_reads
+                >= self.expected_read_messages()
+            )
 
     def workload_finished(self):
         return (
@@ -835,6 +855,7 @@ class ShadowLinkPreAllocTestBase(ShadowLinkTestBase):
         msg_size: int = 128,
         msg_cnt: int = 10000,
         use_transactions: bool = False,
+        use_compaction: bool = False,
         producer_properties: dict[str, Any] | None = None,
     ):
         self.verifier = ClusterLinkingProgressVerifier(
@@ -847,6 +868,7 @@ class ShadowLinkPreAllocTestBase(ShadowLinkTestBase):
             msg_count=msg_cnt,
             msg_size=msg_size,
             use_transactions=use_transactions,
+            use_compaction=use_compaction,
             producer_properties=producer_properties or {},
             timeout_sec=180,
         )

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -835,10 +835,7 @@ class ShadowLinkPreAllocTestBase(ShadowLinkTestBase):
         msg_size: int = 128,
         msg_cnt: int = 10000,
         use_transactions: bool = False,
-        msgs_per_transaction: int | None = None,
-        transaction_abort_rate: float = 0.3,
-        fake_timestamp_ms: int | None = None,
-        producer_rate_limit_bps: int | None = None,
+        producer_properties: dict[str, Any] | None = None,
     ):
         self.verifier = ClusterLinkingProgressVerifier(
             self.test_context,
@@ -850,12 +847,7 @@ class ShadowLinkPreAllocTestBase(ShadowLinkTestBase):
             msg_count=msg_cnt,
             msg_size=msg_size,
             use_transactions=use_transactions,
-            producer_properties={
-                "transaction_abort_rate": transaction_abort_rate,
-                "msgs_per_transaction": msgs_per_transaction,
-                "fake_timestamp_ms": fake_timestamp_ms,
-                "rate_limit_bps": producer_rate_limit_bps,
-            },
+            producer_properties=producer_properties or {},
             timeout_sec=180,
         )
         self.verifier.start()

--- a/tests/rptest/tests/shadow_linking_rnot_test.py
+++ b/tests/rptest/tests/shadow_linking_rnot_test.py
@@ -60,6 +60,7 @@ class ClusterLinkingWorkloadSpec:
         msg_size: int = 4 * 1024,
         validate_number_of_messages_on_target: bool = True,
         use_transactions: bool = False,
+        use_compaction: bool = False,
     ):
         self.topic = topic
         self.topic_properties = topic_properties
@@ -73,6 +74,7 @@ class ClusterLinkingWorkloadSpec:
             validate_number_of_messages_on_target
         )
         self.use_transactions = use_transactions
+        self.use_compaction = use_compaction
 
     def __str__(self) -> str:
         return (
@@ -84,7 +86,8 @@ class ClusterLinkingWorkloadSpec:
             f"msg_count={self.msg_count}, "
             f"msg_size={self.msg_size}, "
             f"validate_number_of_messages_on_target={self.validate_number_of_messages_on_target}, "
-            f"use_transactions={self.use_transactions})"
+            f"use_transactions={self.use_transactions}, "
+            f"use_compaction={self.use_compaction})"
         )
 
 
@@ -127,6 +130,7 @@ class ClusterLinkingWorkloadWorker:
             preallocated_nodes=self.preallocated_nodes,
             logger=self.logger,
             use_transactions=self.spec.use_transactions,
+            use_compaction=self.spec.use_compaction,
             msg_count=self.spec.msg_count,
             msg_size=self.spec.msg_size,
             producer_properties=self.spec.producer_properties,
@@ -347,9 +351,14 @@ class ShadowLinkingRandomOpsTest(ShadowLinkTestBase):
                     partition_count=self.partition_count,
                     msg_count=self.msg_count,
                     msg_size=self.msg_size,
+                    producer_properties={
+                        "key_set_cardinality": 600,
+                        "tombstone_probability": 0.4,
+                    },
                     consumer_properties={
                         "compacted": True,
                     },
+                    use_compaction=True,
                 ),
                 ClusterLinkingWorkloadSpec(
                     topic="topic-txns",

--- a/tests/rptest/tests/shadow_linking_rnot_test.py
+++ b/tests/rptest/tests/shadow_linking_rnot_test.py
@@ -126,6 +126,7 @@ class ClusterLinkingWorkloadWorker:
             topic=self.spec.topic,
             preallocated_nodes=self.preallocated_nodes,
             logger=self.logger,
+            use_transactions=self.spec.use_transactions,
             msg_count=self.spec.msg_count,
             msg_size=self.spec.msg_size,
             producer_properties=self.spec.producer_properties,


### PR DESCRIPTION
Implement data replication ducktape testing.

- DRSH-SYS-REP-020: add a test for replicating a topic with large messages
- DRSH-SYS-REP-060: ensure RNOT test has compactable data and tombstones; add a test to validate that tombstones can replicate, keys can be compacted post-replication, tombstones can be removed post-replication and that the source and target topics end up in an identical state post-compaction.

Fixes https://redpandadata.atlassian.net/browse/DEVPROD-3498

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
