### PR TITLE
CORE-14664 dt: fix client monitoring scale test json output

### DIFF
--- a/tests/rptest/scale_tests/list_kafka_connections_scale_test.py
+++ b/tests/rptest/scale_tests/list_kafka_connections_scale_test.py
@@ -9,7 +9,6 @@
 
 import json
 import time
-
 from typing import Any
 
 from ducktape.mark import parametrize
@@ -146,11 +145,12 @@ class AdminV2ListKafkaConnectionsScaleTest(RedpandaTest):
             duration = time.perf_counter() - start
 
             resp = json.loads(raw_resp)
+            conns = resp.get("connections", [])
 
             matching_conns = [
-                conn for conn in resp if len(conn.get("group_member_id", "")) > 0
+                conn for conn in conns if len(conn.get("group_member_id", "")) > 0
             ]
-            non_matching = [conn for conn in resp if conn not in matching_conns]
+            non_matching = [conn for conn in conns if conn not in matching_conns]
 
             succeeded = len(matching_conns) == client_count and len(non_matching) == 0
             if succeeded:


### PR DESCRIPTION
The json output format recently changed in rpk (https://github.com/redpanda-data/redpanda/pull/28463), so the scale test needs updating.

Fixes https://redpandadata.atlassian.net/browse/CORE-14664

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
