### PR TITLE
tests: Unbreak HighThroughputPartitionMovementTest

### DIFF
--- a/tests/rptest/clients/default.py
+++ b/tests/rptest/clients/default.py
@@ -79,7 +79,7 @@ class DefaultClient:
         client = KafkaCliTools(self._redpanda)
         client.delete_topic(name)
 
-    def describe_topics(self, topics=None):
+    def describe_topics(self, topics: list[str] | None = None):
         """
         Describe topics. Pass topics=None to describe all topics, or a pass a
         list of topic names to restrict the call to a set of specific topics.

--- a/tests/rptest/scale_tests/ht_partition_movement_test.py
+++ b/tests/rptest/scale_tests/ht_partition_movement_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+from typing import Any
 from ducktape.mark import parametrize
 from ducktape.utils.util import wait_until
 
@@ -18,10 +19,11 @@ from rptest.services.kgo_verifier_services import (
 )
 from rptest.tests.partition_movement import PartitionMovementMixin
 from rptest.tests.prealloc_nodes import PreallocNodesTest
+from ducktape.tests.test import TestContext
 
 
 class HighThroughputPartitionMovementTest(PreallocNodesTest, PartitionMovementMixin):
-    def __init__(self, test_context, *args, **kwargs):
+    def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any):
         super().__init__(
             test_context=test_context,
             node_prealloc_count=1,
@@ -43,12 +45,12 @@ class HighThroughputPartitionMovementTest(PreallocNodesTest, PartitionMovementMi
             self._number_of_moves = 2
         else:
             self._partitions = 32
-            self._message_size = 256 * (2**10)  # 256 KB per message
-            self._message_cnt = 819200  # 100GB data
+            self._message_size = 256 * 1024
+            self._message_cnt = 819200
             self._consumers = 8
             self._number_of_moves = 5
 
-    def _start_producer(self, topic_name):
+    def _start_producer(self, topic_name: str):
         self.producer = KgoVerifierProducer(
             self.test_context,
             self.redpanda,
@@ -65,7 +67,7 @@ class HighThroughputPartitionMovementTest(PreallocNodesTest, PartitionMovementMi
             backoff_sec=1,
         )
 
-    def _start_consumer(self, topic_name):
+    def _start_consumer(self, topic_name: str):
         self.consumer = KgoVerifierConsumerGroupConsumer(
             self.test_context,
             self.redpanda,
@@ -76,7 +78,7 @@ class HighThroughputPartitionMovementTest(PreallocNodesTest, PartitionMovementMi
         )
         self.consumer.start(clean=False)
 
-    def verify(self, topic_name):
+    def verify(self, topic_name: str):
         self.producer.wait()
 
         self.consumer.wait()
@@ -96,7 +98,7 @@ class HighThroughputPartitionMovementTest(PreallocNodesTest, PartitionMovementMi
     @cluster(num_nodes=6)
     @parametrize(replication_factor=1)
     @parametrize(replication_factor=3)
-    def test_moving_single_partition_under_load(self, replication_factor):
+    def test_moving_single_partition_under_load(self, replication_factor: int):
         topic = TopicSpec(
             partition_count=self._partitions, replication_factor=replication_factor
         )
@@ -114,7 +116,7 @@ class HighThroughputPartitionMovementTest(PreallocNodesTest, PartitionMovementMi
 
         self.verify(topic.name)
 
-    def _random_move_and_cancel(self, topic, partition):
+    def _random_move_and_cancel(self, topic: str, partition: int):
         previous_assignment, new_assignment = self._dispatch_random_partition_move(
             topic, partition, allow_no_op=False
         )
@@ -130,7 +132,7 @@ class HighThroughputPartitionMovementTest(PreallocNodesTest, PartitionMovementMi
     @cluster(num_nodes=6)
     @parametrize(replication_factor=1)
     @parametrize(replication_factor=3)
-    def test_interrupting_partition_movement_under_load(self, replication_factor):
+    def test_interrupting_partition_movement_under_load(self, replication_factor: int):
         topic = TopicSpec(
             partition_count=self._partitions, replication_factor=replication_factor
         )

--- a/tests/rptest/scale_tests/ht_partition_movement_test.py
+++ b/tests/rptest/scale_tests/ht_partition_movement_test.py
@@ -21,6 +21,8 @@ from rptest.tests.partition_movement import PartitionMovementMixin
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from ducktape.tests.test import TestContext
 
+from rptest.utils.scale_parameters import ScaleParameters
+
 
 class HighThroughputPartitionMovementTest(PreallocNodesTest, PartitionMovementMixin):
     def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any):
@@ -35,28 +37,36 @@ class HighThroughputPartitionMovementTest(PreallocNodesTest, PartitionMovementMi
             **kwargs,
         )
 
+        self._message_size = 16384
         if not self.redpanda.dedicated_nodes:
             # Mini mode, for developers working on the test on their workstation.
             # (not for use in CI)
             self._partitions = 16
-            self._message_size = 16384
-            self._message_cnt = 64000
             self._consumers = 1
             self._number_of_moves = 2
         else:
             self._partitions = 32
-            self._message_size = 256 * 1024
-            self._message_cnt = 819200
             self._consumers = 8
             self._number_of_moves = 5
 
-    def _start_producer(self, topic_name: str):
+    def _target_runtime_seconds(self) -> int:
+        return 2 * 60
+
+    def _start_producer(self, topic_name: str, scale: ScaleParameters):
+        msg_count = (
+            scale.target_per_node_throughput
+            // self._message_size
+            * scale.node_count
+            * self._target_runtime_seconds()
+        )
+
         self.producer = KgoVerifierProducer(
             self.test_context,
             self.redpanda,
             topic_name,
             self._message_size,
-            self._message_cnt,
+            msg_count=msg_count,
+            rate_limit_bps=scale.target_per_node_throughput * scale.node_count,
             custom_node=self.preallocated_nodes,
         )
         self.producer.start(clean=False)
@@ -79,7 +89,7 @@ class HighThroughputPartitionMovementTest(PreallocNodesTest, PartitionMovementMi
         self.consumer.start(clean=False)
 
     def verify(self, topic_name: str):
-        self.producer.wait()
+        self.producer.wait(timeout_sec=int(self._target_runtime_seconds() * 1.2))
 
         self.consumer.wait()
         assert self.consumer.consumer_status.validator.invalid_reads == 0
@@ -99,12 +109,13 @@ class HighThroughputPartitionMovementTest(PreallocNodesTest, PartitionMovementMi
     @parametrize(replication_factor=1)
     @parametrize(replication_factor=3)
     def test_moving_single_partition_under_load(self, replication_factor: int):
+        scale = ScaleParameters(self.redpanda, replication_factor)
         topic = TopicSpec(
             partition_count=self._partitions, replication_factor=replication_factor
         )
         self.client().create_topic(topic)
 
-        self._start_producer(topic.name)
+        self._start_producer(topic.name, scale)
         self._start_consumer(topic.name)
 
         for _ in range(self._number_of_moves):
@@ -133,12 +144,14 @@ class HighThroughputPartitionMovementTest(PreallocNodesTest, PartitionMovementMi
     @parametrize(replication_factor=1)
     @parametrize(replication_factor=3)
     def test_interrupting_partition_movement_under_load(self, replication_factor: int):
+        scale = ScaleParameters(self.redpanda, replication_factor)
+
         topic = TopicSpec(
             partition_count=self._partitions, replication_factor=replication_factor
         )
         self.client().create_topic(topic)
 
-        self._start_producer(topic.name)
+        self._start_producer(topic.name, scale)
         self._start_consumer(topic.name)
 
         for _ in range(self._number_of_moves):

--- a/tests/rptest/tests/partition_movement.py
+++ b/tests/rptest/tests/partition_movement.py
@@ -9,12 +9,17 @@
 
 import copy
 import random
+from typing import Any
 
 import requests
 from ducktape.utils.util import wait_until
 
+from rptest.clients.default import TopicDescription
 from rptest.services.admin import Admin
 from rptest.util import wait_until_result
+
+
+PartitionAssignment = dict[Any, Any]
 
 
 class PartitionMovementMixin:
@@ -23,7 +28,7 @@ class PartitionMovementMixin:
     INVALID_CORE = 12121212
 
     @staticmethod
-    def _random_partition(metadata):
+    def _random_partition(metadata: list[TopicDescription]):
         topic = random.choice(metadata)
         partition = random.choice(topic.partitions)
         return topic.name, partition.id
@@ -121,7 +126,13 @@ class PartitionMovementMixin:
                 result.append(dict(node_id=node_id, core=partition["core"]))
         return result
 
-    def _wait_post_move(self, topic, partition, assignments, timeout_sec):
+    def _wait_post_move(
+        self,
+        topic: str,
+        partition: int,
+        assignments: list[PartitionAssignment],
+        timeout_sec: int,
+    ):
         # We need to add retries, becasue of eventual consistency. Metadata will be updated but it can take some time.
         admin = Admin(self.redpanda, retry_codes=[404, 503, 504], retries_amount=10)
 
@@ -181,7 +192,7 @@ class PartitionMovementMixin:
 
         assert movement_cancelled or movement_finished
 
-    def _do_move_and_verify(self, topic, partition, timeout_sec):
+    def _do_move_and_verify(self, topic: str, partition: int, timeout_sec: int):
         _, new_assignment = self._dispatch_random_partition_move(
             topic=topic, partition=partition
         )
@@ -281,7 +292,11 @@ class PartitionMovementMixin:
                 )
 
     def _dispatch_random_partition_move(
-        self, topic, partition, x_core_only=False, allow_no_op=True
+        self,
+        topic: str,
+        partition: int,
+        x_core_only: bool = False,
+        allow_no_op: bool = True,
     ):
         """
         Request partition replicas to be randomly moved
@@ -324,13 +339,13 @@ class PartitionMovementMixin:
 
     def _request_move_cancel(
         self,
-        topic,
-        partition,
-        previous_assignment,
-        unclean_abort,
-        force_back=False,
-        new_assignment=None,
-        timeout=90,
+        topic: str,
+        partition: int,
+        previous_assignment: list[PartitionAssignment],
+        unclean_abort: bool,
+        force_back: bool = False,
+        new_assignment: list[PartitionAssignment] | None = None,
+        timeout: int = 90,
     ):
         """
         Request partition movement to interrupt and validates

--- a/tests/rptest/utils/scale_parameters.py
+++ b/tests/rptest/utils/scale_parameters.py
@@ -66,6 +66,15 @@ class ScaleParameters:
         self.node_cpus = self.redpanda.get_node_cpu_count()
         node_disk_free = self.redpanda.get_node_disk_free()
 
+        # Targetting m6id.xlarge
+        self.target_per_node_throughput = 80 * 1024 * 1024 // replication_factor
+
+        if not self.redpanda.dedicated_nodes:
+            # Assume we only get one shard worth of throughput (compared to the CDT 4 core case)
+            self.target_per_node_throughput //= 4
+            # Half it for safety
+            self.target_per_node_throughput //= 2
+
         if self.redpanda.dedicated_nodes:
             # Emulate seastar's policy for default reserved memory
             reserved_memory = max(1536, int(0.07 * self.node_memory_mib) + 1)

--- a/tools/type-checking/type-check-strictness.json
+++ b/tools/type-checking/type-check-strictness.json
@@ -31,7 +31,6 @@
         "rptest/remote_scripts/schema_registry_test_helper.py",
         "rptest/remote_scripts/tgkill.py",
         "rptest/scale_tests/franzgo_bench.py",
-        "rptest/scale_tests/ht_partition_movement_test.py",
         "rptest/scale_tests/large_controller_snapshot_test.py",
         "rptest/scale_tests/large_messages_test.py",
         "rptest/scale_tests/list_kafka_connections_scale_test.py",


### PR DESCRIPTION
Fixes HighThroughputPartitionMovementTest which was broken since at least the instance type switches. 

Make the producer target an achievable rate and wait accordingly.

Fixes CORE-8507
Fixes CORE-8508

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
