### PR TITLE
rptest: produce then wait

### DIFF
--- a/tests/rptest/tests/remote_label_test.py
+++ b/tests/rptest/tests/remote_label_test.py
@@ -222,22 +222,21 @@ class RemoteLabelsTest(RedpandaTest):
         num_msgs_per_round = 100
         msg_len = 1024
 
-        def local_storage_trimmed(cluster: RedpandaService):
-            admin = Admin(cluster)
-            status = admin.get_partition_cloud_storage_status(topic_name, 0)
-            return status["local_log_start_offset"] > 0
+        def _local_trimmed():
+            def _cluster_local_trimmed(cluster: RedpandaService):
+                admin = Admin(cluster)
+                status = admin.get_partition_cloud_storage_status(topic_name, 0)
+                return status["local_log_start_offset"] > 0
 
-        def local_trimmed_or_produce():
             # Once we trim local storage from both clusters, we're done.
-            if local_storage_trimmed(c1) and local_storage_trimmed(c2):
-                return True
-            for _ in range(num_msgs_per_round):
-                rpk_c1.produce(topic_name, key="1", msg="1" * msg_len)
-                rpk_c2.produce(topic_name, key="2", msg="2" * msg_len)
-            return False
+            return _cluster_local_trimmed(c1) and _cluster_local_trimmed(c2)
+
+        for _ in range(num_msgs_per_round):
+            rpk_c1.produce(topic_name, key="1", msg="1" * msg_len)
+            rpk_c2.produce(topic_name, key="2", msg="2" * msg_len)
 
         # Keep producing until space management kicks out the local data.
-        wait_until(local_trimmed_or_produce, timeout_sec=30, backoff_sec=1)
+        wait_until(_local_trimmed, timeout_sec=30, backoff_sec=1)
 
         def wipe_cloud_cache(cluster: RedpandaService):
             cache_dir = cluster.cache_dir


### PR DESCRIPTION
The test is slightly flaky when rpk produce takes slightly longer time and we don't have time left to re-check if prefix truncation happened.

Instead of increasing the timeout notice that enough data is already being produced so pull the producing out and produce only once then wait for prefix truncation.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
