### PR TITLE
`storage`: change `has_tx_data_batch` condition

### DIFF
--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -350,8 +350,9 @@ std::ostream& operator<<(std::ostream& o, const index_state& s) {
              << ", self_compact_timestamp:" << s.self_compact_timestamp
              << ", may_have_transaction_control_batches:"
              << s.may_have_transaction_control_batches
-             << ", may_have_transaction_data_batches:"
-             << s.may_have_transaction_data_batches << ", " << s.index << "}";
+             << ", may_have_transaction_data_or_fence_batches:"
+             << s.may_have_transaction_data_or_fence_batches << ", " << s.index
+             << "}";
 }
 
 void index_state::serde_write(iobuf& out) const {
@@ -375,7 +376,7 @@ void index_state::serde_write(iobuf& out) const {
     write(tmp, may_have_tombstone_records);
     write(tmp, self_compact_timestamp);
     write(tmp, may_have_transaction_control_batches);
-    write(tmp, may_have_transaction_data_batches);
+    write(tmp, may_have_transaction_data_or_fence_batches);
 
     crc::crc32c crc;
     crc_extend_iobuf(crc, tmp);
@@ -501,10 +502,11 @@ void read_nested(
         st.may_have_transaction_control_batches = true;
     }
     if (
-      hdr._version >= index_state::may_have_transaction_data_batches_version) {
-        read_nested(p, st.may_have_transaction_data_batches, 0U);
+      hdr._version
+      >= index_state::may_have_transaction_data_or_fence_batches_version) {
+        read_nested(p, st.may_have_transaction_data_or_fence_batches, 0U);
     } else {
-        st.may_have_transaction_data_batches = true;
+        st.may_have_transaction_data_or_fence_batches = true;
     }
 }
 
@@ -574,7 +576,8 @@ index_state::index_state(const index_state& o) noexcept
   , may_have_tombstone_records(o.may_have_tombstone_records)
   , self_compact_timestamp(o.self_compact_timestamp)
   , may_have_transaction_control_batches(o.may_have_transaction_control_batches)
-  , may_have_transaction_data_batches(o.may_have_transaction_data_batches) {}
+  , may_have_transaction_data_or_fence_batches(
+      o.may_have_transaction_data_or_fence_batches) {}
 
 namespace serde_compat {
 uint64_t index_state_serde::checksum(const index_state& r) {

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -140,7 +140,8 @@ struct index_state
     // Added in the same version.
     static constexpr auto self_compact_timestamp_version = 10;
     static constexpr auto may_have_transaction_control_batches_version = 10;
-    static constexpr auto may_have_transaction_data_batches_version = 11;
+    static constexpr auto may_have_transaction_data_or_fence_batches_version
+      = 11;
 
     static index_state
     make_empty_index(model::offset base_offset, offset_delta_time with_offset);
@@ -237,11 +238,12 @@ struct index_state
     // control batches (abort/commit batches, as well as tx_fence markers).
     bool may_have_transaction_control_batches{true};
 
-    // may_have_transaction_data_batches is `true` by default. It remains
-    // `true` until compaction deduplication/segment data copying is performed
-    // and it is proven that the segment does not contain any transactional
-    // data batches (i.e raft data batches with a transactional bit set).
-    bool may_have_transaction_data_batches{true};
+    // `may_have_transaction_data_or_fence_batches` is `true` by default. It
+    // remains `true` until compaction deduplication/segment data copying is
+    // performed and it is proven that the segment does not contain any
+    // transactional data batches (i.e raft data batches with a transactional
+    // bit set) or tx_fence markers.
+    bool may_have_transaction_data_or_fence_batches{true};
 
     size_t size() const;
 

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -208,8 +208,10 @@ ss::future<index_state> deduplicate_segment(
     auto segment_last_offset = seg->offsets().get_committed_offset();
     auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
-    auto unset_transactional_bit_enabled = feature_table.local().is_active(
-      features::feature::coordinated_compaction);
+    auto unset_transactional_bit_enabled
+      = feature_table.local().is_active(
+          features::feature::coordinated_compaction)
+        && !config::shard_local_cfg().log_compaction_disable_tx_batch_removal();
     const bool past_tombstone_delete_horizon
       = internal::is_past_tombstone_delete_horizon(seg, cfg);
     bool may_have_tombstone_records = false;

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -218,7 +218,7 @@ ss::future<index_state> deduplicate_segment(
     const bool past_tx_delete_horizon
       = internal::is_past_transaction_batch_delete_horizon(seg, cfg);
     bool may_have_transaction_control_batches = false;
-    bool may_have_transaction_data_batches = false;
+    bool may_have_transaction_data_or_fence_batches = false;
 
     auto is_latest_record = [&map](
                               const model::record_batch& b,
@@ -236,7 +236,7 @@ ss::future<index_state> deduplicate_segment(
                           &probe,
                           past_tx_delete_horizon,
                           &may_have_transaction_control_batches,
-                          &may_have_transaction_data_batches](
+                          &may_have_transaction_data_or_fence_batches](
                            const model::record_batch& b,
                            const model::record& r,
                            bool is_last_record_in_batch) {
@@ -253,7 +253,7 @@ ss::future<index_state> deduplicate_segment(
           may_have_tombstone_records,
           past_tx_delete_horizon,
           may_have_transaction_control_batches,
-          may_have_transaction_data_batches);
+          may_have_transaction_data_or_fence_batches);
     };
 
     auto copy_reducer = internal::copy_data_segment_reducer(
@@ -301,9 +301,9 @@ ss::future<index_state> deduplicate_segment(
     new_idx.may_have_transaction_control_batches
       = may_have_transaction_control_batches;
 
-    // Set may_have_transaction_data_batches
-    new_idx.may_have_transaction_data_batches
-      = may_have_transaction_data_batches;
+    // Set may_have_transaction_data_or_fence_batches
+    new_idx.may_have_transaction_data_or_fence_batches
+      = may_have_transaction_data_or_fence_batches;
 
     if (
       seg->index().may_have_tombstone_records()

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -41,7 +41,7 @@ segment_index::segment_index(
   bool may_have_tombstone_records,
   std::optional<model::timestamp> self_compact_timestamp,
   bool may_have_transaction_control_batches,
-  bool may_have_transaction_data_batches)
+  bool may_have_transaction_data_or_fence_batches)
   : _path(std::move(path))
   , _step(step)
   , _feature_table(std::ref(feature_table))
@@ -56,8 +56,8 @@ segment_index::segment_index(
     _state.self_compact_timestamp = self_compact_timestamp;
     _state.may_have_transaction_control_batches
       = may_have_transaction_control_batches;
-    _state.may_have_transaction_data_batches
-      = may_have_transaction_data_batches;
+    _state.may_have_transaction_data_or_fence_batches
+      = may_have_transaction_data_or_fence_batches;
 }
 
 segment_index::segment_index(
@@ -97,8 +97,8 @@ void segment_index::reset() {
     auto may_have_tombstone_records = _state.may_have_tombstone_records;
     auto may_have_transaction_control_batches
       = _state.may_have_transaction_control_batches;
-    auto may_have_transaction_data_batches
-      = _state.may_have_transaction_data_batches;
+    auto may_have_transaction_data_or_fence_batches
+      = _state.may_have_transaction_data_or_fence_batches;
 
     _state = index_state::make_empty_index(
       base, storage::internal::should_apply_delta_time_offset(_feature_table));
@@ -108,8 +108,8 @@ void segment_index::reset() {
     _state.may_have_tombstone_records = may_have_tombstone_records;
     _state.may_have_transaction_control_batches
       = may_have_transaction_control_batches;
-    _state.may_have_transaction_data_batches
-      = may_have_transaction_data_batches;
+    _state.may_have_transaction_data_or_fence_batches
+      = may_have_transaction_data_or_fence_batches;
 
     _acc = 0;
 }

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -160,7 +160,7 @@ public:
       bool may_have_tombstone_records = true,
       std::optional<model::timestamp> self_compact_timestamp = std::nullopt,
       bool may_have_transaction_control_batches = true,
-      bool may_have_transaction_data_batches = true);
+      bool may_have_transaction_data_or_fence_batches = true);
 
     ~segment_index() noexcept = default;
     segment_index(segment_index&&) noexcept = default;
@@ -292,8 +292,8 @@ public:
         return _state.may_have_transaction_control_batches;
     }
 
-    bool may_have_transaction_data_batches() const {
-        return _state.may_have_transaction_data_batches;
+    bool may_have_transaction_data_or_fence_batches() const {
+        return _state.may_have_transaction_data_or_fence_batches;
     }
 
     ss::future<bool> materialize_index();

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -400,7 +400,7 @@ ss::future<storage::index_state> do_copy_segment_data(
     const bool past_tx_delete_horizon
       = internal::is_past_transaction_batch_delete_horizon(seg, cfg);
     bool may_have_transaction_control_batches = false;
-    bool may_have_transaction_data_batches = false;
+    bool may_have_transaction_data_or_fence_batches = false;
 
     auto offset_in_compacted_list =
       [compacted_offsets = std::move(compacted_offsets)](
@@ -421,7 +421,7 @@ ss::future<storage::index_state> do_copy_segment_data(
                           &pb,
                           past_tx_delete_horizon,
                           &may_have_transaction_control_batches,
-                          &may_have_transaction_data_batches](
+                          &may_have_transaction_data_or_fence_batches](
                            const model::record_batch& b,
                            const model::record& r,
                            bool is_last_record_in_batch) {
@@ -438,7 +438,7 @@ ss::future<storage::index_state> do_copy_segment_data(
           may_have_tombstone_records,
           past_tx_delete_horizon,
           may_have_transaction_control_batches,
-          may_have_transaction_data_batches);
+          may_have_transaction_data_or_fence_batches);
     };
 
     auto copy_reducer = copy_data_segment_reducer(
@@ -496,9 +496,9 @@ ss::future<storage::index_state> do_copy_segment_data(
     new_index.may_have_transaction_control_batches
       = may_have_transaction_control_batches;
 
-    // Set may_have_transaction_data_batches
-    new_index.may_have_transaction_data_batches
-      = may_have_transaction_data_batches;
+    // Set may_have_transaction_data_or_fence_batches
+    new_index.may_have_transaction_data_or_fence_batches
+      = may_have_transaction_data_or_fence_batches;
 
     if (
       seg->index().may_have_tombstone_records()
@@ -986,9 +986,9 @@ make_concatenated_segment(
 
     // If any of the segments contain a transactional data batch, then the new
     // index should reflect that.
-    auto new_may_have_transaction_data_batches = std::ranges::any_of(
+    auto new_may_have_transaction_data_or_fence_batches = std::ranges::any_of(
       segments, [](const auto& s) {
-          return s->index().may_have_transaction_data_batches();
+          return s->index().may_have_transaction_data_or_fence_batches();
       });
 
     segment_index index(
@@ -1002,7 +1002,7 @@ make_concatenated_segment(
       new_may_have_tombstone_records,
       new_self_compact_timestamp,
       new_may_have_transaction_control_batches,
-      new_may_have_transaction_data_batches);
+      new_may_have_transaction_data_or_fence_batches);
 
     co_return std::make_tuple(
       ss::make_lw_shared<segment>(
@@ -1415,7 +1415,8 @@ bool has_removable_transaction_batches(
   ss::lw_shared_ptr<segment> seg, const compaction::compaction_config& cfg) {
     // If there are transactional data batches, we will unset the transactional
     // bit during compaction.
-    auto has_data_batches = seg->index().may_have_transaction_data_batches();
+    auto has_data_batches
+      = seg->index().may_have_transaction_data_or_fence_batches();
     // If there are removable control batches, they will be removed during
     // compaction.
     auto has_removable_control_batches

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -390,8 +390,10 @@ ss::future<storage::index_state> do_copy_segment_data(
     auto segment_last_offset = seg->offsets().get_committed_offset();
     auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
-    auto unset_transactional_bit_enabled = feature_table.local().is_active(
-      features::feature::coordinated_compaction);
+    auto unset_transactional_bit_enabled
+      = feature_table.local().is_active(
+          features::feature::coordinated_compaction)
+        && !config::shard_local_cfg().log_compaction_disable_tx_batch_removal();
     const bool past_tombstone_delete_horizon
       = internal::is_past_tombstone_delete_horizon(seg, cfg);
     bool may_have_tombstone_records = false;

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -360,15 +360,16 @@ ss::future<bool> should_keep(
   bool& may_have_tombstone_records,
   bool past_tx_delete_horizon,
   bool& has_tx_control_batches,
-  bool& has_tx_data_batches) {
+  bool& has_tx_data_or_fence_batches) {
     const auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
     const auto is_compactible = compaction::is_compactible(b.header());
     const auto is_last_batch = b.last_offset() == segment_last_offset;
     const auto is_tx_control_batch = b.header().attrs.is_control();
-    const auto is_tx_data_batch = b.header().type
-                                    == model::record_batch_type::raft_data
-                                  && b.header().attrs.is_transactional();
+    const auto is_tx_data_batch = (b.header().type == model::record_batch_type::raft_data
+         && b.header().attrs.is_transactional());
+    const auto is_tx_fence_batch = b.header().type
+                                   == model::record_batch_type::tx_fence;
     const auto is_tombstone = r.is_tombstone();
     // once compaction placeholder feature is enabled, we are not
     // worried about empty batches as the reducer then installs a
@@ -389,8 +390,8 @@ ss::future<bool> should_keep(
             has_tx_control_batches = true;
         }
 
-        if (is_tx_data_batch) {
-            has_tx_data_batches = true;
+        if (is_tx_data_batch || is_tx_fence_batch) {
+            has_tx_data_or_fence_batches = true;
         }
 
         co_return true;
@@ -419,6 +420,9 @@ ss::future<bool> should_keep(
         if (is_tx_control_batch) {
             has_tx_control_batches = true;
         }
+        if (is_tx_fence_batch) {
+            has_tx_data_or_fence_batches = true;
+        }
         co_return true;
     }
 
@@ -429,7 +433,7 @@ ss::future<bool> should_keep(
     }
 
     if (is_tx_data_batch && keep) {
-        has_tx_data_batches = true;
+        has_tx_data_or_fence_batches = true;
     }
 
     co_return keep;

--- a/src/v/storage/tests/compaction_e2e_multinode_test.cc
+++ b/src/v/storage/tests/compaction_e2e_multinode_test.cc
@@ -351,16 +351,153 @@ FIXTURE_TEST(segment_tx_flags, compaction_multinode_test) {
         log->housekeeping(conf).get();
     }
 
-    // `may_have_transaction_data_batches` will be false after the previous
-    // compaction, as transactional bits were unset.
-    // `may_have_transaction_control_batches` will also be false due to
+    // `may_have_transaction_data_or_fence_batches` will be false after the
+    // previous compaction, as transactional bits were unset and fences were
+    // removed. `may_have_transaction_control_batches` will also be false due to
     // compacting with `tx_retention_ms` set.
     for (const auto& segment : log->segments()) {
         if (segment->has_self_compact_timestamp()) {
             BOOST_REQUIRE(
               !segment->index().may_have_transaction_control_batches());
             BOOST_REQUIRE(
-              !segment->index().may_have_transaction_data_batches());
+              !segment->index().may_have_transaction_data_or_fence_batches());
         }
     }
+}
+
+FIXTURE_TEST(segment_tx_flags_compaction_disabled, compaction_multinode_test) {
+    scoped_config cfg;
+    cfg.get("log_compaction_disable_tx_batch_removal").set_value(true);
+    cfg.get("log_compaction_merge_max_segments_per_range")
+      .set_value(std::make_optional<uint32_t>(0));
+    cfg.get("log_compaction_merge_max_ranges")
+      .set_value(std::make_optional<uint32_t>(0));
+
+    const model::topic topic{"tapioca"};
+    model::node_id id{0};
+    create_node_application(id);
+    auto* rp = instance(id);
+    wait_for_controller_leadership(id).get();
+
+    cluster::topic_properties props;
+    props.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+    rp->add_topic({model::kafka_namespace, topic}, 1, props).get();
+    model::partition_id pid{0};
+    auto ntp = model::ntp(model::kafka_namespace, topic, pid);
+    RPTEST_REQUIRE_EVENTUALLY(5s, [&] {
+        auto [_, prt] = get_leader(ntp);
+        return prt != nullptr;
+    });
+    auto [_, partition] = get_leader(ntp);
+    auto log = partition->log();
+    using cluster::tx_executor;
+    tx_executor exec;
+    auto make_ctx = [&](int64_t id, model::term_id term) {
+        model::producer_identity pid{id, 0};
+        return tx_executor::tx_op_ctx{
+          exec.data_gen(), partition->rm_stm(), log, pid, term};
+    };
+    // Produce transactional records.
+    tx_executor::sorted_tx_ops_t ops;
+    auto term = partition->raft()->term();
+
+    auto num_segments = 3;
+    int weight = 1;
+    ops.emplace(
+      ss::make_shared(tx_executor::begin_op(make_ctx(1, term), weight++)));
+    ops.emplace(
+      ss::make_shared(tx_executor::roll_op(make_ctx(1, term), weight++)));
+    ops.emplace(
+      ss::make_shared(tx_executor::data_op(make_ctx(1, term), weight++, 1)));
+    ops.emplace(
+      ss::make_shared(tx_executor::roll_op(make_ctx(1, term), weight++)));
+    ops.emplace(
+      ss::make_shared(tx_executor::commit_op(make_ctx(1, term), weight++)));
+
+    exec.execute(std::move(ops)).get();
+    partition->log()->flush().get();
+    partition->log()->force_roll().get();
+
+    // num_segments + 1 for active segment
+    BOOST_REQUIRE_EQUAL(log->segment_count(), num_segments + 1);
+    auto& segments = log->segments();
+
+    // Before compaction, segments should by default have these flags as `true`.
+    for (const auto& segment : segments) {
+        BOOST_REQUIRE(segment->index().may_have_transaction_control_batches());
+        BOOST_REQUIRE(
+          segment->index().may_have_transaction_data_or_fence_batches());
+    }
+
+    ss::abort_source as;
+    auto collect_offset = log->stm_manager()->max_removable_local_log_offset();
+    {
+        // Compact while `log_compaction_disable_tx_batch_removal` is `true`,
+        // preventing unsetting of transactional bits or removal of any control
+        // batches.
+        auto conf = storage::housekeeping_config::make_config(
+          model::timestamp::min(),
+          std::nullopt,
+          collect_offset,
+          collect_offset,
+          collect_offset,
+          std::nullopt,
+          std::nullopt,
+          std::chrono::milliseconds{0},
+          as);
+        log->housekeeping(conf).get();
+    }
+
+    BOOST_REQUIRE_EQUAL(segments.size(), num_segments + 1);
+
+    // First segment has a `tx_fence` batch.
+    BOOST_REQUIRE(
+      segments[0]->index().may_have_transaction_data_or_fence_batches());
+    BOOST_REQUIRE(segments[0]->index().may_have_transaction_control_batches());
+
+    // Second segment has a transactional raft batch.
+    BOOST_REQUIRE(
+      segments[1]->index().may_have_transaction_data_or_fence_batches());
+    BOOST_REQUIRE(!segments[1]->index().may_have_transaction_control_batches());
+
+    // Third segment has a control (commit) batch.
+    BOOST_REQUIRE(
+      !segments[2]->index().may_have_transaction_data_or_fence_batches());
+    BOOST_REQUIRE(segments[2]->index().may_have_transaction_control_batches());
+
+    {
+        cfg.get("log_compaction_disable_tx_batch_removal").set_value(false);
+        // Compact twice to remove transactional batches and unset bits.
+        auto conf = storage::housekeeping_config::make_config(
+          model::timestamp::min(),
+          std::nullopt,
+          collect_offset,
+          collect_offset,
+          collect_offset,
+          std::nullopt,
+          std::chrono::milliseconds{0},
+          std::chrono::milliseconds{0},
+          as);
+        log->housekeeping(conf).get();
+        log->housekeeping(conf).get();
+    }
+
+    BOOST_REQUIRE_EQUAL(segments.size(), num_segments + 1);
+
+    // All segments have a self compact timestamp, and no remaining
+    // transactional control batches or raft data/fence batches.
+    BOOST_REQUIRE(segments[0]->has_self_compact_timestamp());
+    BOOST_REQUIRE(!segments[0]->index().may_have_transaction_control_batches());
+    BOOST_REQUIRE(
+      !segments[0]->index().may_have_transaction_data_or_fence_batches());
+
+    BOOST_REQUIRE(segments[1]->has_self_compact_timestamp());
+    BOOST_REQUIRE(!segments[1]->index().may_have_transaction_control_batches());
+    BOOST_REQUIRE(
+      !segments[1]->index().may_have_transaction_data_or_fence_batches());
+
+    BOOST_REQUIRE(segments[2]->has_self_compact_timestamp());
+    BOOST_REQUIRE(!segments[2]->index().may_have_transaction_control_batches());
+    BOOST_REQUIRE(
+      !segments[2]->index().may_have_transaction_data_or_fence_batches());
 }

--- a/src/v/storage/tests/compaction_e2e_multinode_test.cc
+++ b/src/v/storage/tests/compaction_e2e_multinode_test.cc
@@ -305,7 +305,8 @@ FIXTURE_TEST(segment_tx_flags, compaction_multinode_test) {
     // Before compaction, segments should by default have these flags as `true`.
     for (const auto& segment : log->segments()) {
         BOOST_REQUIRE(segment->index().may_have_transaction_control_batches());
-        BOOST_REQUIRE(segment->index().may_have_transaction_data_batches());
+        BOOST_REQUIRE(
+          segment->index().may_have_transaction_data_or_fence_batches());
     }
 
     ss::abort_source as;
@@ -332,7 +333,7 @@ FIXTURE_TEST(segment_tx_flags, compaction_multinode_test) {
             BOOST_REQUIRE(
               segment->index().may_have_transaction_control_batches());
             BOOST_REQUIRE(
-              !segment->index().may_have_transaction_data_batches());
+              !segment->index().may_have_transaction_data_or_fence_batches());
         }
     }
 


### PR DESCRIPTION
Quick followup to https://github.com/redpanda-data/redpanda/pull/28805.

On second thought, we need to capture the presence of both transactional data raft batches as well as `tx_fence` batches here when computing an MCCO equivalent (which tells us the offset below which control batches are removable).

Otherwise, we are not checking our condition stringently enough when determining what control batches are removable.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
