### PR TITLE
`misc`: skip death tests

### DIFF
--- a/src/v/cluster_link/tests/utils_test.cc
+++ b/src/v/cluster_link/tests/utils_test.cc
@@ -86,6 +86,8 @@ TEST(cluster_link_utils_test, test_tls_value_config) {
 }
 
 TEST(cluster_link_utils_test, test_tls_bad_combo) {
+    GTEST_SKIP()
+      << "TODO(death_tests): re-enable when death tests are made stable in CI.";
     model::metadata md;
     md.connection.tls_enabled = model::connection_config::tls_enabled_t::yes;
     md.connection.cert = model::tls_file_path("/path/to/cert.crt");

--- a/src/v/compression/tests/BUILD
+++ b/src/v/compression/tests/BUILD
@@ -9,8 +9,6 @@ redpanda_cc_gtest(
     # the death test doesn't seem to properly record or parse the expected
     # output when there are multiple reactor threads.
     cpu = 1,
-    # CORE-14523
-    flaky = True,
     deps = [
         "//src/v/base",
         "//src/v/compression",

--- a/src/v/compression/tests/lz4_buf_tests.cc
+++ b/src/v/compression/tests/lz4_buf_tests.cc
@@ -83,6 +83,8 @@ TEST(MixedAllocations, CustomAllocator) {
 }
 
 TEST(MaxBufSizeDeathTest, CustomAllocator) {
+    GTEST_SKIP()
+      << "TODO(death_tests): re-enable when death tests are made stable in CI.";
     auto b = compression::lz4_decompression_buffers{4_MiB, 128_KiB + 1};
     auto allocator = b.custom_mem_alloc();
     ASSERT_DEATH(

--- a/src/v/storage/mvlog/tests/BUILD
+++ b/src/v/storage/mvlog/tests/BUILD
@@ -81,8 +81,6 @@ redpanda_cc_gtest(
     srcs = [
         "entry_stream_utils_death_test.cc",
     ],
-    # CORE-14523
-    flaky = True,
     deps = [
         "//src/v/bytes:iostream",
         "//src/v/storage/mvlog",
@@ -98,8 +96,6 @@ redpanda_cc_gtest(
     srcs = [
         "file_test.cc",
     ],
-    # CORE-14523
-    flaky = True,
     deps = [
         "//src/v/container:chunked_vector",
         "//src/v/storage/mvlog",

--- a/src/v/storage/mvlog/tests/entry_stream_utils_death_test.cc
+++ b/src/v/storage/mvlog/tests/entry_stream_utils_death_test.cc
@@ -15,6 +15,8 @@
 using namespace storage::experimental::mvlog;
 
 TEST(EntryHeaderDeathTest, TestDeserializeTooSmall) {
+    GTEST_SKIP()
+      << "TODO(death_tests): re-enable when death tests are made stable in CI.";
     GTEST_FLAG_SET(death_test_style, "threadsafe");
     entry_header orig_h{0, 0, entry_type::record_batch};
     auto buf = entry_header_to_iobuf(orig_h);

--- a/src/v/storage/mvlog/tests/file_test.cc
+++ b/src/v/storage/mvlog/tests/file_test.cc
@@ -148,6 +148,8 @@ TEST_F_CORO(FileTest, TestAppend) {
 
 using FileDeathTest = FileTest;
 TEST_F(FileDeathTest, TestAppendAfterClose) {
+    GTEST_SKIP()
+      << "TODO(death_tests): re-enable when death tests are made stable in CI.";
     const auto path = test_path("foo");
     auto created = file_mgr_->create_file(path).get();
     created->close().get();
@@ -160,6 +162,8 @@ TEST_F(FileDeathTest, TestAppendAfterClose) {
 }
 
 TEST_F(FileDeathTest, TestStreamAfterClose) {
+    GTEST_SKIP()
+      << "TODO(death_tests): re-enable when death tests are made stable in CI.";
     const auto path = test_path("foo");
     auto created = file_mgr_->create_file(path).get();
     auto buf = tests::random_iobuf();

--- a/src/v/test_utils/tests/BUILD
+++ b/src/v/test_utils/tests/BUILD
@@ -32,8 +32,6 @@ redpanda_cc_gtest(
     srcs = [
         "test_utils_test.cc",
     ],
-    # CORE-14523
-    flaky = True,
     deps = [
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",

--- a/src/v/test_utils/tests/test_utils_test.cc
+++ b/src/v/test_utils/tests/test_utils_test.cc
@@ -30,6 +30,8 @@ TEST(TestUtilsTest, test_macros_pass) {
 }
 
 TEST(TestUtilsDeathTest, test_macros_fail) {
+    GTEST_SKIP()
+      << "TODO(death_tests): re-enable when death tests are made stable in CI.";
     ASSERT_DEATH(RPTEST_FAIL("fail message"), "fail message");
     ASSERT_DEATH(RPTEST_ADD_FAIL("fail message"), "fail message");
     ASSERT_DEATH(RPTEST_FAIL_CORO("fail message"), "fail message");


### PR DESCRIPTION
And remove `flaky` attribute.

Re-enable these when they are proven stable in CI.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
