### PR TITLE
rptest/consumer_group_test: more cleanup on fail

### DIFF
--- a/tests/rptest/misc_tests/README.md
+++ b/tests/rptest/misc_tests/README.md
@@ -1,0 +1,4 @@
+In this directory we have miscellaneous tests which don't run anywhere by
+default, so they can include tests which fail, timeout, etc in order to
+test the ducktape handling of these things (as they can be targeted directly
+by a slash command or locally).

--- a/tests/rptest/misc_tests/hanging_test.py
+++ b/tests/rptest/misc_tests/hanging_test.py
@@ -1,0 +1,42 @@
+from ducktape.mark.resource import cluster
+from ducktape.tests.test import Test
+import threading
+import time
+
+
+class HangingTest(Test):
+    @cluster(num_nodes=0)
+    def test_hanging_thread(self):
+        # this test illustrates the hanging issue in CORE-13453
+        # see also: https://github.com/redpanda-data/redpanda/pull/28745
+        # https://github.com/redpanda-data/ducktape/pull/52
+        # https://redpandadata.atlassian.net/wiki/spaces/CORE/pages/1360658457/Diagnosing+ducktape+failures#Type-IV%3A-Hang-after-tear-down
+
+        # The whole HangingTest should be run to reproduce, test_zafter_2 will fail
+        # in addition to `test_hanging_thread` due to the cross-test corruption
+        self.logger.info("Test begin")
+
+        # create a daemon thread then fail
+        def worker():
+            while True:
+                time.sleep(1)
+
+        t0 = threading.Thread(target=worker)
+        t0.start()
+
+        t0 = threading.Thread(target=worker, daemon=True)
+        t0.start()
+
+        self.logger.info("Started non-daemon and daemon threads, now failing test.")
+
+        raise RuntimeError("Failing test after starting daemon")
+
+    @cluster(num_nodes=0)
+    def test_zafter_1(self):
+        self.logger.info("This test will now wait for 60 seconds.")
+        time.sleep(1)
+
+    @cluster(num_nodes=0)
+    def test_zafter_2(self):
+        self.logger.info("This test will now wait for 60 seconds.")
+        time.sleep(1)

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -8,6 +8,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import asyncio
+from contextlib import closing
 import random
 import threading
 import time
@@ -577,38 +579,39 @@ class ConsumerGroupTest(RedpandaTest):
         rounds = 10
         groups_in_round = 100
 
-        import asyncio
+        with closing(asyncio.new_event_loop()) as ev_loop:
 
-        ev_loop = asyncio.new_event_loop()
+            def poll_once(i):
+                try:
+                    consumer = KafkaConsumer(
+                        group_id=f"g-{i}",
+                        bootstrap_servers=self.redpanda.brokers(),
+                        enable_auto_commit=True,
+                        client_id=f"python-consumer-client-{i}",
+                    )
+                    try:
+                        consumer.subscribe([self.topic_spec.name])
+                        consumer.poll(1)
+                    finally:
+                        consumer.close(autocommit=True)
+                except Exception as e:
+                    self.logger.error(f"Failed to poll group g-{i}: {e}")
+                    raise
 
-        def poll_once(i):
-            try:
-                consumer = KafkaConsumer(
-                    group_id=f"g-{i}",
-                    bootstrap_servers=self.redpanda.brokers(),
-                    enable_auto_commit=True,
-                    client_id=f"python-consumer-client-{i}",
+            async def create_groups(r):
+                results = await asyncio.gather(
+                    *[
+                        asyncio.to_thread(poll_once, i + r * groups_in_round)
+                        for i in range(groups_in_round)
+                    ],
+                    return_exceptions=True,
                 )
-                consumer.subscribe([self.topic_spec.name])
-                consumer.poll(1)
-                consumer.close(autocommit=True)
-            except Exception as e:
-                self.logger.error(f"Failed to poll group g-{i}: {e}")
-                raise
+                for res in results:
+                    if isinstance(res, BaseException):
+                        raise res
 
-        async def create_groups(r):
-            await asyncio.gather(
-                *[
-                    asyncio.to_thread(poll_once, i + r * groups_in_round)
-                    for i in range(groups_in_round)
-                ]
-            )
-
-        for r in range(rounds):
-            ev_loop.run_until_complete(create_groups(r))
-
-        ev_loop.stop()
-        ev_loop.close()
+            for r in range(rounds):
+                ev_loop.run_until_complete(create_groups(r))
 
         rpk = RpkTool(self.redpanda)
         list = rpk.group_list_names()


### PR DESCRIPTION
This test has been observing hanging after failure: tear down completes but the process does not finish. This happens when the test itself is failing to do an exception. See for example test_large_group_count in:

https://ci-artifacts.dev.vectorized.cloud/production-devprod/vtools/26190/019ab4e2-0265-4063-8faa-0c08b34b9266/vbuild/ducktape/results/2025-11-24--001/report.html

The most likely candidates is threads hanging around which have not exited. This is a corrupting failure, i.e., can fail other concurrently running tests.

We are making some changes on the DT side to help diagnose these better but for this specific test, do the following:

 - Always close the event loop, even on expcetion, using context manager
 - In asycio.gather execute all the tasks if some fail, so that they have time to finish and clean up
 - In the group poll tasks, use try/finally to ensure we close the consumer even on exception

Also add a "hanging test" in `misc_tests` (never run) which illustrates the issue in a standalone reproducer.

[CORE-13453]

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none


[CORE-13453]: https://redpandadata.atlassian.net/browse/CORE-13453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ