### PR TITLE
[UX-606] Add cloud support to connections list

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -10,8 +10,8 @@ require (
 	buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.10-20251022210436-bbacedafcd60.1
 	buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.10-20250904135917-9feeb2588236.1
 	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251031193904-15e1d027dabd.1
-	buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251027225853-643acf04839f.2
-	buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-20251027225853-643acf04839f.1
+	buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251110211805-d0a4bce1e86b.2
+	buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-20251110211805-d0a4bce1e86b.1
 	buf.build/gen/go/redpandadata/gatekeeper/connectrpc/go v1.19.1-20251022210437-a5dd600d04b6.2
 	buf.build/gen/go/redpandadata/gatekeeper/protocolbuffers/go v1.36.10-20251022210437-a5dd600d04b6.1
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -12,10 +12,10 @@ buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251031193904-15e1d027
 buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251031193904-15e1d027dabd.2/go.mod h1:YY+peV2t5WRrsN5JCawfDfdePKQVNhaO+0l/9Tsi+oY=
 buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251031193904-15e1d027dabd.1 h1:qbwdlxQSRcBFlq8Kcl532kcMuR+64TuvnhLC49FxzJE=
 buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251031193904-15e1d027dabd.1/go.mod h1:QenSPzqxZpyo9hHIpRzTetvDchelVDzimnmaggHKenc=
-buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251027225853-643acf04839f.2 h1:lleqpbHhE/SYEI/oeW2RVLZghkfhnAtIL1xk+ioTCos=
-buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251027225853-643acf04839f.2/go.mod h1:lhAYzpdAM94nEirXzLwymBud3CxFzmHGPTdMGSEM79U=
-buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-20251027225853-643acf04839f.1 h1:+QCxgPzEelsR15FWSky3nurPjPh7PfelmNZmgvD7nRA=
-buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-20251027225853-643acf04839f.1/go.mod h1:971HJnUM/0fTBc/LowaoI2ybuR8s+LLlQDpCkPxMwN8=
+buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251110211805-d0a4bce1e86b.2 h1:muM0v3dGgtrpCZPZZZlkJDUQHnL/ZpdUvw/zP4RNOjk=
+buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251110211805-d0a4bce1e86b.2/go.mod h1:8GDVd5dG9Iu9nqmueGnYzVNB2rSPY2z4Y1CIZOAICFE=
+buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-20251110211805-d0a4bce1e86b.1 h1:izHsKj0b1F0ATv9UYQShjbXDgE51zwnIgXUgzk5Rdwo=
+buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-20251110211805-d0a4bce1e86b.1/go.mod h1:971HJnUM/0fTBc/LowaoI2ybuR8s+LLlQDpCkPxMwN8=
 buf.build/gen/go/redpandadata/gatekeeper/connectrpc/go v1.19.1-20251022210437-a5dd600d04b6.2 h1:TpeR1/FQQjGM6AjB3c/+AklMivMEsWNcJYZeipcmMGU=
 buf.build/gen/go/redpandadata/gatekeeper/connectrpc/go v1.19.1-20251022210437-a5dd600d04b6.2/go.mod h1:2PhIGolYdEsQckSpa7ZjVNWn+Z6BeLpSZBb20w1oWlw=
 buf.build/gen/go/redpandadata/gatekeeper/protocolbuffers/go v1.36.10-20251022210437-a5dd600d04b6.1 h1:buRXwBZNRhjymido98wvND0dtS3D/Ww5VmlDYwEKfvU=

--- a/src/go/rpk/pkg/cli/cluster/connections/BUILD
+++ b/src/go/rpk/pkg/cli/cluster/connections/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//src/go/rpk/pkg/adminapi",
         "//src/go/rpk/pkg/config",
         "//src/go/rpk/pkg/out",
+        "//src/go/rpk/pkg/publicapi",
         "@build_buf_gen_go_redpandadata_core_protocolbuffers_go//redpanda/core/admin/v2:admin",
         "@com_connectrpc_connect//:connect",
         "@com_github_docker_go_units//:go-units",

--- a/src/go/rpk/pkg/cli/cluster/connections/list.go
+++ b/src/go/rpk/pkg/cli/cluster/connections/list.go
@@ -23,6 +23,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -185,11 +186,9 @@ List extended output for open connections in json format:
 			prof, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 
-			// This doesn't support using the public API yet
-			config.CheckExitCloudAdmin(prof)
-
-			cl, err := adminapi.NewClient(cmd.Context(), fs, prof)
-			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+			if prof.CloudCluster.IsServerless() {
+				out.Die("rpk cluster connections list is not supported on Redpanda serverless clusters")
+			}
 
 			// Build the filters based on the current flag set
 			filterClauses, err := filters.buildFilterClauses()
@@ -206,24 +205,33 @@ List extended output for open connections in json format:
 				PageSize: limit,
 			}
 
-			resp, err := cl.ClusterService().ListKafkaConnections(cmd.Context(), &connect.Request[adminv2.ListKafkaConnectionsRequest]{Msg: &req})
-			out.MaybeDie(err, "error listing connections: %v", err)
+			var response *adminv2.ListKafkaConnectionsResponse
+			if prof.FromCloud {
+				cl, err := publicapi.DataplaneClientFromRpkProfile(prof)
+				out.MaybeDie(err, "unable to initialize cloud API client: %v", err)
 
-			conns := make([]*Connection, len(resp.Msg.Connections))
-			for i, conn := range resp.Msg.Connections {
-				conns[i] = parseConnection(conn)
+				resp, err := cl.Monitoring.ListKafkaConnections(cmd.Context(), &connect.Request[adminv2.ListKafkaConnectionsRequest]{Msg: &req})
+				out.MaybeDie(err, "error listing connections: %v", err)
+
+				response = resp.Msg
+			} else {
+				cl, err := adminapi.NewClient(cmd.Context(), fs, prof)
+				out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+				resp, err := cl.ClusterService().ListKafkaConnections(cmd.Context(), &connect.Request[adminv2.ListKafkaConnectionsRequest]{Msg: &req})
+				out.MaybeDie(err, "error listing connections: %v", err)
+
+				response = resp.Msg
 			}
 
 			if p.Formatter.IsText() {
-				fmt.Println(printConnectionListTable(conns))
-			} else {
-				// Convert from the core format to ours
-				conns := make([]*Connection, len(resp.Msg.Connections))
-				for i, conn := range resp.Msg.Connections {
+				conns := make([]*Connection, len(response.Connections))
+				for i, conn := range response.Connections {
 					conns[i] = parseConnection(conn)
 				}
-
-				_, _, output, err := p.Formatter.Format(conns)
+				fmt.Println(printConnectionListTable(conns))
+			} else {
+				_, _, output, err := p.Formatter.Format(response)
 				out.MaybeDie(err, "unable to print in the required format %q: %v", p.Formatter.Kind, err)
 				out.Exit(output)
 			}

--- a/src/go/rpk/pkg/publicapi/dataplane.go
+++ b/src/go/rpk/pkg/publicapi/dataplane.go
@@ -37,6 +37,7 @@ type DataPlaneClientSet struct {
 	Quota         dataplanev1connect.QuotaServiceClient
 	Secret        dataplanev1connect.SecretServiceClient
 	Security      dataplanev1connect.SecurityServiceClient
+	Monitoring    dataplanev1connect.MonitoringServiceClient
 	KnowledgeBase dataplanev1alpha3connect.KnowledgeBaseServiceClient
 
 	m         sync.RWMutex
@@ -117,6 +118,7 @@ func NewDataPlaneClientSet(host, authToken string, opts ...connect.ClientOption)
 	dpCl.Quota = dataplanev1connect.NewQuotaServiceClient(httpCl, host, opts...)
 	dpCl.Secret = dataplanev1connect.NewSecretServiceClient(httpCl, host, opts...)
 	dpCl.Security = dataplanev1connect.NewSecurityServiceClient(httpCl, host, opts...)
+	dpCl.Monitoring = dataplanev1connect.NewMonitoringServiceClient(httpCl, host, opts...)
 	dpCl.KnowledgeBase = dataplanev1alpha3connect.NewKnowledgeBaseServiceClient(httpCl, host, opts...)
 
 	return dpCl, nil


### PR DESCRIPTION
## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* Adds redpanda cloud support for rpk cluster connection list