### PR TITLE
rpk: print config export message to stderr so that when stdout is used as the export file the message doesn't interfere

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/config/export.go
+++ b/src/go/rpk/pkg/cli/cluster/config/export.go
@@ -174,7 +174,7 @@ to include all properties including these low level tunables.
 			err = exportConfig(file, schema, currentConfig, all)
 			out.MaybeDie(err, "failed to write out config %q: %v", file.Name(), err)
 			err = file.Close()
-			fmt.Printf("Wrote configuration to file %q.\n", file.Name())
+			fmt.Fprintf(os.Stderr, "Wrote configuration to file %q.\n", file.Name())
 			out.MaybeDie(err, "error closing file %q: %v", file.Name(), err)
 		},
 	}


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements

- The message printed by `rpk config export` is now written to stderr instead of stdout, preventing it from interfering with the exported configuration when stdout is used as the output destination. i.e. `rpk config export --all -f /dev/stdout`
