### PR TITLE
rpk: support for shadowlink failover

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -10,8 +10,8 @@ require (
 	buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.10-20251022210436-bbacedafcd60.1
 	buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.10-20250904135917-9feeb2588236.1
 	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251107181116-874373458fcf.1
-	buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251110211805-d0a4bce1e86b.2
-	buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-20251110211805-d0a4bce1e86b.1
+	buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251128071731-da802bad50d5.2
+	buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-20251128071731-da802bad50d5.1
 	buf.build/gen/go/redpandadata/gatekeeper/connectrpc/go v1.19.1-20251022210437-a5dd600d04b6.2
 	buf.build/gen/go/redpandadata/gatekeeper/protocolbuffers/go v1.36.10-20251022210437-a5dd600d04b6.1
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -14,8 +14,12 @@ buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251107181116-87
 buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251107181116-874373458fcf.1/go.mod h1:QenSPzqxZpyo9hHIpRzTetvDchelVDzimnmaggHKenc=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251110211805-d0a4bce1e86b.2 h1:muM0v3dGgtrpCZPZZZlkJDUQHnL/ZpdUvw/zP4RNOjk=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251110211805-d0a4bce1e86b.2/go.mod h1:8GDVd5dG9Iu9nqmueGnYzVNB2rSPY2z4Y1CIZOAICFE=
+buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251128071731-da802bad50d5.2 h1:S7R30h9enYtl1Y+3HzHQAAR6hMsRVvbMYu3OiGovLbk=
+buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251128071731-da802bad50d5.2/go.mod h1:bGJJx93tlnvnY0BvZRiJoWBjI14AkSukTpR0QAU08Mk=
 buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-20251110211805-d0a4bce1e86b.1 h1:izHsKj0b1F0ATv9UYQShjbXDgE51zwnIgXUgzk5Rdwo=
 buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-20251110211805-d0a4bce1e86b.1/go.mod h1:971HJnUM/0fTBc/LowaoI2ybuR8s+LLlQDpCkPxMwN8=
+buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-20251128071731-da802bad50d5.1 h1:vyWAFBNA2rPQ6ibdzu2G3M6L7rYJuLbnKCqITtDhYRI=
+buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-20251128071731-da802bad50d5.1/go.mod h1:971HJnUM/0fTBc/LowaoI2ybuR8s+LLlQDpCkPxMwN8=
 buf.build/gen/go/redpandadata/gatekeeper/connectrpc/go v1.19.1-20251022210437-a5dd600d04b6.2 h1:TpeR1/FQQjGM6AjB3c/+AklMivMEsWNcJYZeipcmMGU=
 buf.build/gen/go/redpandadata/gatekeeper/connectrpc/go v1.19.1-20251022210437-a5dd600d04b6.2/go.mod h1:2PhIGolYdEsQckSpa7ZjVNWn+Z6BeLpSZBb20w1oWlw=
 buf.build/gen/go/redpandadata/gatekeeper/protocolbuffers/go v1.36.10-20251022210437-a5dd600d04b6.1 h1:buRXwBZNRhjymido98wvND0dtS3D/Ww5VmlDYwEKfvU=

--- a/src/go/rpk/pkg/cli/shadow/describe.go
+++ b/src/go/rpk/pkg/cli/shadow/describe.go
@@ -16,6 +16,7 @@ import (
 
 	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
 	corecommonv1 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/common/v1"
+	dataplanev1alpha3 "buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go/redpanda/api/dataplane/v1alpha3"
 	"connectrpc.com/connect"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -151,6 +152,14 @@ func printOverview(link *adminv2.ShadowLink) {
 	if status := link.GetStatus(); status != nil {
 		tw.Print("STATE", strings.TrimPrefix(status.GetState().String(), "SHADOW_LINK_STATE_"))
 	}
+}
+
+func printCloudOverview(link *dataplanev1alpha3.ShadowLink) {
+	tw := out.NewTabWriter()
+	defer tw.Flush()
+	tw.Print("NAME", link.GetName())
+	tw.Print("UID", link.GetUid())
+	tw.Print("STATE", strings.TrimPrefix(link.GetState().String(), "SHADOW_LINK_STATE_"))
 }
 
 func printClient(opts *adminv2.ShadowLinkClientOptions) {

--- a/src/go/rpk/pkg/cli/shadow/failover.go
+++ b/src/go/rpk/pkg/cli/shadow/failover.go
@@ -13,12 +13,15 @@ import (
 	"fmt"
 
 	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
+	dataplanev1alpha3 "buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go/redpanda/api/dataplane/v1alpha3"
 	"connectrpc.com/connect"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
-	"github.com/spf13/afero"
-	"github.com/spf13/cobra"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 )
 
 func newFailoverCommand(fs afero.Fs, p *config.Params) *cobra.Command {
@@ -63,14 +66,55 @@ Failover without confirmation:
 			if !all && topic == "" {
 				out.Die("either --all or --topic must be provided")
 			}
-			p, err := p.LoadVirtualProfile(fs)
+			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "unable to load rpk config: %v", err)
-			config.CheckExitCloudAdmin(p)
-
-			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
-			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+			prof := cfg.VirtualProfile()
+			config.CheckExitCloudAdmin(prof)
 
 			linkName := args[0]
+
+			if prof.CheckFromCloud() {
+				// Cloud path using dataplane API
+				dpClient, err := publicapi.DataplaneClientFromRpkProfile(prof)
+				out.MaybeDie(err, "unable to initialize dataplane client: %v", err)
+
+				if !noConfirm {
+					// Get shadow link info for confirmation display
+					sl, err := dpClient.ShadowLink.GetShadowLink(cmd.Context(), connect.NewRequest(&dataplanev1alpha3.GetShadowLinkRequest{
+						Name: linkName,
+					}))
+					out.MaybeDie(err, "unable to get Shadow Link %q: %v", linkName, handleConnectError(err, "get", linkName))
+
+					printCloudOverview(sl.Msg.GetShadowLink())
+
+					var confirmed bool
+					if all {
+						confirmed, err = out.Confirm("Are you sure you want to failover all topics for Shadow Link %q?", linkName)
+					} else {
+						confirmed, err = out.Confirm("Are you sure you want to failover the topic %q for Shadow Link %q?", topic, linkName)
+					}
+					out.MaybeDie(err, "unable to confirm Shadow Link failover: %v", err)
+					if !confirmed {
+						out.Exit("Command execution canceled.")
+					}
+				}
+
+				// Perform the actual failover operation
+				_, err = dpClient.ShadowLink.FailOver(cmd.Context(), connect.NewRequest(&adminv2.FailOverRequest{
+					Name:            linkName,
+					ShadowTopicName: topic,
+				}))
+				out.MaybeDie(err, "unable to failover Shadow Link: %v", handleConnectError(err, "failover", linkName))
+
+				fmt.Printf(`Successfully initiated the Fail Over for Shadow Link %q. To check the status, run:
+  rpk shadow status %[1]s
+`, linkName)
+				return
+			}
+
+			cl, err := adminapi.NewClient(cmd.Context(), fs, prof)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
 			if !noConfirm {
 				sl, err := cl.ShadowLinkService().GetShadowLink(cmd.Context(), connect.NewRequest(&adminv2.GetShadowLinkRequest{
 					Name: linkName,

--- a/src/go/rpk/pkg/publicapi/dataplane.go
+++ b/src/go/rpk/pkg/publicapi/dataplane.go
@@ -39,6 +39,7 @@ type DataPlaneClientSet struct {
 	Security      dataplanev1connect.SecurityServiceClient
 	Monitoring    dataplanev1connect.MonitoringServiceClient
 	KnowledgeBase dataplanev1alpha3connect.KnowledgeBaseServiceClient
+	ShadowLink    dataplanev1alpha3connect.ShadowLinkServiceClient
 
 	m         sync.RWMutex
 	authToken string
@@ -120,6 +121,7 @@ func NewDataPlaneClientSet(host, authToken string, opts ...connect.ClientOption)
 	dpCl.Security = dataplanev1connect.NewSecurityServiceClient(httpCl, host, opts...)
 	dpCl.Monitoring = dataplanev1connect.NewMonitoringServiceClient(httpCl, host, opts...)
 	dpCl.KnowledgeBase = dataplanev1alpha3connect.NewKnowledgeBaseServiceClient(httpCl, host, opts...)
+	dpCl.ShadowLink = dataplanev1alpha3connect.NewShadowLinkServiceClient(httpCl, host, opts...)
 
 	return dpCl, nil
 }


### PR DESCRIPTION

Add cloud support to the `rpk shadow failover` command. Previously, the failover command only worked with on-premise clusters via the admin API. This PR extends support to cloud profiles by integrating with both the controlplane and dataplane APIs.

The implementation follows the established pattern from other shadow commands (`create`, `list`) where cloud profiles are detected and routed to the appropriate cloud APIs while maintaining backward compatibility with on-premise deployments.

Fixes ux-715


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none


### Features

* Short description of the feature. Explain how to configure.
