### PR TITLE
pre-commit-config: add proto to clang-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,5 @@ repos:
         name: C++ formatting (clang-format)
         entry: ./tools/clang-format -i
         language: script
-        types_or: [c++, c]
-        files: '\.(cc|h)$'
+        types_or: [c++, c, proto]
 


### PR DESCRIPTION
clang-format formats .proto files, so we should add this to the config (I had a CI run fail due to this omission).

Also, remove the files config from the clang-format section since it is ANDed with types_or (despite the name, the or refers to what happens inside the list of types_or only), so it's redundant and confusing to have both.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none
