### PR TITLE
redpanda/tests: disable cloud metadata upload by default

### DIFF
--- a/src/v/redpanda/tests/fixture.cc
+++ b/src/v/redpanda/tests/fixture.cc
@@ -415,6 +415,7 @@ void redpanda_thread_fixture::configure(
         if (archival_cfg) {
             // Copy archival config to this shard to avoid `config::binding`
             // asserting on cross-shard access.
+            // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
             auto local_cfg = archival_cfg;
 
             config.get("cloud_storage_disable_tls").set_value(true);
@@ -457,6 +458,10 @@ void redpanda_thread_fixture::configure(
 
         config.get("enable_shadow_linking")
           .set_value(development_cluster_linking_enabled);
+
+        // Disable automatic cluster metadata uploads by default. Only tests
+        // that explicitly want it should enable it.
+        config.get("enable_cluster_metadata_upload_loop").set_value(false);
     }).get();
 }
 


### PR DESCRIPTION
Save some CPU cycles and log lines especially when s3 imposter is not configured/needed for tests.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
