### PR TITLE
[CORE-14941] `ct/l1`: remove `extent`s in `replace_objects()` below start offset

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -25,11 +25,22 @@ struct extent_range {
 std::optional<extent_range> get_range(
   const partition_state::extent_set_t& extents,
   kafka::offset base,
-  kafka::offset last) {
-    auto base_it = std::ranges::lower_bound(
-      extents, base, std::less<>{}, &extent::base_offset);
-    if (base_it == extents.end() || base_it->base_offset != base) {
-        return std::nullopt;
+  kafka::offset last,
+  kafka::offset log_start_offset) {
+    auto base_it = extents.begin();
+    // If base < log_start_offset, we are considering replacing an extent below
+    // the log start offset. We allow for misalignment between the start offset
+    // and the first extent in the partition, since we need to support partial
+    // truncations- this also means we don't need replacement extents to be
+    // aligned to existing extents below the start offset. Fallthrough here
+    // instead of returning `std::nullopt`- we will still need to validate the
+    // alignment of the range's last offset.
+    if (base >= log_start_offset) {
+        base_it = std::ranges::lower_bound(
+          extents, base, std::less<>{}, &extent::base_offset);
+        if (base_it == extents.end() || base_it->base_offset != base) {
+            return std::nullopt;
+        }
     }
     // Check that the range's last offset aligns with an existing extent.
     auto last_it = std::ranges::lower_bound(
@@ -423,9 +434,11 @@ replace_objects_update::can_apply(const state& state) {
                   fmt::format("Partition {} not tracked by state", tidp)));
             }
 
-            // Check that the new range's offset aligns with existing extents.
+            // Check that the new range's offset aligns with existing extents
+            // above the log's start offset.
             const auto& prt = p_state->get();
-            auto iters = get_range(prt.extents, req_base, req_last);
+            auto iters = get_range(
+              prt.extents, req_base, req_last, prt.start_offset);
             if (!iters.has_value()) {
                 return std::unexpected(stm_update_error(
                   fmt::format(
@@ -579,7 +592,10 @@ replace_objects_update::apply(state& state) {
             auto requested_base = interval.base_offset;
             auto requested_last = interval.last_offset;
             auto iters = get_range(
-              p_state.extents, requested_base, requested_last);
+              p_state.extents,
+              requested_base,
+              requested_last,
+              p_state.start_offset);
             auto [base_it, last_it] = *iters;
             auto end_it = std::next(last_it);
             for (auto iter = base_it; iter != end_it; ++iter) {
@@ -620,6 +636,12 @@ replace_objects_update::apply(state& state) {
             state.objects[extent.oid].total_data_size += extent.len;
         }
     }
+
+    for (const auto& [tidp, _] : new_extents_by_tp) {
+        remove_extents_below_start_offset_for_tp(
+          state, tidp, "Added replacement below start offset");
+    }
+
     for (const auto& [t, t_req] : compaction_updates) {
         for (const auto& [p, compaction_update] : t_req) {
             model::topic_id_partition tidp{t, p};

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -94,6 +94,38 @@ contiguous_intervals_for_extents(
     return ret;
 }
 
+void remove_extents_below_start_offset_for_tp(
+  state& state, model::topic_id_partition tp, std::string_view ctx) {
+    auto& p_state
+      = state.topic_to_state[tp.topic_id].pid_to_state[tp.partition];
+    auto start_offset = p_state.start_offset;
+    while (!p_state.extents.empty()) {
+        if (p_state.extents.begin()->last_offset >= start_offset) {
+            break;
+        }
+        // The front extent falls entirely below the new start offset, meaning
+        // it's can be removed.
+        auto begin_it = p_state.extents.begin();
+        auto oid = begin_it->oid;
+        auto obj_it = state.objects.find(oid);
+        if (obj_it == state.objects.end()) {
+            // Unexpected, but benign.
+            continue;
+        }
+        obj_it->second.removed_data_size += begin_it->len;
+        vlog(
+          cd_log.debug,
+          "{} for {}: {}, removing extent {} [{}, {}]",
+          ctx,
+          tp,
+          start_offset,
+          begin_it->oid,
+          begin_it->base_offset,
+          begin_it->last_offset);
+        p_state.extents.erase(begin_it);
+    }
+}
+
 } // namespace
 
 void new_object::collect_extents_by_tidp(sorted_extents_by_tidp_t* ret) const {
@@ -725,30 +757,8 @@ set_start_offset_update::apply(state& state) {
         return std::monostate{};
     }
     p_state.start_offset = new_start_offset;
-    while (!p_state.extents.empty()) {
-        if (p_state.extents.begin()->last_offset >= new_start_offset) {
-            break;
-        }
-        // The front extent falls entirely below the new start offset, meaning
-        // it's can be removed.
-        auto begin_it = p_state.extents.begin();
-        auto oid = begin_it->oid;
-        auto obj_it = state.objects.find(oid);
-        if (obj_it == state.objects.end()) {
-            // Unexpected, but benign.
-            continue;
-        }
-        obj_it->second.removed_data_size += begin_it->len;
-        vlog(
-          cd_log.debug,
-          "New offset for {}: {}, removing extent {} [{}, {}]",
-          tp,
-          new_start_offset,
-          begin_it->oid,
-          begin_it->base_offset,
-          begin_it->last_offset);
-        p_state.extents.erase(begin_it);
-    }
+    remove_extents_below_start_offset_for_tp(state, tp, "New start offset");
+
     // Now remove terms. Note that the removal should always leave at least one
     // term start, enough to cover `next_offset`, even if the log is empty.
     while (p_state.term_starts.size() > 1) {

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -662,6 +662,232 @@ TEST(StateUpdateTest, TestReplaceInvalidNonContiguousDoesNotSpan) {
     ASSERT_EQ(p.extents.size(), 3);
 }
 
+TEST(StateUpdateTest, TestReplaceSingleExtentBeforeNewStartOffset) {
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100, 1100)
+                        .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
+                        .build())
+                 .add(new_obj_builder(oid2, 100, 1100)
+                        .add(tidp_a, 100_o, 199_o, 1999_t, 0, 99)
+                        .build())
+                 .add(new_obj_builder(oid3, 100, 1100)
+                        .add(tidp_a, 200_o, 299_o, 1999_t, 0, 99)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .build();
+    state s;
+    auto add_res = add.apply(s);
+    ASSERT_TRUE(add_res.has_value());
+
+    auto tp = model::topic_id_partition::from(tidp_a);
+    auto set_start_update = set_start_offset_update::build(s, tp, 150_o);
+    ASSERT_TRUE(set_start_update.has_value());
+
+    auto apply_res = set_start_update->apply(s);
+    ASSERT_TRUE(apply_res.has_value());
+
+    // Attempt to replace with a list of valid objects, with one extent
+    // containing offsets before the truncation point (the new start offset).
+    // The metastore should be able to apply the update by ignoring the first
+    // extent.
+    auto replace = replace_objects_builder()
+                     .add(new_obj_builder(oid4, 100, 1100)
+                            .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
+                            .build())
+                     .add(new_obj_builder(oid5, 100, 1100)
+                            .add(tidp_a, 100_o, 199_o, 1999_t, 0, 99)
+                            .build())
+                     .add(new_obj_builder(oid6, 100, 1100)
+                            .add(tidp_a, 200_o, 299_o, 1999_t, 0, 99)
+                            .build())
+                     .build();
+
+    auto replace_res = replace.apply(s);
+    ASSERT_TRUE(replace_res.has_value());
+}
+
+TEST(StateUpdateTest, TestReplaceWithAlignedExtentsBeforeNewStartOffset) {
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100, 1100)
+                        .add(tidp_a, 0_o, 30_o, 1999_t, 0, 99)
+                        .build())
+                 .add(new_obj_builder(oid2, 100, 1100)
+                        .add(tidp_a, 31_o, 60_o, 1999_t, 0, 99)
+                        .build())
+                 .add(new_obj_builder(oid3, 100, 1100)
+                        .add(tidp_a, 61_o, 100_o, 1999_t, 0, 99)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .build();
+    state s;
+    auto add_res = add.apply(s);
+    ASSERT_TRUE(add_res.has_value());
+
+    auto tp = model::topic_id_partition::from(tidp_a);
+    auto set_start_update = set_start_offset_update::build(s, tp, 61_o);
+    ASSERT_TRUE(set_start_update.has_value());
+
+    auto apply_res = set_start_update->apply(s);
+    ASSERT_TRUE(apply_res.has_value());
+
+    // Attempt to replace with a list of valid objects built before the
+    // truncation occurred. The metastore should be able to accept and prune the
+    // extents below the start offset.
+    auto replace = replace_objects_builder()
+                     .add(new_obj_builder(oid4, 100, 1100)
+                            .add(tidp_a, 0_o, 30_o, 1999_t, 0, 99)
+                            .build())
+                     .add(new_obj_builder(oid5, 100, 1100)
+                            .add(tidp_a, 31_o, 60_o, 1999_t, 0, 99)
+                            .build())
+                     .add(new_obj_builder(oid6, 100, 1100)
+                            .add(tidp_a, 61_o, 100_o, 1999_t, 0, 99)
+                            .build())
+                     .build();
+
+    auto replace_res = replace.apply(s);
+    ASSERT_TRUE(replace_res.has_value());
+
+    auto p_state = s.partition_state(tp);
+    ASSERT_TRUE(p_state.has_value());
+    EXPECT_EQ(p_state->get().extents.size(), 1);
+}
+
+TEST(StateUpdateTest, TestReplaceAllExtentsBeforeNewStartOffset) {
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100, 1100)
+                        .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
+                        .build())
+                 .add(new_obj_builder(oid2, 100, 1100)
+                        .add(tidp_a, 100_o, 199_o, 1999_t, 0, 99)
+                        .build())
+                 .add(new_obj_builder(oid3, 100, 1100)
+                        .add(tidp_a, 200_o, 299_o, 1999_t, 0, 99)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .build();
+    state s;
+    auto add_res = add.apply(s);
+    ASSERT_TRUE(add_res.has_value());
+
+    auto tp = model::topic_id_partition::from(tidp_a);
+    auto set_start_update = set_start_offset_update::build(s, tp, 300_o);
+    ASSERT_TRUE(set_start_update.has_value());
+
+    auto apply_res = set_start_update->apply(s);
+    ASSERT_TRUE(apply_res.has_value());
+
+    // Attempt to replace with a list of valid objects, with all extents
+    // containing offsets before the truncation point (the new start offset).
+    // The metastore should be able to recognize this is a no-op.
+    auto replace = replace_objects_builder()
+                     .add(new_obj_builder(oid4, 100, 1100)
+                            .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
+                            .build())
+                     .add(new_obj_builder(oid5, 100, 1100)
+                            .add(tidp_a, 100_o, 199_o, 1999_t, 0, 99)
+                            .build())
+                     .add(new_obj_builder(oid6, 100, 1100)
+                            .add(tidp_a, 200_o, 299_o, 1999_t, 0, 99)
+                            .build())
+                     .build();
+
+    auto replace_res = replace.apply(s);
+    ASSERT_FALSE(replace_res.has_value());
+    EXPECT_THAT(
+      std::string(replace_res.error()()),
+      testing::ContainsRegex(
+        "Partition .+ doesn't contain extents that span exactly"));
+}
+
+TEST(StateUpdateTest, TestReplaceMultipleExtentsBeforeNewStartOffset) {
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100, 1100)
+                        .add(tidp_a, 0_o, 100_o, 1999_t, 0, 99)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .build();
+    state s;
+    auto add_res = add.apply(s);
+    ASSERT_TRUE(add_res.has_value());
+
+    auto tp = model::topic_id_partition::from(tidp_a);
+    auto set_start_update = set_start_offset_update::build(s, tp, 75_o);
+    ASSERT_TRUE(set_start_update.has_value());
+
+    auto apply_res = set_start_update->apply(s);
+    ASSERT_TRUE(apply_res.has_value());
+
+    // Attempt to replace with a list of valid objects, with some extents
+    // containing offsets before the truncation point (the new start offset).
+    // If we fail to consider the fact that the extent {0,100} is still
+    // present in the existing state, removing the first two extents would
+    // result in a misaligned update and a failure to replace.
+    auto replace = replace_objects_builder()
+                     .add(new_obj_builder(oid2, 100, 1100)
+                            .add(tidp_a, 0_o, 30_o, 1999_t, 0, 99)
+                            .build())
+                     .add(new_obj_builder(oid3, 100, 1100)
+                            .add(tidp_a, 31_o, 60_o, 1999_t, 0, 99)
+                            .build())
+                     .add(new_obj_builder(oid4, 100, 1100)
+                            .add(tidp_a, 61_o, 100_o, 1999_t, 0, 99)
+                            .build())
+                     .build();
+
+    auto replace_res = replace.apply(s);
+    ASSERT_TRUE(replace_res.has_value());
+
+    auto p_state = s.partition_state(tp);
+    ASSERT_TRUE(p_state.has_value());
+    EXPECT_EQ(p_state->get().extents.size(), 1);
+}
+
+TEST(StateUpdateTest, TestReplaceMisalignedButContiguousWithNewStartOffset) {
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100, 1100)
+                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                        .build())
+                 .add(new_obj_builder(oid2, 100, 1100)
+                        .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
+                        .build())
+                 .add(new_obj_builder(oid3, 100, 1100)
+                        .add(tidp_a, 21_o, 30_o, 1999_t, 0, 99)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .build();
+
+    state s;
+    auto add_res = add.apply(s);
+    ASSERT_TRUE(add_res.has_value());
+
+    auto tp = model::topic_id_partition::from(tidp_a);
+    auto set_start_update = set_start_offset_update::build(s, tp, 15_o);
+    ASSERT_TRUE(set_start_update.has_value());
+
+    auto apply_res = set_start_update->apply(s);
+    ASSERT_TRUE(apply_res.has_value());
+
+    // Attempt to replace with a list of extents that are misaligned to the
+    // existing extents ([11,20],[21,30]), but form a valid, contiguous update
+    // when considering the new start offset.
+    auto replace = replace_objects_builder()
+                     .add(new_obj_builder(oid4, 100, 1100)
+                            .add(tidp_a, 0_o, 15_o, 1999_t, 0, 99)
+                            .build())
+                     .add(new_obj_builder(oid5, 100, 1100)
+                            .add(tidp_a, 16_o, 30_o, 1999_t, 0, 99)
+                            .build())
+                     .build();
+
+    auto replace_res = replace.apply(s);
+    ASSERT_TRUE(replace_res.has_value());
+
+    auto p_state = s.partition_state(tp);
+    ASSERT_TRUE(p_state.has_value());
+    EXPECT_EQ(p_state->get().extents.size(), 2);
+}
+
 TEST(StateUpdateTest, TestReplaceWithCompaction) {
     using testing::ElementsAre;
     using range = struct compaction_state_update::cleaned_range;


### PR DESCRIPTION
It is not hard to imagine a concurrent race between a `replace_objects()` and a `set_start_offset()` update to the `metastore` (e.g. a race between compaction of a log and a prefix truncation).
Both outcomes of the race are at the present time handled correctly:

1. If `replace_objects()` lands first, `set_start_offset()` will simply discard whatever extents are in the `metastore` below the new start offset.
2. If `set_start_offset()` lands first, the `replace_objects()` request will _likely_ be rejected (it may still be accepted if the offset update does not remove any existing `extent`s).

Case 2 is currently handled pessimistically. We do not need to reject a `replace_objects()` command just because some of the objects in the update are below the new start offset- it does not affect the validity of the objects above the new start offset.

Handle this case better by removing extents in an update that are fully below a partition's start offset before checking the validity of the update. This is performed in a new free function `remove_extents_below_start_offset()`.

If _all_ new extents for _all_ partitions in the update are removed an error is returned to the caller.



## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
