### PR TITLE
`cloud_io`: use `chunked_vector` for `Delete` related functions

### DIFF
--- a/src/v/cloud_io/BUILD
+++ b/src/v/cloud_io/BUILD
@@ -116,6 +116,7 @@ redpanda_cc_library(
         "//src/v/cloud_roles:types",
         "//src/v/cloud_storage_clients",
         "//src/v/config",
+        "//src/v/container:chunked_vector",
         "//src/v/model",
         "//src/v/utils:lazy_abort_source",
         "@seastar",

--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -18,6 +18,7 @@
 #include "cloud_storage_clients/configuration.h"
 #include "cloud_storage_clients/types.h"
 #include "cloud_storage_clients/util.h"
+#include "container/chunked_vector.h"
 #include "model/metadata.h"
 #include "ssx/future-util.h"
 #include "ssx/semaphore.h"
@@ -764,7 +765,7 @@ ss::future<upload_result> remote::delete_objects(
     }
 
     const auto batches_to_delete = num_chunks(keys, delete_objects_max_keys());
-    std::vector<upload_result> results;
+    chunked_vector<upload_result> results;
     results.reserve(batches_to_delete);
 
     co_await ss::max_concurrent_for_each(
@@ -786,11 +787,10 @@ ss::future<upload_result> remote::delete_objects(
               chunk_end = keys.end();
           }
 
-          std::vector<cloud_storage_clients::object_key> key_batch;
-          key_batch.insert(
-            key_batch.end(),
-            std::make_move_iterator(chunk_begin),
-            std::make_move_iterator(chunk_end));
+          chunked_vector<cloud_storage_clients::object_key> key_batch;
+          auto chunk_size = std::distance(chunk_begin, chunk_end);
+          key_batch.reserve(chunk_size);
+          std::move(chunk_begin, chunk_end, std::back_inserter(key_batch));
 
           vassert(
             key_batch.size() > 0,
@@ -820,7 +820,7 @@ ss::future<upload_result> remote::delete_objects(
 
 ss::future<upload_result> remote::delete_object_batch(
   const cloud_storage_clients::bucket_name& bucket,
-  std::vector<cloud_storage_clients::object_key> keys,
+  chunked_vector<cloud_storage_clients::object_key> keys,
   retry_chain_node& parent,
   std::function<void(size_t)> req_cb) {
     ss::gate::holder gh{_gate};
@@ -841,7 +841,7 @@ ss::future<upload_result> remote::delete_object_batch(
     while (!_gate.is_closed() && permit.is_allowed && !result) {
         req_cb(fib.retry_count());
         auto res = co_await lease.client->delete_objects(
-          bucket, keys, fib.get_timeout());
+          bucket, keys.copy(), fib.get_timeout());
 
         if (res) {
             if (!res.value().undeleted_keys.empty()) {
@@ -947,7 +947,7 @@ ss::future<upload_result> remote::delete_objects_sequentially(
       "sequential deletes",
       _cloud_storage_backend);
 
-    std::vector<key_and_node> key_nodes;
+    chunked_vector<key_and_node> key_nodes;
     key_nodes.reserve(keys.size());
 
     std::transform(
@@ -960,7 +960,7 @@ ss::future<upload_result> remote::delete_objects_sequentially(
             .node = std::make_unique<retry_chain_node>(&parent)};
       });
 
-    std::vector<upload_result> results;
+    chunked_vector<upload_result> results;
     results.reserve(key_nodes.size());
     auto fut = co_await ss::coroutine::as_future(
       ss::max_concurrent_for_each(

--- a/src/v/cloud_io/remote.h
+++ b/src/v/cloud_io/remote.h
@@ -203,7 +203,7 @@ public:
     /// \pre the number of keys is <= delete_objects_max_keys
     ss::future<upload_result> delete_object_batch(
       const cloud_storage_clients::bucket_name& bucket,
-      std::vector<cloud_storage_clients::object_key> keys,
+      chunked_vector<cloud_storage_clients::object_key> keys,
       retry_chain_node& parent,
       std::function<void(size_t)> req_cb);
 

--- a/src/v/cloud_storage_clients/BUILD
+++ b/src/v/cloud_storage_clients/BUILD
@@ -38,6 +38,7 @@ redpanda_cc_library(
         "//src/v/cloud_roles",
         "//src/v/cloud_roles:types",
         "//src/v/config",
+        "//src/v/container:chunked_vector",
         "//src/v/container:intrusive",
         "//src/v/hashing:secure",
         "//src/v/http",

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -798,7 +798,7 @@ ss::future<> abs_client::do_delete_object(
 ss::future<result<abs_client::delete_objects_result, error_outcome>>
 abs_client::delete_objects(
   const bucket_name& bucket,
-  std::vector<object_key> keys,
+  chunked_vector<object_key> keys,
   ss::lowres_clock::duration timeout) {
     abs_client::delete_objects_result delete_objects_result;
     for (const auto& key : keys) {

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -212,7 +212,7 @@ public:
     /// \param timeout is a timeout of the operation
     ss::future<result<delete_objects_result, error_outcome>> delete_objects(
       const bucket_name& bucket,
-      std::vector<object_key> keys,
+      chunked_vector<object_key> keys,
       ss::lowres_clock::duration timeout) override;
 
     struct storage_account_info {

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -19,7 +19,6 @@
 #include <seastar/core/lowres_clock.hh>
 
 #include <chrono>
-#include <vector>
 
 namespace cloud_storage_clients {
 
@@ -178,7 +177,7 @@ public:
     virtual ss::future<result<delete_objects_result, error_outcome>>
     delete_objects(
       const bucket_name& bucket,
-      std::vector<object_key> keys,
+      chunked_vector<object_key> keys,
       ss::lowres_clock::duration timeout)
       = 0;
 };

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -286,7 +286,7 @@ struct delete_objects_body : public ss::data_source_impl {
 
 result<std::tuple<http::client::request_header, ss::input_stream<char>>>
 request_creator::make_delete_objects_request(
-  const bucket_name& name, std::span<const object_key> keys) {
+  const bucket_name& name, chunked_vector<object_key> keys) {
     // https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html
     // will generate this request:
     //
@@ -1156,10 +1156,11 @@ iobuf_to_delete_objects_result(iobuf&& buf) {
 
 auto s3_client::do_delete_objects(
   const bucket_name& bucket,
-  std::span<const object_key> keys,
+  chunked_vector<object_key> keys,
   ss::lowres_clock::duration timeout)
   -> ss::future<client::delete_objects_result> {
-    auto request = _requestor.make_delete_objects_request(bucket, keys);
+    auto request = _requestor.make_delete_objects_request(
+      bucket, std::move(keys));
     if (!request) {
         return ss::make_exception_future<delete_objects_result>(
           std::system_error(request.error()));
@@ -1199,11 +1200,11 @@ auto s3_client::do_delete_objects(
 
 auto s3_client::delete_objects(
   const bucket_name& bucket,
-  std::vector<object_key> keys,
+  chunked_vector<object_key> keys,
   ss::lowres_clock::duration timeout)
   -> ss::future<result<delete_objects_result, error_outcome>> {
     const object_key dummy{""};
     co_return co_await send_request(
-      do_delete_objects(bucket, keys, timeout), bucket, dummy);
+      do_delete_objects(bucket, std::move(keys), timeout), bucket, dummy);
 }
 } // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -87,7 +87,7 @@ public:
     /// \return the header and an the body as an input_stream
     result<std::tuple<http::client::request_header, ss::input_stream<char>>>
     make_delete_objects_request(
-      const bucket_name& name, std::span<const object_key> keys);
+      const bucket_name& name, chunked_vector<object_key> keys);
 
     /// \brief Initialize http header for 'ListObjectsV2' request
     ///
@@ -198,7 +198,7 @@ public:
 
     ss::future<result<delete_objects_result, error_outcome>> delete_objects(
       const bucket_name& bucket,
-      std::vector<object_key> keys,
+      chunked_vector<object_key> keys,
       ss::lowres_clock::duration timeout) override;
 
 private:
@@ -239,7 +239,7 @@ private:
 
     ss::future<delete_objects_result> do_delete_objects(
       const bucket_name& bucket,
-      std::span<const object_key> keys,
+      chunked_vector<object_key> keys,
       ss::lowres_clock::duration timeout);
 
     template<typename T>


### PR DESCRIPTION
We've seen overallocations in the wild here [1].

Switch to `chunked_vector` for `Delete` related APIs.


[1] (Can't find the JIRA for this, but here's one found by splunking buildkite summaries)

```
seastar::current_backtrace() at ././external/+non_module_dependencies+seastar/src/util/backtrace.cc:102
seastar::memory::cpu_pages::warn_large_allocation(unsigned long) at ././external/+non_module_dependencies+seastar/src/core/memory.cc:859
seastar::memory::cpu_pages::check_large_allocation(unsigned long) at ././external/+non_module_dependencies+seastar/src/core/memory.cc:922
 (inlined by) seastar::memory::cpu_pages::allocate_large(unsigned int, bool) at ././external/+non_module_dependencies+seastar/src/core/memory.cc:929
 (inlined by) seastar::memory::allocate_large(unsigned long, bool) at ././external/+non_module_dependencies+seastar/src/core/memory.cc:1552
 (inlined by) seastar::memory::allocate_slowpath(unsigned long) at ././external/+non_module_dependencies+seastar/src/core/memory.cc:1712
operator new(unsigned long) at ././external/+non_module_dependencies+seastar/src/core/memory.cc:1733
void* std::__1::__libcpp_operator_new[abi:ne200100]<unsigned long>(unsigned long) at ./external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__new/allocate.h:37
 (inlined by) (anonymous namespace)::key_and_node* std::__1::__libcpp_allocate[abi:ne200100]<(anonymous namespace)::key_and_node>(std::__1::__element_count, unsigned long) at ./external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__new/allocate.h:64
 (inlined by) std::__1::allocator<(anonymous namespace)::key_and_node>::allocate[abi:ne200100](unsigned long) at ./external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__memory/allocator.h:105
 (inlined by) std::__1::allocator<(anonymous namespace)::key_and_node>::allocate_at_least[abi:ne200100](unsigned long) at ./external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__memory/allocator.h:112
 (inlined by) std::__1::allocation_result<(anonymous namespace)::key_and_node*, unsigned long> std::__1::allocator_traits<std::__1::allocator<(anonymous namespace)::key_and_node> >::allocate_at_least[abi:ne200100]<std::__1::allocator<(anonymous namespace)::key_and_node> >(std::__1::allocator<(anonymous namespace)::key_and_node>&, unsigned long) at ./external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__memory/allocator_traits.h:293
 (inlined by) auto std::__1::__allocate_at_least[abi:ne200100]<std::__1::allocator<(anonymous namespace)::key_and_node> >(std::__1::allocator<(anonymous namespace)::key_and_node>&, unsigned long) at ./external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__memory/allocate_at_least.h:26
 (inlined by) std::__1::__split_buffer<(anonymous namespace)::key_and_node, std::__1::allocator<(anonymous namespace)::key_and_node>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<(anonymous namespace)::key_and_node>&) at ./external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__split_buffer:325
 (inlined by) std::__1::vector<(anonymous namespace)::key_and_node, std::__1::allocator<(anonymous namespace)::key_and_node> >::reserve(unsigned long) at ./external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__vector/vector.h:1086
 (inlined by) seastar::future<cloud_io::upload_result> cloud_io::remote::delete_objects_sequentially<std::__1::deque<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> >, std::__1::allocator<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > > > >(detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, cloud_storage_clients::s3_bucket_name, std::__1::integral_constant<bool, false> > const&, std::__1::deque<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> >, std::__1::allocator<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > > >, basic_retry_chain_node<seastar::lowres_clock>&, std::__1::function<void (unsigned long)>) requires (std::ranges::range<std::__1::deque<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> >, std::__1::allocator<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > > > >)&&(std::same_as<std::__1::conditional<__is_primary_template<std::__1::iterator_traits<__remove_cvref, decltype (std::__1::ranges::__cpo::begin((std::declval<std::__1::deque<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> >, std::__1::allocator<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > > >&>)()))> >::value, std::__1::indirectly_readable_traits<decltype (std::__1::ranges::__cpo::begin((std::declval<std::__1::deque<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> >, std::__1::allocator<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > > >&>)()))>, std::__1::iterator_traits<__remove_cvref, decltype (std::__1::ranges::__cpo::begin((std::declval<std::__1::deque<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> >, std::__1::allocator<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > > >&>)()))> >::type::value_type, detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > >) at ././src/v/cloud_io/remote.cc:951
seastar::future<cloud_io::upload_result> cloud_io::remote::delete_objects<std::__1::deque<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> >, std::__1::allocator<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > > > >(detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, cloud_storage_clients::s3_bucket_name, std::__1::integral_constant<bool, false> > const&, std::__1::deque<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> >, std::__1::allocator<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > > >, basic_retry_chain_node<seastar::lowres_clock>&, std::__1::function<void (unsigned long)>) requires (std::ranges::range<std::__1::deque<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> >, std::__1::allocator<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > > > >)&&(std::same_as<std::__1::conditional<__is_primary_template<std::__1::iterator_traits<__remove_cvref, decltype (std::__1::ranges::__cpo::begin((std::declval<std::__1::deque<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> >, std::__1::allocator<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > > >&>)()))> >::value, std::__1::indirectly_readable_traits<decltype (std::__1::ranges::__cpo::begin((std::declval<std::__1::deque<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> >, std::__1::allocator<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > > >&>)()))>, std::__1::iterator_traits<__remove_cvref, decltype (std::__1::ranges::__cpo::begin((std::declval<std::__1::deque<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> >, std::__1::allocator<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > > >&>)()))> >::type::value_type, detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > >) at ././src/v/cloud_io/remote.cc:762
seastar::future<cloud_io::upload_result> cloud_storage::remote::delete_objects<std::__1::deque<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> >, std::__1::allocator<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > > > >(detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, cloud_storage_clients::s3_bucket_name, std::__1::integral_constant<bool, false> > const&, std::__1::deque<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> >, std::__1::allocator<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > > >, basic_retry_chain_node<seastar::lowres_clock>&) requires (std::ranges::range<std::__1::deque<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> >, std::__1::allocator<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > > > >)&&(std::same_as<std::__1::conditional<__is_primary_template<std::__1::iterator_traits<__remove_cvref, decltype (std::__1::ranges::__cpo::begin((std::declval<std::__1::deque<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> >, std::__1::allocator<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > > >&>)()))> >::value, std::__1::indirectly_readable_traits<decltype (std::__1::ranges::__cpo::begin((std::declval<std::__1::deque<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> >, std::__1::allocator<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > > >&>)()))>, std::__1::iterator_traits<__remove_cvref, decltype (std::__1::ranges::__cpo::begin((std::declval<std::__1::deque<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> >, std::__1::allocator<detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > > >&>)()))> >::type::value_type, detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage_clients::s3_object_key, std::__1::integral_constant<bool, false> > >) at ././src/v/cloud_storage/remote.cc:555
archival::ntp_archiver::garbage_collect() at ././src/v/cluster/archival/ntp_archiver_service.cc:3410
archival::ntp_archiver::housekeeping() at ././src/v/cluster/archival/ntp_archiver_service.cc:2689
std::__1::coroutine_handle<seastar::internal::coroutine_traits_base<void>::promise_type>::resume[abi:ne200100]() const at ./external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__coroutine/coroutine_handle.h:144
 (inlined by) seastar::internal::coroutine_traits_base<void>::promise_type::run_and_dispose() at ./external/+non_module_dependencies+seastar/include/seastar/core/coroutine.hh:122
seastar::reactor::task_queue::run_tasks() at ././external/+non_module_dependencies+seastar/src/core/reactor.cc:2721
seastar::reactor::task_queue_group::run_tasks() at ././external/+non_module_dependencies+seastar/src/core/reactor.cc:3222
 (inlined by) seastar::reactor::task_queue_group::run_some_tasks() at ././external/+non_module_dependencies+seastar/src/core/reactor.cc:3206
 (inlined by) seastar::reactor::do_run() at ././external/+non_module_dependencies+seastar/src/core/reactor.cc:3394
std::__1::__function::__func<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_0, std::__1::allocator<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_0>, void ()>::operator()() at ././external/+non_module_dependencies+seastar/src/core/reactor.cc:4685
seastar::posix_thread::start_routine(void*) at ./external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__functional/function.h:436
addr2line: '/opt/redpanda/lib/libc.so.6': No such file
/opt/redpanda/lib/libc.so.6 0x94ac2 
/opt/redpanda/lib/libc.so.6 0x12684f
```

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
