### PR TITLE
c/migrations: do not assert when building group partition map

### DIFF
--- a/src/v/cluster/controller_stm.cc
+++ b/src/v/cluster/controller_stm.cc
@@ -175,12 +175,14 @@ ss::future<> controller_stm::apply_snapshot(
         // apply members early so that we have rpc clients to all cluster nodes.
         co_await std::get<members_manager&>(_state).apply_snapshot(
           offset, snapshot);
+        // lots of Redpanda downstream components rely on the topic metadata to
+        // be up to date. Therefore apply the topic table state first.
+        co_await std::get<topic_updates_dispatcher&>(_state).apply_snapshot(
+          offset, snapshot);
 
         // apply everything else in no particular order.
         co_await ss::when_all(
           std::get<config_manager&>(_state).apply_snapshot(offset, snapshot),
-          std::get<topic_updates_dispatcher&>(_state).apply_snapshot(
-            offset, snapshot),
           std::get<plugin_backend&>(_state).apply_snapshot(offset, snapshot),
           std::get<cluster_recovery_manager&>(_state).apply_snapshot(
             offset, snapshot),

--- a/src/v/cluster/data_migration_backend.cc
+++ b/src/v/cluster/data_migration_backend.cc
@@ -247,11 +247,31 @@ backend::get_entities_status(id migration_id) {
         result<entities_status, errc> ret{entities_status{}};
 
         auto holder = _gate.hold();
+        auto group_map_result = build_migration_group_map(meta);
 
+        /**
+         * If we failed to build the group map, it might be because the
+         * consumer groups topic does not exist yet. Try to create it and
+         * build the map again.
+         */
+        if (group_map_result.has_error()) {
+            co_await _group_proxy.assure_topic_exists(
+              model::time_from_now(10s));
+            group_map_result = build_migration_group_map(meta);
+        }
+
+        if (group_map_result.has_error()) {
+            vlog(
+              dm_log.warn,
+              "get_entities_status: failed to build group map for migration "
+              "{}: {}",
+              migration_id,
+              group_map_result.error());
+            co_return errc::leadership_changed;
+        }
         chunked_vector<partition_consumer_group_map_t::value_type>
           groups_by_partition(
-            std::from_range,
-            build_migration_group_map(meta) | std::views::as_rvalue);
+            std::from_range, group_map_result.value() | std::views::as_rvalue);
         vlog(
           dm_log.debug,
           "get_entities_status: migration {}, groups by partition: {}",
@@ -1787,7 +1807,7 @@ ss::future<> backend::reconcile_existing_topic(
     }
 }
 
-backend::partition_consumer_group_map_t
+result<backend::partition_consumer_group_map_t, errc>
 backend::build_migration_group_map(const migration_metadata& metadata) const {
     partition_consumer_group_map_t ret;
     const auto& groups = std::visit(
@@ -1798,7 +1818,14 @@ backend::build_migration_group_map(const migration_metadata& metadata) const {
 
     for (const auto& group : groups) {
         auto partition = _group_proxy.partition_for(group);
-        vassert(partition, "cannot get ntp for group {}", group);
+        if (!partition) {
+            vlog(
+              dm_log.warn,
+              "cannot find partition for consumer group {} in migration {}",
+              group,
+              metadata.id);
+            return errc::partition_not_exists;
+        }
         auto [it, ins] = ret.try_emplace(*partition);
         it->second.push_back(group);
     }
@@ -1813,10 +1840,18 @@ ss::future<> backend::reconcile_migration(
       metadata.id,
       mrstate.scope.sought_state);
 
-    if (!mrstate.partition_group_map) {
-        mrstate.partition_group_map.emplace(
-          build_migration_group_map(metadata));
-    }
+    auto res = build_migration_group_map(metadata);
+    /**
+     * This is a fatal error as we cannot proceed with consumer group
+     * migration without being able to build the partition -> groups map.
+     */
+    vassert(
+      !res.has_error(),
+      "failed to build migration group map while reconciling migration - "
+      "error: {}",
+      res.error());
+
+    mrstate.partition_group_map.emplace(std::move(res.value()));
 
     co_await std::visit(
       [this, migration_id = metadata.id, &mrstate](

--- a/src/v/cluster/data_migration_backend.h
+++ b/src/v/cluster/data_migration_backend.h
@@ -290,7 +290,7 @@ private:
       const topic_reconciliation_state& tstate);
     void erase_tstate_if_done(
       migration_reconciliation_state& mrstate, topic_map_t::iterator it);
-    partition_consumer_group_map_t
+    result<partition_consumer_group_map_t, errc>
     build_migration_group_map(const migration_metadata& metadata) const;
 
     // call only with _mutex lock grabbed


### PR DESCRIPTION
When migrating consumer groups migration backend builds a map that associate consumer groups with `__consumer_offsets` topic partitions. The map is built when the migration is reconciled. Previously the race condition between application of state in migration and topic table could lead to a situation in which a `__consumer_offsets` partition is not yet present in partition manager. This is when assertion was triggered.

Added retry with small backoff to wait for the partition to appear instead of asserting and crashing Redpanda application.

Fixes: CORE-14421

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
