### PR TITLE
lsm: improve memtable flush

### DIFF
--- a/src/v/lsm/db/impl.cc
+++ b/src/v/lsm/db/impl.cc
@@ -214,18 +214,14 @@ impl::create_internal_iterator() {
 }
 
 ss::future<> impl::flush() {
-    while (_imm) {
-        co_await _background_work_finished_signal.wait(_as);
-    }
-    if (!_mem->empty()) {
-        _imm = std::exchange(_mem, ss::make_lw_shared<memtable>());
-        if (_background_work_running) {
+    auto applied_seqno = max_applied_seqno();
+    while (applied_seqno > max_persisted_seqno()) {
+        if (_imm) {
             co_await _background_work_finished_signal.wait(_as);
+        } else if (!_mem->empty()) {
+            _imm = std::exchange(_mem, ss::make_lw_shared<memtable>());
+            maybe_schedule_compaction();
         }
-        maybe_schedule_compaction();
-    }
-    while (_imm) {
-        co_await _background_work_finished_signal.wait(_as);
     }
 }
 

--- a/src/v/lsm/lsm.cc
+++ b/src/v/lsm/lsm.cc
@@ -89,6 +89,8 @@ model::offset database::max_applied_offset() const {
     return seqno_cast(_impl->max_applied_seqno());
 }
 
+ss::future<> database::flush() { return _impl->flush(); }
+
 ss::future<> database::apply(write_batch batch) {
     auto b = std::move(batch._batch);
     co_await _impl->apply(std::move(*b));

--- a/src/v/lsm/lsm.h
+++ b/src/v/lsm/lsm.h
@@ -58,6 +58,10 @@ public:
     // not).
     model::offset max_applied_offset() const;
 
+    // Flush existing buffered data such that that `max_persisted_offset()`
+    // becomes >= the current `max_applied_offset()`.
+    ss::future<> flush();
+
     // Apply a batch of data atomically to the database.
     ss::future<> apply(write_batch);
 


### PR DESCRIPTION
- **lsm/db: improve flush**
- **lsm: expose flush in public API**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
