### PR TITLE
rptest/ct: fix flake when transactions are the last aborted batch

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -979,6 +979,7 @@ class RpkTool:
         format: str | None = None,
         timeout: float | None = None,
         use_schema_registry: str | None = None,
+        read_committed: bool = False,
     ) -> str:
         cmd = ["consume", topic]
         if group is not None:
@@ -999,6 +1000,8 @@ class RpkTool:
             cmd += ["--use-schema-registry=" + use_schema_registry]
         elif format is not None:
             cmd += ["-f", format]
+        if read_committed:
+            cmd += ["--read-committed"]
 
         return self._run_topic(
             cmd, timeout=timeout, use_schema_registry=use_schema_registry is not None

--- a/tests/rptest/tests/cloud_topics/e2e_test.py
+++ b/tests/rptest/tests/cloud_topics/e2e_test.py
@@ -97,30 +97,32 @@ class EndToEndCloudTopicsBase(EndToEndTest):
 
     def wait_until_reconciled(self, topic: str, partition: int, transactions: bool):
         def get_offsets():
-            hwm: int | None = None
-            for p in self.rpk.describe_topic(topic):
-                if p.id == partition:
-                    hwm = p.high_watermark
-                    break
+            last_record: int | None = None
+            output = self.rpk.consume(
+                topic,
+                partition=partition,
+                offset=":end",
+                format="%o\n",
+                read_committed=True,
+            )
+            for line in output.splitlines():
+                last_record = int(line)
             metastore = self.admin.metastore()
             req = metastore_pb.GetOffsetsRequest(
                 partition=ntp_pb.TopicPartition(topic=topic, partition=partition)
             )
-            return metastore.get_offsets(req=req).offsets.next_offset, hwm
+            return metastore.get_offsets(req=req).offsets.next_offset, last_record
 
         def is_reconciled() -> bool:
-            next_offset, hwm = get_offsets()
-            if transactions:
-                # This is a little hacky, but if we produced using transactions,
-                # we won't reconcile the last offset because it's an commit or
-                # abort transactional control batch.
-                return next_offset == ((hwm or 0) - 1)
-            return next_offset == hwm
+            next_offset, last_record = get_offsets()
+            # Check the last observable record's offset against the next offset expected.
+            # For transactions, this could be much less than the HWM if there are aborts.
+            return (next_offset - 1) == last_record
 
         def message() -> str:
             try:
-                next_offset, hwm = get_offsets()
-                return f"failed to reconcile all data: topic={topic}, partition={partition}, high_watermark={hwm}, next_offset={next_offset}"
+                next_offset, last_record = get_offsets()
+                return f"failed to reconcile all data: topic={topic}, partition={partition}, last_record={last_record}, next_offset={next_offset}"
             except Exception:
                 return f"failed to reconcile all data: topic={topic}, partition={partition}, unable to fetch offsets"
 


### PR DESCRIPTION
When the last transactional batch is aborted instead of committed, then
the next offset is much lower than `-1`. Instead fix this to just get
the last offset that is visible via the kafka API, since we've already
asserted that is what we expected.

FIXES: CORE-14401

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
