### PR TITLE
[CORE-14791] ct/ctp_stm_test: Fix flaky

### DIFF
--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -391,6 +391,8 @@ TEST_F_CORO(ctp_stm_fixture, can_replay_truncated_log) {
         co_await replicate_record_batch(
           leader, make_record_batch(ct::cluster_epoch{1}, model::offset{o}, 0));
     }
+    // Wait for all nodes to replicate up to offset 1023 before rolling.
+    co_await wait_for_committed_offset(model::offset{1023}, 10s);
     // Segment roll on all the nodes so we can take a snapshot.
     for (auto& vnode : all_vnodes()) {
         co_await node(vnode.id()).raft()->log()->force_roll();

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -357,6 +357,8 @@ TEST_F_CORO(ctp_stm_fixture, truncates_below_lro) {
         co_await replicate_record_batch(
           leader, make_record_batch(ct::cluster_epoch{1}, model::offset{o}, 0));
     }
+    // Wait for all nodes to replicate up to offset 1023 before rolling.
+    co_await wait_for_committed_offset(model::offset{1023}, 10s);
     // Segment roll on all the nodes so we can take a snapshot.
     for (auto& vnode : all_vnodes()) {
         co_await node(vnode.id()).raft()->log()->force_roll();

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2196,6 +2196,11 @@ ss::future<> disk_log_impl::force_roll() {
     auto roll_lock_holder = co_await _segments_rolling_lock.get_units();
     auto t = term();
     auto next_offset = model::next_offset(offsets().dirty_offset);
+    vlog(
+      stlog.debug,
+      "{} force_roll: new segment start offset {}",
+      config().ntp(),
+      next_offset);
     if (_segs.empty()) {
         co_return co_await new_segment(next_offset, t);
     }


### PR DESCRIPTION
The test wants to see a snapshot at offset 1024 on three nodes, but one
of the three may end up behind and snapshot at an earlier offset because
its log is force-rolled before it's caught up with the majority
replicated offset.

Also added a log that would have been useful in the investigation.

Fixes CORE-14791

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
