### PR TITLE
proto: fix field masks and unset oneofs

### DIFF
--- a/bazel/pbgen/main.go
+++ b/bazel/pbgen/main.go
@@ -1001,7 +1001,7 @@ func (g *implGenerator) generateMessageFieldMaskApplyHelper(msg protoreflect.Mes
 					w.Printf("self->set_%s(std::move(update->get_%s()));\n", field.Name(), field.Name())
 				}
 			}
-			if field.ContainingOneof() != nil {
+			if oneof := field.ContainingOneof(); oneof != nil {
 				w.Printf("{%q, []([[maybe_unused]] auto path, auto* self, auto* update) {\n", field.Name())
 				w.Indent()
 				w.Printf("if (update->has_%s()) {\n", field.Name())
@@ -1010,7 +1010,11 @@ func (g *implGenerator) generateMessageFieldMaskApplyHelper(msg protoreflect.Mes
 				w.Dedent()
 				w.Println("} else {")
 				w.Indent()
-				w.Printf("self->set_%s({});\n", field.Name())
+				if oneof.IsSynthetic() {
+					w.Printf("self->clear_%s();\n", field.Name())
+				} else {
+					w.Printf("self->clear_%s();\n", oneof.Name())
+				}
 				w.Dedent()
 				w.Println("}")
 				w.Dedent()

--- a/bazel/pbgen/main.go
+++ b/bazel/pbgen/main.go
@@ -605,6 +605,10 @@ func (g *headerGenerator) generateMessage(msg protoreflect.MessageDescriptor, w 
 					// Deducing this for the win!
 					w.Println("template<typename Self, typename... Args>")
 					w.Printf("auto visit_%s(this Self&& self, Args&&... args) { return seastar::visit(std::forward<Self>(self).%s_, std::forward<Args>(args)...); }\n", oneof.Name(), oneof.Name())
+					w.Printf("bool has_%s() const;\n", oneof.Name())
+					w.Printf("void clear_%s();\n", oneof.Name())
+				} else {
+					w.Printf("void clear_%s();\n", field.Name())
 				}
 			}
 			g.leadingComments(field, w)
@@ -1002,7 +1006,6 @@ func (g *implGenerator) generateMessageFieldMaskApplyHelper(msg protoreflect.Mes
 				w.Indent()
 				w.Printf("if (update->has_%s()) {\n", field.Name())
 				w.Indent()
-
 				printApplyFn()
 				w.Dedent()
 				w.Println("} else {")
@@ -2003,6 +2006,12 @@ func (g *implGenerator) generateMessage(msg protoreflect.MessageDescriptor, w *c
 					displayName: string(oneof.Name()),
 					argValue:    fmt.Sprintf("%s_", oneof.Name()),
 				})
+				if oneof.IsSynthetic() {
+					w.Printf("void %s::clear_%s() { %s_ = std::monostate{}; }\n", parentType, field.Name(), oneof.Name())
+				} else {
+					w.Printf("bool %s::has_%s() const { return %s_.index() != 0; }\n", parentType, oneof.Name(), oneof.Name())
+					w.Printf("void %s::clear_%s() { %s_ = std::monostate{}; }\n", parentType, oneof.Name(), oneof.Name())
+				}
 			}
 			idx := getOneofFieldVariantIndex(oneof, field)
 			w.Printf("bool %s::has_%s() const { return %s_.index() == %d; }\n", parentType, field.Name(), oneof.Name(), idx)

--- a/src/v/redpanda/admin/services/shadow_link/tests/converter_test.cc
+++ b/src/v/redpanda/admin/services/shadow_link/tests/converter_test.cc
@@ -1057,6 +1057,32 @@ TEST(converter_test, update_scram_creds) {
     EXPECT_LE(pwd_updated, now + 5s);
 }
 
+TEST(converter_test, remove_scram_creds) {
+    cluster_link::model::metadata current_md;
+    current_md.name = cluster_link::model::name_t{"test-link"};
+    current_md.uuid = cluster_link::model::uuid_t{uuid_t::create()};
+    current_md.connection.bootstrap_servers = {
+      net::unresolved_address("localhost", 9092)};
+    current_md.connection.authn_config = cluster_link::model::scram_credentials{
+      .username = "old-user",
+      .password = "old-password",
+      .mechanism = "SCRAM-SHA-256",
+      .password_last_updated = model::to_timestamp(
+        std::chrono::system_clock::now() - 1h)};
+    admin::set_client_id(current_md);
+
+    proto::admin::update_shadow_link_request req;
+    serde::pb::field_mask mask;
+    mask.paths.emplace_back(
+      serde::pb::field_mask::path{
+        "configurations", "client_options", "authentication_configuration"});
+    req.set_update_mask(std::move(mask));
+
+    auto update_cmd = admin::create_update_cluster_link_config_cmd(
+      std::move(req), current_md.copy());
+    EXPECT_EQ(update_cmd.connection.authn_config, std::nullopt);
+}
+
 TEST(converter_test, do_not_update_scram_creds) {
     cluster_link::model::metadata current_md;
     current_md.name = cluster_link::model::name_t{"test-link"};

--- a/src/v/serde/protobuf/tests/codegen_test.proto
+++ b/src/v/serde/protobuf/tests/codegen_test.proto
@@ -71,7 +71,7 @@ message WellKnownProtos {
 }
 
 message SayGreetingRequest {
-    string greeting = 1;
+    optional string greeting = 1;
 }
 
 message SayGreetingResponse {

--- a/src/v/serde/protobuf/tests/field_mask_test.cc
+++ b/src/v/serde/protobuf/tests/field_mask_test.cc
@@ -356,5 +356,5 @@ INSTANTIATE_TEST_SUITE_P(
       .input = R"({"oneofUint32": 1})",
       .update = R"({"oneofBool": true})",
       .mask = R"({"mask": "oneofUint32"})",
-      .expected = R"({"oneofUint32": 0})",
+      .expected = R"({})",
     }));

--- a/src/v/serde/protobuf/tests/goldens/codegen_test.proto.cc
+++ b/src/v/serde/protobuf/tests/goldens/codegen_test.proto.cc
@@ -1596,7 +1596,7 @@ void say_greeting_request::apply_field_path_from(std::span<const ss::sstring> pa
       if (update->has_greeting()) {
         self->set_greeting(std::move(update->get_greeting()));
       } else {
-        self->set_greeting({});
+        self->clear_greeting();
       }
     }},
   });

--- a/src/v/serde/protobuf/tests/goldens/codegen_test.proto.cc
+++ b/src/v/serde/protobuf/tests/goldens/codegen_test.proto.cc
@@ -1481,14 +1481,16 @@ say_greeting_request::say_greeting_request() noexcept = default;
 say_greeting_request::say_greeting_request(say_greeting_request&&) noexcept = default;
 say_greeting_request& say_greeting_request::operator=(say_greeting_request&&) noexcept = default;
 say_greeting_request::~say_greeting_request() noexcept = default;
-ss::sstring& say_greeting_request::get_greeting() { return greeting_; }
-const ss::sstring& say_greeting_request::get_greeting() const { return greeting_; }
-void say_greeting_request::set_greeting(ss::sstring&& v) { greeting_ = std::move(v); }
+void say_greeting_request::clear_greeting() { _greeting_ = std::monostate{}; }
+bool say_greeting_request::has_greeting() const { return _greeting_.index() == 1; }
+ss::sstring& say_greeting_request::get_greeting() { return std::get<1>(_greeting_); }
+const ss::sstring& say_greeting_request::get_greeting() const { return std::get<1>(_greeting_); }
+void say_greeting_request::set_greeting(ss::sstring&& v) { _greeting_.emplace<1>(std::move(v)); }
 bool say_greeting_request::operator==(const say_greeting_request& other) const {
-  return (greeting_ == other.greeting_);
+  return (_greeting_ == other._greeting_);
 }
 fmt::iterator say_greeting_request::format_to(fmt::iterator it) const {
-  return fmt::format_to(it, "{{greeting: {}}}", greeting_);
+  return fmt::format_to(it, "{{_greeting: {}}}", _greeting_);
 }
 seastar::future<> say_greeting_request::from_proto(serde::pb::wire_format_parser* parser, say_greeting_request* self) {
   while (parser->bytes_left() > 0) {
@@ -1514,17 +1516,31 @@ seastar::future<say_greeting_request> say_greeting_request::from_proto(iobuf buf
 }
 seastar::future<iobuf> say_greeting_request::to_proto() const {
   iobuf buf;
-  // greeting
-  serde::pb::tag::write({.wire_type = serde::pb::wire_type::length, .field_number = 1}, &buf);
-  serde::pb::write_length(static_cast<int32_t>(get_greeting().size()), &buf);
-  buf.append(get_greeting().data(), get_greeting().size());
+  // _greeting
+  switch (_greeting_.index()) {
+    case 1: {
+      // greeting
+      serde::pb::tag::write({.wire_type = serde::pb::wire_type::length, .field_number = 1}, &buf);
+      serde::pb::write_length(static_cast<int32_t>(get_greeting().size()), &buf);
+      buf.append(get_greeting().data(), get_greeting().size());
+      break;
+    }
+    default: // std::monostate do nothing
+  }
   co_return buf;
 }
 seastar::future<iobuf> say_greeting_request::to_json() const {
   serde::json::writer w;
   w.begin_object();
-  w.key("greeting");
-  w.string(get_greeting());
+  // _greeting
+  switch (_greeting_.index()) {
+    case 1: {
+      w.key("greeting");
+      w.string(get_greeting());
+      break;
+    }
+    default: // std::monostate do nothing
+  }
   w.end_object();
   co_return std::move(w).finish();
 }
@@ -1577,7 +1593,11 @@ void say_greeting_request::apply_field_path_from(std::span<const ss::sstring> pa
   }
   constexpr auto fields = std::to_array<std::pair<std::string_view, void(*)(decltype(path), decltype(this), decltype(update))>>({
     {"greeting", []([[maybe_unused]] auto path, auto* self, auto* update) {
-      self->set_greeting(std::move(update->get_greeting()));
+      if (update->has_greeting()) {
+        self->set_greeting(std::move(update->get_greeting()));
+      } else {
+        self->set_greeting({});
+      }
     }},
   });
   for (const auto& [name, apply] : fields) {
@@ -1612,6 +1632,9 @@ std::optional<serde::pb::field> say_greeting_request::lookup_field(std::span<con
   serde::pb::field found;
   switch (field_numbers.front()) {
   case 1: { // greeting
+    if (!has_greeting()) {
+      set_greeting({});
+    }
     found.value = get_greeting();
     break;
   }

--- a/src/v/serde/protobuf/tests/goldens/codegen_test.proto.h
+++ b/src/v/serde/protobuf/tests/goldens/codegen_test.proto.h
@@ -15,6 +15,7 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/util/variant_utils.hh>
 #include <span>
 
 class iobuf_parser;
@@ -430,6 +431,8 @@ public:
   // Use the iobuf version instead.
   static seastar::future<> from_json(serde::pb::json::peekable_parser*, say_greeting_request*);
 
+  void clear_greeting();
+  bool has_greeting() const;
   ss::sstring& get_greeting();
   const ss::sstring& get_greeting() const;
   void set_greeting(ss::sstring&& v);
@@ -448,7 +451,7 @@ public:
   void apply_field_path_from(std::span<const ss::sstring> path, say_greeting_request* update);
 
 private:
-  ss::sstring greeting_;
+  std::variant<std::monostate, ss::sstring> _greeting_;
 };
 
 class say_greeting_response : public serde::pb::base_message {

--- a/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.cc
+++ b/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.cc
@@ -5015,7 +5015,7 @@ void test_all_types_edition2023::apply_field_path_from(std::span<const ss::sstri
       if (update->has_oneof_uint32()) {
         self->set_oneof_uint32(std::move(update->get_oneof_uint32()));
       } else {
-        self->set_oneof_uint32({});
+        self->clear_oneof_field();
       }
     }},
     {"oneof_nested_message", []([[maybe_unused]] auto path, auto* self, auto* update) {
@@ -5025,56 +5025,56 @@ void test_all_types_edition2023::apply_field_path_from(std::span<const ss::sstri
         }
         self->get_oneof_nested_message().apply_field_path_from(path, &update->get_oneof_nested_message());
       } else {
-        self->set_oneof_nested_message({});
+        self->clear_oneof_field();
       }
     }},
     {"oneof_string", []([[maybe_unused]] auto path, auto* self, auto* update) {
       if (update->has_oneof_string()) {
         self->set_oneof_string(std::move(update->get_oneof_string()));
       } else {
-        self->set_oneof_string({});
+        self->clear_oneof_field();
       }
     }},
     {"oneof_bytes", []([[maybe_unused]] auto path, auto* self, auto* update) {
       if (update->has_oneof_bytes()) {
         self->set_oneof_bytes(std::move(update->get_oneof_bytes()));
       } else {
-        self->set_oneof_bytes({});
+        self->clear_oneof_field();
       }
     }},
     {"oneof_bool", []([[maybe_unused]] auto path, auto* self, auto* update) {
       if (update->has_oneof_bool()) {
         self->set_oneof_bool(std::move(update->get_oneof_bool()));
       } else {
-        self->set_oneof_bool({});
+        self->clear_oneof_field();
       }
     }},
     {"oneof_uint64", []([[maybe_unused]] auto path, auto* self, auto* update) {
       if (update->has_oneof_uint64()) {
         self->set_oneof_uint64(std::move(update->get_oneof_uint64()));
       } else {
-        self->set_oneof_uint64({});
+        self->clear_oneof_field();
       }
     }},
     {"oneof_float", []([[maybe_unused]] auto path, auto* self, auto* update) {
       if (update->has_oneof_float()) {
         self->set_oneof_float(std::move(update->get_oneof_float()));
       } else {
-        self->set_oneof_float({});
+        self->clear_oneof_field();
       }
     }},
     {"oneof_double", []([[maybe_unused]] auto path, auto* self, auto* update) {
       if (update->has_oneof_double()) {
         self->set_oneof_double(std::move(update->get_oneof_double()));
       } else {
-        self->set_oneof_double({});
+        self->clear_oneof_field();
       }
     }},
     {"oneof_enum", []([[maybe_unused]] auto path, auto* self, auto* update) {
       if (update->has_oneof_enum()) {
         self->set_oneof_enum(std::move(update->get_oneof_enum()));
       } else {
-        self->set_oneof_enum({});
+        self->clear_oneof_field();
       }
     }},
     {"groupliketype", []([[maybe_unused]] auto path, auto* self, auto* update) {

--- a/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.cc
+++ b/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.cc
@@ -659,6 +659,8 @@ void test_all_types_edition2023::set_map_string_nested_enum(chunked_hash_map<ss:
 chunked_hash_map<ss::sstring, foreign_enum_edition2023>& test_all_types_edition2023::get_map_string_foreign_enum() { return map_string_foreign_enum_; }
 const chunked_hash_map<ss::sstring, foreign_enum_edition2023>& test_all_types_edition2023::get_map_string_foreign_enum() const { return map_string_foreign_enum_; }
 void test_all_types_edition2023::set_map_string_foreign_enum(chunked_hash_map<ss::sstring, foreign_enum_edition2023>&& v) { map_string_foreign_enum_ = std::move(v); }
+bool test_all_types_edition2023::has_oneof_field() const { return oneof_field_.index() != 0; }
+void test_all_types_edition2023::clear_oneof_field() { oneof_field_ = std::monostate{}; }
 bool test_all_types_edition2023::has_oneof_uint32() const { return oneof_field_.index() == 1; }
 uint32_t test_all_types_edition2023::get_oneof_uint32() const { return std::get<1>(oneof_field_); }
 void test_all_types_edition2023::set_oneof_uint32(uint32_t v) { oneof_field_.emplace<1>(v); }

--- a/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.h
+++ b/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.h
@@ -494,6 +494,8 @@ public:
   void set_map_string_foreign_enum(chunked_hash_map<ss::sstring, foreign_enum_edition2023>&& v);
   template<typename Self, typename... Args>
   auto visit_oneof_field(this Self&& self, Args&&... args) { return seastar::visit(std::forward<Self>(self).oneof_field_, std::forward<Args>(args)...); }
+  bool has_oneof_field() const;
+  void clear_oneof_field();
   bool has_oneof_uint32() const;
   uint32_t get_oneof_uint32() const;
   void set_oneof_uint32(uint32_t v);


### PR DESCRIPTION
- **pbgen: generate has_oneof and clear_oneof methods**
- **pbgen: properly unset oneofs in field masks**
- **shadowlink: add test showing one can remove auth_config**

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
