### PR TITLE
rptest: Re-eable RedpandaKerberosConfigTest

### DIFF
--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -17,4 +17,3 @@ quick:
   - tests/rpk_tuner_test.py
   - tests/rpk_cloud_test.py
   - tests/workload_upgrade_runner_test.py # Excluded until CORE-13748 is fixed. 
-  - tests/redpanda_kerberos_test.py::RedpandaKerberosConfigTest # exclude until CORE-13787 is fixed


### PR DESCRIPTION
This addresses [CORE-13787](https://redpandadata.atlassian.net/browse/CORE-13787) and re-enables the RedpandaKerberosConfigTest, which was previously failing due to a leak that has since been fixed by #28447.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-13787]: https://redpandadata.atlassian.net/browse/CORE-13787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ