### PR TITLE
tools/dt: Two improvements to the dt utility

### DIFF
--- a/tools/dt
+++ b/tools/dt
@@ -701,7 +701,7 @@ class DucktapeRunner:
                         continue
 
                     # Parse test arguments
-                    self.args.ducktape_args = user_input.split()
+                    self.ducktape_args = user_input.split()
 
                     exit_code = self.run_ducktape_tests()
 

--- a/tools/dt
+++ b/tools/dt
@@ -435,6 +435,14 @@ class DucktapeRunner:
         """Stop the docker compose cluster."""
         self.log("Stopping docker compose cluster...")
 
+        # Also stop the ducktape container if it's running.
+        # This can happen e.g. if a test is Ctrl-C'd.
+        subprocess.run(
+            ["docker", "stop", "ducktape"],
+            capture_output=True,
+            check=False,
+        )
+
         env = os.environ.copy()
         env["BUILD_ROOT"] = str(self.build_root)
 


### PR DESCRIPTION
First improvement:

tools/dt: Set correct ducktape args in the REPL

    The repl wasn't properly setting user-provided ducktape args, so when
    trying to run a specific test it would run with the default arguments
    from initialization.

Second improvement:

tools/dt: Stop the ducktape container with the compose cluster

    Also stop the ducktape container when the compose cluster is stopped.
    Sometimes it doesn't get stopped and causes problems cleaning up the
    cluster or running more tests. I saw this happen when Ctrl-C'ing tests
    (because I accidentally ran too many).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
