### PR TITLE
entry_stream_utils_test: split out death tests

### DIFF
--- a/src/v/storage/mvlog/tests/BUILD
+++ b/src/v/storage/mvlog/tests/BUILD
@@ -76,6 +76,23 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "entry_stream_utils_death_test",
+    timeout = "short",
+    srcs = [
+        "entry_stream_utils_death_test.cc",
+    ],
+    # CORE-14523
+    flaky = True,
+    deps = [
+        "//src/v/bytes:iostream",
+        "//src/v/storage/mvlog",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "file_test",
     timeout = "short",
     srcs = [

--- a/src/v/storage/mvlog/tests/entry_stream_utils_death_test.cc
+++ b/src/v/storage/mvlog/tests/entry_stream_utils_death_test.cc
@@ -1,0 +1,28 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "storage/mvlog/entry.h"
+#include "storage/mvlog/entry_stream_utils.h"
+
+#include <gtest/gtest.h>
+
+using namespace storage::experimental::mvlog;
+
+TEST(EntryHeaderDeathTest, TestDeserializeTooSmall) {
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+    entry_header orig_h{0, 0, entry_type::record_batch};
+    auto buf = entry_header_to_iobuf(orig_h);
+    ASSERT_EQ(buf.size_bytes(), packed_entry_header_size);
+
+    // For these lower level utilities, callers are expected to pass in
+    // appropriately sized buffers.
+    buf.pop_back();
+    ASSERT_DEATH(
+      entry_header_from_iobuf(std::move(buf)), "Expected buf of size 9");
+}

--- a/src/v/storage/mvlog/tests/entry_stream_utils_test.cc
+++ b/src/v/storage/mvlog/tests/entry_stream_utils_test.cc
@@ -68,19 +68,6 @@ TEST(EntryHeaderToFromIOBuf, TestRandom) {
     }
 }
 
-TEST(EntryHeaderToFromIObuf, TestDeserializeTooSmall) {
-    GTEST_FLAG_SET(death_test_style, "threadsafe");
-    entry_header orig_h{0, 0, entry_type::record_batch};
-    auto buf = entry_header_to_iobuf(orig_h);
-    ASSERT_EQ(buf.size_bytes(), packed_entry_header_size);
-
-    // For these lower level utilities, callers are expected to pass in
-    // appropriately sized buffers.
-    buf.pop_back();
-    ASSERT_DEATH(
-      entry_header_from_iobuf(std::move(buf)), "Expected buf of size 9");
-}
-
 TEST(EntryHeaderToFromIObuf, TestUnknownEnum) {
     iobuf fake_header_buf;
     serde::write(fake_header_buf, uint32_t{0});


### PR DESCRIPTION
Split out death tests from entry_stream_utils_test.cc into their own file. Rename the suite to DeathTest as recommended by gtest docs. Mark the test flaky, see CORE-14523 for context.

We split it out primarily to make only the death tests as flaky but also a very basic mutation to see if it fixes the flakiness.

Relates to [CORE-14523].

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none


[CORE-14523]: https://redpandadata.atlassian.net/browse/CORE-14523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ