### PR TITLE
rpk shadow update: use field mask when updating

### DIFF
--- a/src/go/rpk/pkg/cli/shadow/BUILD
+++ b/src/go/rpk/pkg/cli/shadow/BUILD
@@ -30,7 +30,9 @@ go_library(
         "@com_github_spf13_cobra//:cobra",
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@org_golang_google_protobuf//types/known/durationpb",
+        "@org_golang_google_protobuf//types/known/fieldmaskpb",
         "@org_golang_google_protobuf//types/known/timestamppb",
+        "@org_uber_go_zap//:zap",
     ],
 )
 
@@ -40,6 +42,7 @@ go_test(
         "create_test.go",
         "mapper_test.go",
         "types_test.go",
+        "update_test.go",
     ],
     embed = [":shadow"],
     deps = [

--- a/src/go/rpk/pkg/cli/shadow/update.go
+++ b/src/go/rpk/pkg/cli/shadow/update.go
@@ -12,6 +12,7 @@ package shadow
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
 	"connectrpc.com/connect"
@@ -21,6 +22,8 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 func newUpdateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
@@ -73,14 +76,21 @@ Update a Shadow Link configuration:
 				out.Die("Shadow Link name cannot be changed; if you need to rename, please delete and recreate the shadow link")
 			}
 
-			if reflect.DeepEqual(originalCfg, updatedCfg) {
+			diff := diffConfigs(originalCfg, updatedCfg)
+			if diff == nil {
 				out.Exit("No changes detected")
 			}
+			updatedSL := shadowLinkConfigToProto(updatedCfg)
+			fm, err := fieldmaskpb.New(updatedSL, diff...)
+			// This should not be possible, as diff is generated from valid
+			// fields, but better to catch the errors here than submit an update
+			// that the user didn't ask for.
+			out.MaybeDie(err, "unrecognized changed fields: %v; please report this with Redpanda Support", err)
 
-			// No field mask used: we update all fields that are set in the
-			// ShadowLink message.
+			zap.L().Sugar().Debugf("Requesting configuration update for: %v", strings.Join(diff, ", "))
 			_, err = cl.ShadowLinkService().UpdateShadowLink(cmd.Context(), connect.NewRequest(&adminv2.UpdateShadowLinkRequest{
-				ShadowLink: shadowLinkConfigToProto(updatedCfg),
+				ShadowLink: updatedSL,
+				UpdateMask: fm,
 			}))
 			out.MaybeDie(err, "unable to update Shadow Link: %v", handleConnectError(err, "update", linkName))
 
@@ -99,5 +109,100 @@ func addRedactedPasswordString(cfg *ShadowLinkConfig, link *adminv2.ShadowLink) 
 	}
 	if auth := cfg.ClientOptions.AuthenticationConfiguration; auth != nil && auth.ScramConfiguration != nil {
 		auth.ScramConfiguration.Password = "<redacted>"
+	}
+}
+
+// diffConfigs compares two ShadowLinkConfig objects and returns a list of
+// fields that changed. It uses Reflect to compare the fields and returns the
+// full JSON path of the changed fields, starting with "configurations".
+//
+// For example, if the 'bootstrap_servers' field changed, it returns
+// "configurations.client_options.bootstrap_servers".
+func diffConfigs(original, updated *ShadowLinkConfig) []string {
+	if reflect.DeepEqual(original, updated) {
+		return nil // deeply equal, no changes.
+	}
+	if original == nil || updated == nil {
+		// One is nil, other is not: everything changed.
+		return []string{"configurations"}
+	}
+
+	var changedPaths []string
+	compareValues(reflect.ValueOf(original), reflect.ValueOf(updated), "configurations", &changedPaths)
+	return changedPaths
+}
+
+// getJSONTag extracts the JSON tag name from a struct field.
+// Returns empty string if the field should be skipped.
+func getJSONTag(field reflect.StructField) string {
+	jsonTag := field.Tag.Get("json")
+	if jsonTag == "" || jsonTag == "-" {
+		return ""
+	}
+	// Extract the name before any options ("name,omitempty" -> "name")
+	parts := strings.Split(jsonTag, ",")
+	return parts[0]
+}
+
+// compareValues recursively compares two reflect.Value objects and records
+// changed paths.
+func compareValues(original, updated reflect.Value, path string, changedPaths *[]string) {
+	if !original.IsValid() && !updated.IsValid() {
+		return
+	}
+	// One invalid, other valid: record as changed
+	if !original.IsValid() || !updated.IsValid() {
+		*changedPaths = append(*changedPaths, path)
+		return
+	}
+
+	// Dereference pointers
+	if original.Kind() == reflect.Ptr {
+		if original.IsNil() && updated.IsNil() {
+			return
+		}
+		if original.IsNil() || updated.IsNil() {
+			*changedPaths = append(*changedPaths, path)
+			return
+		}
+		compareValues(original.Elem(), updated.Elem(), path, changedPaths)
+		return
+	}
+
+	switch original.Kind() {
+	case reflect.Struct:
+		compareStructs(original, updated, path, changedPaths)
+	default:
+		// For other types, just use DeepEqual.
+		if !reflect.DeepEqual(original.Interface(), updated.Interface()) {
+			*changedPaths = append(*changedPaths, path)
+		}
+	}
+}
+
+// compareStructs compares two struct values field by field.
+func compareStructs(original, updated reflect.Value, path string, changedPaths *[]string) {
+	typ := original.Type()
+
+	// Handle empty structs (markers like StartAtEarliest)
+	if typ.NumField() == 0 {
+		// Empty struct - just check existence (already handled by pointer nil check)
+		return
+	}
+
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+
+		if !field.IsExported() {
+			continue
+		}
+
+		jsonTag := getJSONTag(field)
+		if jsonTag == "" {
+			continue
+		}
+		fieldPath := path + "." + jsonTag
+
+		compareValues(original.Field(i), updated.Field(i), fieldPath, changedPaths)
 	}
 }

--- a/src/go/rpk/pkg/cli/shadow/update_test.go
+++ b/src/go/rpk/pkg/cli/shadow/update_test.go
@@ -1,0 +1,277 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package shadow
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiffConfigs(t *testing.T) {
+	tests := []struct {
+		name     string
+		original *ShadowLinkConfig
+		updated  *ShadowLinkConfig
+		want     []string
+	}{
+		{
+			name:     "both nil",
+			original: nil,
+			updated:  nil,
+			want:     nil,
+		},
+		{
+			name:     "original nil",
+			original: nil,
+			updated:  &ShadowLinkConfig{Name: "test"},
+			want:     []string{"configurations"},
+		},
+		{
+			name:     "updated nil",
+			original: &ShadowLinkConfig{Name: "test"},
+			updated:  nil,
+			want:     []string{"configurations"},
+		},
+		{
+			name:     "no changes",
+			original: &ShadowLinkConfig{Name: "test"},
+			updated:  &ShadowLinkConfig{Name: "test"},
+			want:     nil,
+		},
+		{
+			name:     "simple field change - name",
+			original: &ShadowLinkConfig{Name: "old"},
+			updated:  &ShadowLinkConfig{Name: "new"},
+			want:     []string{"configurations.name"},
+		},
+		{
+			name: "nested field change - bootstrap_servers",
+			original: &ShadowLinkConfig{
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"host1:9092"},
+				},
+			},
+			updated: &ShadowLinkConfig{
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"host2:9092"},
+				},
+			},
+			want: []string{"configurations.client_options.bootstrap_servers"},
+		},
+		{
+			name: "deeply nested field change - tls enabled",
+			original: &ShadowLinkConfig{
+				ClientOptions: &ShadowLinkClientOptions{
+					TLSSettings: &TLSSettings{
+						Enabled: false,
+					},
+				},
+			},
+			updated: &ShadowLinkConfig{
+				ClientOptions: &ShadowLinkClientOptions{
+					TLSSettings: &TLSSettings{
+						Enabled: true,
+					},
+				},
+			},
+			want: []string{"configurations.client_options.tls_settings.enabled"},
+		},
+		{
+			name: "slice length change",
+			original: &ShadowLinkConfig{
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"host1:9092"},
+				},
+			},
+			updated: &ShadowLinkConfig{
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"host1:9092", "host2:9092"},
+				},
+			},
+			want: []string{"configurations.client_options.bootstrap_servers"},
+		},
+		{
+			name: "slice content change",
+			original: &ShadowLinkConfig{
+				TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
+					SyncedShadowTopicProperties: []string{"retention.ms"},
+				},
+			},
+			updated: &ShadowLinkConfig{
+				TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
+					SyncedShadowTopicProperties: []string{"segment.ms"},
+				},
+			},
+			want: []string{"configurations.topic_metadata_sync_options.synced_shadow_topic_properties"},
+		},
+		{
+			name: "struct slice change - filters",
+			original: &ShadowLinkConfig{
+				TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
+					AutoCreateShadowTopicFilters: []*NameFilter{
+						{PatternType: PatternTypeLiteral, FilterType: FilterTypeInclude, Name: "test"},
+					},
+				},
+			},
+			updated: &ShadowLinkConfig{
+				TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
+					AutoCreateShadowTopicFilters: []*NameFilter{
+						{PatternType: PatternTypePrefix, FilterType: FilterTypeExclude, Name: "test"},
+					},
+				},
+			},
+			want: []string{"configurations.topic_metadata_sync_options.auto_create_shadow_topic_filters"},
+		},
+		{
+			name: "nil to non-nil pointer change",
+			original: &ShadowLinkConfig{
+				SecuritySyncOptions: nil,
+			},
+			updated: &ShadowLinkConfig{
+				SecuritySyncOptions: &SecuritySettingsSyncOptions{
+					Interval: 30 * time.Second,
+				},
+			},
+			want: []string{"configurations.security_sync_options"},
+		},
+		{
+			name: "non-nil to nil pointer change",
+			original: &ShadowLinkConfig{
+				SecuritySyncOptions: &SecuritySettingsSyncOptions{
+					Interval: 30 * time.Second,
+				},
+			},
+			updated: &ShadowLinkConfig{
+				SecuritySyncOptions: nil,
+			},
+			want: []string{"configurations.security_sync_options"},
+		},
+		{
+			name: "empty struct oneof marker change - start_at_earliest",
+			original: &ShadowLinkConfig{
+				TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
+					StartAtEarliest: nil,
+				},
+			},
+			updated: &ShadowLinkConfig{
+				TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
+					StartAtEarliest: &StartAtEarliest{},
+				},
+			},
+			want: []string{"configurations.topic_metadata_sync_options.start_at_earliest"},
+		},
+		{
+			name: "time.Duration change",
+			original: &ShadowLinkConfig{
+				TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
+					Interval: 30 * time.Second,
+				},
+			},
+			updated: &ShadowLinkConfig{
+				TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
+					Interval: 60 * time.Second,
+				},
+			},
+			want: []string{"configurations.topic_metadata_sync_options.interval"},
+		},
+		{
+			name: "int32 field change",
+			original: &ShadowLinkConfig{
+				ClientOptions: &ShadowLinkClientOptions{
+					MetadataMaxAgeMs: 10000,
+				},
+			},
+			updated: &ShadowLinkConfig{
+				ClientOptions: &ShadowLinkClientOptions{
+					MetadataMaxAgeMs: 20000,
+				},
+			},
+			want: []string{"configurations.client_options.metadata_max_age_ms"},
+		},
+		{
+			name: "multiple field changes",
+			original: &ShadowLinkConfig{
+				Name: "old",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"host1:9092"},
+					SourceClusterID:  "cluster1",
+				},
+			},
+			updated: &ShadowLinkConfig{
+				Name: "new",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"host2:9092"},
+					SourceClusterID:  "cluster2",
+				},
+			},
+			want: []string{
+				"configurations.name",
+				"configurations.client_options.bootstrap_servers",
+				"configurations.client_options.source_cluster_id",
+			},
+		},
+		{
+			name: "union field change - switching tls modes",
+			original: &ShadowLinkConfig{
+				ClientOptions: &ShadowLinkClientOptions{
+					TLSSettings: &TLSSettings{
+						TLSFileSettings: &TLSFileSettings{
+							CAPath: "/path/ca.crt",
+						},
+					},
+				},
+			},
+			updated: &ShadowLinkConfig{
+				ClientOptions: &ShadowLinkClientOptions{
+					TLSSettings: &TLSSettings{
+						TLSPEMSettings: &TLSPEMSettings{
+							CA: "-----BEGIN CERTIFICATE-----",
+						},
+					},
+				},
+			},
+			want: []string{
+				"configurations.client_options.tls_settings.tls_file_settings",
+				"configurations.client_options.tls_settings.tls_pem_settings",
+			},
+		},
+		{
+			name: "union field change - scram config",
+			original: &ShadowLinkConfig{
+				ClientOptions: &ShadowLinkClientOptions{
+					AuthenticationConfiguration: nil,
+				},
+			},
+			updated: &ShadowLinkConfig{
+				ClientOptions: &ShadowLinkClientOptions{
+					AuthenticationConfiguration: &AuthenticationConfiguration{
+						ScramConfiguration: &ScramConfiguration{
+							Username:       "user",
+							Password:       "pass",
+							ScramMechanism: ScramMechanismScramSha256,
+						},
+					},
+				},
+			},
+			want: []string{
+				"configurations.client_options.authentication_configuration",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := diffConfigs(tt.original, tt.updated)
+
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This prevent sending the string '<redacted>' when
a password is set and you update any other field.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

