### PR TITLE
admin: Store decommission_status partitions in a chunked array

### DIFF
--- a/src/v/redpanda/admin/api-doc/broker.json
+++ b/src/v/redpanda/admin/api-doc/broker.json
@@ -457,11 +457,11 @@
                     "description": "a subset of partitions originating from this node with allocation failures. "
                 },
                 "partitions": {
-                    "type": "array",
+                    "type": "chunked_array",
                     "items": {
                         "type": "partition_reconfiguration_status"
                     },
-                    "description": "Array of partition reconfiguration statues"
+                    "description": "Array of partition reconfiguration statuses"
                 },
                 "reallocation_failure_details": {
                     "type": "array",


### PR DESCRIPTION
The in-memory form of the decommission_status API response object stored the partitions in a vector. When there are a lot of partitions being decommissioned, this vector could grow large enough to trigger an oversized allocation warning when it resized.

The fix is to use the chunked_array type instead.

Also a typo fix.

Fixes CORE-14682

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.3.x
- [X] v25.2.x
- [X] v25.1.x
- [X] v24.3.x

## Release Notes

* none
