### PR TITLE
Fix incorrect name for `leader_balancer_node_mute_timeout`

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3390,7 +3390,7 @@ configuration::configuration()
       5min)
   , leader_balancer_node_mute_timeout(
       *this,
-      "leader_balancer_mute_timeout",
+      "leader_balancer_node_mute_timeout",
       "Leadership rebalancing node mute timeout.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       20s)


### PR DESCRIPTION
The `leader_balancer_node_mute_timeout` property was defined with an incorrect string name that matched `leader_balancer_mute_timeout`, causing confusion in documentation generation.

This fix corrects the property definition to use the proper string name that matches the variable name, ensuring consistency across the codebase.

**Before:**
```cpp
, leader_balancer_node_mute_timeout(
    *this,
    "leader_balancer_mute_timeout",   
    "Leadership rebalancing node mute timeout.",
    {...},
    20s)
```

**After:**
```cpp
, leader_balancer_node_mute_timeout(
    *this,
    "leader_balancer_node_mute_timeout",    // - matches variable name
    "Leadership rebalancing node mute timeout.",
    {...},
    20s)
```

## Backports Required

- [x] none - papercut/not impactful enough to backport

## Release Notes

### Bug Fixes

* Fixed incorrect property name string for `leader_balancer_node_mute_timeout` configuration property to match its variable name