### PR TITLE
dt/rp: Fix filtering logic in storage usage post-check

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -4487,7 +4487,10 @@ class RedpandaService(Service, RedpandaServiceABC):
                 return False
             if file.parents[-2].name in ["cloud_storage_cache", "debug-bundle"]:
                 return False
-            if "compaction.staging" in file.name:
+            if (
+                "compaction.staging" in file.name
+                or "compaction.compaction_index" in file.name
+            ):
                 # compaction staging files are temporary and are generally
                 # cleaned up after compaction finishes, or at next round of
                 # compaction if a file was stranded. during shutdown of any

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -4485,7 +4485,7 @@ class RedpandaService(Service, RedpandaServiceABC):
             file, _ = fstat
             if len(file.parents) == 1:
                 return False
-            if file.parents[-2].name == "cloud_storage_cache":
+            if file.parents[-2].name in ["cloud_storage_cache", "debug-bundle"]:
                 return False
             if "compaction.staging" in file.name:
                 # compaction staging files are temporary and are generally


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR adds a couple of file types to the filter in `RedpandaService.raise_on_storage_usage_inconsistency`

- The entire contents of `data/debug-bundle` 
- Any file containing `compaction.compaction_index`

Reasoning is similar to other filtered files in that these are temporary files and are not accounted for by space management.

Fixes:
- [CORE-14787] 
- [CORE-14783]
- [CORE-14785]

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-14787]: https://redpandadata.atlassian.net/browse/CORE-14787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-14783]: https://redpandadata.atlassian.net/browse/CORE-14783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-14785]: https://redpandadata.atlassian.net/browse/CORE-14785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ