### PR TITLE
[v25.3.x] pre-commit-config: add proto to clang-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,5 @@ repos:
         name: C++ formatting (clang-format)
         entry: ./tools/clang-format -i
         language: script
-        types_or: [c++, c]
-        files: '\.(cc|h)$'
+        types_or: [c++, c, proto]
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28696
