### PR TITLE
`clang-tidy`: allow lambda coroutines which deduce `this` and add a `ClangTidyCheck` for static analysis

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 ---
 Checks:          'redpanda-*,clang-diagnostic-*,clang-analyzer-*,cert-*,cppcoreguidelines-*,hicpp-*,modernize-*,performance-*,misc-*,bugprone-*,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-hicpp-named-parameter,-misc-include-cleaner,-clang-analyzer-optin.core.EnumCastOutOfRange,-cppcoreguidelines-avoid-reference-coroutine-parameters'
-WarningsAsErrors: 'redpanda-*,cppcoreguidelines-avoid-capturing-lambda-coroutines,bugprone-use-after-move,bugprone-assert-side-effect,bugprone-assignment-in-if-condition,bugprone-dangling-handle,bugprone-sizeof-container,bugprone-stringview-nullptr,bugprone-unused-return-value,bugprone-suspicious-string-compare,misc-unused-using-decls,misc-unused-alias-decls,modernize-redundant-void-arg,performance-implicit-conversion-in-loop,performance-trivially-destructible,performance-no-automatic-move,bugprone-unused-local-non-trivial-variable'
+WarningsAsErrors: 'redpanda-*,bugprone-use-after-move,bugprone-assert-side-effect,bugprone-assignment-in-if-condition,bugprone-dangling-handle,bugprone-sizeof-container,bugprone-stringview-nullptr,bugprone-unused-return-value,bugprone-suspicious-string-compare,misc-unused-using-decls,misc-unused-alias-decls,modernize-redundant-void-arg,performance-implicit-conversion-in-loop,performance-trivially-destructible,performance-no-automatic-move,bugprone-unused-local-non-trivial-variable'
 HeaderFilterRegex: '^(?!external/.*).*'
 FormatStyle:    file
 CheckOptions:

--- a/bazel/clang_tidy/plugins/BUILD
+++ b/bazel/clang_tidy/plugins/BUILD
@@ -13,6 +13,8 @@ cc_library(
 cc_binary(
     name = "plugins.so",
     srcs = [
+        "redpanda_lambda_coroutine_deduces_this_check.cc",
+        "redpanda_lambda_coroutine_deduces_this_check.h",
         "redpanda_noop_check.h",
         "redpanda_tidy_module.cc",
     ],

--- a/bazel/clang_tidy/plugins/redpanda_lambda_coroutine_deduces_this_check.cc
+++ b/bazel/clang_tidy/plugins/redpanda_lambda_coroutine_deduces_this_check.cc
@@ -1,0 +1,95 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "redpanda_lambda_coroutine_deduces_this_check.h"
+
+#include <clang-tidy/ClangTidyCheck.h>
+#include <clang/AST/ASTContext.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+
+namespace clang::tidy::redpanda {
+
+using namespace clang::ast_matchers;
+
+namespace {
+
+AST_MATCHER(LambdaExpr, hasCoroutineBody) {
+    const Stmt* Body = Node.getBody();
+    return Body != nullptr && CoroutineBodyStmt::classof(Body);
+}
+
+AST_MATCHER(LambdaExpr, invalidCaptures) {
+    auto empty_captures = Node.capture_size() == 0U;
+    if (empty_captures) {
+        // Empty capture clause is okay.
+        return false;
+    } else {
+        // Non-empty capture clause requires deducing this to properly extend
+        // lifetimes of captured elements.
+        // https://github.com/scylladb/seastar/blob/master/doc/lambda-coroutine-fiasco.md#solution-c23-and-up
+        const auto* Call = Node.getCallOperator();
+        bool deduces_this = Call->isExplicitObjectMemberFunction();
+        return !deduces_this;
+    }
+}
+
+} // namespace
+
+void LambdaCoroutineDeducesThis::registerMatchers(MatchFinder* Finder) {
+    Finder->addMatcher(
+      lambdaExpr(hasCoroutineBody(), invalidCaptures()).bind("lambda"), this);
+}
+
+bool LambdaCoroutineDeducesThis::isLanguageVersionSupported(
+  const LangOptions& LangOpts) const {
+    // Deducing this is only supported in C++23 and beyond.
+    return LangOpts.CPlusPlus23;
+}
+
+void LambdaCoroutineDeducesThis::check(const MatchFinder::MatchResult& Result) {
+    const auto* MatchedLambda = Result.Nodes.getNodeAs<LambdaExpr>("lambda");
+    SourceLocation insert_loc;
+    std::string replace;
+    auto* Call = MatchedLambda->getCallOperator();
+    bool has_params = !Call->param_empty();
+
+    if (has_params) {
+        // Lambda already has parameters: insert 'this auto,' before the first
+        // parameter
+        const ParmVarDecl* first_param = Call->parameters().front();
+        insert_loc = first_param->getBeginLoc();
+        replace = "this auto, ";
+    } else {
+        // Lambda has no parameters and may not even have a parameter list:
+        // insert either a new argument list ('(this auto)') or an argument
+        // `this auto`.
+        auto end_of_introducer_range
+          = MatchedLambda->getIntroducerRange().getEnd();
+        auto maybe_paren_loc = end_of_introducer_range.getLocWithOffset(1);
+        auto* SM = Result.SourceManager;
+        if (maybe_paren_loc.isValid()) {
+            const char* token_start = SM->getCharacterData(maybe_paren_loc);
+            if (*token_start == '(') {
+                insert_loc = end_of_introducer_range.getLocWithOffset(2);
+                replace = "this auto";
+            } else {
+                insert_loc = maybe_paren_loc;
+                replace = "(this auto)";
+            }
+        }
+    }
+
+    diag(
+      MatchedLambda->getExprLoc(),
+      "coroutine lambda may cause use-after-free, avoid captures or pass "
+      "`this` as first parameter to lambda arguments")
+      << FixItHint::CreateInsertion(insert_loc, replace);
+}
+
+} // namespace clang::tidy::redpanda

--- a/bazel/clang_tidy/plugins/redpanda_lambda_coroutine_deduces_this_check.h
+++ b/bazel/clang_tidy/plugins/redpanda_lambda_coroutine_deduces_this_check.h
@@ -1,0 +1,35 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include <clang-tidy/ClangTidyCheck.h>
+
+namespace clang::tidy::redpanda {
+
+/**
+ * A clang-tidy check that ensures that any lambda that is a coroutine passes
+ * `this` as the first parameter, thereby forcing captured variables in a lambda
+ * to be moved into the coroutine frame, extending their lifetimes and
+ * preventing what is known as the "lambda coroutine fiasco".
+ * See:
+ * https://github.com/scylladb/seastar/blob/master/doc/lambda-coroutine-fiasco.md
+ *
+ *
+ */
+class LambdaCoroutineDeducesThis : public ClangTidyCheck {
+public:
+    LambdaCoroutineDeducesThis(StringRef Name, ClangTidyContext* Context)
+      : ClangTidyCheck(Name, Context) {}
+    void registerMatchers(ast_matchers::MatchFinder* Finder) override;
+    void check(const ast_matchers::MatchFinder::MatchResult& Result) override;
+    bool isLanguageVersionSupported(const LangOptions& LangOpts) const override;
+};
+
+} // namespace clang::tidy::redpanda

--- a/bazel/clang_tidy/plugins/redpanda_noop_check.h
+++ b/bazel/clang_tidy/plugins/redpanda_noop_check.h
@@ -1,3 +1,12 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
 #pragma once
 
 #include <clang-tidy/ClangTidyCheck.h>

--- a/bazel/clang_tidy/plugins/redpanda_tidy_module.cc
+++ b/bazel/clang_tidy/plugins/redpanda_tidy_module.cc
@@ -1,3 +1,12 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
 #include "redpanda_noop_check.h"
 
 #include <clang-tidy/ClangTidyModule.h>

--- a/bazel/clang_tidy/plugins/redpanda_tidy_module.cc
+++ b/bazel/clang_tidy/plugins/redpanda_tidy_module.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "redpanda_lambda_coroutine_deduces_this_check.h"
 #include "redpanda_noop_check.h"
 
 #include <clang-tidy/ClangTidyModule.h>
@@ -29,6 +30,8 @@ public:
     void addCheckFactories(ClangTidyCheckFactories& check_factories) override {
         // register checks here. for example:
         check_factories.registerCheck<NoopCheck>("redpanda-noop");
+        check_factories.registerCheck<LambdaCoroutineDeducesThis>(
+          "redpanda-lambda-coroutine-deduces-this");
     }
 
     // this is where you might set default options for any configurable checks

--- a/bazel/clang_tidy/plugins/tests/redpanda_lambda_coroutine_deduces_this_check_test.cc.in
+++ b/bazel/clang_tidy/plugins/tests/redpanda_lambda_coroutine_deduces_this_check_test.cc.in
@@ -1,0 +1,159 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// clang-format off
+// Test file for `redpanda-lambda-coroutine-deduces-this`.
+// Run with `./tools/clang-tidy --checks=-*,redpanda-lambda-coroutine-deduces-this bazel/clang_tidy/plugins/tests/redpanda_lambda_coroutine_deduces_this_check_test.cc.in`
+// clang-format on
+#include <coroutine>
+#include <exception>
+
+namespace {
+
+template<typename T>
+struct promise_type {
+    T get_return_object() { return {}; }
+    std::suspend_never initial_suspend() { return {}; }
+    std::suspend_never final_suspend() noexcept { return {}; }
+    void return_void() {}
+    void unhandled_exception() { std::terminate(); }
+};
+
+// Fun hack to get immediate validation in output diagnostics.
+struct CheckShouldFail {
+    using promise_type = ::promise_type<CheckShouldFail>;
+};
+
+struct CheckShouldPass {
+    using promise_type = ::promise_type<CheckShouldPass>;
+};
+
+struct Test {
+    void Caught() {
+        // 1. Basic example, a single captured variable without deducing this.
+        {
+            const int a{};
+            void([a]() -> CheckShouldFail {
+                (void)a;
+                co_return;
+            });
+        }
+        // 2. Basic example, a single captured by reference variable without
+        // deducing this.
+        {
+            const int a{};
+            void([&a]() -> CheckShouldFail {
+                (void)a;
+                co_return;
+            });
+        }
+        // 3. Captures the containing struct `Test` and uses `this`.
+        {
+            void([this]() -> CheckShouldFail {
+                (void)this;
+                co_return;
+            });
+        }
+        // 4. Default captures by reference and uses a variable.
+        {
+            [[maybe_unused]] const int a{};
+            [[maybe_unused]] const bool b{};
+            [[maybe_unused]] const char c{};
+            [[maybe_unused]] const double d{};
+            void([&]() -> CheckShouldFail {
+                (void)a;
+                co_return;
+            });
+        }
+        // 5. Captures a variable and takes one argument.
+        {
+            const int a{};
+            void([&](int n) -> CheckShouldFail {
+                (void)a;
+                (void)n;
+                co_return;
+            });
+        }
+        // 6. Lambda without an argument list.
+        {
+            const int a{};
+            void([a] -> CheckShouldFail {
+                (void)a;
+                co_return;
+            });
+        }
+        // 7. Default captures by reference and uses a member variable (implicit
+        // use of `this->`)
+        {
+            void([&]() -> CheckShouldFail {
+                (void)_a;
+                co_return;
+            });
+        }
+    }
+
+    void Safe() {
+        // No captures.
+        {
+            void([]() -> CheckShouldPass { co_return; });
+        }
+        // Fixed example 1.
+        {
+            const int a{};
+            void([a](this auto) -> CheckShouldPass {
+                (void)a;
+                co_return;
+            });
+        }
+        // Fixed example 2.
+        {
+            const int a{};
+            void([&a](this auto) -> CheckShouldPass {
+                (void)a;
+                co_return;
+            });
+        }
+        // Fixed example 3.
+        {
+            void([this](this auto) -> CheckShouldPass {
+                (void)this;
+                co_return;
+            });
+        }
+        // Fixed example 4.
+        {
+            [[maybe_unused]] const int a{};
+            [[maybe_unused]] const bool b{};
+            [[maybe_unused]] const char c{};
+            [[maybe_unused]] const double d{};
+            void([&]() -> CheckShouldPass { co_return; });
+        }
+        // Fixed example 5.
+        {
+            const int a{};
+            void([&](this auto, int n) -> CheckShouldPass {
+                (void)a;
+                (void)n;
+                co_return;
+            });
+        }
+        // Fixed example 7.
+        {
+            void([&](this auto) -> CheckShouldPass {
+                (void)_a;
+                co_return;
+            });
+        }
+    }
+    [[maybe_unused]] int _a;
+};
+
+} // namespace
+
+int main() { return 0; }

--- a/src/v/cluster_link/replication/tests/partition_data_queue_tests.cc
+++ b/src/v/cluster_link/replication/tests/partition_data_queue_tests.cc
@@ -102,8 +102,7 @@ TEST_F_CORO(PartitionDataQueueTest, testConcurrentFetchEnqueue) {
     static constexpr auto test_time = 5s;
     auto deadline = ss::lowres_clock::now() + test_time;
 
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)
-    auto producer = [&]() -> ss::future<> {
+    auto producer = [&](this auto) -> ss::future<> {
         while (ss::lowres_clock::now() < deadline) {
             co_await enqueue_some_data();
             co_await ss::sleep(
@@ -112,8 +111,7 @@ TEST_F_CORO(PartitionDataQueueTest, testConcurrentFetchEnqueue) {
     };
 
     ss::abort_source as;
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)
-    auto fetcher = [&]() -> ss::future<> {
+    auto fetcher = [&](this auto) -> ss::future<> {
         while (ss::lowres_clock::now() < deadline) {
             try {
                 auto data = co_await _queue->fetch(as);
@@ -124,8 +122,8 @@ TEST_F_CORO(PartitionDataQueueTest, testConcurrentFetchEnqueue) {
               std::chrono::milliseconds(random_generators::get_int(1, 5)));
         }
     };
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)
-    auto resetter = [&]() -> ss::future<> {
+
+    auto resetter = [&](this auto) -> ss::future<> {
         while (ss::lowres_clock::now() < deadline) {
             _queue->reset(kafka::offset{});
             co_await ss::sleep(1s);

--- a/src/v/kafka/server/tests/quota_manager_bench.cc
+++ b/src/v/kafka/server/tests/quota_manager_bench.cc
@@ -167,9 +167,7 @@ future<size_t> run_latency_test(latency_test_case tc) {
       shard < ss::smp::count, "Not enough cores available for the benchmark");
 
     co_await ss::smp::submit_to(
-      shard,
-      // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)
-      seastar::coroutine::lambda([&sqm, &quota_store, tc]() -> ss::future<> {
+      shard, [&sqm, &quota_store, tc](this auto) -> ss::future<> {
           auto& qm = sqm.local();
 
           // Try to create a realistic setup
@@ -227,7 +225,7 @@ future<size_t> run_latency_test(latency_test_case tc) {
           }
 
           perf_tests::stop_measuring_time();
-      }));
+      });
 
     co_await sqm.stop();
     co_await quota_store.stop();

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -6446,14 +6446,14 @@ TEST_F(storage_test_fixture, segment_cached_disk_usage_set_after_compaction) {
         } while (log->segments().back()->size_bytes() < size);
     };
 
-    auto add_segment_func = [&]() {
+    auto add_segment_func = [&](this auto) -> ss::future<> {
         auto size = random_generators::get_int(4_KiB, 10_MiB);
         add_segment(size, model::term_id(0));
-        log->force_roll().get();
+        co_await log->force_roll();
     };
 
-    add_segment_func();
-    add_segment_func();
+    add_segment_func().get();
+    add_segment_func().get();
 
     ss::abort_source as;
     compaction::compaction_config cfg(


### PR DESCRIPTION
Since https://github.com/scylladb/seastar/blob/master/doc/lambda-coroutine-fiasco.md was updated (more reading: [1], [2]) it has been made clear that lambda coroutines can avoid lifetime issues through use of C++23's deducing `this` [3].

Curious readers should refer to the above links for technical explanations (TL;DR deducing `this` passes captured variables into coroutine's frame by value, instead of having the coroutine hold them by reference for proper lifetime extension), but it seems that we can loosen our guidelines around use of lambda coroutines in the codebase by removing `cppcoreguidelines-avoid-capturing-lambda-coroutines` from our list of `clang-tidy` checks.

However, we want to enforce that use of lambda coroutines are going to be safe, if we start checking them into the codebase. To this end, a new `clang-tidy` pass is added since the new hotness from https://github.com/redpanda-data/redpanda/pull/27801 is already in the tree. This pass ensures that either:

1. A lambda coroutine's capture clause is empty
2. A lambda coroutine with a non-empty capture clause passes `this auto` as the first parameter, thereby making use of C++23's deducing `this` to achieve the above magic with coroutines.


[1]: https://github.com/scylladb/seastar/pull/3016
[2]: https://lists.isocpp.org/std-proposals/2025/10/15592.php
[3]: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0847r6.html

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
