### PR TITLE
DR: Warn on Shadow Link creation if connecting to larger cluster

### DIFF
--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -302,6 +302,15 @@ ss::future<err_info> manager::link_preflight_checks(const model::metadata& md) {
         const auto& brokers = cluster->get_brokers();
         auto reported_brokers = brokers.get_broker_ids();
         auto num_reported_brokers = reported_brokers.size();
+        if (num_reported_brokers > _members_table_provider->node_count()) {
+            vlog(
+              cllog.warn,
+              "Cluster link '{}' connecting to source cluster with {} brokers, "
+              "which is more than the shadow cluster's {} nodes",
+              md.name,
+              num_reported_brokers,
+              _members_table_provider->node_count());
+        }
         chunked_vector<ss::sstring> broker_errors;
         broker_errors.reserve(brokers.size());
         co_await ss::max_concurrent_for_each(

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -1547,6 +1547,25 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
         )
 
 
+class ShadowLinkSmallerShadowCluster(ShadowLinkTestBase):
+    """
+    Tests for when the Shadow Cluster is smaller than the source cluster
+    """
+
+    def __init__(self, test_context, *args, **kwargs):
+        super().__init__(test_context, num_brokers=1, *args, **kwargs)
+
+    def _expect_connect_error(self, expected_code: ConnectErrorCode):
+        return expect_exception(ConnectError, lambda e: e.code == expected_code)
+
+    @cluster(num_nodes=4)
+    def test_warn_on_smaller_cluster(self):
+        self.create_link("test-link")
+        assert self.target_cluster_service.search_log_any(
+            "Cluster link 'test-link' connecting to source cluster with 3 brokers, which is more than the shadow cluster's 1 nodes"
+        ), "Did not find expected warning about smaller shadow cluster"
+
+
 class ShadowLinkingAuthzTests(ShadowLinkTestBase):
     SUPERUSER_ERROR = "[permission_denied] Forbidden (superuser role required)"
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Per the title, warns on link creation if shadow link is connecting to a larger source cluster and the filters include all topics to be shadowed.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
