### PR TITLE
k/client: Fix bug with printing TLS info

### DIFF
--- a/src/v/kafka/client/configuration.cc
+++ b/src/v/kafka/client/configuration.cc
@@ -387,9 +387,17 @@ tls_configuration::build_credentials() const {
 
 fmt::iterator tls_configuration::format_to(fmt::iterator it) const {
     fmt::format_to(it, "{{truststore: ");
-    net::format_cert(it, *truststore);
+    if (truststore) {
+        net::format_cert(it, *truststore);
+    } else {
+        fmt::format_to(it, "null");
+    }
     fmt::format_to(it, ", k_store: ");
-    net::format_keystore(it, *k_store);
+    if (k_store) {
+        net::format_keystore(it, *k_store);
+    } else {
+        fmt::format_to(it, "null");
+    }
     return fmt::format_to(
       it, ", provide_sni_hostname: {}}}", provide_sni_hostname);
 }


### PR DESCRIPTION
Check that optional members contain a value before attempting to print the cert or keystore.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
