### PR TITLE
[CORE-14917] `ct/l1`: add `compaction_epoch` to `partition_state`

### DIFF
--- a/src/v/cloud_topics/level_one/domain/domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.cc
@@ -372,7 +372,9 @@ domain_manager::get_compaction_info(rpc::get_compaction_info_request req) {
       .dirty_ratio = get_res->dirty_ratio,
       .earliest_dirty_ts = get_res->earliest_dirty_ts,
       .extents = meta_to_rpc_extent_metadata(
-        std::move(get_res->offsets_response.extents))};
+        std::move(get_res->offsets_response.extents)),
+      .compaction_epoch = partition_state::compaction_epoch_t{
+        get_res->compaction_epoch()}};
 }
 
 ss::future<rpc::get_term_for_offset_reply>

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -233,6 +233,9 @@ public:
     virtual ss::future<std::expected<model::term_id, errc>>
     get_term_for_offset(const model::topic_id_partition&, kafka::offset) = 0;
 
+    using compaction_epoch
+      = named_type<int64_t, struct metastore_compaction_epoch>;
+
     // Compaction metadata updates per partition
     //
     // Kafka compaction works by taking "dirty" ranges of data, collecting the
@@ -281,14 +284,19 @@ public:
         // Timestamp at which the compaction operation happened.
         model::timestamp cleaned_at;
 
+        // The expected compaction epoch of the log at time of update
+        // application.
+        compaction_epoch expected_compaction_epoch;
+
         fmt::iterator format_to(fmt::iterator it) const {
             return fmt::format_to(
               it,
               "{{new_cleaned_ranges:{}, removed_tombstone_ranges:{}, "
-              "cleaned_at:{}}}",
+              "cleaned_at:{}, expected_compaction_epoch: {}}}",
               new_cleaned_ranges,
               removed_tombstones_ranges,
-              cleaned_at);
+              cleaned_at,
+              expected_compaction_epoch);
         }
     };
     using compaction_map_t
@@ -355,14 +363,18 @@ public:
         std::optional<model::timestamp> earliest_dirty_ts;
         // Dirty ranges & removable tombstone ranges.
         compaction_offsets_response offsets_response;
+        // The log's current compaction epoch.
+        compaction_epoch compaction_epoch;
 
         fmt::iterator format_to(fmt::iterator it) const {
             return fmt::format_to(
               it,
-              "{{dirty_ratio:{}, earliest_dirty_ts:{}, offsets_response:{}}}",
+              "{{dirty_ratio:{}, earliest_dirty_ts:{}, offsets_response:{}, "
+              "compaction_epoch:{}}}",
               dirty_ratio,
               earliest_dirty_ts,
-              offsets_response);
+              offsets_response,
+              compaction_epoch);
         }
     };
 

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -79,6 +79,8 @@ meta_to_rpc_compact_update(const metastore::compaction_update& update) {
 
     rpc_update.removed_tombstones_ranges = update.removed_tombstones_ranges;
     rpc_update.cleaned_at = update.cleaned_at;
+    rpc_update.expected_compaction_epoch = partition_state::compaction_epoch_t{
+      update.expected_compaction_epoch()};
 
     return rpc_update;
 }
@@ -685,6 +687,8 @@ replicated_metastore::get_compaction_info(const compaction_info_spec& log) {
       .dirty_ranges = std::move(reply.dirty_ranges),
       .removable_tombstone_ranges = std::move(reply.removable_tombstone_ranges),
       .extents = rpc_to_meta_extent_metadata(std::move(reply.extents))};
+    resp.compaction_epoch = metastore::compaction_epoch{
+      reply.compaction_epoch()};
 
     co_return resp;
 }

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -204,7 +204,7 @@ struct extent_metadata
 struct get_compaction_info_reply
   : serde::envelope<
       get_compaction_info_reply,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     auto serde_fields() {
         return std::tie(
@@ -213,7 +213,8 @@ struct get_compaction_info_reply
           removable_tombstone_ranges,
           dirty_ratio,
           earliest_dirty_ts,
-          extents);
+          extents,
+          compaction_epoch);
     }
 
     errc ec;
@@ -222,6 +223,7 @@ struct get_compaction_info_reply
     double dirty_ratio;
     std::optional<model::timestamp> earliest_dirty_ts;
     chunked_vector<extent_metadata> extents;
+    partition_state::compaction_epoch_t compaction_epoch;
 };
 struct get_compaction_info_request
   : serde::envelope<

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -483,6 +483,8 @@ simple_metastore::compact_objects(
         }
         p_update.removed_tombstones_ranges = cm.removed_tombstones_ranges;
         p_update.cleaned_at = cm.cleaned_at;
+        p_update.expected_compaction_epoch
+          = partition_state::compaction_epoch_t{cm.expected_compaction_epoch()};
         compaction_updates[tp] = std::move(p_update);
     }
 
@@ -655,6 +657,19 @@ simple_metastore::get_earliest_dirty_ts(
     return std::nullopt;
 }
 
+std::expected<metastore::compaction_epoch, metastore::errc>
+simple_metastore::get_compaction_epoch(
+  const state& state, const model::topic_id_partition& tp) {
+    auto prt_ref = state.partition_state(tp);
+
+    if (!prt_ref.has_value()) {
+        return std::unexpected(errc::missing_ntp);
+    }
+
+    const auto& prt = prt_ref->get();
+    return metastore::compaction_epoch{prt.compaction_epoch()};
+}
+
 ss::future<std::expected<metastore::compaction_info_response, metastore::errc>>
 simple_metastore::get_compaction_info(const compaction_info_spec& log) {
     co_return get_compaction_info(
@@ -681,10 +696,16 @@ simple_metastore::get_compaction_info(
         return std::unexpected(offsets.error());
     }
 
+    auto compaction_epoch = get_compaction_epoch(state, tidp);
+    if (!compaction_epoch.has_value()) {
+        return std::unexpected(compaction_epoch.error());
+    }
+
     return compaction_info_response{
       .dirty_ratio = dirty_ratio.value(),
       .earliest_dirty_ts = earliest_dirty_ts.value(),
-      .offsets_response = std::move(offsets).value()};
+      .offsets_response = std::move(offsets).value(),
+      .compaction_epoch = compaction_epoch.value()};
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -121,6 +121,8 @@ private:
     get_dirty_ratio(const state&, const model::topic_id_partition&);
     static std::expected<std::optional<model::timestamp>, errc>
     get_earliest_dirty_ts(const state&, const model::topic_id_partition&);
+    static std::expected<compaction_epoch, errc>
+    get_compaction_epoch(const state&, const model::topic_id_partition&);
     static std::expected<compaction_info_response, errc> get_compaction_info(
       const state&, const model::topic_id_partition&, model::timestamp);
     static std::expected<kafka::offset, errc> get_end_offset_for_term(

--- a/src/v/cloud_topics/level_one/metastore/state.cc
+++ b/src/v/cloud_topics/level_one/metastore/state.cc
@@ -200,6 +200,7 @@ partition_state partition_state::copy() const {
       .compaction_state = compaction_state
                             ? std::make_optional(compaction_state->copy())
                             : std::nullopt,
+      .compaction_epoch = compaction_epoch,
     };
     return res;
 }

--- a/src/v/cloud_topics/level_one/metastore/state.h
+++ b/src/v/cloud_topics/level_one/metastore/state.h
@@ -219,6 +219,16 @@ struct partition_state
     // TODO: should we remove this if cleanup policy is switched?
     std::optional<compaction_state> compaction_state;
 
+    using compaction_epoch_t
+      = named_type<int64_t, struct state_compaction_epoch>;
+    // The current epoch of this partition's compacted log. Effectively
+    // describes the number of logical changes made to the log's underlying
+    // data. Incremented when a compaction or partial compaction has been
+    // applied to this partition.
+    // This is a useful field for optimistic concurrency control, preventing a
+    // compaction job based on stale data from overwriting an updated log.
+    compaction_epoch_t compaction_epoch{0};
+
     // A mapping of terms (used instead of Kafka epochs) to the starting Kafka
     // offset for that term. Both the term and offsets are maintained to be
     // monotonically strictly increasing.

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -459,15 +459,28 @@ replace_objects_update::can_apply(const state& state) {
             model::topic_id_partition tidp{t, p};
             auto p_ref = state.partition_state(tidp);
             const auto& p_state = p_ref->get();
-            // Validate that any cleaned ranges actually correspond to the new
-            // extents.
+            // Validate the expected compaction epoch. If it does not match the
+            // current compaction epoch, there has been a concurrent race.
+            if (
+              compaction_update.expected_compaction_epoch
+              != p_state.compaction_epoch) {
+                return std::unexpected(stm_update_error(
+                  fmt::format(
+                    "Expected compaction epoch {} does not match the current "
+                    "compaction epoch {} for {}",
+                    compaction_update.expected_compaction_epoch,
+                    p_state.compaction_epoch,
+                    tidp)));
+            }
+
+            // Validate that any cleaned ranges actually correspond to the
+            // new extents.
             auto new_extent_iter = new_extents_by_tp.find(tidp);
             if (new_extent_iter == new_extents_by_tp.end()) {
                 return std::unexpected(stm_update_error(
                   fmt::format(
                     "New cleaned range does not refer to partition with "
-                    "extent: "
-                    "{}",
+                    "extent: {}",
                     tidp)));
             }
             if (!compaction_update.new_cleaned_ranges.empty()) {
@@ -551,8 +564,7 @@ replace_objects_update::can_apply(const state& state) {
                     return std::unexpected(stm_update_error(
                       fmt::format(
                         "Tombstone-removed range [{}, {}] for {} is not "
-                        "tracked "
-                        "as having tombstones",
+                        "tracked as having tombstones",
                         req_range.base_offset,
                         req_range.last_offset,
                         tidp)));
@@ -697,6 +709,7 @@ replace_objects_update::apply(state& state) {
                   cleaned_range.base_offset,
                   cleaned_range.last_offset);
             }
+            ++p_state.compaction_epoch;
         }
     }
     return std::monostate{};

--- a/src/v/cloud_topics/level_one/metastore/state_update.h
+++ b/src/v/cloud_topics/level_one/metastore/state_update.h
@@ -99,7 +99,7 @@ struct add_objects_update
 struct compaction_state_update
   : public serde::envelope<
       compaction_state_update,
-      serde::version<1>,
+      serde::version<2>,
       serde::compat_version<0>> {
     // NOTE: intentionally duplicate code from
     // metastore::compaction_update::cleaned_range, defined separately to
@@ -122,7 +122,10 @@ struct compaction_state_update
     };
     auto serde_fields() {
         return std::tie(
-          new_cleaned_ranges, removed_tombstones_ranges, cleaned_at);
+          new_cleaned_ranges,
+          removed_tombstones_ranges,
+          cleaned_at,
+          expected_compaction_epoch);
     }
     // The cleaned ranges for this compaction, if any. Ranges may or may not
     // have tombstones.
@@ -134,6 +137,9 @@ struct compaction_state_update
 
     // Timestamp at which this compaction operation was run.
     model::timestamp cleaned_at;
+
+    // The expected compaction epoch.
+    partition_state::compaction_epoch_t expected_compaction_epoch;
 };
 
 struct replace_objects_update

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -326,6 +326,7 @@ TEST_F(ReplicatedMetastoreTest, TestBasicAdd) {
           testing::ElementsAre(MatchesRange(o{0}, o{999})));
         EXPECT_FLOAT_EQ(cmp_info->dirty_ratio, 1.0);
         EXPECT_TRUE(cmp_info->earliest_dirty_ts.has_value());
+        EXPECT_EQ(cmp_info->compaction_epoch, metastore::compaction_epoch{0});
     }
 }
 
@@ -348,6 +349,7 @@ TEST_F(ReplicatedMetastoreTest, TestBasicCompact) {
         update.new_cleaned_ranges.push_back(
           metastore::compaction_update::cleaned_range{
             .base_offset = o{0}, .last_offset = o{999}});
+        update.expected_compaction_epoch = metastore::compaction_epoch{0};
         cmap[make_tp(i)] = std::move(update);
     }
     auto cmp_res = meta.compact_objects(*new_objs, cmap).get();
@@ -417,6 +419,7 @@ TEST_F(ReplicatedMetastoreTest, TestBasicCompact) {
           << fmt::format("{} is not cleaned", tp);
         EXPECT_FLOAT_EQ(cmp_info->dirty_ratio, 0.0);
         EXPECT_TRUE(!cmp_info->earliest_dirty_ts.has_value());
+        EXPECT_EQ(cmp_info->compaction_epoch, metastore::compaction_epoch{1});
     }
 }
 

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -124,6 +124,13 @@ public:
         cmp_meta.cleaned_at = model::timestamp::now();
         return *this;
     }
+    cm_builder& set_expected_epoch(
+      std::string_view tpr_str, metastore::compaction_epoch epoch) {
+        auto tp = model::topic_id_partition::from(tpr_str);
+        auto& cmp_meta = out[tp];
+        cmp_meta.expected_compaction_epoch = epoch;
+        return *this;
+    }
     cmap_t build() { return std::move(out); }
 
 private:
@@ -857,6 +864,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsets) {
 
         auto cmb = cm_builder();
         cmb.clean(tid_a, 3_o, 5_o, 3000_t);
+        cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{0});
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -902,6 +910,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsets) {
         auto cmb = cm_builder();
         cmb.clean(tid_a, 0_o, 2_o);
         cmb.remove_tombstones(tid_a, 3_o, 4_o);
+        cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{1});
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -926,6 +935,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsets) {
         auto cmb = cm_builder();
         cmb.clean(tid_a, 6_o, 10_o);
         cmb.remove_tombstones(tid_a, 5_o, 5_o);
+        cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{2});
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -956,6 +966,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsNoTombstones) {
 
         auto cmb = cm_builder();
         cmb.clean(tid_a, 3_o, 5_o);
+        cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{0});
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -999,6 +1010,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsNoTombstones) {
 
         auto cmb = cm_builder();
         cmb.clean(tid_a, 0_o, 2_o);
+        cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{1});
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -1021,6 +1033,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsNoTombstones) {
 
         auto cmb = cm_builder();
         cmb.clean(tid_a, 6_o, 10_o);
+        cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{2});
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -1227,6 +1240,7 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
 
         cm_builder cmb;
         cmb.clean(tid_a, 10_o, 19_o);
+        cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{0});
         auto compact_obj_res = m.compact_objects(*ob, cmb.build()).get();
         ASSERT_TRUE(compact_obj_res.has_value());
 
@@ -1508,6 +1522,7 @@ TEST(SimpleMetastoreTest, TestSetStartWithCompactionState) {
 
         auto cmb = cm_builder();
         cmb.clean(tid_a, 5_o, 15_o, 3000_t);
+        cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{0});
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -1569,6 +1584,7 @@ TEST(SimpleMetastoreTest, TestDirtyRatio) {
 
         auto cmb = cm_builder();
         cmb.clean(tid_a, 0_o, 5_o, 3000_t);
+        cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{0});
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -1588,6 +1604,7 @@ TEST(SimpleMetastoreTest, TestDirtyRatio) {
 
         auto cmb = cm_builder();
         cmb.clean(tid_a, 6_o, 9_o, 3000_t);
+        cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{1});
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -1605,6 +1622,7 @@ TEST(SimpleMetastoreTest, TestDirtyRatio) {
 
         auto cmb = cm_builder();
         cmb.clean(tid_a, 10_o, 19_o, 3000_t);
+        cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{2});
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -1672,6 +1690,7 @@ TEST(SimpleMetastoreTest, TestCompactionMultipleDirtyRangesMadeClean) {
 
         auto cmb = cm_builder();
         cmb.clean(tid_a, 5_o, 15_o, 3000_t);
+        cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{0});
         auto compact_res = m.compact_objects(os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -1701,6 +1720,7 @@ TEST(SimpleMetastoreTest, TestCompactionMultipleDirtyRangesMadeClean) {
         auto cmb = cm_builder();
         cmb.clean(tid_a, 0_o, 4_o, 6000_t);
         cmb.clean(tid_a, 16_o, 20_o, 6000_t);
+        cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{1});
         auto compact_res = m.compact_objects(os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -118,6 +118,14 @@ public:
         c_state.removed_tombstones_ranges.insert(base, last);
         return *this;
     }
+    replace_objects_builder& set_expected_epoch(
+      std::string_view tp_str,
+      partition_state::compaction_epoch_t compaction_epoch) {
+        auto tp = model::topic_id_partition::from(tp_str);
+        auto& c_state = out.compaction_updates[tp.topic_id][tp.partition];
+        c_state.expected_compaction_epoch = compaction_epoch;
+        return *this;
+    }
     replace_objects_update build() { return std::move(out); }
 
 private:
@@ -916,6 +924,7 @@ TEST(StateUpdateTest, TestReplaceWithCompaction) {
             range{
               .base_offset = 5_o, .last_offset = 10_o, .has_tombstones = true},
             1999_t)
+          .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{0})
           .build();
 
     auto replace_res = replace.apply(s);
@@ -932,6 +941,7 @@ TEST(StateUpdateTest, TestReplaceWithCompaction) {
     EXPECT_THAT(
       prt_a.compaction_state->cleaned_ranges_with_tombstones,
       ElementsAre(MatchesRange(5_o, 10_o)));
+    EXPECT_EQ(prt_a.compaction_epoch, partition_state::compaction_epoch_t{1});
 
     // Compact an extent, marking [3, 4] cleaned with tombstones.
     replace
@@ -944,6 +954,7 @@ TEST(StateUpdateTest, TestReplaceWithCompaction) {
             range{
               .base_offset = 3_o, .last_offset = 4_o, .has_tombstones = true},
             1999_t)
+          .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{1})
           .build();
     replace_res = replace.apply(s);
     ASSERT_TRUE(replace_res.has_value());
@@ -955,6 +966,7 @@ TEST(StateUpdateTest, TestReplaceWithCompaction) {
     EXPECT_THAT(
       prt_a.compaction_state->cleaned_ranges_with_tombstones,
       ElementsAre(MatchesRange(3_o, 4_o), MatchesRange(5_o, 10_o)));
+    EXPECT_EQ(prt_a.compaction_epoch, partition_state::compaction_epoch_t{2});
 
     // Now mark [3, 8] as having removed tombstones.
     replace = replace_objects_builder()
@@ -962,6 +974,8 @@ TEST(StateUpdateTest, TestReplaceWithCompaction) {
                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                        .build())
                 .clean_tombstones(tidp_a, 3_o, 8_o)
+                .set_expected_epoch(
+                  tidp_a, partition_state::compaction_epoch_t{2})
                 .build();
     replace_res = replace.apply(s);
     ASSERT_TRUE(replace_res.has_value()) << replace_res.error();
@@ -973,6 +987,7 @@ TEST(StateUpdateTest, TestReplaceWithCompaction) {
     EXPECT_THAT(
       prt_a.compaction_state->cleaned_ranges_with_tombstones,
       ElementsAre(MatchesRange(9_o, 10_o)));
+    EXPECT_EQ(prt_a.compaction_epoch, partition_state::compaction_epoch_t{3});
 }
 
 TEST(StateUpdateTest, TestCompactionMissingExtent) {
@@ -1001,6 +1016,7 @@ TEST(StateUpdateTest, TestCompactionMissingExtent) {
             range{
               .base_offset = 5_o, .last_offset = 10_o, .has_tombstones = true},
             1999_t)
+          .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{0})
           .build();
     auto replace_res = replace.apply(s);
     ASSERT_FALSE(replace_res.has_value());
@@ -1035,6 +1051,7 @@ TEST(StateUpdateTest, TestCompactionDoesntReplaceExtents) {
             range{
               .base_offset = 5_o, .last_offset = 11_o, .has_tombstones = true},
             1999_t)
+          .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{0})
           .build();
     auto replace_res = replace.apply(s);
     ASSERT_FALSE(replace_res.has_value());
@@ -1079,6 +1096,7 @@ TEST(StateUpdateTest, TestCompactionDoesntReplaceExtentsStart) {
             range{
               .base_offset = 0_o, .last_offset = 20_o, .has_tombstones = true},
             1999_t)
+          .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{0})
           .build();
     auto replace_res = replace.apply(s);
     ASSERT_FALSE(replace_res.has_value());
@@ -1122,6 +1140,7 @@ TEST(StateUpdateTest, TestCompactionDoesntReplaceLogStart) {
             range{
               .base_offset = 11_o, .last_offset = 20_o, .has_tombstones = true},
             1999_t)
+          .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{0})
           .build();
     auto replace_res = replace.apply(s);
     ASSERT_FALSE(replace_res.has_value());
@@ -1156,6 +1175,7 @@ TEST(StateUpdateTest, TestOverlappingTombstones) {
             range{
               .base_offset = 5_o, .last_offset = 10_o, .has_tombstones = true},
             1999_t)
+          .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{0})
           .build();
     auto replace_res = replace.apply(s);
     ASSERT_TRUE(replace_res.has_value());
@@ -1170,6 +1190,7 @@ TEST(StateUpdateTest, TestOverlappingTombstones) {
             range{
               .base_offset = 10_o, .last_offset = 10_o, .has_tombstones = true},
             1999_t)
+          .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{1})
           .build();
     replace_res = replace.apply(s);
     ASSERT_FALSE(replace_res.has_value());
@@ -1199,6 +1220,8 @@ TEST(StateUpdateTest, TestRemoveNonExistingTombstones) {
                             .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                             .build())
                      .clean_tombstones(tidp_a, 5_o, 10_o)
+                     .set_expected_epoch(
+                       tidp_a, partition_state::compaction_epoch_t{0})
                      .build();
     auto replace_res = replace.apply(s);
     ASSERT_FALSE(replace_res.has_value());
@@ -1601,6 +1624,7 @@ TEST(StateUpdateTest, TestSetStartOffsetWithCompactionState) {
             range{
               .base_offset = 5_o, .last_offset = 15_o, .has_tombstones = true},
             3000_t)
+          .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{0})
           .build();
     auto replace_res = replace_update.apply(s);
     ASSERT_TRUE(replace_res.has_value());
@@ -1617,6 +1641,8 @@ TEST(StateUpdateTest, TestSetStartOffsetWithCompactionState) {
     EXPECT_THAT(
       p_state->get().compaction_state->cleaned_ranges_with_tombstones,
       ElementsAre(MatchesRange(5_o, 15_o)));
+    EXPECT_EQ(
+      p_state->get().compaction_epoch, partition_state::compaction_epoch_t{1});
 
     // Set start offset to fall within the cleaned range (offset 10)
     auto set_start_update = set_start_offset_update::build(s, tp, 10_o);
@@ -1640,6 +1666,8 @@ TEST(StateUpdateTest, TestSetStartOffsetWithCompactionState) {
     EXPECT_THAT(
       p_state->get().compaction_state->cleaned_ranges_with_tombstones,
       ElementsAre(MatchesRange(10_o, 15_o)));
+    EXPECT_EQ(
+      p_state->get().compaction_epoch, partition_state::compaction_epoch_t{1});
 }
 
 TEST(StateUpdateTest, TestRemoveObjectsBasic) {
@@ -1894,4 +1922,73 @@ TEST(StateUpdateTest, TestRemoveMissingTopic) {
     ASSERT_TRUE(remove_topics_res->apply(s).has_value());
     EXPECT_EQ(0, s.topic_to_state.size());
     EXPECT_EQ(1, s.objects.size());
+}
+
+TEST(StateUpdateTest, TestCompactionValidatesEpoch) {
+    using testing::ElementsAre;
+    using range = struct compaction_state_update::cleaned_range;
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 300, 1300)
+                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .build();
+    state s;
+    auto add_res = add.apply(s);
+    ASSERT_TRUE(add_res.has_value());
+
+    {
+        // Attempt to fully compact partition A with an invalid compaction
+        // epoch.
+        auto replace = replace_objects_builder()
+                         .add(new_obj_builder(oid2, 100, 1100)
+                                .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                                .build())
+                         .clean(
+                           tidp_a,
+                           range{
+                             .base_offset = 0_o,
+                             .last_offset = 10_o,
+                             .has_tombstones = true},
+                           1999_t)
+                         .set_expected_epoch(
+                           tidp_a, partition_state::compaction_epoch_t{999})
+                         .build();
+
+        auto replace_res = replace.apply(s);
+        ASSERT_FALSE(replace_res.has_value());
+        EXPECT_THAT(
+          std::string(replace_res.error()()),
+          testing::ContainsRegex(
+            "Expected compaction epoch .+ does not match the current"));
+    }
+
+    {
+        // Fix the expected epoch and see state increment its internal
+        // compaction_epoch.
+        auto replace = replace_objects_builder()
+                         .add(new_obj_builder(oid2, 100, 1100)
+                                .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                                .build())
+                         .clean(
+                           tidp_a,
+                           range{
+                             .base_offset = 0_o,
+                             .last_offset = 10_o,
+                             .has_tombstones = true},
+                           1999_t)
+                         .set_expected_epoch(
+                           tidp_a, partition_state::compaction_epoch_t{0})
+                         .build();
+
+        auto replace_res = replace.apply(s);
+        ASSERT_TRUE(replace_res.has_value());
+        auto tp = model::topic_id_partition::from(tidp_a);
+        auto p_state = s.partition_state(tp);
+        ASSERT_TRUE(p_state.has_value());
+        ASSERT_TRUE(p_state->get().compaction_state.has_value());
+        ASSERT_EQ(
+          p_state->get().compaction_epoch,
+          partition_state::compaction_epoch_t{1});
+    }
 }


### PR DESCRIPTION
Add a field which describes the current epoch of this partition's compacted log. Effectively, it enumerates the number of logical changes made to the log's underlying data, and will be incremented when a compaction or partial compaction has been applied to this partition.

This is a useful field for optimistic concurrency control, and will be used as a means to prevent a compaction job based on stale data from overwriting an updated log.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
