### PR TITLE
[v25.1.x] rptest/services/admin_ops_fuzzer/produce: tolerate rpk error in execute

### DIFF
--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -470,6 +470,9 @@ class ProduceToTopic(Operation):
             )
             return True
 
+        if self.topic is None:  # `execute` failed to assign it
+            return False
+
         partitions = ctx.rpk().describe_topic(self.topic)
         for p in partitions:
             if p.id in self.delivery_offsets:


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28398 