### PR TITLE
[CORE-7942] test: remove s3 storage assumption from test

### DIFF
--- a/tests/rptest/tests/datalake/admin_endpoint_test.py
+++ b/tests/rptest/tests/datalake/admin_endpoint_test.py
@@ -16,7 +16,12 @@ from rptest.clients.admin import v2 as admin_v2
 from rptest.clients.rpk import RpkTool
 from rptest.services.catalog_service import CatalogType
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import CloudStorageType, SISettings, SchemaRegistryConfig
+from rptest.services.redpanda import (
+    CloudStorageType,
+    SISettings,
+    SchemaRegistryConfig,
+    get_cloud_storage_type,
+)
 from rptest.tests.datalake.datalake_services import DatalakeServices
 from rptest.tests.datalake.query_engine_base import QueryEngineType
 from rptest.tests.redpanda_test import RedpandaTest
@@ -46,7 +51,7 @@ class DatalakeAdminEndpointTest(RedpandaTest):
 
     @cluster(num_nodes=6)
     @matrix(
-        cloud_storage_type=[CloudStorageType.S3],
+        cloud_storage_type=get_cloud_storage_type(docker_use_arbitrary=True),
         catalog_type=[CatalogType.REST_JDBC],
     )
     def test_get_coordinator_state(
@@ -147,7 +152,7 @@ class DatalakeAdminEndpointTest(RedpandaTest):
 
     @cluster(num_nodes=7)
     @matrix(
-        cloud_storage_type=[CloudStorageType.S3],
+        cloud_storage_type=get_cloud_storage_type(docker_use_arbitrary=True),
         catalog_type=[CatalogType.REST_JDBC],
     )
     def test_get_coordinator_state_pending(


### PR DESCRIPTION
The two tests changed in this commit assumed S3 as a backend. When run as cdt-on-azure they fail to connect to minio because that is the configured S3 implementation when not run on actual S3 and of course it fails because we don't startup minio.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
