### PR TITLE
rptest: fix BadLogLines exception in __str__

### DIFF
--- a/tests/rptest/services/openmessaging_benchmark.py
+++ b/tests/rptest/services/openmessaging_benchmark.py
@@ -26,7 +26,7 @@ from rptest.services.redpanda import (
     RedpandaService,
     RedpandaServiceCloud,
 )
-from rptest.services.utils import BadLogLines
+from rptest.services.utils import BadLogLines, VersionAndLines
 
 LOG_ALLOW_LIST = ["No such file or directory", "cannot be started once stopped"]
 
@@ -130,14 +130,18 @@ class OpenMessagingBenchmarkWorkers(Service):
             f"Open Messaging Benchmark worker is successfully started on node {node.account.hostname}"
         )
 
-    def raise_on_bad_log_lines(self, node):
+    def raise_on_bad_log_lines(self, node: ClusterNode) -> None:
         """
         Check if benchmark worker logfile contains errors
 
         TimeoutException - means that redpanda node is responding too slow,
         so some records can't be produced or consumed
         """
-        bad_lines = collections.defaultdict(list)
+
+        def make_vl() -> VersionAndLines:
+            return {"version": None, "lines": []}
+
+        bad_lines: dict[ClusterNode, VersionAndLines] = collections.defaultdict(make_vl)
         self.logger.info(f"Scanning node {node.account.hostname} log for errors...")
 
         for line in node.account.ssh_capture(
@@ -150,7 +154,7 @@ class OpenMessagingBenchmarkWorkers(Service):
                     break
 
             if not allowed:
-                bad_lines[node].append(line)
+                bad_lines[node]["lines"].append(line)
 
         if bad_lines:
             raise BadLogLines(bad_lines)
@@ -397,13 +401,17 @@ class OpenMessagingBenchmark(Service):
                 err_msg="Open Messaging Benchmark service didn't start",
             )
 
-    def raise_on_bad_log_lines(self, node):
+    def raise_on_bad_log_lines(self, node: ClusterNode) -> None:
         """
         Check if benchmark logfile contains errors
 
         Here we expect that log doesn't contain java Exceptions
         """
-        bad_lines = collections.defaultdict(list)
+
+        def make_vl() -> VersionAndLines:
+            return {"version": None, "lines": []}
+
+        bad_lines: dict[ClusterNode, VersionAndLines] = collections.defaultdict(make_vl)
         self.logger.info(f"Scanning node {node.account.hostname} log for errors...")
 
         for line in node.account.ssh_capture(
@@ -416,7 +424,7 @@ class OpenMessagingBenchmark(Service):
                     break
 
             if not allowed:
-                bad_lines[node].append(line)
+                bad_lines[node]["lines"].append(line)
 
         if bad_lines:
             raise BadLogLines(bad_lines)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2919,7 +2919,7 @@ class RedpandaService(Service, RedpandaServiceABC):
 
         allow_list = prepare_allow_list(allow_list)
 
-        _searchable_nodes = []
+        _searchable_nodes: list[tuple[str | None, Any]] = []
         for node in self.nodes:
             if self._skip_if_no_redpanda_log and not node.account.exists(
                 RedpandaService.STDOUT_STDERR_CAPTURE
@@ -4454,7 +4454,7 @@ class RedpandaService(Service, RedpandaServiceABC):
         version_str = self.get_version(node)
         return ri_int_tuple(RI_VERSION_RE.findall(version_str)[0])
 
-    def get_version_if_not_head(self, node):
+    def get_version_if_not_head(self, node: ClusterNode) -> str | None:
         """
         Returns the redpanda binary version as a string if it differs from HEAD.
         I.e., if this node is running a previous version of redpanda.

--- a/tests/rptest/services/utils.py
+++ b/tests/rptest/services/utils.py
@@ -1,10 +1,27 @@
-import collections
+from collections import defaultdict
+from logging import Logger
 import re
 import time
 from abc import ABC, abstractmethod
-from typing import Any, Generator
+import traceback
+from typing import Any, Generator, Iterable, TypedDict
 
 from rptest.clients.kubectl import KubectlTool
+
+from ducktape.tests.test import TestContext
+from ducktape.cluster.cluster import ClusterNode
+
+from rptest.services.cloud_broker import CloudBroker
+
+VersionedNodes = Iterable[tuple[str | None, ClusterNode | CloudBroker]]
+
+
+class VersionAndLines(TypedDict):
+    version: str | None
+    lines: list[str]
+
+
+NodeToLines = dict[ClusterNode, VersionAndLines]
 
 
 def assert_int(v: Any) -> int:
@@ -52,18 +69,20 @@ class Stopwatch:
 
 
 class BadLogLines(Exception):
-    def __init__(self, node_to_lines):
+    def __init__(self, node_to_lines: NodeToLines):
         self.node_to_lines = node_to_lines
+        self._str = self._make_str(node_to_lines)
 
-    def __str__(self):
+    @staticmethod
+    def _make_str(node_to_lines: NodeToLines) -> str:
         # Pick the first line from the first node as an example, and include it
         # in the string output so that for single line failures, it isn't necessary
         # for folks to search back in the log to find the culprit.
-        example_lines = next(iter(self.node_to_lines.items()))[1]
+        example_lines = next(iter(node_to_lines.items()))[1]
         example = next(iter(example_lines["lines"]))
 
-        summary_list = []
-        for i in self.node_to_lines.items():
+        summary_list: list[str] = []
+        for i in node_to_lines.items():
             version_or_none = i[1]["version"]
             node_info = (
                 f"<{i[0].account.hostname}:{version_or_none}>"
@@ -73,6 +92,9 @@ class BadLogLines(Exception):
             summary_list.append(f"{node_info}({len(i[1])})")
         summary = ",".join(summary_list)
         return f'<BadLogLines nodes={summary} example="{example}">'
+
+    def __str__(self):
+        return self._str
 
     def __repr__(self):
         return self.__str__()
@@ -114,7 +136,7 @@ class LogSearch(ABC):
         "oversized allocation",
     ]
 
-    def __init__(self, test_context, allow_list, logger) -> None:
+    def __init__(self, test_context: TestContext, allow_list, logger: Logger) -> None:
         self._context = test_context
         self.allow_list = allow_list
         self.logger = logger
@@ -137,7 +159,7 @@ class LogSearch(ABC):
             yield x
 
     @abstractmethod
-    def _get_hostname(self, host) -> str:
+    def _get_hostname(self, host: Any) -> str:
         """Method to get name of the host. Overriden by each child."""
         return ""
 
@@ -173,8 +195,11 @@ class LogSearch(ABC):
             return True
         return False
 
-    def _search(self, versioned_nodes):
-        bad_lines = collections.defaultdict(lambda: {"version": None, "lines": []})
+    def _search(self, versioned_nodes: VersionedNodes):
+        def make_vl() -> VersionAndLines:
+            return {"version": None, "lines": []}
+
+        bad_lines: defaultdict[ClusterNode, VersionAndLines] = defaultdict(make_vl)
         test_name = self._context.function_name
         sw = Stopwatch()
         for version, node in versioned_nodes:
@@ -203,9 +228,9 @@ class LogSearch(ABC):
             self.logger.info(
                 sw.elapsedf(f"##### Time spent to scan bad logs on '{hostname}'")
             )
-        return bad_lines
+        return dict(bad_lines)
 
-    def search_logs(self, versioned_nodes):
+    def search_logs(self, versioned_nodes: VersionedNodes):
         """
         versioned_nodes is a list of Tuple[version, node]
         """


### PR DESCRIPTION
Maybe. In OMB we pass the wrong type to BLL which causes its `__str__` to throw, which confuses DT which doesn't get any stack trace and just prints "Test Passed" (but the test fails).

Also change the BLL __str__ method so it cannot throw. We create the string up front in the constructor, which will throw if it fails, still in the test context so will be reported properly by DT.

Improve types a bit in this area (Stephan has another change which does this more broadly for omb benchmark), since typing would have caught this when the bug was originally introduced.

Fixes CORE-13453.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
