### PR TITLE
Add additional logging to debug shutdown timeout in LargeMessagesTest

### DIFF
--- a/tests/rptest/scale_tests/large_messages_test.py
+++ b/tests/rptest/scale_tests/large_messages_test.py
@@ -90,6 +90,10 @@ class LargeMessagesTest(RedpandaTest):
                 "fetch_max_bytes": self.FETCH_MAX_BYTES_MIB * 2**20,
                 # Similar to above, is deprecated in later versions of RP.
                 "kafka_max_bytes_per_fetch": self.FETCH_MAX_BYTES_MIB * 2**20,
+                # Set this property to something less than the shutdown timeout(30s).
+                # This way additional debug information will be in the logs when the
+                # shutdown timeout is exceeded.
+                "partition_manager_shutdown_watchdog_timeout": 5 * 1000,  # 5s
             },
             # Reduce per-partition log spam
             log_config=LoggingConfig(
@@ -553,4 +557,6 @@ class LargeMessagesTest(RedpandaTest):
         check_tput(recv_tput_avg, "input")
         check_tput(send_tput_avg, "output")
 
-        return
+        # The lines below were added to debug a shutdown hang.
+        # Remove once CORE-13977 is resolved.
+        self.redpanda._admin.set_log_level("raft", "debug")


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
It's proving difficult to reproduce this issue locally. Therefore this PR adds additional logging to the test so that it'll be easier to find the exact cause of the shutdown timeout next time it occurs in CI.

See https://redpandadata.atlassian.net/browse/CORE-13977 for details about the issue.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
