### PR TITLE
`cluster`: bump `tx_compaction_test` timeout

### DIFF
--- a/src/v/cluster/tests/BUILD
+++ b/src/v/cluster/tests/BUILD
@@ -1254,7 +1254,7 @@ redpanda_test_cc_library(
 
 redpanda_cc_btest(
     name = "tx_compaction_tests",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "tx_compaction_tests.cc",
     ],


### PR DESCRIPTION
Saw this timeout in CI. Bump timeout to `moderate`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
