### PR TITLE
Stabilize data migration tests

### DIFF
--- a/src/v/cluster/data_migration_router.cc
+++ b/src/v/cluster/data_migration_router.cc
@@ -32,6 +32,8 @@
 
 namespace cluster::data_migrations {
 
+static constexpr std::chrono::milliseconds max_backoff(60);
+static constexpr std::chrono::milliseconds request_timeout(10);
 router::router(
   model::node_id self,
   group_proxy& group_proxy,
@@ -49,7 +51,7 @@ router::router(
       _get_group_offsets_handler,
       self,
       10,
-      100s)
+      max_backoff)
   , _set_group_offsets_handler{.parent = *this}
   , _set_group_offsets_router(
       shard_table,
@@ -59,7 +61,7 @@ router::router(
       _set_group_offsets_handler,
       self,
       10,
-      100s) {}
+      max_backoff) {}
 
 ss::future<get_group_offsets_reply>
 router::get_group_offsets(get_group_offsets_request&& req) {
@@ -68,7 +70,7 @@ router::get_group_offsets(get_group_offsets_request&& req) {
       std::move(req),
       model::ntp{
         model::kafka_namespace, model::kafka_consumer_offsets_topic, pid},
-      60s);
+      request_timeout);
 }
 
 ss::future<set_group_offsets_reply>
@@ -78,7 +80,7 @@ router::set_group_offsets(set_group_offsets_request&& req) {
       std::move(req),
       model::ntp{
         model::kafka_namespace, model::kafka_consumer_offsets_topic, pid},
-      60s);
+      request_timeout);
 };
 
 get_group_offsets_reply

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1350,6 +1350,7 @@ ss::future<> admin_server::throw_on_error(
         case cluster::errc::data_migration_invalid_resources:
         case cluster::errc::data_migration_invalid_definition:
         case cluster::errc::data_migrations_disabled:
+        case cluster::errc::resource_is_being_migrated:
             throw ss::httpd::bad_request_exception(
               fmt::format("{}", ec.message()));
         case cluster::errc::data_migration_not_exists:

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -482,6 +482,7 @@ class Admin:
         retry_codes: list[int] | None = None,
         auth=None,
         retries_amount: int = 5,
+        timeout_seconds: float = DEFAULT_TIMEOUT,
     ):
         self.redpanda = redpanda
 
@@ -513,6 +514,7 @@ class Admin:
         )
 
         self._session.mount("http://", HTTPAdapter(max_retries=retries))
+        self._timeout_seconds = timeout_seconds
 
     @staticmethod
     def ready(node):
@@ -744,7 +746,7 @@ class Admin:
             retry_connection = False
 
         if kwargs.get("timeout", None) is None:
-            kwargs["timeout"] = DEFAULT_TIMEOUT
+            kwargs["timeout"] = self._timeout_seconds
 
         # We will have to handle redirects ourselves (always set kwargs['allow_redirects'] = False),
         # see comment after _session.request() below.

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -135,8 +135,10 @@ class DataMigrationsApiTest(DataMigrationTestMixin):
         super(DataMigrationsApiTest, self).__init__(
             test_context=test_context, *args, **kwargs
         )
-        self.flaky_admin = Admin(self.redpanda, retry_codes=[503, 504])
-        self.admin = Admin(self.redpanda)
+        self.flaky_admin = Admin(
+            self.redpanda, retry_codes=[503, 504], timeout_seconds=5
+        )
+        self.admin = Admin(self.redpanda, timeout_seconds=5)
         self.last_producer_id = 0
         self.last_consumer_id = 0
 
@@ -1074,8 +1076,8 @@ class DataMigrationsApiTest(DataMigrationTestMixin):
 
         wait_until(
             set_entities_status,
-            timeout_sec=60,
-            backoff_sec=2,
+            timeout_sec=120,
+            backoff_sec=0.5,
             err_msg=f"Entities status for migration {migration_id} not set",
             retry_on_exc=True,
         )

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -269,8 +269,8 @@ class DataMigrationsApiTest(DataMigrationTestMixin):
         self.assure_not_migratable(
             topic,
             {
-                "message": "Unexpected cluster error: Requested operation can not be executed as the resource is undergoing data migration",
-                "code": 500,
+                "message": "Requested operation can not be executed as the resource is undergoing data migration",
+                "code": 400,
             },
         )
 

--- a/tests/rptest/tests/e2e_finjector.py
+++ b/tests/rptest/tests/e2e_finjector.py
@@ -12,6 +12,7 @@ import sys
 import threading
 import time
 from contextlib import contextmanager
+from typing import Optional
 
 from rptest.services.failure_injector import FailureSpec, make_failure_injector
 
@@ -46,6 +47,7 @@ class Finjector:
         self.custom_failures = []
         self.max_concurrent_failures = sys.maxsize
         self.configure_finjector(**kwargs)
+        self.error: Optional[Exception] = None
 
     def add_failure_spec(self, fspec):
         self.custom_failures.append(fspec)
@@ -89,6 +91,13 @@ class Finjector:
             if self.finjector_thread:
                 self.finjector_thread.join()
             self._cleanup(f_injector)
+            if self.error is not None:
+                self.redpanda.logger.error(
+                    f"Failure injector encountered error: {self.error}, failing the test"
+                )
+                raise Exception(
+                    "Failure injector thread encountered error"
+                ) from self.error
 
     @contextmanager
     def finj_manual(self):
@@ -133,8 +142,12 @@ class Finjector:
     def _failure_injector_loop(self, f_injector):
         while self.enable_loop:
             failure = self._next_failure()
-            f_injector.inject_failure(failure)
-
+            try:
+                f_injector.inject_failure(failure)
+            except Exception as e:
+                self.error = e
+                self.enable_loop = False
+                break
             delay = self.failure_delay_provier()
             if f_injector.cnt_in_flight() >= self.max_concurrent_failures:
                 delay = f_injector.time_till_next_recovery() + delay

--- a/tests/rptest/utils/data_migrations.py
+++ b/tests/rptest/utils/data_migrations.py
@@ -16,6 +16,7 @@ from requests.exceptions import ConnectionError
 from rptest.clients.default import DefaultClient
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import (
+    Admin,
     InboundDataMigration,
     InboundTopic,
     MigrationAction,
@@ -40,6 +41,9 @@ def now():
 
 
 class DataMigrationTestMixin(RedpandaTest):
+    def get_admin(self, redpanda: RedpandaService) -> Admin:
+        return Admin(redpanda, timeout_seconds=5)
+
     def wait_partitions_appear(
         self, topics: list[TopicSpec], redpanda: RedpandaService | None = None
     ):
@@ -91,7 +95,7 @@ class DataMigrationTestMixin(RedpandaTest):
             redpanda = self.redpanda
 
         try:
-            return redpanda._admin.get_data_migration(id, node).json()
+            return self.get_admin(redpanda).get_data_migration(id, node).json()
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 404:
                 return None
@@ -103,7 +107,7 @@ class DataMigrationTestMixin(RedpandaTest):
             redpanda = self.redpanda
 
         redpanda.logger.debug("calling self.admin.list_data_migrations")
-        migrations = redpanda._admin.list_data_migrations(node).json()
+        migrations = self.get_admin(redpanda).list_data_migrations(node).json()
         redpanda.logger.debug("received self.admin.list_data_migrations result")
         return {migration["id"]: migration for migration in migrations}
 
@@ -173,14 +177,14 @@ class DataMigrationTestMixin(RedpandaTest):
 
         def migration_id_if_exists():
             for n in redpanda.nodes:
-                for m in redpanda._admin.list_data_migrations(n).json():
+                for m in self.get_admin(redpanda).list_data_migrations(n).json():
                     if m == migration:
                         return m[id]
             return None
 
         time_before_creation = now()
         try:
-            reply = redpanda._admin.create_data_migration(migration).json()
+            reply = self.get_admin(redpanda).create_data_migration(migration).json()
             redpanda.logger.info(f"create migration reply: {reply}")
             migration_id = reply["id"]
         except requests.exceptions.HTTPError as e:
@@ -205,7 +209,7 @@ class DataMigrationTestMixin(RedpandaTest):
             redpanda = self.redpanda
 
         try:
-            redpanda._admin.delete_data_migration(id, node)
+            self.get_admin(redpanda).delete_data_migration(id, node)
             assert False
         except requests.exceptions.HTTPError:
             pass
@@ -251,7 +255,9 @@ class DataMigrationTestMixin(RedpandaTest):
         if redpanda is None:
             redpanda = self.redpanda
 
-        return redpanda._admin.get_migrated_entities_status(migration_id).json()
+        return (
+            self.get_admin(redpanda).get_migrated_entities_status(migration_id).json()
+        )
 
     def set_entities_status(
         self,
@@ -262,7 +268,7 @@ class DataMigrationTestMixin(RedpandaTest):
         if redpanda is None:
             redpanda = self.redpanda
 
-        redpanda._admin.put_migrated_entities_status(migration_id, state_data)
+        self.get_admin(redpanda).put_migrated_entities_status(migration_id, state_data)
 
     def migrate_between_clusters(
         self,
@@ -284,7 +290,9 @@ class DataMigrationTestMixin(RedpandaTest):
         out_migration_id = self.create_and_wait(out_migration, redpanda=source)
         source.logger.info(f"created outbound migration, id {out_migration_id}")
 
-        out_migration = source._admin.get_data_migration(out_migration_id).json()
+        out_migration = (
+            self.get_admin(source).get_data_migration(out_migration_id).json()
+        )
         assert len(out_migration["migration"]["topics"]) == len(topics)
 
         in_topics = []
@@ -313,7 +321,9 @@ class DataMigrationTestMixin(RedpandaTest):
             self.logger.info(
                 f"transitioning migration {rm.migration_id} on {rm.name} to {action}"
             )
-            rm.redpanda._admin.execute_data_migration_action(rm.migration_id, action)
+            self.get_admin(rm.redpanda).execute_data_migration_action(
+                rm.migration_id, action
+            )
 
         def wait_for_state(rm: RpAndMigration, states: List[str]):
             self.wait_for_migration_states(


### PR DESCRIPTION
This PR contains the following fixes: 
- Passing timeout to Admin client in tests to make retries effective
- Fail test when failure injector fails to stop Redpanda
- Handle `resource_migrated_error` correctly
- Reduce timeouts in migration routers to make them more reasonable and be able to shutdown timely

Fixes: CORE-14484

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
