### PR TITLE
bazel: remove kafka/server dep from txn_reader

### DIFF
--- a/src/v/kafka/utils/BUILD
+++ b/src/v/kafka/utils/BUILD
@@ -10,7 +10,6 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         "//src/v/kafka/data:partition_proxy",
-        "//src/v/kafka/server",
         "//src/v/storage",
         "@abseil-cpp//absl/container:btree",
         "@fmt",


### PR DESCRIPTION
## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
