### PR TITLE
[CORE-13407] cl/tests: Improve test_continuous_group_sync

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -980,6 +980,7 @@ class RpkTool:
         timeout: float | None = None,
         use_schema_registry: str | None = None,
         read_committed: bool = False,
+        fetch_max_wait: float | None = None,
     ) -> str:
         cmd = ["consume", topic]
         if group is not None:
@@ -990,6 +991,11 @@ class RpkTool:
             cmd.append("-r")
         if fetch_max_bytes is not None:
             cmd += ["--fetch-max-bytes", str(fetch_max_bytes)]
+        if fetch_max_wait is not None:
+            cmd += [
+                "--fetch-max-wait",
+                f"{str(fetch_max_wait)}s",
+            ]
         if offset is not None:
             cmd += ["-o", f"{offset}"]
         if partition is not None:

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -2249,6 +2249,9 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
                 }
                 for p in g_desc.partitions:
                     if (p.topic, p.partition) not in t_partitions:
+                        self.logger.debug(
+                            f"Group {g_name} partition {p.topic}/{p.partition} not present in target_cluster"
+                        )
                         return False
                     if p.current_offset != t_partitions[(p.topic, p.partition)]:
                         self.logger.warn(

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -2222,6 +2222,7 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
                     n=1,
                     timeout=5,
                     offset="start",
+                    fetch_max_wait=2,
                     format=format,
                 )
             except Exception as e:


### PR DESCRIPTION
* Improve use of `rpk.consume()`
* Improve logging (I can't reproduce locally)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
