### PR TITLE
tools/buildifier: patch find behavior

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -52,6 +52,13 @@ bazel_dep(name = "bzip2", version = "1.0.8.bcr.2")
 bazel_dep(name = "googleapis", version = "0.0.0-20250703-f9d6fe4a")
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2", dev_dependency = True)
+single_version_override(
+    module_name = "buildifier_prebuilt",
+    patches = [
+        "//bazel/thirdparty:buildifier-find.patch",
+    ],
+)
+
 bazel_dep(name = "rules_shell", version = "0.4.1", dev_dependency = True)
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python", dev_dependency = True)

--- a/bazel/thirdparty/buildifier-find.patch
+++ b/bazel/thirdparty/buildifier-find.patch
@@ -1,0 +1,29 @@
+diff --git buildifier/factory.bzl buildifier/factory.bzl
+index 6a8098c..40978bc 100644
+--- buildifier/factory.bzl
++++ buildifier/factory.bzl
+@@ -133,8 +133,8 @@ def buildifier_impl_factory(ctx, *, test_rule):
+     if ctx.attr.exclude_patterns:
+         if test_rule and not ctx.attr.no_sandbox:
+             fail("Cannot use 'exclude_patterns' in a test rule without 'no_sandbox'")
+-        exclude_patterns = ["\\! -path %s" % shell.quote(pattern) for pattern in ctx.attr.exclude_patterns]
+-        exclude_patterns_str = " ".join(exclude_patterns)
++        exclude_patterns = ["-path %s" % shell.quote(pattern) for pattern in ctx.attr.exclude_patterns]
++        exclude_patterns_str = " -o ".join(exclude_patterns) + " -prune -o "
+ 
+     workspace = ""
+     if test_rule and ctx.attr.no_sandbox:
+diff --git runner.bash.template runner.bash.template
+index a23f11b..e181354 100644
+--- runner.bash.template
++++ runner.bash.template
+@@ -31,8 +31,8 @@ fi
+ 
+ # Run buildifier on all starlark files
+ find . \
+-  -type "${FIND_FILE_TYPE:-f}" \
+   @@EXCLUDE_PATTERNS@@ \
++  -type "${FIND_FILE_TYPE:-f}" \
+   \( -name '*.bzl' \
+     -o -name '*.sky' \
+     -o -name '*.bazel' \


### PR DESCRIPTION
Introduce a small patch to buildifier so that it does not fail on unreadable files, which occur in practice due to
vbuild/redpanda_installs which have root-owned files.

This is upstreamed with further details at:

https://github.com/keith/buildifier-prebuilt/pull/127

This patch is from:

https://github.com/travisdowns/buildifier-prebuilt/tree/td-perms-patch

which is on top of 8.2.0.2.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
