### PR TITLE
`storage`: adjust log lines in `disk_log_impl::close/remove()`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -225,6 +225,9 @@ size_t disk_log_impl::compute_max_segment_size() {
 ss::future<> disk_log_impl::remove() {
     vassert(!_closed, "Invalid double closing of log - {}", *this);
 
+    vlog(
+      stlog.debug, "waiting for locks before removing log {}", config().ntp());
+
     // Request abort of compaction before obtaining rewrite lock holder.
     _compaction_as.request_abort();
 
@@ -284,6 +287,9 @@ ss::future<> disk_log_impl::start(
 
 ss::future<std::optional<ss::sstring>> disk_log_impl::close() {
     vassert(!_closed, "Invalid double closing of log - {}", *this);
+
+    vlog(
+      stlog.debug, "waiting for locks before closing log {}", config().ntp());
 
     // Request abort of compaction before obtaining rewrite lock holder.
     _compaction_as.request_abort();


### PR DESCRIPTION
Based on https://github.com/redpanda-data/redpanda/pull/28472.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
