### PR TITLE
[CORE-14704] re-enable post-startup storage checks

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -5492,7 +5492,7 @@ class RedpandaService(Service, RedpandaServiceABC):
         :returns: instances of ClusterStorage
         """
         if nodes is None:
-            nodes = list(self._started)
+            nodes = self._started
         assert nodes, "Empty node list specified for storage stat collection"
 
         store = ClusterStorage()

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -5479,11 +5479,15 @@ class RedpandaService(Service, RedpandaServiceABC):
         return store
 
     def storage(
-        self, all_nodes: bool = False, sizes: bool = False, scan_cache: bool = True
+        self,
+        *,
+        nodes: Collection[ClusterNode] | None = None,
+        sizes: bool = False,
+        scan_cache: bool = True,
     ):
         """
-        :param all_nodes: if true, report on all nodes, otherwise only report
-                          on started nodes.
+        :param nodes: if None, only report on started nodes. Otherwise, report
+                      on the nodes in the `nodes` list parameter.
         :param sizes: if true, stat each segment file and record its size in the
                       `size` attribute of Segment.
         :param scan_cache: if false, skip scanning the tiered storage cache; use
@@ -5491,20 +5495,19 @@ class RedpandaService(Service, RedpandaServiceABC):
 
         :returns: instances of ClusterStorage
         """
+        if nodes is None:
+            nodes = list(self._started)
+        assert nodes, "Empty node list specified for storage stat collection"
+
         store = ClusterStorage()
-        self.logger.debug(
-            f"Starting storage checks all_nodes={all_nodes} sizes={sizes}"
-        )
-        nodes = self.nodes if all_nodes else list(self._started)
+        self.logger.debug(f"Starting storage checks nodes={nodes} sizes={sizes}")
 
         def compute_node_storage(node: ClusterNode):
             s = self.node_storage(node, sizes=sizes, scan_cache=scan_cache)
             store.add_node(s)
 
         self.for_nodes(nodes, compute_node_storage)
-        self.logger.debug(
-            f"Finished storage checks all_nodes={all_nodes} sizes={sizes}"
-        )
+        self.logger.debug(f"Finished storage checks nodes={nodes} sizes={sizes}")
         return store
 
     def copy_data(self, dest: str, node: ClusterNode):

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3374,16 +3374,12 @@ class RedpandaService(Service, RedpandaServiceABC):
         self.wait_for_membership(first_start=first_start)
 
         self.logger.info("Verifying storage is in expected state")
-        storage = self.storage()
+        storage = self.storage(nodes=to_start)
         for node in storage.nodes:
-            # https://redpandadata.slack.com/archives/C07HD9U0EHL/p1762830593745199
-            if node not in to_start:  # pyright: ignore[reportUnnecessaryContains]
-                continue
-            raise RuntimeError("unreachable")
-            unexpected_ns = set(node.ns) - {"redpanda"}  # pyright: ignore[reportUnreachable]
+            unexpected_ns = set(node.ns) - {"redpanda"}
             if unexpected_ns:
-                for ns in unexpected_ns:  # pyright: ignore[reportUnreachable]
-                    self.logger.error(  # pyright: ignore[reportUnreachable]
+                for ns in unexpected_ns:
+                    self.logger.error(
                         f"node {node.name}: unexpected namespace: {ns}, "
                         f"topics: {set(node.ns[ns].topics)}"
                     )
@@ -3394,7 +3390,7 @@ class RedpandaService(Service, RedpandaServiceABC):
                 "kvstore",
             }
             if unexpected_rp_topics:
-                self.logger.error(  # pyright: ignore[reportUnreachable]
+                self.logger.error(
                     f"node {node.name}: unexpected topics in redpanda namespace: "
                     f"{unexpected_rp_topics}"
                 )
@@ -5484,7 +5480,7 @@ class RedpandaService(Service, RedpandaServiceABC):
         nodes: Collection[ClusterNode] | None = None,
         sizes: bool = False,
         scan_cache: bool = True,
-    ):
+    ) -> ClusterStorage:
         """
         :param nodes: if None, only report on started nodes. Otherwise, report
                       on the nodes in the `nodes` list parameter.

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3266,6 +3266,7 @@ class RedpandaService(Service, RedpandaServiceABC):
         auto_assign_node_id: bool = False,
         omit_seeds_on_idx_one: bool = True,
         node_config_overrides: NodeConfigOverridesT = {},
+        skip_storage_init_check: bool = False,
         **kwargs: Any,
     ) -> None:
         """
@@ -3373,34 +3374,38 @@ class RedpandaService(Service, RedpandaServiceABC):
 
         self.wait_for_membership(first_start=first_start)
 
-        self.logger.info("Verifying storage is in expected state")
+        if not skip_storage_init_check:
+            self.logger.info("Verifying storage is in expected state")
 
-        expected = {
-            "redpanda": {"controller", "kvstore"},
-            "kafka": {"_redpanda.audit_log", "_redpanda.transform_logs"},
-            "kafka_internal": {"ct_l1_domain"},
-        }
-        expected["l1_staging"] = set()  # make type deduction happy
+            expected = {
+                "redpanda": {"controller", "kvstore"},
+                "kafka": {
+                    "_redpanda.audit_log",
+                    "_redpanda.transform_logs",
+                },
+                "kafka_internal": {"ct_l1_domain"},
+            }
+            expected["l1_staging"] = set()  # make type deduction happy
 
-        storage = self.storage(nodes=to_start)
-        for node in storage.nodes:
-            unexpected_ns = set(node.ns) - set(expected.keys())
-            if unexpected_ns:
-                for ns in unexpected_ns:
-                    self.logger.error(
-                        f"node {node.name}: unexpected namespace: {ns}, "
-                        f"topics: {set(node.ns[ns].topics)}"
-                    )
-                raise RuntimeError("Unexpected files in data directory")
-
-            for ns in node.ns:
-                unexpected_topics = set(node.ns[ns].topics) - expected[ns]
-                if unexpected_topics:
-                    self.logger.error(
-                        f"node {node.name}: unexpected topics in {ns} namespace: "
-                        f"{unexpected_topics}"
-                    )
+            storage = self.storage(nodes=to_start)
+            for node in storage.nodes:
+                unexpected_ns = set(node.ns) - set(expected.keys())
+                if unexpected_ns:
+                    for ns in unexpected_ns:
+                        self.logger.error(
+                            f"node {node.name}: unexpected namespace: {ns}, "
+                            f"topics: {set(node.ns[ns].topics)}"
+                        )
                     raise RuntimeError("Unexpected files in data directory")
+
+                for ns in node.ns:
+                    unexpected_topics = set(node.ns[ns].topics) - expected[ns]
+                    if unexpected_topics:
+                        self.logger.error(
+                            f"node {node.name}: unexpected topics in {ns} namespace: "
+                            f"{unexpected_topics}"
+                        )
+                        raise RuntimeError("Unexpected files in data directory")
 
         if self.sasl_enabled():
             username, password, algorithm = self._superuser

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3374,9 +3374,17 @@ class RedpandaService(Service, RedpandaServiceABC):
         self.wait_for_membership(first_start=first_start)
 
         self.logger.info("Verifying storage is in expected state")
+
+        expected = {
+            "redpanda": {"controller", "kvstore"},
+            "kafka": {"_redpanda.audit_log", "_redpanda.transform_logs"},
+            "kafka_internal": {"ct_l1_domain"},
+        }
+        expected["l1_staging"] = set()  # make type deduction happy
+
         storage = self.storage(nodes=to_start)
         for node in storage.nodes:
-            unexpected_ns = set(node.ns) - {"redpanda"}
+            unexpected_ns = set(node.ns) - set(expected.keys())
             if unexpected_ns:
                 for ns in unexpected_ns:
                     self.logger.error(
@@ -3385,16 +3393,14 @@ class RedpandaService(Service, RedpandaServiceABC):
                     )
                 raise RuntimeError("Unexpected files in data directory")
 
-            unexpected_rp_topics = set(node.ns["redpanda"].topics) - {
-                "controller",
-                "kvstore",
-            }
-            if unexpected_rp_topics:
-                self.logger.error(
-                    f"node {node.name}: unexpected topics in redpanda namespace: "
-                    f"{unexpected_rp_topics}"
-                )
-                raise RuntimeError("Unexpected files in data directory")
+            for ns in node.ns:
+                unexpected_topics = set(node.ns[ns].topics) - expected[ns]
+                if unexpected_topics:
+                    self.logger.error(
+                        f"node {node.name}: unexpected topics in {ns} namespace: "
+                        f"{unexpected_topics}"
+                    )
+                    raise RuntimeError("Unexpected files in data directory")
 
         if self.sasl_enabled():
             username, password, algorithm = self._superuser

--- a/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
+++ b/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
@@ -145,7 +145,7 @@ class CloudStorageChunkReadTest(PreallocNodesTest):
         finally:
             producer.stop()
 
-        snapshot = self.redpanda.storage(all_nodes=True).segments_by_node(
+        snapshot = self.redpanda.storage(nodes=self.redpanda.nodes).segments_by_node(
             "kafka", self.topic, 0
         )
 

--- a/tests/rptest/tests/cluster_bootstrap_test.py
+++ b/tests/rptest/tests/cluster_bootstrap_test.py
@@ -169,8 +169,14 @@ class ClusterBootstrapFiveNodes(RedpandaTest):
                         node, {"empty_seed_starts_cluster": False}
                     )
 
+                # storage init check is skipped because this test runs
+                # operations against the cluster during bootup which means we
+                # can't know exactly what to expect the state of storage to be
+                # after a broker starts.
                 self.redpanda.start(
-                    auto_assign_node_id=True, omit_seeds_on_idx_one=False
+                    auto_assign_node_id=True,
+                    omit_seeds_on_idx_one=False,
+                    skip_storage_init_check=True,
                 )
             finally:
                 stop_ev.set()

--- a/tests/rptest/tests/compaction_recovery_test.py
+++ b/tests/rptest/tests/compaction_recovery_test.py
@@ -76,7 +76,7 @@ class CompactionRecoveryTest(RedpandaTest):
         # could be outdated by the time we stop the redpanda nodes,
         # e.g due to adjacent segment compaction. Query it here
         # after stopping the cluster.
-        storage = self.redpanda.storage(all_nodes=True)
+        storage = self.redpanda.storage(nodes=self.redpanda.nodes)
         partitions = storage.partitions("kafka", self.topic)
 
         for p in partitions:

--- a/tests/rptest/tests/compatibility/java_compression_test.py
+++ b/tests/rptest/tests/compatibility/java_compression_test.py
@@ -189,7 +189,7 @@ class JavaCompressionTest(EndToEndTest):
         self.redpanda.stop_node(self.redpanda.nodes[0])
 
         # Delete all the compaction indices to force self compaction of segments.
-        storage = self.redpanda.storage(all_nodes=True)
+        storage = self.redpanda.storage(nodes=self.redpanda.nodes)
         partitions = storage.partitions("kafka", self.topic_spec.name)
         for p in partitions:
             p.delete_indices(allow_fail=True)

--- a/tests/rptest/tests/delete_records_test.py
+++ b/tests/rptest/tests/delete_records_test.py
@@ -451,9 +451,9 @@ class DeleteRecordsTest(RedpandaTest, PartitionMovementMixin):
             )
 
             def are_all_local_segments_removed():
-                local_snapshot = self.redpanda.storage(all_nodes=True).segments_by_node(
-                    "kafka", TEST_TOPIC_NAME, 0
-                )
+                local_snapshot = self.redpanda.storage(
+                    nodes=self.redpanda.nodes
+                ).segments_by_node("kafka", TEST_TOPIC_NAME, 0)
                 return all(
                     [
                         all_segments_removed(
@@ -474,9 +474,9 @@ class DeleteRecordsTest(RedpandaTest, PartitionMovementMixin):
             self.redpanda.logger.info(
                 "Timed out waiting for segments, ensure no orphaned segments exist nodes that didn't crash"
             )
-            snapshot = self.redpanda.storage(all_nodes=True).segments_by_node(
-                "kafka", TEST_TOPIC_NAME, 0
-            )
+            snapshot = self.redpanda.storage(
+                nodes=self.redpanda.nodes
+            ).segments_by_node("kafka", TEST_TOPIC_NAME, 0)
             for node_name, segments in snapshot.items():
                 if node_name != stopped_node.name:
                     self.redpanda.logger.debug(

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -586,9 +586,9 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
 
         # Get a snapshot of the current segments, before tightening the
         # retention policy.
-        original_snapshot = self.redpanda.storage(all_nodes=True).segments_by_node(
-            "kafka", self.topic, 0
-        )
+        original_snapshot = self.redpanda.storage(
+            nodes=self.redpanda.nodes
+        ).segments_by_node("kafka", self.topic, 0)
 
         for node, node_segments in original_snapshot.items():
             assert len(node_segments) >= 10, (
@@ -665,9 +665,9 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
             partition_idx=0,
             count=10,
         )
-        original_snapshot = self.redpanda.storage(all_nodes=True).segments_by_node(
-            "kafka", self.topic, 0
-        )
+        original_snapshot = self.redpanda.storage(
+            nodes=self.redpanda.nodes
+        ).segments_by_node("kafka", self.topic, 0)
         self.kafka_tools.alter_topic_config(
             self.topic,
             {
@@ -711,9 +711,9 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
             partition_idx=0,
             count=10,
         )
-        original_snapshot = self.redpanda.storage(all_nodes=True).segments_by_node(
-            "kafka", self.topic, 0
-        )
+        original_snapshot = self.redpanda.storage(
+            nodes=self.redpanda.nodes
+        ).segments_by_node("kafka", self.topic, 0)
         self.kafka_tools.alter_topic_config(
             self.topic,
             {
@@ -813,9 +813,9 @@ class EndToEndShadowIndexingTestCompactedTopic(EndToEndShadowIndexingBase):
         rpk_client = RpkTool(self.redpanda)
         rpk_client.cluster_config_set("log_compaction_interval_ms", f"{2000}")
 
-        original_snapshot = self.redpanda.storage(all_nodes=True).segments_by_node(
-            "kafka", self.topic, 0
-        )
+        original_snapshot = self.redpanda.storage(
+            nodes=self.redpanda.nodes
+        ).segments_by_node("kafka", self.topic, 0)
 
         for node, node_segments in original_snapshot.items():
             assert len(node_segments) >= segment_count, (
@@ -944,9 +944,9 @@ class EndToEndShadowIndexingTestWithDisruptions(EndToEndShadowIndexingBase):
 
         # Get a snapshot of the current segments, before tightening the
         # retention policy.
-        original_snapshot = self.redpanda.storage(all_nodes=True).segments_by_node(
-            "kafka", self.topic, 0
-        )
+        original_snapshot = self.redpanda.storage(
+            nodes=self.redpanda.nodes
+        ).segments_by_node("kafka", self.topic, 0)
 
         for node, node_segments in original_snapshot.items():
             assert len(node_segments) >= 10, (
@@ -1512,9 +1512,9 @@ class EndToEndHydrationTimeoutTest(EndToEndShadowIndexingBase):
         producer.wait(timeout_sec=300)
         producer.free()
 
-        original_snapshot = self.redpanda.storage(all_nodes=True).segments_by_node(
-            "kafka", self.topic, 0
-        )
+        original_snapshot = self.redpanda.storage(
+            nodes=self.redpanda.nodes
+        ).segments_by_node("kafka", self.topic, 0)
 
         for node, node_segments in original_snapshot.items():
             assert len(node_segments) >= 5, (

--- a/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
+++ b/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
@@ -117,9 +117,9 @@ class ShadowIndexingCompactedTopicTest(EndToEndTest):
             timeout_sec=300,
         )
 
-        original_snapshot = self.redpanda.storage(all_nodes=True).segments_by_node(
-            "kafka", self.topic, 0
-        )
+        original_snapshot = self.redpanda.storage(
+            nodes=self.redpanda.nodes
+        ).segments_by_node("kafka", self.topic, 0)
 
         for node, node_segments in original_snapshot.items():
             assert len(node_segments) >= expected_segment_count, (

--- a/tests/rptest/tests/storage_resources_test.py
+++ b/tests/rptest/tests/storage_resources_test.py
@@ -198,7 +198,7 @@ class StorageResourceRestartTest(RedpandaTest):
         return sum(s.value for s in samples)
 
     def _get_partition_segments(self, partition_idx):
-        storage = self.redpanda.storage(all_nodes=True)
+        storage = self.redpanda.storage(nodes=self.redpanda.nodes)
         partitions = list(storage.partitions("kafka", self.topic))
         p = partitions[partition_idx]
         segments = list(p.segments.values())

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -267,7 +267,7 @@ def wait_for_removal_of_n_segments(
 
     def segments_removed():
         current_snapshot = redpanda.storage(
-            all_nodes=True, scan_cache=False
+            nodes=redpanda.nodes, scan_cache=False
         ).segments_by_node("kafka", topic, partition_idx)
 
         redpanda.logger.debug(


### PR DESCRIPTION
Fixes for observation:

> The code block in redpanda.py (lines 3267-3285) is unreachable because the 'continue' statement is always executed. This is due to a type mismatch: 'NodeStorage' is being checked in a list of 'ClusterNodes', which will always be false. The suggested fix is to add 'node' to 'NodeStorage' and use that in the 'in to_start' check. The storage team is requested to take on this task.

I'm a bit skeptical that this provides much value anymore... the original checks were put in place 5 years ago to verify startup. later it appears they were repurposed as a way to catch issues with cleanup. anyway, they seem cheap. if they give us much issue in the future i think we might want to consider removing them.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
