### PR TITLE
Revert "[CORE-14557] `storage`: increment `_stats.fsyncs` in `segment_appender::flush()`"

### DIFF
--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -630,11 +630,11 @@ ss::future<> segment_appender::flush() {
         // dispatching background head write.
         auto f = w.p.get_future();
         dispatch_background_head_write();
-        co_return co_await std::move(f);
+        return f;
     }
 
     if (file_byte_offset() <= _flushed_offset) {
-        co_return;
+        return ss::now();
     }
 
     /*
@@ -643,7 +643,7 @@ ss::future<> segment_appender::flush() {
      */
     if (!_inflight.empty()) {
         auto& w = _flush_ops.emplace_back(file_byte_offset());
-        co_return co_await w.p.get_future();
+        return w.p.get_future();
     }
 
     vassert(
@@ -653,13 +653,9 @@ ss::future<> segment_appender::flush() {
       _stable_offset,
       *this);
 
-    try {
-        co_await _out.flush();
-    } catch (const std::exception& e) {
+    return _out.flush().handle_exception([this](std::exception_ptr e) {
         vunreachable("Could not flush: {} - {}", e, *this);
-    };
-
-    ++_stats.fsyncs;
+    });
 }
 
 ss::future<> segment_appender::hard_flush() {

--- a/src/v/storage/tests/segment_appender_test.cc
+++ b/src/v/storage/tests/segment_appender_test.cc
@@ -233,9 +233,9 @@ TEST_F(SegmentAppenderFixture, TestFlushesAreMerged) {
     }
     ops.emplace_back(flush_op(true));
     execute_operations(ops).get();
-    ASSERT_GE(appender->get_stats().fsyncs, 1);
     // TODO: fix possible redundant flushes in segment appender
-    // ASSERT_LE(appender->get_stats().fsyncs, 2);
+    ASSERT_GE(appender->get_stats().fsyncs, 1);
+    ASSERT_LE(appender->get_stats().fsyncs, 2);
     appender->close().get();
     ASSERT_TRUE(file_content_equal_to_reference().get());
 }


### PR DESCRIPTION
Reverts redpanda-data/redpanda#28413.

small regression in benchmarks (https://redpandadata.slack.com/archives/C06HM5UTWRW/p1762924818400859). revert this for now and i’ll come back and make the appropriate changes later with continuations. 

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
