### PR TITLE
[CORE-8225] dt/archival: Turn off aws-chunked encoding when on GCS

### DIFF
--- a/tests/rptest/archival/s3_client.py
+++ b/tests/rptest/archival/s3_client.py
@@ -132,11 +132,25 @@ class S3Client:
                     populate_handler(h.baseFilename, h.level)
 
     def make_client(self):
+        # Disable automatic checksum calculation for GCS to avoid aws-chunked
+        # Content-Encoding. GCS stores and returns content with this encoding
+        # as-is, which breaks consumers expecting decoded content.
+        if self._is_gcs:
+            checksum_config = {
+                "request_checksum_calculation": "when_required",
+                "response_checksum_validation": "when_required",
+            }
+        else:
+            checksum_config = {}
+
         cfg = Config(
             region_name=self._region,
             signature_version=self._signature_version,
             retries={"max_attempts": 10, "mode": "adaptive"},
-            s3={"addressing_style": f"{self._addressing_style}"},
+            s3={
+                "addressing_style": f"{self._addressing_style}",
+            },
+            **checksum_config,
             use_fips_endpoint=True if self._use_fips_endpoint else None,
         )
         cl = boto3.client(


### PR DESCRIPTION
boto3 by default will use request checksumming in some cases, like PUTs
to S3, which causes the content to be transferred with the aws-chunked
Content-Encoding. GCS will store the content verbatim and return it with
the same Content-Encoding, which breaks our code. This happens in the
inventory test when we use boto3 to upload faked inventory reports to
GCS using boto3 and GCS's S3-compatible-but-not-that-compatible API.
Redpanda fails to parse the aws-chunked encoding as JSON.

Fixes CORE-8225

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
