### PR TITLE
`ct/l1`: allow non-contiguous, extent aligned `replace_objects()` requests in `metastore`

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -40,6 +40,60 @@ std::optional<extent_range> get_range(
     return extent_range{base_it, last_it};
 }
 
+using contiguous_intervals_by_tidp_t = chunked_hash_map<
+  model::topic_id_partition,
+  chunked_vector<offset_interval_set::interval>>;
+
+// Returns a vector of contiguous offset intervals found in
+// `sorted_extents_by_tp` or an `stm_update_error` if the offsets of the
+// provided extent are invalid. That is, the extents `[[0, 99], [100,199],
+// [200,299], [300,399]]` are combined into the single continuous interval
+// `[0,399]`, whereas the extents `[[0, 99], [100,199], [250,299], [300,399]]`
+// would return two continuous intervals `[[0,199], [250,399]]`. An example of
+// an invalid extent input would be `[[0,99], [200, 249], [239, 299]]`.
+std::expected<contiguous_intervals_by_tidp_t, stm_update_error>
+contiguous_intervals_for_extents(
+  const new_object::sorted_extents_by_tidp_t& sorted_extents_by_tp) {
+    contiguous_intervals_by_tidp_t ret;
+    for (const auto& [tidp, extents] : sorted_extents_by_tp) {
+        auto& ret_intervals = ret[tidp];
+        if (extents.empty()) {
+            continue;
+        }
+        auto current_base = extents.begin()->base_offset;
+        auto current_last = extents.begin()->last_offset;
+        // Skip the first entry when iterating over `extents`.
+        for (const auto& extent : extents | std::views::drop(1)) {
+            auto expected_next = kafka::next_offset(current_last);
+            if (extent.base_offset == expected_next) {
+                // A new extent that is contiguous with the current interval.
+                // Extend the current interval with the extent's last offset.
+                current_last = extent.last_offset;
+            } else if (extent.base_offset > expected_next) {
+                // A new extent that is non-contiguous with the current
+                // interval. Push back the current interval and start a new
+                // interval with the extent's offset range.
+                ret_intervals.push_back(
+                  {.base_offset = current_base, .last_offset = current_last});
+                current_base = extent.base_offset;
+                current_last = extent.last_offset;
+            } else {
+                return std::unexpected(stm_update_error(
+                  fmt::format(
+                    "Input object breaks partition {} offset ordering: "
+                    "previous: {}, next: {}",
+                    tidp,
+                    current_last,
+                    extent.base_offset)));
+            }
+        }
+        ret_intervals.push_back(
+          {.base_offset = current_base, .last_offset = current_last});
+    }
+
+    return ret;
+}
+
 } // namespace
 
 void new_object::collect_extents_by_tidp(sorted_extents_by_tidp_t* ret) const {
@@ -320,44 +374,35 @@ replace_objects_update::can_apply(const state& state) {
         o.collect_extents_by_tidp(&new_extents_by_tp);
     }
 
-    for (const auto& [tidp, new_prt_extents] : new_extents_by_tp) {
-        auto req_base = new_prt_extents.begin()->base_offset;
-        auto req_last = std::prev(new_prt_extents.end())->last_offset;
+    auto contiguous_intervals_by_tp = contiguous_intervals_for_extents(
+      new_extents_by_tp);
+    if (!contiguous_intervals_by_tp.has_value()) {
+        return std::unexpected(contiguous_intervals_by_tp.error());
+    }
 
-        auto p_state = state.partition_state(tidp);
-        if (!p_state) {
-            return std::unexpected(stm_update_error(
-              fmt::format("Partition {} not tracked by state", tidp)));
-        }
+    for (const auto& [tidp, intervals] : contiguous_intervals_by_tp.value()) {
+        for (const auto& interval : intervals) {
+            auto req_base = interval.base_offset;
+            auto req_last = interval.last_offset;
 
-        // Check that the new range's offset aligns with existing extents.
-        const auto& prt = p_state->get();
-        auto iters = get_range(prt.extents, req_base, req_last);
-        if (!iters.has_value()) {
-            return std::unexpected(stm_update_error(
-              fmt::format(
-                "Partition {} doesn't contain extents that span exactly [{}, "
-                "{}]",
-                tidp,
-                req_base,
-                req_last)));
-        }
+            auto p_state = state.partition_state(tidp);
+            if (!p_state) {
+                return std::unexpected(stm_update_error(
+                  fmt::format("Partition {} not tracked by state", tidp)));
+            }
 
-        // Check that the new range of extents is contiguous, which in turn
-        // ensures the resulting total set of extents will be contiguous.
-        const auto& [base_it, last_it] = *iters;
-        auto expected_next = base_it->base_offset;
-        for (const auto& new_extent : new_prt_extents) {
-            if (new_extent.base_offset != expected_next) {
+            // Check that the new range's offset aligns with existing extents.
+            const auto& prt = p_state->get();
+            auto iters = get_range(prt.extents, req_base, req_last);
+            if (!iters.has_value()) {
                 return std::unexpected(stm_update_error(
                   fmt::format(
-                    "Input object breaks partition {} offset ordering: "
-                    "expected next: {}, actual: {}",
+                    "Partition {} doesn't contain extents that span exactly "
+                    "[{}, {}]",
                     tidp,
-                    expected_next,
-                    new_extent.base_offset)));
+                    req_base,
+                    req_last)));
             }
-            expected_next = kafka::next_offset(new_extent.last_offset);
         }
     }
     if (compaction_updates.empty()) {
@@ -491,27 +536,43 @@ replace_objects_update::apply(state& state) {
             .object_size = o.object_size,
           });
     }
+
+    auto contiguous_intervals_by_tp
+      = contiguous_intervals_for_extents(new_extents_by_tp).value();
+
+    for (const auto& [tidp, intervals] : contiguous_intervals_by_tp) {
+        auto& p_state
+          = state.topic_to_state[tidp.topic_id].pid_to_state[tidp.partition];
+        for (const auto& interval : intervals) {
+            auto requested_base = interval.base_offset;
+            auto requested_last = interval.last_offset;
+            auto iters = get_range(
+              p_state.extents, requested_base, requested_last);
+            auto [base_it, last_it] = *iters;
+            auto end_it = std::next(last_it);
+            for (auto iter = base_it; iter != end_it; ++iter) {
+                auto& old_extent = *iter;
+                state.objects[old_extent.oid].removed_data_size
+                  += old_extent.len;
+                vlog(
+                  cd_log.debug,
+                  "Removing extent of {} in {} [{}, {}]",
+                  tidp,
+                  old_extent.oid,
+                  old_extent.base_offset,
+                  old_extent.last_offset);
+            }
+
+            p_state.extents.erase(base_it, end_it);
+        }
+    }
+
     for (const auto& [tidp, new_extents] : new_extents_by_tp) {
         auto& p_state
           = state.topic_to_state[tidp.topic_id].pid_to_state[tidp.partition];
-        auto requested_base = new_extents.begin()->base_offset;
-        auto requested_last = new_extents.rbegin()->last_offset;
-        auto iters = get_range(p_state.extents, requested_base, requested_last);
-        auto [base_it, last_it] = *iters;
-        auto end_it = std::next(last_it);
-        for (auto iter = base_it; iter != end_it; ++iter) {
-            auto& old_extent = *iter;
-            state.objects[old_extent.oid].removed_data_size += old_extent.len;
-            vlog(
-              cd_log.debug,
-              "Removing extent of {} in {} [{}, {}]",
-              tidp,
-              old_extent.oid,
-              old_extent.base_offset,
-              old_extent.last_offset);
-        }
+        // NOTE: we don't need to update the start or next offsets since we've
+        // validated that the new extents replace exact ranges.
 
-        p_state.extents.erase(base_it, end_it);
         for (const auto& e : new_extents) {
             p_state.extents.emplace(e);
             vlog(
@@ -522,8 +583,6 @@ replace_objects_update::apply(state& state) {
               e.base_offset,
               e.last_offset);
         }
-        // NOTE: we don't need to update the start or next offsets since we've
-        // validated that the new extents replace exact ranges.
 
         for (const auto& extent : new_extents) {
             state.objects[extent.oid].total_data_size += extent.len;

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -26,6 +26,8 @@ const object_id oid1 = l1::create_object_id();
 const object_id oid2 = l1::create_object_id();
 const object_id oid3 = l1::create_object_id();
 const object_id oid4 = l1::create_object_id();
+const object_id oid5 = l1::create_object_id();
+const object_id oid6 = l1::create_object_id();
 const std::string_view tidp_a = "deadbeef-aaaa-0000-0000-000000000000/0";
 const std::string_view tidp_b = "deadbeef-bbbb-0000-0000-000000000000/0";
 const std::string_view tidp_c = "deadbeef-cccc-0000-0000-000000000000/0";
@@ -496,6 +498,168 @@ TEST(StateUpdateTest, TestEmptyReplace) {
     EXPECT_THAT(
       std::string(replace_res.error()()),
       testing::StrEq("No objects requested"));
+}
+
+TEST(StateUpdateTest, TestReplaceValidNonContiguous) {
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100, 1100)
+                        .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
+                        .build())
+                 .add(new_obj_builder(oid2, 100, 1100)
+                        .add(tidp_a, 100_o, 199_o, 1999_t, 0, 99)
+                        .build())
+                 .add(new_obj_builder(oid3, 100, 1100)
+                        .add(tidp_a, 200_o, 299_o, 1999_t, 0, 99)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .build();
+    state s;
+    auto add_res = add.apply(s);
+    ASSERT_TRUE(add_res.has_value());
+
+    // Attempt to replace oid1 and oid3 while leaving oid2 in place with a
+    // non-contiguous update. While the update itself is non-contiguous, the
+    // individual objects still align with existing extents, and is therefore
+    // valid.
+    auto replace = replace_objects_builder()
+                     .add(new_obj_builder(oid4, 100, 1100)
+                            .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
+                            .build())
+                     .add(new_obj_builder(oid5, 100, 1100)
+                            .add(tidp_a, 200_o, 299_o, 1999_t, 0, 99)
+                            .build())
+                     .build();
+
+    auto replace_res = replace.apply(s);
+    ASSERT_TRUE(replace_res.has_value());
+
+    auto& p = s.partition_state(model::topic_id_partition::from(tidp_a))->get();
+    ASSERT_EQ(p.extents.size(), 3);
+}
+
+TEST(StateUpdateTest, TestReplaceValidNonContiguousSplitExtent) {
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100, 1100)
+                        .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
+                        .build())
+                 .add(new_obj_builder(oid2, 100, 1100)
+                        .add(tidp_a, 100_o, 199_o, 1999_t, 0, 99)
+                        .build())
+                 .add(new_obj_builder(oid3, 100, 1100)
+                        .add(tidp_a, 200_o, 299_o, 1999_t, 0, 99)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .build();
+    state s;
+    auto add_res = add.apply(s);
+    ASSERT_TRUE(add_res.has_value());
+
+    // Attempt to replace oid1 and oid3 while leaving oid2 in place with a
+    // non-contiguous update whose objects align with existing extents.
+    // The update should see oid3 split into two new extents (for a total of 4
+    // extents).
+    auto replace = replace_objects_builder()
+                     .add(new_obj_builder(oid4, 100, 1100)
+                            .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
+                            .build())
+                     .add(new_obj_builder(oid5, 100, 1100)
+                            .add(tidp_a, 200_o, 249_o, 1999_t, 0, 99)
+                            .build())
+                     .add(new_obj_builder(oid6, 100, 1100)
+                            .add(tidp_a, 250_o, 299_o, 1999_t, 0, 99)
+                            .build())
+                     .build();
+
+    auto replace_res = replace.apply(s);
+    ASSERT_TRUE(replace_res.has_value());
+
+    auto& p = s.partition_state(model::topic_id_partition::from(tidp_a))->get();
+    ASSERT_EQ(p.extents.size(), 4);
+}
+
+TEST(StateUpdateTest, TestReplaceInvalidNonContiguousBadOffsets) {
+    using testing::ElementsAre;
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100, 1100)
+                        .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
+                        .build())
+                 .add(new_obj_builder(oid2, 100, 1100)
+                        .add(tidp_a, 100_o, 199_o, 1999_t, 0, 99)
+                        .build())
+                 .add(new_obj_builder(oid3, 100, 1100)
+                        .add(tidp_a, 200_o, 299_o, 1999_t, 0, 99)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .build();
+    state s;
+    auto add_res = add.apply(s);
+    ASSERT_TRUE(add_res.has_value());
+
+    // Attempt to replace oid1 and oid3 while leaving oid2 in place with a
+    // invalid non-contiguous update with bad offsets.
+    auto replace = replace_objects_builder()
+                     .add(new_obj_builder(oid4, 100, 1100)
+                            .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
+                            .build())
+                     .add(new_obj_builder(oid5, 100, 1100)
+                            .add(tidp_a, 200_o, 249_o, 1999_t, 0, 99)
+                            .build())
+                     .add(new_obj_builder(oid6, 100, 1100)
+                            .add(tidp_a, 239_o, 299_o, 1999_t, 0, 99)
+                            .build())
+                     .build();
+
+    auto replace_res = replace.apply(s);
+    ASSERT_FALSE(replace_res.has_value());
+    EXPECT_THAT(
+      std::string(replace_res.error()()),
+      testing::ContainsRegex("breaks partition .+ offset ordering"));
+
+    auto& p = s.partition_state(model::topic_id_partition::from(tidp_a))->get();
+    ASSERT_EQ(p.extents.size(), 3);
+}
+
+TEST(StateUpdateTest, TestReplaceInvalidNonContiguousDoesNotSpan) {
+    using testing::ElementsAre;
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100, 1100)
+                        .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
+                        .build())
+                 .add(new_obj_builder(oid2, 100, 1100)
+                        .add(tidp_a, 100_o, 199_o, 1999_t, 0, 99)
+                        .build())
+                 .add(new_obj_builder(oid3, 100, 1100)
+                        .add(tidp_a, 200_o, 299_o, 1999_t, 0, 99)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .build();
+    state s;
+    auto add_res = add.apply(s);
+    ASSERT_TRUE(add_res.has_value());
+
+    // Attempt to replace oid1 and oid3 while leaving oid2 in place with a
+    // invalid non-contiguous update that doesn't exactly span existing extents.
+    auto replace = replace_objects_builder()
+                     .add(new_obj_builder(oid4, 100, 1100)
+                            .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
+                            .build())
+                     .add(new_obj_builder(oid5, 100, 1100)
+                            .add(tidp_a, 200_o, 249_o, 1999_t, 0, 99)
+                            .build())
+                     .add(new_obj_builder(oid6, 100, 1100)
+                            .add(tidp_a, 250_o, 298_o, 1999_t, 0, 99)
+                            .build())
+                     .build();
+
+    auto replace_res = replace.apply(s);
+    ASSERT_FALSE(replace_res.has_value());
+    EXPECT_THAT(
+      std::string(replace_res.error()()),
+      testing::ContainsRegex(
+        "Partition .+ doesn't contain extents that span exactly"));
+
+    auto& p = s.partition_state(model::topic_id_partition::from(tidp_a))->get();
+    ASSERT_EQ(p.extents.size(), 3);
 }
 
 TEST(StateUpdateTest, TestReplaceWithCompaction) {


### PR DESCRIPTION
Currently, we assume that all extents provided in a `replace_objects()` or `compact_objects()` request to the `metastore` are contiguous. We also assert that the update, as a whole, is aligned to existing `extent`s in the `metastore`.

This is overly restrictive. Consider the following case, in which we have extents `[[0,99], [100,199], [200,299], [300,399]]`, and wish to replace the state with the update `[[100,199], [300,399]]`, perhaps due to a compaction job that decided to only compact those ranges. Currently, the `metastore` implementation would reject my request, as the offsets `199` and `300` are not contiguous.

Update the `metastore` so that the inputs in a `replace_objects()` request are broken into their contiguous components, and checked individually against the existing `metastore` state, thus allowing non-contiguous updates like the above. For an even more complex case, we could attempt to compact the above extents with an update like `[[0,99], [300,349], [350,399]]`, and the update would now be accepted, since the contiguous ranges in the update (`[[0,99], [300,399]]`) are individually still extent aligned.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
