### PR TITLE
`storage`: add `has_transaction_data_batches` to `index_state` 

### DIFF
--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -348,8 +348,9 @@ std::ostream& operator<<(std::ostream& o, const index_state& s) {
              << ", clean_compact_timestamp:" << s.clean_compact_timestamp
              << ", may_have_tombstone_records:" << s.may_have_tombstone_records
              << ", self_compact_timestamp:" << s.self_compact_timestamp
-             << ", may_have_transaction_batches:"
-             << s.may_have_transaction_batches << ", " << s.index << "}";
+             << ", may_have_transaction_control_batches:"
+             << s.may_have_transaction_control_batches << ", " << s.index
+             << "}";
 }
 
 void index_state::serde_write(iobuf& out) const {
@@ -372,7 +373,7 @@ void index_state::serde_write(iobuf& out) const {
     write(tmp, clean_compact_timestamp);
     write(tmp, may_have_tombstone_records);
     write(tmp, self_compact_timestamp);
-    write(tmp, may_have_transaction_batches);
+    write(tmp, may_have_transaction_control_batches);
 
     crc::crc32c crc;
     crc_extend_iobuf(crc, tmp);
@@ -490,10 +491,12 @@ void read_nested(
     } else {
         st.self_compact_timestamp = std::nullopt;
     }
-    if (hdr._version >= index_state::may_have_transaction_batches_version) {
-        read_nested(p, st.may_have_transaction_batches, 0U);
+    if (
+      hdr._version
+      >= index_state::may_have_transaction_control_batches_version) {
+        read_nested(p, st.may_have_transaction_control_batches, 0U);
     } else {
-        st.may_have_transaction_batches = true;
+        st.may_have_transaction_control_batches = true;
     }
 }
 
@@ -562,7 +565,8 @@ index_state::index_state(const index_state& o) noexcept
   , clean_compact_timestamp(o.clean_compact_timestamp)
   , may_have_tombstone_records(o.may_have_tombstone_records)
   , self_compact_timestamp(o.self_compact_timestamp)
-  , may_have_transaction_batches(o.may_have_transaction_batches) {}
+  , may_have_transaction_control_batches(
+      o.may_have_transaction_control_batches) {}
 
 namespace serde_compat {
 uint64_t index_state_serde::checksum(const index_state& r) {

--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -349,8 +349,9 @@ std::ostream& operator<<(std::ostream& o, const index_state& s) {
              << ", may_have_tombstone_records:" << s.may_have_tombstone_records
              << ", self_compact_timestamp:" << s.self_compact_timestamp
              << ", may_have_transaction_control_batches:"
-             << s.may_have_transaction_control_batches << ", " << s.index
-             << "}";
+             << s.may_have_transaction_control_batches
+             << ", may_have_transaction_data_batches:"
+             << s.may_have_transaction_data_batches << ", " << s.index << "}";
 }
 
 void index_state::serde_write(iobuf& out) const {
@@ -374,6 +375,7 @@ void index_state::serde_write(iobuf& out) const {
     write(tmp, may_have_tombstone_records);
     write(tmp, self_compact_timestamp);
     write(tmp, may_have_transaction_control_batches);
+    write(tmp, may_have_transaction_data_batches);
 
     crc::crc32c crc;
     crc_extend_iobuf(crc, tmp);
@@ -498,6 +500,12 @@ void read_nested(
     } else {
         st.may_have_transaction_control_batches = true;
     }
+    if (
+      hdr._version >= index_state::may_have_transaction_data_batches_version) {
+        read_nested(p, st.may_have_transaction_data_batches, 0U);
+    } else {
+        st.may_have_transaction_data_batches = true;
+    }
 }
 
 index_state index_state::copy() const { return *this; }
@@ -565,8 +573,8 @@ index_state::index_state(const index_state& o) noexcept
   , clean_compact_timestamp(o.clean_compact_timestamp)
   , may_have_tombstone_records(o.may_have_tombstone_records)
   , self_compact_timestamp(o.self_compact_timestamp)
-  , may_have_transaction_control_batches(
-      o.may_have_transaction_control_batches) {}
+  , may_have_transaction_control_batches(o.may_have_transaction_control_batches)
+  , may_have_transaction_data_batches(o.may_have_transaction_data_batches) {}
 
 namespace serde_compat {
 uint64_t index_state_serde::checksum(const index_state& r) {

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -131,7 +131,7 @@ private:
    1 byte  - non_data_timestamps
  */
 struct index_state
-  : serde::envelope<index_state, serde::version<10>, serde::compat_version<4>> {
+  : serde::envelope<index_state, serde::version<11>, serde::compat_version<4>> {
     static constexpr auto monotonic_timestamps_version = 5;
     static constexpr auto broker_timestamp_version = 6;
     static constexpr auto num_compactible_records_version = 7;
@@ -140,6 +140,7 @@ struct index_state
     // Added in the same version.
     static constexpr auto self_compact_timestamp_version = 10;
     static constexpr auto may_have_transaction_control_batches_version = 10;
+    static constexpr auto may_have_transaction_data_batches_version = 11;
 
     static index_state
     make_empty_index(model::offset base_offset, offset_delta_time with_offset);
@@ -235,6 +236,12 @@ struct index_state
     // and it is proven that the segment does not contain any transactional
     // control batches (abort/commit batches, as well as tx_fence markers).
     bool may_have_transaction_control_batches{true};
+
+    // may_have_transaction_data_batches is `true` by default. It remains
+    // `true` until compaction deduplication/segment data copying is performed
+    // and it is proven that the segment does not contain any transactional
+    // data batches (i.e raft data batches with a transactional bit set).
+    bool may_have_transaction_data_batches{true};
 
     size_t size() const;
 

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -139,7 +139,7 @@ struct index_state
     static constexpr auto may_have_tombstone_records_version = 9;
     // Added in the same version.
     static constexpr auto self_compact_timestamp_version = 10;
-    static constexpr auto may_have_transaction_batches_version = 10;
+    static constexpr auto may_have_transaction_control_batches_version = 10;
 
     static index_state
     make_empty_index(model::offset base_offset, offset_delta_time with_offset);
@@ -230,10 +230,11 @@ struct index_state
     // delete horizon is set by `self_compact_timestamp + delete.retention.ms`.
     std::optional<model::timestamp> self_compact_timestamp{std::nullopt};
 
-    // may_have_transaction_batches is `true` by default. It remains `true`
-    // until compaction deduplication/segment data copying is performed and and
-    // it is proven that the segment does not contain any transactional batches.
-    bool may_have_transaction_batches{true};
+    // may_have_transaction_control_batches is `true` by default. It remains
+    // `true` until compaction deduplication/segment data copying is performed
+    // and it is proven that the segment does not contain any transactional
+    // control batches (abort/commit batches, as well as tx_fence markers).
+    bool may_have_transaction_control_batches{true};
 
     size_t size() const;
 

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -215,7 +215,7 @@ ss::future<index_state> deduplicate_segment(
     bool may_have_tombstone_records = false;
     const bool past_tx_delete_horizon
       = internal::is_past_transaction_batch_delete_horizon(seg, cfg);
-    bool may_have_transaction_batches = false;
+    bool may_have_transaction_control_batches = false;
 
     auto is_latest_record = [&map](
                               const model::record_batch& b,
@@ -232,7 +232,7 @@ ss::future<index_state> deduplicate_segment(
                           &may_have_tombstone_records,
                           &probe,
                           past_tx_delete_horizon,
-                          &may_have_transaction_batches](
+                          &may_have_transaction_control_batches](
                            const model::record_batch& b,
                            const model::record& r,
                            bool is_last_record_in_batch) {
@@ -248,7 +248,7 @@ ss::future<index_state> deduplicate_segment(
           past_tombstone_delete_horizon,
           may_have_tombstone_records,
           past_tx_delete_horizon,
-          may_have_transaction_batches);
+          may_have_transaction_control_batches);
     };
 
     auto copy_reducer = internal::copy_data_segment_reducer(
@@ -292,8 +292,9 @@ ss::future<index_state> deduplicate_segment(
     // Set may_have_tombstone_records
     new_idx.may_have_tombstone_records = may_have_tombstone_records;
 
-    // Set may_have_transaction_batches
-    new_idx.may_have_transaction_batches = may_have_transaction_batches;
+    // Set may_have_transaction_control_batches
+    new_idx.may_have_transaction_control_batches
+      = may_have_transaction_control_batches;
 
     if (
       seg->index().may_have_tombstone_records()

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -216,6 +216,7 @@ ss::future<index_state> deduplicate_segment(
     const bool past_tx_delete_horizon
       = internal::is_past_transaction_batch_delete_horizon(seg, cfg);
     bool may_have_transaction_control_batches = false;
+    bool may_have_transaction_data_batches = false;
 
     auto is_latest_record = [&map](
                               const model::record_batch& b,
@@ -232,7 +233,8 @@ ss::future<index_state> deduplicate_segment(
                           &may_have_tombstone_records,
                           &probe,
                           past_tx_delete_horizon,
-                          &may_have_transaction_control_batches](
+                          &may_have_transaction_control_batches,
+                          &may_have_transaction_data_batches](
                            const model::record_batch& b,
                            const model::record& r,
                            bool is_last_record_in_batch) {
@@ -248,7 +250,8 @@ ss::future<index_state> deduplicate_segment(
           past_tombstone_delete_horizon,
           may_have_tombstone_records,
           past_tx_delete_horizon,
-          may_have_transaction_control_batches);
+          may_have_transaction_control_batches,
+          may_have_transaction_data_batches);
     };
 
     auto copy_reducer = internal::copy_data_segment_reducer(
@@ -295,6 +298,10 @@ ss::future<index_state> deduplicate_segment(
     // Set may_have_transaction_control_batches
     new_idx.may_have_transaction_control_batches
       = may_have_transaction_control_batches;
+
+    // Set may_have_transaction_data_batches
+    new_idx.may_have_transaction_data_batches
+      = may_have_transaction_data_batches;
 
     if (
       seg->index().may_have_tombstone_records()

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -40,7 +40,7 @@ segment_index::segment_index(
   std::optional<model::timestamp> clean_compact_timestamp,
   bool may_have_tombstone_records,
   std::optional<model::timestamp> self_compact_timestamp,
-  bool may_have_transaction_batches)
+  bool may_have_transaction_control_batches)
   : _path(std::move(path))
   , _step(step)
   , _feature_table(std::ref(feature_table))
@@ -53,7 +53,8 @@ segment_index::segment_index(
     _state.clean_compact_timestamp = clean_compact_timestamp;
     _state.may_have_tombstone_records = may_have_tombstone_records;
     _state.self_compact_timestamp = self_compact_timestamp;
-    _state.may_have_transaction_batches = may_have_transaction_batches;
+    _state.may_have_transaction_control_batches
+      = may_have_transaction_control_batches;
 }
 
 segment_index::segment_index(
@@ -91,7 +92,8 @@ void segment_index::reset() {
     auto self_compact_timestamp = _state.self_compact_timestamp;
     auto clean_compact_timestamp = _state.clean_compact_timestamp;
     auto may_have_tombstone_records = _state.may_have_tombstone_records;
-    auto may_have_transaction_batches = _state.may_have_transaction_batches;
+    auto may_have_transaction_control_batches
+      = _state.may_have_transaction_control_batches;
 
     _state = index_state::make_empty_index(
       base, storage::internal::should_apply_delta_time_offset(_feature_table));
@@ -99,7 +101,8 @@ void segment_index::reset() {
     _state.self_compact_timestamp = self_compact_timestamp;
     _state.clean_compact_timestamp = clean_compact_timestamp;
     _state.may_have_tombstone_records = may_have_tombstone_records;
-    _state.may_have_transaction_batches = may_have_transaction_batches;
+    _state.may_have_transaction_control_batches
+      = may_have_transaction_control_batches;
 
     _acc = 0;
 }

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -40,7 +40,8 @@ segment_index::segment_index(
   std::optional<model::timestamp> clean_compact_timestamp,
   bool may_have_tombstone_records,
   std::optional<model::timestamp> self_compact_timestamp,
-  bool may_have_transaction_control_batches)
+  bool may_have_transaction_control_batches,
+  bool may_have_transaction_data_batches)
   : _path(std::move(path))
   , _step(step)
   , _feature_table(std::ref(feature_table))
@@ -55,6 +56,8 @@ segment_index::segment_index(
     _state.self_compact_timestamp = self_compact_timestamp;
     _state.may_have_transaction_control_batches
       = may_have_transaction_control_batches;
+    _state.may_have_transaction_data_batches
+      = may_have_transaction_data_batches;
 }
 
 segment_index::segment_index(
@@ -94,6 +97,8 @@ void segment_index::reset() {
     auto may_have_tombstone_records = _state.may_have_tombstone_records;
     auto may_have_transaction_control_batches
       = _state.may_have_transaction_control_batches;
+    auto may_have_transaction_data_batches
+      = _state.may_have_transaction_data_batches;
 
     _state = index_state::make_empty_index(
       base, storage::internal::should_apply_delta_time_offset(_feature_table));
@@ -103,6 +108,8 @@ void segment_index::reset() {
     _state.may_have_tombstone_records = may_have_tombstone_records;
     _state.may_have_transaction_control_batches
       = may_have_transaction_control_batches;
+    _state.may_have_transaction_data_batches
+      = may_have_transaction_data_batches;
 
     _acc = 0;
 }

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -159,7 +159,7 @@ public:
       std::optional<model::timestamp> clean_compact_timestamp = std::nullopt,
       bool may_have_tombstone_records = true,
       std::optional<model::timestamp> self_compact_timestamp = std::nullopt,
-      bool may_have_transaction_batches = true);
+      bool may_have_transaction_control_batches = true);
 
     ~segment_index() noexcept = default;
     segment_index(segment_index&&) noexcept = default;
@@ -287,15 +287,8 @@ public:
         return _state.self_compact_timestamp;
     }
 
-    void set_may_have_transaction_batches(bool b) {
-        if (_state.may_have_transaction_batches != b) {
-            _needs_persistence = true;
-        }
-        _state.may_have_transaction_batches = b;
-    }
-
-    bool may_have_transaction_batches() const {
-        return _state.may_have_transaction_batches;
+    bool may_have_transaction_control_batches() const {
+        return _state.may_have_transaction_control_batches;
     }
 
     ss::future<bool> materialize_index();

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -159,7 +159,8 @@ public:
       std::optional<model::timestamp> clean_compact_timestamp = std::nullopt,
       bool may_have_tombstone_records = true,
       std::optional<model::timestamp> self_compact_timestamp = std::nullopt,
-      bool may_have_transaction_control_batches = true);
+      bool may_have_transaction_control_batches = true,
+      bool may_have_transaction_data_batches = true);
 
     ~segment_index() noexcept = default;
     segment_index(segment_index&&) noexcept = default;
@@ -289,6 +290,10 @@ public:
 
     bool may_have_transaction_control_batches() const {
         return _state.may_have_transaction_control_batches;
+    }
+
+    bool may_have_transaction_data_batches() const {
+        return _state.may_have_transaction_data_batches;
     }
 
     ss::future<bool> materialize_index();

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -397,7 +397,7 @@ ss::future<storage::index_state> do_copy_segment_data(
     bool may_have_tombstone_records = false;
     const bool past_tx_delete_horizon
       = internal::is_past_transaction_batch_delete_horizon(seg, cfg);
-    bool may_have_transaction_batches = false;
+    bool may_have_transaction_control_batches = false;
 
     auto offset_in_compacted_list =
       [compacted_offsets = std::move(compacted_offsets)](
@@ -417,7 +417,7 @@ ss::future<storage::index_state> do_copy_segment_data(
                           &may_have_tombstone_records,
                           &pb,
                           past_tx_delete_horizon,
-                          &may_have_transaction_batches](
+                          &may_have_transaction_control_batches](
                            const model::record_batch& b,
                            const model::record& r,
                            bool is_last_record_in_batch) {
@@ -433,7 +433,7 @@ ss::future<storage::index_state> do_copy_segment_data(
           past_tombstone_delete_horizon,
           may_have_tombstone_records,
           past_tx_delete_horizon,
-          may_have_transaction_batches);
+          may_have_transaction_control_batches);
     };
 
     auto copy_reducer = copy_data_segment_reducer(
@@ -487,8 +487,9 @@ ss::future<storage::index_state> do_copy_segment_data(
     // Set may_have_tombstone_records
     new_index.may_have_tombstone_records = may_have_tombstone_records;
 
-    // Set may_have_transaction_batches
-    new_index.may_have_transaction_batches = may_have_transaction_batches;
+    // Set may_have_transaction_control_batches
+    new_index.may_have_transaction_control_batches
+      = may_have_transaction_control_batches;
 
     if (
       seg->index().may_have_tombstone_records()
@@ -969,9 +970,10 @@ make_concatenated_segment(
 
     // If any of the segments contain a transactional batch, then the new index
     // should reflect that.
-    auto new_may_have_transaction_batches = std::ranges::any_of(
-      segments,
-      [](const auto& s) { return s->index().may_have_transaction_batches(); });
+    auto new_may_have_transaction_control_batches = std::ranges::any_of(
+      segments, [](const auto& s) {
+          return s->index().may_have_transaction_control_batches();
+      });
 
     segment_index index(
       index_path,
@@ -983,7 +985,7 @@ make_concatenated_segment(
       new_clean_compact_timestamp,
       new_may_have_tombstone_records,
       new_self_compact_timestamp,
-      new_may_have_transaction_batches);
+      new_may_have_transaction_control_batches);
 
     co_return std::make_tuple(
       ss::make_lw_shared<segment>(
@@ -1394,7 +1396,7 @@ bool is_past_transaction_batch_delete_horizon(
 
 bool has_removable_transaction_batches(
   ss::lw_shared_ptr<segment> seg, const compaction::compaction_config& cfg) {
-    return seg->index().may_have_transaction_batches()
+    return seg->index().may_have_transaction_control_batches()
            && is_past_transaction_batch_delete_horizon(seg, cfg);
 }
 

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -398,6 +398,7 @@ ss::future<storage::index_state> do_copy_segment_data(
     const bool past_tx_delete_horizon
       = internal::is_past_transaction_batch_delete_horizon(seg, cfg);
     bool may_have_transaction_control_batches = false;
+    bool may_have_transaction_data_batches = false;
 
     auto offset_in_compacted_list =
       [compacted_offsets = std::move(compacted_offsets)](
@@ -417,7 +418,8 @@ ss::future<storage::index_state> do_copy_segment_data(
                           &may_have_tombstone_records,
                           &pb,
                           past_tx_delete_horizon,
-                          &may_have_transaction_control_batches](
+                          &may_have_transaction_control_batches,
+                          &may_have_transaction_data_batches](
                            const model::record_batch& b,
                            const model::record& r,
                            bool is_last_record_in_batch) {
@@ -433,7 +435,8 @@ ss::future<storage::index_state> do_copy_segment_data(
           past_tombstone_delete_horizon,
           may_have_tombstone_records,
           past_tx_delete_horizon,
-          may_have_transaction_control_batches);
+          may_have_transaction_control_batches,
+          may_have_transaction_data_batches);
     };
 
     auto copy_reducer = copy_data_segment_reducer(
@@ -490,6 +493,10 @@ ss::future<storage::index_state> do_copy_segment_data(
     // Set may_have_transaction_control_batches
     new_index.may_have_transaction_control_batches
       = may_have_transaction_control_batches;
+
+    // Set may_have_transaction_data_batches
+    new_index.may_have_transaction_data_batches
+      = may_have_transaction_data_batches;
 
     if (
       seg->index().may_have_tombstone_records()
@@ -968,11 +975,18 @@ make_concatenated_segment(
           .self_compact_timestamp()
           .value();
 
-    // If any of the segments contain a transactional batch, then the new index
-    // should reflect that.
+    // If any of the segments contain a transactional control batch, then the
+    // new index should reflect that.
     auto new_may_have_transaction_control_batches = std::ranges::any_of(
       segments, [](const auto& s) {
           return s->index().may_have_transaction_control_batches();
+      });
+
+    // If any of the segments contain a transactional data batch, then the new
+    // index should reflect that.
+    auto new_may_have_transaction_data_batches = std::ranges::any_of(
+      segments, [](const auto& s) {
+          return s->index().may_have_transaction_data_batches();
       });
 
     segment_index index(
@@ -985,7 +999,8 @@ make_concatenated_segment(
       new_clean_compact_timestamp,
       new_may_have_tombstone_records,
       new_self_compact_timestamp,
-      new_may_have_transaction_control_batches);
+      new_may_have_transaction_control_batches,
+      new_may_have_transaction_data_batches);
 
     co_return std::make_tuple(
       ss::make_lw_shared<segment>(
@@ -1396,8 +1411,15 @@ bool is_past_transaction_batch_delete_horizon(
 
 bool has_removable_transaction_batches(
   ss::lw_shared_ptr<segment> seg, const compaction::compaction_config& cfg) {
-    return seg->index().may_have_transaction_control_batches()
-           && is_past_transaction_batch_delete_horizon(seg, cfg);
+    // If there are transactional data batches, we will unset the transactional
+    // bit during compaction.
+    auto has_data_batches = seg->index().may_have_transaction_data_batches();
+    // If there are removable control batches, they will be removed during
+    // compaction.
+    auto has_removable_control_batches
+      = seg->index().may_have_transaction_control_batches()
+        && is_past_transaction_batch_delete_horizon(seg, cfg);
+    return has_data_batches || has_removable_control_batches;
 }
 
 } // namespace storage::internal

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "compaction/key_offset_map.h"
 #include "compaction/utils.h"
+#include "model/record.h"
 #include "model/record_batch_reader.h"
 #include "model/record_batch_types.h"
 #include "storage/compacted_index.h"
@@ -358,12 +359,16 @@ ss::future<bool> should_keep(
   bool past_tombstone_delete_horizon,
   bool& may_have_tombstone_records,
   bool past_tx_delete_horizon,
-  bool& has_tx_batches) {
+  bool& has_tx_control_batches,
+  bool& has_tx_data_batches) {
     const auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
     const auto is_compactible = compaction::is_compactible(b.header());
     const auto is_last_batch = b.last_offset() == segment_last_offset;
-    const auto is_control_batch = b.header().attrs.is_control();
+    const auto is_tx_control_batch = b.header().attrs.is_control();
+    const auto is_tx_data_batch = b.header().type
+                                    == model::record_batch_type::raft_data
+                                  && b.header().attrs.is_transactional();
     const auto is_tombstone = r.is_tombstone();
     // once compaction placeholder feature is enabled, we are not
     // worried about empty batches as the reducer then installs a
@@ -380,8 +385,12 @@ ss::future<bool> should_keep(
             may_have_tombstone_records = true;
         }
 
-        if (is_control_batch) {
-            has_tx_batches = true;
+        if (is_tx_control_batch) {
+            has_tx_control_batches = true;
+        }
+
+        if (is_tx_data_batch) {
+            has_tx_data_batches = true;
         }
 
         co_return true;
@@ -400,15 +409,15 @@ ss::future<bool> should_keep(
         if (is_tombstone) {
             pb.add_removed_tombstone();
         }
-        if (is_control_batch) {
+        if (is_tx_control_batch) {
             pb.add_removed_control_batch();
         }
         co_return false;
     }
 
     if (!is_compactible) {
-        if (is_control_batch) {
-            has_tx_batches = true;
+        if (is_tx_control_batch) {
+            has_tx_control_batches = true;
         }
         co_return true;
     }
@@ -417,6 +426,10 @@ ss::future<bool> should_keep(
 
     if (is_tombstone && keep) {
         may_have_tombstone_records = true;
+    }
+
+    if (is_tx_data_batch && keep) {
+        has_tx_data_batches = true;
     }
 
     co_return keep;

--- a/src/v/storage/tests/compaction_e2e_multinode_test.cc
+++ b/src/v/storage/tests/compaction_e2e_multinode_test.cc
@@ -249,3 +249,117 @@ FIXTURE_TEST(compact_transactions_and_replicate, compaction_multinode_test) {
     new_log->housekeeping(conf2).get();
     exec.validate(new_log).get();
 }
+
+FIXTURE_TEST(segment_tx_flags, compaction_multinode_test) {
+    const model::topic topic{"tapioca"};
+    model::node_id id{0};
+    create_node_application(id);
+    auto* rp = instance(id);
+    wait_for_controller_leadership(id).get();
+
+    cluster::topic_properties props;
+    props.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+    rp->add_topic({model::kafka_namespace, topic}, 1, props).get();
+    model::partition_id pid{0};
+    auto ntp = model::ntp(model::kafka_namespace, topic, pid);
+    RPTEST_REQUIRE_EVENTUALLY(5s, [&] {
+        auto [_, prt] = get_leader(ntp);
+        return prt != nullptr;
+    });
+    auto [_, partition] = get_leader(ntp);
+    auto log = partition->log();
+    using cluster::tx_executor;
+    tx_executor exec;
+    auto make_ctx = [&](int64_t id, model::term_id term) {
+        model::producer_identity pid{id, 0};
+        return tx_executor::tx_op_ctx{
+          exec.data_gen(), partition->rm_stm(), log, pid, term};
+    };
+    // Produce transactional records.
+    tx_executor::sorted_tx_ops_t ops;
+    auto term = partition->raft()->term();
+
+    int weight = 1;
+    ops.emplace(
+      ss::make_shared(tx_executor::begin_op(make_ctx(1, term), weight++)));
+    ops.emplace(
+      ss::make_shared(tx_executor::roll_op(make_ctx(1, term), weight++)));
+    ops.emplace(
+      ss::make_shared(tx_executor::data_op(make_ctx(1, term), weight++, 1)));
+    ops.emplace(
+      ss::make_shared(tx_executor::roll_op(make_ctx(1, term), weight++)));
+
+    ops.emplace(
+      ss::make_shared(tx_executor::abort_op(make_ctx(1, term), weight++)));
+    ops.emplace(
+      ss::make_shared(tx_executor::begin_op(make_ctx(2, term), weight++)));
+    ops.emplace(
+      ss::make_shared(tx_executor::data_op(make_ctx(2, term), weight++, 1)));
+    ops.emplace(
+      ss::make_shared(tx_executor::abort_op(make_ctx(2, term), weight++)));
+
+    exec.execute(std::move(ops)).get();
+    partition->log()->flush().get();
+    partition->log()->force_roll().get();
+
+    // Before compaction, segments should by default have these flags as `true`.
+    for (const auto& segment : log->segments()) {
+        BOOST_REQUIRE(segment->index().may_have_transaction_control_batches());
+        BOOST_REQUIRE(segment->index().may_have_transaction_data_batches());
+    }
+
+    ss::abort_source as;
+    auto collect_offset = log->stm_manager()->max_removable_local_log_offset();
+    {
+        auto conf = storage::housekeeping_config::make_config(
+          model::timestamp::min(),
+          std::nullopt,
+          collect_offset,
+          collect_offset,
+          collect_offset,
+          std::nullopt,
+          std::nullopt,
+          std::chrono::milliseconds{0},
+          as);
+        log->housekeeping(conf).get();
+    }
+
+    // After the first compaction, control batches are still present, but data
+    // batches have had their bit unset (due to being compacted twice over
+    // during self compaction -> sliding window compaction)
+    for (const auto& segment : log->segments()) {
+        if (segment->has_self_compact_timestamp()) {
+            BOOST_REQUIRE(
+              segment->index().may_have_transaction_control_batches());
+            BOOST_REQUIRE(
+              !segment->index().may_have_transaction_data_batches());
+        }
+    }
+
+    {
+        auto conf = storage::housekeeping_config::make_config(
+          model::timestamp::min(),
+          std::nullopt,
+          collect_offset,
+          collect_offset,
+          collect_offset,
+          std::nullopt,
+          std::chrono::milliseconds{0},
+          std::chrono::milliseconds{0},
+          as);
+        log->housekeeping(conf).get();
+    }
+
+    // `may_have_transaction_data_batches` will be false after the previous
+    // compaction, as transactional bits were unset.
+    // `may_have_transaction_control_batches` will also be false due to
+    // compacting with `tx_retention_ms` set.
+    for (const auto& segment : log->segments()) {
+        if (segment->has_self_compact_timestamp()) {
+            BOOST_REQUIRE(
+              !segment->index().may_have_transaction_control_batches());
+            BOOST_REQUIRE(
+              !segment->index().may_have_transaction_data_batches());
+        }
+    }
+}


### PR DESCRIPTION
We need to be able to ensure that compaction of `segment`s with transactional raft data occurs (so that their transactional bit is unset) before it is safe to remove transactional control batches during compaction.

Add a new flag, `has_transaction_data_batches` which defaults to `true`, and force compaction of `segments` using it. Likely this will only need to force a single re-compaction of each `segment` to ensure that transactional raft batches have their transactional bit unset.

In the future, a new coordinated compaction offset based on the prefix of `segment`s in the `log` which have `segment->has_transaction_data_batches()` will be used to gate removal of transactional control batches, similar to the MCCO for tombstone removal as of today.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
