### PR TITLE
[CORE-14530] rptests: skip scrubbing/diagnostics in datalake many_top…

### DIFF
--- a/tests/rptest/tests/datalake/many_topics_test.py
+++ b/tests/rptest/tests/datalake/many_topics_test.py
@@ -21,7 +21,7 @@ from ducktape.mark import matrix
 from rptest.clients.rpk import RpkTool
 from rptest.services.catalog_service import CatalogType
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import SISettings, SchemaRegistryConfig
+from rptest.services.redpanda import LoggingConfig, SISettings, SchemaRegistryConfig
 from rptest.tests.datalake.datalake_services import DatalakeServices
 from rptest.tests.datalake.query_engine_base import QueryEngineType
 from rptest.tests.datalake.utils import supported_storage_types
@@ -42,6 +42,12 @@ class DatalakeManyTopicsTest(RedpandaTest):
                 "iceberg_catalog_commit_interval_ms": 5000,
                 "iceberg_target_lag_ms": 5000,
             },
+            # Configure less-than-trace logging. Given how many
+            # topics/partitions there may be, log size can get huge,
+            # particularly in CDT.
+            log_config=LoggingConfig(
+                "debug",
+            ),
             disable_cloud_storage_diagnostics=True,
             schema_registry_config=SchemaRegistryConfig(),
             *args,

--- a/tests/rptest/tests/datalake/many_topics_test.py
+++ b/tests/rptest/tests/datalake/many_topics_test.py
@@ -34,12 +34,15 @@ class DatalakeManyTopicsTest(RedpandaTest):
         super(DatalakeManyTopicsTest, self).__init__(
             test_ctx,
             num_brokers=6,
-            si_settings=SISettings(test_context=test_ctx),
+            si_settings=SISettings(
+                test_context=test_ctx, skip_end_of_test_scrubbing=True
+            ),
             extra_rp_conf={
                 "iceberg_enabled": True,
                 "iceberg_catalog_commit_interval_ms": 5000,
                 "iceberg_target_lag_ms": 5000,
             },
+            disable_cloud_storage_diagnostics=True,
             schema_registry_config=SchemaRegistryConfig(),
             *args,
             **kwargs,


### PR DESCRIPTION
…ics_test

We've seen a run of this test that took roughly 20 minutes, and then spent over 10 minutes in scrubbing and performing collecting objects for cloud diagnostics.

As we do for other scale-shaped tests, this commit updates the test to skip both of these steps.

Also drops the log level to debug, since the logs for this test in CDT are huge (over 1GiB compressed).
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
