### PR TITLE
[CORE-14250] Ducktape: Reduce cost of datalake/schema_evolution_test.py

### DIFF
--- a/tests/rptest/tests/datalake/schema_evolution_test.py
+++ b/tests/rptest/tests/datalake/schema_evolution_test.py
@@ -621,6 +621,27 @@ class SchemaEvolutionE2ETests(RedpandaTest):
                     assert len(select_out) == count * 2, (
                         f"Expected {count * 2} rows, got {select_out}"
                     )
+
+                    # check that we can still produce with the original schema and that
+                    # the current table schema doesn't change back as a result
+                    tc.initial_schema.produce(dl, topic, count, ctx, mode=produce_mode)
+                    tc.next_schema.check_table_schema(dl, table, query_engine)
+                    select_out = self.select(
+                        dl, table, query_engine, tc.next_schema.field_names
+                    )
+                    assert len(select_out) == count * 3, (
+                        f"Expected {count * 3} rows, got {len(select_out)}"
+                    )
+
+                    # and finally check that producing with latest schema still works
+                    tc.next_schema.produce(dl, topic, count, ctx, mode=produce_mode)
+                    select_out = self.select(
+                        dl, table, query_engine, tc.next_schema.field_names
+                    )
+                    assert len(select_out) == count * 4, (
+                        f"Expected {count * 4} rows, got {len(select_out)}"
+                    )
+
                 else:
                     tc.initial_schema.check_table_schema(dl, table, query_engine)
 
@@ -672,53 +693,3 @@ class SchemaEvolutionE2ETests(RedpandaTest):
                     assert all(r[1] == field for r in select_out), (
                         f"{field} column mangled: {select_out}"
                     )
-
-    @cluster(num_nodes=3)
-    @matrix(
-        cloud_storage_type=supported_storage_types(),
-        query_engine=QUERY_ENGINES,
-        catalog_type=supported_catalog_types(),
-    )
-    def test_old_schema_writer(self, cloud_storage_type, query_engine, catalog_type):
-        """
-        Tests that, after a backwards compatible update from schema A to schema B, we can keep
-        translating records produced with schema A without another schema update.
-        """
-        with self.setup_services(
-            query_engine,
-            catalog_type=catalog_type,
-            test_cases=self.valid_cases,
-            with_partitioning=False,
-        ) as dl:
-            for label, tc, produce_mode in self.cases_by_modes(self.valid_cases):
-                topic, table = self.topic_and_table(label, produce_mode)
-                count = 10
-                ctx = TranslationContext()
-
-                initial_schema, next_schema, _, _ = tc
-
-                for schema in [initial_schema, next_schema]:
-                    schema.produce(dl, topic, count, ctx, mode=produce_mode)
-                    schema.check_table_schema(dl, table, query_engine)
-
-                initial_schema.produce(dl, topic, count, ctx, mode=produce_mode)
-                next_schema.check_table_schema(dl, table, query_engine)
-
-                select_out = self.select(
-                    dl, table, query_engine, next_schema.field_names
-                )
-
-                assert len(select_out) == count * 3, (
-                    f"Expected {count * 3} rows, got {len(select_out)}"
-                )
-
-                # Check that producing with latest schema still works too.
-                next_schema.produce(dl, topic, count, ctx, mode=produce_mode)
-
-                select_out = self.select(
-                    dl, table, query_engine, next_schema.field_names
-                )
-
-                assert len(select_out) == count * 4, (
-                    f"Expected {count * 4} rows, got {len(select_out)}"
-                )

--- a/tests/rptest/tests/datalake/schema_evolution_test.py
+++ b/tests/rptest/tests/datalake/schema_evolution_test.py
@@ -479,6 +479,28 @@ PRODUCER_MODES = [
 ]
 
 
+def query_engines_and_catalogs() -> list[list[QueryEngineType | CatalogType]]:
+    """
+    Produce a list of QueryEngineType/CatalogType pairs that includes each member
+    of each set at least once. The general idea here is to avoid redundant work,
+    in the sense that we're not interested in testing combinations of query engine
+    and catalog but rather verifying that our schema evolution approach doesn't
+    break any particular one of either.
+
+    Returns a list of lists rather than tuples so the result is json roundtrippable
+    for use in matrix params.
+    """
+    n_engines = len(QUERY_ENGINES)
+    n_catalogs = len(supported_catalog_types())
+    return [
+        [
+            QUERY_ENGINES[i % n_engines],
+            supported_catalog_types()[i % n_catalogs],
+        ]
+        for i in range(0, max(n_engines, n_catalogs))
+    ]
+
+
 class SchemaEvolutionE2ETests(RedpandaTest):
     def __init__(self, test_ctx, *args, **kwargs):
         super(SchemaEvolutionE2ETests, self).__init__(
@@ -585,15 +607,14 @@ class SchemaEvolutionE2ETests(RedpandaTest):
     @cluster(num_nodes=3)
     @matrix(
         cloud_storage_type=supported_storage_types(),
-        query_engine=QUERY_ENGINES,
-        catalog_type=supported_catalog_types(),
+        qe_and_cat=query_engines_and_catalogs(),
     )
-    def test_schema_evolution(self, cloud_storage_type, query_engine, catalog_type):
+    def test_schema_evolution(self, cloud_storage_type, qe_and_cat):
         """
         Test that rows written with schema A are still readable after evolving
         the table to schema B.
         """
-
+        query_engine, catalog_type = qe_and_cat
         with self.setup_services(
             query_engine,
             catalog_type=catalog_type,
@@ -658,14 +679,14 @@ class SchemaEvolutionE2ETests(RedpandaTest):
     @cluster(num_nodes=3)
     @matrix(
         cloud_storage_type=supported_storage_types(),
-        query_engine=QUERY_ENGINES,
-        catalog_type=supported_catalog_types(),
+        qe_and_cat=query_engines_and_catalogs(),
     )
-    def test_reorder_columns(self, cloud_storage_type, query_engine, catalog_type):
+    def test_reorder_columns(self, cloud_storage_type, qe_and_cat):
         """
         Test that changing the order of columns doesn't change the values
         associated with a column or field name.
         """
+        query_engine, catalog_type = qe_and_cat
         label = "reorder_columns"
         tc = self.valid_cases[label]
         with self.setup_services(

--- a/tests/rptest/tests/datalake/schema_evolution_test.py
+++ b/tests/rptest/tests/datalake/schema_evolution_test.py
@@ -11,6 +11,7 @@ import tempfile
 from collections.abc import Callable
 from contextlib import contextmanager
 from enum import Enum
+from itertools import product
 from time import time
 from typing import NamedTuple
 
@@ -244,9 +245,10 @@ class EvolutionTestCase(NamedTuple):
     initial_schema: GenericSchema
     next_schema: GenericSchema
     partition_spec: str | None = None
+    valid: bool = True
 
 
-LEGAL_TEST_CASES = {
+TEST_CASES = {
     "add_column": EvolutionTestCase(
         initial_schema=GenericSchema(
             fields=[
@@ -432,10 +434,7 @@ LEGAL_TEST_CASES = {
         ),
         partition_spec="(first)",
     ),
-}
-
-ILLEGAL_TEST_CASES = {
-    "illegal promotion int->string": EvolutionTestCase(
+    "illegal_promotion_int_to_string": EvolutionTestCase(
         initial_schema=GenericSchema(
             fields=[
                 {
@@ -464,6 +463,7 @@ ILLEGAL_TEST_CASES = {
                 "ordinal": str(x),
             },
         ),
+        valid=False,
     ),
 }
 
@@ -495,8 +495,6 @@ class SchemaEvolutionE2ETests(RedpandaTest):
             **kwargs,
         )
         self.test_ctx = test_ctx
-        self.topic_name = "test"
-        self.table_name = f"redpanda.{self.topic_name}"
 
     def setUp(self):
         # redpanda will be started by DatalakeServices
@@ -505,25 +503,52 @@ class SchemaEvolutionE2ETests(RedpandaTest):
     def select(
         self,
         dl: DatalakeServices,
+        table: str,
         query_engine: QueryEngineType,
         cols: list[str],
         sort_by_offset: bool = True,
     ):
         qe = dl.spark() if query_engine == QueryEngineType.SPARK else dl.trino()
-        query = f"select redpanda.offset, {', '.join(cols)} from {self.table_name}"
+        query = f"select redpanda.offset, {', '.join(cols)} from {table}"
         self.redpanda.logger.debug(f"QUERY: '{query}'")
         out = qe.run_query_fetch_all(query)
         if sort_by_offset:
             out.sort(key=lambda r: r[0])
         return out
 
+    @property
+    def valid_cases(self) -> dict[str, EvolutionTestCase]:
+        return {label: tc for label, tc in self.all_cases.items() if tc.valid}
+
+    @property
+    def invalid_cases(self) -> dict[str, EvolutionTestCase]:
+        return {label: tc for label, tc in self.all_cases.items() if not tc.valid}
+
+    @property
+    def all_cases(self) -> dict[str, EvolutionTestCase]:
+        return TEST_CASES
+
+    def cases_by_modes(
+        self, cases: dict[str, EvolutionTestCase]
+    ) -> list[tuple[str, EvolutionTestCase, ProducerType]]:
+        return [t + (p,) for t, p in product(cases.items(), PRODUCER_MODES)]
+
+    def topic_and_table(self, base: str, mode: ProducerType) -> tuple[str, str]:
+        topic = f"{base}_{mode}"
+        table = f"redpanda.{topic}"
+        return (
+            topic,
+            table,
+        )
+
     @contextmanager
     def setup_services(
         self,
         query_engine: QueryEngineType,
         compat_level: str = "NONE",
-        partition_spec: str | None = None,
         catalog_type: CatalogType = filesystem_catalog_type(),
+        test_cases: dict[str, EvolutionTestCase] = {},
+        with_partitioning: bool = False,
     ):
         with DatalakeServices(
             self.test_ctx,
@@ -533,168 +558,167 @@ class SchemaEvolutionE2ETests(RedpandaTest):
                 query_engine,
             ],
         ) as dl:
-            config = {TopicSpec.PROPERTY_ICEBERG_INVALID_RECORD_ACTION: "dlq_table"}
-            if partition_spec is not None:
-                config["redpanda.iceberg.partition.spec"] = partition_spec
-            dl.create_iceberg_enabled_topic(
-                self.topic_name,
-                iceberg_mode="value_schema_id_prefix",
-                config=config,
-            )
-            SchemaRegistryClient(
-                {"url": self.redpanda.schema_reg().split(",")[0]}
-            ).set_compatibility(
-                subject_name=f"{self.topic_name}-value", level=compat_level
-            )
+            for label, tc, produce_mode in self.cases_by_modes(test_cases):
+                topic, _ = self.topic_and_table(label, produce_mode)
+                config = {TopicSpec.PROPERTY_ICEBERG_INVALID_RECORD_ACTION: "dlq_table"}
+                if with_partitioning and tc.partition_spec is not None:
+                    config["redpanda.iceberg.partition.spec"] = tc.partition_spec
+                dl.create_iceberg_enabled_topic(
+                    topic,
+                    iceberg_mode="value_schema_id_prefix",
+                    config=config,
+                )
+                SchemaRegistryClient(
+                    {"url": self.redpanda.schema_reg().split(",")[0]}
+                ).set_compatibility(subject_name=f"{topic}-value", level=compat_level)
             yield dl
             # make sure nothing we did trashed our ability to read the whole table
-            self.select(dl, query_engine, cols=["*"])
+            for label, tc, produce_mode in self.cases_by_modes(test_cases):
+                _, table = self.topic_and_table(label, produce_mode)
+                self.select(
+                    dl,
+                    table,
+                    query_engine,
+                    cols=["*"],
+                )
 
     @cluster(num_nodes=3)
     @matrix(
         cloud_storage_type=supported_storage_types(),
         query_engine=QUERY_ENGINES,
-        test_case=list(LEGAL_TEST_CASES.keys()),
-        produce_mode=PRODUCER_MODES,
         catalog_type=supported_catalog_types(),
     )
-    def test_legal_schema_evolution(
-        self, cloud_storage_type, query_engine, test_case, produce_mode, catalog_type
-    ):
+    def test_schema_evolution(self, cloud_storage_type, query_engine, catalog_type):
         """
         Test that rows written with schema A are still readable after evolving
         the table to schema B.
         """
-        tc = LEGAL_TEST_CASES[test_case]
+
         with self.setup_services(
-            query_engine, partition_spec=tc.partition_spec, catalog_type=catalog_type
+            query_engine,
+            catalog_type=catalog_type,
+            test_cases=self.all_cases,
         ) as dl:
-            count = 10
-            ctx = TranslationContext()
-            tc.initial_schema.produce(
-                dl, self.topic_name, count, ctx, mode=produce_mode
-            )
+            for label, tc, produce_mode in self.cases_by_modes(self.all_cases):
+                topic, table = self.topic_and_table(label, produce_mode)
+                count = 10
+                ctx = TranslationContext()
+                tc.initial_schema.produce(dl, topic, count, ctx, mode=produce_mode)
 
-            tc.initial_schema.check_table_schema(dl, self.table_name, query_engine)
-            tc.next_schema.produce(dl, self.topic_name, count, ctx, mode=produce_mode)
-            tc.next_schema.check_table_schema(dl, self.table_name, query_engine)
+                tc.initial_schema.check_table_schema(dl, table, query_engine)
+                tc.next_schema.produce(
+                    dl, topic, count, ctx, mode=produce_mode, should_translate=tc.valid
+                )
+                if tc.valid:
+                    tc.next_schema.check_table_schema(dl, table, query_engine)
 
-            select_out = self.select(dl, query_engine, tc.next_schema.field_names)
-            assert len(select_out) == count * 2, (
-                f"Expected {count * 2} rows, got {select_out}"
-            )
+                    select_out = self.select(
+                        dl,
+                        table,
+                        query_engine,
+                        tc.next_schema.field_names,
+                    )
+                    assert len(select_out) == count * 2, (
+                        f"Expected {count * 2} rows, got {select_out}"
+                    )
+                else:
+                    tc.initial_schema.check_table_schema(dl, table, query_engine)
+
+                    select_out = self.select(
+                        dl, table, query_engine, tc.next_schema.field_names
+                    )
+                    assert len(select_out) == count, (
+                        f"Expected {count} rows, got {select_out}"
+                    )
+                    assert ctx.dlq == count, (
+                        f"Expected {count} records were dlq'ed, got {ctx.dlq}"
+                    )
 
     @cluster(num_nodes=3)
     @matrix(
         cloud_storage_type=supported_storage_types(),
         query_engine=QUERY_ENGINES,
-        test_case=list(ILLEGAL_TEST_CASES.keys()),
-        produce_mode=PRODUCER_MODES,
         catalog_type=supported_catalog_types(),
     )
-    def test_illegal_schema_evolution(
-        self, cloud_storage_type, query_engine, test_case, produce_mode, catalog_type
-    ):
-        """
-        check that records produced with an incompatible schema don't wind up
-        in the table.
-        """
-        tc = ILLEGAL_TEST_CASES[test_case]
-        with self.setup_services(
-            query_engine, partition_spec=tc.partition_spec, catalog_type=catalog_type
-        ) as dl:
-            count = 10
-            ctx = TranslationContext()
-            tc.initial_schema.produce(
-                dl, self.topic_name, count, ctx, mode=produce_mode
-            )
-            tc.initial_schema.check_table_schema(dl, self.table_name, query_engine)
-            tc.next_schema.produce(
-                dl,
-                self.topic_name,
-                count,
-                ctx,
-                mode=produce_mode,
-                should_translate=False,
-            )
-            tc.initial_schema.check_table_schema(dl, self.table_name, query_engine)
-
-            select_out = self.select(dl, query_engine, tc.next_schema.field_names)
-            assert len(select_out) == count, f"Expected {count} rows, got {select_out}"
-            assert ctx.dlq == count, (
-                f"Expected {count} records were dlq'ed, got {ctx.dlq}"
-            )
-
-    @cluster(num_nodes=3)
-    @matrix(
-        cloud_storage_type=supported_storage_types(),
-        query_engine=QUERY_ENGINES,
-        produce_mode=PRODUCER_MODES,
-        catalog_type=supported_catalog_types(),
-    )
-    def test_reorder_columns(
-        self, cloud_storage_type, query_engine, produce_mode, catalog_type
-    ):
+    def test_reorder_columns(self, cloud_storage_type, query_engine, catalog_type):
         """
         Test that changing the order of columns doesn't change the values
         associated with a column or field name.
         """
-        with self.setup_services(query_engine, catalog_type=catalog_type) as dl:
-            count = 10
-            ctx = TranslationContext()
-            initial_schema, next_schema, _ = LEGAL_TEST_CASES["reorder_columns"]
-            for schema in [initial_schema, next_schema]:
-                schema.produce(dl, self.topic_name, count, ctx, mode=produce_mode)
-                schema.check_table_schema(dl, self.table_name, query_engine)
+        label = "reorder_columns"
+        tc = self.valid_cases[label]
+        with self.setup_services(
+            query_engine,
+            catalog_type=catalog_type,
+            test_cases={
+                label: tc,
+            },
+        ) as dl:
+            for produce_mode in PRODUCER_MODES:
+                topic, table = self.topic_and_table(label, produce_mode)
+                count = 10
+                ctx = TranslationContext()
+                initial_schema = tc.initial_schema
+                next_schema = tc.next_schema
+                for schema in [initial_schema, next_schema]:
+                    schema.produce(dl, topic, count, ctx, mode=produce_mode)
+                    schema.check_table_schema(dl, table, query_engine)
 
-            for field in initial_schema.field_names:
-                select_out = self.select(dl, query_engine, [field])
-                assert len(select_out) == count * 2, (
-                    f"Expected {count * 2} rows, got {len(select_out)}"
-                )
-                assert all(r[1] == field for r in select_out), (
-                    f"{field} column mangled: {select_out}"
-                )
+                for field in initial_schema.field_names:
+                    select_out = self.select(dl, table, query_engine, [field])
+                    assert len(select_out) == count * 2, (
+                        f"Expected {count * 2} rows, got {len(select_out)}"
+                    )
+                    assert all(r[1] == field for r in select_out), (
+                        f"{field} column mangled: {select_out}"
+                    )
 
     @cluster(num_nodes=3)
     @matrix(
         cloud_storage_type=supported_storage_types(),
         query_engine=QUERY_ENGINES,
-        test_case=list(LEGAL_TEST_CASES.keys()),
-        produce_mode=PRODUCER_MODES,
         catalog_type=supported_catalog_types(),
     )
-    def test_old_schema_writer(
-        self, cloud_storage_type, query_engine, test_case, produce_mode, catalog_type
-    ):
+    def test_old_schema_writer(self, cloud_storage_type, query_engine, catalog_type):
         """
         Tests that, after a backwards compatible update from schema A to schema B, we can keep
         translating records produced with schema A without another schema update.
         """
-        with self.setup_services(query_engine, catalog_type=catalog_type) as dl:
-            count = 10
-            ctx = TranslationContext()
+        with self.setup_services(
+            query_engine,
+            catalog_type=catalog_type,
+            test_cases=self.valid_cases,
+            with_partitioning=False,
+        ) as dl:
+            for label, tc, produce_mode in self.cases_by_modes(self.valid_cases):
+                topic, table = self.topic_and_table(label, produce_mode)
+                count = 10
+                ctx = TranslationContext()
 
-            initial_schema, next_schema, _ = LEGAL_TEST_CASES[test_case]
+                initial_schema, next_schema, _, _ = tc
 
-            for schema in [initial_schema, next_schema]:
-                schema.produce(dl, self.topic_name, count, ctx, mode=produce_mode)
-                schema.check_table_schema(dl, self.table_name, query_engine)
+                for schema in [initial_schema, next_schema]:
+                    schema.produce(dl, topic, count, ctx, mode=produce_mode)
+                    schema.check_table_schema(dl, table, query_engine)
 
-            initial_schema.produce(dl, self.topic_name, count, ctx, mode=produce_mode)
-            next_schema.check_table_schema(dl, self.table_name, query_engine)
+                initial_schema.produce(dl, topic, count, ctx, mode=produce_mode)
+                next_schema.check_table_schema(dl, table, query_engine)
 
-            select_out = self.select(dl, query_engine, next_schema.field_names)
+                select_out = self.select(
+                    dl, table, query_engine, next_schema.field_names
+                )
 
-            assert len(select_out) == count * 3, (
-                f"Expected {count * 3} rows, got {len(select_out)}"
-            )
+                assert len(select_out) == count * 3, (
+                    f"Expected {count * 3} rows, got {len(select_out)}"
+                )
 
-            # Check that producing with latest schema still works too.
-            next_schema.produce(dl, self.topic_name, count, ctx, mode=produce_mode)
+                # Check that producing with latest schema still works too.
+                next_schema.produce(dl, topic, count, ctx, mode=produce_mode)
 
-            select_out = self.select(dl, query_engine, next_schema.field_names)
+                select_out = self.select(
+                    dl, table, query_engine, next_schema.field_names
+                )
 
-            assert len(select_out) == count * 4, (
-                f"Expected {count * 4} rows, got {len(select_out)}"
-            )
+                assert len(select_out) == count * 4, (
+                    f"Expected {count * 4} rows, got {len(select_out)}"
+                )

--- a/tests/rptest/tests/datalake/schema_evolution_test.py
+++ b/tests/rptest/tests/datalake/schema_evolution_test.py
@@ -621,60 +621,70 @@ class SchemaEvolutionE2ETests(RedpandaTest):
             test_cases=self.all_cases,
         ) as dl:
             for label, tc, produce_mode in self.cases_by_modes(self.all_cases):
-                topic, table = self.topic_and_table(label, produce_mode)
-                count = 10
-                ctx = TranslationContext()
-                tc.initial_schema.produce(dl, topic, count, ctx, mode=produce_mode)
-
-                tc.initial_schema.check_table_schema(dl, table, query_engine)
-                tc.next_schema.produce(
-                    dl, topic, count, ctx, mode=produce_mode, should_translate=tc.valid
-                )
-                if tc.valid:
-                    tc.next_schema.check_table_schema(dl, table, query_engine)
-
-                    select_out = self.select(
-                        dl,
-                        table,
-                        query_engine,
-                        tc.next_schema.field_names,
-                    )
-                    assert len(select_out) == count * 2, (
-                        f"Expected {count * 2} rows, got {select_out}"
-                    )
-
-                    # check that we can still produce with the original schema and that
-                    # the current table schema doesn't change back as a result
+                try:
+                    topic, table = self.topic_and_table(label, produce_mode)
+                    count = 10
+                    ctx = TranslationContext()
                     tc.initial_schema.produce(dl, topic, count, ctx, mode=produce_mode)
-                    tc.next_schema.check_table_schema(dl, table, query_engine)
-                    select_out = self.select(
-                        dl, table, query_engine, tc.next_schema.field_names
-                    )
-                    assert len(select_out) == count * 3, (
-                        f"Expected {count * 3} rows, got {len(select_out)}"
-                    )
 
-                    # and finally check that producing with latest schema still works
-                    tc.next_schema.produce(dl, topic, count, ctx, mode=produce_mode)
-                    select_out = self.select(
-                        dl, table, query_engine, tc.next_schema.field_names
-                    )
-                    assert len(select_out) == count * 4, (
-                        f"Expected {count * 4} rows, got {len(select_out)}"
-                    )
-
-                else:
                     tc.initial_schema.check_table_schema(dl, table, query_engine)
+                    tc.next_schema.produce(
+                        dl,
+                        topic,
+                        count,
+                        ctx,
+                        mode=produce_mode,
+                        should_translate=tc.valid,
+                    )
+                    if tc.valid:
+                        tc.next_schema.check_table_schema(dl, table, query_engine)
 
-                    select_out = self.select(
-                        dl, table, query_engine, tc.next_schema.field_names
-                    )
-                    assert len(select_out) == count, (
-                        f"Expected {count} rows, got {select_out}"
-                    )
-                    assert ctx.dlq == count, (
-                        f"Expected {count} records were dlq'ed, got {ctx.dlq}"
-                    )
+                        select_out = self.select(
+                            dl,
+                            table,
+                            query_engine,
+                            tc.next_schema.field_names,
+                        )
+                        assert len(select_out) == count * 2, (
+                            f"Expected {count * 2} rows, got {select_out}"
+                        )
+
+                        # check that we can still produce with the original schema and that
+                        # the current table schema doesn't change back as a result
+                        tc.initial_schema.produce(
+                            dl, topic, count, ctx, mode=produce_mode
+                        )
+                        tc.next_schema.check_table_schema(dl, table, query_engine)
+                        select_out = self.select(
+                            dl, table, query_engine, tc.next_schema.field_names
+                        )
+                        assert len(select_out) == count * 3, (
+                            f"Expected {count * 3} rows, got {len(select_out)}"
+                        )
+
+                        # and finally check that producing with latest schema still works
+                        tc.next_schema.produce(dl, topic, count, ctx, mode=produce_mode)
+                        select_out = self.select(
+                            dl, table, query_engine, tc.next_schema.field_names
+                        )
+                        assert len(select_out) == count * 4, (
+                            f"Expected {count * 4} rows, got {len(select_out)}"
+                        )
+
+                    else:
+                        tc.initial_schema.check_table_schema(dl, table, query_engine)
+
+                        select_out = self.select(
+                            dl, table, query_engine, tc.next_schema.field_names
+                        )
+                        assert len(select_out) == count, (
+                            f"Expected {count} rows, got {select_out}"
+                        )
+                        assert ctx.dlq == count, (
+                            f"Expected {count} records were dlq'ed, got {ctx.dlq}"
+                        )
+                except Exception as e:
+                    raise Exception(f"Test failed for {label=}, {produce_mode=}") from e
 
     @cluster(num_nodes=3)
     @matrix(
@@ -697,20 +707,24 @@ class SchemaEvolutionE2ETests(RedpandaTest):
             },
         ) as dl:
             for produce_mode in PRODUCER_MODES:
-                topic, table = self.topic_and_table(label, produce_mode)
-                count = 10
-                ctx = TranslationContext()
-                initial_schema = tc.initial_schema
-                next_schema = tc.next_schema
-                for schema in [initial_schema, next_schema]:
-                    schema.produce(dl, topic, count, ctx, mode=produce_mode)
-                    schema.check_table_schema(dl, table, query_engine)
+                try:
+                    topic, table = self.topic_and_table(label, produce_mode)
+                    count = 10
+                    ctx = TranslationContext()
+                    initial_schema = tc.initial_schema
+                    next_schema = tc.next_schema
+                    for schema in [initial_schema, next_schema]:
+                        schema.produce(dl, topic, count, ctx, mode=produce_mode)
+                        schema.check_table_schema(dl, table, query_engine)
 
-                for field in initial_schema.field_names:
-                    select_out = self.select(dl, table, query_engine, [field])
-                    assert len(select_out) == count * 2, (
-                        f"Expected {count * 2} rows, got {len(select_out)}"
-                    )
-                    assert all(r[1] == field for r in select_out), (
-                        f"{field} column mangled: {select_out}"
-                    )
+                    for field in initial_schema.field_names:
+                        select_out = self.select(dl, table, query_engine, [field])
+                        assert len(select_out) == count * 2, (
+                            f"Expected {count * 2} rows, got {len(select_out)}"
+                        )
+                        assert all(r[1] == field for r in select_out), (
+                            f"{field} column mangled: {select_out}"
+                        )
+
+                except Exception as e:
+                    raise Exception(f"Test failed for {produce_mode=}") from e


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

PR refactors `datalake/schema_evolution_test.py` to cut down on wasted work setting up and tearing down datalake services for every test case. The general idea is to remove test case & schema language parameterization from test functions, instead iterating through them manually, within a single test run.

Also changed the way we combine query engines and catalogs. Previously we would parameterize with a cartesian product of query engines & catalog types, resulting in 6 (at the time of this writing) combinations. My claim is that we only really care about running with each QE & catalog at least once, so we can instead generate N combinations thereof where `N = max(n_qe, n_catalog)`. The effect of this is less pronounced for docker builds, which run exclusively against s3 (minio) due to azurite issues.

#### Other adjustments we could make:
- [ ] Don't worry about testing all of avro, proto2, proto3

The reports below show a reduction in test time for schema_evolution_test.py running in isolation in release mode w/ otherwise default settings, though ducktape parallelism probably has an effect here.

### New build

#### flatten case & schema type
https://buildkite.com/redpanda/redpanda/builds/76066#019a74ff-2497-4da5-b044-58700827e2c5

```
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2025-11-11--001
run time:         27 minutes 25.268 seconds
tests run:        18
passed:           18
flaky:            0
failed:           0
ignored:          0
```

#### also combine old schema and base evo tests
https://buildkite.com/redpanda/redpanda/builds/76080#019a7588-0de9-42c1-ba29-d445e28a7462

```
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2025-11-12--001
run time:         21 minutes 49.953 seconds
tests run:        12
passed:           12
flaky:            0
failed:           0
ignored:          0
```

#### and then cut the number of query engine / catalog combos in half
https://buildkite.com/redpanda/redpanda/builds/76092#019a76f6-a2dc-47c8-bc52-370bbfdbdf97

```
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2025-11-12--001
run time:         19 minutes 1.410 seconds
tests run:        6
passed:           6
flaky:            0
failed:           0
ignored:          0
```

### Old build
https://buildkite.com/redpanda/redpanda/builds/76067#019a7500-9b42-4fbd-a01f-7eb5d9d1d978

```
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2025-11-11--001
run time:         33 minutes 14.114 seconds
tests run:        180
passed:           180
flaky:            0
failed:           0
ignored:          0
```

## Backports Required


<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x
- [x] v24.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
