### PR TITLE
[v25.3.x] [CORE-13407] CI failure (Inconsistent group states) in ShadowLinkConsumeGroupsMirroringTest.test_continuous_group_sync

### DIFF
--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -2394,9 +2394,9 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
                     topic=topic,
                     group=group_id,
                     n=1,
-                    timeout=5,
+                    timeout=10,
                     offset="start",
-                    fetch_max_wait=2,
+                    fetch_max_wait=5,
                     format=format,
                 )
             except Exception as e:

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -433,6 +433,7 @@ class ShadowLinkTestBase(PreallocNodesTest):
         kwargs.setdefault("extra_rp_conf", {}).update(
             {
                 "enable_shadow_linking": True,
+                "group_initial_rebalance_delay": 1000,
             }
         )
         kwargs.setdefault(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28515
