### PR TITLE
[CORE-13407] CI failure (Inconsistent group states) in ShadowLinkConsumeGroupsMirroringTest.test_continuous_group_sync

### DIFF
--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -2394,9 +2394,9 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
                     topic=topic,
                     group=group_id,
                     n=1,
-                    timeout=5,
+                    timeout=10,
                     offset="start",
-                    fetch_max_wait=2,
+                    fetch_max_wait=5,
                     format=format,
                 )
             except Exception as e:

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -433,6 +433,7 @@ class ShadowLinkTestBase(PreallocNodesTest):
         kwargs.setdefault("extra_rp_conf", {}).update(
             {
                 "enable_shadow_linking": True,
+                "group_initial_rebalance_delay": 1000,
             }
         )
         kwargs.setdefault(


### PR DESCRIPTION
Consumers are generally created at the same time, no need to wait 3s for them all to join the group.

Set `group_initial_rebalance_delay` to 1s instead of default.

Give the consumers a little more time to balance and fetch.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

