### PR TITLE
bazel: Emit relocation sections for the redpanda binary

### DIFF
--- a/src/v/redpanda/BUILD
+++ b/src/v/redpanda/BUILD
@@ -134,6 +134,20 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+# Enable or disable --emit-relocs for the redpanda binary (only)
+bool_flag(
+    name = "emit_relocs",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "use_emit_relocs",
+    flag_values = {
+        ":emit_relocs": "true",
+    },
+    visibility = ["//visibility:public"],
+)
+
 redpanda_cc_binary(
     name = "redpanda",
     srcs = [
@@ -144,6 +158,13 @@ redpanda_cc_binary(
             ":use_lto": [
                 "-flto=thin",
                 "-ffat-lto-objects",
+            ],
+            "//conditions:default": [
+            ],
+        }) +
+        select({
+            ":use_emit_relocs": [
+                "-Wl,--emit-relocs",
             ],
             "//conditions:default": [
             ],


### PR DESCRIPTION
These are needed for optimization by BOLT.

This is flagged off for now as it adds ~400MB to the redpanda binary
size.

We can enable it conditionally in task when building for BOLT.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none
