### PR TITLE
[CORE-13254] ct: calculate global gc eligible L0 epoch

### DIFF
--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -106,6 +106,7 @@ ss::future<> app::construct(
       ss::sharded_parameter([&] { return &remote->local(); }),
       bucket,
       &controller->get_health_monitor(),
+      &controller->get_controller_stm(),
       &controller->get_topics_state());
 
     co_await construct_service(housekeeper_manager, ss::sharded_parameter([&] {

--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -105,7 +105,8 @@ ss::future<> app::construct(
       l0_gc,
       ss::sharded_parameter([&] { return &remote->local(); }),
       bucket,
-      &controller->get_health_monitor());
+      &controller->get_health_monitor(),
+      &controller->get_topics_state());
 
     co_await construct_service(housekeeper_manager, ss::sharded_parameter([&] {
                                    return &replicated_metastore.local();

--- a/src/v/cloud_topics/level_zero/gc/BUILD
+++ b/src/v/cloud_topics/level_zero/gc/BUILD
@@ -20,6 +20,7 @@ redpanda_cc_library(
         "//src/v/cloud_io:io_result",
         "//src/v/cloud_storage_clients",
         "//src/v/cloud_topics:types",
+        "//src/v/container:chunked_hash_map",
         "//src/v/model",
         "@seastar",
     ],

--- a/src/v/cloud_topics/level_zero/gc/BUILD
+++ b/src/v/cloud_topics/level_zero/gc/BUILD
@@ -1,6 +1,21 @@
 load("//bazel:build.bzl", "redpanda_cc_library")
 
 redpanda_cc_library(
+    name = "level_zero_gc_probe",
+    srcs = [
+        "level_zero_gc_probe.cc",
+    ],
+    hdrs = [
+        "level_zero_gc_probe.h",
+    ],
+    deps = [
+        "//src/v/metrics",
+        "@fmt",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "level_zero_gc",
     srcs = [
         "level_zero_gc.cc",
@@ -17,6 +32,7 @@ redpanda_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":level_zero_gc_probe",
         "//src/v/cloud_io:io_result",
         "//src/v/cloud_storage_clients",
         "//src/v/cloud_topics:types",

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -69,6 +69,68 @@ private:
     const cloud_storage_clients::bucket_name bucket_;
 };
 
+seastar::future<std::expected<std::optional<cluster_epoch>, std::string>>
+level_zero_gc::cluster_support::max_gc_eligible_epoch(
+  seastar::abort_source* as) {
+    /*
+     * First retrieve a consistent snapshot of cloud topic partitions. This
+     * establishes a set of partitions from which we must obtain an epoch
+     * bound on garbage collection.
+     */
+    auto partitions = co_await get_partitions(as);
+    if (!partitions.has_value()) {
+        co_return std::unexpected(partitions.error());
+    }
+    if (partitions.value().partitions.empty()) {
+        co_return std::nullopt;
+    }
+
+    /*
+     * Next we retrieve the latest reported epoch bounds from all cloud
+     * topic partitions. The source for this information is distributed,
+     * while the source for the `partitions` set above is centralized, and
+     * this is why we have these two different collection steps.
+     */
+    auto gc_epochs = co_await get_partitions_max_gc_epoch(as);
+    if (!gc_epochs.has_value()) {
+        co_return std::unexpected(gc_epochs.error());
+    }
+
+    /*
+     * The final result begins as the maximum epoch for the given snapshot.
+     * Below we merge the two result sets and walk the final result back to
+     * account for the partition with the smallest eligible gc epoch.
+     */
+    auto result = cluster_epoch(partitions.value().last_applied());
+
+    for (const auto& partition : partitions.value().partitions) {
+        const auto& tp_ns = partition.first;
+        auto nit = gc_epochs.value().find(tp_ns);
+        if (nit == gc_epochs.value().end()) {
+            co_return std::unexpected(
+              fmt::format(
+                "Topic '{}' in snapshot has no reported max GC epoch", tp_ns));
+        }
+
+        for (const auto p_id : partition.second) {
+            auto pit = nit->second.find(p_id);
+            if (pit == nit->second.end()) {
+                co_return std::unexpected(
+                  fmt::format(
+                    "Partition '{}/{}' in snapshot has no reported max GC "
+                    "epoch",
+                    tp_ns,
+                    p_id));
+            }
+
+            // this partition may hold back the max GC eligible epoch
+            result = std::min(result, pit->second);
+        }
+    }
+
+    co_return result;
+}
+
 class cluster_support_impl : public level_zero_gc::cluster_support {
 public:
     explicit cluster_support_impl(
@@ -183,68 +245,6 @@ public:
 
             if (as && as->abort_requested()) {
                 co_return std::unexpected("Abort requested");
-            }
-        }
-
-        co_return result;
-    }
-
-    seastar::future<std::expected<std::optional<cluster_epoch>, std::string>>
-    max_gc_eligible_epoch(seastar::abort_source* as) override {
-        /*
-         * First retrieve a consistent snapshot of cloud topic partitions. This
-         * establishes a set of partitions from which we must obtain an epoch
-         * bound on garbage collection.
-         */
-        auto partitions = co_await get_partitions(as);
-        if (!partitions.has_value()) {
-            co_return std::unexpected(partitions.error());
-        }
-        if (partitions.value().partitions.empty()) {
-            co_return std::nullopt;
-        }
-
-        /*
-         * Next we retrieve the latest reported epoch bounds from all cloud
-         * topic partitions. The source for this information is distributed,
-         * while the source for the `partitions` set above is centralized, and
-         * this is why we have these two different collection steps.
-         */
-        auto gc_epochs = co_await get_partitions_max_gc_epoch(as);
-        if (!gc_epochs.has_value()) {
-            co_return std::unexpected(gc_epochs.error());
-        }
-
-        /*
-         * The final result begins as the maximum epoch for the given snapshot.
-         * Below we merge the two result sets and walk the final result back to
-         * account for the partition with the smallest eligible gc epoch.
-         */
-        auto result = cluster_epoch(partitions.value().last_applied());
-
-        for (const auto& partition : partitions.value().partitions) {
-            const auto& tp_ns = partition.first;
-            auto nit = gc_epochs.value().find(tp_ns);
-            if (nit == gc_epochs.value().end()) {
-                co_return std::unexpected(
-                  fmt::format(
-                    "Topic '{}' in snapshot has no reported max GC epoch",
-                    tp_ns));
-            }
-
-            for (const auto p_id : partition.second) {
-                auto pit = nit->second.find(p_id);
-                if (pit == nit->second.end()) {
-                    co_return std::unexpected(
-                      fmt::format(
-                        "Partition '{}/{}' in snapshot has no reported max GC "
-                        "epoch",
-                        tp_ns,
-                        p_id));
-                }
-
-                // this partition may hold back the max GC eligible epoch
-                result = std::min(result, pit->second);
             }
         }
 

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -70,8 +70,7 @@ private:
 };
 
 seastar::future<std::expected<std::optional<cluster_epoch>, std::string>>
-level_zero_gc::cluster_support::max_gc_eligible_epoch(
-  seastar::abort_source* as) {
+level_zero_gc::epoch_source::max_gc_eligible_epoch(seastar::abort_source* as) {
     /*
      * First retrieve a consistent snapshot of cloud topic partitions. This
      * establishes a set of partitions from which we must obtain an epoch
@@ -146,9 +145,9 @@ level_zero_gc::cluster_support::max_gc_eligible_epoch(
     co_return result;
 }
 
-class cluster_support_impl : public level_zero_gc::cluster_support {
+class epoch_source_impl : public level_zero_gc::epoch_source {
 public:
-    explicit cluster_support_impl(
+    explicit epoch_source_impl(
       seastar::sharded<cluster::health_monitor_frontend>* health_monitor,
       seastar::sharded<cluster::controller_stm>* controller_stm,
       seastar::sharded<cluster::topic_table>* topic_table)
@@ -324,10 +323,10 @@ private:
 level_zero_gc::level_zero_gc(
   level_zero_gc_config config,
   std::unique_ptr<object_storage> storage,
-  std::unique_ptr<cluster_support> cluster_support)
+  std::unique_ptr<epoch_source> epoch_source)
   : config_(config)
   , storage_(std::move(storage))
-  , cluster_support_(std::move(cluster_support))
+  , epoch_source_(std::move(epoch_source))
   , should_run_(false) // begin in a stopped state
   , should_shutdown_(false)
   , worker_(worker())
@@ -343,7 +342,7 @@ level_zero_gc::level_zero_gc(
   : level_zero_gc(
       config,
       std::make_unique<object_storage_remote_impl>(remote, std::move(bucket)),
-      std::make_unique<cluster_support_impl>(
+      std::make_unique<epoch_source_impl>(
         health_monitor, controller_stm, topic_table)) {}
 
 void level_zero_gc::start() {
@@ -440,7 +439,7 @@ level_zero_gc::try_to_collect() {
     }
 
     const auto maybe_max_gc_epoch
-      = co_await cluster_support_->max_gc_eligible_epoch(&asrc_);
+      = co_await epoch_source_->max_gc_eligible_epoch(&asrc_);
     if (!maybe_max_gc_epoch.has_value()) {
         vlog(
           cd_log.debug,

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -238,11 +238,21 @@ public:
                 const auto& tp_ns = topic_status.first;
                 for (const auto& partition_status : topic_status.second) {
                     /*
-                     * partition_status is the partition health reported by a
-                     * replica. a reported epoch is valid when it is collected,
-                     * independent of the replica's current leadership status.
-                     * we reduce across replicas using `max` because that is the
-                     * most optimistic value we can take.
+                     * calculate the max gc epoch for each partition. the catch
+                     * here is that this value is reported through the health
+                     * reporting system, and that system reports information for
+                     * all partition replicas (leader and followers). so how do
+                     * we know which value to use here? first, the max gc epoch
+                     * only increases in value. second, we recognize that
+                     * all reported values from any replica are valid at (and
+                     * forever after) the moment they are reported. third, only
+                     * the leader advances the epoch.
+                     *
+                     * because of the second point, using max gc epoch from any
+                     * replica will result in correct behavior, however it may
+                     * be pessimistic. using the one from the leader is better,
+                     * but leadership is a lagging signal. instead, we can take
+                     * the maximum reported as the most optimistic value.
                      *
                      * if a replica reports no epoch then it is considered to be
                      * in an indeterminite state and it has no affect on the

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -150,8 +150,10 @@ class cluster_support_impl : public level_zero_gc::cluster_support {
 public:
     explicit cluster_support_impl(
       seastar::sharded<cluster::health_monitor_frontend>* health_monitor,
+      seastar::sharded<cluster::controller_stm>* controller_stm,
       seastar::sharded<cluster::topic_table>* topic_table)
       : health_monitor_(health_monitor)
+      , controller_stm_(controller_stm)
       , topic_table_(topic_table) {}
 
     seastar::future<std::expected<partitions_snapshot, std::string>>
@@ -161,8 +163,17 @@ public:
         // this revision is for detecting concurrent modifications
         const auto iter_start_rev = topic_table.topics_map_revision();
 
+        /*
+         * The controller stm last applied offset is used, as opposed to using
+         * the topic table last applied offset, because we need the version to
+         * move forward. the controller stm offset is a at the top of the stm
+         * hierarchy and is consistent with the topic table last applied offset.
+         */
         partitions_snapshot snap;
-        snap.last_applied = topic_table.last_applied_revision();
+        snap.last_applied = co_await controller_stm_->invoke_on(
+          cluster::controller_stm_shard, [](auto& stm) {
+              return model::revision_id(stm.get_last_applied_offset());
+          });
 
         for (const auto& topic : topic_table.topics_map()) {
             // we only care about cloud topics
@@ -268,6 +279,7 @@ public:
 
 private:
     seastar::sharded<cluster::health_monitor_frontend>* health_monitor_;
+    seastar::sharded<cluster::controller_stm>* controller_stm_;
     seastar::sharded<cluster::topic_table>* topic_table_;
 };
 
@@ -287,12 +299,14 @@ level_zero_gc::level_zero_gc(
   cloud_io::remote* remote,
   cloud_storage_clients::bucket_name bucket,
   seastar::sharded<cluster::health_monitor_frontend>* health_monitor,
+  seastar::sharded<cluster::controller_stm>* controller_stm,
   seastar::sharded<cluster::topic_table>* topic_table,
   level_zero_gc_config config)
   : level_zero_gc(
       config,
       std::make_unique<object_storage_remote_impl>(remote, std::move(bucket)),
-      std::make_unique<cluster_support_impl>(health_monitor, topic_table)) {}
+      std::make_unique<cluster_support_impl>(
+        health_monitor, controller_stm, topic_table)) {}
 
 void level_zero_gc::start() {
     vlog(cd_log.info, "Starting cloud topics L0 GC worker");

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -14,6 +14,7 @@
 #include "cloud_topics/logger.h"
 #include "cloud_topics/object_utils.h"
 #include "cluster/health_monitor_frontend.h"
+#include "cluster/topic_table.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/sleep.hh>
@@ -71,8 +72,10 @@ private:
 class epoch_source_cluster_impl : public level_zero_gc::epoch_source {
 public:
     explicit epoch_source_cluster_impl(
-      seastar::sharded<cluster::health_monitor_frontend>* health_monitor)
-      : health_monitor_(health_monitor) {}
+      seastar::sharded<cluster::health_monitor_frontend>* health_monitor,
+      seastar::sharded<cluster::topic_table>* topic_table)
+      : health_monitor_(health_monitor)
+      , topic_table_(topic_table) {}
 
     seastar::future<std::expected<std::optional<cluster_epoch>, std::string>>
     max_gc_eligible_epoch(seastar::abort_source*) override {
@@ -86,6 +89,7 @@ public:
 private:
     [[maybe_unused]] seastar::sharded<cluster::health_monitor_frontend>*
       health_monitor_;
+    [[maybe_unused]] seastar::sharded<cluster::topic_table>* topic_table_;
 };
 
 level_zero_gc::level_zero_gc(
@@ -103,11 +107,13 @@ level_zero_gc::level_zero_gc(
   cloud_io::remote* remote,
   cloud_storage_clients::bucket_name bucket,
   seastar::sharded<cluster::health_monitor_frontend>* health_monitor,
+  seastar::sharded<cluster::topic_table>* topic_table,
   level_zero_gc_config config)
   : level_zero_gc(
       config,
       std::make_unique<object_storage_remote_impl>(remote, std::move(bucket)),
-      std::make_unique<epoch_source_cluster_impl>(health_monitor)) {}
+      std::make_unique<epoch_source_cluster_impl>(
+        health_monitor, topic_table)) {}
 
 void level_zero_gc::start() {
     vlog(cd_log.info, "Starting cloud topics L0 GC worker");

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -280,7 +280,8 @@ level_zero_gc::level_zero_gc(
   , cluster_support_(std::move(cluster_support))
   , should_run_(false) // begin in a stopped state
   , should_shutdown_(false)
-  , worker_(worker()) {}
+  , worker_(worker())
+  , probe_(config::shard_local_cfg().disable_metrics()) {}
 
 level_zero_gc::level_zero_gc(
   cloud_io::remote* remote,
@@ -490,6 +491,8 @@ level_zero_gc::try_to_collect() {
           res.error());
         co_return std::unexpected(collection_error::service_error);
     }
+
+    probe_.objects_deleted(num_eligible);
 
     vlog(
       cd_log.debug, "Deleted {} L0 data objects eligible for GC", num_eligible);

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -77,19 +77,183 @@ public:
       : health_monitor_(health_monitor)
       , topic_table_(topic_table) {}
 
-    seastar::future<std::expected<std::optional<cluster_epoch>, std::string>>
-    max_gc_eligible_epoch(seastar::abort_source*) override {
+    seastar::future<std::expected<partitions_snapshot, std::string>>
+    get_partitions(seastar::abort_source* as) override {
+        const auto& topic_table = topic_table_->local();
+
+        // this revision is for detecting concurrent modifications
+        const auto iter_start_rev = topic_table.topics_map_revision();
+
+        partitions_snapshot snap;
+        snap.last_applied = topic_table.last_applied_revision();
+
+        for (const auto& topic : topic_table.topics_map()) {
+            // we only care about cloud topics
+            if (!topic.second.get_metadata()
+                   .get_configuration()
+                   .is_cloud_topic()) {
+                continue;
+            }
+
+            auto& partitions = snap.partitions[topic.first];
+            for (const auto& partition : topic.second.partitions) {
+                partitions.push_back(model::partition_id(partition.first));
+            }
+
+            co_await seastar::maybe_yield();
+
+            if (as && as->abort_requested()) {
+                co_return std::unexpected("Abort requested");
+            }
+
+            // Detect concurrent changes to the topic table.
+            topic_table.check_topics_map_stable(iter_start_rev);
+        }
+
+        co_return snap;
+    }
+
+    seastar::future<std::expected<partitions_max_gc_epoch, std::string>>
+    get_partitions_max_gc_epoch(seastar::abort_source* as) override {
         /*
-         * TODO(noah): missing an integration of epochs with the partition
-         * table. for now we report no eligible epoch.
+         * Get a recent health report. Partitions use the health reporting
+         * mechanism to self-report their max GC eligible epoch.
          */
-        co_return std::nullopt;
+        constexpr auto health_report_query_timeout = 10s;
+
+        auto health_report
+          = co_await health_monitor_->local().get_cluster_health(
+            cluster::cluster_report_filter{},
+            cluster::force_refresh::no,
+            model::timeout_clock::now() + health_report_query_timeout);
+
+        if (!health_report.has_value()) {
+            co_return std::unexpected(
+              fmt::format(
+                "Error retrieving cluster health report: {}",
+                health_report.error()));
+        }
+
+        partitions_max_gc_epoch result;
+        for (const auto& node_health : health_report.value().node_reports) {
+            for (const auto& topic_status : node_health->topics) {
+                const auto& tp_ns = topic_status.first;
+                for (const auto& partition_status : topic_status.second) {
+                    /*
+                     * partition_status is the partition health reported by a
+                     * replica. a reported epoch is valid when it is collected,
+                     * independent of the replica's current leadership status.
+                     * we reduce across replicas using `max` because that is the
+                     * most optimistic value we can take.
+                     *
+                     * if a replica reports no epoch then it is considered to be
+                     * in an indeterminite state and it has no affect on the
+                     * computed result. this has the side effect / benefit of
+                     * skipping any non-cloud topic partitions.
+                     */
+                    const auto maybe_max_gc_epoch
+                      = partition_status.second
+                          .cloud_topic_max_gc_eligible_epoch;
+                    if (!maybe_max_gc_epoch.has_value()) {
+                        continue;
+                    }
+                    const auto max_gc_epoch = cluster_epoch(
+                      maybe_max_gc_epoch.value());
+
+                    const auto p_id = partition_status.first;
+                    auto& partition_epochs = result[tp_ns];
+                    const auto it = partition_epochs.find(p_id);
+                    if (it == partition_epochs.end()) {
+                        partition_epochs.try_emplace(p_id, max_gc_epoch);
+                    } else {
+                        it->second = std::max(it->second, max_gc_epoch);
+                    }
+                }
+            }
+
+            /*
+             * A scheduling point is injected after looking at each node's
+             * report. We own the list of node reports which is a set of shared
+             * pointers, so iteration is safe, and the scheduling point is
+             * intended to help avoid reactor stalls. If we need to inject
+             * scheduling points at a finer granularity we'll need to take a
+             * closer look at concurrency rules of the reports themselves.
+             */
+            co_await seastar::maybe_yield();
+
+            if (as && as->abort_requested()) {
+                co_return std::unexpected("Abort requested");
+            }
+        }
+
+        co_return result;
+    }
+
+    seastar::future<std::expected<std::optional<cluster_epoch>, std::string>>
+    max_gc_eligible_epoch(seastar::abort_source* as) override {
+        /*
+         * First retrieve a consistent snapshot of cloud topic partitions. This
+         * establishes a set of partitions from which we must obtain an epoch
+         * bound on garbage collection.
+         */
+        auto partitions = co_await get_partitions(as);
+        if (!partitions.has_value()) {
+            co_return std::unexpected(partitions.error());
+        }
+        if (partitions.value().partitions.empty()) {
+            co_return std::nullopt;
+        }
+
+        /*
+         * Next we retrieve the latest reported epoch bounds from all cloud
+         * topic partitions. The source for this information is distributed,
+         * while the source for the `partitions` set above is centralized, and
+         * this is why we have these two different collection steps.
+         */
+        auto gc_epochs = co_await get_partitions_max_gc_epoch(as);
+        if (!gc_epochs.has_value()) {
+            co_return std::unexpected(gc_epochs.error());
+        }
+
+        /*
+         * The final result begins as the maximum epoch for the given snapshot.
+         * Below we merge the two result sets and walk the final result back to
+         * account for the partition with the smallest eligible gc epoch.
+         */
+        auto result = cluster_epoch(partitions.value().last_applied());
+
+        for (const auto& partition : partitions.value().partitions) {
+            const auto& tp_ns = partition.first;
+            auto nit = gc_epochs.value().find(tp_ns);
+            if (nit == gc_epochs.value().end()) {
+                co_return std::unexpected(
+                  fmt::format(
+                    "Topic '{}' in snapshot has no reported max GC epoch",
+                    tp_ns));
+            }
+
+            for (const auto p_id : partition.second) {
+                auto pit = nit->second.find(p_id);
+                if (pit == nit->second.end()) {
+                    co_return std::unexpected(
+                      fmt::format(
+                        "Partition '{}/{}' in snapshot has no reported max GC "
+                        "epoch",
+                        tp_ns,
+                        p_id));
+                }
+
+                // this partition may hold back the max GC eligible epoch
+                result = std::min(result, pit->second);
+            }
+        }
+
+        co_return result;
     }
 
 private:
-    [[maybe_unused]] seastar::sharded<cluster::health_monitor_frontend>*
-      health_monitor_;
-    [[maybe_unused]] seastar::sharded<cluster::topic_table>* topic_table_;
+    seastar::sharded<cluster::health_monitor_frontend>* health_monitor_;
+    seastar::sharded<cluster::topic_table>* topic_table_;
 };
 
 level_zero_gc::level_zero_gc(

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -103,6 +103,11 @@ level_zero_gc::cluster_support::max_gc_eligible_epoch(
      */
     auto result = cluster_epoch(partitions.value().last_applied());
 
+    vlog(
+      cd_log.debug,
+      "Calculating max GC eligible epoch with snapshot epoch {}",
+      result);
+
     for (const auto& partition : partitions.value().partitions) {
         const auto& tp_ns = partition.first;
         auto nit = gc_epochs.value().find(tp_ns);
@@ -124,7 +129,17 @@ level_zero_gc::cluster_support::max_gc_eligible_epoch(
             }
 
             // this partition may hold back the max GC eligible epoch
+            const auto prev_result = result;
             result = std::min(result, pit->second);
+
+            vlog(
+              cd_log.debug,
+              "Reducing result {} from min(result={}, p={}) for {}/{}",
+              result,
+              prev_result,
+              pit->second,
+              tp_ns,
+              p_id);
         }
     }
 
@@ -390,6 +405,12 @@ level_zero_gc::try_to_collect() {
     const auto max_gc_birthday = std::chrono::system_clock::now()
                                  - config_.deletion_grace_period;
 
+    vlog(
+      cd_log.debug,
+      "Attempting L0 GC at epoch {} and last modified limit {}",
+      max_gc_epoch.value(),
+      max_gc_birthday);
+
     // objects that can be safely deleted
     std::vector<cloud_storage_clients::client::list_bucket_item>
       eligible_objects;
@@ -471,7 +492,7 @@ level_zero_gc::try_to_collect() {
     }
 
     vlog(
-      cd_log.info, "Deleted {} L0 data objects eligible for GC", num_eligible);
+      cd_log.debug, "Deleted {} L0 data objects eligible for GC", num_eligible);
 
     co_return num_eligible;
 }

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -69,9 +69,9 @@ private:
     const cloud_storage_clients::bucket_name bucket_;
 };
 
-class epoch_source_cluster_impl : public level_zero_gc::epoch_source {
+class cluster_support_impl : public level_zero_gc::cluster_support {
 public:
-    explicit epoch_source_cluster_impl(
+    explicit cluster_support_impl(
       seastar::sharded<cluster::health_monitor_frontend>* health_monitor,
       seastar::sharded<cluster::topic_table>* topic_table)
       : health_monitor_(health_monitor)
@@ -259,10 +259,10 @@ private:
 level_zero_gc::level_zero_gc(
   level_zero_gc_config config,
   std::unique_ptr<object_storage> storage,
-  std::unique_ptr<epoch_source> epoch_source)
+  std::unique_ptr<cluster_support> cluster_support)
   : config_(config)
   , storage_(std::move(storage))
-  , epoch_source_(std::move(epoch_source))
+  , cluster_support_(std::move(cluster_support))
   , should_run_(false) // begin in a stopped state
   , should_shutdown_(false)
   , worker_(worker()) {}
@@ -276,8 +276,7 @@ level_zero_gc::level_zero_gc(
   : level_zero_gc(
       config,
       std::make_unique<object_storage_remote_impl>(remote, std::move(bucket)),
-      std::make_unique<epoch_source_cluster_impl>(
-        health_monitor, topic_table)) {}
+      std::make_unique<cluster_support_impl>(health_monitor, topic_table)) {}
 
 void level_zero_gc::start() {
     vlog(cd_log.info, "Starting cloud topics L0 GC worker");
@@ -373,7 +372,7 @@ level_zero_gc::try_to_collect() {
     }
 
     const auto maybe_max_gc_epoch
-      = co_await epoch_source_->max_gc_eligible_epoch(&asrc_);
+      = co_await cluster_support_->max_gc_eligible_epoch(&asrc_);
     if (!maybe_max_gc_epoch.has_value()) {
         vlog(
           cd_log.debug,

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -196,7 +196,16 @@ public:
 
             // Detect concurrent changes to the topic table to avoid accessing
             // an invalid iterator.
-            topic_table.check_topics_map_stable(iter_start_rev);
+            try {
+                topic_table.check_topics_map_stable(iter_start_rev);
+            } catch (...) {
+                // TODO: its rare, so should we retry immediately or abort this
+                // round and wait for the next GC loop? i think it's a balance
+                // of more code/complexity and behavior. For now I think it is
+                // fine.
+                co_return std::unexpected(
+                  "Concurrent container iteration invalidation. Will retry");
+            }
         }
 
         co_return snap;

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -256,8 +256,25 @@ public:
                      *
                      * if a replica reports no epoch then it is considered to be
                      * in an indeterminite state and it has no affect on the
-                     * computed result. this has the side effect / benefit of
-                     * skipping any non-cloud topic partitions.
+                     * computed result (effectively it is treated as having
+                     * epoch 0 in the max reduction across replicas).
+                     *
+                     * if all replicas report no epoch then the partition is not
+                     * included in the result set returned to the caller. this
+                     * covers two cases.
+                     *
+                     * the first case is that the partition is part of a
+                     * standard topic. in this case the partition will also not
+                     * be in the set returned by `get_partitions` and thus the
+                     * join in `max_gc_eligible_epoch` will ignore the topic.
+                     *
+                     * in the second case the join would fail, and later succeed
+                     * in the once at least one replica is returning max gc
+                     * epoch. this shouldn't be a problem in practice: there is
+                     * a narrow window at start-up time where a partition is
+                     * bootstrapping the L0 CT STM state where the state is
+                     * unknown. for brand new partitions this should be the
+                     * partition's creation revision ID.
                      */
                     const auto maybe_max_gc_epoch
                       = partition_status.second

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -101,7 +101,7 @@ level_zero_gc::cluster_support::max_gc_eligible_epoch(
      * Below we merge the two result sets and walk the final result back to
      * account for the partition with the smallest eligible gc epoch.
      */
-    auto result = cluster_epoch(partitions.value().last_applied());
+    auto result = partitions.value().snap_revision;
 
     vlog(
       cd_log.debug,
@@ -170,10 +170,11 @@ public:
          * hierarchy and is consistent with the topic table last applied offset.
          */
         partitions_snapshot snap;
-        snap.last_applied = co_await controller_stm_->invoke_on(
-          cluster::controller_stm_shard, [](auto& stm) {
-              return model::revision_id(stm.get_last_applied_offset());
-          });
+        snap.snap_revision = cluster_epoch(
+          co_await controller_stm_->invoke_on(
+            cluster::controller_stm_shard, [](auto& stm) {
+                return model::revision_id(stm.get_last_applied_offset());
+            }));
 
         for (const auto& topic : topic_table.topics_map()) {
             // we only care about cloud topics

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -194,7 +194,8 @@ public:
                 co_return std::unexpected("Abort requested");
             }
 
-            // Detect concurrent changes to the topic table.
+            // Detect concurrent changes to the topic table to avoid accessing
+            // an invalid iterator.
             topic_table.check_topics_map_stable(iter_start_rev);
         }
 

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
@@ -212,7 +212,7 @@ public:
          */
         virtual seastar::future<
           std::expected<std::optional<cluster_epoch>, std::string>>
-        max_gc_eligible_epoch(seastar::abort_source*) = 0;
+        max_gc_eligible_epoch(seastar::abort_source*);
 
         /*
          * Snapshot of existing cloud topic partition identifiers along with the

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
@@ -12,6 +12,7 @@
 #include "cloud_io/io_result.h"
 #include "cloud_storage_clients/client.h"
 #include "cloud_topics/types.h"
+#include "container/chunked_hash_map.h"
 
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/future.hh>
@@ -180,6 +181,23 @@ public:
      */
     class epoch_source {
     public:
+        struct partitions_snapshot {
+            using partition_map = chunked_hash_map<
+              model::topic_namespace,
+              chunked_vector<model::partition_id>,
+              model::topic_namespace_hash,
+              model::topic_namespace_eq>;
+
+            partition_map partitions;
+            model::revision_id last_applied;
+        };
+
+        using partitions_max_gc_epoch = chunked_hash_map<
+          model::topic_namespace,
+          chunked_hash_map<model::partition_id, cluster_epoch>,
+          model::topic_namespace_hash,
+          model::topic_namespace_eq>;
+
         epoch_source() = default;
         epoch_source(const epoch_source&) = default;
         epoch_source(epoch_source&&) = delete;
@@ -195,6 +213,20 @@ public:
         virtual seastar::future<
           std::expected<std::optional<cluster_epoch>, std::string>>
         max_gc_eligible_epoch(seastar::abort_source*) = 0;
+
+        /*
+         * Snapshot of existing cloud topic partition identifiers along with the
+         * maximum possible GC eligible epoch for the set of partitions.
+         */
+        virtual seastar::future<std::expected<partitions_snapshot, std::string>>
+        get_partitions(seastar::abort_source*) = 0;
+
+        /*
+         * Reported max GC eligible epochs for cloud topic partitions.
+         */
+        virtual seastar::future<
+          std::expected<partitions_max_gc_epoch, std::string>>
+        get_partitions_max_gc_epoch(seastar::abort_source*) = 0;
     };
 
 public:

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
@@ -59,7 +59,7 @@ namespace cloud_topics {
  *
  * The `level_zero_gc` class implements L0 garbage collection as described
  * above. It uses two service provider interfaces defined in the class. The
- * `cluster_support` interface provides access to the safe-to-delete epoch, and
+ * `epoch_source` interface provides access to the safe-to-delete epoch, and
  * the `object_storage` interface provides access to listing and deleting
  * objects from the configured storage service.
  *
@@ -181,7 +181,7 @@ public:
     /*
      * Interface for computing the maximum epoch eligible for GC.
      */
-    class cluster_support {
+    class epoch_source {
     public:
         struct partitions_snapshot {
             using partition_map = chunked_hash_map<
@@ -200,12 +200,12 @@ public:
           model::topic_namespace_hash,
           model::topic_namespace_eq>;
 
-        cluster_support() = default;
-        cluster_support(const cluster_support&) = default;
-        cluster_support(cluster_support&&) = delete;
-        cluster_support& operator=(const cluster_support&) = default;
-        cluster_support& operator=(cluster_support&&) = delete;
-        virtual ~cluster_support() = default;
+        epoch_source() = default;
+        epoch_source(const epoch_source&) = default;
+        epoch_source(epoch_source&&) = delete;
+        epoch_source& operator=(const epoch_source&) = default;
+        epoch_source& operator=(epoch_source&&) = delete;
+        virtual ~epoch_source() = default;
 
         /*
          * L0 objects with epochs <= the return value may be deleted. An
@@ -239,7 +239,7 @@ public:
     level_zero_gc(
       level_zero_gc_config,
       std::unique_ptr<object_storage>,
-      std::unique_ptr<cluster_support>);
+      std::unique_ptr<epoch_source>);
 
     /*
      * Construct with default implementations of storage and epoch providers.
@@ -268,7 +268,7 @@ public:
 private:
     level_zero_gc_config config_;
     std::unique_ptr<object_storage> storage_;
-    std::unique_ptr<cluster_support> cluster_support_;
+    std::unique_ptr<epoch_source> epoch_source_;
 
     bool should_run_;
     bool should_shutdown_;

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
@@ -191,7 +191,7 @@ public:
               model::topic_namespace_eq>;
 
             partition_map partitions;
-            model::revision_id last_applied;
+            cluster_epoch snap_revision;
         };
 
         using partitions_max_gc_epoch = chunked_hash_map<

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
@@ -11,6 +11,7 @@
 
 #include "cloud_io/io_result.h"
 #include "cloud_storage_clients/client.h"
+#include "cloud_topics/level_zero/gc/level_zero_gc_probe.h"
 #include "cloud_topics/types.h"
 #include "container/chunked_hash_map.h"
 
@@ -276,6 +277,8 @@ private:
     seastar::future<> worker();
     enum class collection_error : int8_t;
     seastar::future<std::expected<size_t, collection_error>> try_to_collect();
+
+    level_zero_gc_probe probe_;
 };
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
@@ -27,7 +27,8 @@ class remote;
 
 namespace cluster {
 class health_monitor_frontend;
-}
+class topic_table;
+} // namespace cluster
 
 namespace cloud_topics {
 
@@ -213,6 +214,7 @@ public:
       cloud_io::remote*,
       cloud_storage_clients::bucket_name,
       seastar::sharded<cluster::health_monitor_frontend>*,
+      seastar::sharded<cluster::topic_table>*,
       level_zero_gc_config = {});
 
     /*

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
@@ -28,6 +28,7 @@ class remote;
 }
 
 namespace cluster {
+class controller_stm;
 class health_monitor_frontend;
 class topic_table;
 } // namespace cluster
@@ -247,6 +248,7 @@ public:
       cloud_io::remote*,
       cloud_storage_clients::bucket_name,
       seastar::sharded<cluster::health_monitor_frontend>*,
+      seastar::sharded<cluster::controller_stm>*,
       seastar::sharded<cluster::topic_table>*,
       level_zero_gc_config = {});
 

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
@@ -57,9 +57,9 @@ namespace cloud_topics {
  *
  * The `level_zero_gc` class implements L0 garbage collection as described
  * above. It uses two service provider interfaces defined in the class. The
- * `epoch_source` interface provides access to the safe-to-delete epoch, and the
- * `object_storage` interface provides access to listing and deleting objects
- * from the configured storage service.
+ * `cluster_support` interface provides access to the safe-to-delete epoch, and
+ * the `object_storage` interface provides access to listing and deleting
+ * objects from the configured storage service.
  *
  * Incremental collection
  * ======================
@@ -179,7 +179,7 @@ public:
     /*
      * Interface for computing the maximum epoch eligible for GC.
      */
-    class epoch_source {
+    class cluster_support {
     public:
         struct partitions_snapshot {
             using partition_map = chunked_hash_map<
@@ -198,12 +198,12 @@ public:
           model::topic_namespace_hash,
           model::topic_namespace_eq>;
 
-        epoch_source() = default;
-        epoch_source(const epoch_source&) = default;
-        epoch_source(epoch_source&&) = delete;
-        epoch_source& operator=(const epoch_source&) = default;
-        epoch_source& operator=(epoch_source&&) = delete;
-        virtual ~epoch_source() = default;
+        cluster_support() = default;
+        cluster_support(const cluster_support&) = default;
+        cluster_support(cluster_support&&) = delete;
+        cluster_support& operator=(const cluster_support&) = default;
+        cluster_support& operator=(cluster_support&&) = delete;
+        virtual ~cluster_support() = default;
 
         /*
          * L0 objects with epochs <= the return value may be deleted. An
@@ -237,7 +237,7 @@ public:
     level_zero_gc(
       level_zero_gc_config,
       std::unique_ptr<object_storage>,
-      std::unique_ptr<epoch_source>);
+      std::unique_ptr<cluster_support>);
 
     /*
      * Construct with default implementations of storage and epoch providers.
@@ -265,7 +265,7 @@ public:
 private:
     level_zero_gc_config config_;
     std::unique_ptr<object_storage> storage_;
-    std::unique_ptr<epoch_source> epoch_source_;
+    std::unique_ptr<cluster_support> cluster_support_;
 
     bool should_run_;
     bool should_shutdown_;

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc_probe.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc_probe.cc
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "cloud_topics/level_zero/gc/level_zero_gc_probe.h"
+
+#include "metrics/metrics.h"
+#include "metrics/prometheus_sanitize.h"
+
+#include <seastar/core/metrics.hh>
+#include <seastar/core/metrics_types.hh>
+#include <seastar/core/shared_ptr.hh>
+
+namespace cloud_topics {
+
+level_zero_gc_probe::level_zero_gc_probe(bool disable) {
+    setup_internal_metrics(disable);
+}
+
+void level_zero_gc_probe::setup_internal_metrics(bool disable) {
+    if (disable) {
+        return;
+    }
+
+    namespace sm = ss::metrics;
+    std::vector<sm::label_instance> labels;
+
+    _metrics.add_group(
+      prometheus_sanitize::metrics_name("cloud_topics_l0_gc"),
+      {
+        sm::make_counter(
+          "objects_deleted",
+          [this] { return objects_deleted_; },
+          sm::description(
+            "Number of L0 objects deleted by garbage collection."),
+          labels),
+      });
+}
+
+} // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc_probe.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc_probe.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "metrics/metrics.h"
+
+#include <seastar/core/metrics_registration.hh>
+#include <seastar/core/metrics_types.hh>
+
+namespace cloud_topics {
+
+class level_zero_gc_probe {
+public:
+    explicit level_zero_gc_probe(bool disable);
+
+    void objects_deleted(uint64_t count = 1) { objects_deleted_ += count; }
+
+private:
+    void setup_internal_metrics(bool disable);
+
+    uint64_t objects_deleted_{0};
+
+    metrics::internal_metric_groups _metrics;
+};
+
+} // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
+++ b/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
@@ -217,7 +217,7 @@ public:
         }
         co_return partitions_snapshot{
           .partitions = std::move(partitions),
-          .last_applied = src.last_applied,
+          .snap_revision = src.snap_revision,
         };
     }
 
@@ -297,7 +297,7 @@ TEST_F(LevelZeroGCMaxEpochTest, EmptyGcEpochReport) {
 }
 
 TEST_F(LevelZeroGCMaxEpochTest, MinReduce) {
-    get_partitions_value.last_applied = model::revision_id(100);
+    get_partitions_value.snap_revision = cloud_topics::cluster_epoch(100);
     get_partitions_value.partitions[tpns0].push_back(model::partition_id(0));
 
     // the minimum is the last applied

--- a/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
+++ b/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
@@ -67,10 +67,10 @@ public:
     std::vector<cloud_storage_clients::client::list_bucket_item>* deleted_;
 };
 
-class cluster_support_test_impl
-  : public cloud_topics::level_zero_gc::cluster_support {
+class epoch_source_test_impl
+  : public cloud_topics::level_zero_gc::epoch_source {
 public:
-    explicit cluster_support_test_impl(std::optional<int64_t>* epoch)
+    explicit epoch_source_test_impl(std::optional<int64_t>* epoch)
       : epoch_(epoch) {}
 
     /*
@@ -115,7 +115,7 @@ public:
             .throttle_no_progress = 10ms,
           },
           std::make_unique<object_storage_test_impl>(&listed, &deleted),
-          std::make_unique<cluster_support_test_impl>(&max_epoch)) {}
+          std::make_unique<epoch_source_test_impl>(&max_epoch)) {}
 
     void TearDown() override { gc.stop().get(); }
 
@@ -198,10 +198,10 @@ TEST_F(LevelZeroGCTest, NoDeletesForYoungObjects) {
  * This fixture is intended to test the default implementation of the max gc
  * eligible epoch calculation, so that is not overriden.
  */
-class cluster_support_test_default_impl
-  : public cloud_topics::level_zero_gc::cluster_support {
+class epoch_source_test_default_impl
+  : public cloud_topics::level_zero_gc::epoch_source {
 public:
-    explicit cluster_support_test_default_impl(
+    explicit epoch_source_test_default_impl(
       partitions_snapshot* get_partitions_value,
       partitions_max_gc_epoch* get_partitions_max_gc_epoch_value)
       : get_partitions_value_(get_partitions_value)
@@ -244,24 +244,21 @@ private:
 
 class LevelZeroGCMaxEpochTest : public testing::Test {
 public:
-    using cluster_support_type = cloud_topics::level_zero_gc::cluster_support;
-    using partitions_snapshot = cluster_support_type::partitions_snapshot;
-    using partitions_max_gc_epoch
-      = cluster_support_type::partitions_max_gc_epoch;
+    using epoch_source_type = cloud_topics::level_zero_gc::epoch_source;
+    using partitions_snapshot = epoch_source_type::partitions_snapshot;
+    using partitions_max_gc_epoch = epoch_source_type::partitions_max_gc_epoch;
 
     LevelZeroGCMaxEpochTest()
-      : cluster_support(
-          std::make_unique<cluster_support_test_default_impl>(
+      : epoch_source(
+          std::make_unique<epoch_source_test_default_impl>(
             &get_partitions_value, &get_partitions_max_gc_epoch_value)) {}
 
     partitions_snapshot get_partitions_value;
     partitions_max_gc_epoch get_partitions_max_gc_epoch_value;
-    std::unique_ptr<cluster_support_type> cluster_support;
+    std::unique_ptr<epoch_source_type> epoch_source;
 
     // shortcut accessors
-    auto max_gc() {
-        return cluster_support->max_gc_eligible_epoch(nullptr).get();
-    }
+    auto max_gc() { return epoch_source->max_gc_eligible_epoch(nullptr).get(); }
     auto& snapshot() { return get_partitions_value; }
     auto& partition_epochs() { return get_partitions_max_gc_epoch_value; }
 };

--- a/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
+++ b/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
@@ -85,6 +85,22 @@ public:
         co_return std::nullopt;
     }
 
+    seastar::future<std::expected<partitions_snapshot, std::string>>
+    get_partitions(seastar::abort_source*) override {
+        /*
+         * this impl only cares about the final derived value
+         */
+        co_return std::unexpected("unimplemented");
+    }
+
+    seastar::future<std::expected<partitions_max_gc_epoch, std::string>>
+    get_partitions_max_gc_epoch(seastar::abort_source*) override {
+        /*
+         * this impl only cares about the final derived value
+         */
+        co_return std::unexpected("unimplemented");
+    }
+
 private:
     std::optional<int64_t>* epoch_;
 };

--- a/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
+++ b/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
@@ -192,3 +192,128 @@ TEST_F(LevelZeroGCTest, NoDeletesForYoungObjects) {
     gc.start();
     EXPECT_TRUE(Eventually([this] { return deleted.size() == 88; }));
 }
+
+/*
+ * Returns copies of the configured output for the two pure virtual methods.
+ * This fixture is intended to test the default implementation of the max gc
+ * eligible epoch calculation, so that is not overriden.
+ */
+class cluster_support_test_default_impl
+  : public cloud_topics::level_zero_gc::cluster_support {
+public:
+    explicit cluster_support_test_default_impl(
+      partitions_snapshot* get_partitions_value,
+      partitions_max_gc_epoch* get_partitions_max_gc_epoch_value)
+      : get_partitions_value_(get_partitions_value)
+      , get_partitions_max_gc_epoch_value_(get_partitions_max_gc_epoch_value) {}
+
+    seastar::future<std::expected<partitions_snapshot, std::string>>
+    get_partitions(seastar::abort_source*) override {
+        // manually copy out from the fragmented map structure
+        const auto& src = *get_partitions_value_;
+        partitions_snapshot::partition_map partitions;
+        for (const auto& entry : src.partitions) {
+            partitions[entry.first] = entry.second.copy();
+        }
+        co_return partitions_snapshot{
+          .partitions = std::move(partitions),
+          .last_applied = src.last_applied,
+        };
+    }
+
+    seastar::future<std::expected<partitions_max_gc_epoch, std::string>>
+    get_partitions_max_gc_epoch(seastar::abort_source*) override {
+        // manually copy the two-level fragmented map structure
+        const auto& src = *get_partitions_max_gc_epoch_value_;
+        partitions_max_gc_epoch ret;
+        for (const auto& entry : src) {
+            chunked_hash_map<model::partition_id, cloud_topics::cluster_epoch>
+              copy;
+            for (const auto& partition : entry.second) {
+                copy[partition.first] = partition.second;
+            }
+            ret[entry.first] = std::move(copy);
+        }
+        co_return ret;
+    }
+
+private:
+    partitions_snapshot* get_partitions_value_;
+    partitions_max_gc_epoch* get_partitions_max_gc_epoch_value_;
+};
+
+class LevelZeroGCMaxEpochTest : public testing::Test {
+public:
+    using cluster_support_type = cloud_topics::level_zero_gc::cluster_support;
+    using partitions_snapshot = cluster_support_type::partitions_snapshot;
+    using partitions_max_gc_epoch
+      = cluster_support_type::partitions_max_gc_epoch;
+
+    LevelZeroGCMaxEpochTest()
+      : cluster_support(
+          std::make_unique<cluster_support_test_default_impl>(
+            &get_partitions_value, &get_partitions_max_gc_epoch_value)) {}
+
+    partitions_snapshot get_partitions_value;
+    partitions_max_gc_epoch get_partitions_max_gc_epoch_value;
+    std::unique_ptr<cluster_support_type> cluster_support;
+
+    // shortcut accessors
+    auto max_gc() {
+        return cluster_support->max_gc_eligible_epoch(nullptr).get();
+    }
+    auto& snapshot() { return get_partitions_value; }
+    auto& partition_epochs() { return get_partitions_max_gc_epoch_value; }
+};
+
+TEST_F(LevelZeroGCMaxEpochTest, EmptySnapshot) {
+    // no error
+    ASSERT_TRUE(max_gc().has_value());
+    // no result
+    ASSERT_FALSE(max_gc().value().has_value());
+}
+
+namespace {
+model::topic_namespace tpns0(model::ns("ns0"), model::topic("t0"));
+}
+
+TEST_F(LevelZeroGCMaxEpochTest, EmptyGcEpochReport) {
+    // here we have a non-empty snapshot, but no reported epochs from individual
+    // partitions. in this case there should be no result after the join
+    get_partitions_value.partitions[tpns0].push_back(model::partition_id(0));
+    ASSERT_FALSE(max_gc().has_value());
+    ASSERT_EQ(
+      max_gc().error(),
+      "Topic '{ns0/t0}' in snapshot has no reported max GC epoch");
+
+    // now we add the topic/ns to the report, but report on a different
+    // partition so there is still no output in the join
+    get_partitions_max_gc_epoch_value[tpns0][model::partition_id(1)]
+      = cloud_topics::cluster_epoch(0);
+    ASSERT_FALSE(max_gc().has_value());
+    ASSERT_EQ(
+      max_gc().error(),
+      "Partition '{ns0/t0}/0' in snapshot has no reported max GC epoch");
+}
+
+TEST_F(LevelZeroGCMaxEpochTest, MinReduce) {
+    get_partitions_value.last_applied = model::revision_id(100);
+    get_partitions_value.partitions[tpns0].push_back(model::partition_id(0));
+
+    // the minimum is the last applied
+    get_partitions_max_gc_epoch_value[tpns0][model::partition_id(0)]
+      = cloud_topics::cluster_epoch(200);
+    ASSERT_EQ(max_gc().value().value(), cloud_topics::cluster_epoch(100));
+
+    // now its the epoch from the report
+    get_partitions_max_gc_epoch_value[tpns0][model::partition_id(0)]
+      = cloud_topics::cluster_epoch(50);
+    ASSERT_EQ(max_gc().value().value(), cloud_topics::cluster_epoch(50));
+}
+
+TEST_F(LevelZeroGCMaxEpochTest, EmptySnapshotNonEmptyReport) {
+    get_partitions_max_gc_epoch_value[tpns0][model::partition_id(0)]
+      = cloud_topics::cluster_epoch(200);
+    ASSERT_TRUE(max_gc().has_value());
+    ASSERT_FALSE(max_gc().value().has_value());
+}

--- a/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
+++ b/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
@@ -67,10 +67,10 @@ public:
     std::vector<cloud_storage_clients::client::list_bucket_item>* deleted_;
 };
 
-class epoch_source_test_impl
-  : public cloud_topics::level_zero_gc::epoch_source {
+class cluster_support_test_impl
+  : public cloud_topics::level_zero_gc::cluster_support {
 public:
-    explicit epoch_source_test_impl(std::optional<int64_t>* epoch)
+    explicit cluster_support_test_impl(std::optional<int64_t>* epoch)
       : epoch_(epoch) {}
 
     /*
@@ -115,7 +115,7 @@ public:
             .throttle_no_progress = 10ms,
           },
           std::make_unique<object_storage_test_impl>(&listed, &deleted),
-          std::make_unique<epoch_source_test_impl>(&max_epoch)) {}
+          std::make_unique<cluster_support_test_impl>(&max_epoch)) {}
 
     void TearDown() override { gc.stop().get(); }
 

--- a/src/v/cluster/cluster_epoch_service.cc
+++ b/src/v/cluster/cluster_epoch_service.cc
@@ -524,7 +524,8 @@ void cluster_epoch_service<Clock>::set_raft0(
 
 template<typename Clock>
 bool cluster_epoch_service<Clock>::cache_entry_expired() const noexcept {
-    return Clock::now() > (_cached_epoch_time + epoch_cache_timeout);
+    return Clock::now()
+           > (_cached_epoch_time + config::shard_local_cfg().epoch_service_cached_epoch_age_soft_limit());
 }
 template<typename Clock>
 bool cluster_epoch_service<Clock>::cache_entry_needs_updated() const noexcept {

--- a/src/v/cluster/cluster_epoch_service.cc
+++ b/src/v/cluster/cluster_epoch_service.cc
@@ -154,7 +154,8 @@ ss::future<> cluster_epoch_service<Clock>::raft0_state::service_loop() {
     while (!_abort_source.abort_requested()) {
         try {
             co_await ss::sleep_abortable<Clock>(
-              epoch_bump_interval, _abort_source);
+              config::shard_local_cfg().epoch_service_max_epoch_age(),
+              _abort_source);
         } catch (const ss::sleep_aborted& e) {
             std::ignore = e;
         }

--- a/src/v/cluster/cluster_epoch_service.cc
+++ b/src/v/cluster/cluster_epoch_service.cc
@@ -154,7 +154,8 @@ ss::future<> cluster_epoch_service<Clock>::raft0_state::service_loop() {
     while (!_abort_source.abort_requested()) {
         try {
             co_await ss::sleep_abortable<Clock>(
-              config::shard_local_cfg().epoch_service_max_epoch_age(),
+              config::shard_local_cfg()
+                .cloud_topics_epoch_service_epoch_increment_interval(),
               _abort_source);
         } catch (const ss::sleep_aborted& e) {
             std::ignore = e;

--- a/src/v/cluster/cluster_epoch_service.cc
+++ b/src/v/cluster/cluster_epoch_service.cc
@@ -526,7 +526,7 @@ void cluster_epoch_service<Clock>::set_raft0(
 template<typename Clock>
 bool cluster_epoch_service<Clock>::cache_entry_expired() const noexcept {
     return Clock::now()
-           > (_cached_epoch_time + config::shard_local_cfg().epoch_service_cached_epoch_age_soft_limit());
+           > (_cached_epoch_time + config::shard_local_cfg().cloud_topics_epoch_service_local_epoch_cache_duration());
 }
 template<typename Clock>
 bool cluster_epoch_service<Clock>::cache_entry_needs_updated() const noexcept {

--- a/src/v/cluster/cluster_epoch_service.h
+++ b/src/v/cluster/cluster_epoch_service.h
@@ -55,9 +55,6 @@ class cluster_epoch_service
 
 public:
     // TODO(cloud-topics): make these configuration knobs.
-    // The amount of time to cache the current epoch before we attempt an
-    // update.
-    constexpr static ss::lowres_clock::duration epoch_cache_timeout = 1min;
     // Maximum amount of time to cache the same epoch before we block on the
     // update.
     constexpr static ss::lowres_clock::duration max_same_epoch_cache_duration

--- a/src/v/cluster/cluster_epoch_service.h
+++ b/src/v/cluster/cluster_epoch_service.h
@@ -58,8 +58,6 @@ public:
     // The amount of time to cache the current epoch before we attempt an
     // update.
     constexpr static ss::lowres_clock::duration epoch_cache_timeout = 1min;
-    // The interval on which we bump our epoch.
-    constexpr static ss::lowres_clock::duration epoch_bump_interval = 10min;
     // Maximum amount of time to cache the same epoch before we block on the
     // update.
     constexpr static ss::lowres_clock::duration max_same_epoch_cache_duration

--- a/src/v/cluster/tests/epoch_service_test.cc
+++ b/src/v/cluster/tests/epoch_service_test.cc
@@ -99,7 +99,9 @@ TEST_F_CORO(ClusterEpochService, TestCaching) {
     co_await tests::drain_task_queue();
     EXPECT_EQ(accesses, 1);
     // After the timeout we async re-fetch the value
-    ss::manual_clock::advance(epoch_service::epoch_cache_timeout + 1us);
+    ss::manual_clock::advance(
+      config::shard_local_cfg().epoch_service_cached_epoch_age_soft_limit()
+      + 1us);
     auto barrier = co_await acquire_barrier();
     EXPECT_EQ(co_await get_cached_epoch(), cluster_epoch - 1);
     barrier.unlock();
@@ -121,13 +123,17 @@ TEST_F_CORO(ClusterEpochService, IncrementMustHappenEventually) {
     auto must_refresh_deadline = ss::manual_clock::now()
                                  + epoch_service::max_same_epoch_cache_duration;
     // After the timeout we async re-fetch the value
-    ss::manual_clock::advance(epoch_service::epoch_cache_timeout + 1us);
+    ss::manual_clock::advance(
+      config::shard_local_cfg().epoch_service_cached_epoch_age_soft_limit()
+      + 1us);
     while (ss::manual_clock::now() < must_refresh_deadline) {
         auto accesses_before = accesses.load();
         EXPECT_EQ(co_await get_cached_epoch(), cluster_epoch);
         co_await tests::drain_task_queue();
         EXPECT_EQ(accesses, accesses_before + 1);
-        ss::manual_clock::advance(epoch_service::epoch_cache_timeout + 1us);
+        ss::manual_clock::advance(
+          config::shard_local_cfg().epoch_service_cached_epoch_age_soft_limit()
+          + 1us);
     }
     // After the max duration we wait to fetch the value, and will fail if we
     // cannot
@@ -154,7 +160,9 @@ TEST_F_CORO(ClusterEpochService, FetchesLimitedToShard0) {
     // Bumping the epoch and awaiting for the cache to expire should only cause
     // one additional fetch
     ++cluster_epoch;
-    ss::manual_clock::advance(epoch_service::epoch_cache_timeout + 1us);
+    ss::manual_clock::advance(
+      config::shard_local_cfg().epoch_service_cached_epoch_age_soft_limit()
+      + 1us);
     auto barrier = co_await acquire_barrier();
     EXPECT_THAT(co_await all_epochs(), ElementsAre(0, 0));
     barrier.unlock();

--- a/src/v/cluster/tests/epoch_service_test.cc
+++ b/src/v/cluster/tests/epoch_service_test.cc
@@ -100,7 +100,8 @@ TEST_F_CORO(ClusterEpochService, TestCaching) {
     EXPECT_EQ(accesses, 1);
     // After the timeout we async re-fetch the value
     ss::manual_clock::advance(
-      config::shard_local_cfg().epoch_service_cached_epoch_age_soft_limit()
+      config::shard_local_cfg()
+        .cloud_topics_epoch_service_local_epoch_cache_duration()
       + 1us);
     auto barrier = co_await acquire_barrier();
     EXPECT_EQ(co_await get_cached_epoch(), cluster_epoch - 1);
@@ -124,7 +125,8 @@ TEST_F_CORO(ClusterEpochService, IncrementMustHappenEventually) {
                                  + epoch_service::max_same_epoch_cache_duration;
     // After the timeout we async re-fetch the value
     ss::manual_clock::advance(
-      config::shard_local_cfg().epoch_service_cached_epoch_age_soft_limit()
+      config::shard_local_cfg()
+        .cloud_topics_epoch_service_local_epoch_cache_duration()
       + 1us);
     while (ss::manual_clock::now() < must_refresh_deadline) {
         auto accesses_before = accesses.load();
@@ -132,7 +134,8 @@ TEST_F_CORO(ClusterEpochService, IncrementMustHappenEventually) {
         co_await tests::drain_task_queue();
         EXPECT_EQ(accesses, accesses_before + 1);
         ss::manual_clock::advance(
-          config::shard_local_cfg().epoch_service_cached_epoch_age_soft_limit()
+          config::shard_local_cfg()
+            .cloud_topics_epoch_service_local_epoch_cache_duration()
           + 1us);
     }
     // After the max duration we wait to fetch the value, and will fail if we
@@ -161,7 +164,8 @@ TEST_F_CORO(ClusterEpochService, FetchesLimitedToShard0) {
     // one additional fetch
     ++cluster_epoch;
     ss::manual_clock::advance(
-      config::shard_local_cfg().epoch_service_cached_epoch_age_soft_limit()
+      config::shard_local_cfg()
+        .cloud_topics_epoch_service_local_epoch_cache_duration()
       + 1us);
     auto barrier = co_await acquire_barrier();
     EXPECT_THAT(co_await all_epochs(), ElementsAre(0, 0));

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4511,6 +4511,12 @@ configuration::configuration()
       "term storage.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5min)
+  , epoch_service_max_epoch_age(
+      *this,
+      "epoch_service_max_epoch_age",
+      "The maximum age of an epoch that the epoch service will publish",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      10min)
   , development_feature_property_testing_only(
       *this,
       "development_feature_property_testing_only",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4514,13 +4514,13 @@ configuration::configuration()
   , cloud_topics_epoch_service_epoch_increment_interval(
       *this,
       "cloud_topics_epoch_service_epoch_increment_interval",
-      "The interval at which the cluster epoch is incremented",
+      "The interval at which the cluster epoch is incremented.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10min)
   , cloud_topics_epoch_service_local_epoch_cache_duration(
       *this,
       "cloud_topics_epoch_service_local_epoch_cache_duration",
-      "The local cache duration of a cluster wide epoch",
+      "The local cache duration of a cluster wide epoch.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1min)
   , development_feature_property_testing_only(
@@ -4537,7 +4537,7 @@ configuration::configuration()
       "are a concern. To enable experimental features, set the value of this "
       "configuration option to the current unix epoch expressed in seconds. "
       "The value must be within one hour of the current time on the broker."
-      "Once experimental features are enabled they cannot be disabled",
+      "Once experimental features are enabled they cannot be disabled.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       "",
       [this](const ss::sstring& v) -> std::optional<ss::sstring> {

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4511,10 +4511,10 @@ configuration::configuration()
       "term storage.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5min)
-  , epoch_service_max_epoch_age(
+  , cloud_topics_epoch_service_epoch_increment_interval(
       *this,
-      "epoch_service_max_epoch_age",
-      "The maximum age of an epoch that the epoch service will publish",
+      "cloud_topics_epoch_service_epoch_increment_interval",
+      "The interval at which the cluster epoch is incremented",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10min)
   , epoch_service_cached_epoch_age_soft_limit(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4517,6 +4517,13 @@ configuration::configuration()
       "The maximum age of an epoch that the epoch service will publish",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10min)
+  , epoch_service_cached_epoch_age_soft_limit(
+      *this,
+      "epoch_service_cached_epoch_age_soft_limit",
+      "When the age of a cached epoch reaches the soft limit it triggers a "
+      "background refresh",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      1min)
   , development_feature_property_testing_only(
       *this,
       "development_feature_property_testing_only",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4517,11 +4517,10 @@ configuration::configuration()
       "The interval at which the cluster epoch is incremented",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10min)
-  , epoch_service_cached_epoch_age_soft_limit(
+  , cloud_topics_epoch_service_local_epoch_cache_duration(
       *this,
-      "epoch_service_cached_epoch_age_soft_limit",
-      "When the age of a cached epoch reaches the soft limit it triggers a "
-      "background refresh",
+      "cloud_topics_epoch_service_local_epoch_cache_duration",
+      "The local cache duration of a cluster wide epoch",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1min)
   , development_feature_property_testing_only(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -818,7 +818,8 @@ public:
     property<std::chrono::milliseconds> cloud_topics_reconciliation_interval;
     property<std::chrono::milliseconds>
       cloud_topics_long_term_garbage_collection_interval;
-    property<std::chrono::milliseconds> epoch_service_max_epoch_age;
+    property<std::chrono::milliseconds>
+      cloud_topics_epoch_service_epoch_increment_interval;
     property<std::chrono::milliseconds>
       epoch_service_cached_epoch_age_soft_limit;
 

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -818,6 +818,7 @@ public:
     property<std::chrono::milliseconds> cloud_topics_reconciliation_interval;
     property<std::chrono::milliseconds>
       cloud_topics_long_term_garbage_collection_interval;
+    property<std::chrono::milliseconds> epoch_service_max_epoch_age;
 
     development_feature_property<int> development_feature_property_testing_only;
 

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -819,6 +819,8 @@ public:
     property<std::chrono::milliseconds>
       cloud_topics_long_term_garbage_collection_interval;
     property<std::chrono::milliseconds> epoch_service_max_epoch_age;
+    property<std::chrono::milliseconds>
+      epoch_service_cached_epoch_age_soft_limit;
 
     development_feature_property<int> development_feature_property_testing_only;
 

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -821,7 +821,7 @@ public:
     property<std::chrono::milliseconds>
       cloud_topics_epoch_service_epoch_increment_interval;
     property<std::chrono::milliseconds>
-      epoch_service_cached_epoch_age_soft_limit;
+      cloud_topics_epoch_service_local_epoch_cache_duration;
 
     development_feature_property<int> development_feature_property_testing_only;
 

--- a/tests/rptest/tests/cloud_topics/l0_gc_test.py
+++ b/tests/rptest/tests/cloud_topics/l0_gc_test.py
@@ -1,0 +1,92 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+from rptest.context.cloud_storage import CloudStorageType
+from rptest.services.kgo_repeater_service import repeater_traffic
+from ducktape.mark import matrix
+from ducktape.utils.util import wait_until
+
+from ducktape.tests.test import TestContext
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import (
+    SISettings,
+    get_cloud_storage_type,
+    CLOUD_TOPICS_CONFIG_STR,
+)
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class CloudTopicsL0GCTest(RedpandaTest):
+    def __init__(self, test_context: TestContext):
+        self.test_context = test_context
+        si_settings = SISettings(
+            test_context=test_context,
+            cloud_storage_max_connections=10,
+            cloud_storage_enable_remote_read=False,
+            cloud_storage_enable_remote_write=False,
+            fast_uploads=True,
+        )
+        extra_rp_conf = {
+            CLOUD_TOPICS_CONFIG_STR: True,
+            "cloud_topics_reconciliation_interval": 2000,
+            "epoch_service_max_epoch_age": 5000,
+            "epoch_service_cached_epoch_age_soft_limit": 5000,
+        }
+        super(CloudTopicsL0GCTest, self).__init__(
+            test_context=test_context,
+            extra_rp_conf=extra_rp_conf,
+            si_settings=si_settings,
+        )
+
+    def __create_topics(self, topics: list[TopicSpec]):
+        rpk = RpkTool(self.redpanda)
+        for spec in topics:
+            rpk.create_topic(
+                spec.name,
+                spec.partition_count,
+                spec.replication_factor,
+                config={"redpanda.cloud_topic.enabled": "true"},
+            )
+
+    @cluster(num_nodes=4)
+    @matrix(cloud_storage_type=[get_cloud_storage_type()[1]])
+    def test_l0_gc(self, cloud_storage_type: CloudStorageType):
+        self.topics = [TopicSpec(partition_count=2)]
+        self.__create_topics(self.topics)
+
+        with repeater_traffic(
+            context=self.test_context,
+            redpanda=self.redpanda,
+            topics=[spec.name for spec in self.topics],
+            msg_size=1024,
+            rate_limit_bps=2 * 1024 * 1024,
+            workers=1,
+        ) as repeater:
+            repeater.await_group_ready()
+            repeater.await_progress(300, timeout_sec=90)
+
+        # TODO: we are only checking that deletes are happening here (and should
+        # also be happening in parallel with the repeater's fetch/produce
+        # workload), but we do want to add tests that check constraints
+        def get_num_objects_deleted():
+            samples = self.redpanda.metrics_sample(
+                "vectorized_cloud_topics_l0_gc_objects_deleted_total"
+            )
+            self.logger.info(samples)
+            if samples is not None and samples.samples:
+                return int(sum(s.value for s in samples.samples))
+            return 0
+
+        wait_until(
+            lambda: get_num_objects_deleted() > 0,
+            timeout_sec=30,
+            backoff_sec=5,
+            retry_on_exc=True,
+        )

--- a/tests/rptest/tests/cloud_topics/l0_gc_test.py
+++ b/tests/rptest/tests/cloud_topics/l0_gc_test.py
@@ -36,7 +36,7 @@ class CloudTopicsL0GCTest(RedpandaTest):
         extra_rp_conf = {
             CLOUD_TOPICS_CONFIG_STR: True,
             "cloud_topics_reconciliation_interval": 2000,
-            "epoch_service_max_epoch_age": 5000,
+            "cloud_topics_epoch_service_epoch_increment_interval": 5000,
             "epoch_service_cached_epoch_age_soft_limit": 5000,
         }
         super(CloudTopicsL0GCTest, self).__init__(

--- a/tests/rptest/tests/cloud_topics/l0_gc_test.py
+++ b/tests/rptest/tests/cloud_topics/l0_gc_test.py
@@ -37,7 +37,7 @@ class CloudTopicsL0GCTest(RedpandaTest):
             CLOUD_TOPICS_CONFIG_STR: True,
             "cloud_topics_reconciliation_interval": 2000,
             "cloud_topics_epoch_service_epoch_increment_interval": 5000,
-            "epoch_service_cached_epoch_age_soft_limit": 5000,
+            "cloud_topics_epoch_service_local_epoch_cache_duration": 5000,
         }
         super(CloudTopicsL0GCTest, self).__init__(
             test_context=test_context,


### PR DESCRIPTION
Computes the top-level safe to delete L0 GC epoch value. There is a very simple ducktape test that verifies that deletes are occuring. I want to get some better testing into the ducktap setup for 25.3.x. I struggled a lot with figuring out how to get a fixture test working, so that's also on the todo list, but may not really be necessary for 25.3.x--Oren is going to take over getting this across the GA line.

Fixes: https://redpandadata.atlassian.net/browse/CORE-13254
Fixes: https://redpandadata.atlassian.net/browse/CORE-14824

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
