### PR TITLE
Additional debug logging for admin_server shutdown

### DIFF
--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -551,8 +551,11 @@ ss::future<> admin_server::start() {
 
 ss::future<> admin_server::stop() {
     _blocked_reactor_notify_reset_timer.cancel();
+    vlog(adminlog.debug, "admin_server::stop() - timer cancelled");
     _memory_semaphore.broken();
+    vlog(adminlog.debug, "admin_server::stop() - memory semaphore broken");
     co_await _server.stop();
+    vlog(adminlog.debug, "admin_server::stop() - _server stopped");
     co_await _debug_bundle_file_handler.stop();
 }
 


### PR DESCRIPTION
I can't figure out why the admin_server is handing in shutdown in some tests. This will narrow down the subcomponent that's hanging.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
