### PR TITLE
gha: add missing permissions for dispatch-api-docs.yml

### DIFF
--- a/.github/workflows/dispatch-api-docs.yml
+++ b/.github/workflows/dispatch-api-docs.yml
@@ -6,6 +6,7 @@ on:
     types: [published]
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:


### PR DESCRIPTION
jira: [DEVPROD-3671]

To resolve [error](https://github.com/redpanda-data/redpanda/actions/runs/19515474232/job/55866875005):
```
It looks like you might be trying to authenticate with OIDC. Did you mean to set the `id-token` permission?
```

ref:
- [docs](https://docs.github.com/en/enterprise-cloud@latest/actions/reference/security/oidc#required-permission)
- #27947

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

[DEVPROD-3671]: https://redpandadata.atlassian.net/browse/DEVPROD-3671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ