### PR TITLE
[CORE-14529] storage: throw instead of vassert if closed

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2334,7 +2334,7 @@ ss::future<> disk_log_impl::apply_segment_ms() {
 
 ss::future<model::record_batch_reader>
 disk_log_impl::make_unchecked_reader(local_log_reader_config config) {
-    vassert(!_closed, "make_reader on closed log - {}", *this);
+    throw_if_closed();
     return _lock_mngr.range_lock(config).then(
       [this, cfg = config](std::unique_ptr<lock_manager::lease> lease) {
           return model::make_record_batch_reader<log_reader>(
@@ -2344,7 +2344,7 @@ disk_log_impl::make_unchecked_reader(local_log_reader_config config) {
 
 ss::future<model::record_batch_reader>
 disk_log_impl::make_cached_reader(local_log_reader_config config) {
-    vassert(!_closed, "make_reader on closed log - {}", *this);
+    throw_if_closed();
 
     auto rdr = _readers_cache->get_reader(config);
     if (rdr) {
@@ -3063,7 +3063,7 @@ disk_log_impl::max_eligible_for_compacted_reupload_offset(
 
 ss::future<model::record_batch_reader>
 disk_log_impl::make_reader(local_log_reader_config config) {
-    vassert(!_closed, "make_reader on closed log - {}", *this);
+    throw_if_closed();
     if (config.start_offset < _start_offset) {
         return ss::make_exception_future<model::record_batch_reader>(
           std::runtime_error(
@@ -3088,7 +3088,7 @@ disk_log_impl::make_reader(local_log_reader_config config) {
 
 ss::future<model::record_batch_reader>
 disk_log_impl::make_reader(timequery_config config) {
-    vassert(!_closed, "make_reader on closed log - {}", *this);
+    throw_if_closed();
     return _lock_mngr.range_lock(config).then(
       [this, cfg = config](std::unique_ptr<lock_manager::lease> lease) {
           auto start_offset = cfg.min_offset;
@@ -4582,6 +4582,12 @@ bool disk_log_impl::needs_compaction() const {
 
     auto dr = dirty_ratio();
     return dr >= config().min_cleanable_dirty_ratio() || exceed_compact_lag;
+}
+
+void disk_log_impl::throw_if_closed() const {
+    if (_closed) {
+        throw ss::abort_requested_exception();
+    }
 }
 
 } // namespace storage

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -441,6 +441,8 @@ private:
     //    cleanable dirty ratio.
     bool needs_compaction() const final;
 
+    void throw_if_closed() const;
+
 private:
     // Computes the segment size based on the latest max_segment_size
     // configuration. This takes into consideration any segment size


### PR DESCRIPTION
There are cases where the log is accessed by external callers after the log has been closed. Rather than vasserting, this commit makes certain calls throw an abort_requested_exception, with the expectation that callers will handle it properly. This isn't necessarily the case right now (it is left as short-term future work), but throwing seems better than crashing.

This was caught in a test with transforms, where the transforms subsystem was attempting a timequery after the log was shut down, resulting in:

```
ERROR 2025-11-03 16:39:15,936 [shard 0:tran] assert - Assert failure: (src/v/storage/disk_log_impl.cc:3216) '!_closed' timequery on closed log - {offsets: {start_offset:0, committed_offset:0, committed_offset_term:1, dirty_offset:0, dirty_offset_term:1}, is_closed: true, segments: [{size: 1, [{offset_tracker:{term:1, base_offset:0, committed_offset:0, stable_offset:0, dirty_offset:0}, compacted_segment=0, finished_self_compaction=0, finished_windowed_compaction=0, generation=3, reader={/var/lib/redpanda/data/kafka/topic-fadnsotldv/6_28/0-1-v1.log, (155 bytes)}, writer={closed:true, fallocation_offset:155, stable_offset:155, flushed_offset:155, committed_offset:155, inflight: 0, bytes_flush_pending:0, stats: { merged_writes: 0, bytes_requested : 155, bytes_written : 4096, appends : 2, flushes: 2, fsyncs: 3, truncates: 1, fallocations: 1, last_page_hydrations: 0}}, cache={cache_size=0, dirty tracker: {min: -9223372036854775808, max: -9223372036854775808}}, compaction_index:nullopt, closed=1, tombstone=0, index={file:/var/lib/redpanda/data/kafka/topic-fadnsotldv/6_28/0-1-v1.base_index, offsets:0, index:{header_bitflags:0, base_offset:0, max_offset:0, base_timestamp:{timestamp: 1762187916005}, max_timestamp:{timestamp: 1762187916005}, batch_timestamps_are_monotonic:1, with_offset:true, non_data_timestamps:1, broker_timestamp:{nullopt}, num_compactible_records_appended:{0}, clean_compact_timestamp:{nullopt}, may_have_tombstone_records:1, self_compact_timestamp:{nullopt}, may_have_transaction_batches:1, index(1, 1, 1)}, step:32768, needs_persistence:0}}]}], config: {ntp: {kafka/topic-fadnsotldv/6}, base_dir: /var/lib/redpanda/data, overrides: {compaction_strategy: {nullopt}, cleanup_policy_bitflags: {delete}, segment_size: {nullopt}, retention_bytes: {{nullopt}}, retention_time_ms: {{nullopt}}, recovery_enabled: false, retention_local_target_bytes: {{nullopt}}, retention_local_target_ms: {{nullopt}}, remote_delete: {true}, segment_ms: {{nullopt}}, initial_retention_local_target_bytes: {{nullopt}}, initial_retention_local_target_ms: {{nullopt}}, write_caching: {nullopt}, flush_ms: {nullopt}, flush_bytes: {nullopt}, iceberg_mode: disabled, remote_allow_gaps: {nullopt}, delete_retention_ms: {disabled}, min_cleanable_dirty_ratio: {{nullopt}}, min_compaction_lag_ms: {nullopt}, max_compaction_lag_ms: {nullopt} }}, revision: 28, topic_revision: 28, remote_revision: 28}}
```

This plugs up a few storage-log calls that are accessible from the Kafka partition layer.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [x] v24.3.x

## Release Notes

### Bug Fixes

* Fixes a bug that could result in a crash if a partition is being moved or shutdown while serving certain Kafka requests (timequeries or fetches).
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
