### PR TITLE
CORE-14574 sec/oidc: do not wait for EOF on OIDC requests

### DIFF
--- a/src/v/security/oidc_service.cc
+++ b/src/v/security/oidc_service.cc
@@ -381,7 +381,9 @@ struct service::impl {
         http::client client{net::base_transport::configuration{
           .server_addr = {url.host, url.port},
           .credentials = is_https ? _creds : nullptr,
-          .tls_sni_hostname = tls_host}};
+          .tls_sni_hostname = tls_host,
+          .wait_for_tls_server_eof = false,
+        }};
 
         http::client::request_header req_hdr;
         req_hdr.method(boost::beast::http::verb::get);


### PR DESCRIPTION
The typical TLS shutdown process consists of the client sending a close_notify to the server, then the server closing the connection in response to that.

However, many servers are non-compliant and they just drop the connection on close_notify instead of doing an orderly shutdown on it.

We see this in particular in our default-configured OIDC server, which is showing up as flakiness in the OIDCTlsTest's.

It is in-spec to not wait for EOF on shutdown, in fact, a recent upstream seastar change (https://github.com/scylladb/seastar/pull/2986) will make this the default behaviour.

So this commit implements a targeted, easily-backportable test-flakiness-fix by skipping waiting for EOF for requests to the OIDC server.

Ref: https://datatracker.ietf.org/doc/html/rfc8446

>   Both parties need not wait to receive a
>   "close_notify" alert before closing their read side of the
>   connection, though doing so would introduce the possibility of
>   truncation.

and because we are using TCP we have that

>   Note: It is assumed that closing the write side of a connection
>   reliably delivers pending data before destroying the transport.

Fixes https://redpandadata.atlassian.net/browse/CORE-14574

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes
* Do not wait for EOF from OIDC server on TLS connection shutdown.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
