### PR TITLE
[v25.3.x] rpk: check operation status before returning in rpk cluster config set

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/config/BUILD
+++ b/src/go/rpk/pkg/cli/cluster/config/BUILD
@@ -34,6 +34,7 @@ go_library(
         "@org_golang_google_protobuf//types/known/anypb",
         "@org_golang_google_protobuf//types/known/fieldmaskpb",
         "@org_golang_google_protobuf//types/known/structpb",
+        "@org_golang_x_term//:term",
         "@org_uber_go_zap//:zap",
     ],
 )
@@ -50,9 +51,12 @@ go_test(
     ],
     embed = [":config"],
     deps = [
+        "//src/go/rpk/pkg/publicapi",
+        "@build_buf_gen_go_redpandadata_cloud_protocolbuffers_go//redpanda/api/controlplane/v1:controlplane",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v3//:yaml_v3",
+        "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/structpb",
     ],
 )

--- a/src/go/rpk/pkg/cli/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set.go
@@ -129,8 +129,7 @@ Use the flag '--no-confirm' to avoid the confirmation prompt.`,
 						fmt.Printf("Configuration update failed. Operation ID: %s\n", operationID)
 					}
 				} else {
-					// Timeout - operation still in progress
-					fmt.Print("Processing configuration, this operation may take up to 10 minutes. To check the status, run 'rpk cluster config status'\n\n")
+					fmt.Printf("Configuration update is in progress and may take up to 10 minutes. We've waited for %s. To check the status, run 'rpk cluster config status' with the operation ID below.\n\n", timeout)
 					fmt.Printf("Operation ID: %s\n", operationID)
 				}
 			} else {
@@ -171,7 +170,7 @@ Use the flag '--no-confirm' to avoid the confirmation prompt.`,
 	}
 
 	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt")
-	cmd.Flags().DurationVar(&timeout, "timeout", 10*time.Second, "Maximum time to wait for the operation to complete (e.g. 300ms, 1.5s, 30s)")
+	cmd.Flags().DurationVar(&timeout, "timeout", 10*time.Second, "Maximum time to poll for operation completion before displaying operation ID for manual status checking (e.g. 300ms, 1.5s, 30s)")
 	return cmd
 }
 
@@ -308,7 +307,9 @@ func pollOperationStatus(ctx context.Context, cloudClient *publicapi.CloudClient
 	deadline := time.Now().Add(timeout)
 	startTime := time.Now()
 
-	// Start with 2 second delay to allow fast operations to complete before first check
+	// Initial 2 second delay before first poll:
+	// This avoids unnecessary early checks for operations that typically take at least a few seconds,
+	// reducing load and noise from polling. Most operations are not expected to complete instantly.
 	initialDelay := 2 * time.Second
 	fastPollInterval := 500 * time.Millisecond
 	slowPollInterval := 1 * time.Second

--- a/src/go/rpk/pkg/cli/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set.go
@@ -66,7 +66,10 @@ func parseArgs(args []string) ([]string, error) {
 }
 
 func newSetCommand(fs afero.Fs, p *config.Params) *cobra.Command {
-	var noConfirm bool
+	var (
+		noConfirm bool
+		timeout   time.Duration
+	)
 	cmd := &cobra.Command{
 		Use:   "set [KEY] [VALUE]",
 		Short: "Set a single cluster configuration property",
@@ -103,7 +106,7 @@ Use the flag '--no-confirm' to avoid the confirmation prompt.`,
 
 				// Poll operation status
 				cloudClient := publicapi.NewCloudClientSet(cfg.DevOverrides().PublicAPIURL, vp.CurrentAuth().AuthToken)
-				finalOp, completedInTime, err := pollOperationStatus(cmd.Context(), cloudClient, operationID)
+				finalOp, completedInTime, err := pollOperationStatus(cmd.Context(), cloudClient, operationID, timeout)
 				out.MaybeDieErr(err)
 
 				// Handle the result based on state
@@ -157,6 +160,7 @@ Use the flag '--no-confirm' to avoid the confirmation prompt.`,
 	}
 
 	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt")
+	cmd.Flags().DurationVar(&timeout, "timeout", 10*time.Second, "Maximum time to wait for the operation to complete (e.g. 300ms, 1.5s, 30s)")
 	return cmd
 }
 
@@ -286,12 +290,26 @@ func setCloudConfig(ctx context.Context, cfg *config.Config, p *config.RpkProfil
 	return operation.Msg, nil
 }
 
-// pollOperationStatus polls the operation status every 1 second for up to 10 seconds.
+// pollOperationStatus polls the operation status with adaptive backoff for up to the specified timeout.
+// Uses aggressive polling (500ms) in the first 5 seconds for fast operations, then falls back to 1s polling.
 // Returns the final operation state and whether it completed within the timeout.
-func pollOperationStatus(ctx context.Context, cloudClient *publicapi.CloudClientSet, operationID string) (*controlplanev1.Operation, bool, error) {
-	timeout := 10 * time.Second
-	pollInterval := 1 * time.Second
+func pollOperationStatus(ctx context.Context, cloudClient *publicapi.CloudClientSet, operationID string, timeout time.Duration) (*controlplanev1.Operation, bool, error) {
 	deadline := time.Now().Add(timeout)
+	startTime := time.Now()
+
+	// Start with 2 second delay to allow fast operations to complete before first check
+	initialDelay := 2 * time.Second
+	fastPollInterval := 500 * time.Millisecond
+	slowPollInterval := 1 * time.Second
+	fastPollThreshold := 5 * time.Second
+
+	// Wait for initial delay before first poll
+	select {
+	case <-time.After(initialDelay):
+		// Continue to first poll
+	case <-ctx.Done():
+		return nil, false, fmt.Errorf("context cancelled while waiting for initial delay: %w", ctx.Err())
+	}
 
 	for time.Now().Before(deadline) {
 		resp, err := cloudClient.Operations.GetOperation(ctx, connect.NewRequest(&controlplanev1.GetOperationRequest{
@@ -306,6 +324,13 @@ func pollOperationStatus(ctx context.Context, cloudClient *publicapi.CloudClient
 
 		if state == controlplanev1.Operation_STATE_COMPLETED || state == controlplanev1.Operation_STATE_FAILED {
 			return op, true, nil
+		}
+
+		// Adaptive polling: fast polling (500ms) for first 5 seconds, then slow polling (1s)
+		elapsed := time.Since(startTime)
+		pollInterval := slowPollInterval
+		if elapsed < fastPollThreshold {
+			pollInterval = fastPollInterval
 		}
 
 		// Wait for next poll or context cancellation

--- a/src/go/rpk/pkg/cli/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set.go
@@ -111,7 +111,7 @@ Use the flag '--no-confirm' to avoid the confirmation prompt.`,
 				cloudClient := publicapi.NewCloudClientSet(cfg.DevOverrides().PublicAPIURL, vp.CurrentAuth().AuthToken)
 				pollCtx, cancel := context.WithTimeout(cmd.Context(), timeout)
 				defer cancel()
-				finalOp, completedInTime, err := pollOperationStatus(pollCtx, cloudClient, operationID, isTerminal)
+				finalOp, completedInTime, err := pollOperationStatusWithConfig(pollCtx, cloudClient, operationID, isTerminal, nil)
 				out.MaybeDieErr(err)
 
 				// Clear the progress line
@@ -309,14 +309,6 @@ type pollConfig struct {
 	fastPollThreshold time.Duration
 }
 
-// pollOperationStatus polls the operation status with adaptive backoff until the context deadline is reached.
-// Uses aggressive polling (500ms) in the first 5 seconds for fast operations, then exponential backoff
-// (1s, 2s, 4s, 8s, 16s, 32s) for longer-running operations to reduce server load.
-// Returns the final operation state and whether it completed within the timeout.
-func pollOperationStatus(ctx context.Context, cloudClient *publicapi.CloudClientSet, operationID string, isTerminal bool) (*controlplanev1.Operation, bool, error) {
-	return pollOperationStatusWithConfig(ctx, cloudClient, operationID, isTerminal, nil)
-}
-
 // pollOperationStatusWithConfig is the same as pollOperationStatus but allows overriding timing configuration.
 // This is primarily useful for testing with shorter intervals.
 func pollOperationStatusWithConfig(ctx context.Context, cloudClient *publicapi.CloudClientSet, operationID string, isTerminal bool, cfg *pollConfig) (*controlplanev1.Operation, bool, error) {
@@ -340,6 +332,15 @@ func pollOperationStatusWithConfig(ctx context.Context, cloudClient *publicapi.C
 	currentSlowInterval := slowPollInterval
 	maxSlowInterval := 32 * time.Second
 
+	// Cap initial delay at half the timeout to ensure time for at least one poll
+	if deadline, ok := ctx.Deadline(); ok {
+		timeRemaining := time.Until(deadline)
+		maxInitialDelay := timeRemaining / 2
+		if initialDelay > maxInitialDelay {
+			initialDelay = maxInitialDelay
+		}
+	}
+
 	// Wait for initial delay before first poll
 	select {
 	case <-time.After(initialDelay):
@@ -350,7 +351,7 @@ func pollOperationStatusWithConfig(ctx context.Context, cloudClient *publicapi.C
 	case <-ctx.Done():
 		if ctx.Err() == context.DeadlineExceeded {
 			// Timeout during initial delay - get final status
-			return getFinalOperationStatus(cloudClient, operationID)
+			return getFinalOperationStatus(ctx, cloudClient, operationID)
 		}
 		return nil, false, fmt.Errorf("context cancelled while waiting for initial delay: %w", ctx.Err())
 	}
@@ -362,7 +363,7 @@ func pollOperationStatusWithConfig(ctx context.Context, cloudClient *publicapi.C
 		if err != nil {
 			// Check if timeout was reached
 			if ctx.Err() == context.DeadlineExceeded {
-				return getFinalOperationStatus(cloudClient, operationID)
+				return getFinalOperationStatus(ctx, cloudClient, operationID)
 			}
 			return nil, false, fmt.Errorf("failed to get operation status: %v", err)
 		}
@@ -401,7 +402,7 @@ func pollOperationStatusWithConfig(ctx context.Context, cloudClient *publicapi.C
 			// Continue to next iteration
 		case <-ctx.Done():
 			if ctx.Err() == context.DeadlineExceeded {
-				return getFinalOperationStatus(cloudClient, operationID)
+				return getFinalOperationStatus(ctx, cloudClient, operationID)
 			}
 			return nil, false, fmt.Errorf("context cancelled while polling operation status: %w", ctx.Err())
 		}
@@ -410,7 +411,11 @@ func pollOperationStatusWithConfig(ctx context.Context, cloudClient *publicapi.C
 
 // getFinalOperationStatus retrieves the operation status one final time after timeout.
 // Uses context.Background() to ensure this call isn't affected by the timeout.
-func getFinalOperationStatus(cloudClient *publicapi.CloudClientSet, operationID string) (*controlplanev1.Operation, bool, error) {
+// The ctx parameter is accepted to satisfy linters but is intentionally not used.
+func getFinalOperationStatus(ctx context.Context, cloudClient *publicapi.CloudClientSet, operationID string) (*controlplanev1.Operation, bool, error) {
+	_ = ctx // Explicitly mark as intentionally unused to satisfy linters
+	// Use context.Background() to ensure this call succeeds even though the original context timed out
+	//nolint:contextcheck // Intentionally using context.Background() since ctx has already timed out
 	resp, err := cloudClient.Operations.GetOperation(context.Background(), connect.NewRequest(&controlplanev1.GetOperationRequest{
 		Id: operationID,
 	}))

--- a/src/go/rpk/pkg/cli/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set.go
@@ -13,10 +13,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 	"time"
 
+	"golang.org/x/term"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 
 	controlplanev1 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1"
@@ -102,12 +104,21 @@ Use the flag '--no-confirm' to avoid the confirmation prompt.`,
 				out.MaybeDieErr(err)
 
 				operationID := operation.GetOperation().GetId()
-				fmt.Println("Processing configuration...")
+				fmt.Print("Processing configuration...")
 
+				// Check if stdout is a terminal for progress indication
+				isTerminal := term.IsTerminal(int(os.Stdout.Fd()))
 				// Poll operation status
 				cloudClient := publicapi.NewCloudClientSet(cfg.DevOverrides().PublicAPIURL, vp.CurrentAuth().AuthToken)
-				finalOp, completedInTime, err := pollOperationStatus(cmd.Context(), cloudClient, operationID, timeout)
+				finalOp, completedInTime, err := pollOperationStatus(cmd.Context(), cloudClient, operationID, timeout, isTerminal)
 				out.MaybeDieErr(err)
+
+				// Clear the progress line
+				if isTerminal {
+					fmt.Print("\r\033[K")
+				} else {
+					fmt.Println() // Add newline for non-terminal output
+				}
 
 				// Handle the result based on state
 				state := finalOp.GetState()
@@ -293,7 +304,7 @@ func setCloudConfig(ctx context.Context, cfg *config.Config, p *config.RpkProfil
 // pollOperationStatus polls the operation status with adaptive backoff for up to the specified timeout.
 // Uses aggressive polling (500ms) in the first 5 seconds for fast operations, then falls back to 1s polling.
 // Returns the final operation state and whether it completed within the timeout.
-func pollOperationStatus(ctx context.Context, cloudClient *publicapi.CloudClientSet, operationID string, timeout time.Duration) (*controlplanev1.Operation, bool, error) {
+func pollOperationStatus(ctx context.Context, cloudClient *publicapi.CloudClientSet, operationID string, timeout time.Duration, isTerminal bool) (*controlplanev1.Operation, bool, error) {
 	deadline := time.Now().Add(timeout)
 	startTime := time.Now()
 
@@ -306,7 +317,10 @@ func pollOperationStatus(ctx context.Context, cloudClient *publicapi.CloudClient
 	// Wait for initial delay before first poll
 	select {
 	case <-time.After(initialDelay):
-		// Continue to first poll
+		// Print initial progress after initial delay
+		if isTerminal {
+			fmt.Printf("\rProcessing configuration... (%ds elapsed)", int(time.Since(startTime).Seconds()))
+		}
 	case <-ctx.Done():
 		return nil, false, fmt.Errorf("context cancelled while waiting for initial delay: %w", ctx.Err())
 	}
@@ -326,8 +340,13 @@ func pollOperationStatus(ctx context.Context, cloudClient *publicapi.CloudClient
 			return op, true, nil
 		}
 
-		// Adaptive polling: fast polling (500ms) for first 5 seconds, then slow polling (1s)
+		// Print progress with elapsed time
 		elapsed := time.Since(startTime)
+		if isTerminal {
+			fmt.Printf("\rProcessing configuration... (%ds elapsed)", int(elapsed.Seconds()))
+		}
+
+		// Adaptive polling: fast polling (500ms) for first 5 seconds, then slow polling (1s)
 		pollInterval := slowPollInterval
 		if elapsed < fastPollThreshold {
 			pollInterval = fastPollInterval

--- a/src/go/rpk/pkg/cli/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set.go
@@ -310,7 +310,8 @@ type pollConfig struct {
 }
 
 // pollOperationStatus polls the operation status with adaptive backoff until the context deadline is reached.
-// Uses aggressive polling (500ms) in the first 5 seconds for fast operations, then falls back to 1s polling.
+// Uses aggressive polling (500ms) in the first 5 seconds for fast operations, then exponential backoff
+// (1s, 2s, 4s, 8s, 16s, 32s) for longer-running operations to reduce server load.
 // Returns the final operation state and whether it completed within the timeout.
 func pollOperationStatus(ctx context.Context, cloudClient *publicapi.CloudClientSet, operationID string, isTerminal bool) (*controlplanev1.Operation, bool, error) {
 	return pollOperationStatusWithConfig(ctx, cloudClient, operationID, isTerminal, nil)
@@ -334,6 +335,10 @@ func pollOperationStatusWithConfig(ctx context.Context, cloudClient *publicapi.C
 	fastPollInterval := cfg.fastPollInterval
 	slowPollInterval := cfg.slowPollInterval
 	fastPollThreshold := cfg.fastPollThreshold
+
+	// For exponential backoff in slow polling phase
+	currentSlowInterval := slowPollInterval
+	maxSlowInterval := 32 * time.Second
 
 	// Wait for initial delay before first poll
 	select {
@@ -375,10 +380,19 @@ func pollOperationStatusWithConfig(ctx context.Context, cloudClient *publicapi.C
 			fmt.Printf("\rProcessing configuration... (%ds elapsed)", int(elapsed.Seconds()))
 		}
 
-		// Adaptive polling: fast polling (500ms) for first 5 seconds, then slow polling (1s)
-		pollInterval := slowPollInterval
+		// Adaptive polling with exponential backoff:
+		// - Fast polling (500ms) for first 5 seconds
+		// - Exponential backoff after 5 seconds: 1s, 2s, 4s, 8s, 16s, 32s (max)
+		var pollInterval time.Duration
 		if elapsed < fastPollThreshold {
 			pollInterval = fastPollInterval
+		} else {
+			pollInterval = currentSlowInterval
+			nextInterval := currentSlowInterval * 2
+			if nextInterval > maxSlowInterval {
+				nextInterval = maxSlowInterval
+			}
+			currentSlowInterval = nextInterval
 		}
 
 		// Wait for next poll or context cancellation

--- a/src/go/rpk/pkg/cli/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set.go
@@ -108,9 +108,10 @@ Use the flag '--no-confirm' to avoid the confirmation prompt.`,
 
 				// Check if stdout is a terminal for progress indication
 				isTerminal := term.IsTerminal(int(os.Stdout.Fd()))
-				// Poll operation status
 				cloudClient := publicapi.NewCloudClientSet(cfg.DevOverrides().PublicAPIURL, vp.CurrentAuth().AuthToken)
-				finalOp, completedInTime, err := pollOperationStatus(cmd.Context(), cloudClient, operationID, timeout, isTerminal)
+				pollCtx, cancel := context.WithTimeout(cmd.Context(), timeout)
+				defer cancel()
+				finalOp, completedInTime, err := pollOperationStatus(pollCtx, cloudClient, operationID, isTerminal)
 				out.MaybeDieErr(err)
 
 				// Clear the progress line
@@ -300,11 +301,10 @@ func setCloudConfig(ctx context.Context, cfg *config.Config, p *config.RpkProfil
 	return operation.Msg, nil
 }
 
-// pollOperationStatus polls the operation status with adaptive backoff for up to the specified timeout.
+// pollOperationStatus polls the operation status with adaptive backoff until the context deadline is reached.
 // Uses aggressive polling (500ms) in the first 5 seconds for fast operations, then falls back to 1s polling.
 // Returns the final operation state and whether it completed within the timeout.
-func pollOperationStatus(ctx context.Context, cloudClient *publicapi.CloudClientSet, operationID string, timeout time.Duration, isTerminal bool) (*controlplanev1.Operation, bool, error) {
-	deadline := time.Now().Add(timeout)
+func pollOperationStatus(ctx context.Context, cloudClient *publicapi.CloudClientSet, operationID string, isTerminal bool) (*controlplanev1.Operation, bool, error) {
 	startTime := time.Now()
 
 	// Initial 2 second delay before first poll:
@@ -323,14 +323,22 @@ func pollOperationStatus(ctx context.Context, cloudClient *publicapi.CloudClient
 			fmt.Printf("\rProcessing configuration... (%ds elapsed)", int(time.Since(startTime).Seconds()))
 		}
 	case <-ctx.Done():
+		if ctx.Err() == context.DeadlineExceeded {
+			// Timeout during initial delay - get final status
+			return getFinalOperationStatus(cloudClient, operationID)
+		}
 		return nil, false, fmt.Errorf("context cancelled while waiting for initial delay: %w", ctx.Err())
 	}
 
-	for time.Now().Before(deadline) {
+	for {
 		resp, err := cloudClient.Operations.GetOperation(ctx, connect.NewRequest(&controlplanev1.GetOperationRequest{
 			Id: operationID,
 		}))
 		if err != nil {
+			// Check if timeout was reached
+			if ctx.Err() == context.DeadlineExceeded {
+				return getFinalOperationStatus(cloudClient, operationID)
+			}
 			return nil, false, fmt.Errorf("failed to get operation status: %v", err)
 		}
 
@@ -358,17 +366,22 @@ func pollOperationStatus(ctx context.Context, cloudClient *publicapi.CloudClient
 		case <-time.After(pollInterval):
 			// Continue to next iteration
 		case <-ctx.Done():
+			if ctx.Err() == context.DeadlineExceeded {
+				return getFinalOperationStatus(cloudClient, operationID)
+			}
 			return nil, false, fmt.Errorf("context cancelled while polling operation status: %w", ctx.Err())
 		}
 	}
+}
 
-	// Timeout - get the final status
-	resp, err := cloudClient.Operations.GetOperation(ctx, connect.NewRequest(&controlplanev1.GetOperationRequest{
+// getFinalOperationStatus retrieves the operation status one final time after timeout.
+// Uses context.Background() to ensure this call isn't affected by the timeout.
+func getFinalOperationStatus(cloudClient *publicapi.CloudClientSet, operationID string) (*controlplanev1.Operation, bool, error) {
+	resp, err := cloudClient.Operations.GetOperation(context.Background(), connect.NewRequest(&controlplanev1.GetOperationRequest{
 		Id: operationID,
 	}))
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to get operation status: %v", err)
+		return nil, false, fmt.Errorf("failed to get final operation status: %v", err)
 	}
-
 	return resp.Msg.Operation, false, nil
 }

--- a/src/go/rpk/pkg/cli/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 
@@ -96,8 +97,28 @@ Use the flag '--no-confirm' to avoid the confirmation prompt.`,
 				out.MaybeDie(err, "rpk unable to load config: %v", err)
 				operation, err := setCloudConfig(cmd.Context(), cfg, vp, configs)
 				out.MaybeDieErr(err)
-				fmt.Print("Processing configuration, this operation may take up to 10 minutes. To check the status, run 'rpk cluster config status'\n\n")
-				fmt.Printf("Operation ID: %s \n", operation.GetOperation().GetId())
+
+				operationID := operation.GetOperation().GetId()
+				fmt.Println("Processing configuration...")
+
+				// Poll operation status
+				cloudClient := publicapi.NewCloudClientSet(cfg.DevOverrides().PublicAPIURL, vp.CurrentAuth().AuthToken)
+				finalOp, completedInTime, err := pollOperationStatus(cmd.Context(), cloudClient, operationID)
+				out.MaybeDieErr(err)
+
+				// Handle the result based on state
+				state := finalOp.GetState()
+				if completedInTime {
+					if state == controlplanev1.Operation_STATE_COMPLETED {
+						fmt.Printf("Configuration update completed successfully. Operation ID: %s\n", operationID)
+					} else if state == controlplanev1.Operation_STATE_FAILED {
+						fmt.Printf("Configuration update failed. Operation ID: %s\n", operationID)
+					}
+				} else {
+					// Timeout - operation still in progress
+					fmt.Print("Processing configuration, this operation may take up to 10 minutes. To check the status, run 'rpk cluster config status'\n\n")
+					fmt.Printf("Operation ID: %s\n", operationID)
+				}
 			} else {
 				client, err := adminapi.NewClient(cmd.Context(), fs, vp)
 				out.MaybeDie(err, "unable to initialize admin client: %v", err)
@@ -263,4 +284,46 @@ func setCloudConfig(ctx context.Context, cfg *config.Config, p *config.RpkProfil
 		return nil, fmt.Errorf("internal error while updating redpanda cloud configs: %v", err)
 	}
 	return operation.Msg, nil
+}
+
+// pollOperationStatus polls the operation status every 1 second for up to 10 seconds.
+// Returns the final operation state and whether it completed within the timeout.
+func pollOperationStatus(ctx context.Context, cloudClient *publicapi.CloudClientSet, operationID string) (*controlplanev1.Operation, bool, error) {
+	timeout := 10 * time.Second
+	pollInterval := 1 * time.Second
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		resp, err := cloudClient.Operations.GetOperation(ctx, connect.NewRequest(&controlplanev1.GetOperationRequest{
+			Id: operationID,
+		}))
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to get operation status: %v", err)
+		}
+
+		op := resp.Msg.Operation
+		state := op.GetState()
+
+		if state == controlplanev1.Operation_STATE_COMPLETED || state == controlplanev1.Operation_STATE_FAILED {
+			return op, true, nil
+		}
+
+		// Wait for next poll or context cancellation
+		select {
+		case <-time.After(pollInterval):
+			// Continue to next iteration
+		case <-ctx.Done():
+			return nil, false, fmt.Errorf("context cancelled while polling operation status: %w", ctx.Err())
+		}
+	}
+
+	// Timeout - get the final status
+	resp, err := cloudClient.Operations.GetOperation(ctx, connect.NewRequest(&controlplanev1.GetOperationRequest{
+		Id: operationID,
+	}))
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to get operation status: %v", err)
+	}
+
+	return resp.Msg.Operation, false, nil
 }

--- a/src/go/rpk/pkg/cli/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set.go
@@ -301,19 +301,39 @@ func setCloudConfig(ctx context.Context, cfg *config.Config, p *config.RpkProfil
 	return operation.Msg, nil
 }
 
+// pollConfig contains timing configuration for operation polling.
+type pollConfig struct {
+	initialDelay      time.Duration
+	fastPollInterval  time.Duration
+	slowPollInterval  time.Duration
+	fastPollThreshold time.Duration
+}
+
 // pollOperationStatus polls the operation status with adaptive backoff until the context deadline is reached.
 // Uses aggressive polling (500ms) in the first 5 seconds for fast operations, then falls back to 1s polling.
 // Returns the final operation state and whether it completed within the timeout.
 func pollOperationStatus(ctx context.Context, cloudClient *publicapi.CloudClientSet, operationID string, isTerminal bool) (*controlplanev1.Operation, bool, error) {
-	startTime := time.Now()
+	return pollOperationStatusWithConfig(ctx, cloudClient, operationID, isTerminal, nil)
+}
 
-	// Initial 2 second delay before first poll:
-	// This avoids unnecessary early checks for operations that typically take at least a few seconds,
-	// reducing load and noise from polling. Most operations are not expected to complete instantly.
-	initialDelay := 2 * time.Second
-	fastPollInterval := 500 * time.Millisecond
-	slowPollInterval := 1 * time.Second
-	fastPollThreshold := 5 * time.Second
+// pollOperationStatusWithConfig is the same as pollOperationStatus but allows overriding timing configuration.
+// This is primarily useful for testing with shorter intervals.
+func pollOperationStatusWithConfig(ctx context.Context, cloudClient *publicapi.CloudClientSet, operationID string, isTerminal bool, cfg *pollConfig) (*controlplanev1.Operation, bool, error) {
+	// Use default production timing if no config provided
+	if cfg == nil {
+		cfg = &pollConfig{
+			initialDelay:      2 * time.Second,
+			fastPollInterval:  500 * time.Millisecond,
+			slowPollInterval:  1 * time.Second,
+			fastPollThreshold: 5 * time.Second,
+		}
+	}
+
+	startTime := time.Now()
+	initialDelay := cfg.initialDelay
+	fastPollInterval := cfg.fastPollInterval
+	slowPollInterval := cfg.slowPollInterval
+	fastPollThreshold := cfg.fastPollThreshold
 
 	// Wait for initial delay before first poll
 	select {

--- a/src/go/rpk/pkg/cli/cluster/config/set_test.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set_test.go
@@ -73,6 +73,43 @@ func TestParseArgs(t *testing.T) {
 	}
 }
 
+// createMockOperationServer creates a test server that simulates the operation status API.
+// The handler function receives the request count and returns the operation state.
+func createMockOperationServer(t *testing.T, operationID string, handler func(requestCount int32) controlplanev1.Operation_State) (*httptest.Server, *atomic.Int32) {
+	var requestCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Contains(t, r.URL.Path, "redpanda.api.controlplane.v1.OperationService/GetOperation")
+
+		count := requestCount.Add(1)
+		state := handler(count)
+
+		response := &controlplanev1.GetOperationResponse{
+			Operation: &controlplanev1.Operation{
+				Id:    operationID,
+				State: state,
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/proto")
+		w.WriteHeader(http.StatusOK)
+
+		marshaled, err := proto.Marshal(response)
+		require.NoError(t, err)
+		_, _ = w.Write(marshaled)
+	}))
+
+	return server, &requestCount
+}
+
+// createMockErrorServer creates a test server that returns an HTTP error.
+func createMockErrorServer(statusCode int, message string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(statusCode)
+		_, _ = w.Write([]byte(message))
+	}))
+}
+
 func TestPollOperationStatus(t *testing.T) {
 	t.Parallel()
 
@@ -139,38 +176,16 @@ func TestPollOperationStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			var pollCount atomic.Int32
 			operationID := "test-operation-id"
 
-			// Create a mock server that simulates the operation status API
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				// Check that it's a GetOperation request
-				require.Contains(t, r.URL.Path, "redpanda.api.controlplane.v1.OperationService/GetOperation")
-
-				count := pollCount.Add(1)
+			server, pollCount := createMockOperationServer(t, operationID, func(count int32) controlplanev1.Operation_State {
 				state := tt.initialState
-
 				// Transition to the target state after the specified number of polls
 				if tt.transitionAfter > 0 && int(count) >= tt.transitionAfter {
 					state = tt.transitionToState
 				}
-
-				response := &controlplanev1.GetOperationResponse{
-					Operation: &controlplanev1.Operation{
-						Id:    operationID,
-						State: state,
-					},
-				}
-
-				// Use application/proto content type for Connect RPC
-				w.Header().Set("Content-Type", "application/proto")
-				w.WriteHeader(http.StatusOK)
-
-				// Marshal the response using proto binary format
-				marshaled, err := proto.Marshal(response)
-				require.NoError(t, err)
-				_, _ = w.Write(marshaled)
-			}))
+				return state
+			})
 			defer server.Close()
 
 			// Create a cloud client pointing to our mock server
@@ -238,22 +253,9 @@ func TestPollOperationStatus_ContextCancellation(t *testing.T) {
 
 	operationID := "test-operation-id"
 
-	// Create a mock server that always returns in_progress
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		response := &controlplanev1.GetOperationResponse{
-			Operation: &controlplanev1.Operation{
-				Id:    operationID,
-				State: controlplanev1.Operation_STATE_IN_PROGRESS,
-			},
-		}
-
-		w.Header().Set("Content-Type", "application/proto")
-		w.WriteHeader(http.StatusOK)
-
-		marshaled, err := proto.Marshal(response)
-		require.NoError(t, err)
-		_, _ = w.Write(marshaled)
-	}))
+	server, _ := createMockOperationServer(t, operationID, func(count int32) controlplanev1.Operation_State {
+		return controlplanev1.Operation_STATE_IN_PROGRESS
+	})
 	defer server.Close()
 
 	cloudClient := publicapi.NewCloudClientSet(server.URL, "test-token")
@@ -299,10 +301,7 @@ func TestPollOperationStatus_APIError(t *testing.T) {
 	operationID := "test-operation-id"
 
 	// Create a mock server that returns an error
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`{"code":"internal","message":"internal server error"}`))
-	}))
+	server := createMockErrorServer(http.StatusInternalServerError, `{"code":"internal","message":"internal server error"}`)
 	defer server.Close()
 
 	cloudClient := publicapi.NewCloudClientSet(server.URL, "test-token")
@@ -334,22 +333,9 @@ func TestPollOperationStatus_CustomTimeout(t *testing.T) {
 
 	operationID := "test-operation-id"
 
-	// Create a mock server that always returns in_progress
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		response := &controlplanev1.GetOperationResponse{
-			Operation: &controlplanev1.Operation{
-				Id:    operationID,
-				State: controlplanev1.Operation_STATE_IN_PROGRESS,
-			},
-		}
-
-		w.Header().Set("Content-Type", "application/proto")
-		w.WriteHeader(http.StatusOK)
-
-		marshaled, err := proto.Marshal(response)
-		require.NoError(t, err)
-		_, _ = w.Write(marshaled)
-	}))
+	server, _ := createMockOperationServer(t, operationID, func(count int32) controlplanev1.Operation_State {
+		return controlplanev1.Operation_STATE_IN_PROGRESS
+	})
 	defer server.Close()
 
 	cloudClient := publicapi.NewCloudClientSet(server.URL, "test-token")

--- a/src/go/rpk/pkg/cli/cluster/config/set_test.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set_test.go
@@ -356,3 +356,45 @@ func TestPollOperationStatus_CustomTimeout(t *testing.T) {
 	require.GreaterOrEqual(t, elapsed, customTimeout, "should have waited full timeout period")
 	require.Less(t, elapsed, 200*time.Millisecond, "should not have exceeded timeout significantly")
 }
+
+func TestPollOperationStatus_TimeoutShorterThanInitialDelay(t *testing.T) {
+	t.Parallel()
+
+	// Use config where initialDelay (200ms) is longer than timeout (150ms)
+	testCfg := &pollConfig{
+		initialDelay:      200 * time.Millisecond,
+		fastPollInterval:  10 * time.Millisecond,
+		slowPollInterval:  10 * time.Millisecond,
+		fastPollThreshold: 50 * time.Millisecond,
+	}
+
+	operationID := "test-operation-id"
+
+	// Create server that returns completed immediately
+	server, pollCount := createMockOperationServer(t, operationID, func(count int32) controlplanev1.Operation_State {
+		return controlplanev1.Operation_STATE_COMPLETED
+	})
+	defer server.Close()
+
+	cloudClient := publicapi.NewCloudClientSet(server.URL, "test-token")
+
+	// Use timeout (150ms) that is shorter than initialDelay (200ms)
+	// Initial delay will be capped at timeout/2 = 75ms to reserve time for polling
+	shortTimeout := 150 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+	defer cancel()
+	startTime := time.Now()
+	operation, completedInTime, err := pollOperationStatusWithConfig(ctx, cloudClient, operationID, false, testCfg)
+	elapsed := time.Since(startTime)
+
+	// Should complete successfully with capped initial delay
+	require.NoError(t, err)
+	require.True(t, completedInTime, "should have completed")
+	require.Equal(t, controlplanev1.Operation_STATE_COMPLETED, operation.GetState())
+
+	// Should have completed quickly (initial delay capped at ~75ms instead of 200ms)
+	require.Less(t, elapsed, 150*time.Millisecond, "should cap initial delay to timeout/2")
+
+	// Should have polled at least once
+	require.GreaterOrEqual(t, pollCount.Load(), int32(1), "should have polled at least once")
+}

--- a/src/go/rpk/pkg/cli/cluster/config/set_test.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set_test.go
@@ -1,9 +1,17 @@
 package config
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	controlplanev1 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestParseArgs(t *testing.T) {
@@ -62,4 +70,203 @@ func TestParseArgs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPollOperationStatus(t *testing.T) {
+	tests := []struct {
+		name               string
+		initialState       controlplanev1.Operation_State
+		transitionToState  controlplanev1.Operation_State
+		transitionAfter    int // number of polls before transition
+		expectCompleted    bool
+		expectTimeout      bool
+		expectedFinalState controlplanev1.Operation_State
+	}{
+		{
+			name:               "operation completes immediately",
+			initialState:       controlplanev1.Operation_STATE_COMPLETED,
+			expectCompleted:    true,
+			expectTimeout:      false,
+			expectedFinalState: controlplanev1.Operation_STATE_COMPLETED,
+		},
+		{
+			name:               "operation fails immediately",
+			initialState:       controlplanev1.Operation_STATE_FAILED,
+			expectCompleted:    true,
+			expectTimeout:      false,
+			expectedFinalState: controlplanev1.Operation_STATE_FAILED,
+		},
+		{
+			name:               "operation transitions from in_progress to completed",
+			initialState:       controlplanev1.Operation_STATE_IN_PROGRESS,
+			transitionToState:  controlplanev1.Operation_STATE_COMPLETED,
+			transitionAfter:    2, // transition after 2 polls
+			expectCompleted:    true,
+			expectTimeout:      false,
+			expectedFinalState: controlplanev1.Operation_STATE_COMPLETED,
+		},
+		{
+			name:               "operation transitions from in_progress to failed",
+			initialState:       controlplanev1.Operation_STATE_IN_PROGRESS,
+			transitionToState:  controlplanev1.Operation_STATE_FAILED,
+			transitionAfter:    3,
+			expectCompleted:    true,
+			expectTimeout:      false,
+			expectedFinalState: controlplanev1.Operation_STATE_FAILED,
+		},
+		{
+			name:               "operation stays in_progress and times out",
+			initialState:       controlplanev1.Operation_STATE_IN_PROGRESS,
+			transitionToState:  controlplanev1.Operation_STATE_IN_PROGRESS,
+			transitionAfter:    100, // never transitions
+			expectCompleted:    false,
+			expectTimeout:      true,
+			expectedFinalState: controlplanev1.Operation_STATE_IN_PROGRESS,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var pollCount atomic.Int32
+			operationID := "test-operation-id"
+
+			// Create a mock server that simulates the operation status API
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Check that it's a GetOperation request
+				require.Contains(t, r.URL.Path, "redpanda.api.controlplane.v1.OperationService/GetOperation")
+
+				count := pollCount.Add(1)
+				state := tt.initialState
+
+				// Transition to the target state after the specified number of polls
+				if tt.transitionAfter > 0 && int(count) >= tt.transitionAfter {
+					state = tt.transitionToState
+				}
+
+				response := &controlplanev1.GetOperationResponse{
+					Operation: &controlplanev1.Operation{
+						Id:    operationID,
+						State: state,
+					},
+				}
+
+				// Use application/proto content type for Connect RPC
+				w.Header().Set("Content-Type", "application/proto")
+				w.WriteHeader(http.StatusOK)
+
+				// Marshal the response using proto binary format
+				marshaled, err := proto.Marshal(response)
+				require.NoError(t, err)
+				_, _ = w.Write(marshaled)
+			}))
+			defer server.Close()
+
+			// Create a cloud client pointing to our mock server
+			cloudClient := publicapi.NewCloudClientSet(server.URL, "test-token")
+
+			ctx := context.Background()
+			startTime := time.Now()
+
+			// Call the function under test
+			operation, completedInTime, err := pollOperationStatus(ctx, cloudClient, operationID)
+
+			// Verify no error occurred
+			require.NoError(t, err)
+			require.NotNil(t, operation)
+
+			// Verify the completion status
+			require.Equal(t, tt.expectCompleted, completedInTime, "completedInTime mismatch")
+
+			// Verify the final state
+			require.Equal(t, tt.expectedFinalState, operation.GetState(), "final state mismatch")
+
+			// Verify operation ID is preserved
+			require.Equal(t, operationID, operation.Id)
+
+			// Additional time-based checks
+			elapsed := time.Since(startTime)
+			if tt.expectTimeout {
+				// Should take at least 10 seconds when timing out
+				require.GreaterOrEqual(t, elapsed, 10*time.Second, "should have waited full timeout period")
+			} else {
+				// Should complete before the 10 second timeout
+				require.Less(t, elapsed, 10*time.Second, "should complete before timeout")
+			}
+
+			// Verify polling happened the expected number of times
+			if tt.expectTimeout {
+				// Should poll multiple times (approximately 10 times for 10 seconds with 1 second interval)
+				require.GreaterOrEqual(t, pollCount.Load(), int32(9), "should have polled multiple times during timeout")
+			} else if tt.transitionAfter > 0 {
+				// Should have polled at least until the transition
+				require.GreaterOrEqual(t, pollCount.Load(), int32(tt.transitionAfter), "should have polled until transition")
+			}
+		})
+	}
+}
+
+func TestPollOperationStatus_ContextCancellation(t *testing.T) {
+	operationID := "test-operation-id"
+
+	// Create a mock server that always returns in_progress
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := &controlplanev1.GetOperationResponse{
+			Operation: &controlplanev1.Operation{
+				Id:    operationID,
+				State: controlplanev1.Operation_STATE_IN_PROGRESS,
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/proto")
+		w.WriteHeader(http.StatusOK)
+
+		marshaled, err := proto.Marshal(response)
+		require.NoError(t, err)
+		_, _ = w.Write(marshaled)
+	}))
+	defer server.Close()
+
+	cloudClient := publicapi.NewCloudClientSet(server.URL, "test-token")
+
+	// Create a context that we'll cancel after 500ms (during the first sleep)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel the context after 500ms
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		cancel()
+	}()
+
+	startTime := time.Now()
+	_, _, err := pollOperationStatus(ctx, cloudClient, operationID)
+	elapsed := time.Since(startTime)
+
+	// Should get a context cancellation error
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "context cancelled while polling operation status")
+
+	// Should return quickly after cancellation (within ~600ms), not wait for full polling interval
+	// Give some buffer for test execution, but it should be much less than 2 seconds
+	require.Less(t, elapsed, 1500*time.Millisecond, "should have been cancelled immediately, not waited for next poll")
+	require.GreaterOrEqual(t, elapsed, 500*time.Millisecond, "should have waited at least until cancellation")
+}
+
+func TestPollOperationStatus_APIError(t *testing.T) {
+	operationID := "test-operation-id"
+
+	// Create a mock server that returns an error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"code":"internal","message":"internal server error"}`))
+	}))
+	defer server.Close()
+
+	cloudClient := publicapi.NewCloudClientSet(server.URL, "test-token")
+
+	ctx := context.Background()
+	_, _, err := pollOperationStatus(ctx, cloudClient, operationID)
+
+	// Should return an error
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to get operation status")
 }

--- a/src/go/rpk/pkg/cli/cluster/config/set_test.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set_test.go
@@ -165,11 +165,12 @@ func TestPollOperationStatus(t *testing.T) {
 			// Create a cloud client pointing to our mock server
 			cloudClient := publicapi.NewCloudClientSet(server.URL, "test-token")
 
-			ctx := context.Background()
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
 			startTime := time.Now()
 
 			// Call the function under test
-			operation, completedInTime, err := pollOperationStatus(ctx, cloudClient, operationID, 10*time.Second, false)
+			operation, completedInTime, err := pollOperationStatus(ctx, cloudClient, operationID, false)
 
 			// Verify no error occurred
 			require.NoError(t, err)
@@ -239,7 +240,7 @@ func TestPollOperationStatus_ContextCancellation(t *testing.T) {
 	}()
 
 	startTime := time.Now()
-	_, _, err := pollOperationStatus(ctx, cloudClient, operationID, 10*time.Second, false)
+	_, _, err := pollOperationStatus(ctx, cloudClient, operationID, false)
 	elapsed := time.Since(startTime)
 
 	// Should get a context cancellation error
@@ -268,8 +269,9 @@ func TestPollOperationStatus_APIError(t *testing.T) {
 
 	cloudClient := publicapi.NewCloudClientSet(server.URL, "test-token")
 
-	ctx := context.Background()
-	_, _, err := pollOperationStatus(ctx, cloudClient, operationID, 10*time.Second, false)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, _, err := pollOperationStatus(ctx, cloudClient, operationID, false)
 
 	// Should return an error
 	require.Error(t, err)
@@ -300,9 +302,10 @@ func TestPollOperationStatus_CustomTimeout(t *testing.T) {
 	cloudClient := publicapi.NewCloudClientSet(server.URL, "test-token")
 
 	// Test with a shorter timeout (3 seconds)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
 	startTime := time.Now()
-	_, completedInTime, err := pollOperationStatus(ctx, cloudClient, operationID, 3*time.Second, false)
+	_, completedInTime, err := pollOperationStatus(ctx, cloudClient, operationID, false)
 	elapsed := time.Since(startTime)
 
 	// Should timeout without error

--- a/src/go/rpk/pkg/cli/cluster/config/set_test.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set_test.go
@@ -169,7 +169,7 @@ func TestPollOperationStatus(t *testing.T) {
 			startTime := time.Now()
 
 			// Call the function under test
-			operation, completedInTime, err := pollOperationStatus(ctx, cloudClient, operationID, 10*time.Second)
+			operation, completedInTime, err := pollOperationStatus(ctx, cloudClient, operationID, 10*time.Second, false)
 
 			// Verify no error occurred
 			require.NoError(t, err)
@@ -239,7 +239,7 @@ func TestPollOperationStatus_ContextCancellation(t *testing.T) {
 	}()
 
 	startTime := time.Now()
-	_, _, err := pollOperationStatus(ctx, cloudClient, operationID, 10*time.Second)
+	_, _, err := pollOperationStatus(ctx, cloudClient, operationID, 10*time.Second, false)
 	elapsed := time.Since(startTime)
 
 	// Should get a context cancellation error
@@ -269,7 +269,7 @@ func TestPollOperationStatus_APIError(t *testing.T) {
 	cloudClient := publicapi.NewCloudClientSet(server.URL, "test-token")
 
 	ctx := context.Background()
-	_, _, err := pollOperationStatus(ctx, cloudClient, operationID, 10*time.Second)
+	_, _, err := pollOperationStatus(ctx, cloudClient, operationID, 10*time.Second, false)
 
 	// Should return an error
 	require.Error(t, err)
@@ -302,7 +302,7 @@ func TestPollOperationStatus_CustomTimeout(t *testing.T) {
 	// Test with a shorter timeout (3 seconds)
 	ctx := context.Background()
 	startTime := time.Now()
-	_, completedInTime, err := pollOperationStatus(ctx, cloudClient, operationID, 3*time.Second)
+	_, completedInTime, err := pollOperationStatus(ctx, cloudClient, operationID, 3*time.Second, false)
 	elapsed := time.Since(startTime)
 
 	// Should timeout without error

--- a/src/go/rpk/pkg/cli/cluster/config/set_test.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -168,7 +169,7 @@ func TestPollOperationStatus(t *testing.T) {
 			startTime := time.Now()
 
 			// Call the function under test
-			operation, completedInTime, err := pollOperationStatus(ctx, cloudClient, operationID)
+			operation, completedInTime, err := pollOperationStatus(ctx, cloudClient, operationID, 10*time.Second)
 
 			// Verify no error occurred
 			require.NoError(t, err)
@@ -228,7 +229,7 @@ func TestPollOperationStatus_ContextCancellation(t *testing.T) {
 
 	cloudClient := publicapi.NewCloudClientSet(server.URL, "test-token")
 
-	// Create a context that we'll cancel after 500ms (during the first sleep)
+	// Create a context that we'll cancel after 500ms (during the initial delay)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Cancel the context after 500ms
@@ -238,12 +239,16 @@ func TestPollOperationStatus_ContextCancellation(t *testing.T) {
 	}()
 
 	startTime := time.Now()
-	_, _, err := pollOperationStatus(ctx, cloudClient, operationID)
+	_, _, err := pollOperationStatus(ctx, cloudClient, operationID, 10*time.Second)
 	elapsed := time.Since(startTime)
 
 	// Should get a context cancellation error
+	// Can happen during initial delay or polling loop
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "context cancelled while polling operation status")
+	require.True(t,
+		strings.Contains(err.Error(), "context cancelled while polling operation status") ||
+			strings.Contains(err.Error(), "context cancelled while waiting for initial delay"),
+		"expected context cancellation error, got: %v", err)
 
 	// Should return quickly after cancellation (within ~600ms), not wait for full polling interval
 	// Give some buffer for test execution, but it should be much less than 2 seconds
@@ -264,9 +269,47 @@ func TestPollOperationStatus_APIError(t *testing.T) {
 	cloudClient := publicapi.NewCloudClientSet(server.URL, "test-token")
 
 	ctx := context.Background()
-	_, _, err := pollOperationStatus(ctx, cloudClient, operationID)
+	_, _, err := pollOperationStatus(ctx, cloudClient, operationID, 10*time.Second)
 
 	// Should return an error
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to get operation status")
+}
+
+func TestPollOperationStatus_CustomTimeout(t *testing.T) {
+	operationID := "test-operation-id"
+
+	// Create a mock server that always returns in_progress
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := &controlplanev1.GetOperationResponse{
+			Operation: &controlplanev1.Operation{
+				Id:    operationID,
+				State: controlplanev1.Operation_STATE_IN_PROGRESS,
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/proto")
+		w.WriteHeader(http.StatusOK)
+
+		marshaled, err := proto.Marshal(response)
+		require.NoError(t, err)
+		_, _ = w.Write(marshaled)
+	}))
+	defer server.Close()
+
+	cloudClient := publicapi.NewCloudClientSet(server.URL, "test-token")
+
+	// Test with a shorter timeout (3 seconds)
+	ctx := context.Background()
+	startTime := time.Now()
+	_, completedInTime, err := pollOperationStatus(ctx, cloudClient, operationID, 3*time.Second)
+	elapsed := time.Since(startTime)
+
+	// Should timeout without error
+	require.NoError(t, err)
+	require.False(t, completedInTime, "should have timed out")
+
+	// Should have taken approximately 3 seconds, not 10
+	require.GreaterOrEqual(t, elapsed, 3*time.Second, "should have waited full timeout period")
+	require.Less(t, elapsed, 4*time.Second, "should not have exceeded timeout significantly")
 }

--- a/src/go/rpk/pkg/cli/cluster/config/set_test.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set_test.go
@@ -74,6 +74,16 @@ func TestParseArgs(t *testing.T) {
 }
 
 func TestPollOperationStatus(t *testing.T) {
+	t.Parallel()
+
+	// Use fast polling intervals for tests to speed up execution
+	testCfg := &pollConfig{
+		initialDelay:      10 * time.Millisecond,
+		fastPollInterval:  10 * time.Millisecond,
+		slowPollInterval:  10 * time.Millisecond,
+		fastPollThreshold: 50 * time.Millisecond,
+	}
+
 	tests := []struct {
 		name               string
 		initialState       controlplanev1.Operation_State
@@ -128,6 +138,7 @@ func TestPollOperationStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var pollCount atomic.Int32
 			operationID := "test-operation-id"
 
@@ -165,12 +176,17 @@ func TestPollOperationStatus(t *testing.T) {
 			// Create a cloud client pointing to our mock server
 			cloudClient := publicapi.NewCloudClientSet(server.URL, "test-token")
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			// Use shorter timeout for tests since we're using fast polling intervals
+			testTimeout := 200 * time.Millisecond
+			if tt.expectTimeout {
+				testTimeout = 200 * time.Millisecond // Enough time for multiple polls
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 			defer cancel()
 			startTime := time.Now()
 
-			// Call the function under test
-			operation, completedInTime, err := pollOperationStatus(ctx, cloudClient, operationID, false)
+			// Call the function under test with fast test config
+			operation, completedInTime, err := pollOperationStatusWithConfig(ctx, cloudClient, operationID, false, testCfg)
 
 			// Verify no error occurred
 			require.NoError(t, err)
@@ -188,17 +204,19 @@ func TestPollOperationStatus(t *testing.T) {
 			// Additional time-based checks
 			elapsed := time.Since(startTime)
 			if tt.expectTimeout {
-				// Should take at least 10 seconds when timing out
-				require.GreaterOrEqual(t, elapsed, 10*time.Second, "should have waited full timeout period")
+				// Should take at least the test timeout period (200ms)
+				require.GreaterOrEqual(t, elapsed, testTimeout, "should have waited full timeout period")
 			} else {
-				// Should complete before the 10 second timeout
-				require.Less(t, elapsed, 10*time.Second, "should complete before timeout")
+				// Should complete before the test timeout
+				require.Less(t, elapsed, testTimeout, "should complete before timeout")
 			}
 
 			// Verify polling happened the expected number of times
 			if tt.expectTimeout {
-				// Should poll multiple times (approximately 10 times for 10 seconds with 1 second interval)
-				require.GreaterOrEqual(t, pollCount.Load(), int32(9), "should have polled multiple times during timeout")
+				// Should poll multiple times during the timeout period
+				// With 10ms intervals and 200ms timeout, expect at least 5 polls
+				// (actual may vary due to network latency and goroutine scheduling)
+				require.GreaterOrEqual(t, pollCount.Load(), int32(5), "should have polled multiple times during timeout")
 			} else if tt.transitionAfter > 0 {
 				// Should have polled at least until the transition
 				require.GreaterOrEqual(t, pollCount.Load(), int32(tt.transitionAfter), "should have polled until transition")
@@ -208,6 +226,16 @@ func TestPollOperationStatus(t *testing.T) {
 }
 
 func TestPollOperationStatus_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	// Use fast polling intervals for tests
+	testCfg := &pollConfig{
+		initialDelay:      10 * time.Millisecond,
+		fastPollInterval:  10 * time.Millisecond,
+		slowPollInterval:  10 * time.Millisecond,
+		fastPollThreshold: 50 * time.Millisecond,
+	}
+
 	operationID := "test-operation-id"
 
 	// Create a mock server that always returns in_progress
@@ -230,34 +258,44 @@ func TestPollOperationStatus_ContextCancellation(t *testing.T) {
 
 	cloudClient := publicapi.NewCloudClientSet(server.URL, "test-token")
 
-	// Create a context that we'll cancel after 500ms (during the initial delay)
+	// Create a context that we'll cancel after 50ms
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Cancel the context after 500ms
+	// Cancel the context after 50ms (after initial delay but during polling)
 	go func() {
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 		cancel()
 	}()
 
 	startTime := time.Now()
-	_, _, err := pollOperationStatus(ctx, cloudClient, operationID, false)
+	_, _, err := pollOperationStatusWithConfig(ctx, cloudClient, operationID, false, testCfg)
 	elapsed := time.Since(startTime)
 
 	// Should get a context cancellation error
-	// Can happen during initial delay or polling loop
+	// Can happen during initial delay, polling loop, or API call
 	require.Error(t, err)
 	require.True(t,
 		strings.Contains(err.Error(), "context cancelled while polling operation status") ||
-			strings.Contains(err.Error(), "context cancelled while waiting for initial delay"),
+			strings.Contains(err.Error(), "context cancelled while waiting for initial delay") ||
+			strings.Contains(err.Error(), "failed to get operation status") && strings.Contains(err.Error(), "canceled"),
 		"expected context cancellation error, got: %v", err)
 
-	// Should return quickly after cancellation (within ~600ms), not wait for full polling interval
-	// Give some buffer for test execution, but it should be much less than 2 seconds
-	require.Less(t, elapsed, 1500*time.Millisecond, "should have been cancelled immediately, not waited for next poll")
-	require.GreaterOrEqual(t, elapsed, 500*time.Millisecond, "should have waited at least until cancellation")
+	// Should return quickly after cancellation (within ~100ms), not wait for full polling interval
+	require.Less(t, elapsed, 100*time.Millisecond, "should have been cancelled immediately, not waited for next poll")
+	require.GreaterOrEqual(t, elapsed, 50*time.Millisecond, "should have waited at least until cancellation")
 }
 
 func TestPollOperationStatus_APIError(t *testing.T) {
+	t.Parallel()
+
+	// Use fast polling intervals for tests
+	testCfg := &pollConfig{
+		initialDelay:      10 * time.Millisecond,
+		fastPollInterval:  10 * time.Millisecond,
+		slowPollInterval:  10 * time.Millisecond,
+		fastPollThreshold: 50 * time.Millisecond,
+	}
+
 	operationID := "test-operation-id"
 
 	// Create a mock server that returns an error
@@ -269,16 +307,31 @@ func TestPollOperationStatus_APIError(t *testing.T) {
 
 	cloudClient := publicapi.NewCloudClientSet(server.URL, "test-token")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	_, _, err := pollOperationStatus(ctx, cloudClient, operationID, false)
+	_, _, err := pollOperationStatusWithConfig(ctx, cloudClient, operationID, false, testCfg)
 
 	// Should return an error
+	// Can be either "failed to get operation status" or "failed to get final operation status"
+	// depending on when the error occurs
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to get operation status")
+	require.True(t,
+		strings.Contains(err.Error(), "failed to get operation status") ||
+			strings.Contains(err.Error(), "failed to get final operation status"),
+		"expected operation status error, got: %v", err)
 }
 
 func TestPollOperationStatus_CustomTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Use fast polling intervals for tests
+	testCfg := &pollConfig{
+		initialDelay:      10 * time.Millisecond,
+		fastPollInterval:  10 * time.Millisecond,
+		slowPollInterval:  10 * time.Millisecond,
+		fastPollThreshold: 50 * time.Millisecond,
+	}
+
 	operationID := "test-operation-id"
 
 	// Create a mock server that always returns in_progress
@@ -301,18 +354,19 @@ func TestPollOperationStatus_CustomTimeout(t *testing.T) {
 
 	cloudClient := publicapi.NewCloudClientSet(server.URL, "test-token")
 
-	// Test with a shorter timeout (3 seconds)
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	// Test with a custom timeout (150ms)
+	customTimeout := 150 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), customTimeout)
 	defer cancel()
 	startTime := time.Now()
-	_, completedInTime, err := pollOperationStatus(ctx, cloudClient, operationID, false)
+	_, completedInTime, err := pollOperationStatusWithConfig(ctx, cloudClient, operationID, false, testCfg)
 	elapsed := time.Since(startTime)
 
 	// Should timeout without error
 	require.NoError(t, err)
 	require.False(t, completedInTime, "should have timed out")
 
-	// Should have taken approximately 3 seconds, not 10
-	require.GreaterOrEqual(t, elapsed, 3*time.Second, "should have waited full timeout period")
-	require.Less(t, elapsed, 4*time.Second, "should not have exceeded timeout significantly")
+	// Should have taken approximately 150ms
+	require.GreaterOrEqual(t, elapsed, customTimeout, "should have waited full timeout period")
+	require.Less(t, elapsed, 200*time.Millisecond, "should not have exceeded timeout significantly")
 }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28553
