### PR TITLE
kgo: Set linger to 0 in kgo-repeater

### DIFF
--- a/tests/go/kgo-verifier/pkg/worker/repeater/repeater_worker.go
+++ b/tests/go/kgo-verifier/pkg/worker/repeater/repeater_worker.go
@@ -290,6 +290,7 @@ func (v *Worker) Init() {
 		opts = append(opts, []kgo.Opt{
 			kgo.ProducerBatchMaxBytes(1024 * 1024),
 			kgo.RecordPartitioner(kgo.StickyKeyPartitioner(nil)),
+			kgo.ProducerLinger(0),
 		}...)
 
 		if v.transactionsEnabled {


### PR DESCRIPTION
franz-go changed the default linger in 1.20 from 0 to 10ms.

This broke the kgo-repeater in the MPT TS. kgo-repeater uses a
"round-robin" pattern where messages are produced and then explicitly
consumed. There is only a limited amount of concurrency in the system
because of this.

Linger kind of works against this pattern as you want your messages in
and out of the loop as fast as possible such that you can send the next.
Hence, this can affect throughput.

Restore previous behaviour pre franz-go 1.20 to avoid this issue. We
could change various other parameters likely as well but I think it's
best to just restore original behaviour.

There is probably some second order effect here in how this interacts
with TS which is why this only fails the TS version but overall I don't
think linger fits the kgo-repeater pattern well.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none


