### PR TITLE
kafka/produce: make validation async

### DIFF
--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -214,7 +214,7 @@ ss::future<produce_response::partition> do_produce_topic_partition(
   ntp_produce_request req,
   std::unique_ptr<ss::promise<>> dispatched) {
     auto start = std::chrono::steady_clock::now();
-    auto validate_batch_res = validate_batch({
+    auto validate_batch_res = co_await validate_batch({
       .batch = *req.batch,
       .timestamp_type = req.timestamp_type,
       .message_timestamp_before_max_ms = req.message_timestamp_before_max_ms,

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -22,6 +22,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/namespace.h"
+#include "model/record.h"
 #include "model/timestamp.h"
 #include "pandaproxy/schema_registry/validation.h"
 #include "raft/errc.h"
@@ -72,14 +73,6 @@ struct topic_produce_stages {
     ss::future<> dispatched;
     ss::future<produce_response::topic> produced;
 };
-
-partition_produce_stages make_ready_stage(produce_response::partition p) {
-    return partition_produce_stages{
-      .dispatched = ss::now(),
-      .produced = ss::make_ready_future<produce_response::partition>(
-        std::move(p)),
-    };
-}
 
 raft::replicate_options
 acks_to_replicate_options(int16_t acks, std::chrono::milliseconds timeout) {
@@ -186,10 +179,10 @@ partition_produce_stages partition_append(
     };
 }
 
-ss::future<produce_response::partition> finalize_request_with_error_code(
+produce_response::partition finalize_request_with_error_code(
   error_code ec,
   std::unique_ptr<ss::promise<>> dispatch,
-  model::ntp ntp,
+  const model::ntp& ntp,
   ss::shard_id source_shard,
   std::optional<ss::sstring> err_msg = std::nullopt) {
     // submit back to promise source shard
@@ -198,11 +191,168 @@ ss::future<produce_response::partition> finalize_request_with_error_code(
           dispatch->set_value();
           dispatch.reset();
       });
-    return ss::make_ready_future<produce_response::partition>(
-      produce_response::partition{
-        .partition_index = ntp.tp.partition,
-        .error_code = ec,
-        .error_message = std::move(err_msg)});
+    return produce_response::partition{
+      .partition_index = ntp.tp.partition,
+      .error_code = ec,
+      .error_message = std::move(err_msg)};
+}
+
+struct ntp_produce_request {
+    model::ntp ntp;
+    std::unique_ptr<model::record_batch> batch;
+    std::optional<pandaproxy::schema_registry::schema_id_validator>
+      schema_id_validator;
+
+    size_t batch_max_bytes;
+    model::timestamp_type timestamp_type;
+    std::chrono::milliseconds message_timestamp_before_max_ms;
+    std::chrono::milliseconds message_timestamp_after_max_ms;
+};
+
+ss::future<produce_response::partition> do_produce_topic_partition(
+  produce_ctx& octx,
+  ntp_produce_request req,
+  std::unique_ptr<ss::promise<>> dispatched) {
+    auto start = std::chrono::steady_clock::now();
+    auto validate_batch_res = validate_batch({
+      .batch = *req.batch,
+      .timestamp_type = req.timestamp_type,
+      .message_timestamp_before_max_ms = req.message_timestamp_before_max_ms,
+      .message_timestamp_after_max_ms = req.message_timestamp_after_max_ms,
+      .probe = octx.rctx.probe(),
+    });
+
+    if (validate_batch_res.has_value()) {
+        co_return finalize_request_with_error_code(
+          validate_batch_res->err,
+          std::move(dispatched),
+          req.ntp,
+          ss::this_shard_id(),
+          std::move(validate_batch_res->msg));
+    }
+
+    auto batch_size = req.batch->size_bytes();
+    if (static_cast<uint32_t>(batch_size) > req.batch_max_bytes) {
+        auto msg = ssx::sformat(
+          "batch size {} exceeds max {}", batch_size, req.batch_max_bytes);
+        thread_local static ss::logger::rate_limit rate(1s);
+        vloglr(klog, ss::log_level::warn, rate, "{}", msg);
+        co_return finalize_request_with_error_code(
+          error_code::message_too_large,
+          std::move(dispatched),
+          req.ntp,
+          ss::this_shard_id(),
+          std::move(msg));
+    }
+
+    if (auto& validator = req.schema_id_validator) {
+        auto ec = co_await (*validator)(*req.batch);
+        if (ec != error_code::none) {
+            // TODO: It's a bit much to post this to the partition probe for
+            // this metric. We should probably move the metric.
+            auto shard = octx.rctx.shards().shard_for(req.ntp);
+            if (shard) {
+                co_await octx.rctx.partition_manager().invoke_on(
+                  *shard,
+                  [](cluster::partition_manager& pm, const model::ntp& ntp) {
+                      if (auto p = pm.get(ntp)) {
+                          p->probe().add_schema_id_validation_failed();
+                      }
+                      return ss::now();
+                  },
+                  req.ntp);
+            }
+            co_return finalize_request_with_error_code(
+              ec, std::move(dispatched), req.ntp, ss::this_shard_id());
+        }
+    }
+
+    // A single produce request may contain record batches for many
+    // different partitions that are managed different cores.
+    auto shard = octx.rctx.shards().shard_for(req.ntp);
+    if (!shard) {
+        co_return finalize_request_with_error_code(
+          error_code::not_leader_for_partition,
+          std::move(dispatched),
+          req.ntp,
+          ss::this_shard_id());
+    }
+
+    auto m = octx.rctx.probe().auto_produce_measurement();
+    octx.rctx.probe().record_batch(
+      batch_size, req.batch->header().attrs.compression());
+    octx.rctx.connection()->attributes().produce_bytes.record(batch_size);
+    octx.rctx.connection()->attributes().produce_batch_count.record(1);
+
+    auto timeout = octx.request.data.timeout_ms;
+    if (timeout < 0ms) {
+        static constexpr std::chrono::milliseconds max_timeout{
+          std::numeric_limits<int32_t>::max()};
+        // negative timeout translates to no timeout
+        timeout = max_timeout;
+    }
+
+    auto p = co_await octx.rctx.partition_manager().invoke_on(
+      *shard,
+      octx.ssg,
+      [batch = std::move(req.batch),
+       ntp = std::move(req.ntp),
+       dispatch = std::move(dispatched),
+       acks = octx.request.data.acks,
+       timeout,
+       source_shard = ss::this_shard_id()](
+        cluster::partition_manager& mgr) mutable {
+          auto partition = kafka::make_partition_proxy(ntp, mgr);
+          if (!partition || !partition->is_leader()) {
+              return ss::as_ready_future(finalize_request_with_error_code(
+                error_code::not_leader_for_partition,
+                std::move(dispatch),
+                ntp,
+                source_shard));
+          }
+
+          auto bid = model::batch_identity::from(batch->header());
+          auto num_records = batch->record_count();
+          auto batch_size = batch->size_bytes();
+          auto stages = partition_append(
+            ntp.tp.partition,
+            std::move(*partition),
+            bid,
+            std::move(batch),
+            acks,
+            num_records,
+            batch_size,
+            timeout);
+          return stages.dispatched
+            .then_wrapped([source_shard, dispatch = std::move(dispatch)](
+                            ss::future<> f) mutable {
+                if (f.failed()) {
+                    ssx::background = ss::smp::submit_to(
+                      source_shard,
+                      [dispatch = std::move(dispatch),
+                       e = f.get_exception()]() mutable {
+                          dispatch->set_exception(e);
+                          dispatch.reset();
+                      });
+                    return;
+                }
+                ssx::background = ss::smp::submit_to(
+                  source_shard, [dispatch = std::move(dispatch)]() mutable {
+                      dispatch->set_value();
+                      dispatch.reset();
+                  });
+            })
+            .then([f = std::move(stages.produced)]() mutable {
+                return std::move(f);
+            });
+      });
+    if (p.error_code == error_code::none) {
+        auto dur = std::chrono::steady_clock::now() - start;
+        octx.rctx.connection()->server().update_produce_latency(dur);
+    } else {
+        m->cancel();
+    }
+    co_return p;
 }
 
 struct topic_configuration_context {
@@ -223,177 +373,28 @@ partition_produce_stages produce_topic_partition(
   const topic_configuration_context& cfg_ctx) {
     auto ntp = model::ntp(
       model::kafka_namespace, topic.name, part.partition_index);
-
-    /*
-     * A single produce request may contain record batches for many
-     * different partitions that are managed different cores.
-     */
-    auto shard = octx.rctx.shards().shard_for(ntp);
-
-    if (!shard) {
-        return make_ready_stage(
-          produce_response::partition{
-            .partition_index = ntp.tp.partition,
-            .error_code = error_code::not_leader_for_partition});
-    }
-
-    // steal the batch from the adapter
-    auto batch = std::make_unique<model::record_batch>(
-      std::move(part.records->adapter.batch.value()));
-
-    auto validate_batch_res = validate_batch(
-      {.batch = *batch,
-       .timestamp_type = cfg_ctx.timestamp_type,
-       .message_timestamp_before_max_ms
-       = cfg_ctx.message_timestamp_before_max_ms,
-       .message_timestamp_after_max_ms = cfg_ctx.message_timestamp_after_max_ms,
-       .probe = octx.rctx.probe()});
-
-    if (validate_batch_res.has_value()) {
-        auto dispatch_f = ss::now();
-        auto f = ss::make_ready_future<produce_response::partition>(
-          produce_response::partition{
-            .partition_index = ntp.tp.partition,
-            .error_code = validate_batch_res->err,
-            .error_message = std::move(validate_batch_res->msg)});
-        return partition_produce_stages{
-          .dispatched = std::move(dispatch_f), .produced = std::move(f)};
-    }
-
-    const auto& hdr = batch->header();
-    auto bid = model::batch_identity::from(hdr);
-    auto batch_size = batch->size_bytes();
-    auto num_records = batch->record_count();
     auto validator
       = pandaproxy::schema_registry::maybe_make_schema_id_validator(
         octx.rctx.schema_registry(), topic.name, *cfg_ctx.properties);
-    auto start = std::chrono::steady_clock::now();
-
+    // steal the batch from the adapter
+    auto batch = std::make_unique<model::record_batch>(
+      std::move(part.records->adapter.batch.value()));
     auto dispatch = std::make_unique<ss::promise<>>();
     auto dispatch_f = dispatch->get_future();
-    auto m = octx.rctx.probe().auto_produce_measurement();
-    octx.rctx.probe().record_batch(batch_size, hdr.attrs.compression());
-    octx.rctx.connection()->attributes().produce_bytes.record(batch_size);
-    octx.rctx.connection()->attributes().produce_batch_count.record(1);
-    auto timeout = octx.request.data.timeout_ms;
-    if (timeout < 0ms) {
-        static constexpr std::chrono::milliseconds max_timeout{
-          std::numeric_limits<int32_t>::max()};
-        // negative timeout translates to no timeout
-        timeout = max_timeout;
-    }
-    auto f
-      = octx.rctx.partition_manager()
-          .invoke_on(
-            *shard,
-            octx.ssg,
-            [batch = std::move(batch),
-             validator = std::move(validator),
-             ntp = std::move(ntp),
-             dispatch = std::move(dispatch),
-             num_records,
-             batch_size,
-             bid,
-             acks = octx.request.data.acks,
-             batch_max_bytes = cfg_ctx.batch_max_bytes,
-             timeout,
-             source_shard = ss::this_shard_id()](
-              cluster::partition_manager& mgr) mutable {
-                auto partition = kafka::make_partition_proxy(ntp, mgr);
-                if (!partition) {
-                    return finalize_request_with_error_code(
-                      error_code::not_leader_for_partition,
-                      std::move(dispatch),
-                      ntp,
-                      source_shard);
-                }
-                if (unlikely(
-                      static_cast<uint32_t>(batch_size) > batch_max_bytes)) {
-                    auto msg = ssx::sformat(
-                      "batch size {} exceeds max {}",
-                      batch_size,
-                      batch_max_bytes);
-                    thread_local static ss::logger::rate_limit rate(1s);
-                    vloglr(klog, ss::log_level::warn, rate, "{}", msg);
-                    return finalize_request_with_error_code(
-                      error_code::message_too_large,
-                      std::move(dispatch),
-                      ntp,
-                      source_shard,
-                      std::move(msg));
-                }
-                if (unlikely(!partition->is_leader())) {
-                    return finalize_request_with_error_code(
-                      error_code::not_leader_for_partition,
-                      std::move(dispatch),
-                      ntp,
-                      source_shard);
-                }
-
-                auto probe = std::addressof(partition->probe());
-                auto f = pandaproxy::schema_registry::maybe_validate_schema_id(
-                  std::move(validator), *batch, probe);
-
-                return std::move(f).then(
-                  [ntp{std::move(ntp)},
-                   partition{std::move(*partition)},
-                   dispatch = std::move(dispatch),
-                   bid,
-                   acks,
-                   source_shard,
-                   num_records,
-                   batch_size,
-                   timeout,
-                   batch = std::move(batch)](kafka::error_code err) mutable {
-                      if (err != kafka::error_code::none) {
-                          return finalize_request_with_error_code(
-                            err, std::move(dispatch), ntp, source_shard);
-                      }
-                      auto stages = partition_append(
-                        ntp.tp.partition,
-                        std::move(partition),
-                        bid,
-                        std::move(batch),
-                        acks,
-                        num_records,
-                        batch_size,
-                        timeout);
-                      return stages.dispatched
-                        .then_wrapped(
-                          [source_shard, dispatch = std::move(dispatch)](
-                            ss::future<> f) mutable {
-                              if (f.failed()) {
-                                  (void)ss::smp::submit_to(
-                                    source_shard,
-                                    [dispatch = std::move(dispatch),
-                                     e = f.get_exception()]() mutable {
-                                        dispatch->set_exception(e);
-                                        dispatch.reset();
-                                    });
-                                  return;
-                              }
-                              (void)ss::smp::submit_to(
-                                source_shard,
-                                [dispatch = std::move(dispatch)]() mutable {
-                                    dispatch->set_value();
-                                    dispatch.reset();
-                                });
-                          })
-                        .then([f = std::move(stages.produced)]() mutable {
-                            return std::move(f);
-                        });
-                  });
-            })
-          .then([&octx, start, m = std::move(m)](
-                  produce_response::partition p) {
-              if (p.error_code == error_code::none) {
-                  auto dur = std::chrono::steady_clock::now() - start;
-                  octx.rctx.connection()->server().update_produce_latency(dur);
-              } else {
-                  m->cancel();
-              }
-              return p;
-          });
+    auto f = do_produce_topic_partition(
+      octx,
+      ntp_produce_request{
+        .ntp = std::move(ntp),
+        .batch = std::move(batch),
+        .schema_id_validator = std::move(validator),
+        .batch_max_bytes = cfg_ctx.batch_max_bytes,
+        .timestamp_type = cfg_ctx.timestamp_type,
+        .message_timestamp_before_max_ms
+        = cfg_ctx.message_timestamp_before_max_ms,
+        .message_timestamp_after_max_ms
+        = cfg_ctx.message_timestamp_after_max_ms,
+      },
+      std::move(dispatch));
     return partition_produce_stages{
       .dispatched = std::move(dispatch_f),
       .produced = std::move(f),

--- a/src/v/kafka/server/handlers/produce_validation.cc
+++ b/src/v/kafka/server/handlers/produce_validation.cc
@@ -432,7 +432,8 @@ std::optional<error_code_and_msg> validate_batch(
 
 } // namespace
 
-std::optional<error_code_and_msg> validate_batch(const validation_args& args) {
+ss::future<std::optional<error_code_and_msg>>
+validate_batch(const validation_args& args) {
     const auto& validation_mode
       = config::shard_local_cfg().kafka_produce_batch_validation();
 
@@ -444,14 +445,22 @@ std::optional<error_code_and_msg> validate_batch(const validation_args& args) {
 
     if (batch.compressed()) {
         if (should_decompress(batch, validation_mode)) {
-            maybe_decompressed_batch = model::decompress_batch_sync(batch);
+            try {
+                maybe_decompressed_batch = co_await model::decompress_batch(
+                  batch);
+            } catch (...) {
+                co_return error_code_and_msg{
+                  .err = error_code::corrupt_message,
+                  .msg = "unable to decompress batch",
+                };
+            }
             maybe_decompressed_batch_ref = maybe_decompressed_batch.value();
         }
     } else {
         maybe_decompressed_batch_ref = batch;
     }
 
-    return validate_batch(
+    co_return validate_batch(
       batch,
       maybe_decompressed_batch_ref,
       validation_mode,

--- a/src/v/kafka/server/handlers/produce_validation.h
+++ b/src/v/kafka/server/handlers/produce_validation.h
@@ -43,6 +43,7 @@ struct validation_args {
 };
 
 // Entry point for batch validation.
-std::optional<error_code_and_msg> validate_batch(const validation_args&);
+ss::future<std::optional<error_code_and_msg>>
+validate_batch(const validation_args&);
 
 } // namespace kafka

--- a/src/v/pandaproxy/schema_registry/validation.cc
+++ b/src/v/pandaproxy/schema_registry/validation.cc
@@ -11,14 +11,10 @@
 #include "pandaproxy/schema_registry/validation.h"
 
 #include "bytes/iobuf_parser.h"
-#include "cluster/partition_probe.h"
-#include "cluster/types.h"
 #include "config/configuration.h"
 #include "kafka/protocol/errors.h"
 #include "model/batch_compression.h"
 #include "model/record.h"
-#include "model/record_batch_reader.h"
-#include "model/timeout_clock.h"
 #include "pandaproxy/logger.h"
 #include "pandaproxy/schema_registry/avro.h"
 #include "pandaproxy/schema_registry/json.h"
@@ -37,11 +33,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/coroutine/exception.hh>
 
-#include <algorithm>
-#include <iterator>
 #include <optional>
-#include <stdexcept>
-#include <type_traits>
 
 namespace pandaproxy::schema_registry {
 
@@ -443,20 +435,13 @@ std::optional<schema_id_validator> maybe_make_schema_id_validator(
     return std::nullopt;
 }
 
-ss::future<kafka::error_code> schema_id_validator::operator()(
-  const model::record_batch& batch, cluster::partition_probe* probe) {
+ss::future<kafka::error_code>
+schema_id_validator::operator()(const model::record_batch& batch) {
     using futurator = ss::futurize<kafka::error_code>;
-    return (*_impl)(batch)
-      .handle_exception([](std::exception_ptr e) {
-          vlog(srlog.warn, "Invalid record due to exception: {}", e);
-          return futurator::convert(kafka::error_code::invalid_record);
-      })
-      .then([probe](futurator::value_type res) {
-          if (res != kafka::error_code::none) {
-              probe->add_schema_id_validation_failed();
-          }
-          return res;
-      });
+    return (*_impl)(batch).handle_exception([](std::exception_ptr e) {
+        vlog(srlog.warn, "Invalid record due to exception: {}", e);
+        return futurator::convert(kafka::error_code::invalid_record);
+    });
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/validation.h
+++ b/src/v/pandaproxy/schema_registry/validation.h
@@ -11,7 +11,6 @@
 #pragma once
 
 #include "base/seastarx.h"
-#include "cluster/fwd.h"
 #include "cluster/topic_properties.h"
 #include "kafka/protocol/errors.h"
 #include "model/fundamental.h"
@@ -19,10 +18,6 @@
 #include "pandaproxy/schema_registry/schema_id_validation.h"
 
 #include <seastar/core/future.hh>
-
-namespace cluster {
-class partition_probe;
-}
 
 namespace pandaproxy::schema_registry {
 
@@ -40,8 +35,7 @@ public:
     schema_id_validator& operator=(const schema_id_validator&) = delete;
     ~schema_id_validator() noexcept;
 
-    ss::future<kafka::error_code>
-    operator()(const model::record_batch&, cluster::partition_probe* probe);
+    ss::future<kafka::error_code> operator()(const model::record_batch&);
 
 private:
     std::unique_ptr<impl> _impl;
@@ -51,15 +45,5 @@ std::optional<schema_id_validator> maybe_make_schema_id_validator(
   const std::unique_ptr<api>& api,
   const model::topic& topic,
   const cluster::topic_properties& props);
-
-inline ss::future<kafka::error_code> maybe_validate_schema_id(
-  std::optional<schema_id_validator> validator,
-  const model::record_batch& batch,
-  cluster::partition_probe* probe) {
-    if (validator) {
-        co_return co_await (*validator)(batch, probe);
-    }
-    co_return kafka::error_code::none;
-}
 
 } // namespace pandaproxy::schema_registry


### PR DESCRIPTION
- **kafka/produce: futurize produce handler validation**
- **kafka/produce: decompress batches async**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
