### PR TITLE
dt: Unbreak the MPT

### DIFF
--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -11,7 +11,8 @@ import concurrent.futures
 import math
 import time
 from collections import Counter
-
+from typing import Any, Callable
+from ducktape.cluster.cluster import ClusterNode
 import numpy
 from ducktape.mark import parametrize
 from ducktape.utils.util import TimeoutError, wait_until
@@ -24,6 +25,7 @@ from rptest.services.kgo_verifier_services import (
     KgoVerifierProducer,
     KgoVerifierRandomConsumer,
 )
+from ducktape.tests.test import TestContext
 from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
 from rptest.services.openmessaging_benchmark_configs import OMBSampleConfigurations
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, LoggingConfig
@@ -78,7 +80,7 @@ class ManyPartitionsTest(PreallocNodesTest):
 
     LEADER_BALANCER_PERIOD_MS = 30000
 
-    def __init__(self, test_ctx, *args, **kwargs):
+    def __init__(self, test_ctx: TestContext, *args: Any, **kwargs: Any):
         self._ctx = test_ctx
         super(ManyPartitionsTest, self).__init__(
             test_ctx,
@@ -177,7 +179,7 @@ class ManyPartitionsTest(PreallocNodesTest):
                 partitions = list(self.rpk.describe_topic(tn, tolerant=True))
             except RpkException as e:
                 # same as in _node_leadership_balanced
-                self.logger.warn(f"RPK error, assuming retryable: {e}")
+                self.logger.warning(f"RPK error, assuming retryable: {e}")
                 return False
 
             if len(partitions) < p_per_topic:
@@ -196,7 +198,7 @@ class ManyPartitionsTest(PreallocNodesTest):
         return not any_incomplete
 
     def _node_leadership_balanced(self, topic_names: list[str], p_per_topic: int):
-        node_leader_counts = Counter()
+        node_leader_counts: Counter[int] = Counter()
         any_incomplete = False
         for tn in topic_names:
             try:
@@ -205,7 +207,7 @@ class ManyPartitionsTest(PreallocNodesTest):
                 # We can get e.g. timeouts from rpk if it is trying to describe
                 # a big topic on a heavily loaded cluster: treat these as retryable
                 # and let our caller call us again.
-                self.logger.warn(f"RPK error, assuming retryable: {e}")
+                self.logger.warning(f"RPK error, assuming retryable: {e}")
                 return False
 
             if len(partitions) < p_per_topic:
@@ -252,7 +254,7 @@ class ManyPartitionsTest(PreallocNodesTest):
         that doing so does not exhaust redpanda resources.
         """
 
-        def consumer_saw_msgs(consumer):
+        def consumer_saw_msgs(consumer: RpkConsumer):
             self.logger.info(
                 f"Consumer message_count={consumer.message_count} / {msg_count_per_topic}"
             )
@@ -278,7 +280,7 @@ class ManyPartitionsTest(PreallocNodesTest):
             consumer.stop()
             consumer.free()
 
-    def _repeater_worker_count(self, scale):
+    def _repeater_worker_count(self, scale: ScaleParameters):
         workers = 32 * scale.node_cpus
         if self.redpanda.dedicated_nodes:
             # 768 workers on a 24 core node has been seen to work well.
@@ -291,18 +293,17 @@ class ManyPartitionsTest(PreallocNodesTest):
         # ResourceSettings based on its parameters.
         pass
 
-    def _get_fd_counts(self):
+    def _get_fd_counts(self) -> list[tuple[str, int]]:
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=len(self.redpanda.nodes)
         ) as executor:
-            return list(
-                executor.map(
-                    lambda n: tuple(
-                        [n.name, sum(1 for _ in self.redpanda.lsof_node(n))]
-                    ),
-                    self.redpanda.nodes,
-                )
-            )
+
+            def count_node(n: ClusterNode) -> tuple[str, int]:
+                return (str(n.name), sum(1 for _ in self.redpanda.lsof_node(n)))
+
+            fd_counts = list(executor.map(count_node, self.redpanda.nodes))
+
+            return fd_counts
 
     def _concurrent_restart(self):
         """
@@ -315,7 +316,7 @@ class ManyPartitionsTest(PreallocNodesTest):
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=len(self.redpanda.nodes)
         ) as executor:
-            futs = []
+            futs: list[concurrent.futures.Future[Any]] = []
             for node in self.redpanda.nodes:
                 futs.append(
                     executor.submit(
@@ -331,7 +332,7 @@ class ManyPartitionsTest(PreallocNodesTest):
                 f.result()
 
     def _single_node_restart(
-        self, scale: ScaleParameters, topic_names: list, n_partitions: int
+        self, scale: ScaleParameters, topic_names: list[str], n_partitions: int
     ):
         """
         Restart a single node to check stability through the movement of
@@ -382,9 +383,9 @@ class ManyPartitionsTest(PreallocNodesTest):
     def _restart_stress(
         self,
         scale: ScaleParameters,
-        topic_names: list,
+        topic_names: list[str],
         n_partitions: int,
-        inter_restart_check: callable,
+        inter_restart_check: Callable[[], None],
     ):
         """
         Restart the cluster several times, to check stability
@@ -422,7 +423,7 @@ class ManyPartitionsTest(PreallocNodesTest):
                     f"Open files after {i} restarts on {node_name}: {file_count}"
                 )
 
-    def _tiered_storage_warmup(self, scale, topic_name):
+    def _tiered_storage_warmup(self, scale: ScaleParameters, topic_name: str):
         """
         When testing tiered storage, we want a realistic amount of metadata in the
         system: it takes too long to actually play in a day or week's worth of data,
@@ -463,7 +464,7 @@ class ManyPartitionsTest(PreallocNodesTest):
                 f"Tiered storage warmup: waiting {expect_runtime}s for {target_cloud_segments} to be created"
             )
             msg_count = math.ceil(warmup_total_size / warmup_message_size)
-            producer = None
+            producer: KgoVerifierProducer | None = None
             try:
                 producer = KgoVerifierProducer(
                     self.test_context,
@@ -483,7 +484,8 @@ class ManyPartitionsTest(PreallocNodesTest):
                     err_msg="Waiting for cloud segments upload",
                 )
             finally:
-                producer.stop()
+                if producer:
+                    producer.stop()
                 self.free_preallocated_nodes()
         finally:
             self.logger.info(
@@ -498,7 +500,7 @@ class ManyPartitionsTest(PreallocNodesTest):
                 str(scale.local_retention_after_warmup),
             )
 
-    def _write_and_random_read(self, scale: ScaleParameters, topic_names):
+    def _write_and_random_read(self, scale: ScaleParameters, topic_names: list[str]):
         """
         This is a relatively low intensity test, that covers random
         and sequential reads & validates correctness of offsets in the
@@ -518,7 +520,7 @@ class ManyPartitionsTest(PreallocNodesTest):
         # Now that we've tested basic ability to form consensus and survive some
         # restarts, move on to a more general stress test.
         self.logger.info("Entering traffic stress test")
-        target_topic = topic_names[0]
+        target_topic: str = topic_names[0]
 
         # Assume fetches will be 10MB, the franz-go default
         fetch_bytes_per_partition = 10 * 1024 * 1024
@@ -763,7 +765,7 @@ class ManyPartitionsTest(PreallocNodesTest):
         topic_partitions_per_shard=DEFAULT_PARTITIONS_PER_SHARD,
     )
     def test_many_partitions_compacted(
-        self, mib_per_partition, topic_partitions_per_shard
+        self, mib_per_partition: float, topic_partitions_per_shard: int
     ):
         self._test_many_partitions(
             compacted=True,
@@ -776,7 +778,9 @@ class ManyPartitionsTest(PreallocNodesTest):
         mib_per_partition=DEFAULT_MIB_PER_PARTITION,
         topic_partitions_per_shard=DEFAULT_PARTITIONS_PER_SHARD,
     )
-    def test_many_partitions(self, mib_per_partition, topic_partitions_per_shard):
+    def test_many_partitions(
+        self, mib_per_partition: float, topic_partitions_per_shard: int
+    ):
         self._test_many_partitions(
             compacted=False,
             mib_per_partition=mib_per_partition,
@@ -791,7 +795,7 @@ class ManyPartitionsTest(PreallocNodesTest):
         topic_partitions_per_shard=DEFAULT_PARTITIONS_PER_SHARD,
     )
     def test_many_partitions_tiered_storage(
-        self, compacted, mib_per_partition, topic_partitions_per_shard
+        self, compacted: bool, mib_per_partition: float, topic_partitions_per_shard: int
     ):
         self._test_many_partitions(
             compacted=compacted,
@@ -828,10 +832,10 @@ class ManyPartitionsTest(PreallocNodesTest):
 
     def _test_many_partitions(
         self,
-        compacted,
-        mib_per_partition,
-        topic_partitions_per_shard,
-        tiered_storage_enabled=False,
+        compacted: bool,
+        mib_per_partition: float,
+        topic_partitions_per_shard: int,
+        tiered_storage_enabled: bool = False,
     ):
         """
         Validate that redpanda works with partition counts close to its resource
@@ -922,7 +926,7 @@ class ManyPartitionsTest(PreallocNodesTest):
         topic_names = [f"scale_{i:06d}" for i in range(0, n_topics)]
         for tn in topic_names:
             self.logger.info(f"Creating topic {tn} with {n_partitions} partitions")
-            config = {
+            config: dict[str, Any] = {
                 "segment.bytes": scale.segment_size,
                 "retention.bytes": scale.retention_bytes,
             }
@@ -965,7 +969,7 @@ class ManyPartitionsTest(PreallocNodesTest):
 
         # Start kgo-repeater
 
-        repeater_kwargs = {}
+        repeater_kwargs: dict[str, Any] = {}
         if compacted:
             # Each partition gets roughly 10 unique keys, after which
             # compaction should kick in.
@@ -976,6 +980,7 @@ class ManyPartitionsTest(PreallocNodesTest):
             # across partitions.
             repeater_kwargs["key_count"] = 2**32
 
+        self.logger.info("Entering restart stress test phase")
         # Main test phase: with continuous background traffic, exercise restarts and
         # any other cluster changes that might trip up at scale.
         repeater_msg_size = 16384
@@ -1015,7 +1020,7 @@ class ManyPartitionsTest(PreallocNodesTest):
                 )
                 t1 = time.time()
                 repeater.await_progress(
-                    repeater_await_msgs, t, err_msg="Waiting for repeater messages"
+                    repeater_await_msgs, int(t), err_msg="Waiting for repeater messages"
                 )
                 t2 = time.time()
 
@@ -1043,9 +1048,9 @@ class ManyPartitionsTest(PreallocNodesTest):
             # soak for two minutes
             soak_time_seconds = 120
             soak_await_bytes = soak_time_seconds * scale.expect_bandwidth
-            soak_await_msgs = soak_await_bytes / repeater_msg_size
+            soak_await_msgs = int(soak_await_bytes / repeater_msg_size)
             # Add some leeway to avoid flakiness
-            soak_timeout = soak_time_seconds * 1.25
+            soak_timeout = int(soak_time_seconds * 1.25)
             t1 = time.time()
             initial_p, _ = repeater.total_messages()
             try:

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -281,6 +281,9 @@ class ManyPartitionsTest(PreallocNodesTest):
             consumer.free()
 
     def _repeater_worker_count(self, scale: ScaleParameters):
+        assert scale.node_memory_mib / scale.node_cpus >= 3500, (
+            "Insufficient memory on client nodes for kgo-repeater worker count"
+        )
         # Takes about half of the memory on 4GB per core nodes
         workers = 16 * scale.node_cpus
         if self.redpanda.dedicated_nodes:

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -1045,8 +1045,7 @@ class ManyPartitionsTest(PreallocNodesTest):
             # Done with restarts, now do a longer traffic soak
             self.logger.info("Entering traffic soak phase")
 
-            # soak for two minutes
-            soak_time_seconds = 120
+            soak_time_seconds = 60
             soak_await_bytes = soak_time_seconds * scale.expect_bandwidth
             soak_await_msgs = int(soak_await_bytes / repeater_msg_size)
             # Add some leeway to avoid flakiness

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -281,9 +281,9 @@ class ManyPartitionsTest(PreallocNodesTest):
             consumer.free()
 
     def _repeater_worker_count(self, scale: ScaleParameters):
-        workers = 32 * scale.node_cpus
+        # Takes about half of the memory on 4GB per core nodes
+        workers = 16 * scale.node_cpus
         if self.redpanda.dedicated_nodes:
-            # 768 workers on a 24 core node has been seen to work well.
             return workers
         else:
             return min(workers, 4)

--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -192,7 +192,7 @@ class KgoRepeaterService(Service):
 
         wait_until(
             lambda: self._is_ready(node),
-            timeout_sec=5,
+            timeout_sec=10,
             backoff_sec=0.5,
             err_msg=f"Timed out waiting for status endpoint {self.who_am_i()} to be available",
         )

--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -14,7 +14,7 @@ import time
 from collections import defaultdict
 from contextlib import contextmanager
 from functools import partial, reduce
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 import requests
 from ducktape.cluster.cluster import ClusterNode
@@ -414,7 +414,9 @@ class KgoRepeaterService(Service):
         summed = reduce(partial(tuple_op, operator.add), latencies, (0, 0, 0))
         return tuple_op(operator.truediv, summed, (n, n, n))
 
-    def await_progress(self, msg_count, timeout_sec, err_msg=None):
+    def await_progress(
+        self, msg_count: int, timeout_sec: int, err_msg: str | Callable[[], str] = ""
+    ):
         """
         Call this in places you want to assert some progress
         is really being made: say how many messages should be
@@ -457,7 +459,11 @@ class KgoRepeaterService(Service):
 
 @contextmanager
 def repeater_traffic(
-    context, redpanda, *args, cleanup: Optional[Callable] = None, **kwargs
+    context: TestContext,
+    redpanda: RedpandaService,
+    *args: Any,
+    cleanup: Callable[[], None] | None = None,
+    **kwargs: Any,
 ):
     svc = KgoRepeaterService(context, redpanda, *args, **kwargs)
     svc.start()

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2809,7 +2809,7 @@ class RedpandaService(Service, RedpandaServiceABC):
             auto_assign_node_id=auto_assign_node_id,
         )
 
-    def set_resource_settings(self, rs):
+    def set_resource_settings(self, rs: ResourceSettings):
         self._resource_settings = rs
 
     @property
@@ -3001,7 +3001,7 @@ class RedpandaService(Service, RedpandaServiceABC):
     def require_client_auth(self):
         return self._security.require_client_auth
 
-    def get_node_memory_mb(self):
+    def get_node_memory_mb(self) -> int:
         if self._resource_settings.memory_mb is not None:
             self.logger.info("get_node_memory_mb: got from ResourceSettings")
             return self._resource_settings.memory_mb
@@ -3018,7 +3018,7 @@ class RedpandaService(Service, RedpandaServiceABC):
             )
             # Output line is like "MemTotal:       32552236 kB"
             memory_kb = int(line.strip().split()[1])
-            return memory_kb / 1024
+            return memory_kb // 1024
 
     def get_node_cpu_count(self) -> int:
         if self._resource_settings.num_cpus is not None:

--- a/tests/rptest/utils/scale_parameters.py
+++ b/tests/rptest/utils/scale_parameters.py
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0
 
 from math import floor
-from typing import Optional
+from typing import Any, Optional
 from rptest.services.redpanda import RedpandaService, ResourceSettings, SISettings
 
 
@@ -50,10 +50,10 @@ class ScaleParameters:
         self,
         redpanda: RedpandaService,
         replication_factor: int,
-        mib_per_partition=DEFAULT_MIB_PER_PARTITION,
-        topic_replicas_per_shard=DEFAULT_PARTITIONS_PER_SHARD,
-        tiered_storage_enabled=False,
-        partition_memory_reserve_percentage=DEFAULT_PARTITIONS_MEMORY_ALLOCATION_PERCENT,
+        mib_per_partition: float = DEFAULT_MIB_PER_PARTITION,
+        topic_replicas_per_shard: int = DEFAULT_PARTITIONS_PER_SHARD,
+        tiered_storage_enabled: bool = False,
+        partition_memory_reserve_percentage: int = DEFAULT_PARTITIONS_MEMORY_ALLOCATION_PERCENT,
     ):
         self.partition_limit: int
         self.redpanda = redpanda
@@ -264,7 +264,7 @@ class ScaleParameters:
 
         self.logger.info(rnm_message)
 
-        resource_settings_args = {}
+        resource_settings_args: dict[str, Any] = {}
         if not self.redpanda.dedicated_nodes:
             # In docker, assume we're on a laptop drive and not doing
             # real testing, so disable fsync to make test run faster.

--- a/tests/rptest/utils/scale_parameters.py
+++ b/tests/rptest/utils/scale_parameters.py
@@ -62,24 +62,24 @@ class ScaleParameters:
 
         self.node_count = node_count = len(self.redpanda.nodes)
 
-        node_memory_mib = self.redpanda.get_node_memory_mb()
+        self.node_memory_mib = self.redpanda.get_node_memory_mb()
         self.node_cpus = self.redpanda.get_node_cpu_count()
         node_disk_free = self.redpanda.get_node_disk_free()
 
         if self.redpanda.dedicated_nodes:
             # Emulate seastar's policy for default reserved memory
-            reserved_memory = max(1536, int(0.07 * node_memory_mib) + 1)
-            effective_node_memory = node_memory_mib - reserved_memory
+            reserved_memory = max(1536, int(0.07 * self.node_memory_mib) + 1)
+            effective_node_memory = self.node_memory_mib - reserved_memory
         else:
             reserved_memory = 0
             # when in docker, we always end up passing --memory=node_memory
             # explicitly, and this amount does not have the reserve subtracted
             # from it, so we use the full amount. For details see:
             # https://github.com/scylladb/seastar/issues/375#issuecomment-2530012089
-            effective_node_memory = node_memory_mib
+            effective_node_memory = self.node_memory_mib
 
         self.logger.info(
-            f"Nodes have {self.node_cpus} cores, {node_memory_mib}MB memory, {effective_node_memory}MB available memory, {node_disk_free / (1024 * 1024)}MB free disk"
+            f"Nodes have {self.node_cpus} cores, {self.node_memory_mib}MB memory, {effective_node_memory}MB available memory, {node_disk_free / (1024 * 1024)}MB free disk"
         )
 
         # On large nodes, reserve half of shard 0 to minimize interference
@@ -291,7 +291,7 @@ class ScaleParameters:
         if effective_node_memory < required_node_memory:
             raise RuntimeError(
                 f"Node memory is too small. Effective memory: {effective_node_memory}MB "
-                f"({node_memory_mib}MB node - {reserved_memory}MB reserved), "
+                f"({self.node_memory_mib}MB node - {reserved_memory}MB reserved), "
                 f"required memory: {required_node_memory}MB, ({rnm_message})"
             )
 

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -26,7 +26,11 @@ from rptest.clients.offline_log_viewer import OfflineLogViewer
 from rptest.clients.rp_storage_tool import RpStorageTool
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
-from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, MetricsEndpoint
+from rptest.services.redpanda import (
+    RESTART_LOG_ALLOW_LIST,
+    MetricsEndpoint,
+    RedpandaService,
+)
 
 EMPTY_SEGMENT_SIZE = 4096
 
@@ -623,7 +627,9 @@ def get_expected_ntp_restored_size(
     return expected_restored_sizes
 
 
-def nodes_report_cloud_segments(redpanda, target_segments, topic_name=None):
+def nodes_report_cloud_segments(
+    redpanda: RedpandaService, target_segments: int, topic_name: str | None = None
+):
     """
     Returns true if the nodes in the cluster collectively report having
     above the given number of segments for a specific topic, if provided.

--- a/tools/type-checking/type-check-strictness.json
+++ b/tools/type-checking/type-check-strictness.json
@@ -179,7 +179,6 @@
         "rptest/tests/redpanda_test.py",
         "rptest/tests/remote_label_test.py",
         "rptest/tests/replication_factor_change_test.py",
-        "rptest/tests/resource_limits_test.py",
         "rptest/tests/restart_services_test.py",
         "rptest/tests/rpk_acl_test.py",
         "rptest/tests/rpk_cloud_test.py",
@@ -245,7 +244,6 @@
         "rptest/utils/partition_metrics.py",
         "rptest/utils/rpcn_utils.py",
         "rptest/utils/rpk_config.py",
-        "rptest/utils/scale_parameters.py",
         "rptest/utils/schema_registry_utils.py",
         "rptest/utils/unit_test.py"
     ],
@@ -291,7 +289,6 @@
         "rptest/remote_scripts/stream_verifier_txn.py",
         "rptest/scale_tests/audit_log_test.py",
         "rptest/scale_tests/cloud_storage_compaction_test.py",
-        "rptest/scale_tests/many_partitions_test.py",
         "rptest/scale_tests/many_topics_test.py",
         "rptest/scale_tests/tiered_storage_cache_stress_test.py",
         "rptest/scale_tests/tiered_storage_single_partition_test.py",


### PR DESCRIPTION
MPT is currently perma broken. These commits make it work again:
 - Fix a kgo-repeater startup timeout
 - Fix a kgo-repeater OOM during the restart test phase

At the same time move the MPT test to strict type checking.

Fixes CORE-9749
Fixes CORE-9750
Fixes CORE-9751

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
