### PR TITLE
[v25.3.x] [CORE-9493] [CORE-9492] [CORE-9494] dt/dl: Use progress-oriented wait for datalake translation

### DIFF
--- a/tests/rptest/tests/datalake/custom_partitioning_test.py
+++ b/tests/rptest/tests/datalake/custom_partitioning_test.py
@@ -169,7 +169,8 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
         msg_count,
         already_produced=0,
         gen_record=None,
-        wait_time_s=30,
+        wait_time_s=90,
+        progress_sec=None,
     ):
         # Have all records share the same timestamp, so that they are
         # guaranteed to end up in the same hour partition.
@@ -193,7 +194,10 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
             )
         producer.flush()
         dl.wait_for_translation(
-            topic_name, msg_count=already_produced + msg_count, timeout=wait_time_s
+            topic_name,
+            msg_count=already_produced + msg_count,
+            timeout=wait_time_s,
+            progress_sec=wait_time_s // 3 if progress_sec is None else progress_sec,
         )
 
     def describe_partitioning(self, dl, topic_name):
@@ -668,6 +672,7 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
                     "timestamp_us": int(t + n),
                 },
                 wait_time_s=900,
+                progress_sec=90,
             )
 
             describe_partitioning = self.describe_partitioning(dl, topic_name)

--- a/tests/rptest/tests/datalake/databricks_test.py
+++ b/tests/rptest/tests/datalake/databricks_test.py
@@ -130,7 +130,9 @@ class DatabricksTest(RedpandaTest):
             dl.create_iceberg_enabled_topic(self.topic_name, partitions=10)
             dl.produce_to_topic(self.topic_name, 1024, count)
 
-            dl.wait_for_translation(self.topic_name, msg_count=count, timeout=60)
+            dl.wait_for_translation(
+                self.topic_name, msg_count=count, timeout=120, progress_sec=30
+            )
 
             actual_schema = fetch_dbx_schema(dl, f"redpanda.{self.topic_name}")
             expected_schema = [
@@ -280,7 +282,10 @@ class DatabricksTest(RedpandaTest):
                 produced_total += num_msgs
 
                 dl.wait_for_translation(
-                    self.topic_name, msg_count=produced_total, timeout=60
+                    self.topic_name,
+                    msg_count=produced_total,
+                    timeout=120,
+                    progress_sec=30,
                 )
 
             self.logger.info("Producing data to the topic with no partitioning")
@@ -413,7 +418,9 @@ class DatabricksTest(RedpandaTest):
                 self.logger.info(f"Producing data to the topic, iteration {i + 1}")
                 num_produced += 100
                 dl.produce_to_topic(self.topic_name, 1024, 100)
-                dl.wait_for_translation(self.topic_name, num_produced, timeout=60)
+                dl.wait_for_translation(
+                    self.topic_name, num_produced, timeout=120, progress_sec=30
+                )
 
             table = dl.catalog_client().load_table(table_name)
             files_before = len(table.inspect.files())
@@ -432,7 +439,9 @@ class DatabricksTest(RedpandaTest):
 
             self.logger.info("Producing more data to the topic after optimization")
             dl.produce_to_topic(self.topic_name, 1024, 10)
-            dl.wait_for_translation(self.topic_name, num_produced + 10, timeout=60)
+            dl.wait_for_translation(
+                self.topic_name, num_produced + 10, timeout=120, progress_sec=30
+            )
 
             self.logger.info("Verifying that all data is accessible after optimization")
             DatalakeVerifier.oneshot(

--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -28,6 +28,9 @@ from rptest.services.spark_service import SparkService
 from rptest.services.trino_service import TrinoService
 from rptest.tests.datalake.query_engine_base import QueryEngineBase, QueryEngineType
 from rptest.tests.datalake.query_engine_factory import get_query_engine_by_type
+from rptest.util import (
+    wait_until_with_progress_check,
+)
 
 
 class DatalakeServices:
@@ -319,7 +322,8 @@ class DatalakeServices:
         self,
         topic,
         msg_count,
-        timeout=30,
+        timeout=90,
+        progress_sec=30,
         backoff_sec=5,
         table_override=None,
         op=operator.eq,
@@ -331,27 +335,38 @@ class DatalakeServices:
 
         self.wait_for_iceberg_table("redpanda", table_name, timeout, backoff_sec)
 
-        def translation_done():
+        def get_counts():
             assert len(self.query_engines) > 0, (
                 "At least one query engine is required to check translation status"
             )
 
-            counts = dict(
+            return dict(
                 map(
                     lambda e: (e.engine_name(), e.count_table("redpanda", table_name)),
                     self.query_engines,
                 )
             )
+
+        # just want to know that something moved
+        def total_count():
+            counts = get_counts()
+            return sum(c for _, c in counts.items())
+
+        def translation_done():
+            counts = get_counts()
             self.redpanda.logger.debug(
                 f"Current counts for {table_name}: {counts}, want {op=} {msg_count}"
             )
             return all([op(c, msg_count) for _, c in counts.items()])
 
-        wait_until(
-            translation_done,
+        wait_until_with_progress_check(
+            check=total_count,
+            condition=translation_done,
             timeout_sec=timeout,
+            progress_sec=progress_sec,
             backoff_sec=backoff_sec,
             err_msg=f"Timed out waiting for events from {topic} to appear in datalake",
+            logger=self.redpanda.logger,
         )
 
     def produce_to_topic(self, topic, msg_size, msg_count, rate_limit_bps=None):

--- a/tests/rptest/tests/datalake/duckdb_test.py
+++ b/tests/rptest/tests/datalake/duckdb_test.py
@@ -62,7 +62,9 @@ class DuckDBTest(RedpandaTest):
             dl.create_iceberg_enabled_topic(self.topic_name, partitions=1)
             dl.produce_to_topic(self.topic_name, 1024, count)
 
-            dl.wait_for_translation(self.topic_name, msg_count=count, timeout=60)
+            dl.wait_for_translation(
+                self.topic_name, msg_count=count, timeout=120, progress_sec=30
+            )
 
             # TODO add test with WHERE clause which currently is broken.
             #   Even `WHERE value IS NOT NULL` fails with:

--- a/tests/rptest/tests/datalake/iceberg_toggling_test.py
+++ b/tests/rptest/tests/datalake/iceberg_toggling_test.py
@@ -199,7 +199,11 @@ class IcebergTogglingTest(RedpandaTest):
                 # Wait for records to be translated.
                 min_records_expected = total_records_sent()
                 dl.wait_for_translation(
-                    self.topic_name, min_records_expected, timeout=60, op=operator.gt
+                    self.topic_name,
+                    msg_count=min_records_expected,
+                    timeout=120,
+                    progress_sec=30,
+                    op=operator.gt,
                 )
 
                 self.rpk.alter_topic_config(
@@ -253,7 +257,10 @@ class IcebergTogglingTest(RedpandaTest):
 
             try:
                 dl.wait_for_translation(
-                    self.topic_name, msg_count=produced_records, timeout=30
+                    self.topic_name,
+                    msg_count=produced_records,
+                    timeout=90,
+                    progress_sec=30,
                 )
                 assert False, "Expected translation to fail but it did not"
             except ducktape.errors.TimeoutError:
@@ -262,7 +269,10 @@ class IcebergTogglingTest(RedpandaTest):
             self.set_iceberg_mode("value_schema_id_prefix")
 
             dl.wait_for_translation(
-                self.topic_name, msg_count=produced_records, timeout=30
+                self.topic_name,
+                msg_count=produced_records,
+                timeout=90,
+                progress_sec=30,
             )
 
     @cluster(num_nodes=3)
@@ -307,5 +317,5 @@ class IcebergTogglingTest(RedpandaTest):
 
             self.set_iceberg_mode("value_schema_id_prefix")
             dl.wait_for_translation(
-                self.topic_name, msg_count=total_produced, timeout=30
+                self.topic_name, msg_count=total_produced, timeout=90, progress_sec=30
             )

--- a/tests/rptest/tests/datalake/recovery_mode_test.py
+++ b/tests/rptest/tests/datalake/recovery_mode_test.py
@@ -90,8 +90,12 @@ class DatalakeRecoveryModeTest(RedpandaTest):
             dl.produce_to_topic("foo", 1024, count)
             dl.produce_to_topic("bar", 1024, count)
 
-            dl.wait_for_translation("foo", msg_count=2 * count, timeout=120)
-            dl.wait_for_translation("bar", msg_count=count, timeout=120)
+            dl.wait_for_translation(
+                "foo", msg_count=2 * count, timeout=240, progress_sec=30
+            )
+            dl.wait_for_translation(
+                "bar", msg_count=count, timeout=240, progress_sec=30
+            )
 
     @cluster(num_nodes=6)
     @matrix(
@@ -126,5 +130,9 @@ class DatalakeRecoveryModeTest(RedpandaTest):
             dl.produce_to_topic("foo", 1024, count)
             dl.produce_to_topic("bar", 1024, count)
 
-            dl.wait_for_translation("foo", msg_count=2 * count, timeout=120)
-            dl.wait_for_translation("bar", msg_count=count, timeout=120)
+            dl.wait_for_translation(
+                "foo", msg_count=2 * count, timeout=240, progress_sec=30
+            )
+            dl.wait_for_translation(
+                "bar", msg_count=count, timeout=240, progress_sec=30
+            )


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28195
