### PR TITLE
Improve tls truststore search

### DIFF
--- a/src/v/net/BUILD
+++ b/src/v/net/BUILD
@@ -8,6 +8,9 @@ redpanda_cc_library(
     hdrs = [
         "tls.h",
     ],
+    implementation_deps = [
+        "@openssl",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",

--- a/src/v/net/tls.cc
+++ b/src/v/net/tls.cc
@@ -18,10 +18,39 @@
 #include <seastar/util/later.hh>
 #include <seastar/util/log.hh>
 
+#include <openssl/x509.h>
+
 #include <array>
 namespace net {
 
 static ss::logger tlslog("net_tls");
+
+namespace {
+std::optional<ss::sstring> get_default_cert_location() {
+    auto default_cert_file = X509_get_default_cert_file();
+    if (default_cert_file == nullptr) {
+        return std::nullopt;
+    }
+    return ss::sstring(default_cert_file);
+}
+
+std::optional<std::filesystem::path> get_default_cert_directory() {
+    auto default_cert_dir = X509_get_default_cert_dir();
+    if (default_cert_dir == nullptr) {
+        return std::nullopt;
+    }
+    return std::filesystem::path(default_cert_dir);
+}
+
+bool is_within_directory(
+  const ss::sstring& file, const std::filesystem::path& dir) {
+    std::filesystem::path file_path(file);
+    auto [file_it, dir_it] = std::mismatch(
+      dir.begin(), dir.end(), file_path.begin(), file_path.end());
+
+    return dir_it == dir.end();
+}
+} // namespace
 
 ss::future<std::optional<ss::sstring>> find_ca_file() {
     // list of all possible ca-cert file locations on different linux distros
@@ -101,15 +130,41 @@ get_credentials_builder(credentials_configuration cfg) {
               return ss::now();
           });
     } else {
+        auto default_cert_location = get_default_cert_location();
+        vlog(
+          tlslog.trace,
+          "Default cert location: {}",
+          default_cert_location.value_or("<none>"));
+        auto default_cert_dir = get_default_cert_directory();
+        vlog(
+          tlslog.trace,
+          "Default cert directory: {}",
+          default_cert_dir.has_value() ? default_cert_dir->string()
+                                       : std::string("<none>"));
+
         auto ca_file = co_await find_ca_file();
-        if (ca_file) {
-            vlog(tlslog.info, "Found system CA trust file at {}", *ca_file);
+        vlog(tlslog.trace, "CA File location: {}", ca_file.value_or("<none>"));
+
+        if (!ca_file || ca_file == default_cert_location) {
+            // If the CA file is not found in the known locations or it matches
+            // what OpenSSL is using, then use the system trust
+            vlog(tlslog.info, "Using system trust");
+            co_await builder.set_system_trust();
+        } else if (
+          ca_file && default_cert_dir
+          && is_within_directory(*ca_file, *default_cert_dir)) {
+            vlog(
+              tlslog.info,
+              "Using system trust - ca file ({}) is within default cert "
+              "directory ({})",
+              *ca_file,
+              default_cert_dir->string());
+            co_await builder.set_system_trust();
+        } else {
+            // Here CA file exists and does not match what OpenSSL is using
+            vlog(tlslog.info, "Found CA trust file at {}", *ca_file);
             co_await builder.set_x509_trust_file(
               *ca_file, ss::tls::x509_crt_format::PEM);
-        } else {
-            vlog(
-              tlslog.info, "No system CA trust file found, using system trust");
-            co_await builder.set_system_trust();
         }
     }
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This change will first check to see if the default trust store file that
OpenSSL uses exists before attempting to load one via the
set_x509_trust_file API. If it does, call set_system_trust rather than
loading a system trust file via the set_x509_trust_file API.

This pattern should avoid occurrences of oversized allocations which
happen when reading and loading a sufficiently large trust store.

Todo:

- [x] Run in CDT

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.3.x
- [X] v25.2.x
- [X] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements

* Reduce possibility of oversized allocs from occurring when loading the system trust store file