### PR TITLE
[v25.3.x] rpk: print config export message to stderr so that when stdout is used as the export file the message doesn't interfere

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/config/export.go
+++ b/src/go/rpk/pkg/cli/cluster/config/export.go
@@ -174,7 +174,7 @@ to include all properties including these low level tunables.
 			err = exportConfig(file, schema, currentConfig, all)
 			out.MaybeDie(err, "failed to write out config %q: %v", file.Name(), err)
 			err = file.Close()
-			fmt.Printf("Wrote configuration to file %q.\n", file.Name())
+			fmt.Fprintf(os.Stderr, "Wrote configuration to file %q.\n", file.Name())
 			out.MaybeDie(err, "error closing file %q: %v", file.Name(), err)
 		},
 	}


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28760
