### PR TITLE
[v25.3.x] [CORE-14678] - Lower logger severity for invalid buffer size in kafka server

### DIFF
--- a/src/v/cloud_storage_clients/BUILD
+++ b/src/v/cloud_storage_clients/BUILD
@@ -48,6 +48,7 @@ redpanda_cc_library(
         "//src/v/model",
         "//src/v/net",
         "//src/v/net:tls",
+        "//src/v/net:types",
         "//src/v/ssx:future_util",
         "//src/v/ssx:sformat",
         "//src/v/ssx:watchdog",

--- a/src/v/cloud_storage_clients/tests/BUILD
+++ b/src/v/cloud_storage_clients/tests/BUILD
@@ -46,6 +46,7 @@ redpanda_cc_btest(
         "//src/v/hashing:secure",
         "//src/v/http/tests:utils",
         "//src/v/net",
+        "//src/v/net:types",
         "//src/v/test_utils:seastar_boost",
         "//src/v/utils:base64",
         "//src/v/utils:unresolved_address",

--- a/src/v/cluster/BUILD
+++ b/src/v/cluster/BUILD
@@ -712,6 +712,7 @@ redpanda_cc_library(
         "//src/v/model:fips_config",
         "//src/v/net",
         "//src/v/net:tls",
+        "//src/v/net:types",
         "//src/v/pandaproxy/schema_registry:config",
         "//src/v/pandaproxy/schema_registry:subject_name_strategy",
         "//src/v/raft",

--- a/src/v/cluster/archival/tests/BUILD
+++ b/src/v/cluster/archival/tests/BUILD
@@ -144,6 +144,7 @@ redpanda_cc_btest(
         "//src/v/config",
         "//src/v/model",
         "//src/v/net",
+        "//src/v/net:types",
         "//src/v/ssx:sformat",
         "//src/v/storage",
         "//src/v/storage:resources",

--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -119,6 +119,9 @@ redpanda_cc_library(
     hdrs = [
         "credential_manager.h",
     ],
+    implementation_deps = [
+        "//src/v/net:types",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         ":logger",

--- a/src/v/iceberg/rest_client/BUILD
+++ b/src/v/iceberg/rest_client/BUILD
@@ -28,6 +28,7 @@ redpanda_cc_library(
         "//src/v/http",
         "//src/v/metrics",
         "//src/v/net",
+        "//src/v/net:types",
     ],
 )
 

--- a/src/v/kafka/protocol/BUILD
+++ b/src/v/kafka/protocol/BUILD
@@ -73,6 +73,7 @@ redpanda_cc_library(
     deps = [
         ":messages",
         ":protocol",
+        "//src/v/net:types",
         "//src/v/utils:vint",
         "@seastar",
     ] + MESSAGE_TYPES,

--- a/src/v/kafka/protocol/flex_versions.cc
+++ b/src/v/kafka/protocol/flex_versions.cc
@@ -12,6 +12,7 @@
 #include "kafka/protocol/messages.h"
 #include "kafka/protocol/types.h"
 #include "kafka/protocol/wire.h"
+#include "net/types.h"
 #include "utils/vint_iostream.h"
 
 #include <seastar/core/iostream.hh>
@@ -105,13 +106,19 @@ parse_tags(ss::input_stream<char>& src) {
 }
 
 namespace {
+struct invalid_buffer_size_exception : public net::parsing_exception {
+public:
+    explicit invalid_buffer_size_exception(const std::string& m)
+      : net::parsing_exception(m) {}
+};
 size_t parse_size_buffer(ss::temporary_buffer<char> buf) {
     iobuf data;
     data.append(std::move(buf));
     protocol::decoder reader(std::move(data));
     auto size = reader.read_int32();
     if (size < 0) {
-        throw std::runtime_error("kafka::parse_size_buffer is negative");
+        throw invalid_buffer_size_exception(
+          "kafka::parse_size_buffer is negative");
     }
     return size_t(size);
 }

--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -366,6 +366,7 @@ redpanda_cc_library(
         "//src/v/model",
         "//src/v/model:batch_compression",
         "//src/v/net",
+        "//src/v/net:types",
         "//src/v/pandaproxy/schema_registry:config",
         "//src/v/pandaproxy/schema_registry:server",
         "//src/v/pandaproxy/schema_registry:subject_name_strategy",

--- a/src/v/net/BUILD
+++ b/src/v/net/BUILD
@@ -16,6 +16,17 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "types",
+    hdrs = [
+        "types.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "net",
     srcs = [
         "batched_output_stream.cc",
@@ -40,7 +51,6 @@ redpanda_cc_library(
         "server_probe.h",
         "tls_certificate_probe.h",
         "transport.h",
-        "types.h",
     ],
     implementation_deps = [
         "//src/v/strings:utf8",
@@ -48,6 +58,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":tls",
+        ":types",
         "//src/v/base",
         "//src/v/bytes",
         "//src/v/config",

--- a/src/v/rpc/BUILD
+++ b/src/v/rpc/BUILD
@@ -53,6 +53,7 @@ redpanda_cc_library(
         "//src/v/metrics",
         "//src/v/model",
         "//src/v/net",
+        "//src/v/net:types",
         "//src/v/reflection:adl",
         "//src/v/serde",
         "//src/v/ssx:future_util",

--- a/src/v/security/BUILD
+++ b/src/v/security/BUILD
@@ -145,6 +145,7 @@ redpanda_cc_library(
         "//src/v/metrics",
         "//src/v/model",
         "//src/v/net",
+        "//src/v/net:types",
         "//src/v/pandaproxy/schema_registry:types",
         "//src/v/reflection:adl",
         "//src/v/security/audit:types",

--- a/src/v/security/audit/BUILD
+++ b/src/v/security/audit/BUILD
@@ -106,6 +106,7 @@ redpanda_cc_library(
         "//src/v/metrics",
         "//src/v/model",
         "//src/v/net",
+        "//src/v/net:types",
         "//src/v/reflection:type_traits",
         "//src/v/security",
         "//src/v/security:request_auth",

--- a/src/v/transform/rpc/tests/BUILD
+++ b/src/v/transform/rpc/tests/BUILD
@@ -17,6 +17,7 @@ redpanda_cc_gtest(
         "//src/v/model",
         "//src/v/model/tests:random",
         "//src/v/net",
+        "//src/v/net:types",
         "//src/v/random:generators",
         "//src/v/rpc",
         "//src/v/test_utils:gtest",


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28590
