### PR TITLE
[CORE-13480] kafka/client: improve topic caching behavior

### DIFF
--- a/src/v/kafka/client/cluster.cc
+++ b/src/v/kafka/client/cluster.cc
@@ -68,6 +68,7 @@ cluster::cluster(connection_configuration config)
   : _config(std::move(config))
   , _logger(
       kclog, fmt::format("{}", _config.client_id.value_or("kafka-client")))
+  , _topic_cache(metadata_age_multiplier * _config.max_metadata_age)
   , _brokers(_logger, std::make_unique<remote_broker_factory>(_config, _logger))
   , _next_seed(
       random_generators::get_int<size_t>(0, _config.initial_brokers.size() - 1))
@@ -385,6 +386,9 @@ ss::future<> cluster::do_update_configuration(connection_configuration config) {
 
     vlog(_logger.debug, "Updating cluster config to '{}'", config);
     _config = std::move(config);
+
+    _topic_cache.set_topic_timeout(
+      metadata_age_multiplier * _config.max_metadata_age);
 
     // all updates to the cluster brokers should happen under the
     // metadata update lock

--- a/src/v/kafka/client/cluster.h
+++ b/src/v/kafka/client/cluster.h
@@ -198,6 +198,10 @@ private:
 
     ss::future<> do_update_configuration(connection_configuration config);
 
+    // This multiplier is applied to the max_metadata_age to define the
+    // topic_timeout for the topic_cache
+    static constexpr int metadata_age_multiplier = 3;
+
     connection_configuration _config;
     prefix_logger _logger;
     topic_cache _topic_cache;

--- a/src/v/kafka/client/test/BUILD
+++ b/src/v/kafka/client/test/BUILD
@@ -426,6 +426,7 @@ redpanda_cc_gtest(
     deps = [
         "//src/v/kafka/client:brokers",
         "//src/v/kafka/client:cluster",
+        "//src/v/kafka/client:configuration",
         "//src/v/kafka/client:utils",
         "//src/v/kafka/data:log_reader_config",
         "//src/v/kafka/protocol",

--- a/src/v/kafka/client/test/BUILD
+++ b/src/v/kafka/client/test/BUILD
@@ -377,6 +377,22 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "topic_cache_test",
+    timeout = "short",
+    srcs = [
+        "topic_cache_test.cc",
+    ],
+    deps = [
+        "//src/v/container:chunked_vector",
+        "//src/v/kafka/client:topic_cache",
+        "//src/v/kafka/protocol:metadata",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
 redpanda_cc_btest(
     name = "list_offsets",
     timeout = "short",

--- a/src/v/kafka/client/test/BUILD
+++ b/src/v/kafka/client/test/BUILD
@@ -390,6 +390,7 @@ redpanda_cc_gtest(
         "//src/v/model",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
+        "@seastar",
     ],
 )
 

--- a/src/v/kafka/client/test/cluster_test.cc
+++ b/src/v/kafka/client/test/cluster_test.cc
@@ -1,4 +1,5 @@
 #include "kafka/client/cluster.h"
+#include "kafka/client/configuration.h"
 #include "kafka/protocol/produce.h"
 #include "redpanda/tests/fixture.h"
 #include "storage/types.h"
@@ -6,7 +7,18 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+
 using namespace kafka::client;
+
+kafka::client::connection_configuration
+make_cluster_config(std::chrono::milliseconds max_metadata_age) {
+    return kafka::client::connection_configuration{
+      .initial_brokers = {net::unresolved_address{"localhost", 9092}},
+      .client_id = "test_client",
+      .max_metadata_age = max_metadata_age,
+    };
+}
 
 class ClusterFixture
   : public redpanda_thread_fixture
@@ -21,12 +33,9 @@ public:
         return seastar::make_ready_future<>();
     }
 
-    kafka::client::cluster create_cluster() {
-        kafka::client::connection_configuration config{
-          .initial_brokers = {net::unresolved_address{"localhost", 9092}},
-          .client_id = "test_client",
-        };
-        return kafka::client::cluster{std::move(config)};
+    kafka::client::cluster
+    create_cluster(std::chrono::milliseconds max_metadata_age = 10s) {
+        return kafka::client::cluster{make_cluster_config(max_metadata_age)};
     }
 };
 
@@ -238,4 +247,51 @@ TEST_F(ClusterFixture, TestDispatchingMultipleRequests) {
         auto r_number = serde::from_iobuf<int>(records[0].value().copy());
         ASSERT_EQ(static_cast<int64_t>(r_number), b.base_offset()());
     }
+}
+
+TEST_F(ClusterFixture, TestTopicTimeout) {
+    wait_for_controller_leadership().get();
+
+    // Create and start the client cluster
+    auto cluster = create_cluster(500ms);
+    cluster.start().get();
+    auto deferred_stop = ss::defer([&] { cluster.stop().get(); });
+
+    model::topic tpa("test-topic-a");
+    model::topic_namespace tpa_ns{model::kafka_namespace, tpa};
+
+    add_topic(tpa_ns).get();
+    RPTEST_REQUIRE_EVENTUALLY(3s, [&cluster, &tpa] {
+        return std::ranges::contains(cluster.get_topics().topics(), tpa);
+    });
+    delete_topic(tpa_ns).get();
+
+    // The timings in these checks are meant to bring us half a second before
+    // the stale time and then half a second after the stale time
+    ss::sleep(1000ms).get();
+    cluster.request_metadata_update().get();
+    ASSERT_TRUE(std::ranges::contains(cluster.get_topics().topics(), tpa));
+
+    ss::sleep(1000ms).get();
+    cluster.request_metadata_update().get();
+    ASSERT_FALSE(std::ranges::contains(cluster.get_topics().topics(), tpa));
+
+    // Check that updates happen correctly, as well
+    kafka::client::connection_configuration new_config = make_cluster_config(
+      1s);
+    cluster.update_configuration(std::move(new_config));
+
+    add_topic(tpa_ns).get();
+    RPTEST_REQUIRE_EVENTUALLY(3s, [&cluster, &tpa] {
+        return std::ranges::contains(cluster.get_topics().topics(), tpa);
+    });
+    delete_topic(tpa_ns).get();
+
+    ss::sleep(2500ms).get();
+    cluster.request_metadata_update().get();
+    ASSERT_TRUE(std::ranges::contains(cluster.get_topics().topics(), tpa));
+
+    ss::sleep(1000ms).get();
+    cluster.request_metadata_update().get();
+    ASSERT_FALSE(std::ranges::contains(cluster.get_topics().topics(), tpa));
 }

--- a/src/v/kafka/client/test/topic_cache_test.cc
+++ b/src/v/kafka/client/test/topic_cache_test.cc
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "container/chunked_vector.h"
+#include "kafka/client/topic_cache.h"
+#include "kafka/protocol/metadata.h"
+#include "model/fundamental.h"
+
+#include <gtest/gtest.h>
+
+using namespace kafka;
+using namespace kafka::client;
+
+metadata_response::topic make_response_topic(
+  model::topic name,
+  int n_partitions,
+  std::optional<model::topic_id> id = std::nullopt,
+  std::optional<kafka::leader_epoch> leader_epoch = std::nullopt) {
+    metadata_response::topic ret;
+    ret.name = name;
+    ret.topic_id = id.value_or(model::topic_id::create());
+
+    for (int i_part = 0; i_part < n_partitions; ++i_part) {
+        ret.partitions.push_back(
+          metadata_response::partition{
+            .partition_index = model::partition_id{i_part},
+            .leader_epoch = leader_epoch.value_or(
+              kafka::leader_epoch{i_part})});
+    }
+
+    return ret;
+}
+
+TEST(TopicCache, TestCacheUpdate) {
+    topic_cache cache;
+
+    const auto get_leader_epoch = [](const auto& data, int id) {
+        return data.partitions.find(model::partition_id{id})
+          ->second.leader_epoch;
+    };
+
+    const auto topic_a = model::topic{"topic-a"};
+    const auto topic_b = model::topic{"topic-b"};
+    const auto topic_a_id = model::topic_id::create();
+    const auto topic_b_id = model::topic_id::create();
+
+    // Check state after initial update.
+    {
+        chunked_vector<metadata_response::topic> init_update;
+        init_update.push_back(make_response_topic(topic_a, 3, topic_a_id));
+        init_update.push_back(make_response_topic(topic_b, 5, topic_b_id));
+
+        cache.apply(init_update);
+
+        ASSERT_TRUE(std::ranges::contains(cache.topics(), topic_a));
+        ASSERT_TRUE(std::ranges::contains(cache.topics(), topic_b));
+
+        const auto& topic_a_data = cache.cache().find(topic_a)->second;
+        ASSERT_EQ(topic_a_data.topic_id, topic_a_id);
+        ASSERT_EQ(topic_a_data.partitions.size(), 3);
+        for (const auto& [par_id, par_data] : topic_a_data.partitions) {
+            ASSERT_EQ(par_data.leader_epoch, kafka::leader_epoch{par_id});
+        }
+
+        const auto& topic_b_data = cache.cache().find(topic_b)->second;
+        ASSERT_EQ(topic_b_data.topic_id, topic_b_id);
+        ASSERT_EQ(topic_b_data.partitions.size(), 5);
+        for (const auto& [par_id, par_data] : topic_b_data.partitions) {
+            ASSERT_EQ(par_data.leader_epoch, kafka::leader_epoch{par_id});
+        }
+    }
+
+    // Update topic-b with the same topic id
+    {
+        chunked_vector<metadata_response::topic> update_topic_b;
+        update_topic_b.push_back(
+          make_response_topic(topic_b, 6, topic_b_id, kafka::leader_epoch{2}));
+
+        cache.apply(update_topic_b);
+
+        ASSERT_TRUE(std::ranges::contains(cache.topics(), topic_a));
+        ASSERT_TRUE(std::ranges::contains(cache.topics(), topic_b));
+
+        // topic a state should be as before
+        const auto& topic_a_data = cache.cache().find(topic_a)->second;
+        ASSERT_EQ(topic_a_data.topic_id, topic_a_id);
+        ASSERT_EQ(topic_a_data.partitions.size(), 3);
+        for (const auto& [par_id, par_data] : topic_a_data.partitions) {
+            ASSERT_EQ(par_data.leader_epoch, kafka::leader_epoch{par_id});
+        }
+
+        // topic b should have updated partitions for those with leader epoch
+        // higher than before
+        const auto& topic_b_data = cache.cache().find(topic_b)->second;
+        ASSERT_EQ(topic_b_data.topic_id, topic_b_id);
+        ASSERT_EQ(topic_b_data.partitions.size(), 6);
+        ASSERT_EQ(get_leader_epoch(topic_b_data, 0), 2);
+        ASSERT_EQ(get_leader_epoch(topic_b_data, 1), 2);
+        ASSERT_EQ(get_leader_epoch(topic_b_data, 2), 2);
+        ASSERT_EQ(get_leader_epoch(topic_b_data, 3), 3);
+        ASSERT_EQ(get_leader_epoch(topic_b_data, 4), 4);
+        ASSERT_EQ(get_leader_epoch(topic_b_data, 5), 2);
+    }
+
+    // Update topic b with different topic id
+    {
+        chunked_vector<metadata_response::topic> update_topic_b;
+        update_topic_b.push_back(make_response_topic(topic_b, 3));
+
+        cache.apply(update_topic_b);
+
+        ASSERT_TRUE(std::ranges::contains(cache.topics(), topic_b));
+
+        const auto& topic_b_data = cache.cache().find(topic_b)->second;
+        ASSERT_NE(topic_b_data.topic_id, topic_b_id);
+        ASSERT_EQ(topic_b_data.partitions.size(), 3);
+        for (const auto& [par_id, par_data] : topic_b_data.partitions) {
+            ASSERT_EQ(par_data.leader_epoch, kafka::leader_epoch{par_id});
+        }
+    }
+}

--- a/src/v/kafka/client/test/topic_cache_test.cc
+++ b/src/v/kafka/client/test/topic_cache_test.cc
@@ -14,10 +14,13 @@
 #include "kafka/protocol/metadata.h"
 #include "model/fundamental.h"
 
+#include <seastar/core/sleep.hh>
+
 #include <gtest/gtest.h>
 
 using namespace kafka;
 using namespace kafka::client;
+using namespace std::chrono_literals;
 
 metadata_response::topic make_response_topic(
   model::topic name,
@@ -126,4 +129,36 @@ TEST(TopicCache, TestCacheUpdate) {
             ASSERT_EQ(par_data.leader_epoch, kafka::leader_epoch{par_id});
         }
     }
+}
+
+TEST(TopicCache, TestCacheUpdateStaleTopic) {
+    topic_cache cache;
+    cache.set_topic_timeout(1s);
+
+    const auto topic_a = model::topic{"topic-a"};
+    const auto topic_b = model::topic{"topic-b"};
+    const auto topic_a_id = model::topic_id::create();
+    const auto topic_b_id = model::topic_id::create();
+
+    // Set up cache with both topics.
+    chunked_vector<metadata_response::topic> init_update;
+    init_update.push_back(make_response_topic(topic_a, 3, topic_a_id));
+    init_update.push_back(make_response_topic(topic_b, 5, topic_b_id));
+
+    cache.apply(init_update);
+
+    ASSERT_TRUE(std::ranges::contains(cache.topics(), topic_a));
+    ASSERT_TRUE(std::ranges::contains(cache.topics(), topic_b));
+
+    // Wait enough time for the topics to be considered stale
+    ss::sleep(2s).get();
+
+    // Update only topic-a
+    chunked_vector<metadata_response::topic> update_topic_a;
+    update_topic_a.push_back(make_response_topic(topic_a, 3, topic_a_id));
+
+    cache.apply(update_topic_a);
+
+    ASSERT_TRUE(std::ranges::contains(cache.topics(), topic_a));
+    ASSERT_FALSE(std::ranges::contains(cache.topics(), topic_b));
 }

--- a/src/v/kafka/client/topic_cache.cc
+++ b/src/v/kafka/client/topic_cache.cc
@@ -16,13 +16,19 @@
 
 #include <seastar/core/future.hh>
 
+#include <ranges>
+
 namespace kafka::client {
 
 void topic_cache::apply(
   const chunked_vector<metadata_response::topic>& topics) {
     topics_t new_cache;
     new_cache.reserve(topics.size());
-    for (const auto& t : topics) {
+
+    const auto get_successful = std::views::filter([](const auto& resp) {
+        return resp.error_code == kafka::error_code::none;
+    });
+    for (const auto& t : topics | get_successful) {
         static_assert(
           api_version_for(metadata_request::api_type::key) < api_version(12),
           "topic::name is nullable in v12+");

--- a/src/v/kafka/client/topic_cache.cc
+++ b/src/v/kafka/client/topic_cache.cc
@@ -13,6 +13,7 @@
 #include "kafka/client/types.h"
 #include "kafka/client/utils.h"
 #include "kafka/protocol/metadata.h"
+#include "model/fundamental.h"
 
 #include <seastar/core/future.hh>
 
@@ -22,8 +23,8 @@ namespace kafka::client {
 
 void topic_cache::apply(
   const chunked_vector<metadata_response::topic>& topics) {
-    topics_t new_cache;
-    new_cache.reserve(topics.size());
+    topics_t cache_update;
+    cache_update.reserve(topics.size());
 
     const auto get_successful = std::views::filter([](const auto& resp) {
         return resp.error_code == kafka::error_code::none;
@@ -32,7 +33,8 @@ void topic_cache::apply(
         static_assert(
           api_version_for(metadata_request::api_type::key) < api_version(12),
           "topic::name is nullable in v12+");
-        auto& cache_t = new_cache.emplace(*t.name, topic_data{}).first->second;
+        auto& cache_t
+          = cache_update.emplace(*t.name, topic_data{}).first->second;
         cache_t.authorized_operations = t.topic_authorized_operations;
         if (t.topic_id != model::topic_id{}) {
             cache_t.topic_id = t.topic_id;
@@ -49,7 +51,64 @@ void topic_cache::apply(
         }
     }
 
-    std::exchange(_topics, std::move(new_cache));
+    merge_topics(std::move(cache_update));
+}
+
+topic_cache::topic_data topic_cache::merge_topic_data(
+  topic_data&& cached_topic, topic_data&& updated_topic) {
+    for (auto& [partition_id, updated_data] : updated_topic.partitions) {
+        auto it = cached_topic.partitions.find(partition_id);
+        if (it == cached_topic.partitions.end()) {
+            // No cached data for this topic id
+            continue;
+        }
+
+        auto& cached_data = it->second;
+        if (cached_data.leader_epoch > updated_data.leader_epoch) {
+            // Stale update. Keep old data
+            updated_data = std::move(cached_data);
+        }
+    }
+
+    return std::move(updated_topic);
+}
+
+void topic_cache::merge_topics(topics_t cache_update) {
+    topics_t merged;
+
+    for (auto& [topic, cached_topic] : _topics) {
+        auto it = cache_update.find(topic);
+        if (it != cache_update.end()) {
+            // topic exist in update. It will be handled by the update loop
+            continue;
+        }
+
+        // topic doesn't exist in update. Keep cached value
+        merged.emplace(topic, std::move(cached_topic));
+    }
+
+    for (auto& [topic, updated_topic] : cache_update) {
+        auto it = _topics.find(topic);
+        if (it == _topics.end()) {
+            // topic doesn't have cached data. Accept new value
+            merged.emplace(topic, std::move(updated_topic));
+            continue;
+        }
+
+        auto& cached_topic = it->second;
+        if (cached_topic.topic_id != updated_topic.topic_id) {
+            // topic has new id. Keep updated value
+            merged.emplace(topic, std::move(updated_topic));
+            continue;
+        }
+
+        // topic exists in both cache and update. Merge their data
+        merged.emplace(
+          topic,
+          merge_topic_data(std::move(cached_topic), std::move(updated_topic)));
+    }
+
+    _topics = std::move(merged);
 }
 
 std::optional<model::node_id>

--- a/src/v/kafka/client/topic_cache.cc
+++ b/src/v/kafka/client/topic_cache.cc
@@ -26,6 +26,7 @@ void topic_cache::apply(
     topics_t cache_update;
     cache_update.reserve(topics.size());
 
+    auto now = ss::lowres_clock::now();
     const auto get_successful = std::views::filter([](const auto& resp) {
         return resp.error_code == kafka::error_code::none;
     });
@@ -35,6 +36,7 @@ void topic_cache::apply(
           "topic::name is nullable in v12+");
         auto& cache_t
           = cache_update.emplace(*t.name, topic_data{}).first->second;
+        cache_t.last_seen_time = now;
         cache_t.authorized_operations = t.topic_authorized_operations;
         if (t.topic_id != model::topic_id{}) {
             cache_t.topic_id = t.topic_id;
@@ -52,6 +54,7 @@ void topic_cache::apply(
     }
 
     merge_topics(std::move(cache_update));
+    remove_timeout_topics();
 }
 
 topic_cache::topic_data topic_cache::merge_topic_data(
@@ -109,6 +112,17 @@ void topic_cache::merge_topics(topics_t cache_update) {
     }
 
     _topics = std::move(merged);
+}
+
+void topic_cache::remove_timeout_topics() {
+    auto now = ss::lowres_clock::now();
+    for (auto it = _topics.begin(); it != _topics.end();) {
+        if (now - it->second.last_seen_time > _topic_timeout) {
+            it = _topics.erase(it);
+        } else {
+            ++it;
+        }
+    }
 }
 
 std::optional<model::node_id>

--- a/src/v/kafka/client/topic_cache.h
+++ b/src/v/kafka/client/topic_cache.h
@@ -68,6 +68,12 @@ public:
     const topics_t& cache() const noexcept;
 
 private:
+    /// \brief merges info from new_topics and _topics
+    void merge_topics(topics_t new_topics);
+
+    /// \brief merges cached and update topic data
+    static topic_data merge_topic_data(topic_data&&, topic_data&&);
+
     /// \brief Cache of topic information.
     topics_t _topics;
 };

--- a/src/v/kafka/client/topic_cache.h
+++ b/src/v/kafka/client/topic_cache.h
@@ -33,6 +33,7 @@ class topic_cache {
           = kafka::topic_authorized_operations_not_set;
         int16_t replication_factor;
         std::optional<model::topic_id> topic_id;
+        ss::lowres_clock::time_point last_seen_time;
     };
 
     using topics_t = chunked_hash_map<model::topic, topic_data>;
@@ -44,6 +45,10 @@ public:
     topic_cache& operator=(const topic_cache&) = delete;
     topic_cache& operator=(topic_cache&&) = delete;
     ~topic_cache() noexcept = default;
+
+    explicit topic_cache(std::chrono::milliseconds topic_timeout)
+      : _topics{}
+      , _topic_timeout{std::move(topic_timeout)} {}
 
     /// \brief Apply the given metadata response.
     void apply(const chunked_vector<metadata_response::topic>& topics);
@@ -67,15 +72,24 @@ public:
 
     const topics_t& cache() const noexcept;
 
+    void set_topic_timeout(std::chrono::milliseconds s) { _topic_timeout = s; }
+
 private:
     /// \brief merges info from new_topics and _topics
     void merge_topics(topics_t new_topics);
+
+    /// \brief remove topics that haven't been seen for _topic_timeout or more
+    void remove_timeout_topics();
 
     /// \brief merges cached and update topic data
     static topic_data merge_topic_data(topic_data&&, topic_data&&);
 
     /// \brief Cache of topic information.
     topics_t _topics;
+
+    /// \brief If a topic hasn't been updated in this much time, it will be
+    /// considered stale and removed
+    std::chrono::milliseconds _topic_timeout = std::chrono::seconds{60};
 };
 
 } // namespace kafka::client


### PR DESCRIPTION
Implements: [CORE-13480](https://redpandadata.atlassian.net/browse/CORE-13480)

Change how updates to topic cache are being applied. Instead of the new data overwriting the old ones, they are merged. This happens according to:
- A partition is not updated if the old state has higher leader epoch
- A topic is erased from the cache if it isn't part of N consecutive updates (arbitrarily set to 5)
- If a topic changes ID, the old data are discarded in favor or the new
- If a requested topic returns an error, it is explicitly removed from the topic cache.

Also, the list of topics to request metadata for is no longer part of cluster's api, but it is provided through the configuration.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-13480]: https://redpandadata.atlassian.net/browse/CORE-13480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ