### PR TITLE
Fixed non translatable high watermark

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -1639,7 +1639,14 @@ model::offset partition::committed_offset() const {
     return _raft->committed_offset();
 }
 model::offset partition::high_watermark() const {
-    return model::next_offset(_raft->last_visible_index());
+    auto lsi = _raft->last_visible_index();
+    auto start_offset = _raft->start_offset();
+    if (lsi < start_offset) {
+        // Doesn't need next_offset since start_offset is already
+        // the first offset that can be produced to.
+        return start_offset;
+    }
+    return model::next_offset(lsi);
 }
 model::offset partition::leader_high_watermark() const {
     return model::next_offset(_raft->last_leader_visible_index());

--- a/src/v/kafka/server/tests/write_at_offset_stm_test.cc
+++ b/src/v/kafka/server/tests/write_at_offset_stm_test.cc
@@ -27,6 +27,15 @@ copy_batches(const chunked_vector<model::record_batch>& batches) {
 
 static ss::logger t_log{"test_log"};
 using namespace testing;
+namespace kafka {
+class write_at_offset_stm_accessor {
+public:
+    static kafka::offset
+    get_expected_last_offset(const kafka::write_at_offset_stm& stm) {
+        return stm.expected_last_offset();
+    }
+};
+} // namespace kafka
 struct WriteAtOffsetStmFixture
   : public raft::stm_raft_fixture<kafka::write_at_offset_stm> {
     std::tuple<ss::shared_ptr<kafka::write_at_offset_stm>> create_stms(
@@ -70,6 +79,38 @@ struct WriteAtOffsetStmFixture
         return batches;
     }
 
+    std::
+      tuple<chunked_vector<chunked_vector<model::record_batch>>, kafka::offset>
+      generate_data_with_deltas(
+        kafka::offset starting_at,
+        size_t batch_count,
+        size_t records_per_batch) {
+        chunked_vector<chunked_vector<model::record_batch>> batches;
+
+        // randomly split batches into multiple batch groups
+        for (auto i : boost::irange(batch_count)) {
+            if (batches.empty() || tests::random_bool()) {
+                batches.emplace_back();
+            }
+            auto type
+              = i % 2 == 0
+                  ? model::record_batch_type::raft_data
+                  : model::record_batch_type::partition_properties_update;
+            storage::record_batch_builder builder(
+              type, kafka::offset_cast(starting_at));
+
+            for (size_t j = 0; j < records_per_batch; ++j) {
+                builder.add_raw_kv(
+                  serde::to_iobuf(tests::random_bytes(64)),
+                  serde::to_iobuf(starting_at()));
+                if (type == model::record_batch_type::raft_data) {
+                    starting_at++;
+                }
+            }
+            batches.back().push_back(std::move(builder).build());
+        }
+        return std::make_tuple(std::move(batches), kafka::offset(starting_at));
+    }
     struct offset_validating_consumer {
         ss::future<ss::stop_iteration> operator()(model::record_batch& batch) {
             if (batch.header().type != model::record_batch_type::raft_data) {
@@ -85,7 +126,7 @@ struct WriteAtOffsetStmFixture
                 if (offset() != expected_offset) {
                     valid = false;
                     t_log.error(
-                      "Expected offset {} does not batch {} record offset: {}",
+                      "Expected offset {} does not match {} record offset: {}",
                       expected_offset,
                       batch.header(),
                       offset);
@@ -444,26 +485,26 @@ TEST_F(WriteAtOffsetStmFixture, test_recovery_from_snapshot) {
     initialize_state_machines(3).get();
     auto leader_id = wait_for_leader(10s).get();
     auto stm = get_leader_stm();
+    auto leader_raft = node(leader_id).raft();
     kafka::offset gen_offset{0};
     // store the truncation point, it is the base offset of second replicated
     // batch.
     model::offset snapshot_offset{};
-    for (int i = 0; i < 10; ++i) {
-        auto data = generate_data(
+    for (int i = 0; i < 200; ++i) {
+        auto res = generate_data_with_deltas(
           gen_offset,
           random_generators::get_int(1, 10),
           random_generators::get_int(1, 10));
-        gen_offset = model::offset_cast(
-          model::next_offset(data.back().back().last_offset()));
+        auto [data, last_offset] = std::move(res);
+        gen_offset = last_offset;
         for (auto& batches : data) {
-            auto expected_offsets = start_offsets(batches);
-            auto stages = stm->get()->replicate(
-              std::move(batches),
-              std::move(expected_offsets),
-              std::nullopt,
-              10s);
-            stages.request_enqueued.get();
-            auto result = stages.replicate_finished.get();
+            auto result = leader_raft
+                            ->replicate(
+                              std::move(batches),
+                              raft::replicate_options(
+                                raft::consistency_level::quorum_ack))
+                            .get();
+
             ASSERT_FALSE(result.has_error());
         }
         if (snapshot_offset == model::offset{}) {
@@ -494,6 +535,24 @@ TEST_F(WriteAtOffsetStmFixture, test_recovery_from_snapshot) {
     ASSERT_THAT(
       follower.raft()->log()->offsets().start_offset,
       Eq(model::next_offset(snapshot_offset)));
+
+    auto leader_stm = get_leader_stm();
+    ASSERT_TRUE(leader_stm.has_value());
+    auto leader_last_offset
+      = leader_stm.value()->get_expected_last_offset(10s).get();
+    ASSERT_FALSE(leader_last_offset.has_error());
+    for (auto& [id, node] : nodes()) {
+        auto stm
+          = node->raft()->stm_manager()->get<kafka::write_at_offset_stm>();
+        stm->wait(node->raft()->committed_offset(), model::no_timeout).get();
+        auto last_offset
+          = kafka::write_at_offset_stm_accessor::get_expected_last_offset(*stm);
+        ASSERT_EQ(last_offset, leader_last_offset.value()) << fmt::format(
+          "Node {} has last offset {} but leader has {}",
+          id,
+          last_offset,
+          leader_last_offset.value());
+    }
     ASSERT_TRUE(logs_content_is_valid().get());
 }
 

--- a/src/v/kafka/server/write_at_offset_stm.h
+++ b/src/v/kafka/server/write_at_offset_stm.h
@@ -137,6 +137,7 @@ public:
     get_expected_last_offset(model::timeout_clock::duration sync_timeout);
 
 private:
+    friend class write_at_offset_stm_accessor;
     ss::future<> do_apply(const model::record_batch& b) final;
 
     ss::future<raft::local_snapshot_applied>


### PR DESCRIPTION
It is possible that log is truncated before Raft visible index is
updated, in this situation translating the offset returned by
`cluster::hight_watermark` to kafka offset fails as the
`offset_translator` may no longer contain a range of not truncated high
watermark.

In order to fix the issue implemented the semantics in which an empty
log high watermark is equal to its start offset. Which translates to:
```
last_visible_index(empty_log) = start_offset - 1
```
Fixes: CORE-14535
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none