### PR TITLE
tests/kgo: add throughput logging to validator

### DIFF
--- a/tests/go/kgo-verifier/pkg/worker/verifier/validator_status.go
+++ b/tests/go/kgo-verifier/pkg/worker/verifier/validator_status.go
@@ -55,6 +55,9 @@ type ValidatorStatus struct {
 	// For emitting checkpoints on time intervals
 	lastCheckpoint time.Time
 
+	// User bytes read since last checkpoint (payload without protocol overhead)
+	userBytesSinceLastCheckpoint int64
+
 	// Last consumed offset per partition. Used to assert monotonicity and check for gaps.
 	lastOffsetConsumed map[int32]int64
 
@@ -77,6 +80,9 @@ func (cs *ValidatorStatus) ValidateRecord(r *kgo.Record, validRanges *TopicOffse
 	if r.Value == nil {
 		cs.TombstonesConsumed += 1
 	}
+
+	// Rough estimate of bytes read
+	cs.userBytesSinceLastCheckpoint += int64(recordUserSize(r))
 
 	if r.LeaderEpoch < cs.lastLeaderEpoch[r.Partition] {
 		log.Panicf("Out of order leader epoch on p=%d at o=%d leaderEpoch=%d. Previous leaderEpoch=%d",
@@ -183,10 +189,31 @@ func (cs *ValidatorStatus) SetMonotonicityTestStateForPartition(partition int32,
 
 func (cs *ValidatorStatus) Checkpoint() {
 	log.Infof("Validator status: %s", cs.String())
+
+	elapsed := time.Since(cs.lastCheckpoint)
+	if elapsed <= 0 {
+		return
+	}
+
+	// Calculate throughput in MB/s
+	mbRead := float64(cs.userBytesSinceLastCheckpoint) / (1024.0 * 1024.0)
+	throughput := mbRead / elapsed.Seconds()
+	log.Infof("Validator throughput (user payload): %.2f MB/s", throughput)
+
+	// Reset byte counter
+	cs.userBytesSinceLastCheckpoint = 0
 }
 
 func (cs *ValidatorStatus) String() string {
 	data, err := json.Marshal(cs)
 	util.Chk(err, "Status serialization error")
 	return string(data)
+}
+
+func recordUserSize(r *kgo.Record) int {
+	sz := len(r.Key) + len(r.Value)
+	for _, h := range r.Headers {
+		sz += len(h.Key) + len(h.Value)
+	}
+	return sz
 }


### PR DESCRIPTION
Track user bytes consumed (payload without protocol overhead) and log throughput in MB/s at each checkpoint. Useful for investigating timeouts and performance issues.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
