### PR TITLE
[CORE-14465] `rptest`: deflake `CompactionWithRecoveryTest`

### DIFF
--- a/tests/rptest/transactions/compaction_e2e_test.py
+++ b/tests/rptest/transactions/compaction_e2e_test.py
@@ -194,6 +194,12 @@ class CompactionWithRecoveryTest(RedpandaTest, PartitionMovementMixin):
             "raft_max_recovery_memory": 32 * 1024,
             "log_compaction_interval_ms": 2000,
             "min_cleanable_dirty_ratio": 0.0,
+            # Disable leader balancer, as this test is doing its own
+            # partition movement and the balancer would interfere
+            "enable_leader_balancer": False,
+            "partition_autobalancing_mode": "off",
+            "core_balancing_on_core_count_change": False,
+            "core_balancing_continuous": False,
         }
         super(CompactionWithRecoveryTest, self).__init__(
             test_context=test_context, extra_rp_conf=extra_rp_conf


### PR DESCRIPTION
This could race with a cross-shard (and potentially cross node?) naturally occuring partition movement. An example observed in CI:

```
1. [INFO  - 2025-10-25 05:00:24,458 - partition_movement - cores_converged - lineno:144]: current core placement for topic-monjwggmry/0: [{'node_id': 2, 'core': 2}]
2. [INFO  - 2025-10-25 05:00:25,467 - partition_movement - _dispatch_random_partition_move - lineno:302]: chose 1 replacements for topic-monjwggmry/0: [{'node_id': 2}] -> [{'node_id': 2, 'core': 0}]
3. DEBUG 2025-10-25 05:00:25,541 [shard 0:main] cluster - partition_manager.cc:287 - Log created manage completed, ntp: {kafka/topic-monjwggmry/0}, rev: 45, 17 segments, 2198651 bytes
4. DEBUG 2025-10-25 05:00:27,554 [shard 5:main] cluster - partition_manager.cc:287 - Log created manage completed, ntp: {kafka/topic-monjwggmry/0}, rev: 45, 20 segments, 4767212 bytes
5. [INFO  - 2025-10-25 05:00:29,530 - partition_movement - cores_converged - lineno:144]: current core placement for topic-monjwggmry/0: [{'node_id': 2, 'core': 5}]
6. [INFO  - 2025-10-25 05:00:31,538 - partition_movement - cores_converged - lineno:144]: current core placement for topic-monjwggmry/0: [{'node_id': 2, 'core': 5}]
7. [INFO  - 2025-10-25 05:00:33,546 - partition_movement - cores_converged - lineno:144]: current core placement for topic-monjwggmry/0: [{'node_id': 2, 'core': 5}]
...
```

In step 1, the initial assignment for the partition is observe as core 0. Next, in step 2, core 0 is chosen as the destination for the cross-shard movement for partition 0, and about ~100ms later in step 3, the log is created on shard 0. However, in step 4, the log is moved once again to shard 5, where it is now hosted. In step 5 and beyond, we timeout waiting for the cross-shard transfer to finish with core 0 as the destination, since the log has been moved to shard 5 in the interium and the partition movement request has been stepped upon.

Fixes https://redpandadata.atlassian.net/browse/CORE-14465.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
