### PR TITLE
CORE-14561: bump REST catalog start timeout

### DIFF
--- a/tests/rptest/services/apache_iceberg_catalog.py
+++ b/tests/rptest/services/apache_iceberg_catalog.py
@@ -231,7 +231,7 @@ class IcebergRESTCatalog(CatalogService):
         )
         node.account.ssh(cmd, allow_fail=False)
         self._catalog_url = f"http://{node.account.hostname}:{self.iceberg_rest_port}"
-        self.wait(timeout_sec=30)
+        self.wait(timeout_sec=60)
 
     def wait_node(self, node, timeout_sec=None):
         check_cmd = f"pyiceberg --uri {self.iceberg_rest_url} create namespace default"


### PR DESCRIPTION
In one instance we saw the catalog took 36 seconds to start up.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
