### PR TITLE
[v25.2.x] c/tests/decommissioning: increase timeout to moderate

### DIFF
--- a/src/v/cluster/tests/BUILD
+++ b/src/v/cluster/tests/BUILD
@@ -658,7 +658,7 @@ redpanda_cc_btest(
 
 redpanda_cc_btest(
     name = "decommissioning_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "decommissioning_tests.cc",
     ],


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28774
