### PR TITLE
ct: Use expected instead of result

### DIFF
--- a/src/v/cloud_topics/data_plane_impl.cc
+++ b/src/v/cloud_topics/data_plane_impl.cc
@@ -113,8 +113,12 @@ public:
       cluster_epoch min_epoch,
       chunked_vector<model::record_batch> r,
       model::timeout_clock::time_point timeout) override {
-        return _write_pipeline.local().write_and_debounce(
+        auto res = co_await _write_pipeline.local().write_and_debounce(
           std::move(ntp), min_epoch, std::move(r), timeout);
+        if (res.has_value()) {
+            co_return std::move(res.value());
+        }
+        co_return res.error();
     }
 
     ss::future<result<chunked_vector<model::record_batch>>> materialize(

--- a/src/v/cloud_topics/level_zero/batcher/batcher.cc
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.cc
@@ -240,7 +240,7 @@ ss::future<> batcher<Clock>::bg_controller_loop() {
     while (!_as.abort_requested()) {
         if (!more_work) {
             auto wait_res = co_await _stage.wait_next(&_as);
-            if (wait_res.has_error()) {
+            if (!wait_res.has_value()) {
                 // Shutting down
                 vlog(
                   _logger.info,

--- a/src/v/cloud_topics/level_zero/batcher/tests/aggregator_test.cc
+++ b/src/v/cloud_topics/level_zero/batcher/tests/aggregator_test.cc
@@ -83,7 +83,7 @@ TEST(AggregatorTest, SingleRequestDtorWithStagedRequest) {
     }
     ASSERT_TRUE(fut.available());
     auto err = fut.get();
-    ASSERT_TRUE(err.has_error());
+    ASSERT_TRUE(!err.has_value());
     ASSERT_TRUE(err.error() == cloud_topics::errc::timeout);
 }
 
@@ -103,7 +103,7 @@ TEST(AggregatorTest, SingleRequestDtorWithPreparedRequest) {
     }
     ASSERT_TRUE(fut.available());
     auto err = fut.get();
-    ASSERT_TRUE(err.has_error());
+    ASSERT_TRUE(!err.has_value());
     ASSERT_TRUE(err.error() == cloud_topics::errc::timeout);
 }
 
@@ -134,7 +134,7 @@ TEST(AggregatorTest, SingleRequestDtorWithLostRequestStaged) {
     }
     ASSERT_TRUE(fut.available());
     auto err = fut.get();
-    ASSERT_TRUE(err.has_error());
+    ASSERT_TRUE(!err.has_value());
     ASSERT_TRUE(err.error() == cloud_topics::errc::timeout);
 }
 
@@ -164,7 +164,7 @@ TEST(AggregatorTest, SingleRequestDtorWithLostRequestPrepared) {
     }
     ASSERT_TRUE(fut.available());
     auto err = fut.get();
-    ASSERT_TRUE(err.has_error());
+    ASSERT_TRUE(!err.has_value());
     ASSERT_TRUE(err.error() == cloud_topics::errc::timeout);
 }
 

--- a/src/v/cloud_topics/level_zero/batcher/tests/batcher_test.cc
+++ b/src/v/cloud_topics/level_zero/batcher/tests/batcher_test.cc
@@ -227,7 +227,9 @@ TEST_CORO(batcher_test, many_write_requests) {
 
     const auto timeout = 1s;
     auto deadline = ss::manual_clock::now() + timeout;
-    std::vector<ss::future<result<chunked_vector<cloud_topics::extent_meta>>>>
+    std::vector<ss::future<std::expected<
+      chunked_vector<cloud_topics::extent_meta>,
+      std::error_code>>>
       futures;
     futures.push_back(pipeline.write_and_debounce(
       model::controller_ntp, min_epoch, std::move(reader1), deadline));
@@ -338,7 +340,7 @@ TEST_CORO(batcher_test, expired_write_request) {
     auto [pass_result, fail_result] = co_await ss::when_all_succeed(
       std::move(expect_pass_fut), std::move(expect_fail_fut));
 
-    ASSERT_TRUE_CORO(fail_result.has_error());
+    ASSERT_TRUE_CORO(!fail_result.has_value());
 
     ASSERT_TRUE_CORO(pass_result.has_value());
     auto placeholder_batches = std::move(pass_result.value());

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -343,7 +343,7 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
         // Ask data layer to bring data from the cloud storage.
         auto mat_res = co_await _ct_api->materialize(
           _ctp->ntp(), materialize_bytes, std::move(to_materialize), deadline);
-        if (mat_res.has_error()) {
+        if (!mat_res.has_value()) {
             if (mat_res.error() == errc::shutting_down) {
                 vlog(_log.debug, "Materialize aborted due to shutdown");
                 _current = state::end_of_stream_state;

--- a/src/v/cloud_topics/level_zero/pipeline/read_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/read_pipeline.cc
@@ -61,7 +61,8 @@ read_pipeline<Clock>::read_pipeline()
       config::shard_local_cfg().disable_public_metrics()) {}
 
 template<class Clock>
-ss::future<result<dataplane_query_result>> read_pipeline<Clock>::make_reader(
+ss::future<std::expected<dataplane_query_result, std::error_code>>
+read_pipeline<Clock>::make_reader(
   model::ntp ntp, dataplane_query query, timestamp_t timeout) {
     auto h = this->hold_gate();
     auto& as = this->get_root_rtc().root_abort_source();
@@ -91,7 +92,7 @@ ss::future<result<dataplane_query_result>> read_pipeline<Clock>::make_reader(
     case circuit_breaker_state::closed:
         err_fallback.cancel();
         _probe.register_request_timeout();
-        co_return errc::timeout;
+        co_return std::unexpected(errc::timeout);
     }
 
     // TODO: add timeout
@@ -128,16 +129,16 @@ ss::future<result<dataplane_query_result>> read_pipeline<Clock>::make_reader(
 
     if (this->stopped()) {
         err_fallback.cancel();
-        co_return errc::shutting_down;
+        co_return std::unexpected(errc::shutting_down);
     }
     auto res = co_await std::move(fut);
 
-    if (res.has_error()) {
+    if (!res.has_value()) {
         if (res.error() == errc::timeout) {
             err_fallback.cancel();
             _probe.register_request_timeout();
         }
-        co_return res.error();
+        co_return std::unexpected(make_error_code(res.error()));
     }
     err_fallback.cancel();
     _probe.register_request_completed();

--- a/src/v/cloud_topics/level_zero/pipeline/read_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/read_pipeline.h
@@ -27,6 +27,8 @@
 #include <seastar/core/loop.hh>
 #include <seastar/core/lowres_clock.hh>
 
+#include <expected>
+
 namespace cloud_topics::l0 {
 
 struct read_pipeline_accessor;
@@ -45,7 +47,7 @@ public:
     /// that should be materialized.
     /// The result of the query is a reader that contains the
     /// actual raft_data batches.
-    ss::future<result<dataplane_query_result>>
+    ss::future<std::expected<dataplane_query_result, std::error_code>>
     make_reader(model::ntp ntp, dataplane_query query, timestamp_t timeout);
 
     using read_requests_list
@@ -69,7 +71,7 @@ public:
         /// Wait until fetch requests are available in the pipeline
         /// stage and return them (the requests are pulled out of
         /// the pipeline).
-        ss::future<checked<read_requests_list, errc>>
+        ss::future<std::expected<read_requests_list, errc>>
         pull_fetch_requests(size_t max_bytes) {
             l0::event_filter<Clock> filter(
               l0::event_type::new_read_request, _ps);
@@ -77,9 +79,9 @@ public:
               filter, _parent->get_abort_source());
             switch (event.type) {
             case l0::event_type::shutting_down:
-                co_return errc::shutting_down;
+                co_return std::unexpected(errc::shutting_down);
             case l0::event_type::err_timedout:
-                co_return errc::timeout;
+                co_return std::unexpected(errc::timeout);
             case l0::event_type::new_write_request:
             case l0::event_type::none:
                 vunreachable("Unexpected event type in the read_pipeline");

--- a/src/v/cloud_topics/level_zero/pipeline/read_request.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/read_request.cc
@@ -47,7 +47,7 @@ template<class Clock>
 void read_request<Clock>::set_value(errc e) noexcept {
     try {
         vlog(rtc_logger.debug, "Setting request error to: {}", e);
-        response.set_value(e);
+        response.set_value(std::unexpected(e));
     } catch (const ss::broken_promise&) {
         vlog(
           cd_log.error,

--- a/src/v/cloud_topics/level_zero/pipeline/read_request.h
+++ b/src/v/cloud_topics/level_zero/pipeline/read_request.h
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include "base/outcome.h"
 #include "base/seastarx.h"
 #include "cloud_topics/errc.h"
 #include "cloud_topics/level_zero/common/extent_meta.h"
@@ -23,6 +22,8 @@
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/weak_ptr.hh>
+
+#include <expected>
 
 namespace cloud_topics::l0 {
 
@@ -64,7 +65,7 @@ struct read_request : ss::weakly_referencable<read_request<Clock>> {
     /// Per-request logger
     basic_retry_chain_logger<Clock> rtc_logger;
 
-    using response_t = checked<dataplane_query_result, errc>;
+    using response_t = std::expected<dataplane_query_result, errc>;
 
     /// The promise is used to signal to the caller
     /// after the data is fetched

--- a/src/v/cloud_topics/level_zero/pipeline/tests/pipeline_bench.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/tests/pipeline_bench.cc
@@ -41,7 +41,7 @@ struct read_pipeline_sink {
         auto h = _gate.hold();
         while (!_pipeline->stopped()) {
             auto res = co_await _my_stage.pull_fetch_requests(0x100000);
-            if (res.has_error()) {
+            if (!res.has_value()) {
                 throw std::system_error(res.error());
             }
             for (auto& req : res.value().requests) {

--- a/src/v/cloud_topics/level_zero/pipeline/tests/write_pipeline_test.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/tests/write_pipeline_test.cc
@@ -122,7 +122,7 @@ TEST_CORO(batcher_test, expired_write_request) {
     auto [pass_result, fail_result] = co_await ss::when_all_succeed(
       std::move(expect_pass_fut), std::move(expect_fail_fut));
 
-    ASSERT_TRUE_CORO(fail_result.has_error());
+    ASSERT_TRUE_CORO(!fail_result.has_value());
 
     ASSERT_TRUE_CORO(pass_result.has_value());
 }

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -64,7 +64,7 @@ template<class Clock>
 write_pipeline<Clock>::~write_pipeline() = default;
 
 template<class Clock>
-ss::future<result<chunked_vector<extent_meta>>>
+ss::future<std::expected<chunked_vector<extent_meta>, std::error_code>>
 write_pipeline<Clock>::write_and_debounce(
   model::ntp ntp,
   cluster_epoch min_epoch,
@@ -115,12 +115,12 @@ write_pipeline<Clock>::write_and_debounce(
     this->signal(stage);
 
     auto res = co_await std::move(fut);
-    if (res.has_error()) {
+    if (!res.has_value()) {
         if (res.error() == errc::timeout) {
             err_probe.cancel();
             _probe.register_request_timeout();
         }
-        co_return res.error();
+        co_return std::unexpected(make_error_code(res.error()));
     }
     err_probe.cancel();
     _probe.register_request_completed();
@@ -244,7 +244,7 @@ write_pipeline<Clock>::stage::pull_write_requests(
 }
 
 template<class Clock>
-ss::future<checked<event, errc>> write_pipeline<Clock>::stage::wait_until(
+ss::future<std::expected<event, errc>> write_pipeline<Clock>::stage::wait_until(
   size_t max_bytes,
   typename Clock::time_point deadline,
   ss::abort_source* maybe_as) noexcept {
@@ -259,14 +259,14 @@ ss::future<checked<event, errc>> write_pipeline<Clock>::stage::wait_until(
     if (event_fut.failed()) {
         auto err = event_fut.get_exception();
         if (ssx::is_shutdown_exception(err)) {
-            co_return errc::shutting_down;
+            co_return std::unexpected(errc::shutting_down);
         }
-        co_return errc::unexpected_failure;
+        co_return std::unexpected(errc::unexpected_failure);
     }
     auto event = event_fut.get();
     switch (event.type) {
     case l0::event_type::shutting_down:
-        co_return errc::shutting_down;
+        co_return std::unexpected(errc::shutting_down);
     case l0::event_type::new_write_request:
     case l0::event_type::err_timedout:
         break;
@@ -278,14 +278,14 @@ ss::future<checked<event, errc>> write_pipeline<Clock>::stage::wait_until(
 }
 
 template<class Clock>
-ss::future<checked<event, errc>>
+ss::future<std::expected<event, errc>>
 write_pipeline<Clock>::stage::wait_next(ss::abort_source* maybe_as) noexcept {
     l0::event_filter<Clock> filter(l0::event_type::new_write_request, _ps);
     auto [sub, as] = choose_abort_source(maybe_as);
     auto event = co_await _parent->subscribe(filter, *as);
     switch (event.type) {
     case l0::event_type::shutting_down:
-        co_return errc::shutting_down;
+        co_return std::unexpected(errc::shutting_down);
     case l0::event_type::err_timedout:
     case l0::event_type::new_read_request:
     case l0::event_type::none:

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
@@ -25,6 +25,7 @@
 #include <seastar/util/optimized_optional.hh>
 
 #include <exception>
+#include <expected>
 #include <functional>
 #include <type_traits>
 
@@ -53,7 +54,8 @@ public:
 
     /// Add write request to the pipeline
     /// The revision id is the topic creation revision id for the ntp.
-    ss::future<result<chunked_vector<extent_meta>>> write_and_debounce(
+    ss::future<std::expected<chunked_vector<extent_meta>, std::error_code>>
+    write_and_debounce(
       model::ntp ntp,
       cluster_epoch min_epoch,
       chunked_vector<model::record_batch> batches,
@@ -92,13 +94,13 @@ public:
 
         /// Wait until either the 'deadline' is reached or the pipeline
         /// accumulated 'max_bytes' bytes
-        ss::future<checked<event, errc>> wait_until(
+        ss::future<std::expected<event, errc>> wait_until(
           size_t max_bytes,
           Clock::time_point deadline,
           ss::abort_source* as = nullptr) noexcept;
 
         /// Wait until the next write_request is added to the pipeline
-        ss::future<checked<event, errc>>
+        ss::future<std::expected<event, errc>>
         wait_next(ss::abort_source* as = nullptr) noexcept;
 
         /// Apply lambda function to every write request at certain stage.
@@ -109,7 +111,7 @@ public:
         /// When this happens the write request is unlinked from the list.
         template<class Fn>
         requires std::is_nothrow_invocable_r_v<
-          checked<request_processing_result, errc>,
+          std::expected<request_processing_result, errc>,
           Fn,
           write_request<Clock>&>
         void process(Fn&& fn) {
@@ -117,8 +119,8 @@ public:
             uint32_t count = 0;
             for (auto& req : _parent->get_pending()) {
                 if (req.stage == _ps) {
-                    checked<request_processing_result, errc> r = fn(req);
-                    if (r.has_error()) {
+                    std::expected<request_processing_result, errc> r = fn(req);
+                    if (!r.has_value()) {
                         // Drop write request using the error code from the
                         // result
                         req.set_value(r.error());

--- a/src/v/cloud_topics/level_zero/pipeline/write_request.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_request.cc
@@ -33,7 +33,7 @@ write_request<Clock>::write_request(
 template<class Clock>
 void write_request<Clock>::set_value(errc e) noexcept {
     try {
-        response.set_value(e);
+        response.set_value(std::unexpected(e));
     } catch (const ss::broken_promise&) {
         vlog(
           cd_log.error,

--- a/src/v/cloud_topics/level_zero/pipeline/write_request.h
+++ b/src/v/cloud_topics/level_zero/pipeline/write_request.h
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include "base/outcome.h"
 #include "base/seastarx.h"
 #include "cloud_topics/errc.h"
 #include "cloud_topics/level_zero/common/extent_meta.h"
@@ -23,6 +22,8 @@
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/weak_ptr.hh>
+
+#include <expected>
 
 namespace cloud_topics::l0 {
 
@@ -47,7 +48,7 @@ struct write_request : ss::weakly_referencable<write_request<Clock>> {
     /// List of all write requests
     intrusive_list_hook _hook;
 
-    using response_t = checked<chunked_vector<extent_meta>, errc>;
+    using response_t = std::expected<chunked_vector<extent_meta>, errc>;
     /// The promise is used to signal to the caller
     /// after the upload is completed
     ss::promise<response_t> response;

--- a/src/v/cloud_topics/level_zero/read_fanout/read_fanout.cc
+++ b/src/v/cloud_topics/level_zero/read_fanout/read_fanout.cc
@@ -47,7 +47,7 @@ ss::future<> read_fanout::bg_process() {
             continue;
         }
         auto fut_res = std::move(fut).get();
-        if (fut_res.has_error()) {
+        if (!fut_res.has_value()) {
             auto err = fut_res.error();
             if (err == errc::shutting_down) {
                 vlog(
@@ -88,7 +88,8 @@ ss::future<> read_fanout::process_single_request(l0::read_request<>* req) {
         }
 
         const chunked_vector<extent_meta>& metadata = req->query.meta;
-        using ret_future_t = ss::future<checked<dataplane_query_result, errc>>;
+        using ret_future_t
+          = ss::future<std::expected<dataplane_query_result, errc>>;
         chunked_vector<ret_future_t> futures;
         std::optional<dataplane_query> curr_query;
         curr_query.emplace();
@@ -164,7 +165,7 @@ ss::future<> read_fanout::process_single_request(l0::read_request<>* req) {
         chunked_vector<model::record_batch> results;
         for (auto& fut : fut_res) {
             auto res = fut.get();
-            if (res.has_error()) {
+            if (!res.has_value()) {
                 vlog(
                   req->rtc_logger.warn,
                   "Materialize operation returned error: {}",

--- a/src/v/cloud_topics/level_zero/read_fanout/tests/read_fanout_bench.cc
+++ b/src/v/cloud_topics/level_zero/read_fanout/tests/read_fanout_bench.cc
@@ -68,7 +68,7 @@ struct fetch_handler {
             auto result = co_await stage.pull_fetch_requests(
               std::numeric_limits<size_t>::max());
 
-            if (result.has_error()) {
+            if (!result.has_value()) {
                 // Expected during shutdown
                 co_return;
             }

--- a/src/v/cloud_topics/level_zero/read_fanout/tests/read_fanout_test.cc
+++ b/src/v/cloud_topics/level_zero/read_fanout/tests/read_fanout_test.cc
@@ -66,7 +66,7 @@ struct fake_fetch_handler {
             auto result = co_await stage.pull_fetch_requests(
               std::numeric_limits<size_t>::max());
 
-            if (result.has_error()) {
+            if (!result.has_value()) {
                 // Expected during shutdown
                 co_return;
             }
@@ -162,7 +162,7 @@ TEST_F_CORO(read_fanout_fixture, test_bypass) {
       extent_meta{.byte_range_size = byte_range_size_t{1_MiB}});
     auto result = co_await pipeline.local().make_reader(
       test_ntp0, std::move(query), ss::lowres_clock::now() + 10s);
-    ASSERT_FALSE_CORO(result.has_error());
+    ASSERT_TRUE_CORO(result.has_value());
     ASSERT_EQ_CORO(result.value().results.size(), 1);
     ASSERT_EQ_CORO(
       result.value().results.front().header().base_offset, model::offset{0});
@@ -208,7 +208,7 @@ TEST_F_CORO(read_fanout_fixture, test_scatter_gather) {
     auto result = co_await pipeline.local().make_reader(
       test_ntp0, std::move(query), ss::lowres_clock::now() + 10s);
 
-    ASSERT_FALSE_CORO(result.has_error());
+    ASSERT_TRUE_CORO(result.has_value());
     ASSERT_EQ_CORO(result.value().results.size(), 4);
     ASSERT_EQ_CORO(
       result.value().results.front().header().base_offset, model::offset{0});
@@ -252,7 +252,7 @@ TEST_F_CORO(read_fanout_fixture, test_failure) {
     auto result = co_await pipeline.local().make_reader(
       test_ntp0, std::move(query), ss::lowres_clock::now() + 10s);
 
-    ASSERT_TRUE_CORO(result.has_error());
+    ASSERT_TRUE_CORO(!result.has_value());
 
     auto [in, out, fail] = this->fanout.local().get_stats();
     ASSERT_NE_CORO(in, out);

--- a/src/v/cloud_topics/level_zero/reader/fetch_request_handler.cc
+++ b/src/v/cloud_topics/level_zero/reader/fetch_request_handler.cc
@@ -74,7 +74,7 @@ ss::future<> fetch_handler::bg_process_requests() {
             }
         } else {
             auto res = fut.get();
-            if (res.has_error()) {
+            if (!res.has_value()) {
                 if (res.error() == errc::shutting_down) {
                     vlog(_logger.debug, "Shutting down");
                     co_return;
@@ -129,7 +129,7 @@ ss::future<> fetch_handler::process_single_request(l0::read_request<>* req) {
         // The registration happens even for failed requests because
         // failed requests are consuming resources (API calls).
         _pipeline_stage.register_micro_probe(probe);
-        if (res.has_error()) {
+        if (!res.has_value()) {
             vlog(
               req->rtc_logger.warn,
               "Failed to materialize placeholders, error: {} ({})",
@@ -177,7 +177,7 @@ ss::future<checked<bool, errc>> fetch_handler::process_requests() {
     // instances.
     // TODO: use proper limit
     auto to_process = co_await _pipeline_stage.pull_fetch_requests(100_MiB);
-    if (to_process.has_error()) {
+    if (!to_process.has_value()) {
         co_return to_process.error();
     }
     vlog(

--- a/src/v/cloud_topics/level_zero/reader/materialized_extent.cc
+++ b/src/v/cloud_topics/level_zero/reader/materialized_extent.cc
@@ -81,7 +81,7 @@ result<T> result_from_ready_future(ss::future<T>&& ready, FormatFunc fmt) {
 /// The type of the error code should be known
 template<class T, class E>
 result<T> result_convert(result<T>&& res) {
-    if (res.has_error()) {
+    if (!res.has_value()) {
         errc_converter<E, errc> conv;
         return conv(res.error());
     }
@@ -187,14 +187,14 @@ ss::future<result<bool>> materialize(
     if (status.value() == cloud_io::cache_element_status::available) {
         auto res = co_await materialize_from_cache(
           cache_file_name, cache, probe);
-        if (res.has_error()) {
+        if (!res.has_value()) {
             co_return res.error();
         }
         ext->object = std::move(res.value());
     } else {
         auto res = co_await materialize_from_cloud_storage(
           cache_file_name, bucket, api, cache, rtc, probe);
-        if (res.has_error()) {
+        if (!res.has_value()) {
             co_return res.error();
         }
         ext->object = std::move(res.value());
@@ -214,7 +214,7 @@ ss::future<result<iobuf>> materialize_from_cache(
       cache->get_stream(cache_file_name, buffer_size, read_ahead));
     auto sz_stream_result = result_from_ready_future<errc::cache_read_error>(
       std::move(fut));
-    if (sz_stream_result.has_error()) {
+    if (!sz_stream_result.has_value()) {
         co_return sz_stream_result.error();
     }
     auto sz_stream = std::move(sz_stream_result.value());
@@ -259,7 +259,7 @@ ss::future<result<iobuf>> materialize_from_cloud_storage(
           vlog(cd_log.error, "Unexpected error during L0 download: {}", e);
       });
 
-    if (dl_result.has_error()) {
+    if (!dl_result.has_value()) {
         co_return dl_result.error();
     }
 
@@ -287,7 +287,7 @@ ss::future<result<iobuf>> materialize_from_cloud_storage(
     // by increasing the load. And we do have data from the cloud
     // storage at this point anyway.
 
-    if (!sr_guard.has_error()) {
+    if (!!sr_guard.has_value()) {
         // TODO: use proper priority class
         probe->num_cache_writes++;
         auto put_future = co_await ss::coroutine::as_future(

--- a/src/v/cloud_topics/level_zero/reader/materialized_extent.cc
+++ b/src/v/cloud_topics/level_zero/reader/materialized_extent.cc
@@ -287,7 +287,7 @@ ss::future<result<iobuf>> materialize_from_cloud_storage(
     // by increasing the load. And we do have data from the cloud
     // storage at this point anyway.
 
-    if (!!sr_guard.has_value()) {
+    if (sr_guard.has_value()) {
         // TODO: use proper priority class
         probe->num_cache_writes++;
         auto put_future = co_await ss::coroutine::as_future(

--- a/src/v/cloud_topics/level_zero/reader/materialized_extent_reader.cc
+++ b/src/v/cloud_topics/level_zero/reader/materialized_extent_reader.cc
@@ -53,7 +53,7 @@ ss::future<result<chunked_vector<materialized_extent>>> materialize_sorted_run(
         } else {
             auto res = co_await materialize(
               &back, bucket, api, cache, rtc, probe);
-            if (res.has_error()) {
+            if (!res.has_value()) {
                 co_return res.error();
             }
             hydrated.insert(
@@ -76,7 +76,7 @@ ss::future<materialize_result> materialize_placeholders(
     micro_probe probe;
     auto extents = co_await materialize_sorted_run(
       std::move(query), bucket, &api, &cache, &rtc, &probe);
-    if (extents.has_error()) {
+    if (!extents.has_value()) {
         vlog(
           logger.warn,
           "Failed to materialize sorted run: {}",

--- a/src/v/cloud_topics/level_zero/reader/tests/materialized_extent_reader_test.cc
+++ b/src/v/cloud_topics/level_zero/reader/tests/materialized_extent_reader_test.cc
@@ -137,6 +137,6 @@ TEST_F_CORO(materialized_extent_fixture, timeout_test) {
       rtc,
       logger);
 
-    ASSERT_TRUE_CORO(actual.has_error());
+    ASSERT_TRUE_CORO(!actual.has_value());
     ASSERT_TRUE_CORO(actual.error() == cloud_topics::errc::timeout);
 }

--- a/src/v/cloud_topics/level_zero/reader/tests/materialized_extent_test.cc
+++ b/src/v/cloud_topics/level_zero/reader/tests/materialized_extent_test.cc
@@ -40,7 +40,7 @@ TEST_F_CORO(materialized_extent_fixture, materialize_from_cache) {
       &rtc,
       &probe);
 
-    ASSERT_FALSE_CORO(res.has_error());
+    ASSERT_TRUE_CORO(res.has_value());
 
     chunked_vector<model::record_batch> actual;
     actual.emplace_back(make_raft_data_batch(std::move(extent)));
@@ -72,7 +72,7 @@ TEST_F_CORO(materialized_extent_fixture, cache_get_fails) {
       &rtc,
       &probe);
 
-    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_TRUE_CORO(!res.has_value());
     ASSERT_EQ_CORO(res.error(), cloud_topics::errc::cache_read_error);
     ASSERT_EQ_CORO(probe.num_cache_reads, 1);
 }
@@ -99,7 +99,7 @@ TEST_F_CORO(materialized_extent_fixture, cache_get_throws) {
       &rtc,
       &probe);
 
-    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_TRUE_CORO(!res.has_value());
     ASSERT_EQ_CORO(res.error(), cloud_topics::errc::cache_read_error);
     ASSERT_EQ_CORO(probe.num_cache_reads, 1);
 }
@@ -127,7 +127,7 @@ TEST_F_CORO(materialized_extent_fixture, cache_get_shutdown) {
       &rtc,
       &probe);
 
-    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_TRUE_CORO(!res.has_value());
     ASSERT_EQ_CORO(res.error(), cloud_topics::errc::shutting_down);
     ASSERT_EQ_CORO(probe.num_cache_reads, 1);
 }
@@ -155,7 +155,7 @@ TEST_F_CORO(materialized_extent_fixture, is_cached_throws) {
       &rtc,
       &probe);
 
-    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_TRUE_CORO(!res.has_value());
     ASSERT_EQ_CORO(res.error(), cloud_topics::errc::cache_read_error);
     ASSERT_EQ_CORO(probe.num_cache_reads, 0);
 }
@@ -183,7 +183,7 @@ TEST_F_CORO(materialized_extent_fixture, is_cached_throws_shutdown) {
       &rtc,
       &probe);
 
-    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_TRUE_CORO(!res.has_value());
     ASSERT_EQ_CORO(res.error(), cloud_topics::errc::shutting_down);
     ASSERT_EQ_CORO(probe.num_cache_reads, 0);
 }
@@ -210,7 +210,7 @@ TEST_F_CORO(materialized_extent_fixture, is_cached_stall_then_success) {
       &rtc,
       &probe);
 
-    ASSERT_FALSE_CORO(res.has_error());
+    ASSERT_TRUE_CORO(res.has_value());
 
     chunked_vector<model::record_batch> actual;
     actual.emplace_back(
@@ -245,7 +245,7 @@ TEST_F_CORO(materialized_extent_fixture, is_cached_stall_then_timeout) {
       &rtc,
       &probe);
 
-    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_TRUE_CORO(!res.has_value());
     ASSERT_EQ_CORO(res.error(), cloud_topics::errc::timeout);
     ASSERT_EQ_CORO(probe.num_cache_reads, 0);
 }
@@ -268,7 +268,7 @@ TEST_F_CORO(materialized_extent_fixture, materialize_from_cloud) {
       &rtc,
       &probe);
 
-    ASSERT_FALSE_CORO(res.has_error());
+    ASSERT_TRUE_CORO(res.has_value());
 
     chunked_vector<model::record_batch> actual;
     actual.emplace_back(
@@ -306,7 +306,7 @@ TEST_F_CORO(materialized_extent_fixture, cloud_get_return_failure) {
       &rtc,
       &probe);
 
-    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_TRUE_CORO(!res.has_value());
     ASSERT_EQ_CORO(res.error(), cloud_topics::errc::download_failure);
 }
 
@@ -332,7 +332,7 @@ TEST_F_CORO(materialized_extent_fixture, cloud_get_throw_shutdown) {
       &rtc,
       &probe);
 
-    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_TRUE_CORO(!res.has_value());
     ASSERT_EQ_CORO(res.error(), cloud_topics::errc::shutting_down);
     ASSERT_EQ_CORO(probe.num_cache_reads, 0);
 }
@@ -359,7 +359,7 @@ TEST_F_CORO(materialized_extent_fixture, cloud_get_return_notfound) {
       &rtc,
       &probe);
 
-    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_TRUE_CORO(!res.has_value());
     ASSERT_EQ_CORO(res.error(), cloud_topics::errc::download_not_found);
     ASSERT_EQ_CORO(probe.num_cache_reads, 0);
 }
@@ -386,7 +386,7 @@ TEST_F_CORO(materialized_extent_fixture, cloud_get_return_timeout) {
       &rtc,
       &probe);
 
-    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_TRUE_CORO(!res.has_value());
     ASSERT_EQ_CORO(res.error(), cloud_topics::errc::timeout);
     ASSERT_EQ_CORO(probe.num_cache_reads, 0);
 }
@@ -413,7 +413,7 @@ TEST_F_CORO(materialized_extent_fixture, cloud_get_throw_error) {
       &rtc,
       &probe);
 
-    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_TRUE_CORO(!res.has_value());
     ASSERT_EQ_CORO(res.error(), cloud_topics::errc::unexpected_failure);
     ASSERT_EQ_CORO(probe.num_cache_reads, 0);
 }
@@ -442,7 +442,7 @@ TEST_F_CORO(materialized_extent_fixture, cache_reserve_space_throws) {
       &rtc,
       &probe);
 
-    ASSERT_FALSE_CORO(res.has_error());
+    ASSERT_TRUE_CORO(res.has_value());
 
     chunked_vector<model::record_batch> actual;
     actual.emplace_back(
@@ -477,7 +477,7 @@ TEST_F_CORO(materialized_extent_fixture, cache_reserve_space_throws_shutdown) {
       &rtc,
       &probe);
 
-    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_TRUE_CORO(!res.has_value());
     ASSERT_EQ_CORO(res.error(), cloud_topics::errc::shutting_down);
     ASSERT_EQ_CORO(probe.num_cache_reads, 0);
 }
@@ -505,7 +505,7 @@ TEST_F_CORO(materialized_extent_fixture, cache_put_throws) {
       &rtc,
       &probe);
 
-    ASSERT_FALSE_CORO(res.has_error());
+    ASSERT_TRUE_CORO(res.has_value());
 
     chunked_vector<model::record_batch> actual;
     actual.emplace_back(
@@ -539,6 +539,6 @@ TEST_F_CORO(materialized_extent_fixture, cache_put_throws_shutdown) {
       &rtc,
       &probe);
 
-    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_TRUE_CORO(!res.has_value());
     ASSERT_EQ_CORO(res.error(), cloud_topics::errc::shutting_down);
 }

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
@@ -59,7 +59,7 @@ ctp_stm_api::replicated_apply(
     opts.set_force_flush();
     auto res = co_await _stm->_raft->replicate(std::move(batch), opts);
 
-    if (res.has_error()) {
+    if (!res.has_value()) {
         vlog(_log.debug, "Failed to replicate batch: {}", res.error());
         if (res.error() == raft::errc::not_leader) {
             co_return std::unexpected(ctp_stm_api_errc::not_leader);

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_bench.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_bench.cc
@@ -67,7 +67,7 @@ struct pipeline_sink {
         auto h = _gate.hold();
         while (!_as.abort_requested()) {
             auto res = co_await stage.wait_next(&_as);
-            if (res.has_error()) {
+            if (!res.has_value()) {
                 co_return;
             }
             auto event = res.value();

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_test.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_test.cc
@@ -63,7 +63,7 @@ struct pipeline_sink {
               stage.id());
             auto res = co_await stage.wait_next(&_as);
             vlog(test_log.debug, "pipeline_sink event");
-            if (res.has_error()) {
+            if (!res.has_value()) {
                 vlog(
                   test_log.error, "Event subscription failed: {}", res.error());
                 continue;
@@ -189,7 +189,9 @@ static ss::future<size_t> write_until_threshold(
   write_request_balancer_fixture& fix, size_t size_threshold) {
     size_t num_requests_sent = 0;
     size_t total_size = 0;
-    std::vector<ss::future<result<chunked_vector<extent_meta>>>> wd;
+    std::vector<
+      ss::future<std::expected<chunked_vector<extent_meta>, std::error_code>>>
+      wd;
     while (total_size < size_threshold) {
         auto buf = co_await model::test::make_random_batches();
         chunked_vector<model::record_batch> batches;
@@ -443,10 +445,10 @@ TEST_F_CORO(
         auto num_requests = request_sink.local().write_requests_acked;
         ASSERT_EQ_CORO(num_requests, 3);
 
-        ASSERT_FALSE_CORO(ph00.has_error());
-        ASSERT_TRUE_CORO(ph11.has_error());
+        ASSERT_TRUE_CORO(ph00.has_value());
+        ASSERT_TRUE_CORO(!ph11.has_value());
         ASSERT_TRUE_CORO(ph11.error() == cloud_topics::errc::upload_failure);
-        ASSERT_FALSE_CORO(ph10.has_error());
+        ASSERT_TRUE_CORO(ph10.has_value());
     }
     // This test case is about the same as the previous one with the only
     // difference that the failure is injected on shard 0 (the uploading shard).
@@ -466,10 +468,10 @@ TEST_F_CORO(
         auto num_requests = request_sink.local().write_requests_acked;
         ASSERT_EQ_CORO(num_requests, 6);
 
-        ASSERT_FALSE_CORO(ph00.has_error());
-        ASSERT_TRUE_CORO(ph01.has_error());
+        ASSERT_TRUE_CORO(ph00.has_value());
+        ASSERT_TRUE_CORO(!ph01.has_value());
         ASSERT_TRUE_CORO(ph01.error() == cloud_topics::errc::upload_failure);
-        ASSERT_FALSE_CORO(ph10.has_error());
+        ASSERT_TRUE_CORO(ph10.has_value());
     }
     // The data is uploaded on shard 1 and the failure is injected on shard 0.
     {
@@ -491,10 +493,10 @@ TEST_F_CORO(
           ss::shard_id(1), [](auto& s) { return s.write_requests_acked; });
         ASSERT_EQ_CORO(num_requests1, 3);
 
-        ASSERT_FALSE_CORO(ph00.has_error());
-        ASSERT_TRUE_CORO(ph01.has_error());
+        ASSERT_TRUE_CORO(ph00.has_value());
+        ASSERT_TRUE_CORO(!ph01.has_value());
         ASSERT_TRUE_CORO(ph01.error() == cloud_topics::errc::upload_failure);
-        ASSERT_FALSE_CORO(ph10.has_error());
+        ASSERT_TRUE_CORO(ph10.has_value());
     }
 
     co_await stop();

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
@@ -81,7 +81,7 @@ size_t write_request_scheduler::shard_bytes() noexcept {
     _stage.process(
       [&total_bytes, &total_requests, this](
         const l0::write_request<>& req) noexcept
-        -> checked<l0::request_processing_result, errc> {
+        -> std::expected<l0::request_processing_result, errc> {
           total_bytes += req.size_bytes();
           total_requests++;
           return total_requests < _max_cardinality()
@@ -98,7 +98,7 @@ ss::future<> write_request_scheduler::bg_data_threshold() {
     while (!_as.abort_requested()) {
         auto req = co_await _stage.wait_until(
           _max_buffer_size(), ss::lowres_clock::time_point::max(), &_as);
-        if (req.has_error()) {
+        if (!req.has_value()) {
             if (req.error() == errc::shutting_down) {
                 vlog(cd_log.debug, "bg_data_threshold: shutting down");
                 co_return;
@@ -120,7 +120,7 @@ ss::future<> write_request_scheduler::bg_data_threshold() {
         // Propagate to the next stage
         _stage.process(
           [this](const l0::write_request<>& r) noexcept
-            -> checked<l0::request_processing_result, errc> {
+            -> std::expected<l0::request_processing_result, errc> {
               _probe.register_data_threshold(r.size_bytes());
               return l0::request_processing_result::advance_and_continue;
           });
@@ -350,7 +350,7 @@ write_request_scheduler::proxy_write_request(
         co_return std::unexpected(errc::upload_failure);
     }
     auto extents = extents_fut.get();
-    if (extents.has_error()) {
+    if (!extents.has_value()) {
         // Normal errors (S3 upload failure or timeout)
         // are handled here
         errc e = extents.error();


### PR DESCRIPTION
This PR replaces all uses of result in L0 with expected. Mostly mechanical change.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none