### PR TITLE
http: improve connection lifecycle management

### DIFF
--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -527,9 +527,7 @@ remote::download_object(download_request download_request) {
         if (resp) {
             vlog(ctxlog.debug, "Receive OK response from {}", path);
             try {
-                auto buffer
-                  = co_await cloud_storage_clients::util::drain_response_stream(
-                    resp.value());
+                auto buffer = co_await http::drain(resp.value());
                 download_request.payload.append_fragments(std::move(buffer));
                 transfer_details.on_success();
                 co_return download_result::success;

--- a/src/v/cloud_roles/request_response_helpers.cc
+++ b/src/v/cloud_roles/request_response_helpers.cc
@@ -33,23 +33,6 @@ using http_call = ss::noncopyable_function<ss::future<api_response>(
 
 namespace {
 
-ss::future<iobuf>
-drain_response_stream(http::client::response_stream_ref resp) {
-    return ss::do_with(
-      iobuf(), [resp = std::move(resp)](iobuf& outbuf) mutable {
-          return ss::do_until(
-                   [resp] { return resp->is_done(); },
-                   [resp, &outbuf] {
-                       return resp->recv_some().then([&outbuf](iobuf&& chunk) {
-                           outbuf.append(std::move(chunk));
-                       });
-                   })
-            .then([&outbuf] {
-                return ss::make_ready_future<iobuf>(std::move(outbuf));
-            });
-      });
-}
-
 /// Helper function to catch and log common HTTP errors around user supplied
 /// operation.
 ss::future<api_response>
@@ -83,7 +66,7 @@ do_request(http::client::request_header req, http_call func) {
 }
 
 ss::future<> log_error_response(http::client::response_stream_ref stream) {
-    auto buf = co_await drain_response_stream(stream);
+    auto buf = co_await http::drain(stream);
     iobuf_parser p{std::move(buf)};
     auto response_string = p.read_string(p.bytes_left());
     vlog(
@@ -111,7 +94,7 @@ ss::future<api_response> make_request_without_payload(
         co_return make_abort_error(
           fmt::format("http request failed:{}", status), status);
     }
-    co_return co_await drain_response_stream(std::move(response_stream));
+    co_return co_await http::drain(std::move(response_stream));
 }
 
 ss::future<api_response> make_request_with_payload(
@@ -140,7 +123,7 @@ ss::future<api_response> make_request_with_payload(
         co_return make_abort_error(
           fmt::format("http request failed:{}", status), status);
     }
-    auto data = co_await drain_response_stream(std::move(response));
+    auto data = co_await http::drain(std::move(response));
     co_await stream.close();
     co_return data;
 }

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -636,8 +636,7 @@ ss::future<http::client::response_stream_ref> abs_client::do_get_object(
 
         const auto content_type = util::get_response_content_type(
           response_stream->get_headers());
-        auto buf = co_await util::drain_response_stream(
-          std::move(response_stream));
+        auto buf = co_await http::drain(std::move(response_stream));
         throw parse_rest_error_response(content_type, status, std::move(buf));
     }
 
@@ -694,8 +693,7 @@ ss::future<> abs_client::do_put_object(
         status != created && !is_no_content_and_accepted) {
         const auto content_type = util::get_response_content_type(
           response_stream->get_headers());
-        auto buf = co_await util::drain_response_stream(
-          std::move(response_stream));
+        auto buf = co_await http::drain(std::move(response_stream));
         throw parse_rest_error_response(content_type, status, std::move(buf));
     }
 }
@@ -811,8 +809,7 @@ ss::future<> abs_client::do_delete_object(
     if (status != boost::beast::http::status::accepted) {
         const auto content_type = util::get_response_content_type(
           response_stream->get_headers());
-        auto buf = co_await util::drain_response_stream(
-          std::move(response_stream));
+        auto buf = co_await http::drain(std::move(response_stream));
         throw parse_rest_error_response(content_type, status, std::move(buf));
     }
 }
@@ -892,7 +889,7 @@ ss::future<abs_client::list_bucket_result> abs_client::do_list_objects(
     if (status != boost::beast::http::status::ok) {
         const auto content_type = util::get_response_content_type(
           response_stream->get_headers());
-        iobuf buf = co_await util::drain_response_stream(response_stream);
+        iobuf buf = co_await http::drain(response_stream);
         throw parse_rest_error_response(content_type, status, std::move(buf));
     }
 
@@ -1037,8 +1034,7 @@ ss::future<> abs_client::do_delete_file(
       && status != boost::beast::http::status::ok) {
         const auto content_type = util::get_response_content_type(
           response_stream->get_headers());
-        auto buf = co_await util::drain_response_stream(
-          std::move(response_stream));
+        auto buf = co_await http::drain(std::move(response_stream));
         throw parse_rest_error_response(content_type, status, std::move(buf));
     }
 }

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -835,7 +835,7 @@ ss::future<s3_client::head_object_result> s3_client::do_head_object(
       .then(
         [key](const http::client::response_stream_ref& ref)
           -> ss::future<head_object_result> {
-            return ref->prefetch_headers().then(
+            return http::drain<void>(ref).then(
               [ref, key]() -> ss::future<head_object_result> {
                   auto status = ref->get_headers().result();
                   if (status == boost::beast::http::status::not_found) {

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -800,7 +800,7 @@ ss::future<http::client::response_stream_ref> s3_client::do_get_object(
                   }
                   const auto content_type = util::get_response_content_type(
                     ref->get_headers());
-                  return util::drain_response_stream(std::move(ref))
+                  return http::drain(std::move(ref))
                     .then([content_type, result](iobuf&& res) {
                         return parse_rest_error_response<
                           http::client::response_stream_ref>(
@@ -918,27 +918,26 @@ ss::future<> s3_client::do_put_object(
           return ss::futurize_invoke(make_request)
             .then([id, accept_no_content](
                     const http::client::response_stream_ref& ref) {
-                return util::drain_response_stream(ref).then(
-                  [ref, id, accept_no_content](iobuf&& res) {
-                      auto status = ref->get_headers().result();
-                      using enum boost::beast::http::status;
-                      if (const auto is_no_content_and_accepted
-                          = status == no_content && accept_no_content;
-                          status != ok && !is_no_content_and_accepted) {
-                          vlog(
-                            s3_log.warn,
-                            "S3 PUT request failed for key {}: {} {:l}",
-                            id,
-                            status,
-                            ref->get_headers());
-                          const auto content_type
-                            = util::get_response_content_type(
-                              ref->get_headers());
-                          return parse_rest_error_response<>(
-                            content_type, status, std::move(res));
-                      }
-                      return ss::now();
-                  });
+                return http::drain(ref).then([ref, id, accept_no_content](
+                                               iobuf&& res) {
+                    auto status = ref->get_headers().result();
+                    using enum boost::beast::http::status;
+                    if (const auto is_no_content_and_accepted
+                        = status == no_content && accept_no_content;
+                        status != ok && !is_no_content_and_accepted) {
+                        vlog(
+                          s3_log.warn,
+                          "S3 PUT request failed for key {}: {} {:l}",
+                          id,
+                          status,
+                          ref->get_headers());
+                        const auto content_type
+                          = util::get_response_content_type(ref->get_headers());
+                        return parse_rest_error_response<>(
+                          content_type, status, std::move(res));
+                    }
+                    return ss::now();
+                });
             })
             .handle_exception_type(
               [](const ss::abort_requested_exception& err) {
@@ -1030,7 +1029,7 @@ ss::future<s3_client::list_bucket_result> s3_client::do_list_objects_v2(
                       header);
                     // In the error path we drain the response stream fully, the
                     // error response should not be very large.
-                    return util::drain_chunked_response_stream(resp).then(
+                    return http::drain(resp).then(
                       [result = header.result(), content_type](iobuf buf) {
                           return parse_rest_error_response<list_bucket_result>(
                             content_type, result, std::move(buf));
@@ -1089,7 +1088,7 @@ ss::future<> s3_client::do_delete_object(
     vlog(s3_log.trace, "send https request:\n{}", header.value());
     return _client.request(std::move(header.value()), timeout)
       .then([key](const http::client::response_stream_ref& ref) {
-          return util::drain_response_stream(ref).then([ref, key](iobuf&& res) {
+          return http::drain(ref).then([ref, key](iobuf&& res) {
               auto status = ref->get_headers().result();
               if (
                 status != boost::beast::http::status::ok
@@ -1190,25 +1189,24 @@ auto s3_client::do_delete_objects(
                    .finally([&] { return to_delete.close(); });
              })
       .then([](const http::client::response_stream_ref& response) {
-          return util::drain_response_stream(response).then(
-            [response](iobuf&& res) {
-                auto status = response->get_headers().result();
-                if (status != boost::beast::http::status::ok) {
-                    const auto content_type = util::get_response_content_type(
-                      response->get_headers());
-                    return parse_rest_error_response<delete_objects_result>(
-                      content_type, status, std::move(res));
-                }
-                auto parse_result = iobuf_to_delete_objects_result(
-                  std::move(res));
-                if (std::holds_alternative<client::delete_objects_result>(
-                      parse_result)) {
-                    return ss::make_ready_future<delete_objects_result>(
-                      std::get<client::delete_objects_result>(parse_result));
-                }
-                return ss::make_exception_future<delete_objects_result>(
-                  std::get<rest_error_response>(parse_result));
-            });
+          return http::drain(response).then([response](iobuf&& res) {
+              auto status = response->get_headers().result();
+              if (status != boost::beast::http::status::ok) {
+                  const auto content_type = util::get_response_content_type(
+                    response->get_headers());
+                  return parse_rest_error_response<delete_objects_result>(
+                    content_type, status, std::move(res));
+              }
+              auto parse_result = iobuf_to_delete_objects_result(
+                std::move(res));
+              if (std::holds_alternative<client::delete_objects_result>(
+                    parse_result)) {
+                  return ss::make_ready_future<delete_objects_result>(
+                    std::get<client::delete_objects_result>(parse_result));
+              }
+              return ss::make_exception_future<delete_objects_result>(
+                std::get<rest_error_response>(parse_result));
+          });
       });
 }
 

--- a/src/v/cloud_storage_clients/util.cc
+++ b/src/v/cloud_storage_clients/util.cc
@@ -150,52 +150,6 @@ handle_client_transport_error<ss::logger>(std::exception_ptr, ss::logger&);
 template error_outcome handle_client_transport_error<retry_chain_logger>(
   std::exception_ptr, retry_chain_logger&);
 
-ss::future<iobuf>
-drain_response_stream(http::client::response_stream_ref resp) {
-    const auto transfer_encoding = resp->get_headers().find(
-      boost::beast::http::field::transfer_encoding);
-
-    if (
-      transfer_encoding != resp->get_headers().end()
-      && transfer_encoding->value().find("chunked")) {
-        return drain_chunked_response_stream(resp);
-    }
-
-    return ss::do_with(
-      iobuf(), [resp = std::move(resp)](iobuf& outbuf) mutable {
-          return ss::do_until(
-                   [resp] { return resp->is_done(); },
-                   [resp, &outbuf] {
-                       return resp->recv_some().then([&outbuf](iobuf&& chunk) {
-                           outbuf.append(std::move(chunk));
-                       });
-                   })
-            .then([&outbuf] {
-                return ss::make_ready_future<iobuf>(std::move(outbuf));
-            });
-      });
-}
-
-ss::future<iobuf>
-drain_chunked_response_stream(http::client::response_stream_ref resp) {
-    return ss::do_with(
-      resp->as_input_stream(),
-      iobuf(),
-      [resp](ss::input_stream<char>& stream, iobuf& outbuf) mutable {
-          return ss::do_until(
-                   [&stream] { return stream.eof(); },
-                   [&stream, &outbuf] {
-                       return stream.read().then(
-                         [&outbuf](ss::temporary_buffer<char>&& chunk) {
-                             outbuf.append(std::move(chunk));
-                         });
-                   })
-            .then([&outbuf] {
-                return ss::make_ready_future<iobuf>(std::move(outbuf));
-            });
-      });
-}
-
 boost::property_tree::ptree iobuf_to_ptree(iobuf&& buf, ss::logger& logger) {
     namespace pt = boost::property_tree;
     try {

--- a/src/v/cloud_storage_clients/util.h
+++ b/src/v/cloud_storage_clients/util.h
@@ -28,15 +28,6 @@ template<typename Logger>
 error_outcome handle_client_transport_error(
   std::exception_ptr current_exception, Logger& logger);
 
-/// \brief: Drain the reponse stream pointed to by the 'resp' handle into an
-/// iobuf
-ss::future<iobuf> drain_response_stream(http::client::response_stream_ref resp);
-
-/// \brief: Drain the reponse stream pointed to by the 'resp' handle into an
-/// iobuf
-ss::future<iobuf>
-drain_chunked_response_stream(http::client::response_stream_ref resp);
-
 /// \brief: Convert iobuf that contains xml data to boost::property_tree
 boost::property_tree::ptree iobuf_to_ptree(iobuf&& buf, ss::logger& logger);
 

--- a/src/v/http/BUILD
+++ b/src/v/http/BUILD
@@ -36,7 +36,6 @@ redpanda_cc_library(
         "probe.h",
     ],
     deps = [
-        ":utils",
         "//src/v/base",
         "//src/v/bytes",
         "//src/v/bytes:iobuf",

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -318,7 +318,12 @@ client::response_stream::response_stream(
 }
 
 client::response_stream::~response_stream() {
-    if (!is_header_done()) {
+    if (!is_done()) {
+        vlog(
+          _ctxlog.warn,
+          "response_stream destroyed before complete read, shutting down "
+          "client");
+        _client->shutdown();
         return;
     }
 

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -308,7 +308,7 @@ static client_probe::verb convert_to_pverb(client::response_stream::verb v) {
 client::response_stream::response_stream(
   client* client, client::response_stream::verb v, ss::sstring target)
   : _client(client)
-  , _ctxlog(http_log, ssx::sformat("{}", std::move(target)))
+  , _ctxlog(http_log, ssx::sformat("{} {}", v, std::move(target)))
   , _parser()
   , _buffer()
   , _sprobe(client->_probe->create_request_subprobe(convert_to_pverb(v))) {

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -316,6 +316,24 @@ client::response_stream::response_stream(
     _parser.eager(true);
 }
 
+client::response_stream::~response_stream() {
+    if (!is_header_done()) {
+        return;
+    }
+
+    const auto& headers = get_headers();
+    auto conn_header_it = headers.find(boost::beast::http::field::connection);
+    if (
+      conn_header_it != headers.end()
+      && boost::beast::iequals(conn_header_it->value(), "close")) {
+        vlog(
+          _ctxlog.trace,
+          "response_stream indicates connection close via header, "
+          "shutting down the client");
+        _client->shutdown();
+    }
+}
+
 bool client::response_stream::is_done() const {
     return _prefetch.empty() && _parser.is_done();
 }

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -16,7 +16,6 @@
 #include "bytes/scattered_message.h"
 #include "config/base_property.h"
 #include "http/logger.h"
-#include "http/utils.h"
 #include "ssx/sformat.h"
 
 #include <seastar/core/abort_source.hh>

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -314,6 +314,7 @@ client::response_stream::response_stream(
   , _sprobe(client->_probe->create_request_subprobe(convert_to_pverb(v))) {
     _parser.body_limit(std::numeric_limits<uint64_t>::max());
     _parser.eager(true);
+    _parser.skip(v == client::response_stream::verb::head);
 }
 
 client::response_stream::~response_stream() {

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -775,12 +775,20 @@ status(client::response_stream_ref response) {
     co_return response->get_headers().result();
 }
 
+template<>
 ss::future<iobuf> drain(client::response_stream_ref response) {
     iobuf buffer;
     while (!response->is_done()) {
         buffer.append(co_await response->recv_some());
     }
     co_return buffer;
+}
+
+template<>
+ss::future<> drain(client::response_stream_ref response) {
+    while (!response->is_done()) {
+        std::ignore = co_await response->recv_some();
+    }
 }
 
 } // namespace http

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -327,6 +327,11 @@ bool client::response_stream::is_header_done() const {
 
 /// Access response headers (should only be called if is_header_done() == true)
 const client::response_header& client::response_stream::get_headers() const {
+    if (!is_header_done()) {
+        throw std::runtime_error(
+          "invariant violation: response headers are not available yet");
+    }
+
     return _parser.get();
 }
 

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -360,7 +360,15 @@ redacted_fields();
 ss::future<boost::beast::http::status>
 status(client::response_stream_ref response);
 
+template<typename T = iobuf>
+requires std::same_as<T, iobuf> || std::same_as<T, void>
+ss::future<T> drain(client::response_stream_ref response);
+
+template<>
 ss::future<iobuf> drain(client::response_stream_ref response);
+
+template<>
+ss::future<> drain(client::response_stream_ref response);
 
 } // namespace http
 

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -155,6 +155,7 @@ public:
         using verb = boost::beast::http::verb;
         /// C-tor can only be called by http_request
         explicit response_stream(client* client, verb v, ss::sstring target);
+        ~response_stream() override;
 
         response_stream(response_stream&&) = delete;
         response_stream(const response_stream&) = delete;
@@ -268,6 +269,9 @@ public:
       request_header&& request,
       std::optional<iobuf> payload = std::nullopt,
       ss::lowres_clock::duration timeout = default_connect_timeout) final;
+
+    /// Whether the client has a valid connection.
+    using net::base_transport::is_valid;
 
     /**
      * Dispatch a request with the provided headers and body.

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -648,7 +648,10 @@ SEASTAR_THREAD_TEST_CASE(test_http_via_impostor_chunked_encoding) {
       boost::beast::http::field::content_type, "application/json");
 
     // Generate response
-    http::chunked_encoder encoder{false};
+    constexpr size_t http_body_chunk_size = 16;
+    // Ensure we have data for more than one chunk for a more robust test.
+    BOOST_REQUIRE(std::strlen(httpd_server_reply) / http_body_chunk_size > 1);
+    http::chunked_encoder encoder{false, http_body_chunk_size};
     ss::sstring response_data = httpd_server_reply;
     http::client::response_header resp_hdr;
     resp_hdr.result(boost::beast::http::status::ok);

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -190,11 +190,7 @@ void test_http_request(
     // Send request
     auto resp_stream = client->request(std::move(header), request_data).get();
     // Receive response
-    iobuf response_body;
-    while (!resp_stream->is_done()) {
-        iobuf res = resp_stream->recv_some().get();
-        response_body.append(std::move(res));
-    }
+    iobuf response_body = http::drain(resp_stream).get();
     // Check response
     check_reply(resp_stream->get_headers(), std::move(response_body));
     server->stop().get();

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -113,6 +113,15 @@ void set_routes(ss::httpd::routes& r) {
       "json");
 
     r.add(operation_type::GET, url("/headers"), get_headers_handler);
+
+    auto connection_close_handler = new function_handler(
+      [](const_req, ss::http::reply& rep) {
+          rep.add_header("Connection", "close");
+          return "";
+      },
+      "text/plain");
+    r.add(
+      operation_type::GET, url("/connection-close"), connection_close_handler);
 }
 
 /// Http server and client
@@ -1055,4 +1064,52 @@ SEASTAR_THREAD_TEST_CASE(test_send_abort_race) {
 
     // Clean up
     server->stop().get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_connection_keep_alive) {
+    auto config = transport_configuration();
+    http::client::request_header header;
+    header.method(boost::beast::http::verb::get);
+    header.target("/get");
+    header_set_host(header, config.server_addr);
+
+    // Send request
+    auto [server, client] = started_client_and_server(config);
+    auto stop_action = ss::defer([server]() { server->stop().get(); });
+
+    {
+        auto resp_stream = client->request(std::move(header), iobuf{}).get();
+        http::drain<void>(resp_stream).get();
+
+        // Check response
+        BOOST_REQUIRE_EQUAL(
+          resp_stream->get_headers().result(), boost::beast::http::status::ok);
+    }
+
+    // Our client should still be valid.
+    BOOST_REQUIRE(client->is_valid());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_connection_close) {
+    auto config = transport_configuration();
+    http::client::request_header header;
+    header.method(boost::beast::http::verb::get);
+    header.target("/connection-close");
+    header_set_host(header, config.server_addr);
+
+    // Send request
+    auto [server, client] = started_client_and_server(config);
+    auto stop_action = ss::defer([server]() { server->stop().get(); });
+
+    {
+        auto resp_stream = client->request(std::move(header), iobuf{}).get();
+        http::drain<void>(resp_stream).get();
+
+        // Check response
+        BOOST_REQUIRE_EQUAL(
+          resp_stream->get_headers().result(), boost::beast::http::status::ok);
+    }
+
+    // Our client shouldn't be valid after server requested connection close.
+    BOOST_REQUIRE(!client->is_valid());
 }

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -78,6 +78,15 @@ void set_routes(ss::httpd::routes& r) {
     });
     r.add(operation_type::GET, url("/fail-status-500"), fail_handler);
 
+    auto head_handler = new function_handler(
+      [](const_req, ss::http::reply& rep) {
+          rep.add_header(
+            "Content-Length", std::to_string(strlen(httpd_server_reply)));
+          return "";
+      },
+      "text/plain");
+    r.add(operation_type::HEAD, url("/get"), head_handler);
+
     auto get_handler = new function_handler(
       [](const_req) -> ss::sstring { return httpd_server_reply; });
     r.add(operation_type::GET, url("/get"), get_handler);
@@ -338,6 +347,22 @@ SEASTAR_THREAD_TEST_CASE(test_error_500) {
             header.result(), boost::beast::http::status::internal_server_error);
           std::string actual = body.linearize_to_string();
           BOOST_REQUIRE(actual.find("/fail-status-500") != std::string::npos);
+      });
+}
+
+SEASTAR_THREAD_TEST_CASE(test_http_HEAD_roundtrip) {
+    // No request data
+    auto config = transport_configuration();
+    http::client::request_header header;
+    header.method(boost::beast::http::verb::head);
+    header.target("/get");
+    header_set_host(header, config.server_addr);
+    test_http_request(
+      config,
+      std::move(header),
+      std::nullopt,
+      [](const http::client::response_header& header, const iobuf&) {
+          BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
       });
 }
 

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -1115,6 +1115,31 @@ SEASTAR_THREAD_TEST_CASE(test_connection_keep_alive) {
     BOOST_REQUIRE(client->is_valid());
 }
 
+SEASTAR_THREAD_TEST_CASE(test_invalidate_improper_client_usage) {
+    auto config = transport_configuration();
+    http::client::request_header header;
+    header.method(boost::beast::http::verb::get);
+    header.target("/get");
+    header_set_host(header, config.server_addr);
+
+    // Send request
+    auto [server, client] = started_client_and_server(config);
+    auto stop_action = ss::defer([server]() { server->stop().get(); });
+
+    {
+        auto resp_stream = client->request(std::move(header), iobuf{}).get();
+        // Improper usage: prefetch headers but don't consume the response body.
+        resp_stream->prefetch_headers().get();
+
+        // Check response
+        BOOST_REQUIRE_EQUAL(
+          resp_stream->get_headers().result(), boost::beast::http::status::ok);
+    }
+
+    // Our client shouldn't be valid after improper usage.
+    BOOST_REQUIRE(!client->is_valid());
+}
+
 SEASTAR_THREAD_TEST_CASE(test_connection_close) {
     auto config = transport_configuration();
     http::client::request_header header;


### PR DESCRIPTION
[Copilot summary](https://github.com/redpanda-data/redpanda/pull/28788#pullrequestreview-3519748268)

> This PR improves HTTP client connection handling and reuse by properly managing keep-alive connections and detecting when connections should be closed. The changes ensure the client properly invalidates itself when responses are not fully consumed or when the server explicitly requests connection closure via the "Connection: close" header.
> 
> Key changes:
> 
> - Added destructor logic to response_stream to detect improper usage and server-requested connection closure
> - Added support for HTTP HEAD requests by configuring the parser to skip the response body
> - Exposed the is_valid() method from base_transport to allow checking connection validity
> 

  See individual commits for details.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* Minor improvements to http client for better connection reuse in certain edge cases.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
