### PR TITLE
sec/audit: wait for 25.3 for audit rpc

### DIFF
--- a/src/v/security/audit/BUILD
+++ b/src/v/security/audit/BUILD
@@ -38,6 +38,7 @@ redpanda_cc_library(
         "types.h",
     ],
     implementation_deps = [
+        "//src/v/features",
         "//src/v/kafka/data:record_batcher",
         "@abseil-cpp//absl/algorithm:container",
     ],

--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -121,39 +121,6 @@ audit_log_manager::audit_log_manager(
         return 1.0
                - (static_cast<double>(_queue_bytes_sem.available_units()) / static_cast<double>(_max_queue_size_bytes));
     });
-    // NOTE: construct a sink on every shard, unconditionally. the kafka
-    // sinks on the non-client shards will be inactive.
-    if (config::shard_local_cfg().audit_use_rpc()) {
-        vlog(adtlog.info, "Audit log in RPC mode");
-        _sink = audit_sink::make_rpc_sink(
-          this, _controller, &_rpc_client->local());
-    } else {
-        vlog(adtlog.info, "Audit log in Kafka Client mode");
-        _sink = audit_sink::make_kafka_sink(
-          this, _controller, *_config, [this](bool v) {
-              return container().invoke_on_all(
-                [v](audit_log_manager& mgr) { mgr.set_auth_misconfigured(v); });
-          });
-    }
-
-    _drain_timer.set_callback([this] {
-        ssx::spawn_with_gate(_gate, [this]() {
-            return ss::get_units(_active_drain, 1)
-              .then([this](auto units) mutable {
-                  return drain()
-                    .handle_exception([&probe = probe()](std::exception_ptr e) {
-                        vlog(
-                          adtlog.warn,
-                          "Exception in audit_log_manager fiber: {}",
-                          e);
-                        probe.audit_error();
-                    })
-                    .finally([this, units = std::move(units)] {
-                        _drain_timer.arm(_queue_drain_interval_ms());
-                    });
-              });
-        });
-    });
     set_enabled_events();
     _audit_event_types.watch([this] { set_enabled_events(); });
     _audit_excluded_topics_binding.watch([this] {
@@ -201,6 +168,41 @@ ss::future<> audit_log_manager::start() {
           "Redpanda is operating in recovery mode.  Auditing is disabled!");
         co_return;
     }
+
+    // NOTE: construct a sink on every shard, unconditionally. the kafka
+    // sinks on the non-client shards will be inactive.
+    if (config::shard_local_cfg().audit_use_rpc()) {
+        vlog(adtlog.info, "Audit log in RPC mode");
+        _sink = audit_sink::make_rpc_sink(
+          this, _controller, &_rpc_client->local());
+    } else {
+        vlog(adtlog.info, "Audit log in Kafka Client mode");
+        _sink = audit_sink::make_kafka_sink(
+          this, _controller, *_config, [this](bool v) {
+              return container().invoke_on_all(
+                [v](audit_log_manager& mgr) { mgr.set_auth_misconfigured(v); });
+          });
+    }
+
+    _drain_timer.set_callback([this] {
+        ssx::spawn_with_gate(_gate, [this]() {
+            return ss::get_units(_active_drain, 1)
+              .then([this](auto units) mutable {
+                  return drain()
+                    .handle_exception([&probe = probe()](std::exception_ptr e) {
+                        vlog(
+                          adtlog.warn,
+                          "Exception in audit_log_manager fiber: {}",
+                          e);
+                        probe.audit_error();
+                    })
+                    .finally([this, units = std::move(units)] {
+                        _drain_timer.arm(_queue_drain_interval_ms());
+                    });
+              });
+        });
+    });
+
     _audit_enabled.watch([this] {
         try {
             sink().toggle(_audit_enabled());
@@ -224,7 +226,9 @@ ss::future<> audit_log_manager::stop() {
     _drain_timer.cancel();
     _as.request_abort();
     vlog(adtlog.info, "Shutting down audit log manager");
-    co_await sink().stop();
+    if (_sink) {
+        co_await sink().stop();
+    }
     if (!_gate.is_closed()) {
         /// Gate may already be closed if ::pause() had been called
         co_await _gate.close();

--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -19,6 +19,7 @@
 #include "cluster/security_frontend.h"
 #include "config/configuration.h"
 #include "config/types.h"
+#include "features/feature_table.h"
 #include "kafka/client/client.h"
 #include "kafka/client/config_utils.h"
 #include "kafka/data/record_batcher.h"
@@ -171,11 +172,23 @@ ss::future<> audit_log_manager::start() {
 
     // NOTE: construct a sink on every shard, unconditionally. the kafka
     // sinks on the non-client shards will be inactive.
-    if (config::shard_local_cfg().audit_use_rpc()) {
+    const bool internal_rpcs_available
+      = _controller->get_feature_table().local().get_active_version()
+        >= features::to_cluster_version(features::release_version::v25_3_1);
+    if (config::shard_local_cfg().audit_use_rpc() && internal_rpcs_available) {
         vlog(adtlog.info, "Audit log in RPC mode");
         _sink = audit_sink::make_rpc_sink(
           this, _controller, &_rpc_client->local());
     } else {
+        if (
+          config::shard_local_cfg().audit_use_rpc() && !internal_rpcs_available
+          && ss::this_shard_id() == 0) {
+            vlog(
+              adtlog.warn,
+              "Audit log RPC mode requested but not available cluster-wide. "
+              "Falling back to Kafka Client mode. RPC mode will be available "
+              "on the next restart after all brokers are upgraded to v25.3.1+");
+        }
         vlog(adtlog.info, "Audit log in Kafka Client mode");
         _sink = audit_sink::make_kafka_sink(
           this, _controller, *_config, [this](bool v) {

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -14,7 +14,7 @@ import threading
 import time
 from enum import Enum
 from functools import partial, reduce
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Dict, Optional, Sequence, Union
 from urllib.parse import urlparse
 
 import confluent_kafka as ck
@@ -35,6 +35,7 @@ from rptest.services.keycloak import DEFAULT_REALM, KeycloakService
 from rptest.services.ocsf_server import OcsfServer
 from rptest.services.redpanda import (
     AUDIT_LOG_ALLOW_LIST,
+    RESTART_LOG_ALLOW_LIST,
     LoggingConfig,
     MetricSamples,
     MetricsEndpoint,
@@ -43,6 +44,7 @@ from rptest.services.redpanda import (
     SecurityConfig,
     TLSProvider,
 )
+from rptest.services.redpanda_installer import RedpandaInstaller, RedpandaVersion
 from rptest.services.redpanda_types import SaslCredentials
 from rptest.services.rpk_consumer import RpkConsumer
 from rptest.tests.cluster_config_test import wait_for_version_sync
@@ -290,6 +292,7 @@ class AuditLogConfig:
         num_partitions: int = 8,
         event_types=["management", "admin"],
         failure_policy: AuditFailurePolicy = AuditFailurePolicy.REJECT,
+        use_rpc: bool | None = False,
     ):
         """Initializes the config
 
@@ -308,7 +311,7 @@ class AuditLogConfig:
         self.num_partitions = num_partitions
         self.event_types = event_types
         self.failure_policy = failure_policy
-        self.use_rpc = False
+        self.use_rpc = use_rpc
 
     def to_conf(self) -> {str, str}:
         """Converts conf to dict
@@ -318,13 +321,17 @@ class AuditLogConfig:
         {str, str}
             Key,value dictionary of configs
         """
-        return {
+        result = {
             "audit_enabled": self.enabled,
             "audit_log_num_partitions": self.num_partitions,
             "audit_enabled_event_types": self.event_types,
             "audit_failure_policy": self.failure_policy.value,
-            "audit_use_rpc": self.use_rpc,
         }
+
+        if self.use_rpc is not None:
+            result["audit_use_rpc"] = self.use_rpc
+
+        return result
 
 
 class AuditLogTestSecurityConfig(SecurityConfig):
@@ -3282,3 +3289,124 @@ class AuditLogTestSmallBuffers(AuditLogTestBypassBase):
             },
             permit_no_auth=False,
         )
+
+
+class AuditLogUpgradeTest(AuditLogTestBase):
+    """
+    Tests audit logging functionality during version upgrades to ensure
+    audit logging continues to work on all nodes throughout the upgrade process.
+    """
+
+    def __init__(self, test_context):
+        security = AuditLogTestSecurityConfig.default_credentials()
+        audit_config = AuditLogConfig(
+            enabled=True,
+            num_partitions=3,
+            event_types=["admin"],
+            failure_policy=AuditFailurePolicy.REJECT,
+            use_rpc=None,
+        )
+
+        super(AuditLogUpgradeTest, self).__init__(
+            test_context=test_context,
+            num_brokers=3,
+            security=security,
+            audit_log_config=audit_config,
+            log_config=LoggingConfig(
+                "info", logger_levels={"auditing": "trace", "admin_api_server": "trace"}
+            ),
+        )
+
+        self.installer = self.redpanda._installer
+        self.initial_version = self.installer.highest_from_prior_feature_version(
+            RedpandaInstaller.HEAD
+        )
+
+    def setUp(self):
+        # Start with previous version
+        self.installer.install(self.redpanda.nodes, self.initial_version)
+        super().setUp()
+
+    def _test_audit_on_node(self, node: ClusterNode, phase_name: str):
+        # Get initial audit message count
+        initial_count = self._get_audit_message_count(node)
+
+        # Make admin API call to generate audit messages
+        _ = self.admin.get_features(node=node)
+
+        # Wait for audit messages to appear
+        def audit_messages_generated():
+            current_count = self._get_audit_message_count(node)
+            return current_count > initial_count
+
+        wait_until(
+            audit_messages_generated,
+            timeout_sec=30,
+            backoff_sec=2,
+            retry_on_exc=True,
+            err_msg=f"{phase_name}: No audit messages generated for node {node.name}",
+        )
+
+    def _test_audit_on_all_nodes(self, phase_name: str):
+        self.logger.info(f"{phase_name}: Testing audit logging on all nodes")
+
+        for node in self.redpanda.nodes:
+            self.logger.info(f"{phase_name}: Testing audit logging on node {node.name}")
+            self._test_audit_on_node(node, phase_name)
+
+        self.logger.info(f"{phase_name}: All nodes succeeded")
+
+    def _get_audit_message_count(self, node: ClusterNode):
+        def filter_fn(record):
+            hostname = record.get("http_request", {}).get("url", {}).get("hostname", "")
+            return node.name in hostname
+
+        # Read for up to 10 seconds, which should be enough to read all existing messages
+        start_time = time.time()
+
+        def stop_cond(records):
+            return time.time() > start_time + 10
+
+        return len(self.read_all_from_audit_log(filter_fn, stop_cond))
+
+    @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_audit_log_upgrade_all_nodes(self):
+        """
+        Test that audit logging works on all nodes during rolling upgrade
+        from previous major version to current version.
+        """
+
+        self.logger.info(
+            f"Starting audit log upgrade test: {self.initial_version} -> HEAD"
+        )
+
+        # Phase 1: Upgrade nodes one by one, testing after each upgrade
+        for i, node in enumerate(self.redpanda.nodes):
+            self.logger.info(f"Upgrading node {node.name}")
+            self.installer.install([node], self.installer.head_version())
+            self.redpanda.restart_nodes([node])
+
+            # Wait for cluster to stabilize
+            self.redpanda.wait_until(
+                self.redpanda.healthy,
+                timeout_sec=60,
+                backoff_sec=2,
+                err_msg=f"Cluster failed to stabilize after upgrading {node.name}",
+            )
+
+            # Test audit logging on all nodes (mix of old and new versions)
+            self._test_audit_on_all_nodes(f"upgraded_{i}")
+
+        # Phase 2: Test after rolling restart with all nodes upgraded
+        self.logger.info("Testing audit logging post-upgrade, post-rolling restart")
+        self.redpanda.rolling_restart_nodes(self.redpanda.nodes)
+
+        # Wait for cluster to stabilize
+        self.redpanda.wait_until(
+            self.redpanda.healthy,
+            timeout_sec=60,
+            backoff_sec=2,
+            err_msg="Cluster failed to stabilize after rolling restart",
+        )
+
+        self._test_audit_on_all_nodes("post_upgrade_restart")


### PR DESCRIPTION
The internal kafka RPCs are only available consistently after 25.3. Previously, they were only conditionally available, only if WASM is enabled, so we cannot rely on them being available during a 25.2 -> 25.3 upgrade.

Fixes https://redpandadata.atlassian.net/browse/CORE-14573

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
