### PR TITLE
Revert "raft: defer commit index notifications until log truncation"

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1492,11 +1492,8 @@ consensus::do_start(std::optional<xshard_transfer_state> xst_state) {
         std::optional<storage::truncate_prefix_config> start_truncate_cfg;
         auto snapshot_units = co_await _snapshot_lock.get_units();
         auto metadata = co_await read_snapshot_metadata();
-        // only set if snapshot was applied.
-        std::optional<model::offset> last_snapshot_index;
         if (metadata.has_value()) {
-            update_snapshot_offset(metadata.value());
-            last_snapshot_index = _last_snapshot_index;
+            update_offset_from_snapshot(metadata.value());
             co_await _configuration_manager.add(
               _last_snapshot_index, std::move(metadata->latest_configuration));
             _probe->configuration_update();
@@ -1511,17 +1508,8 @@ consensus::do_start(std::optional<xshard_transfer_state> xst_state) {
             _snapshot_size = co_await _snapshot_mgr.get_snapshot_size();
         }
         co_await _log->start(start_truncate_cfg, _as);
-        if (last_snapshot_index) {
-            auto prev_commit_index = _commit_index;
-            _commit_index = std::max(_commit_index, *last_snapshot_index);
-            maybe_update_last_visible_index(_commit_index);
-            if (prev_commit_index != _commit_index) {
-                _commit_index_updated.broadcast();
-                _replication_monitor.notify_committed();
-                _event_manager.notify_commit_index();
-            }
-        }
         snapshot_units.return_all();
+
         vlog(
           _ctxlog.debug,
           "Starting raft bootstrap from {}",
@@ -2405,8 +2393,7 @@ ss::future<> consensus::hydrate_snapshot() {
     if (!metadata.has_value()) {
         co_return;
     }
-    update_snapshot_offset(metadata.value());
-    auto last_snapshot_index = _last_snapshot_index;
+    update_offset_from_snapshot(metadata.value());
     co_await _configuration_manager.add(
       _last_snapshot_index, std::move(metadata->latest_configuration));
     _probe->configuration_update();
@@ -2416,19 +2403,6 @@ ss::future<> consensus::hydrate_snapshot() {
     }
     _snapshot_size = co_await _snapshot_mgr.get_snapshot_size();
     update_follower_states(_configuration_manager.get_latest());
-    // update to commit index is deferred until the log is truncated
-    // to the snapshot last included index. This is done to ensure that
-    // the offset translator changes in the snapshot are applied before
-    // we move the commit index forward, so that any reads at or beyond
-    // the commit index can be properly translated.
-    auto prev_commit_index = _commit_index;
-    _commit_index = std::max(_commit_index, last_snapshot_index);
-    maybe_update_last_visible_index(_commit_index);
-    if (prev_commit_index != _commit_index) {
-        _commit_index_updated.broadcast();
-        _replication_monitor.notify_committed();
-        _event_manager.notify_commit_index();
-    }
 }
 
 std::optional<storage::truncate_prefix_config>
@@ -2495,7 +2469,7 @@ consensus::read_snapshot_metadata() {
     co_return metadata;
 }
 
-void consensus::update_snapshot_offset(
+void consensus::update_offset_from_snapshot(
   const raft::snapshot_metadata& metadata) {
     vassert(
       metadata.last_included_index >= _last_snapshot_index,
@@ -2510,6 +2484,15 @@ void consensus::update_snapshot_offset(
 
     _last_snapshot_index = metadata.last_included_index;
     _last_snapshot_term = metadata.last_included_term;
+
+    auto prev_commit_index = _commit_index;
+    _commit_index = std::max(_last_snapshot_index, _commit_index);
+    maybe_update_last_visible_index(_commit_index);
+    if (prev_commit_index != _commit_index) {
+        _commit_index_updated.broadcast();
+        _replication_monitor.notify_committed();
+        _event_manager.notify_commit_index();
+    }
 }
 
 ss::future<install_snapshot_reply>

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -617,7 +617,7 @@ private:
      */
     ss::future<> hydrate_snapshot();
 
-    void update_snapshot_offset(const snapshot_metadata&);
+    void update_offset_from_snapshot(const snapshot_metadata&);
     ss::future<std::optional<snapshot_metadata>> read_snapshot_metadata();
 
     /**


### PR DESCRIPTION
This reverts commit bd6ff66ebe8f5cd544e1ab37c029cee55158d9bc.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none