### PR TITLE
[CORE-9236] rptest: stop datalake_verifier if all translated

### DIFF
--- a/tests/rptest/tests/datalake/datalake_verifier.py
+++ b/tests/rptest/tests/datalake/datalake_verifier.py
@@ -362,7 +362,7 @@ class DatalakeVerifier:
         try:
             while not self._all_offsets_translated():
                 wait_until(
-                    lambda: self._made_progress(),
+                    lambda: self._made_progress() or self._all_offsets_translated(),
                     progress_timeout_sec,
                     backoff_sec=3,
                     err_msg=f"Error waiting for the query to make progress for topic {self.topic}",


### PR DESCRIPTION
We are seeing a failure of a test where it appears that we have progressed up to the HWMs, but don't exit out of the wait(). This appears to be because the verifier doesn't hold a lock in between checking for translation completion and progress, which allows for a window for progress to be made to get translated up to the HWMs.

This commit addresses this by having the progress function also check for translation completion.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
