### PR TITLE
[CORE-14010] rptest: more iceberg client logs lines to ignore

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -187,6 +187,9 @@ DEFAULT_LOG_ALLOW_LIST: list[CompiledLogAllowElem] = [
     # just indicate a race in committing to Iceberg.
     re.compile(r"UpdateRequirement.*Assert"),
     re.compile("assert-ref-snapshot-id"),
+    re.compile("assert-current-schema-id"),
+    re.compile("assert-last-assigned-partition-id"),
+    re.compile("assert-default-spec-id"),
     # Temporary: https://redpandadata.atlassian.net/browse/CORE-9897
     # there is an ongoing investigation into s3_client receiving 400 Bad Request. For now, stop the CI bleed
     re.compile(


### PR DESCRIPTION
We already ignore log lines with assert-ref-snapshot-id (logged because we log the request we're sending to the Iceberg catalog). Turns out there are a few others, seen below, that this commit adds to the ignored list.

```
TRACE 2025-10-15 21:43:42,626 [shard 1:main] iceberg - catalog_client.cc:65 - Failed to perform commit_table_update request: {"identifier":{"name":"topic_000976","namespace":["redpanda"]},"requirements":[{"type":"assert-current-schema-id","current-schema-id":1},{"type":"assert-last-assigned-partition-id","last-assigned-partition-id":1000},{"type":"assert-default-spec-id","default-spec-id":0}],"updates":[{"action":"add-spec","spec":{"spec-id":1,"fields":[{"source-id":12,"field-id":1001,"name":"event_type","transform":"identity"}]}},{"action":"set-default-spec","spec-id":-1}]}"
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
