### PR TITLE
[v25.3.x] gha: add missing permissions for dispatch-api-docs.yml

### DIFF
--- a/.github/workflows/dispatch-api-docs.yml
+++ b/.github/workflows/dispatch-api-docs.yml
@@ -6,6 +6,7 @@ on:
     types: [published]
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28641
