### PR TITLE
storage: throw if timequerying a closed log

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2038,7 +2038,7 @@ ss::future<> disk_log_impl::new_segment(model::offset o, model::term_id t) {
       .then([this](ss::lw_shared_ptr<segment> handles) mutable {
           return remove_empty_segments().then(
             [this, h = std::move(handles)]() mutable {
-                vassert(!_closed, "cannot add log segment to closed log");
+                throw_if_closed();
                 if (config().is_locally_compacted()) {
                     h->mark_as_compacted_segment();
                 }
@@ -2065,7 +2065,7 @@ model::offset get_next_append_offset(const offset_stats& offsets) {
 
 // config timeout is for the one calling reader consumer
 log_appender disk_log_impl::make_appender(log_append_config cfg) {
-    vassert(!_closed, "make_appender on closed log - {}", *this);
+    throw_if_closed();
     auto now = log_clock::now();
     auto ofs = offsets();
     model::offset next_offset = get_next_append_offset(ofs);
@@ -2081,7 +2081,7 @@ log_appender disk_log_impl::make_appender(log_append_config cfg) {
 }
 
 ss::future<> disk_log_impl::flush() {
-    vassert(!_closed, "flush on closed log - {}", *this);
+    throw_if_closed();
     if (_segs.empty()) {
         return ss::make_ready_future<>();
     }
@@ -3346,7 +3346,7 @@ disk_log_impl::remove_prefix_full_segments(truncate_prefix_config cfg) {
 }
 
 ss::future<> disk_log_impl::truncate_prefix(truncate_prefix_config cfg) {
-    vassert(!_closed, "truncate_prefix() on closed log - {}", *this);
+    throw_if_closed();
     co_await _failure_probes.truncate_prefix().then([this, cfg]() mutable {
         // dispatch the actual truncation
         return do_truncate_prefix(cfg)
@@ -3434,7 +3434,7 @@ ss::future<> disk_log_impl::do_truncate_prefix(truncate_prefix_config cfg) {
 }
 
 ss::future<> disk_log_impl::truncate(truncate_config cfg) {
-    vassert(!_closed, "truncate() on closed log - {}", *this);
+    throw_if_closed();
     // We are truncating the offset translator before truncating the log
     // because if saving offset translator state fails (e.g. because of a
     // crash), we can retry and eventually log and offset translator will

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -3214,7 +3214,7 @@ disk_log_impl::index_batch_base_offset_lower_bound(model::offset o) const {
 
 ss::future<std::optional<timequery_result>>
 disk_log_impl::timequery(timequery_config cfg) {
-    vassert(!_closed, "timequery on closed log - {}", *this);
+    throw_if_closed();
     if (_segs.empty()) {
         co_return std::nullopt;
     }


### PR DESCRIPTION
This is follow-up to
https://github.com/redpanda-data/redpanda/pull/28328.

The previous PR added throws to timequery reader calls, but omitted the check for timequery() itself.

```
ERROR 2025-11-03 16:39:15,936 [shard 0:tran] assert - Assert failure: (src/v/storage/disk_log_impl.cc:3216) '!_closed' timequery on closed log - {offsets: {start_offset:0, committed_offset:0, committed_offset_term:1, dirty_offset:0, dirty_offset_term:1}, is_closed: true, segments: [{size: 1, [{offset_tracker:{term:1, base_offset:0, committed_offset:0, stable_offset:0, dirty_offset:0}, compacted_segment=0, finished_self_compaction=0, finished_windowed_compaction=0, generation=3, reader={/var/lib/redpanda/data/kafka/topic-fadnsotldv/6_28/0-1-v1.log, (155 bytes)}, writer={closed:true, fallocation_offset:155, stable_offset:155, flushed_offset:155, committed_offset:155, inflight: 0, bytes_flush_pending:0, stats: { merged_writes: 0, bytes_requested : 155, bytes_written : 4096, appends : 2, flushes: 2, fsyncs: 3, truncates: 1, fallocations: 1, last_page_hydrations: 0}}, cache={cache_size=0, dirty tracker: {min: -9223372036854775808, max: -9223372036854775808}}, compaction_index:nullopt, closed=1, tombstone=0, index={file:/var/lib/redpanda/data/kafka/topic-fadnsotldv/6_28/0-1-v1.base_index, offsets:0, index:{header_bitflags:0, base_offset:0, max_offset:0, base_timestamp:{timestamp: 1762187916005}, max_timestamp:{timestamp: 1762187916005}, batch_timestamps_are_monotonic:1, with_offset:true, non_data_timestamps:1, broker_timestamp:{nullopt}, num_compactible_records_appended:{0}, clean_compact_timestamp:{nullopt}, may_have_tombstone_records:1, self_compact_timestamp:{nullopt}, may_have_transaction_batches:1, index(1, 1, 1)}, step:32768, needs_persistence:0}}]}], config: {ntp: {kafka/topic-fadnsotldv/6}, base_dir: /var/lib/redpanda/data, overrides: {compaction_strategy: {nullopt}, cleanup_policy_bitflags: {delete}, segment_size: {nullopt}, retention_bytes: {{nullopt}}, retention_time_ms: {{nullopt}}, recovery_enabled: false, retention_local_target_bytes: {{nullopt}}, retention_local_target_ms: {{nullopt}}, remote_delete: {true}, segment_ms: {{nullopt}}, initial_retention_local_target_bytes: {{nullopt}}, initial_retention_local_target_ms: {{nullopt}}, write_caching: {nullopt}, flush_ms: {nullopt}, flush_bytes: {nullopt}, iceberg_mode: disabled, remote_allow_gaps: {nullopt}, delete_retention_ms: {disabled}, min_cleanable_dirty_ratio: {{nullopt}}, min_compaction_lag_ms: {nullopt}, max_compaction_lag_ms: {nullopt} }}, revision: 28, topic_revision: 28, remote_revision: 28}}
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
