### PR TITLE
[CORE-14909] storage/e2e_test: Guard against underflow and OOB

### DIFF
--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -4579,7 +4579,7 @@ TEST_F(storage_test_fixture, test_offset_range_size2) {
     // timed uploads.
     size_t tail_length = 5;
 
-    for (size_t i = 0; i < tail_length; i++) {
+    for (size_t i = 0; i < std::min(tail_length, summaries.size()); i++) {
         auto ix_batch = summaries.size() - 1 - i;
         res = log
                 ->offset_range_size(
@@ -5041,7 +5041,7 @@ TEST_F(storage_test_fixture, test_offset_range_size2_compacted) {
     // timed uploads.
     size_t tail_length = 5;
 
-    for (size_t i = 0; i < tail_length; i++) {
+    for (size_t i = 0; i < std::min(tail_length, c_summaries.size()); i++) {
         SUCCEED() << fmt::format("Checking i = {}", i);
         auto ix_batch = c_summaries.size() - 1 - i;
         res = log


### PR DESCRIPTION
Two test cases in the end-to-end test did a lot of compaction, then checked batches at the end of the log. They assumed there would be at least 5 batches left, but rarely this was not the case and it would cause underflow and an out-of-bounds index access of a vector. The fix is to clamp so too much isn't read.

This caused failures ~30/10000 runs. I reran 10000 tests with the fix and saw no failures.

Fixes CORE-14909

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
