### PR TITLE
dev_cluster: remove grafana/prom logging

### DIFF
--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -240,16 +240,9 @@ class Prometheus:
 
         self.process = await asyncio.create_subprocess_shell(
             cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
         )
-
-        while True:
-            line = await self.process.stdout.readline()
-            if not line:
-                break
-            line = line.decode("utf8").rstrip()
-            print(f"prometheus: {line}")
 
         await self.process.wait()
 
@@ -334,17 +327,10 @@ class Grafana:
         self.process = await asyncio.create_subprocess_shell(
             cmd,
             env=env,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
             cwd=grafana_home,
         )
-
-        while True:
-            line = await self.process.stdout.readline()
-            if not line:
-                break
-            line = line.decode("utf8").rstrip()
-            print(f"grafana: {line}")
 
         await self.process.wait()
 


### PR DESCRIPTION
This is just noise and not useful, if we really need it, it's in the log file.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
