### PR TITLE
[CORE-14856] `storage`: remove early return path in `self_compact_segment()`

### DIFF
--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -799,18 +799,6 @@ ss::future<compaction_result> self_compact_segment(
       = co_await maybe_rebuild_compaction_index(
         s, stm_manager, cfg, read_holder, resources, pb, feature_table);
 
-    const bool segment_already_compacted
-      = (state == compacted_index::recovery_state::already_compacted);
-
-    if (segment_already_compacted && !should_force_compaction) {
-        vlog(
-          gclog.debug,
-          "detected {} is already compacted",
-          s->path().to_compacted_index());
-        co_await internal::mark_segment_as_finished_self_compaction(s, pb);
-        co_return compaction_result{s->size_bytes()};
-    }
-
     const bool is_valid_index_state
       = (state == compacted_index::recovery_state::index_recovered)
         || (state == compacted_index::recovery_state::already_compacted);


### PR DESCRIPTION
This is actually a bug that was revealed by transactional control batch removal.

Take the following steps:

```
1a) 20.log:INFO  2025-11-24 16:15:04,147 [shard 0:lc  ] storage-gc - segment_utils.cc:691 - Rebuilding index file... (/var/lib/redpanda/data/kafka/topic-jxifylkscz/0_55/79964-17-v1.compaction_index)
1b) 20.log:INFO  2025-11-24 16:15:04,157 [shard 0:lc  ] storage-gc - segment_utils.cc:668 - tx reducer path: /var/lib/redpanda/data/kafka/topic-jxifylkscz/0_55/79964-17-v1.compaction_index stats { batches processed: 1273, aborted_txs: 76, discarded batches: 744 }
2) 20.log:TRACE 2025-11-24 16:15:04,157 [shard 0:lc  ] storage-gc - segment_utils.cc:576 - self compacting segment /var/lib/redpanda/data/kafka/topic-jxifylkscz/0_55/79964-17-v1.log
3a) 20.log:DEBUG 2025-11-24 16:15:04,159 [shard 0:main] storage - disk_log_impl.cc:307 - closing log {...}
3b) 20.log:DEBUG 2025-11-24 16:15:04,159 [shard 0:lc  ] storage-gc - disk_log_impl.cc:1393 - Cleaning up leftover file: /var/lib/redpanda/data/kafka/topic-jxifylkscz/0_55/79964-17-v1.log.staging
...
[X-shard partition move from shard 0 to shard 1]
...
4) 20.log:DEBUG 2025-11-24 16:15:05,437 [shard 1:lc  ] storage-gc - segment_utils.cc:809 - detected /var/lib/redpanda/data/kafka/topic-jxifylkscz/0_55/79964-17-v1.compaction_index is already compacted
```

Here we have the following situation:

1. In a)/b), the `compaction_index` for `segment` `79964-17-v1.log` is rebuilt using the `tx_reducer`, which filters out aborted transactional data _but only in the `.compaction_index` file_. This process also marks the footer with the `self_compaction` footer flag, which is a terribly confusing and potentially outdated bit of code, since the code wants to interpret this as meaning the `segment` has also gone through a self compaction, which is _not_ true.
2. We begin to self compact the `segment` itself. This is the necessary step to ensure that aborted transactional data is removed, since those offset deltas won't exist in the bitmap generated from the `compaction_index`. A key detail to remember here is that window compaction does _not_ remove data that isn't indexed in the key-offset map generated from the `compaction_index`, which means sliding window compaction _cannot_ remove aborted transactional data.
3. In a), the `log` is closed due to a cross-shard move of the partition. In b), we can see that the replacement `segment` `79964-17-v1.log.staging` undergoing self compaction gets removed before it can replace `79964-17-v1.log`
4. On next attempted self compaction of `79964-17-v1.log`, we detect that the `self_compaction` footer flag has been set in the `.compaction_index`, and interpret that as indicating `segment` `79964-17-v1.log` has been self compacted already.

We then early exit, mark `79964-17-v1.log` as self compacted (even though it isn't), and sliding window compaction can then:

1. Remove the `tx_fence` batch
2. Unset the transactional bits in the aborted raft data batches
3. Remove the `tx_abort` control batch

Leading to a persistence of aborted data and a CI failure such as:

```
  File "/root/tests/rptest/transactions/verifiers/compacted_verifier.py", line 238, in _remote_info
    self.raise_on_violation(self._node)
rptest.transactions.verifiers.compacted_verifier.ConsistencyViolationException: 86784	102	0	violation	read aborted key3=71009@85210
```

To fix the race described in the steps above, simply remove the faulty check that is based on the footer flag in the `compaction_index`. While it did make sense to have this check in order to prevent unnecessary re-compaction of data over upgrades, the `self_compact_timestamp` flag has been present since `v25.2.1` and should be considered the source of truth of whether a `segment` has been self compacted or not.

This failure also proves that it _must_ be guaranteed that a `segment` has undergone self compaction before sliding window compaction, or else (due to the key detail mentioned above) we can get into a situation where `tx_fence`, transactional bits, and control batches can be removed before the aborted transactional data itself.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes

* Fixes a bug in which a `segment` could be incorrectly marked as having finished self compaction during a race with a `log` shutdown
