### PR TITLE
ct/reconciler: Fix object size budget underflow

### DIFF
--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -459,9 +459,6 @@ reconciler::build_object(
             co_return std::unexpected(
               reconcile_error("abort requested while building object"));
         }
-        auto start_offset = kafka::next_offset(src->last_reconciled_offset());
-        auto read_result = co_await add_source_to_object(
-          ctx, src, start_offset);
 
         // Enforce the size limit, but always allow one partition in.
         auto current_size = ctx.builder->file_size();
@@ -473,7 +470,13 @@ reconciler::build_object(
               max_object_size);
             break;
         }
-        ctx.size_budget = max_object_size - current_size;
+        // It shouldn't happen, but beware underflow.
+        ctx.size_budget = current_size >= max_object_size
+                            ? 0
+                            : max_object_size - current_size;
+        auto start_offset = kafka::next_offset(src->last_reconciled_offset());
+        auto read_result = co_await add_source_to_object(
+          ctx, src, start_offset);
 
         if (!read_result.has_value()) {
             // Log an error, we don't want a single stuck partition to

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -470,7 +470,8 @@ reconciler::build_object(
               max_object_size);
             break;
         }
-        // It shouldn't happen, but beware underflow.
+        // Beware underflow if the first partition sneaks a batch in over the
+        // size limit.
         ctx.size_budget = current_size >= max_object_size
                             ? 0
                             : max_object_size - current_size;

--- a/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
@@ -240,6 +240,43 @@ TEST_F(ReconcilerTest, ObjectSizeLimitMultipleSources) {
       metastore_next_offset(src2), Optional(kafka::offset{last_offset_2 + 1}));
 }
 
+// Test that when two sources each exceed max_object_size (64MiB), only one
+// is processed per reconciliation round. This verifies that the size_budget
+// calculation doesn't underflow (which would allow both to be processed).
+TEST_F(ReconcilerTest, ObjectSizeLimitOneSourcePerRound) {
+    auto src1 = add_source();
+    auto src2 = add_source();
+
+    // Each source: 13 batches of 5MiB = 65MiB, exceeding the 64MiB limit.
+    constexpr auto batch_count = 13;
+    constexpr auto record_count = 1;
+    constexpr auto record_size = 5_MiB;
+    for (size_t i = 0; i < batch_count; ++i) {
+        src1->add_batch(
+          {.allow_compression = false,
+           .count = record_count,
+           .record_sizes = std::vector<size_t>(record_count, record_size)});
+        src2->add_batch(
+          {.allow_compression = false,
+           .count = record_count,
+           .record_sizes = std::vector<size_t>(record_count, record_size)});
+    }
+
+    reconcile();
+
+    constexpr auto last_offset = batch_count * record_count - 1;
+    auto lro1 = src1->last_reconciled_offset();
+    auto lro2 = src2->last_reconciled_offset();
+
+    // Exactly one source should be fully processed, the other should not
+    // advance. We're agnostic to which one goes first.
+    bool src1_done = lro1 == kafka::offset{last_offset};
+    bool src2_done = lro2 == kafka::offset{last_offset};
+    EXPECT_TRUE(src1_done != src2_done)
+      << "Expected exactly one source to be processed per round. "
+      << "src1 LRO: " << lro1 << ", src2 LRO: " << lro2;
+}
+
 TEST_F(ReconcilerTest, SourceReadFailure) {
     auto src = add_source();
     src->add_batch({.count = 10});


### PR DESCRIPTION
Our remaining size budget calculation could underflow if the first partition has more than the max object size worth of data to reconcile, allowing the second partition to add an essentially unbounded amount of data.

This change prevents underflow, and also reorders the check and read so we avoid reading entirely if there's no budget.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
