### PR TITLE
[v25.2.x] CORE-13739 Update schema registry to use chunked_vector

### DIFF
--- a/src/v/datalake/tests/record_generator.cc
+++ b/src/v/datalake/tests/record_generator.cc
@@ -118,7 +118,7 @@ record_generator::add_random_protobuf_record(
                             },
                             [](const protobuf_schema_definition& pb_def)
                               -> std::optional<protobuf_schema_definition> {
-                                return {pb_def};
+                                return {pb_def.copy()};
                             },
                             [](const json_schema_definition&)
                               -> std::optional<protobuf_schema_definition> {

--- a/src/v/pandaproxy/schema_registry/BUILD
+++ b/src/v/pandaproxy/schema_registry/BUILD
@@ -27,6 +27,7 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         "//src/v/bytes:iobuf_parser",
+        "//src/v/container:fragmented_vector",
         "//src/v/model",
         "//src/v/pandaproxy:error",
         "//src/v/strings:string_switch",

--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -584,7 +584,7 @@ make_avro_schema_definition(schema_getter& store, subject_schema schema) {
     std::optional<avro::Exception> ex;
     try {
         auto name = schema.sub()();
-        auto schema_refs = schema.def().refs();
+        auto schema_refs = schema.def().refs().copy();
         auto refs = co_await collect_schema(store, {}, name, std::move(schema));
         iobuf_istream sis{std::move(refs).flatten()()};
         auto is = avro::istreamInputStream(sis.istream());
@@ -641,7 +641,7 @@ sanitize_avro_schema_definition(schema_definition def) {
     return schema_definition{
       schema_definition::raw_string{std::move(buf).as_iobuf()},
       schema_type::avro,
-      def.refs()};
+      std::move(def).refs()};
 }
 
 ss::future<subject_schema> make_canonical_avro_schema(
@@ -650,7 +650,7 @@ ss::future<subject_schema> make_canonical_avro_schema(
     auto [def, type, refs] = std::move(unparsed).destructure();
     if (norm) {
         std::sort(refs.begin(), refs.end());
-        refs.erase(std::unique(refs.begin(), refs.end()), refs.end());
+        refs.erase_to_end(std::unique(refs.begin(), refs.end()));
     }
     schema_definition schema{std::move(def), type, std::move(refs)};
     // TODO: Check references

--- a/src/v/pandaproxy/schema_registry/compatibility.h
+++ b/src/v/pandaproxy/schema_registry/compatibility.h
@@ -18,7 +18,6 @@
 
 #include <filesystem>
 #include <string_view>
-#include <vector>
 
 /**
  * compatibility.h
@@ -253,6 +252,19 @@ class raw_compatibility_result {
 public:
     raw_compatibility_result() = default;
 
+    raw_compatibility_result(const raw_compatibility_result& other)
+      : _errors(other._errors.copy()) {}
+
+    raw_compatibility_result(raw_compatibility_result&&) = default;
+    raw_compatibility_result& operator=(const raw_compatibility_result& other) {
+        if (this != &other) {
+            _errors = other._errors.copy();
+        }
+        return *this;
+    }
+    raw_compatibility_result& operator=(raw_compatibility_result&&) = default;
+    ~raw_compatibility_result() = default;
+
     template<typename T, typename... Args>
     requires std::constructible_from<T, Args&&...>
              && std::convertible_to<T, schema_incompatibility>
@@ -278,7 +290,7 @@ public:
     bool has_error() const { return !_errors.empty(); }
 
 private:
-    std::vector<schema_incompatibility> _errors{};
+    chunked_vector<schema_incompatibility> _errors{};
 };
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -2379,7 +2379,7 @@ ss::future<subject_schema> make_canonical_json_schema(
     if (norm) {
         sort(ctx.doc);
         std::sort(refs.begin(), refs.end());
-        refs.erase(std::unique(refs.begin(), refs.end()), refs.end());
+        refs.erase_to_end(std::unique(refs.begin(), refs.end()));
     }
     json::chunked_buffer out;
     json::Writer<json::chunked_buffer> w{out};

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -627,7 +627,7 @@ operator<<(std::ostream& os, const protobuf_schema_definition& def) {
 
 ss::future<protobuf_schema_definition> make_protobuf_schema_definition(
   schema_getter& store, subject_schema schema, normalize norm) {
-    auto refs = schema.def().refs();
+    auto refs = schema.def().refs().copy();
     auto impl = ss::make_shared<protobuf_schema_definition::impl>();
     impl->fdp = co_await import_schema(
       impl->_dp, store, std::move(schema), normalize(norm));
@@ -635,7 +635,7 @@ ss::future<protobuf_schema_definition> make_protobuf_schema_definition(
     if (norm) {
         std::sort(refs.begin(), refs.end());
         auto uniq = std::ranges::unique(refs);
-        refs.erase(uniq.begin(), uniq.end());
+        refs.erase_to_end(uniq.begin());
     }
     impl->fd = impl->_dp.FindFileByName(impl->fdp.name());
     co_return protobuf_schema_definition{std::move(impl), std::move(refs)};
@@ -648,7 +648,7 @@ ss::future<schema_definition> validate_protobuf_schema(
   output_format format) {
     auto res = co_await make_protobuf_schema_definition(
       store, std::move(schema), norm);
-    co_return schema_definition{res.raw(format), res.type(), res.refs()};
+    co_return schema_definition{res.raw(format), res.type(), res.refs().copy()};
 }
 
 ss::future<subject_schema> make_canonical_protobuf_schema(

--- a/src/v/pandaproxy/schema_registry/requests/compatibility.h
+++ b/src/v/pandaproxy/schema_registry/requests/compatibility.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "container/fragmented_vector.h"
 #include "pandaproxy/json/rjson_util.h"
 #include "pandaproxy/schema_registry/types.h"
 
@@ -18,7 +19,7 @@ namespace pandaproxy::schema_registry {
 
 struct post_compatibility_res {
     bool is_compat{false};
-    std::vector<ss::sstring> messages;
+    chunked_vector<ss::sstring> messages;
 
     // `is_verbose` is not rendered into the response but `messages` are
     // conditionally rendered based on `is_verbose`

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -94,7 +94,9 @@ struct batch_builder : public storage::record_batch_builder {
         }
     }
 
-    void operator()(const std::vector<seq_marker>& sequences) {
+    template<typename Container>
+    requires std::same_as<std::ranges::range_value_t<Container>, seq_marker>
+    void operator()(const Container& sequences) {
         for (const seq_marker& s : sequences) {
             (*this)(s);
         }

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -28,6 +28,7 @@
 #include <seastar/coroutine/as_future.hh>
 
 #include <exception>
+#include <optional>
 
 using namespace std::chrono_literals;
 
@@ -498,13 +499,8 @@ seq_writer::do_delete_subject_impermanent(subject sub, model::offset write_at) {
         co_return std::make_optional(std::move(versions));
     }
 
-    auto is_referenced = co_await ssx::parallel_transform(
-      versions.begin(), versions.end(), [this, &sub](const auto& ver) {
-          return _store.is_referenced(sub, ver);
-      });
-    if (std::any_of(is_referenced.begin(), is_referenced.end(), [](auto v) {
-            return v;
-        })) {
+    // Check that the subject is not referenced
+    if (co_await _store.is_referenced(sub, std::nullopt)) {
         throw as_exception(has_references(sub, versions.back()));
     }
 

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -486,20 +486,16 @@ seq_writer::delete_subject_version(subject sub, schema_version version) {
       });
 }
 
-ss::future<std::optional<std::vector<schema_version>>>
+ss::future<std::optional<chunked_vector<schema_version>>>
 seq_writer::do_delete_subject_impermanent(subject sub, model::offset write_at) {
     co_await check_mutable(sub);
 
     // Grab the versions before they're gone.
-    // TODO: Temporarily convert chunked_vector to vector. Will remove.
-    auto chunked_versions = co_await _store.get_versions(
-      sub, include_deleted::no);
-    auto versions = std::vector(
-      chunked_versions.begin(), chunked_versions.end());
+    auto versions = co_await _store.get_versions(sub, include_deleted::no);
 
     // Inspect the subject to see if its already deleted
     if (co_await _store.is_subject_deleted(sub)) {
-        co_return std::make_optional(versions);
+        co_return std::make_optional(std::move(versions));
     }
 
     auto is_referenced = co_await ssx::parallel_transform(
@@ -542,7 +538,7 @@ seq_writer::do_delete_subject_impermanent(subject sub, model::offset write_at) {
     }
 }
 
-ss::future<std::vector<schema_version>>
+ss::future<chunked_vector<schema_version>>
 seq_writer::delete_subject_impermanent(subject sub) {
     vlog(srlog.debug, "delete_subject_impermanent sub={}", sub);
     return sequenced_write(
@@ -555,7 +551,7 @@ seq_writer::delete_subject_impermanent(subject sub) {
 /// records) do not themselves need sequence numbers.
 /// Include a version if we are only to hard delete that version, otherwise
 /// will hard-delete the whole subject.
-ss::future<std::vector<schema_version>> seq_writer::delete_subject_permanent(
+ss::future<chunked_vector<schema_version>> seq_writer::delete_subject_permanent(
   subject sub, std::optional<schema_version> version) {
     return sequenced_write(
       [sub{std::move(sub)}, version](model::offset, seq_writer& seq) {
@@ -563,7 +559,7 @@ ss::future<std::vector<schema_version>> seq_writer::delete_subject_permanent(
       });
 }
 
-ss::future<std::optional<std::vector<schema_version>>>
+ss::future<std::optional<chunked_vector<schema_version>>>
 seq_writer::delete_subject_permanent_inner(
   subject sub, std::optional<schema_version> version) {
     std::vector<seq_marker> sequences;
@@ -582,11 +578,7 @@ seq_writer::delete_subject_permanent_inner(
     }
 
     // Stash the list of versions to return at end
-    // TODO: Temporarily convert chunked_vector to vector. Will remove.
-    auto chunked_versions = co_await _store.get_versions(
-      sub, include_deleted::yes);
-    auto versions = std::vector(
-      chunked_versions.begin(), chunked_versions.end());
+    auto versions = co_await _store.get_versions(sub, include_deleted::yes);
 
     // Deleting the subject, or the last version, deletes the subject
     if (!version.has_value() || versions.size() == 1) {

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -491,7 +491,11 @@ seq_writer::do_delete_subject_impermanent(subject sub, model::offset write_at) {
     co_await check_mutable(sub);
 
     // Grab the versions before they're gone.
-    auto versions = co_await _store.get_versions(sub, include_deleted::no);
+    // TODO: Temporarily convert chunked_vector to vector. Will remove.
+    auto chunked_versions = co_await _store.get_versions(
+      sub, include_deleted::no);
+    auto versions = std::vector(
+      chunked_versions.begin(), chunked_versions.end());
 
     // Inspect the subject to see if its already deleted
     if (co_await _store.is_subject_deleted(sub)) {
@@ -578,7 +582,11 @@ seq_writer::delete_subject_permanent_inner(
     }
 
     // Stash the list of versions to return at end
-    auto versions = co_await _store.get_versions(sub, include_deleted::yes);
+    // TODO: Temporarily convert chunked_vector to vector. Will remove.
+    auto chunked_versions = co_await _store.get_versions(
+      sub, include_deleted::yes);
+    auto versions = std::vector(
+      chunked_versions.begin(), chunked_versions.end());
 
     // Deleting the subject, or the last version, deletes the subject
     if (!version.has_value() || versions.size() == 1) {

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -95,9 +95,7 @@ struct batch_builder : public storage::record_batch_builder {
         }
     }
 
-    template<typename Container>
-    requires std::same_as<std::ranges::range_value_t<Container>, seq_marker>
-    void operator()(const Container& sequences) {
+    void operator()(const chunked_vector<seq_marker>& sequences) {
         for (const seq_marker& s : sequences) {
             (*this)(s);
         }
@@ -558,7 +556,7 @@ ss::future<chunked_vector<schema_version>> seq_writer::delete_subject_permanent(
 ss::future<std::optional<chunked_vector<schema_version>>>
 seq_writer::delete_subject_permanent_inner(
   subject sub, std::optional<schema_version> version) {
-    std::vector<seq_marker> sequences;
+    chunked_vector<seq_marker> sequences;
     batch_builder rb{model::offset{0}, sub};
 
     /// Check for whether our victim is already soft-deleted happens

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -63,10 +63,10 @@ public:
     ss::future<bool>
     delete_subject_version(subject sub, schema_version version);
 
-    ss::future<std::vector<schema_version>>
+    ss::future<chunked_vector<schema_version>>
     delete_subject_impermanent(subject sub);
 
-    ss::future<std::vector<schema_version>> delete_subject_permanent(
+    ss::future<chunked_vector<schema_version>> delete_subject_permanent(
       subject sub, std::optional<schema_version> version);
 
 private:
@@ -98,10 +98,10 @@ private:
     ss::future<std::optional<bool>> do_delete_subject_version(
       subject sub, schema_version version, model::offset write_at);
 
-    ss::future<std::optional<std::vector<schema_version>>>
+    ss::future<std::optional<chunked_vector<schema_version>>>
     do_delete_subject_impermanent(subject sub, model::offset write_at);
 
-    ss::future<std::optional<std::vector<schema_version>>>
+    ss::future<std::optional<chunked_vector<schema_version>>>
     delete_subject_permanent_inner(
       subject sub, std::optional<schema_version> version);
 
@@ -168,7 +168,7 @@ private:
             co_return std::current_exception();
         }
         if (r.has_value()) {
-            co_return r.value();
+            co_return std::move(r.value());
         } else {
             throw exception(
               error_code::write_collision,

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -543,7 +543,7 @@ ss::future<std::vector<schema_id>> sharded_store::referenced_by(
     co_return std::vector<schema_id>{references.begin(), references.end()};
 }
 
-ss::future<std::vector<schema_version>> sharded_store::delete_subject(
+ss::future<chunked_vector<schema_version>> sharded_store::delete_subject(
   seq_marker marker, subject sub, permanent_delete permanent) {
     auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -486,7 +486,8 @@ sharded_store::get_versions(subject sub, include_deleted inc_del) {
       });
 }
 
-ss::future<bool> sharded_store::is_referenced(subject sub, schema_version ver) {
+ss::future<bool>
+sharded_store::is_referenced(subject sub, std::optional<schema_version> ver) {
     // Find all the schema that reference this sub-ver
     auto references = co_await _store.map_reduce0(
       [sub{std::move(sub)}, ver](store& s) {

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -569,7 +569,7 @@ sharded_store::is_subject_version_deleted(subject sub, schema_version ver) {
       });
 }
 
-ss::future<std::vector<seq_marker>>
+ss::future<chunked_vector<seq_marker>>
 sharded_store::get_subject_written_at(subject sub) {
     auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -505,7 +505,7 @@ sharded_store::is_referenced(subject sub, std::optional<schema_version> ver) {
       std::logical_or<>{});
 }
 
-ss::future<std::vector<schema_id>> sharded_store::referenced_by(
+ss::future<chunked_vector<schema_id>> sharded_store::referenced_by(
   subject sub, std::optional<schema_version> opt_ver) {
     schema_version ver;
     // Ensure the subject exists
@@ -541,7 +541,7 @@ ss::future<std::vector<schema_id>> sharded_store::referenced_by(
       store::schema_id_set{},
       set_accumulator);
 
-    co_return std::vector<schema_id>{references.begin(), references.end()};
+    co_return chunked_vector<schema_id>{references.begin(), references.end()};
 }
 
 ss::future<chunked_vector<schema_version>> sharded_store::delete_subject(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -200,14 +200,14 @@ sharded_store::get_schema_version(stored_schema schema) {
     const auto versions = co_await _store.invoke_on(
       shard_for(sub),
       _smp_opts,
-      [sub](auto& s) -> std::vector<subject_version_entry> {
+      [sub](auto& s) -> chunked_vector<subject_version_entry> {
           auto res = s.get_version_ids(sub, include_deleted::no);
           if (
             res.has_error()
             && res.assume_error().code() == error_code::subject_not_found) {
               return {};
           }
-          return res.value();
+          return res.value().copy();
       });
 
     std::optional<schema_version> v_id;

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -597,7 +597,7 @@ sharded_store::get_subject_mode_written_at(subject sub) {
       });
 }
 
-ss::future<std::vector<seq_marker>>
+ss::future<chunked_vector<seq_marker>>
 sharded_store::get_subject_version_written_at(subject sub, schema_version ver) {
     auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -579,7 +579,7 @@ sharded_store::get_subject_written_at(subject sub) {
       });
 }
 
-ss::future<std::vector<seq_marker>>
+ss::future<chunked_vector<seq_marker>>
 sharded_store::get_subject_config_written_at(subject sub) {
     auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -588,7 +588,7 @@ sharded_store::get_subject_config_written_at(subject sub) {
       });
 }
 
-ss::future<std::vector<seq_marker>>
+ss::future<chunked_vector<seq_marker>>
 sharded_store::get_subject_mode_written_at(subject sub) {
     auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -880,7 +880,7 @@ ss::future<compatibility_result> sharded_store::do_is_compatible(
         auto old_valid = co_await make_valid_schema(
           std::move(old_schema.schema));
 
-        std::vector<ss::sstring> version_messages;
+        chunked_vector<ss::sstring> version_messages;
 
         if (
           compat == compatibility_level::backward

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -477,7 +477,7 @@ ss::future<bool> sharded_store::has_subjects(include_deleted inc_del) {
     return _store.map_reduce0(map, false, std::logical_or<>{});
 }
 
-ss::future<std::vector<schema_version>>
+ss::future<chunked_vector<schema_version>>
 sharded_store::get_versions(subject sub, include_deleted inc_del) {
     auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -120,7 +120,7 @@ public:
     is_referenced(subject sub, std::optional<schema_version> ver);
 
     ///\brief Return the schema_ids that reference a subject version.
-    ss::future<std::vector<schema_id>>
+    ss::future<chunked_vector<schema_id>>
     referenced_by(subject sub, std::optional<schema_version> ver);
 
     ///\brief Delete a subject.

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -123,7 +123,7 @@ public:
     referenced_by(subject sub, std::optional<schema_version> ver);
 
     ///\brief Delete a subject.
-    ss::future<std::vector<schema_version>>
+    ss::future<chunked_vector<schema_version>>
     delete_subject(seq_marker marker, subject sub, permanent_delete permanent);
 
     ss::future<is_deleted> is_subject_deleted(subject sub);

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -142,7 +142,7 @@ public:
 
     ///\brief Get sequence number history of subject mode. Subject need
     /// not be soft-deleted first
-    ss::future<std::vector<seq_marker>>
+    ss::future<chunked_vector<seq_marker>>
     get_subject_mode_written_at(subject sub);
 
     ///\brief Get sequence number history (errors out if not soft-deleted)

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -112,7 +112,7 @@ public:
     ss::future<bool> has_subjects(include_deleted inc_del);
 
     ///\brief Return a list of versions and associated schema_id.
-    ss::future<std::vector<schema_version>>
+    ss::future<chunked_vector<schema_version>>
     get_versions(subject sub, include_deleted inc_del);
 
     ///\brief Return whether there are any references to a subject version.

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -116,7 +116,8 @@ public:
     get_versions(subject sub, include_deleted inc_del);
 
     ///\brief Return whether there are any references to a subject version.
-    ss::future<bool> is_referenced(subject sub, schema_version ver);
+    ss::future<bool>
+    is_referenced(subject sub, std::optional<schema_version> ver);
 
     ///\brief Return the schema_ids that reference a subject version.
     ss::future<std::vector<schema_id>>

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -137,7 +137,7 @@ public:
 
     ///\brief Get sequence number history of subject config. Subject need
     /// not be soft-deleted first
-    ss::future<std::vector<seq_marker>>
+    ss::future<chunked_vector<seq_marker>>
     get_subject_config_written_at(subject sub);
 
     ///\brief Get sequence number history of subject mode. Subject need

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -146,7 +146,7 @@ public:
     get_subject_mode_written_at(subject sub);
 
     ///\brief Get sequence number history (errors out if not soft-deleted)
-    ss::future<std::vector<seq_marker>>
+    ss::future<chunked_vector<seq_marker>>
     get_subject_version_written_at(subject sub, schema_version version);
 
     ///\brief Delete a subject version

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -132,7 +132,7 @@ public:
     is_subject_version_deleted(subject sub, schema_version version);
 
     ///\brief Get sequence number history (errors out if not soft-deleted)
-    ss::future<std::vector<seq_marker>> get_subject_written_at(subject sub);
+    ss::future<chunked_vector<seq_marker>> get_subject_written_at(subject sub);
 
     ///\brief Get sequence number history of subject config. Subject need
     /// not be soft-deleted first

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -251,7 +251,7 @@ public:
     /// \brief Return the seq_marker write history of a subject
     ///
     /// \return A vector with at least one element
-    result<std::vector<seq_marker>>
+    result<chunked_vector<seq_marker>>
     get_subject_written_at(const subject& sub) const {
         auto sub_it = BOOST_OUTCOME_TRYX(
           get_subject_iter(sub, include_deleted::yes));
@@ -269,7 +269,7 @@ public:
                 return not_found(sub);
             }
 
-            return sub_it->second.written_at;
+            return sub_it->second.written_at.copy();
         }
     }
 
@@ -519,12 +519,8 @@ public:
         // that when we later hard-delete the subject, we do not
         // emit more tombstones for versions already tombstoned
         auto& markers = sub_it->second.written_at;
-        markers.erase(
-          std::remove_if(
-            markers.begin(),
-            markers.end(),
-            [&version](auto sm) { return sm.version == version; }),
-          markers.end());
+        markers.erase_to_end(
+          std::ranges::remove(markers, version, &seq_marker::version).begin());
 
         if (versions.empty()) {
             _subjects.erase(sub_it);
@@ -569,7 +565,8 @@ public:
         BOOST_OUTCOME_TRYX(check_mode_mutability(f));
         auto sub_it = BOOST_OUTCOME_TRYX(
           get_subject_iter(sub, include_deleted::yes));
-        std::erase(sub_it->second.written_at, marker);
+        auto& vec = sub_it->second.written_at;
+        vec.erase_to_end(std::ranges::remove(vec, marker).begin());
         return std::exchange(sub_it->second.mode, std::nullopt) != std::nullopt;
     }
 
@@ -615,7 +612,8 @@ public:
     clear_compatibility(const seq_marker& marker, const subject& sub) {
         auto sub_it = BOOST_OUTCOME_TRYX(
           get_subject_iter(sub, include_deleted::yes));
-        std::erase(sub_it->second.written_at, marker);
+        auto& vec = sub_it->second.written_at;
+        vec.erase_to_end(std::ranges::remove(vec, marker).begin());
         return std::exchange(sub_it->second.compatibility, std::nullopt)
                != std::nullopt;
     }
@@ -805,7 +803,7 @@ private:
         std::vector<subject_version_entry> versions;
         is_deleted deleted{false};
 
-        std::vector<seq_marker> written_at;
+        chunked_vector<seq_marker> written_at;
 
     private:
         metrics::internal_metric_groups _metrics;

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -457,7 +457,7 @@ public:
     }
 
     ///\brief Delete a subject.
-    result<std::vector<schema_version>> delete_subject(
+    result<chunked_vector<schema_version>> delete_subject(
       seq_marker marker, const subject& sub, permanent_delete permanent) {
         auto sub_it = BOOST_OUTCOME_TRYX(
           get_subject_iter(sub, include_deleted::yes));
@@ -474,7 +474,7 @@ public:
         sub_it->second.deleted = is_deleted::yes;
 
         auto& versions = sub_it->second.versions;
-        std::vector<schema_version> res;
+        chunked_vector<schema_version> res;
         res.reserve(versions.size());
         for (const auto& ver : versions) {
             if (permanent || !ver.deleted) {

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -332,7 +332,7 @@ public:
     /// \brief Return the seq_marker write history of a version.
     ///
     /// \return A vector with at least one element
-    result<std::vector<seq_marker>> get_subject_version_written_at(
+    result<chunked_vector<seq_marker>> get_subject_version_written_at(
       const subject& sub, schema_version version) const {
         auto sub_it = BOOST_OUTCOME_TRYX(
           get_subject_iter(sub, include_deleted::yes));
@@ -347,7 +347,7 @@ public:
             return not_deleted(sub, version);
         }
 
-        std::vector<seq_marker> result;
+        chunked_vector<seq_marker> result;
         for (auto s : sub_it->second.written_at) {
             if (s.version == version) {
                 result.push_back(s);

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -277,7 +277,7 @@ public:
     /// config_keys
     ///
     /// \return A vector (possibly empty)
-    result<std::vector<seq_marker>>
+    result<chunked_vector<seq_marker>>
     get_subject_config_written_at(const subject& sub) const {
         auto sub_it = BOOST_OUTCOME_TRYX(
           get_subject_iter(sub, include_deleted::yes));
@@ -289,7 +289,7 @@ public:
             return not_found(sub);
         }
 
-        std::vector<seq_marker> result;
+        chunked_vector<seq_marker> result;
         std::copy_if(
           sub_it->second.written_at.begin(),
           sub_it->second.written_at.end(),

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -398,11 +398,11 @@ public:
     }
 
     ///\brief Return a list of versions and associated schema_id.
-    result<std::vector<subject_version_entry>>
+    result<chunked_vector<subject_version_entry>>
     get_version_ids(const subject& sub, include_deleted inc_del) const {
         auto sub_it = BOOST_OUTCOME_TRYX(get_subject_iter(sub, inc_del));
-        std::vector<subject_version_entry> res;
-        absl::c_copy_if(
+        chunked_vector<subject_version_entry> res;
+        std::ranges::copy_if(
           sub_it->second.versions,
           std::back_inserter(res),
           [inc_del](const subject_version_entry& e) {

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -151,11 +151,11 @@ public:
 
         if (!version.has_value()) {
             const auto& versions = sub_it->second.versions;
-            auto it = std::find_if(
-              versions.rbegin(), versions.rend(), [inc_del](const auto& ver) {
-                  return inc_del || !ver.deleted;
-              });
-            if (it == versions.rend()) {
+            auto reversed = versions | std::views::reverse;
+            auto it = std::ranges::find_if(
+              reversed,
+              [inc_del](const auto& ver) { return inc_del || !ver.deleted; });
+            if (it == std::ranges::end(reversed)) {
                 return not_found(sub);
             }
             return *it;
@@ -513,7 +513,10 @@ public:
             return not_deleted(sub, version);
         }
 
-        versions.erase(v_it);
+        // chunked_vector doesn't support erase(), so we need to
+        // manually erase
+        std::shift_left(v_it, versions.end(), 1);
+        versions.pop_back();
 
         // Trim any seq_markers referring to this version, so
         // that when we later hard-delete the subject, we do not
@@ -698,7 +701,12 @@ public:
         if (found) {
             *v_it = subject_version_entry(version, id, deleted);
         } else {
-            versions.emplace(v_it, version, id, deleted);
+            // chunked_vector doesn't support emplace(), so we need to manually
+            // emplace at the back and rotate it into position
+            auto idx = v_it - versions.begin();
+            versions.emplace_back(version, id, deleted);
+            std::rotate(
+              versions.begin() + idx, versions.end() - 1, versions.end());
         }
 
         const auto all_deleted = is_deleted(
@@ -800,7 +808,7 @@ private:
         explicit subject_entry(const subject& sub) { setup_metrics(sub); }
         std::optional<compatibility_level> compatibility;
         std::optional<mode> mode;
-        std::vector<subject_version_entry> versions;
+        chunked_vector<subject_version_entry> versions;
         is_deleted deleted{false};
 
         chunked_vector<seq_marker> written_at;
@@ -874,18 +882,20 @@ private:
         return sub_it;
     }
 
-    static result<std::vector<subject_version_entry>::iterator>
+    static result<chunked_vector<subject_version_entry>::iterator>
     get_version_iter(
       subject_map::value_type& sub_entry,
       schema_version version,
       include_deleted inc_del) {
         const subject_map::value_type& const_entry = sub_entry;
-        return detail::make_non_const_iterator(
-          sub_entry.second.versions,
+        // Get equivalent non-const iterator
+        auto& v = sub_entry.second.versions;
+        auto cit = BOOST_OUTCOME_TRYX(
           get_version_iter(const_entry, version, inc_del));
+        return v.begin() + std::distance(v.cbegin(), cit);
     }
 
-    static result<std::vector<subject_version_entry>::const_iterator>
+    static result<chunked_vector<subject_version_entry>::const_iterator>
     get_version_iter(
       const subject_map::value_type& sub_entry,
       schema_version version,

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -305,7 +305,7 @@ public:
     /// mode_keys
     ///
     /// \return A vector (possibly empty)
-    result<std::vector<seq_marker>>
+    result<chunked_vector<seq_marker>>
     get_subject_mode_written_at(const subject& sub) const {
         auto sub_it = BOOST_OUTCOME_TRYX(
           get_subject_iter(sub, include_deleted::yes));
@@ -317,7 +317,7 @@ public:
             return not_found(sub);
         }
 
-        std::vector<seq_marker> result;
+        chunked_vector<seq_marker> result;
         std::copy_if(
           sub_it->second.written_at.begin(),
           sub_it->second.written_at.end(),

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -214,14 +214,14 @@ public:
     }
 
     ///\brief Return a list of versions and associated schema_id.
-    result<std::vector<schema_version>>
+    result<chunked_vector<schema_version>>
     get_versions(const subject& sub, include_deleted inc_del) const {
         auto sub_it = BOOST_OUTCOME_TRYX(get_subject_iter(sub, inc_del));
         const auto& versions = sub_it->second.versions;
         if (versions.empty()) {
             return not_found(sub);
         }
-        std::vector<schema_version> res;
+        chunked_vector<schema_version> res;
         res.reserve(versions.size());
         for (const auto& ver : versions) {
             if (inc_del || !ver.deleted) {

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -422,11 +422,12 @@ public:
         });
     }
 
-    schema_id_set referenced_by(const subject& sub, schema_version ver) {
+    schema_id_set
+    referenced_by(const subject& sub, std::optional<schema_version> ver) {
         schema_id_set references;
         for (const auto& s : _schemas) {
             for (const auto& r : s.second.definition.refs()) {
-                if (r.sub == sub && r.version == ver) {
+                if (r.sub == sub && (!ver.has_value() || r.version == *ver)) {
                     references.insert(s.first);
                 }
             }

--- a/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
@@ -65,7 +65,7 @@ inline model::record_batch make_delete_subject_batch(pps::subject sub) {
 }
 
 inline model::record_batch make_delete_subject_permanently_batch(
-  pps::subject sub, const std::vector<pps::schema_version>& versions) {
+  pps::subject sub, const chunked_vector<pps::schema_version>& versions) {
     storage::record_batch_builder rb{
       model::record_batch_type::raft_data, model::offset{0}};
 

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -167,7 +167,7 @@ public:
         explicit raw_string(std::string_view sv)
           : schema_definition_iobuf{iobuf::from(sv)} {}
     };
-    using references = std::vector<schema_reference>;
+    using references = chunked_vector<schema_reference>;
 
     schema_definition() = default;
     schema_definition(schema_definition&&) noexcept = default;
@@ -206,14 +206,16 @@ public:
     const references& refs() const& { return _refs; }
     references refs() && { return std::move(_refs); }
 
-    schema_definition share() const { return {shared_raw(), type(), refs()}; }
+    schema_definition share() const {
+        return {shared_raw(), type(), refs().copy()};
+    }
 
     schema_definition copy() const {
-        return {raw_string{_def().copy()}, type(), refs()};
+        return {raw_string{_def().copy()}, type(), refs().copy()};
     }
 
     auto destructure() && {
-        return make_tuple(std::move(_def), _type, std::move(_refs));
+        return std::make_tuple(std::move(_def), _type, std::move(_refs));
     }
 
 private:
@@ -242,7 +244,7 @@ public:
     constexpr schema_type type() const { return schema_type::avro; }
 
     explicit operator schema_definition() const {
-        return {raw(), type(), refs()};
+        return {raw(), type(), refs().copy()};
     }
 
     ss::sstring name() const;
@@ -277,6 +279,10 @@ public:
 
     constexpr schema_type type() const { return schema_type::protobuf; }
 
+    protobuf_schema_definition copy() const {
+        return protobuf_schema_definition{_impl, _refs.copy()};
+    }
+
     ::result<ss::sstring, kafka::error_code>
     name(const std::vector<int>& fields) const;
 
@@ -307,7 +313,7 @@ public:
     constexpr schema_type type() const { return schema_type::json; }
 
     explicit operator schema_definition() const {
-        return {raw(), type(), refs()};
+        return {raw(), type(), refs().copy()};
     }
 
     ss::sstring name() const;
@@ -366,7 +372,7 @@ public:
     }
 
     schema_definition::raw_string raw() && {
-        return visit([](auto def) {
+        return visit([](auto& def) {
             return schema_definition::raw_string{std::move(def).raw()()};
         });
     }

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -13,6 +13,7 @@
 
 #include "base/outcome.h"
 #include "base/seastarx.h"
+#include "container/fragmented_vector.h"
 #include "json/iobuf_writer.h"
 #include "kafka/protocol/errors.h"
 #include "model/metadata.h"
@@ -542,7 +543,7 @@ struct compatibility_result {
     friend std::ostream& operator<<(std::ostream&, const compatibility_result&);
 
     bool is_compat;
-    std::vector<ss::sstring> messages;
+    chunked_vector<ss::sstring> messages;
 };
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/wasm/schema_registry_module.cc
+++ b/src/v/wasm/schema_registry_module.cc
@@ -84,7 +84,7 @@ read_encoded_schema_def(ffi::reader* r) {
         auto v = int(r->read_varint());
         refs.emplace_back(name, subject(sub), schema_version(v));
     }
-    return {def, *type, refs};
+    return {std::move(def), *type, std::move(refs)};
 }
 
 template<typename T>

--- a/tests/rptest/scale_tests/schema_registry_scale_test.py
+++ b/tests/rptest/scale_tests/schema_registry_scale_test.py
@@ -1,0 +1,216 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import json
+import requests
+
+from ducktape.mark import parametrize
+from ducktape.tests.test import TestContext
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import SchemaRegistryConfig
+from rptest.tests.schema_registry_test import (
+    SchemaRegistryEndpoints,
+    create_topic_names,
+    schema1_def,
+)
+from rptest.utils.mode_checks import skip_debug_mode
+
+from typing import Any
+
+
+class SchemaRegistryScaleTest(SchemaRegistryEndpoints):
+    """
+    Test class for schema registry scaling tests.
+    """
+
+    def __init__(self, context: TestContext, **kwargs: Any) -> None:
+        super(SchemaRegistryScaleTest, self).__init__(context, **kwargs)
+
+    @cluster(num_nodes=1)
+    @skip_debug_mode
+    @parametrize(iterations=4097)
+    def test_post_subjects_subject_versions_and_delete_repeated(self, iterations: int):
+        """
+        Verify posting a schema and deleting it many times to trigger
+        oversized allocation warnings in subject_entry::written_at and
+        subject_entry::versions.
+        """
+
+        topic = create_topic_names(1)[0]
+        subject = f"{topic}-key"
+        schema_1_data = json.dumps({"schema": schema1_def})
+
+        for _ in range(iterations):
+            result_raw = self.sr_client.post_subjects_subject_versions(
+                subject=subject, data=schema_1_data
+            )
+            self.logger.debug(result_raw)
+            self.logger.debug(result_raw.json())
+            assert result_raw.status_code == requests.codes.ok
+            assert result_raw.json()["id"] == 1
+
+            result_raw = self.sr_client.delete_subject_version(
+                subject=subject, version="latest"
+            )
+            self.logger.debug(result_raw)
+            assert result_raw.status_code == requests.codes.ok
+
+    @cluster(num_nodes=1)
+    @skip_debug_mode
+    @parametrize(iterations=32769)
+    def test_post_subjects_subject_versions_unique(self, iterations: int):
+        """
+        Verify repeatedly posting a unique version of a schema to trigger
+        oversized allocation warnings in store::get_version_ids and
+        store::get_versions.
+        """
+
+        topic = create_topic_names(1)[0]
+        subject = f"{topic}-key"
+        schema_1_dict = json.loads(schema1_def)
+
+        for i in range(iterations):
+            # Change the doc field to make the schema unique
+            schema_1_dict["doc"] = str(i)
+            schema_1_data = json.dumps({"schema": json.dumps(schema_1_dict)})
+            result_raw = self.sr_client.post_subjects_subject_versions(
+                subject=subject, data=schema_1_data
+            )
+
+            self.logger.debug(result_raw)
+            self.logger.debug(result_raw.json())
+            assert result_raw.status_code == requests.codes.ok
+            assert result_raw.json()["id"] == i + 1
+
+        result_raw = self.sr_client.get_subjects_subject_versions(subject=subject)
+        self.logger.debug(result_raw.json())
+        assert result_raw.status_code == requests.codes.ok
+        assert len(result_raw.json()) == iterations
+
+        self.logger.debug("Deleting the subject")
+        result_raw = self.sr_client.delete_subject(subject=subject)
+        self.logger.debug(result_raw.json())
+        assert result_raw.status_code == requests.codes.ok
+
+    @cluster(num_nodes=1)
+    @skip_debug_mode
+    @parametrize(iterations=4097)
+    def test_set_subject_config_repeated(self, iterations: int):
+        """
+        Verify repeatedly setting subject config and then deleting it to trigger
+        oversized allocation warnings in store::get_subject_config_written_at.
+        """
+
+        topic = create_topic_names(1)[0]
+        subject = f"{topic}-key"
+
+        compatibilities = ["NONE", "BACKWARD"]
+        compatibility = compatibilities[0]
+
+        for i in range(iterations):
+            compatibility = compatibilities[i % len(compatibilities)]
+            result_raw = self.sr_client.set_config_subject(
+                subject=subject,
+                data=json.dumps({"compatibility": compatibility}),
+            )
+            assert result_raw.status_code == requests.codes.ok
+            assert result_raw.json()["compatibility"] == compatibility
+
+        result_raw = self.sr_client.delete_config_subject(subject=subject)
+        assert result_raw.status_code == requests.codes.ok
+        assert result_raw.json()["compatibilityLevel"] == compatibility
+
+    @cluster(num_nodes=1)
+    @skip_debug_mode
+    @parametrize(iterations=32769)
+    def test_many_references(self, iterations: int):
+        """
+        Create many schemas referencing the same base schema to trigger
+        oversized allocation warnings in sharded_store::referenced_by.
+        """
+
+        topic = create_topic_names(1)[0]
+        base_subject = f"{topic}-key"
+        base_version = 1
+        schema_dict = json.loads(schema1_def)
+
+        schema_data = json.dumps({"schema": json.dumps(schema_dict)})
+        result_raw = self.sr_client.post_subjects_subject_versions(
+            subject=base_subject, data=schema_data
+        )
+
+        assert result_raw.status_code == requests.codes.ok
+
+        for i in range(iterations):
+            # Change the doc field to make the schema unique
+            schema_dict["doc"] = str(i)
+            schema_data = json.dumps(
+                {
+                    "schema": json.dumps(schema_dict),
+                    "references": [
+                        {
+                            "name": "test-ref",
+                            "subject": base_subject,
+                            "version": base_version,
+                        }
+                    ],
+                }
+            )
+            result_raw = self.sr_client.post_subjects_subject_versions(
+                subject=base_subject, data=schema_data
+            )
+
+            assert result_raw.status_code == requests.codes.ok
+
+        result_raw = self.sr_client.get_subjects_subject_versions_version_referenced_by(
+            subject=base_subject, version=str(base_version)
+        )
+        assert result_raw.status_code == requests.codes.ok
+        assert len(result_raw.json()) == iterations
+
+
+class SchemaRegistryModeMutableScaleTest(SchemaRegistryEndpoints):
+    """
+    Test class for schema registry subject mode scaling tests.
+    """
+
+    def __init__(self, context: TestContext, **kwargs: Any) -> None:
+        self.schema_registry_config = SchemaRegistryConfig()
+        self.schema_registry_config.mode_mutability = True
+        super(SchemaRegistryModeMutableScaleTest, self).__init__(
+            context, schema_registry_config=self.schema_registry_config, **kwargs
+        )
+
+    @cluster(num_nodes=1)
+    @skip_debug_mode
+    @parametrize(iterations=4097)
+    def test_set_subject_mode_repeated(self, iterations: int):
+        """
+        Verify repeatedly setting subject mode and then deleting it to trigger
+        oversized allocation warnings in store::get_subject_mode_written_at.
+        """
+
+        topic = create_topic_names(1)[0]
+        subject = f"{topic}-key"
+
+        modes = ["READWRITE", "READONLY"]
+        mode = modes[0]
+
+        for i in range(iterations):
+            mode = modes[i % len(modes)]
+            result_raw = self.sr_client.set_mode_subject(
+                subject=subject,
+                data=json.dumps({"mode": mode}),
+            )
+            assert result_raw.status_code == requests.codes.ok
+            assert result_raw.json()["mode"] == mode
+
+        result_raw = self.sr_client.delete_mode_subject(subject=subject)
+        assert result_raw.status_code == requests.codes.ok
+        assert result_raw.json()["mode"] == mode

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1684,6 +1684,32 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             )
             self.logger.debug(result_raw)
             assert result_raw.status_code == requests.codes.ok
+    
+    @ignore
+    @cluster(num_nodes=1)
+    @parametrize(iterations=8194)  # oversized alloc for store::get_version_ids.
+    def test_post_subjects_subject_versions_unique(self, iterations: int):
+        """
+        Verify repeatedly posting a unique version of a schema to trigger
+        oversized allocation warnings in store::get_version_ids.
+        """
+
+        topic = create_topic_names(1)[0]
+        subject = f"{topic}-key"
+        schema_1_dict = json.loads(schema1_def)
+
+        for i in range(iterations):
+            # Change the doc field to make the schema unique
+            schema_1_dict["doc"] = str(i)
+            schema_1_data = json.dumps({"schema": json.dumps(schema_1_dict)})
+            result_raw = self.sr_client.post_subjects_subject_versions(
+                subject=subject, data=schema_1_data
+            )
+
+            self.logger.debug(result_raw)
+            self.logger.debug(result_raw.json())
+            assert result_raw.status_code == requests.codes.ok
+            assert result_raw.json()["id"] == i + 1
 
     @cluster(num_nodes=3)
     def test_post_subjects_subject_versions_metadata_ruleset(self):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -29,7 +29,7 @@ from confluent_kafka.schema_registry import (
     topic_subject_name_strategy,
 )
 from confluent_kafka.serialization import MessageField, SerializationContext
-from ducktape.mark import matrix, parametrize
+from ducktape.mark import matrix, parametrize, ignore
 from ducktape.services.background_thread import BackgroundThreadService
 from ducktape.utils.util import wait_until
 
@@ -1657,19 +1657,20 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             assert result_raw.json()["id"] == 1
 
     @cluster(num_nodes=1)
-    def test_post_subjects_subject_versions_and_delete_repeated(self):
+    @ignore(iterations=4097)
+    @parametrize(iterations=2049)  # oversized alloc for subject_entry::written_at.
+    @parametrize(iterations=4097)  # oversized alloc for subject_entry::versions.
+    def test_post_subjects_subject_versions_and_delete_repeated(self, iterations: int):
         """
         Verify posting a schema and deleting it many times to trigger
-        oversized allocation warnings for subject_entry::written_at.
+        oversized allocation warnings.
         """
 
         topic = create_topic_names(1)[0]
         subject = f"{topic}-key"
         schema_1_data = json.dumps({"schema": schema1_def})
 
-        # 2049 is the number of times we need to repeat this to trigger
-        # the oversized allocation warning.
-        for _ in range(2048 + 1):
+        for _ in range(iterations):
             result_raw = self.sr_client.post_subjects_subject_versions(
                 subject=subject, data=schema_1_data
             )

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -29,7 +29,7 @@ from confluent_kafka.schema_registry import (
     topic_subject_name_strategy,
 )
 from confluent_kafka.serialization import MessageField, SerializationContext
-from ducktape.mark import matrix, parametrize
+from ducktape.mark import matrix, parametrize, ignore
 from ducktape.services.background_thread import BackgroundThreadService
 from ducktape.utils.util import wait_until
 
@@ -1655,6 +1655,35 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             self.logger.debug(result_raw)
             assert result_raw.status_code == requests.codes.ok
             assert result_raw.json()["id"] == 1
+
+    @ignore  # Ignore failing test
+    @cluster(num_nodes=1)
+    def test_post_subjects_subject_versions_and_delete_repeated(self):
+        """
+        Verify posting a schema and deleting it many times to trigger
+        oversized allocation warnings for subject_entry::written_at.
+        """
+
+        topic = create_topic_names(1)[0]
+        subject = f"{topic}-key"
+        schema_1_data = json.dumps({"schema": schema1_def})
+
+        # 2049 is the number of times we need to repeat this to trigger
+        # the oversized allocation warning.
+        for _ in range(2048 + 1):
+            result_raw = self.sr_client.post_subjects_subject_versions(
+                subject=subject, data=schema_1_data
+            )
+            self.logger.debug(result_raw)
+            self.logger.debug(result_raw.json())
+            assert result_raw.status_code == requests.codes.ok
+            assert result_raw.json()["id"] == 1
+
+            result_raw = self.sr_client.delete_subject_version(
+                subject=subject, version="latest"
+            )
+            self.logger.debug(result_raw)
+            assert result_raw.status_code == requests.codes.ok
 
     @cluster(num_nodes=3)
     def test_post_subjects_subject_versions_metadata_ruleset(self):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1724,7 +1724,6 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         assert result_raw.status_code == requests.codes.ok
 
     @cluster(num_nodes=1)
-    @ignore(iterations=4097)
     @parametrize(
         iterations=4097
     )  # oversized alloc for store::get_subject_config_written_at.

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1723,6 +1723,35 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         self.logger.debug(result_raw.json())
         assert result_raw.status_code == requests.codes.ok
 
+    @cluster(num_nodes=1)
+    @ignore(iterations=4097)
+    @parametrize(
+        iterations=4097
+    )  # oversized alloc for store::get_subject_config_written_at.
+    def test_set_subject_config_repeated(self, iterations: int):
+        """
+        Verify repeatedly setting subject config and then deleting it to trigger
+        oversized allocation warnings.
+        """
+
+        topic = create_topic_names(1)[0]
+        subject = f"{topic}-key"
+
+        modes = ["NONE", "BACKWARD"]
+
+        for i in range(iterations):
+            mode = modes[i % len(modes)]
+            result_raw = self.sr_client.set_config_subject(
+                subject=subject,
+                data=json.dumps({"compatibility": mode}),
+            )
+            assert result_raw.status_code == requests.codes.ok
+            assert result_raw.json()["compatibility"] == mode
+
+        result_raw = self.sr_client.delete_config_subject(subject=subject)
+        assert result_raw.status_code == requests.codes.ok
+        assert result_raw.json()["compatibilityLevel"] == mode
+
     @cluster(num_nodes=3)
     def test_post_subjects_subject_versions_metadata_ruleset(self):
         """

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1684,14 +1684,16 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             )
             self.logger.debug(result_raw)
             assert result_raw.status_code == requests.codes.ok
-    
-    @ignore
+
     @cluster(num_nodes=1)
+    @ignore(iterations=8194)
     @parametrize(iterations=8194)  # oversized alloc for store::get_version_ids.
+    @ignore(iterations=32769)
+    @parametrize(iterations=32769)  # oversized alloc for store::get_versions.
     def test_post_subjects_subject_versions_unique(self, iterations: int):
         """
         Verify repeatedly posting a unique version of a schema to trigger
-        oversized allocation warnings in store::get_version_ids.
+        oversized allocation warnings.
         """
 
         topic = create_topic_names(1)[0]
@@ -1710,6 +1712,11 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             self.logger.debug(result_raw.json())
             assert result_raw.status_code == requests.codes.ok
             assert result_raw.json()["id"] == i + 1
+
+        result_raw = self.sr_client.get_subjects_subject_versions(subject=subject)
+        self.logger.debug(result_raw.json())
+        assert result_raw.status_code == requests.codes.ok
+        assert len(result_raw.json()) == iterations
 
     @cluster(num_nodes=3)
     def test_post_subjects_subject_versions_metadata_ruleset(self):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1718,6 +1718,11 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         assert result_raw.status_code == requests.codes.ok
         assert len(result_raw.json()) == iterations
 
+        self.logger.debug("Deleting the subject")
+        result_raw = self.sr_client.delete_subject(subject=subject)
+        self.logger.debug(result_raw.json())
+        assert result_raw.status_code == requests.codes.ok
+
     @cluster(num_nodes=3)
     def test_post_subjects_subject_versions_metadata_ruleset(self):
         """

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -29,7 +29,7 @@ from confluent_kafka.schema_registry import (
     topic_subject_name_strategy,
 )
 from confluent_kafka.serialization import MessageField, SerializationContext
-from ducktape.mark import matrix, parametrize, ignore
+from ducktape.mark import matrix, parametrize
 from ducktape.services.background_thread import BackgroundThreadService
 from ducktape.utils.util import wait_until
 
@@ -1656,7 +1656,6 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             assert result_raw.status_code == requests.codes.ok
             assert result_raw.json()["id"] == 1
 
-    @ignore  # Ignore failing test
     @cluster(num_nodes=1)
     def test_post_subjects_subject_versions_and_delete_repeated(self):
         """

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1751,6 +1751,54 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.json()["compatibilityLevel"] == mode
 
+    @cluster(num_nodes=1)
+    @ignore(iterations=32769)
+    @parametrize(iterations=32769)  # oversized alloc for sharded_store::referenced_by.
+    def test_many_references(self, iterations: int):
+        """
+        Create many schemas referencing the same base schema to trigger
+        oversized allocation warnings.
+        """
+
+        topic = create_topic_names(1)[0]
+        base_subject = f"{topic}-key"
+        base_version = 1
+        schema_dict = json.loads(schema1_def)
+
+        schema_data = json.dumps({"schema": json.dumps(schema_dict)})
+        result_raw = self.sr_client.post_subjects_subject_versions(
+            subject=base_subject, data=schema_data
+        )
+
+        assert result_raw.status_code == requests.codes.ok
+
+        for i in range(iterations):
+            # Change the doc field to make the schema unique
+            schema_dict["doc"] = str(i)
+            schema_data = json.dumps(
+                {
+                    "schema": json.dumps(schema_dict),
+                    "references": [
+                        {
+                            "name": "test-ref",
+                            "subject": base_subject,
+                            "version": base_version,
+                        }
+                    ],
+                }
+            )
+            result_raw = self.sr_client.post_subjects_subject_versions(
+                subject=base_subject, data=schema_data
+            )
+
+            assert result_raw.status_code == requests.codes.ok
+
+        result_raw = self.sr_client.get_subjects_subject_versions_version_referenced_by(
+            subject=base_subject, version=base_version
+        )
+        assert result_raw.status_code == requests.codes.ok
+        assert len(result_raw.json()) == iterations
+
     @cluster(num_nodes=3)
     def test_post_subjects_subject_versions_metadata_ruleset(self):
         """

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -16,7 +16,7 @@ import time
 import urllib.parse
 import uuid
 from enum import Enum
-from typing import NamedTuple, Optional
+from typing import Any, NamedTuple, Optional, TypeAlias
 
 import requests
 from confluent_kafka.schema_registry import (
@@ -29,8 +29,9 @@ from confluent_kafka.schema_registry import (
     topic_subject_name_strategy,
 )
 from confluent_kafka.serialization import MessageField, SerializationContext
-from ducktape.mark import matrix, parametrize, ignore
+from ducktape.mark import matrix, parametrize
 from ducktape.services.background_thread import BackgroundThreadService
+from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 
 from rptest.clients.rpk import RpkException, RpkTool
@@ -57,6 +58,8 @@ from rptest.util import expect_exception, inject_remote_script, search_logs_with
 from rptest.utils.log_utils import wait_until_nag_is_set
 from rptest.utils.mode_checks import skip_fips_mode
 
+Headers: TypeAlias = dict[str, str] | None
+
 
 class SchemaIdValidationMode(str, Enum):
     NONE = "none"
@@ -64,7 +67,7 @@ class SchemaIdValidationMode(str, Enum):
     COMPAT = "compat"
 
 
-def create_topic_names(count):
+def create_topic_names(count: int) -> list[str]:
     return list(f"pandaproxy-topic-{uuid.uuid4()}" for _ in range(count))
 
 
@@ -913,12 +916,20 @@ class SchemaRegistryRedpandaClient:
             **kwargs,
         )
 
-    def set_config_subject(self, subject, data, headers=HTTP_POST_HEADERS, **kwargs):
+    def set_config_subject(
+        self,
+        subject: str,
+        data: Any,
+        headers: Headers = HTTP_POST_HEADERS,
+        **kwargs: Any,
+    ):
         return self.request(
             "PUT", f"config/{subject}", headers=headers, data=data, **kwargs
         )
 
-    def delete_config_subject(self, subject, headers=HTTP_DELETE_HEADERS, **kwargs):
+    def delete_config_subject(
+        self, subject: str, headers: Headers = HTTP_DELETE_HEADERS, **kwargs: Any
+    ):
         return self.request("DELETE", f"config/{subject}", headers=headers, **kwargs)
 
     def get_mode(self, headers=HTTP_GET_HEADERS, **kwargs):
@@ -944,7 +955,12 @@ class SchemaRegistryRedpandaClient:
         )
 
     def set_mode_subject(
-        self, subject, data, force=False, headers=HTTP_POST_HEADERS, **kwargs
+        self,
+        subject: str,
+        data: Any,
+        force: bool = False,
+        headers: Headers = HTTP_POST_HEADERS,
+        **kwargs: Any,
     ):
         return self.request(
             "PUT",
@@ -954,7 +970,9 @@ class SchemaRegistryRedpandaClient:
             **kwargs,
         )
 
-    def delete_mode_subject(self, subject, headers=HTTP_DELETE_HEADERS, **kwargs):
+    def delete_mode_subject(
+        self, subject: str, headers: Headers = HTTP_DELETE_HEADERS, **kwargs: Any
+    ):
         return self.request("DELETE", f"mode/{subject}", headers=headers, **kwargs)
 
     def get_schemas_types(
@@ -1022,7 +1040,12 @@ class SchemaRegistryRedpandaClient:
         )
 
     def post_subjects_subject_versions(
-        self, subject, data, normalize=False, headers=HTTP_POST_HEADERS, **kwargs
+        self,
+        subject: str,
+        data: Any,
+        normalize: bool = False,
+        headers: Headers = HTTP_POST_HEADERS,
+        **kwargs: Any,
     ):
         params = {}
         if normalize:
@@ -1065,7 +1088,11 @@ class SchemaRegistryRedpandaClient:
         )
 
     def get_subjects_subject_versions_version_referenced_by(
-        self, subject, version, headers=HTTP_GET_HEADERS, **kwargs
+        self,
+        subject: str,
+        version: str,
+        headers: Headers = HTTP_GET_HEADERS,
+        **kwargs: Any,
     ):
         deprecated = self.request(
             "GET",
@@ -1083,7 +1110,11 @@ class SchemaRegistryRedpandaClient:
         return standard
 
     def get_subjects_subject_versions(
-        self, subject, deleted=False, headers=HTTP_GET_HEADERS, **kwargs
+        self,
+        subject: str,
+        deleted: bool = False,
+        headers: Headers = HTTP_GET_HEADERS,
+        **kwargs: Any,
     ):
         return self.request(
             "GET",
@@ -1093,7 +1124,11 @@ class SchemaRegistryRedpandaClient:
         )
 
     def delete_subject(
-        self, subject, permanent=False, headers=HTTP_GET_HEADERS, **kwargs
+        self,
+        subject: str,
+        permanent: bool = False,
+        headers: Headers = HTTP_GET_HEADERS,
+        **kwargs: Any,
     ):
         return self.request(
             "DELETE",
@@ -1103,7 +1138,12 @@ class SchemaRegistryRedpandaClient:
         )
 
     def delete_subject_version(
-        self, subject, version, permanent=False, headers=HTTP_DELETE_HEADERS, **kwargs
+        self,
+        subject: str,
+        version: str,
+        permanent: bool = False,
+        headers: Headers = HTTP_DELETE_HEADERS,
+        **kwargs: Any,
     ):
         return self.request(
             "DELETE",
@@ -1195,10 +1235,10 @@ class SchemaRegistryEndpoints(RedpandaTest):
 
     def __init__(
         self,
-        context,
-        schema_registry_config=SchemaRegistryConfig(),
-        num_brokers=3,
-        **kwargs,
+        context: TestContext,
+        schema_registry_config: SchemaRegistryConfig = SchemaRegistryConfig(),
+        num_brokers: int = 3,
+        **kwargs: Any,
     ):
         super(SchemaRegistryEndpoints, self).__init__(
             context,
@@ -1655,149 +1695,6 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             self.logger.debug(result_raw)
             assert result_raw.status_code == requests.codes.ok
             assert result_raw.json()["id"] == 1
-
-    @cluster(num_nodes=1)
-    @ignore(iterations=4097)
-    @parametrize(iterations=2049)  # oversized alloc for subject_entry::written_at.
-    @parametrize(iterations=4097)  # oversized alloc for subject_entry::versions.
-    def test_post_subjects_subject_versions_and_delete_repeated(self, iterations: int):
-        """
-        Verify posting a schema and deleting it many times to trigger
-        oversized allocation warnings.
-        """
-
-        topic = create_topic_names(1)[0]
-        subject = f"{topic}-key"
-        schema_1_data = json.dumps({"schema": schema1_def})
-
-        for _ in range(iterations):
-            result_raw = self.sr_client.post_subjects_subject_versions(
-                subject=subject, data=schema_1_data
-            )
-            self.logger.debug(result_raw)
-            self.logger.debug(result_raw.json())
-            assert result_raw.status_code == requests.codes.ok
-            assert result_raw.json()["id"] == 1
-
-            result_raw = self.sr_client.delete_subject_version(
-                subject=subject, version="latest"
-            )
-            self.logger.debug(result_raw)
-            assert result_raw.status_code == requests.codes.ok
-
-    @cluster(num_nodes=1)
-    @ignore(iterations=8194)
-    @parametrize(iterations=8194)  # oversized alloc for store::get_version_ids.
-    @ignore(iterations=32769)
-    @parametrize(iterations=32769)  # oversized alloc for store::get_versions.
-    def test_post_subjects_subject_versions_unique(self, iterations: int):
-        """
-        Verify repeatedly posting a unique version of a schema to trigger
-        oversized allocation warnings.
-        """
-
-        topic = create_topic_names(1)[0]
-        subject = f"{topic}-key"
-        schema_1_dict = json.loads(schema1_def)
-
-        for i in range(iterations):
-            # Change the doc field to make the schema unique
-            schema_1_dict["doc"] = str(i)
-            schema_1_data = json.dumps({"schema": json.dumps(schema_1_dict)})
-            result_raw = self.sr_client.post_subjects_subject_versions(
-                subject=subject, data=schema_1_data
-            )
-
-            self.logger.debug(result_raw)
-            self.logger.debug(result_raw.json())
-            assert result_raw.status_code == requests.codes.ok
-            assert result_raw.json()["id"] == i + 1
-
-        result_raw = self.sr_client.get_subjects_subject_versions(subject=subject)
-        self.logger.debug(result_raw.json())
-        assert result_raw.status_code == requests.codes.ok
-        assert len(result_raw.json()) == iterations
-
-        self.logger.debug("Deleting the subject")
-        result_raw = self.sr_client.delete_subject(subject=subject)
-        self.logger.debug(result_raw.json())
-        assert result_raw.status_code == requests.codes.ok
-
-    @cluster(num_nodes=1)
-    @parametrize(
-        iterations=4097
-    )  # oversized alloc for store::get_subject_config_written_at.
-    def test_set_subject_config_repeated(self, iterations: int):
-        """
-        Verify repeatedly setting subject config and then deleting it to trigger
-        oversized allocation warnings.
-        """
-
-        topic = create_topic_names(1)[0]
-        subject = f"{topic}-key"
-
-        modes = ["NONE", "BACKWARD"]
-
-        for i in range(iterations):
-            mode = modes[i % len(modes)]
-            result_raw = self.sr_client.set_config_subject(
-                subject=subject,
-                data=json.dumps({"compatibility": mode}),
-            )
-            assert result_raw.status_code == requests.codes.ok
-            assert result_raw.json()["compatibility"] == mode
-
-        result_raw = self.sr_client.delete_config_subject(subject=subject)
-        assert result_raw.status_code == requests.codes.ok
-        assert result_raw.json()["compatibilityLevel"] == mode
-
-    @cluster(num_nodes=1)
-    @ignore(iterations=32769)
-    @parametrize(iterations=32769)  # oversized alloc for sharded_store::referenced_by.
-    def test_many_references(self, iterations: int):
-        """
-        Create many schemas referencing the same base schema to trigger
-        oversized allocation warnings.
-        """
-
-        topic = create_topic_names(1)[0]
-        base_subject = f"{topic}-key"
-        base_version = 1
-        schema_dict = json.loads(schema1_def)
-
-        schema_data = json.dumps({"schema": json.dumps(schema_dict)})
-        result_raw = self.sr_client.post_subjects_subject_versions(
-            subject=base_subject, data=schema_data
-        )
-
-        assert result_raw.status_code == requests.codes.ok
-
-        for i in range(iterations):
-            # Change the doc field to make the schema unique
-            schema_dict["doc"] = str(i)
-            schema_data = json.dumps(
-                {
-                    "schema": json.dumps(schema_dict),
-                    "references": [
-                        {
-                            "name": "test-ref",
-                            "subject": base_subject,
-                            "version": base_version,
-                        }
-                    ],
-                }
-            )
-            result_raw = self.sr_client.post_subjects_subject_versions(
-                subject=base_subject, data=schema_data
-            )
-
-            assert result_raw.status_code == requests.codes.ok
-
-        result_raw = self.sr_client.get_subjects_subject_versions_version_referenced_by(
-            subject=base_subject, version=base_version
-        )
-        assert result_raw.status_code == requests.codes.ok
-        assert len(result_raw.json()) == iterations
 
     @cluster(num_nodes=3)
     def test_post_subjects_subject_versions_metadata_ruleset(self):
@@ -4070,7 +3967,7 @@ class SchemaRegistryModeMutableTest(SchemaRegistryEndpoints):
     Test schema registry mode against a redpanda cluster.
     """
 
-    def __init__(self, context, **kwargs):
+    def __init__(self, context: TestContext, **kwargs: Any):
         self.schema_registry_config = SchemaRegistryConfig()
         self.schema_registry_config.mode_mutability = True
         super(SchemaRegistryModeMutableTest, self).__init__(
@@ -4331,34 +4228,6 @@ class SchemaRegistryModeMutableTest(SchemaRegistryEndpoints):
 
         result_raw = self.sr_client.get_schemas_ids_id_versions(id=1)
         assert result_raw.status_code == 200
-
-    @cluster(num_nodes=1)
-    @parametrize(
-        iterations=4097
-    )  # oversized alloc for store::get_subject_mode_written_at.
-    def test_set_subject_mode_repeated(self, iterations: int):
-        """
-        Verify repeatedly setting subject mode and then deleting it to trigger
-        oversized allocation warnings.
-        """
-
-        topic = create_topic_names(1)[0]
-        subject = f"{topic}-key"
-
-        modes = ["READWRITE", "READONLY"]
-
-        for i in range(iterations):
-            mode = modes[i % len(modes)]
-            result_raw = self.sr_client.set_mode_subject(
-                subject=subject,
-                data=json.dumps({"mode": mode}),
-            )
-            assert result_raw.status_code == requests.codes.ok
-            assert result_raw.json()["mode"] == mode
-
-        result_raw = self.sr_client.delete_mode_subject(subject=subject)
-        assert result_raw.status_code == requests.codes.ok
-        assert result_raw.json()["mode"] == mode
 
 
 class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -4257,7 +4257,6 @@ class SchemaRegistryModeMutableTest(SchemaRegistryEndpoints):
         assert result_raw.status_code == 200
 
     @cluster(num_nodes=1)
-    @ignore(iterations=4097)
     @parametrize(
         iterations=4097
     )  # oversized alloc for store::get_subject_mode_written_at.

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -4256,6 +4256,35 @@ class SchemaRegistryModeMutableTest(SchemaRegistryEndpoints):
         result_raw = self.sr_client.get_schemas_ids_id_versions(id=1)
         assert result_raw.status_code == 200
 
+    @cluster(num_nodes=1)
+    @ignore(iterations=4097)
+    @parametrize(
+        iterations=4097
+    )  # oversized alloc for store::get_subject_mode_written_at.
+    def test_set_subject_mode_repeated(self, iterations: int):
+        """
+        Verify repeatedly setting subject mode and then deleting it to trigger
+        oversized allocation warnings.
+        """
+
+        topic = create_topic_names(1)[0]
+        subject = f"{topic}-key"
+
+        modes = ["READWRITE", "READONLY"]
+
+        for i in range(iterations):
+            mode = modes[i % len(modes)]
+            result_raw = self.sr_client.set_mode_subject(
+                subject=subject,
+                data=json.dumps({"mode": mode}),
+            )
+            assert result_raw.status_code == requests.codes.ok
+            assert result_raw.json()["mode"] == mode
+
+        result_raw = self.sr_client.delete_mode_subject(subject=subject)
+        assert result_raw.status_code == requests.codes.ok
+        assert result_raw.json()["mode"] == mode
+
 
 class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
     """


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28073 

Two additional adjustments needed for conflicts:
- [Switch extra std::vector to chunked_vector](https://github.com/nguyen-andrew/redpanda/commit/c9a7e8f73875d154cdab6e828cf8a9aa7420de0c)
- [Use chunked_vector defined in fragmented_vector](https://github.com/nguyen-andrew/redpanda/commit/aba4075232696609ce13927b905fdb7ee4807678)