### PR TITLE
`container`: add reverse iterators to `chunked_vector`

### DIFF
--- a/src/v/container/chunked_vector.h
+++ b/src/v/container/chunked_vector.h
@@ -482,6 +482,9 @@ public:
     using const_iterator = iter<true>;
     using iterator = iter<false>;
 
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+
     iterator begin() { return iterator(this, 0); }
     iterator end() { return iterator(this, _size); }
 
@@ -490,6 +493,23 @@ public:
 
     const_iterator cbegin() const { return const_iterator(this, 0); }
     const_iterator cend() const { return const_iterator(this, _size); }
+
+    reverse_iterator rbegin() { return reverse_iterator(end()); }
+    reverse_iterator rend() { return reverse_iterator(begin()); }
+
+    const_reverse_iterator rbegin() const {
+        return const_reverse_iterator(end());
+    }
+    const_reverse_iterator rend() const {
+        return const_reverse_iterator(begin());
+    }
+
+    const_reverse_iterator crbegin() const {
+        return const_reverse_iterator(end());
+    }
+    const_reverse_iterator crend() const {
+        return const_reverse_iterator(begin());
+    }
 
     /**
      * @brief Erases all elements from begin to the end of the vector.

--- a/src/v/container/tests/chunked_vector_test.cc
+++ b/src/v/container/tests/chunked_vector_test.cc
@@ -263,6 +263,8 @@ TEST(Vector, IteratorTypes) {
     using vtype = chunked_vector<int64_t>;
     using iter = vtype::iterator;
     using citer = vtype::const_iterator;
+    using riter = vtype::reverse_iterator;
+    using criter = vtype::const_reverse_iterator;
     auto v = vtype{};
 
     // const and non-const iterators should be different!
@@ -273,6 +275,16 @@ TEST(Vector, IteratorTypes) {
     static_assert(std::is_same_v<
                   decltype(std::as_const(v).begin()),
                   decltype(v)::const_iterator>);
+
+    // const and non-const reverse iterators should be different!
+    static_assert(!std::is_same_v<riter, criter>);
+    static_assert(std::is_same_v<decltype(v.rbegin()), riter>);
+    static_assert(
+      std::
+        is_same_v<decltype(v.crbegin()), decltype(v)::const_reverse_iterator>);
+    static_assert(std::is_same_v<
+                  decltype(std::as_const(v).rbegin()),
+                  decltype(v)::const_reverse_iterator>);
 }
 
 struct foo {
@@ -293,7 +305,18 @@ TEST(Vector, IteratorAccess) {
     EXPECT_EQ(vec.begin()->a, 2);
 }
 
-TEST(Vector, IteartorArithmetic) {
+TEST(Vector, ReverseIteratorAccess) {
+    using vtype = chunked_vector<foo>;
+    auto vec = vtype{};
+    vec.push_back(foo{2});
+    vec.push_back(foo{3});
+
+    EXPECT_EQ(*vec.rbegin(), foo{3});
+    EXPECT_EQ((*vec.rbegin()).a, 3);
+    EXPECT_EQ(vec.rbegin()->a, 3);
+}
+
+TEST(Vector, IteratorArithmetic) {
     auto v = checker<int64_t>::make({0, 1, 2, 3});
 
     auto b = v->begin();
@@ -311,6 +334,26 @@ TEST(Vector, IteartorArithmetic) {
     EXPECT_EQ(*(e - 2), 2);
     EXPECT_EQ(*(e - 3), 1);
     EXPECT_EQ(*(e - 4), 0);
+}
+
+TEST(Vector, ReverseIteratorArithmetic) {
+    auto v = checker<int64_t>::make({0, 1, 2, 3});
+
+    auto b = v->rbegin();
+
+    EXPECT_EQ(*(b + 0), 3);
+    EXPECT_EQ(*(b + 1), 2);
+    EXPECT_EQ(*(b + 2), 1);
+    EXPECT_EQ(*(b + 3), 0);
+
+    auto e = v->rend();
+
+    EXPECT_EQ((e - 0), e);
+
+    EXPECT_EQ(*(e - 1), 0);
+    EXPECT_EQ(*(e - 2), 1);
+    EXPECT_EQ(*(e - 3), 2);
+    EXPECT_EQ(*(e - 4), 3);
 }
 
 TEST(Vector, IteratorCmp) {


### PR DESCRIPTION

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
