### PR TITLE
[CORE-14438] `ct/l1`: misc utility fixes & updates for CT compaction

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/log_info_collector.cc
+++ b/src/v/cloud_topics/level_one/compaction/log_info_collector.cc
@@ -165,7 +165,7 @@ log_info_collector::get_logs_to_collect(
 }
 
 void log_info_collector::populate_log_infos(
-  const metastore::compaction_info_map& compaction_infos,
+  metastore::compaction_info_map& compaction_infos,
   log_set_t& logs_set,
   log_list_t& logs_list,
   log_compaction_queue& compaction_queue,

--- a/src/v/cloud_topics/level_one/compaction/log_info_collector.h
+++ b/src/v/cloud_topics/level_one/compaction/log_info_collector.h
@@ -69,7 +69,7 @@ private:
     // `compaction_info_map` collected from the metastore and pushes logs
     // eligible for compaction to the provided `log_compaction_queue`.
     void populate_log_infos(
-      const metastore::compaction_info_map&,
+      metastore::compaction_info_map&,
       log_set_t&,
       log_list_t&,
       log_compaction_queue&,

--- a/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
@@ -141,7 +141,7 @@ TEST_F(ReducerTestFixture, Reducer) {
     auto src = std::make_unique<l1::compaction_source>(
       ntp,
       tidp,
-      compaction_info->offsets_response,
+      std::move(compaction_info->offsets_response),
       &map,
       &_metastore,
       &_io,

--- a/src/v/cloud_topics/level_one/compaction/worker.cc
+++ b/src/v/cloud_topics/level_one/compaction/worker.cc
@@ -155,8 +155,11 @@ ss::future<> compaction_worker::compact_log(log_compaction_meta* log) {
     _job_state = compaction_job_state::running;
     _inflight_ntp = ntp;
 
-    // Copy
-    auto compaction_offsets = log->info_and_ts->info.offsets_response;
+    auto compaction_offsets = metastore::compaction_offsets_response{
+      .dirty_ranges = log->info_and_ts->info.offsets_response.dirty_ranges,
+      .removable_tombstone_ranges
+      = log->info_and_ts->info.offsets_response.removable_tombstone_ranges,
+      .extents = log->info_and_ts->info.offsets_response.extents.copy()};
 
     // Lazy initialization of offset map.
     if (!_map) {
@@ -166,7 +169,7 @@ ss::future<> compaction_worker::compact_log(log_compaction_meta* log) {
     auto src = std::make_unique<compaction_source>(
       std::move(ntp),
       tidp,
-      compaction_offsets,
+      std::move(compaction_offsets),
       _map.get(),
       _metastore,
       _io,

--- a/src/v/cloud_topics/level_one/domain/domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.cc
@@ -45,6 +45,21 @@ rpc::errc convert_metastore_errc(metastore::errc e) {
         return rpc::errc::timed_out;
     }
 }
+
+chunked_vector<rpc::extent_metadata>
+meta_to_rpc_extent_metadata(metastore::extent_metadata_vec v) {
+    chunked_vector<rpc::extent_metadata> res;
+    res.reserve(v.size());
+    for (auto& e : v) {
+        res.push_back(
+          rpc::extent_metadata{
+            .base_offset = e.base_offset,
+            .last_offset = e.last_offset,
+            .max_timestamp = e.max_timestamp});
+    }
+    return res;
+}
+
 } // namespace
 
 domain_manager::domain_manager(ss::shared_ptr<simple_stm> stm, io* io)
@@ -355,7 +370,9 @@ domain_manager::get_compaction_info(rpc::get_compaction_info_request req) {
       .removable_tombstone_ranges = std::move(
         get_res->offsets_response.removable_tombstone_ranges),
       .dirty_ratio = get_res->dirty_ratio,
-      .earliest_dirty_ts = get_res->earliest_dirty_ts};
+      .earliest_dirty_ts = get_res->earliest_dirty_ts,
+      .extents = meta_to_rpc_extent_metadata(
+        std::move(get_res->offsets_response.extents))};
 }
 
 ss::future<rpc::get_term_for_offset_reply>

--- a/src/v/cloud_topics/level_one/metastore/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/BUILD
@@ -142,6 +142,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":metastore",
+        ":offset_interval_set",
         ":state",
         "//src/v/base",
         "//src/v/cloud_topics/level_one/common:object_id",

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -274,6 +274,23 @@ public:
     };
     using compaction_map_t
       = chunked_hash_map<model::topic_id_partition, compaction_update>;
+
+    struct extent_metadata {
+        kafka::offset base_offset;
+        kafka::offset last_offset;
+        model::timestamp max_timestamp;
+
+        fmt::iterator format_to(fmt::iterator it) const {
+            return fmt::format_to(
+              it,
+              "{{offsets:({}-{}), max_timestamp:{}}}",
+              base_offset,
+              last_offset,
+              max_timestamp);
+        }
+    };
+    using extent_metadata_vec = chunked_vector<extent_metadata>;
+
     struct compaction_offsets_response {
         // Offset ranges whose keys have not been fully deduplicated from the
         // start of the log.
@@ -285,6 +302,8 @@ public:
         // A compaction method, when iterating over a tombstone record, may
         // consult this to determine if the tombstone should be removed.
         offset_interval_set removable_tombstone_ranges;
+
+        extent_metadata_vec extents;
     };
     // Similar to replace_objects(), but with additional constraints based on
     // compaction metadata. See get_compaction_info() for more details on

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -260,6 +260,15 @@ public:
 
             // Whether or not the cleaned range included any tombstones.
             bool has_tombstones{false};
+
+            fmt::iterator format_to(fmt::iterator it) const {
+                return fmt::format_to(
+                  it,
+                  "{{offsets:({}~{}), has_tombstones:{}}}",
+                  base_offset,
+                  last_offset,
+                  has_tombstones);
+            }
         };
         // Ranges indicating that the data's keys have been fully deduplicated
         // from the start of the log.
@@ -271,6 +280,16 @@ public:
 
         // Timestamp at which the compaction operation happened.
         model::timestamp cleaned_at;
+
+        fmt::iterator format_to(fmt::iterator it) const {
+            return fmt::format_to(
+              it,
+              "{{new_cleaned_ranges:{}, removed_tombstone_ranges:{}, "
+              "cleaned_at:{}}}",
+              new_cleaned_ranges,
+              removed_tombstones_ranges,
+              cleaned_at);
+        }
     };
     using compaction_map_t
       = chunked_hash_map<model::topic_id_partition, compaction_update>;
@@ -283,7 +302,7 @@ public:
         fmt::iterator format_to(fmt::iterator it) const {
             return fmt::format_to(
               it,
-              "{{offsets:({}-{}), max_timestamp:{}}}",
+              "{{offsets:({}~{}), max_timestamp:{}}}",
               base_offset,
               last_offset,
               max_timestamp);
@@ -304,6 +323,15 @@ public:
         offset_interval_set removable_tombstone_ranges;
 
         extent_metadata_vec extents;
+
+        fmt::iterator format_to(fmt::iterator it) const {
+            return fmt::format_to(
+              it,
+              "{{dirty_ranges:{}, removable_tombstone_ranges:{}, extents:{}}}",
+              dirty_ranges,
+              removable_tombstone_ranges,
+              extents);
+        }
     };
     // Similar to replace_objects(), but with additional constraints based on
     // compaction metadata. See get_compaction_info() for more details on
@@ -327,6 +355,15 @@ public:
         std::optional<model::timestamp> earliest_dirty_ts;
         // Dirty ranges & removable tombstone ranges.
         compaction_offsets_response offsets_response;
+
+        fmt::iterator format_to(fmt::iterator it) const {
+            return fmt::format_to(
+              it,
+              "{{dirty_ratio:{}, earliest_dirty_ts:{}, offsets_response:{}}}",
+              dirty_ratio,
+              earliest_dirty_ts,
+              offsets_response);
+        }
     };
 
     // Returns metadata required to determine what to compact for the given

--- a/src/v/cloud_topics/level_one/metastore/offset_interval_set.h
+++ b/src/v/cloud_topics/level_one/metastore/offset_interval_set.h
@@ -56,6 +56,10 @@ public:
     chunked_vector<interval> to_vec() const;
     void truncate_with_new_start_offset(kafka::offset);
 
+    fmt::iterator format_to(fmt::iterator it) const {
+        return fmt::format_to(it, "{}", iset_);
+    }
+
 private:
     interval_set<kafka::offset::type> iset_;
 };

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -208,6 +208,16 @@ replicated_object_builder::finish(
     return {};
 }
 
+metastore::extent_metadata_vec
+rpc_to_meta_extent_metadata(chunked_vector<rpc::extent_metadata> v) {
+    metastore::extent_metadata_vec res;
+    res.reserve(v.size());
+    for (auto& e : v) {
+        res.emplace_back(e.base_offset, e.last_offset, e.max_timestamp);
+    }
+    return res;
+}
+
 } // anonymous namespace
 
 replicated_metastore::replicated_metastore(leader_router& fe)
@@ -672,8 +682,9 @@ replicated_metastore::get_compaction_info(const compaction_info_spec& log) {
     resp.dirty_ratio = reply.dirty_ratio;
     resp.earliest_dirty_ts = reply.earliest_dirty_ts;
     resp.offsets_response = {
-      .dirty_ranges = reply.dirty_ranges,
-      .removable_tombstone_ranges = reply.removable_tombstone_ranges};
+      .dirty_ranges = std::move(reply.dirty_ranges),
+      .removable_tombstone_ranges = std::move(reply.removable_tombstone_ranges),
+      .extents = rpc_to_meta_extent_metadata(std::move(reply.extents))};
 
     co_return resp;
 }

--- a/src/v/cloud_topics/level_one/metastore/retry.h
+++ b/src/v/cloud_topics/level_one/metastore/retry.h
@@ -65,4 +65,12 @@ auto retry_metastore_op(Func&& func, retry_chain_node& rtc)
       std::unexpected(metastore::errc::transport_error)};
 }
 
+template<typename Func>
+requires metastore_operation<Func>
+auto retry_metastore_op_with_default_rtc(Func&& func, ss::abort_source& as)
+  -> ss::future<typename std::invoke_result_t<Func>::value_type> {
+    auto rtc = make_default_metastore_rtc(as);
+    co_return co_await retry_metastore_op(std::forward<Func>(func), rtc);
+}
+
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -189,6 +189,18 @@ struct get_offsets_request
     model::topic_id_partition tp;
 };
 
+struct extent_metadata
+  : serde::
+      envelope<extent_metadata, serde::version<0>, serde::compat_version<0>> {
+    auto serde_fields() {
+        return std::tie(base_offset, last_offset, max_timestamp);
+    }
+
+    kafka::offset base_offset;
+    kafka::offset last_offset;
+    model::timestamp max_timestamp;
+};
+
 struct get_compaction_info_reply
   : serde::envelope<
       get_compaction_info_reply,
@@ -200,7 +212,8 @@ struct get_compaction_info_reply
           dirty_ranges,
           removable_tombstone_ranges,
           dirty_ratio,
-          earliest_dirty_ts);
+          earliest_dirty_ts,
+          extents);
     }
 
     errc ec;
@@ -208,6 +221,7 @@ struct get_compaction_info_reply
     offset_interval_set removable_tombstone_ranges;
     double dirty_ratio;
     std::optional<model::timestamp> earliest_dirty_ts;
+    chunked_vector<extent_metadata> extents;
 };
 struct get_compaction_info_request
   : serde::envelope<

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -10,6 +10,7 @@
 #include "cloud_topics/level_one/metastore/simple_metastore.h"
 
 #include "cloud_topics/level_one/common/object_id.h"
+#include "cloud_topics/level_one/metastore/offset_interval_set.h"
 #include "cloud_topics/level_one/metastore/state.h"
 #include "cloud_topics/level_one/metastore/state_update.h"
 #include "cloud_topics/logger.h"
@@ -532,6 +533,15 @@ simple_metastore::get_compaction_offsets(
     }
     auto& prt = prt_ref->get();
     compaction_offsets_response resp;
+
+    resp.extents.reserve(prt.extents.size());
+    for (const auto& extent : prt.extents) {
+        resp.extents.push_back(
+          {.base_offset = extent.base_offset,
+           .last_offset = extent.last_offset,
+           .max_timestamp = extent.max_timestamp});
+    }
+
     if (prt.start_offset >= prt.next_offset) {
         // The log is empty, nothing to compact.
         return resp;

--- a/src/v/cloud_topics/level_one/metastore/state.h
+++ b/src/v/cloud_topics/level_one/metastore/state.h
@@ -49,6 +49,18 @@ struct extent
     size_t len;
     // TODO: avoid duplicating the UUIDs with some indirection.
     object_id oid;
+
+    fmt::iterator format_to(fmt::iterator it) const {
+        return fmt::format_to(
+          it,
+          "{{offsets:({}~{}), max_timestamp:{}, filepos:{}, len:{}, oid:{}",
+          base_offset,
+          last_offset,
+          max_timestamp,
+          filepos,
+          len,
+          oid);
+    }
 };
 
 // Offset that corresponds to the start of a given term.

--- a/src/v/compaction/types.cc
+++ b/src/v/compaction/types.cc
@@ -40,10 +40,12 @@ std::ostream& operator<<(std::ostream& o, const stats& s) {
     fmt::print(
       o,
       "{{ batches_processed: {}, batches_discarded: {}, "
-      "records_discarded: {}, non_compactible_batches: {}{}}}",
+      "records_discarded: {}, expired_tombstones_discarded: {}, "
+      "non_compactible_batches: {}{}}}",
       s.batches_processed,
       s.batches_discarded,
       s.records_discarded,
+      s.expired_tombstones_discarded,
       s.non_compactible_batches,
       s.control_batches_discarded > 0
         ? fmt::format(

--- a/src/v/compaction/types.h
+++ b/src/v/compaction/types.h
@@ -115,11 +115,15 @@ struct stats {
     // Number of transactional control batches that were removed.
     // This is only relevant for local storage compaction.
     size_t control_batches_discarded{0};
+    // Number of tombstone records that were removed due to expiration (not
+    // including those removed by de-duplication)
+    size_t expired_tombstones_discarded{0};
 
     // Returns whether any data was removed by this reducer.
     bool has_removed_data() const {
         return batches_discarded > 0 || records_discarded > 0
-               || control_batches_discarded > 0;
+               || control_batches_discarded > 0
+               || expired_tombstones_discarded > 0;
     }
 
     friend std::ostream& operator<<(std::ostream& os, const stats& s);

--- a/src/v/container/BUILD
+++ b/src/v/container/BUILD
@@ -44,9 +44,11 @@ redpanda_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/v/base",
         "//src/v/bytes:iobuf_parser",
         "//src/v/serde",
         "//src/v/serde:map",
+        "//src/v/utils:to_string",
         "@abseil-cpp//absl/container:btree",
     ],
 )

--- a/src/v/container/interval_set.h
+++ b/src/v/container/interval_set.h
@@ -11,9 +11,11 @@
 #pragma once
 
 #include "absl/container/btree_map.h"
+#include "base/format_to.h"
 #include "bytes/iobuf_parser.h"
 #include "serde/rw/map.h"
 #include "serde/rw/rw.h"
+#include "utils/to_string.h"
 
 /**
  * A container that contains non-empty, open intervals.
@@ -105,6 +107,10 @@ public:
     friend void write(iobuf& out, interval_set is) {
         using serde::write;
         return write(out, std::move(is.set_));
+    }
+
+    fmt::iterator format_to(fmt::iterator it) const {
+        return fmt::format_to(it, "{}", set_);
     }
 
 private:

--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -165,6 +165,7 @@ redpanda_cc_library(
     hdrs = ["to_string.h"],
     deps = [
         "//src/v/base",
+        "@abseil-cpp//absl/container:btree",
         "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/container:node_hash_map",
         "@fmt",

--- a/src/v/utils/tests/uuid_test.cc
+++ b/src/v/utils/tests/uuid_test.cc
@@ -34,11 +34,15 @@ SEASTAR_THREAD_TEST_CASE(test_uuid_default_construct) {
     auto uuid = uuid_t{};
     BOOST_REQUIRE_EQUAL(
       uuid, uuid_t::from_string("00000000-0000-0000-0000-000000000000"));
+    BOOST_REQUIRE(uuid.is_nil());
+    BOOST_REQUIRE(!uuid);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_lt) {
-    BOOST_REQUIRE_LT(
-      uuid_t{}, uuid_t::from_string("00000000-0000-0000-0000-000000000001"));
+    auto uuid = uuid_t::from_string("00000000-0000-0000-0000-000000000001");
+    BOOST_REQUIRE_LT(uuid_t{}, uuid);
+    BOOST_REQUIRE(!uuid.is_nil());
+    BOOST_REQUIRE(uuid);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_named_uuid_type) {

--- a/src/v/utils/to_string.h
+++ b/src/v/utils/to_string.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include "absl/container/btree_map.h"
+#include "absl/container/btree_set.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/node_hash_map.h"
 #include "base/seastarx.h"
@@ -88,6 +90,37 @@ std::ostream& operator<<(std::ostream& o, const absl::node_hash_map<K, V>& r) {
     o << "}";
     return o;
 }
+
+template<typename K, typename V>
+std::ostream& operator<<(std::ostream& o, const absl::btree_map<K, V>& r) {
+    o << "{";
+    bool first = true;
+    for (const auto& [k, v] : r) {
+        if (!first) {
+            o << ", ";
+        }
+        o << "{" << k << " -> " << v << "}";
+        first = false;
+    }
+    o << "}";
+    return o;
+}
+
+template<typename K>
+std::ostream& operator<<(std::ostream& o, const absl::btree_set<K>& s) {
+    o << "{";
+    bool first = true;
+    for (const auto& k : s) {
+        if (!first) {
+            o << ", ";
+        }
+        o << k;
+        first = false;
+    }
+    o << "}";
+    return o;
+}
+
 } // namespace absl
 
 template<>

--- a/src/v/utils/uuid.cc
+++ b/src/v/utils/uuid.cc
@@ -61,3 +61,6 @@ std::strong_ordering operator<=>(const uuid_t& u, const uuid_t& v) {
 uuid_t::operator ss::sstring() const { return fmt::format("{}", _uuid); }
 
 bool operator<(const uuid_t& l, const uuid_t& r) { return l.uuid() < r.uuid(); }
+
+bool uuid_t::is_nil() const noexcept { return _uuid.is_nil(); }
+uuid_t::operator bool() const noexcept { return !is_nil(); }

--- a/src/v/utils/uuid.h
+++ b/src/v/utils/uuid.h
@@ -46,6 +46,9 @@ public:
     friend bool operator==(const uuid_t& u, const uuid_t& v) = default;
     friend std::strong_ordering operator<=>(const uuid_t& u, const uuid_t& v);
 
+    bool is_nil() const noexcept;
+    explicit operator bool() const noexcept;
+
     operator ss::sstring() const; // NOLINT(*explicit*)
 
     template<typename H>


### PR DESCRIPTION
Part of a slow drip of https://github.com/redpanda-data/redpanda/compare/dev...WillemKauf:redpanda:ct_final_squashed.

Mostly utilitarian changes here that will be necessary for future cloud topics compaction PRs.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
