### PR TITLE
storage/tests: fail fast(er) in segment ms test

### DIFF
--- a/src/v/storage/tests/storage_e2e_fixture.h
+++ b/src/v/storage/tests/storage_e2e_fixture.h
@@ -35,10 +35,10 @@ struct storage_e2e_fixture : public redpanda_thread_fixture {
                       tests::kv_t::sequence(i, 1));
                 }
             }
-            *incomplete -= 1;
         } catch (...) {
             eptr = std::current_exception();
         }
+        *incomplete -= 1;
         co_await producer.stop();
         if (eptr) {
             std::rethrow_exception(eptr);

--- a/src/v/storage/tests/storage_e2e_fixture_test.cc
+++ b/src/v/storage/tests/storage_e2e_fixture_test.cc
@@ -27,6 +27,9 @@
 using namespace std::chrono_literals;
 
 namespace {
+
+ss::logger test_logger("storage_e2e_fixture_test");
+
 ss::future<> force_roll_log(storage::disk_log_impl* log) {
     try {
         co_await log->force_roll();
@@ -65,11 +68,21 @@ FIXTURE_TEST(test_compaction_segment_ms, storage_e2e_fixture) {
     auto partition = app.partition_manager.local().get(ntp);
     auto* log = dynamic_cast<storage::disk_log_impl*>(partition->log().get());
 
+    // Apply segment_ms while produces are in-flight.
+    size_t retention_rounds = 0;
     while (incomplete > 0) {
         log->apply_segment_ms().get();
+        retention_rounds++;
         ss::sleep(500ms).get();
     }
 
+    // Sanity check: ensure segment_ms was applied multiple times.
+    BOOST_REQUIRE_MESSAGE(
+      retention_rounds > 3, "segment_ms not applied enough times");
+
+    vlog(test_logger.info, "Applied segment_ms {} times", retention_rounds);
+
+    // Ensure all produces completed successfully.
     for (auto&& p : produces) {
         std::move(p).get();
     }


### PR DESCRIPTION
This test had a few failures with test timeouts (300s) due to timeouts during produce. I think they were caused by bad disks we ran the tests on for a while.

Anyway, we can do better than wait for 300 seconds for test to fail (never if run outside the test framework). Always mark the "async produce" as completed so that the test can continue with other assertions including checking that "produce" tasks succeeded.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
