### PR TITLE
[v25.2.x] [CORE-14579] bazel: Patch krb5-1.21.3 to address leak

### DIFF
--- a/bazel/thirdparty/0001-Fix-two-unlikely-memory-leaks.patch
+++ b/bazel/thirdparty/0001-Fix-two-unlikely-memory-leaks.patch
@@ -200,6 +200,21 @@ index 8c7e30c21..149de98b0 100644
  	return (FALSE);
  }
  
+diff --git a/src/lib/gssapi/krb5/acquire_cred.c b/src/lib/gssapi/krb5/acquire_cred.c
+index 006eba114..b91de7cc1 100644
+--- a/src/lib/gssapi/krb5/acquire_cred.c
++++ b/src/lib/gssapi/krb5/acquire_cred.c
+@@ -242,6 +242,10 @@ cleanup:
+         krb5_kt_close(context, kt);
+     if (rc != NULL)
+         k5_rc_close(context, rc);
++    if (cred->acceptor_mprinc != NULL) {
++        krb5_free_principal(context, cred->acceptor_mprinc);
++        cred->acceptor_mprinc = NULL;
++    }
+     *minor_status = code;
+     return major;
+ }
 -- 
 2.34.1
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28447
