### PR TITLE
gha: run trigger-snyk on change to workflow

### DIFF
--- a/.github/workflows/trigger-snyk.yml
+++ b/.github/workflows/trigger-snyk.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [dev, 'v*', '!v24.*']
     paths:
+      - '.github/workflows/trigger-snyk.yml'
       - 'MODULE.bazel'
       - 'bazel/repositories.bzl'
 permissions:


### PR DESCRIPTION
jira: [DEVPROD-3668]

the [trigger-snyk.yml](https://github.com/redpanda-data/redpanda/actions/workflows/trigger-snyk.yml) workflow should also run if the yml file changes. forgot to suggest this in the review of PR #28630

needs backport to the `v25.*` branches.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

* none


[DEVPROD-3668]: https://redpandadata.atlassian.net/browse/DEVPROD-3668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ