### PR TITLE
python-type-checking: apply only on dev

### DIFF
--- a/.github/workflows/type-check-python.yaml
+++ b/.github/workflows/type-check-python.yaml
@@ -13,6 +13,7 @@ on:
     tags-ignore:
       - '**'
   pull_request:
+    branches: [dev]
     paths:
       - 'tests/**/*.py'
       - 'tools/type-checking/**'


### PR DESCRIPTION
Apply only on PRs to the dev branch, as discussed in:

https://redpandadata.slack.com/archives/C07HD9U0EHL/p1764163986119649?thread_ts=1758049873.545929&cid=C07HD9U0EHL


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
