### PR TITLE
rptest/omb: update open-messaging benchmark

### DIFF
--- a/tests/docker/ducktape-deps/omb
+++ b/tests/docker/ducktape-deps/omb
@@ -2,5 +2,5 @@
 set -e
 git -C /opt clone https://github.com/redpanda-data/openmessaging-benchmark.git
 cd /opt/openmessaging-benchmark
-git reset --hard 092eb7c78a106906f21288b99b1e2a4c3cfc652a
+git reset --hard 9cff468d5124cc9eb6cfce90798c2c9a5c354f6c
 mvn clean package -DskipTests


### PR DESCRIPTION
To 9cff468d5124cc9eb6cfce90798c2c9a5c354f6c. This pulls in nearly a year of changes, though many are to "deploy" which don't affect runtime in the DT context.

The driver was for the tip change (9cff468) which adds logging which we want to diagnose possible hangs in the serverless test.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required



- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
