### PR TITLE
rptest: properly format ducktape @cluster

### DIFF
--- a/tests/typings/ducktape/mark/resource.pyi
+++ b/tests/typings/ducktape/mark/resource.pyi
@@ -1,5 +1,6 @@
 from _typeshed import Incomplete
-from ducktape.mark._mark import Mark as Mark
+from typing import Any
+from ducktape.mark._mark import Mark as Mark, P, T, PassDecorator
 
 CLUSTER_SPEC_KEYWORD: str
 CLUSTER_SIZE_KEYWORD: str
@@ -11,4 +12,4 @@ class ClusterUseMetadata(Mark):
     def name(self): ...
     def apply(self, seed_context, context_list): ...
 
-def cluster(**kwargs): ...
+def cluster(**kwargs: Any) -> PassDecorator[P, T]: ...


### PR DESCRIPTION
We don't use the DT version of @cluster much as we have our override, but it is still useful in some places. Properly type it.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
