### PR TITLE
ct/reconciler: Add debug log after adding objects

### DIFF
--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -677,6 +677,11 @@ ss::future<std::expected<void, reconcile_error>> reconciler::commit_objects(
           add_objects_result.error()));
     }
 
+    vlog(
+      lg.debug,
+      "Successfully added {} objects to L1 metastore",
+      objects.size());
+
     // Now update the LRO, taking into account any corrections from
     // the metastore.
     const auto& corrected_next_offsets


### PR DESCRIPTION
Just a lil helpful log.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
