### PR TITLE
[CORE-8225] cloud_storage_clients/abs: Drop showonly=files when using a delimiter

### DIFF
--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -867,9 +867,14 @@ ss::future<abs_client::list_bucket_result> abs_client::do_list_objects(
   ss::lowres_clock::duration timeout,
   std::optional<char> delimiter,
   std::optional<item_filter> collect_item_if) {
+    // Don't use files_only (showonly=files) when a delimiter is specified.
+    // The showonly=files parameter excludes BlobPrefix entries from the
+    // response, but BlobPrefix entries are exactly what we want when using
+    // a delimiter to discover virtual directories.
+    const bool files_only = _adls_client.has_value() && !delimiter.has_value();
     auto header = _requestor.make_list_blobs_request(
       name,
-      _adls_client.has_value(),
+      files_only,
       std::move(prefix),
       max_results,
       std::move(marker),


### PR DESCRIPTION
cloud_storage_clients/abs: Drop showonly=files when using a delimiter

When listing blobs on an Azure account with HNS enabled, the client was
adding showonly=files to the list objects request even when using a
delimiter. However, the inventory report was using this request to
discover virtual directories, so showonly=files broke it. This caused
the CloudStorageInventoryTest.test_load_inventory_report to fail on
Azure with HNS enabled.

The fix is to remove showonly=files when a delimiter is specified,
because the purpose of the delimiter is to group nested objects into
prefixes, and showonly=files negates that.

I'm not sure about the backport... seems this was always broken, but
clearly nobody used this feature on Azure with HNS or they'd've noticed
it was broken.

Fixes CORE-8225

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
