### PR TITLE
rptest/typing: add a few additional checks

### DIFF
--- a/tests/pyrightconfig.json
+++ b/tests/pyrightconfig.json
@@ -12,5 +12,25 @@
 
     "typeCheckingMode": "strict",
 
+    // additionally enabled checks which aren't in strict
+
+    "reportPropertyTypeMismatch": "error",
+    "reportUnnecessaryTypeIgnoreComment": "warning",
+    "reportUnreachable": "warning",
+
+    // things we'd like to enable soon
+    // "deprecateTypingAliases": true,
+
+    // annoyingly, reports for classes without a superclass
+    // https://github.com/microsoft/pyright/issues/3968
+    //"reportMissingSuperCall": "error",
+
+    // still reports cycles gated by if TYPE_CHECKING meaning
+    // we can't use it effectively, see https://github.com/microsoft/pyright/issues/11121
+    // "reportImportCycles": "error",
+
+    // disabled checks
+
+    // widespread, allow for now
     "reportPrivateUsage": "none"
 }

--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -353,7 +353,7 @@ class KubectlTool:
             "bash",
             "-c",
         ] + ['"' + remote_cmd + '"']
-        return self._ssh_cmd(cmd)  # type: ignore
+        return self._ssh_cmd(cmd)
 
     def exists(self, remote_path: str, pod_name: str | None = None) -> bool:
         self._install()

--- a/tests/rptest/clients/ping_pong.py
+++ b/tests/rptest/clients/ping_pong.py
@@ -1,23 +1,26 @@
 import random
 import time
+from collections.abc import Callable, Generator
+from logging import Logger
 
 from confluent_kafka import (
     OFFSET_BEGINNING,
     Consumer,
     KafkaError,
     KafkaException,
+    Message,
     Producer,
     TopicPartition,
 )
 
 
 class SyncProducer:
-    def __init__(self, bootstrap):
+    def __init__(self, bootstrap: str) -> None:
         self.bootstrap = bootstrap
-        self.producer = None
-        self.last_msg = None
+        self.producer: Producer | None = None
+        self.last_msg: Message | None = None
 
-    def init(self):
+    def init(self) -> None:
         self.producer = Producer(
             {
                 "bootstrap.servers": self.bootstrap,
@@ -27,13 +30,16 @@ class SyncProducer:
             }
         )
 
-    def on_delivery(self, err, msg):
+    def on_delivery(self, err: KafkaError | None, msg: Message) -> None:
         if err is not None:
             raise KafkaException(err)
         self.last_msg = msg
 
-    def produce(self, topic, partition, key, value, timeout_s):
+    def produce(
+        self, topic: str, partition: int, key: str, value: str, timeout_s: float
+    ) -> int:
         self.last_msg = None
+        assert self.producer is not None
         self.producer.produce(
             topic,
             key=key.encode("utf-8"),
@@ -52,12 +58,12 @@ class SyncProducer:
 
 
 class LogReader:
-    def __init__(self, bootstrap):
+    def __init__(self, bootstrap: str) -> None:
         self.bootstrap = bootstrap
-        self.consumer = None
-        self.stream = None
+        self.consumer: Consumer | None = None
+        self.stream: Generator[Message, None, None] | None = None
 
-    def init(self, group, topic, partition):
+    def init(self, group: str, topic: str, partition: int) -> None:
         self.consumer = Consumer(
             {
                 "bootstrap.servers": self.bootstrap,
@@ -70,27 +76,36 @@ class LogReader:
         self.consumer.assign([TopicPartition(topic, partition, OFFSET_BEGINNING)])
         self.stream = self.stream_gen()
 
-    def stream_gen(self):
+    def stream_gen(self) -> Generator[Message, None, None]:
+        assert self.consumer is not None
         while True:
             msgs = self.consumer.consume(timeout=10)
             for msg in msgs:
                 yield msg
 
-    def read_until(self, check, timeout_s):
+    def read_until(
+        self, check: Callable[[int, str, str], bool], timeout_s: float
+    ) -> None:
+        assert self.stream is not None
         begin = time.time()
         while True:
             if time.time() - begin > timeout_s:
                 raise KafkaException(KafkaError(KafkaError._TIMED_OUT))
             for msg in self.stream:
                 offset = msg.offset()
-                value = msg.value().decode("utf-8")
-                key = msg.key().decode("utf-8")
+                assert offset is not None
+                value_bytes = msg.value()
+                assert value_bytes is not None
+                value = value_bytes.decode("utf-8")
+                key_bytes = msg.key()
+                assert key_bytes is not None
+                key = key_bytes.decode("utf-8")
                 if check(offset, key, value):
                     return
 
 
-def expect(offset, key, value):
-    def check(ro, rk, rv):
+def expect(offset: int, key: str, value: str) -> Callable[[int, str, str], bool]:
+    def check(ro: int, rk: str, rv: str) -> bool:
         if ro < offset:
             return False
         if ro == offset:
@@ -105,7 +120,9 @@ def expect(offset, key, value):
 
 
 class PingPong:
-    def __init__(self, brokers, topic, partition, logger):
+    def __init__(
+        self, brokers: list[str], topic: str, partition: int, logger: Logger
+    ) -> None:
         self.brokers = brokers
         random.shuffle(self.brokers)
         bootstrap = ",".join(self.brokers)
@@ -117,13 +134,13 @@ class PingPong:
         self.topic = topic
         self.partition = partition
 
-    def ping_pong(self, timeout_s=5, retries=0):
+    def ping_pong(self, timeout_s: float = 5, retries: int = 0) -> None:
         key = str(random.randint(0, 1000))
         value = str(random.randint(0, 1000))
 
         start = time.time()
 
-        offset = None
+        offset: int | None = None
         count = 0
         while True:
             count += 1
@@ -139,10 +156,14 @@ class PingPong:
             except KafkaException as e:
                 if count > retries:
                     raise
-                if e.args[0].code() == KafkaError._MSG_TIMED_OUT:
-                    pass
-                elif e.args[0].code() == KafkaError._TIMED_OUT:
-                    pass
+                kafka_error = e.args[0]
+                if isinstance(kafka_error, KafkaError):
+                    error_code = kafka_error.code()
+                    if (
+                        error_code != KafkaError._MSG_TIMED_OUT
+                        and error_code != KafkaError._TIMED_OUT
+                    ):
+                        raise
                 else:
                     raise
                 random.shuffle(self.brokers)
@@ -155,6 +176,7 @@ class PingPong:
                 self.producer.init()
                 self.logger.info(f"produce request {key}={value} timed out")
 
+        assert offset is not None
         self.consumer.read_until(expect(offset, key, value), timeout_s=timeout_s)
         latency = time.time() - start
         self.logger.info(

--- a/tests/rptest/direct_consumer_tests/direct_consumer_test.py
+++ b/tests/rptest/direct_consumer_tests/direct_consumer_test.py
@@ -118,8 +118,6 @@ class DirectConsumerVerifierTest(RedpandaTest):
                 )
             case FailureMode.NONE:
                 return NoopThread()
-            case _:
-                return NoopThread()
 
     @cluster(num_nodes=5)
     @matrix(

--- a/tests/rptest/e2e_tests/flink_scale_test.py
+++ b/tests/rptest/e2e_tests/flink_scale_test.py
@@ -115,7 +115,7 @@ class FlinkScaleTests(RedpandaTest):
     # Calculate per-node vectorized_internal_rpc_latency_sum/commit_tx
     def _get_commit_requests_counts(self, method, nodes) -> list[MetricSamples]:
         # Get metrics from redpanda nodes
-        metrics = self.redpanda.metrics_sample(  # type: ignore
+        metrics = self.redpanda.metrics_sample(
             "vectorized_internal_rpc_latency_sum",
             nodes=nodes,
             metrics_endpoint=MetricsEndpoint.METRICS,

--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -787,14 +787,14 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
 
             # Stop a node, wait for enough time for movement to occur, then
             # restart.
-            self.stage_stop_wait_start(
+            self.stage_stop_wait_start(  # pyright: ignore[reportUnreachable]
                 forced_stop=False, downtime=self.unavailable_timeout
             )
 
             # Block traffic to/from one node.
             self.stage_block_node_traffic()
 
-        self.redpanda.assert_cluster_is_reusable()
+        self.redpanda.assert_cluster_is_reusable()  # pyright: ignore[reportUnreachable]
 
     NOS3_LOG_ALLOW_LIST = [
         re.compile(

--- a/tests/rptest/remote_scripts/python_librdkafka_serde_client.py
+++ b/tests/rptest/remote_scripts/python_librdkafka_serde_client.py
@@ -20,7 +20,7 @@ from typing import Optional
 from uuid import uuid4
 
 import payload_pb2
-from confluent_kafka import DeserializingConsumer, SerializingProducer
+from confluent_kafka import DeserializingConsumer, SerializingProducer, Message
 from confluent_kafka.cimpl import KafkaError
 from confluent_kafka.schema_registry import (
     SchemaRegistryClient,
@@ -268,7 +268,7 @@ class SerdeClient:
         }
 
     def produce(self, count: int):
-        def increment(err: KafkaError, msg):
+        def increment(err: KafkaError | None, msg: Message | None):
             if err is not None:
                 self.logger.error(f"Produce err: {err}")
                 sys.exit(err.code())

--- a/tests/rptest/scale_tests/large_messages_test.py
+++ b/tests/rptest/scale_tests/large_messages_test.py
@@ -13,6 +13,8 @@ import time
 from enum import Enum
 from typing import Any
 
+from typing_extensions import assert_never
+
 import numpy
 from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
@@ -335,7 +337,7 @@ class LargeMessagesTest(RedpandaTest):
             )
             self.unique = False
         else:
-            assert False
+            assert_never(mode)  # pyright: ignore[reportUnreachable]
 
         self.topic_prefix_template = "large-messages"
         self.topic_prefixes = [

--- a/tests/rptest/scale_tests/tiered_storage_cache_stress_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_cache_stress_test.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
+from typing_extensions import assert_never
+
 from ducktape.mark import matrix
 
 from rptest.clients.rpk import RpkTool
@@ -148,7 +150,7 @@ class TieredStorageCacheStressTest(RedpandaTest):
             assert node_storage.cache.objects <= max_objects
             assert hwm_objects <= max_objects
         else:
-            raise NotImplementedError(limit_mode)
+            assert_never(limit_mode)  # pyright: ignore[reportUnreachable]
 
         return any_cache_usage
 

--- a/tests/rptest/services/kcat_consumer.py
+++ b/tests/rptest/services/kcat_consumer.py
@@ -129,7 +129,7 @@ class KcatConsumer(BackgroundThreadService):
             if isinstance(offset_default, KcatConsumer.OffsetDefaultMeta):
                 self._cmd += ["-X", f"auto.offset.reset={offset_default.value}"]
             else:
-                assert False, "offset_default must be an OffsetMeta"
+                assert False, "offset_default must be an OffsetMeta"  # pyright: ignore[reportUnreachable]
 
         if num_msgs is not None:
             self._cmd += ["-c", f"{num_msgs}"]

--- a/tests/rptest/services/kerberos.py
+++ b/tests/rptest/services/kerberos.py
@@ -129,7 +129,7 @@ def render_local_kadmin_command(command):
     return LOCAL_KADMIN_TMPL.format(command=command)
 
 
-def render_add_principal_command(principal: str, password: str = None):
+def render_add_principal_command(principal: str, password: str | None = None):
     if password is None:
         keytype = "-randkey"
     else:

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2458,7 +2458,7 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
                         f"bash {remote_path} '{pod.name}' '{test_start_time}'".split(),
                         capture=True,
                     ):
-                        lfile.writelines([line])  # type: ignore
+                        lfile.writelines([line])
             except Exception as e:
                 self.logger.warning(f"Error getting logs for {pod.name}: {e}")
             return pod.name
@@ -3371,10 +3371,10 @@ class RedpandaService(Service, RedpandaServiceABC):
             if node not in to_start:  # pyright: ignore[reportUnnecessaryContains]
                 continue
             raise RuntimeError("unreachable")
-            unexpected_ns = set(node.ns) - {"redpanda"}
+            unexpected_ns = set(node.ns) - {"redpanda"}  # pyright: ignore[reportUnreachable]
             if unexpected_ns:
-                for ns in unexpected_ns:
-                    self.logger.error(
+                for ns in unexpected_ns:  # pyright: ignore[reportUnreachable]
+                    self.logger.error(  # pyright: ignore[reportUnreachable]
                         f"node {node.name}: unexpected namespace: {ns}, "
                         f"topics: {set(node.ns[ns].topics)}"
                     )
@@ -3385,7 +3385,7 @@ class RedpandaService(Service, RedpandaServiceABC):
                 "kvstore",
             }
             if unexpected_rp_topics:
-                self.logger.error(
+                self.logger.error(  # pyright: ignore[reportUnreachable]
                     f"node {node.name}: unexpected topics in redpanda namespace: "
                     f"{unexpected_rp_topics}"
                 )

--- a/tests/rptest/services/tls.py
+++ b/tests/rptest/services/tls.py
@@ -384,8 +384,6 @@ class TLSCertManager:
 
                 if retries >= 3:
                     raise
-            else:
-                self._logger.debug(output)
 
             retries += 1
 
@@ -490,7 +488,7 @@ class TLSCertManager:
         elif format == DNFormat.RFC2253:
             nameopt = "-nameopt rfc2253"
         else:
-            raise ValueError(f"Unknown DN format: {format}")
+            raise ValueError(f"Unknown DN format: {format}")  # pyright: ignore[reportUnreachable]
 
         resp = self._exec(f"openssl x509 -in {cert.crt} -noout -subject {nameopt}")
         assert resp.startswith("subject="), (

--- a/tests/rptest/services/utils.py
+++ b/tests/rptest/services/utils.py
@@ -290,9 +290,9 @@ class LogSearchCloud(LogSearch):
             tz = tz[0] if len(tz) > 0 else "+00:00"
             # Find all log files for target pod
             # Return type without capture is always str, so ignore type
-            logfiles = pod.nodeshell("find /var/log/pods -type f")  # type: ignore
+            logfiles = pod.nodeshell("find /var/log/pods -type f")
             for logfile in logfiles:
-                if pod.name in logfile and "redpanda-configurator" not in logfile:  # type: ignore
+                if pod.name in logfile and "redpanda-configurator" not in logfile:
                     self.logger.info(f"Inspecting '{logfile}'")
                     lines = pod.nodeshell(f"cat {logfile} | grep {expr}")
                     loglines += lines

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -609,7 +609,7 @@ class AccessControlListTest(AccessControlListTestBase):
             elif format == tls.DNFormat.RFC2253:
                 return "rfc2253"
             else:
-                raise ValueError(f"Unknown format: {format}")
+                raise ValueError(f"Unknown format: {format}")  # pyright: ignore[reportUnreachable]
 
         dn_name = self.tls.get_cert_subject_dn(
             self.cluster_describe_user_cert, format=dn_format

--- a/tests/rptest/tests/controller_forced_reconfiguration_test.py
+++ b/tests/rptest/tests/controller_forced_reconfiguration_test.py
@@ -266,7 +266,7 @@ class ControllerForceReconfigurationTest(RedpandaTest):
 
         self.client().create_topic(topic)
 
-        KgoVerifierProducer.oneshot(  # type: ignore
+        KgoVerifierProducer.oneshot(
             self.test_context,
             self.redpanda,
             topic,
@@ -346,7 +346,7 @@ class ControllerForceReconfigurationTest(RedpandaTest):
 
         self._check_topic_recovered(topic, cluster_size, killed_node_ids)
 
-        KgoVerifierProducer.oneshot(  # type: ignore
+        KgoVerifierProducer.oneshot(
             self.test_context,
             self.redpanda,
             topic,

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -1129,7 +1129,7 @@ message_type {
         custom_partition_spec=[None, "(timestamp_us)", "(number)"],
     )
     def test_iceberg_partition_key_file_location(
-        self, cloud_storage_type, catalog_type, custom_partition_spec: str
+        self, cloud_storage_type, catalog_type, custom_partition_spec: str | None
     ):
         """
         Test that the data file location includes the partition key

--- a/tests/rptest/tests/datalake/schemas/data_types.py
+++ b/tests/rptest/tests/datalake/schemas/data_types.py
@@ -28,7 +28,7 @@ class GenericDataType:
         elif producer_type == ProducerType.PROTO3:
             return cls.to_proto()
         else:
-            raise NotImplementedError(f"Unknown ProducerType {producer_type}")
+            raise NotImplementedError(f"Unknown ProducerType {producer_type}")  # pyright: ignore[reportUnreachable]
 
     @staticmethod
     def name() -> str:

--- a/tests/rptest/tests/datalake/schemas/schema_generator.py
+++ b/tests/rptest/tests/datalake/schemas/schema_generator.py
@@ -34,17 +34,15 @@ class SchemaGenerator:
         self,
         producer_type: ProducerType,
         complex_types: list[GenericDataType] = ALL_COMPLEX_DATA_TYPES,
-        complex_type_probabilities: list[float] = None,
+        complex_type_probabilities: list[float] | None = None,
         primitive_types: list[GenericDataType] = ALL_PRIMITIVE_DATA_TYPES,
-        primitive_type_probabilities: list[float] = None,
+        primitive_type_probabilities: list[float] | None = None,
         max_depth: int = 5,
         max_fields: int = 10,
         max_fields_per_type: int = 10,
     ):
         if complex_type_probabilities is None:
-            complex_type_probabilities: list[float] = [1.0 / len(complex_types)] * len(
-                complex_types
-            )
+            complex_type_probabilities = [1.0 / len(complex_types)] * len(complex_types)
         if primitive_type_probabilities is None:
             primitive_type_probabilities = [1.0 / len(primitive_types)] * len(
                 primitive_types

--- a/tests/rptest/tests/redpanda_startup_test.py
+++ b/tests/rptest/tests/redpanda_startup_test.py
@@ -10,6 +10,8 @@
 import os
 from time import sleep
 
+from typing_extensions import assert_never
+
 from ducktape.cluster.cluster import ClusterNode
 from ducktape.mark import ignore
 from ducktape.utils.util import wait_until
@@ -47,7 +49,7 @@ class RedpandaFIPSStartupTestBase(RedpandaTest):
         elif fips_mode == RedpandaService.FIPSMode.permissive:
             return "permissive"
         else:
-            assert False, f"Unknown FIPS Mode; {fips_mode}"
+            assert_never(fips_mode)  # pyright: ignore[reportUnreachable]
 
     def __init__(
         self,

--- a/tests/rptest/tests/scram_test.py
+++ b/tests/rptest/tests/scram_test.py
@@ -16,6 +16,8 @@ import urllib.parse
 from enum import IntEnum
 from typing import List
 
+from typing_extensions import assert_never
+
 import requests
 from confluent_kafka import KafkaError, KafkaException
 from ducktape.cluster.cluster import ClusterNode
@@ -520,7 +522,7 @@ class SaslPlainTest(BaseScramTest):
                 self.redpanda, user=username, passwd=password, algorithm=algorithm
             )
         else:
-            assert False, f"Unknown client type: {client_type}"
+            assert_never(client_type)  # pyright: ignore[reportUnreachable]
 
     def _make_topic(
         self,
@@ -553,7 +555,7 @@ class SaslPlainTest(BaseScramTest):
             elif isinstance(client, KafkaCliTools):
                 client.create_topic(topic)
             else:
-                assert False, f"Unknown client type: {client} ({type(client)})"
+                assert False, f"Unknown client type: {client} ({type(client)})"  # pyright: ignore[reportUnreachable]
             assert expect_success, "Should have failed with SASL/PLAIN disabled"
         except RpkException as e:
             assert isinstance(client, RpkTool), (

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -647,7 +647,7 @@ class RedpandaServiceSelfRawTest(Test):
         try:
             test.setUp()
             try:
-                test.run()  # type: ignore
+                test.run()
                 raise RuntimeError("inner test passed when it shouldn't")
             except BadLogLines:
                 # expected, as the test intentionally emits a bad log line

--- a/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
+++ b/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
@@ -73,7 +73,7 @@ class ShadowIndexingCompactedTopicTest(EndToEndTest):
         def capture_description_is_ok():
             nonlocal description
             description = list(self._rpk_client.describe_topic(topic))
-            return description is not None and len(description) > 0
+            return len(description) > 0
 
         wait_until(
             capture_description_is_ok,
@@ -82,7 +82,8 @@ class ShadowIndexingCompactedTopicTest(EndToEndTest):
             err_msg=f"failed to get describe_topic {topic}",
         )
         assert description is not None, "description is None"
-        return description
+        # pyright can't see the nonlocal write
+        return description  # pyright: ignore[reportUnreachable]
 
     @cluster(num_nodes=4)
     @matrix(cloud_storage_type=get_cloud_storage_type())
@@ -247,7 +248,7 @@ class TSWithAlreadyCompactedTopic(EndToEndTest):
         def capture_description_is_ok():
             nonlocal description
             description = list(self._rpk_client.describe_topic(topic))
-            return description is not None and len(description) > 0
+            return len(description) > 0
 
         wait_until(
             capture_description_is_ok,
@@ -256,7 +257,7 @@ class TSWithAlreadyCompactedTopic(EndToEndTest):
             err_msg=f"failed to get describe_topic {topic}",
         )
         assert description is not None, "description is None"
-        return description
+        return description  # pyright: ignore[reportUnreachable]
 
     @cluster(num_nodes=4)
     def test_initial_upload(self):

--- a/tests/rptest/tests/tiered_storage_model_test.py
+++ b/tests/rptest/tests/tiered_storage_model_test.py
@@ -13,7 +13,7 @@ import time
 from collections import defaultdict
 from concurrent.futures import Future, ThreadPoolExecutor
 from threading import Condition
-from typing import List
+from typing import Any, List
 
 from ducktape.mark import matrix
 
@@ -591,7 +591,7 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
     def test_tiered_storage(
         self,
         cloud_storage_type_and_url_style: List[CloudStorageTypeAndUrlStyle],
-        test_case: TestCase,
+        test_case: Any,
     ):
         """This is a main entry point of the test.
         The test runs if 5 phases:

--- a/tests/rptest/tests/tls_version_test.py
+++ b/tests/rptest/tests/tls_version_test.py
@@ -74,8 +74,6 @@ def tls_version_to_openssl(ver: TLSVersion) -> str:
         return "-tls1_2"
     elif ver == TLSVersion.v1_3:
         return "-tls1_3"
-    else:
-        raise ValueError(f"Unknown TLS Version: {ver}")
 
 
 def tls_version_to_config(ver: TLSVersion) -> str:
@@ -87,8 +85,6 @@ def tls_version_to_config(ver: TLSVersion) -> str:
         return "v1.2"
     elif ver == TLSVersion.v1_3:
         return "v1.3"
-    else:
-        raise ValueError(f"Unknown TLS Version: {ver}")
 
 
 class TLSVersionTestBase(RedpandaTest):
@@ -230,8 +226,6 @@ class TLSVersionTestBase(RedpandaTest):
             ]
         elif key_type == TLSKeyType.ECDSA:
             return [c for c in ciphers if c.startswith("ECDHE-ECDSA")]
-        else:
-            raise ValueError(f"Unsupported key type: {key_type}")
 
     def _get_openssl_ciphers(self, key_type: TLSKeyType) -> List:
         # Get the list of ciphers supported by the installed version of OpenSSL

--- a/tests/rptest/transactions/verifiers/stream_verifier.py
+++ b/tests/rptest/transactions/verifiers/stream_verifier.py
@@ -79,7 +79,6 @@ class StreamVerifier(Service):
                     f"'{r['status']}' "
                 )
                 return False
-            return True
         except requests.exceptions.ConnectionError:
             return False
 

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -64,6 +64,7 @@ setup(
         "duckdb==1.3.1",
         "connect-python==0.4.2",
         "avro==1.12.0",
+        "typing-extensions==4.15",
     ],
     scripts=[],
 )

--- a/tools/type-checking/type-check-strictness.json
+++ b/tools/type-checking/type-check-strictness.json
@@ -272,7 +272,6 @@
     "off": [
         "**/*_pb2_connect.py",
         "rptest/chaos_tests/single_fault_test.py",
-        "rptest/clients/ping_pong.py",
         "rptest/clients/rpk.py",
         "rptest/clients/rpk_remote.py",
         "rptest/context/databricks.py",


### PR DESCRIPTION
Add some additional checks which aren't turned on in strict mode:

reportImportCycles

The original reason for this change: blocks import cycles which can often come up when adding types.

reportPropertyTypeMismatch
reportUnnecessaryTypeIgnoreComment

Removed a few # type: ignore comments which are no longer needed

reportUnreachable

Probably the most quality-improving check in this batch. Fixed all existing cases of this warning. Many cases would ideally use `assert_never`, but this doesn't work as well you'd like due to https://github.com/microsoft/pyright/issues/11120, but that is used in some places, and in others we just surpress the error (typically this happens when some if/else or match cases are exhaustive and we have an "unexpected value" case as the default).

In other cases code was truly dead and was deleted and in others the code was live but the typing above it was wrong, in these cases I fixed the typing. One such case was ping_pong.py and there I typed the entire file.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
