### PR TITLE
Auto decommission pillory PR

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -796,6 +796,8 @@ ss::future<> controller::start(
       config::shard_local_cfg()
         .partition_autobalancing_node_availability_timeout_sec.bind(),
       config::shard_local_cfg()
+        .partition_autobalancing_node_autodecommission_time.bind(),
+      config::shard_local_cfg()
         .partition_autobalancing_max_disk_usage_percent.bind(),
       config::shard_local_cfg().partition_autobalancing_tick_interval_ms.bind(),
       config::shard_local_cfg().partition_autobalancing_concurrent_moves.bind(),

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -54,6 +54,7 @@ partition_balancer_backend::partition_balancer_backend(
   ss::sharded<topics_frontend>& topics_frontend,
   ss::sharded<members_frontend>& members_frontend,
   config::binding<std::chrono::seconds>&& availability_timeout,
+  config::binding<std::chrono::seconds>&& decommission_timeout,
   config::binding<unsigned> max_disk_usage_percent,
   config::binding<std::chrono::milliseconds>&& tick_interval,
   config::binding<size_t>&& max_concurrent_actions,
@@ -76,6 +77,7 @@ partition_balancer_backend::partition_balancer_backend(
         features::license_required_feature::
           partition_auto_balancing_continuous>())
   , _availability_timeout(std::move(availability_timeout))
+  , _decommission_timeout(std::move(decommission_timeout))
   , _max_disk_usage_percent(std::move(max_disk_usage_percent))
   , _tick_interval(std::move(tick_interval))
   , _max_concurrent_actions(std::move(max_concurrent_actions))
@@ -448,7 +450,8 @@ ss::future<> partition_balancer_backend::do_tick() {
           "violations: unavailable nodes: {}, full nodes: {}; "
           "nodes to rebalance count: {}; on demand rebalance requested: {}; "
           "updates in progress: {}; "
-          "action counts: reassignments: {}, cancellations: {}, failed: {}; "
+          "action counts: reassignments: {}, cancellations: {}, nodes to "
+          "decommission: {}, failed: {}; "
           "counts rebalancing finished: {}, force refresh health report: {}",
           _cur_term->last_status,
           _cur_term->last_violations.unavailable_nodes.size(),
@@ -458,6 +461,7 @@ ss::future<> partition_balancer_backend::do_tick() {
           _state.topics().updates_in_progress().size(),
           plan_data.reassignments.size(),
           plan_data.cancellations.size(),
+          plan_data.decommissions.size(),
           plan_data.failed_actions_count,
           plan_data.counts_rebalancing_finished,
           _cur_term->_force_health_report_refresh);
@@ -549,6 +553,24 @@ ss::future<> partition_balancer_backend::do_tick() {
     _cur_term->last_tick_in_progress_updates = moves_before
                                                + plan_data.cancellations.size()
                                                + plan_data.reassignments.size();
+
+    for (auto node_to_decommission : plan_data.decommissions) {
+        vlog(
+          clusterlog.info,
+          "submitting decommission on unresponsive node: {}",
+          node_to_decommission);
+
+        auto decom_error = co_await _members_frontend.decommission_node(
+          node_to_decommission);
+
+        if (decom_error) {
+            vlog(
+              clusterlog.warn,
+              "node: {}, failed to decommission with error: {}",
+              node_to_decommission,
+              decom_error);
+        }
+    }
 }
 
 partition_balancer_overview_reply partition_balancer_backend::overview() const {

--- a/src/v/cluster/partition_balancer_backend.h
+++ b/src/v/cluster/partition_balancer_backend.h
@@ -43,6 +43,7 @@ public:
       ss::sharded<topics_frontend>&,
       ss::sharded<members_frontend>&,
       config::binding<std::chrono::seconds>&& availability_timeout,
+      config::binding<std::chrono::seconds>&& decommission_timeout,
       config::binding<unsigned> max_disk_usage_percent,
       config::binding<std::chrono::milliseconds>&& tick_interval,
       config::binding<size_t>&& max_concurrent_actions,
@@ -102,6 +103,7 @@ private:
       config::enum_property<model::partition_autobalancing_mode>>
       _mode;
     config::binding<std::chrono::seconds> _availability_timeout;
+    config::binding<std::chrono::seconds> _decommission_timeout;
     config::binding<unsigned> _max_disk_usage_percent;
     config::binding<std::chrono::milliseconds> _tick_interval;
     config::binding<size_t> _max_concurrent_actions;

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -23,6 +23,7 @@
 #include "cluster/scheduling/types.h"
 #include "cluster/types.h"
 #include "container/chunked_hash_map.h"
+#include "model/metadata.h"
 #include "model/namespace.h"
 #include "random/generators.h"
 #include "ssx/sformat.h"
@@ -31,8 +32,11 @@
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/util/defer.hh>
 
+#include <algorithm>
 #include <functional>
+#include <iterator>
 #include <optional>
+#include <ranges>
 
 namespace cluster {
 
@@ -260,6 +264,9 @@ private:
       _topic2node_counts;
     absl::node_hash_map<model::ntp, reassignment_info> _reassignments;
     absl::node_hash_map<model::ntp, allocated_partition> _force_reassignments;
+    // nodes to request to decommission, not nodes which are currently
+    // decommissioning
+    absl::flat_hash_set<model::node_id> _decommissionable_nodes;
     size_t _failed_actions_count = 0;
     // we track missing partition size info separately as it requires force
     // refresh of health report
@@ -362,11 +369,10 @@ void partition_balancer_planner::init_per_node_state(
             ctx.all_unavailable_nodes.insert(id);
         }
 
-        if (time_since_last_seen > _config.node_availability_timeout_sec) {
-            ctx.timed_out_unavailable_nodes.insert(id);
-
-            if (
-              _config.mode == model::partition_autobalancing_mode::continuous) {
+        if (_config.mode == model::partition_autobalancing_mode::continuous) {
+            // get all the nodes which are unresponsive enough to drain
+            if (time_since_last_seen > _config.node_availability_timeout_sec) {
+                ctx.timed_out_unavailable_nodes.insert(id);
                 model::timestamp unavailable_since = model::to_timestamp(
                   model::timestamp_clock::now()
                   - std::chrono::duration_cast<
@@ -375,52 +381,61 @@ void partition_balancer_planner::init_per_node_state(
                 result.violations.unavailable_nodes.emplace_back(
                   id, unavailable_since);
             }
-        }
-    }
 
-    for (const auto& node_report : health_report.node_reports) {
-        if (
-          ctx.config().space_management_enabled
-          && !node_report->local_state.log_data_size) {
-            // Since space management is enabled, we expect log_data_size to be
-            // present in the health report. If it is not present, probably the
-            // node was recently restarted and hasn't yet had time to calculate
-            // it for the first time. To avoid possible skew caused by using raw
-            // disk usage numbers for some nodes and not the others, we skip
-            // this disk report.
-            continue;
+            // get all nodes which are unresponsive enough to decom
+            if (time_since_last_seen > _config.decommission_timeout) {
+                if (!ctx.decommissioning_nodes.contains(id)) {
+                    ctx._decommissionable_nodes.insert(id);
+                }
+            }
         }
 
-        const auto [total, free] = get_node_bytes_info(
-          node_report->local_state);
-        auto disk_info = node_disk_space{node_report->id, total, total - free};
-        const bool is_full = disk_info.original_used_ratio()
-                             > _config.max_disk_usage_ratio;
-        vlogl(
-          clusterlog,
-          is_full ? ss::log_level::info : ss::log_level::debug,
-          "node {} disk used: {}, total: {} (ratio: {:.4}, is_full: {}), "
-          "node report: {}",
-          node_report->id,
-          human::bytes(disk_info.used),
-          human::bytes(disk_info.total),
-          disk_info.original_used_ratio(),
-          is_full,
-          node_report->local_state);
-        ctx.node_disk_reports.emplace(node_report->id, disk_info);
+        for (const auto& node_report : health_report.node_reports) {
+            if (
+              ctx.config().space_management_enabled
+              && !node_report->local_state.log_data_size) {
+                // Since space management is enabled, we expect log_data_size to
+                // be present in the health report. If it is not present,
+                // probably the node was recently restarted and hasn't yet had
+                // time to calculate it for the first time. To avoid possible
+                // skew caused by using raw disk usage numbers for some nodes
+                // and not the others, we skip this disk report.
+                continue;
+            }
 
-        if (
-          is_full
-          && _config.mode == model::partition_autobalancing_mode::continuous) {
-            result.violations.full_nodes.emplace_back(
+            const auto [total, free] = get_node_bytes_info(
+              node_report->local_state);
+            auto disk_info = node_disk_space{
+              node_report->id, total, total - free};
+            const bool is_full = disk_info.original_used_ratio()
+                                 > _config.max_disk_usage_ratio;
+            vlogl(
+              clusterlog,
+              is_full ? ss::log_level::info : ss::log_level::debug,
+              "node {} disk used: {}, total: {} (ratio: {:.4}, is_full: {}), "
+              "node report: {}",
               node_report->id,
-              uint32_t(disk_info.original_used_ratio() * 100.0));
-        }
-    }
+              human::bytes(disk_info.used),
+              human::bytes(disk_info.total),
+              disk_info.original_used_ratio(),
+              is_full,
+              node_report->local_state);
+            ctx.node_disk_reports.emplace(node_report->id, disk_info);
 
-    for (model::node_id id : ctx.all_nodes) {
-        if (!ctx.node_disk_reports.contains(id)) {
-            vlog(clusterlog.info, "node {}: no disk report", id);
+            if (
+              is_full
+              && _config.mode
+                   == model::partition_autobalancing_mode::continuous) {
+                result.violations.full_nodes.emplace_back(
+                  node_report->id,
+                  uint32_t(disk_info.original_used_ratio() * 100.0));
+            }
+        }
+
+        for (model::node_id id : ctx.all_nodes) {
+            if (!ctx.node_disk_reports.contains(id)) {
+                vlog(clusterlog.info, "node {}: no disk report", id);
+            }
         }
     }
 }
@@ -453,8 +468,8 @@ ss::future<> partition_balancer_planner::init_ntp_sizes_from_health_report(
                     non_reclaimable = ctx.config().segment_fallocation_step;
                 }
 
-                // assume that the "true" non-reclaimable size is the max of all
-                // replicas.
+                // assume that the "true" non-reclaimable size is the max of
+                // all replicas.
                 sizes.non_reclaimable = std::max(
                   sizes.non_reclaimable, non_reclaimable);
             }
@@ -532,8 +547,8 @@ partition_balancer_planner::init_topic_node_counts(request_context& ctx) {
                 counts[bs.node_id] += 1;
             }
             // NOTE: we can't use ssx::async_for_each_counter here, as there
-            // would be no way to call it.check() immediately after maybe_yield
-            // (and before we check the range bounds).
+            // would be no way to call it.check() immediately after
+            // maybe_yield (and before we check the range bounds).
             co_await ss::coroutine::maybe_yield();
             it.check();
         }
@@ -792,7 +807,8 @@ public:
     }
 
     enum class immutability_reason {
-        // not enough replicas on live nodes, reassignment unlikely to succeed
+        // not enough replicas on live nodes, reassignment unlikely to
+        // succeed
         no_quorum,
         // no partition size information
         no_size_info,
@@ -978,8 +994,8 @@ auto partition_balancer_planner::request_context::do_with_partition(
         }
 
         if (state == reconfiguration_state::in_progress) {
-            // partition is dead in the water, it lost quorum in the middle of
-            // moving
+            // partition is dead in the water, it lost quorum in the middle
+            // of moving
             if (!has_quorum(all_unavailable_nodes, orig_replicas)) {
                 partition part{immutable_partition{
                   ntp,
@@ -1111,8 +1127,8 @@ auto partition_balancer_planner::request_context::do_with_partition(
                   ntp, std::move(*reassignable._reallocated));
             }
         } else if (reassignment_it != _reassignments.end()) {
-            // We no longer need to reassign this partition (presumably due to
-            // revert)
+            // We no longer need to reassign this partition (presumably due
+            // to revert)
             _reassignments.erase(reassignment_it);
         }
     });
@@ -1270,11 +1286,13 @@ partition_balancer_planner::reassignable_partition::move_replica(
     }
 
     // Verify that we are moving only original replicas. This assumption
-    // simplifies the code considerably (although in the future nothing stops us
-    // from supporting moving already moved replicas several times).
+    // simplifies the code considerably (although in the future nothing
+    // stops us from supporting moving already moved replicas several
+    // times).
     vassert(
       _reallocated->partition.is_original(replica),
-      "ntp {}: trying to move replica {} which was already reassigned earlier",
+      "ntp {}: trying to move replica {} which was already reassigned "
+      "earlier",
       _ntp,
       replica);
 
@@ -1311,8 +1329,8 @@ partition_balancer_planner::reassignable_partition::move_replica(
           reason);
 
         /**
-         * Reallocation may require policy update as previous reason might have
-         * been different.
+         * Reallocation may require policy update as previous reason might
+         * have been different.
          */
         _reallocated->reconfiguration_policy
           = request_context::update_reconfiguration_policy(
@@ -1542,7 +1560,8 @@ void partition_balancer_planner::force_reassignable_partition::
 
 /*
  * Function is trying to move ntp out of unavailable nodes
- * It can move to nodes that are violating soft_max_disk_usage_ratio constraint
+ * It can move to nodes that are violating soft_max_disk_usage_ratio
+ * constraint
  */
 ss::future<> partition_balancer_planner::get_node_drain_actions(
   request_context& ctx,
@@ -1618,15 +1637,15 @@ ss::future<> partition_balancer_planner::get_node_drain_actions(
 }
 
 /// Try to fix ntps that have several replicas in one rack (these ntps can
-/// appear because rack awareness constraint is not a hard constraint, e.g. when
-/// a rack dies and we move all replicas that resided on dead nodes to live
-/// ones).
+/// appear because rack awareness constraint is not a hard constraint, e.g.
+/// when a rack dies and we move all replicas that resided on dead nodes to
+/// live ones).
 ///
-/// We go over all such ntps (a list maintained by partition_balancer_state) and
-/// if the number of currently live racks is more than the number of racks that
-/// the ntp is replicated to, we try to schedule a move. For each rack we
-/// arbitrarily choose the first appearing replica to remain there (note: this
-/// is probably not optimal choice).
+/// We go over all such ntps (a list maintained by partition_balancer_state)
+/// and if the number of currently live racks is more than the number of
+/// racks that the ntp is replicated to, we try to schedule a move. For each
+/// rack we arbitrarily choose the first appearing replica to remain there
+/// (note: this is probably not optimal choice).
 ss::future<> partition_balancer_planner::get_rack_constraint_repair_actions(
   request_context& ctx) {
     if (ctx.state().ntps_with_broken_rack_constraint().empty()) {
@@ -1706,8 +1725,8 @@ ss::future<> partition_balancer_planner::get_rack_constraint_repair_actions(
 }
 
 /**
- * This is the place where we decide about the order in which partitions will be
- * moved in the case when node disk is being full.
+ * This is the place where we decide about the order in which partitions
+ * will be moved in the case when node disk is being full.
  */
 size_t partition_balancer_planner::calculate_full_disk_partition_move_priority(
   model::node_id node_id,
@@ -1724,7 +1743,8 @@ size_t partition_balancer_planner::calculate_full_disk_partition_move_priority(
      *      (min_default_priority, min_internal_partition_priority]
      *
      *  - small partition (which size is bellow the size threshold)
-     *        (min_internal_partition_priority, min_small_partition_priority]
+     *        (min_internal_partition_priority,
+     * min_small_partition_priority]
      */
     enum priority_tiers : size_t {
         max_priority = 1000000,
@@ -1743,9 +1763,9 @@ size_t partition_balancer_planner::calculate_full_disk_partition_move_priority(
       = priority_tiers::max_priority - priority_tiers::min_default_priority;
 
     // clamp partition size with the total disk space to have well defined
-    // behavior in case the size is incorrectly reported, this is required as we
-    // normalize the size with disk capacity and we do not want the ration of
-    // p_size/disk_capacity to be larger than 1.0.
+    // behavior in case the size is incorrectly reported, this is required
+    // as we normalize the size with disk capacity and we do not want the
+    // ration of p_size/disk_capacity to be larger than 1.0.
     const size_t partition_size = std::min(
       p.sizes().get_current(node_id), it->second.total);
 
@@ -1760,8 +1780,8 @@ size_t partition_balancer_planner::calculate_full_disk_partition_move_priority(
                + min_small_partition_priority;
     }
     /**
-     * Assign internal partitions to its priority tier, order from smallest to
-     * largest one (the same as all other partitions)
+     * Assign internal partitions to its priority tier, order from smallest
+     * to largest one (the same as all other partitions)
      */
     if (
       p.ntp().ns == model::kafka_internal_namespace
@@ -1774,19 +1794,19 @@ size_t partition_balancer_planner::calculate_full_disk_partition_move_priority(
                + priority_tiers::min_internal_partition_priority;
     }
 
-    // normalize and offset to match the default partition priority tier, where
-    // max value would represent a partition that is of the full disk capacity
-    // size. We subtract it from the max priority to prioritize smallest
-    // partitions.
+    // normalize and offset to match the default partition priority tier,
+    // where max value would represent a partition that is of the full disk
+    // capacity size. We subtract it from the max priority to prioritize
+    // smallest partitions.
     return (default_range - (default_range * partition_size) / it->second.total)
            + priority_tiers::min_default_priority;
 }
 
 /*
  * Function is trying to move ntps out of node that are violating
- * soft_max_disk_usage_ratio. It takes nodes in reverse used space ratio order.
- * For each node it is trying to collect set of partitions to move. Partitions
- * are selected in ascending order of their size.
+ * soft_max_disk_usage_ratio. It takes nodes in reverse used space ratio
+ * order. For each node it is trying to collect set of partitions to move.
+ * Partitions are selected in ascending order of their size.
  *
  * If more than one replica in a group is on a node violating disk usage
  * constraints, we try to reallocate all such replicas. Some of reallocation
@@ -1824,7 +1844,8 @@ partition_balancer_planner::get_full_node_actions(request_context& ctx) {
         }
     };
 
-    // build an index of move candidates: full node -> movement priority -> ntp
+    // build an index of move candidates: full node -> movement priority ->
+    // ntp
     absl::flat_hash_map<
       model::node_id,
       absl::btree_multimap<size_t, model::ntp, std::greater<>>>
@@ -1852,8 +1873,8 @@ partition_balancer_planner::get_full_node_actions(request_context& ctx) {
         return ss::stop_iteration::no;
     });
 
-    // move partitions, starting from partitions with replicas on the most full
-    // node
+    // move partitions, starting from partitions with replicas on the most
+    // full node
     for (const auto* node_disk : sorted_full_nodes) {
         if (!ctx.can_add_reassignment()) {
             co_return;
@@ -1901,8 +1922,8 @@ partition_balancer_planner::get_full_node_actions(request_context& ctx) {
                           }
                       }
 
-                      // Try to reallocate replicas starting from the most full
-                      // node
+                      // Try to reallocate replicas starting from the most
+                      // full node
                       std::sort(
                         full_node_replicas.begin(),
                         full_node_replicas.end(),
@@ -2017,20 +2038,20 @@ ss::future<> partition_balancer_planner::get_counts_rebalancing_actions(
 
     double orig_objective = calc_objective();
 
-    // The algorithm is simple: just go over all replicas and try to move them
-    // to a better node (this is driven by allocation constraints). If we
-    // haven't been able to improve the objective, this means that we've reached
-    // (local) optimum and rebalance can be finished.
+    // The algorithm is simple: just go over all replicas and try to move
+    // them to a better node (this is driven by allocation constraints). If
+    // we haven't been able to improve the objective, this means that we've
+    // reached (local) optimum and rebalance can be finished.
 
     bool should_stop = true;
     co_await ctx.for_each_replica_random_order(
       [&](partition& part, model::node_id node) {
           if (!ctx.can_add_reassignment()) {
-              // Finish early, even though in theory we could add more replica
-              // moves to existing reassignments. The reason is that this will
-              // bias the algorithm towards adding more moves to partitions
-              // that we already reassigned, which we want to avoid (to avoid
-              // formation of isolated replica subsets).
+              // Finish early, even though in theory we could add more
+              // replica moves to existing reassignments. The reason is that
+              // this will bias the algorithm towards adding more moves to
+              // partitions that we already reassigned, which we want to
+              // avoid (to avoid formation of isolated replica subsets).
               should_stop = false;
               return ss::stop_iteration::yes;
           }
@@ -2173,6 +2194,11 @@ void partition_balancer_planner::request_context::collect_actions(
       || result.counts_rebalancing_finished) {
         result.status = status::actions_planned;
     }
+
+    result.decommissions.reserve(_decommissionable_nodes.size());
+    std::ranges::move(
+      std::move(_decommissionable_nodes),
+      std::back_inserter(result.decommissions));
 }
 
 ss::future<partition_balancer_planner::plan_data>
@@ -2211,7 +2237,10 @@ partition_balancer_planner::plan_actions(
           change_reason::node_unavailable);
         co_await get_full_node_actions(ctx);
         co_await get_rack_constraint_repair_actions(ctx);
+        // get node decommission actions is already part of
+        // init_per_node_state
     }
+
     co_await get_counts_rebalancing_actions(ctx);
     co_await get_force_repair_actions(ctx);
 

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -42,7 +42,12 @@ struct planner_config {
     double max_disk_usage_ratio;
     // Max number of actions that can be scheduled in one planning iteration
     size_t max_concurrent_actions;
+    // If a node is unresponsive for more than node_availability_timeout_sec,
+    // begin moving partitions off of that node
     std::chrono::seconds node_availability_timeout_sec;
+    // If a node is unresponsive for more than decommission timeout, launch a
+    // decommission operation against it
+    std::chrono::seconds decommission_timeout;
     // If the user manually requested a rebalance (not connected to node
     // addition)
     bool ondemand_rebalance_requested = false;
@@ -86,6 +91,7 @@ public:
         chunked_vector<model::ntp> cancellations;
         chunked_hash_map<model::ntp, reallocation_failure_details>
           reallocation_failures;
+        chunked_vector<model::node_id> decommissions;
         bool counts_rebalancing_finished = false;
         size_t failed_actions_count = 0;
         status status = status::empty;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3311,6 +3311,15 @@ configuration::configuration()
       "`continuous`.      ",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       15min)
+  , partition_autobalancing_node_autodecommission_time(
+      *this,
+      "partition_autobalancing_node_autodecommission_time",
+      "When a node is unavailable for at least this timeout duration, it "
+      "triggers Redpanda to decommission the node. This property "
+      "applies only when `partition_autobalancing_mode` is set to "
+      "`continuous`.      ",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      24h)
   , partition_autobalancing_max_disk_usage_percent(
       *this,
       "partition_autobalancing_max_disk_usage_percent",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -603,6 +603,10 @@ struct configuration final : public config_store {
       partition_autobalancing_mode;
     property<std::chrono::seconds>
       partition_autobalancing_node_availability_timeout_sec;
+
+    property<std::chrono::seconds>
+      partition_autobalancing_node_autodecommission_time;
+
     bounded_property<unsigned> partition_autobalancing_max_disk_usage_percent;
     property<std::chrono::milliseconds>
       partition_autobalancing_tick_interval_ms;

--- a/tests/rptest/tests/auto_decommission_test.py
+++ b/tests/rptest/tests/auto_decommission_test.py
@@ -1,0 +1,301 @@
+# Copyright 2020 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+
+from ducktape.mark import matrix
+from ducktape.utils.util import wait_until
+
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.services.kgo_verifier_services import (
+    KgoVerifierConsumerGroupConsumer,
+    KgoVerifierProducer,
+)
+from rptest.services.redpanda import (
+    CHAOS_LOG_ALLOW_LIST,
+    SISettings,
+)
+from rptest.tests.prealloc_nodes import PreallocNodesTest
+from rptest.utils.node_operations import NodeDecommissionWaiter
+
+
+class AutoDecommissionTest(PreallocNodesTest):
+    """
+    Test automatic node decommissioning when a node is unresponsive.
+    """
+
+    def __init__(self, test_context):
+        self._topic = None
+
+        si_settings = SISettings(
+            test_context=test_context,
+            cloud_storage_max_connections=10,
+            cloud_storage_enable_remote_read=False,
+            cloud_storage_enable_remote_write=False,
+            fast_uploads=True,
+        )
+
+        extra_rp_conf = dict(
+            enable_cluster_metadata_upload_loop=False,
+            retention_local_trim_interval=5_000,
+        )
+
+        super(AutoDecommissionTest, self).__init__(
+            test_context=test_context,
+            num_brokers=5,
+            node_prealloc_count=1,
+            si_settings=si_settings,
+            extra_rp_conf=extra_rp_conf,
+        )
+
+    def setup(self):
+        # defer starting redpanda to test body
+        pass
+
+    @property
+    def admin(self):
+        # retry on timeout and service unavailable
+        return Admin(self.redpanda, retry_codes=[503, 504])
+
+    def _create_topics(
+        self, replication_factors: list[int] = [1, 3]
+    ):
+        """
+        :return: total number of partitions in all topics
+        """
+        total_partitions = 0
+        topics: list[TopicSpec] = []
+        for _ in range(10):
+            partitions = random.randint(1, 10)
+            spec = TopicSpec(
+                partition_count=partitions,
+                replication_factor=random.choice(replication_factors)            )
+            topics.append(spec)
+            total_partitions += partitions
+
+        for spec in topics:
+            rpk = RpkTool(self.redpanda)
+            rpk.create_topic(
+                topic=spec.name,
+                partitions=spec.partition_count,
+                replicas=spec.replication_factor
+            )
+
+        self._topic = random.choice(topics).name
+
+        return total_partitions
+    
+    def _not_decommissioned_node(self, *args):
+        decom_node_ids = args
+        return [
+            n
+            for n in self.redpanda.started_nodes()
+            if self.redpanda.node_id(n) not in decom_node_ids
+        ][0]
+
+
+    def _check_state_consistent(self, decommissioned_id: int):
+        not_decommissioned = [
+            n
+            for n in self.redpanda.started_nodes()
+            if self.redpanda.node_id(n) != decommissioned_id
+        ]
+
+        def _state_consistent():
+            for n in not_decommissioned:
+                cfg_status = self.admin.get_cluster_config_status(n)
+                brokers = self.admin.get_brokers(n)
+                config_ids = [s["node_id"] for s in cfg_status]
+                brokers_ids = [b["node_id"] for b in brokers]
+                self.logger.info(
+                    f"broker_ids: {brokers_ids}, ids from configuration status: {config_ids}"
+                )
+                if sorted(brokers_ids) != sorted(config_ids):
+                    return False
+                if decommissioned_id in brokers_ids:
+                    return False
+
+            return True
+
+        wait_until(
+            _state_consistent,
+            10,
+            1,
+            err_msg="Timeout waiting for nodes reported from configuration and cluster state to be consistent",
+        )
+
+    def _wait_for_node_removed(self, decommissioned_id: int):
+        waiter = NodeDecommissionWaiter(
+            self.redpanda, decommissioned_id, self.logger, progress_timeout=60
+        )
+        waiter.wait_for_removal()
+
+        self._check_state_consistent(decommissioned_id)
+
+    @property
+    def msg_size(self):
+        return 64
+
+    @property
+    def msg_count(self):
+        return int(20 * self.producer_throughput / self.msg_size)
+
+    @property
+    def producer_throughput(self):
+        return 1024 if self.debug_mode else 1024 * 1024
+
+    def start_producer(self):
+        self.logger.info(
+            f"starting kgo-verifier producer with {self.msg_count} messages of size {self.msg_size} and throughput: {self.producer_throughput} bps"
+        )
+        self.producer = KgoVerifierProducer(
+            self.test_context,
+            self.redpanda,
+            self._topic,
+            self.msg_size,
+            self.msg_count,
+            custom_node=self.preallocated_nodes,
+            rate_limit_bps=self.producer_throughput,
+        )
+
+        self.producer.start(clean=False)
+
+        wait_until(
+            lambda: self.producer.produce_status.acked > 10,
+            timeout_sec=120,
+            backoff_sec=1,
+        )
+
+    def start_consumer(self):
+        self.consumer = KgoVerifierConsumerGroupConsumer(
+            self.test_context,
+            self.redpanda,
+            self._topic,
+            self.msg_size,
+            readers=1,
+            nodes=self.preallocated_nodes,
+        )
+
+        self.consumer.start(clean=False)
+
+    def verify(self):
+        self.logger.info(
+            f"verifying workload: topic: {self._topic}, with [rate_limit: {self.producer_throughput}, message size: {self.msg_size}, message count: {self.msg_count}]"
+        )
+        self.producer.wait()
+
+        # Await the consumer that is reading only the subset of data that
+        # was written before it started.
+        self.consumer.wait()
+
+        assert self.consumer.consumer_status.validator.invalid_reads == 0, (
+            f"Invalid reads in topic: {self._topic}, invalid reads count: {self.consumer.consumer_status.validator.invalid_reads}"
+        )
+        del self.consumer
+
+        # Start a new consumer to read all data written
+        self.start_consumer()
+        self.consumer.wait()
+
+        assert self.consumer.consumer_status.validator.invalid_reads == 0, (
+            f"Invalid reads in topic: {self._topic}, invalid reads count: {self.consumer.consumer_status.validator.invalid_reads}"
+        )
+
+    def start_redpanda(self, new_bootstrap: bool = True):
+        if new_bootstrap:
+            self.redpanda.set_seed_servers(self.redpanda.nodes)
+
+        self.redpanda.start(
+            auto_assign_node_id=new_bootstrap, omit_seeds_on_idx_one=not new_bootstrap
+        )
+
+    @cluster(num_nodes=6, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    def test_automatic_node_decommissioning(self):
+        """
+        Test that a node is automatically decommissioned when it's unresponsive
+        for the configured timeout period.
+        """
+        # tick < unavailable < autodecommission
+        partition_balancer_tick_interval_ms = 5000
+        partition_balancer_unavailable_timeout_s = 15
+        autodecommission_timeout_s = 30
+
+        # Configure partition autobalancing for auto-decommission
+        self.redpanda.add_extra_rp_conf({
+            "partition_autobalancing_mode": "continuous",
+            "partition_autobalancing_node_availability_timeout_sec": partition_balancer_unavailable_timeout_s,
+            "partition_autobalancing_node_autodecommission_time": autodecommission_timeout_s,
+            "partition_autobalancing_tick_interval_ms": partition_balancer_tick_interval_ms,
+        })
+
+        # start four nodes s.t. any one node can fail and autobalancer can move the paritions elsewhere
+        self.start_redpanda(new_bootstrap=True)
+        self._create_topics(replication_factors=[3])
+
+        self.start_producer()
+        self.start_consumer()
+
+        # Select a random node to make unresponsive
+        to_decommission = random.choice(self.redpanda.nodes)
+        node_id = self.redpanda.node_id(to_decommission)
+
+        self.logger.info(
+            f"Stopping node {node_id} to trigger automatic decommissioning"
+        )
+
+        # Stop the node to make it unresponsive
+        self.redpanda.stop_node(node=to_decommission)
+
+        # Wait for the timeout period plus buffer for processing
+        # Total wait: timeout + extra time for detection and decommission start
+        wait_time_sec =autodecommission_timeout_s * 2
+        self.logger.info(
+            f"Waiting {wait_time_sec} seconds for automatic decommissioning to trigger"
+        )
+
+        # just make sure we're not pinging the dead node
+        survivor_node = self._not_decommissioned_node(node_id)
+
+        # Verify that the node status changes to 'draining' (decommissioning)
+        def node_is_draining():
+            try:
+                brokers = self.admin.get_brokers(node=survivor_node)
+                for b in brokers:
+                    if b["node_id"] == node_id:
+                        self.logger.info(f"Node {node_id} status: {b['membership_status']}")
+                        return b["membership_status"] == "draining"
+                return False
+            except Exception as e:
+                self.logger.warn(f"Error checking broker status: {e}")
+                return False
+
+        # Wait for the node to be automatically marked as draining
+        wait_until(
+            node_is_draining,
+            timeout_sec=wait_time_sec,
+            backoff_sec=5,
+            err_msg=f"Node {node_id} was not automatically decommissioned after {wait_time_sec} seconds"
+        )
+
+        self.logger.info(
+            f"Node {node_id} was automatically marked for decommissioning"
+        )
+
+        # Wait for the decommission process to complete
+        self._wait_for_node_removed(node_id)
+
+        self.logger.info(
+            f"Node {node_id} was successfully auto-decommissioned and removed"
+        )
+
+        # Verify data integrity
+        self.verify()


### PR DESCRIPTION
This pr a proof of concept for a simple implementation of node autodecommission per CORE-7111

The overview is essentially:
1. add a configuration for the time at which to declare a node a lost cause (decommission it)
2. wire that configuration into partition_balancer_planner
3. similar to the draining check for unresponsive brokers, extend that functionality to also request a node decommission if the broker is unresponsive for longer than the configuration in 1)

Pros of this approach:
Its a logical continuation of the draining functionality in partition_balancer_planner

Cons of this approach:
"PARTITION_balancer_planner"
we are creeping the scope of partition_balancer_planner. Maybe this is an opportunity to add a membership planner separate from partition balancer planner

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
