### PR TITLE
.gitignore: ignore claude local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -283,3 +283,6 @@ bazel_cc_flags.json
 
 # rpk CLAUDE.md
 /**/**/CLAUDE.md
+
+# claude local settings
+**/.claude/settings.local.json


### PR DESCRIPTION
These are created by claude vscode integration, and should not be source-controlled.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

 * none
