### PR TITLE
L0 memory

### DIFF
--- a/src/v/cloud_topics/level_zero/read_fanout/BUILD
+++ b/src/v/cloud_topics/level_zero/read_fanout/BUILD
@@ -22,6 +22,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_zero/pipeline:event_filter",
         "//src/v/cloud_topics/level_zero/pipeline:read_pipeline",
         "//src/v/cloud_topics/level_zero/pipeline:read_request",
+        "//src/v/config",
         "//src/v/container:chunked_vector",
         "//src/v/model",
         "//src/v/ssx:future_util",

--- a/src/v/cloud_topics/level_zero/read_fanout/read_fanout.cc
+++ b/src/v/cloud_topics/level_zero/read_fanout/read_fanout.cc
@@ -10,12 +10,39 @@
 #include "cloud_topics/level_zero/read_fanout/read_fanout.h"
 
 #include "cloud_topics/level_zero/pipeline/read_request.h"
+#include "config/configuration.h"
 #include "container/chunked_vector.h"
 #include "ssx/future-util.h"
+
+#include <algorithm>
 
 namespace cloud_topics::l0 {
 
 constexpr size_t max_bytes_per_iter = 10_MiB;
+
+namespace {
+
+// Calculate memory estimate based on unique object IDs. This accounts
+// for the fact that we download entire L0 objects which contain data
+// from multiple partitions.
+size_t estimate_memory_for_extents(const chunked_vector<extent_meta>& extents) {
+    chunked_vector<object_id> ids;
+    ids.reserve(extents.size());
+    for (const auto& extent : extents) {
+        ids.push_back(extent.id);
+    }
+    std::ranges::sort(ids);
+    auto [first, last] = std::ranges::unique(ids);
+    auto unique_count = std::distance(ids.begin(), first);
+
+    // Use configured L0 object size target as estimate.
+    auto estimated_object_size
+      = config::shard_local_cfg()
+          .cloud_topics_produce_batching_size_threshold();
+    return unique_count * estimated_object_size;
+}
+
+} // namespace
 
 read_fanout::read_fanout(l0::read_pipeline<>::stage s)
   : _pipeline_stage(s) {}
@@ -82,6 +109,14 @@ ss::future<> read_fanout::process_single_request(l0::read_request<>* req) {
         _stats.requests_in++;
         if (req->query.meta.size() <= 1) {
             // Fast path
+            if (!req->query.meta.empty()) {
+                // Set estimate directly to save work.
+                // See estimate_memory_for_extents.
+                auto estimated_object_size
+                  = config::shard_local_cfg()
+                      .cloud_topics_produce_batching_size_threshold();
+                req->query.output_size_estimate = estimated_object_size;
+            }
             _stats.requests_out++;
             _pipeline_stage.push_next_stage(*req);
             co_return;
@@ -97,7 +132,6 @@ ss::future<> read_fanout::process_single_request(l0::read_request<>* req) {
             if (
               curr_query->meta.empty()
               || curr_query->meta.back().id == meta.id) {
-                curr_query->output_size_estimate += meta.byte_range_size();
                 curr_query->meta.push_back(meta);
                 continue;
             }
@@ -118,10 +152,12 @@ ss::future<> read_fanout::process_single_request(l0::read_request<>* req) {
 
             futures.emplace_back(std::move(fut));
             curr_query.emplace();
-            curr_query->output_size_estimate = meta.byte_range_size();
             curr_query->meta.push_back(meta);
         }
         if (!curr_query->meta.empty()) {
+            curr_query->output_size_estimate = estimate_memory_for_extents(
+              curr_query->meta);
+
             auto proxy = ss::make_lw_shared<l0::read_request<>>(
               req->ntp,
               std::move(curr_query.value()),

--- a/src/v/cloud_topics/level_zero/reader/materialized_extent.cc
+++ b/src/v/cloud_topics/level_zero/reader/materialized_extent.cc
@@ -254,7 +254,7 @@ ss::future<result<iobuf>> materialize_from_cloud_storage(
         co_return conv(dl_result.value());
     }
 
-    auto buf_str = make_iobuf_input_stream(payload.copy());
+    auto buf_str = make_iobuf_input_stream(payload.share());
     // TODO: use circuit-breaker here, if the operation fails
     // repeatedly it can be temporarily short-circuited to avoid
     // burning cycles.


### PR DESCRIPTION
This improves L0 fetch path memory usage in two ways:

1. It shares the object payload with the cache write instead of copying it.
2. It estimates the fetch memory usage as # object * expected max object size, because we materialize whole objects in memory and not just the ranges of partition data.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
