### PR TITLE
Partition balancer planner quorum loss

### DIFF
--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -363,6 +363,12 @@ void partition_balancer_planner::init_per_node_state(
         }
 
         if (time_since_last_seen > _config.node_availability_timeout_sec) {
+            vlog(
+              clusterlog.info,
+              "node {} is unresponsive and unavailable, time since last status "
+              "reply: {} ms",
+              id,
+              time_since_last_seen / 1ms);
             ctx.timed_out_unavailable_nodes.insert(id);
 
             if (
@@ -980,7 +986,13 @@ auto partition_balancer_planner::request_context::do_with_partition(
         if (state == reconfiguration_state::in_progress) {
             // partition is dead in the water, it lost quorum in the middle of
             // moving
+
             if (!has_quorum(all_unavailable_nodes, orig_replicas)) {
+                vlog(
+                  clusterlog.trace,
+                  "[{}] in progress move found to have source replica quorum "
+                  "loss",
+                  ntp);
                 partition part{immutable_partition{
                   ntp,
                   orig_replicas,
@@ -1549,15 +1561,6 @@ ss::future<> partition_balancer_planner::get_node_drain_actions(
   const absl::flat_hash_set<model::node_id>& nodes,
   change_reason reason) {
     if (nodes.empty()) {
-        co_return;
-    }
-
-    if (std::all_of(nodes.begin(), nodes.end(), [&](model::node_id id) {
-            auto it = ctx.allocation_nodes().find(id);
-            return it != ctx.allocation_nodes().end()
-                   && it->second->final_partitions()() == 0;
-        })) {
-        // all nodes already drained
         co_return;
     }
 

--- a/src/v/cluster/tests/partition_balancer_simulator_test.cc
+++ b/src/v/cluster/tests/partition_balancer_simulator_test.cc
@@ -30,6 +30,8 @@ static constexpr size_t recovery_batch_size = 512_KiB;
 static constexpr size_t recovery_throttle_burst = 100_MiB;
 static constexpr size_t recovery_throttle_ticks_between_refills = 10;
 
+static constexpr auto node_responsiveness_timeout = std::chrono::seconds(10);
+
 class partition_balancer_sim_fixture {
 public:
     void add_node(
@@ -67,6 +69,8 @@ public:
         _nodes.emplace(
           id, node_state{.id = id, .total = total_size, .used = initial_used});
     }
+
+    void remove_node(model::node_id id) { _nodes.erase(id); }
 
     const auto& nodes() const { return _nodes; }
 
@@ -229,39 +233,43 @@ public:
 
     // return the number of scheduled actions
     size_t run_balancer() {
+        auto plan_data = do_run_balancer();
+
+        logger.info(
+          "planned action counts: reassignments: {}, cancellations: {}, "
+          "failed: {}",
+          plan_data.reassignments.size(),
+          plan_data.cancellations.size(),
+          plan_data.failed_actions_count);
+
+        size_t actions_count = plan_data.reassignments.size()
+                               + plan_data.cancellations.size();
+
+        _last_run_in_progress_updates
+          = _workers.table.local().updates_in_progress().size() + actions_count;
+
+        for (const auto& reassignment : plan_data.reassignments) {
+            dispatch_move(reassignment.ntp, reassignment.allocated.replicas());
+        }
+        for (const auto& ntp : plan_data.cancellations) {
+            dispatch_cancel(ntp);
+        }
+
+        return actions_count;
+    }
+
+    // run the balancer planner, return its plan
+    cluster::partition_balancer_planner::plan_data do_run_balancer() {
         auto hr = create_health_report();
         populate_node_status_table();
 
         auto planner = make_planner();
 
-        {
-            ss::abort_source as;
-            auto plan_data = planner.plan_actions(hr, as).get();
+        ss::abort_source as;
 
-            logger.info(
-              "planned action counts: reassignments: {}, cancellations: {}, "
-              "failed: {}",
-              plan_data.reassignments.size(),
-              plan_data.cancellations.size(),
-              plan_data.failed_actions_count);
+        auto plan_data = planner.plan_actions(hr, as).get();
 
-            size_t actions_count = plan_data.reassignments.size()
-                                   + plan_data.cancellations.size();
-
-            _last_run_in_progress_updates
-              = _workers.table.local().updates_in_progress().size()
-                + actions_count;
-
-            for (const auto& reassignment : plan_data.reassignments) {
-                dispatch_move(
-                  reassignment.ntp, reassignment.allocated.replicas());
-            }
-            for (const auto& ntp : plan_data.cancellations) {
-                dispatch_cancel(ntp);
-            }
-
-            return actions_count;
-        }
+        return plan_data;
     }
 
     size_t last_run_in_progress_updates() const {
@@ -523,7 +531,7 @@ private:
             .max_concurrent_actions = 50,
             .node_availability_timeout_sec = std::chrono::minutes(1),
             .segment_fallocation_step = 16_MiB,
-            .node_responsiveness_timeout = std::chrono::seconds(10),
+            .node_responsiveness_timeout = node_responsiveness_timeout,
             .topic_aware = true,
           },
           _workers.state.local(),
@@ -977,4 +985,42 @@ FIXTURE_TEST(test_mixed_replication_factors, partition_balancer_sim_fixture) {
     BOOST_REQUIRE(run_to_completion(total_replicas() * 3));
     set_decommissioning(model::node_id{4});
     BOOST_REQUIRE(run_to_completion(total_replicas() * 3));
+}
+
+// this test checks that the partition balancer planner will report
+// reallocation failures when a decommissioning node's partitions have lost
+// source quorum
+//
+// 1. create a number of RF=1 partitions
+// 2. decommission a node to start partition moves
+// 3. remove the decommissioned node, wait for it to be deemed unresponsive
+// 4. run the planner again to check that the moving partitions have become
+//    reallocation failures
+FIXTURE_TEST(
+  test_report_dead_decom_as_realloc_failure, partition_balancer_sim_fixture) {
+    add_node(model::node_id{0}, 100_GiB, 1);
+    add_node(model::node_id{1}, 100_GiB, 1);
+    add_node(model::node_id{2}, 100_GiB, 1);
+
+    model::node_id node_to_kill{1};
+
+    // if randomly distributed, 10^-6 probability that no partition lands on
+    // node_to_kill
+    for (int i = 0; i < 33; ++i) {
+        add_topic(fmt::format("topic_rf_1_iteration_{}", i), 1, 1, 10_MiB);
+    }
+
+    run_balancer();
+
+    // start a decommission and run the planner
+    set_decommissioning(node_to_kill);
+    std::ignore = do_run_balancer();
+
+    remove_node(node_to_kill);
+
+    // guarantee that the node will be deemed unresponsive
+    ss::sleep(node_responsiveness_timeout + 1s).get();
+
+    auto plan = do_run_balancer();
+    BOOST_REQUIRE(plan.reallocation_failures.size() > 0);
 }


### PR DESCRIPTION
Changes get_node_drain_actions to remove early exit.

Previously if all replicas on all draining nodes had existing moves to
elsewhere in the cluster, get_node_drain_actions would exit early.

This prevented partition_balancer_planner from identifying these
partitions as having reallocation failures in the case of a partition
losing its source quorum.

Without this check, so long as there is an ongoing decommission,
partition_balancer_planner will reevaluate the draining partitions and
report out correctly.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
### Improvements

* Partition balancer reallocation failures now includes moves which lost source quorum

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
