### PR TITLE
migrations: deflake data_migrations_api_test

### DIFF
--- a/src/v/cluster/data_migration_frontend.cc
+++ b/src/v/cluster/data_migration_frontend.cc
@@ -32,6 +32,8 @@
 
 #include <fmt/ostream.h>
 
+#include <exception>
+
 namespace cluster::data_migrations {
 
 frontend::frontend(
@@ -313,8 +315,19 @@ ss::future<result<id>> frontend::do_create_migration(data_migration migration) {
     co_return result<data_migrations::id>(id);
 }
 
-ss::future<chunked_vector<migration_metadata>> frontend::list_migrations() {
-    return _table.invoke_on_instance(&migrations_table::list_migrations);
+ss::future<result<chunked_vector<migration_metadata>>>
+frontend::list_migrations() {
+    try {
+        co_return co_await _table.invoke_on_instance(
+          &migrations_table::list_migrations);
+    } catch (...) {
+        auto eptr = std::current_exception();
+        if (ssx::is_shutdown_exception(eptr)) {
+            co_return cluster::errc::shutting_down;
+        }
+        vlog(dm_log.error, "unexpected exception on list_migrations {}", eptr);
+        throw;
+    }
 }
 
 ss::future<result<migration_metadata>>

--- a/src/v/cluster/data_migration_frontend.h
+++ b/src/v/cluster/data_migration_frontend.h
@@ -58,7 +58,7 @@ public:
       model::node_id node, check_ntp_states_request&& req);
 
     ss::future<result<migration_metadata>> get_migration(id);
-    ss::future<chunked_vector<migration_metadata>> list_migrations();
+    ss::future<result<chunked_vector<migration_metadata>>> list_migrations();
 
     using list_mountable_topics_result
       = result<chunked_vector<cloud_storage::topic_mount_manifest_path>>;

--- a/src/v/redpanda/admin/migrations.cc
+++ b/src/v/redpanda/admin/migrations.cc
@@ -385,9 +385,15 @@ void admin_server::register_data_migration_routes() {
 }
 
 ss::future<std::unique_ptr<ss::http::reply>> admin_server::list_data_migrations(
-  std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply> reply) {
+  std::unique_ptr<ss::http::request> req,
+  std::unique_ptr<ss::http::reply> reply) {
     auto& frontend = _controller->get_data_migration_frontend();
-    auto migrations = co_await frontend.local().list_migrations();
+    auto maybe_migrations = co_await frontend.local().list_migrations();
+    if (maybe_migrations.has_error()) {
+        co_await admin_server::throw_on_error(
+          *req, maybe_migrations.assume_error(), model::controller_ntp);
+    }
+    auto& migrations = maybe_migrations.assume_value();
     json::StringBuffer buf;
     json::Writer<json::StringBuffer> writer(buf);
     writer.StartArray();


### PR DESCRIPTION
Myriad fixes for data_migration_api_test.
1. catch sleep aborted exceptions and map them to the appropriate http error.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
### Improvements

* reduce test failures on data_migrations_api_test
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
