### PR TITLE
tests: Exclude batch creation timeouts

### DIFF
--- a/tests/rptest/services/openmessaging_benchmark.py
+++ b/tests/rptest/services/openmessaging_benchmark.py
@@ -30,7 +30,11 @@ from rptest.services.utils import BadLogLines, VersionAndLines
 
 from ducktape.tests.test import TestContext
 
-LOG_ALLOW_LIST = ["No such file or directory", "cannot be started once stopped"]
+LOG_ALLOW_LIST = [
+    "No such file or directory",
+    "cannot be started once stopped",
+    "has passed since batch creation",
+]
 
 
 class LocalPayloadDirectory:


### PR DESCRIPTION
Add batch creation timeouts as these sometimes flake in the OMB test.

Fixes CORE-8762
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none


