### PR TITLE
[CORE-7351] Improve chances of finding a scrubber hit

### DIFF
--- a/tests/rptest/tests/cloud_storage_scrubber_test.py
+++ b/tests/rptest/tests/cloud_storage_scrubber_test.py
@@ -335,13 +335,16 @@ class CloudStorageScrubberTest(RedpandaTest):
     def _delete_segment_and_await_anomaly(
         self, expected_anomalies: DefaultDict[NTPR, Anomalies]
     ):
-        segment_metas = [
-            meta
-            for meta in self.cloud_storage_client.list_objects(self.bucket_name)
-            if ".log" in meta.key
-            and not meta.key.endswith(".index")
-            and not meta.key.endswith(".tx")
-        ]
+        def get_segment_metas():
+            return [
+                meta
+                for meta in self.cloud_storage_client.list_objects(self.bucket_name)
+                if ".log" in meta.key
+                and not meta.key.endswith(".index")
+                and not meta.key.endswith(".tx")
+            ]
+
+        segment_metas = get_segment_metas()
 
         view = BucketView(self.redpanda)
         attempts = 1
@@ -362,7 +365,11 @@ class CloudStorageScrubberTest(RedpandaTest):
                     break
 
             attempts += 1
-            assert attempts < 100, "Too many attempts to find a segment to delete"
+            if attempts % 20 == 0:
+                # refresh and relax. let objects and manifests land
+                segment_metas = get_segment_metas()
+                time.sleep(0.25)
+            assert attempts <= 100, "Too many attempts to find a segment to delete"
 
         self.logger.info(f"Deleting segment at {to_delete.key}")
         self.cloud_storage_client.delete_object(

--- a/tests/rptest/tests/cloud_storage_scrubber_test.py
+++ b/tests/rptest/tests/cloud_storage_scrubber_test.py
@@ -338,7 +338,9 @@ class CloudStorageScrubberTest(RedpandaTest):
         segment_metas = [
             meta
             for meta in self.cloud_storage_client.list_objects(self.bucket_name)
-            if "log" in meta.key
+            if ".log" in meta.key
+            and not meta.key.endswith(".index")
+            and not meta.key.endswith(".tx")
         ]
 
         view = BucketView(self.redpanda)

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -1574,6 +1574,7 @@ class BucketView:
         """
         try:
             if not self.path_matcher.is_segment(o):
+                self.logger.debug(f"Object '{o}' is not a segment")
                 return None
 
             segment_path = parse_s3_segment_path(o.key)


### PR DESCRIPTION
Scrubber test picks a random object out of S3 and deletes it if it is in the manifest. The test was failing occasionally because no object chosen could be found in the manifest. Couple issues observed: First, spill over was happening so presumably objects were in S3 but not in head manifest. Second, we were using up our retries looking at objects that weren't segments, so we filtered those out. Third, we never refreshed the object listing, so we did that if we failed a bunch.

Overall I think these changes should make the test more reliable. There was a proposal by Oren that we instead choose a segment out of the manifest since ultimately it has to be in there anyway. That's a reasonable option too, but I didn't take that approach here primarily because I don't understand the full history of the test and this change seems to retain the essense.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
