### PR TITLE
Deflake offset for leader epoch

### DIFF
--- a/tests/rptest/tests/offset_for_leader_epoch_test.py
+++ b/tests/rptest/tests/offset_for_leader_epoch_test.py
@@ -30,6 +30,25 @@ class OffsetForLeaderEpochTest(PreallocNodesTest):
     Check offset for leader epoch handling
     """
 
+    def _get_offsets_and_epochs(self, rpk: RpkTool, topic_name: str):
+        offsets = []
+
+        def refresh():
+            result = rpk.describe_topic(topic_name)
+            offsets.clear()
+            offsets.extend(result)
+
+        def all_offsets_valid():
+            refresh()
+            # metadata request may return INVALID_EPOCH aka -1
+            # this should not be used because INVALID_EPOCH maps to latest available
+            # epoch in OffsetForLeaderEpochRequest
+            return all([p.high_watermark >= 0 and p.leader_epoch >= 0 for p in offsets])
+
+        wait_until(all_offsets_valid, 30, 1)
+
+        return offsets
+
     def _all_have_leaders(self):
         admin = Admin(self.redpanda)
 
@@ -146,8 +165,8 @@ class OffsetForLeaderEpochTest(PreallocNodesTest):
         )
         rpk = RpkTool(self.redpanda)
         for t in topics:
-            tp_desc = rpk.describe_topic(t.name)
-            for p in tp_desc:
+            partition_descriptions = self._get_offsets_and_epochs(rpk, t.name)
+            for p in partition_descriptions:
                 for o in kcl.offset_for_leader_epoch(
                     topics=f"{t.name}:{p.id}",
                     leader_epoch=p.leader_epoch,
@@ -226,22 +245,6 @@ class OffsetForLeaderEpochTest(PreallocNodesTest):
 
         rpk = RpkTool(self.redpanda)
 
-        def get_offsets_and_epochs():
-            offsets = []
-
-            def refresh():
-                result = rpk.describe_topic(topic.name)
-                offsets.clear()
-                offsets.extend(result)
-
-            def all_offsets_valid():
-                refresh()
-                return all([p.high_watermark >= 0 for p in offsets])
-
-            wait_until(all_offsets_valid, 30, 1)
-
-            return offsets
-
         # store offsets after each epoch change
         offsets_after_epochs = []
 
@@ -249,7 +252,7 @@ class OffsetForLeaderEpochTest(PreallocNodesTest):
         for _ in range(5):
             produce_some()
             # store partition epoch and offsets
-            offsets = get_offsets_and_epochs()
+            offsets = self._get_offsets_and_epochs(rpk, topic.name)
             offsets_after_epochs.append(list(offsets))
 
             for p in offsets_after_epochs[-1]:


### PR DESCRIPTION
Describe paritition can occasionally return -1 aka UNKNOWN_EPOCH for a
partition's term.

This epoch is subsequently fed into offset_for_leader_epoch.

This is an illegal value for offset_for_leader_epoch.

This commit changes the logic for gathering partition data to require
first that all parition descriptions returned have a valid high
watermark and a valid epoch.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x
- [x] v24.3.x

## Release Notes
### Bug Fixes

* deflake offset for leader epoch

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
