### PR TITLE
[CORE-13995] iceberg/filesystem_catalog: check version hint before writing table

### DIFF
--- a/src/v/iceberg/filesystem_catalog.cc
+++ b/src/v/iceberg/filesystem_catalog.cc
@@ -82,15 +82,9 @@ filesystem_catalog::create_table(
       .sort_orders = std::move(sort_orders),
       .default_sort_order_id = sort_order::id_t{0},
     };
-    // First ensure no version hint exists for this table. That would mean the
+    // Ensure no version hint exists for this table. That would mean the
     // table effectively already exists.
     static constexpr std::optional<int32_t> expect_no_vhint = std::nullopt;
-    auto vhint_res = co_await check_expected_version_hint(
-      vhint_path(table_ident), expect_no_vhint);
-    if (vhint_res.has_error()) {
-        co_return vhint_res.error();
-    }
-    // Then write the table metadata.
     auto ret = co_await write_table_meta(table_ident, tmeta, expect_no_vhint);
     if (ret.has_error()) {
         co_return ret.error();
@@ -250,7 +244,20 @@ filesystem_catalog::write_table_meta(
     // TODO: this is an imperfect check for version hint existence. Maybe we
     // can use conditional writes to ensure an atomic update?
 
-    // First, upload the table metadata.
+    // First check to make sure the version hint matches what we expect.
+    auto table_vhint_path = vhint_path(table_ident);
+    auto vhint_check_res = co_await check_expected_version_hint(
+      table_vhint_path, expected_cur_version);
+    if (vhint_check_res.has_error()) {
+        vlog(
+          log.debug,
+          "Version-hint check on file {} failed before uploading table "
+          "metadata, exiting early without writing metadata",
+          table_vhint_path);
+        co_return vhint_check_res.error();
+    }
+
+    // Then upload the table metadata.
     auto expected_next_version = expected_cur_version.value_or(-1) + 1;
     auto path = tmeta_path(table_ident, expected_next_version);
     auto res = co_await table_io_.upload_table_meta(path, tmeta);
@@ -258,11 +265,17 @@ filesystem_catalog::write_table_meta(
         co_return to_catalog_errc(res.error());
     }
 
-    // Then check to make sure the version hint still matches what we expect.
-    auto table_vhint_path = vhint_path(table_ident);
-    auto vhint_check_res = co_await check_expected_version_hint(
+    // Then check again to make sure the version hint still matches what we
+    // expect.
+    vhint_check_res = co_await check_expected_version_hint(
       table_vhint_path, expected_cur_version);
     if (vhint_check_res.has_error()) {
+        vlog(
+          log.warn,
+          "Version-hint check on file {} failed after uploading table metadata "
+          "{}, table may be inconsistent",
+          table_vhint_path,
+          path);
         co_return vhint_check_res.error();
     }
 
@@ -271,6 +284,12 @@ filesystem_catalog::write_table_meta(
     auto vhint_up_res = co_await table_io_.upload_version_hint(
       table_vhint_path, expected_next_version);
     if (vhint_up_res.has_error()) {
+        vlog(
+          log.warn,
+          "Version-hint upload of file {} failed after uploading table "
+          "metadata {}, table may be inconsistent",
+          table_vhint_path,
+          path);
         co_return to_catalog_errc(vhint_up_res.error());
     }
     co_return std::nullopt;


### PR DESCRIPTION
In DatalakeCustomPartitioningTest.test_spec_evolution_rpcn the datalake verifier complained that it was missing data.

```
AssertionError: Topic foo validation errors: ['Offset from Iceberg table 2325 is greater than next consumed offset 1042 for partition 4, most likely there is a gap in the table']
```

Upon further inspection, it seems to actually legitimately be missing data, because it is using the filesystem catalog, which is unsafe.

To understand this, we can see that the translators are definitely processing record batches in range [1042, 2287]:

```
TRACE 2025-10-15 01:42:04,643 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:444 - multiplexer finish complete: offset_range=[1013,1041], total_records=29, kafka_bytes=3451
TRACE 2025-10-15 01:42:04,712 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:130 - processing batch: offset_range=[1042,1042], records=1, raw_bytes=119, decompressed_bytes=119
TRACE 2025-10-15 01:42:04,759 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:364 - batch processing complete: last_offset=1042, writers_active=1
TRACE 2025-10-15 01:42:04,759 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:130 - processing batch: offset_range=[1043,1043], records=1, raw_bytes=119, decompressed_bytes=119
TRACE 2025-10-15 01:42:04,759 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:364 - batch processing complete: last_offset=1043, writers_active=1
TRACE 2025-10-15 01:42:04,759 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:130 - processing batch: offset_range=[1044,1044], records=1, raw_bytes=119, decompressed_bytes=119
TRACE 2025-10-15 01:42:04,759 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:364 - batch processing complete: last_offset=1044, writers_active=1
TRACE 2025-10-15 01:42:04,759 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:130 - processing batch: offset_range=[1045,1045], records=1, raw_bytes=119, decompressed_bytes=119
TRACE 2025-10-15 01:42:04,759 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:364 - batch processing complete: last_offset=1045, writers_active=1
TRACE 2025-10-15 01:42:04,759 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:130 - processing batch: offset_range=[1046,1046], records=1, raw_bytes=119, decompressed_bytes=119
TRACE 2025-10-15 01:42:04,759 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:364 - batch processing complete: last_offset=1046, writers_active=1
TRACE 2025-10-15 01:42:04,759 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:130 - processing batch: offset_range=[1047,1047], records=1, raw_bytes=119, decompressed_bytes=119
TRACE 2025-10-15 01:42:04,759 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:364 - batch processing complete: last_offset=1047, writers_active=1
TRACE 2025-10-15 01:42:04,759 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:130 - processing batch: offset_range=[1048,1048], records=1, raw_bytes=119, decompressed_bytes=119
...
TRACE 2025-10-15 01:42:10,778 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:130 - processing batch: offset_range=[2283,2283], records=1, raw_bytes=120, decompressed_bytes=120
TRACE 2025-10-15 01:42:10,778 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:364 - batch processing complete: last_offset=2283, writers_active=1
TRACE 2025-10-15 01:42:10,778 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:130 - processing batch: offset_range=[2284,2284], records=1, raw_bytes=120, decompressed_bytes=120
TRACE 2025-10-15 01:42:10,778 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:364 - batch processing complete: last_offset=2284, writers_active=1
TRACE 2025-10-15 01:42:10,778 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:130 - processing batch: offset_range=[2285,2285], records=1, raw_bytes=120, decompressed_bytes=120
TRACE 2025-10-15 01:42:10,778 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:364 - batch processing complete: last_offset=2285, writers_active=1
TRACE 2025-10-15 01:42:10,778 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:130 - processing batch: offset_range=[2286,2286], records=1, raw_bytes=120, decompressed_bytes=120
TRACE 2025-10-15 01:42:10,778 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:364 - batch processing complete: last_offset=2286, writers_active=1
TRACE 2025-10-15 01:42:10,778 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:130 - processing batch: offset_range=[2287,2287], records=1, raw_bytes=120, decompressed_bytes=120
TRACE 2025-10-15 01:42:10,778 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:364 - batch processing complete: last_offset=2287, writers_active=1
TRACE 2025-10-15 01:42:10,778 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:391 - starting multiplexer finish: writers=1, kafka_bytes_processed=148970
TRACE 2025-10-15 01:42:10,779 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:404 - writer finished: files_created=1)
TRACE 2025-10-15 01:42:10,779 [shard 5:data] datalake - {kafka/foo/4} - record_multiplexer.cc:444 - multiplexer finish complete: offset_range=[1042,2287], total_records=1246, kafka_bytes=148970
```

On the coordinator side, we see the files being added:

```
DEBUG 2025-10-15 01:42:10,923 [shard 7:main] datalake - coordinator.cc:557 - Sync add files requested {foo/4} (topic rev: 30): [1042, 2287], kafka_bytes: 148970 files: 1
...
DEBUG 2025-10-15 01:42:10,927 [shard 7:main] datalake - [{kafka_internal/datalake_coordinator/1} (datalake_coordinator_stm.snapshot)] - state_machine.cc:113 - Applying update_key::add_files from offset 17: {tp: {foo/4}, revision: 30, entries: [{start_offset: 1042, last_offset: 2287, files: [{remote_path: redpanda-iceberg-catalog/redpanda/foo/data/timestamp_hour=2025-10-15-01/4-e4113761-672a-4c87-b683-ac255fd22dd4.parquet, row_count: 1246, file_size_bytes: 42464, hour_deprecated: 0, table_schema_id: 0, partition_spec_id: 0}], dlq_files: [], kafka_bytes_processed: 148970}] (1 entries)}
...
DEBUG 2025-10-15 01:42:11,118 [shard 7:main] datalake - [{kafka_internal/datalake_coordinator/1} (datalake_coordinator_stm.snapshot)] - state_machine.cc:113 - Applying update_key::add_files from offset 18: {tp: {foo/4}, revision: 30, entries: [{start_offset: 2288, last_offset: 2324, files: [{remote_path: redpanda-iceberg-catalog/redpanda/foo/data/timestamp_hour=2025-10-15-01/4-62cd79cb-2cac-46fc-8d81-2b48e7c44761.parquet, row_count: 37, file_size_bytes: 2991, hour_deprecated: 0, table_schema_id: 0, partition_spec_id: 0}], dlq_files: [], kafka_bytes_processed: 4440}] (1 entries)}
...
DEBUG 2025-10-15 01:42:12,893 [shard 7:main] datalake - iceberg_file_committer.cc:345 - Adding 2 files to Iceberg table {ns: redpanda, table: foo}
INFO  2025-10-15 01:42:12,893 [shard 7:main] iceberg - merge_append_action.cc:173 - Building append update for 2 data files
...
INFO  2025-10-15 01:42:12,901 [shard 7:main] iceberg - merge_append_action.cc:425 - Considering 1 existing manifest files and 2 data files to merge
DEBUG 2025-10-15 01:42:12,901 [shard 7:main] iceberg - merge_append_action.cc:485 - Merging 0 manifest files and 2 added manifest entries
INFO  2025-10-15 01:42:12,901 [shard 7:main] iceberg - merge_append_action.cc:372 - Uploading manifest with 2 entries to abfss://panda-container-fe7e7294-a967-11f0-a3df-83d155232e47@cdtstrg473865226548.dfs.core.windows.net/redpanda-iceberg-catalog/redpanda/foo/metadata/f1c3dbd8-cc17-4d95-8439-00127c5fadb1-m0.avro
...
DEBUG 2025-10-15 01:42:12,995 [shard 7:main] cloud_io - [fiber66~0|1|30000ms] - remote.cc:1166 - Uploading iceberg::table_metadata to path "redpanda-iceberg-catalog/redpanda/foo/metadata/v2.metadata.json", length 2925
TRACE 2025-10-15 01:42:12,995 [shard 7:main] http - [/panda-container-fe7e7294-a967-11f0-a3df-83d155232e47/redpanda-iceberg-catalog/redpanda/foo/metadata/v2.metadata.json] - client.cc:125 - client.make_request PUT /panda-container-fe7e7294-a967-11f0-a3df-83d155232e47/redpanda-iceberg-catalog/redpanda/foo/metadata/v2.metadata.json HTTP/1.1
DEBUG 2025-10-15 01:42:12,995 [shard 7:main] http - [/panda-container-fe7e7294-a967-11f0-a3df-83d155232e47/redpanda-iceberg-catalog/redpanda/foo/metadata/v2.metadata.json] - client.cc:137 - reusing connection, age 0
TRACE 2025-10-15 01:42:12,995 [shard 7:main] http - /panda-container-fe7e7294-a967-11f0-a3df-83d155232e47/redpanda-iceberg-catalog/redpanda/foo/metadata/v2.metadata.json - client.cc:507 - request_stream.send_some 2925
TRACE 2025-10-15 01:42:13,057 [shard 7:main] http - /panda-container-fe7e7294-a967-11f0-a3df-83d155232e47/redpanda-iceberg-catalog/redpanda/foo/metadata/v2.metadata.json - client.cc:368 - chunk received, chunk length 398
...
DEBUG 2025-10-15 01:42:13,130 [shard 7:main] datalake - [{kafka_internal/datalake_coordinator/1} (datalake_coordinator_stm.snapshot)] - state_machine.cc:121 - Applying update_key::mark_files_committed from offset 19: {tp: {foo/4}, revision: 30, new_committed: 2324, kafka_bytes_processed: 153410}
```

The commit ends up in v2.metadata.json.

Concurrently, we see the following operation to update the schema coming in, which also ends up rewriting v2.metadata.json.

```
DEBUG 2025-10-15 01:42:13,071 [shard 7:main] datalake - coordinator.cc:324 - sync_ensure_table_exists requested, topic: foo rev: 30
...
DEBUG 2025-10-15 01:42:13,131 [shard 7:main] cloud_io - [fiber75~0|1|30000ms] - remote.cc:1166 - Uploading iceberg::table_metadata to path "redpanda-iceberg-catalog/redpanda/foo/metadata/v2.metadata.json", length 2371
...
WARN  2025-10-15 01:42:13,230 [shard 7:main] iceberg - filesystem_catalog.cc:217 - Version hint file "redpanda-iceberg-catalog/redpanda/foo/metadata/version-hint.text" refers to version 2, expected 1
WARN  2025-10-15 01:42:13,230 [shard 7:main] datalake - catalog_schema_manager.cc:51 - Error while committing schema update to table {ns: redpanda, table: foo}: catalog::errc::unexpected_state
```

This unintentional overwrite of v2.metadata.json effectively removes the files that we just committed.

One way to decrease (but not completely eliminate) the chance of this happening is to check the version hint before writing metadata, rather than only doing the check after. This commit makes this change.

A more robust solution would be to use atomic writes, but that is a much larger project.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes

* Reduces a window in which Redpanda may end up missing data when using the `object_storage` catalog for Iceberg Topics. Reminder: the `object_storage` is generally unsafe and should not be used in production.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
