### PR TITLE
`ct/l1`: vectorize `cleaned_ranges` in `compaction_state_update`

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -261,9 +261,9 @@ public:
             // Whether or not the cleaned range included any tombstones.
             bool has_tombstones{false};
         };
-        // A range indicating that the data's keys have been fully deduplicated
+        // Ranges indicating that the data's keys have been fully deduplicated
         // from the start of the log.
-        std::optional<cleaned_range> new_cleaned_range;
+        chunked_vector<cleaned_range> new_cleaned_ranges;
 
         // Ranges of cleaned offsets that previously had tombstones, that have
         // been removed.

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -64,12 +64,17 @@ compaction_state_update
 meta_to_rpc_compact_update(const metastore::compaction_update& update) {
     compaction_state_update rpc_update;
 
-    if (update.new_cleaned_range) {
-        compaction_state_update::cleaned_range range;
-        range.base_offset = update.new_cleaned_range->base_offset;
-        range.last_offset = update.new_cleaned_range->last_offset;
-        range.has_tombstones = update.new_cleaned_range->has_tombstones;
-        rpc_update.new_cleaned_range = std::move(range);
+    if (!update.new_cleaned_ranges.empty()) {
+        auto& new_cleaned_ranges = update.new_cleaned_ranges;
+        chunked_vector<compaction_state_update::cleaned_range> ranges;
+        ranges.reserve(new_cleaned_ranges.size());
+        for (const auto& cleaned_range : new_cleaned_ranges) {
+            ranges.push_back(
+              {.base_offset = cleaned_range.base_offset,
+               .last_offset = cleaned_range.last_offset,
+               .has_tombstones = cleaned_range.has_tombstones});
+        }
+        rpc_update.new_cleaned_ranges = std::move(ranges);
     }
 
     rpc_update.removed_tombstones_ranges = update.removed_tombstones_ranges;
@@ -345,7 +350,7 @@ replicated_metastore::replace_objects(
         req.new_objects = std::move(new_objects);
 
         // Empty compaction updates for basic replace
-        req.compaction_updates = {};
+        req.compaction_updates.clear();
         auto reply_fut = co_await ss::coroutine::as_future(
           fe_.replace_objects(std::move(req)));
         if (reply_fut.failed()) {

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -468,13 +468,17 @@ simple_metastore::compact_objects(
       compaction_updates;
     for (const auto& [tp, cm] : compaction_metas) {
         compaction_state_update p_update;
-        if (cm.new_cleaned_range.has_value()) {
-            p_update.new_cleaned_range.emplace(
-              compaction_state_update::cleaned_range{
-                .base_offset = cm.new_cleaned_range->base_offset,
-                .last_offset = cm.new_cleaned_range->last_offset,
-                .has_tombstones = cm.new_cleaned_range->has_tombstones,
-              });
+        if (!cm.new_cleaned_ranges.empty()) {
+            auto& new_cleaned_ranges = cm.new_cleaned_ranges;
+            chunked_vector<compaction_state_update::cleaned_range> ranges;
+            ranges.reserve(new_cleaned_ranges.size());
+            for (const auto& cleaned_range : new_cleaned_ranges) {
+                ranges.push_back(
+                  {.base_offset = cleaned_range.base_offset,
+                   .last_offset = cleaned_range.last_offset,
+                   .has_tombstones = cleaned_range.has_tombstones});
+            }
+            p_update.new_cleaned_ranges = std::move(ranges);
         }
         p_update.removed_tombstones_ranges = cm.removed_tombstones_ranges;
         p_update.cleaned_at = cm.cleaned_at;

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -380,32 +380,33 @@ replace_objects_update::can_apply(const state& state) {
                     "{}",
                     tidp)));
             }
-            if (compaction_update.new_cleaned_range.has_value()) {
-                const auto& req_cleaned_range
-                  = *compaction_update.new_cleaned_range;
-
+            if (!compaction_update.new_cleaned_ranges.empty()) {
+                const auto& req_cleaned_ranges
+                  = compaction_update.new_cleaned_ranges;
                 // Check that the new extents span the start of the log to the
                 // end of the new clean range.
                 auto& [_, new_extents] = *new_extent_iter;
                 auto req_last = new_extents.rbegin()->last_offset;
-                if (req_cleaned_range.last_offset > req_last) {
+                auto clean_last = req_cleaned_ranges.back().last_offset;
+                if (clean_last > req_last) {
                     return std::unexpected(stm_update_error(
                       fmt::format(
                         "Cleaned range for {} does not match requested new "
                         "extents' last_offset {} > {}",
                         tidp,
-                        req_cleaned_range.last_offset,
+                        clean_last,
                         req_last)));
                 }
                 auto req_extents_base = new_extents.begin()->base_offset;
-                if (req_extents_base > req_cleaned_range.base_offset) {
+                auto clean_base = req_cleaned_ranges.front().base_offset;
+                if (req_extents_base > clean_base) {
                     return std::unexpected(stm_update_error(
                       fmt::format(
                         "Cleaned range start_offset for {} is not covered by "
                         "extents: {} > {}",
                         tidp,
                         req_extents_base,
-                        req_cleaned_range.base_offset)));
+                        clean_base)));
                 }
 
                 // Check that the extents replace down to the start of the log.
@@ -423,23 +424,26 @@ replace_objects_update::can_apply(const state& state) {
 
                 // Check that ranges with tombstones don't overlap with existing
                 // ranges with tombstones.
-                if (
-                  req_cleaned_range.has_tombstones
-                  && p_state.compaction_state.has_value()
-                  && !p_state.compaction_state->may_add(
-                    compaction_state::cleaned_range_with_tombstones{
-                      .base_offset = req_cleaned_range.base_offset,
-                      .last_offset = req_cleaned_range.last_offset,
-                      .cleaned_with_tombstones_at
-                      = compaction_update.cleaned_at,
-                    })) {
-                    return std::unexpected(stm_update_error(
-                      fmt::format(
-                        "Cleaned range for {} has tombstones and overlaps with "
-                        "an existing cleaned range with tombstones: [{}, {}]",
-                        tidp,
-                        req_cleaned_range.base_offset,
-                        req_cleaned_range.last_offset)));
+                for (const auto& req_cleaned_range : req_cleaned_ranges) {
+                    if (
+                      req_cleaned_range.has_tombstones
+                      && p_state.compaction_state.has_value()
+                      && !p_state.compaction_state->may_add(
+                        compaction_state::cleaned_range_with_tombstones{
+                          .base_offset = req_cleaned_range.base_offset,
+                          .last_offset = req_cleaned_range.last_offset,
+                          .cleaned_with_tombstones_at
+                          = compaction_update.cleaned_at,
+                        })) {
+                        return std::unexpected(stm_update_error(
+                          fmt::format(
+                            "Cleaned range for {} has tombstones and overlaps "
+                            "with an existing cleaned range with tombstones: "
+                            "[{}, {}]",
+                            tidp,
+                            req_cleaned_range.base_offset,
+                            req_cleaned_range.last_offset)));
+                    }
                 }
             }
 
@@ -533,33 +537,36 @@ replace_objects_update::apply(state& state) {
             if (!p_state.compaction_state.has_value()) {
                 p_state.compaction_state.emplace();
             }
-            if (compaction_update.new_cleaned_range.has_value()) {
-                const auto& req_cleaned_range
-                  = *compaction_update.new_cleaned_range;
-                [[maybe_unused]] auto inserted
-                  = p_state.compaction_state->cleaned_ranges.insert(
-                    req_cleaned_range.base_offset,
-                    req_cleaned_range.last_offset);
-                dassert(
-                  inserted,
-                  "Invalid interval [{}, {}]",
-                  req_cleaned_range.base_offset,
-                  req_cleaned_range.last_offset);
-                if (req_cleaned_range.has_tombstones) {
+            if (!compaction_update.new_cleaned_ranges.empty()) {
+                const auto& req_cleaned_ranges
+                  = compaction_update.new_cleaned_ranges;
+                for (const auto& req_cleaned_range : req_cleaned_ranges) {
                     [[maybe_unused]] auto inserted
-                      = p_state.compaction_state->add(
-                        compaction_state::cleaned_range_with_tombstones{
-                          .base_offset = req_cleaned_range.base_offset,
-                          .last_offset = req_cleaned_range.last_offset,
-                          .cleaned_with_tombstones_at
-                          = compaction_update.cleaned_at,
-                        });
+                      = p_state.compaction_state->cleaned_ranges.insert(
+                        req_cleaned_range.base_offset,
+                        req_cleaned_range.last_offset);
                     dassert(
                       inserted,
-                      "Failed to insert cleaned range with tombstones: [{}, "
-                      "{}]",
+                      "Invalid interval [{}, {}]",
                       req_cleaned_range.base_offset,
                       req_cleaned_range.last_offset);
+                    if (req_cleaned_range.has_tombstones) {
+                        [[maybe_unused]] auto inserted
+                          = p_state.compaction_state->add(
+                            compaction_state::cleaned_range_with_tombstones{
+                              .base_offset = req_cleaned_range.base_offset,
+                              .last_offset = req_cleaned_range.last_offset,
+                              .cleaned_with_tombstones_at
+                              = compaction_update.cleaned_at,
+                            });
+                        dassert(
+                          inserted,
+                          "Failed to insert cleaned range with tombstones: "
+                          "[{}, "
+                          "{}]",
+                          req_cleaned_range.base_offset,
+                          req_cleaned_range.last_offset);
+                    }
                 }
             }
 

--- a/src/v/cloud_topics/level_one/metastore/state_update.h
+++ b/src/v/cloud_topics/level_one/metastore/state_update.h
@@ -99,7 +99,7 @@ struct add_objects_update
 struct compaction_state_update
   : public serde::envelope<
       compaction_state_update,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     // NOTE: intentionally duplicate code from
     // metastore::compaction_update::cleaned_range, defined separately to
@@ -122,11 +122,11 @@ struct compaction_state_update
     };
     auto serde_fields() {
         return std::tie(
-          new_cleaned_range, removed_tombstones_ranges, cleaned_at);
+          new_cleaned_ranges, removed_tombstones_ranges, cleaned_at);
     }
-    // The cleaned range for this compaction, if any. May or may not have
-    // tombstones.
-    std::optional<cleaned_range> new_cleaned_range;
+    // The cleaned ranges for this compaction, if any. Ranges may or may not
+    // have tombstones.
+    chunked_vector<cleaned_range> new_cleaned_ranges;
 
     // Expected that these ranges correspond to existing cleaned ranges with
     // tombstones, and indicate that these ranges may be removed.

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -345,9 +345,9 @@ TEST_F(ReplicatedMetastoreTest, TestBasicCompact) {
     for (int i = 0; i < partitions_count; ++i) {
         metastore::compaction_update update;
         update.cleaned_at = model::timestamp::now();
-        update.new_cleaned_range.emplace();
-        update.new_cleaned_range->base_offset = o{0};
-        update.new_cleaned_range->last_offset = o{999};
+        update.new_cleaned_ranges.push_back(
+          metastore::compaction_update::cleaned_range{
+            .base_offset = o{0}, .last_offset = o{999}});
         cmap[make_tp(i)] = std::move(update);
     }
     auto cmp_res = meta.compact_objects(*new_objs, cmap).get();

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -105,12 +105,12 @@ public:
       std::optional<model::timestamp> with_tombstones_ts = std::nullopt) {
         auto tp = model::topic_id_partition::from(tpr_str);
         auto& cmp_meta = out[tp];
-        cmp_meta.new_cleaned_range
-          = metastore::compaction_update::cleaned_range{
+        cmp_meta.new_cleaned_ranges.push_back(
+          metastore::compaction_update::cleaned_range{
             .base_offset = base,
             .last_offset = last,
             .has_tombstones = with_tombstones_ts.has_value(),
-          };
+          });
         if (with_tombstones_ts) {
             cmp_meta.cleaned_at = *with_tombstones_ts;
         }
@@ -1648,4 +1648,70 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetAfterBytes) {
     ASSERT_FALSE(get_res.has_value()) << "for size: " << query_size;
     ASSERT_EQ(get_res.error(), metastore::errc::out_of_range)
       << "for size: " << query_size;
+}
+
+TEST(SimpleMetastoreTest, TestCompactionMultipleDirtyRangesMadeClean) {
+    simple_metastore m;
+    {
+        om_list_t os;
+        os.emplace_back(om_builder(oid1, 100, 1100)
+                          .add(tid_a, 0_o, 20_o, 2000_t, 0, 99)
+                          .build());
+        auto add_res = m.add_objects(
+                          os, terms_builder().add(tid_a, 0_tm, 0_o).build())
+                         .get();
+        ASSERT_TRUE(add_res.has_value());
+    }
+
+    // Clean range is [5, 15].
+    {
+        om_list_t os;
+        os.emplace_back(om_builder(oid2, 100, 1100)
+                          .add(tid_a, 0_o, 20_o, 2000_t, 0, 99)
+                          .build());
+
+        auto cmb = cm_builder();
+        cmb.clean(tid_a, 5_o, 15_o, 3000_t);
+        auto compact_res = m.compact_objects(os, cmb.build()).get();
+        ASSERT_TRUE(compact_res.has_value());
+    }
+
+    auto tp = model::topic_id_partition::from(tid_a);
+
+    {
+        // Verify compaction state and dirty ranges: [0, 4] and [16, 20].
+        auto cmp = m.get_compaction_offsets(tp, 3000_t).get();
+        ASSERT_TRUE(cmp.has_value());
+        EXPECT_THAT(
+          cmp->dirty_ranges.to_vec(),
+          testing::ElementsAre(
+            MatchesRange(0_o, 4_o), MatchesRange(16_o, 20_o)));
+        EXPECT_THAT(
+          cmp->removable_tombstone_ranges.to_vec(),
+          testing::ElementsAre(MatchesRange(5_o, 15_o)));
+    }
+
+    // Clean range is [5, 15]. Try to make both of [[0, 4], [16, 20]] clean.
+    {
+        om_list_t os;
+        os.emplace_back(om_builder(oid3, 100, 1100)
+                          .add(tid_a, 0_o, 20_o, 2000_t, 0, 99)
+                          .build());
+
+        auto cmb = cm_builder();
+        cmb.clean(tid_a, 0_o, 4_o, 6000_t);
+        cmb.clean(tid_a, 16_o, 20_o, 6000_t);
+        auto compact_res = m.compact_objects(os, cmb.build()).get();
+        ASSERT_TRUE(compact_res.has_value());
+    }
+
+    {
+        // Verify compaction state (no dirty ranges).
+        auto cmp_before = m.get_compaction_offsets(tp, 6000_t).get();
+        ASSERT_TRUE(cmp_before.has_value());
+        EXPECT_THAT(cmp_before->dirty_ranges.to_vec(), testing::IsEmpty());
+        EXPECT_THAT(
+          cmp_before->removable_tombstone_ranges.to_vec(),
+          testing::ElementsAre(MatchesRange(0_o, 20_o)));
+    }
 }

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -101,12 +101,12 @@ public:
     }
     replace_objects_builder& clean(
       std::string_view tp_str,
-      struct compaction_state_update::cleaned_range r,
+      compaction_state_update::cleaned_range r,
       model::timestamp cleaned_at) {
         auto tp = model::topic_id_partition::from(tp_str);
         auto& c_state = out.compaction_updates[tp.topic_id][tp.partition];
         c_state.cleaned_at = cleaned_at;
-        c_state.new_cleaned_range = r;
+        c_state.new_cleaned_ranges.push_back(std::move(r));
         return *this;
     }
     replace_objects_builder& clean_tombstones(


### PR DESCRIPTION
Imagine the log is:

```
   Dirty   Clean    Dirty
[ [0, 4], [5, 15], [16, 20] ]
```

In the current `compaction_state_update` implementation, which contains a single `std::optional<cleaned_range>`, it isn't possible to represent a compaction job which indexes both dirty ranges `[0, 4]` and `[16, 20]` and wants to commit a compaction update marking them both as clean.

Vectorize the update in the relevant `serde` structs as well as update the backend `metastore` update implementations so that representing the above update is simple.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
