### PR TITLE
many_topics_test: unsafe decom flakey fix

### DIFF
--- a/tests/rptest/scale_tests/many_topics_test.py
+++ b/tests/rptest/scale_tests/many_topics_test.py
@@ -590,7 +590,7 @@ class ManyTopicsTest(RedpandaTest):
         self.logger.debug(f"Adding node {node_to_decom.name} to the cluster")
         self.redpanda.clean_node(node_to_decom)
         self.redpanda.start_node(
-            node_to_decom, first_start=True, auto_assign_node_id=True
+            node_to_decom, auto_assign_node_id=True, omit_seeds_on_idx_one=False
         )
         self.node_ops_exec.decommission(
             self.redpanda.idx(node_to_decom), node_id=node_id


### PR DESCRIPTION
Occasionally we are doubly unlucky.

First, test_decommission_node_unsafely will choose the 0th index seed node as the node to restart.

Second, this node on restart will finish booting before it gets an append entries from any other node in the cluster.

When both of these happen, the node declares itself the seed broker of a new cluster and attempts to lead the remainder of the healthy nodes.

Resolution here is to provide the other brokers as seed nodes on restart so the restarting node reaches out with a join node request.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x
- [x] v24.3.x

## Release Notes
### Bug Fixes

* deflake ManyTopicsTest.test_decommission_node_unsafely

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
