### PR TITLE
bazel: add aarch64 variants of grafana/prom/minio

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -410,14 +410,21 @@ http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_file(
-    name = "minio",
+    name = "minio_x86_64",
     executable = True,
     integrity = "sha256-zr1iiuhZtGcN6cBLDL9WAKSYFm2iAxrWNMmHII2JrpQ=",
     urls = ["https://dl.min.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2025-04-03T14-56-28Z"],
 )
 
+http_file(
+    name = "minio_aarch64",
+    executable = True,
+    integrity = "sha256-Xs94kSmK6+SVko+E5urztZy33dtJnHrdjFAn6wuo8Ok=",
+    urls = ["https://dl.min.io/server/minio/release/linux-arm64/archive/minio.RELEASE.2025-04-03T14-56-28Z"],
+)
+
 http_archive(
-    name = "prometheus",
+    name = "prometheus_x86_64",
     add_prefix = "prom",
     build_file = "//bazel/thirdparty:prometheus.BUILD",
     integrity = "sha256-ouionAmxSyJ35hUeh/yO0YhYSGy/iTcmVtcfzWZrUdo=",
@@ -426,9 +433,26 @@ http_archive(
 )
 
 http_archive(
-    name = "grafana",
+    name = "prometheus_aarch64",
+    add_prefix = "prom",
+    build_file = "//bazel/thirdparty:prometheus.BUILD",
+    integrity = "sha256-ft4/PwVBub/SzMqc71evgFVPExuOeviQCJbG5J7S1O8=",
+    strip_prefix = "prometheus-3.7.1.linux-arm64",
+    urls = ["https://github.com/prometheus/prometheus/releases/download/v3.7.1/prometheus-3.7.1.linux-arm64.tar.gz"],
+)
+
+http_archive(
+    name = "grafana_x86_64",
     build_file = "//bazel/thirdparty:grafana.BUILD",
     integrity = "sha256-L+f4mkpjbAHVS6BQnkLZnrirmH8tEeJcxcVeaAkBa/c=",
     strip_prefix = "grafana-12.2.1",
     urls = ["https://dl.grafana.com/grafana/release/12.2.1/grafana_12.2.1_18655849634_linux_amd64.tar.gz"],
+)
+
+http_archive(
+    name = "grafana_aarch64",
+    build_file = "//bazel/thirdparty:grafana.BUILD",
+    integrity = "sha256-bWTD/jaZs7sukoMUvCqWhSCQnaR+qrx1W4Z1YOOlc98=",
+    strip_prefix = "grafana-12.2.1",
+    urls = ["https://dl.grafana.com/grafana/release/12.2.1/grafana_12.2.1_18655849634_linux_arm64.tar.gz"],
 )

--- a/bazel/thirdparty/BUILD
+++ b/bazel/thirdparty/BUILD
@@ -1,0 +1,28 @@
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
+native_binary(
+    name = "minio",
+    src = select({
+        "@platforms//cpu:x86_64": "@minio_x86_64//file",
+        "@platforms//cpu:aarch64": "@minio_aarch64//file",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "prometheus",
+    actual = select({
+        "@platforms//cpu:x86_64": "@prometheus_x86_64//:prometheus",
+        "@platforms//cpu:aarch64": "@prometheus_aarch64//:prometheus",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "grafana",
+    actual = select({
+        "@platforms//cpu:x86_64": "@grafana_x86_64//:grafana",
+        "@platforms//cpu:aarch64": "@grafana_aarch64//:grafana",
+    }),
+    visibility = ["//visibility:public"],
+)

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,4 +1,3 @@
-load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
@@ -25,11 +24,6 @@ buildifier(
     mode = "fix",
 )
 
-native_binary(
-    name = "minio",
-    src = "@minio//file",
-)
-
 # Run a dev_cluster, by default the data directory is in the repository root.
 #
 #     bazel run //tools:dev_cluster -- --nodes 1
@@ -44,22 +38,22 @@ py_binary(
         "dev_cluster.py",
     ],
     args = [
-        "-e $(rootpath //src/v/redpanda:redpanda)",
-        "-o $(rootpath :minio)",
+        "--executable $(rootpath //src/v/redpanda:redpanda)",
         "--rpk $(rootpath //src/go/rpk/cmd/rpk)",
-        "--prometheus $(rootpath @prometheus//:prometheus)",
-        "--grafana $(rootpath @grafana//:grafana)",
+        "--minio_executable $(rootpath //bazel/thirdparty:minio)",
+        "--prometheus $(rootpath //bazel/thirdparty:prometheus)",
+        "--grafana $(rootpath //bazel/thirdparty:grafana)",
         "--lsan_suppression_file $(rootpath //:lsan_suppressions)",
         "--ubsan_suppression_file $(rootpath //:ubsan_suppressions)",
     ],
     data = [
-        ":minio",
         "//:lsan_suppressions",
         "//:ubsan_suppressions",
+        "//bazel/thirdparty:grafana",
+        "//bazel/thirdparty:minio",
+        "//bazel/thirdparty:prometheus",
         "//src/go/rpk/cmd/rpk",
         "//src/v/redpanda",
-        "@grafana",
-        "@prometheus",
     ],
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
In order to support platform selected binaries for these tools, we alias
them in `bazel/thirdparty` so if you want to use one you just need to
`bazel run //bazel/thirdparty:minio` for example.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
