### PR TITLE
CORE-13378 cl/test: accept abort exception on aborted fetch

### DIFF
--- a/src/v/cluster_link/replication/tests/mux_consumer_fixture_tests.cc
+++ b/src/v/cluster_link/replication/tests/mux_consumer_fixture_tests.cc
@@ -187,15 +187,20 @@ TEST_P(MuxConsumerFixture, TestResetPartition) {
     ss::abort_source as;
     // no data in the partition right now.
     auto fetch = _mux_consumer->fetch(tp, as);
-    // reset the consumer to offset 50, this should reset any inflight fetches.
 
     // publish some data into the partition in two batches.
     produce_to_partition(topic, 0, 100).get();
     produce_to_partition(topic, 0, 100).get();
+
+    // reset the consumer to offset 101, this should reset any inflight fetches.
     reset = _mux_consumer->reset(tp, kafka::offset{101});
     ASSERT_TRUE(reset.has_value()) << reset.error();
+
     // ignore first fetch result
-    auto first_fetch_res = fetch.get();
+    fetch.discard_result()
+      .handle_exception_type([](const ss::abort_requested_exception&) {})
+      .get();
+
     // note: consumer always fetches on batch boundaries.
     // fetch should fetch from offset [100 - 199) = 100 offsets
     auto fetch_res = _mux_consumer->fetch(tp, as).get();


### PR DESCRIPTION
In this test, we issue a fetch and then reset the client soon after. Depending on whether the fetch completes earlier or the reset, the fetching future either returns some data or an
abort_requested_exception. So allow either, otherwise the test fails with an uncaught exception.

The reproducer is to add some sleep to the fetch path to force the abort_requested_exception to simulate the timing issue: https://gist.github.com/pgellert/52653f5b67553e06032f65bf2ea6b656

Fixes https://redpandadata.atlassian.net/browse/CORE-13378

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
