### PR TITLE
tests: Add a test for AIO limit crash

### DIFF
--- a/tests/rptest/tests/aio_limit_test.py
+++ b/tests/rptest/tests/aio_limit_test.py
@@ -1,0 +1,49 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.clients.rpk import RpkTool
+from rptest.services.cluster import cluster
+from ducktape.tests.test import TestContext
+from rptest.services.producer_swarm import ProducerSwarm
+from rptest.tests.redpanda_test import RedpandaTest
+
+# Test for https://github.com/redpanda-data/seastar/pull/87
+# We spawn RP with --max-networking-io-control-blocks=100 and then create 500
+# which would make us run into the assert. With the patch we don't crash but just slow down.
+
+
+class AioLimitTest(RedpandaTest):
+    TARGET_IOCBS = 100
+
+    def __init__(self, ctx: TestContext):
+        super().__init__(test_context=ctx)
+
+    def setUp(self):
+        aio_arg = f"--max-networking-io-control-blocks={self.TARGET_IOCBS}"
+        self.redpanda.start_node(self.redpanda.nodes[0], extra_cli=[aio_arg])
+        self.rpk = RpkTool(self.redpanda)
+
+    def teardown(self):
+        super().teardown()
+
+    @cluster(num_nodes=2)
+    def test_aio_limit(self):
+        topic = "test-topic"
+        self.rpk.create_topic(topic, partitions=5, replicas=1)
+        producer = ProducerSwarm(
+            self.test_context,
+            self.redpanda,
+            topic=topic,
+            producers=self.TARGET_IOCBS * 5,
+            records_per_producer=20,
+            messages_per_second_per_producer=1,
+        )
+        producer.start()
+        # RP shouldn't crash and still be able to handle the low rate
+        producer.wait(timeout_sec=80)


### PR DESCRIPTION
This adds a test for https://github.com/redpanda-data/seastar/pull/87

We artifically lower the general context IOCB count to 100 at which
point we can easily reproduce the assert using client swarm.

With the patch applied the test passes fine.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none


