### PR TITLE
partition/timequery: Fix tiered storage timequery bug

### DIFF
--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -771,6 +771,116 @@ TEST_P(CloudStorageEndToEndManualTest, TestTimequeryAfterArchivalGC) {
       kafka::next_offset(first_seg.last_kafka_offset()));
 }
 
+TEST_P(
+  CloudStorageEndToEndManualTest, TestTimequeryWithShortRetentionAndCloudData) {
+    // Regression test for a bug where timequery on a topic using tiered storage
+    // incorrectly returns no result when:
+    // 1. The timequery's max offset is before the start offset of the local
+    // log.
+    // 2. The timestamp is after the start timestamp of the local log.
+    // This can happen, for example, if retention is short and the entire local
+    // log is truncated. The local log will retain the active segment, so the
+    // start offset of the local log will be the high watermark and the start
+    // timestamp will be the base timestamp of the active segment.
+
+    // Enable time-based uploads with a short interval to force partial uploads
+    test_local_cfg.get("cloud_storage_segment_max_upload_interval_sec")
+      .set_value(std::make_optional<std::chrono::seconds>(1s));
+
+    ASSERT_TRUE(archiver->sync_for_tests().get());
+
+    // Write some data.
+    const auto batches_per_segment = 200;
+    const auto num_segs = 3;
+    tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
+    auto total_records = gen.num_segments(num_segs)
+                           .batches_per_segment(batches_per_segment)
+                           .base_timestamp(model::timestamp{0})
+                           .batch_time_delta_ms(1)
+                           .produce()
+                           .get();
+    ASSERT_EQ(total_records, batches_per_segment * num_segs);
+
+    // Append batches to the active segment without rolling. This ensures
+    // the active segment has a base timestamp from user data.
+    auto ts = model::timestamp{600};
+    std::vector<kv_t> records0 = kv_t::sequence(total_records, 100);
+    gen.producer()
+      .produce_to_partition(
+        partition->ntp().tp.topic,
+        partition->ntp().tp.partition,
+        std::move(records0),
+        ts)
+      .get();
+
+    // Our goal is to advance the log's raft start offset to the HWM
+    // after the writes.
+    auto hwm = partition->high_watermark();
+    auto target_offset = model::prev_offset(hwm);
+
+    // Flush to ensure data is on disk, otherwise it can't be uploaded.
+    partition->log()->flush().get();
+
+    // Request archiver to flush uploads up to high watermark
+    // This uses the time-based upload mechanism since
+    // cloud_storage_segment_max_upload_interval_sec is set
+    auto flush_res = archiver->flush();
+    ASSERT_EQ(flush_res.response, archival::flush_response::accepted);
+
+    // Wait for upload interval to expire, then trigger upload.
+    // This will force the active segment's data to be uploaded.
+    ss::sleep(1100ms).get();
+
+    ASSERT_TRUE(archiver->sync_for_tests().get());
+    archiver
+      ->upload_next_candidates(
+        archival::archival_stm_fence{.emit_rw_fence_cmd = false})
+      .get();
+
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&]() {
+        auto manifest_last = archiver->manifest().get_last_offset();
+        return manifest_last >= target_offset;
+    });
+
+    auto manifest_res = archiver->upload_manifest("test").get();
+    ASSERT_EQ(manifest_res, cloud_storage::upload_result::success);
+    archiver->flush_manifest_clean_offset().get();
+
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&]() {
+        auto manifest_last = archiver->manifest().get_last_offset();
+        auto last_clean = partition->archival_meta_stm()->get_last_clean_at();
+        return std::min(manifest_last, last_clean) >= target_offset;
+    });
+
+    // The archival_meta_stm should have written a snapshot that advances the
+    // raft start offset past the uploaded data. Let's verify and potentially
+    // trigger another snapshot to ensure the raft start offset advances.
+    auto target_snapshot_offset
+      = partition->archival_meta_stm()->cloud_recoverable_offset();
+    if (partition->raft()->start_offset() < target_snapshot_offset) {
+        auto snapshot_data = partition->archival_meta_stm()
+                               ->take_raft_snapshot(target_snapshot_offset)
+                               .get();
+        partition->raft()
+          ->write_snapshot(
+            raft::write_snapshot_cfg(
+              target_snapshot_offset, std::move(snapshot_data)))
+          .get();
+    }
+
+    // Now we have the scenario where raft start offset is past data in the
+    // active segment.
+    tests::kafka_list_offsets_transport lister(make_kafka_client().get());
+    lister.start().get();
+    auto deferred_l_close = ss::defer([&lister] { lister.stop().get(); });
+
+    auto offset
+      = lister.list_offset_for_partition(topic_name, model::partition_id(0), ts)
+          .get();
+    ASSERT_EQ(offset, model::offset{600});
+}
+
 class CloudStorageManualMultiNodeTestBase
   : public cloud_storage_manual_multinode_test_base
   , public ::testing::Test {};
@@ -1433,6 +1543,5 @@ TEST_F(ManualFixture, TestSpilloverWithTruncationRetainsStartOffset) {
 }
 
 INSTANTIATE_TEST_SUITE_P(WithOverride, EndToEndFixture, ::testing::Bool());
-
 INSTANTIATE_TEST_SUITE_P(
-  ManualWithOverride, CloudStorageEndToEndManualTest, ::testing::Bool());
+  WithOverride, CloudStorageEndToEndManualTest, ::testing::Bool());

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -620,7 +620,7 @@ partition::timequery(storage::timequery_config cfg) {
     const bool local_covers_offsets = local_start_offset <= cfg.max_offset;
     const bool may_answer_from_local = local_covers_timestamp
                                        && local_covers_offsets;
-    if (may_answer_from_local) {
+    if (may_answer_from_local || !may_answer_from_cloud) {
         // The query is ahead of the local data's start_timestamp and
         // potentially overlaps with the local data offset range: this means it
         // _might_ hit on local data: start_timestamp is not precise, so once we
@@ -640,28 +640,10 @@ partition::timequery(storage::timequery_config cfg) {
     }
 
     if (may_answer_from_cloud) {
-        // Timestamp is before local storage but within cloud storage.
         co_return co_await cloud_storage_timequery(cfg);
     }
 
-    // If the timequery doesn't have an answer yet, then either
-    // 1. The local timequery returned no result, or
-    // 2. the local log starts after the timequery's offset range, or
-    // 3. the local log start timestamp is after the timequery's timestamp.
-    // If 1 or 2 hold, there is no offset to return. Otherwise, fall back
-    // to a local timequery, which should return the start of the log.
-    if (may_answer_from_local || !local_covers_offsets) {
-        co_return std::nullopt;
-    }
-
-    // Adjust the lower bound for the local query as the min_offset
-    // corresponds to the full log (including tiered storage).
-    auto local_query_cfg = cfg;
-    local_query_cfg.min_offset = std::max(
-      log()->from_log_offset(_raft->start_offset()),
-      local_query_cfg.min_offset);
-
-    co_return co_await local_timequery(local_query_cfg, false);
+    co_return std::nullopt;
 }
 
 bool partition::may_read_from_cloud() const {

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -39,6 +39,7 @@
 #include <seastar/util/defer.hh>
 
 #include <chrono>
+#include <optional>
 
 namespace cluster {
 
@@ -598,6 +599,10 @@ ss::future<> partition::stop() {
 
 ss::future<std::optional<storage::timequery_result>>
 partition::timequery(storage::timequery_config cfg) {
+    if (cfg.min_offset > cfg.max_offset) {
+        co_return std::nullopt;
+    }
+
     // Read replicas never consider local raft data
     if (_raft->log_config().is_read_replica_mode_enabled()) {
         co_return co_await cloud_storage_timequery(cfg);
@@ -609,58 +614,54 @@ partition::timequery(storage::timequery_config cfg) {
         && cfg.min_offset < kafka::offset_cast(
              _cloud_storage_partition->next_kafka_offset());
 
-    if (_raft->log()->start_timestamp() <= cfg.time) {
-        // The query is ahead of the local data's start_timestamp: this
-        // means it _might_ hit on local data: start_timestamp is not
-        // precise, so once we query we might still fall back to cloud
-        // storage
+    const bool local_covers_timestamp = _raft->log()->start_timestamp()
+                                        <= cfg.time;
+    auto local_start_offset = log()->from_log_offset(_raft->start_offset());
+    const bool local_covers_offsets = local_start_offset <= cfg.max_offset;
+    const bool may_answer_from_local = local_covers_timestamp
+                                       && local_covers_offsets;
+    if (may_answer_from_local) {
+        // The query is ahead of the local data's start_timestamp and
+        // potentially overlaps with the local data offset range: this means it
+        // _might_ hit on local data: start_timestamp is not precise, so once we
+        // query we might still fall back to cloud storage
         //
         // We also need to adjust the lower bound for the local query as the
         // min_offset corresponds to the full log (including tiered storage).
         auto local_query_cfg = cfg;
         local_query_cfg.min_offset = std::max(
-          log()->from_log_offset(_raft->start_offset()),
-          local_query_cfg.min_offset);
-
-        // If the min_offset is ahead of max_offset, the local log is empty
-        // or was truncated since the timequery_config was created.
-        if (local_query_cfg.min_offset > local_query_cfg.max_offset) {
-            co_return std::nullopt;
-        }
+          local_start_offset, local_query_cfg.min_offset);
 
         auto result = co_await local_timequery(
           local_query_cfg, may_answer_from_cloud);
         if (result.has_value()) {
             co_return result;
-        } else {
-            // The local storage hit a case where it needs to fall back
-            // to querying cloud storage.
-            co_return co_await cloud_storage_timequery(cfg);
-        }
-    } else {
-        if (may_answer_from_cloud) {
-            // Timestamp is before local storage but within cloud storage
-            co_return co_await cloud_storage_timequery(cfg);
-        } else {
-            // No cloud data OR not allowed to read from cloud: queries earlier
-            // than the start of the log will hit on the start of the log.
-            //
-            // Adjust the lower bound for the local query as the min_offset
-            // corresponds to the full log (including tiered storage).
-            auto local_query_cfg = cfg;
-            local_query_cfg.min_offset = std::max(
-              log()->from_log_offset(_raft->start_offset()),
-              local_query_cfg.min_offset);
-
-            // If the min_offset is ahead of max_offset, the local log is empty
-            // or was truncated since the timequery_config was created.
-            if (local_query_cfg.min_offset > local_query_cfg.max_offset) {
-                co_return std::nullopt;
-            }
-
-            co_return co_await local_timequery(local_query_cfg, false);
         }
     }
+
+    if (may_answer_from_cloud) {
+        // Timestamp is before local storage but within cloud storage.
+        co_return co_await cloud_storage_timequery(cfg);
+    }
+
+    // If the timequery doesn't have an answer yet, then either
+    // 1. The local timequery returned no result, or
+    // 2. the local log starts after the timequery's offset range, or
+    // 3. the local log start timestamp is after the timequery's timestamp.
+    // If 1 or 2 hold, there is no offset to return. Otherwise, fall back
+    // to a local timequery, which should return the start of the log.
+    if (may_answer_from_local || !local_covers_offsets) {
+        co_return std::nullopt;
+    }
+
+    // Adjust the lower bound for the local query as the min_offset
+    // corresponds to the full log (including tiered storage).
+    auto local_query_cfg = cfg;
+    local_query_cfg.min_offset = std::max(
+      log()->from_log_offset(_raft->start_offset()),
+      local_query_cfg.min_offset);
+
+    co_return co_await local_timequery(local_query_cfg, false);
 }
 
 bool partition::may_read_from_cloud() const {

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -663,6 +663,12 @@ partition::cloud_storage_timequery(storage::timequery_config cfg) {
     // find the earliest data that has timestamp >= the query time.
     vlog(clusterlog.debug, "timequery (cloud) {} cfg(k)={}", _raft->ntp(), cfg);
 
+    // Test before translation to handle empty log cases where
+    // max_offset is before min_offset = start_offset.
+    if (cfg.min_offset > cfg.max_offset) {
+        co_return std::nullopt;
+    }
+
     // remote_partition pre-translates offsets for us, so no call into
     // the offset translator here
     auto result = co_await _cloud_storage_partition->timequery(cfg);
@@ -681,6 +687,12 @@ partition::cloud_storage_timequery(storage::timequery_config cfg) {
 ss::future<std::optional<storage::timequery_result>> partition::local_timequery(
   storage::timequery_config cfg, bool allow_cloud_fallback) {
     vlog(clusterlog.debug, "timequery (raft) {} cfg(k)={}", _raft->ntp(), cfg);
+
+    // Test before translation to handle empty log cases where
+    // max_offset is before min_offset = start_offset.
+    if (cfg.min_offset > cfg.max_offset) {
+        co_return std::nullopt;
+    }
 
     cfg.min_offset = _raft->log()->to_log_offset(cfg.min_offset);
     cfg.max_offset = _raft->log()->to_log_offset(cfg.max_offset);


### PR DESCRIPTION
This change refactors timequery logic to fix a rare bug where a timequery would return no result despite an offset matching the timestamp existing in cloud storage and local storage.

The bug is observed in the tiered storage model test when querying timestamps corresponding to offsets in the final, active segment of the log of a partition with tiered storage enabled and with aggressive cleanup settings. The partition gets into a state where the local log is truncated up to the high watermark, but the active segment remains. Querying for a timestamp within the bounds of the active segment meant that the timestamp was after the start timestamp for the local log, which comes from the base timestamp of the only segment, but the start offset of the log was after the max offset set by the timequery, which is the HWM and comes from the Kafka handler. This caused the timequery to return no result, incorrectly, without checking local or cloud storage.

The refactor fixes the bug and hopefully cleans up the logic a bit. Regression test included.

Fixes CORE-14569

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.3.x
- [X] v25.2.x
- [X] v25.1.x
- [X] v24.3.x

## Release Notes

### Bug Fixes

* Fixed a rare bug that causes timequeries against partitions using tiered storage to incorrectly return no result when the partition's local log is empty but retains an active segment.

