### PR TITLE
[v25.2.x] [CORE-14581] `cluster`: `partition_balancer` multiple fibers in `do_tick()` check

### DIFF
--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -271,6 +271,13 @@ void partition_balancer_backend::tick() {
       = ssx::spawn_with_gate_then(
           _gate,
           [this] {
+              if (_tick_in_progress) {
+                  vlog(
+                    clusterlog.debug,
+                    "skipping tick, tick already in progress");
+                  return ss::now();
+              }
+
               _tick_in_progress = ss::abort_source{};
               return do_tick().finally([this] {
                   _tick_in_progress = {};

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -271,6 +271,7 @@ void partition_balancer_backend::tick() {
       = ssx::spawn_with_gate_then(
           _gate,
           [this] {
+              _tick_in_progress = ss::abort_source{};
               return do_tick().finally([this] {
                   _tick_in_progress = {};
                   maybe_rearm_timer(
@@ -343,8 +344,6 @@ ss::future<> partition_balancer_backend::do_tick() {
         // TODO: add term checks to planner
         co_return;
     }
-
-    _tick_in_progress = ss::abort_source{};
 
     const bool force_refresh_this_tick
       = _cur_term->_force_health_report_refresh;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28460
