### PR TITLE
[v25.3.x]  [CORE-14743] dt/dl: Crank the timeout in DatalakeCustomPartitioningTest.test_many_partitions

### DIFF
--- a/tests/rptest/tests/datalake/custom_partitioning_test.py
+++ b/tests/rptest/tests/datalake/custom_partitioning_test.py
@@ -672,7 +672,7 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
                     "timestamp_us": int(t + n),
                 },
                 wait_time_s=900,
-                progress_sec=90,
+                progress_sec=900,
             )
 
             describe_partitioning = self.describe_partitioning(dl, topic_name)

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -161,7 +161,8 @@ def wait_until_with_progress_check(
       - logger: log progress after each progress_sec iteration
     """
     val = check()
-    while timeout_sec > 0:
+    elapsed_sec = 0
+    while elapsed_sec < timeout_sec:
         try:
             wait_until(
                 condition,
@@ -170,13 +171,17 @@ def wait_until_with_progress_check(
                 err_msg=err_msg,
             )
         except TimeoutError as e:
+            elapsed_sec += progress_sec
             next_v = check()
             if next_v == val:
-                raise TimeoutError(f"Stopped making progress: {str(e)}")
+                raise TimeoutError(
+                    f"Stopped making progress after {elapsed_sec=}: {str(e)}"
+                )
             if logger is not None:
-                logger.debug(f"Progress: prev: {val} curr: {next_v}...")
+                logger.debug(
+                    f"Progress after {elapsed_sec=}: prev: {val} curr: {next_v}..."
+                )
             val = next_v
-            timeout_sec = timeout_sec - progress_sec
         else:
             break
 

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -162,6 +162,7 @@ def wait_until_with_progress_check(
     """
     val = check()
     elapsed_sec = 0
+    last_exception: TimeoutError | None = None
     while elapsed_sec < timeout_sec:
         try:
             wait_until(
@@ -170,7 +171,9 @@ def wait_until_with_progress_check(
                 backoff_sec=backoff_sec,
                 err_msg=err_msg,
             )
+            break
         except TimeoutError as e:
+            last_exception = e
             elapsed_sec += progress_sec
             next_v = check()
             if next_v == val:
@@ -182,8 +185,17 @@ def wait_until_with_progress_check(
                     f"Progress after {elapsed_sec=}: prev: {val} curr: {next_v}..."
                 )
             val = next_v
-        else:
-            break
+
+    if condition():
+        return
+
+    assert last_exception is not None, (
+        "If the condition doesn't hold an exception should have fired"
+    )
+
+    raise TimeoutError(
+        f"{err_msg if err_msg is not None else ''} after {timeout_sec=}"
+    ) from last_exception
 
 
 def segments_count(redpanda, topic, partition_idx):


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28804
