### PR TITLE
[CORE-14506] rptest: limit duck_db test to S3

### DIFF
--- a/tests/rptest/tests/datalake/datalake_dlq_test.py
+++ b/tests/rptest/tests/datalake/datalake_dlq_test.py
@@ -18,6 +18,7 @@ from rptest.clients.serde_client_utils import SchemaType, SerdeClientType
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import (
+    CloudStorageType,
     MetricsEndpoint,
     PandaproxyConfig,
     SISettings,
@@ -339,7 +340,8 @@ class DatalakeDLQTest(RedpandaTest):
 
     @cluster(num_nodes=3)
     @matrix(
-        cloud_storage_type=supported_storage_types(),
+        # TODO: make our DuckDB query service support more than just S3.
+        cloud_storage_type=[CloudStorageType.S3],
         # Lightweight matrix as we only care about custom suffix behavior here.
         query_engine=[QueryEngineType.DUCKDB_PY],
         catalog_type=[filesystem_catalog_type()],


### PR DESCRIPTION
Our duckdb query service requires S3 (presumably it just needs more work on our end):

```
AssertionError: DuckDBPy query service is implemented only for S3 credentials
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
