### PR TITLE
Direct consumer progress timeout

### DIFF
--- a/tests/rptest/direct_consumer_tests/direct_consumer_test.py
+++ b/tests/rptest/direct_consumer_tests/direct_consumer_test.py
@@ -73,8 +73,6 @@ class LoopThread(threading.Thread):
         return self._stop_event.is_set()
 
 
-# TODO: This test must be enabled once the direct consumer verifier support
-# is added to vtools.
 class DirectConsumerVerifierTest(RedpandaTest):
     def __init__(self, test_context: TestContext, **kwargs: Any):
         super().__init__(test_context, **kwargs)

--- a/tests/rptest/direct_consumer_tests/direct_consumer_test.py
+++ b/tests/rptest/direct_consumer_tests/direct_consumer_test.py
@@ -211,7 +211,7 @@ class DirectConsumerVerifierTest(RedpandaTest):
                 get_consumption,
                 condition=lambda: get_consumption() >= msg_count,
                 timeout_sec=600,
-                progress_sec=10,
+                progress_sec=30,
                 backoff_sec=2,
                 err_msg="Stopped consuming",
                 logger=self.logger,


### PR DESCRIPTION
A recent CI failure showed that direct consumer test timeout out because KGO producer stalled for 20s.

Changes the progress time on direct consumer to be 30 seconds to allow more time for kgo to recover.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
### Improvements

* deflake direct consumer test

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
