### PR TITLE
[CORE-14907] Fix overflow in coordinated recovery throttling

### DIFF
--- a/src/v/raft/coordinated_recovery_throttle.cc
+++ b/src/v/raft/coordinated_recovery_throttle.cc
@@ -71,8 +71,8 @@ ss::future<> coordinated_recovery_throttle::token_bucket::throttle(
 }
 
 void coordinated_recovery_throttle::token_bucket::renew_capacity(
-  size_t granted_capacity) {
-    _available_units += granted_capacity;
+  ssize_t added_capacity) {
+    _available_units += added_capacity;
     _last_reset_capacity = _available_units;
     _admitted_bytes_since_last_reset = 0;
     vlog(
@@ -182,19 +182,19 @@ coordinated_recovery_throttle::required_capacity() const {
                                      + _throttler.admitted_bytes()};
 }
 
-ss::future<>
-coordinated_recovery_throttle::renew_capacity_all_shards(size_t new_capacity) {
+ss::future<> coordinated_recovery_throttle::renew_capacity_all_shards(
+  ssize_t added_capacity) {
     co_await container().invoke_on_all(
-      [new_capacity](coordinated_recovery_throttle& local) {
-          local._throttler.renew_capacity(new_capacity);
+      [added_capacity](coordinated_recovery_throttle& local) {
+          local._throttler.renew_capacity(added_capacity);
       });
 }
 
 ss::future<> coordinated_recovery_throttle::renew_capacity_on_shard(
-  ss::shard_id shard, size_t new_capacity) {
+  ss::shard_id shard, ssize_t added_capacity) {
     co_await container().invoke_on(
-      shard, [new_capacity](coordinated_recovery_throttle& local) {
-          local._throttler.renew_capacity(new_capacity);
+      shard, [added_capacity](coordinated_recovery_throttle& local) {
+          local._throttler.renew_capacity(added_capacity);
       });
 }
 
@@ -338,8 +338,8 @@ ss::future<> coordinated_recovery_throttle::renew_capacity_on_shards(
                    | std::views::transform(
                      [this, &added_capacity_calculator, shard(ss::shard_id{0})](
                        const shard_capacity_request& req) mutable {
-                         size_t capacity = added_capacity_calculator(req);
-                         return renew_capacity_on_shard(shard++, capacity);
+                         return renew_capacity_on_shard(
+                           shard++, added_capacity_calculator(req));
                      });
     co_await ss::when_all(futures.begin(), futures.end());
 }

--- a/src/v/raft/coordinated_recovery_throttle.h
+++ b/src/v/raft/coordinated_recovery_throttle.h
@@ -77,7 +77,7 @@ private:
         explicit token_bucket(size_t /*initial_size*/);
         ss::future<> throttle(size_t /*bytes*/, ss::abort_source&);
         /// Adds granted capacity to the token bucket (removes if negative)
-        void renew_capacity(size_t granted_capacity);
+        void renew_capacity(ssize_t added_capacity);
         void shutdown() {
             _mutex.broken();
             _cv.broken();
@@ -87,7 +87,7 @@ private:
             return _admitted_bytes_since_last_reset;
         }
         ssize_t available() const { return _available_units; }
-        size_t last_reset_capacity() const { return _last_reset_capacity; }
+        ssize_t last_reset_capacity() const { return _last_reset_capacity; }
 
     private:
         ssize_t _available_units{0};
@@ -99,13 +99,13 @@ private:
         /// is last reset. We use this as a heuristic when estimating
         /// the capacity needed for the next tick. See required_capacity().
         size_t _admitted_bytes_since_last_reset{0};
-        size_t _last_reset_capacity;
+        ssize_t _last_reset_capacity;
     };
 
     /// Helpers to reset capacity on all/specific shard to the passed capacity.
     /// Used by the coordinator.
-    ss::future<> renew_capacity_all_shards(size_t /* new capacity*/);
-    ss::future<> renew_capacity_on_shard(ss::shard_id, size_t /*new capacity*/);
+    ss::future<> renew_capacity_all_shards(ssize_t added_capacity);
+    ss::future<> renew_capacity_on_shard(ss::shard_id, ssize_t added_capacity);
 
     void arm_coordinator_timer();
 

--- a/src/v/raft/tests/coordinated_recovery_throttle_test.cc
+++ b/src/v/raft/tests/coordinated_recovery_throttle_test.cc
@@ -411,3 +411,28 @@ FIXTURE_TEST(overusing_on_zero_rate, test_fixture) {
     coordinator_tick().get();
     f.get();
 }
+
+FIXTURE_TEST(allowance_staying_negative, test_fixture) {
+    ssize_t original_rate = 100 * ss::smp::count;
+    ssize_t reduced_rate = 10 * ss::smp::count;
+    ssize_t oversized_request = 10000 * ss::smp::count;
+
+    update_rate(original_rate);
+    coordinator_tick().get();
+
+    throttle_on_shard(0, oversized_request).get();
+    update_rate(reduced_rate);
+    coordinator_tick().get();
+
+    auto available = all_available().get();
+    BOOST_REQUIRE(std::ranges::all_of(available, [this](auto current) {
+        vlog(logger.info, "current: {}", current);
+        return current < 0;
+    }));
+    auto sum = std::ranges::fold_left(available, ssize_t{0}, std::plus{});
+    auto expected_sum = original_rate + reduced_rate - oversized_request;
+
+    auto deviation = abs(sum - expected_sum);
+    // allow for rounding errors
+    BOOST_REQUIRE(deviation <= ss::smp::count);
+}

--- a/src/v/raft/tests/coordinated_recovery_throttle_test.cc
+++ b/src/v/raft/tests/coordinated_recovery_throttle_test.cc
@@ -238,10 +238,10 @@ FIXTURE_TEST(throttler_test_rebalancing, test_fixture) {
         // bandwidth after rebalancing.
         ssize_t total_available = 0;
         for (auto current : all_available().get()) {
-            BOOST_REQUIRE(abs(current) < ss::smp::count);
+            BOOST_REQUIRE(std::abs(current) < ss::smp::count);
             total_available += current;
         }
-        BOOST_REQUIRE(abs(total_available) < ss::smp::count);
+        BOOST_REQUIRE(std::abs(total_available) < ss::smp::count);
 
         // Nothing waiting
         BOOST_REQUIRE_EQUAL(
@@ -270,7 +270,7 @@ FIXTURE_TEST(throttler_test_rebalancing, test_fixture) {
             }
             ++shard_id;
         }
-        BOOST_REQUIRE(abs(total_available) < ss::smp::count);
+        BOOST_REQUIRE(std::abs(total_available) < ss::smp::count);
 
         // Step 5: In a few ticks, all shards should be back to fair rate.
         wait_until([this] {
@@ -355,7 +355,7 @@ FIXTURE_TEST(overusing, test_fixture) {
         return current >= 0;
     }));
     auto sum = std::ranges::fold_left(available, ssize_t{0}, std::plus{});
-    auto deviation_from_full = abs(
+    auto deviation_from_full = std::abs(
       sum - ss::smp::count * initial_rate_per_shard);
     // allow for rounding errors
     BOOST_REQUIRE(deviation_from_full <= ss::smp::count);
@@ -432,7 +432,7 @@ FIXTURE_TEST(allowance_staying_negative, test_fixture) {
     auto sum = std::ranges::fold_left(available, ssize_t{0}, std::plus{});
     auto expected_sum = original_rate + reduced_rate - oversized_request;
 
-    auto deviation = abs(sum - expected_sum);
+    auto deviation = std::abs(sum - expected_sum);
     // allow for rounding errors
     BOOST_REQUIRE(deviation <= ss::smp::count);
 }

--- a/src/v/raft/tests/coordinated_recovery_throttle_test.cc
+++ b/src/v/raft/tests/coordinated_recovery_throttle_test.cc
@@ -351,7 +351,7 @@ FIXTURE_TEST(overusing, test_fixture) {
     // Check that available capacity is back to normal.
     // and balance is non-negative on all shards
     auto available = all_available().get();
-    BOOST_REQUIRE(std::ranges::all_of(available, [](size_t current) {
+    BOOST_REQUIRE(std::ranges::all_of(available, [](auto current) {
         return current >= 0;
     }));
     auto sum = std::ranges::fold_left(available, ssize_t{0}, std::plus{});
@@ -391,7 +391,7 @@ FIXTURE_TEST(overusing_a_lot, test_fixture) {
     all_available()
       .then([](auto available) {
           return std::ranges::all_of(
-            available, [](size_t current) { return current >= 0; });
+            available, [](auto current) { return current >= 0; });
       })
       .get();
 }


### PR DESCRIPTION
We recently added allowance overusing facility to recovery throttler. It's prone to problems due to arithmetic overflow. Fix this.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
