### PR TITLE
[CORE-13714] `rptest`: ignore `parser_error` `ERROR` log line for checksumming

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -257,6 +257,12 @@ PREV_VERSION_LOG_ALLOW_LIST = [
     "raft - .*recovery append entries error.*client_request_timeout",
     # Pre v23.2 Redpanda's don't know how to interact with HNS Storage Accounts correctly
     "abs - .*FeatureNotYetSupportedForHierarchicalNamespaceAccounts",
+    # We added a condition to log these storage parser errors at `DEBUG` during
+    # recovery here: https://github.com/redpanda-data/redpanda/pull/27287
+    # However, old versions will still log at `ERROR` when there are not enough bytes
+    # left due to unclean shutdown in a segment being recovered. Ignore these
+    # in a mixed version test.
+    "storage - .*parser::consume_records error: parser_errc::input_stream_not_enough_bytes .* storage::checksumming_consumer",
 ]
 
 AUDIT_LOG_ALLOW_LIST = RESTART_LOG_ALLOW_LIST + [


### PR DESCRIPTION
We added a log these storage parser errors at `DEBUG` during recovery here: https://github.com/redpanda-data/redpanda/pull/27287. However, old versions will still log at `ERROR` when there are not enough bytes left due to unclean shutdown in a segment being recovered. Ignore these in a mixed version test.

Adding an exception for this log line is safe (i.e won't silence other cases of data corruption or errors) because the `checksumming_consumer` is only be used within the `log_replayer`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
