### PR TITLE
[CORE-14534] k/s/conn_ctx: Ignore exception on input_shutdown

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -202,6 +202,9 @@ ss::future<> connection_context::start() {
     if (conn) {
         ssx::background
           = conn->wait_for_input_shutdown()
+              .handle_exception([](std::exception_ptr) {
+                  // ignore
+              })
               .finally([this]() {
                   vlog(
                     klog.debug,


### PR DESCRIPTION
`net::connection::wait_for_input_shutdown` can throw.

It's not very interesting, so just ignore the exception.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [x] v25.2.x
- [x] v25.1.x
- [x] v24.3.x

## Release Notes

### Improvements

* kafka/server: Fix rare uncaught exceptional future on connection shutdown