### PR TITLE
[CORE-14647] ct: Take max applied epoch into account

### DIFF
--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -336,25 +336,30 @@ ss::future<cluster_epoch_fence> ctp_stm::fence_epoch(cluster_epoch e) {
         throw std::runtime_error(fmt_with_ctx(fmt::format, "Sync timeout"));
     }
     auto term = _raft->confirmed_term();
-    auto max_seen_epoch = _state.get_max_seen_epoch();
-    if (max_seen_epoch.has_value() && max_seen_epoch.value() == e) {
+    // The max_seen_epoch is not persisted to disk as part of the snapshot
+    // because it represents in-flight batches. If this epoch is nullopt we
+    // should take max_applied_epoch into account.
+    auto get_applied_epoch = [this] { return _state.get_max_epoch(); };
+    auto fence_epoch = _state.get_max_seen_epoch().or_else(get_applied_epoch);
+    if (fence_epoch.has_value() && fence_epoch.value() == e) {
         // Case 1. Same epoch, need to acquire read-lock.
         auto unit = co_await _lock.hold_read_lock();
-        // Invariant: the max_seen_epoch is not nullopt because once
-        // set the max_seen_epoch is never resets.
-        if (_state.get_max_seen_epoch() == e) {
+        if (_state.get_max_seen_epoch().or_else(get_applied_epoch) == e) {
             // The max_seen_epoch didn't advance after the scheduling point
-            co_return cluster_epoch_fence{std::move(unit), term};
+            co_return cluster_epoch_fence{
+              .unit = std::move(unit), .term = term};
         }
     } else {
         // Case 2. New epoch, need to acquire write-lock.
         auto unit = co_await _lock.hold_write_lock();
-        auto current_epoch = _state.get_max_seen_epoch();
+        auto current_epoch = _state.get_max_seen_epoch().or_else(
+          get_applied_epoch);
         if (!current_epoch.has_value() || current_epoch.value() <= e) {
             _state.advance_max_seen_epoch(e);
             // Demote to reader lock after max_seen_epoch is updated.
             unit.return_units(unit.count() - 1);
-            co_return cluster_epoch_fence{std::move(unit), term};
+            co_return cluster_epoch_fence{
+              .unit = std::move(unit), .term = term};
         }
     }
     // If we reach here, it means that we need to discard the batch.

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -19,6 +19,7 @@
 namespace cloud_topics {
 
 class ctp_stm_api;
+struct ctp_stm_accessor;
 
 /// The STM that tracks current cluster epoch and LRO.
 /// The goal is to guarantee that the cluster epoch is monotonic and
@@ -29,6 +30,7 @@ class ctp_stm_api;
 /// metadata batch to its in-memory state.
 class ctp_stm final : public raft::persisted_stm<> {
     friend class ctp_stm_api;
+    friend struct ctp_stm_accessor; // for tests
 
 public:
     static constexpr const char* name = "ctp_stm";

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -33,6 +33,17 @@ struct ctp_stm_api_accessor {
     ct::ctp_stm_api api;
 };
 
+namespace cloud_topics {
+struct ctp_stm_accessor {
+    auto take_snapshot(ctp_stm& stm) { return stm.take_local_snapshot({}); }
+
+    auto install_snapshot(ctp_stm& stm, raft::stm_snapshot snapshot) {
+        return stm.apply_local_snapshot(
+          snapshot.header, std::move(snapshot.data));
+    }
+};
+} // namespace cloud_topics
+
 class ctp_stm_fixture : public raft::stm_raft_fixture<ct::ctp_stm> {
 public:
     ss::future<> start() {
@@ -408,4 +419,40 @@ TEST_F_CORO(ctp_stm_fixture, can_replay_truncated_log) {
     auto follower_stm = get_stm<0>(node(follower_id));
     co_await follower_stm->wait(dirty_offset, model::no_timeout);
     vlog(ct::cd_log.info, "recovery done: {}", follower_id);
+}
+
+TEST_F_CORO(ctp_stm_fixture, test_snapshot) {
+    co_await start();
+
+    co_await wait_for_leader(raft::default_timeout());
+
+    auto gc_epoch = co_await api(node(*get_leader())).get_inactive_epoch();
+
+    ASSERT_TRUE_CORO(gc_epoch);
+    ASSERT_FALSE_CORO(gc_epoch->has_value());
+
+    auto b1 = make_record_batch(ct::cluster_epoch{2}, model::offset{0}, 0);
+    auto res = co_await replicate_record_batch(
+      node(*get_leader()), std::move(b1));
+    ASSERT_TRUE_CORO(res.has_value());
+
+    auto max_epoch = api(node(*get_leader())).get_max_epoch();
+    auto max_seen_epoch = api(node(*get_leader())).get_max_seen_epoch();
+    ASSERT_TRUE_CORO(max_epoch.has_value());
+    ASSERT_TRUE_CORO(max_seen_epoch.has_value());
+    ASSERT_EQ_CORO(max_epoch.value(), ct::cluster_epoch{2});
+    ASSERT_EQ_CORO(max_seen_epoch.value(), ct::cluster_epoch{2});
+
+    auto& leader = node(*get_leader());
+    auto stm = get_stm<0>(leader);
+    ct::ctp_stm_accessor a;
+    auto snapshot = co_await a.take_snapshot(*stm);
+
+    co_await a.install_snapshot(*stm, std::move(snapshot));
+
+    // Acquire the fence for epoch 1 (should fail)
+    {
+        auto fence = co_await api(leader).fence_epoch(ct::cluster_epoch{1});
+        ASSERT_FALSE_CORO(fence.unit.has_value());
+    }
 }


### PR DESCRIPTION
1. The fencing is done based on max-seen-epoch value.
2. The max-seen-epoch value is not persisted to disk as part of the snapshot because it represents an in-flight request.

Normally, this is not the problem. When every placeholder batch is applied we're updating both max-seen and max-applied epoch values ('ctp_stm_state::advance_epoch' method). The problem is that right after the snapshot is loaded the max-seen-epoch is nullopt so it is possible to acquire a fence for every epoch.

This commit fixes this by checking both max-seen and max-applied.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none