### PR TITLE
[v25.3.x] [CORE-7942] test: remove s3 storage assumption from test

### DIFF
--- a/tests/rptest/tests/datalake/admin_endpoint_test.py
+++ b/tests/rptest/tests/datalake/admin_endpoint_test.py
@@ -16,7 +16,12 @@ from rptest.clients.admin import v2 as admin_v2
 from rptest.clients.rpk import RpkTool
 from rptest.services.catalog_service import CatalogType
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import CloudStorageType, SISettings, SchemaRegistryConfig
+from rptest.services.redpanda import (
+    CloudStorageType,
+    SISettings,
+    SchemaRegistryConfig,
+    get_cloud_storage_type,
+)
 from rptest.tests.datalake.datalake_services import DatalakeServices
 from rptest.tests.datalake.query_engine_base import QueryEngineType
 from rptest.tests.redpanda_test import RedpandaTest
@@ -46,7 +51,7 @@ class DatalakeAdminEndpointTest(RedpandaTest):
 
     @cluster(num_nodes=6)
     @matrix(
-        cloud_storage_type=[CloudStorageType.S3],
+        cloud_storage_type=get_cloud_storage_type(docker_use_arbitrary=True),
         catalog_type=[CatalogType.REST_JDBC],
     )
     def test_get_coordinator_state(
@@ -147,7 +152,7 @@ class DatalakeAdminEndpointTest(RedpandaTest):
 
     @cluster(num_nodes=7)
     @matrix(
-        cloud_storage_type=[CloudStorageType.S3],
+        cloud_storage_type=get_cloud_storage_type(docker_use_arbitrary=True),
         catalog_type=[CatalogType.REST_JDBC],
     )
     def test_get_coordinator_state_pending(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28669
