### PR TITLE
Enable ruff check (linter) in pre-commit and CI

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -21,7 +21,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
+      - name: Ruff format --check
+        uses: astral-sh/ruff-action@v3
         with:
           args: "format --check --diff"
+          version: "0.12.10"
+      - name: Ruff check (/tests only)
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "check --output-format=github"
+          src: "./tests"
           version: "0.12.10"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,9 +10,11 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.10
     hooks:
-      # we can't enable this one yet because we aren't ruff-check clean
-      # - id: ruff-check
-      #   args: [--fix, --exit-non-zero-on-fix]
+      # checked in CI by lint-python.yml
+      - id: ruff-check
+        args: [--fix, --exit-non-zero-on-fix]
+        files: '^tests/.*\.pyi?$'
+      # checked in CI by lint-python.yml
       - id: ruff-format
 
   # Shell script formatting

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -4,5 +4,5 @@ exclude = ["*_pb2.pyi", "*_pb2.py", "*_pb2_connect.py"]
 [lint.isort]
 case-sensitive = true
 [lint]
-ignore = ["E741"]
-exclude = ["*_pb2.pyi", "*_pb2.py", "*_pb2_connect.py"]
+ignore = ["E741", "E712"]
+exclude = ["*_pb2.pyi", "*_pb2.py", "*_pb2_connect.py", "__init__.pyi"]

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1060,7 +1060,7 @@ class RpkTool:
                 if out is not None:
                     return parse_describe_group(out)
                 return None
-            except:
+            except Exception:
                 # rpk will not print out the COORDINATOR-PARTITION field for
                 # parsing when __consumer_offsets topic hasn't been created yet.
                 # instead of trying to be fancy and adapt to such output, we

--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
 
 from rptest.utils.bookend_collection import BookendCollection
 from rptest.utils.mode_checks import in_fips_environment
-from typing import Any
 
 # Match any version that may result from a redpanda binary, which may not be a
 # released version.


### PR DESCRIPTION
Adds `ruff check` to CI and pre-commit.

This pull request updates our Python linting and formatting configuration to improve code quality checks and streamline our workflows. The main changes include enabling more comprehensive Ruff linting in both CI and pre-commit, and refining the Ruff configuration for better compatibility with our codebase.

**CI and Pre-commit Linting Improvements:**

- Enabled the `ruff-check` hook in `.pre-commit-config.yaml`, allowing automatic fixing of issues and failing on unfixable problems. This was previously commented out and is now active, aligning local and CI checks.
- Updated the GitHub Actions workflow (`lint-python.yml`) to:
  - Add a named Ruff format check step.
  - Add a new Ruff check step that targets only the `tests` directory, outputting results in GitHub format.

**Ruff Configuration Adjustments:**

- Updated `.ruff.toml` to:
  - Ignore an additional linting rule (`E712`) as I don't plan to fix this now.
  - Exclude `__init__.pyi` files from linting, preventing spurious warnings about (intentional) unused imports.
  - 
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
