### PR TITLE
lsm: expose options

### DIFF
--- a/src/v/lsm/BUILD
+++ b/src/v/lsm/BUILD
@@ -12,6 +12,7 @@ redpanda_cc_library(
         "//src/v/lsm/core/internal:files",
         "//src/v/lsm/core/internal:iterator",
         "//src/v/lsm/core/internal:keys",
+        "//src/v/lsm/core/internal:options",
         "//src/v/lsm/db:impl",
         "//src/v/lsm/db:memtable",
     ],

--- a/src/v/lsm/core/compression.cc
+++ b/src/v/lsm/core/compression.cc
@@ -26,12 +26,6 @@ compression::type convert_type(compression_type type) {
     switch (type) {
     case compression_type::zstd:
         return compression::type::zstd;
-    case compression_type::java_snappy:
-        return compression::type::java_snappy;
-    case compression_type::lz4:
-        return compression::type::lz4;
-    case compression_type::gzip:
-        return compression::type::gzip;
     case compression_type::none:
         throw invalid_argument_exception(
           "attempted to compress with type none");
@@ -57,9 +51,6 @@ compression_type compression_type_from_raw(uint8_t v) {
     switch (ct) {
     case compression_type::none:
     case compression_type::zstd:
-    case compression_type::java_snappy:
-    case compression_type::lz4:
-    case compression_type::gzip:
         return ct;
     }
     throw corruption_exception("unknown compression type: {}", v);

--- a/src/v/lsm/core/compression.h
+++ b/src/v/lsm/core/compression.h
@@ -26,9 +26,6 @@ namespace lsm {
 enum class compression_type : uint8_t {
     none = 0,
     zstd = 1,
-    java_snappy = 2,
-    lz4 = 3,
-    gzip = 4,
 };
 
 // Convert a raw byte to a compression type (or throw)

--- a/src/v/lsm/core/internal/files.cc
+++ b/src/v/lsm/core/internal/files.cc
@@ -19,11 +19,7 @@
 namespace lsm::internal {
 
 ss::sstring sst_file_name(file_handle handle) noexcept {
-    return ss::format(
-      "{:020}-{:020}-{:020}.sst",
-      handle.id(),
-      handle.epoch.inter,
-      handle.epoch.intra);
+    return ss::format("{:020}-{:020}.sst", handle.id(), handle.epoch);
 }
 
 std::optional<file_handle>
@@ -37,32 +33,21 @@ parse_sst_file_name(std::string_view filename) noexcept {
     if (ext != ".sst") {
         return std::nullopt;
     }
-    std::array<std::string_view, 3> split = absl::StrSplit(
-      stem, absl::MaxSplits('-', 2));
-    auto [str_id, str_epoch_hi, str_epoch_lo] = split;
+    std::array<std::string_view, 2> split = absl::StrSplit(
+      stem, absl::MaxSplits('-', 1));
+    auto [str_id, str_epoch] = split;
     uint64_t raw_id = 0;
     if (!absl::SimpleAtoi(str_id, &raw_id)) {
         return std::nullopt;
     }
-    uint64_t raw_epoch_hi = 0;
-    if (!absl::SimpleAtoi(str_epoch_hi, &raw_epoch_hi)) {
-        return std::nullopt;
-    }
-    uint64_t raw_epoch_lo = 0;
-    if (!absl::SimpleAtoi(str_epoch_lo, &raw_epoch_lo)) {
+    uint64_t raw_epoch = 0;
+    if (!absl::SimpleAtoi(str_epoch, &raw_epoch)) {
         return std::nullopt;
     }
     return file_handle{
       .id = file_id{raw_id},
-      .epoch = database_epoch{
-        .inter = raw_epoch_hi,
-        .intra = raw_epoch_lo,
-      },
+      .epoch = database_epoch{raw_epoch},
     };
-}
-
-fmt::iterator database_epoch::format_to(fmt::iterator it) const {
-    return fmt::format_to(it, "{{inter={},intra={}}}", inter, intra);
 }
 
 fmt::iterator file_handle::format_to(fmt::iterator it) const {

--- a/src/v/lsm/core/internal/files.h
+++ b/src/v/lsm/core/internal/files.h
@@ -44,25 +44,10 @@ consteval file_id operator""_file_id(unsigned long long val) {
 // For example, if replicating a WAL using raft, then writing the WAL to object
 // storage, each raft term could become it's own database_epoch, which would
 // mean that old leaders cannot clobber a new leader's files while shutting
-// down. On top of this there are an additional 64 bits that can be used for
-// restarts of a raft group within a single term (think cross shard movement)
-// to ensure old leaders on the same node never clobber a new node's files.
-// This second additional 64 bits could be implemented as either a global
-// counter or something like a timestamp from a monotonic clock.
-struct database_epoch {
-    uint64_t inter;
-    uint64_t intra;
-    bool operator==(const database_epoch&) const = default;
-    auto operator<=>(const database_epoch&) const = default;
-    fmt::iterator format_to(fmt::iterator) const;
-    template<typename H>
-    friend H AbslHashValue(H h, const database_epoch& c) {
-        return H::combine(std::move(h), c.inter, c.intra);
-    }
-};
-
+// down.
+using database_epoch = named_type<uint64_t, struct database_epoch_tag>;
 consteval database_epoch operator""_db_epoch(unsigned long long val) {
-    return database_epoch{.inter = val};
+    return database_epoch{val};
 }
 
 // File handle is a combination of a file's ID and the database epoch at which

--- a/src/v/lsm/core/internal/options.h
+++ b/src/v/lsm/core/internal/options.h
@@ -83,7 +83,8 @@ struct options {
         return multiplier * target_file_size();
     }
 
-    // The max number of SST files that should be opened at one time.
+    // The approximate max number of SST files that should be opened at one
+    // time.
     constexpr static uint32_t default_max_open_files = 1000;
     uint32_t max_open_files = default_max_open_files;
 
@@ -118,8 +119,9 @@ struct options {
     // This imples that 125 seeks cost the same as the compaction of
     // 1MB of data. I.e., one seek costs approximately the same as
     // the compaction of 8KiB of data.
-    constexpr static size_t default_compact_after_seek_bytes = 8_KiB;
-    size_t compact_after_seek_bytes = default_compact_after_seek_bytes;
+    constexpr static size_t default_seek_compaction_bytes_cost_ratio = 8_KiB;
+    size_t seek_compaction_bytes_cost_ratio
+      = default_seek_compaction_bytes_cost_ratio;
 
     // Approximate gap in bytes between samples of data read during iteration.
     constexpr static size_t default_read_bytes_period = 10_MiB;

--- a/src/v/lsm/core/internal/tests/files_test.cc
+++ b/src/v/lsm/core/internal/tests/files_test.cc
@@ -14,8 +14,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <limits>
-
 namespace {
 using namespace lsm::internal;
 using ::testing::Optional;
@@ -23,22 +21,19 @@ using ::testing::Optional;
 
 TEST(Files, SstFileName) {
     EXPECT_EQ(
-      "00000000000000000001-00000000000000000000-00000000000000000000.sst",
+      "00000000000000000001-00000000000000000000.sst",
       std::string(sst_file_name({1_file_id, 0_db_epoch})));
     EXPECT_EQ(
-      "00000000000000000123-00000000000000000001-00000000000000000000.sst",
+      "00000000000000000123-00000000000000000001.sst",
       std::string(sst_file_name({123_file_id, 1_db_epoch})));
     EXPECT_EQ(
-      "00000000000000000000-00000000000000000123-00000000000000000000.sst",
+      "00000000000000000000-00000000000000000123.sst",
       std::string(sst_file_name({0_file_id, 123_db_epoch})));
     EXPECT_EQ(
-      "18446744073709551615-18446744073709551615-18446744073709551615.sst",
+      "18446744073709551615-18446744073709551615.sst",
       std::string(sst_file_name({
         file_id::max(),
-        database_epoch{
-          .inter = std::numeric_limits<uint64_t>::max(),
-          .intra = std::numeric_limits<uint64_t>::max(),
-        },
+        database_epoch::max(),
       })));
 }
 
@@ -51,14 +46,10 @@ TEST(Files, ParseFilename_SstFile) {
       parse_sst_file_name(sst_file_name({123_file_id, 432_db_epoch})),
       Optional(file_handle{123_file_id, 432_db_epoch}));
 
-    auto max_epoch = database_epoch{
-      .inter = std::numeric_limits<uint64_t>::max(),
-      .intra = std::numeric_limits<uint64_t>::max(),
-    };
     EXPECT_THAT(
       parse_sst_file_name(
-        sst_file_name(file_handle{file_id::max(), max_epoch})),
-      Optional(file_handle{file_id::max(), max_epoch}));
+        sst_file_name(file_handle{file_id::max(), database_epoch::max()})),
+      Optional(file_handle{file_id::max(), database_epoch::max()}));
 }
 
 TEST(Files, ParseFilename_Invalid) {
@@ -71,16 +62,12 @@ TEST(Files, ParseFilename_Invalid) {
 
     // Missing splits
     EXPECT_EQ(std::nullopt, parse_sst_file_name("00000000000000000001.sst"));
-    EXPECT_EQ(
-      std::nullopt,
-      parse_sst_file_name("00000000000000000001-00000000000000000001.sst"));
 
     // Extra split
     EXPECT_EQ(
       std::nullopt,
       parse_sst_file_name(
-        "00000000000000000001-00000000000000000001-00000000000000000001-"
-        "00000000000000000001.sst"));
+        "00000000000000000001-00000000000000000001-00000000000000000001.sst"));
 
     // Invalid numeric ID for sst
     EXPECT_EQ(std::nullopt, parse_sst_file_name("notanumber-123.sst"));

--- a/src/v/lsm/db/iter.h
+++ b/src/v/lsm/db/iter.h
@@ -19,7 +19,7 @@ namespace lsm::db {
 
 // A function that records a sample of bytes read at the specified internal key.
 // Samples are taken approximately every
-// `internal::config::compact_after_seek_bytes`.
+// `internal::config::read_bytes_period`.
 using key_sample_fn
   = ss::noncopyable_function<ss::future<>(internal::key_view)>;
 

--- a/src/v/lsm/db/manifest.proto
+++ b/src/v/lsm/db/manifest.proto
@@ -41,20 +41,12 @@ message Version {
     repeated Level levels = 1;
 }
 
-// The version of the database being opened.
-message DatabaseEpoch {
-    // The inter-process epoch
-    uint64 inter = 1;
-    // The intra-process epoch
-    uint64 intra = 2;
-}
-
 // Metadata for an SST file in the database.
 message FileMetaData {
     // The file's ID.
     uint64 id = 1;
     // The database epoch when the file as created.
-    DatabaseEpoch epoch = 2;
+    uint64 database_epoch = 2;
     // The size of the file in bytes.
     uint64 file_size = 3;
     // The smallest key in the table.

--- a/src/v/lsm/db/version_set.cc
+++ b/src/v/lsm/db/version_set.cc
@@ -52,10 +52,8 @@ public:
         internal::file_handle handle;
         std::memcpy(&handle.id, it, sizeof(handle.id));
         std::advance(it, sizeof(handle.id));
-        std::memcpy(&handle.epoch.inter, it, sizeof(handle.epoch.inter));
-        std::advance(it, sizeof(handle.epoch.inter));
-        std::memcpy(&handle.epoch.intra, it, sizeof(handle.epoch.intra));
-        std::advance(it, sizeof(handle.epoch.intra));
+        std::memcpy(&handle.epoch, it, sizeof(handle.epoch));
+        std::advance(it, sizeof(handle.epoch));
         uint64_t file_size = 0;
         std::memcpy(&file_size, it, sizeof(file_size));
         return std::make_pair(handle, file_size);
@@ -94,17 +92,14 @@ public:
     internal::key_view key() override { return (*_files)[_index]->largest; }
     iobuf value() override {
         iobuf v;
-        auto placeholder = v.reserve(sizeof(uint64_t) * 4);
+        auto placeholder = v.reserve(sizeof(uint64_t) * 3);
         const auto& f = (*_files)[_index];
         auto id = std::bit_cast<std::array<char, sizeof(uint64_t)>>(
           f->handle.id);
         placeholder.write(id.data(), id.size());
-        auto epoch_hi = std::bit_cast<std::array<char, sizeof(uint64_t)>>(
-          f->handle.epoch.inter);
-        placeholder.write(epoch_hi.data(), epoch_hi.size());
-        auto epoch_lo = std::bit_cast<std::array<char, sizeof(uint64_t)>>(
-          f->handle.epoch.intra);
-        placeholder.write(epoch_lo.data(), epoch_lo.size());
+        auto epoch = std::bit_cast<std::array<char, sizeof(uint64_t)>>(
+          f->handle.epoch);
+        placeholder.write(epoch.data(), epoch.size());
         auto size = std::bit_cast<std::array<char, sizeof(uint64_t)>>(
           f->file_size);
         placeholder.write(size.data(), size.size());
@@ -582,8 +577,7 @@ ss::future<> version_set::write_manifest(manifest m) {
         for (const auto& file : files) {
             proto::file_meta_data file_proto;
             file_proto.set_id(file->handle.id());
-            file_proto.get_epoch().set_inter(file->handle.epoch.inter);
-            file_proto.get_epoch().set_intra(file->handle.epoch.intra);
+            file_proto.set_database_epoch(file->handle.epoch());
             file_proto.set_file_size(file->file_size);
             file_proto.set_encoded_smallest_key(iobuf(file->smallest));
             file_proto.set_encoded_largest_key(iobuf(file->largest));
@@ -623,9 +617,7 @@ ss::future<std::optional<version_set::manifest>> version_set::read_manifest() {
             auto meta = ss::make_lw_shared<file_meta_data>();
             meta->handle.id = internal::file_id{file_proto.get_id()};
             meta->handle.epoch = internal::database_epoch{
-              .inter = file_proto.get_epoch().get_inter(),
-              .intra = file_proto.get_epoch().get_intra(),
-            };
+              file_proto.get_database_epoch()};
             meta->file_size = file_proto.get_file_size();
             meta->smallest = internal::key(
               file_proto.get_encoded_smallest_key());

--- a/src/v/lsm/db/version_set.cc
+++ b/src/v/lsm/db/version_set.cc
@@ -139,7 +139,8 @@ public:
             for (const auto& added_file : mutation.added_files) {
                 auto copy = ss::make_lw_shared(*added_file);
                 copy->allowed_seeks = static_cast<int32_t>(
-                  copy->file_size / _vset->_options->compact_after_seek_bytes);
+                  copy->file_size
+                  / _vset->_options->seek_compaction_bytes_cost_ratio);
                 constexpr static int32_t min_allowed_seeks = 100;
                 if (copy->allowed_seeks < min_allowed_seeks) {
                     copy->allowed_seeks = min_allowed_seeks;
@@ -274,7 +275,7 @@ ss::future<bool> version::record_read_sample(internal::key_view key) {
     // deletions? Should we have another mechanism for finding such files?
     if (matches >= 2) {
         // 1MiB cost is about 1 seek (see comment in
-        // options::compact_after_seek_bytes).
+        // options::seek_compaction_bytes_cost_ratio).
         co_return update_stats(stats);
     }
     co_return false;

--- a/src/v/lsm/io/cloud_persistence.cc
+++ b/src/v/lsm/io/cloud_persistence.cc
@@ -495,8 +495,7 @@ private:
     cloud_storage_clients::object_key
     manifest_key(internal::database_epoch epoch) const {
         return cloud_storage_clients::object_key{
-          _prefix()
-          / fmt::format("MANIFEST.{:020}-{:020}", epoch.inter, epoch.intra)};
+          _prefix() / fmt::format("MANIFEST.{:020}", epoch)};
     }
 
     cloud_io::remote* _remote;

--- a/src/v/lsm/io/disk_persistence.cc
+++ b/src/v/lsm/io/disk_persistence.cc
@@ -89,8 +89,7 @@ public:
 
     ss::future<std::optional<iobuf>>
     read_manifest(internal::database_epoch epoch) override {
-        auto latest_filename = fmt::format(
-          "{:020}-{:020}.MANIFEST", epoch.inter, epoch.intra);
+        auto latest_filename = fmt::format("{:020}.MANIFEST", epoch);
         std::string filename;
         auto generator = list_all_files();
         while (auto entry = co_await generator()) {
@@ -124,8 +123,7 @@ public:
 
     ss::future<>
     write_manifest(internal::database_epoch epoch, iobuf b) override {
-        auto filename = fmt::format(
-          "{:020}-{:020}.MANIFEST", epoch.inter, epoch.intra);
+        auto filename = fmt::format("{:020}.MANIFEST", epoch);
         auto staging_name = fmt::format(
           "{}.lsm-staging", filename, uuid_t::create());
         try {

--- a/src/v/lsm/lsm.cc
+++ b/src/v/lsm/lsm.cc
@@ -13,6 +13,7 @@
 
 #include "lsm/core/internal/iterator.h"
 #include "lsm/core/internal/keys.h"
+#include "lsm/core/internal/options.h"
 #include "lsm/db/impl.h"
 #include "lsm/db/memtable.h"
 
@@ -24,9 +25,90 @@ namespace lsm {
 
 namespace {
 
-ss::lw_shared_ptr<internal::options> translate_options(options) {
-    // TODO: implement me
-    return ss::make_lw_shared<internal::options>();
+ss::lw_shared_ptr<internal::options> translate_options(options opts) {
+    if (opts.num_levels < 2) {
+        throw std::invalid_argument(
+          fmt::format(
+            "num_levels must be at least 2, got {}", opts.num_levels));
+    }
+
+    if (
+      opts.level_zero_stop_writes_trigger
+      <= opts.level_zero_slowdown_writes_trigger) {
+        throw std::invalid_argument(
+          fmt::format(
+            "level_zero_stop_writes_trigger ({}) must be greater than "
+            "level_zero_slowdown_writes_trigger ({})",
+            opts.level_zero_stop_writes_trigger,
+            opts.level_zero_slowdown_writes_trigger));
+    }
+
+    if (
+      opts.sst_filter_period != 0
+      && (opts.sst_filter_period & (opts.sst_filter_period - 1)) != 0) {
+        throw std::invalid_argument(
+          fmt::format(
+            "sst_filter_period must be a power of two, got {}",
+            opts.sst_filter_period));
+    }
+
+    if (
+      opts.level_one_compaction_trigger
+      >= opts.level_zero_slowdown_writes_trigger) {
+        throw std::invalid_argument(
+          fmt::format(
+            "level_one_compaction_trigger ({}) must be less than "
+            "level_zero_slowdown_writes_trigger ({})",
+            opts.level_one_compaction_trigger,
+            opts.level_zero_slowdown_writes_trigger));
+    }
+
+    // Create the internal options
+    auto internal_opts = ss::make_lw_shared<internal::options>();
+
+    // Set database epoch
+    internal_opts->database_epoch = internal::database_epoch{
+      opts.database_epoch};
+
+    // Create level configs based on num_levels
+    internal_opts->levels.clear();
+    internal_opts->levels.reserve(opts.num_levels);
+    for (uint8_t i = 0; i < opts.num_levels; ++i) {
+        internal_opts->levels.emplace_back(internal::level{i});
+    }
+
+    internal_opts->level_zero_slowdown_writes_trigger
+      = opts.level_zero_slowdown_writes_trigger;
+    internal_opts->level_zero_stop_writes_trigger
+      = opts.level_zero_stop_writes_trigger;
+    internal_opts->write_buffer_size = opts.write_buffer_size;
+    internal_opts->level_one_compaction_trigger
+      = opts.level_one_compaction_trigger;
+    internal_opts->max_file_size = opts.max_file_size;
+    internal_opts->max_open_files = opts.max_open_files;
+    internal_opts->block_cache_size = opts.block_cache_size;
+    internal_opts->sst_block_size = opts.sst_block_size;
+    internal_opts->sst_filter_period = opts.sst_filter_period;
+
+    switch (opts.compression) {
+    case options::compression_type::none:
+        internal_opts->compression = compression_type::none;
+        break;
+    case options::compression_type::zstd:
+        internal_opts->compression = compression_type::zstd;
+        break;
+    case options::compression_type::java_snappy:
+        internal_opts->compression = compression_type::java_snappy;
+        break;
+    case options::compression_type::lz4:
+        internal_opts->compression = compression_type::lz4;
+        break;
+    case options::compression_type::gzip:
+        internal_opts->compression = compression_type::gzip;
+        break;
+    }
+
+    return internal_opts;
 }
 
 model::offset seqno_cast(internal::sequence_number seqno) {

--- a/src/v/lsm/lsm.cc
+++ b/src/v/lsm/lsm.cc
@@ -97,15 +97,6 @@ ss::lw_shared_ptr<internal::options> translate_options(options opts) {
     case options::compression_type::zstd:
         internal_opts->compression = compression_type::zstd;
         break;
-    case options::compression_type::java_snappy:
-        internal_opts->compression = compression_type::java_snappy;
-        break;
-    case options::compression_type::lz4:
-        internal_opts->compression = compression_type::lz4;
-        break;
-    case options::compression_type::gzip:
-        internal_opts->compression = compression_type::gzip;
-        break;
     }
 
     return internal_opts;

--- a/src/v/lsm/lsm.h
+++ b/src/v/lsm/lsm.h
@@ -33,7 +33,94 @@ class iterator;
 class iterator;
 
 // Options for the database.
-struct options {};
+struct options {
+    // Database epoch are assigned to a file such that on shared storage mediums
+    // databases that share persistence locations that write with different
+    // epochs will not collide with each other.
+    //
+    // For example, if replicating a WAL using raft, then writing the WAL to
+    // object storage, each raft term could become it's own database_epoch,
+    // which would mean that old leaders cannot clobber a new leader's files
+    // while shutting down.
+    //
+    // This value should never decrease.
+    uint64_t database_epoch = 0;
+
+    // The number of levels in the LSM tree. More levels allow more smaller and
+    // faster compactions, but causes more read amplication.
+    //
+    // There must be at least 2 levels in the database:
+    // * one for unsorted data (where memtables get flushed to)
+    // * one for sorted data
+    //
+    // Currently, it is only valid for this value to be increased each time the
+    // database is opened.
+    constexpr static uint8_t default_num_levels = 7;
+    uint8_t num_levels = default_num_levels;
+
+    // At what point do we start throttling writes in terms of the number of L0
+    // files
+    constexpr static size_t default_level_zero_slowdown_writes_trigger = 8;
+    size_t level_zero_slowdown_writes_trigger
+      = default_level_zero_slowdown_writes_trigger;
+
+    // At what point do we halt writes in terms of number of L0 files
+    constexpr static size_t default_level_zero_stop_writes_trigger = 12;
+    size_t level_zero_stop_writes_trigger
+      = default_level_zero_stop_writes_trigger;
+
+    // How big to let memtable accumulate in bytes before flushing.
+    constexpr static size_t default_write_buffer_size = 16_MiB;
+    size_t write_buffer_size = default_write_buffer_size;
+
+    // When do we trigger compaction into L1 in terms of number of L0 files
+    constexpr static size_t default_level_one_compaction_trigger = 4;
+    size_t level_one_compaction_trigger = default_level_one_compaction_trigger;
+
+    // Write up to this amount of bytes to a file before switching to a new one.
+    // Increasing this provides better file system efficiency with larger files,
+    // but the downside of increasing this is longer compactions and longer
+    // latency/performance hiccups.
+    size_t max_file_size = 2_GiB;
+
+    // The approximate max number of SST files that should be opened at one
+    // time.
+    constexpr static uint32_t default_max_open_files = 1000;
+    uint32_t max_open_files = default_max_open_files;
+
+    // The size of the cache that stores uncompressed blocks.
+    constexpr static size_t default_block_cache_size = 10_MiB;
+    size_t block_cache_size = default_block_cache_size;
+
+    // The size of a single block within an SST file.
+    constexpr static size_t default_sst_block_size = 4_KiB;
+    size_t sst_block_size = default_sst_block_size;
+
+    // The frequency at which to generate a new bloom filter.
+    //
+    // If set to 0 then no bloom filters will be generated.
+    //
+    // This value may be changed between different opens of the database.
+    //
+    // REQUIRED: this value must be a power of two
+    constexpr static size_t default_sst_filter_period = 2_KiB;
+    size_t sst_filter_period = default_sst_filter_period;
+
+    // The supported compression algorithms
+    enum class compression_type : uint8_t {
+        none = 0,
+        zstd = 1,
+        java_snappy = 2,
+        lz4 = 3,
+        gzip = 4,
+    };
+    // The compression to use for SST blocks.
+    //
+    // This value may be changed between different opens of the database.
+    //
+    // TODO: support different compression types per level
+    compression_type compression = compression_type::none;
+};
 
 class write_batch;
 

--- a/src/v/lsm/lsm.h
+++ b/src/v/lsm/lsm.h
@@ -110,9 +110,6 @@ struct options {
     enum class compression_type : uint8_t {
         none = 0,
         zstd = 1,
-        java_snappy = 2,
-        lz4 = 3,
-        gzip = 4,
     };
     // The compression to use for SST blocks.
     //

--- a/src/v/lsm/sst/tests/iterator_test.cc
+++ b/src/v/lsm/sst/tests/iterator_test.cc
@@ -72,8 +72,7 @@ private:
 
 using SSTIteratorType = ::testing::Types<
   sst_iterator_factory<lsm::compression_type::none>,
-  sst_iterator_factory<lsm::compression_type::zstd>,
-  sst_iterator_factory<lsm::compression_type::gzip>>;
+  sst_iterator_factory<lsm::compression_type::zstd>>;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(
   SSTIteratorSuite, CoreIteratorTest, SSTIteratorType);


### PR DESCRIPTION
- **lsm: simplify database_epoch**
- **lsm: expose public options**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
