### PR TITLE
rptest: add schemaregistry as extra for for kafka

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -16,7 +16,7 @@ setup(
         "prometheus-client==0.9.0",
         "kafka-python==2.0.6",
         "crc32c==2.2",
-        "confluent-kafka==2.12.2",
+        "confluent-kafka[schemaregistry]==2.12.2",
         "types-confluent-kafka==1.4.0",
         "zstandard==0.23.0",
         "xxhash==3.5.0",


### PR DESCRIPTION
Install confluent_kafka as `confluent-kafka[schemaregistry]` as otherwise schema registry support is incomplete (e.g., deps are missing).

Should make the build greener.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
