### PR TITLE
gha: add trigger-snyk.yml

### DIFF
--- a/.github/workflows/trigger-snyk.yml
+++ b/.github/workflows/trigger-snyk.yml
@@ -1,0 +1,24 @@
+---
+name: trigger-snyk
+on:
+  push:
+    branches: [dev, 'v*', '!v24.*']
+    paths:
+      - 'MODULE.bazel'
+      - 'bazel/repositories.bzl'
+jobs:
+  gh:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,sdlc/prod/github/actions_bot_token
+          parse-json-secrets: true
+      - run: gh workflow run --repo redpanda-data/vtools --raw-field redpanda-branches='["${{ github.ref_name }}"]' snyk-redpanda.yml
+        env:
+          GH_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}


### PR DESCRIPTION
jira: [DEVPROD-3266]

currently, after bazel deps are updated, the [snyk-redpanda.yml](https://github.com/redpanda-data/vtools/actions/workflows/snyk-redpanda.yml) workflow in `vtools` needs to be manually triggered.

this PR adds a new gha to automatically trigger that workflow when bazel deps are updated.

see [wiki](https://redpandadata.atlassian.net/wiki/x/AoDPU) for reference

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

[DEVPROD-3266]: https://redpandadata.atlassian.net/browse/DEVPROD-3266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ