### PR TITLE
`misc`: deal with flakey DEATH tests

### DIFF
--- a/src/v/compression/tests/BUILD
+++ b/src/v/compression/tests/BUILD
@@ -9,6 +9,8 @@ redpanda_cc_gtest(
     # the death test doesn't seem to properly record or parse the expected
     # output when there are multiple reactor threads.
     cpu = 1,
+    # CORE-14523
+    flaky = True,
     deps = [
         "//src/v/base",
         "//src/v/compression",

--- a/src/v/storage/mvlog/tests/BUILD
+++ b/src/v/storage/mvlog/tests/BUILD
@@ -98,6 +98,8 @@ redpanda_cc_gtest(
     srcs = [
         "file_test.cc",
     ],
+    # CORE-14523
+    flaky = True,
     deps = [
         "//src/v/container:chunked_vector",
         "//src/v/storage/mvlog",

--- a/src/v/test_utils/tests/BUILD
+++ b/src/v/test_utils/tests/BUILD
@@ -32,6 +32,8 @@ redpanda_cc_gtest(
     srcs = [
         "test_utils_test.cc",
     ],
+    # CORE-14523
+    flaky = True,
     deps = [
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",

--- a/src/v/test_utils/tests/test_utils_test.cc
+++ b/src/v/test_utils/tests/test_utils_test.cc
@@ -20,7 +20,7 @@
 
 #include <gtest/gtest.h>
 
-TEST(test_utils_test, test_macros_pass) {
+TEST(TestUtilsTest, test_macros_pass) {
     RPTEST_REQUIRE(true);
     RPTEST_REQUIRE_EQ(1, 1);
     RPTEST_REQUIRE_NE(1, 2);
@@ -29,7 +29,7 @@ TEST(test_utils_test, test_macros_pass) {
     RPTEST_EXPECT_EQ(1, 1);
 }
 
-TEST(test_utils_test, test_macros_fail) {
+TEST(TestUtilsDeathTest, test_macros_fail) {
     ASSERT_DEATH(RPTEST_FAIL("fail message"), "fail message");
     ASSERT_DEATH(RPTEST_ADD_FAIL("fail message"), "fail message");
     ASSERT_DEATH(RPTEST_FAIL_CORO("fail message"), "fail message");


### PR DESCRIPTION
Tests which use `ASSERT_DEATH` seem quite flakey with our CI infra. Mark them as potentially flakey until a more permanent fix is found.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none
