### PR TITLE
Trigger docs property automation on latest release tag change

### DIFF
--- a/.github/workflows/dispatch-docs-updates.yml
+++ b/.github/workflows/dispatch-docs-updates.yml
@@ -1,5 +1,5 @@
 ---
-name: Dispatch Admin API docs update on latest release
+name: Dispatch docs updates on latest release
 
 on:
   release:
@@ -51,13 +51,24 @@ jobs:
             echo "is_latest=false" >> $GITHUB_OUTPUT
           fi
 
-      # Dispatch to docs repo if latest
-      - name: Dispatch to docs repo
+      # Dispatch to api-docs repo if latest
+      - name: Dispatch to api-docs repo
         if: steps.latest.outputs.is_latest == 'true'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           repository: redpanda-data/api-docs
           event-type: redpanda-openapi-bundle
+          client-payload: |
+            { "tag": "${{ github.event.release.tag_name }}" }
+
+      # Dispatch to docs repo for property docs generation if latest
+      - name: Dispatch property docs generation to docs repo
+        if: steps.latest.outputs.is_latest == 'true'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ env.ACTIONS_BOT_TOKEN }}
+          repository: redpanda-data/docs
+          event-type: trigger-property-docs-generation
           client-payload: |
             { "tag": "${{ github.event.release.tag_name }}" }


### PR DESCRIPTION
Extends the GitHub Actions workflow to trigger documentation property generation in addition to the existing API docs update when a new latest Redpanda release is published.

Key changes:

Updated workflow name to reflect its broader scope beyond just Admin API docs
Added a new dispatch action to trigger property documentation generation in the docs repository
Clarified existing comments to distinguish between api-docs and docs repositories

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
