### PR TITLE
Disallow concurrent consumer group migrations

### DIFF
--- a/src/v/cluster/data_migrated_resources.h
+++ b/src/v/cluster/data_migrated_resources.h
@@ -48,10 +48,12 @@ public:
     bool is_already_migrated(const model::topic_namespace& topic) const {
         return _topics.contains(topic);
     }
-    /// Checks if consumer group  is already migrated
+    /// Checks if consumer group is already migrated
     bool is_already_migrated(const consumer_group& cg) const {
         return _groups.contains(cg);
     }
+    /// Checks if any group is already migrated
+    bool is_any_group_migrated() const { return !_groups.empty(); }
 
 private:
     void apply_snapshot(

--- a/src/v/cluster/data_migration_table.cc
+++ b/src/v/cluster/data_migration_table.cc
@@ -264,14 +264,10 @@ migrations_table::validate_migrated_resources(
         }
     }
 
-    for (const auto& group : idm.groups) {
-        if (_resources.local().is_already_migrated(group)) {
-            return {
-              {errc::resource_is_being_migrated,
-               ssx::sformat(
-                 "group with name {} is already part of active migration",
-                 group)}};
-        }
+    if (!idm.groups.empty() && _resources.local().is_any_group_migrated()) {
+        return {
+          {errc::resource_is_being_migrated,
+           "cannot migrate groups when there are active group migrations"}};
     }
 
     return std::nullopt;
@@ -315,14 +311,10 @@ migrations_table::validate_migrated_resources(
         }
     }
 
-    for (const auto& group : odm.groups) {
-        if (_resources.local().is_already_migrated(group)) {
-            return {
-              {errc::resource_is_being_migrated,
-               ssx::sformat(
-                 "group with name {} is already part of active migration",
-                 group)}};
-        }
+    if (!odm.groups.empty() && _resources.local().is_any_group_migrated()) {
+        return {
+          {errc::resource_is_being_migrated,
+           "cannot migrate groups when there are active group migrations"}};
     }
 
     return std::nullopt;

--- a/src/v/cluster/tests/data_migration_table_test.cc
+++ b/src/v/cluster/tests/data_migration_table_test.cc
@@ -284,12 +284,7 @@ TEST_F_CORO(data_migration_table_fixture, test_crud_operations) {
         cluster::data_migrations::create_migration_cmd_data{
           .id = id_2,
           .migration = cluster::data_migrations::inbound_migration{
-            .topics = create_inbound_topics({"in-t-1"}),
-            .groups = create_groups({"g-3", "g-4"})}}));
-
-    validate_group_resource_state(
-      {{"g-3", data_migrations::migrated_resource_state::metadata_locked},
-       {"g-4", data_migrations::migrated_resource_state::metadata_locked}});
+            .topics = create_inbound_topics({"in-t-1"}), .groups = {}}}));
 
     validate_topic_resource_state(
       {{"in-t-1", data_migrations::migrated_resource_state::metadata_locked}});
@@ -507,8 +502,7 @@ TEST_F_CORO(data_migration_table_fixture, test_resource_validation) {
     inbound_topics[0].alias = model::topic_namespace(
       model::kafka_namespace, model::topic("alias-of-topic-1"));
     data_migrations::inbound_migration idm_with_alias{
-      .topics = inbound_topics.copy(),
-      .groups = create_groups({"gr-4", "gr-5"})};
+      .topics = inbound_topics.copy(), .groups = {}};
 
     /**
      * Requested topics do not exists, migration creation should fail

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -229,16 +229,24 @@ class DataMigrationsApiTest(DataMigrationTestMixin):
             err_msg=f"Expected migration with id {migration_id} is absent",
         )
 
-    def assure_not_migratable(self, topic: TopicSpec, expected_response=None):
-        out_migration = OutboundDataMigration(
-            [make_namespaced_topic(topic.name)], consumer_groups=[]
-        )
+    def assure_not_migratable(
+        self, topic: TopicSpec | None, group: str | None, expected_response
+    ):
+        topics = [make_namespaced_topic(topic.name)] if topic is not None else []
+        groups = [group] if group is not None else []
+        out_migration = OutboundDataMigration(topics=topics, consumer_groups=groups)
         try:
             self.create_and_wait(out_migration)
-            assert False
+            assert False, (
+                f"Expected migration creation to fail with {expected_response}"
+            )
         except requests.exceptions.HTTPError as e:
-            if expected_response is not None:
-                assert e.response.json() == expected_response
+            assert e.response is not None, (
+                f"Expected error response to be present in exception {e}"
+            )
+            assert e.response.json() == expected_response, (
+                f"Expected error response: {expected_response}; actual: {e.response.json()}; "
+            )
 
     @cluster(num_nodes=3, log_allow_list=MIGRATION_LOG_ALLOW_LIST)
     def test_listing_inexistent_migration(self):
@@ -248,7 +256,9 @@ class DataMigrationsApiTest(DataMigrationTestMixin):
     def test_outbound_missing_topic(self):
         topic = TopicSpec(partition_count=3)
         self.assure_not_migratable(
-            topic, {"message": "Topic does not exists", "code": 400}
+            topic=topic,
+            group=None,
+            expected_response={"message": "Topic does not exists", "code": 400},
         )
 
     @cluster(
@@ -267,8 +277,9 @@ class DataMigrationsApiTest(DataMigrationTestMixin):
         )
         self.create_and_wait(out1)
         self.assure_not_migratable(
-            topic,
-            {
+            topic=topic,
+            group=None,
+            expected_response={
                 "message": "Requested operation can not be executed as the resource is undergoing data migration",
                 "code": 400,
             },
@@ -307,8 +318,9 @@ class DataMigrationsApiTest(DataMigrationTestMixin):
             {"cloud_storage_enable_remote_write": True}, expect_restart=True
         )
         self.assure_not_migratable(
-            topic,
-            {
+            topic=topic,
+            group=None,
+            expected_response={
                 "message": "Data migration contains resources that are not eligible",
                 "code": 400,
             },
@@ -365,7 +377,9 @@ class DataMigrationsApiTest(DataMigrationTestMixin):
         self.redpanda.set_cluster_config({param_to_disable: False}, expect_restart=True)
         topic = TopicSpec(partition_count=3)
         self.client().create_topic(topic)
-        self.assure_not_migratable(topic, expected_error)
+        self.assure_not_migratable(
+            topic=topic, group=None, expected_response=expected_error
+        )
         # for scrubbing to complete
         self.redpanda.set_cluster_config({param_to_disable: True}, expect_restart=True)
 
@@ -521,8 +535,9 @@ class DataMigrationsApiTest(DataMigrationTestMixin):
             time.sleep(2)  # make sure test harness can see Redpanda is live
             self.toggle_license(on=False)
             self.assure_not_migratable(
-                topics[0],
-                {
+                topic=topics[0],
+                group=None,
+                expected_response={
                     "message": "Unexpected cluster error: Requested feature is disabled",
                     "code": 500,
                 },

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -288,6 +288,28 @@ class DataMigrationsApiTest(DataMigrationTestMixin):
     @cluster(
         num_nodes=3,
         log_allow_list=MIGRATION_LOG_ALLOW_LIST
+        + [
+            "Requested operation can not be executed as the resource is undergoing data migration"
+        ],
+    )
+    def test_conflicting_group_migrations(self):
+        topic = TopicSpec(partition_count=3)
+        self.client().create_topic(topic)
+        self.wait_partitions_appear([topic])
+        out1 = OutboundDataMigration([], consumer_groups=["group1"])
+        self.create_and_wait(out1)
+        self.assure_not_migratable(
+            topic=None,
+            group="group2",
+            expected_response={
+                "message": "Requested operation can not be executed as the resource is undergoing data migration",
+                "code": 400,
+            },
+        )
+
+    @cluster(
+        num_nodes=3,
+        log_allow_list=MIGRATION_LOG_ALLOW_LIST
         + ["The topic has already been created"],
     )
     def test_inbound_existing_topic(self):


### PR DESCRIPTION
Currently data migration reconciliation mechanism in `backend` and `worker` classes assume each topic and each partition only belongs to no more than one migration.

When this is fixed we can lift this restriction.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
