### PR TITLE
[CORE-14806] `rptest`: use `ssh_capture()` instead of `ssh_output()` in `offline_log_viewer`

### DIFF
--- a/tests/rptest/clients/offline_log_viewer.py
+++ b/tests/rptest/clients/offline_log_viewer.py
@@ -36,7 +36,9 @@ class OfflineLogViewer:
 
     def _json_cmd(self, node: ClusterNode, suffix: str) -> Any:
         cmd = self._cmd(suffix=suffix)
-        json_out = node.account.ssh_output(cmd, combine_stderr=False)
+        # TODO: avoid ssh_{output/capture}() for log analysis
+        # https://redpandadata.atlassian.net/browse/CORE-14822
+        json_out = "".join(node.account.ssh_capture(cmd, combine_stderr=False))
         try:
             return json.loads(json_out)
         except json.decoder.JSONDecodeError:


### PR DESCRIPTION
`ssh_output()` will write output to `DEBUG` log by default in ducktape. For large outputs, this can be undesirable and lead to very large log files.

Use `ssh_capture()` instead to avoiding logging the output.


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
