### PR TITLE
rpk: warn the user when the cluster is likely a cloud cluster but rpk…

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/config/edit.go
+++ b/src/go/rpk/pkg/cli/cluster/config/edit.go
@@ -48,6 +48,7 @@ to edit all properties including these tunables.
 		Run: func(cmd *cobra.Command, _ []string) {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
+			config.WarnIfMisconfiguredCloudProfile(p)
 			config.CheckExitCloudAdmin(p)
 
 			client, err := adminapi.NewClient(cmd.Context(), fs, p)

--- a/src/go/rpk/pkg/cli/cluster/config/export.go
+++ b/src/go/rpk/pkg/cli/cluster/config/export.go
@@ -147,6 +147,7 @@ to include all properties including these low level tunables.
 		Run: func(cmd *cobra.Command, _ []string) {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
+			config.WarnIfMisconfiguredCloudProfile(p)
 			config.CheckExitCloudAdmin(p)
 
 			client, err := adminapi.NewClient(cmd.Context(), fs, p)

--- a/src/go/rpk/pkg/cli/cluster/config/import.go
+++ b/src/go/rpk/pkg/cli/cluster/config/import.go
@@ -305,6 +305,7 @@ from the YAML file, it is reset to its default value.  `,
 		Run: func(cmd *cobra.Command, _ []string) {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
+			config.WarnIfMisconfiguredCloudProfile(p)
 			config.CheckExitCloudAdmin(p)
 
 			client, err := adminapi.NewClient(cmd.Context(), fs, p)

--- a/src/go/rpk/pkg/cli/cluster/config/lint.go
+++ b/src/go/rpk/pkg/cli/cluster/config/lint.go
@@ -56,6 +56,7 @@ central configuration store (and via 'rpk cluster config edit').
 			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			p := cfg.VirtualProfile()
+			config.WarnIfMisconfiguredCloudProfile(p)
 			config.CheckExitCloudAdmin(p)
 
 			client, err := adminapi.NewClient(cmd.Context(), fs, p)

--- a/src/go/rpk/pkg/cli/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set.go
@@ -99,6 +99,8 @@ Use the flag '--no-confirm' to avoid the confirmation prompt.`,
 				fmt.Print("Processing configuration, this operation may take up to 10 minutes. To check the status, run 'rpk cluster config status'\n\n")
 				fmt.Printf("Operation ID: %s \n", operation.GetOperation().GetId())
 			} else {
+				config.WarnIfMisconfiguredCloudProfile(vp)
+
 				client, err := adminapi.NewClient(cmd.Context(), fs, vp)
 				out.MaybeDie(err, "unable to initialize admin client: %v", err)
 

--- a/src/go/rpk/pkg/cli/cluster/config/status.go
+++ b/src/go/rpk/pkg/cli/cluster/config/status.go
@@ -68,6 +68,7 @@ is offline.`,
 					}{op.OperationID, op.Status, op.Started, op.Completed})
 				}
 			} else {
+				config.WarnIfMisconfiguredCloudProfile(vp)
 				client, err := adminapi.NewClient(cmd.Context(), fs, vp)
 				out.MaybeDie(err, "unable to initialize admin client: %v", err)
 

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -327,3 +327,44 @@ func ParseAdditionalStartFlags(flags []string) map[string]string {
 	}
 	return parsed
 }
+
+// isLikelyCloudCluster checks if the broker URLs indicate this is a cloud cluster.
+func isLikelyCloudCluster(p *RpkProfile) bool {
+	// Check KafkaAPI brokers
+	for _, broker := range p.KafkaAPI.Brokers {
+		if isLikelyCloudBrokerURL(broker) {
+			return true
+		}
+	}
+	// Check AdminAPI addresses
+	for _, addr := range p.AdminAPI.Addresses {
+		if isLikelyCloudBrokerURL(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+// isLikelyCloudBrokerURL checks if a broker URL matches known cloud cluster patterns.
+func isLikelyCloudBrokerURL(url string) bool {
+	return strings.Contains(strings.ToLower(url), ".cloud.redpanda.com")
+}
+
+// WarnIfMisconfiguredCloudProfile checks if the cluster appears to be a cloud cluster
+// but the profile is not properly configured with FromCloud=true. If so, it prints
+// a helpful warning message and exits.
+func WarnIfMisconfiguredCloudProfile(p *RpkProfile) {
+	if !p.FromCloud && isLikelyCloudCluster(p) {
+		fmt.Println(`This appears to be a Redpanda Cloud cluster, but your rpk profile is not aware of it.
+
+Please configure rpk to use Redpanda Cloud by running:
+
+  rpk cloud login
+
+Then create or select a cloud profile with:
+
+  rpk cloud cluster profile use <cluster-name>
+
+For more information, visit: https://docs.redpanda.com/redpanda-cloud/reference/rpk/rpk-cloud/rpk-cloud-cluster`)
+	}
+}

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -1048,3 +1048,128 @@ func Test_ParseFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestIsCloudBrokerURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected bool
+	}{
+		{
+			name:     "cloud.redpanda.com URL",
+			url:      "seed-123.abc.cloud.redpanda.com:9092",
+			expected: true,
+		},
+		{
+			name:     "byoc cluster URL",
+			url:      "seed-7c375997.d4bpfk5875ie32jp5ut0.byoc.ign.cloud.redpanda.com:9644",
+			expected: true,
+		},
+		{
+			name:     "ign.cloud.redpanda.com URL",
+			url:      "example.ign.cloud.redpanda.com:9092",
+			expected: true,
+		},
+		{
+			name:     "localhost",
+			url:      "localhost:9092",
+			expected: false,
+		},
+		{
+			name:     "self-hosted IP",
+			url:      "192.168.1.100:9092",
+			expected: false,
+		},
+		{
+			name:     "self-hosted domain",
+			url:      "redpanda.example.com:9092",
+			expected: false,
+		},
+		{
+			name:     "case insensitive cloud URL",
+			url:      "SEED-123.ABC.CLOUD.REDPANDA.COM:9092",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isLikelyCloudBrokerURL(tt.url)
+			if result != tt.expected {
+				t.Errorf("isCloudBrokerURL(%q) = %v, want %v", tt.url, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsLikelyCloudCluster(t *testing.T) {
+	tests := []struct {
+		name     string
+		profile  *RpkProfile
+		expected bool
+	}{
+		{
+			name: "cloud cluster with kafka broker",
+			profile: &RpkProfile{
+				KafkaAPI: RpkKafkaAPI{
+					Brokers: []string{"seed-123.abc.cloud.redpanda.com:9092"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "cloud cluster with admin API",
+			profile: &RpkProfile{
+				AdminAPI: RpkAdminAPI{
+					Addresses: []string{"seed-123.abc.byoc.ign.cloud.redpanda.com:9644"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "self-hosted cluster",
+			profile: &RpkProfile{
+				KafkaAPI: RpkKafkaAPI{
+					Brokers: []string{"localhost:9092"},
+				},
+				AdminAPI: RpkAdminAPI{
+					Addresses: []string{"localhost:9644"},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "mixed URLs (one cloud)",
+			profile: &RpkProfile{
+				KafkaAPI: RpkKafkaAPI{
+					Brokers: []string{
+						"localhost:9092",
+						"seed-123.abc.cloud.redpanda.com:9092",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "empty profile",
+			profile: &RpkProfile{
+				KafkaAPI: RpkKafkaAPI{
+					Brokers: []string{},
+				},
+				AdminAPI: RpkAdminAPI{
+					Addresses: []string{},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isLikelyCloudCluster(tt.profile)
+			if result != tt.expected {
+				t.Errorf("isLikelyCloudCluster() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

- rpk will warn users when they interact with a cloud cluster using an rpk profile that isn't properly configured for cloud.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
