### PR TITLE
[CORE-14249] ts: Fix cache trim race

### DIFF
--- a/src/v/cloud_io/access_time_tracker.cc
+++ b/src/v/cloud_io/access_time_tracker.cc
@@ -293,15 +293,18 @@ access_time_tracker::get(const std::string& key) const {
 
 bool access_time_tracker::is_dirty() const { return _dirty; }
 
-chunked_vector<file_list_item> access_time_tracker::lru_entries() const {
+ss::future<chunked_vector<file_list_item>> access_time_tracker::lru_entries() {
+    auto lock_guard = co_await ss::get_units(_table_lock, 1);
     chunked_vector<file_list_item> items;
     items.reserve(_table.size());
     for (const auto& [path, metadata] : _table) {
         items.emplace_back(metadata.time_point(), path, metadata.size);
     }
+    lock_guard.return_all();
+    on_released_table_lock();
     std::ranges::sort(
       items, {}, [](const auto& item) { return item.access_time; });
-    return items;
+    co_return items;
 }
 
 std::chrono::system_clock::time_point file_metadata::time_point() const {

--- a/src/v/cloud_io/access_time_tracker.h
+++ b/src/v/cloud_io/access_time_tracker.h
@@ -65,7 +65,7 @@ public:
 
     size_t size() const { return _table.size(); }
 
-    chunked_vector<file_list_item> lru_entries() const;
+    ss::future<chunked_vector<file_list_item>> lru_entries();
 
 private:
     /// Returns true if the key's metadata should be tracked.
@@ -82,7 +82,7 @@ private:
     // Lock taken during async loops over the table (ser/de and trim())
     // modifications may proceed without the lock if it is not taken.
     // When releasing lock, drain _pending_upserts.
-    ss::semaphore _table_lock{1};
+    mutable ss::semaphore _table_lock{1};
 
     // Calls into add/remove populate this if the _serialization_lock is
     // unavailable.  The serialization code is responsible for draining it upon

--- a/src/v/cloud_io/cache_service.cc
+++ b/src/v/cloud_io/cache_service.cc
@@ -371,7 +371,7 @@ ss::future<> cache::trim(
         - std::min(
           target_objects, _current_cache_objects + _reserved_cache_objects);
 
-    auto tracker_lru_entries = _access_time_tracker.lru_entries();
+    auto tracker_lru_entries = co_await _access_time_tracker.lru_entries();
     vlog(
       log.debug,
       "in-memory trim: set target_size {}/{}, size {}/{}, reserved {}/{}, "


### PR DESCRIPTION
The race happens when the fast trim can't remove enough data and starts full trim. If while the fast trim was running the access time tracker was snapshotted the updates generated by the fast trim may not be immediately available for reading because they will be added to the _pending_upserts collection.

If the next trim is started when this collection is not empty the trim may try to remove files which are already removed. The method 'lru_entries' previously didn't take '_pending_upserts' into account.

This commit futurizes 'lru_entries'. The method first acquires units and then returns the result. When the units are acquired it's guaranteed that the collection is empty and 'lru_entries' will return up to date results.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none