### PR TITLE
Clamp RF from source clusters

### DIFF
--- a/src/v/cluster_link/deps.cc
+++ b/src/v/cluster_link/deps.cc
@@ -11,6 +11,7 @@
 
 #include "cluster_link/deps.h"
 
+#include "cluster/members_table.h"
 #include "cluster/security_frontend.h"
 #include "cluster_link/errc.h"
 #include "cluster_link/utils.h"
@@ -49,6 +50,20 @@ public:
 private:
     ss::sharded<kafka::data::rpc::client>* _client;
 };
+
+class members_table_provider_impl : public members_table_provider {
+public:
+    explicit members_table_provider_impl(
+      ss::sharded<cluster::members_table>* members_table)
+      : _members_table(members_table) {}
+
+    size_t node_count() const final {
+        return _members_table->local().node_count();
+    }
+
+private:
+    ss::sharded<cluster::members_table>* _members_table;
+};
 } // namespace
 
 std::unique_ptr<security_service> security_service::make_default(
@@ -66,5 +81,10 @@ std::unique_ptr<kafka_rpc_client_service>
 kafka_rpc_client_service::make_default(
   ss::sharded<kafka::data::rpc::client>* client) {
     return std::make_unique<kafka_rpc_client_impl>(client);
+}
+
+std::unique_ptr<members_table_provider> members_table_provider::make_default(
+  ss::sharded<cluster::members_table>* members_table) {
+    return std::make_unique<members_table_provider_impl>(members_table);
 }
 } // namespace cluster_link

--- a/src/v/cluster_link/deps.h
+++ b/src/v/cluster_link/deps.h
@@ -222,4 +222,19 @@ public:
       get_partition_offsets(chunked_vector<kafka::data::rpc::topic_partitions>)
       = 0;
 };
+
+class members_table_provider {
+public:
+    members_table_provider() = default;
+    members_table_provider(const members_table_provider&) = delete;
+    members_table_provider(members_table_provider&&) = delete;
+    members_table_provider& operator=(const members_table_provider&) = delete;
+    members_table_provider& operator=(members_table_provider&&) = delete;
+    virtual ~members_table_provider() = default;
+
+    virtual size_t node_count() const = 0;
+
+    static std::unique_ptr<members_table_provider>
+    make_default(ss::sharded<cluster::members_table>*);
+};
 } // namespace cluster_link

--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -423,6 +423,10 @@ link::get_partition_offsets_report() const {
     return _replication_mgr.get_partition_offsets_report();
 }
 
+members_table_provider& link::get_members_table_provider() noexcept {
+    return _manager->get_members_table_provider();
+}
+
 bool link::should_start_task(task* t) const {
     return t->should_start(ss::this_shard_id(), _self);
 }

--- a/src/v/cluster_link/link.h
+++ b/src/v/cluster_link/link.h
@@ -127,6 +127,8 @@ public:
     chunked_hash_map<::model::ntp, replication::partition_offsets_report>
     get_partition_offsets_report() const;
 
+    members_table_provider& get_members_table_provider() noexcept;
+
 private:
     bool should_start_task(task* t) const;
     bool should_stop_task(task* t) const;

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -220,13 +220,14 @@ ss::future<err_info> manager::broker_preflight_check(
                   versions->max,
                   min_version,
                   max_version);
-                unsupported_api_errors.push_back(fmt::format(
-                  "{}: supported [{}, {}], required [{}, {}]",
-                  api_key,
-                  versions->min,
-                  versions->max,
-                  min_version,
-                  max_version));
+                unsupported_api_errors.push_back(
+                  fmt::format(
+                    "{}: supported [{}, {}], required [{}, {}]",
+                    api_key,
+                    versions->min,
+                    versions->max,
+                    min_version,
+                    max_version));
             }
         }
         if (!unsupported_api_errors.empty()) {

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -92,6 +92,7 @@ manager::manager(
   std::unique_ptr<consumer_groups_router> group_router,
   std::unique_ptr<partition_metadata_provider> partition_metadata_provider,
   std::unique_ptr<kafka_rpc_client_service> kafka_rpc_client_service,
+  std::unique_ptr<members_table_provider> members_table_provider,
   ss::lowres_clock::duration task_reconciler_interval,
   config::binding<int16_t> default_topic_replication,
   ss::scheduling_group scheduling_group)
@@ -107,6 +108,7 @@ manager::manager(
   , _group_router(std::move(group_router))
   , _partition_metadata_provider(std::move(partition_metadata_provider))
   , _kafka_rpc_client_service(std::move(kafka_rpc_client_service))
+  , _members_table_provider(std::move(members_table_provider))
   , _queue(
       scheduling_group,
       [](const std::exception_ptr& ex) {

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -220,14 +220,13 @@ ss::future<err_info> manager::broker_preflight_check(
                   versions->max,
                   min_version,
                   max_version);
-                unsupported_api_errors.push_back(
-                  fmt::format(
-                    "{}: supported [{}, {}], required [{}, {}]",
-                    api_key,
-                    versions->min,
-                    versions->max,
-                    min_version,
-                    max_version));
+                unsupported_api_errors.push_back(fmt::format(
+                  "{}: supported [{}, {}], required [{}, {}]",
+                  api_key,
+                  versions->min,
+                  versions->max,
+                  min_version,
+                  max_version));
             }
         }
         if (!unsupported_api_errors.empty()) {
@@ -841,6 +840,10 @@ manager::get_partition_offsets_report_for_link(model::id_t link_id) const {
           ssx::sformat("Link with id '{}' not found", link_id));
     }
     return link_it->second->get_partition_offsets_report();
+}
+
+members_table_provider& manager::get_members_table_provider() noexcept {
+    return *_members_table_provider;
 }
 
 ss::future<> manager::link_task_reconciler() {

--- a/src/v/cluster_link/manager.h
+++ b/src/v/cluster_link/manager.h
@@ -212,6 +212,8 @@ public:
       chunked_hash_map<::model::ntp, replication::partition_offsets_report>>
     get_partition_offsets_report_for_link(model::id_t link_id) const;
 
+    members_table_provider& get_members_table_provider() noexcept;
+
 private:
     /// Called periodically to reconcile registered tasks on created links
     ss::future<> link_task_reconciler();

--- a/src/v/cluster_link/manager.h
+++ b/src/v/cluster_link/manager.h
@@ -55,6 +55,7 @@ public:
       std::unique_ptr<consumer_groups_router> group_router,
       std::unique_ptr<partition_metadata_provider> partition_metadata_provider,
       std::unique_ptr<kafka_rpc_client_service> kafka_rpc_client_service,
+      std::unique_ptr<members_table_provider> members_table_provider,
       ss::lowres_clock::duration task_reconciler_interval,
       config::binding<int16_t> default_topic_replication,
       ss::scheduling_group scheduling_group);
@@ -237,6 +238,7 @@ private:
     std::unique_ptr<consumer_groups_router> _group_router;
     std::unique_ptr<partition_metadata_provider> _partition_metadata_provider;
     std::unique_ptr<kafka_rpc_client_service> _kafka_rpc_client_service;
+    std::unique_ptr<members_table_provider> _members_table_provider;
     ssx::work_queue _queue;
 
     chunked_vector<std::unique_ptr<task_factory>> _task_factories;

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -19,6 +19,7 @@
 #include "cluster/members_table.h"
 #include "cluster/metadata_cache.h"
 #include "cluster/partition_manager.h"
+#include "cluster_link/deps.h"
 #include "cluster_link/group_mirroring_task.h"
 #include "cluster_link/link.h"
 #include "cluster_link/link_probe.h"
@@ -1206,6 +1207,7 @@ ss::future<> service::maybe_start_manager() {
       std::make_unique<health_monitor_based_partition_metadata_provider>(
         _hm_frontend),
       kafka_rpc_client_service::make_default(_kafka_data_rpc_client),
+      members_table_provider::make_default(&_controller->get_members_table()),
       30s, // Temporary until we have a proper configuration for this
       config::shard_local_cfg().default_topic_replication.bind(),
       _scheduling_group);

--- a/src/v/cluster_link/source_topic_syncer.cc
+++ b/src/v/cluster_link/source_topic_syncer.cc
@@ -649,7 +649,9 @@ source_topic_syncer::find_candidate_topics_for_update(
             topic_metadata{
               .partition_count = partition_count,
               // Only mirror source topic replication factor if configured to do
-              .rf = mirror_rf ? std::make_optional(rf) : std::nullopt,
+              .rf = mirror_rf
+                      ? std::make_optional<int16_t>(maybe_clamp_rf(rf, topic))
+                      : std::nullopt,
               .topic_id = topic_id},
             std::move(mirror_metadata)));
     }
@@ -759,7 +761,9 @@ source_topic_syncer::find_candidate_topics_for_creation(
             .partition_count = partition_count,
             // Only mirror source topic replication factor if configured to do
             // so
-            .rf = mirror_rf ? std::make_optional(rf) : std::nullopt,
+            .rf = mirror_rf
+                    ? std::make_optional<int16_t>(maybe_clamp_rf(rf, topic))
+                    : std::nullopt,
             .topic_id = topic_id});
     }
 
@@ -842,6 +846,22 @@ source_topic_syncer::check_if_schema_registry_is_empty() {
     co_return pit->second.offsets.high_watermark == kafka::offset(0)
       ? sr_is_empty_t::yes
       : sr_is_empty_t::no;
+}
+
+int16_t source_topic_syncer::maybe_clamp_rf(
+  int16_t source_rf, const ::model::topic& topic) noexcept {
+    auto node_count = get_link()->get_members_table_provider().node_count();
+    if (std::cmp_less(node_count, source_rf)) {
+        vlog(
+          logger().info,
+          "Topic {} has a replication factor greater than current node "
+          "count ({} > {}).  Clamping replication factor",
+          topic,
+          source_rf,
+          node_count);
+        return static_cast<int16_t>(node_count);
+    }
+    return source_rf;
 }
 
 std::string_view

--- a/src/v/cluster_link/source_topic_syncer.h
+++ b/src/v/cluster_link/source_topic_syncer.h
@@ -93,6 +93,8 @@ private:
       const chunked_vector<::model::topic>& topics,
       const model::topic_metadata_mirroring_config::properties_set& configs);
     ss::future<sr_is_empty_t> check_if_schema_registry_is_empty();
+    int16_t
+    maybe_clamp_rf(int16_t source_rf, const ::model::topic& topic) noexcept;
 
 private:
     model::topic_metadata_mirroring_config _config;

--- a/src/v/cluster_link/tests/deps.cc
+++ b/src/v/cluster_link/tests/deps.cc
@@ -95,6 +95,11 @@ ss::future<> cluster_link_manager_test_fixture::wire_up_and_start(
           _tkrcs = rpc.get();
           return rpc;
       }),
+      ss::sharded_parameter([this]() {
+          auto fmtp = std::make_unique<fake_members_table_provider>();
+          _fmtp = fmtp.get();
+          return fmtp;
+      }),
       1s,
       _default_topic_replication.bind(),
       ss::default_scheduling_group());

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -699,6 +699,8 @@ public:
         return *_ftpc;
     }
 
+    fake_members_table_provider& members_table_provider() { return *_fmtp; }
+
 private:
     void setup_cluster_mock();
 

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -594,6 +594,15 @@ private:
     container_type _acls;
 };
 
+class fake_members_table_provider : public members_table_provider {
+public:
+    void set_node_count(size_t count) { _node_count = count; }
+    size_t node_count() const final { return _node_count; }
+
+private:
+    size_t _node_count{3};
+};
+
 class cluster_link_manager_test_fixture {
 public:
     explicit cluster_link_manager_test_fixture(::model::node_id self);
@@ -709,6 +718,7 @@ private:
     test_consumer_group_router* _consumer_group_router{nullptr};
     test_partition_metadata_provider* _partition_metadata_provider{nullptr};
     test_kafka_rpc_client_service* _tkrcs{nullptr};
+    fake_members_table_provider* _fmtp{nullptr};
     ss::sharded<manager> _manager;
     config::mock_property<int16_t> _default_topic_replication{1};
 

--- a/src/v/cluster_link/tests/link_test.cc
+++ b/src/v/cluster_link/tests/link_test.cc
@@ -193,6 +193,7 @@ public:
           std::make_unique<test_consumer_group_router>(),
           std::make_unique<test_partition_metadata_provider>(),
           std::make_unique<test_kafka_rpc_client_service>(_tmc),
+          std::make_unique<fake_members_table_provider>(),
           task_reconciler_interval,
           _default_topic_replication.bind(),
           ss::default_scheduling_group());
@@ -438,6 +439,7 @@ public:
           std::make_unique<test_consumer_group_router>(),
           std::make_unique<test_partition_metadata_provider>(),
           std::make_unique<test_kafka_rpc_client_service>(_tmc),
+          std::make_unique<fake_members_table_provider>(),
           task_reconciler_interval,
           _default_topic_replication.bind(),
           ss::default_scheduling_group());

--- a/src/v/cluster_link/tests/source_topic_syncer_test.cc
+++ b/src/v/cluster_link/tests/source_topic_syncer_test.cc
@@ -485,6 +485,43 @@ TEST_F_CORO(source_topic_syncer_test, topic_with_no_replicas) {
     EXPECT_TRUE(mirror_topics.empty());
 }
 
+TEST_F_CORO(source_topic_syncer_test, topic_with_high_rf) {
+    fixture()->members_table_provider().set_node_count(1);
+    fixture()->get_cluster_mock().add_topic(
+      ::model::topic("test_topic"),
+      3,
+      3,
+      kafka::topic_authorized_operations(0x508));
+
+    co_await fixture()->upsert_link(get_default_metadata());
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this] {
+        auto link_metadata = fixture()->find_link_by_name(
+          model::name_t("test_link"));
+        return link_metadata->get().state.mirror_topics.contains(
+          ::model::topic("test_topic"));
+    });
+
+    auto link_metadata = fixture()->find_link_by_name(
+      model::name_t("test_link"));
+    auto& mirror_topics = link_metadata->get().state.mirror_topics;
+    auto mirror_topic_it = mirror_topics.find(::model::topic("test_topic"));
+    ASSERT_NE_CORO(mirror_topic_it, mirror_topics.end());
+    EXPECT_EQ(mirror_topic_it->second.replication_factor, 1);
+
+    fixture()->members_table_provider().set_node_count(3);
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this] {
+        auto link_metadata = fixture()->find_link_by_name(
+          model::name_t("test_link"));
+        auto& mirror_topics = link_metadata->get().state.mirror_topics;
+        auto mirror_topic_it = mirror_topics.find(::model::topic("test_topic"));
+        if (mirror_topic_it == mirror_topics.end()) {
+            return false;
+        }
+        return mirror_topic_it->second.replication_factor == 3;
+    });
+}
+
 class invalid_describe_configs_test : public source_topic_syncer_test {
 public:
     virtual ss::future<> SetUpAsync() override {


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

If the source cluster happens to have more brokers than the shadow cluster, then it is possible that source topics may have an RF greater than the Shadow Cluster's broker count.  This PR will clamp the incoming RF (if RF mirroring is enabled) to the broker count.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
