### PR TITLE
partition_balancer: report quorum loss moves as...

### DIFF
--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -957,6 +957,8 @@ auto partition_balancer_planner::request_context::do_with_partition(
   Visitor& visitor) {
     const bool is_disabled = _parent._state.topics().is_disabled(ntp);
     const auto& orig_replicas = assignment.replicas;
+
+    // check if there is an in progress move
     auto in_progress_it = _parent._state.topics().updates_in_progress().find(
       ntp);
     if (in_progress_it != _parent._state.topics().updates_in_progress().end()) {
@@ -976,28 +978,39 @@ auto partition_balancer_planner::request_context::do_with_partition(
         }
 
         if (state == reconfiguration_state::in_progress) {
-            if (can_add_cancellation()) {
-                partition part{
-                  moving_partition{ntp, replicas, orig_replicas, *this}};
-                return visitor(part);
-            } else {
+            // partition is dead in the water, it lost quorum in the middle of
+            // moving
+            if (!has_quorum(all_unavailable_nodes, orig_replicas)) {
                 partition part{immutable_partition{
                   ntp,
-                  replicas,
-                  immutable_partition::immutability_reason::batch_full,
+                  orig_replicas,
+                  immutable_partition::immutability_reason::no_quorum,
                   state,
                   *this}};
                 return visitor(part);
             }
-        } else {
+            // if theres enough reconfiguration badwidth to process a cancel
+            if (can_add_cancellation()) {
+                partition part{
+                  moving_partition{ntp, replicas, orig_replicas, *this}};
+                return visitor(part);
+            }
+            // otherwise its immutable for now
             partition part{immutable_partition{
               ntp,
               replicas,
-              immutable_partition::immutability_reason::reconfiguration_state,
+              immutable_partition::immutability_reason::batch_full,
               state,
               *this}};
             return visitor(part);
         }
+        partition part{immutable_partition{
+          ntp,
+          replicas,
+          immutable_partition::immutability_reason::reconfiguration_state,
+          state,
+          *this}};
+        return visitor(part);
     }
 
     if (is_disabled) {


### PR DESCRIPTION
...immutable

nodes_decommissioning_test.py
::NodesDecommissioningTest
.test_decommissioning_node_rf_1_replica

would periodically fail on partitions not being reported as allocation failures. This happened because there was a race. A partition would NOT be reported as an allocation failure if there was a move in progress.

In this test, the node is stopped and then the decommed. As a result, the broker could be picked up as unresponsive, which would init a move before the decomission is made visible to the planner.

This commit changes pbp to report in-progress moves with quorum loss on the original replica set as immutable.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required


<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x
- [x] v24.3.x

## Release Notes
### Improvements

* partitions with an in-flight move and original replica quorum loss will now be reported as immutable
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
