### PR TITLE
r/persisted_stm: do not load local snapshot if it is from 'future'

### DIFF
--- a/src/v/cluster/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/cluster/archival/tests/archival_metadata_stm_test.cc
@@ -128,6 +128,22 @@ struct archival_metadata_stm_base_fixture
           .get();
     }
 
+    void populate_log_with_data(size_t record_count) {
+        for (size_t i = 0; i < record_count; ++i) {
+            auto batch = model::test::make_random_batch(
+              model::test::record_batch_spec{
+                .count = 1,
+                .bt = model::record_batch_type::raft_data,
+              });
+            batch.header().ctx.term = model::term_id(1);
+            auto appender = _raft->log()->make_appender(
+              storage::log_append_config{});
+            auto rdr = model::make_memory_record_batch_reader(std::move(batch));
+            rdr.for_each_ref(std::move(appender), model::no_timeout).get();
+        }
+        _raft->log()->flush().get();
+    }
+
     ~archival_metadata_stm_base_fixture() override {
         stop_all();
         cloud_conn_pool.local().shutdown_connections();
@@ -319,6 +335,7 @@ void check_snapshot_size(
 
 FIXTURE_TEST(test_snapshot_loading, archival_metadata_stm_base_fixture) {
     create_raft();
+    populate_log_with_data(43);
     auto& ntp_cfg = _raft->log_config();
     partition_manifest m(ntp_cfg.ntp(), ntp_cfg.get_remote_revision());
     m.add(
@@ -400,7 +417,9 @@ FIXTURE_TEST(test_snapshot_loading, archival_metadata_stm_base_fixture) {
     }
 
     BOOST_REQUIRE_EQUAL(archival_stm->get_start_offset(), model::offset{100});
-    BOOST_REQUIRE(archival_stm->manifest() == m);
+    BOOST_REQUIRE(
+      archival_stm->manifest().make_manifest_metadata()
+      == m.make_manifest_metadata());
     check_snapshot_size(*archival_stm, ntp_cfg);
 
     // A snapshot constructed with make_snapshot is always clean
@@ -411,6 +430,7 @@ FIXTURE_TEST(test_snapshot_loading, archival_metadata_stm_base_fixture) {
 
 FIXTURE_TEST(test_sname_derivation, archival_metadata_stm_base_fixture) {
     create_raft();
+    populate_log_with_data(50);
     auto& ntp_cfg = _raft->log_config();
     partition_manifest m(ntp_cfg.ntp(), ntp_cfg.get_remote_revision());
 
@@ -668,57 +688,6 @@ ss::future<> make_old_snapshot(
 
     co_await cluster::details::archival_metadata_stm_accessor::persist_snapshot(
       tmp_snapshot_mgr, std::move(snapshot));
-}
-
-FIXTURE_TEST(
-  test_archival_metadata_stm_snapshot_version_compatibility,
-  archival_metadata_stm_base_fixture) {
-    create_raft();
-    auto& ntp_cfg = _raft->log_config();
-    partition_manifest m(ntp_cfg.ntp(), ntp_cfg.get_remote_revision());
-    m.add(
-      segment_name("0-1-v1.log"),
-      segment_meta{
-        .base_offset = model::offset(0),
-        .committed_offset = model::offset(99),
-        .archiver_term = model::term_id(1),
-        .segment_term = model::term_id(1),
-      });
-    m.add(
-      segment_name("100-1-v1.log"),
-      segment_meta{
-        .base_offset = model::offset(100),
-        .committed_offset = model::offset(199),
-        .archiver_term = model::term_id(1),
-        .segment_term = model::term_id(1),
-      });
-    m.add(
-      segment_name("200-1-v1.log"),
-      segment_meta{
-        .base_offset = model::offset(200),
-        .committed_offset = model::offset(299),
-        .archiver_term = model::term_id(1),
-        .segment_term = model::term_id(1),
-      });
-    m.advance_insync_offset(model::offset(3));
-
-    make_old_snapshot(ntp_cfg, m, model::offset{3}).get();
-
-    raft::state_machine_manager_builder builder;
-    auto archival_stm = builder.create_stm<cluster::archival_metadata_stm>(
-      _raft.get(),
-      cloud_api.local(),
-      _feature_table.local(),
-      logger,
-      std::nullopt,
-      std::nullopt);
-
-    _raft->start(std::move(builder)).get();
-    _started = true;
-    wait_for_confirmed_leader();
-
-    BOOST_REQUIRE(archival_stm->manifest() == m);
-    check_snapshot_size(*archival_stm, ntp_cfg);
 }
 
 FIXTURE_TEST(test_archival_stm_batching, archival_metadata_stm_fixture) {

--- a/src/v/raft/persisted_stm.cc
+++ b/src/v/raft/persisted_stm.cc
@@ -582,7 +582,9 @@ ss::future<> persisted_stm_base<BaseT, T>::start() {
     if (maybe_snapshot) {
         stm_snapshot& snapshot = *maybe_snapshot;
         auto next_offset = model::next_offset(snapshot.header.offset);
-        if (next_offset >= _raft->start_offset()) {
+        if (
+          next_offset >= _raft->start_offset()
+          && snapshot.header.offset <= _raft->dirty_offset()) {
             auto snapshot_applied = co_await apply_local_snapshot(
               snapshot.header, std::move(snapshot.data));
             if (snapshot_applied == local_snapshot_applied::yes) {
@@ -607,8 +609,11 @@ ss::future<> persisted_stm_base<BaseT, T>::start() {
             // it in the apply fiber by calling handle_eviction.
             vlog(
               _log.warn,
-              "Skipping snapshot {} since it's out of sync with the log",
-              _snapshot_backend.store_path());
+              "Skipping snapshot {} since it's out of sync with the log. Log "
+              "offsets: {}, last included snapshot offset: {}",
+              _snapshot_backend.store_path(),
+              _raft->log()->offsets(),
+              snapshot.header.offset);
         }
 
     } else {


### PR DESCRIPTION
When `persisted_stm` is staring it uses the local snapshot to speed up recovery and skip replying the whole log. It may happen that sometimes the snapshot is not correctly removed from the kvstore in this case the state machine may load the snapshot that was intended to be used for the previos revision of the same NTP.

The local snapshot with incorrect offset may prevent the state machine manager from applying the log entries to the state machines as its next offset is incorrectly set.

This PR prevents the stm from loading the snapshot with offset that is greater than current log dirty offset. This isn't a full fix of the issue and will be accompanied with future work leading to changing the way snaphots are stored in kvstore.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- prevents state machine from loading local  snapshot with offsets greater than log dirty offset