### PR TITLE
[CORE-13943] rptest: bump pyiceberg version

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -48,7 +48,7 @@ setup(
         #   Using a hash to unreleased version because we depend on new
         #   pluggable authentication mechanism.
         # "pyiceberg==0.9.1",
-        "pyiceberg@git+https://github.com/apache/iceberg-python@76a6451cd6863fe3d0e10d33da9b78af12e50111",
+        "pyiceberg@git+https://github.com/apache/iceberg-python@bb41a6dc7b7cd69bef67e11b989953c727a6193b",
         "adlfs==2024.7.0",
         "pyarrow",
         "pandas",


### PR DESCRIPTION
There was recently a bug fixed caused by pydantic:

```
TimeoutError('Error waiting for Iceberg table to have data') Traceback (most recent call last):
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/utils/util.py", line 44, in wait_until
    if condition():
  File "/home/ubuntu/redpanda/tests/rptest/tests/datalake/rest_catalog_connection_test.py", line 116, in data_available_in_iceberg_table
    table = catalog.load_table(f"{namespace}.{topic.name}")
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/tenacity/__init__.py", line 338, in wrapped_f
    return copy(f, *args, **kw)
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/tenacity/__init__.py", line 477, in __call__
    do = self.iter(retry_state=retry_state)
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/tenacity/__init__.py", line 378, in iter
    result = action(retry_state)
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/tenacity/__init__.py", line 400, in <lambda>
    self._add_action_func(lambda rs: rs.outcome.result())
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 451, in result
    return self.__get_result()
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/tenacity/__init__.py", line 480, in __call__
    result = fn(*args, **kwargs)
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/pyiceberg/catalog/rest/__init__.py", line 636, in load_table
    table_response = TableResponse.model_validate_json(response.text)
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/pydantic/main.py", line 766, in model_validate_json
    return cls.__pydantic_validator__.validate_json(
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/pyiceberg/table/metadata.py", line 494, in check_schemas
    return check_schemas(table_metadata)
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/pyiceberg/table/metadata.py", line 82, in check_schemas
    current_schema_id = table_metadata.current_schema_id
AttributeError: 'pydantic_core._pydantic_core.ValidationInfo' object has no attribute 'current_schema_id'
```
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
