### PR TITLE
[CORE-8556] rptest: ignore sync errors when resetting manifest

### DIFF
--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -519,7 +519,11 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
                 except HTTPError as ex:
                     if "would cause data loss" in ex.response.text:
                         resets_refused += 1
+                    elif "Could not sync with log" in ex.response.text:
+                        # Benign, transient error.
+                        pass
                     else:
+                        # Some other unexpected error.
                         resets_failed += 1
                     self.logger.info(f"Reset from cloud failed: {ex}")
                 next_reset = now + timedelta(seconds=seconds_between_reset)


### PR DESCRIPTION
Sync errors may happen for a variety of reasons, but generally they are transient. This was causing the test to fail:

```
[WARNING - 2025-10-08 10:01:40,588 - admin - _request - lineno:805]: Response 500: {"message": "Could not sync with log", "code": 500}
[INFO  - 2025-10-08 10:01:40,588 - e2e_shadow_indexing_test - test_reset_from_cloud - lineno:524]: Reset from cloud failed: 500 Server Error: Internal Server Error for url: http://docker-rp-6:9644/v1/cloud_storage/unsafe_reset_metadata_from_cloud/kafka/panda-topic/0
[DEBUG - 2025-10-08 10:01:43,407 - kgo_verifier_services - _ingest_status - lineno:433]: KgoVerifierProducer-0-139894623949760 status: [{'topic': 'panda-topic', 'sent': 89864, 'acked': 88839, 'bad_offsets': 0, 'max_offsets_produced': {'0': 88838}, 'restarts': 0, 'fails': 0, 'tombstones_produced': 0, 'failed_transactions': 0, 'aborted_transaction_msgs': 0, 'latency': {'p50': 13798.5, 'p90': 21826, 'p99': 370127}, 'active': True}]
...
[ERROR - 2025-10-08 10:02:05,643 - cluster - _do_post_test_checks - lineno:136]: Test failed, doing failure checks on RedpandaService-0-139894623572640...
Traceback (most recent call last):
  File "/root/tests/rptest/services/cluster.py", line 246, in wrapped
    r = f(self, *args, **kwargs)
  File "/root/tests/rptest/tests/e2e_shadow_indexing_test.py", line 537, in test_reset_from_cloud
    assert resets_failed == 0, f"{resets_failed} resets failed during the test"
AssertionError: 1 resets failed during the test
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
