### PR TITLE
tools: Disable redpanda log trimming in dt script

### DIFF
--- a/tools/dt
+++ b/tools/dt
@@ -334,7 +334,7 @@ class DucktapeRunner:
             "scale": "local",
             "enable_cov": "OFF",
             "use_xfs_partitions": False,
-            "trim_logs": True,
+            "trim_logs": self.args.trim_logs,
             "random_seed": None,
         }
 
@@ -813,6 +813,13 @@ def main():
         default=False,
         help="Run redpanda in fips permissive mode",
     )
+    run_parser.add_argument(
+        "--trim-logs",
+        action="store_true",
+        default=False,
+        help="Enable redpanda log trimming",
+    )
+
 
     # 'start' subcommand
     start_parser = subparsers.add_parser(
@@ -881,6 +888,12 @@ def main():
         default=False,
         help="Run redpanda in fips permissive mode",
     )
+    test_parser.add_argument(
+        "--trim-logs",
+        action="store_true",
+        default=False,
+        help="Enable redpanda log trimming",
+    )
 
     # 'stop' subcommand
     _ = subparsers.add_parser(
@@ -943,6 +956,12 @@ def main():
         action="store_true",
         default=False,
         help="Run redpanda in fips permissive mode",
+    )
+    repl_parser.add_argument(
+        "--trim-logs",
+        action="store_true",
+        default=False,
+        help="Enable redpanda log trimming",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
Changed default behavior of `tools/dt` to not trim redpanda logs.

A new optional flag, `--trim-logs`, has been added to revert to old behavior.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
