### PR TITLE
rptest/RedpandaMixedTestSelfTest: fix flake

### DIFF
--- a/tests/rptest/tests/mixed_self_test.py
+++ b/tests/rptest/tests/mixed_self_test.py
@@ -184,9 +184,19 @@ class RedpandaMixedTestSelfTest(RedpandaMixedTest):
             )
 
             assert isinstance(res1, float), f"expected float {metric} on {ep}"
-            assert res2 > res1, (
-                f"expected {metric} to increase over time: {res1} {res2}"
+
+            assert res1 > 0 and res2 > 0, (
+                f"expected positive {metric} on {ep}, got {res1}, {res2}"
             )
+
+            if metric == awake:
+                # awake is too quantized (ms level) to increase every time
+                valid = res2 >= res1
+                msg = "not decrease"
+            else:
+                valid = res2 > res1
+                msg = "increase"
+            assert valid, f"expected {metric} to {msg} over time: {res1} {res2}"
 
         for m in [uptime, polls, awake]:
             test_sum(MetricsEndpoint.METRICS, m)


### PR DESCRIPTION
Fix flake in RedpandaMixedTestSelfTest.test_metrics because the awake metric does not always increase in release as it is quantized to milliseconds and we may not get a full millisecond of load between polls.

After this change 1000 release runs finish cleanly.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

