### PR TITLE
[CORE-14579] bazel: Patch krb5-1.21.3 to address leak

### DIFF
--- a/bazel/thirdparty/0001-Fix-two-unlikely-memory-leaks.patch
+++ b/bazel/thirdparty/0001-Fix-two-unlikely-memory-leaks.patch
@@ -200,6 +200,21 @@ index 8c7e30c21..149de98b0 100644
  	return (FALSE);
  }
  
+diff --git a/src/lib/gssapi/krb5/acquire_cred.c b/src/lib/gssapi/krb5/acquire_cred.c
+index 006eba114..b91de7cc1 100644
+--- a/src/lib/gssapi/krb5/acquire_cred.c
++++ b/src/lib/gssapi/krb5/acquire_cred.c
+@@ -242,6 +242,10 @@ cleanup:
+         krb5_kt_close(context, kt);
+     if (rc != NULL)
+         k5_rc_close(context, rc);
++    if (cred->acceptor_mprinc != NULL) {
++        krb5_free_principal(context, cred->acceptor_mprinc);
++        cred->acceptor_mprinc = NULL;
++    }
+     *minor_status = code;
+     return major;
+ }
 -- 
 2.34.1
 


### PR DESCRIPTION
Fix a leak when the keytab cannot be found.

```
Direct leak of 120 byte(s) in 3 object(s) allocated from:
    #0 0x58cc434ea154 in malloc /src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:67:3
    #1 0x736a590858ad in krb5_build_principal_alloc_va ../../.././src/lib/krb5/krb/bld_princ.c:124:9
    #2 0x736a590858ad in krb5_build_principal ../../.././src/lib/krb5/krb/bld_princ.c:148:14
    #3 0x736a595ae86a in kg_acceptor_princ ../../.././src/lib/gssapi/krb5/naming_exts.c:165:12
    #4 0x736a59560092 in acquire_accept_cred ../../.././src/lib/gssapi/krb5/acquire_cred.c:199:16
    #5 0x736a59560092 in acquire_cred_context ../../.././src/lib/gssapi/krb5/acquire_cred.c:845:15
    #6 0x736a5955f43d in acquire_cred_from ../../.././src/lib/gssapi/krb5/acquire_cred.c:1320:11
    #7 0x736a5955ed49 in krb5_gss_acquire_cred_from ../../.././src/lib/gssapi/krb5/acquire_cred.c:1348:12
    #8 0x736a594fa4c4 in gss_add_cred_from ../../.././src/lib/gssapi/mechglue/g_acquire_cred.c:544:11
    #9 0x736a594f9361 in gss_acquire_cred_from ../../.././src/lib/gssapi/mechglue/g_acquire_cred.c:190:10
    #10 0x736a595cde33 in get_available_mechs ../../.././src/lib/gssapi/spnego/spnego_mech.c:3109:18
    #11 0x736a595cd788 in spnego_gss_acquire_cred_from ../../.././src/lib/gssapi/spnego/spnego_mech.c:377:11
    #12 0x736a594fa4c4 in gss_add_cred_from ../../.././src/lib/gssapi/mechglue/g_acquire_cred.c:544:11
    #13 0x736a594f9361 in gss_acquire_cred_from ../../.././src/lib/gssapi/mechglue/g_acquire_cred.c:190:10
    #14 0x58cc523cf7de in security::gssapi_authenticator::impl::init() src/v/security/gssapi_authenticator.cc:293:20
```

The associated log line is:
```
INFO  2025-11-10 12:29:46,682 security - gssapi_authenticator.cc:71 - GSS_API error gss init failed to acquire credentials for principal redpanda in keytab /var/lib/redpanda/redpanda.keytab: No credentials were supplied, or the credentials were unavailable or inaccessible
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* kafka/server: Fix a memory leak when the keytab cannot be found.
