### PR TITLE
krb5/acquire_cred: Improve fix of leak of principal

### DIFF
--- a/bazel/thirdparty/0001-Fix-two-unlikely-memory-leaks.patch
+++ b/bazel/thirdparty/0001-Fix-two-unlikely-memory-leaks.patch
@@ -201,20 +201,17 @@ index 8c7e30c21..149de98b0 100644
  }
  
 diff --git a/src/lib/gssapi/krb5/acquire_cred.c b/src/lib/gssapi/krb5/acquire_cred.c
-index 006eba114..b91de7cc1 100644
+index aa1a486dc..12e6b7ea8 100644
 --- a/src/lib/gssapi/krb5/acquire_cred.c
 +++ b/src/lib/gssapi/krb5/acquire_cred.c
-@@ -242,6 +242,10 @@ cleanup:
-         krb5_kt_close(context, kt);
-     if (rc != NULL)
-         k5_rc_close(context, rc);
-+    if (cred->acceptor_mprinc != NULL) {
+@@ -912,6 +912,7 @@ error_out:
+         if (cred->name)
+             kg_release_name(context, &cred->name);
+         krb5_free_principal(context, cred->impersonator);
 +        krb5_free_principal(context, cred->acceptor_mprinc);
-+        cred->acceptor_mprinc = NULL;
-+    }
-     *minor_status = code;
-     return major;
- }
+         zapfreestr(cred->password);
+         k5_mutex_destroy(&cred->lock);
+         xfree(cred);
 -- 
 2.34.1
 


### PR DESCRIPTION
Improve the fix in https://github.com/redpanda-data/redpanda/pull/28447 after advice from https://github.com/krb5/krb5/pull/1470#issuecomment-3514372182

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* kafka/server: Fix a memory leak when the keytab cannot be found.