### PR TITLE
[CORE-14557] `storage`: increment fsyncs in `flush()`

### DIFF
--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -653,9 +653,11 @@ ss::future<> segment_appender::flush() {
       _stable_offset,
       *this);
 
-    return _out.flush().handle_exception([this](std::exception_ptr e) {
-        vunreachable("Could not flush: {} - {}", e, *this);
-    });
+    return _out.flush()
+      .then([this] { ++_stats.fsyncs; })
+      .handle_exception([this](std::exception_ptr e) {
+          vunreachable("Could not flush: {} - {}", e, *this);
+      });
 }
 
 ss::future<> segment_appender::hard_flush() {

--- a/src/v/storage/tests/segment_appender_test.cc
+++ b/src/v/storage/tests/segment_appender_test.cc
@@ -233,9 +233,9 @@ TEST_F(SegmentAppenderFixture, TestFlushesAreMerged) {
     }
     ops.emplace_back(flush_op(true));
     execute_operations(ops).get();
+    EXPECT_GE(appender->get_stats().fsyncs, 1);
     // TODO: fix possible redundant flushes in segment appender
-    ASSERT_GE(appender->get_stats().fsyncs, 1);
-    ASSERT_LE(appender->get_stats().fsyncs, 2);
+    EXPECT_LE(appender->get_stats().fsyncs, 2);
     appender->close().get();
     ASSERT_TRUE(file_content_equal_to_reference().get());
 }


### PR DESCRIPTION
Second shot at https://github.com/redpanda-data/redpanda/pull/28413 since that was reverted in https://github.com/redpanda-data/redpanda/pull/28486 due to regressions thanks to my coroutinization of a `segment_appender` function. Keep the code as continuations this time around while still incrementing `_stats.fsyncs` in `flush()`.

We increment `_stats.fsyncs` elsewhere we call `_out.flush()` in `segment_appender`, but not at this call site. Amend the call site to match the others.

This seems to have manifested in a test failure:

```
src/v/storage/tests/segment_appender_test.cc:237: Failure
Expected: (appender->get_stats().fsyncs) >= (1), actual: 0 vs 1
```

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
