### PR TITLE
tests: More MTT fixes

### DIFF
--- a/tests/rptest/scale_tests/many_topics_test.py
+++ b/tests/rptest/scale_tests/many_topics_test.py
@@ -1089,6 +1089,8 @@ class ManyTopicsTest(RedpandaTest):
         else:
             self.redpanda.start()
 
+        # run forever, stop explicitly in the test
+        profile_overrides |= {"message_count": 1000 * 60}
         profile = self._set_profile("topic_profile_t40k_p1", profile_overrides)
 
         ##
@@ -1138,17 +1140,13 @@ class ManyTopicsTest(RedpandaTest):
         # Validate results
         #
 
-        # Calculate how much time ideally needed for the producers to finish
-        # and account for delays from the various lifecycle tests.
-        running_time_sec = int(test_slowdown_factor * profile.total_running_time())
-
         # Run checks if swarm nodes finished
-        self.logger.info("Make sure that swarm node producers are finished")
+        self.logger.info("Stop client-swarm producers")
         for s in swarm_producers:
-            s.wait(running_time_sec)
-        self.logger.info("Make sure that swarm node consumers are finished")
+            s.stop()
+        self.logger.info("Stop client-swarm consumers")
         for s in swarm_consumers:
-            s.wait(running_time_sec)
+            s.stop()
 
         # Clean
         self._swarm_producers = []
@@ -1168,9 +1166,6 @@ class ManyTopicsTest(RedpandaTest):
             # It takes ~4mins to safely restart a node, hence, we limit the total
             # number of nodes to restart to avoid a ~40min test.
             lambda: self._rolling_restarts(max_nodes=3),
-            profile_overrides={
-                "message_count": 10 * 60,  # 10 mins
-            },
         )
 
     @cluster(num_nodes=16, log_allow_list=RESTART_LOG_ALLOW_LIST)

--- a/tests/rptest/scale_tests/many_topics_test.py
+++ b/tests/rptest/scale_tests/many_topics_test.py
@@ -98,7 +98,8 @@ class ManyTopicsTest(RedpandaTest):
             # Increase partition allocation percent to ensure that we can fit 40k
             # topics on a `m6id.xlarge` cluster.
             "topic_partitions_memory_allocation_percent": self.PARTITIONS_MEMORY_ALLOCATION_PERCENT,
-            "log_segment_size": 16777216,
+            "log_segment_size": 8000000,
+            "log_segment_size_min": 8000000,
         }
 
         # Reduce per-partition log spam

--- a/tests/rptest/scale_tests/topic_scale_profiles.py
+++ b/tests/rptest/scale_tests/topic_scale_profiles.py
@@ -33,68 +33,6 @@ class TopicScaleTestProfile:
 
 
 class ProfileDefinitions:
-    # Minimal load
-    # 2 vcpus, 1 msg/sec, min batch sizing
-    default = {
-        "topic_count": 6000,
-        "batch_size": 512,
-        "topic_name_length": 128,
-        "num_partitions": 1,
-        "num_replicas": 3,
-        "use_kafka_batching": True,
-        "profile_name": "topic-scale-default",
-        "message_count": 100,
-        "message_period": "1s",
-        "topics_per_client": 1,
-    }
-    topic_profile_t10k_p1 = {
-        "topic_count": 10000,
-        "batch_size": 2048,
-        "topic_name_length": 200,
-        "num_partitions": 1,
-        "num_replicas": 3,
-        "use_kafka_batching": True,
-        "profile_name": "topic-scale-t10k_p1",
-        "message_count": 1000,
-        "message_period": "1s",
-        "topics_per_client": 1,
-    }
-    topic_profile_t20k_p1 = {
-        "topic_count": 19_998,
-        "batch_size": 2048,
-        "topic_name_length": 200,
-        "num_partitions": 1,
-        "num_replicas": 3,
-        "use_kafka_batching": True,
-        "profile_name": "topic-scale-t20k_p1",
-        "message_period": "6s",
-        "message_count": 2 * (60 // 6),  # 2 mins
-        "topics_per_client": 1,
-    }
-    topic_profile_t10k_p4 = {
-        "topic_count": 10000,
-        "batch_size": 2048,
-        "topic_name_length": 200,
-        "num_partitions": 4,
-        "num_replicas": 3,
-        "use_kafka_batching": True,
-        "profile_name": "topic-scale-t10k-p4",
-        "message_count": 1000,
-        "message_period": "1s",
-        "topics_per_client": 1,
-    }
-    topic_profile_t1_p40k = {
-        "topic_count": 1,
-        "batch_size": 2048,
-        "topic_name_length": 200,
-        "num_partitions": 40000,
-        "num_replicas": 3,
-        "use_kafka_batching": True,
-        "profile_name": "topic-scale-t1-p40k",
-        "message_count": 1000,
-        "message_period": "1s",
-        "topics_per_client": 1,
-    }
     topic_profile_t40k_p1 = {
         "topic_count": 39_996,
         "batch_size": 4096,


### PR DESCRIPTION
First night of MTT runs exposed some more instabilities. Try to address these.

The MTT life cycle tests are structured in this way where there is the
generic outer layer that creates the topics and runs the client-swarm
for a given amount of time.

The inner layer is then test specific which implements the test
scenarios like restarting etc.

Previously we would have configured the client-swarms to run for 6
minutes. However, there was no contract or coordination between the
inner test function and the outer layer. Such it could be that the
client-swarms would have stopped already part ways through the actual
inner test.

This is bad because it meant that tests which check the client
throughput would fail as the swarms are gone and also it would remove
the client load during the test.

To fix this just run the client-swarm forever and stop it explicitly
after the inner test is done. This matches what we do in other tests
more closely.

This also avoids client-swarm issues like stuck sub-clients.

Fixes CORE-13029
Fixes CORE-12946

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
