### PR TITLE
[CORE-14510] dt/cluster_linking: test_continuous_group_sync: Handle None

### DIFF
--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -2175,7 +2175,7 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
                     p, consumed = (int(v) for v in r.split(","))
                     # sanity check the result against group description
                     # assume the CG protocol works correctly for the rest of the partitions
-                    expected = partitions[(topic, p)]
+                    expected = partitions[(topic, p)] or 0
                     assert consumed == expected, (
                         f"{group_name=}: {topic}/{p} {consumed=} but {expected=}"
                     )


### PR DESCRIPTION
Handle errors of the form:
```
group_name='test_group_6': source-topic-0/4 consumed=0 but expected=None
```
The `None` comes from describing the current offset when describing a group, it's possible there are no committed offsets for a partition.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
