### PR TITLE
[v25.1.x] manual backport of shard_placement_table: unchecked optional fix

### DIFF
--- a/src/v/cluster/shard_placement_table.cc
+++ b/src/v/cluster/shard_placement_table.cc
@@ -1006,6 +1006,11 @@ ss::future<std::error_code> shard_placement_table::prepare_create(
     }
     auto& state = state_it->second;
 
+    if (!state.assigned()) {
+        // assignments got updated while we were waiting for the lock
+        co_return errc::waiting_for_shard_placement_update;
+    }
+
     if (state.assigned()->log_revision != expected_log_rev) {
         // assignments got updated while we were waiting for the lock
         co_return errc::waiting_for_shard_placement_update;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28575 

change needed: theres no remake_state in the old version of the code, so theres no need to fix an unchecked optional there.