### PR TITLE
cluster: fix topic label aggregation on restart

### DIFF
--- a/src/v/cluster/topic_metrics_watcher.cc
+++ b/src/v/cluster/topic_metrics_watcher.cc
@@ -23,6 +23,8 @@ topic_metrics_watcher::topic_metrics_watcher(
     tt.register_topic_delta_notification(
       [this](const auto&) { maybe_aggregate_topic_label(); });
     _topic_agg_limit.watch([this] { maybe_aggregate_topic_label(); });
+
+    maybe_aggregate_topic_label();
 }
 
 ss::future<> topic_metrics_watcher::stop() { return _gate.close(); }

--- a/tests/rptest/tests/topic_label_aggregation_test.py
+++ b/tests/rptest/tests/topic_label_aggregation_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+from typing import Any
 from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec
@@ -19,34 +20,50 @@ class TopicLabelAggregationTest(RedpandaTest):
     TOPIC_LABEL = "topic"
     PARTITION_LABEL = "partition"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(num_brokers=3, *args, **kwargs)
+
+    def _aggregated_metrics_have_topic_label(self) -> bool:
+        for node in self.redpanda.nodes:
+            for family in self.redpanda.metrics(
+                node, metrics_endpoint=MetricsEndpoint.METRICS
+            ):
+                for sample in family.samples:
+                    # If the partition label isn't aggregated then neither will the topic label.
+                    if (
+                        self.TOPIC_LABEL in sample.labels.keys()
+                        and self.PARTITION_LABEL not in sample.labels.keys()
+                    ):
+                        return True
+
+        return False
+
+    def _unaggregated_metrics_have_topic_label(self) -> bool:
+        for node in self.redpanda.nodes:
+            for family in self.redpanda.metrics(
+                node, metrics_endpoint=MetricsEndpoint.METRICS
+            ):
+                for sample in family.samples:
+                    # Only consider series that would have their topic label aggregated
+                    # when topic label aggregation is enabled.
+                    if (
+                        self.TOPIC_LABEL in sample.labels.keys()
+                        and self.PARTITION_LABEL in sample.labels.keys()
+                    ):
+                        return True
+
+        return False
+
+    def _create_topics(self, topics: list[TopicSpec]):
+        for t in topics:
+            self.client().create_topic(t)
+
+    def _delete_topics(self, topics: list[TopicSpec]):
+        for t in topics:
+            self.client().delete_topic(t.name)
 
     @cluster(num_nodes=3)
     def test_topic_label_aggregation(self):
-        def metrics_have_topic_label() -> bool:
-            for node in self.redpanda.nodes:
-                for family in self.redpanda.metrics(
-                    node, metrics_endpoint=MetricsEndpoint.METRICS
-                ):
-                    for sample in family.samples:
-                        # If the partition label isn't aggregated then neither will the topic label.
-                        if (
-                            self.TOPIC_LABEL in sample.labels.keys()
-                            and self.PARTITION_LABEL not in sample.labels.keys()
-                        ):
-                            return True
-
-            return False
-
-        def create_topics(topics: list[TopicSpec]):
-            for t in topics:
-                self.client().create_topic(t)
-
-        def delete_topics(topics: list[TopicSpec]):
-            for t in topics:
-                self.client().delete_topic(t.name)
-
         initial_topic_count = len(self.client().describe_topics())
         topics_to_create = [TopicSpec() for _ in range(50)]
         topic_aggregation_limit = len(topics_to_create) + initial_topic_count - 1
@@ -57,11 +74,13 @@ class TopicLabelAggregationTest(RedpandaTest):
                 "topic_label_aggregation_limit": topic_aggregation_limit,
             }
         )
-        assert metrics_have_topic_label(), "topic label shouldn't be aggregated yet"
+        assert self._aggregated_metrics_have_topic_label(), (
+            "topic label shouldn't be aggregated yet"
+        )
 
-        create_topics(topics_to_create)
+        self._create_topics(topics_to_create)
         wait_until(
-            lambda: not metrics_have_topic_label(),
+            lambda: not self._aggregated_metrics_have_topic_label(),
             timeout_sec=60,
             backoff_sec=10,
             err_msg="topic label wasn't aggregated",
@@ -77,23 +96,23 @@ class TopicLabelAggregationTest(RedpandaTest):
         topic_count_to_delete = int(current_topic_count - agg_limit_lower_bound) - 1
         assert topic_count_to_delete > 1
 
-        delete_topics(topics_to_create[:topic_count_to_delete])
-        assert not metrics_have_topic_label()
+        self._delete_topics(topics_to_create[:topic_count_to_delete])
+        assert not self._aggregated_metrics_have_topic_label()
 
         # Have topic count fall bellow the 95% limit.
-        delete_topics(
+        self._delete_topics(
             topics_to_create[topic_count_to_delete : (topic_count_to_delete + 2)]
         )
         wait_until(
-            lambda: metrics_have_topic_label(),
+            lambda: self._aggregated_metrics_have_topic_label(),
             timeout_sec=60,
             backoff_sec=10,
             err_msg="topic label wasn't un-aggregated",
         )
 
-        create_topics(topics_to_create[: (topic_count_to_delete + 2)])
+        self._create_topics(topics_to_create[: (topic_count_to_delete + 2)])
         wait_until(
-            lambda: not metrics_have_topic_label(),
+            lambda: not self._aggregated_metrics_have_topic_label(),
             timeout_sec=60,
             backoff_sec=10,
             err_msg="topic label wasn't aggregated",
@@ -101,8 +120,75 @@ class TopicLabelAggregationTest(RedpandaTest):
 
         self.redpanda.set_cluster_config({"topic_label_aggregation_limit": None})
         wait_until(
-            lambda: metrics_have_topic_label(),
+            lambda: self._aggregated_metrics_have_topic_label(),
             timeout_sec=60,
             backoff_sec=10,
             err_msg="topic label wasn't un-aggregated",
+        )
+
+    @cluster(num_nodes=3)
+    def test_topic_aggregate_on_toggle(self):
+        """
+        Topic labels are not aggregated when metrics aggregation is turned off in general.
+        This tests that they are aggregated when metrics aggregation is enabled. Assuming
+        that the topic count meets the aggregation threshold.
+        """
+        initial_topic_count = len(self.client().describe_topics())
+        topics_to_create = [TopicSpec() for _ in range(50)]
+        topic_aggregation_limit = len(topics_to_create) + initial_topic_count - 1
+
+        self.redpanda.set_cluster_config(
+            {
+                "aggregate_metrics": False,
+                "topic_label_aggregation_limit": topic_aggregation_limit,
+            }
+        )
+
+        self._create_topics(topics_to_create)
+        assert self._unaggregated_metrics_have_topic_label(), (
+            "topic label shouldn't be aggregated yet"
+        )
+
+        self.redpanda.set_cluster_config(
+            {
+                "aggregate_metrics": True,
+            }
+        )
+        wait_until(
+            lambda: not self._aggregated_metrics_have_topic_label(),
+            timeout_sec=60,
+            backoff_sec=10,
+            err_msg="topic label wasn't aggregated",
+        )
+
+    @cluster(num_nodes=3)
+    def test_topic_aggregate_on_restart(self):
+        """
+        Tests that topic labels remain aggregated when a node restarts.
+        """
+        initial_topic_count = len(self.client().describe_topics())
+        topics_to_create = [TopicSpec() for _ in range(50)]
+        topic_aggregation_limit = len(topics_to_create) + initial_topic_count - 1
+
+        self.redpanda.set_cluster_config(
+            {
+                "aggregate_metrics": True,
+                "topic_label_aggregation_limit": topic_aggregation_limit,
+            }
+        )
+
+        self._create_topics(topics_to_create)
+        wait_until(
+            lambda: not self._aggregated_metrics_have_topic_label(),
+            timeout_sec=60,
+            backoff_sec=10,
+            err_msg="topic label wasn't aggregated",
+        )
+
+        self.redpanda.rolling_restart_nodes(self.redpanda.nodes)
+        wait_until(
+            lambda: not self._aggregated_metrics_have_topic_label(),
+            timeout_sec=60,
+            backoff_sec=10,
+            err_msg="topic label wasn't aggregated",
         )

--- a/tools/type-checking/type-check-strictness.json
+++ b/tools/type-checking/type-check-strictness.json
@@ -199,7 +199,6 @@
         "rptest/tests/tiered_storage_pause_test.py",
         "rptest/tests/timestamp_policy_test.py",
         "rptest/tests/topic_id_migrator_test.py",
-        "rptest/tests/topic_label_aggregation_test.py",
         "rptest/tests/topic_limits_test.py",
         "rptest/tests/upgrade_with_workload.py",
         "rptest/tests/usage_stats_test.py",


### PR DESCRIPTION
Prior to this PR topic label aggregation wouldn't be enabled on restart until either the topics were modified or the topic label aggregation property was changed.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
