### PR TITLE
copilot: Advise to use requests with an explicit timeout

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -169,6 +169,7 @@ src/v/base/format_to.h.
 
 - Avoid catching bare `except:` as this can hide system exceptions, including exceptions
   raised by a signal when a test is being forcibly timed out. Instead use `except Exception:`.
+- When using the `requests` library make sure to always specify a sensible timeout
 
 ### Instructions for type hints
 


### PR DESCRIPTION
Avoid too long default timeouts.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none
