### PR TITLE
tests: Reduce segment size in MTT

### DIFF
--- a/tests/rptest/scale_tests/many_topics_test.py
+++ b/tests/rptest/scale_tests/many_topics_test.py
@@ -98,6 +98,7 @@ class ManyTopicsTest(RedpandaTest):
             # Increase partition allocation percent to ensure that we can fit 40k
             # topics on a `m6id.xlarge` cluster.
             "topic_partitions_memory_allocation_percent": self.PARTITIONS_MEMORY_ALLOCATION_PERCENT,
+            "log_segment_size": 16777216,
         }
 
         # Reduce per-partition log spam


### PR DESCRIPTION
MTT runs at quite high partition density. This makes us run into disk limits which confuses the partition balancer. This seems to be especially an issue in `test_decommission_node_unsafely` where we just remove one node before adding a new one.

Lower segment size to avoid such issues.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none

