### PR TITLE
[v25.3.x] bazel: remove kafka/server dep from txn_reader

### DIFF
--- a/src/v/kafka/utils/BUILD
+++ b/src/v/kafka/utils/BUILD
@@ -10,7 +10,6 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         "//src/v/kafka/data:partition_proxy",
-        "//src/v/kafka/server",
         "//src/v/storage",
         "@abseil-cpp//absl/container:btree",
         "@fmt",


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28747
