### PR TITLE
[backport] [v25.3.x] shadowing: stop replicators on topic deletion

### DIFF
--- a/proto/redpanda/core/admin/v2/shadow_link.proto
+++ b/proto/redpanda/core/admin/v2/shadow_link.proto
@@ -435,7 +435,8 @@ message ScramConfig {
     // SCRAM username
     string username = 1;
     // Password
-    string password = 2 [(google.api.field_behavior) = INPUT_ONLY];
+    string password = 2
+        [(google.api.field_behavior) = INPUT_ONLY, debug_redact = true];
     // Indicates that the password has been set
     bool password_set = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
     // Timestamp of when the password was last set - only valid if password_set

--- a/proto/redpanda/core/common/v1/tls.proto
+++ b/proto/redpanda/core/common/v1/tls.proto
@@ -53,7 +53,8 @@ message TLSPEMSettings {
     string ca = 1;
     // Key and Cert are optional but if one is provided, then both must be
     // The key
-    string key = 2 [(google.api.field_behavior) = INPUT_ONLY];
+    string key = 2
+        [(google.api.field_behavior) = INPUT_ONLY, debug_redact = true];
     // The SHA-256 of the key, in base64 format
     string key_fingerprint = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
     // The cert

--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -210,12 +210,18 @@ void link::update_config(
       config,
       revision);
     chunked_vector<::model::topic> new_topics_to_replicate;
+    chunked_vector<::model::topic> topics_no_longer_mirroring;
     for (const auto& [topic, m] : config.state.mirror_topics) {
         if (
           !_config.state.mirror_topics.contains(topic)
           && mirror_active_state(m.status)) {
             vlog(cllog.debug, "New topic to replicate: {}", topic);
             new_topics_to_replicate.push_back(topic);
+        }
+    }
+    for (const auto& [topic, _] : _config.state.mirror_topics) {
+        if (!config.state.mirror_topics.contains(topic)) {
+            topics_no_longer_mirroring.push_back(topic);
         }
     }
     _config = std::move(config);
@@ -244,6 +250,13 @@ void link::update_config(
           _config.name);
         _replication_mgr.stop_replicators();
     } else {
+        for (const auto& topic : topics_no_longer_mirroring) {
+            vlog(
+              cllog.debug,
+              "Topic {} is no longer mirrored, stopping its replicators",
+              topic);
+            _replication_mgr.stop_replicators(topic);
+        }
         for (const auto& [topic, _] : _config.state.mirror_topics) {
             if (requires_active_replicators(topic)) {
                 continue;

--- a/src/v/redpanda/admin/services/shadow_link/converter.cc
+++ b/src/v/redpanda/admin/services/shadow_link/converter.cc
@@ -991,6 +991,13 @@ chunked_vector<shadow_topic> create_shadow_topics(
           return model_to_shadow_topic(p.first, p.second, status_report);
       });
 
+    std::ranges::sort(
+      shadow_topics.begin(),
+      shadow_topics.end(),
+      [](const shadow_topic& a, const shadow_topic& b) {
+          return a.get_name() < b.get_name();
+      });
+
     return shadow_topics;
 }
 
@@ -1189,7 +1196,10 @@ chunked_vector<topic_partition_information> status_to_partition_information(
         info.set_high_watermark(report.shadow_partition_high_watermark);
         resp.emplace_back(std::move(info));
     }
-
+    std::ranges::sort(
+      resp,
+      std::ranges::less{},
+      &topic_partition_information::get_partition_id);
     return resp;
 }
 } // namespace

--- a/src/v/redpanda/admin/services/shadow_link/shadow_link.cc
+++ b/src/v/redpanda/admin/services/shadow_link/shadow_link.cc
@@ -32,7 +32,6 @@ shadow_link_service_impl::shadow_link_service_impl(
 ss::future<proto::admin::create_shadow_link_response>
 shadow_link_service_impl::create_shadow_link(
   serde::pb::rpc::context, proto::admin::create_shadow_link_request req) {
-    vlog(sllog.trace, "create_shadow_link: {}", req);
     auto redirect_node = redirect_to(model::controller_ntp);
     if (redirect_node) {
         vlog(
@@ -45,7 +44,7 @@ shadow_link_service_impl::create_shadow_link(
             *redirect_node)
           .create_shadow_link(serde::pb::rpc::context{}, std::move(req));
     }
-
+    vlog(sllog.info, "create_shadow_link: {}", req);
     auto md = convert_create_to_metadata(std::move(req));
     auto get_resp = _service->local().get_cluster_link(md.name);
     if (get_resp.has_value()) {
@@ -65,7 +64,6 @@ shadow_link_service_impl::create_shadow_link(
 ss::future<proto::admin::delete_shadow_link_response>
 shadow_link_service_impl::delete_shadow_link(
   serde::pb::rpc::context ctx, proto::admin::delete_shadow_link_request req) {
-    vlog(sllog.trace, "delete_shadow_link: {}", req);
     auto redirect_node = redirect_to(model::controller_ntp);
     if (redirect_node) {
         vlog(
@@ -78,7 +76,7 @@ shadow_link_service_impl::delete_shadow_link(
             *redirect_node)
           .delete_shadow_link(ctx, std::move(req));
     }
-
+    vlog(sllog.info, "delete_shadow_link: {}", req);
     handle_error(
       co_await _service->local().delete_cluster_link(
         cluster_link::model::name_t{req.get_name()}, req.get_force()));
@@ -147,7 +145,6 @@ shadow_link_service_impl::list_shadow_links(
 ss::future<proto::admin::update_shadow_link_response>
 shadow_link_service_impl::update_shadow_link(
   serde::pb::rpc::context ctx, proto::admin::update_shadow_link_request req) {
-    vlog(sllog.trace, "update_shadow_link: {}", req);
     auto redirect_node = redirect_to(model::controller_ntp);
     if (redirect_node) {
         vlog(
@@ -161,6 +158,7 @@ shadow_link_service_impl::update_shadow_link(
           .update_shadow_link(ctx, std::move(req));
     }
 
+    vlog(sllog.info, "update_shadow_link: {}", req);
     auto link_name = cluster_link::model::name_t{
       req.get_shadow_link().get_name()};
 
@@ -187,7 +185,6 @@ shadow_link_service_impl::update_shadow_link(
 ss::future<proto::admin::fail_over_response>
 shadow_link_service_impl::fail_over(
   serde::pb::rpc::context ctx, proto::admin::fail_over_request req) {
-    vlog(sllog.trace, "fail_over_request: {}", req);
     auto redirect_node = redirect_to(model::controller_ntp);
     if (redirect_node) {
         vlog(
@@ -200,6 +197,7 @@ shadow_link_service_impl::fail_over(
             *redirect_node)
           .fail_over(ctx, std::move(req));
     }
+    vlog(sllog.info, "fail_over_request: {}", req);
     auto link_name = cluster_link::model::name_t{req.get_name()};
     auto current_link = handle_error(
       _service->local().get_cluster_link(link_name));

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -1787,7 +1787,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         topic = TopicSpec(name="source-topic", partition_count=5, replication_factor=3)
 
         self.source_default_client().create_topic(topic)
-        shadow_link = self.create_link("test-link")
+        self.create_link("test-link")
 
         self.target_cluster.service.wait_until(
             lambda: self.topic_partitions_exists_in_target(topic),
@@ -1806,24 +1806,34 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         ):
             target_client.delete_topic(topic.name)
 
-        shadow_link.configurations.topic_metadata_sync_options.auto_create_shadow_topic_filters.extend(
-            [
-                shadow_link_pb2.NameFilter(
-                    pattern_type=shadow_link_pb2.PATTERN_TYPE_LITERAL,
-                    filter_type=shadow_link_pb2.FILTER_TYPE_EXCLUDE,
-                    name=topic.name,
-                ),
-            ]
-        )
-        update_mask: google.protobuf.field_mask_pb2.FieldMask = google.protobuf.field_mask_pb2.FieldMask(
-            paths=[
-                "configurations.topic_metadata_sync_options.auto_create_shadow_topic_filters"
-            ]
-        )
-        updated_link = self.update_link(
-            shadow_link=shadow_link, update_mask=update_mask
-        )
+        def update_link_config(include: bool) -> None:
+            shadow_link = self.get_link("test-link")
+            shadow_link.configurations.topic_metadata_sync_options.ClearField(
+                "auto_create_shadow_topic_filters"
+            )
+            filter_type = (
+                shadow_link_pb2.FILTER_TYPE_INCLUDE
+                if include
+                else shadow_link_pb2.FILTER_TYPE_EXCLUDE
+            )
+            shadow_link.configurations.topic_metadata_sync_options.auto_create_shadow_topic_filters.extend(
+                [
+                    shadow_link_pb2.NameFilter(
+                        pattern_type=shadow_link_pb2.PATTERN_TYPE_LITERAL,
+                        filter_type=filter_type,
+                        name=topic.name,
+                    ),
+                ]
+            )
+            update_mask: google.protobuf.field_mask_pb2.FieldMask = (
+                google.protobuf.field_mask_pb2.FieldMask(
+                    paths=["configurations.topic_metadata_sync_options"]
+                )
+            )
+            self.update_link(shadow_link=shadow_link, update_mask=update_mask)
 
+        # Update the link to exclude the topic from autocreation filters
+        update_link_config(include=False)
         # Now the topic should be deletable, as it is not in the autocreate filters
         target_client.delete_topic(topic.name)
         link_state = self.get_link("test-link")
@@ -1831,6 +1841,19 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             "Expected empty shadow_topic list. "
             f"Instead got {link_state.status.shadow_topics}"
         )
+        # Re-add the topic to the autocreation filters
+        update_link_config(include=True)
+        # Verify that the shadow topic is re-created
+        self.target_cluster.service.wait_until(
+            lambda: self.topic_partitions_exists_in_target(topic),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"Topic {topic.name} not found in target cluster after re-adding to autocreation filters",
+        )
+
+        # Replicate more data to ensure replication still works
+        with self.producer_consumer(topic=topic.name, msg_size=128, msg_cnt=200000):
+            self.verify()
 
     @cluster(num_nodes=7)
     def test_replication_with_transactions(self):


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/redpanda/issues/28853

dev PR: https://github.com/redpanda-data/redpanda/pull/28825

Fixes the reconciliation logic to stop the replicators that are no longer needed after topic got deleted.

Additionally

* Improves logging for state mutating requests (bumped to info)
* Sort partitions and topics in the status output for consistent reporting.

Fixes

https://redpandadata.atlassian.net/browse/CORE-14890
https://redpandadata.atlassian.net/browse/CORE-14891
https://redpandadata.atlassian.net/browse/CORE-14892


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
### Bug Fixes
* Avoids runaway replicators after topics got deleted. Additionally improve some observability related to shadow requests.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
