### PR TITLE
[CORE-14593] rptest: Allow rpc error log line

### DIFF
--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -44,7 +44,9 @@ from rptest.utils.mode_checks import skip_debug_mode, skip_fips_mode
 # Errors we should tolerate when moving partitions around
 PARTITION_MOVEMENT_LOG_ERRORS = [
     # e.g.  raft - [follower: {id: {1}, revision: {10}}] [group_id:3, {kafka/topic/2}] - recovery_stm.cc:422 - recovery append entries error: raft group does not exist on target broker
-    "raft - .*raft group does not exist on target broker"
+    "raft - .*raft group does not exist on target broker",
+    # this could happen because the log truncation is happening concurrently on a source broker
+    "Service handler for method .*threw an exception",
 ]
 
 
@@ -995,7 +997,10 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
     # before v24.2, dns query to s3 endpoint do not include the bucketname, which is required for AWS S3 fips endpoints
     @skip_fips_mode
     @skip_debug_mode  # rolling restarts require more reliable recovery that a slow debug mode cluster can provide
-    @cluster(num_nodes=5, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
+    @cluster(
+        num_nodes=5,
+        log_allow_list=PREV_VERSION_LOG_ALLOW_LIST + PARTITION_MOVEMENT_LOG_ERRORS,
+    )
     @matrix(
         num_to_upgrade=[0, 2],
         cloud_storage_type=get_cloud_storage_type(),
@@ -1063,7 +1068,10 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
 
         self._finish_upgrade(num_to_upgrade)
 
-    @cluster(num_nodes=5, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
+    @cluster(
+        num_nodes=5,
+        log_allow_list=PREV_VERSION_LOG_ALLOW_LIST + PARTITION_MOVEMENT_LOG_ERRORS,
+    )
     @skip_debug_mode  # rolling restarts require more reliable recovery that a slow debug mode cluster can provide
     # Redpandas before v23.1 did not have support for ABS.
     @matrix(


### PR DESCRIPTION
The log line is:
```
rpc_server.cc:263 - Service handler for method 3105104740 threw an exception: std::runtime_error (ntp {kafka/topic/0}: log offset 0 is outside the translation range (starting at 5048))
```

This is expected and can happen when log truncation races with partition movement. The operation is retried and the test passes.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none