### PR TITLE
[CORE-13320] Fix tests that librdkafka update broke

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -485,6 +485,7 @@ class RpkTool:
         perm = f"--allow-{ptype}" if not deny else f"--deny-{ptype}"
 
         cmd = [
+            "security",
             "acl",
             "create",
             perm,

--- a/tests/rptest/tests/redpanda_oauth_test.py
+++ b/tests/rptest/tests/redpanda_oauth_test.py
@@ -14,14 +14,15 @@ import time
 from urllib.parse import urlparse
 
 import requests
-from ducktape.mark import ignore, parametrize
+from ducktape.cluster.cluster import ClusterNode
+from ducktape.mark import parametrize
 from ducktape.tests.test import Test
 from ducktape.utils.util import wait_until
 from keycloak import KeycloakOpenID
 
 from rptest.clients.kafka_cli_tools import AuthorizationError, KafkaCliTools
 from rptest.clients.python_librdkafka import PythonLibrdkafka
-from rptest.clients.rpk import RpkTool
+from rptest.clients.rpk import AclList, RpkTool
 from rptest.services.cluster import cluster
 from rptest.services.keycloak import (
     DEFAULT_AT_LIFESPAN_S,
@@ -608,7 +609,6 @@ class OIDCReauthTest(RedpandaOIDCTestBase):
             **kwargs,
         )
 
-    @ignore  # https://github.com/redpanda-data/redpanda/pull/26968 - broken by newer librdkafka
     @cluster(num_nodes=4)
     def test_oidc_reauth(self):
         kc_node = self.keycloak.nodes[0]
@@ -616,7 +616,7 @@ class OIDCReauthTest(RedpandaOIDCTestBase):
         client_id = CLIENT_ID
         service_user_id = self.create_service_user(client_id)
 
-        self.rpk.create_topic(EXAMPLE_TOPIC)
+        self.redpanda.logger.info("Creating ACL")
         self.rpk.sasl_allow_principal(
             f"User:{service_user_id}",
             ["all"],
@@ -627,6 +627,10 @@ class OIDCReauthTest(RedpandaOIDCTestBase):
             self.su_algorithm,
         )
 
+        self.redpanda.logger.info("Creating topic")
+        self.rpk.create_topic(EXAMPLE_TOPIC)
+
+        self.redpanda.logger.info("Creating producer")
         cfg = self.keycloak.generate_oauth_config(kc_node, CLIENT_ID)
         assert cfg.client_secret is not None
         assert cfg.token_endpoint is not None
@@ -634,21 +638,52 @@ class OIDCReauthTest(RedpandaOIDCTestBase):
             self.redpanda, algorithm="OAUTHBEARER", oauth_config=cfg
         )
         producer = k_client.get_producer()
-        producer.poll(1.0)
+        producer.poll(0.0)
 
-        expected_topics = set([EXAMPLE_TOPIC])
+        def has_leader():
+            topics = producer.list_topics(topic=EXAMPLE_TOPIC, timeout=5).topics
+            topic = topics.get(EXAMPLE_TOPIC, None)
+            has_leader = (
+                topic is not None
+                and len(topic.partitions) == 1
+                and topic.partitions[0].error is None
+                and topic.partitions[0].leader != -1
+            )
+            if not has_leader:
+                self.redpanda.logger.debug(
+                    f"has_leader: topic={topic}, parts: {topic.partitions[0] if topic else None}"
+                )
+            return has_leader
+
+        self.redpanda.logger.info("Waiting for topic")
         wait_until(
-            lambda: set(producer.list_topics(timeout=5).topics.keys())
-            == expected_topics,
-            timeout_sec=5,
+            has_leader,
+            timeout_sec=10,
+            backoff_sec=1,
+            retry_on_exc=True,
         )
 
+        def has_acl(node: ClusterNode):
+            lst = AclList.parse_raw(self.rpk.acl_list(node=node))
+            return lst.has_permission(
+                f"{service_user_id}", "all", "topic", EXAMPLE_TOPIC
+            )
+
+        self.redpanda.logger.info("Waiting for ACL")
+        wait_until(
+            lambda: all(has_acl(node) for node in self.redpanda.nodes),
+            timeout_sec=10,
+            backoff_sec=1,
+            retry_on_exc=False,
+        )
+
+        self.redpanda.logger.info("Producing to topic")
         for _ in range(0, self.PRODUCE_ITER):
-            producer.poll(0.0)
             producer.produce(topic=EXAMPLE_TOPIC, key="bar", value="23")
             time.sleep(self.PRODUCE_INTERVAL_S)
+            producer.flush(5)
 
-        producer.flush(timeout=5)
+        self.redpanda.logger.info("Produced to topic")
 
         metrics = get_sasl_metrics(self.redpanda)
         self.redpanda.logger.debug(f"SASL metrics: {metrics}")
@@ -659,8 +694,8 @@ class OIDCReauthTest(RedpandaOIDCTestBase):
         assert REAUTH_METRIC in metrics.keys()
         assert metrics[REAUTH_METRIC] > 0, "Expected client reauth on some broker..."
 
-        assert k_client.oauth_count == 2, (
-            f"Expected 2 OAUTH challenges, got {k_client.oauth_count}"
+        assert k_client.oauth_count > 1, (
+            f"Expected at least 2 OAUTH challenges, got {k_client.oauth_count}"
         )
 
 

--- a/tests/rptest/transactions/tx_authorization_test.py
+++ b/tests/rptest/transactions/tx_authorization_test.py
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0
 
 import confluent_kafka as ck
-from ducktape.mark import ignore
+from ducktape.cluster.cluster import ClusterNode
 from ducktape.utils.util import wait_until
 
 from rptest.clients.rpk import AclList, RpkTool
@@ -37,6 +37,7 @@ class TransactionsAuthorizationTest(RedpandaTest, TransactionsMixin):
         extra_rp_conf = {
             "enable_leader_balancer": False,
             "partition_autobalancing_mode": "off",
+            "group_initial_rebalance_delay": 1,
         }
 
         super().__init__(
@@ -95,15 +96,15 @@ class TransactionsAuthorizationTest(RedpandaTest, TransactionsMixin):
     def allow_principal_sync(self, principal, operations, resource, resource_name):
         self.rpk.sasl_allow_principal(principal, operations, resource, resource_name)
 
-        def acl_ready():
-            lst = AclList.parse_raw(self.rpk.acl_list())
+        def acl_ready(node: ClusterNode):
+            lst = AclList.parse_raw(self.rpk.acl_list(node=node))
             return [
                 lst.has_permission(principal, op, resource, resource_name)
                 for op in operations
             ]
 
         wait_until(
-            lambda: acl_ready(),
+            lambda: all(acl_ready(node) for node in self.redpanda.nodes),
             timeout_sec=5,
             backoff_sec=1,
             err_msg="ACL not updated in time",
@@ -126,7 +127,6 @@ class TransactionsAuthorizationTest(RedpandaTest, TransactionsMixin):
 
         self.sasl_txn_producer(user, cfg=producer_cfg)
 
-    @ignore  # https://github.com/redpanda-data/redpanda/pull/26968 - broken by newer librdkafka
     @cluster(num_nodes=3)
     def simple_authz_test(self):
         consume_user = self.USER_1
@@ -186,16 +186,8 @@ class TransactionsAuthorizationTest(RedpandaTest, TransactionsMixin):
         with try_transaction(
             producer,
             consumer,
-            send_offset_err=ck.KafkaError.GROUP_AUTHORIZATION_FAILED,
-            commit_err=ck.KafkaError.GROUP_AUTHORIZATION_FAILED,
-        ):
-            process_records(producer, records, on_delivery_purged)
-
-        self.allow_principal_sync(produce_user.username, ["read"], "group", "test")
-
-        producer = self.sasl_txn_producer(produce_user, cfg=producer_cfg)
-        with try_transaction(
-            producer, consumer, commit_err=ck.KafkaError.TOPIC_AUTHORIZATION_FAILED
+            send_offset_err=ck.KafkaError.TOPIC_AUTHORIZATION_FAILED,
+            commit_err=ck.KafkaError.TOPIC_AUTHORIZATION_FAILED,
         ):
             process_records(producer, records, on_delivery_purged)
 
@@ -203,10 +195,18 @@ class TransactionsAuthorizationTest(RedpandaTest, TransactionsMixin):
             produce_user.username, ["write"], "topic", self.output_t.name
         )
 
+        with try_transaction(
+            producer,
+            consumer,
+            send_offset_err=ck.KafkaError.GROUP_AUTHORIZATION_FAILED,
+            commit_err=ck.KafkaError.GROUP_AUTHORIZATION_FAILED,
+        ):
+            process_records(producer, records, self.on_delivery)
+
+        self.allow_principal_sync(produce_user.username, ["read"], "group", "test")
+
         # Now we have all the requisite permissions set up, and we should be able to
         # make progress
-
-        producer = self.sasl_txn_producer(produce_user, cfg=producer_cfg)
 
         num_consumed_records = 0
         consumed_from_input_topic = []

--- a/tests/rptest/transactions/util.py
+++ b/tests/rptest/transactions/util.py
@@ -38,7 +38,8 @@ def try_transaction(
 
     yield
 
-    producer.flush(0.0)
+    while producer.flush(0) > 0:
+        producer.poll(0.1)
 
     with expect_kafka_error(send_offset_err):
         producer.send_offsets_to_transaction(


### PR DESCRIPTION
Redo of https://github.com/redpanda-data/redpanda/pull/28628 but without updating librdkafka.

* `dt/clients/rpk`: Move acl management inside security (drive-by fix)
* Enable `TransactionsAuthorizationTest.simple_authz_test with tweaked error handling`
* Enable `OIDCReAuthTest.test_oidc_reauth`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
