### PR TITLE
gha: use env instead of secret

### DIFF
--- a/.github/workflows/trigger-snyk.yml
+++ b/.github/workflows/trigger-snyk.yml
@@ -26,4 +26,4 @@ jobs:
           parse-json-secrets: true
       - run: gh workflow run --repo redpanda-data/vtools --raw-field redpanda-branches='["${{ github.ref_name }}"]' snyk-redpanda.yml
         env:
-          GH_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
+          GH_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}


### PR DESCRIPTION
jira: [DEVPROD-3668]

this is a follow-up to PR #28652
to address [error](https://github.com/redpanda-data/redpanda/actions/runs/19542981994/job/55954158367) on merge to `dev`:
```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```

needs backport to `v25.*` branches.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

* none


[DEVPROD-3668]: https://redpandadata.atlassian.net/browse/DEVPROD-3668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ