### PR TITLE
[CORE-14581] `cluster`: `partition_balancer` multiple fibers in `do_tick()` check

### DIFF
--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -273,6 +273,13 @@ void partition_balancer_backend::tick() {
       = ssx::spawn_with_gate_then(
           _gate,
           [this] {
+              if (_tick_in_progress) {
+                  vlog(
+                    clusterlog.debug,
+                    "skipping tick, tick already in progress");
+                  return ss::now();
+              }
+
               _tick_in_progress = ss::abort_source{};
               return do_tick().finally([this] {
                   _tick_in_progress = {};

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -273,6 +273,7 @@ void partition_balancer_backend::tick() {
       = ssx::spawn_with_gate_then(
           _gate,
           [this] {
+              _tick_in_progress = ss::abort_source{};
               return do_tick().finally([this] {
                   _tick_in_progress = {};
                   maybe_rearm_timer(
@@ -345,8 +346,6 @@ ss::future<> partition_balancer_backend::do_tick() {
         // TODO: add term checks to planner
         co_return;
     }
-
-    _tick_in_progress = ss::abort_source{};
 
     const bool force_refresh_this_tick
       = _cur_term->_force_health_report_refresh;


### PR DESCRIPTION
Previously, [we saw a SIGILL](https://redpandadata.slack.com/archives/C07HD9U0EHL/p1762787867182419?thread_ts=1762787811.751279&cid=C07HD9U0EHL) in CI that traces back to this lambda in `partition_balancer_backend`:

https://github.com/redpanda-data/redpanda/blob/2ac5cb76f1de263aa7c640f3866c485db4a5f139/src/v/cluster/partition_balancer_backend.cc#L467-L484

The issue here appears to be multiple fibers entering the continuation within `tick()`: this could easily result in `_tick_in_progress` being unset in one fiber's invocation while the other fiber is still working:

https://github.com/redpanda-data/redpanda/blob/2ac5cb76f1de263aa7c640f3866c485db4a5f139/src/v/cluster/partition_balancer_backend.cc#L271-L281

Prevent concurrent access in `partition_balancer_backend::do_tick()` by assigning and checking `_tick_in_progress` up front.

Fixes https://redpandadata.atlassian.net/browse/CORE-14581.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [X] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes

* Prevent a very narrow race condition in the `partition_balancer_backend`.
