### PR TITLE
`kafka/server`: alter `tristate` handling

### DIFF
--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -608,8 +608,8 @@ void parse_and_set_tristate(
         using config_t
           = std::conditional_t<std::is_floating_point_v<T>, T, int64_t>;
         auto parsed = boost::lexical_cast<config_t>(*value);
-        if (parsed <= 0) {
-            property.value = tristate<T>{};
+        if (parsed < 0) {
+            property.value = tristate<T>{disable_tristate};
         } else {
             property.value = tristate<T>(std::make_optional<T>(parsed));
         }

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -190,7 +190,7 @@ get_tristate_value(const config_map_t& config, std::string_view key) {
         return tristate<T>(std::nullopt);
     }
     // disabled case
-    if (v <= 0) {
+    if (v < 0) {
         return tristate<T>(disable_tristate);
     }
     return tristate<T>(std::make_optional<T>(*v));

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -1639,3 +1639,83 @@ FIXTURE_TEST(
   test_unlicensed_alter_configs_no_cluster_config, alter_config_test_fixture) {
     alter_config_no_license_test(false);
 }
+
+FIXTURE_TEST(test_tristate_handling_alter_config, alter_config_test_fixture) {
+    model::topic test_tp{"topic-1"};
+    create_topic(test_tp, 6);
+    using map_t = absl::flat_hash_map<
+      ss::sstring,
+      std::pair<std::optional<ss::sstring>, kafka::config_resource_operation>>;
+
+    // 0 is a valid value for a tristate.
+    {
+        map_t properties;
+        properties.emplace(
+          "min.cleanable.dirty.ratio",
+          std::make_pair("0", kafka::config_resource_operation::set));
+
+        auto resp = incremental_alter_configs(
+          make_incremental_alter_topic_config_resource_cv(test_tp, properties));
+
+        BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+        BOOST_REQUIRE_EQUAL(
+          resp.data.responses[0].error_code, kafka::error_code::none);
+        auto describe_resp = describe_configs(test_tp);
+        assert_property_value(
+          test_tp, "min.cleanable.dirty.ratio", "0", describe_resp);
+    }
+
+    // -1 disables a tristate.
+    {
+        map_t properties;
+        properties.emplace(
+          "min.cleanable.dirty.ratio",
+          std::make_pair("-1", kafka::config_resource_operation::set));
+
+        auto resp = incremental_alter_configs(
+          make_incremental_alter_topic_config_resource_cv(test_tp, properties));
+
+        BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+        BOOST_REQUIRE_EQUAL(
+          resp.data.responses[0].error_code, kafka::error_code::none);
+        auto describe_resp = describe_configs(test_tp);
+        assert_property_value(
+          test_tp, "min.cleanable.dirty.ratio", "-1", describe_resp);
+    }
+
+    // Valid values are valid.
+    {
+        map_t properties;
+        properties.emplace(
+          "min.cleanable.dirty.ratio",
+          std::make_pair("0.8", kafka::config_resource_operation::set));
+
+        auto resp = incremental_alter_configs(
+          make_incremental_alter_topic_config_resource_cv(test_tp, properties));
+
+        BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+        BOOST_REQUIRE_EQUAL(
+          resp.data.responses[0].error_code, kafka::error_code::none);
+        auto describe_resp = describe_configs(test_tp);
+        assert_property_value(
+          test_tp, "min.cleanable.dirty.ratio", "0.8", describe_resp);
+    }
+
+    // Anything < 0 disables a tristate.
+    {
+        map_t properties;
+        properties.emplace(
+          "min.cleanable.dirty.ratio",
+          std::make_pair("-999", kafka::config_resource_operation::set));
+
+        auto resp = incremental_alter_configs(
+          make_incremental_alter_topic_config_resource_cv(test_tp, properties));
+
+        BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+        BOOST_REQUIRE_EQUAL(
+          resp.data.responses[0].error_code, kafka::error_code::none);
+        auto describe_resp = describe_configs(test_tp);
+        assert_property_value(
+          test_tp, "min.cleanable.dirty.ratio", "-1", describe_resp);
+    }
+}

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -691,3 +691,45 @@ FIXTURE_TEST(create_topic_assigns_topic_id, create_topic_fixture) {
     BOOST_REQUIRE(tp_id.has_value());
     BOOST_REQUIRE_EQUAL(resp.data.topics[0].topic_id, *tp_id);
 }
+
+FIXTURE_TEST(test_tristate_handling_create_topic, create_topic_fixture) {
+    auto topic = make_topic(
+      "tapioca",
+      std::nullopt,
+      std::nullopt,
+      std::map<ss::sstring, ss::sstring>{
+        {"segment.ms", "0"},
+        {"min.cleanable.dirty.ratio", "0"},
+        {"retention.ms", "-1"},
+        {"retention.bytes", "-999"},
+        {"delete.retention.ms", "1000"}});
+
+    auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
+    client.connect().get();
+    auto resp = client.dispatch(make_req({topic}), kafka::api_version(5)).get();
+
+    BOOST_CHECK_EQUAL(resp.data.topics[0].error_code, kafka::error_code::none);
+    BOOST_CHECK_EQUAL(resp.data.topics[0].name, "tapioca");
+
+    auto tpn = model::topic_namespace{
+      model::kafka_namespace, model::topic{"tapioca"}};
+    auto md = app.controller->get_topics_state().local().get_topic_metadata(
+      tpn);
+    auto ntp_config = md->get_configuration().make_ntp_config(
+      "work_dir",
+      model::partition_id{0},
+      model::revision_id{0},
+      model::revision_id{0},
+      model::initial_revision_id{0});
+
+    BOOST_REQUIRE(ntp_config.segment_ms().has_value());
+    BOOST_REQUIRE(ntp_config.min_cleanable_dirty_ratio().has_value());
+    BOOST_REQUIRE(!ntp_config.retention_duration().has_value());
+    BOOST_REQUIRE(!ntp_config.retention_bytes().has_value());
+    BOOST_REQUIRE(ntp_config.delete_retention_ms().has_value());
+
+    BOOST_REQUIRE_EQUAL(0ms, ntp_config.segment_ms().value());
+    BOOST_REQUIRE_EQUAL(0.0, ntp_config.min_cleanable_dirty_ratio().value());
+    BOOST_REQUIRE_EQUAL(1000ms, ntp_config.delete_retention_ms().value());
+}


### PR DESCRIPTION
`<= 0` is not a good condition for the `-1` "disabled" case for a `tristate`. `0` is a valid value for a number of `tristate` values, and a `tristate` should only be considered `disabled` for values `< 0`.

For example, `min.cleanable.dirty.ratio` is a `tristate` and `0` is a perfectly acceptable value for it.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes

* Fixes a bug in which `tristate` topic properties would be considered disabled if set with the value `0` during a `CreateTopic` or `AlterConfig` request. Now, topic properties set with `0` will reflect that value exactly. This affects the following topic properties: `segment.ms`, `retention.bytes`, `retention.ms`, `retention.local.target.bytes`, `retention.local.target.ms`, `initial.retention.local.target.bytes`, `initial.retention.local.target.ms`, `delete.retention.ms`, `min.cleanable.dirty.ratio`. 
