### PR TITLE
rptest/services/admin_ops_fuzzer/produce: tolerate rpk error in execute

### DIFF
--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -485,7 +485,9 @@ class ProduceToTopic(Operation):
             )
             return True
 
-        assert self.topic  # we've assigned it in execute
+        if self.topic is None:  # `execute` failed to assign it
+            return False
+
         partitions = ctx.rpk().describe_topic(self.topic)
         for p in partitions:
             if p.id in self.delivery_offsets:


### PR DESCRIPTION
CORE-14119
rpk may fail to list_topics in `execute`,
`validate` should not crash the test in this case

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x
- [x] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
