### PR TITLE
[CORE-14422] rptest: set log_segment_size_min in delayed_translation_test

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -561,6 +561,7 @@ class SISettings:
         test_context: TestContext,
         *,
         log_segment_size: int = 16 * 1000000,
+        log_segment_size_min: int | None = None,
         cloud_storage_cache_chunk_size: int | None = None,
         cloud_storage_credentials_source: str = "config_file",
         cloud_storage_access_key: str = "panda-user",
@@ -670,6 +671,7 @@ class SISettings:
             )
 
         self.log_segment_size = log_segment_size
+        self.log_segment_size_min = log_segment_size_min
         self.cloud_storage_cache_chunk_size = cloud_storage_cache_chunk_size
         self.cloud_storage_cache_size = cloud_storage_cache_size
         self.cloud_storage_cache_max_objects = cloud_storage_cache_max_objects
@@ -883,6 +885,9 @@ class SISettings:
             conf["cloud_storage_azure_shared_key"] = self.cloud_storage_azure_shared_key
 
         conf["log_segment_size"] = self.log_segment_size
+        if self.log_segment_size_min is not None:
+            conf["log_segment_size_min"] = self.log_segment_size_min
+
         if self.cloud_storage_cache_chunk_size:
             conf["cloud_storage_cache_chunk_size"] = self.cloud_storage_cache_chunk_size
 

--- a/tests/rptest/tests/datalake/delayed_translation_test.py
+++ b/tests/rptest/tests/datalake/delayed_translation_test.py
@@ -51,6 +51,7 @@ class DatalakeDelayedTranslationTest(RedpandaTest):
             si_settings=SISettings(
                 test_context=test_ctx,
                 log_segment_size=10 * 1024,
+                log_segment_size_min=10 * 1024,
                 cloud_storage_max_connections=5,
                 cloud_storage_enable_remote_read=True,
                 cloud_storage_enable_remote_write=True,


### PR DESCRIPTION
We would previously see test timeouts like the following:

```
TimeoutError('Failed waiting for all partitions to be GCed')
Traceback (most recent call last):
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/tests/runner_client.py", line 381, in _do_run
    data = self.run_test(self.test_runner_timeout)
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/tests/runner_client.py", line 453, in run_test
    return self.test_context.function(self.test)
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/mark/_mark.py", line 443, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/home/ubuntu/redpanda/tests/rptest/services/cluster.py", line 246, in wrapped
    r = f(self, *args, **kwargs)
  File "/home/ubuntu/redpanda/tests/rptest/tests/datalake/delayed_translation_test.py", line 161, in test_basic
    log_starts = self.produce_until_result(
  File "/home/ubuntu/redpanda/tests/rptest/tests/datalake/delayed_translation_test.py", line 108, in produce_until_result
    return wait_until_result(*args, **kwargs)
  File "/home/ubuntu/redpanda/tests/rptest/util.py", line 128, in wait_until_result
    wait_until(wrapped_condition, *args, **kwargs)
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/utils/util.py", line 57, in wait_until
    raise TimeoutError(err_msg() if callable(err_msg) else err_msg) from last_exception
ducktape.errors.TimeoutError: Failed waiting for all partitions to be GCed
```

It seems that in the test we don't get to locally GC all the partitions because several of the first segments of the partitions are still active, and we'll only remove inactive segments. Upon further inspection we set log_segment_size, but not log_segment_size_min, so our segments end up much closer to 1MiB (the default) rather than 10KiB. This commit updates the test to also set log_segment_size_min.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* None