### PR TITLE
cloud_storage: fix request signing with special chars

### DIFF
--- a/src/v/cloud_roles/signature.cc
+++ b/src/v/cloud_roles/signature.cc
@@ -230,10 +230,14 @@ static ss::sstring get_canonical_query_string(
         if (cnt++ > 0) {
             result.append("&", 1);
         }
+
+        // Decode the params first so that we don't double encode them.
+        ss::sstring decoded_value = http::uri_decode(pvalue);
+
         result += ssx::sformat(
           "{}={}",
           http::uri_encode(pname, http::uri_encode_slash::yes),
-          http::uri_encode(pvalue, http::uri_encode_slash::yes));
+          http::uri_encode(decoded_value, http::uri_encode_slash::yes));
     }
     return result;
 }

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -213,19 +213,37 @@ request_creator::make_list_objects_v2_request(
     auto host = make_host(name);
     auto key = fmt::format("?list-type=2");
     if (prefix.has_value()) {
-        key = fmt::format("{}&prefix={}", key, (*prefix)().string());
+        key = fmt::format(
+          "{}&prefix={}",
+          key,
+
+          http::uri_encode((*prefix)().string(), http::uri_encode_slash::yes));
     }
     if (start_after.has_value()) {
-        key = fmt::format("{}&start-after={}", key, *start_after);
+        key = fmt::format(
+          "{}&start-after={}",
+          key,
+
+          http::uri_encode(
+            (*start_after)().string(), http::uri_encode_slash::yes));
     }
     if (max_keys.has_value()) {
         key = fmt::format("{}&max-keys={}", key, *max_keys);
     }
     if (continuation_token.has_value()) {
-        key = fmt::format("{}&continuation-token={}", key, *continuation_token);
+        key = fmt::format(
+          "{}&continuation-token={}",
+          key,
+          http::uri_encode(
+            std::string_view(*continuation_token),
+            http::uri_encode_slash::yes));
     }
     if (delimiter.has_value()) {
-        key = fmt::format("{}&delimiter={}", key, *delimiter);
+        key = fmt::format(
+          "{}&delimiter={}",
+          key,
+          http::uri_encode(
+            std::string_view{&*delimiter, 1}, http::uri_encode_slash::yes));
     }
     auto target = make_target(name, object_key{key});
     header.method(boost::beast::http::verb::get);

--- a/src/v/http/utils.cc
+++ b/src/v/http/utils.cc
@@ -12,6 +12,7 @@
 #include "http/utils.h"
 
 #include <boost/algorithm/string/join.hpp>
+
 namespace {
 /**
  * Each URI encoded byte is formed by a '%' and the two-digit hexadecimal
@@ -46,6 +47,36 @@ ss::sstring uri_encode(std::string_view input, uri_encode_slash encode_slash) {
             }
         } else {
             append_hex_utf8(result, ch);
+        }
+    }
+    return result;
+}
+
+ss::sstring uri_decode(std::string_view input) {
+    ss::sstring result;
+    // Reset errno before starting decoding
+    errno = 0;
+    for (size_t i = 0; i < input.size(); ++i) {
+        char ch = input[i];
+        bool is_hex_code = ch == '%' && i + 2 < input.size()
+                           && std::isxdigit(input[i + 1]);
+        if (is_hex_code) {
+            std::array<char, 3> hex_str = {input[i + 1], input[i + 2], '\0'};
+            char decoded_char = static_cast<char>(
+              std::strtol(hex_str.data(), nullptr, 16));
+            if (errno == ERANGE) {
+                // Should never happen as we already checked the input is
+                // valid hex digits, but just in case.
+                // Not a vassert since it's hard to cover all edge cases in
+                // tests.
+                throw std::invalid_argument(
+                  "Invalid percent-encoding input passed to "
+                  "uri_decode");
+            }
+            result.append(&decoded_char, 1);
+            i += 2; // Skip the next two hex characters
+        } else {
+            result.append(&ch, 1);
         }
     }
     return result;

--- a/src/v/http/utils.h
+++ b/src/v/http/utils.h
@@ -23,6 +23,8 @@ namespace http {
 using uri_encode_slash = ss::bool_class<struct uri_encode_slash_t>;
 ss::sstring uri_encode(std::string_view input, uri_encode_slash encode_slash);
 
+ss::sstring uri_decode(std::string_view input);
+
 iobuf form_encode_data(
   const absl::flat_hash_map<ss::sstring, ss::sstring>& data);
 


### PR DESCRIPTION
cloud_storage: fix request signing with special chars

We found an issue where continuation token contains chars which look
like url encoded, e.g. plus sign (+). If we send it as-is in the query
param but then we url-encode it in the signature the server responds
with invalid signature error. That's because it (aws server)
unconditionally decodes the query parameters first.

Even if we fixed the request signature it is like that listing won't
work as the `+` sign must be sent as `+` and not let the server decode
it as a space instead!

So we need to encode query params. This PR does that. But now, during
request signature, to avoid double-encoding we have to decode query
params first.

We control query param names so we avoid encode/decode dance there.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
