### PR TITLE
[CORE-13407] dt/cl: test_continuous_group_sync: retry consume on failure

### DIFF
--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -2380,6 +2380,7 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
     def test_continuous_group_sync(self, with_failures, source_cluster_spec):
         partition_count = 120
         topic_count = 6
+        failure_duration = 10 if with_failures else 0
 
         topics = [
             TopicSpec(
@@ -2398,13 +2399,16 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
 
         def _maybe_failure_injector():
             if with_failures:
-                return self.create_source_failure_injector()
+                return self.create_source_failure_injector(
+                    max_suspend_duration_seconds=failure_duration
+                )
             else:
                 return self._nop_context_manager()
 
         def _consume_with_group(
             topic: str,
             group_id: str,
+            fetch_max_wait: float,
             rpk: RpkTool = source_rpk,
             format: str | None = None,
         ) -> str | None:
@@ -2413,9 +2417,9 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
                     topic=topic,
                     group=group_id,
                     n=1,
-                    timeout=10,
+                    timeout=fetch_max_wait + 5,
                     offset="start",
-                    fetch_max_wait=5,
+                    fetch_max_wait=fetch_max_wait,
                     format=format,
                 )
             except Exception as e:
@@ -2454,11 +2458,29 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
             return True
 
         def _execute_random_updates(cnt: int):
+            backoff_sec = 2
+            backoff_and_a_bit_sec = backoff_sec + 1
+            retries = 3
+            fetch_max_wait_sec = failure_duration + 5
+            fetch_timeout_sec = fetch_max_wait_sec + 5
+            iteration_timeout_sec = (
+                fetch_timeout_sec + backoff_and_a_bit_sec
+            ) * retries
             for _ in range(cnt):
                 topic = topics[random.randint(0, len(topics) - 1)].name
                 group = groups[random.randint(0, len(groups) - 1)]
                 self.logger.debug(f"Consuming from topic {topic}, group {group}")
-                _consume_with_group(topic, group)
+                wait_until(
+                    lambda: _consume_with_group(
+                        topic,
+                        group,
+                        fetch_max_wait=fetch_max_wait_sec,
+                    )
+                    is not None,
+                    timeout_sec=iteration_timeout_sec,
+                    backoff_sec=backoff_sec,
+                    err_msg=f"Failed to consume from topic {topic}, group {group}",
+                )
 
         for t in topics:
             self.source_default_client().create_topic(t)
@@ -2527,6 +2549,7 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
                         group_name,
                         rpk=target_rpk,
                         format="%p,%o\n",
+                        fetch_max_wait=5,
                     )
                     assert r is not None, f"Failed to consume from {group_name=}"
                     p, consumed = (int(v) for v in r.split(","))


### PR DESCRIPTION
* `_consume_with_group` waits 5s and swallows the exception `_execute_random_updates` doesn't retry
* `with _maybe_failure_injector` doesn't retry
* `failure_injector` can pause for `max_suspend_duration_seconds = 10`

This can lead to the scenario where the consumer failed to consume..

```
[DEBUG - 2025-11-18 06:21:58,323 - cluster_linking_e2e_test - _consume_with_group - lineno:2422]: Failed to consume from topic source-topic-1, group test_group_6: RpkException<command `/var/lib/buildkite-agent/builds/redpanda-bk-agent-v6-core-m7gd12xlarge-xfs-partitions-i-025e3c145fd340884-1/redpanda/redpanda/vbuild/redpanda_installs/ci/bin/rpk topic -X brokers=docker-rp-33:9092,docker-rp-32:9092,docker-rp-34:9092 consume source-topic-1 -g test_group_6 -n1 --fetch-max-wait 5s -o start -X globals.request_timeout_overhead=10s -v' timed out; stderr: ... (72 lines skipped)
```

And then groups are inconsistent

Retry the consume on the source topic if there was a failure.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
