### PR TITLE
Patch franz-go for EOF-before-first-response behavior

### DIFF
--- a/tests/docker/ducktape-deps/kgo-verifier
+++ b/tests/docker/ducktape-deps/kgo-verifier
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -e
-git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git
-cd /opt/kgo-verifier
-git reset --hard f97884cb0815d60eca41950f818d51c70b665890
-go mod tidy
-make

--- a/tests/go/kgo-verifier/go.mod
+++ b/tests/go/kgo-verifier/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1
+	// franz-go is replaced below, keep it in sync, see CORE-14849
 	github.com/twmb/franz-go v1.20.2
 	github.com/twmb/franz-go/pkg/kadm v1.17.1
 	github.com/twmb/franz-go/pkg/kmsg v1.12.0
@@ -16,6 +17,9 @@ require (
 	golang.org/x/sync v0.17.0
 	golang.org/x/time v0.9.0
 )
+
+// temporary workaround for CORE-14849/CORE-13402
+replace github.com/twmb/franz-go v1.20.2 => github.com/travisdowns/franz-go v1.20.2-CORE-14849-fix
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect


### PR DESCRIPTION
Tests are flaking flake when kgo-repeater dies with a
non-retriable error right after connection. This happens when franz-go
gets EOF right after connecting but before receiving any response, as
a heuristic it assumes this is a SASL misconfiguration as that is the
broker behavior in that case. However, this can also occur because
Redpanda is stopped/killed after the connection is made but before
the initial requests can be responded to.

This means the producer will fail if a producer dies/is killed/stops
during a critical window between the connection and receiving the first
response. This is reasonably likely in stress/chaos tests where
producers are being started and stopped all the time.

This is a relatively recent change (~6 months ago) in franz-go,
which was brought in a few months ago by a franz-go upgrade.

For now we use a forked version of franz-go which reverts this change.

Details in CORE-14849.

Fixes CORE-14898.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

