### PR TITLE
[CORE-9223] `rptest`: disable idempotent producer in compaction test

### DIFF
--- a/tests/rptest/tests/compacted_term_rolled_recovery_test.py
+++ b/tests/rptest/tests/compacted_term_rolled_recovery_test.py
@@ -73,7 +73,7 @@ class CompactionTermRollRecoveryTest(RedpandaTest):
         kafka_tools = KafkaCliTools(self.redpanda)
 
         def done():
-            kafka_tools.produce(self.topic, 1024, 1024)
+            kafka_tools.produce(self.topic, 1024, 1024, enable_idempotence=False)
             curr = self._compacted_segments(nodes, topic)
             return all(map(lambda cnt: cnt[0] > cnt[1], zip(curr, target)))
 


### PR DESCRIPTION
Idempotency is not required for this test nor does it have anything to do with any other test expectations. However, it can lead to flakes due to `OUT_OF_ORDER_SEQUENCE_NUMBER` errors.

This is a protocol issue concerning how we skip sequence checks on the first request of an unknown producer:

https://github.com/redpanda-data/redpanda/blob/38d9c6c9f6f9d4e4b87ba54f7506d780ba274170/src/v/cluster/rm_stm.cc#L1151

Because produce requests are dispatched in parallel, they may be reordered, and we can end up in an `OUT_OF_ORDER_SEQUENCE_NUMBER` case.

https://github.com/redpanda-data/redpanda/blob/38d9c6c9f6f9d4e4b87ba54f7506d780ba274170/src/v/cluster/producer_state.cc#L192-L194

In the produce requests in failures of this test:

```
[1] TRACE 2025-12-03 16:04:04,458 [shard 1:prod] kafka - handler.h:81 - [client_id: {ducktape}] handling produce v7 request {transactional_id={nullopt} acks=-1 timeout_ms=30000ms topics=[{name=topic-wqmpsfztzz partitions=[{partition_index=0 records={batch {records: 79, size: 81683} v2_format true valid_crc true}}]}]}
[2] TRACE 2025-12-03 16:04:04,460 [shard 1:prod] kafka - handler.h:81 - [client_id: {ducktape}] handling produce v7 request {transactional_id={nullopt} acks=-1 timeout_ms=30000ms topics=[{name=topic-wqmpsfztzz partitions=[{partition_index=0 records={batch {records: 79, size: 81683} v2_format true valid_crc true}}]}]}
[3] TRACE 2025-12-03 16:04:04,464 [shard 1:prod] kafka - handler.h:81 - [client_id: {ducktape}] handling produce v7 request {transactional_id={nullopt} acks=-1 timeout_ms=30000ms topics=[{name=topic-wqmpsfztzz partitions=[{partition_index=0 records={batch {records: 79, size: 81683} v2_format true valid_crc true}}]}]}
[4] TRACE 2025-12-03 16:04:04,465 [shard 1:prod] kafka - handler.h:81 - [client_id: {ducktape}] handling produce v7 request {transactional_id={nullopt} acks=-1 timeout_ms=30000ms topics=[{name=topic-wqmpsfztzz partitions=[{partition_index=0 records={batch {records: 79, size: 81683} v2_format true valid_crc true}}]}]}
[5] TRACE 2025-12-03 16:04:04,577 [shard 1:prod] kafka - handler.h:81 - [client_id: {ducktape}] handling produce v7 request {transactional_id={nullopt} acks=-1 timeout_ms=30000ms topics=[{name=topic-wqmpsfztzz partitions=[{partition_index=0 records={batch {records: 79, size: 81683} v2_format true valid_crc true}}]}]}
```

 we can imagine that each batch of 79 records are requests `1,2,3,4,5`, with `seq_ids 0, 79, 158, 237, 316` in that order. What has appeared to have happened here is that the requests arrived instead in order `2,3,4,1`, leading us to accept `79` (because we skipped sequence checks for an unknown producer), then `158, 237`, which succeed, and then we try to produce with `seq_id=0`, leading to an `OUT_OF_ORDER_SEQUENCE_NUMBER` error, and an eventual timeout of the producer as it is hard stuck. We can see this is the case in the smoking gun of a log line:

```
WARN  2025-12-03 16:04:04,462 [shard 1:prod] tx - [{kafka/topic-wqmpsfztzz/0}] - rm_stm.cc:1158 - Accepting batch from unknown producer that likely got evicted: {pid: {producer_identity: id=1, epoch=0}, first_seq: 158, is_transactional: false, record_count: 79, last_seq: 236}, term: 2
```

Anyways, clearly none of that has to do with compaction, so just disable idempotency for the producer in this test.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
