### PR TITLE
[CORE-14405] ts: Don't log shutdown error on 'error' level

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -344,11 +344,7 @@ public:
             } catch (...) {
                 auto eptr = std::current_exception();
                 if (ssx::is_shutdown_exception(eptr)) {
-                    // Shutdown exception is not expected here. We're only
-                    // using this abort source to propagate exceptions.
-                    // The exception will be handled correctly but we need
-                    // to have an audit trail.
-                    vlog(_ctxlog.error, "Unexpected shutdown error: {}", eptr);
+                    vlog(_ctxlog.debug, "Shutdown error: {}", eptr);
                 } else {
                     auto reason = net::is_disconnect_exception(eptr);
                     if (reason.has_value()) {


### PR DESCRIPTION
Previously, it was assumed that only the actual errors are propagated to the remote partition reader via the log reader config. This is actually not the case and the kafka layer can propagate shutdown errors too. This leads to the correct behavior. The current async operation stops due to shutdown exception but the exception is not propagated further. The kafka layer propagates 'ssx::shutdown_requested_exception' which is derived from the 'ss::abort_requested_exception' so the catch block inside the 'partition_record_batch_reader_impl::do_load_slice' can handle it. The 'throw_on_external_abort' also converts any connection related error to 'ss::abort_requested_exception' so it is definitely safe to allow this exception to be propagated.

The commit changes the log level and the message and removes the comment which is no longer correct.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none