### PR TITLE
[v25.1.x] fix partition shutdown watchdog state reporting

### DIFF
--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -437,7 +437,7 @@ partition_manager::remove(const model::ntp& ntp, partition_removal_mode mode) {
     // remove partition from ntp & raft tables
     _ntp_table.erase(ntp);
     _raft_table.erase(group_id);
-    shutdown_state.update(partition_shutdown_stage::stopping_raft);
+    shutdown_state.update(partition_shutdown_stage::removing_raft);
     co_await _raft_manager.local().remove(partition->raft());
     _unmanage_watchers.notify(
       ntp, model::topic_partition_view(partition->ntp().tp));


### PR DESCRIPTION
Partial backport of PR https://github.com/redpanda-data/redpanda/pull/28387 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none