### PR TITLE
[CORE-13694] dt/services/redpanda: Allow SR sleep aborted bad log

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -292,6 +292,8 @@ PREV_VERSION_LOG_ALLOW_LIST = [
     # left due to unclean shutdown in a segment being recovered. Ignore these
     # in a mixed version test.
     "storage - .*parser::consume_records error: parser_errc::input_stream_not_enough_bytes .* storage::checksumming_consumer",
+    # Failure to handle Schema Registry requests due to Redpanda being shutdown (fix is in https://github.com/redpanda-data/redpanda/pull/26909)
+    "schemaregistry - .* - exception_reply: .*seastar::sleep_aborted",
 ]
 
 AUDIT_LOG_ALLOW_LIST = RESTART_LOG_ALLOW_LIST + [


### PR DESCRIPTION
The fix was done in: https://github.com/redpanda-data/redpanda/pull/26909

But the backport has not made it yet, so ignore the bad log.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
