### PR TITLE
[CORE-14406] rptest: Wait until schemas topic is created

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -2164,7 +2164,7 @@ class RpkTool:
 
         return self._run_registry(cmd)
 
-    def list_schemas(self, subjects=[], deleted=False):
+    def list_schemas(self, subjects: list[str] = [], deleted: bool = False):
         cmd = ["schema", "list"]
 
         if len(subjects) > 0:

--- a/tests/rptest/tests/random_node_operations_smoke_test.py
+++ b/tests/rptest/tests/random_node_operations_smoke_test.py
@@ -503,6 +503,23 @@ class RandomNodeOperationsBase(PreallocNodesTest):
 
         client = DefaultClient(self.redpanda)
 
+        # wait until schema registry topic is created
+        # to avoid topic creation errors during restarts
+        def schema_registry_topic_created():
+            rpk = RpkTool(self.redpanda)
+            try:
+                rpk.list_schemas()
+            except:
+                return False
+            return True
+
+        wait_until(
+            schema_registry_topic_created,
+            180,
+            backoff_sec=2,
+            err_msg="Error waiting for schema registry topic to be created",
+        )
+
         # create some initial topics
         self._create_topics(self.topic_count)
         regular_topic = TopicSpec(


### PR DESCRIPTION
The test sometimes fail due to bad log line which is triggered after the failure to create a scheams topic. This happens due to shutdown. This commit adds logic that forces the test to wait until schemas are available. Only after that the test starts running.

This is a fix for RNOST test which is triggered by `service.cc:366 - Schema registry failed to initialize: std::runtime_error (Failed to create internal topic: cluster::errc::timeout` log line. The log line is emitted when the topic is created during the shutdown.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none