### PR TITLE
dt: ensure stopping of kgo services in cluster linking tests

### DIFF
--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -1900,7 +1900,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
 
         def wait_for_records(rpk: RpkTool, offset: int, expected_partition_count: int):
             num_parts = 0
-            for part in rpk.describe_topic("source-topic"):
+            for part in rpk.describe_topic(topic_name):
                 num_parts += 1
                 if (part.high_watermark or 0) < offset:
                     return False
@@ -1922,14 +1922,14 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
 
             self.logger.info(f"Trimming source topic prefixes to {o}")
             self.source_cluster_rpk.trim_prefix(
-                topic="source-topic", partitions=partitions, offset=o
+                topic=topic_name, partitions=partitions, offset=o
             )
 
             def wait_for_start_offset(
                 rpk: RpkTool, offset: int, expected_partition_count: int
             ):
                 num_parts = 0
-                for part in rpk.describe_topic("source-topic"):
+                for part in rpk.describe_topic(topic_name):
                     num_parts += 1
                     self.logger.info(
                         f"Offset for source-topic/{part.id} is {part.start_offset}"
@@ -1953,7 +1953,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             for part in range(0, partition_count):
                 self.logger.info(f"Producing trim-trigger message to partition {part}")
                 self.source_cluster_rpk.produce(
-                    topic="source-topic",
+                    topic=topic_name,
                     key="trim-trigger",
                     msg="trim-trigger",
                     partition=part,

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -1720,8 +1720,8 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         with self.leadership_shuffler(
             self.target_cluster.service, topic.name, enabled=shuffle_leadership
         ):
-            self.start_producer_consumer(topic=topic.name, msg_size=128, msg_cnt=100000)
-            self.verify()
+            with self.producer_consumer(topic=topic.name, msg_size=128, msg_cnt=100000):
+                self.verify()
 
         self.logger.info("Starting cycle looking for shadow topic status")
         wait_until(
@@ -1756,12 +1756,12 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             err_msg=f"Topic {topic.name} not found in target cluster",
         )
 
-        self.start_producer_consumer(topic=topic.name, msg_size=128, msg_cnt=100000)
-        with (
-            self.create_source_failure_injector(),
-            self.create_target_failure_injector(),
-        ):
-            self.verify()
+        with self.producer_consumer(topic=topic.name, msg_size=128, msg_cnt=100000):
+            with (
+                self.create_source_failure_injector(),
+                self.create_target_failure_injector(),
+            ):
+                self.verify()
 
         self.logger.info("Starting cycle looking for shadow topic status")
         wait_until(
@@ -1795,8 +1795,8 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             backoff_sec=1,
             err_msg=f"Topic {topic.name} not found in target cluster",
         )
-        self.start_producer_consumer(topic=topic.name, msg_size=128, msg_cnt=100000)
-        self.verify()
+        with self.producer_consumer(topic=topic.name, msg_size=128, msg_cnt=100000):
+            self.verify()
 
         target_client = self.target_default_client()
 
@@ -1844,14 +1844,14 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             err_msg=f"Topic {topic.name} not found in target cluster",
         )
 
-        self.start_producer_consumer(
+        with self.producer_consumer(
             topic=topic.name,
             msg_size=128,
             msg_cnt=10000,
             use_transactions=True,
             producer_properties={"transaction_abort_rate": "0.3"},
-        )
-        self.verify()
+        ):
+            self.verify()
 
     @cluster(num_nodes=8)
     def test_replication_with_truncated_topic(self):
@@ -1895,7 +1895,6 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             return self._nop_context_manager()
 
     def _perform_auto_prefix_trimming(self, topic_name: str, partition_count: int):
-        self.start_producer_consumer(topic=topic_name, msg_size=128, msg_cnt=100000)
         offsets = [1000, 1001, 1200, 1500, 2000, 2500]
 
         def wait_for_records(rpk: RpkTool, offset: int, expected_partition_count: int):
@@ -2007,7 +2006,8 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         )
 
         with self._maybe_failure_injector(with_failures):
-            self._perform_auto_prefix_trimming(topic.name, partition_count)
+            with self.producer_consumer(topic=topic.name, msg_size=128, msg_cnt=100000):
+                self._perform_auto_prefix_trimming(topic.name, partition_count)
 
     @cluster(num_nodes=7)
     @matrix(
@@ -2042,7 +2042,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         )
         msg_cnt = 100
         base_ts = 1664453149000
-        self.start_producer_consumer(
+        with self.producer_consumer(
             topic=topic.name,
             msg_size=128,
             msg_cnt=msg_cnt,
@@ -2050,8 +2050,8 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
                 "fake_timestamp_ms": base_ts,
                 "rate_limit_bps": 1024,
             },
-        )
-        self.verify()
+        ):
+            self.verify()
 
         def get_timestamps(rpk: RpkTool, n: int, offset: str):
             return {
@@ -2110,13 +2110,13 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             err_msg=f"Topic {topic.name} not found in target cluster",
         )
 
-        self.start_producer_consumer(
+        with self.producer_consumer(
             topic=topic.name,
             msg_size=msg_size,
             msg_cnt=20,
             producer_properties={"batch_max_bytes": max_bytes},
-        )
-        self.verify()
+        ):
+            self.verify()
 
     @cluster(num_nodes=7)
     def test_replication_with_compaction(self):
@@ -2147,7 +2147,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             err_msg=f"Topic {topic.name} not found in target cluster",
         )
 
-        self.start_producer_consumer(
+        with self.producer_consumer(
             topic=topic.name,
             msg_size=128,
             msg_cnt=10000,
@@ -2155,8 +2155,8 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
                 "key_set_cardinality": 600,
                 "tombstone_probability": 0.4,
             },
-        )
-        self.verify()
+        ):
+            self.verify()
 
         def get_compaction_progress(
             rpk: RpkTool = self.target_cluster_rpk,
@@ -2256,17 +2256,17 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             name="source-topic-1", partition_count=3, replication_factor=1
         )
         self.source_default_client().create_topic(topic_1)
-        self.start_producer_consumer(topic=topic_1.name, msg_size=128, msg_cnt=100000)
-        restart_nodes(self.target_cluster_service)
-        self.verify()
+        with self.producer_consumer(topic=topic_1.name, msg_size=128, msg_cnt=100000):
+            restart_nodes(self.target_cluster_service)
+            self.verify()
 
         topic_2 = TopicSpec(
             name="source-topic-2", partition_count=3, replication_factor=1
         )
         self.source_default_client().create_topic(topic_2)
-        self.start_producer_consumer(topic=topic_2.name, msg_size=128, msg_cnt=100000)
-        restart_nodes(self.source_cluster_service)
-        self.verify()
+        with self.producer_consumer(topic=topic_2.name, msg_size=128, msg_cnt=100000):
+            restart_nodes(self.source_cluster_service)
+            self.verify()
 
 
 class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
@@ -3178,8 +3178,8 @@ class ShadowLinkingMetricsTests(ShadowLinkPreAllocTestBase):
         self.source_default_client().create_topic(topic_1)
         self.create_link("test-link")
 
-        self.start_producer_consumer(topic=topic_1.name, msg_size=128, msg_cnt=1000)
-        self.verify()
+        with self.producer_consumer(topic=topic_1.name, msg_size=128, msg_cnt=1000):
+            self.verify()
 
         def collect_shadow_topic_states(
             node_samples: list[dict[str, MetricSamples]],
@@ -3336,8 +3336,8 @@ class ShadowLinkingMetricsTests(ShadowLinkPreAllocTestBase):
             name="test-topic-2", partition_count=3, replication_factor=1
         )
         self.source_default_client().create_topic(topic_2)
-        self.start_producer_consumer(topic=topic_2.name, msg_size=128, msg_cnt=1500)
-        self.verify()
+        with self.producer_consumer(topic=topic_2.name, msg_size=128, msg_cnt=1500):
+            self.verify()
 
         validate_metrics(
             timeout_sec=10,
@@ -3363,7 +3363,7 @@ class ShadowLinkingMetricsTests(ShadowLinkPreAllocTestBase):
             err_msg=f"Topic {topic_3.name} not found in target cluster",
         )
 
-        self.start_producer_consumer(
+        with self.producer_consumer(
             topic=topic_3.name,
             msg_size=128,
             msg_cnt=5000000,
@@ -3372,14 +3372,14 @@ class ShadowLinkingMetricsTests(ShadowLinkPreAllocTestBase):
                 "msgs_per_transaction": "10000",
                 "transaction_abort_rate": "0.3",
             },
-        )
-        validate_metrics(
-            timeout_sec=30,
-            metric_validators=[
-                (self.SHADOW_LAG, check_shadow_lag_positive),
-            ],
-        )
-        self.verify()
+        ):
+            validate_metrics(
+                timeout_sec=30,
+                metric_validators=[
+                    (self.SHADOW_LAG, check_shadow_lag_positive),
+                ],
+            )
+            self.verify()
 
         validate_metrics(
             timeout_sec=30,

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -279,6 +279,11 @@ class ClusterLinkingProgressVerifier:
             total += lag
         return total
 
+    def stop_kgo_services(self):
+        self.source_consumer.stop()
+        self.target_consumer.stop()
+        self.producer.stop()
+
     def validate_progress(self, progress_timeout=60, backoff_delay=5):
         total_last_lag = float("inf")
         replication_last_progress = time.time()
@@ -321,9 +326,6 @@ class ClusterLinkingProgressVerifier:
                 self.logger.error(
                     f"No workload progress for {progress_timeout}s, source reads: {source_reads} (last: {source_consumer_last_reads}), target reads: {target_reads} (last: {target_consumer_last_reads}), producer acks: {producer_acked} (last: {producer_last_acked})"
                 )
-                self.source_consumer.stop()
-                self.target_consumer.stop()
-                self.producer.stop()
                 raise Exception("Workload stalled")
 
             total_last_lag = total_current_lag
@@ -922,7 +924,7 @@ class ShadowLinkPreAllocTestBase(ShadowLinkTestBase):
         self.verifier: ClusterLinkingProgressVerifier
         self.started = False
 
-    def start_producer_consumer(
+    def _start_producer_consumer(
         self,
         topic: str = "test-topic",
         msg_size: int = 128,
@@ -947,6 +949,14 @@ class ShadowLinkPreAllocTestBase(ShadowLinkTestBase):
         )
         self.verifier.start()
         self.started = True
+
+    @contextmanager
+    def producer_consumer(self, **kwargs: Any):
+        self._start_producer_consumer(**kwargs)
+        try:
+            yield
+        finally:
+            self.verifier.stop_kgo_services()
 
     def verify(self):
         success, error = self.verifier.wait_and_verify()


### PR DESCRIPTION
There were issues with kgo services not stopping properly as part of the cluster linking tests.

Changed to a context-based approach to ensure that the kgo services are properly shut down.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
