### PR TITLE
rpk: fix iotune multi-eval-dir handling

### DIFF
--- a/src/go/rpk/pkg/cli/iotune/iotune.go
+++ b/src/go/rpk/pkg/cli/iotune/iotune.go
@@ -73,7 +73,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&outputFile, "out", filepath.Join(filepath.Dir(config.DefaultRedpandaYamlPath), "io-config.yaml"), "The file path where the IO config will be written")
-	cmd.Flags().StringSliceVar(&directories, "directories", []string{}, "List of directories to evaluate")
+	cmd.Flags().StringSliceVar(&directories, "directories", []string{}, "Comma separated list of directories to evaluate")
 	cmd.Flags().DurationVar(&duration, "duration", 10*time.Minute, "Duration of tests (e.g. 300ms, 1.5s, 2h45m)")
 	cmd.Flags().DurationVar(&timeout, "timeout", 1*time.Hour, "The maximum time after --duration to wait for iotune to complete (e.g. 300ms, 1.5s, 2h45m)")
 	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt if the iotune file already exists")

--- a/src/go/rpk/pkg/tuners/iotune/io_tune.go
+++ b/src/go/rpk/pkg/tuners/iotune/io_tune.go
@@ -70,8 +70,10 @@ func ioTuneCommandLineArgs(args IoTuneArgs) ([]string, error) {
 		return nil, errors.New("at least one directory is required for iotune")
 	}
 	var cmdArgs []string
-	cmdArgs = append(cmdArgs, "--evaluation-directory")
-	cmdArgs = append(cmdArgs, args.Dirs...)
+	for _, dir := range args.Dirs {
+		cmdArgs = append(cmdArgs, "--evaluation-directory")
+		cmdArgs = append(cmdArgs, dir)
+	}
 	if args.Format != "" {
 		cmdArgs = append(cmdArgs, "--format")
 		cmdArgs = append(cmdArgs, string(args.Format))


### PR DESCRIPTION
Allows multiple directories to be used with rpk iotune.

Fixes: https://github.com/redpanda-data/redpanda/issues/14013
Fixes: https://github.com/redpanda-data/redpanda/issues/14012
Fixes: https://redpandadata.atlassian.net/browse/CORE-1492
Fixes: https://redpandadata.atlassian.net/browse/CORE-1491

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
