### PR TITLE
CORE-14550: In health report don't calculate HWM for non-started partitions

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -950,7 +950,8 @@ partition_status build_partition_status(const partition& p) {
       = p.cloud_topic_max_gc_eligible_epoch();
     status.shard = ss::this_shard_id();
 
-    if (p.ntp().ns == model::kafka_namespace) {
+    if (p.ntp().ns == model::kafka_namespace && p.started()) {
+        // HWM cannot be reliably retrieved until raft has started
         status.high_watermark = model::offset_cast(
           p.log()->from_log_offset(p.high_watermark()));
     }

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -439,7 +439,7 @@ partition_manager::remove(const model::ntp& ntp, partition_removal_mode mode) {
     // remove partition from ntp & raft tables
     _ntp_table.erase(ntp);
     _raft_table.erase(group_id);
-    shutdown_state.update(partition_shutdown_stage::stopping_raft);
+    shutdown_state.update(partition_shutdown_stage::removing_raft);
     co_await _raft_manager.local().remove(partition->raft());
     _unmanage_watchers.notify(
       ntp, model::topic_partition_view(partition->ntp().tp));


### PR DESCRIPTION
High watermark is unreliable if raft hasn't fully started, and offset translator may fail to translate it. Report invalid offset instead.

Also, fix slow partition shutdown logging.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
