### PR TITLE
cloud_io: support conditional writes

### DIFF
--- a/src/v/cloud_io/io_result.cc
+++ b/src/v/cloud_io/io_result.cc
@@ -25,6 +25,9 @@ std::ostream& operator<<(std::ostream& o, const download_result& r) {
     case download_result::failed:
         o << "{failed}";
         break;
+    case download_result::precondition_failed:
+        o << "{precondition_failed}";
+        break;
     };
     return o;
 }
@@ -42,6 +45,9 @@ std::ostream& operator<<(std::ostream& o, const upload_result& r) {
         break;
     case upload_result::cancelled:
         o << "{cancelled}";
+        break;
+    case upload_result::precondition_failed:
+        o << "{precondition_failed}";
         break;
     };
     return o;

--- a/src/v/cloud_io/io_result.h
+++ b/src/v/cloud_io/io_result.h
@@ -19,6 +19,7 @@ enum class [[nodiscard]] download_result : int32_t {
     notfound,
     timedout,
     failed,
+    precondition_failed,
 };
 
 enum class [[nodiscard]] upload_result : int32_t {
@@ -26,6 +27,7 @@ enum class [[nodiscard]] upload_result : int32_t {
     timedout,
     failed,
     cancelled,
+    precondition_failed,
 };
 std::ostream& operator<<(std::ostream& o, const download_result& r);
 std::ostream& operator<<(std::ostream& o, const upload_result& r);

--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -391,7 +391,10 @@ ss::future<download_result> remote::download_stream(
         auto download_latency_measure
           = transfer_details.scoped_latency_measurement();
         auto resp = co_await lease.client->get_object(
-          bucket, path, fib.get_timeout(), false, byte_range);
+          bucket,
+          path,
+          fib.get_timeout(),
+          {.expect_no_such_key = false, .byte_range = byte_range});
 
         if (resp) {
             vlog(ctxlog.debug, "Receive OK response from {}", path);
@@ -511,7 +514,10 @@ remote::download_object(download_request download_request) {
     while (!_gate.is_closed() && permit.is_allowed && !result) {
         download_request.transfer_details.on_request(fib.retry_count());
         auto resp = co_await lease.client->get_object(
-          bucket, path, fib.get_timeout(), download_request.expect_missing);
+          bucket,
+          path,
+          fib.get_timeout(),
+          {.expect_no_such_key = download_request.expect_missing});
 
         if (resp) {
             vlog(ctxlog.debug, "Receive OK response from {}", path);
@@ -1168,7 +1174,7 @@ ss::future<upload_result> remote::upload_object(upload_request upload_request) {
           content_length,
           make_iobuf_input_stream(std::move(to_upload)),
           fib.get_timeout(),
-          upload_request.accept_no_content_response);
+          {.accept_no_content = upload_request.accept_no_content_response});
 
         if (res) {
             transfer_details.on_success();

--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -293,7 +293,10 @@ ss::future<upload_result> remote::upload_stream(
           path,
           content_length,
           reader_handle->take_stream(),
-          fib.get_timeout());
+          fib.get_timeout(),
+          {
+            .precondition = transfer_details.precondition,
+          });
 
         // `put_object` closed the encapsulated input_stream, but we must
         // call close() on the segment_reader_handle to release the FD.
@@ -394,7 +397,11 @@ ss::future<download_result> remote::download_stream(
           bucket,
           path,
           fib.get_timeout(),
-          {.expect_no_such_key = false, .byte_range = byte_range});
+          {
+            .expect_no_such_key = false,
+            .byte_range = byte_range,
+            .precondition = transfer_details.precondition,
+          });
 
         if (resp) {
             vlog(ctxlog.debug, "Receive OK response from {}", path);
@@ -517,7 +524,10 @@ remote::download_object(download_request download_request) {
           bucket,
           path,
           fib.get_timeout(),
-          {.expect_no_such_key = download_request.expect_missing});
+          {
+            .expect_no_such_key = download_request.expect_missing,
+            .precondition = download_request.transfer_details.precondition,
+          });
 
         if (resp) {
             vlog(ctxlog.debug, "Receive OK response from {}", path);
@@ -1174,7 +1184,10 @@ ss::future<upload_result> remote::upload_object(upload_request upload_request) {
           content_length,
           make_iobuf_input_stream(std::move(to_upload)),
           fib.get_timeout(),
-          {.accept_no_content = upload_request.accept_no_content_response});
+          {
+            .accept_no_content = upload_request.accept_no_content_response,
+            .precondition = upload_request.transfer_details.precondition,
+          });
 
         if (res) {
             transfer_details.on_success();

--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -333,6 +333,9 @@ ss::future<upload_result> remote::upload_stream(
         case cloud_storage_clients::error_outcome::fail:
             result = upload_result::failed;
             break;
+        case cloud_storage_clients::error_outcome::precondition_failed:
+            result = upload_result::precondition_failed;
+            break;
         }
     }
 
@@ -470,6 +473,9 @@ ss::future<download_result> remote::download_stream(
         case cloud_storage_clients::error_outcome::key_not_found:
             result = download_result::notfound;
             break;
+        case cloud_storage_clients::error_outcome::precondition_failed:
+            result = download_result::precondition_failed;
+            break;
         }
     }
     transfer_details.on_failure();
@@ -568,6 +574,9 @@ remote::download_object(download_request download_request) {
         case cloud_storage_clients::error_outcome::key_not_found:
             result = download_result::notfound;
             break;
+        case cloud_storage_clients::error_outcome::precondition_failed:
+            result = download_result::precondition_failed;
+            break;
         }
     }
     transfer_details.on_failure();
@@ -648,6 +657,9 @@ ss::future<download_result> remote::object_exists(
         case cloud_storage_clients::error_outcome::key_not_found:
             result = download_result::notfound;
             break;
+        case cloud_storage_clients::error_outcome::precondition_failed:
+            result = download_result::precondition_failed;
+            break;
         }
     }
     if (!result) {
@@ -721,6 +733,9 @@ remote::delete_object(transfer_details transfer_details) {
             [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:
             result = upload_result::failed;
+            break;
+        case cloud_storage_clients::error_outcome::precondition_failed:
+            result = upload_result::precondition_failed;
             break;
         case cloud_storage_clients::error_outcome::key_not_found:
             vassert(
@@ -887,6 +902,9 @@ ss::future<upload_result> remote::delete_object_batch(
             [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:
             result = upload_result::failed;
+            break;
+        case cloud_storage_clients::error_outcome::precondition_failed:
+            result = upload_result::precondition_failed;
             break;
         case cloud_storage_clients::error_outcome::key_not_found:
             vassert(
@@ -1124,6 +1142,9 @@ ss::future<list_result> remote::list_objects(
         case cloud_storage_clients::error_outcome::fail:
             result = cloud_storage_clients::error_outcome::fail;
             break;
+        case cloud_storage_clients::error_outcome::precondition_failed:
+            result = cloud_storage_clients::error_outcome::precondition_failed;
+            break;
         case cloud_storage_clients::error_outcome::key_not_found:
             vassert(
               false,
@@ -1215,6 +1236,9 @@ ss::future<upload_result> remote::upload_object(upload_request upload_request) {
             [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:
             result = upload_result::failed;
+            break;
+        case cloud_storage_clients::error_outcome::precondition_failed:
+            result = upload_result::precondition_failed;
             break;
         }
     }

--- a/src/v/cloud_io/remote.h
+++ b/src/v/cloud_io/remote.h
@@ -42,12 +42,6 @@ class remote final
   : public remote_api<>
   , public ss::peering_sharded_service<remote> {
 public:
-    /// Functor that should be provided by user when list_objects api is called.
-    /// It receives every key that matches the query as well as it's modifiation
-    /// time, size in bytes, and etag.
-    using list_objects_consumer = std::function<ss::stop_iteration(
-      ss::sstring, std::chrono::system_clock::time_point, size_t, ss::sstring)>;
-
     /// \brief Initialize 'remote'
     ///
     /// \param limit is a number of simultaneous connections

--- a/src/v/cloud_io/transfer_details.h
+++ b/src/v/cloud_io/transfer_details.h
@@ -33,6 +33,8 @@ struct basic_transfer_details {
     cloud_storage_clients::bucket_name bucket;
     cloud_storage_clients::object_key key;
 
+    cloud_storage_clients::precondition precondition;
+
     basic_retry_chain_node<Clock>& parent_rtc;
 
     std::optional<probe_callback_t> success_cb{std::nullopt};

--- a/src/v/cloud_storage/download_exception.cc
+++ b/src/v/cloud_storage/download_exception.cc
@@ -25,6 +25,8 @@ download_exception::download_exception(
 
 const char* download_exception::what() const noexcept {
     switch (result) {
+    case download_result::precondition_failed:
+        return "PreconditionFailed";
     case download_result::failed:
         return "Failed";
     case download_result::notfound:

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -166,7 +166,8 @@ abs_request_creator::abs_request_creator(
 result<http::client::request_header> abs_request_creator::make_get_blob_request(
   const bucket_name& name,
   const object_key& key,
-  std::optional<http_byte_range> byte_range) {
+  std::optional<http_byte_range> byte_range,
+  precondition precondition) {
     // GET /{container-id}/{blob-id} HTTP/1.1
     // Host: {storage-account-id}.blob.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
@@ -187,6 +188,16 @@ result<http::client::request_header> abs_request_creator::make_get_blob_request(
             byte_range.value().first,
             byte_range.value().second));
     }
+    ss::visit(
+      precondition,
+      [](const std::monostate&) {},
+      [&header](const if_none_match&) {
+          header.insert(boost::beast::http::field::if_none_match, "*");
+      },
+      [&header](const if_match& value) {
+          header.insert(
+            boost::beast::http::field::if_match, std::string_view(value.etag));
+      });
     auto error_code = _apply_credentials->add_auth(header);
     if (error_code) {
         return error_code;
@@ -196,7 +207,10 @@ result<http::client::request_header> abs_request_creator::make_get_blob_request(
 }
 
 result<http::client::request_header> abs_request_creator::make_put_blob_request(
-  const bucket_name& name, const object_key& key, size_t payload_size_bytes) {
+  const bucket_name& name,
+  const object_key& key,
+  size_t payload_size_bytes,
+  precondition precondition) {
     // PUT /{container-id}/{blob-id} HTTP/1.1
     // Host: {storage-account-id}.blob.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
@@ -216,6 +230,16 @@ result<http::client::request_header> abs_request_creator::make_put_blob_request(
       boost::beast::http::field::content_length,
       std::to_string(payload_size_bytes));
     header.insert(blob_type_name, blob_type_value);
+    ss::visit(
+      precondition,
+      [](const std::monostate&) {},
+      [&header](const if_none_match&) {
+          header.insert(boost::beast::http::field::if_none_match, "*");
+      },
+      [&header](const if_match& value) {
+          header.insert(
+            boost::beast::http::field::if_match, std::string_view(value.etag));
+      });
 
     auto error_code = _apply_credentials->add_auth(header);
     if (error_code) {
@@ -582,7 +606,10 @@ ss::future<http::client::response_stream_ref> abs_client::do_get_object(
   get_object_options options) {
     bool is_byte_range_requested = options.byte_range.has_value();
     auto header = _requestor.make_get_blob_request(
-      name, key, std::move(options.byte_range));
+      name,
+      key,
+      std::move(options.byte_range),
+      std::move(options.precondition));
     if (!header) {
         vlog(
           abs_log.warn, "Failed to create request header: {}", header.error());
@@ -650,7 +677,8 @@ ss::future<> abs_client::do_put_object(
   ss::input_stream<char> body,
   ss::lowres_clock::duration timeout,
   put_object_options options) {
-    auto header = _requestor.make_put_blob_request(name, key, payload_size);
+    auto header = _requestor.make_put_blob_request(
+      name, key, payload_size, std::move(options.precondition));
     if (!header) {
         co_await body.close();
 

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -14,6 +14,7 @@
 #include "bytes/iostream.h"
 #include "bytes/streambuf.h"
 #include "cloud_storage_clients/abs_error.h"
+#include "cloud_storage_clients/client.h"
 #include "cloud_storage_clients/configuration.h"
 #include "cloud_storage_clients/logger.h"
 #include "cloud_storage_clients/util.h"
@@ -569,24 +570,19 @@ abs_client::get_object(
   const bucket_name& name,
   const object_key& key,
   ss::lowres_clock::duration timeout,
-  bool expect_no_such_key,
-  std::optional<http_byte_range> byte_range) {
+  get_object_options options) {
     return send_request(
-      do_get_object(
-        name, key, timeout, expect_no_such_key, std::move(byte_range)),
-      key,
-      op_type_tag::download);
+      do_get_object(name, key, timeout, options), key, op_type_tag::download);
 }
 
 ss::future<http::client::response_stream_ref> abs_client::do_get_object(
   const bucket_name& name,
   const object_key& key,
   ss::lowres_clock::duration timeout,
-  bool expect_no_such_key,
-  std::optional<http_byte_range> byte_range) {
-    bool is_byte_range_requested = byte_range.has_value();
+  get_object_options options) {
+    bool is_byte_range_requested = options.byte_range.has_value();
     auto header = _requestor.make_get_blob_request(
-      name, key, std::move(byte_range));
+      name, key, std::move(options.byte_range));
     if (!header) {
         vlog(
           abs_log.warn, "Failed to create request header: {}", header.error());
@@ -608,7 +604,7 @@ ss::future<http::client::response_stream_ref> abs_client::do_get_object(
     }
     if (request_failed) {
         if (
-          expect_no_such_key
+          options.expect_no_such_key
           && status == boost::beast::http::status::not_found) {
             vlog(
               abs_log.debug,
@@ -638,10 +634,9 @@ abs_client::put_object(
   size_t payload_size,
   ss::input_stream<char> body,
   ss::lowres_clock::duration timeout,
-  bool accept_no_content) {
+  put_object_options options) {
     return send_request(
-      do_put_object(
-        name, key, payload_size, std::move(body), timeout, accept_no_content)
+      do_put_object(name, key, payload_size, std::move(body), timeout, options)
         .then(
           []() { return ss::make_ready_future<no_response>(no_response{}); }),
       key,
@@ -654,7 +649,7 @@ ss::future<> abs_client::do_put_object(
   size_t payload_size,
   ss::input_stream<char> body,
   ss::lowres_clock::duration timeout,
-  bool accept_no_content) {
+  put_object_options options) {
     auto header = _requestor.make_put_blob_request(name, key, payload_size);
     if (!header) {
         co_await body.close();
@@ -676,7 +671,7 @@ ss::future<> abs_client::do_put_object(
     const auto status = response_stream->get_headers().result();
     using enum boost::beast::http::status;
 
-    if (const auto is_no_content_and_accepted = accept_no_content
+    if (const auto is_no_content_and_accepted = options.accept_no_content
                                                 && status == no_content;
         status != created && !is_no_content_and_accepted) {
         const auto content_type = util::get_response_content_type(

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -65,11 +65,7 @@ constexpr std::string_view set_expiry_test_file = "testsetexpiry";
 
 bool is_error_retryable(
   const cloud_storage_clients::abs_rest_error_response& err) {
-    return std::find(
-             retryable_http_codes.begin(),
-             retryable_http_codes.end(),
-             err.http_code())
-           != retryable_http_codes.end();
+    return std::ranges::contains(retryable_http_codes, err.http_code());
 }
 } // namespace
 
@@ -568,6 +564,12 @@ ss::future<result<T, error_outcome>> abs_client::send_request(
               "OperationNotSupportedOnDirectory response received {}",
               key);
             outcome = error_outcome::operation_not_supported;
+            _probe->register_failure(err.code());
+        } else if (
+          err.code() == abs_error_code::condition_not_met
+          || err.code() == abs_error_code::blob_already_exists) {
+            vlog(abs_log.debug, "ConditionNotMet response received {}", key);
+            outcome = error_outcome::precondition_failed;
             _probe->register_failure(err.code());
         } else {
             vlog(

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -149,8 +149,7 @@ public:
       const bucket_name& name,
       const object_key& key,
       ss::lowres_clock::duration timeout,
-      bool expect_no_such_key = false,
-      std::optional<http_byte_range> byte_range = std::nullopt) override;
+      get_object_options options = {}) override;
 
     /// Send Get Blob Metadata request.
     /// \param name is a container name
@@ -175,7 +174,7 @@ public:
       size_t payload_size,
       ss::input_stream<char> body,
       ss::lowres_clock::duration timeout,
-      bool accept_no_content = false) override;
+      put_object_options options = {}) override;
 
     /// Send List Blobs request
     /// \param name is a container name
@@ -255,8 +254,7 @@ private:
       const bucket_name& name,
       const object_key& key,
       ss::lowres_clock::duration timeout,
-      bool expect_no_such_key = false,
-      std::optional<http_byte_range> byte_range = std::nullopt);
+      get_object_options);
 
     ss::future<> do_put_object(
       const bucket_name& name,
@@ -264,7 +262,7 @@ private:
       size_t payload_size,
       ss::input_stream<char> body,
       ss::lowres_clock::duration timeout,
-      bool accept_no_content = false);
+      put_object_options);
 
     ss::future<head_object_result> do_head_object(
       const bucket_name& name,

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -37,7 +37,8 @@ public:
     result<http::client::request_header> make_put_blob_request(
       const bucket_name& name,
       const object_key& key,
-      size_t payload_size_bytes);
+      size_t payload_size_bytes,
+      precondition precondition);
 
     /// \brief Create a 'Get Blob' request header
     ///
@@ -47,7 +48,8 @@ public:
     result<http::client::request_header> make_get_blob_request(
       const bucket_name& name,
       const object_key& key,
-      std::optional<http_byte_range> byte_range = std::nullopt);
+      std::optional<http_byte_range> byte_range,
+      precondition precondition);
 
     /// \brief Create a 'Get Blob Metadata' request header
     ///

--- a/src/v/cloud_storage_clients/abs_error.cc
+++ b/src/v/cloud_storage_clients/abs_error.cc
@@ -49,6 +49,11 @@ std::istream& operator>>(std::istream& i, abs_error_code& code) {
           .match(
             "OperationNotSupportedOnDirectory",
             abs_error_code::operation_not_supported_on_directory)
+          .match("ConditionNotMet", abs_error_code::condition_not_met)
+          .match(
+            "SourceConditionNotMet", abs_error_code::source_condition_not_met)
+          .match(
+            "TargetConditionNotMet", abs_error_code::target_condition_not_met)
           .default_match(abs_error_code::_unknown);
 
     return i;

--- a/src/v/cloud_storage_clients/abs_error.h
+++ b/src/v/cloud_storage_clients/abs_error.h
@@ -41,7 +41,10 @@ enum class abs_error_code {
     container_not_found,
     directory_not_empty,
     path_not_found,
-    operation_not_supported_on_directory
+    operation_not_supported_on_directory,
+    condition_not_met,
+    source_condition_not_met,
+    target_condition_not_met,
 };
 
 /// Operators to use with lexical_cast

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -35,11 +35,13 @@ using http_byte_range = std::pair<uint64_t, uint64_t>;
 struct get_object_options {
     bool expect_no_such_key = false;
     std::optional<http_byte_range> byte_range;
+    precondition precondition;
 };
 
 // Options for putting an object.
 struct put_object_options {
     bool accept_no_content = false;
+    precondition precondition;
 };
 
 class client {

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -31,6 +31,17 @@ namespace cloud_storage_clients {
 // of the requested range.
 using http_byte_range = std::pair<uint64_t, uint64_t>;
 
+// Options for getting an object.
+struct get_object_options {
+    bool expect_no_such_key = false;
+    std::optional<http_byte_range> byte_range;
+};
+
+// Options for putting an object.
+struct put_object_options {
+    bool accept_no_content = false;
+};
+
 class client {
 public:
     struct no_response {};
@@ -51,15 +62,13 @@ public:
     /// \param name is a bucket name
     /// \param key is an object key
     /// \param timeout is a timeout of the operation
-    /// \param expect_no_such_key log missing key events as warnings if false
     /// \return future that becomes ready after request was sent
     virtual ss::future<result<http::client::response_stream_ref, error_outcome>>
     get_object(
       const bucket_name& name,
       const object_key& key,
       ss::lowres_clock::duration timeout,
-      bool expect_no_such_key = false,
-      std::optional<http_byte_range> byte_range = std::nullopt)
+      get_object_options options = {})
       = 0;
 
     struct head_object_result {
@@ -94,7 +103,7 @@ public:
       size_t payload_size,
       ss::input_stream<char> body,
       ss::lowres_clock::duration timeout,
-      bool accept_no_content = false)
+      put_object_options options = {})
       = 0;
 
     struct list_bucket_item {

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -86,7 +86,8 @@ request_creator::request_creator(
 result<http::client::request_header> request_creator::make_get_object_request(
   const bucket_name& name,
   const object_key& key,
-  std::optional<http_byte_range> byte_range) {
+  std::optional<http_byte_range> byte_range,
+  precondition precondition) {
     http::client::request_header header{};
     // Virtual Style:
     // GET /{object-id} HTTP/1.1
@@ -114,6 +115,16 @@ result<http::client::request_header> request_creator::make_get_object_request(
             byte_range.value().first,
             byte_range.value().second));
     }
+    ss::visit(
+      precondition,
+      [](const std::monostate&) {},
+      [&header](const if_none_match&) {
+          header.insert(boost::beast::http::field::if_none_match, "*");
+      },
+      [&header](const if_match& value) {
+          header.insert(
+            boost::beast::http::field::if_match, std::string_view(value.etag));
+      });
     auto ec = _apply_credentials->add_auth(header);
     if (ec) {
         return ec;
@@ -153,7 +164,10 @@ result<http::client::request_header> request_creator::make_head_object_request(
 
 result<http::client::request_header>
 request_creator::make_unsigned_put_object_request(
-  const bucket_name& name, const object_key& key, size_t payload_size_bytes) {
+  const bucket_name& name,
+  const object_key& key,
+  size_t payload_size_bytes,
+  precondition precondition) {
     // Virtual Style:
     // PUT /my-image.jpg HTTP/1.1
     // Host: {bucket-name}.s3.{region}.amazonaws.com
@@ -181,6 +195,16 @@ request_creator::make_unsigned_put_object_request(
     header.insert(
       boost::beast::http::field::content_length,
       std::to_string(payload_size_bytes));
+    ss::visit(
+      precondition,
+      [](const std::monostate&) {},
+      [&header](const if_none_match&) {
+          header.insert(boost::beast::http::field::if_none_match, "*");
+      },
+      [&header](const if_match& value) {
+          header.insert(
+            boost::beast::http::field::if_match, std::string_view(value.etag));
+      });
 
     auto ec = _apply_credentials->add_auth(header);
     if (ec) {
@@ -725,7 +749,8 @@ s3_client::get_object(
   const object_key& key,
   ss::lowres_clock::duration timeout,
   get_object_options options) {
-    return send_request(do_get_object(name, key, timeout, options), name, key);
+    return send_request(
+      do_get_object(name, key, timeout, std::move(options)), name, key);
 }
 
 ss::future<http::client::response_stream_ref> s3_client::do_get_object(
@@ -735,7 +760,10 @@ ss::future<http::client::response_stream_ref> s3_client::do_get_object(
   get_object_options options) {
     bool is_byte_range_requested = options.byte_range.has_value();
     auto header = _requestor.make_get_object_request(
-      name, key, std::move(options.byte_range));
+      name,
+      key,
+      std::move(options.byte_range),
+      std::move(options.precondition));
     if (!header) {
         return ss::make_exception_future<http::client::response_stream_ref>(
           std::system_error(header.error()));
@@ -868,7 +896,8 @@ ss::future<result<s3_client::no_response, error_outcome>> s3_client::put_object(
   ss::lowres_clock::duration timeout,
   put_object_options options) {
     return send_request(
-      do_put_object(name, key, payload_size, std::move(body), timeout, options)
+      do_put_object(
+        name, key, payload_size, std::move(body), timeout, std::move(options))
         .then(
           []() { return ss::make_ready_future<no_response>(no_response{}); }),
       name,
@@ -883,7 +912,7 @@ ss::future<> s3_client::do_put_object(
   ss::lowres_clock::duration timeout,
   put_object_options options) {
     auto header = _requestor.make_unsigned_put_object_request(
-      name, id, payload_size);
+      name, id, payload_size, std::move(options.precondition));
     if (!header) {
         return body.close().then([header] {
             return ss::make_exception_future<>(

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -17,6 +17,7 @@
 #include "bytes/iobuf_parser.h"
 #include "bytes/iostream.h"
 #include "bytes/streambuf.h"
+#include "cloud_storage_clients/client.h"
 #include "cloud_storage_clients/logger.h"
 #include "cloud_storage_clients/s3_error.h"
 #include "cloud_storage_clients/util.h"
@@ -723,32 +724,27 @@ s3_client::get_object(
   const bucket_name& name,
   const object_key& key,
   ss::lowres_clock::duration timeout,
-  bool expect_no_such_key,
-  std::optional<http_byte_range> byte_range) {
-    return send_request(
-      do_get_object(
-        name, key, timeout, expect_no_such_key, std::move(byte_range)),
-      name,
-      key);
+  get_object_options options) {
+    return send_request(do_get_object(name, key, timeout, options), name, key);
 }
 
 ss::future<http::client::response_stream_ref> s3_client::do_get_object(
   const bucket_name& name,
   const object_key& key,
   ss::lowres_clock::duration timeout,
-  bool expect_no_such_key,
-  std::optional<http_byte_range> byte_range) {
-    bool is_byte_range_requested = byte_range.has_value();
+  get_object_options options) {
+    bool is_byte_range_requested = options.byte_range.has_value();
     auto header = _requestor.make_get_object_request(
-      name, key, std::move(byte_range));
+      name, key, std::move(options.byte_range));
     if (!header) {
         return ss::make_exception_future<http::client::response_stream_ref>(
           std::system_error(header.error()));
     }
     vlog(s3_log.trace, "send https request:\n{}", header.value());
     return _client.request(std::move(header.value()), timeout)
-      .then([expect_no_such_key, is_byte_range_requested, key](
-              http::client::response_stream_ref&& ref) {
+      .then([expect_no_such_key = options.expect_no_such_key,
+             is_byte_range_requested,
+             key](http::client::response_stream_ref&& ref) {
           // here we didn't receive any bytes from the socket and
           // ref->is_header_done() is 'false', we need to prefetch
           // the header first
@@ -870,10 +866,9 @@ ss::future<result<s3_client::no_response, error_outcome>> s3_client::put_object(
   size_t payload_size,
   ss::input_stream<char> body,
   ss::lowres_clock::duration timeout,
-  bool accept_no_content) {
+  put_object_options options) {
     return send_request(
-      do_put_object(
-        name, key, payload_size, std::move(body), timeout, accept_no_content)
+      do_put_object(name, key, payload_size, std::move(body), timeout, options)
         .then(
           []() { return ss::make_ready_future<no_response>(no_response{}); }),
       name,
@@ -886,7 +881,7 @@ ss::future<> s3_client::do_put_object(
   size_t payload_size,
   ss::input_stream<char> body,
   ss::lowres_clock::duration timeout,
-  bool accept_no_content) {
+  put_object_options options) {
     auto header = _requestor.make_unsigned_put_object_request(
       name, id, payload_size);
     if (!header) {
@@ -898,7 +893,11 @@ ss::future<> s3_client::do_put_object(
     vlog(s3_log.trace, "send https request:\n{}", header.value());
     return ss::do_with(
       std::move(body),
-      [this, timeout, header = std::move(header), id, accept_no_content](
+      [this,
+       timeout,
+       header = std::move(header),
+       id,
+       accept_no_content = options.accept_no_content](
         ss::input_stream<char>& body) mutable {
           auto make_request = [this, &header, &body, &timeout]() {
               return _client.request(std::move(header.value()), body, timeout);

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -605,6 +605,9 @@ ss::future<result<T, error_outcome>> s3_client::send_request(
               key,
               bucket);
             outcome = error_outcome::retry;
+        } else if (err.code() == s3_error_code::precondition_failed) {
+            vlog(s3_log.debug, "PreconditionFailed response recieved {}", key);
+            outcome = error_outcome::precondition_failed;
         } else {
             // Unexpected REST API error, we can't recover from this
             // because the issue is not temporary (e.g. bucket doesn't

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -51,7 +51,8 @@ public:
     result<http::client::request_header> make_unsigned_put_object_request(
       const bucket_name& name,
       const object_key& key,
-      size_t payload_size_bytes);
+      size_t payload_size_bytes,
+      precondition precondition);
 
     /// \brief Create a 'GetObject' request header
     ///
@@ -62,7 +63,8 @@ public:
     result<http::client::request_header> make_get_object_request(
       const bucket_name& name,
       const object_key& key,
-      std::optional<http_byte_range> byte_range = std::nullopt);
+      std::optional<http_byte_range> byte_range,
+      precondition precondition);
 
     /// \brief Create a 'HeadObject' request header
     ///

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -155,8 +155,7 @@ public:
       const bucket_name& name,
       const object_key& key,
       ss::lowres_clock::duration timeout,
-      bool expect_no_such_key = false,
-      std::optional<http_byte_range> byte_range = std::nullopt) override;
+      get_object_options options = {}) override;
 
     /// HeadObject request.
     /// \param name is a bucket name
@@ -179,7 +178,7 @@ public:
       size_t payload_size,
       ss::input_stream<char> body,
       ss::lowres_clock::duration timeout,
-      bool accept_no_content = false) override;
+      put_object_options options = {}) override;
 
     ss::future<result<list_bucket_result, error_outcome>> list_objects(
       const bucket_name& name,
@@ -211,8 +210,7 @@ private:
       const bucket_name& name,
       const object_key& key,
       ss::lowres_clock::duration timeout,
-      bool expect_no_such_key = false,
-      std::optional<http_byte_range> byte_range = std::nullopt);
+      get_object_options);
 
     ss::future<> do_put_object(
       const bucket_name& name,
@@ -220,7 +218,7 @@ private:
       size_t payload_size,
       ss::input_stream<char> body,
       ss::lowres_clock::duration timeout,
-      bool accept_no_content = false);
+      put_object_options);
 
     ss::future<list_bucket_result> do_list_objects_v2(
       const bucket_name& name,

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -812,7 +812,7 @@ ss::future<> do_test_put_object_no_response(bool acceptable) {
                 expected_payload_size,
                 std::move(payload_stream),
                 100ms,
-                acceptable)
+                {.accept_no_content = acceptable})
               .get();
         if (acceptable) {
             BOOST_REQUIRE(response);
@@ -842,7 +842,7 @@ ss::future<> do_test_no_such_configuration(bool acceptable) {
                                   "test-bucket"),
                                 cloud_storage_clients::object_key("no-config"),
                                 100ms,
-                                acceptable)
+                                {.expect_no_such_key = acceptable})
                               .get();
         // acceptable only affects the log level, the end response is always 404
         BOOST_REQUIRE(!result);

--- a/src/v/cloud_storage_clients/types.h
+++ b/src/v/cloud_storage_clients/types.h
@@ -28,6 +28,16 @@ using endpoint_url = named_type<ss::sstring, struct s3_endpoint_url>;
 using ca_trust_file
   = named_type<std::filesystem::path, struct s3_ca_trust_file>;
 
+// If none match ensures that put requests have no content
+struct if_none_match {};
+// If match ensures that the put request have specific content
+struct if_match {
+    ss::sstring etag;
+};
+// A precondition for GET/PUT requests that translate into conditional
+// operations.
+using precondition = std::variant<std::monostate, if_none_match, if_match>;
+
 enum class error_outcome {
     retry,
     /// Error condition that couldn't be retried
@@ -36,7 +46,9 @@ enum class error_outcome {
     key_not_found,
     /// Currently used for directory deletion errors in ABS, typically treated
     /// as regular failure outcomes.
-    operation_not_supported
+    operation_not_supported,
+    // The precondition failed (ie. if-match or if-none-match)
+    // precondition_failed,
 };
 
 struct error_outcome_category final : public std::error_category {

--- a/src/v/cloud_storage_clients/types.h
+++ b/src/v/cloud_storage_clients/types.h
@@ -48,7 +48,7 @@ enum class error_outcome {
     /// as regular failure outcomes.
     operation_not_supported,
     // The precondition failed (ie. if-match or if-none-match)
-    // precondition_failed,
+    precondition_failed,
 };
 
 struct error_outcome_category final : public std::error_category {
@@ -66,6 +66,8 @@ struct error_outcome_category final : public std::error_category {
             return "Key not found error";
         case error_outcome::operation_not_supported:
             return "Operation not supported error";
+        case error_outcome::precondition_failed:
+            return "Precondition failed";
         default:
             return "Undefined error_outcome encountered";
         }

--- a/src/v/cloud_topics/level_one/common/file_io.cc
+++ b/src/v/cloud_topics/level_one/common/file_io.cc
@@ -148,6 +148,7 @@ file_io::put_object(object_id oid, staging_file* file, ss::abort_source* as) {
     case cloud_io::upload_result::timedout:
     case cloud_io::upload_result::cancelled:
         co_return std::unexpected(io::errc::cloud_op_timeout);
+    case cloud_io::upload_result::precondition_failed:
     case cloud_io::upload_result::failed:
         co_return std::unexpected(io::errc::cloud_op_error);
     }
@@ -245,6 +246,7 @@ file_io::read_object(object_extent extent, ss::abort_source* as) {
         case cloud_io::download_result::timedout:
             co_return std::unexpected(io::errc::cloud_op_timeout);
         case cloud_io::download_result::failed:
+        case cloud_io::download_result::precondition_failed:
             co_return std::unexpected(io::errc::cloud_op_error);
         }
         std::unreachable();
@@ -280,6 +282,7 @@ file_io::delete_objects(chunked_vector<object_id> ids, ss::abort_source* as) {
     case cloud_io::upload_result::cancelled:
         co_return std::unexpected(io::errc::cloud_op_timeout);
     case cloud_io::upload_result::failed:
+    case cloud_io::upload_result::precondition_failed:
         co_return std::unexpected(io::errc::cloud_op_error);
     }
     std::unreachable();

--- a/src/v/cloud_topics/level_zero/batcher/batcher.cc
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.cc
@@ -110,6 +110,7 @@ batcher<Clock>::upload_object(object_id id, iobuf payload) {
             err = errc::timeout;
             break;
         case cloud_io::upload_result::failed:
+        case cloud_io::upload_result::precondition_failed:
             err = errc::upload_failure;
         }
     } catch (...) {

--- a/src/v/cloud_topics/level_zero/reader/materialized_extent.cc
+++ b/src/v/cloud_topics/level_zero/reader/materialized_extent.cc
@@ -38,6 +38,7 @@ struct errc_converter<cloud_io::download_result, errc> {
         case cloud_io::download_result::notfound:
             return errc::download_not_found;
         case cloud_io::download_result::failed:
+        case cloud_io::download_result::precondition_failed:
             return errc::download_failure;
         case cloud_io::download_result::timedout:
             return errc::timeout;

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -1797,6 +1797,7 @@ ss::future<ntp_archiver_upload_result> ntp_archiver::upload_segment(
     auto upload_result = upload_segment_ready.get();
     switch (upload_result) {
     case cloud_storage::upload_result::failed:
+    case cloud_storage::upload_result::precondition_failed:
     case cloud_storage::upload_result::timedout:
         vlog(
           ctxlog.info,

--- a/src/v/cluster/self_test/cloudcheck.cc
+++ b/src/v/cluster/self_test/cloudcheck.cc
@@ -95,7 +95,7 @@ cloudcheck::run(cloudcheck_opts opts) {
 ss::future<>
 cloudcheck::clear_self_test_folder(cloud_storage_clients::bucket_name bucket) {
     auto rtc = retry_chain_node(_opts.timeout, _opts.backoff, &_rtc);
-    const cloud_storage::remote::list_result object_list
+    cloud_storage::remote::list_result object_list
       = co_await _cloud_storage_api.local().list_objects(
         bucket, rtc, self_test_prefix);
 
@@ -103,8 +103,7 @@ cloudcheck::clear_self_test_folder(cloud_storage_clients::bucket_name bucket) {
         std::vector<cloud_storage_clients::object_key> objects_to_delete;
         objects_to_delete.reserve(object_list.value().contents.size());
         for (auto& object : object_list.value().contents) {
-            objects_to_delete.push_back(
-              cloud_storage_clients::object_key{std::move(object.key)});
+            objects_to_delete.emplace_back(std::move(object.key));
         }
 
         std::ignore = co_await _cloud_storage_api.local().delete_objects(
@@ -165,10 +164,8 @@ ss::future<std::vector<self_test_result>> cloudcheck::run_benchmarks() {
     if (is_uploaded && object_list) {
         // Check that uploaded object exists in object_list contents.
         auto& object_list_contents = object_list.value().contents;
-        auto payload_item_it = std::find_if(
-          object_list_contents.begin(),
-          object_list_contents.end(),
-          [self_test_key](const auto& item) {
+        auto payload_item_it = std::ranges::find_if(
+          object_list_contents, [self_test_key](const auto& item) {
               return item.key == self_test_key();
           });
 
@@ -196,10 +193,8 @@ ss::future<std::vector<self_test_result>> cloudcheck::run_benchmarks() {
         }
 
         // Get the smallest file from object_list.
-        auto smallest_object = *std::min_element(
-          object_list_contents.begin(),
-          object_list_contents.end(),
-          [](const auto& a, const auto& b) {
+        auto smallest_object = *std::ranges::min_element(
+          object_list_contents, [](const auto& a, const auto& b) {
               return a.size_bytes < b.size_bytes;
           });
         return cloud_storage_clients::object_key{smallest_object.key};
@@ -320,7 +315,9 @@ ss::future<cloudcheck::verify_list_result> cloudcheck::verify_list(
     if (_cancelled) {
         result.warning = "Run was manually cancelled.";
         co_return verify_list_result{
-          cloud_storage_clients::error_outcome::fail, result};
+          .list_result = cloud_storage_clients::error_outcome::fail,
+          .test_result = result,
+        };
     }
 
     try {
@@ -333,13 +330,18 @@ ss::future<cloudcheck::verify_list_result> cloudcheck::verify_list(
             result.error = "Failed to list objects in cloud storage.";
         }
 
-        co_return verify_list_result{std::move(object_list), std::move(result)};
+        co_return verify_list_result{
+          .list_result = std::move(object_list),
+          .test_result = std::move(result),
+        };
     } catch (const std::exception& e) {
         result.error = e.what();
     }
 
     co_return verify_list_result{
-      cloud_storage_clients::error_outcome::fail, std::move(result)};
+      .list_result = cloud_storage_clients::error_outcome::fail,
+      .test_result = std::move(result),
+    };
 }
 
 ss::future<cloudcheck::verify_head_result> cloudcheck::verify_head(
@@ -397,13 +399,19 @@ ss::future<cloudcheck::verify_download_result> cloudcheck::verify_download(
 
     if (_cancelled) {
         result.warning = "Run was manually cancelled.";
-        co_return verify_download_result{std::nullopt, result};
+        co_return verify_download_result{
+          .buf = std::nullopt,
+          .test_result = result,
+        };
     }
 
     if (!key) {
         result.warning = "Could not download from cloud storage (no file was "
                          "found in the bucket).";
-        co_return verify_download_result{std::nullopt, result};
+        co_return verify_download_result{
+          .buf = std::nullopt,
+          .test_result = result,
+        };
     }
 
     std::optional<iobuf> result_payload = std::nullopt;
@@ -438,7 +446,9 @@ ss::future<cloudcheck::verify_download_result> cloudcheck::verify_download(
     }
 
     co_return verify_download_result{
-      std::move(result_payload), std::move(result)};
+      .buf = std::move(result_payload),
+      .test_result = std::move(result),
+    };
 }
 
 ss::future<cloudcheck::verify_delete_result> cloudcheck::verify_delete(
@@ -488,7 +498,7 @@ ss::future<cloudcheck::verify_deletes_result> cloudcheck::verify_deletes(
     }
 
     std::vector<cloud_storage_clients::object_key> keys(num_objects);
-    std::generate(keys.begin(), keys.end(), []() {
+    std::ranges::generate(keys, []() {
         return cloud_storage_clients::object_key{ss::sstring{uuid_t::create()}};
     });
 

--- a/src/v/cluster/self_test/cloudcheck.cc
+++ b/src/v/cluster/self_test/cloudcheck.cc
@@ -294,6 +294,8 @@ ss::future<cloudcheck::verify_upload_result> cloudcheck::verify_upload(
         switch (upload_result) {
         case cloud_storage::upload_result::success:
             break;
+        case cloud_storage::upload_result::precondition_failed:
+            [[fallthrough]];
         case cloud_storage::upload_result::timedout:
             [[fallthrough]];
         case cloud_storage::upload_result::failed:
@@ -369,6 +371,8 @@ ss::future<cloudcheck::verify_head_result> cloudcheck::verify_head(
         switch (head_result) {
         case cloud_storage::download_result::success:
             break;
+        case cloud_storage::download_result::precondition_failed:
+            [[fallthrough]];
         case cloud_storage::download_result::timedout:
             [[fallthrough]];
         case cloud_storage::download_result::failed:
@@ -419,6 +423,8 @@ ss::future<cloudcheck::verify_download_result> cloudcheck::verify_download(
         case cloud_storage::download_result::success:
             result_payload = std::move(download_payload);
             break;
+        case cloud_storage::download_result::precondition_failed:
+            [[fallthrough]];
         case cloud_storage::download_result::timedout:
             [[fallthrough]];
         case cloud_storage::download_result::failed:
@@ -454,6 +460,8 @@ ss::future<cloudcheck::verify_delete_result> cloudcheck::verify_delete(
         switch (delete_result) {
         case cloud_storage::upload_result::success:
             break;
+        case cloud_storage::upload_result::precondition_failed:
+            [[fallthrough]];
         case cloud_storage::upload_result::timedout:
             [[fallthrough]];
         case cloud_storage::upload_result::failed:
@@ -497,6 +505,8 @@ ss::future<cloudcheck::verify_deletes_result> cloudcheck::verify_deletes(
         switch (delete_result) {
         case cloud_storage::upload_result::success:
             break;
+        case cloud_storage::upload_result::precondition_failed:
+            [[fallthrough]];
         case cloud_storage::upload_result::timedout:
             [[fallthrough]];
         case cloud_storage::upload_result::failed:

--- a/src/v/cluster/self_test/cloudcheck.cc
+++ b/src/v/cluster/self_test/cloudcheck.cc
@@ -13,6 +13,7 @@
 
 #include "base/vlog.h"
 #include "cloud_storage/types.h"
+#include "cloud_storage_clients/types.h"
 #include "cluster/logger.h"
 #include "cluster/self_test/metrics.h"
 #include "config/configuration.h"
@@ -229,6 +230,11 @@ ss::future<std::vector<self_test_result>> cloudcheck::run_benchmarks() {
     auto deletes_test_result = co_await do_run_test(
       &cloudcheck::verify_deletes, bucket, num_default_objects);
     results.push_back(std::move(deletes_test_result.test_result));
+
+    // Test CAS
+    auto cas_test_result = co_await do_run_test(
+      &cloudcheck::verify_cas, bucket);
+    results.push_back(std::move(cas_test_result.test_result));
 
     co_await clear_self_test_folder(bucket);
 
@@ -527,6 +533,159 @@ ss::future<cloudcheck::verify_deletes_result> cloudcheck::verify_deletes(
         }
     } catch (const std::exception& e) {
         result.error = e.what();
+    }
+
+    co_return result;
+}
+
+namespace {
+
+ss::future<cloud_storage::upload_result> upload_with_precondition(
+  cloud_storage::remote* remote,
+  cloud_storage_clients::bucket_name bucket,
+  cloud_storage_clients::object_key key,
+  iobuf payload,
+  cloud_storage_clients::precondition precondition,
+  retry_chain_node& rtc) {
+    try {
+        co_return co_await remote->upload_object({
+          .transfer_details = {
+            .bucket = std::move(bucket),
+            .key = std::move(key),
+            .precondition = precondition,
+            .parent_rtc = rtc,
+          },
+          .type = cloud_storage::upload_type::object,
+          .payload = std::move(payload),
+        });
+    } catch (const std::exception& e) {
+        co_return cloud_storage::upload_result::failed;
+    }
+}
+
+ss::future<result<ss::sstring, cloud_storage_clients::error_outcome>> get_etag(
+  cloud_storage::remote* remote,
+  cloud_storage_clients::bucket_name bucket,
+  cloud_storage_clients::object_key key,
+  retry_chain_node& rtc) {
+    try {
+        auto result = co_await remote->list_objects(bucket, rtc, key);
+        if (result.has_error()) {
+            co_return result.error();
+        }
+        for (const auto& item : result.value().contents) {
+            if (item.key == key()) {
+                co_return item.etag;
+            }
+        }
+        co_return cloud_storage_clients::error_outcome::key_not_found;
+    } catch (const std::exception& e) {
+        co_return cloud_storage_clients::error_outcome::fail;
+    }
+}
+
+} // namespace
+
+ss::future<cloudcheck::verify_cas_result>
+cloudcheck::verify_cas(cloud_storage_clients::bucket_name bucket) {
+    auto result = self_test_result{
+      .name = _opts.name, .info = "Compare and Swap", .test_type = "cloud"};
+
+    if (_cancelled) {
+        result.warning = "Run was manually cancelled.";
+        co_return result;
+    }
+    auto rtc = retry_chain_node(_opts.timeout, _opts.backoff, &_rtc);
+
+    using namespace cloud_storage_clients;
+
+    auto* remote = &_cloud_storage_api.local();
+    auto key1 = object_key{
+      self_test_prefix / object_key{ss::sstring{uuid_t::create()}}};
+    auto payload1 = make_random_payload();
+    auto payload2 = make_random_payload();
+    auto upload_result = co_await upload_with_precondition(
+      remote,
+      bucket,
+      key1,
+      payload1.copy(),
+      precondition{if_none_match{}},
+      rtc);
+    switch (upload_result) {
+    case cloud_storage::upload_result::success:
+        break;
+    case cloud_storage::upload_result::precondition_failed:
+    case cloud_storage::upload_result::timedout:
+    case cloud_storage::upload_result::failed:
+    case cloud_storage::upload_result::cancelled:
+        result.error = "Failed to upload to cloud storage with If-None-Match.";
+        co_return result;
+    }
+    upload_result = co_await upload_with_precondition(
+      remote,
+      bucket,
+      key1,
+      payload2.copy(),
+      precondition{if_none_match{}},
+      rtc);
+    switch (upload_result) {
+    case cloud_storage::upload_result::precondition_failed:
+        break;
+    case cloud_storage::upload_result::success:
+        result.warning = "Expected If-None-Match to fail with existing key.";
+        co_return result;
+    case cloud_storage::upload_result::timedout:
+    case cloud_storage::upload_result::failed:
+    case cloud_storage::upload_result::cancelled:
+        result.error = "Expected precondition failure to upload to cloud "
+                       "storage with If-None-Match and existing object.";
+        co_return result;
+    }
+
+    auto etag_payload1_result = co_await get_etag(remote, bucket, key1, rtc);
+    if (etag_payload1_result.has_error()) {
+        result.warning
+          = "Unable to find etag while listing objects in cloud storage.";
+        co_return result;
+    }
+    upload_result = co_await upload_with_precondition(
+      remote,
+      bucket,
+      key1,
+      payload2.copy(),
+      precondition{if_match{etag_payload1_result.value()}},
+      rtc);
+    switch (upload_result) {
+    case cloud_storage::upload_result::success:
+        break;
+    case cloud_storage::upload_result::precondition_failed:
+    case cloud_storage::upload_result::timedout:
+    case cloud_storage::upload_result::failed:
+    case cloud_storage::upload_result::cancelled:
+        result.error = "Expected success when uploading to cloud "
+                       "storage with If-Match and existing object etag.";
+        co_return result;
+    }
+
+    upload_result = co_await upload_with_precondition(
+      remote,
+      bucket,
+      key1,
+      payload1.copy(),
+      precondition{if_match{etag_payload1_result.value()}},
+      rtc);
+    switch (upload_result) {
+    case cloud_storage::upload_result::precondition_failed:
+        break;
+    case cloud_storage::upload_result::success:
+        result.warning = "Expected If-Match to fail with wrong payload key.";
+        co_return result;
+    case cloud_storage::upload_result::timedout:
+    case cloud_storage::upload_result::failed:
+    case cloud_storage::upload_result::cancelled:
+        result.error = "Expected precondition failure when uploading to cloud "
+                       "storage with If-Match and wrong object etag.";
+        co_return result;
     }
 
     co_return result;

--- a/src/v/cluster/self_test/cloudcheck.h
+++ b/src/v/cluster/self_test/cloudcheck.h
@@ -147,6 +147,14 @@ private:
       cloud_storage_clients::bucket_name bucket,
       size_t num_objects = num_default_objects);
 
+    struct verify_cas_result {
+        self_test_result test_result;
+    };
+
+    // Verify that compare and swap operations in cloud storage works.
+    ss::future<verify_cas_result>
+    verify_cas(cloud_storage_clients::bucket_name bucket);
+
 private:
     static constexpr size_t num_default_objects = 5;
     bool _cancelled{false};

--- a/src/v/datalake/cloud_data_io.cc
+++ b/src/v/datalake/cloud_data_io.cc
@@ -48,6 +48,7 @@ map_upload_result(cloud_io::upload_result result) {
     case cloud_io::upload_result::timedout:
         return cloud_data_io::errc::cloud_op_timeout;
     case cloud_io::upload_result::failed:
+    case cloud_io::upload_result::precondition_failed:
     case cloud_io::upload_result::cancelled:
         return cloud_data_io::errc::cloud_op_error;
     }

--- a/src/v/iceberg/metadata_io.h
+++ b/src/v/iceberg/metadata_io.h
@@ -105,6 +105,7 @@ public:
         case timedout:
             co_return errc::timedout;
         case failed:
+        case precondition_failed:
             co_return errc::failed;
         }
     }
@@ -152,6 +153,7 @@ protected:
             // Not found is not a retriable error.
             [[fallthrough]];
         case failed:
+        case precondition_failed:
             co_return errc::failed;
         }
         try {
@@ -208,6 +210,7 @@ protected:
         case cancelled:
             co_return errc::shutting_down;
         case failed:
+        case precondition_failed:
             co_return errc::failed;
         case timedout:
             co_return errc::timedout;
@@ -248,6 +251,7 @@ protected:
         case notfound:
             co_return false;
         case failed:
+        case precondition_failed:
             co_return errc::failed;
         }
     }

--- a/src/v/iceberg/table_io.cc
+++ b/src/v/iceberg/table_io.cc
@@ -114,6 +114,7 @@ table_io::delete_all_metadata(const metadata_location_path& path) {
             co_return errc::timedout;
         case cloud_io::upload_result::cancelled:
             co_return errc::shutting_down;
+        case cloud_io::upload_result::precondition_failed:
         case cloud_io::upload_result::failed:
             co_return errc::failed;
         }

--- a/tests/rptest/tests/self_test_test.py
+++ b/tests/rptest/tests/self_test_test.py
@@ -13,9 +13,14 @@ from collections import defaultdict
 from math import comb
 
 from ducktape.utils.util import wait_until
+from ducktape.mark import matrix
 
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, SISettings
+from rptest.services.redpanda import (
+    RESTART_LOG_ALLOW_LIST,
+    SISettings,
+    get_cloud_storage_type,
+)
 from rptest.services.redpanda_installer import InstallOptions, RedpandaVersionLine
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.util import wait_until_result
@@ -47,8 +52,10 @@ class SelfTestTest(EndToEndTest):
         return wait_until_result(all_idle, timeout_sec=90, backoff_sec=1)
 
     @cluster(num_nodes=3)
-    def test_self_test(self):
+    @matrix(cloud_storage_type=get_cloud_storage_type())
+    def test_self_test(self, cloud_storage_type):
         """Assert the self test starts/completes with success."""
+        _ = cloud_storage_type
         num_nodes = 3
         self.start_redpanda(
             num_nodes=num_nodes, si_settings=SISettings(test_context=self.test_context)
@@ -62,8 +69,8 @@ class SelfTestTest(EndToEndTest):
             assert node["status"] == "idle"
             assert node.get("results") is not None
             for report in node["results"]:
-                assert "error" not in report
-                assert "warning" not in report
+                assert "error" not in report, report.get("error")
+                assert "warning" not in report, report.get("warning")
 
         # Ensure the results appear as expected. Assertions aren't performed
         # on specific results, but rather what tests are oberved to have run
@@ -82,7 +89,7 @@ class SelfTestTest(EndToEndTest):
         cloud_results = [r for r in reports if r["test_type"] == "cloud"]
 
         read_tests = ["List", "Head", "Get"]
-        write_tests = ["Put", "Delete", "Plural Delete"]
+        write_tests = ["Put", "Delete", "Plural Delete", "Compare and Swap"]
 
         num_expected_cloud_storage_read_tests = num_nodes * len(read_tests)
         num_expected_cloud_storage_write_tests = num_nodes * len(write_tests)
@@ -260,10 +267,10 @@ class SelfTestTest(EndToEndTest):
         assert len(reports) > 0
         for report in reports:
             if report["test_type"] in unknown_report_types:
-                assert "error" in report
+                assert "error" in report, report
             else:
-                assert "error" not in report
-                assert "warning" not in report
+                assert "error" not in report, report.get("error", None)
+                assert "warning" not in report, report.get("warning", None)
 
     @cluster(num_nodes=3)
     def test_self_test_mixed_node_controller_lower_version(self):
@@ -342,7 +349,7 @@ class SelfTestTest(EndToEndTest):
             assert len(results) > 0
             for result in results:
                 if result["test_type"] in unknown_checks_map[node]:
-                    assert "error" in result
+                    assert "error" in result, result
                 else:
                     if "error" in result:
                         if (


### PR DESCRIPTION
This patch set implements the ability to do compare and swap on object storage.
This is currently not used, but the cloud self test is extended to support it.
However, since this is not used the self check failures are marked as warnings.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
