### PR TITLE
ts: Refresh auth token on 403

### DIFF
--- a/src/v/cloud_io/auth_refresh_bg_op.cc
+++ b/src/v/cloud_io/auth_refresh_bg_op.cc
@@ -16,6 +16,7 @@
 #include <optional>
 
 namespace cloud_io {
+static constexpr auto refresh_rate = std::chrono::seconds(10);
 
 auth_refresh_bg_op::auth_refresh_bg_op(
   ss::gate& gate,
@@ -111,6 +112,26 @@ void auth_refresh_bg_op::do_start_auth_refresh_op(
 bool auth_refresh_bg_op::is_static_config() const {
     return _cloud_credentials_source
            == model::cloud_credentials_source::config_file;
+}
+
+void auth_refresh_bg_op::maybe_refresh_credentials() {
+    _refresh_cnt++;
+    auto refresh_allowed = [this]() {
+        if (!_last_refresh_time.has_value()) {
+            return true;
+        }
+        auto ts = _last_refresh_time.value();
+        auto now = ss::lowres_clock::now();
+        return ts < now ? now - ts > refresh_rate : false;
+    }();
+    if (refresh_allowed && _refresh_credentials.has_value()) {
+        _refresh_credentials->refresh();
+        _last_refresh_time = ss::lowres_clock::now();
+    }
+}
+
+uint64_t auth_refresh_bg_op::token_refresh_count() const noexcept {
+    return _refresh_cnt;
 }
 
 cloud_roles::credentials auth_refresh_bg_op::build_static_credentials() const {

--- a/src/v/cloud_io/auth_refresh_bg_op.h
+++ b/src/v/cloud_io/auth_refresh_bg_op.h
@@ -54,6 +54,14 @@ public:
 
     ss::future<> stop();
 
+    // Trigger credentials refresh (in case if IAM is used).
+    // Also, apply some basic rate limiting.
+    void maybe_refresh_credentials();
+
+    // The method returns a counter which is incremented every
+    // time the token refresh is requested.
+    uint64_t token_refresh_count() const noexcept;
+
 private:
     void do_start_auth_refresh_op(
       cloud_roles::credentials_update_cb_t credentials_update_cb,
@@ -64,6 +72,8 @@ private:
     cloud_storage_clients::client_configuration _client_conf;
     model::cloud_credentials_source _cloud_credentials_source;
     std::optional<cloud_roles::refresh_credentials> _refresh_credentials;
+    std::optional<ss::lowres_clock::time_point> _last_refresh_time;
+    uint64_t _refresh_cnt{0};
 };
 
 } // namespace cloud_io

--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -11,6 +11,7 @@
 #include "cloud_io/remote.h"
 
 #include "bytes/iostream.h"
+#include "cloud_io/auth_refresh_bg_op.h"
 #include "cloud_io/logger.h"
 #include "cloud_io/provider.h"
 #include "cloud_io/transfer_details.h"
@@ -330,6 +331,11 @@ ss::future<upload_result> remote::upload_stream(
         case cloud_storage_clients::error_outcome::fail:
             result = upload_result::failed;
             break;
+        case cloud_storage_clients::error_outcome::authentication_failed:
+            vlog(ctxlog.info, "Token expired, refreshing credentials");
+            maybe_request_auth_refresh();
+            result = upload_result::failed;
+            break;
         }
     }
 
@@ -460,6 +466,11 @@ ss::future<download_result> remote::download_stream(
         case cloud_storage_clients::error_outcome::key_not_found:
             result = download_result::notfound;
             break;
+        case cloud_storage_clients::error_outcome::authentication_failed:
+            vlog(ctxlog.info, "Token expired, refreshing credentials");
+            maybe_request_auth_refresh();
+            result = download_result::failed;
+            break;
         }
     }
     transfer_details.on_failure();
@@ -552,6 +563,11 @@ remote::download_object(download_request download_request) {
         case cloud_storage_clients::error_outcome::key_not_found:
             result = download_result::notfound;
             break;
+        case cloud_storage_clients::error_outcome::authentication_failed:
+            vlog(ctxlog.info, "Token expired, refreshing credentials");
+            maybe_request_auth_refresh();
+            result = download_result::failed;
+            break;
         }
     }
     transfer_details.on_failure();
@@ -631,6 +647,11 @@ ss::future<download_result> remote::object_exists(
             break;
         case cloud_storage_clients::error_outcome::key_not_found:
             result = download_result::notfound;
+            break;
+        case cloud_storage_clients::error_outcome::authentication_failed:
+            vlog(ctxlog.info, "Token expired, refreshing credentials");
+            maybe_request_auth_refresh();
+            result = download_result::failed;
             break;
         }
     }
@@ -713,6 +734,11 @@ remote::delete_object(transfer_details transfer_details) {
               "from bucket {}",
               path,
               bucket);
+            break;
+        case cloud_storage_clients::error_outcome::authentication_failed:
+            vlog(ctxlog.info, "Token expired, refreshing credentials");
+            maybe_request_auth_refresh();
+            result = upload_result::failed;
             break;
         }
     }
@@ -879,6 +905,11 @@ ss::future<upload_result> remote::delete_object_batch(
               "from bucket {}",
               keys.size(),
               bucket);
+            break;
+        case cloud_storage_clients::error_outcome::authentication_failed:
+            vlog(ctxlog.info, "Token expired, refreshing credentials");
+            maybe_request_auth_refresh();
+            result = upload_result::failed;
             break;
         }
     }
@@ -1114,6 +1145,11 @@ ss::future<list_result> remote::list_objects(
               "Unexpected key_not_found outcome received when listing bucket "
               "{}",
               bucket);
+        case cloud_storage_clients::error_outcome::authentication_failed:
+            vlog(ctxlog.info, "Token expired, refreshing credentials");
+            maybe_request_auth_refresh();
+            result = cloud_storage_clients::error_outcome::fail;
+            break;
         }
     }
 
@@ -1197,6 +1233,11 @@ ss::future<upload_result> remote::upload_object(upload_request upload_request) {
         case cloud_storage_clients::error_outcome::fail:
             result = upload_result::failed;
             break;
+        case cloud_storage_clients::error_outcome::authentication_failed:
+            vlog(ctxlog.info, "Token expired, refreshing credentials");
+            maybe_request_auth_refresh();
+            result = upload_result::failed;
+            break;
         }
     }
 
@@ -1230,6 +1271,22 @@ remote::propagate_credentials(cloud_roles::credentials credentials) {
       [c = std::move(credentials)](remote& svc) mutable {
           svc._pool.local().load_credentials(std::move(c));
       });
+}
+
+void remote::maybe_request_auth_refresh() {
+    if (ss::this_shard_id() == auth_refresh_shard_id) {
+        _auth_refresh_bg_op.maybe_refresh_credentials();
+    } else {
+        ssx::spawn_with_gate(_gate, [this] {
+            return container().invoke_on(auth_refresh_shard_id, [](remote& r) {
+                r._auth_refresh_bg_op.maybe_refresh_credentials();
+            });
+        });
+    }
+}
+
+uint64_t remote::token_refresh_count() const noexcept {
+    return _auth_refresh_bg_op.token_refresh_count();
 }
 
 } // namespace cloud_io

--- a/src/v/cloud_io/remote.h
+++ b/src/v/cloud_io/remote.h
@@ -209,8 +209,12 @@ public:
 
     const io_resources& resources() const { return *_resources; }
 
+    // The method is supposed to be used by tests.
+    uint64_t token_refresh_count() const noexcept;
+
 private:
     ss::future<> propagate_credentials(cloud_roles::credentials credentials);
+    void maybe_request_auth_refresh();
 
     ss::sharded<cloud_storage_clients::client_pool>& _pool;
     ss::gate _gate;

--- a/src/v/cloud_roles/refresh_credentials.cc
+++ b/src/v/cloud_roles/refresh_credentials.cc
@@ -27,11 +27,20 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/loop.hh>
+#include <seastar/util/defer.hh>
 
 #include <charconv>
 #include <exception>
+#include <stdexcept>
 
 namespace cloud_roles {
+
+// Special type of the abort exception which indicates that the abort
+// is not triggered by the shutdown.
+struct transient_abort_requested : std::runtime_error {
+    transient_abort_requested()
+      : std::runtime_error("transient_abort_requested") {}
+};
 
 /// This environment variable can be used to override the default hostname and
 /// port for fetching temporary credentials for testing, in the format host:port
@@ -224,6 +233,8 @@ ss::future<> refresh_credentials::stop() {
     _probe->reset();
 }
 
+void refresh_credentials::refresh() { _impl->refresh(); }
+
 std::chrono::milliseconds
 refresh_credentials::impl::calculate_sleep_duration(uint32_t expiry_sec) const {
     vlog(
@@ -286,6 +297,14 @@ void refresh_credentials::impl::reset_retries() {
     }
 }
 
+void refresh_credentials::impl::refresh() {
+    vlog(clrl_log.trace, "refresh: {}", _per_sleep_as.has_value());
+    if (_per_sleep_as.has_value()) {
+        _per_sleep_as.value().request_abort_ex(
+          std::make_exception_ptr(transient_abort_requested()));
+    }
+}
+
 void refresh_credentials::impl::next_sleep_duration(
   std::chrono::milliseconds sd) {
     vlog(
@@ -315,7 +334,23 @@ refresh_credentials::impl::handle_response(api_response resp) {
 
 ss::future<> refresh_credentials::impl::sleep_until_expiry() const {
     if (_sleep_duration) {
-        co_await ss::sleep_abortable(*_sleep_duration, _as);
+        vassert(!_per_sleep_as.has_value(), "Already sleeping");
+        _per_sleep_as.emplace();
+        auto notification = _as.subscribe(
+          [this](const std::optional<std::exception_ptr>&) noexcept {
+              vlog(clrl_log.trace, "refresh abort source is triggered");
+              vassert(
+                _per_sleep_as.has_value(),
+                "The subscription is not terminated properly");
+              _per_sleep_as.value().request_abort();
+          });
+        auto auto_reset = ss::defer([this] { _per_sleep_as.reset(); });
+        try {
+            co_await ss::sleep_abortable(
+              *_sleep_duration, _per_sleep_as.value());
+        } catch (const transient_abort_requested&) {
+            vlog(clrl_log.trace, "sleep aborted by the refresh operation");
+        }
     }
 }
 

--- a/src/v/cloud_roles/refresh_credentials.h
+++ b/src/v/cloud_roles/refresh_credentials.h
@@ -70,6 +70,8 @@ public:
 
         void reset_retries();
 
+        void refresh();
+
     protected:
         /// Returns an http client with the API host and port applied
         ss::future<http::client> make_api_client(
@@ -122,6 +124,7 @@ public:
         ss::abort_source& _as;
         retry_params _retry_params;
         ss::shared_ptr<ss::tls::certificate_credentials> _tls_certs = nullptr;
+        mutable std::optional<ss::abort_source> _per_sleep_as;
     };
 
     refresh_credentials(
@@ -140,6 +143,13 @@ public:
     }
 
     ss::future<> stop();
+
+    // Refresh credential as soon as possible.
+    //
+    // This is needed in a situation when the endpoint returned 403 or
+    // service specific REST API error (ExpiredToken). In this case we
+    // need to refresh credentials without waiting.
+    void refresh();
 
 private:
     ss::future<> do_start();

--- a/src/v/cloud_roles/tests/fetch_credentials_tests.cc
+++ b/src/v/cloud_roles/tests/fetch_credentials_tests.cc
@@ -890,3 +890,40 @@ FIXTURE_TEST(test_abs_vm_credentials, fixture) {
     run_check_once();
     BOOST_CHECK(cred_requests >= 2);
 }
+
+FIXTURE_TEST(test_token_refresh_request, fixture) {
+    // Check that the credentials are refreshed when 'refresh'
+    // method is called.
+    when()
+      .request(cloud_role_tests::gcp_url)
+      .then_reply_with(cloud_role_tests::gcp_oauth_token);
+    listen();
+
+    ss::abort_source as;
+    std::optional<cloud_roles::credentials> c;
+
+    two_fetches s(c);
+
+    auto count = s.get_counter();
+
+    auto refresh = cloud_roles::make_refresh_credentials(
+      model::cloud_credentials_source::gcp_instance_metadata,
+      as,
+      s,
+      cloud_roles::aws_service_name{"s3"},
+      cloud_roles::aws_region_name{""},
+      address());
+
+    refresh.start();
+    auto deferred = ss::defer([&refresh] { refresh.stop().get(); });
+
+    tests::cooperative_spin_wait_with_timeout(30s, [count] {
+        return *count == 1;
+    }).get();
+
+    refresh.refresh();
+
+    tests::cooperative_spin_wait_with_timeout(30s, [count] {
+        return *count == 2;
+    }).get();
+}

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -16,6 +16,7 @@
 #include "cloud_storage_clients/abs_error.h"
 #include "cloud_storage_clients/configuration.h"
 #include "cloud_storage_clients/logger.h"
+#include "cloud_storage_clients/types.h"
 #include "cloud_storage_clients/util.h"
 #include "cloud_storage_clients/xml_sax_parser.h"
 #include "config/configuration.h"
@@ -500,12 +501,24 @@ ss::future<result<T, error_outcome>> abs_client::send_request(
           || err.http_code() == status::unauthorized) {
             vlog(
               abs_log.error,
-              "Received [{}] {} error response from ABS. This indicates "
-              "misconfiguration of ABS and/or Redpanda: {}",
+              "Received [{}] {} error response from ABS. This could indicate "
+              "either misconfiguration (e.g. unauthorized IP address) or "
+              "invalidation of the SAS token: {}.",
               err.http_code(),
               err.code_string(),
               err.message());
-            outcome = error_outcome::fail;
+            if (err.code() == abs_error_code::authentication_failed) {
+                // Unfortunately, we can only get a common REST API error code
+                // here:
+                // https://learn.microsoft.com/en-us/rest/api/storageservices/common-rest-api-error-codes
+                // According to this page:
+                // https://learn.microsoft.com/en-us/troubleshoot/azure/azure-storage/blobs/authentication/storage-troubleshoot-403-errors
+                // the expired token will trigger generic AuthenticationFailed
+                // error.
+                outcome = error_outcome::authentication_failed;
+            } else {
+                outcome = error_outcome::fail;
+            }
             _probe->register_failure(err.code());
         } else if (
           err.code() == abs_error_code::container_being_disabled

--- a/src/v/cloud_storage_clients/abs_error.cc
+++ b/src/v/cloud_storage_clients/abs_error.cc
@@ -27,6 +27,7 @@ std::istream& operator>>(std::istream& i, abs_error_code& code) {
 
     code
       = string_switch<abs_error_code>(c)
+          .match("AuthenticationFailed", abs_error_code::authentication_failed)
           .match("BlobNotFound", abs_error_code::blob_not_found)
           .match("ServerBusy", abs_error_code::server_busy)
           .match("InternalError", abs_error_code::internal_error)

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -567,7 +567,9 @@ ss::future<result<T, error_outcome>> s3_client::send_request(
               key,
               bucket);
             outcome = error_outcome::retry;
-        } else if (err.code() == s3_error_code::expired_token) {
+        } else if (
+          err.code() == s3_error_code::expired_token
+          || err.code() == s3_error_code::authentication_required) {
             // Unexpected REST API error, we can't recover from this
             vlog(
               s3_log.error,

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -567,6 +567,15 @@ ss::future<result<T, error_outcome>> s3_client::send_request(
               key,
               bucket);
             outcome = error_outcome::retry;
+        } else if (err.code() == s3_error_code::expired_token) {
+            // Unexpected REST API error, we can't recover from this
+            vlog(
+              s3_log.error,
+              "{} auth error response received {} in {}",
+              err.code(),
+              key,
+              bucket);
+            outcome = error_outcome::authentication_failed;
         } else {
             // Unexpected REST API error, we can't recover from this
             // because the issue is not temporary (e.g. bucket doesn't

--- a/src/v/cloud_storage_clients/s3_error.cc
+++ b/src/v/cloud_storage_clients/s3_error.cc
@@ -30,6 +30,9 @@ std::ostream& operator<<(std::ostream& o, s3_error_code code) {
     case s3_error_code::ambiguous_grant_by_email_address:
         o << "AmbiguousGrantByEmailAddress";
         break;
+    case s3_error_code::authentication_required:
+        o << "AuthenticationRequired";
+        break;
     case s3_error_code::authorization_header_malformed:
         o << "AuthorizationHeaderMalformed";
         break;
@@ -425,6 +428,7 @@ static const std::map<ss::sstring, s3_error_code> known_aws_error_codes = {
   {"AllAccessDisabled", s3_error_code::all_access_disabled},
   {"AmbiguousGrantByEmailAddress",
    s3_error_code::ambiguous_grant_by_email_address},
+  {"AuthenticationRequired", s3_error_code::authentication_required},
   {"AuthorizationHeaderMalformed",
    s3_error_code::authorization_header_malformed},
   {"BadDigest", s3_error_code::bad_digest},

--- a/src/v/cloud_storage_clients/s3_error.h
+++ b/src/v/cloud_storage_clients/s3_error.h
@@ -30,6 +30,8 @@ enum class s3_error_code {
     account_problem,
     all_access_disabled,
     ambiguous_grant_by_email_address,
+    // authentication_required is GCP specific error code for expired tokens.
+    authentication_required,
     authorization_header_malformed,
     bad_digest,
     bucket_already_exists,

--- a/src/v/cloud_storage_clients/types.h
+++ b/src/v/cloud_storage_clients/types.h
@@ -36,7 +36,9 @@ enum class error_outcome {
     key_not_found,
     /// Currently used for directory deletion errors in ABS, typically treated
     /// as regular failure outcomes.
-    operation_not_supported
+    operation_not_supported,
+    /// Authentication failed
+    authentication_failed,
 };
 
 struct error_outcome_category final : public std::error_category {
@@ -54,6 +56,8 @@ struct error_outcome_category final : public std::error_category {
             return "Key not found error";
         case error_outcome::operation_not_supported:
             return "Operation not supported error";
+        case error_outcome::authentication_failed:
+            return "Authentication failed";
         default:
             return "Undefined error_outcome encountered";
         }

--- a/src/v/cluster/archival/tests/ntp_archiver_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_test.cc
@@ -332,6 +332,8 @@ FIXTURE_TEST(
     // This test asserts that uploading of segment index will only happen if the
     // segment upload is successful. Indices uploaded without segments are not
     // found during cleanup, thus leaving behind orphan items in the bucket.
+    // The test triggers ExpiredToken error which forces token to be refreshed.
+    // There is a check that validates that the refresh was requested.
 
     std::vector<segment_desc> segments = {
       {manifest_ntp, model::offset(0), model::term_id(1)},
@@ -346,12 +348,14 @@ FIXTURE_TEST(
     auto fail_resp = http_test_utils::response{
       .body = R"xml(<?xml version="1.0" encoding="UTF-8"?>
 <Error>
-    <Code>AccessDenied</Code>
-    <Message>Access Denied</Message>
+    <Code>ExpiredToken</Code>
+    <Message>ExpiredToken</Message>
     <Resource>resource</Resource>
     <RequestId>requestid</RequestId>
 </Error>)xml",
-      .status = http_test_utils::response::status_type::forbidden};
+      .status = http_test_utils::response::status_type::forbidden,
+      .content_type = "xml",
+    };
     std::regex logexpr{".*/0-.*log\\.\\d+"};
     fail_request_if(
       [&logexpr](const ss::http::request& req) {
@@ -392,6 +396,7 @@ FIXTURE_TEST(
     BOOST_REQUIRE_EQUAL(non_compacted_result.num_succeeded, 0);
     BOOST_REQUIRE_EQUAL(non_compacted_result.num_failed, 1);
     requests_size_eventually(1);
+    auth_token_refresh_eventually(1);
 }
 
 // NOLINTNEXTLINE

--- a/src/v/cluster/archival/tests/service_fixture.h
+++ b/src/v/cluster/archival/tests/service_fixture.h
@@ -207,6 +207,13 @@ public:
           to, [&] { return get_requests().size() == expected; });
     }
 
+    void auth_token_refresh_eventually(
+      size_t expected, ss::lowres_clock::duration to = 3s) {
+        RPTEST_REQUIRE_EVENTUALLY(to, [this, expected] {
+            return io.local().token_refresh_count() == expected;
+        });
+    }
+
     ss::sharded<cloud_storage_clients::client_pool> pool;
     ss::sharded<cloud_io::remote> io;
     ss::sharded<cloud_storage::remote> remote;

--- a/src/v/http/tests/http_imposter.cc
+++ b/src/v/http/tests/http_imposter.cc
@@ -119,6 +119,10 @@ void http_imposter_fixture::set_routes(ss::httpd::routes& r) {
               if (fp[i](req)) {
                   auto response = _fail_responses[i];
                   repl.set_status(response.status);
+                  if (response.content_type.has_value()) {
+                      content_type = response.content_type.value();
+                      repl.set_content_type(content_type);
+                  }
                   vlog(
                     http_imposter_log.trace,
                     "HTTP imposter id {} failing request {} - {} - {} with "

--- a/src/v/http/tests/registered_urls.h
+++ b/src/v/http/tests/registered_urls.h
@@ -26,6 +26,7 @@ struct response {
     ss::sstring body;
     std::vector<std::pair<ss::sstring, ss::sstring>> headers;
     status_type status;
+    std::optional<ss::sstring> content_type;
 };
 
 struct request_info {


### PR DESCRIPTION
This PR adds new functionality to `cloud_roles` and `cloud_io`.
The `refresh_credentials` gets a method that forces early refresh. The `ExpiredToken` or `403` error is mapped to a new error code. When this error code is returned by the cloud storage client in the `cloud_io::remote` the refresh is triggered.
The refresh can only happen on one shard and it can only happen once every 10 seconds or more.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements

* The restart is no longer required if the cloud storage auth token is invalidated.