### PR TITLE
`cloud_io`: make `delete_objects` pass by const-ref

### DIFF
--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -841,7 +841,7 @@ ss::future<upload_result> remote::delete_object_batch(
     while (!_gate.is_closed() && permit.is_allowed && !result) {
         req_cb(fib.retry_count());
         auto res = co_await lease.client->delete_objects(
-          bucket, keys.copy(), fib.get_timeout());
+          bucket, keys, fib.get_timeout());
 
         if (res) {
             if (!res.value().undeleted_keys.empty()) {

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -798,7 +798,7 @@ ss::future<> abs_client::do_delete_object(
 ss::future<result<abs_client::delete_objects_result, error_outcome>>
 abs_client::delete_objects(
   const bucket_name& bucket,
-  chunked_vector<object_key> keys,
+  const chunked_vector<object_key>& keys,
   ss::lowres_clock::duration timeout) {
     abs_client::delete_objects_result delete_objects_result;
     for (const auto& key : keys) {

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -212,7 +212,7 @@ public:
     /// \param timeout is a timeout of the operation
     ss::future<result<delete_objects_result, error_outcome>> delete_objects(
       const bucket_name& bucket,
-      chunked_vector<object_key> keys,
+      const chunked_vector<object_key>& keys,
       ss::lowres_clock::duration timeout) override;
 
     struct storage_account_info {

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -177,7 +177,7 @@ public:
     virtual ss::future<result<delete_objects_result, error_outcome>>
     delete_objects(
       const bucket_name& bucket,
-      chunked_vector<object_key> keys,
+      const chunked_vector<object_key>& keys,
       ss::lowres_clock::duration timeout)
       = 0;
 };

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -286,7 +286,7 @@ struct delete_objects_body : public ss::data_source_impl {
 
 result<std::tuple<http::client::request_header, ss::input_stream<char>>>
 request_creator::make_delete_objects_request(
-  const bucket_name& name, chunked_vector<object_key> keys) {
+  const bucket_name& name, const chunked_vector<object_key>& keys) {
     // https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html
     // will generate this request:
     //
@@ -1156,11 +1156,10 @@ iobuf_to_delete_objects_result(iobuf&& buf) {
 
 auto s3_client::do_delete_objects(
   const bucket_name& bucket,
-  chunked_vector<object_key> keys,
+  const chunked_vector<object_key>& keys,
   ss::lowres_clock::duration timeout)
   -> ss::future<client::delete_objects_result> {
-    auto request = _requestor.make_delete_objects_request(
-      bucket, std::move(keys));
+    auto request = _requestor.make_delete_objects_request(bucket, keys);
     if (!request) {
         return ss::make_exception_future<delete_objects_result>(
           std::system_error(request.error()));
@@ -1200,11 +1199,11 @@ auto s3_client::do_delete_objects(
 
 auto s3_client::delete_objects(
   const bucket_name& bucket,
-  chunked_vector<object_key> keys,
+  const chunked_vector<object_key>& keys,
   ss::lowres_clock::duration timeout)
   -> ss::future<result<delete_objects_result, error_outcome>> {
     const object_key dummy{""};
     co_return co_await send_request(
-      do_delete_objects(bucket, std::move(keys), timeout), bucket, dummy);
+      do_delete_objects(bucket, keys, timeout), bucket, dummy);
 }
 } // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -13,8 +13,10 @@
 #include "base/units.h"
 #include "base/vlog.h"
 #include "bytes/bytes.h"
+#include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
 #include "bytes/iostream.h"
+#include "bytes/streambuf.h"
 #include "cloud_storage_clients/logger.h"
 #include "cloud_storage_clients/s3_error.h"
 #include "cloud_storage_clients/util.h"
@@ -331,7 +333,9 @@ request_creator::make_delete_objects_request(
             delete_tree.add_child("Delete.Object", key_tree);
         }
 
-        auto out = std::ostringstream{};
+        iobuf buf;
+        iobuf_ostreambuf obuf(buf);
+        std::ostream out(&obuf);
         boost::property_tree::write_xml(out, delete_tree);
         if (!out.good()) {
             throw std::runtime_error(fmt_with_ctx(
@@ -339,7 +343,7 @@ request_creator::make_delete_objects_request(
               "failed to create delete request, state: {}",
               out.rdstate()));
         }
-        return out.str();
+        return buf;
     }();
 
     auto body_md5 = [&] {
@@ -364,17 +368,14 @@ request_creator::make_delete_objects_request(
 
     header.insert(
       boost::beast::http::field::content_length,
-      fmt::format("{}", body.size()));
+      fmt::format("{}", body.size_bytes()));
 
     auto ec = _apply_credentials->add_auth(header);
     if (ec) {
         return ec;
     }
     util::url_encode_target(header);
-    return {
-      std::move(header),
-      ss::input_stream<char>{ss::data_source{
-        std::make_unique<delete_objects_body>(std::move(body))}}};
+    return {std::move(header), make_iobuf_input_stream(std::move(body))};
 }
 
 std::string request_creator::make_host(const bucket_name& name) const {

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -276,16 +276,6 @@ request_creator::make_delete_object_request(
     return header;
 }
 
-struct delete_objects_body : public ss::data_source_impl {
-    ss::temporary_buffer<char> data;
-    explicit delete_objects_body(std::string_view body) noexcept
-      : data{body.data(), body.size()} {}
-    auto get() -> ss::future<ss::temporary_buffer<char>> override {
-        return ss::make_ready_future<ss::temporary_buffer<char>>(
-          std::exchange(data, {}));
-    }
-};
-
 result<std::tuple<http::client::request_header, ss::input_stream<char>>>
 request_creator::make_delete_objects_request(
   const bucket_name& name, const chunked_vector<object_key>& keys) {

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -87,7 +87,7 @@ public:
     /// \return the header and an the body as an input_stream
     result<std::tuple<http::client::request_header, ss::input_stream<char>>>
     make_delete_objects_request(
-      const bucket_name& name, chunked_vector<object_key> keys);
+      const bucket_name& name, const chunked_vector<object_key>& keys);
 
     /// \brief Initialize http header for 'ListObjectsV2' request
     ///
@@ -198,7 +198,7 @@ public:
 
     ss::future<result<delete_objects_result, error_outcome>> delete_objects(
       const bucket_name& bucket,
-      chunked_vector<object_key> keys,
+      const chunked_vector<object_key>& keys,
       ss::lowres_clock::duration timeout) override;
 
 private:
@@ -239,7 +239,7 @@ private:
 
     ss::future<delete_objects_result> do_delete_objects(
       const bucket_name& bucket,
-      chunked_vector<object_key> keys,
+      const chunked_vector<object_key>& keys,
       ss::lowres_clock::duration timeout);
 
     template<typename T>


### PR DESCRIPTION
Quick follow-up to https://github.com/redpanda-data/redpanda/pull/28382.

To avoid a call to `.copy()` in `cloud_io::remote`.

We already pass the bucket by const-ref, the lifetimes here are sane, we can avoid full copies of our `chunked_vector` of keys easily.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
