### PR TITLE
ct: Write L0 objects to the cloud storage cache from the batcher

### DIFF
--- a/src/v/cloud_topics/data_plane_impl.cc
+++ b/src/v/cloud_topics/data_plane_impl.cc
@@ -64,6 +64,7 @@ public:
           }),
           ss::sharded_parameter([bucket] { return bucket; }),
           ss::sharded_parameter([io] { return std::ref(io->local()); }),
+          ss::sharded_parameter([cache] { return std::ref(cache->local()); }),
           ss::sharded_parameter([this] { return &_cluster_services.local(); }));
 
         co_await construct_service(_read_pipeline);

--- a/src/v/cloud_topics/level_zero/batcher/BUILD
+++ b/src/v/cloud_topics/level_zero/batcher/BUILD
@@ -42,6 +42,7 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         ":aggregator",
+        "//src/v/cloud_io:basic_cache_service_api",
         "//src/v/cloud_io:remote",
         "//src/v/cloud_topics:logger",
         "//src/v/cloud_topics:object_utils",
@@ -54,6 +55,7 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/bytes",
         "//src/v/bytes:iobuf",
+        "//src/v/bytes:iostream",
         "//src/v/cloud_topics:cluster_services_interface",
         "//src/v/cloud_topics:types",
         "//src/v/cloud_topics/level_zero/cluster_services_impl",

--- a/src/v/cloud_topics/level_zero/batcher/batcher.cc
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.cc
@@ -10,6 +10,7 @@
 
 #include "cloud_topics/level_zero/batcher/batcher.h"
 
+#include "bytes/iostream.h"
 #include "cloud_io/remote.h"
 #include "cloud_topics/errc.h"
 #include "cloud_topics/level_zero/batcher/aggregator.h"
@@ -39,9 +40,11 @@ batcher<Clock>::batcher(
   write_pipeline<Clock>::stage stage,
   cloud_storage_clients::bucket_name bucket,
   cloud_io::remote_api<Clock>& remote_api,
+  cloud_io::basic_cache_service_api<Clock>& cache_api,
   cloud_topics::cluster_services* cluster_services)
   : _cluster_services(cluster_services)
   , _remote(remote_api)
+  , _cache_api(cache_api)
   , _bucket(std::move(bucket))
   , _upload_timeout(
       config::shard_local_cfg().cloud_storage_segment_upload_timeout_ms.bind())
@@ -132,6 +135,37 @@ batcher<Clock>::upload_object(object_id id, iobuf payload) {
 }
 
 template<class Clock>
+ss::future<std::expected<size_t, errc>>
+batcher<Clock>::cache_object(object_id id, iobuf payload) {
+    auto path = object_path_factory::level_zero_path(id);
+    auto size = payload.size_bytes();
+    auto guard = co_await _cache_api.reserve_space(size, 1);
+    auto stream = make_iobuf_input_stream(std::move(payload));
+    constexpr uint64_t default_write_buffer_size = 128_KiB;
+    constexpr uint32_t default_write_behind = 2;
+    uint64_t write_buffer_size = default_write_buffer_size;
+    uint32_t write_behind = default_write_behind;
+    if (write_buffer_size * write_behind > size) {
+        write_behind = 1;
+        write_buffer_size = size;
+    }
+    auto units = co_await _stage.acquire_mem_units(
+      write_behind * write_buffer_size);
+    auto fut = co_await ss::coroutine::as_future(
+      _cache_api.put(path(), stream, guard, write_buffer_size, write_behind));
+    if (fut.failed()) {
+        auto e = fut.get_exception();
+        vlog(
+          _logger.warn,
+          "Failed to put object {} into the cloud storage cache: {}",
+          path,
+          e);
+        co_return std::unexpected(errc::cache_write_error);
+    }
+    co_return size;
+}
+
+template<class Clock>
 ss::future<std::expected<std::monostate, errc>> batcher<Clock>::run_once(
   write_pipeline<Clock>::write_requests_list list) noexcept {
     try {
@@ -198,8 +232,7 @@ ss::future<std::expected<std::monostate, errc>> batcher<Clock>::run_once(
         // TODO: skip waiting if list.completed is not true
         auto object = aggregator.prepare(object_id::create(object_epoch));
         auto size_bytes = object.payload.size_bytes();
-        auto result = co_await upload_object(
-          object.id, std::move(object.payload));
+        auto result = co_await upload_object(object.id, object.payload.share());
         if (!result) {
             // TODO: fix the error
             // NOTE: it should be possible to translate the
@@ -210,8 +243,11 @@ ss::future<std::expected<std::monostate, errc>> batcher<Clock>::run_once(
             _probe.register_error();
             co_return std::unexpected{result.error()};
         }
+        // Unblock requests
         aggregator.ack();
         _probe.register_upload(size_bytes);
+        std::ignore = co_await cache_object(
+          object.id, std::move(object.payload));
         co_return std::monostate{};
     } catch (...) {
         auto err = std::current_exception();

--- a/src/v/cloud_topics/level_zero/batcher/batcher.h
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.h
@@ -15,6 +15,7 @@
 #include "base/seastarx.h"
 #include "base/units.h"
 #include "bytes/iobuf.h"
+#include "cloud_io/basic_cache_service_api.h"
 #include "cloud_topics/cluster_services.h"
 #include "cloud_topics/level_zero/cluster_services_impl/cluster_services.h"
 #include "cloud_topics/level_zero/common/level_zero_probe.h"
@@ -70,6 +71,7 @@ public:
       write_pipeline<Clock>::stage stage,
       cloud_storage_clients::bucket_name bucket,
       cloud_io::remote_api<Clock>& remote_api,
+      cloud_io::basic_cache_service_api<Clock>& cache_api,
       cloud_topics::cluster_services* cluster_services);
 
     ss::future<> start();
@@ -95,16 +97,21 @@ private:
     /// The method should only be invoked on shard 0
     ss::future<> bg_controller_loop();
 
-    /// Upload L0 object based on placeholders
-    ///
-    /// Collect data from every shard and upload stream of data to S3.
+    /// Upload L0 object
     ///
     /// \return size of the uploaded object or error code
     ss::future<std::expected<size_t, errc>>
     upload_object(object_id id, iobuf payload);
 
+    /// Put L0 object to the cloud storage cache
+    ///
+    /// \return size of the uploaded object or error code
+    ss::future<std::expected<size_t, errc>>
+    cache_object(object_id id, iobuf payload);
+
     cloud_topics::cluster_services* _cluster_services;
     cloud_io::remote_api<Clock>& _remote;
+    cloud_io::basic_cache_service_api<Clock>& _cache_api;
     cloud_storage_clients::bucket_name _bucket;
     config::binding<std::chrono::milliseconds> _upload_timeout;
     config::binding<std::chrono::milliseconds> _upload_backoff_interval;

--- a/src/v/cloud_topics/level_zero/batcher/tests/BUILD
+++ b/src/v/cloud_topics/level_zero/batcher/tests/BUILD
@@ -33,6 +33,7 @@ redpanda_cc_gtest(
         "//src/v/base",
         "//src/v/bytes",
         "//src/v/bytes:iostream",
+        "//src/v/cloud_io:basic_cache_service_api",
         "//src/v/cloud_io:io_result",
         "//src/v/cloud_io:remote",
         "//src/v/cloud_storage_clients",

--- a/src/v/cloud_topics/level_zero/batcher/tests/batcher_test.cc
+++ b/src/v/cloud_topics/level_zero/batcher/tests/batcher_test.cc
@@ -137,14 +137,16 @@ sleep_until(std::chrono::milliseconds delta, Fn&& fn, int retry_limit = 100) {
 }
 
 TEST_CORO(batcher_test, single_write_request) {
-    remote_mock mock;
+    remote_mock remote;
+    cache_mock cache;
     cloud_storage_clients::bucket_name bucket("foo");
     cloud_topics::l0::write_pipeline<ss::manual_clock> pipeline;
     static_cluster_services cluster_services;
     cloud_topics::l0::batcher<ss::manual_clock> batcher(
       pipeline.register_write_pipeline_stage(),
       bucket,
-      mock,
+      remote,
+      cache,
       &cluster_services);
     cloud_topics::l0::batcher_accessor batcher_accessor{
       .batcher = &batcher,
@@ -155,7 +157,9 @@ TEST_CORO(batcher_test, single_write_request) {
     int num_batches = 10;
     auto [_, records, reader] = get_random_batches(num_batches, 10);
     // Expect single upload to be made
-    mock.expect_upload_object(records);
+    remote.expect_upload_object(records);
+    cache.expect_reserve_space();
+    cache.expect_put();
 
     const auto timeout = 1s;
     auto deadline = ss::manual_clock::now() + timeout;
@@ -173,8 +177,8 @@ TEST_CORO(batcher_test, single_write_request) {
     ASSERT_TRUE_CORO(write_res.has_value());
 
     // Expect single L0 upload
-    ASSERT_EQ_CORO(mock.keys.size(), 1);
-    auto id = mock.keys.back();
+    ASSERT_EQ_CORO(remote.keys.size(), 1);
+    auto id = remote.keys.back();
 
     // Check that uuid in the placeholder can be used to
     // access the data in S3.
@@ -187,14 +191,16 @@ TEST_CORO(batcher_test, single_write_request) {
 }
 
 TEST_CORO(batcher_test, many_write_requests) {
-    remote_mock mock;
+    remote_mock remote;
+    cache_mock cache;
     cloud_storage_clients::bucket_name bucket("foo");
     cloud_topics::l0::write_pipeline<ss::manual_clock> pipeline;
     static_cluster_services cluster_services;
     cloud_topics::l0::batcher<ss::manual_clock> batcher(
       pipeline.register_write_pipeline_stage(),
       bucket,
-      mock,
+      remote,
+      cache,
       &cluster_services);
     cloud_topics::l0::batcher_accessor batcher_accessor{
       .batcher = &batcher,
@@ -223,7 +229,9 @@ TEST_CORO(batcher_test, many_write_requests) {
       std::back_inserter(all_records));
 
     // Expect single upload to be made
-    mock.expect_upload_object(all_records);
+    remote.expect_upload_object(all_records);
+    cache.expect_reserve_space();
+    cache.expect_put();
 
     const auto timeout = 1s;
     auto deadline = ss::manual_clock::now() + timeout;
@@ -245,8 +253,8 @@ TEST_CORO(batcher_test, many_write_requests) {
     auto res = co_await batcher_accessor.run_once();
 
     // Expect single L0 upload
-    ASSERT_EQ_CORO(mock.keys.size(), 1);
-    auto id = mock.keys.back();
+    ASSERT_EQ_CORO(remote.keys.size(), 1);
+    auto id = remote.keys.back();
 
     ASSERT_TRUE_CORO(res.has_value());
 
@@ -272,14 +280,16 @@ TEST_CORO(batcher_test, expired_write_request) {
     // The test starts two write request but one of which is expected to
     // timeout. The expectation is that uploaded L0 object will not contain any
     // data from the expired write request.
-    remote_mock mock;
+    remote_mock remote;
+    cache_mock cache;
     cloud_storage_clients::bucket_name bucket("foo");
     cloud_topics::l0::write_pipeline<ss::manual_clock> pipeline;
     static_cluster_services cluster_services;
     cloud_topics::l0::batcher<ss::manual_clock> batcher(
       pipeline.register_write_pipeline_stage(),
       bucket,
-      mock,
+      remote,
+      cache,
       &cluster_services);
     cloud_topics::l0::batcher_accessor batcher_accessor{
       .batcher = &batcher,
@@ -305,7 +315,9 @@ TEST_CORO(batcher_test, expired_write_request) {
       std::back_inserter(all_records));
 
     // Expect single upload to be made
-    mock.expect_upload_object(all_records);
+    remote.expect_upload_object(all_records);
+    cache.expect_reserve_space();
+    cache.expect_put();
 
     const auto timeout = 1s;
     auto deadline = ss::manual_clock::now() + timeout;
@@ -330,8 +342,8 @@ TEST_CORO(batcher_test, expired_write_request) {
     auto res = co_await batcher_accessor.run_once();
 
     // Expect single L0 upload
-    ASSERT_EQ_CORO(mock.keys.size(), 1);
-    auto id = mock.keys.back();
+    ASSERT_EQ_CORO(remote.keys.size(), 1);
+    auto id = remote.keys.back();
 
     ASSERT_TRUE_CORO(res.has_value());
 

--- a/src/v/cloud_topics/level_zero/batcher/tests/remote_mock.h
+++ b/src/v/cloud_topics/level_zero/batcher/tests/remote_mock.h
@@ -11,6 +11,7 @@
 #include "base/vlog.h"
 #include "bytes/bytes.h"
 #include "bytes/iostream.h"
+#include "cloud_io/basic_cache_service_api.h"
 #include "cloud_io/io_result.h"
 #include "cloud_io/remote.h"
 #include "cloud_storage_clients/types.h"
@@ -137,4 +138,68 @@ public:
     bool disable_request_collection{false};
     std::vector<cloud_storage_clients::object_key> keys;
     std::vector<bytes> payloads;
+};
+
+class cache_mock : public cloud_io::basic_cache_service_api<ss::manual_clock> {
+public:
+    MOCK_METHOD(
+      ss::future<std::optional<cloud_io::cache_item_stream>>,
+      get_stream,
+      (std::filesystem::path key,
+       size_t read_buffer_size,
+       unsigned int read_ahead),
+      ());
+
+    MOCK_METHOD(
+      ss::future<>,
+      put,
+      (std::filesystem::path key,
+       ss::input_stream<char>& data,
+       cloud_io::basic_space_reservation_guard<ss::manual_clock>& reservation,
+       size_t write_buffer_size,
+       unsigned int write_behind),
+      ());
+
+    MOCK_METHOD(
+      ss::future<cloud_io::cache_element_status>,
+      is_cached,
+      (const std::filesystem::path&),
+      ());
+
+    MOCK_METHOD(
+      ss::future<cloud_io::basic_space_reservation_guard<ss::manual_clock>>,
+      reserve_space,
+      (uint64_t, size_t),
+      ());
+
+    MOCK_METHOD(
+      void, reserve_space_release, (uint64_t, size_t, uint64_t, size_t), ());
+
+    void expect_put(std::exception_ptr e = nullptr) {
+        ss::future<> result = ss::now();
+        if (e != nullptr) {
+            result = ss::make_exception_future<>(e);
+        }
+        EXPECT_CALL(
+          *this,
+          put(
+            ::testing::_,
+            ::testing::_,
+            ::testing::_,
+            ::testing::_,
+            ::testing::_))
+          .Times(1)
+          .WillOnce(::testing::Return(std::move(result)));
+    }
+
+    void expect_reserve_space() {
+        cloud_io::basic_space_reservation_guard<ss::manual_clock> guard(
+          *this, 1, 1);
+        auto result = ss::make_ready_future<
+          cloud_io::basic_space_reservation_guard<ss::manual_clock>>(
+          std::move(guard));
+        EXPECT_CALL(*this, reserve_space(::testing::_, 1))
+          .Times(1)
+          .WillOnce(::testing::Return(std::move(result)));
+    }
 };

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
@@ -148,6 +148,12 @@ public:
 
         pipeline_stage id() const noexcept { return _ps; }
 
+        /// Pipeline components can invoke this method to acquire units
+        /// before allocating memory.
+        auto acquire_mem_units(uint64_t units) {
+            return ss::get_units(_parent->_mem_budget, units);
+        }
+
     private:
         /// Pick the right abort source to use.
         ///


### PR DESCRIPTION
Currently, we're not writing L0 objects from the batcher cache into the disk cache. This is problematic because in the read path we can potentially fetch from the cloud storage cache but since we're never writing to the cloud storage cache we're not testing this code path at all. The L0 object can get cached by the read path anyway so we need to be able to exercise this code path.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none