### PR TITLE
cloud_io/cache: Prevent double counting of cache metrics

### DIFF
--- a/src/v/cloud_io/cache_service.cc
+++ b/src/v/cloud_io/cache_service.cc
@@ -1136,7 +1136,6 @@ ss::future<std::optional<cloud_io::cache_item_stream>> cache::get_stream(
 ss::future<std::optional<cache_item>> cache::_get(std::filesystem::path key) {
     auto guard = _gate.hold();
     vlog(log.debug, "Trying to get {} from archival cache.", key.native());
-    probe.get();
     ss::file cache_file;
 
     size_t data_size{0};
@@ -1159,14 +1158,12 @@ ss::future<std::optional<cache_item>> cache::_get(std::filesystem::path key) {
         }
     } catch (const std::filesystem::filesystem_error& e) {
         if (e.code() == std::errc::no_such_file_or_directory) {
-            probe.miss_get();
             co_return std::nullopt;
         } else {
             throw;
         }
     }
 
-    probe.cached_get();
     co_return std::optional(cache_item{std::move(cache_file), data_size});
 }
 


### PR DESCRIPTION
Remove redundant probe metric calls from the internal _get() method to prevent double counting. The metrics are already correctly tracked in the public get() method which calls _get() after trying all candidate object names.

Previously, both get() and _get() were recording metrics, causing cache hits and misses to be counted multiple times when a single file was accessed.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x
- [x] v24.3.x

## Release Notes

### Bug Fixes

* Fix double-counting in tiered storage cache operations metrics.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
