### PR TITLE
[CORE-14918] Cleanup Redpanda service on all preallocated test nodes

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -40,7 +40,6 @@ from typing import (
     Literal,
     Mapping,
     NamedTuple,
-    Protocol,
     Set,
     Tuple,
     TypedDict,
@@ -53,7 +52,7 @@ from signal import SIGKILL, SIGTERM, Signals
 import requests
 import yaml
 from ducktape.cluster.cluster import ClusterNode
-from ducktape.cluster.remoteaccount import RemoteAccount, RemoteCommandError
+from ducktape.cluster.remoteaccount import RemoteCommandError
 from ducktape.errors import TimeoutError
 from ducktape.services.service import Service
 from ducktape.tests.test import TestContext
@@ -329,13 +328,6 @@ OIDC_ALLOW_LIST = [
 ]
 
 CLOUD_TOPICS_CONFIG_STR = "unstable_beta_feature_cloud_topics_enabled"
-
-
-class RemoteClusterNode(Protocol):
-    account: RemoteAccount
-
-    @property
-    def name(self) -> str: ...
 
 
 @dataclass
@@ -2186,7 +2178,7 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
             return "unknown_version"
         return self._cloud_cluster.get_install_pack_version()
 
-    def sockets_clear(self, node: RemoteClusterNode) -> bool:
+    def sockets_clear(self, node: ClusterNode) -> bool:
         return True
 
     def all_up(self) -> bool:
@@ -3643,7 +3635,7 @@ class RedpandaService(Service, RedpandaServiceABC):
             self.signal_redpanda(node, signal=signal.SIGCONT)
             self.add_to_started_nodes(node)
 
-    def sockets_clear(self, node: RemoteClusterNode):
+    def sockets_clear(self, node: ClusterNode):
         """
         Check that high-numbered redpanda ports (in practice, just the internal
         RPC port) are clear on the node, to avoid TIME_WAIT sockets from previous

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3660,6 +3660,7 @@ class RedpandaService(Service, RedpandaServiceABC):
                 self.logger.info(
                     f"Port collision on node {node.name}: {src}->{dst} {state}"
                 )
+                self._log_node_process_state(node)
                 return False
 
         # Fall through: no problematic lines found

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -4867,13 +4867,17 @@ class RedpandaService(Service, RedpandaServiceABC):
 
                 raise e
 
-    def clean_node(
+    def clean_node_state(
         self,
         node: ClusterNode,
         preserve_logs: bool = False,
         preserve_current_install: bool = False,
         **kwargs: Any,
     ):
+        """
+        Cleans the node state such as killing processes and removing persistent
+        state on disk.
+        """
         assert not kwargs, f"Unknown args {kwargs}"
         # These are allow_fail=True to allow for a race where kill_process finds
         # the PID, but then the process has died before it sends the SIGKILL.  This
@@ -4915,6 +4919,17 @@ class RedpandaService(Service, RedpandaServiceABC):
             # installation to preserve!
             self._installer.reset_current_install([node])
 
+    def clean_node(
+        self,
+        node: ClusterNode,
+        preserve_logs: bool = False,
+        preserve_current_install: bool = False,
+        **kwargs: Any,
+    ):
+        """
+        Cleans both the physical node and service metadata about the node.
+        """
+        self.clean_node_state(node, preserve_logs, preserve_current_install, **kwargs)
         self.clear_cached_broker_metadata(node)
 
     def remove_local_data(self, node: ClusterNode):

--- a/tests/rptest/tests/prealloc_nodes.py
+++ b/tests/rptest/tests/prealloc_nodes.py
@@ -53,6 +53,22 @@ class PreallocNodesTest(RedpandaTest):
             for node in self._preallocated_nodes:
                 self.logger.debug(f"Allocated node {node.name}")
 
+            # preallocated nodes may be used by any service (e.g. redpanda
+            # broker, OMB worker, etc.). However, note below in
+            # free_preallocated_nodes that clean-up specific to a redpanda
+            # broker is performed (RedpandaService::sockets_clear), which waits
+            # for Redpanda broker ports to be cleaned up. We've seen that fail
+            # on a pre-allocated node which was using a non-Redpanda broker
+            # service, suggesting that a previous user of the node was a
+            # Redpanda broker and it failed to clean up, and that most likely
+            # that broker was still running and listening on the port. So before
+            # we use the preallocated node, clean off the node for leftovers of a
+            # previous Redpanda broker service even if it is not the service
+            # which will be using this node.
+            for node in self._preallocated_nodes:
+                self.logger.debug(f"Cleaning node {node.name}")
+                self.redpanda.clean_node_state(node)
+
         return self._preallocated_nodes
 
     def free_nodes(self):


### PR DESCRIPTION
This PR addresses an issue where preallocated test nodes may retain running Redpanda broker processes from previous test runs (we try to clean up on test shutdown, but we also proactively try to clean on test start-up since sometimes shutdown cleanup isn't reliable), causing port conflicts when the nodes are reused. The fix proactively cleans all preallocated nodes before allocation, regardless of their intended service, to ensure any leftover Redpanda processes are removed.

Key Changes:

* Add cleanup logic in preallocated_nodes() to clean all nodes before allocation
* Remove unused RemoteClusterNode Protocol type
* Improve debugging by logging process state when socket conflicts are detected

Fixes https://redpandadata.atlassian.net/browse/CORE-14918

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
