### PR TITLE
tests: pass timeout when stopping stream

### DIFF
--- a/tests/rptest/services/redpanda_connect.py
+++ b/tests/rptest/services/redpanda_connect.py
@@ -108,8 +108,10 @@ logger:
         self.logger.debug(f"Starting stream {name} with config {json.dumps(config)}")
         self._request("POST", f"streams/{name}", json=config)
 
-    def remove_stream(self, name: str):
-        self._request("DELETE", f"streams/{name}")
+    def remove_stream(self, name: str, operation_timeout_sec=30):
+        self._request(
+            "DELETE", f"streams/{name}", params={"timeout": f"{operation_timeout_sec}s"}
+        )
 
     def stream_metrics(self, name: str):
         metrics_resp = self._request("GET", "metrics")


### PR DESCRIPTION
Pass timeout when stopping Iceberg data generating stream. Previously the stream never stopped leading to test timing out.

Fixes: CORE-14402
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none