### PR TITLE
[CORE-14656] dt: rework logic of metric fetching in cl metric test

### DIFF
--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -3114,6 +3114,9 @@ class ShadowLinkUpdateBrokersTests(ShadowLinkPreAllocTestBase):
         ), f"Topic {old_source_topic} should not be visible to the target cluster"
 
 
+Validator = Callable[[list[dict[str, MetricSamples]]], bool]
+
+
 class ShadowLinkingMetricsTests(ShadowLinkPreAllocTestBase):
     SHADOW_TOPIC_STATE = "redpanda_shadow_link_shadow_topic_state"
     TOTAL_RECORDS_FETCHED = "redpanda_shadow_link_total_records_fetched"
@@ -3128,22 +3131,11 @@ class ShadowLinkingMetricsTests(ShadowLinkPreAllocTestBase):
         node: ClusterNode,
         patterns: list[str],
     ) -> Optional[dict[str, MetricSamples]]:
-        def get_metrics_from_node_sync(patterns: list[str]):
-            samples = self.redpanda.metrics_samples(
-                patterns, [node], MetricsEndpoint.PUBLIC_METRICS
-            )
-            success = set(samples.keys()) == set(patterns)
-            return success, samples
-
-        try:
-            samples = wait_until_result(
-                lambda: get_metrics_from_node_sync(patterns),
-                timeout_sec=2,
-                backoff_sec=0.1,
-            )
-            return samples
-        except ducktape.errors.TimeoutError:
-            return None
+        samples = self.redpanda.metrics_samples(
+            patterns, [node], MetricsEndpoint.PUBLIC_METRICS
+        )
+        self.logger.debug(f"patterns: {patterns} node: {node.name} samples: {samples}")
+        return samples
 
     def _get_metrics_for_nodes(
         self,
@@ -3160,10 +3152,7 @@ class ShadowLinkingMetricsTests(ShadowLinkPreAllocTestBase):
         return metrics
 
     def _validate_metrics(
-        self,
-        nodes: list[ClusterNode],
-        patterns: list[str],
-        validator: Callable[[list[dict[str, MetricSamples]]], bool],
+        self, nodes: list[ClusterNode], patterns: list[str], validator: Validator
     ):
         metrics = self._get_metrics_for_nodes(nodes, patterns)
         if metrics is None:
@@ -3304,10 +3293,12 @@ class ShadowLinkingMetricsTests(ShadowLinkPreAllocTestBase):
             return check_metric_exists(node_samples, self.CLIENT_ERRORS)
 
         def validate_metrics(
-            timeout_sec: int, metric_validators: list[tuple[str, Callable]]
+            timeout_sec: int, metric_validators: list[tuple[str, Validator]]
         ):
             for metric_name, validator in metric_validators:
-                self.logger.debug(f"Validating values of metric: {metric_name}")
+                self.logger.debug(
+                    f"Validating values of metric: '{metric_name}', method: '{getattr(validator, '__name__')}'"
+                )
                 wait_until(
                     lambda: self._validate_metrics(
                         target_nodes, [metric_name], validator


### PR DESCRIPTION
Adds logging to help with [CORE-14656](https://redpandadata.atlassian.net/browse/CORE-14656)

Some metrics are only on the controller leader, so the internal waiting loop ends up wasting time for no reason. Instead let the outer waiting loop iterate over metric calls until the desired state is achieved.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-14656]: https://redpandadata.atlassian.net/browse/CORE-14656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ