### PR TITLE
`rptest`: deflake `tx_upgrade_test`

### DIFF
--- a/tests/rptest/transactions/tx_upgrade_test.py
+++ b/tests/rptest/transactions/tx_upgrade_test.py
@@ -12,7 +12,7 @@ import random
 import string
 from enum import Enum
 from threading import Lock, Semaphore, Thread
-from time import sleep
+from time import sleep, time
 
 import confluent_kafka as ck
 from ducktape.errors import TimeoutError
@@ -85,6 +85,22 @@ class TxUpgradeTestBase(RedpandaTest):
                 )
             producer.commit_transaction()
             producer.flush()
+
+    def _produce_with_transactions(self, topic, retries=10, timeout_sec=300):
+        deadline = time() + timeout_sec
+        while retries > 0 and time() < deadline:
+            retries -= 1
+            try:
+                self._populate_tx_coordinator(topic)
+                break
+            except Exception as e:
+                self.logger.debug(
+                    f"Caught exception {e} while trying to produce to topic {topic}. {retries} retries left."
+                )
+                pass
+            sleep(1)
+        else:
+            assert False, f"Failed to produce to topic {topic}"
 
     def _get_tx_id_mapping(self):
         mapping = {}
@@ -217,7 +233,7 @@ class TxUpgradeCompactionTest(TxUpgradeTestBase, LogCompactionTxRemovalMixin):
         assert prev_version_str in unique_versions, unique_versions
 
         for new_version in self.installer.upgrade_path_to_head(self.initial_version):
-            self._populate_tx_coordinator(topic=self.topic_spec.name)
+            self._produce_with_transactions(topic=self.topic_spec.name)
             initial_mapping = self._get_tx_id_mapping()
             self.logger.info(f"Initial mapping {initial_mapping}")
 
@@ -234,7 +250,7 @@ class TxUpgradeCompactionTest(TxUpgradeTestBase, LogCompactionTxRemovalMixin):
             )
 
             # verify if txs are handled correctly with mixed versions
-            self._populate_tx_coordinator(topic=self.topic_spec.name)
+            self._produce_with_transactions(topic=self.topic_spec.name)
 
             # Only once we upgrade the rest of the nodes do we converge on the new
             # version.
@@ -247,7 +263,7 @@ class TxUpgradeCompactionTest(TxUpgradeTestBase, LogCompactionTxRemovalMixin):
             prev_version_str = ver_string(new_version)
 
         # One last round of producing
-        self._populate_tx_coordinator(topic=self.topic_spec.name)
+        self._produce_with_transactions(topic=self.topic_spec.name)
 
         # Restart the redpanda broker to roll segments
         self.redpanda.restart_nodes(self.redpanda.nodes)


### PR DESCRIPTION
This test occasionally flakes with

```
KafkaException(KafkaError{code=_TIMED_OUT,val=-185,str="Timed out waiting for operation to finish, retry call to resume"})
Traceback (most recent call last):
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/tests/runner_client.py", line 381, in _do_run
    data = self.run_test(self.test_runner_timeout)
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/tests/runner_client.py", line 453, in run_test
    return self.test_context.function(self.test)
  File "/root/tests/rptest/services/cluster.py", line 285, in wrapped
    r = f(self, *args, **kwargs)
  File "/root/tests/rptest/transactions/tx_upgrade_test.py", line 220, in upgrade_with_compaction_test
    self._populate_tx_coordinator(topic=self.topic_spec.name)
  File "/root/tests/rptest/transactions/tx_upgrade_test.py", line 76, in _populate_tx_coordinator
    producer.init_transactions()
cimpl.KafkaException: KafkaError{code=_TIMED_OUT,val=-185,str="Timed out waiting for operation to finish, retry call to resume"}
```
These are transient producer errors, and can be easily fixed by a simply retry mechanism.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
