### PR TITLE
rptest: Enable fast uploads in datalake test

### DIFF
--- a/tests/rptest/tests/datalake/delayed_translation_test.py
+++ b/tests/rptest/tests/datalake/delayed_translation_test.py
@@ -55,6 +55,7 @@ class DatalakeDelayedTranslationTest(RedpandaTest):
                 cloud_storage_max_connections=5,
                 cloud_storage_enable_remote_read=True,
                 cloud_storage_enable_remote_write=True,
+                fast_uploads=True,
             ),
             extra_rp_conf={"iceberg_enabled": False},
             schema_registry_config=SchemaRegistryConfig(),
@@ -96,13 +97,14 @@ class DatalakeDelayedTranslationTest(RedpandaTest):
 
     def produce_until_result(self, *args, **kwargs):
         try:
+            count = 50000 if self.redpanda.dedicated_nodes else 10000
             self._connect.start_stream(
                 name="ducky_stream",
                 config=counter_stream_config(
                     self.redpanda,
                     self.TOPIC_NAME,
                     self.SCHEMA_NAME,
-                    {"weight": "range(0, 10000)"},
+                    {"weight": f"range(0, {count})"},
                     0,
                 ),
             )


### PR DESCRIPTION
The test expects uplads to happen in 10 minutes. The problem is that it create different number of partitions in docker and on a dedicated machine (100 vs 1000). With 1000 partitions the chance that one partition will receive not enough data to roll a segment is relatively high.

The fix is to force uploads and to increase the amount of data on a dedicated node.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none