### PR TITLE
k/group_router: correctly pass require_stable flag in offset fetch

### DIFF
--- a/src/v/kafka/server/group_router.cc
+++ b/src/v/kafka/server/group_router.cc
@@ -270,9 +270,10 @@ group_router::offset_fetch(offset_fetch_request request) {
     offset_fetch_response response;
     // Collect requests by shard
     for (auto& group : request.data.groups) {
-        requests_by_shard
-          .try_emplace(shard_for(group.group_id), offset_fetch_request{})
-          .first->second.data.groups.push_back(std::move(group));
+        auto [it, _] = requests_by_shard.try_emplace(
+          shard_for(group.group_id), offset_fetch_request{});
+        it->second.data.groups.push_back(std::move(group));
+        it->second.data.require_stable = request.data.require_stable;
     }
     // Collect responses
     for (auto& [key, request] : requests_by_shard) {


### PR DESCRIPTION
When offset fetch handler was changed to a new version supporting querying multiple groups at a time w `require_stable` flag for the request was lost. The default value for the flag is `false`. Even if consumer fetched offsets with the `require_stable` flag set to true.

This small issue resulted in a very severe bug impacting atomic-produce-consume workloads. Without the `require_stable` flag set to `true` the consumer fetching offsets didn't know about an open transaction in a group. This may lead to duplicates in the workload that is promised to be 'exactly once'.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none