### PR TITLE
gtest: print backtraces on sigill

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,9 @@ common --@toolchains_llvm//toolchain/config:compiler-rt=False
 build --linkopt --unwindlib=libgcc
 build --linkopt -stdlib=libc++
 
+# Enable absl integration for googletest with this fla
+build --define=absl=1
+
 common:clang-19 --extra_toolchains=@previous_llvm_toolchain//:all
 
 # Use Bash instead of system python for finding the hermetic interpreter

--- a/src/v/serde/protobuf/tests/parser_test.cc
+++ b/src/v/serde/protobuf/tests/parser_test.cc
@@ -597,7 +597,7 @@ TEST_F(ProtobufParserFixture, RandomData) {
 
 class ProtobufParserFuzzer : public ProtobufParserFixture {
 public:
-    ProtobufParserFuzzer() { mutator_.Seed(testing::FLAGS_gtest_random_seed); }
+    ProtobufParserFuzzer() { mutator_.Seed(GTEST_FLAG_GET(random_seed)); }
 
     void mutate(pb::Message* msg) { mutator_.Mutate(msg, 3_MiB); }
 

--- a/src/v/test_utils/BUILD
+++ b/src/v/test_utils/BUILD
@@ -22,6 +22,7 @@ redpanda_test_cc_library(
         "//src/v/base",
         "//src/v/model:timeout_clock",
         "//src/v/ssx:sformat",
+        "@abseil-cpp//absl/debugging:failure_signal_handler",
         "@fmt",
         "@googletest//:gtest",
         "@seastar",

--- a/src/v/test_utils/BUILD
+++ b/src/v/test_utils/BUILD
@@ -22,7 +22,6 @@ redpanda_test_cc_library(
         "//src/v/base",
         "//src/v/model:timeout_clock",
         "//src/v/ssx:sformat",
-        "@abseil-cpp//absl/debugging:failure_signal_handler",
         "@fmt",
         "@googletest//:gtest",
         "@seastar",

--- a/src/v/test_utils/gtest_main.cc
+++ b/src/v/test_utils/gtest_main.cc
@@ -8,14 +8,35 @@
  * the Business Source License, use of this software will be governed
  * by the Apache License, Version 2.0
  */
+#include "absl/debugging/failure_signal_handler.h"
 #include "test_utils/gtest_utils.h"
 
+#include <seastar/core/smp.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/testing/test_runner.hh>
+
+#include <csignal>
+
+namespace {
+
+seastar::future<> unblock_sigill() {
+    // A workaround until https://github.com/scylladb/seastar/pull/3102 lands
+    return seastar::smp::invoke_on_all([] {
+        ::sigset_t set;
+        ::sigemptyset(&set);
+        ::sigaddset(&set, SIGILL);
+        auto r = ::pthread_sigmask(SIG_UNBLOCK, &set, nullptr);
+        ss::throw_pthread_error(r);
+    });
+}
+
+} // namespace
 
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);
     GTEST_FLAG_SET(death_test_style, "threadsafe");
+    // Fall back signal handlers if our crash tracker isn't registered
+    absl::InstallFailureSignalHandler({});
 
     auto& listeners = ::testing::UnitTest::GetInstance()->listeners();
     listeners.Append(new rp_test_listener());
@@ -34,8 +55,10 @@ int main(int argc, char** argv) {
     seastar::testing::global_test_runner().start(argc, argv);
 
     int ret = 0;
-    seastar::testing::global_test_runner().run_sync(
-      [&ret] { return seastar::async([&ret] { ret = RUN_ALL_TESTS(); }); });
+    seastar::testing::global_test_runner().run_sync([&ret] {
+        return unblock_sigill().then(
+          [&ret] { return seastar::async([&ret] { ret = RUN_ALL_TESTS(); }); });
+    });
 
     int ss_ret = seastar::testing::global_test_runner().finalize();
     if (ret) {

--- a/src/v/test_utils/gtest_main.cc
+++ b/src/v/test_utils/gtest_main.cc
@@ -8,7 +8,6 @@
  * the Business Source License, use of this software will be governed
  * by the Apache License, Version 2.0
  */
-#include "absl/debugging/failure_signal_handler.h"
 #include "test_utils/gtest_utils.h"
 
 #include <seastar/core/smp.hh>
@@ -35,8 +34,7 @@ seastar::future<> unblock_sigill() {
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);
     GTEST_FLAG_SET(death_test_style, "threadsafe");
-    // Fall back signal handlers if our crash tracker isn't registered
-    absl::InstallFailureSignalHandler({});
+    GTEST_FLAG_SET(install_failure_signal_handler, true);
 
     auto& listeners = ::testing::UnitTest::GetInstance()->listeners();
     listeners.Append(new rp_test_listener());


### PR DESCRIPTION
https://redpandadata.slack.com/archives/C07HD9U0EHL/p1763091066630739?thread_ts=1763061976.219569&cid=C07HD9U0EHL

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
