### PR TITLE
[CORE-6999] dt: deflake offset retention test

### DIFF
--- a/tests/rptest/tests/offset_retention_test.py
+++ b/tests/rptest/tests/offset_retention_test.py
@@ -271,6 +271,9 @@ class OffsetRetentionTest(RedpandaTest):
             desc = self.rpk.group_describe(group)
             return len(desc.partitions) > 0
 
+        # This is a fix to a flakiness where the first produce would timeout
+        self.rpk.produce(self.topic, "k", "v", timeout=20)
+
         # consume from the group for twice as long as the retention period
         # setting and verify that group offsets exist for the entire time.
         start = time.time()


### PR DESCRIPTION
Fixes: [CORE-6999](https://redpandadata.atlassian.net/browse/CORE-6999)

The first rpk produce command sometimes takes a bit more time.

Add an initial call with higher timeout.

Note: A different dt test was failing this time, for the same reason, so PT added it in the existing ticket.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-6999]: https://redpandadata.atlassian.net/browse/CORE-6999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ