### PR TITLE
Default configuration property for RPC request timeout

### DIFF
--- a/src/v/cloud_topics/level_one/domain/domain_supervisor.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_supervisor.cc
@@ -186,13 +186,13 @@ private:
     ss::future<> update_topic(cluster::topic_properties_update update) {
         cluster::errc ec{};
         try {
-            auto res
-              = co_await _controller->get_topics_frontend()
-                  .local()
-                  .update_topic_properties(
-                    {update},
-                    ss::lowres_clock::now()
-                      + config::shard_local_cfg().alter_topic_cfg_timeout_ms());
+            auto res = co_await _controller->get_topics_frontend()
+                         .local()
+                         .update_topic_properties(
+                           {update},
+                           ss::lowres_clock::now()
+                             + config::shard_local_cfg()
+                                 .internal_rpc_request_timeout_ms());
             vassert(res.size() == 1, "expected a single result");
             ec = res[0].ec;
         } catch (const std::exception& ex) {
@@ -223,7 +223,8 @@ private:
                          .local()
                          .autocreate_topics(
                            {std::move(topic_cfg)},
-                           config::shard_local_cfg().create_topic_timeout_ms());
+                           config::shard_local_cfg()
+                             .internal_rpc_request_timeout_ms());
             vassert(res.size() == 1, "expected a single result");
             ec = res[0].ec;
             // fall through to handle ec value

--- a/src/v/cluster/id_allocator_frontend.cc
+++ b/src/v/cluster/id_allocator_frontend.cc
@@ -234,7 +234,8 @@ ss::future<bool> id_allocator_frontend::try_create_id_allocator_topic() {
     return _controller->get_topics_frontend()
       .local()
       .autocreate_topics(
-        {std::move(topic)}, config::shard_local_cfg().create_topic_timeout_ms())
+        {std::move(topic)},
+        config::shard_local_cfg().internal_rpc_request_timeout_ms())
       .then([](std::vector<cluster::topic_result> res) {
           vassert(res.size() == 1, "expected exactly one result");
           if (res[0].ec != cluster::errc::success) {

--- a/src/v/cluster/members_frontend.cc
+++ b/src/v/cluster/members_frontend.cc
@@ -35,7 +35,7 @@ members_frontend::members_frontend(
   ss::sharded<ss::abort_source>& as)
   : _self(*config::node().node_id())
   , _node_op_timeout(
-      config::shard_local_cfg().node_management_operation_timeout_ms)
+      config::shard_local_cfg().internal_rpc_request_timeout_ms())
   , _stm(stm)
   , _connections(connections)
   , _leaders(leaders)

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -85,7 +85,8 @@ rm_stm::rm_stm(
   ss::sharded<tx::producer_state_manager>& producer_state_manager,
   std::optional<model::vcluster_id> vcluster_id)
   : raft::persisted_stm<>(rm_stm_snapshot, logger, c)
-  , _sync_timeout(config::shard_local_cfg().rm_sync_timeout_ms.bind())
+  , _sync_timeout(
+      config::shard_local_cfg().internal_rpc_request_timeout_ms.bind())
   , _tx_timeout_delay(config::shard_local_cfg().tx_timeout_delay_ms.value())
   , _abort_interval_ms(
       config::shard_local_cfg()

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -69,7 +69,8 @@ model::record_batch tm_stm::serialize_tx(tx_metadata tx) {
 
 tm_stm::tm_stm(ss::logger& logger, raft::consensus* c)
   : raft::persisted_stm<>(tm_stm_snapshot, logger, c)
-  , _sync_timeout(config::shard_local_cfg().tm_sync_timeout_ms.value())
+  , _sync_timeout(
+      config::shard_local_cfg().internal_rpc_request_timeout_ms.value())
   , _transactional_id_expiration(
       config::shard_local_cfg().transactional_id_expiration_ms.bind())
   , _ctx_log(logger, ssx::sformat("[{}]", _raft->ntp())) {}

--- a/src/v/cluster/topic_recovery_service.cc
+++ b/src/v/cluster/topic_recovery_service.cc
@@ -418,7 +418,7 @@ topic_recovery_service::create_topics(const recovery_request& request) {
 
     co_return co_await _topics_frontend.local().autocreate_topics(
       std::move(topic_configs),
-      config::shard_local_cfg().create_topic_timeout_ms());
+      config::shard_local_cfg().internal_rpc_request_timeout_ms());
 }
 
 void topic_recovery_service::start_download_bg_tracker() {

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -877,7 +877,8 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::limit_init_tm_tx(
               old_tx.id);
             auto tx_units = co_await stm->lock_tx(old_tx.id, "init_tm_tx");
 
-            auto timeout = config::shard_local_cfg().create_topic_timeout_ms();
+            auto timeout
+              = config::shard_local_cfg().internal_rpc_request_timeout_ms();
             auto tx_maybe = co_await find_and_try_progressing_transaction(
               term, stm, old_tx.id, timeout);
             if (tx_maybe.has_value()) {
@@ -2624,7 +2625,7 @@ ss::future<> tx_gateway_frontend::expire_old_tx(
     }
 
     auto term = sync_result.value();
-    auto timeout = config::shard_local_cfg().create_topic_timeout_ms();
+    auto timeout = config::shard_local_cfg().internal_rpc_request_timeout_ms();
 
     auto tx_maybe = co_await find_and_try_progressing_transaction(
       term, stm, tx_id, timeout);
@@ -2867,14 +2868,8 @@ ss::future<result<tx_metadata, tx::errc>> tx_gateway_frontend::describe_tx(
         co_return sync_result.error();
     }
     auto term = sync_result.value();
-
-    // create_topic_timeout_ms isn't the right timeout here but this change
-    // is intendent to be a backport so we're not at will to introduce new
-    // configuration; what we need there is a timeout which acts as an upper
-    // boundary for happy case replication and create_topic_timeout_ms is a
-    // good approximation, we already use it for that purpose in other api:
-    // init_producer_id, add_offsets_to_txn etc
-    auto timeout = config::shard_local_cfg().create_topic_timeout_ms();
+    const auto timeout
+      = config::shard_local_cfg().internal_rpc_request_timeout_ms();
     co_return co_await find_and_try_progressing_transaction(
       term, stm, tid, timeout);
 }

--- a/src/v/cluster/tx_topic_manager.cc
+++ b/src/v/cluster/tx_topic_manager.cc
@@ -165,7 +165,8 @@ ss::future<std::error_code> tx_topic_manager::try_create_coordinator_topic() {
       .local()
       .autocreate_topics(
         {std::move(topic_cfg)},
-        config::shard_local_cfg().create_topic_timeout_ms() * partition_count)
+        config::shard_local_cfg().internal_rpc_request_timeout_ms()
+          * partition_count)
       .then([](std::vector<cluster::topic_result> results) {
           vassert(
             results.size() == 1,

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -701,23 +701,10 @@ configuration::configuration()
       "controls the number retries.",
       {.visibility = visibility::tunable},
       30)
-  , tm_sync_timeout_ms(
-      *this,
-      "tm_sync_timeout_ms",
-      "Transaction manager's synchronization timeout. Maximum time to wait for "
-      "internal state machine to catch up before rejecting a request.",
-      {.visibility = visibility::user},
-      10s)
+  , tm_sync_timeout_ms(*this, "tm_sync_timeout_ms")
   , tx_registry_sync_timeout_ms(*this, "tx_registry_sync_timeout_ms")
   , tm_violation_recovery_policy(*this, "tm_violation_recovery_policy")
-  , rm_sync_timeout_ms(
-      *this,
-      "rm_sync_timeout_ms",
-      "Resource manager's synchronization timeout. Specifies the maximum time "
-      "for this node to wait for the internal state machine to catch up with "
-      "all events written by previous leaders before rejecting a request.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      10s)
+  , rm_sync_timeout_ms(*this, "rm_sync_timeout_ms")
   , find_coordinator_timeout_ms(*this, "find_coordinator_timeout_ms")
   , seq_table_min_size(*this, "seq_table_min_size")
   , tx_timeout_delay_ms(
@@ -799,16 +786,7 @@ configuration::configuration()
       "milliseconds.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       100ms)
-  , alter_topic_cfg_timeout_ms(
-      *this,
-      "alter_topic_cfg_timeout_ms",
-      "The duration, in milliseconds, that Redpanda waits for the replication "
-      "of entries in the controller log when executing a request to alter "
-      "topic configurations. This timeout ensures that configuration changes "
-      "are replicated across the cluster before the alteration request is "
-      "considered complete.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      5s)
+  , alter_topic_cfg_timeout_ms(*this, "alter_topic_cfg_timeout_ms")
   , log_cleanup_policy(
       *this,
       "log_cleanup_policy",
@@ -916,13 +894,7 @@ configuration::configuration()
       "Use separate scheduler group to handle parsing Kafka protocol requests",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       true)
-  , metadata_status_wait_timeout_ms(
-      *this,
-      "metadata_status_wait_timeout_ms",
-      "Maximum time to wait in metadata request for cluster health to be "
-      "refreshed.",
-      {.visibility = visibility::tunable},
-      2s)
+  , metadata_status_wait_timeout_ms(*this, "metadata_status_wait_timeout_ms")
   , kafka_tcp_keepalive_idle_timeout_seconds(
       *this,
       "kafka_tcp_keepalive_timeout",
@@ -1249,18 +1221,8 @@ configuration::configuration()
       {.needs_restart = needs_restart::no,
        .visibility = visibility::deprecated},
       10s)
-  , create_topic_timeout_ms(
-      *this,
-      "create_topic_timeout_ms",
-      "Timeout, in milliseconds, to wait for new topic creation.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      2'000ms)
-  , wait_for_leader_timeout_ms(
-      *this,
-      "wait_for_leader_timeout_ms",
-      "Timeout to wait for leadership in metadata cache.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      5'000ms)
+  , create_topic_timeout_ms(*this, "create_topic_timeout_ms")
+  , wait_for_leader_timeout_ms(*this, "wait_for_leader_timeout_ms")
   , default_topic_partitions(
       *this,
       "default_topic_partitions",
@@ -1291,13 +1253,7 @@ configuration::configuration()
       "Timeout for append entry requests issued while replicating entries.",
       {.visibility = visibility::tunable},
       3s)
-  , recovery_append_timeout_ms(
-      *this,
-      "recovery_append_timeout_ms",
-      "Timeout for append entry requests issued while updating a stale "
-      "follower.",
-      {.visibility = visibility::tunable},
-      5s)
+  , recovery_append_timeout_ms(*this, "recovery_append_timeout_ms")
   , raft_replicate_batch_window_size(
       *this,
       "raft_replicate_batch_window_size",
@@ -1771,11 +1727,7 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1s)
   , node_management_operation_timeout_ms(
-      *this,
-      "node_management_operation_timeout_ms",
-      "Timeout for executing node management operations.",
-      {.visibility = visibility::tunable},
-      5s)
+      *this, "node_management_operation_timeout_ms")
   , kafka_request_max_bytes(
       *this,
       "kafka_request_max_bytes",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4504,6 +4504,12 @@ configuration::configuration()
       "cluster for data replication.",
       meta{.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
+  , internal_rpc_request_timeout_ms(
+      *this,
+      "internal_rpc_request_timeout_ms",
+      "Default timeout for RPC requests between Redpanda nodes.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      10s)
   , cloud_topics_enabled(
       *this,
       true,

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -211,10 +211,10 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> metadata_dissemination_interval_ms;
     property<std::chrono::milliseconds> metadata_dissemination_retry_delay_ms;
     property<int16_t> metadata_dissemination_retries;
-    property<std::chrono::milliseconds> tm_sync_timeout_ms;
+    deprecated_property tm_sync_timeout_ms;
     deprecated_property tx_registry_sync_timeout_ms;
     deprecated_property tm_violation_recovery_policy;
-    property<std::chrono::milliseconds> rm_sync_timeout_ms;
+    deprecated_property rm_sync_timeout_ms;
     deprecated_property find_coordinator_timeout_ms;
     deprecated_property seq_table_min_size;
     property<std::chrono::milliseconds> tx_timeout_delay_ms;
@@ -227,7 +227,7 @@ struct configuration final : public config_store {
     bounded_property<double, numeric_bounds>
       fetch_pid_target_utilization_fraction;
     property<std::chrono::milliseconds> fetch_pid_max_debounce_ms;
-    property<std::chrono::milliseconds> alter_topic_cfg_timeout_ms;
+    deprecated_property alter_topic_cfg_timeout_ms;
     property<model::cleanup_policy_bitflags> log_cleanup_policy;
     enum_property<model::timestamp_type> log_message_timestamp_type;
     deprecated_property log_message_timestamp_alert_before_ms;
@@ -243,7 +243,7 @@ struct configuration final : public config_store {
     property<bool> use_fetch_scheduler_group;
     property<bool> use_produce_scheduler_group;
     property<bool> use_kafka_handler_scheduler_group;
-    property<std::chrono::milliseconds> metadata_status_wait_timeout_ms;
+    deprecated_property metadata_status_wait_timeout_ms;
     property<std::chrono::seconds> kafka_tcp_keepalive_idle_timeout_seconds;
     property<std::chrono::seconds> kafka_tcp_keepalive_probe_interval_seconds;
     property<uint32_t> kafka_tcp_keepalive_probes;
@@ -291,14 +291,14 @@ struct configuration final : public config_store {
     // same as transaction.max.timeout.ms in Apache Kafka.
     property<std::chrono::milliseconds> transaction_max_timeout_ms;
     property<std::chrono::seconds> tx_log_stats_interval_s;
-    property<std::chrono::milliseconds> create_topic_timeout_ms;
-    property<std::chrono::milliseconds> wait_for_leader_timeout_ms;
+    deprecated_property create_topic_timeout_ms;
+    deprecated_property wait_for_leader_timeout_ms;
     property<int32_t> default_topic_partitions;
     property<bool> disable_batch_cache;
     property<std::chrono::milliseconds> raft_election_timeout_ms;
     property<std::chrono::milliseconds> kafka_group_recovery_timeout_ms;
     property<std::chrono::milliseconds> replicate_append_timeout_ms;
-    property<std::chrono::milliseconds> recovery_append_timeout_ms;
+    deprecated_property recovery_append_timeout_ms;
     property<size_t> raft_replicate_batch_window_size;
     property<size_t> raft_learner_recovery_rate;
     property<bool> raft_recovery_throttle_disable_dynamic_mode;
@@ -362,7 +362,7 @@ struct configuration final : public config_store {
     property<bool> kafka_enable_partition_reassignment;
     property<std::chrono::milliseconds>
       controller_backend_housekeeping_interval_ms;
-    property<std::chrono::milliseconds> node_management_operation_timeout_ms;
+    deprecated_property node_management_operation_timeout_ms;
     property<uint32_t> kafka_request_max_bytes;
     property<uint32_t> kafka_batch_max_bytes;
     property<std::vector<ss::sstring>> kafka_nodelete_topics;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -803,6 +803,7 @@ struct configuration final : public config_store {
     bounded_property<size_t> datalake_scheduler_disk_reservation_block_size;
     property<bool> consumer_offsets_topic_batch_cache_enabled;
     enterprise<property<bool>> enable_shadow_linking;
+    property<std::chrono::milliseconds> internal_rpc_request_timeout_ms;
 
     configuration();
 

--- a/src/v/datalake/coordinator/frontend.cc
+++ b/src/v/datalake/coordinator/frontend.cc
@@ -297,7 +297,7 @@ ss::future<bool> frontend::ensure_topic_exists() {
     try {
         auto res = co_await _topics_frontend->local().autocreate_topics(
           {std::move(topic)},
-          config::shard_local_cfg().create_topic_timeout_ms());
+          config::shard_local_cfg().internal_rpc_request_timeout_ms());
         vassert(
           res.size() == 1,
           "Incorrect result when creating {}, expected 1 response, got: {}",

--- a/src/v/kafka/data/rpc/deps.cc
+++ b/src/v/kafka/data/rpc/deps.cc
@@ -150,7 +150,8 @@ public:
                          .local()
                          .autocreate_topics(
                            {std::move(topic_cfg)},
-                           config::shard_local_cfg().create_topic_timeout_ms());
+                           config::shard_local_cfg()
+                             .internal_rpc_request_timeout_ms());
             vassert(res.size() == 1, "expected a single result");
             co_return res[0].ec;
         } catch (const std::exception& ex) {
@@ -187,13 +188,13 @@ public:
     ss::future<cluster::errc>
     update_topic(cluster::topic_properties_update update) final {
         try {
-            auto res
-              = co_await _controller->get_topics_frontend()
-                  .local()
-                  .update_topic_properties(
-                    {update},
-                    ss::lowres_clock::now()
-                      + config::shard_local_cfg().alter_topic_cfg_timeout_ms());
+            auto res = co_await _controller->get_topics_frontend()
+                         .local()
+                         .update_topic_properties(
+                           {update},
+                           ss::lowres_clock::now()
+                             + config::shard_local_cfg()
+                                 .internal_rpc_request_timeout_ms());
             vassert(res.size() == 1, "expected a single result");
             co_return res[0].ec;
         } catch (const std::exception& ex) {

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -3330,7 +3330,7 @@ group::do_try_abort_old_tx(model::producer_identity pid) {
         producer_tx.coordinator_partition,
         pid,
         producer_tx.tx_seq,
-        config::shard_local_cfg().rm_sync_timeout_ms.value()));
+        config::shard_local_cfg().internal_rpc_request_timeout_ms.value()));
 
     if (r.ec != cluster::tx::errc::none) {
         co_return r.ec;

--- a/src/v/kafka/server/group_initializer.cc
+++ b/src/v/kafka/server/group_initializer.cc
@@ -101,7 +101,8 @@ ss::future<bool> group_initializer::try_create_consumer_group_topic() {
     }
     return _topics_frontend.local()
       .autocreate_topics(
-        {std::move(topic)}, config::shard_local_cfg().create_topic_timeout_ms())
+        {std::move(topic)},
+        config::shard_local_cfg().internal_rpc_request_timeout_ms())
       .then([this](std::vector<cluster::topic_result> res) {
           /*
            * kindly ask client to retry on error

--- a/src/v/kafka/server/handlers/details/alter_config_utils.h
+++ b/src/v/kafka/server/handlers/details/alter_config_utils.h
@@ -229,7 +229,7 @@ ss::future<chunked_vector<R>> do_alter_topics_configuration(
       = co_await ctx.topics_frontend().update_topic_properties(
         std::move(updates),
         model::timeout_clock::now()
-          + config::shard_local_cfg().alter_topic_cfg_timeout_ms());
+          + config::shard_local_cfg().internal_rpc_request_timeout_ms());
     for (auto& res : update_results) {
         responses.push_back(
           R{

--- a/src/v/kafka/server/handlers/find_coordinator.cc
+++ b/src/v/kafka/server/handlers/find_coordinator.cc
@@ -66,8 +66,9 @@ ss::future<kafka::coordinator_response> partition_to_coordinator(
         co_return return_element;
     }
 
-    auto timeout = ss::lowres_clock::now()
-                   + config::shard_local_cfg().wait_for_leader_timeout_ms();
+    auto timeout
+      = ss::lowres_clock::now()
+        + config::shard_local_cfg().internal_rpc_request_timeout_ms();
 
     model::ntp consumer_offsets_ntp{
       model::kafka_namespace,

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -643,7 +643,7 @@ static ss::future<chunked_vector<resp_resource_t>> alter_broker_configuration(
               .patch(
                 std::move(req),
                 model::timeout_clock::now()
-                  + config::shard_local_cfg().alter_topic_cfg_timeout_ms())
+                  + config::shard_local_cfg().internal_rpc_request_timeout_ms())
               .then([resource = std::move(resource_c)](
                       cluster::config_frontend::patch_result pr) {
                   std::error_code& ec = pr.errc;

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -203,7 +203,7 @@ ss::future<metadata_response::topic> create_topic(
       topic,
       config::shard_local_cfg().default_topic_partitions(),
       config::shard_local_cfg().default_topic_replication()};
-    auto tout = config::shard_local_cfg().create_topic_timeout_ms();
+    auto tout = config::shard_local_cfg().internal_rpc_request_timeout_ms();
     try {
         auto res = co_await ctx.topics_frontend().autocreate_topics(
           {std::move(cfg)}, tout);

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -987,7 +987,8 @@ ss::future<response_ptr> end_txn_handler::handle(
           .committed = request.data.committed};
         return ctx.tx_gateway_frontend()
           .end_txn(
-            tx_request, config::shard_local_cfg().create_topic_timeout_ms())
+            tx_request,
+            config::shard_local_cfg().internal_rpc_request_timeout_ms())
           .then([&ctx](cluster::end_tx_reply tx_response) {
               end_txn_response_data data;
               data.error_code = map_tx_errc(tx_response.error_code);
@@ -1044,7 +1045,8 @@ add_offsets_to_txn_handler::handle(request_context ctx, ss::smp_service_group) {
           .group_id = request.data.group_id};
 
         auto f = ctx.tx_gateway_frontend().add_offsets_to_tx(
-          tx_request, config::shard_local_cfg().create_topic_timeout_ms());
+          tx_request,
+          config::shard_local_cfg().internal_rpc_request_timeout_ms());
 
         return f.then([&ctx](cluster::add_offsets_tx_reply tx_response) {
             add_offsets_to_txn_response_data data;
@@ -1120,7 +1122,8 @@ ss::future<response_ptr> add_partitions_to_txn_handler::handle(
 
         return ctx.tx_gateway_frontend()
           .add_partition_to_tx(
-            tx_request, config::shard_local_cfg().create_topic_timeout_ms())
+            tx_request,
+            config::shard_local_cfg().internal_rpc_request_timeout_ms())
           .then([&ctx](cluster::add_partitions_tx_reply tx_response) {
               add_partitions_to_txn_response_data data;
               for (auto& tx_topic : tx_response.results) {
@@ -1855,7 +1858,7 @@ ss::future<response_ptr> init_producer_id_handler::handle(
               .init_tm_tx(
                 request.data.transactional_id.value(),
                 request.data.transaction_timeout_ms,
-                config::shard_local_cfg().create_topic_timeout_ms(),
+                config::shard_local_cfg().internal_rpc_request_timeout_ms(),
                 expected_pid == model::no_pid
                   ? std::optional<model::producer_identity>()
                   : expected_pid)
@@ -1902,7 +1905,8 @@ ss::future<response_ptr> init_producer_id_handler::handle(
         }
 
         return ctx.id_allocator_frontend()
-          .allocate_id(config::shard_local_cfg().create_topic_timeout_ms())
+          .allocate_id(
+            config::shard_local_cfg().internal_rpc_request_timeout_ms())
           .then([&ctx](cluster::allocate_id_reply r) {
               init_producer_id_response reply;
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -143,7 +143,7 @@ consensus::consensus(
   , _replicate_append_timeout(
       config::shard_local_cfg().replicate_append_timeout_ms())
   , _recovery_append_timeout(
-      config::shard_local_cfg().recovery_append_timeout_ms())
+      config::shard_local_cfg().internal_rpc_request_timeout_ms())
   , _heartbeat_disconnect_failures(
       config::shard_local_cfg().raft_heartbeat_disconnect_failures())
   , _storage(storage)

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -3204,7 +3204,7 @@ void application::start_runtime_services(
             feature_table);
           pm.register_factory<cluster::partition_properties_stm_factory>(
             storage.local().kvs(),
-            config::shard_local_cfg().rm_sync_timeout_ms.bind());
+            config::shard_local_cfg().internal_rpc_request_timeout_ms.bind());
           pm.register_factory<datalake::coordinator::stm_factory>();
           pm.register_factory<datalake::translation::stm_factory>(
             config::shard_local_cfg().iceberg_enabled());

--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -422,7 +422,7 @@ class UpdateConfigOperation(Operation):
         "log_message_timestamp_type": lambda: random.choice(
             ["CreateTime", "LogAppendTime"]
         ),
-        "alter_topic_cfg_timeout_ms": lambda: random.randint(2000, 10000),
+        "internal_rpc_request_timeout_ms": lambda: random.randint(8000, 12000),
     }
 
     def __init__(self):


### PR DESCRIPTION
Added a configuration property intended to unify the RPC timeout
management throughout the application. The property is intended to
replace some existing timeout configuration variable and be a default
for future RPC requests and services. Other timeouts f.e. max value of
backoff timeout may and should be derived based on this property.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
