### PR TITLE
ducktape: Add tiered storage model test timequery debugging

### DIFF
--- a/tests/rptest/clients/kafka_cat.py
+++ b/tests/rptest/clients/kafka_cat.py
@@ -68,6 +68,9 @@ class KafkaCat:
 
     def _cmd(self, cmd: list[str], input: str | None = None):
         res = self._cmd_raw(cmd + ["-J"], input=input)
+        assert res and not res.isspace(), (
+            f"kcat returned empty output for command: {' '.join(cmd)}"
+        )
         res = json.loads(res)
         self._redpanda.logger.debug(json.dumps(res, indent=2))
         return res

--- a/tests/rptest/tests/tiered_storage_model_test.py
+++ b/tests/rptest/tests/tiered_storage_model_test.py
@@ -465,6 +465,13 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
         self.logger.info(f"Running timequery check, map size {len(self.timequery_map)}")
         if len(self.timequery_map) == 0:
             return
+
+        # For debugging timequery failures.
+        start_offset, end_offset = self.kafka_cat.list_offsets(self.topic, 0)
+        self.logger.debug(
+            f"Partition offset range before timequery: start={start_offset}, end={end_offset}"
+        )
+
         for ts, expected_offset in self.timequery_map.items():
             self.logger.debug(
                 f"Timequery check for timestamp: {ts}, expected offset: {expected_offset}"


### PR DESCRIPTION
The timequeries in the tiered storage model test sometimes fail to find a message. This happens for the highest offset queried so far, close to the max offset in the examples I've seen. This results in a generic JSONDecodeError, which makes triaging the failure harder because it gets lumped in with other failures. This change adds a specific assertion for nonempty output, and some logging that will help investigate the issue further.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
