### PR TITLE
tests: bump ducktape SHA

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -12,7 +12,7 @@ setup(
     package_data={"": ["*.md"]},
     include_package_data=True,
     install_requires=[
-        "ducktape@git+https://github.com/redpanda-data/ducktape.git@b1a8012b066a823953e70b73f3659d572dd206b6",
+        "ducktape@git+https://github.com/redpanda-data/ducktape.git@c3266e0740781cb26b56e74715c0da48ad59c6c7",
         "prometheus-client==0.9.0",
         "kafka-python==2.0.6",
         "crc32c==2.2",


### PR DESCRIPTION
Bump ducktape to c3266e0740781cb26b56e74715c0da48ad59c6c7, which pulls in the changes from:

https://github.com/redpanda-data/ducktape/pull/52

For improvements around tests which time out after teardown (aka ["TYPE IV" timeouts](https://redpandadata.atlassian.net/wiki/spaces/CORE/pages/1360658457/Diagnosing+ducktape+failures#Type-IV%3A-Hang-after-tear-down)). For example such tests will no longer be reported as "Test passed" in the details but have a message from DT indicating the type of the failure.

This "fixes" CORE-13453 in the sense that it will no longer report "test passed" so we should not get more failures triaged to that issue, though the underlying problems may persist.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
