### PR TITLE
type-checking: allow running from anywhere

### DIFF
--- a/tools/type-checking/type-check.sh
+++ b/tools/type-checking/type-check.sh
@@ -19,8 +19,8 @@ if [[ ${TC_SKIP_DOCKER_BUILD:-0} != "0" ]]; then
   echo "Skipping Docker build because TC_SKIP_DOCKER_BUILD=${TC_SKIP_DOCKER_BUILD}" >&2
 else
   echo "Building Docker image $tag..."
-  docker build -t $tag -f "tools/type-checking/Dockerfile" \
-    ${TARGET:+--target=$TARGET} ${TC_DOCKER_ARGS-} tests
+  docker build -t $tag -f "$ROOT_DIR/tools/type-checking/Dockerfile" \
+    ${TARGET:+--target=$TARGET} ${TC_DOCKER_ARGS-} "$ROOT_DIR/tests"
 fi
 
 # Run the container with the tests directory mounted


### PR DESCRIPTION
type-check.sh should work from anywhere but it got broken at some point.

Prefix docker build stuff with $ROOT_DIR to fix this.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
