### PR TITLE
kafka: return partition error metadata if no term

### DIFF
--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -16,6 +16,7 @@
 #include "config/configuration.h"
 #include "config/node_config.h"
 #include "container/chunked_vector.h"
+#include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/metadata_response.h"
 #include "kafka/protocol/types.h"
 #include "kafka/server/errors.h"
@@ -158,6 +159,19 @@ metadata_response::topic make_topic_response_from_topic_metadata(
         if (lt && !is_node_isolated && p.error_code == error_code::none) {
             p.leader_id = lt->leader.value_or(no_leader);
             p.leader_epoch = leader_epoch_from_term(lt->term);
+            if (!lt->term.has_value()) {
+                // The Java client treats this metadata as unreliable and
+                // forgets about any cached epochs, regardless of the error.
+                // https://github.com/apache/kafka/blob/9529003fffd93a9d7e3f6ff7ab081ed84942fd13/clients/src/main/java/org/apache/kafka/clients/Metadata.java#L596-L601
+
+                // Franz go skips processing the partition altogether if there
+                // is an error, regardless of whether there is a missing term,
+                // opting to retry later. This is preferrable over accepting
+                // the missing term (-1) as a valid term and treating it as a
+                // term moving backwards.
+                // https://github.com/twmb/franz-go/blob/3affad808a82ebfe1555d01d27732431093ac8e1/pkg/kgo/metadata.go#L811-L857
+                p.error_code = error_code::leader_not_available;
+            }
         }
         if (is_node_isolated && p.error_code == error_code::none) {
             auto replicas_for_sfuffle = replicas;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
When the metadata cache is missing term information for a given partition (e.g.
when starting up) we return an invalid (-1) term with no error.

The Java client treats this metadata as unreliable and forgets about any cached
epochs, regardless of any errors[1].

Franz go skips processing the partition altogether if there is an error,
regardless of whether there is a missing term, opting to retry later. It
otherwise accepts the missing term (-1) as a valid term and treating
it as a term moving backwards[2].

This updates the metadata handler to return an error, which seems like it
shouldn't affect the Java client, but should help Franz go ignore the invalid
metadata.

Relevant Redpanda commits in reverse chronological order:
- https://github.com/redpanda-data/redpanda/commit/a441290876ff9bb01d6d58532f388b94f3719bfe
- https://github.com/redpanda-data/redpanda/commit/7a60b758ad9ff9f2a2d7ec343f2a404ffaf51e89
- https://github.com/redpanda-data/redpanda/commit/86d583b486d033377be4c9f2b331be25ff6d9632

1. https://github.com/apache/kafka/blob/9529003fffd93a9d7e3f6ff7ab081ed84942fd13/clients/src/main/java/org/apache/kafka/clients/Metadata.java#L596-L601
2. https://github.com/twmb/franz-go/blob/3affad808a82ebfe1555d01d27732431093ac8e1/pkg/kgo/metadata.go#L811-L857


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
