### PR TITLE
application: stop schema_registry clients before datalake subsystems

### DIFF
--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -112,6 +112,10 @@ ss::future<> api::start() {
     co_await _service.invoke_on_all(&service::start);
 }
 
+ss::future<> api::stop_clients() {
+    co_await _client.invoke_on_all(&kafka::client::client::stop);
+}
+
 ss::future<> api::stop() {
     vlog(srlog.debug, "Stopping schema registry API...");
     co_await _client.invoke_on_all(&kafka::client::client::stop);

--- a/src/v/pandaproxy/schema_registry/api.h
+++ b/src/v/pandaproxy/schema_registry/api.h
@@ -49,6 +49,7 @@ public:
 
     ss::future<> start();
     ss::future<> stop();
+    ss::future<> stop_clients();
     ss::future<> restart();
 
     const configuration& get_config() const;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -374,6 +374,11 @@ void application::shutdown() {
             return cloud_io.invoke_on_all(&cloud_io::remote::request_stop);
         });
     }
+    // Shutdown schema registry clients before the datalake subsystems to
+    // ensure the datalake subsystems can shutdown quickly.
+    if (_schema_registry) {
+        _schema_registry->stop_clients().get();
+    }
     /**
      * Shutdown the datalake services before stopping all the partitions.
      * NOTE: translators may call into the coordinator via the coordinator


### PR DESCRIPTION
We've seen a shutdown hang that appears to be caused by a datalake translator getting stuck repeatedly trying to query the schema registry.

This attempts to fix this by moving schema registry client shutdown to before datalake shutdown.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
