### PR TITLE
tests: Various fixes for the MTT

### DIFF
--- a/src/v/cloud_storage/read_path_probes.cc
+++ b/src/v/cloud_storage/read_path_probes.cc
@@ -51,8 +51,8 @@ partition_probe::partition_probe(const model::ntp& ntp) {
           sm::description("Size of chunk downloaded from cloud storage"),
           partition_labels),
       },
-      {sm::shard_label},
-      {sm::shard_label, metrics::partition_label});
+      {},
+      {metrics::partition_label});
 }
 
 ts_read_path_probe::ts_read_path_probe() {

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -268,8 +268,7 @@ void probe::setup_metrics(const model::ntp& ntp) {
           "compaction_ratio",
           [this] { return _compaction_ratio; },
           sm::description("Average segment compaction ratio"),
-          labels)
-          .aggregate({sm::shard_label}),
+          labels),
       });
 }
 

--- a/tests/rptest/scale_tests/many_topics_test.py
+++ b/tests/rptest/scale_tests/many_topics_test.py
@@ -132,6 +132,9 @@ class ManyTopicsTest(RedpandaTest):
         self._target_port = None
         self._target_downtime_sec = 2 * 60  # 2 mins
 
+        # lots of topic operations going on
+        self.redpanda.set_expected_controller_records(10000)
+
     def setUp(self):
         # start the nodes manually
         pass

--- a/tests/rptest/services/client_swarm_base.py
+++ b/tests/rptest/services/client_swarm_base.py
@@ -134,7 +134,7 @@ class ClientSwarmBase(Service, ABC):
         """
         url = self._remote_url(node, rest_handle)
         try:
-            r = requests.get(url, timeout=10)
+            r = requests.get(url, timeout=30)
         except Exception as e:
             raise RuntimeError(f"Failed to get data from '{url}'") from e
         return r.json()


### PR DESCRIPTION
Various smallish fixes to make the MTT more stable.

Haven't run all the failing MTT subtests yet so will need to see but got a passing run for `test_restart_safely` like this.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

