### PR TITLE
shared_placement_scale_test: adjust threshold

### DIFF
--- a/tests/rptest/scale_tests/shard_placement_scale_test.py
+++ b/tests/rptest/scale_tests/shard_placement_scale_test.py
@@ -19,6 +19,15 @@ from rptest.services.redpanda import LoggingConfig, SISettings
 from rptest.tests.prealloc_nodes import RedpandaTest
 from rptest.utils.mode_checks import skip_debug_mode
 
+# Empirically this test gets the expected throughput, but this is not an
+# exact measurement given sampling intervals, clients which start and stop
+# and operated in a batched manner, so we can't really just compare that
+# the observed throughput is == or >= the target throughput, since this
+# will flake, rather we check that is above the given fraction of the
+# nominal/expected throughput. The observed throughput in the cases I
+# looked at was much closer, e.g., between 99 and 101% of the target.
+ACTUAL_TO_EXPECTED_TPUT_THRESHOLD = 0.9
+
 
 class ShardPlacementScaleTest(RedpandaTest):
     def __init__(self, ctx, *args, **kwargs):
@@ -80,7 +89,9 @@ class ShardPlacementScaleTest(RedpandaTest):
         }
         validator = {
             OMBSampleConfigurations.AVG_THROUGHPUT_MBPS: [
-                OMBSampleConfigurations.gte(producer_rate_mbps)
+                OMBSampleConfigurations.gte(
+                    producer_rate_mbps * ACTUAL_TO_EXPECTED_TPUT_THRESHOLD
+                )
             ]
         }
 


### PR DESCRIPTION
Adjust the expected throughput threshold.

Empirically this test gets the expected throughput (100 MiB/s), but this is not an exact measurement given sampling intervals, distributed clients which start and stop and operated in a batched manner, so we can't really just compare that the observed throughput is == or >= the target throughput, since this will flake, rather we check that is above the given fraction of the nominal/expected throughput.

The observed throughput in the cases I looked at was much closer, e.g., mostly between 99 and 101% of the target, though I saw as low as 97% in one test out of ~15.

After this change 39 of 40 runs passed and the other failure wasn't throughput related.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes [CORE-8117].

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

* none


[CORE-8117]: https://redpandadata.atlassian.net/browse/CORE-8117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ