### PR TITLE
admin/rpc: support access the auth result in handlers

### DIFF
--- a/src/v/redpanda/admin/proxy/BUILD
+++ b/src/v/redpanda/admin/proxy/BUILD
@@ -17,6 +17,17 @@ redpanda_cc_library(
     ],
 )
 
+redpanda_cc_library(
+    name = "context",
+    srcs = ["context.cc"],
+    hdrs = ["context.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/model",
+        "//src/v/serde/protobuf:rpc",
+    ],
+)
+
 redpanda_cc_rpc_library(
     name = "proxy_rpc",
     src = "proxy_service.json",
@@ -35,6 +46,7 @@ redpanda_cc_library(
         "client.h",
     ],
     implementation_deps = [
+        ":context",
         ":proxy_rpc",
     ],
     visibility = ["//visibility:public"],
@@ -60,6 +72,7 @@ redpanda_cc_library(
         "service.h",
     ],
     implementation_deps = [
+        ":context",
         "//src/v/rpc",
     ],
     visibility = ["//visibility:public"],

--- a/src/v/redpanda/admin/proxy/client.cc
+++ b/src/v/redpanda/admin/proxy/client.cc
@@ -12,6 +12,7 @@
 #include "redpanda/admin/proxy/client.h"
 
 #include "base/vlog.h"
+#include "redpanda/admin/proxy/context.h"
 #include "redpanda/admin/proxy/proxy_service.h"
 #include "redpanda/admin/proxy/types.h"
 #include "rpc/connection_cache.h"
@@ -52,20 +53,20 @@ template<typename T>
 
 ss::future<iobuf> client::send(
   model::node_id target, serde::pb::rpc::context ctx, iobuf payload) noexcept {
-    if (ctx.has_visited_node(_self)) {
+    if (has_proxied_node(ctx, _self)) {
         vlog(
           log.warn,
           "proxy loop detected (self={}, via={})",
           target,
-          ctx.proxied_nodes);
+          get_proxied_nodes(ctx));
         throw serde::pb::rpc::unavailable_exception("proxy loop detected");
     }
     proxy_request req;
     req.service = ss::sstring(ctx.service_name);
     req.method = ss::sstring(ctx.method_name);
-    req.via = ctx.proxied_nodes;
-    req.via.push_back(_self);
     req.payload = std::move(payload);
+    req.via = get_proxied_nodes(ctx);
+    req.via.push_back(_self);
     // TODO: Cluster config for this timeout
     constexpr static std::chrono::milliseconds rpc_timeout = 10s;
     proxy_response proxy_resp;

--- a/src/v/redpanda/admin/proxy/context.cc
+++ b/src/v/redpanda/admin/proxy/context.cc
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "redpanda/admin/proxy/context.h"
+
+namespace admin::proxy {
+
+bool is_proxied(const serde::pb::rpc::context& ctx) {
+    auto* list = ctx.get_optional_value<std::vector<model::node_id>>();
+    return list != nullptr && !list->empty();
+}
+
+bool has_proxied_node(
+  const serde::pb::rpc::context& ctx, model::node_id node_id) {
+    auto* list = ctx.get_optional_value<std::vector<model::node_id>>();
+    return list != nullptr && std::ranges::contains(*list, node_id);
+}
+
+std::vector<model::node_id>
+get_proxied_nodes(const serde::pb::rpc::context& ctx) {
+    auto* list = ctx.get_optional_value<std::vector<model::node_id>>();
+    return list != nullptr ? *list : std::vector<model::node_id>{};
+}
+
+void append_proxied_nodes(
+  serde::pb::rpc::context& ctx, std::vector<model::node_id> node_ids) {
+    auto* list = ctx.get_optional_value<std::vector<model::node_id>>();
+    if (list == nullptr) {
+        ctx.set_value(std::move(node_ids));
+    } else {
+        list->append_range(std::move(node_ids));
+    }
+}
+
+} // namespace admin::proxy

--- a/src/v/redpanda/admin/proxy/context.h
+++ b/src/v/redpanda/admin/proxy/context.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "model/fundamental.h"
+#include "serde/protobuf/rpc.h"
+
+namespace admin::proxy {
+
+// Check if this request has been proxied by another broker.
+bool is_proxied(const serde::pb::rpc::context& ctx);
+
+// Check if this node_id has already proxied this request.
+bool has_proxied_node(
+  const serde::pb::rpc::context& ctx, model::node_id node_id);
+
+// Get the list of proxied nodes from this context.
+std::vector<model::node_id>
+get_proxied_nodes(const serde::pb::rpc::context& ctx);
+
+// Mutate the context and add `node_ids` to the list of nodes it contains.
+void append_proxied_nodes(
+  serde::pb::rpc::context& ctx, std::vector<model::node_id>);
+
+} // namespace admin::proxy

--- a/src/v/redpanda/admin/proxy/service.cc
+++ b/src/v/redpanda/admin/proxy/service.cc
@@ -12,6 +12,7 @@
 #include "redpanda/admin/proxy/service.h"
 
 #include "base/vlog.h"
+#include "redpanda/admin/proxy/context.h"
 #include "serde/protobuf/rpc.h"
 
 #include <exception>
@@ -46,8 +47,8 @@ service_impl::proxy_rpc(proxy_request req, rpc::streaming_context&) {
       .service_name = req.service,
       .method_name = req.method,
       .content_type = serde::pb::rpc::content_type::proto,
-      .proxied_nodes = req.via,
     };
+    append_proxied_nodes(ctx, req.via);
     proxy_response response;
     try {
         auto payload = co_await _handler(

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -352,7 +352,7 @@ namespace {
 class rpc_handler : public ss::httpd::handler_base {
 public:
     rpc_handler(
-      ss::noncopyable_function<void(const ss::http::request&)>
+      ss::noncopyable_function<request_auth_result(const ss::http::request&)>
         authenticate_request,
       serde::pb::rpc::route_descriptor descriptor)
       : _authenticate_request(std::move(authenticate_request))
@@ -363,8 +363,9 @@ public:
       std::unique_ptr<ss::http::request> req,
       std::unique_ptr<ss::http::reply> rep) override {
         try {
-            check_authentication(*req);
+            auto auth_result = check_authentication(*req);
             auto ctx = make_context(*req);
+            ctx.set_value(std::move(auth_result));
             auto is_proto = ctx.content_type
                             == serde::pb::rpc::content_type::proto;
             iobuf request_payload = co_await extract_payload(std::move(req));
@@ -398,9 +399,9 @@ public:
     }
 
 private:
-    void check_authentication(const ss::http::request& req) {
+    request_auth_result check_authentication(const ss::http::request& req) {
         try {
-            _authenticate_request(req);
+            return _authenticate_request(req);
         } catch (const ss::httpd::base_exception& e) {
             switch (e.status()) {
             case seastar::http::reply::status_type::unauthorized:
@@ -449,7 +450,7 @@ private:
         co_return payload;
     }
 
-    ss::noncopyable_function<void(const ss::http::request&)>
+    ss::noncopyable_function<request_auth_result(const ss::http::request&)>
       _authenticate_request;
     serde::pb::rpc::route_descriptor _descriptor;
 };
@@ -467,27 +468,28 @@ void admin_server::add_service(
           /*path_parameters=*/{},
           /*mandatory_params=*/{},
         };
-        ss::noncopyable_function<void(const ss::http::request&)> auth_handler;
+        ss::noncopyable_function<request_auth_result(const ss::http::request&)>
+          auth_handler;
         switch (route.authz_level) {
         case serde::pb::rpc::authz_level::unauthenticated:
             auth_handler = [this](const ss::http::request& req) {
-                std::optional<request_auth_result> auth_state;
-                auth_state.emplace(apply_auth<publik>(req));
-                log_request(req, auth_state.value());
+                auto auth_result = apply_auth<publik>(req);
+                log_request(req, auth_result);
+                return auth_result;
             };
             break;
         case serde::pb::rpc::authz_level::user:
             auth_handler = [this](const ss::http::request& req) {
-                std::optional<request_auth_result> auth_state;
-                auth_state.emplace(apply_auth<user>(req));
-                log_request(req, auth_state.value());
+                auto auth_result = apply_auth<user>(req);
+                log_request(req, auth_result);
+                return auth_result;
             };
             break;
         case serde::pb::rpc::authz_level::superuser:
             auth_handler = [this](const ss::http::request& req) {
-                std::optional<request_auth_result> auth_state;
-                auth_state.emplace(apply_auth<superuser>(req));
-                log_request(req, auth_state.value());
+                auto auth_result = apply_auth<superuser>(req);
+                log_request(req, auth_result);
+                return auth_result;
             };
             break;
         }

--- a/src/v/redpanda/admin/services/BUILD
+++ b/src/v/redpanda/admin/services/BUILD
@@ -32,6 +32,9 @@ redpanda_cc_library(
     name = "cluster",
     srcs = ["cluster.cc"],
     hdrs = ["cluster.h"],
+    implementation_deps = [
+        "//src/v/redpanda/admin/proxy:context",
+    ],
     deps = [
         ":utils",
         "//proto/redpanda/core/admin/v2:cluster_redpanda_proto",

--- a/src/v/redpanda/admin/services/cluster.cc
+++ b/src/v/redpanda/admin/services/cluster.cc
@@ -14,6 +14,7 @@
 #include "features/feature_table.h"
 #include "proto/redpanda/core/admin/v2/cluster.proto.h"
 #include "redpanda/admin/kafka_connections_service.h"
+#include "redpanda/admin/proxy/context.h"
 #include "redpanda/admin/services/utils.h"
 #include "serde/protobuf/rpc.h"
 
@@ -52,7 +53,7 @@ cluster_service_impl::list_kafka_connections(
     auto& kcs = _kafka_connections_service.local();
 
     auto rate_units = std::optional<kafka_connections_service::remote_units>{};
-    if (!ctx.is_proxied()) {
+    if (!proxy::is_proxied(ctx)) {
         // Only apply rate limiting on external requests to avoid deadlock on
         // concurrent requests arriving at the same time through two different
         // nodes.
@@ -79,7 +80,7 @@ cluster_service_impl::list_kafka_connections(
 
     auto mem_units = co_await kcs.memory_limit(capped_page_size);
 
-    auto resp = ctx.is_proxied()
+    auto resp = proxy::is_proxied(ctx)
                   ? co_await kcs.list_kafka_connections_local(std::move(req))
                   : co_await kcs.list_kafka_connections_cluster_wide(
                       _proxy_client, ctx, std::move(req));

--- a/src/v/serde/protobuf/BUILD
+++ b/src/v/serde/protobuf/BUILD
@@ -102,7 +102,6 @@ redpanda_cc_library(
         "//src/v/bytes:iobuf",
         "//src/v/bytes:iostream",
         "//src/v/container:chunked_hash_map",
-        "//src/v/model",
         "//src/v/serde/json:writer",
         "@seastar",
     ],

--- a/src/v/serde/protobuf/rpc.h
+++ b/src/v/serde/protobuf/rpc.h
@@ -12,14 +12,14 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "bytes/iobuf.h"
 #include "container/chunked_hash_map.h"
-#include "model/fundamental.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/util/log.hh>
 
-#include <algorithm>
+#include <any>
 #include <memory>
 
 namespace seastar::http {
@@ -54,18 +54,48 @@ struct context {
     ss::sstring service_name;
     ss::sstring method_name;
     content_type content_type;
-    // A list of nodes that have proxied this request.
+    // Arbitrary extra values to be able to pass through this context.
+    // Access this map using `get_value` and `set_value`.
+    // Types in this map may be copied, so ensure types are cheap to copy.
     //
-    // This is used to service similar purposes as the `Via` HTTP header.
-    //
-    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Via
-    std::vector<model::node_id> proxied_nodes;
+    // Types used in this map:
+    // - std::vector<model::node_id> nodes `Via` like header to prevent proxy
+    //   loops
+    // - request_auth_result the authorization result for the Admin V2 API
+    std::map<std::type_index, std::any> values;
 
-    // If the request is being proxied from another broker or not.
-    bool is_proxied() const { return !proxied_nodes.empty(); }
-    // Return true if the given node has already proxied this request.
-    bool has_visited_node(model::node_id node) const {
-        return std::ranges::contains(proxied_nodes, node);
+    // Return a value associated with this context.
+    template<typename T>
+    auto get_value(this auto&& self) -> std::conditional_t<
+      std::is_const_v<std::remove_reference_t<decltype(self)>>,
+      const T&,
+      T&> {
+        using result_type = std::conditional_t<
+          std::is_const_v<std::remove_reference_t<decltype(self)>>,
+          const T&,
+          T&>;
+        return std::any_cast<result_type>(
+          self.values.at(std::type_index(typeid(T))));
+    }
+    // Return a value associated with this context if it exists.
+    template<typename T>
+    auto get_optional_value(this auto&& self) -> std::conditional_t<
+      std::is_const_v<std::remove_reference_t<decltype(self)>>,
+      const T*,
+      T*> {
+        auto it = self.values.find(std::type_index(typeid(T)));
+        using result_type = std::conditional_t<
+          std::is_const_v<std::remove_reference_t<decltype(self)>>,
+          const T&,
+          T&>;
+        return it == self.values.end()
+                 ? nullptr
+                 : &std::any_cast<result_type>(it->second);
+    }
+    // Associate some value with this context.
+    template<typename T>
+    void set_value(T&& t) {
+        values.insert_or_assign(std::type_index(typeid(T)), std::forward<T>(t));
     }
 };
 


### PR DESCRIPTION
The simplest way that doesn't introduce extra build dependencies to pass
through the auth result is to use `std::any` and an map container to
be able to pass through arbitrary values from the context.

In the future there might be additional information in the context, like
possibly the proxy information or other global information that could
save from passing into every admin service.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
