### PR TITLE
[v25.3.x] [CORE-13776] Handle `rpk.describe_group` racing with `__consumer_offsets` creation

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -682,8 +682,12 @@ class RpkTool:
     @overload
     def list_topics(self, detailed: Literal[True]) -> list[list[str]]: ...
 
-    def list_topics(self, detailed: bool = False) -> list[str | list[str]]:
+    def list_topics(
+        self, detailed: bool = False, internal: bool = False
+    ) -> list[str | list[str]]:
         cmd = ["list"]
+        if internal:
+            cmd.append("-i")
 
         output = self._run_topic(cmd)
         if "No topics found." in output:

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -29,7 +29,7 @@ from rptest.services.redpanda_types import (
     KafkaClientSecurity,
     check_username_password,
 )
-from rptest.util import wait_until_result
+from rptest.util import wait_until, wait_until_result
 
 DEFAULT_TIMEOUT = 30
 
@@ -1028,14 +1028,14 @@ class RpkTool:
             assert m is not None, f"Field string '{string}' does not match the pattern"
             return m["value"]
 
-        def try_describe_group(group):
+        def describe_group(group):
             if summary:
                 cmd = ["describe", "-s", group]
             else:
                 cmd = ["describe", group]
 
             try:
-                out = self._run_group(cmd)
+                return self._run_group(cmd)
             except RpkException as e:
                 if "COORDINATOR_NOT_AVAILABLE" in e.msg + e.stderr:
                     # Transient, return None to retry
@@ -1054,6 +1054,40 @@ class RpkTool:
                 else:
                     raise
 
+        def try_describe_group(group):
+            try:
+                out = describe_group(group)
+                if out is not None:
+                    return parse_describe_group(out)
+                return None
+            except:
+                # rpk will not print out the COORDINATOR-PARTITION field for
+                # parsing when __consumer_offsets topic hasn't been created yet.
+                # instead of trying to be fancy and adapt to such output, we
+                # wait for it to be created and try again. NOTE: in the context
+                # in which this wait has been added we see that the topic is
+                # created as a side effect of rpk running find_coordinator. this
+                # behavior might be specific to the test prompting this change.
+                # if you see a similar parsing problem (see git blame for
+                # details) in the future, another option would be to explicitly
+                # poke redpanda in a way so as to create the consumer offsets
+                # topic by running a command where the consumer offsets topic is
+                # created as a side effect.
+                self._redpanda.logger.debug(
+                    "Waiting for __consumer_offsets topic to exist"
+                )
+                wait_until(
+                    lambda: "__consumer_offsets" in self.list_topics(internal=True),
+                    timeout_sec=10,
+                    backoff_sec=1,
+                    err_msg="__consumer_offsets topic not created",
+                )
+                out = describe_group(group)
+                if out is not None:
+                    return parse_describe_group(out)
+                return None
+
+        def parse_describe_group(out):
             lines = out.splitlines()
             group_name = parse_field("GROUP", lines[0])
             coordinator_node = parse_field("COORDINATOR-NODE", lines[1])


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28060
