### PR TITLE
ct/l0: Use batch size histogram with proper scale factor

### DIFF
--- a/src/v/cloud_topics/level_zero/common/level_zero_probe.cc
+++ b/src/v/cloud_topics/level_zero/common/level_zero_probe.cc
@@ -99,7 +99,7 @@ void pipeline_probe::setup_internal_metrics(bool disable, ss::sstring name) {
         sm::make_histogram(
           "request_size_bytes",
           [this] {
-              return _request_memory_histogram.public_histogram_logform();
+              return _request_memory_histogram.batch_size_histogram_logform();
           },
           sm::description("Request size histogram."),
           labels),


### PR DESCRIPTION
The pipeline request size histogram was using the wrong histogram type, which meant its values got divided by 1,000,000.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

