### PR TITLE
[v25.2.x] archival: treat purge key_not_found error as success

### DIFF
--- a/src/v/cluster/archival/purger.cc
+++ b/src/v/cluster/archival/purger.cc
@@ -271,8 +271,13 @@ ss::future<purger::purge_result> purger::purge_manifest(
       bucket, {format, manifest_key}, manifest, manifest_purge_rtc);
 
     if (manifest_get_result == download_result::notfound) {
-        vlog(ctxlog.debug, "Partition manifest get {} not found", manifest_key);
-        result.status = purge_status::permanent_failure;
+        vlog(
+          ctxlog.debug,
+          "Partition manifest get {} not found, assuming success",
+          manifest_key);
+        // It's possible multiple purgers raced and a different node succeeded
+        // in purging the manifest, so treat this as a success.
+        result.status = purge_status::success;
         co_return result;
     } else if (manifest_get_result != download_result::success) {
         vlog(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26889

Fixes: https://redpandadata.atlassian.net/browse/CORE-13392