### PR TITLE
[CORE-14858] Adaptive timeout waiting for segments

### DIFF
--- a/tests/rptest/tests/datalake/compaction_test.py
+++ b/tests/rptest/tests/datalake/compaction_test.py
@@ -118,7 +118,8 @@ class CompactionGapsTest(RedpandaTest):
             # # Disable iceberg
             dl.set_iceberg_mode_on_topic(self.topic_name, "disabled")
             # Append more data
-            self.produce_until_segment_count(8)
+            curr_count = self.partition_segments()
+            self.produce_until_segment_count(max(curr_count + 3, 8))
             # # Compact the data
             # # One closed segment and one open (current) segment
             self.wait_until_segment_count(2)

--- a/tests/rptest/tests/datalake/compaction_test.py
+++ b/tests/rptest/tests/datalake/compaction_test.py
@@ -66,10 +66,10 @@ class CompactionGapsTest(RedpandaTest):
         self.redpanda.logger.debug(f"Current segment count: {segment_count}")
         return segment_count
 
-    def wait_until_segment_count(self, count):
+    def wait_until_segment_count(self, count: int, timeout_sec: int = 120):
         wait_until(
             lambda: self.partition_segments() == count,
-            timeout_sec=120,
+            timeout_sec=timeout_sec,
             backoff_sec=2,
             err_msg=f"Timed out waiting for segment count to reach {count}",
         )
@@ -122,7 +122,15 @@ class CompactionGapsTest(RedpandaTest):
             self.produce_until_segment_count(max(curr_count + 3, 8))
             # # Compact the data
             # # One closed segment and one open (current) segment
-            self.wait_until_segment_count(2)
+            curr_count = self.partition_segments()
+            assert curr_count >= 2, f"unexpected number of segments {curr_count}"
+            # the test only establishes lower bounds the number of segments
+            # created. in practice we've seen 10+ segments created and it can
+            # take some time then for compaction to reduce this count. based on
+            # observations in the log and the housekeeping interval of 10
+            # seconds we can make a better guess at the timeout needed.
+            timeout_sec = 2 * (curr_count * 10)
+            self.wait_until_segment_count(count=2, timeout_sec=timeout_sec)
             # # Enable iceberg again
             dl.set_iceberg_mode_on_topic(self.topic_name, "key_value")
 


### PR DESCRIPTION
Fixes timeout in test where there was more work than expected for the fixed timeout.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
