### PR TITLE
[v25.2.x] krb5/acquire_cred: Improve fix of leak of principal

### DIFF
--- a/bazel/thirdparty/0001-Fix-two-unlikely-memory-leaks.patch
+++ b/bazel/thirdparty/0001-Fix-two-unlikely-memory-leaks.patch
@@ -201,20 +201,17 @@ index 8c7e30c21..149de98b0 100644
  }
  
 diff --git a/src/lib/gssapi/krb5/acquire_cred.c b/src/lib/gssapi/krb5/acquire_cred.c
-index 006eba114..b91de7cc1 100644
+index aa1a486dc..12e6b7ea8 100644
 --- a/src/lib/gssapi/krb5/acquire_cred.c
 +++ b/src/lib/gssapi/krb5/acquire_cred.c
-@@ -242,6 +242,10 @@ cleanup:
-         krb5_kt_close(context, kt);
-     if (rc != NULL)
-         k5_rc_close(context, rc);
-+    if (cred->acceptor_mprinc != NULL) {
+@@ -912,6 +912,7 @@ error_out:
+         if (cred->name)
+             kg_release_name(context, &cred->name);
+         krb5_free_principal(context, cred->impersonator);
 +        krb5_free_principal(context, cred->acceptor_mprinc);
-+        cred->acceptor_mprinc = NULL;
-+    }
-     *minor_status = code;
-     return major;
- }
+         zapfreestr(cred->password);
+         k5_mutex_destroy(&cred->lock);
+         xfree(cred);
 -- 
 2.34.1
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28469
