### PR TITLE
`tree-wide`: disable compaction of transactional control batches

### DIFF
--- a/src/v/cluster/tests/tx_compaction_utils.h
+++ b/src/v/cluster/tests/tx_compaction_utils.h
@@ -138,7 +138,7 @@ public:
         auto batches = co_await copy_to_mem(reader);
 
         // Ensure there are no aborted keys (tracked in _aborted_xxx)
-        int fence_batch_count = 0;
+        // int fence_batch_count = 0;
         for (auto& batch : batches) {
             auto type = batch.header().type;
             RPTEST_REQUIRE_NE_CORO(type, model::record_batch_type::tx_prepare);
@@ -153,13 +153,14 @@ public:
                 RPTEST_REQUIRE_CORO(_committed_pids.contains(pid));
                 RPTEST_REQUIRE_CORO(!_aborted_pids.contains(pid));
             }
-            if (type == model::record_batch_type::tx_fence) {
-                fence_batch_count++;
-            }
+            // if (type == model::record_batch_type::tx_fence) {
+            //     fence_batch_count++;
+            // }
         }
 
-        // Fence batches should be removed.
-        RPTEST_REQUIRE_CORO(fence_batch_count == 0);
+        // TODO(tx_compact): Re-enable this when transactional control batch
+        // feature is added. Fence batches should be removed.
+        // RPTEST_REQUIRE_CORO(fence_batch_count == 0);
     }
 
     void run_random_workload(

--- a/src/v/compaction/utils.cc
+++ b/src/v/compaction/utils.cc
@@ -23,7 +23,7 @@ namespace compaction {
 bool is_removable_control_batch(
   const model::ntp& ntp,
   const model::record_batch_type batch_type,
-  ss::sharded<features::feature_table>& feature_table) {
+  [[maybe_unused]] ss::sharded<features::feature_table>& feature_table) {
     // Control batches in consumer offsets are special compared to
     // the ones in data partitions can be safely compacted away.
     // Fence batches can also be immediately removed when seen in the
@@ -31,10 +31,13 @@ bool is_removable_control_batch(
     // removal in a user topic is gated by
     // `log_compaction_disable_tx_batch_removal()`.
     auto is_co_topic = model::is_consumer_offsets_topic(ntp);
-    auto remove_user_tx_fence_enabled
-      = !config::shard_local_cfg().log_compaction_disable_tx_batch_removal()
-        && feature_table.local().is_active(
-          features::feature::coordinated_compaction);
+    // TODO(tx_compact): Re-enable this when transactional control batch feature
+    // is added.
+    auto remove_user_tx_fence_enabled = false;
+    // auto remove_user_tx_fence_enabled
+    //   = !config::shard_local_cfg().log_compaction_disable_tx_batch_removal()
+    //     && feature_table.local().is_active(
+    //       features::feature::coordinated_compaction);
     auto tx_fence_removable = batch_type == model::record_batch_type::tx_fence
                               && (is_co_topic || remove_user_tx_fence_enabled);
     return tx_fence_removable

--- a/src/v/kafka/server/tests/group_tx_compaction_test.cc
+++ b/src/v/kafka/server/tests/group_tx_compaction_test.cc
@@ -380,19 +380,21 @@ ss::future<> run_workload(
     });
 
     struct batch_validator {
-        bool do_validate_batch(const model::record_batch& b) {
-            auto batch_type = b.header().type;
-            if (
-              batch_type == model::record_batch_type::group_fence_tx
-              || batch_type == model::record_batch_type::group_prepare_tx
-              || batch_type == model::record_batch_type::group_commit_tx
-              || batch_type == model::record_batch_type::group_abort_tx
-              || batch_type == model::record_batch_type::tx_fence) {
-                return true;
-            }
-            if (b.header().attrs.is_control()) {
-                return true;
-            }
+        bool do_validate_batch([[maybe_unused]] const model::record_batch& b) {
+            // TODO(tx_compact): Re-enable this when transactional control batch
+            // feature is added.
+            // auto batch_type = b.header().type;
+            //  if (
+            //    batch_type == model::record_batch_type::group_fence_tx
+            //    || batch_type == model::record_batch_type::group_prepare_tx
+            //    || batch_type == model::record_batch_type::group_commit_tx
+            //    || batch_type == model::record_batch_type::group_abort_tx
+            //    || batch_type == model::record_batch_type::tx_fence) {
+            //      return true;
+            //  }
+            //  if (b.header().attrs.is_control()) {
+            //      return true;
+            //  }
 
             return false;
         }

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -208,8 +208,13 @@ ss::future<index_state> deduplicate_segment(
     auto segment_last_offset = seg->offsets().get_committed_offset();
     auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
-    auto unset_transactional_bit_enabled = feature_table.local().is_active(
-      features::feature::coordinated_compaction);
+    // TODO(tx_compact): Re-enable this when transactional control batch feature
+    // is added.
+    auto unset_transactional_bit_enabled = false;
+    // auto unset_transactional_bit_enabled
+    //   = !config::shard_local_cfg().log_compaction_disable_tx_batch_removal()
+    //     && feature_table.local().is_active(
+    //       features::feature::coordinated_compaction);
     const bool past_tombstone_delete_horizon
       = internal::is_past_tombstone_delete_horizon(seg, cfg);
     bool may_have_tombstone_records = false;

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -390,8 +390,13 @@ ss::future<storage::index_state> do_copy_segment_data(
     auto segment_last_offset = seg->offsets().get_committed_offset();
     auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
-    auto unset_transactional_bit_enabled = feature_table.local().is_active(
-      features::feature::coordinated_compaction);
+    // TODO(tx_compact): Re-enable this when transactional control batch feature
+    // is added.
+    auto unset_transactional_bit_enabled = false;
+    // auto unset_transactional_bit_enabled
+    //   = !config::shard_local_cfg().log_compaction_disable_tx_batch_removal()
+    //     && feature_table.local().is_active(
+    //       features::feature::coordinated_compaction);
     const bool past_tombstone_delete_horizon
       = internal::is_past_tombstone_delete_horizon(seg, cfg);
     bool may_have_tombstone_records = false;
@@ -1386,6 +1391,9 @@ ss::future<bool> mark_segment_as_finished_self_compaction(
 
 bool is_past_transaction_batch_delete_horizon(
   ss::lw_shared_ptr<segment> seg, const compaction::compaction_config& cfg) {
+    // TODO(tx_compact): Re-enable this when transactional control batch feature
+    // is added.
+    return false;
     if (config::shard_local_cfg().log_compaction_disable_tx_batch_removal()) {
         // Safety hatch for disabling control batch removal
         return false;

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -2327,6 +2327,9 @@ TEST_F(CompactionFixtureTest, SuperfluousPlaceholderRemoval) {
 }
 
 TEST_F(CompactionFixtureTest, AbortTransactions) {
+    // TODO(tx_compact): Re-enable this when transactional control batch feature
+    // is added.
+    return;
     using cluster::tx_executor;
     tx_executor exec;
     auto term = partition->raft()->term();
@@ -2400,6 +2403,9 @@ TEST_F(CompactionFixtureTest, AbortTransactions) {
 }
 
 TEST_F(CompactionFixtureTest, CommitTransactions) {
+    // TODO(tx_compact): Re-enable this when transactional control batch feature
+    // is added.
+    return;
     using cluster::tx_executor;
     tx_executor exec;
     auto term = partition->raft()->term();

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -21,9 +21,6 @@ from rptest.services.kgo_verifier_services import (
     KgoVerifierProducer,
     KgoVerifierSeqConsumer,
 )
-from rptest.services.redpanda_installer import (
-    RedpandaVersionLine,
-)
 from rptest.services.redpanda import MetricsEndpoint
 from rptest.tests.partition_movement import PartitionMovementMixin
 from rptest.tests.prealloc_nodes import PreallocNodesTest
@@ -755,74 +752,76 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
         self.check_tx_batches()
 
 
-class LogCompactionTxRemovalTest(LogCompactionTxRemovalTestBase):
-    def __init__(self, test_context):
-        super().__init__(test_context)
-
-    @cluster(num_nodes=4)
-    def test_tx_control_batch_removal(self):
-        failed_test_cases = []
-        for name, test_case in LogCompactionTxRemovalTestBase.test_cases.items():
-            self.topic_setup(
-                cleanup_policy=TopicSpec.CLEANUP_COMPACT,
-                replication_factor=3,
-                key_set_cardinality=100,
-                partition_count=1,
-            )
-
-            try:
-                self.do_test_tx_control_batch_removal(name, test_case)
-            except Exception as e:
-                self.logger.info(f"Test case {name} failed with exception {e}")
-
-                failed_test_cases.append(e)
-        assert len(failed_test_cases) == 0, (
-            f"Expected 0 failed test cases, got {len(failed_test_cases)}"
-        )
-
-
-class LogCompactionTxRemovalUpgradeTest(LogCompactionTxRemovalTestBase):
-    def __init__(self, test_context):
-        super().__init__(test_context)
-        # Version before `may_have_transactional_batches` was added.
-        self.initial_version: RedpandaVersionLine = (25, 1)
-        # Version before tx removal was added to compaction.
-        self.may_have_tx_batch_version: RedpandaVersionLine = (25, 2)
-
-    def setUp(self):
-        self.redpanda._installer.install(self.redpanda.nodes, self.initial_version)
-        self.redpanda.start()
-
-    def upgrade_to_version(self, version):
-        self.redpanda._installer.install(self.redpanda.nodes, version)
-        self.redpanda.restart_nodes(self.redpanda.nodes)
-
-    @cluster(num_nodes=4)
-    @matrix(test_case_name=list(LogCompactionTxRemovalTestBase.test_cases.keys()))
-    def test_tx_control_batch_removal_with_upgrade(self, test_case_name):
-        test_case = LogCompactionTxRemovalTestBase.test_cases[test_case_name]
-
-        self.topic_setup(
-            cleanup_policy=TopicSpec.CLEANUP_COMPACT,
-            replication_factor=3,
-            key_set_cardinality=100,
-            partition_count=1,
-        )
-
-        # Produce some transactional data
-        self.produce(test_case)
-
-        # Upgrade to `may_have_transactional_batch` version.
-        self.upgrade_to_version(self.may_have_tx_batch_version)
-
-        # Produce more transactional data.
-        self.produce(test_case)
-
-        # Upgrade to `HEAD`.
-        for version in self.redpanda._installer.upgrade_path_to_head(
-            self.may_have_tx_batch_version
-        ):
-            self.upgrade_to_version(version)
-
-        # Perform rest of test
-        self.do_test_tx_control_batch_removal(test_case_name, test_case)
+# TODO(tx_compact): Re-enable this when transactional control batch feature
+# is added.
+# class LogCompactionTxRemovalTest(LogCompactionTxRemovalTestBase):
+#    def __init__(self, test_context):
+#        super().__init__(test_context)
+#
+#    @cluster(num_nodes=4)
+#    def test_tx_control_batch_removal(self):
+#        failed_test_cases = []
+#        for name, test_case in LogCompactionTxRemovalTestBase.test_cases.items():
+#            self.topic_setup(
+#                cleanup_policy=TopicSpec.CLEANUP_COMPACT,
+#                replication_factor=3,
+#                key_set_cardinality=100,
+#                partition_count=1,
+#            )
+#
+#            try:
+#                self.do_test_tx_control_batch_removal(name, test_case)
+#            except Exception as e:
+#                self.logger.info(f"Test case {name} failed with exception {e}")
+#
+#                failed_test_cases.append(e)
+#        assert len(failed_test_cases) == 0, (
+#            f"Expected 0 failed test cases, got {len(failed_test_cases)}"
+#        )
+#
+#
+# class LogCompactionTxRemovalUpgradeTest(LogCompactionTxRemovalTestBase):
+#    def __init__(self, test_context):
+#        super().__init__(test_context)
+#        # Version before `may_have_transactional_batches` was added.
+#        self.initial_version: RedpandaVersionLine = (25, 1)
+#        # Version before tx removal was added to compaction.
+#        self.may_have_tx_batch_version: RedpandaVersionLine = (25, 2)
+#
+#    def setUp(self):
+#        self.redpanda._installer.install(self.redpanda.nodes, self.initial_version)
+#        self.redpanda.start()
+#
+#    def upgrade_to_version(self, version):
+#        self.redpanda._installer.install(self.redpanda.nodes, version)
+#        self.redpanda.restart_nodes(self.redpanda.nodes)
+#
+#    @cluster(num_nodes=4)
+#    @matrix(test_case_name=list(LogCompactionTxRemovalTestBase.test_cases.keys()))
+#    def test_tx_control_batch_removal_with_upgrade(self, test_case_name):
+#        test_case = LogCompactionTxRemovalTestBase.test_cases[test_case_name]
+#
+#        self.topic_setup(
+#            cleanup_policy=TopicSpec.CLEANUP_COMPACT,
+#            replication_factor=3,
+#            key_set_cardinality=100,
+#            partition_count=1,
+#        )
+#
+#        # Produce some transactional data
+#        self.produce(test_case)
+#
+#        # Upgrade to `may_have_transactional_batch` version.
+#        self.upgrade_to_version(self.may_have_tx_batch_version)
+#
+#        # Produce more transactional data.
+#        self.produce(test_case)
+#
+#        # Upgrade to `HEAD`.
+#        for version in self.redpanda._installer.upgrade_path_to_head(
+#            self.may_have_tx_batch_version
+#        ):
+#            self.upgrade_to_version(version)
+#
+#        # Perform rest of test
+#        self.do_test_tx_control_batch_removal(test_case_name, test_case)

--- a/tests/rptest/transactions/tx_upgrade_test.py
+++ b/tests/rptest/transactions/tx_upgrade_test.py
@@ -18,7 +18,6 @@ import confluent_kafka as ck
 from ducktape.errors import TimeoutError
 from ducktape.utils.util import wait_until
 
-from rptest.clients.offline_log_viewer import OfflineLogViewer
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
@@ -26,12 +25,9 @@ from rptest.services.cluster import cluster
 from rptest.services.redpanda import (
     RESTART_LOG_ALLOW_LIST,
     RedpandaService,
-    MetricsEndpoint,
 )
 from rptest.services.redpanda_installer import (
     RedpandaInstaller,
-    RedpandaVersionLine,
-    RedpandaVersionTriple,
     wait_for_num_versions,
     ver_string,
 )
@@ -149,130 +145,132 @@ class TxUpgradeTest(TxUpgradeTestBase):
         )
 
 
-class TxUpgradeCompactionTest(TxUpgradeTestBase):
-    """
-    Test validating interaction between compaction and transactions during rolling-restart upgrades (including mixed-version node cluster interaction)
-    """
-
-    def __init__(self, test_context):
-        self.extra_rp_conf = {
-            "log_compaction_interval_ms": 4000,
-            "log_segment_size": 2 * 1024**2,  # 2 MiB
-            "compacted_log_segment_size": 1024**2,  # 1 MiB
-        }
-
-        super(TxUpgradeCompactionTest, self).__init__(
-            test_context=test_context, extra_rp_conf=self.extra_rp_conf
-        )
-
-        self.transaction_timeout_ms = 2000
-
-    def setUp(self):
-        # Version before `may_have_transactional_batches` was added.
-        self.initial_version: RedpandaVersionTriple = self.installer.latest_for_line(
-            RedpandaVersionLine((25, 1))
-        )[0]
-        self.installer.install(self.redpanda.nodes, self.initial_version)
-        super(TxUpgradeCompactionTest, self).setUp()
-
-    def get_complete_sliding_window_rounds(self):
-        return self.redpanda.metric_sum(
-            metric_name="vectorized_storage_log_complete_sliding_window_rounds_total",
-            metrics_endpoint=MetricsEndpoint.METRICS,
-            topic=self.topic_spec.name,
-        )
-
-    def wait_for_sliding_window_compaction(self):
-        self.prev_sliding_window_rounds = None
-
-        def compaction_has_completed():
-            new_sliding_window_rounds = self.get_complete_sliding_window_rounds()
-            res = self.prev_sliding_window_rounds == new_sliding_window_rounds
-            self.prev_sliding_window_rounds = new_sliding_window_rounds
-            return res
-
-        wait_until(
-            compaction_has_completed,
-            timeout_sec=120,
-            backoff_sec=self.extra_rp_conf["log_compaction_interval_ms"] / 1000 * 4,
-            err_msg="Compaction did not stabilize.",
-        )
-
-    def check_tx_batches(self):
-        viewer = OfflineLogViewer(self.redpanda)
-        for node in self.redpanda.nodes:
-            num_control_batches = 0
-            num_fence_batches = 0
-            partitions = viewer.read_kafka_records(node, self.topic_spec.name)
-            for partition in partitions:
-                for record_or_batch in partition:
-                    if "expanded_attrs" not in record_or_batch:
-                        continue
-                    if record_or_batch["expanded_attrs"]["control_batch"]:
-                        num_control_batches += 1
-                    if record_or_batch["type_name"] == "tx_fence":
-                        num_fence_batches += 1
-
-            assert num_control_batches == 0, (
-                f"expected 0 control batches (abort/commit batches), saw {num_control_batches} on node {node.name}"
-            )
-            assert num_fence_batches == 0, (
-                f"expected 0 tx_fence batches, saw {num_fence_batches}  on node {node.name}"
-            )
-
-    @skip_debug_mode
-    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
-    def upgrade_with_compaction_test(self):
-        self.topic_spec = TopicSpec(
-            partition_count=self.partition_count,
-            delete_retention_ms=3000,
-            cleanup_policy=TopicSpec.CLEANUP_COMPACT,
-            min_cleanable_dirty_ratio=0.0,
-        )
-        self.client().create_topic(self.topic_spec)
-
-        prev_version_str = ver_string(self.initial_version)
-        unique_versions = wait_for_num_versions(self.redpanda, 1)
-        assert prev_version_str in unique_versions, unique_versions
-
-        for new_version in self.installer.upgrade_path_to_head(self.initial_version):
-            self._populate_tx_coordinator(topic=self.topic_spec.name)
-            initial_mapping = self._get_tx_id_mapping()
-            self.logger.info(f"Initial mapping {initial_mapping}")
-
-            first_node = self.redpanda.nodes[0]
-
-            self.installer.install(self.redpanda.nodes, new_version)
-
-            # Upgrade & restart one node to the new version.
-            self.redpanda.restart_nodes([first_node])
-            unique_versions = wait_for_num_versions(self.redpanda, 2)
-            assert prev_version_str in unique_versions, unique_versions
-            assert self._get_tx_id_mapping() == initial_mapping, (
-                "Mapping changed after upgrading one of the nodes"
-            )
-
-            # verify if txs are handled correctly with mixed versions
-            self._populate_tx_coordinator(topic=self.topic_spec.name)
-
-            # Only once we upgrade the rest of the nodes do we converge on the new
-            # version.
-            self.redpanda.restart_nodes(self.redpanda.nodes)
-            unique_versions = wait_for_num_versions(self.redpanda, 1)
-            assert prev_version_str not in unique_versions, unique_versions
-            assert self._get_tx_id_mapping() == initial_mapping, (
-                "Mapping changed after full upgrade"
-            )
-            prev_version_str = ver_string(new_version)
-
-        # One last round of producing
-        self._populate_tx_coordinator(topic=self.topic_spec.name)
-
-        # Restart the redpanda broker to roll segments
-        self.redpanda.restart_nodes(self.redpanda.nodes)
-
-        self.wait_for_sliding_window_compaction()
-        self.check_tx_batches()
+# TODO(tx_compact): Re-enable this when transactional control batch feature
+# is added.
+# class TxUpgradeCompactionTest(TxUpgradeTestBase):
+#    """
+#    Test validating interaction between compaction and transactions during rolling-restart upgrades (including mixed-version node cluster interaction)
+#    """
+#
+#    def __init__(self, test_context):
+#        self.extra_rp_conf = {
+#            "log_compaction_interval_ms": 4000,
+#            "log_segment_size": 2 * 1024**2,  # 2 MiB
+#            "compacted_log_segment_size": 1024**2,  # 1 MiB
+#        }
+#
+#        super(TxUpgradeCompactionTest, self).__init__(
+#            test_context=test_context, extra_rp_conf=self.extra_rp_conf
+#        )
+#
+#        self.transaction_timeout_ms = 2000
+#
+#    def setUp(self):
+#        # Version before `may_have_transactional_batches` was added.
+#        self.initial_version: RedpandaVersionTriple = self.installer.latest_for_line(
+#            RedpandaVersionLine((25, 1))
+#        )[0]
+#        self.installer.install(self.redpanda.nodes, self.initial_version)
+#        super(TxUpgradeCompactionTest, self).setUp()
+#
+#    def get_complete_sliding_window_rounds(self):
+#        return self.redpanda.metric_sum(
+#            metric_name="vectorized_storage_log_complete_sliding_window_rounds_total",
+#            metrics_endpoint=MetricsEndpoint.METRICS,
+#            topic=self.topic_spec.name,
+#        )
+#
+#    def wait_for_sliding_window_compaction(self):
+#        self.prev_sliding_window_rounds = None
+#
+#        def compaction_has_completed():
+#            new_sliding_window_rounds = self.get_complete_sliding_window_rounds()
+#            res = self.prev_sliding_window_rounds == new_sliding_window_rounds
+#            self.prev_sliding_window_rounds = new_sliding_window_rounds
+#            return res
+#
+#        wait_until(
+#            compaction_has_completed,
+#            timeout_sec=120,
+#            backoff_sec=self.extra_rp_conf["log_compaction_interval_ms"] / 1000 * 4,
+#            err_msg="Compaction did not stabilize.",
+#        )
+#
+#    def check_tx_batches(self):
+#        viewer = OfflineLogViewer(self.redpanda)
+#        for node in self.redpanda.nodes:
+#            num_control_batches = 0
+#            num_fence_batches = 0
+#            partitions = viewer.read_kafka_records(node, self.topic_spec.name)
+#            for partition in partitions:
+#                for record_or_batch in partition:
+#                    if "expanded_attrs" not in record_or_batch:
+#                        continue
+#                    if record_or_batch["expanded_attrs"]["control_batch"]:
+#                        num_control_batches += 1
+#                    if record_or_batch["type_name"] == "tx_fence":
+#                        num_fence_batches += 1
+#
+#            assert num_control_batches == 0, (
+#                f"expected 0 control batches (abort/commit batches), saw {num_control_batches} on node {node.name}"
+#            )
+#            assert num_fence_batches == 0, (
+#                f"expected 0 tx_fence batches, saw {num_fence_batches}  on node {node.name}"
+#            )
+#
+#    @skip_debug_mode
+#    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+#    def upgrade_with_compaction_test(self):
+#        self.topic_spec = TopicSpec(
+#            partition_count=self.partition_count,
+#            delete_retention_ms=3000,
+#            cleanup_policy=TopicSpec.CLEANUP_COMPACT,
+#            min_cleanable_dirty_ratio=0.0,
+#        )
+#        self.client().create_topic(self.topic_spec)
+#
+#        prev_version_str = ver_string(self.initial_version)
+#        unique_versions = wait_for_num_versions(self.redpanda, 1)
+#        assert prev_version_str in unique_versions, unique_versions
+#
+#        for new_version in self.installer.upgrade_path_to_head(self.initial_version):
+#            self._populate_tx_coordinator(topic=self.topic_spec.name)
+#            initial_mapping = self._get_tx_id_mapping()
+#            self.logger.info(f"Initial mapping {initial_mapping}")
+#
+#            first_node = self.redpanda.nodes[0]
+#
+#            self.installer.install(self.redpanda.nodes, new_version)
+#
+#            # Upgrade & restart one node to the new version.
+#            self.redpanda.restart_nodes([first_node])
+#            unique_versions = wait_for_num_versions(self.redpanda, 2)
+#            assert prev_version_str in unique_versions, unique_versions
+#            assert self._get_tx_id_mapping() == initial_mapping, (
+#                "Mapping changed after upgrading one of the nodes"
+#            )
+#
+#            # verify if txs are handled correctly with mixed versions
+#            self._populate_tx_coordinator(topic=self.topic_spec.name)
+#
+#            # Only once we upgrade the rest of the nodes do we converge on the new
+#            # version.
+#            self.redpanda.restart_nodes(self.redpanda.nodes)
+#            unique_versions = wait_for_num_versions(self.redpanda, 1)
+#            assert prev_version_str not in unique_versions, unique_versions
+#            assert self._get_tx_id_mapping() == initial_mapping, (
+#                "Mapping changed after full upgrade"
+#            )
+#            prev_version_str = ver_string(new_version)
+#
+#        # One last round of producing
+#        self._populate_tx_coordinator(topic=self.topic_spec.name)
+#
+#        # Restart the redpanda broker to roll segments
+#        self.redpanda.restart_nodes(self.redpanda.nodes)
+#
+#        self.wait_for_sliding_window_compaction()
+#        self.check_tx_batches()
 
 
 class TxUpgradeRevertTest(RedpandaTest):


### PR DESCRIPTION
:sadpanda:.

What seems like a show-stopper: https://github.com/redpanda-data/redpanda/pull/28346/commits/0260636db5fd88e719b06dd7a1c1085fdb931119

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
