### PR TITLE
dt: export cluster config even if there are bad loglines

### DIFF
--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -138,6 +138,8 @@ def cluster(
                 f"Test {status_str}, doing failure checks on {redpanda.who_am_i()}..."
             )
 
+            redpanda.export_cluster_config()
+
             if not test_failed and check_allowed_error_logs:
                 # Only do log inspections on tests that are otherwise
                 # successful.  This executes *before* the end-of-test
@@ -154,8 +156,6 @@ def cluster(
                     if isinstance(redpanda, RedpandaService):
                         redpanda.cloud_storage_diagnostics()
                     raise
-
-            redpanda.export_cluster_config()
 
             if isinstance(redpanda, RedpandaService):
                 if test_failed:

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -2019,6 +2019,8 @@ class AuditLogTestInvalidConfig(AuditLogTestInvalidConfigBase):
         log_allow_list=[
             r"Failed to append authentication event to audit log",
             r"Failed to audit.*",
+            # This comes from logging the cluster configuration at the post-ops of the test"
+            r"modify or view cluster configuration was not audited due to audit queues being full.*",
         ],
     )
     @matrix(audit_transport_mode=get_audit_modes())
@@ -2071,6 +2073,8 @@ class AuditLogTestInvalidConfigMTLS(AuditLogTestInvalidConfigBase):
             r"Failed to append authentication event to audit log",
             r"Failed to audit.*",
             r"Failed to enqueue mTLS authentication event - audit log system error",
+            # This comes from logging the cluster configuration at the post-ops of the test"
+            r"modify or view cluster configuration was not audited due to audit queues being full.*",
         ],
     )
     @matrix(audit_transport_mode=get_audit_modes())


### PR DESCRIPTION
Move export config before check for bad loglines.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
