### PR TITLE
cl/tests: ClusterLinkingProgressVerifier fix

### DIFF
--- a/tests/rptest/scale_tests/cluster_linking_many_partitions_test.py
+++ b/tests/rptest/scale_tests/cluster_linking_many_partitions_test.py
@@ -23,7 +23,7 @@ class ClusterLinkingScaleTest(ShadowLinkPreAllocTestBase):
             partition_memory_reserve_percentage=ScaleParameters.DEFAULT_PARTITIONS_MEMORY_ALLOCATION_PERCENT,
         )
 
-    @cluster(num_nodes=8)
+    @cluster(num_nodes=7)
     @matrix(topic_count=[1, 5, 10])
     def test_many_partitions(self, topic_count: int):
         topics = [

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -1671,7 +1671,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
 
         return self._check_partitions_match(rpk, shadow_topic_name, shadow_topic)
 
-    @cluster(num_nodes=8)
+    @cluster(num_nodes=7)
     @matrix(
         shuffle_leadership=[True, False],
         source_cluster_spec=[
@@ -1714,7 +1714,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         )
 
     @cluster(
-        num_nodes=8,
+        num_nodes=7,
         log_allow_list=[
             re.compile(".*Failed to sync write_at_offset_stm for partition"),
         ],
@@ -1753,7 +1753,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             retry_on_exc=True,
         )
 
-    @cluster(num_nodes=8)
+    @cluster(num_nodes=7)
     @matrix(
         source_cluster_spec=[
             SecondaryClusterSpec(ServiceType.REDPANDA),
@@ -1811,7 +1811,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             f"Instead got {link_state.status.shadow_topics}"
         )
 
-    @cluster(num_nodes=8)
+    @cluster(num_nodes=7)
     def test_replication_with_transactions(self):
         topic = TopicSpec(name="source-topic", partition_count=1, replication_factor=3)
 
@@ -1955,7 +1955,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
                 err_msg=f"Timed out waiting for target to get start offset to be {o} in each partition",
             )
 
-    @cluster(num_nodes=8)
+    @cluster(num_nodes=7)
     @ignore(
         with_failures=True,
         source_cluster_spec=SecondaryClusterSpec(
@@ -1990,7 +1990,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         with self._maybe_failure_injector(with_failures):
             self._perform_auto_prefix_trimming(topic.name, partition_count)
 
-    @cluster(num_nodes=8)
+    @cluster(num_nodes=7)
     @matrix(
         timestamp_type=[
             "CreateTime",
@@ -2070,7 +2070,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             f"Timestamps don't match {expected_timestamps=} vs {consumed=}"
         )
 
-    @cluster(num_nodes=8)
+    @cluster(num_nodes=7)
     def test_replication_with_large_msgs(self):
         msg_size = 2 * 1024 * 1024
         max_bytes = 10 * msg_size
@@ -2099,7 +2099,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         )
         self.verify()
 
-    @cluster(num_nodes=8)
+    @cluster(num_nodes=7)
     def test_replication_with_compaction(self):
         self.logger.info(
             "Create a topic with compaction settings set but without compaction and tombstone removal enabled"
@@ -2224,7 +2224,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             err_msg="Compaction state is not consistent between clusters",
         )
 
-    @cluster(num_nodes=9)
+    @cluster(num_nodes=7)
     def test_with_restart(self):
         self.create_link("test-link")
 
@@ -3151,7 +3151,7 @@ class ShadowLinkingMetricsTests(ShadowLinkPreAllocTestBase):
             return False
         return validator(metrics)
 
-    @cluster(num_nodes=10)
+    @cluster(num_nodes=7)
     def test_link_metrics(self):
         topic_1 = TopicSpec(
             name="test-topic-1", partition_count=3, replication_factor=1

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -171,6 +171,7 @@ class ClusterLinkingProgressVerifier:
         )
         self.producer.start(clean=True)
         self.producer.wait_for_acks(10, 40, 1)
+        self.producer.wait_for_offset_map()
         readers = 8
 
         self.source_consumer = KgoVerifierConsumerGroupConsumer(
@@ -181,6 +182,7 @@ class ClusterLinkingProgressVerifier:
             readers=readers,
             use_transactions=self.use_transactions,
             group_name=f"source-cg-{self.topic}",
+            nodes=self.preallocated_nodes,
             continuous=True,
             **self.consumer_properties,
         )

--- a/tests/rptest/tests/shadow_linking_rnot_test.py
+++ b/tests/rptest/tests/shadow_linking_rnot_test.py
@@ -301,7 +301,7 @@ class ShadowLinkingRandomOpsTest(ShadowLinkTestBase):
             self.total_node_ops = 5
             self.partition_count = 12
 
-    @cluster(num_nodes=14)
+    @cluster(num_nodes=11)
     @matrix(failures=[False, True])
     def test_node_operations(self, failures: bool):
         self.setup_scale()


### PR DESCRIPTION
There are a class of failures that result in errors such as:
```
ducktape.errors.TimeoutError: Timed out waiting for status endpoint KgoVerifierConsumerGroupConsumer-0-140503148073056 to be available
```

This is due to:
```
time="2025-11-07T15:15:05Z" level=info msg="Reading with consumer group source-cg-source-topic"
time="2025-11-07T15:15:05Z" level=error msg="More partitions in valid_offsets file than in topic!"
```

And the reason for that is that the consumer is running on a different node than the producer.

The fix is in two parts:
* Wait for the file before creating the consumer
* Run the consumer on the same node as the producer

Fixes https://redpandadata.atlassian.net/browse/CORE-14327
Fixes https://redpandadata.atlassian.net/browse/CORE-14518


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
