### PR TITLE
.github/workflows: add missing permissions for oidc

### DIFF
--- a/.github/workflows/trigger-snyk.yml
+++ b/.github/workflows/trigger-snyk.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - 'MODULE.bazel'
       - 'bazel/repositories.bzl'
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   gh:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Add missing permissions for oidc connect

jira: [DEVPROD-3668]

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none



[DEVPROD-3668]: https://redpandadata.atlassian.net/browse/DEVPROD-3668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ