### PR TITLE
[CORE-14558] `storage`: prevent race between `disk_log_appender` and `remove_prefix_full_segments()`

### DIFF
--- a/src/v/storage/disk_log_appender.cc
+++ b/src/v/storage/disk_log_appender.cc
@@ -50,7 +50,9 @@ ss::future<> disk_log_appender::initialize() {
 }
 
 bool disk_log_appender::segment_is_appendable(model::term_id batch_term) const {
-    if (!_seg || !_seg->has_appender() || _seg->is_tombstone()) {
+    if (
+      !_seg || !_seg->has_appender() || _seg->is_tombstone()
+      || _seg->is_closed()) {
         // The latest segment with which this log_appender has called
         // initialize() has been rolled and no longer has an segment appender
         // (e.g. because segment.ms rolled onto a new segment). There is likely

--- a/src/v/storage/disk_log_appender.cc
+++ b/src/v/storage/disk_log_appender.cc
@@ -114,12 +114,9 @@ disk_log_appender::operator()(model::record_batch& batch) {
         co_return stop;
     } catch (...) {
         release_lock();
-        vlog(
-          stlog.info,
-          "Could not append batch: {} - {}",
-          std::current_exception(),
-          *this);
-        _log.get_probe().batch_write_error(std::current_exception());
+        auto e = std::current_exception();
+        vlog(stlog.error, "Could not append batch: {} - {}", e, *this);
+        _log.get_probe().batch_write_error();
         throw;
     }
 }

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -22,6 +22,7 @@
 #include "model/timestamp.h"
 #include "reflection/adl.h"
 #include "ssx/future-util.h"
+#include "ssx/semaphore.h"
 #include "ssx/watchdog.h"
 #include "storage/api.h"
 #include "storage/chunk_cache.h"
@@ -3328,37 +3329,48 @@ disk_log_impl::remove_prefix_full_segments(truncate_prefix_config cfg) {
           // guaranteed that no other operation will remove the segment from the
           // segment list head (front).
           auto ptr = _segs.front();
-          return _readers_cache->evict_segment_readers(ptr).then(
-            [this, ptr, prefix_truncate_offset](
-              readers_cache::range_lock_holder cache_lock) {
-                return ptr->write_lock().then(
-                  [this,
-                   ptr,
-                   prefix_truncate_offset,
-                   cache_lock = std::move(cache_lock)](
-                    ss::rwlock::holder lock_holder) {
-                      // after the lock is acquired, check if the segment is
-                      // still eligible for deletion as there might have been
-                      // concurrent appends. If segments collection is empty we
-                      // can skip prefix truncation as the segments were removed
-                      if (
-                        keep_segment_after_prefix_truncate(
-                          ptr, prefix_truncate_offset)
-                        || _segs.empty()) {
-                          return ss::make_ready_future<>();
-                      }
-                      _segs.pop_front();
-                      _probe->add_bytes_prefix_truncated(ptr->file_size());
-                      // first call the remove segments, then release the lock
-                      // before waiting for future to finish
-                      auto f = remove_segment_permanently(
-                        ptr, "remove_prefix_full_segments");
-                      lock_holder.return_all();
-
-                      return f;
-                  });
-            });
+          return do_remove_prefix_full_segment(
+            std::move(ptr), prefix_truncate_offset);
       });
+}
+
+ss::future<> disk_log_impl::do_remove_prefix_full_segment(
+  ss::lw_shared_ptr<segment> ptr, model::offset prefix_truncate_offset) {
+    auto cache_lock = co_await _readers_cache->evict_segment_readers(ptr);
+
+    // We will be calling `remove_segment_permanently()` below on what is
+    // potentially the active segment. If there is a concurrent append occuring,
+    // we may get into a race with the `disk_log_appender` since we return the
+    // units in `lock_holder` (i.e the segment's write lock) while the future
+    // for `remove_segment_permanently()` is still unresolved. In this case, we
+    // need to obtain units from `_segments_rolling_lock` to prevent any
+    // concurrency issues.
+    std::optional<ssx::semaphore_units> seg_rolling_units;
+    if (ptr->has_appender()) {
+        // This cannot throw due to a broken semaphore, as we are already
+        // holding `_segment_rewrite_lock`.
+        seg_rolling_units = co_await _segments_rolling_lock.get_units();
+    }
+
+    auto lock_holder = co_await ptr->write_lock();
+
+    // after the locks are acquired, check if the segment is
+    // still eligible for deletion as there might have been
+    // concurrent appends. If segments collection is empty we
+    // can skip prefix truncation as the segments were removed
+    if (
+      keep_segment_after_prefix_truncate(ptr, prefix_truncate_offset)
+      || _segs.empty()) {
+        co_return;
+    }
+    _segs.pop_front();
+    _probe->add_bytes_prefix_truncated(ptr->file_size());
+    // first call the remove segments, then release the lock
+    // before waiting for future to finish
+    auto f = remove_segment_permanently(ptr, "remove_prefix_full_segments");
+    lock_holder.return_all();
+
+    co_return co_await std::move(f);
 }
 
 ss::future<> disk_log_impl::truncate_prefix(truncate_prefix_config cfg) {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -224,6 +224,14 @@ size_t disk_log_impl::compute_max_segment_size() {
 ss::future<> disk_log_impl::remove() {
     vassert(!_closed, "Invalid double closing of log - {}", *this);
 
+    // Request abort of compaction before obtaining rewrite lock holder.
+    _compaction_as.request_abort();
+
+    // To prevent a race between prefix truncation and closing, obtain the
+    // rewrite lock here and indicate it as broken for any future waiters.
+    auto rewrite_lock_holder = co_await _segment_rewrite_lock.get_units();
+    _segment_rewrite_lock.broken();
+
     // To prevent racing with a new segment being rolled, obtain the mutex here,
     // and indicate it as broken for any future waiters.
     auto roll_lock_holder = co_await _segments_rolling_lock.get_units();
@@ -231,7 +239,6 @@ ss::future<> disk_log_impl::remove() {
 
     _closed = true;
     // wait for compaction to finish
-    _compaction_as.request_abort();
     co_await _compaction_housekeeping_gate.close();
     // gets all the futures started in the background
     std::vector<ss::future<>> permanent_delete;
@@ -277,6 +284,14 @@ ss::future<> disk_log_impl::start(
 ss::future<std::optional<ss::sstring>> disk_log_impl::close() {
     vassert(!_closed, "Invalid double closing of log - {}", *this);
 
+    // Request abort of compaction before obtaining rewrite lock holder.
+    _compaction_as.request_abort();
+
+    // To prevent a race between prefix truncation and closing, obtain the
+    // rewrite lock here and indicate it as broken for any future waiters.
+    auto rewrite_lock_holder = co_await _segment_rewrite_lock.get_units();
+    _segment_rewrite_lock.broken();
+
     // To prevent racing with a new segment being rolled, obtain the mutex here,
     // and indicate it as broken for any future waiters.
     auto roll_lock_holder = co_await _segments_rolling_lock.get_units();
@@ -289,10 +304,11 @@ ss::future<std::optional<ss::sstring>> disk_log_impl::close() {
       && !_eviction_monitor->promise.get_future().available()) {
         _eviction_monitor->promise.set_exception(segment_closed_exception());
     }
+
     // wait for compaction to finish
     vlog(stlog.trace, "waiting for {} compaction to finish", config().ntp());
-    _compaction_as.request_abort();
     co_await _compaction_housekeeping_gate.close();
+
     vlog(stlog.trace, "stopping {} readers cache", config().ntp());
 
     // close() on the segments is not expected to fail, but it might

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -374,6 +374,8 @@ private:
 
     ss::future<> do_truncate_prefix(truncate_prefix_config);
     ss::future<> remove_prefix_full_segments(truncate_prefix_config);
+    ss::future<>
+      do_remove_prefix_full_segment(ss::lw_shared_ptr<segment>, model::offset);
 
     // Propagate a request to the Raft layer to evict segments up until the
     // specified offest.

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -279,10 +279,7 @@ void probe::delete_segment(const segment& s) {
     _partition_bytes -= s.file_size();
 }
 
-void probe::batch_write_error(const std::exception_ptr& e) {
-    stlog.error("Error writing record batch {}", e);
-    ++_batch_write_errors;
-}
+void probe::batch_write_error() { ++_batch_write_errors; }
 
 void readers_cache_probe::setup_metrics(const model::ntp& ntp) {
     if (config::shard_local_cfg().disable_metrics()) {

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -94,7 +94,7 @@ public:
         _num_adjacent_segments_compacted += num_segments_compacted;
     }
 
-    void batch_write_error(const std::exception_ptr& e);
+    void batch_write_error();
 
     void add_batches_read(uint32_t batches) { _batches_read += batches; }
     void add_cached_batches_read(uint32_t batches) {

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -7000,3 +7000,87 @@ TEST_F(storage_test_fixture, adjacent_merge_compaction_advances_generation_id) {
 
     ASSERT_EQ(gen_id_after(), gen_id_before() + 1);
 }
+
+TEST_F(storage_test_fixture, truncate_prefix_append_and_close) {
+    using namespace storage;
+    disk_log_builder b;
+    b | start();
+    auto log = b.get_log();
+    auto& disk_log = b.get_disk_log_impl();
+    const auto num_segs = 5;
+    const auto start_offset = 0;
+    const auto records_per_seg = 150;
+    for (int i = 0; i < num_segs; ++i) {
+        auto offset = start_offset + i * records_per_seg;
+        b | add_segment(offset)
+          | add_random_batch(
+            offset, records_per_seg, maybe_compress_batches::yes);
+        disk_log.force_roll().get();
+    }
+
+    ss::abort_source as;
+    mutex log_mutex{"e2e_test::log_mutex"};
+    auto random_sleep = [](int min, int max) {
+        return ss::sleep(
+          std::chrono::milliseconds(random_generators::get_int(min, max)));
+    };
+    static constexpr auto append_sleep_min = 5;
+    static constexpr auto append_sleep_max = 20;
+    auto append_fut = ss::do_until(
+      [&]() { return as.abort_requested(); },
+      [&]() {
+          auto maybe_u = log_mutex.try_get_units();
+          if (!maybe_u.has_value()) {
+              return ss::now();
+          }
+          auto u = std::move(maybe_u).value();
+          return append_single_record_batch_coro(log, 10, model::term_id{0})
+            .then([&, u = std::move(u)]() mutable {
+                u.return_all();
+                return random_sleep(append_sleep_min, append_sleep_max);
+            });
+      });
+
+    static constexpr auto close_sleep_min = 150;
+    static constexpr auto close_sleep_max = 200;
+    auto close_fut = random_sleep(close_sleep_min, close_sleep_max).then([&]() {
+        return log_mutex.get_units().then([&](ssx::semaphore_units u) {
+            (void)u;
+            log_mutex.broken();
+            // Calling `builder.stop()` will stop the log_manager and therefore
+            // close the log.
+            return b.stop();
+        });
+    });
+    static constexpr auto prefix_truncate_sleep_min = 100;
+    static constexpr auto prefix_truncate_sleep_max = 149;
+    // Expect 0 segments after prefix truncation in the happy path.
+    size_t expected_segment_count = 0;
+    auto prefix_truncate_fut
+      = random_sleep(prefix_truncate_sleep_min, prefix_truncate_sleep_max)
+          .then([&]() {
+              return log_mutex.get_units().then([&](ssx::semaphore_units u) {
+                  as.request_abort();
+                  u.return_all();
+                  return log
+                    ->truncate_prefix(truncate_prefix_config(
+                      model::next_offset(log->offsets().dirty_offset)))
+                    .handle_exception([&](const std::exception_ptr&) {
+                        // We may have raced with a close() operation when
+                        // attempting to obtain locks within
+                        // `truncate_prefix()`. In this case, we should expect
+                        // that no segments were removed from the log.
+                        expected_segment_count = log->segment_count();
+                        return ss::now();
+                    });
+              });
+          });
+
+    ss::when_all(
+      std::move(append_fut),
+      std::move(close_fut),
+      std::move(prefix_truncate_fut))
+      .get();
+
+    ASSERT_EQ(log->segment_count(), expected_segment_count);
+}

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -1289,7 +1289,7 @@ TEST_F(storage_test_fixture, test_compaction_preserve_state) {
     ASSERT_EQ(log->offsets().dirty_offset, model::offset(2));
 }
 
-void append_single_record_batch(
+ss::future<> append_single_record_batch_coro(
   ss::shared_ptr<storage::log> log,
   int cnt,
   model::term_id term,
@@ -1324,10 +1324,18 @@ void append_single_record_batch(
           .timeout = model::no_timeout,
         };
 
-        std::move(reader)
-          .for_each_ref(log->make_appender(cfg), cfg.timeout)
-          .get();
+        co_await std::move(reader).for_each_ref(
+          log->make_appender(cfg), cfg.timeout);
     }
+}
+
+void append_single_record_batch(
+  ss::shared_ptr<storage::log> log,
+  int cnt,
+  model::term_id term,
+  size_t val_size = 0,
+  bool rand_key = false) {
+    append_single_record_batch_coro(log, cnt, term, val_size, rand_key).get();
 }
 
 /**


### PR DESCRIPTION
### New Cover Letter

Here be dragons. Read individual commit messages to understand races and their fixes

### Old Cover Letter

(This only covers one of the discovered issues/race conditions)

This can race with a `segment::close()` operation and result in an exception being thrown:

```
1. F1: 13:12:39,356 [shard 0:clus] storage - disk_log_impl.cc:3236 - Removing "/var/lib/redpanda/data/redpanda/controller/0_0/0-1-v1.log" (remove_prefix_full_segments...)
2. F2: 13:12:39,356 [shard 0:rr  ] storage - disk_log_impl.cc:2077 - creating log appender for: {redpanda/controller/0}, next offset: 24, log offsets: {start_offset:24, committed_offset:23, committed_offset_term:1, dirty_offset:23, dirty_offset_term:1}
3. F1: 13:12:39,357 [shard 0:clus] storage - disk_log_impl.cc:3249 - Segment has outstanding locks. Might take a while to close:/var/lib/redpanda/data/redpanda/controller/0_0/0-1-v1.log
4. F2: _log.maybe_roll_unlocked() in disk_log_appender
5. F1: TRACE 2025-11-06 13:12:39,357 [shard 0:clus] storage - segment.cc:94 - closing segment: {offset_tracker:{term:1, base_offset:0, committed_offset:23, stable_offset:23, dirty_offset:23}, compacted_segment=0, finished_self_compaction=0, finished_windowed_compaction=0, generation=48, reader={/var/lib/redpanda/data/redpanda/controller/0_0/0-1-v1.log
6. F1: _gate in segment 0-1-v1.log is closed as a result of the above
7. F2: We have an appender, so maybe_roll_unlocked() goes into segment::release_appender()
8. F2: We are forced into release_appender_in_background() due to held segment locks
9. F2: _gate.check(); in release_appender_in_background() throws.
```

Or, I hypothesize, we could end up attempting to append to a closed segment, which would also be an exceptional case. 

Fixes https://redpandadata.atlassian.net/browse/CORE-14558.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes

* Prevent a slew of races between operations in the `storage` layer that could lead to attempting to append to a closed segment or a failed assert 
