### PR TITLE
rptest: set the full scrub internal low in cleanup

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -5783,11 +5783,19 @@ class RedpandaService(Service, RedpandaServiceABC):
         if not cloud_storage_partitions:
             return None
 
+        # Set the scrub interval down very low so the scrubs happen "soon"
+        # note that because we reset the scrubbing metadata below, the next
+        # scrub will effectively be a full scrub (since the last scrubbed
+        # offset will be forgotten).
         self.set_cluster_config(
             {
                 "cloud_storage_enable_scrubbing": True,
+                # these two intervals usually don't matter as the metadata reset
+                # forces an immediate scrub, but sometimes due to leadership
+                # transfer we end up waiting for the next full scrub cycle,
+                # see CORE-14424
                 "cloud_storage_partial_scrub_interval_ms": 100,
-                "cloud_storage_full_scrub_interval_ms": 1000 * 60 * 10,
+                "cloud_storage_full_scrub_interval_ms": 10 * 1000,
                 "cloud_storage_scrubbing_interval_jitter_ms": 100,
                 "cloud_storage_background_jobs_quota": 5000,
                 "cloud_storage_housekeeping_interval_ms": 100,


### PR DESCRIPTION
In the test cleanup, we wait for a cloud stoarge scrub to happen in order to identify any anomalies. To make this happen in a timely manner, we have to do something. Currently we reset the scrub metadata which actually ends up triggering a "first scrub" right away, ignoring the partial/full scrub interval.

However, if a leadership change happens at a critical moment, the metadata ends up being populated again, so the "full scrub" interval will apply is 10 minutes. This will time out the test.

To fix set the full scrub interval down to 10 seconds so the scrubs happen "soon" even in this case. Because we reset the scrubbing metadata, the next scrub will effecitvely be a full scrub (since the last scrubbed offset will be forgotten), so that is the interval that applies.

We don't set it super low in order not to do a ton of full scrubs during this teardown phase.

Fixes [CORE-14424].

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none


[CORE-14424]: https://redpandadata.atlassian.net/browse/CORE-14424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ