### PR TITLE
[CORE-14821] ct/metastore: Fix shutdown hang by timing out metastore replicates

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/simple_stm.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_stm.cc
@@ -84,10 +84,17 @@ simple_stm::sync(model::timeout_clock::duration timeout) {
 ss::future<std::expected<void, simple_stm::errc>>
 simple_stm::replicate_and_wait(
   model::term_id term, model::record_batch batch, ss::abort_source& as) {
+    // This timeout should prevent services that depend on the metastore from
+    // hanging during shutdown because they are waiting on a replicate. The OCC
+    // checks in the apply fiber should prevent issues with replicates that
+    // succeed after the timeout pops.
+    // 10s chosen because it's a long time but less than the 15s it takes for a
+    // "slow shutdown" log.
+    constexpr auto replicate_timeout = 10s;
     auto opts = raft::replicate_options(
       raft::consistency_level::quorum_ack,
       /*expected_term=*/term,
-      /*timeout=*/std::nullopt,
+      replicate_timeout,
       std::ref(as));
     opts.set_force_flush();
     auto res = co_await _raft->replicate(std::move(batch), opts);


### PR DESCRIPTION
Reconciler shutdown could hang when one node waits on replicating add_objects after the other members of the quorum have shut down. The replication has no timeout and will not be aborted by shutdown because the metastore shuts down after the reconciler, which depends on it. This change adds a timeout to the replicate request.

Fixes CORE-14821

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
