### PR TITLE
[CORE-14805] `rptest`: wait for healthy cluster and controller 0 after restart

### DIFF
--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -930,6 +930,16 @@ class LogCompactionTxRemovalUpgradeTest(LogCompactionTxRemovalTestBase):
         self.redpanda._installer.install(self.redpanda.nodes, version)
         self.redpanda.restart_nodes(self.redpanda.nodes)
 
+        wait_until(
+            self.redpanda.healthy,
+            timeout_sec=20,
+            backoff_sec=2,
+            err_msg="Cluster did not become healthy after restart/upgrade",
+        )
+        self.redpanda._admin.await_stable_leader(
+            namespace="redpanda", topic="controller", partition=0
+        )
+
     @cluster(num_nodes=4)
     @matrix(test_case_name=list(LogCompactionTxRemovalTestBase.test_cases.keys()))
     def test_tx_control_batch_removal_with_upgrade(self, test_case_name):


### PR DESCRIPTION
We have seen the log lines

```
[Initial version]
INFO  2025-11-22 02:40:43,149 [shard 0:main] cluster - feature_backend.cc:149 - Saving feature_table_snapshot at version 15...
[Restart/upgrade]
DEBUG 2025-11-22 02:41:04,670 [shard 0:main] main - application.cc:3441 - Loaded feature table snapshot at cluster version 15 (vs my binary 16)
[Next restart/upgrade]
DEBUG 2025-11-22 02:41:31,382 [shard 0:main] main - application.cc:3634 - Loaded feature table snapshot at cluster version 15 (vs my binary 17)
INFO  2025-11-22 02:41:31,383 [shard 0:main] features - feature_table.cc:855 - Upgrading: this node has logical version 17 (Redpanda v25.3.1-rc3 - f8256e01b14f840d6db382cace2879a36088d525), cluster is undergoing upgrade from previous logical version 15
ERROR 2025-11-22 02:41:31,383 [shard 0:main] assert - Assert failure: (src/v/features/feature_table.cc:874) 'false' Attempted to upgrade from incompatible logical version 15 to logical version 17!
```

In a multi-stage logical cluster version upgrades, where the intermediate state cluster version 16 has been lost since a `feature_table_snapshot` was never written with this version.

This could be the case if a stable `controller/0` leader was never elected in between upgrade cycles. Add two new wait conditions for a healthy cluster and a stable leader for `controller/0` to ensure that the cluster recognizes the intermediate state for cluster version 16 before proceeding to upgrade to cluster version 17.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
