### PR TITLE
tests/dm: allow larger time drift when validating migration timing

### DIFF
--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -143,7 +143,7 @@ class DataMigrationsApiTest(DataMigrationTestMixin):
     def validate_timing(self, time_before, happened_at):
         time_now = now()
         self.logger.debug(f"{time_before=}, {happened_at=}, {time_now=}")
-        err_ms = 5  # allow for ntp error across nodes
+        err_ms = 100  # allow for ntp error across nodes
         assert time_before - err_ms <= happened_at <= time_now + err_ms
 
     def get_topic_initial_revision(self, topic_name):


### PR DESCRIPTION
Cloud infrastructure is very noisy and there are a lot of interference. Made timing test more permissive by allowing larger time drift between nodes. This will make the test more stable.

Fixes: CORE-14487

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none