### PR TITLE
[CORE-13761] rptest: Re-enable RedpandaOIDCTlsTest

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -101,6 +101,7 @@ from rptest.util import (
     ssh_output_stderr,
     wait_until_result,
     wait_until_with_progress_check,
+    debounce,
 )
 from rptest.utils.mode_checks import in_fips_environment
 from rptest.utils.rpenv import sample_license
@@ -4604,13 +4605,17 @@ class RedpandaService(Service, RedpandaServiceABC):
 
         stop_timeout = timeout or 30
 
+        @debounce(0.5)
+        def debounced_log_process_status():
+            self._log_process_status(node, pid)
+
         def check_redpanda_process_stopped():
             is_stopped = self.redpanda_pid(node) is None
             if not is_stopped:
                 self.logger.debug(
                     f"{node.name}: Redpanda process (pid {pid}) still running."
                 )
-                self._log_process_status(node, pid)
+                debounced_log_process_status()
 
             return is_stopped
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3768,6 +3768,23 @@ class RedpandaService(Service, RedpandaServiceABC):
         for line in node.account.ssh_capture("netstat -panelot", timeout_sec=30):
             self.logger.debug(line.strip())
 
+    def _log_process_status(self, node: ClusterNode, pid: int):
+        """
+        Log the status of a process from /proc/[pid]/status
+        """
+        self.logger.debug(f"{node.name}: Gathering /proc/{pid}/status for node...")
+        cmd = f"cat /proc/{pid}/status"
+        lines = []
+        for line in node.account.ssh_capture(cmd, allow_fail=True, timeout_sec=10):
+            if re.search(r"CoreDumping:\s*1", line):
+                self.logger.warn(
+                    f"{node.name}: Detected core dumping in process {pid} status."
+                )
+            lines.append(line.strip())
+
+        output_str = "\n".join(lines)
+        self.logger.debug(f"{node.name}: /proc/{pid}/status:\n{output_str}")
+
     def start_service(self, node, start):
         # Maybe the service collides with something that wasn't cleaned up
         # properly: let's peek at what's going on on the node before starting it.
@@ -4579,17 +4596,32 @@ class RedpandaService(Service, RedpandaServiceABC):
         if pid is None:
             return
 
+        self.logger.info(f"{node.name}: Stopping redpanda (pid {pid})")
+
         node.account.signal(
             pid, signal.SIGKILL if forced else signal.SIGTERM, allow_fail=False
         )
 
         stop_timeout = timeout or 30
+
+        def check_redpanda_process_stopped():
+            is_stopped = self.redpanda_pid(node) is None
+            if not is_stopped:
+                self.logger.debug(
+                    f"{node.name}: Redpanda process (pid {pid}) still running."
+                )
+                self._log_process_status(node, pid)
+
+            return is_stopped
+
         try:
             wait_until(
-                lambda: self.redpanda_pid(node) is None,
+                check_redpanda_process_stopped,
                 timeout_sec=stop_timeout,
                 err_msg=f"Redpanda node {node.account.hostname} failed to stop in {stop_timeout} seconds",
             )
+
+            self.logger.info(f"{node.name}: Redpanda process has exited.")
         except TimeoutError:
             sleep_sec = 10
             self.logger.warn(
@@ -4598,6 +4630,7 @@ class RedpandaService(Service, RedpandaServiceABC):
             self._set_trace_loggers_and_sleep(node, time_sec=sleep_sec)
             self.logger.warn(f"Node {node.name} status:")
             self._log_node_process_state(node)
+            self._log_process_status(node, pid)
             self._log_node_shutdown_analysis(node)
             # Kill the process if it's still running. If redpanda still runs we
             # might fail to collect logs as the file will be modified while we

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3763,11 +3763,17 @@ class RedpandaService(Service, RedpandaServiceABC):
         process_lines = []
         for line in node.account.ssh_capture("ps aux --sort=-%mem", timeout_sec=30):
             process_lines.append(line.strip())
-            self.logger.debug(line.strip())
+
+        output_str = "\n".join(process_lines)
+        self.logger.debug(f"{node.name}: ps aux output:\n{output_str}")
 
         # Capture network information
+        netstat_lines = []
         for line in node.account.ssh_capture("netstat -panelot", timeout_sec=30):
-            self.logger.debug(line.strip())
+            netstat_lines.append(line.strip())
+
+        output_str = "\n".join(netstat_lines)
+        self.logger.debug(f"{node.name}: netstat -panelot output:\n{output_str}")
 
     def _log_process_status(self, node: ClusterNode, pid: int):
         """
@@ -4731,7 +4737,7 @@ class RedpandaService(Service, RedpandaServiceABC):
                 if "--version" in line:
                     continue
 
-                self.logger.debug(f"pgrep output: {line}")
+                self.logger.debug(f"{node.name}: pgrep output: {line}")
 
                 # The pid is listed first, that's all we need
                 return int(line.split()[0])
@@ -4739,7 +4745,10 @@ class RedpandaService(Service, RedpandaServiceABC):
         except RemoteCommandError as e:
             # 1 - No processes matched or none of them could be signalled.
             if e.exit_status == 1:
+                self.logger.debug(f"{node.name}: redpanda process not found")
                 return None
+
+            self.logger.error(f"{node.name}: error checking redpanda pid: {e}")
 
             raise e
 

--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -17,5 +17,4 @@ quick:
   - tests/rpk_tuner_test.py
   - tests/rpk_cloud_test.py
   - tests/workload_upgrade_runner_test.py # Excluded until CORE-13748 is fixed. 
-  - tests/redpanda_oauth_test.py::RedpandaOIDCTlsTest # exclude until CORE-13761 is fixed
   - tests/redpanda_kerberos_test.py::RedpandaKerberosConfigTest # exclude until CORE-13787 is fixed

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -7,11 +7,13 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+from functools import wraps
 import os
 import pprint
 import threading
 from contextlib import contextmanager
 from logging import Logger
+import time
 from typing import Any, Callable, ContextManager, Optional, Type, TypeVar
 
 from ducktape.cluster.remoteaccount import RemoteCommandError
@@ -642,3 +644,25 @@ def not_none(value: T | None) -> T:
     if value is None:
         raise ValueError("value was unexpectedly None")
     return value
+
+
+def debounce(wait_sec: float):
+    """
+    Decorator that prevents a function from being called more than once
+    every `wait_sec` seconds. Subsequent calls within the wait period are ignored.
+    """
+
+    def decorator(func):
+        last_call_time = 0.0
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            nonlocal last_call_time
+            now = time.monotonic()
+            if now - last_call_time >= wait_sec:
+                last_call_time = now
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
This addresses [CORE-13761](https://redpandadata.atlassian.net/browse/CORE-13761). Previously, the RedpandaOIDCTlsTest exercised some [known OpenSSL issues](https://redpandadata.slack.com/archives/C07HD9U0EHL/p1761273685944229?thread_ts=1761272908.914599&cid=C07HD9U0EHL) which caused ASan/LSan to trigger large core dumps on process shutdown. These core dumps took a long time and cause ducktape to timeout, which it registered as a test failure. The root cause has been fixed by #28425, so this PR re-enables the test and introduces additional logging improvements in RedpandaService to make core dumps in ducktape more visible.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none



[CORE-13761]: https://redpandadata.atlassian.net/browse/CORE-13761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ