### PR TITLE
cl: Return partition report even if missing source offsets

### DIFF
--- a/src/v/cluster_link/model/types.h
+++ b/src/v/cluster_link/model/types.h
@@ -1107,11 +1107,11 @@ struct shadow_topic_partition_leader_report
       serde::version<0>,
       serde::compat_version<0>> {
     ::model::partition_id partition;
-    kafka::offset source_partition_start_offset;
-    kafka::offset source_partition_high_watermark;
-    kafka::offset source_partition_last_stable_offset;
-    std::chrono::milliseconds last_update_time;
-    kafka::offset shadow_partition_high_watermark;
+    kafka::offset source_partition_start_offset{-1};
+    kafka::offset source_partition_high_watermark{-1};
+    kafka::offset source_partition_last_stable_offset{-1};
+    std::chrono::milliseconds last_update_time{0};
+    kafka::offset shadow_partition_high_watermark{-1};
 
     friend bool operator==(
       const shadow_topic_partition_leader_report&,

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -1496,22 +1496,20 @@ service::shard_local_shadow_link_report(model::id_t id) {
     result.err_code = errc::success;
 
     for (const auto& [topic, offsets] : value) {
-        if (offsets.update_time == ss::lowres_clock::time_point{}) {
-            // no offsets have been set for this partition
-            continue;
+        auto& report = result.topic_responses[topic.tp.topic]
+                         .partition_reports[topic.tp.partition];
+        report.partition = topic.tp.partition;
+        report.shadow_partition_high_watermark = offsets.shadow_hwm;
+        // If last update time is default time_point, then we have not received
+        // a new offset report from the source cluster for this partition
+        if (offsets.update_time != ss::lowres_clock::time_point{}) {
+            report.source_partition_start_offset = offsets.source_start_offset;
+            report.source_partition_high_watermark = offsets.source_hwm;
+            report.source_partition_last_stable_offset = offsets.source_lso;
+            report.last_update_time
+              = std::chrono::duration_cast<std::chrono::milliseconds>(
+                offsets.update_time.time_since_epoch());
         }
-        result.topic_responses[topic.tp.topic]
-          .partition_reports[topic.tp.partition]
-          = rpc::shadow_topic_partition_leader_report{
-            .partition = topic.tp.partition,
-            .source_partition_start_offset = offsets.source_start_offset,
-            .source_partition_high_watermark = offsets.source_hwm,
-            .source_partition_last_stable_offset = offsets.source_lso,
-            .last_update_time
-            = std::chrono::duration_cast<std::chrono::milliseconds>(
-              offsets.update_time.time_since_epoch()),
-            .shadow_partition_high_watermark = offsets.shadow_hwm,
-          };
     }
 
     auto task_report_res = _manager->get_task_status_report(id);


### PR DESCRIPTION
This addresses a flaky CI issue where not all partition information was returned in a Shadow Topic report.  Originally we did not report anything about a partition if source partition information was missing. Now we will return the partition info with default values.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None