### PR TITLE
[CORE-13419] dt: fix await leader logic

### DIFF
--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -54,7 +54,12 @@ from rptest.services.redpanda_types import SaslCredentials
 from rptest.services.serde_client import SerdeClient
 from rptest.tests.pandaproxy_test import PandaProxyTLSProvider, User
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.util import expect_exception, inject_remote_script, search_logs_with_timeout
+from rptest.util import (
+    expect_exception,
+    inject_remote_script,
+    search_logs_with_timeout,
+    wait_until_result,
+)
 from rptest.utils.log_utils import wait_until_nag_is_set
 from rptest.utils.mode_checks import skip_fips_mode
 
@@ -2978,6 +2983,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
     @parametrize(move_controller_leader=True)
     def test_restarts(self, move_controller_leader: bool):
         admin = Admin(self.redpanda)
+        rpk = RpkTool(self.redpanda)
 
         def check_connection(hostname: str):
             result_raw = self.sr_client.get_subjects(hostname=hostname)
@@ -2985,6 +2991,22 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             self.logger.info(result_raw.json())
             assert result_raw.status_code == requests.codes.ok
             assert result_raw.json() == []
+
+        def get_leader_epoch():
+            def rpk_get_leader_epoch():
+                partitions = rpk.describe_topic("_schemas")
+                par_0 = next((p for p in partitions if p.id == 0), None)
+                if not par_0:
+                    return (False, (-1))
+                return (True, par_0.leader_epoch)
+
+            leader_epoch = wait_until_result(
+                rpk_get_leader_epoch,
+                timeout_sec=10,
+                backoff_sec=1,
+                err_msg="Could not get leader info",
+            )
+            return leader_epoch
 
         def restart_leader():
             leader = admin.get_partition_leader(
@@ -2995,11 +3017,25 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 admin.partition_transfer_leadership(
                     namespace="redpanda", topic="controller", partition=0
                 )
+            last_epoch = get_leader_epoch()
             self.logger.info(f"Restarting node: {leader}")
             self.redpanda.restart_nodes(self.redpanda.get_node(leader))
-            admin.await_stable_leader(topic="_schemas", partition=0, namespace="kafka")
 
-        for _ in range(20):
+            def get_new_leader():
+                new_epoch = get_leader_epoch()
+                had_election = last_epoch < new_epoch
+                return (had_election, new_epoch)
+
+            new_epoch = wait_until_result(
+                get_new_leader,
+                timeout_sec=20,
+                backoff_sec=1,
+                err_msg="Leadership did not stabilize",
+            )
+            self.logger.info(f"Epoch: {new_epoch}")
+
+        for i in range(20):
+            self.logger.info(f"Iteration {i}")
             for n in self.redpanda.nodes:
                 check_connection(n.account.hostname)
             restart_leader()


### PR DESCRIPTION
Fixes: [CORE-13419](https://redpandadata.atlassian.net/browse/CORE-13419)

When calling the await_stable_leader, the admin api will report the cached state of the leadership of the partition on each node. After a restart, this may be stale, but it will still be the same across every node. When restart happens very quickly, it doesn't take into account the new election that will start shortly after the restart, usually by the previous leader. Until this election is finished, all list_offset requests will return not_partition_leader. This may eat up some of the available retry attempts of the kafka client. Because of the restarts, there are also some few attempts burned at communicating sasl_credentials. When it also happens to get a few broker_not_available errors thrown in the mix, the retries run out and the test fails.
    
Switch to a more thorough wait condition to verify that a new leader has been elected after the restart.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-13419]: https://redpandadata.atlassian.net/browse/CORE-13419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ