### PR TITLE
tests/ops_fuzzer: use property supported across versions

### DIFF
--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -422,7 +422,9 @@ class UpdateConfigOperation(Operation):
         "log_message_timestamp_type": lambda: random.choice(
             ["CreateTime", "LogAppendTime"]
         ),
-        "internal_rpc_request_timeout_ms": lambda: random.randint(8000, 12000),
+        "log_segment_ms_max": lambda: random.randint(
+            24 * 3600 * 1000, 48 * 3600 * 1000
+        ),
     }
 
     def __init__(self):


### PR DESCRIPTION
Newly introduced property `internal_rpc_timeout_ms` is not supported by older versions of Redpanda, this makes the admin operation fuzzer to fail the test when running tests in mixed version cluster. Changed the property to the one which is present in older Redpanda versions.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
