### PR TITLE
tx/rm_stm: tighten lso computation and monotonicity

### DIFF
--- a/src/v/cluster/producer_state.cc
+++ b/src/v/cluster/producer_state.cc
@@ -333,7 +333,7 @@ bool producer_state::can_evict() {
       // Check if there are operations pending state machine sync
       || !_requests._inflight_requests.empty()
       //  Check if there are any open transactions on this producer.
-      || has_transaction_in_progress()) {
+      || has_transaction_in_progress() || _in_flight_begin_hook.is_linked()) {
         vlog(_logger.debug, "[{}] cannot evict producer.", *this);
         return false;
     }
@@ -341,6 +341,33 @@ bool producer_state::can_evict() {
     _evicted = true;
     shutdown_input();
     return true;
+}
+
+void producer_state::gc_old_inflight_begin(model::term_id current_term) {
+    if (!_inflight_tx_term_offset) {
+        return;
+    }
+
+    if (_inflight_tx_term_offset->term < current_term) {
+        vlog(
+          _logger.debug,
+          "[{}] gc'ing inflight begin tx at term {} due to term bump to {}",
+          *this,
+          _inflight_tx_term_offset->term,
+          current_term);
+        reset_inflight_begin();
+    }
+}
+
+void producer_state::reset_inflight_begin() {
+    _inflight_tx_term_offset.reset();
+    _in_flight_begin_hook.unlink();
+}
+std::optional<model::offset> producer_state::inflight_begin_estimate() const {
+    if (_inflight_tx_term_offset) {
+        return _inflight_tx_term_offset->committed_offset;
+    }
+    return std::nullopt;
 }
 
 void producer_state::reset_with_new_epoch(model::producer_epoch new_epoch) {
@@ -408,11 +435,15 @@ result<request_ptr> producer_state::try_emplace_request(
 void producer_state::apply_data(
   const model::record_batch_header& header, kafka::offset offset) {
     auto bid = model::batch_identity::from(header);
+    gc_old_inflight_begin(header.ctx.term);
     if (!bid.is_idempotent() || _evicted) {
         return;
     }
     if (!bid.is_transactional && bid.pid.epoch > _id.epoch) {
         reset_with_new_epoch(bid.pid.epoch);
+    }
+    if (bid.is_transactional) {
+        reset_inflight_begin();
     }
     _requests.stm_apply(bid, header.ctx.term, offset);
     if (bid.is_transactional) {
@@ -453,6 +484,7 @@ void producer_state::apply_transaction_begin(
           header);
         return;
     }
+    reset_inflight_begin();
     if (has_transaction_in_progress() || _active_transaction_hook.is_linked()) {
         // We have checks in place in the stm so this does not happen. If it
         // still does it could be a bug or the log has been truncated and some
@@ -485,7 +517,7 @@ producer_state::apply_transaction_end(model::control_record_type crt) {
       && crt != model::control_record_type::tx_commit) {
         return std::nullopt;
     }
-
+    reset_inflight_begin();
     if (!_transaction_state) {
         vlog(
           _logger.debug,
@@ -590,6 +622,27 @@ std::optional<expiration_info> producer_state::get_expiration_info() const {
       .timeout = timeout,
       .last_update = tx::clock_type::now() - duration,
       .is_expiration_requested = has_transaction_expired()};
+}
+
+void producer_state::mark_tx_inflight(
+  model::term_id term, model::offset committed_offset) {
+    vassert(
+      !_inflight_tx_term_offset,
+      "There is already an inflight transaction begin batch for producer: {}",
+      *this);
+    vassert(
+      !has_transaction_in_progress(),
+      "Cannot mark transaction begin inflight for producer with active "
+      "transaction: {}",
+      *this);
+    // should be set first before marking the begin batch as inflight
+    vassert(
+      _in_flight_begin_hook.is_linked(),
+      "In flight begin hook must be linked when marking tx inflight for "
+      "producer: {}",
+      *this);
+    _inflight_tx_term_offset = std::make_unique<inflight_term_offset>(
+      inflight_term_offset{.term = term, .committed_offset = committed_offset});
 }
 
 } // namespace cluster::tx

--- a/src/v/cluster/producer_state.h
+++ b/src/v/cluster/producer_state.h
@@ -276,6 +276,9 @@ public:
     // on the partition using this producer.
     safe_intrusive_list_hook _active_transaction_hook;
 
+    // Used to track all the begin transaction batches that are in-flight
+    intrusive_list_hook _in_flight_begin_hook;
+
     std::chrono::milliseconds ms_since_last_update() const {
         return std::chrono::duration_cast<std::chrono::milliseconds>(
           ss::lowres_system_clock::now() - _last_updated_ts);
@@ -290,6 +293,21 @@ public:
     void reset_with_new_epoch(model::producer_epoch new_epoch);
 
     const requests& idempotent_request_state() const { return _requests; }
+
+    std::optional<model::offset> inflight_begin_estimate() const;
+
+private:
+    struct inflight_term_offset {
+        model::term_id term;
+        model::offset committed_offset;
+    };
+
+    // GCs any inflight begin requests from older terms.
+    void gc_old_inflight_begin(model::term_id current_term);
+    void reset_inflight_begin();
+
+public:
+    void mark_tx_inflight(model::term_id term, model::offset committed_offset);
 
 private:
     prefix_logger& _logger;
@@ -334,6 +352,9 @@ private:
     // Used to implement force eviction via admin APIs for forcing an eviction
     // of this producer.
     bool _force_transaction_expiry{false};
+
+    // Only set if there is an inflight transaction begin batch.
+    std::unique_ptr<inflight_term_offset> _inflight_tx_term_offset;
     friend class producer_state_manager;
     friend struct ::test_fixture;
 };

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1852,6 +1852,7 @@ model::offset rm_stm::to_log_offset(kafka::offset k_offset) const {
 
 ss::future<raft::local_snapshot_applied>
 rm_stm::apply_local_snapshot(raft::stm_snapshot_header hdr, iobuf&& tx_ss_buf) {
+    auto data_buf = std::move(tx_ss_buf);
     auto units = co_await _state_lock.hold_write_lock();
 
     vlog(
@@ -1859,7 +1860,7 @@ rm_stm::apply_local_snapshot(raft::stm_snapshot_header hdr, iobuf&& tx_ss_buf) {
       "applying snapshot with last included offset: {}",
       hdr.offset);
     tx_snapshot_v6 data;
-    iobuf_parser data_parser(std::move(tx_ss_buf));
+    iobuf_parser data_parser(std::move(data_buf));
     if (hdr.version == tx_snapshot_v4::version) {
         tx_snapshot_v4 data_v4
           = co_await reflection::async_adl<tx_snapshot_v4>{}.from(data_parser);

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1264,6 +1264,9 @@ ss::future<result<kafka_result>> rm_stm::replicate_msg(
 }
 
 model::offset rm_stm::last_stable_offset() {
+    if (_as.abort_requested()) [[unlikely]] {
+        return model::invalid_lso;
+    }
     // There are two main scenarios we deal with here.
     // 1. stm is still bootstrapping
     // 2. stm is past bootstrapping.

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -738,7 +738,7 @@ ss::future<tx::errc> rm_stm::do_abort_tx(
             // Or it may mean that a tx coordinator
             //   - lost its state
             //   - rolled back to previous op
-            //   - the previous op happend to be an abort
+            //   - the previous op happened to be an abort
             //   - the coordinator retried it
             //
             // In the first case the least impactful way to reject the request.
@@ -1281,6 +1281,8 @@ model::offset rm_stm::last_stable_offset() {
     // We optimize for the case where there are no inflight transactional
     // batch to return the high water mark.
     auto last_applied = last_applied_offset();
+
+    // scenario 1: still bootstrapping
     if (unlikely(
           !_bootstrap_committed_offset
           || last_applied < _bootstrap_committed_offset.value())) {
@@ -1290,6 +1292,7 @@ model::offset rm_stm::last_stable_offset() {
         return model::invalid_lso;
     }
 
+    // scenario 2: past bootstrapping
     // Check for any in-flight transactions.
     auto first_tx_start = model::offset::max();
     if (_is_tx_enabled && !_active_tx_producers.empty()) {

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1293,6 +1293,18 @@ model::offset rm_stm::last_stable_offset() {
     }
 
     // scenario 2: past bootstrapping
+    auto read_units = _state_lock.try_hold_read_lock();
+    if (!read_units) {
+        // A reset in progress means the stm may not be in a consistent state
+        // for LSO calculation. In this case we return the last known LSO to be
+        // conservative.
+        vlog(
+          _ctx_log.trace,
+          "state machine is resetting, last_known_lso: {}, last_applied: {}",
+          _last_known_lso,
+          last_applied);
+        return _last_known_lso;
+    }
     // Check for any in-flight transactions.
     auto first_tx_start = model::offset::max();
     if (_is_tx_enabled && !_active_tx_producers.empty()) {

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1331,6 +1331,37 @@ model::offset rm_stm::last_stable_offset() {
         // transactions.
         lso = std::min(first_tx_start, next_to_apply);
     } else if (synced_leader) {
+        ////////////////  WARNING ///////////
+        // there is a real bug lurking here that overestimates the LSO beyond
+        // an open transaction.
+        //
+        // The issue here if a begin_tx is replicated but not yet applied
+        // in the stm and a caller queries LSO, we return LSO beyond the
+        // begin_tx which is incorrect. The problem is _active_tx_producers
+        // is only updated on apply, so it is not yet up to date.
+
+        // Another problem is we do not let lso move backwards once
+        // computed (see _last_known_lso update below), So even if the
+        // stm has applied the begin_tx later, we will not correct
+        // the LSO to reflect the begin_tx presence.
+
+        // There is a test that caught this issue in rm_stm_tests which
+        // is disabled for now until we can fix the underlying problem.
+
+        // The impact of this overestimation is that compaction may compact
+        // away open transaction begin marker as it relies on LSO. The
+        // chances are rare but not impossible :(. if at that point the replica
+        // restarts and there are no furher updates in the transaction, the
+        // transaction has no record of ever beginning.
+
+        // We need a better way to track in-flight transactions for the purposes
+        // of LSO calculation.
+
+        // An obvious solution is to clamp LSO to next_to_apply in all cases
+        // but it was tried in the past and caused performance regressions
+        // in non transaction workloads like write_caching, acks=0/1. So that
+        // is not a viable solution.
+
         // no inflight transactions in (last_applied, last_visible_index]
         lso = model::next_offset(last_visible_index);
     } else {

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -247,6 +247,7 @@ ss::future<> rm_stm::reset_producers() {
             *producer, _vcluster_id);
           return ss::now();
       });
+    _inflight_begin_producers.clear();
     _active_tx_producers.clear();
     _producers.clear();
 }
@@ -439,6 +440,9 @@ ss::future<checked<model::term_id, tx::errc>> rm_stm::do_begin_tx(
           *producer);
         co_return tx::errc::request_rejected;
     }
+
+    _inflight_begin_producers.push_back(*producer);
+    producer->mark_tx_inflight(synced_term, _raft->committed_offset());
 
     model::record_batch batch = make_fence_batch(
       pid, tx_seq, transaction_timeout_ms, tm);
@@ -1306,12 +1310,12 @@ model::offset rm_stm::last_stable_offset() {
         return _last_known_lso;
     }
     // Check for any in-flight transactions.
-    auto first_tx_start = model::offset::max();
+    auto first_active_tx_start = model::offset::max();
     if (_is_tx_enabled && !_active_tx_producers.empty()) {
         const auto& earliest_open_tx_producer = _active_tx_producers.begin();
         const auto& tx_state = earliest_open_tx_producer->transaction_state();
         if (tx_state) {
-            first_tx_start = tx_state->first;
+            first_active_tx_start = tx_state->first;
         } else {
             vlog(
               _ctx_log.error,
@@ -1321,6 +1325,13 @@ model::offset rm_stm::last_stable_offset() {
         }
     }
 
+    auto first_inflight_begin = model::offset::max();
+    if (_is_tx_enabled && !_inflight_begin_producers.empty()) {
+        first_inflight_begin = _inflight_begin_producers.begin()
+                                 ->inflight_begin_estimate()
+                                 .value_or(model::offset::max());
+    }
+    auto first_tx_start = std::min(first_active_tx_start, first_inflight_begin);
     auto synced_leader = _raft->is_leader() && _raft->term() == _insync_term;
     model::offset lso{-1};
     auto last_visible_index = _raft->last_visible_index();
@@ -1331,38 +1342,6 @@ model::offset rm_stm::last_stable_offset() {
         // transactions.
         lso = std::min(first_tx_start, next_to_apply);
     } else if (synced_leader) {
-        ////////////////  WARNING ///////////
-        // there is a real bug lurking here that overestimates the LSO beyond
-        // an open transaction.
-        //
-        // The issue here if a begin_tx is replicated but not yet applied
-        // in the stm and a caller queries LSO, we return LSO beyond the
-        // begin_tx which is incorrect. The problem is _active_tx_producers
-        // is only updated on apply, so it is not yet up to date.
-
-        // Another problem is we do not let lso move backwards once
-        // computed (see _last_known_lso update below), So even if the
-        // stm has applied the begin_tx later, we will not correct
-        // the LSO to reflect the begin_tx presence.
-
-        // There is a test that caught this issue in rm_stm_tests which
-        // is disabled for now until we can fix the underlying problem.
-
-        // The impact of this overestimation is that compaction may compact
-        // away open transaction begin marker as it relies on LSO. The
-        // chances are rare but not impossible :(. if at that point the replica
-        // restarts and there are no furher updates in the transaction, the
-        // transaction has no record of ever beginning.
-
-        // We need a better way to track in-flight transactions for the purposes
-        // of LSO calculation.
-
-        // An obvious solution is to clamp LSO to next_to_apply in all cases
-        // but it was tried in the past and caused performance regressions
-        // in non transaction workloads like write_caching, acks=0/1. So that
-        // is not a viable solution.
-
-        // no inflight transactions in (last_applied, last_visible_index]
         lso = model::next_offset(last_visible_index);
     } else {
         // a follower or hasn't synced yet leader doesn't know about the
@@ -1923,6 +1902,9 @@ rm_stm::apply_local_snapshot(raft::stm_snapshot_header hdr, iobuf&& tx_ss_buf) {
     _aborted_tx_state.abort_indexes = std::move(data.abort_indexes);
 
     co_await reset_producers();
+
+    // sleep induced to allow other coroutines to run
+    co_await ss::sleep(5ms);
 
     vlog(_ctx_log.debug, "Loading snapshot: {}", data);
     chunked_vector<producer_ptr> transactional_producers;

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -117,7 +117,7 @@ namespace cluster {
  * This stm periodically checks if there is any pending transaction for
  * expiration. The expiration kicks in the transaction is not committed/aborted
  * within the user set transaction timeout. A producer with an active
- * transaction cannot be evicted, so exipration ensures that with timely
+ * transaction cannot be evicted, so expiration ensures that with timely
  * expiration of open transactions, the producer states are candidates for
  * eviction.
  */

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -428,6 +428,17 @@ private:
       &tx::producer_state::_active_transaction_hook>;
     active_transactional_producers_t _active_tx_producers;
 
+    // This list tracks all producers that have an inflight begin requet.
+    // we do this to clamp the LSO correctly if there is a racy request
+    // to compute LSO while there are inflight begin requests. This list
+    // clamps the LSO to the committed offset at the time of the begin requset
+    // and is removed when the begin request / any subsequent batch from the
+    // transaction is applied.
+    using inflight_begin_producers_t = intrusive_list<
+      tx::producer_state,
+      &tx::producer_state::_in_flight_begin_hook>;
+    inflight_begin_producers_t _inflight_begin_producers;
+
     metrics::internal_metric_groups _metrics;
     ss::abort_source _as;
     ss::gate _gate;

--- a/src/v/cluster/tests/rm_stm_test_fixture.h
+++ b/src/v/cluster/tests/rm_stm_test_fixture.h
@@ -20,11 +20,13 @@
 static ss::logger logger{"rm_stm-test"};
 static prefix_logger ctx_logger{logger, ""};
 
+static constexpr auto large_timeout = std::chrono::minutes(30);
+
 struct rm_stm_test_fixture : simple_raft_fixture {
     void create_stm_and_start_raft(
       storage::ntp_config::default_overrides overrides = {}) {
         max_concurent_producers.start(std::numeric_limits<size_t>::max()).get();
-        producer_expiration_ms.start(std::chrono::milliseconds::max()).get();
+        producer_expiration_ms.start(large_timeout).get();
         producer_state_manager
           .start(
             ss::sharded_parameter(

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -945,6 +945,10 @@ FIXTURE_TEST(test_concurrent_producer_evictions, rm_stm_test_fixture) {
 }
 
 FIXTURE_TEST(test_lso_bound_by_open_tx, rm_stm_test_fixture) {
+    // disabled, this test exposed a real bug in bounded LSO computation and
+    // hence disabled until it is fixed. check comment in
+    // rm_stm::last_stable_offset() for more details.
+    return;
     create_stm_and_start_raft();
     auto& stm = *_stm;
     auto raft = _raft;

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -945,10 +945,6 @@ FIXTURE_TEST(test_concurrent_producer_evictions, rm_stm_test_fixture) {
 }
 
 FIXTURE_TEST(test_lso_bound_by_open_tx, rm_stm_test_fixture) {
-    // disabled, this test exposed a real bug in bounded LSO computation and
-    // hence disabled until it is fixed. check comment in
-    // rm_stm::last_stable_offset() for more details.
-    return;
     create_stm_and_start_raft();
     auto& stm = *_stm;
     auto raft = _raft;

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -981,3 +981,89 @@ FIXTURE_TEST(test_concurrent_producer_evictions, rm_stm_test_fixture) {
     ss::when_all_succeed(std::move(replicate_f), std::move(reset_f)).get();
     gate.close().get();
 }
+
+FIXTURE_TEST(test_lso_bound_by_open_tx, rm_stm_test_fixture) {
+    create_stm_and_start_raft();
+    auto& stm = *_stm;
+    auto raft = _raft;
+    stm.start().get();
+    stm.testing_only_disable_auto_abort();
+
+    wait_for_confirmed_leader();
+    wait_for_meta_initialized();
+
+    auto pid = model::producer_identity{0, 0};
+
+    auto random_sleep = []() {
+        auto sleep_ms = std::chrono::milliseconds{
+          random_generators::get_int(0, 5)};
+        return ss::sleep(sleep_ms);
+    };
+
+    auto snapshot_and_apply = [&] {
+        return local_snapshot(cluster::tx::tx_snapshot::version)
+          .then([&](auto snapshot) {
+              return random_sleep().then(
+                [this, snapshot = std::move(snapshot)]() mutable {
+                    return apply_snapshot(
+                             snapshot.header, std::move(snapshot.data))
+                      .discard_result();
+                });
+          });
+    };
+
+    std::optional<model::offset> earliest_open_tx;
+    auto tx_and_snapshot = [&](model::tx_seq tx_seq) {
+        auto timeout = std::chrono::milliseconds(
+          std::numeric_limits<int32_t>::max());
+        // begin tx
+        BOOST_REQUIRE(
+          stm.begin_tx(pid, tx_seq, timeout, model::partition_id(0)).get());
+
+        earliest_open_tx = raft->committed_offset();
+
+        if (tests::random_bool()) {
+            // snapshot
+            snapshot_and_apply().get();
+        }
+        // replicate some batches
+        random_sleep().get();
+        auto result = replicate_all(stm, make_batches(pid, 0, 5, true)).get();
+        BOOST_REQUIRE(result.has_value());
+        // commit
+        if (tests::random_bool()) {
+            // snapshot
+            snapshot_and_apply().get();
+        }
+        random_sleep().get();
+
+        earliest_open_tx.reset();
+        BOOST_REQUIRE_EQUAL(
+          stm.commit_tx(pid, tx_seq, timeout).get(), cluster::tx::errc::none);
+    };
+
+    ss::abort_source as;
+    auto lso_bound_checker_f = ss::do_until(
+      [&as] { return as.abort_requested(); },
+      [&] {
+          auto current_lso = stm.last_stable_offset();
+          auto lso_bound = !earliest_open_tx || current_lso == earliest_open_tx;
+          if (!lso_bound) {
+              vlog(
+                logger.error,
+                "LSO {} exceeded earliest open tx offset {}",
+                current_lso,
+                earliest_open_tx);
+          }
+          BOOST_REQUIRE(lso_bound);
+          return ss::now();
+      });
+
+    auto deadline = ss::lowres_clock::now() + 10s;
+    model::tx_seq tx_seq{0};
+    while (ss::lowres_clock::now() < deadline) {
+        tx_and_snapshot(tx_seq++);
+    }
+    as.request_abort();
+    std::move(lso_bound_checker_f).get();
+}

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -37,6 +37,8 @@ using namespace std::chrono_literals;
 static const failure_type<cluster::errc>
   invalid_producer_epoch(cluster::errc::invalid_producer_epoch);
 
+static constexpr auto timeout = 30min;
+
 struct batches_with_identity {
     model::batch_identity id;
     chunked_vector<model::record_batch> batches;
@@ -141,14 +143,8 @@ FIXTURE_TEST(test_tx_happy_tx, rm_stm_test_fixture) {
     }).get();
 
     auto pid2 = model::producer_identity{2, 0};
-    auto term_op = stm
-                     .begin_tx(
-                       pid2,
-                       tx_seq,
-                       std::chrono::milliseconds(
-                         std::numeric_limits<int32_t>::max()),
-                       model::partition_id(0))
-                     .get();
+    auto term_op
+      = stm.begin_tx(pid2, tx_seq, timeout, model::partition_id(0)).get();
     BOOST_REQUIRE((bool)term_op);
     BOOST_REQUIRE_EQUAL(stm.highest_producer_id(), pid2.get_id());
 
@@ -208,14 +204,8 @@ FIXTURE_TEST(test_tx_aborted_tx_1, rm_stm_test_fixture) {
     }).get();
 
     auto pid2 = model::producer_identity{2, 0};
-    auto term_op = stm
-                     .begin_tx(
-                       pid2,
-                       tx_seq,
-                       std::chrono::milliseconds(
-                         std::numeric_limits<int32_t>::max()),
-                       model::partition_id(0))
-                     .get();
+    auto term_op
+      = stm.begin_tx(pid2, tx_seq, timeout, model::partition_id(0)).get();
     BOOST_REQUIRE((bool)term_op);
     BOOST_REQUIRE_EQUAL(stm.highest_producer_id(), pid2.get_id());
 
@@ -284,14 +274,8 @@ FIXTURE_TEST(test_tx_aborted_tx_2, rm_stm_test_fixture) {
     }).get();
 
     auto pid2 = model::producer_identity{2, 0};
-    auto term_op = stm
-                     .begin_tx(
-                       pid2,
-                       tx_seq,
-                       std::chrono::milliseconds(
-                         std::numeric_limits<int32_t>::max()),
-                       model::partition_id(0))
-                     .get();
+    auto term_op
+      = stm.begin_tx(pid2, tx_seq, timeout, model::partition_id(0)).get();
     BOOST_REQUIRE_EQUAL(stm.highest_producer_id(), pid2.get_id());
     BOOST_REQUIRE((bool)term_op);
 
@@ -370,14 +354,12 @@ FIXTURE_TEST(test_stale_begin_tx_fenced, rm_stm_test_fixture) {
     auto tx_seq_old = model::tx_seq(9);
     auto tx_seq_new = model::tx_seq(11);
     auto pid1 = model::producer_identity{1, 0};
-    auto timeout = std::chrono::milliseconds(
-      std::numeric_limits<int32_t>::max());
 
-    auto begin_tx = [&stm, &pid1, timeout](model::tx_seq seq) {
+    auto begin_tx = [&stm, &pid1](model::tx_seq seq) {
         return stm.begin_tx(pid1, seq, timeout, model::partition_id(0)).get();
     };
 
-    auto commit_tx = [&stm, &pid1, timeout](model::tx_seq seq) {
+    auto commit_tx = [&stm, &pid1](model::tx_seq seq) {
         return stm.commit_tx(pid1, seq, timeout).get();
     };
 
@@ -421,25 +403,13 @@ FIXTURE_TEST(test_tx_begin_fences_produce, rm_stm_test_fixture) {
     BOOST_REQUIRE((bool)offset_r);
 
     auto pid20 = model::producer_identity{2, 0};
-    auto term_op = stm
-                     .begin_tx(
-                       pid20,
-                       tx_seq,
-                       std::chrono::milliseconds(
-                         std::numeric_limits<int32_t>::max()),
-                       model::partition_id(0))
-                     .get();
+    auto term_op
+      = stm.begin_tx(pid20, tx_seq, timeout, model::partition_id(0)).get();
     BOOST_REQUIRE((bool)term_op);
 
     auto pid21 = model::producer_identity{2, 1};
-    term_op = stm
-                .begin_tx(
-                  pid21,
-                  tx_seq,
-                  std::chrono::milliseconds(
-                    std::numeric_limits<int32_t>::max()),
-                  model::partition_id(0))
-                .get();
+    term_op
+      = stm.begin_tx(pid21, tx_seq, timeout, model::partition_id(0)).get();
     BOOST_REQUIRE((bool)term_op);
 
     rreader = make_batches(pid20, 0, 5, true);
@@ -468,14 +438,8 @@ FIXTURE_TEST(test_tx_post_aborted_produce, rm_stm_test_fixture) {
     BOOST_REQUIRE((bool)offset_r);
 
     auto pid20 = model::producer_identity{2, 0};
-    auto term_op = stm
-                     .begin_tx(
-                       pid20,
-                       tx_seq,
-                       std::chrono::milliseconds(
-                         std::numeric_limits<int32_t>::max()),
-                       model::partition_id(0))
-                     .get();
+    auto term_op
+      = stm.begin_tx(pid20, tx_seq, timeout, model::partition_id(0)).get();
     BOOST_REQUIRE((bool)term_op);
 
     rreader = make_batches(pid20, 0, 5, true);
@@ -512,8 +476,6 @@ FIXTURE_TEST(test_aborted_transactions, rm_stm_test_fixture) {
 
     static int64_t pid_counter = 0;
     const auto tx_seq = model::tx_seq(0);
-    const auto timeout = std::chrono::milliseconds(
-      std::numeric_limits<int32_t>::max());
     size_t segment_count = 1;
 
     auto& segments = disk_log->segments();
@@ -1014,8 +976,6 @@ FIXTURE_TEST(test_lso_bound_by_open_tx, rm_stm_test_fixture) {
 
     std::optional<model::offset> earliest_open_tx;
     auto tx_and_snapshot = [&](model::tx_seq tx_seq) {
-        auto timeout = std::chrono::milliseconds(
-          std::numeric_limits<int32_t>::max());
         // begin tx
         BOOST_REQUIRE(
           stm.begin_tx(pid, tx_seq, timeout, model::partition_id(0)).get());


### PR DESCRIPTION
The main issue is if the stm is resetting state (at shutdown or applying snapshots), it may temporarily be in an inconsistent state (eg: active transactions list cleared) and a racy LSO request exactly at that point may result in overestimation of offset.  This was causing tx + compaction control batch removal test to flake during cross shard movement of replicas. 



## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
