### PR TITLE
 [CORE-14743] dt/dl: Crank the timeout in DatalakeCustomPartitioningTest.test_many_partitions

### DIFF
--- a/tests/rptest/tests/datalake/custom_partitioning_test.py
+++ b/tests/rptest/tests/datalake/custom_partitioning_test.py
@@ -672,7 +672,7 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
                     "timestamp_us": int(t + n),
                 },
                 wait_time_s=900,
-                progress_sec=90,
+                progress_sec=900,
             )
 
             describe_partitioning = self.describe_partitioning(dl, topic_name)

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -163,6 +163,7 @@ def wait_until_with_progress_check(
     """
     val = check()
     elapsed_sec = 0
+    last_exception: TimeoutError | None = None
     while elapsed_sec < timeout_sec:
         try:
             wait_until(
@@ -171,7 +172,9 @@ def wait_until_with_progress_check(
                 backoff_sec=backoff_sec,
                 err_msg=err_msg,
             )
+            break
         except TimeoutError as e:
+            last_exception = e
             elapsed_sec += progress_sec
             next_v = check()
             if next_v == val:
@@ -183,8 +186,17 @@ def wait_until_with_progress_check(
                     f"Progress after {elapsed_sec=}: prev: {val} curr: {next_v}..."
                 )
             val = next_v
-        else:
-            break
+
+    if condition():
+        return
+
+    assert last_exception is not None, (
+        "If the condition doesn't hold an exception should have fired"
+    )
+
+    raise TimeoutError(
+        f"{err_msg if err_msg is not None else ''} after {timeout_sec=}"
+    ) from last_exception
 
 
 def segments_count(redpanda, topic, partition_idx):

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -162,7 +162,8 @@ def wait_until_with_progress_check(
       - logger: log progress after each progress_sec iteration
     """
     val = check()
-    while timeout_sec > 0:
+    elapsed_sec = 0
+    while elapsed_sec < timeout_sec:
         try:
             wait_until(
                 condition,
@@ -171,13 +172,17 @@ def wait_until_with_progress_check(
                 err_msg=err_msg,
             )
         except TimeoutError as e:
+            elapsed_sec += progress_sec
             next_v = check()
             if next_v == val:
-                raise TimeoutError(f"Stopped making progress: {str(e)}")
+                raise TimeoutError(
+                    f"Stopped making progress after {elapsed_sec=}: {str(e)}"
+                )
             if logger is not None:
-                logger.debug(f"Progress: prev: {val} curr: {next_v}...")
+                logger.debug(
+                    f"Progress after {elapsed_sec=}: prev: {val} curr: {next_v}..."
+                )
             val = next_v
-            timeout_sec = timeout_sec - progress_sec
         else:
             break
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Crank up the progress timeout in datalake test for pathological custom partitioning config.

CDT looks good: https://buildkite.com/redpanda/redpanda/builds/77206#019ae090-395f-4f57-92cb-64dd65574d4d

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
