### PR TITLE
sl: Fix bug with password set timestamp

### DIFF
--- a/src/v/redpanda/admin/services/shadow_link/converter.cc
+++ b/src/v/redpanda/admin/services/shadow_link/converter.cc
@@ -1184,6 +1184,7 @@ void update_timestamps(
                   *from.connection.authn_config);
               // If the passwords do not match, then update the timestamp of
               // when the password was set
+              c.password_last_updated = from_creds.password_last_updated;
               if (from_creds.password != c.password) {
                   c.password_last_updated = model::timestamp::now();
                   return;

--- a/tests/rptest/tests/cluster_linking_topic_syncing_test.py
+++ b/tests/rptest/tests/cluster_linking_topic_syncing_test.py
@@ -431,6 +431,35 @@ class ClusterLinkingTopicSyncingWithScram(ClusterLinkingTopicSyncingTestBase):
             }
         )
 
+    @cluster(num_nodes=6)
+    def test_set_same_password(self):
+        shadow_link_req = self.create_default_link_request("test-link")
+        created_link = self.create_link_with_request(req=shadow_link_req)
+
+        orig_timestamp = created_link.configurations.client_options.authentication_configuration.scram_configuration.password_set_at
+        self.logger.debug(f"Original password set at: {orig_timestamp}")
+
+        # Update with the exact same password
+        shadow_link_update = shadow_link_req.shadow_link
+
+        update_mask: google.protobuf.field_mask_pb2.FieldMask = (
+            google.protobuf.field_mask_pb2.FieldMask(
+                paths=["configurations.client_options"]
+            )
+        )
+
+        updated_link = self.update_link(
+            shadow_link=shadow_link_update, update_mask=update_mask
+        )
+
+        new_timestamp = updated_link.configurations.client_options.authentication_configuration.scram_configuration.password_set_at
+
+        self.logger.debug(f"New timestamp: {new_timestamp}")
+
+        assert new_timestamp == orig_timestamp, (
+            f"Password set timestamp should not have changed: {new_timestamp} != {orig_timestamp}"
+        )
+
 
 class ClusterLinkingTopicSyncingWithPlain(ClusterLinkingTopicSyncingTestBase):
     """


### PR DESCRIPTION
This fixes a bug where if a user updates a Shadow Link with the same password the set at timestamp clears to Unix Epoch.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug Fixes

* Fixed a bug where if a user updates a Shadow Link with the same password the password set at timestamp was cleared.  Now if they use the same password, the timestamp is kept at its previous value
