### PR TITLE
c/archival: do not limit collector size for adj reupload

### DIFF
--- a/src/v/cluster/archival/adjacent_segment_merger.cc
+++ b/src/v/cluster/archival/adjacent_segment_merger.cc
@@ -16,8 +16,6 @@
 #include "cluster/archival/types.h"
 #include "config/configuration.h"
 #include "model/fundamental.h"
-#include "storage/disk_log_impl.h"
-#include "utils/human.h"
 
 namespace archival {
 
@@ -74,86 +72,6 @@ retry_chain_node* adjacent_segment_merger::get_root_retry_chain_node() {
 
 ss::sstring adjacent_segment_merger::name() const {
     return ssx::sformat("adjacent_segment_merger:{}", _archiver.get_ntp());
-}
-
-std::optional<adjacent_segment_run> adjacent_segment_merger::scan_manifest(
-  model::offset local_start_offset,
-  const cloud_storage::partition_manifest& manifest) {
-    auto [min_segment_size, max_segment_size] = get_low_high_segment_size(
-      _archiver.get_local_segment_size(),
-      _min_segment_size,
-      _target_segment_size);
-    model::offset so = _last;
-    if (so == model::offset{} && _is_local) {
-        // Local lookup, start from local start offset
-        so = std::max(
-          manifest.get_start_offset().value_or(local_start_offset),
-          local_start_offset);
-    } else if (!_is_local) {
-        // Remote lookup, start from start offset in the manifest (or 0)
-        so = _archiver.manifest().get_start_offset().value_or(model::offset{0});
-    }
-    vlog(
-      _ctxlog.debug,
-      "Searching for adjacent segment run, start: {}, is_local: {}, "
-      "local_start_offset: {}, low watermark: {}, high watermark: {}",
-      so,
-      _is_local,
-      local_start_offset,
-      min_segment_size,
-      max_segment_size);
-
-    adjacent_segment_run run(_archiver.get_ntp());
-
-    for (auto it = manifest.segment_containing(so), end_it = manifest.end();
-         it != end_it;
-         ++it) {
-        if (!_is_local && it->committed_offset >= local_start_offset) {
-            // We're looking for the remote segment
-            break;
-        }
-        if (run.maybe_add_segment(
-              manifest,
-              *it,
-              max_segment_size,
-              _archiver.remote_path_provider())) {
-            // We have found a run with the size close to max_segment_size
-            // and can proceed early.
-            break;
-        }
-    }
-    if (run.num_segments > 1 && run.meta.size_bytes > min_segment_size) {
-        // Normal reupload, the upload candidate is larger than
-        // min_segment_size and contains more than one segments.
-        vlog(_ctxlog.debug, "Found adjacent segment run {}", run);
-        return run;
-    }
-    if (
-      run.num_segments > 1
-      && run.meta.committed_offset != manifest.get_last_offset()) {
-        // Reupload if we have a run of small segments between large
-        // segments but this run is smaller than min_segment_size. In this
-        // case its stil makes sense to reupload it.
-        vlog(
-          _ctxlog.debug,
-          "Found adjacent segment run {} which is smaller than the "
-          "limit "
-          "{}",
-          run,
-          min_segment_size);
-        return run;
-    }
-    vlog(
-      _ctxlog.debug,
-      "Adjacent segment run not found, num {}, segments {}, size-bytes "
-      "{}, "
-      "offset range {} - {}",
-      run.num_segments,
-      run.segments.size(),
-      run.meta.size_bytes,
-      run.meta.base_offset,
-      run.meta.committed_offset);
-    return std::nullopt;
 }
 
 ss::future<housekeeping_job::run_result>
@@ -284,6 +202,109 @@ void adjacent_segment_merger::interrupt() { _as.request_abort(); }
 
 bool adjacent_segment_merger::interrupted() const {
     return _as.abort_requested();
+}
+
+std::optional<adjacent_segment_run> adjacent_segment_merger::scan_manifest(
+  model::offset local_start_offset,
+  const cloud_storage::partition_manifest& manifest) {
+    auto [min_segment_size, max_segment_size] = get_low_high_segment_size(
+      _archiver.get_local_segment_size(),
+      _min_segment_size,
+      _target_segment_size);
+
+    model::offset from_offset = _last;
+    if (from_offset == model::offset{} && _is_local) {
+        // Local lookup, start from local start offset
+        from_offset = std::max(
+          manifest.get_start_offset().value_or(local_start_offset),
+          local_start_offset);
+    } else if (!_is_local) {
+        // Remote lookup, start from start offset in the manifest (or 0)
+        from_offset = _archiver.manifest().get_start_offset().value_or(
+          model::offset{0});
+    }
+    vlog(
+      _ctxlog.debug,
+      "Searching for adjacent segment run, start: {}, is_local: {}, "
+      "local_start_offset: {}, low watermark: {}, high watermark: {}",
+      from_offset,
+      _is_local,
+      local_start_offset,
+      min_segment_size,
+      max_segment_size);
+
+    return adjacent_segment_scanner::scan_manifest(
+      _ctxlog,
+      _archiver,
+      local_start_offset,
+      manifest,
+      from_offset,
+      min_segment_size,
+      max_segment_size,
+      _is_local);
+}
+
+std::optional<adjacent_segment_run> adjacent_segment_scanner::scan_manifest(
+  retry_chain_logger& ctxlog,
+  ntp_archiver& archiver,
+  model::offset local_start_offset,
+  const cloud_storage::partition_manifest& manifest,
+  model::offset from_offset,
+  size_t min_segment_size,
+  size_t max_segment_size,
+  bool is_local) {
+    adjacent_segment_run run(archiver.get_ntp());
+
+    for (auto it = manifest.segment_containing(from_offset),
+              end_it = manifest.end();
+         it != end_it;
+         ++it) {
+        if (!is_local && it->committed_offset >= local_start_offset) {
+            // We're looking for the remote segment
+            break;
+        }
+        if (run.maybe_add_segment(
+              manifest,
+              *it,
+              max_segment_size,
+              archiver.remote_path_provider())) {
+            // We have found a run with the size close to max_segment_size
+            // and can proceed early.
+            break;
+        }
+    }
+    if (run.num_segments > 1 && run.meta.size_bytes > min_segment_size) {
+        // Normal reupload, the upload candidate is larger than
+        // min_segment_size and contains more than one segments.
+        vlog(ctxlog.debug, "Found adjacent segment run {}", run);
+        return run;
+    }
+    if (
+      run.num_segments > 1
+      && run.meta.committed_offset != manifest.get_last_offset()) {
+        // Reupload if we have a run of small segments between large
+        // segments but this run is smaller than min_segment_size. In this
+        // case its stil makes sense to reupload it.
+        vlog(
+          ctxlog.debug,
+          "Found adjacent segment run {} which is smaller than the "
+          "limit "
+          "{}",
+          run,
+          min_segment_size);
+        return run;
+    }
+    vlog(
+      ctxlog.debug,
+      "Adjacent segment run not found, num {}, segments {}, size-bytes "
+      "{}, "
+      "offset range {} - {}",
+      run.num_segments,
+      run.segments.size(),
+      run.meta.size_bytes,
+      run.meta.base_offset,
+      run.meta.committed_offset);
+    return std::nullopt;
 }
 
 } // namespace archival

--- a/src/v/cluster/archival/adjacent_segment_merger.h
+++ b/src/v/cluster/archival/adjacent_segment_merger.h
@@ -69,4 +69,21 @@ private:
     ss::gate::holder _holder;
 };
 
+/// Scans for adjacent segments to merge.
+class adjacent_segment_scanner {
+public:
+    adjacent_segment_scanner() = delete;
+
+public:
+    static std::optional<adjacent_segment_run> scan_manifest(
+      retry_chain_logger& ctxlog,
+      ntp_archiver& archiver,
+      model::offset local_start_offset,
+      const cloud_storage::partition_manifest& manifest,
+      model::offset from_offset,
+      size_t min_segment_size,
+      size_t max_segment_size,
+      bool is_local);
+};
+
 } // namespace archival

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -3516,7 +3516,9 @@ ntp_archiver::find_reupload_candidate(
           run->meta.base_offset,
           manifest(),
           log,
-          run->meta.size_bytes,
+          // We want to upload exactly the same range as in the run we got based
+          // on the manifest so do not limit collected range on the size.
+          std::numeric_limits<size_t>::max(),
           run->meta.committed_offset);
         collector.collect_segments();
         auto candidate = co_await collector.make_upload_candidate_stream(

--- a/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
@@ -11,7 +11,7 @@
 #include "cloud_storage/async_manifest_view.h"
 #include "cloud_storage/read_path_probes.h"
 #include "cloud_storage/remote_path_provider.h"
-#include "cloud_storage_clients/client_pool.h"
+#include "cluster/archival/adjacent_segment_merger.h"
 #include "cluster/archival/archival_metadata_stm.h"
 #include "cluster/archival/tests/service_fixture.h"
 #include "config/configuration.h"
@@ -921,4 +921,97 @@ FIXTURE_TEST(test_upload_compacted_segments_cross_term, reupload_fixture) {
         BOOST_REQUIRE_EQUAL(it->committed_offset, model::offset(1009));
         BOOST_REQUIRE_EQUAL(it->segment_term, model::term_id(4));
     }
+}
+
+/// Test adjacent segment merging for a scenario where local segments are not
+/// aligned with the manifest segments. E.g. uploads were triggered by time
+/// thresholds or from different replica.
+FIXTURE_TEST(test_adjacent_merging, reupload_fixture) {
+    std::vector<segment_desc> segments = {
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(0),
+       .term = model::term_id(1),
+       .num_records = 10,
+       .records_per_batch = 1},
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(10),
+       .term = model::term_id(1),
+       .num_records = 10,
+       .records_per_batch = 1},
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(20),
+       .term = model::term_id(1),
+       .num_records = 10,
+       .records_per_batch = 1},
+    };
+
+    initialize(segments, false);
+    auto action = ss::defer([this] { archiver->stop().get(); });
+
+    auto part = app.partition_manager.local().get(manifest_ntp);
+
+    cluster::details::archival_metadata_stm_accessor stm_acc{
+      *part->archival_meta_stm()};
+
+    // Note that last offset is on purpose set to 100 to avoid merger bailing
+    // out because of reaching end of manifest.
+    static constexpr std::string_view manifest = R"json({
+"version": 1,
+"namespace": "kafka",
+"topic": "test-topic",
+"partition": 42,
+"revision": 0,
+"last_offset": 100,
+"segments": {
+    "0-1-v1.log": {
+        "is_compacted": false,
+        "size_bytes": 1,
+        "base_offset": 0,
+        "committed_offset": 4
+    },
+    "5-1-v1.log": {
+        "is_compacted": false,
+        "size_bytes": 1,
+        "base_offset": 5,
+        "committed_offset": 19
+    },
+    "20-1-v1.log": {
+        "is_compacted": false,
+        "size_bytes": 1,
+        "base_offset": 20,
+        "committed_offset": 29
+    }
+}
+})json";
+
+    stm_acc.replace_manifest(manifest);
+
+    ss::abort_source as;
+    retry_chain_node rcn{as};
+    retry_chain_logger ctxlog{test_log, rcn};
+
+    auto scanner = [&](
+                     model::offset local_start_offset,
+                     const cloud_storage::partition_manifest& manifest) {
+        return adjacent_segment_scanner::scan_manifest(
+          ctxlog,
+          archiver.value(),
+          local_start_offset,
+          manifest,
+          model::offset{0},
+          1024,
+          1024 * 1024,
+          true);
+    };
+
+    auto res = archiver->find_reupload_candidate(scanner, as).get();
+
+    // We don't get an upload stream due to an implementation detail were we
+    // validate that the local stream size must match scanner reported size. In
+    // this test we don't have real segments with real sizes so the sizes don't
+    // match.
+    //
+    // This is good enough for this test. We just want to verify that no errors
+    // are hit during the process and the scanner makes forward progress.
+    BOOST_REQUIRE_EQUAL(res.skip_to, model::offset{29});
 }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes

* Fix a rare bug where adjacent segment merging in tiered storage fails with `Candidate creation error: candidate creation error: failed to seek end offset` which could result in degraded tiered storage read performance.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
