### PR TITLE
[v25.3.x] cl: Rename logger from 'cluster_link' -> 'shadow_link'

### DIFF
--- a/src/v/cluster_link/logger.cc
+++ b/src/v/cluster_link/logger.cc
@@ -12,5 +12,5 @@
 #include "cluster_link/logger.h"
 
 namespace cluster_link {
-ss::logger cllog("cluster_link");
+ss::logger cllog("shadow_link");
 }

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -442,7 +442,7 @@ class ShadowLinkTestBase(PreallocNodesTest):
                 "info",
                 logger_levels={
                     "cluster": "trace",
-                    "cluster_link": "trace",
+                    "shadow_link": "trace",
                     "kafka/client": "trace",
                     "kafka": "trace",
                     "archival": "trace",

--- a/tests/rptest/tests/cluster_linking_topic_syncing_test.py
+++ b/tests/rptest/tests/cluster_linking_topic_syncing_test.py
@@ -699,7 +699,7 @@ message CType {
             log_config=LoggingConfig(
                 "info",
                 logger_levels={
-                    "cluster_link": "trace",
+                    "shadow_link": "trace",
                     "kafka/client": "trace",
                     "kafka": "trace",
                     "schemaregistry": "trace",


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28521
