### PR TITLE
`storage`: more tx control batch fixes

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -257,7 +257,8 @@ std::optional<shard_placement_target> placement_target_on_node(
 
 partition_state get_partition_state(ss::lw_shared_ptr<partition> partition) {
     partition_state state{};
-    if (unlikely(!partition)) {
+    if (!partition || !partition->log() || !partition->log()->stm_manager())
+      [[unlikely]] {
         return state;
     }
     state.start_offset = partition->raft_start_offset();
@@ -270,6 +271,8 @@ partition_state get_partition_state(ss::lw_shared_ptr<partition> partition) {
     state.revision_id = partition->get_revision_id();
     state.log_size_bytes = partition->size_bytes();
     state.non_log_disk_size_bytes = partition->non_log_disk_size_bytes();
+    state.max_tombstone_removable_offset
+      = partition->log()->stm_manager()->max_removable_local_log_offset();
     state.is_read_replica_mode_enabled
       = partition->is_read_replica_mode_enabled();
     state.is_remote_fetch_enabled = partition->is_remote_fetch_enabled();
@@ -379,6 +382,8 @@ std::vector<partition_stm_state> get_partition_stm_state(consensus_ptr ptr) {
         state.last_applied_offset = stm->last_applied();
         state.max_removable_local_log_offset
           = stm->max_removable_local_log_offset();
+        state.last_local_snapshot_offset
+          = stm->last_locally_snapshotted_offset();
         result.push_back(std::move(state));
     }
     return result;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2758,15 +2758,19 @@ struct partition_state_request
 struct partition_stm_state
   : serde::envelope<
       partition_stm_state,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     ss::sstring name;
     model::offset last_applied_offset;
     model::offset max_removable_local_log_offset;
+    model::offset last_local_snapshot_offset;
 
     auto serde_fields() {
         return std::tie(
-          name, last_applied_offset, max_removable_local_log_offset);
+          name,
+          last_applied_offset,
+          max_removable_local_log_offset,
+          last_local_snapshot_offset);
     }
 };
 
@@ -2899,7 +2903,7 @@ struct partition_raft_state
 
 struct partition_state
   : serde::
-      envelope<partition_state, serde::version<1>, serde::compat_version<0>> {
+      envelope<partition_state, serde::version<2>, serde::compat_version<0>> {
     model::offset start_offset;
     model::offset committed_offset;
     model::offset last_stable_offset;
@@ -2917,6 +2921,7 @@ struct partition_state
     ss::sstring read_replica_bucket;
     ss::sstring iceberg_mode;
     partition_raft_state raft_state;
+    model::offset max_tombstone_removable_offset;
 
     auto serde_fields() {
         return std::tie(
@@ -2936,7 +2941,8 @@ struct partition_state
           is_cloud_data_available,
           read_replica_bucket,
           raft_state,
-          iceberg_mode);
+          iceberg_mode,
+          max_tombstone_removable_offset);
     }
 
     friend bool operator==(const partition_state&, const partition_state&)

--- a/src/v/compaction/types.cc
+++ b/src/v/compaction/types.cc
@@ -23,11 +23,13 @@ std::ostream& operator<<(std::ostream& o, const compaction_config& c) {
       o,
       "{{max_removable_local_log_offset:{}, "
       "max_tombstone_remove_offset:{}, "
+      "max_tx_remove_offset:{}, "
       "should_sanitize:{}, "
       "tombstone_retention_ms:{}, "
       "tx_retention_ms:{}}}",
       c.max_removable_local_log_offset,
       c.max_tombstone_remove_offset,
+      c.max_tx_remove_offset,
       c.sanitizer_config,
       c.tombstone_retention_ms,
       c.tx_retention_ms);

--- a/src/v/compaction/types.h
+++ b/src/v/compaction/types.h
@@ -51,6 +51,9 @@ struct compaction_config {
     // Cannot remove tombstones past this offset
     model::offset max_tombstone_remove_offset;
 
+    // Cannot remove transactional control batches past this offset
+    model::offset max_tx_remove_offset;
+
     // The retention time for tombstones. Tombstone removal occurs only for
     // "clean" compacted segments past the tombstone deletion horizon timestamp,
     // which is a segment's `clean_compact_timestamp + tombstone_retention_ms`.

--- a/src/v/kafka/server/tests/group_tx_compaction_test.cc
+++ b/src/v/kafka/server/tests/group_tx_compaction_test.cc
@@ -346,18 +346,19 @@ ss::future<> run_workload(
             return ss::make_ready_future<>();
         }
         return log->apply_segment_ms().then([&] {
-            return log
-              ->housekeeping(
-                storage::housekeeping_config{
-                  model::timestamp::max(),
-                  std::nullopt,
-                  log->stm_manager()->max_removable_local_log_offset(),
-                  log->stm_manager()->max_removable_local_log_offset(),
-                  std::nullopt,
-                  std::chrono::milliseconds{0},
-                  std::chrono::milliseconds{0},
-                  dummy_as,
-                })
+            auto collect_offset
+              = log->stm_manager()->max_removable_local_log_offset();
+            auto cfg = storage::housekeeping_config::make_config(
+              model::timestamp::max(),
+              std::nullopt,
+              collect_offset,
+              collect_offset,
+              collect_offset,
+              std::nullopt,
+              std::chrono::milliseconds{0},
+              std::chrono::milliseconds{0},
+              dummy_as);
+            return log->housekeeping(std::move(cfg))
               .handle_exception_type(
                 [](const storage::segment_closed_exception&) {});
         });

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -223,6 +223,10 @@ public:
 
     const prefix_logger& log() const { return _log; }
 
+    model::offset last_locally_snapshotted_offset() const override {
+        return _last_snapshot_offset;
+    }
+
 protected:
     ss::future<> start() override;
 

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -1193,6 +1193,10 @@
                 "max_removable_local_log_offset": {
                     "type": "long",
                     "description": "Max removable offset"
+                },
+                "last_local_snapshot_offset": {
+                    "type": "long",
+                    "description": "Last local snapshot offset"
                 }
             }
         },
@@ -1389,6 +1393,10 @@
                 "iceberg_mode": {
                     "type": "string",
                     "description": "Iceberg enablement mode for the topic"
+                },
+                "max_tombstone_removable_offset": {
+                    "type": "long",
+                    "description": "Maximum offset up to which tombstones/transaction end markers can be removed."
                 },
                 "raft_state": {
                     "type": "raft_replica_state",

--- a/src/v/redpanda/admin/debug.cc
+++ b/src/v/redpanda/admin/debug.cc
@@ -108,6 +108,7 @@ void fill_raft_state(
         state.last_applied_offset = stm.last_applied_offset;
         state.max_removable_local_log_offset
           = stm.max_removable_local_log_offset;
+        state.last_local_snapshot_offset = stm.last_local_snapshot_offset;
         raft_state.stms.push(std::move(state));
     }
     if (src.recovery_state) {
@@ -922,6 +923,8 @@ admin_server::get_partition_state_handler(
         replica.revision_id = state.revision_id;
         replica.log_size_bytes = state.log_size_bytes;
         replica.non_log_disk_size_bytes = state.non_log_disk_size_bytes;
+        replica.max_tombstone_removable_offset
+          = state.max_tombstone_removable_offset;
         replica.is_read_replica_mode_enabled
           = state.is_read_replica_mode_enabled;
         replica.read_replica_bucket = state.read_replica_bucket;

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -433,18 +433,19 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
           = current_log.handle->stm_manager()->max_tombstone_remove_offset();
         model::offset tx_snapshot_offset
           = current_log.handle->stm_manager()->tx_snapshot_offset();
-        // We clamp the offset up to which we can remove tombstones to the
-        // last snapshot taken by the transactional stm. This ensures that we
-        // do not remove tombstones that may be needed to reconstruct the
-        // state machine during recovery.
+        // We clamp the offset up to which we can remove transactional control
+        // batches to the last snapshot taken by the transactional stm. This
+        // ensures that we do not remove control batches that may be needed to
+        // reconstruct the state machine during recovery.
+        model::offset max_tx_remove_offset = std::min(
+          max_tombstone_remove_offset, tx_snapshot_offset);
+
         vlog(
           gclog.trace,
-          "{}: max tombstone remove offset: {}, tx snapshot offset: {}",
+          "{}: max tombstone remove offset: {}, max tx remove offset: {}",
           ntp,
           max_tombstone_remove_offset,
-          tx_snapshot_offset);
-        max_tombstone_remove_offset = std::min(
-          max_tombstone_remove_offset, tx_snapshot_offset);
+          max_tx_remove_offset);
         if (
           max_unpinned_offset
           && *max_unpinned_offset < max_compactible_offset) {
@@ -458,17 +459,19 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
               max_compactible_offset);
             max_compactible_offset = *max_unpinned_offset;
         }
-        co_await current_log.handle->housekeeping(housekeeping_config(
-          collection_threshold,
-          _config.retention_bytes(),
-          max_compactible_offset,
-          max_tombstone_remove_offset,
-          current_log.handle->config().tombstone_retention_ms(),
-          current_log.handle->config().tx_retention_ms(),
-          current_log.handle->config().min_compaction_lag_ms(),
-          _abort_source,
-          std::move(ntp_sanitizer_cfg),
-          _compaction_hash_key_map.get()));
+        co_await current_log.handle->housekeeping(
+          housekeeping_config::make_config(
+            collection_threshold,
+            _config.retention_bytes(),
+            max_compactible_offset,
+            max_tombstone_remove_offset,
+            max_tx_remove_offset,
+            current_log.handle->config().tombstone_retention_ms(),
+            current_log.handle->config().tx_retention_ms(),
+            current_log.handle->config().min_compaction_lag_ms(),
+            _abort_source,
+            std::move(ntp_sanitizer_cfg),
+            _compaction_hash_key_map.get()));
         _probe->housekeeping_log_processed();
     }
 }

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -431,6 +431,20 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
           = current_log.handle->stm_manager()->max_removable_local_log_offset();
         model::offset max_tombstone_remove_offset
           = current_log.handle->stm_manager()->max_tombstone_remove_offset();
+        model::offset tx_snapshot_offset
+          = current_log.handle->stm_manager()->tx_snapshot_offset();
+        // We clamp the offset up to which we can remove tombstones to the
+        // last snapshot taken by the transactional stm. This ensures that we
+        // do not remove tombstones that may be needed to reconstruct the
+        // state machine during recovery.
+        vlog(
+          gclog.trace,
+          "{}: max tombstone remove offset: {}, tx snapshot offset: {}",
+          ntp,
+          max_tombstone_remove_offset,
+          tx_snapshot_offset);
+        max_tombstone_remove_offset = std::min(
+          max_tombstone_remove_offset, tx_snapshot_offset);
         if (
           max_unpinned_offset
           && *max_unpinned_offset < max_compactible_offset) {

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -1393,8 +1393,7 @@ bool is_past_transaction_batch_delete_horizon(
 
     if (
       seg->has_self_compact_timestamp() && cfg.tx_retention_ms.has_value()
-      && seg->offsets().get_stable_offset()
-           <= cfg.max_tombstone_remove_offset) {
+      && seg->offsets().get_stable_offset() <= cfg.max_tx_remove_offset) {
         const auto now = model::to_time_point(model::timestamp::now());
         return (now
                 - model::to_time_point(

--- a/src/v/storage/tests/compaction_e2e_multinode_test.cc
+++ b/src/v/storage/tests/compaction_e2e_multinode_test.cc
@@ -72,9 +72,10 @@ FIXTURE_TEST(replicate_after_compaction, compaction_multinode_test) {
     first_log->force_roll().get();
     BOOST_REQUIRE_EQUAL(first_log->segment_count(), 2);
     ss::abort_source as;
-    storage::housekeeping_config conf(
+    auto conf = storage::housekeeping_config::make_config(
       model::timestamp::min(),
       std::nullopt,
+      first_log->stm_manager()->max_removable_local_log_offset(),
       first_log->stm_manager()->max_removable_local_log_offset(),
       first_log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
@@ -125,9 +126,10 @@ FIXTURE_TEST(replicate_after_compaction, compaction_multinode_test) {
 
     // The segments should maintain their last records.
     // {[3]} {[5]} {[0 1 2 3 4 5]}
-    storage::housekeeping_config conf2(
+    auto conf2 = storage::housekeeping_config::make_config(
       model::timestamp::min(),
       std::nullopt,
+      new_log->stm_manager()->max_removable_local_log_offset(),
       new_log->stm_manager()->max_removable_local_log_offset(),
       new_log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
@@ -200,11 +202,14 @@ FIXTURE_TEST(compact_transactions_and_replicate, compaction_multinode_test) {
     first_log->flush().get();
     first_log->force_roll().get();
     ss::abort_source as;
-    storage::housekeeping_config conf(
+    auto collect_offset
+      = first_log->stm_manager()->max_removable_local_log_offset();
+    auto conf = storage::housekeeping_config::make_config(
       model::timestamp::min(),
       std::nullopt,
-      first_log->stm_manager()->max_removable_local_log_offset(),
-      first_log->stm_manager()->max_removable_local_log_offset(),
+      collect_offset,
+      collect_offset,
+      collect_offset,
       std::nullopt,
       std::nullopt,
       std::chrono::milliseconds{0},
@@ -231,9 +236,10 @@ FIXTURE_TEST(compact_transactions_and_replicate, compaction_multinode_test) {
     new_log->flush().get();
     new_log->force_roll().get();
 
-    storage::housekeeping_config conf2(
+    auto conf2 = storage::housekeeping_config::make_config(
       model::timestamp::min(),
       std::nullopt,
+      new_log->stm_manager()->max_removable_local_log_offset(),
       new_log->stm_manager()->max_removable_local_log_offset(),
       new_log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -257,6 +257,7 @@ public:
           std::chrono::milliseconds{0},
           nullptr,
           nullptr);
+        cfg.max_tx_remove_offset = max_collect_offset;
         auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
         // sliding_window_compact takes cfg by const&, so return will be a
         // use-after-free

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -36,6 +36,13 @@ model::offset stm_manager::max_removable_local_log_offset() {
     return result;
 }
 
+model::offset stm_manager::tx_snapshot_offset() const {
+    if (_tx_stm) {
+        return _tx_stm->last_locally_snapshotted_offset();
+    }
+    return model::offset::max();
+}
+
 std::optional<kafka::offset> stm_manager::lowest_pinned_data_offset() const {
     std::optional<kafka::offset> result;
     for (const auto& stm : _stms) {

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -481,6 +481,31 @@ struct housekeeping_config {
     compaction::compaction_config compact;
     gc_config gc;
 
+    static housekeeping_config make_config(
+      model::timestamp upper,
+      std::optional<size_t> max_bytes_in_log,
+      model::offset max_collect_offset,
+      model::offset max_tombstone_remove_offset,
+      std::optional<std::chrono::milliseconds> tombstone_retention_ms,
+      std::optional<std::chrono::milliseconds> tx_retention_ms,
+      std::chrono::milliseconds min_lag_ms,
+      ss::abort_source& as,
+      std::optional<ntp_sanitizer_config> san_cfg = std::nullopt,
+      compaction::hash_key_offset_map* key_map = nullptr) {
+        auto cfg = housekeeping_config(
+          upper,
+          max_bytes_in_log,
+          max_collect_offset,
+          max_tombstone_remove_offset,
+          tombstone_retention_ms,
+          tx_retention_ms,
+          min_lag_ms,
+          as,
+          san_cfg,
+          key_map);
+        return cfg;
+    }
+
     friend std::ostream& operator<<(std::ostream&, const housekeeping_config&);
 };
 

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -76,6 +76,8 @@ public:
     // equal to the high watermark.
     virtual std::optional<kafka::offset> lowest_pinned_data_offset() const = 0;
 
+    virtual model::offset last_locally_snapshotted_offset() const = 0;
+
     virtual model::offset last_applied() const = 0;
 
     virtual const ss::sstring& name() = 0;
@@ -181,6 +183,12 @@ public:
     const ss::shared_ptr<snapshotable_stm> transactional_stm() const {
         return _tx_stm;
     }
+
+    /**
+     * Returns the offset of the last snapshot taken by the transactional state
+     * machine. if no transactional stm is registered, returns max offset.
+     */
+    model::offset tx_snapshot_offset() const;
 
 private:
     ss::shared_ptr<snapshotable_stm> _tx_stm;

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -486,6 +486,7 @@ struct housekeeping_config {
       std::optional<size_t> max_bytes_in_log,
       model::offset max_collect_offset,
       model::offset max_tombstone_remove_offset,
+      model::offset max_tx_remove_offset,
       std::optional<std::chrono::milliseconds> tombstone_retention_ms,
       std::optional<std::chrono::milliseconds> tx_retention_ms,
       std::chrono::milliseconds min_lag_ms,
@@ -503,6 +504,7 @@ struct housekeeping_config {
           as,
           san_cfg,
           key_map);
+        cfg.compact.max_tx_remove_offset = max_tx_remove_offset;
         return cfg;
     }
 

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -29,6 +29,7 @@ from rptest.tests.partition_movement import PartitionMovementMixin
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.utils.mode_checks import skip_debug_mode
+from rptest.util import wait_until_result
 
 
 class LogCompactionTestBase(PartitionMovementMixin):
@@ -678,6 +679,9 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
             "log_compaction_interval_ms": 1000,
             "log_segment_size": 2 * 1024**2,  # 2 MiB
             "compacted_log_segment_size": 1024**2,  # 1 MiB
+            # Trigger tombstone removal quickly
+            "storage_target_replay_bytes": 100,
+            "log_segment_ms": 60,
         }
         self.transaction_timeout_ms = 2000
 
@@ -711,12 +715,14 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
         producer.wait(timeout_sec=180)
         producer.stop()
 
-    def check_tx_batches(self):
+    def all_tx_batches_removed(self):
         viewer = OfflineLogViewer(self.redpanda)
+        node_results = []
         for node in self.redpanda.nodes:
             num_control_batches = 0
             num_fence_batches = 0
             partitions = viewer.read_kafka_records(node, self.topic_spec.name)
+            partition_results = []
             for partition in partitions:
                 for record_or_batch in partition:
                     if "expanded_attrs" not in record_or_batch:
@@ -726,12 +732,104 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
                     if record_or_batch["type_name"] == "tx_fence":
                         num_fence_batches += 1
 
-                assert num_control_batches == 0, (
-                    f"expected 0 control batches (abort/commit batches), saw {num_control_batches} on node {node.name}"
+                partition_results.append((num_control_batches, num_fence_batches))
+            self.redpanda.logger.debug(
+                f"Node {node.name} compaction results {partition_results}"
+            )
+            node_results.append(
+                all(
+                    [
+                        num_control_batches == 0 and num_fence_batches == 0
+                        for num_control_batches, num_fence_batches in partition_results
+                    ]
                 )
-                assert num_fence_batches == 0, (
-                    f"expected 0 tx_fence batches, saw {num_fence_batches}  on node {node.name}"
+            )
+        return all(node_results)
+
+    def wait_until_stms_caught_up(self):
+        # grab the debug partition dump for each partition ensure
+        # committed index matches last applied offset
+        def stms_caught_up(partition_id: int):
+            state = self.redpanda._admin.get_partition_state(
+                namespace="kafka", topic=self.topic_spec.name, partition=partition_id
+            )
+            raft_states = [r["raft_state"] for r in state["replicas"]]
+            commit_indexes = []
+            commit_and_applied = []
+            for s in raft_states:
+                commit_index = s["commit_index"]
+                commit_indexes.append(commit_index)
+                last_applied = -1
+                for stm in s["stms"]:
+                    if stm["name"] == "tx.snapshot":
+                        last_applied = stm["last_applied_offset"]
+                commit_and_applied.append(commit_index == last_applied)
+            synced = all(commit_and_applied) and len(set(commit_indexes)) == 1
+            # Returns whether all STMs are caught up, and the commit index
+            # at which they are caught up.
+            return (synced, commit_indexes[0])
+
+        def all_partition_stms_caught_up():
+            stm_results = [
+                stms_caught_up(partition_id)
+                for partition_id in range(self.partition_count)
+            ]
+            synced, commit_indexes = map(list, zip(*stm_results))
+            return all(synced), commit_indexes
+
+        return wait_until_result(
+            all_partition_stms_caught_up,
+            timeout_sec=120,
+            backoff_sec=5,
+            err_msg="STMs did not catch up for all partitions.",
+            retry_on_exc=True,
+        )
+
+    def wait_for_local_snaphot_catchup(self, offsets: list[int]):
+        def stms_snaphotted(partition_id: int, target_offset: int):
+            state = self.redpanda._admin.get_partition_state(
+                namespace="kafka", topic=self.topic_spec.name, partition=partition_id
+            )
+            raft_states = [r["raft_state"] for r in state["replicas"]]
+            snapshotted = []
+            for s in raft_states:
+                for stm in s["stms"]:
+                    if stm["name"] == "tx.snapshot":
+                        last_snapshot = stm["last_local_snapshot_offset"]
+                        snapshotted.append(last_snapshot >= target_offset)
+            return all(snapshotted) and len(snapshotted) == len(raft_states)
+
+        def all_partition_stms_snaphotted():
+            return all(
+                [
+                    stms_snaphotted(partition_id, offsets[partition_id])
+                    for partition_id in range(self.partition_count)
+                ]
+            )
+
+        deadline = time.time() + 120
+        while True:
+            if time.time() > deadline:
+                raise TimeoutError(
+                    "Not all STMs have local snapshots at target offsets."
                 )
+            try:
+                if all_partition_stms_snaphotted():
+                    return
+                # Produce some garbage to force snapshots
+                KgoVerifierProducer.oneshot(
+                    context=self.test_context,
+                    redpanda=self.redpanda,
+                    topic=self.topic_spec.name,
+                    msg_size=1024,
+                    msg_count=10000,
+                    custom_node=self.preallocated_nodes,
+                )
+            except Exception as e:
+                self.redpanda.logger.warning(
+                    f"Exception while checking STM snapshots, retrying... {e}"
+                )
+            time.sleep(5)
 
     def do_test_tx_control_batch_removal(self, test_case_name, test_case):
         self.logger.info(
@@ -751,8 +849,19 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
 
         self.stop_partition_movement()
 
+        commit_idxs = self.wait_until_stms_caught_up()
+        self.logger.debug(
+            f"STMs caught up at commit indexes {commit_idxs}, waiting for local snapshots to catchup"
+        )
+        self.wait_for_local_snaphot_catchup(commit_idxs)
         # Check that no tx batches are seen after compaction settles
-        self.check_tx_batches()
+        self.redpanda.wait_until(
+            self.all_tx_batches_removed,
+            timeout_sec=240,
+            backoff_sec=5,
+            err_msg="Transactional batches were not removed after compaction.",
+            retry_on_exc=True,
+        )
 
 
 class LogCompactionTxRemovalTest(LogCompactionTxRemovalTestBase):

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -637,7 +637,149 @@ class LogCompactionEnableSlidingWindow(RedpandaTest):
             )
 
 
-class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
+class LogCompactionTxRemovalMixin:
+    def wait_for_all_tx_batches_removed(
+        self, produce_func, timeout_sec=240, backoff_sec=5
+    ):
+        assert self.redpanda, (
+            "Must set self.redpanda before calling wait_for_all_tx_batches_removed()"
+        )
+        assert self.topic_spec, (
+            "Must set self.topic_spec before calling wait_for_all_tx_batches_removed()"
+        )
+        assert self.partition_count, (
+            "Must set self.partition_count before calling wait_for_all_tx_batches_removed()"
+        )
+
+        commit_idxs = self.wait_until_stms_caught_up()
+        self.logger.debug(
+            f"STMs caught up at commit indexes {commit_idxs}, waiting for local snapshots to catchup"
+        )
+
+        self.wait_for_local_snapshot_catchup(commit_idxs, produce_func)
+
+        # Check that no tx batches are seen after compaction settles
+        self.redpanda.wait_until(
+            self.all_tx_batches_removed,
+            timeout_sec=timeout_sec,
+            backoff_sec=backoff_sec,
+            err_msg="Transactional batches were not removed after compaction.",
+            retry_on_exc=True,
+        )
+
+    def all_tx_batches_removed(self):
+        viewer = OfflineLogViewer(self.redpanda)
+        node_results = []
+        for node in self.redpanda.nodes:
+            num_control_batches = 0
+            num_fence_batches = 0
+            partitions = viewer.read_kafka_records(node, self.topic_spec.name)
+            partition_results = []
+            for partition in partitions:
+                for record_or_batch in partition:
+                    if "expanded_attrs" not in record_or_batch:
+                        continue
+                    if record_or_batch["expanded_attrs"]["control_batch"]:
+                        num_control_batches += 1
+                    if record_or_batch["type_name"] == "tx_fence":
+                        num_fence_batches += 1
+
+                partition_results.append((num_control_batches, num_fence_batches))
+            self.redpanda.logger.debug(
+                f"Node {node.name} compaction results {partition_results}"
+            )
+            node_results.append(
+                all(
+                    [
+                        num_control_batches == 0 and num_fence_batches == 0
+                        for num_control_batches, num_fence_batches in partition_results
+                    ]
+                )
+            )
+        return all(node_results)
+
+    def wait_until_stms_caught_up(self):
+        # grab the debug partition dump for each partition ensure
+        # committed index matches last applied offset
+        def stms_caught_up(partition_id: int):
+            state = self.redpanda._admin.get_partition_state(
+                namespace="kafka", topic=self.topic_spec.name, partition=partition_id
+            )
+            raft_states = [r["raft_state"] for r in state["replicas"]]
+            commit_indexes = []
+            commit_and_applied = []
+            for s in raft_states:
+                commit_index = s["commit_index"]
+                commit_indexes.append(commit_index)
+                last_applied = -1
+                for stm in s["stms"]:
+                    if stm["name"] == "tx.snapshot":
+                        last_applied = stm["last_applied_offset"]
+                commit_and_applied.append(commit_index == last_applied)
+            synced = all(commit_and_applied) and len(set(commit_indexes)) == 1
+            # Returns whether all STMs are caught up, and the commit index
+            # at which they are caught up.
+            return (synced, commit_indexes[0])
+
+        def all_partition_stms_caught_up():
+            stm_results = [
+                stms_caught_up(partition_id)
+                for partition_id in range(self.partition_count)
+            ]
+            synced, commit_indexes = map(list, zip(*stm_results))
+            return all(synced), commit_indexes
+
+        return wait_until_result(
+            all_partition_stms_caught_up,
+            timeout_sec=120,
+            backoff_sec=5,
+            err_msg="STMs did not catch up for all partitions.",
+            retry_on_exc=True,
+        )
+
+    def wait_for_local_snapshot_catchup(self, offsets: list[int], produce_func):
+        def stms_snapshotted(partition_id: int, target_offset: int):
+            state = self.redpanda._admin.get_partition_state(
+                namespace="kafka", topic=self.topic_spec.name, partition=partition_id
+            )
+            raft_states = [r["raft_state"] for r in state["replicas"]]
+            snapshotted = []
+            for s in raft_states:
+                for stm in s["stms"]:
+                    if stm["name"] == "tx.snapshot":
+                        last_snapshot = stm["last_local_snapshot_offset"]
+                        snapshotted.append(last_snapshot >= target_offset)
+            return all(snapshotted) and len(snapshotted) == len(raft_states)
+
+        def all_partition_stms_snapshotted():
+            return all(
+                [
+                    stms_snapshotted(partition_id, offsets[partition_id])
+                    for partition_id in range(self.partition_count)
+                ]
+            )
+
+        deadline = time.time() + 120
+        while True:
+            if time.time() > deadline:
+                raise TimeoutError(
+                    "Not all STMs have local snapshots at target offsets."
+                )
+            try:
+                if all_partition_stms_snapshotted():
+                    return
+                # Produce some garbage to force snapshots
+                produce_func()
+            except Exception as e:
+                self.redpanda.logger.warning(
+                    f"Exception while checking STM snapshots, retrying... {e}"
+                )
+            time.sleep(5)
+
+
+class LogCompactionTxRemovalTestBase(
+    LogCompactionTestBase, LogCompactionTxRemovalMixin, PreallocNodesTest
+):
     @dataclass
     class TestCase:
         msg_size: int
@@ -715,122 +857,6 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
         producer.wait(timeout_sec=180)
         producer.stop()
 
-    def all_tx_batches_removed(self):
-        viewer = OfflineLogViewer(self.redpanda)
-        node_results = []
-        for node in self.redpanda.nodes:
-            num_control_batches = 0
-            num_fence_batches = 0
-            partitions = viewer.read_kafka_records(node, self.topic_spec.name)
-            partition_results = []
-            for partition in partitions:
-                for record_or_batch in partition:
-                    if "expanded_attrs" not in record_or_batch:
-                        continue
-                    if record_or_batch["expanded_attrs"]["control_batch"]:
-                        num_control_batches += 1
-                    if record_or_batch["type_name"] == "tx_fence":
-                        num_fence_batches += 1
-
-                partition_results.append((num_control_batches, num_fence_batches))
-            self.redpanda.logger.debug(
-                f"Node {node.name} compaction results {partition_results}"
-            )
-            node_results.append(
-                all(
-                    [
-                        num_control_batches == 0 and num_fence_batches == 0
-                        for num_control_batches, num_fence_batches in partition_results
-                    ]
-                )
-            )
-        return all(node_results)
-
-    def wait_until_stms_caught_up(self):
-        # grab the debug partition dump for each partition ensure
-        # committed index matches last applied offset
-        def stms_caught_up(partition_id: int):
-            state = self.redpanda._admin.get_partition_state(
-                namespace="kafka", topic=self.topic_spec.name, partition=partition_id
-            )
-            raft_states = [r["raft_state"] for r in state["replicas"]]
-            commit_indexes = []
-            commit_and_applied = []
-            for s in raft_states:
-                commit_index = s["commit_index"]
-                commit_indexes.append(commit_index)
-                last_applied = -1
-                for stm in s["stms"]:
-                    if stm["name"] == "tx.snapshot":
-                        last_applied = stm["last_applied_offset"]
-                commit_and_applied.append(commit_index == last_applied)
-            synced = all(commit_and_applied) and len(set(commit_indexes)) == 1
-            # Returns whether all STMs are caught up, and the commit index
-            # at which they are caught up.
-            return (synced, commit_indexes[0])
-
-        def all_partition_stms_caught_up():
-            stm_results = [
-                stms_caught_up(partition_id)
-                for partition_id in range(self.partition_count)
-            ]
-            synced, commit_indexes = map(list, zip(*stm_results))
-            return all(synced), commit_indexes
-
-        return wait_until_result(
-            all_partition_stms_caught_up,
-            timeout_sec=120,
-            backoff_sec=5,
-            err_msg="STMs did not catch up for all partitions.",
-            retry_on_exc=True,
-        )
-
-    def wait_for_local_snapshot_catchup(self, offsets: list[int]):
-        def stms_snapshotted(partition_id: int, target_offset: int):
-            state = self.redpanda._admin.get_partition_state(
-                namespace="kafka", topic=self.topic_spec.name, partition=partition_id
-            )
-            raft_states = [r["raft_state"] for r in state["replicas"]]
-            snapshotted = []
-            for s in raft_states:
-                for stm in s["stms"]:
-                    if stm["name"] == "tx.snapshot":
-                        last_snapshot = stm["last_local_snapshot_offset"]
-                        snapshotted.append(last_snapshot >= target_offset)
-            return all(snapshotted) and len(snapshotted) == len(raft_states)
-
-        def all_partition_stms_snapshotted():
-            return all(
-                [
-                    stms_snapshotted(partition_id, offsets[partition_id])
-                    for partition_id in range(self.partition_count)
-                ]
-            )
-
-        deadline = time.time() + 120
-        while True:
-            if time.time() > deadline:
-                raise TimeoutError(
-                    "Not all STMs have local snapshots at target offsets."
-                )
-            try:
-                if all_partition_stms_snapshotted():
-                    return
-                # Produce some garbage to force snapshots
-                KgoVerifierProducer.oneshot(
-                    context=self.test_context,
-                    redpanda=self.redpanda,
-                    topic=self.topic_spec.name,
-                    msg_size=1024,
-                    msg_count=10000,
-                    custom_node=self.preallocated_nodes,
-                )
-            except Exception as e:
-                self.redpanda.logger.warning(
-                    f"Exception while checking STM snapshots, retrying... {e}"
-                )
-            time.sleep(5)
-
     def do_test_tx_control_batch_removal(self, test_case_name, test_case):
         self.logger.info(
             f"Running test case {test_case_name} with topic {self.topic_spec.name}"
@@ -849,19 +875,17 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
 
         self.stop_partition_movement()
 
-        commit_idxs = self.wait_until_stms_caught_up()
-        self.logger.debug(
-            f"STMs caught up at commit indexes {commit_idxs}, waiting for local snapshots to catchup"
-        )
-        self.wait_for_local_snapshot_catchup(commit_idxs)
-        # Check that no tx batches are seen after compaction settles
-        self.redpanda.wait_until(
-            self.all_tx_batches_removed,
-            timeout_sec=240,
-            backoff_sec=5,
-            err_msg="Transactional batches were not removed after compaction.",
-            retry_on_exc=True,
-        )
+        def produce_func():
+            KgoVerifierProducer.oneshot(
+                context=self.test_context,
+                redpanda=self.redpanda,
+                topic=self.topic_spec.name,
+                msg_size=1024,
+                msg_count=10000,
+                custom_node=self.preallocated_nodes,
+            )
+
+        self.wait_for_all_tx_batches_removed(produce_func)
 
 
 class LogCompactionTxRemovalTest(LogCompactionTxRemovalTestBase):

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -785,8 +785,8 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
             retry_on_exc=True,
         )
 
-    def wait_for_local_snaphot_catchup(self, offsets: list[int]):
-        def stms_snaphotted(partition_id: int, target_offset: int):
+    def wait_for_local_snapshot_catchup(self, offsets: list[int]):
+        def stms_snapshotted(partition_id: int, target_offset: int):
             state = self.redpanda._admin.get_partition_state(
                 namespace="kafka", topic=self.topic_spec.name, partition=partition_id
             )
@@ -799,10 +799,10 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
                         snapshotted.append(last_snapshot >= target_offset)
             return all(snapshotted) and len(snapshotted) == len(raft_states)
 
-        def all_partition_stms_snaphotted():
+        def all_partition_stms_snapshotted():
             return all(
                 [
-                    stms_snaphotted(partition_id, offsets[partition_id])
+                    stms_snapshotted(partition_id, offsets[partition_id])
                     for partition_id in range(self.partition_count)
                 ]
             )
@@ -814,7 +814,7 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
                     "Not all STMs have local snapshots at target offsets."
                 )
             try:
-                if all_partition_stms_snaphotted():
+                if all_partition_stms_snapshotted():
                     return
                 # Produce some garbage to force snapshots
                 KgoVerifierProducer.oneshot(
@@ -853,7 +853,7 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
         self.logger.debug(
             f"STMs caught up at commit indexes {commit_idxs}, waiting for local snapshots to catchup"
         )
-        self.wait_for_local_snaphot_catchup(commit_idxs)
+        self.wait_for_local_snapshot_catchup(commit_idxs)
         # Check that no tx batches are seen after compaction settles
         self.redpanda.wait_until(
             self.all_tx_batches_removed,

--- a/tests/rptest/transactions/tx_upgrade_test.py
+++ b/tests/rptest/transactions/tx_upgrade_test.py
@@ -18,7 +18,6 @@ import confluent_kafka as ck
 from ducktape.errors import TimeoutError
 from ducktape.utils.util import wait_until
 
-from rptest.clients.offline_log_viewer import OfflineLogViewer
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
@@ -37,6 +36,7 @@ from rptest.services.redpanda_installer import (
 )
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.utils.mode_checks import skip_debug_mode
+from rptest.tests.log_compaction_test import LogCompactionTxRemovalMixin
 
 
 class TxUpgradeTestBase(RedpandaTest):
@@ -149,7 +149,7 @@ class TxUpgradeTest(TxUpgradeTestBase):
         )
 
 
-class TxUpgradeCompactionTest(TxUpgradeTestBase):
+class TxUpgradeCompactionTest(TxUpgradeTestBase, LogCompactionTxRemovalMixin):
     """
     Test validating interaction between compaction and transactions during rolling-restart upgrades (including mixed-version node cluster interaction)
     """
@@ -159,6 +159,9 @@ class TxUpgradeCompactionTest(TxUpgradeTestBase):
             "log_compaction_interval_ms": 4000,
             "log_segment_size": 2 * 1024**2,  # 2 MiB
             "compacted_log_segment_size": 1024**2,  # 1 MiB
+            # Trigger tombstone removal quickly
+            "storage_target_replay_bytes": 100,
+            "log_segment_ms": 60,
         }
 
         super(TxUpgradeCompactionTest, self).__init__(
@@ -197,28 +200,6 @@ class TxUpgradeCompactionTest(TxUpgradeTestBase):
             backoff_sec=self.extra_rp_conf["log_compaction_interval_ms"] / 1000 * 4,
             err_msg="Compaction did not stabilize.",
         )
-
-    def check_tx_batches(self):
-        viewer = OfflineLogViewer(self.redpanda)
-        for node in self.redpanda.nodes:
-            num_control_batches = 0
-            num_fence_batches = 0
-            partitions = viewer.read_kafka_records(node, self.topic_spec.name)
-            for partition in partitions:
-                for record_or_batch in partition:
-                    if "expanded_attrs" not in record_or_batch:
-                        continue
-                    if record_or_batch["expanded_attrs"]["control_batch"]:
-                        num_control_batches += 1
-                    if record_or_batch["type_name"] == "tx_fence":
-                        num_fence_batches += 1
-
-            assert num_control_batches == 0, (
-                f"expected 0 control batches (abort/commit batches), saw {num_control_batches} on node {node.name}"
-            )
-            assert num_fence_batches == 0, (
-                f"expected 0 tx_fence batches, saw {num_fence_batches}  on node {node.name}"
-            )
 
     @skip_debug_mode
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
@@ -272,7 +253,22 @@ class TxUpgradeCompactionTest(TxUpgradeTestBase):
         self.redpanda.restart_nodes(self.redpanda.nodes)
 
         self.wait_for_sliding_window_compaction()
-        self.check_tx_batches()
+
+        def produce_func():
+            producer = ck.Producer({"bootstrap.servers": self.redpanda.brokers()})
+
+            def random_string(n=5):
+                return "".join(random.choice(string.ascii_letters) for _ in range(n))
+
+            for i in range(0, 10000):
+                producer.produce(
+                    topic=self.topic_spec.name,
+                    key=random_string(),
+                    value=random_string(1024),
+                )
+            producer.flush()
+
+        self.wait_for_all_tx_batches_removed(produce_func)
 
 
 class TxUpgradeRevertTest(RedpandaTest):


### PR DESCRIPTION
Some commits pulled from https://github.com/redpanda-data/redpanda/pull/28296, and additional commits to split `max_tx_removal_offset` and `max_tombstone_removal_offset` into two separate variables.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
