### PR TITLE
rpk: warn when the cluster is likely a cloud cluster

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/config/get.go
+++ b/src/go/rpk/pkg/cli/cluster/config/get.go
@@ -48,7 +48,7 @@ output, use the 'edit' and 'export' commands respectively.`,
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 
 			p := cfg.VirtualProfile()
-			if p.FromCloud {
+			if p.CheckFromCloud() {
 				if p.CloudCluster.IsServerless() {
 					out.Die("rpk cluster config get is not supported for serverless clusters")
 				}

--- a/src/go/rpk/pkg/cli/cluster/config/list.go
+++ b/src/go/rpk/pkg/cli/cluster/config/list.go
@@ -67,7 +67,7 @@ List configuration properties in YAML format:
 
 			var configMap map[string]any
 
-			if p.FromCloud {
+			if p.CheckFromCloud() {
 				if p.CloudCluster.IsServerless() {
 					out.Die("rpk cluster config list is not supported for serverless clusters")
 				}

--- a/src/go/rpk/pkg/cli/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set.go
@@ -89,7 +89,7 @@ Use the flag '--no-confirm' to avoid the confirmation prompt.`,
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			vp := cfg.VirtualProfile()
 
-			if vp.FromCloud {
+			if vp.CheckFromCloud() {
 				if vp.CloudCluster.IsServerless() {
 					out.Die("rpk cluster config set is not supported on Redpanda serverless clusters")
 				}

--- a/src/go/rpk/pkg/cli/cluster/config/status.go
+++ b/src/go/rpk/pkg/cli/cluster/config/status.go
@@ -49,7 +49,7 @@ is offline.`,
 			vp, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 
-			if vp.FromCloud {
+			if vp.CheckFromCloud() {
 				if vp.CloudCluster.IsServerless() {
 					out.Die("rpk cluster config status is not supported on Redpanda serverless clusters")
 				}

--- a/src/go/rpk/pkg/cli/cluster/connections/list.go
+++ b/src/go/rpk/pkg/cli/cluster/connections/list.go
@@ -211,10 +211,7 @@ List extended output for open connections in json format:
 
 			prof, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
-
-			if prof.CloudCluster.IsServerless() {
-				out.Die("rpk cluster connections list is not supported on Redpanda serverless clusters")
-			}
+			config.CheckExitServerlessAdmin(prof)
 
 			// Build the filters based on the current flag set
 			filterClauses, err := filters.buildFilterClauses()
@@ -232,7 +229,7 @@ List extended output for open connections in json format:
 			}
 
 			var response *adminv2.ListKafkaConnectionsResponse
-			if prof.FromCloud {
+			if prof.CheckFromCloud() {
 				cl, err := publicapi.DataplaneClientFromRpkProfile(prof)
 				out.MaybeDie(err, "unable to initialize cloud API client: %v", err)
 

--- a/src/go/rpk/pkg/cli/cluster/storage/cancel-mount.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/cancel-mount.go
@@ -46,7 +46,7 @@ Cancel a mount/unmount operation
 			migrationID, err := strconv.Atoi(from[0])
 			out.MaybeDie(err, "invalid migration ID: %v", err)
 
-			if p.FromCloud {
+			if p.CheckFromCloud() {
 				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 

--- a/src/go/rpk/pkg/cli/cluster/storage/list-mount.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/list-mount.go
@@ -60,7 +60,7 @@ Use filter to list only migrations in a specific state
 			config.CheckExitServerlessAdmin(p)
 
 			var migrations []rpadmin.MigrationState
-			if p.FromCloud {
+			if p.CheckFromCloud() {
 				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 

--- a/src/go/rpk/pkg/cli/cluster/storage/list-mountable.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/list-mountable.go
@@ -41,7 +41,7 @@ List all mountable topics:
 			config.CheckExitServerlessAdmin(p)
 
 			var mountableTopics []rpadmin.MountableTopic
-			if p.FromCloud {
+			if p.CheckFromCloud() {
 				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 

--- a/src/go/rpk/pkg/cli/cluster/storage/mount.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/mount.go
@@ -60,7 +60,7 @@ with my-new-topic as the new topic name
 			an, at := nsTopic(to)
 			alias := t
 			var id int
-			if p.FromCloud {
+			if p.CheckFromCloud() {
 				if ns != "" && strings.ToLower(ns) != "kafka" {
 					out.Die("Namespace %q not allowed. Only kafka topics can be mounted in Redpanda Cloud clusters", ns)
 				}

--- a/src/go/rpk/pkg/cli/cluster/storage/status-mount.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/status-mount.go
@@ -63,7 +63,7 @@ Status for a mount/unmount operation
 				}
 			}
 
-			if p.FromCloud {
+			if p.CheckFromCloud() {
 				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 

--- a/src/go/rpk/pkg/cli/cluster/storage/unmount.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/unmount.go
@@ -60,7 +60,7 @@ Unmount topic 'my-topic' from the cluster in the 'my-namespace'
 			}
 
 			var id int
-			if p.FromCloud {
+			if p.CheckFromCloud() {
 				if ns != "" && strings.ToLower(ns) != "kafka" {
 					out.Die("Namespace %q not allowed. Only kafka topics can be unmounted in Redpanda Cloud clusters", ns)
 				}

--- a/src/go/rpk/pkg/cli/security/secret/create.go
+++ b/src/go/rpk/pkg/cli/security/secret/create.go
@@ -41,7 +41,7 @@ redpanda_connect, redpanda_cluster`,
 
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
-			if !p.FromCloud {
+			if !p.CheckFromCloud() {
 				out.Die("this command is only available for cloud clusters")
 			}
 			var url string

--- a/src/go/rpk/pkg/cli/security/secret/delete.go
+++ b/src/go/rpk/pkg/cli/security/secret/delete.go
@@ -34,7 +34,7 @@ func newDeleteCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
-			if !p.FromCloud {
+			if !p.CheckFromCloud() {
 				out.Die("this command is only available for cloud clusters")
 			}
 			var url string

--- a/src/go/rpk/pkg/cli/security/secret/list.go
+++ b/src/go/rpk/pkg/cli/security/secret/list.go
@@ -32,7 +32,7 @@ func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Run: func(cmd *cobra.Command, _ []string) {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
-			if !p.FromCloud {
+			if !p.CheckFromCloud() {
 				out.Die("this command is only available for cloud clusters")
 			}
 			var url string

--- a/src/go/rpk/pkg/cli/security/secret/update.go
+++ b/src/go/rpk/pkg/cli/security/secret/update.go
@@ -41,7 +41,7 @@ overwrite its scopes. Available scope options are: redpanda_connect, redpanda_cl
 
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
-			if !p.FromCloud {
+			if !p.CheckFromCloud() {
 				out.Die("this command is only available for cloud clusters")
 			}
 			var url string

--- a/src/go/rpk/pkg/cli/security/user/create.go
+++ b/src/go/rpk/pkg/cli/security/user/create.go
@@ -102,7 +102,7 @@ acl help text for more info.
 				out.Die("unsupported mechanism %q", mechanism)
 			}
 
-			if p.FromCloud && !p.CloudCluster.IsServerless() {
+			if p.CheckFromCloud() && !p.CloudCluster.IsServerless() {
 				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 				req := connect.NewRequest(

--- a/src/go/rpk/pkg/cli/security/user/delete.go
+++ b/src/go/rpk/pkg/cli/security/user/delete.go
@@ -53,7 +53,7 @@ delete any ACLs that may exist for this user.
 				out.Die("missing required username argument")
 			}
 
-			if p.FromCloud && !p.CloudCluster.IsServerless() {
+			if p.CheckFromCloud() && !p.CloudCluster.IsServerless() {
 				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 

--- a/src/go/rpk/pkg/cli/security/user/list.go
+++ b/src/go/rpk/pkg/cli/security/user/list.go
@@ -35,7 +35,7 @@ func newListUsersCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 
 			var users []string
-			if p.FromCloud && !p.CloudCluster.IsServerless() {
+			if p.CheckFromCloud() && !p.CloudCluster.IsServerless() {
 				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 

--- a/src/go/rpk/pkg/cli/security/user/update.go
+++ b/src/go/rpk/pkg/cli/security/user/update.go
@@ -34,7 +34,7 @@ func newUpdateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			user := args[0]
-			if p.FromCloud && !p.CloudCluster.IsServerless() {
+			if p.CheckFromCloud() && !p.CloudCluster.IsServerless() {
 				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 

--- a/src/go/rpk/pkg/cli/transform/delete.go
+++ b/src/go/rpk/pkg/cli/transform/delete.go
@@ -44,7 +44,7 @@ func newDeleteCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 					out.Exit("Deletion canceled.")
 				}
 			}
-			if p.FromCloud && !p.CloudCluster.IsServerless() {
+			if p.CheckFromCloud() && !p.CloudCluster.IsServerless() {
 				url, err := p.CloudCluster.CheckClusterURL()
 				out.MaybeDie(err, "unable to get cluster information: %v", err)
 

--- a/src/go/rpk/pkg/cli/transform/deploy.go
+++ b/src/go/rpk/pkg/cli/transform/deploy.go
@@ -133,7 +133,7 @@ committed offset. Recall that this state is maintained until the transform is de
 				CompressionMode: cfg.Compression,
 				FromOffset:      offset,
 			}
-			if p.FromCloud && !p.CloudCluster.IsServerless() {
+			if p.CheckFromCloud() && !p.CloudCluster.IsServerless() {
 				url, err := p.CloudCluster.CheckClusterURL()
 				out.MaybeDie(err, "unable to get cluster information: %v", err)
 

--- a/src/go/rpk/pkg/cli/transform/list.go
+++ b/src/go/rpk/pkg/cli/transform/list.go
@@ -84,7 +84,7 @@ The --detailed flag (-d) opts in to printing extra per-processor information.
 			config.CheckExitServerlessAdmin(p)
 
 			var l []rpadmin.TransformMetadata
-			if p.FromCloud && !p.CloudCluster.IsServerless() {
+			if p.CheckFromCloud() && !p.CloudCluster.IsServerless() {
 				url, err := p.CloudCluster.CheckClusterURL()
 				out.MaybeDie(err, "unable to get cluster information: %v", err)
 

--- a/src/go/rpk/pkg/config/rpk_yaml.go
+++ b/src/go/rpk/pkg/config/rpk_yaml.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"time"
 
 	controlplanev1 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1"
@@ -367,6 +368,13 @@ func (p *RpkProfile) ActualConfig() (*RpkYaml, bool) {
 	return p.c.ActualRpkYaml()
 }
 
+// CheckFromCloud returns if this profile is a cloud profile, warning if
+// the profile is targeting a Cloud profile but is not marked as such.
+func (p *RpkProfile) CheckFromCloud() bool {
+	warnIfMisconfiguredCloudProfile(p)
+	return p.FromCloud
+}
+
 // HasClientCredentials returns if both ClientID and ClientSecret are non-empty.
 func (a *RpkCloudAuth) HasClientCredentials() bool {
 	return a.ClientID != "" && a.ClientSecret != ""
@@ -517,5 +525,46 @@ func MaybePrintAuthSwitchMessage(priorAuth *RpkCloudAuth, currentAuth *RpkCloudA
 	}
 	if priorAuth.Name != currentAuth.Name {
 		fmt.Printf("rpk switched from talking to organization %q (%s) to %q (%s).\n", priorAuth.Organization, priorAuth.OrgID, currentAuth.Organization, currentAuth.OrgID)
+	}
+}
+
+// isLikelyCloudCluster checks if the broker URLs indicate this is a cloud
+// cluster.
+func isLikelyCloudCluster(p *RpkProfile) bool {
+	for _, broker := range p.KafkaAPI.Brokers {
+		if isLikelyCloudBrokerURL(broker) {
+			return true
+		}
+	}
+	for _, addr := range p.AdminAPI.Addresses {
+		if isLikelyCloudBrokerURL(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+// isLikelyCloudBrokerURL checks if a broker URL matches known cloud cluster
+// patterns.
+func isLikelyCloudBrokerURL(url string) bool {
+	return strings.Contains(strings.ToLower(url), ".cloud.redpanda.com")
+}
+
+// warnIfMisconfiguredCloudProfile checks if the cluster appears to be a cloud
+// cluster but the profile is not properly configured with FromCloud=true. If
+// so, it prints a helpful warning message and exits.
+func warnIfMisconfiguredCloudProfile(p *RpkProfile) {
+	if !p.FromCloud && isLikelyCloudCluster(p) {
+		fmt.Fprintln(os.Stderr, `This appears to be a Redpanda Cloud cluster, but your rpk profile is not aware of it.
+
+Please configure rpk to use Redpanda Cloud by running:
+
+  rpk cloud login
+
+Then select a cluster or use:
+
+  rpk cloud cluster select
+
+For more information, run 'rpk cloud cluster select --help'.`)
 	}
 }

--- a/src/go/rpk/pkg/config/rpk_yaml_test.go
+++ b/src/go/rpk/pkg/config/rpk_yaml_test.go
@@ -13,6 +13,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestRpkYamlVersion(t *testing.T) {
@@ -31,5 +33,126 @@ func TestRpkYamlVersion(t *testing.T) {
 	if shastr != expsha {
 		t.Errorf("rpk.yaml type shape has changed (got sha %s != exp %s, if fields were reordered, update the valid v3 sha, otherwise bump the rpk.yaml version number", shastr, expsha)
 		t.Errorf("current shape:\n%s\n", s)
+	}
+}
+
+func TestIsCloudBrokerURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected bool
+	}{
+		{
+			name:     "cloud.redpanda.com URL",
+			url:      "seed-123.abc.cloud.redpanda.com:9092",
+			expected: true,
+		},
+		{
+			name:     "byoc cluster URL",
+			url:      "seed-7c375997.d4bpfk5875ie32jp5ut0.byoc.ign.cloud.redpanda.com:9644",
+			expected: true,
+		},
+		{
+			name:     "ign.cloud.redpanda.com URL",
+			url:      "example.ign.cloud.redpanda.com:9092",
+			expected: true,
+		},
+		{
+			name:     "localhost",
+			url:      "localhost:9092",
+			expected: false,
+		},
+		{
+			name:     "self-hosted IP",
+			url:      "192.168.1.100:9092",
+			expected: false,
+		},
+		{
+			name:     "self-hosted domain",
+			url:      "redpanda.example.com:9092",
+			expected: false,
+		},
+		{
+			name:     "case insensitive cloud URL",
+			url:      "SEED-123.ABC.CLOUD.REDPANDA.COM:9092",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isLikelyCloudBrokerURL(tt.url)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsLikelyCloudCluster(t *testing.T) {
+	tests := []struct {
+		name     string
+		profile  *RpkProfile
+		expected bool
+	}{
+		{
+			name: "cloud cluster with kafka broker",
+			profile: &RpkProfile{
+				KafkaAPI: RpkKafkaAPI{
+					Brokers: []string{"seed-123.abc.cloud.redpanda.com:9092"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "cloud cluster with admin API",
+			profile: &RpkProfile{
+				AdminAPI: RpkAdminAPI{
+					Addresses: []string{"seed-123.abc.byoc.ign.cloud.redpanda.com:9644"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "self-hosted cluster",
+			profile: &RpkProfile{
+				KafkaAPI: RpkKafkaAPI{
+					Brokers: []string{"localhost:9092"},
+				},
+				AdminAPI: RpkAdminAPI{
+					Addresses: []string{"localhost:9644"},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "mixed URLs (one cloud)",
+			profile: &RpkProfile{
+				KafkaAPI: RpkKafkaAPI{
+					Brokers: []string{
+						"localhost:9092",
+						"seed-123.abc.cloud.redpanda.com:9092",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "empty profile",
+			profile: &RpkProfile{
+				KafkaAPI: RpkKafkaAPI{
+					Brokers: []string{},
+				},
+				AdminAPI: RpkAdminAPI{
+					Addresses: []string{},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isLikelyCloudCluster(tt.profile)
+			require.Equal(t, tt.expected, result)
+		})
 	}
 }


### PR DESCRIPTION
Continuation of https://github.com/redpanda-data/redpanda/pull/28586

This adds a warning to stderr if the user is
talking to a cloud cluster without configuring the profile first.

Specially important as we grow our Cloud support
in rpk. Currently the profile holds the cloud API
endpoints, TLS config and more, so we need to start enforcing it more.

(cherry picked from commit bcb5f50f04a6e746658236b24beb9dc7f024ba93)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* rpk will warn users when they interact with a cloud cluster using an rpk profile that isn't properly configured for cloud.