### PR TITLE
http: Add TCP keepalive to http APIs

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -250,7 +250,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "FaiVu9kJMjRigCMxiD7htsI7wNFLQWTacBkk0qTsvJs=",
+        "bzlTransitiveDigest": "0hbC1VfEIRFBJc29eJCqdn9uE0zwWEyn/Z4xefLfLbE=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -421,9 +421,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "2d207dca1a9a621bce713518f2a502dbe8c753f2a498c00a45e9de53c72258b2",
-              "strip_prefix": "seastar-4a38189a9c3bc3b7bdef068ad774f868cef995e5",
-              "url": "https://github.com/redpanda-data/seastar/archive/4a38189a9c3bc3b7bdef068ad774f868cef995e5.tar.gz"
+              "sha256": "73fecd1f4d73ed72e8048de07636652dd15a6970acfacf72a95cc3819398362a",
+              "strip_prefix": "seastar-81284fb0f209380b0c537e98ec9cb8ef5a4ebfa2",
+              "url": "https://github.com/redpanda-data/seastar/archive/81284fb0f209380b0c537e98ec9cb8ef5a4ebfa2.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -162,9 +162,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "2d207dca1a9a621bce713518f2a502dbe8c753f2a498c00a45e9de53c72258b2",
-        strip_prefix = "seastar-4a38189a9c3bc3b7bdef068ad774f868cef995e5",
-        url = "https://github.com/redpanda-data/seastar/archive/4a38189a9c3bc3b7bdef068ad774f868cef995e5.tar.gz",
+        sha256 = "73fecd1f4d73ed72e8048de07636652dd15a6970acfacf72a95cc3819398362a",
+        strip_prefix = "seastar-81284fb0f209380b0c537e98ec9cb8ef5a4ebfa2",
+        url = "https://github.com/redpanda-data/seastar/archive/81284fb0f209380b0c537e98ec9cb8ef5a4ebfa2.tar.gz",
     )
 
     http_archive(

--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -212,6 +212,12 @@ server::server(
     _api20.register_api_file(_server._routes, header);
     _api20.add_definitions_file(_server._routes, definitions);
     _server.set_content_streaming(true);
+    _server.set_keepalive_parameters(
+      ss::net::tcp_keepalive_params{
+        .idle = std::chrono::seconds{120},
+        .interval = std::chrono::seconds{60},
+        .count = 3,
+      });
 }
 
 /*

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -346,6 +346,12 @@ admin_server::admin_server(
       ss::engine().get_blocked_reactor_notify_ms())
   , _memory_semaphore(_cfg.max_memory_usage_bytes, "admin/server-mem") {
     _server.set_content_streaming(true);
+    _server.set_keepalive_parameters(
+      ss::net::tcp_keepalive_params{
+        .idle = std::chrono::seconds{120},
+        .interval = std::chrono::seconds{60},
+        .count = 3,
+      });
 }
 
 namespace {


### PR DESCRIPTION
This enables TCP keepalive on the Admin API, PP, SR and possibly others
that use the `ctx_server`.

We hardcode the defaults that we are currently using on the kafka API
which we have never changed anywhere.

This will prevent issues with leaking connections that go through the
AWS NLBs and get silently dropped (as we have previously already seen on
the Kafka API).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

