### PR TITLE
rptest/rpk_tuner_test.py: fix whitespace issues

### DIFF
--- a/tests/rptest/tests/rpk_tuner_test.py
+++ b/tests/rptest/tests/rpk_tuner_test.py
@@ -69,7 +69,8 @@ class RpkTunerTest(RedpandaTest):
         rpk.config_set("rpk.tune_transparent_hugepages", "true")
         rpk.config_set("rpk.tune_coredump", "true")
 
-        expected = """TUNER                  ENABLED  SUPPORTED  UNSUPPORTED-REASON
+        expected = """
+TUNER                  ENABLED  SUPPORTED  UNSUPPORTED-REASON
 aio_events             true     true
 ballast_file           true     true
 clocksource            true     true
@@ -98,5 +99,12 @@ transparent_hugepages  true     true
         )
 
         output = rpk.tune("list", verbose=False)
+
+        def clean(input: str) -> str:
+            """strip leading/trailing whitespace and remove blank lines"""
+            strip = [l.strip() for l in input.splitlines(keepends=False) if l.strip()]
+            return "\n".join(strip)
+
+        output, expected = clean(output), clean(expected)
 
         assert output == expected, f"expected:\n{expected}\ngot:\n{output}"


### PR DESCRIPTION
I edited this file which trimmed away trailing whitespace on some lines which were part of a multi-line string. This broke the test, which does an exact match. Since trailing whitespace is generally considered a rude houseguest, we don't add it back, but rather do the comparison based on a cleaned up version of the string, removing leading and trailing whitespace and dropping empty lines.

Fixes CORE-14695.

## Backports Required



- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
