### PR TITLE
rpk shadow status: add shard info to status output

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -9,7 +9,7 @@ require (
 	buf.build/gen/go/redpandadata/cloud/connectrpc/go v1.19.1-20251022210436-bbacedafcd60.2
 	buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.10-20251022210436-bbacedafcd60.1
 	buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.10-20250904135917-9feeb2588236.1
-	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251031041656-b5652b54ce76.1
+	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251031193904-15e1d027dabd.1
 	buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251027225853-643acf04839f.2
 	buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-20251027225853-643acf04839f.1
 	buf.build/gen/go/redpandadata/gatekeeper/connectrpc/go v1.19.1-20251022210437-a5dd600d04b6.2
@@ -86,7 +86,7 @@ require (
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.10-20250912141014-52f32327d4b0.1 // indirect
 	buf.build/gen/go/grpc-ecosystem/grpc-gateway/protocolbuffers/go v1.36.10-20240617172850-a48fcebcf8f1.1 // indirect
-	buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251031041656-b5652b54ce76.2 // indirect
+	buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251031193904-15e1d027dabd.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/BurntSushi/toml v1.1.0 // indirect
 	github.com/Microsoft/go-winio v0.4.14 // indirect

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -8,10 +8,10 @@ buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.10-20251022210436-b
 buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.10-20251022210436-bbacedafcd60.1/go.mod h1:LUiEZ+N+YdoSrXkiPjXMLIrGZA/rQ891zrqwzXeNzgw=
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.10-20250904135917-9feeb2588236.1 h1:vjdv8if8q5whtYaE6tfbhoX80qWi/pnguP4RAxEaMaU=
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.10-20250904135917-9feeb2588236.1/go.mod h1:EhA16a3hhvTg9rzQ69ch2mJ2ppasEGJFy8ViCc8PYUE=
-buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251031041656-b5652b54ce76.2 h1:3S5JlZUa2mG5n5+K51gjEsRPx6O/jvLMSyP/NWHojwo=
-buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251031041656-b5652b54ce76.2/go.mod h1:DzxK2flGZATOVQYj2Yr2Vxgw6gA3S2O1gr1jxquVZBk=
-buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251031041656-b5652b54ce76.1 h1:sieB4fNFl0YhNthhlvByeBOtI67FNxlKjg3wNDbFm2U=
-buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251031041656-b5652b54ce76.1/go.mod h1:QenSPzqxZpyo9hHIpRzTetvDchelVDzimnmaggHKenc=
+buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251031193904-15e1d027dabd.2 h1:jCG4Odp8EuikMWru6WwVylzjrSfJImAfrNeImtfp6rs=
+buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251031193904-15e1d027dabd.2/go.mod h1:YY+peV2t5WRrsN5JCawfDfdePKQVNhaO+0l/9Tsi+oY=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251031193904-15e1d027dabd.1 h1:qbwdlxQSRcBFlq8Kcl532kcMuR+64TuvnhLC49FxzJE=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251031193904-15e1d027dabd.1/go.mod h1:QenSPzqxZpyo9hHIpRzTetvDchelVDzimnmaggHKenc=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251027225853-643acf04839f.2 h1:lleqpbHhE/SYEI/oeW2RVLZghkfhnAtIL1xk+ioTCos=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251027225853-643acf04839f.2/go.mod h1:lhAYzpdAM94nEirXzLwymBud3CxFzmHGPTdMGSEM79U=
 buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-20251027225853-643acf04839f.1 h1:+QCxgPzEelsR15FWSky3nurPjPh7PfelmNZmgvD7nRA=

--- a/src/go/rpk/pkg/cli/shadow/status.go
+++ b/src/go/rpk/pkg/cli/shadow/status.go
@@ -124,10 +124,10 @@ func printTaskStatus(tasks []*adminv2.ShadowLinkTaskStatus) {
 		fmt.Println("No tasks to display right now.")
 		return
 	}
-	t := out.NewTable("Name", "Broker_ID", "State", "Reason")
+	t := out.NewTable("Name", "Broker_ID", "Shard", "State", "Reason")
 	defer t.Flush()
 	for _, task := range tasks {
-		t.Print(task.GetName(), task.GetBrokerId(), strings.TrimPrefix(task.GetState().String(), "TASK_STATE_"), task.GetReason())
+		t.Print(task.GetName(), task.GetBrokerId(), task.GetShard(), strings.TrimPrefix(task.GetState().String(), "TASK_STATE_"), task.GetReason())
 	}
 }
 


### PR DESCRIPTION
Example:
```
$ rpk shadow status shadow-from-docker -X user=admin -X pass=admin
OVERVIEW
========
NAME   shadow-from-docker
UID    49d74192-9ba0-439c-b6f3-0ae646f48bf5
STATE  ACTIVE

TASKS
=====
NAME                      BROKER_ID  SHARD  STATE   REASON
Source Topic Sync         0          0      ACTIVE  Source Topic Sync has started
Consumer Group Mirroring  0          0      ACTIVE  Consumer Group Mirroring has started
Security Migrator Task    0          0      ACTIVE  Security Migrator Task has started
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

