### PR TITLE
[CORE-14905] `cluster`: prevent `std::rethrow_exception` of a null `exception_ptr`

### DIFF
--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -50,7 +50,7 @@ static auto with(
   ss::shared_ptr<tm_stm> stm,
   const kafka::transactional_id& tx_id,
   const std::string_view name,
-  Func&& func) noexcept {
+  Func&& func) {
     return stm->lock_tx(tx_id, name)
       .then([stm, func = std::forward<Func>(func)](auto units) mutable {
           return ss::futurize_invoke(std::forward<Func>(func))
@@ -63,7 +63,7 @@ static auto with_free(
   ss::shared_ptr<tm_stm> stm,
   const kafka::transactional_id& tx_id,
   const std::string_view name,
-  Func&& func) noexcept {
+  Func&& func) {
     auto units = stm->try_lock_tx(tx_id, name);
     auto f = ss::now();
 

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1920,11 +1920,8 @@ tx_gateway_frontend::handle_abort_tx(
                 outcome->set_value(tx::errc::none);
                 co_return r.value();
             }
-            vlogl(
-              txlog,
-              ssx::is_shutdown_exception(std::current_exception())
-                ? ss::log_level::debug
-                : ss::log_level::error,
+            vlog(
+              txlog.warn,
               "[tx_id={}] error aborting transaction: {} - {}",
               tx.id,
               tx,


### PR DESCRIPTION
This piece of code isn't in a `catch` block, there are no guarantees `std::current_exception()` isn't just `null`. Rethrowing a null `exception_ptr` [is undefined behavior as stated by the standard](https://en.cppreference.com/w/cpp/error/rethrow_exception.html) (but libc++ likes to terminate immediately)

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
