### PR TITLE
`ct/l1`: compaction queue concurrency fix

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/log_info_collector.cc
+++ b/src/v/cloud_topics/level_one/compaction/log_info_collector.cc
@@ -100,7 +100,7 @@ log_info_collector::get_logs_to_collect(
             continue;
         }
 
-        if (log.inflight) {
+        if (log.state == log_compaction_meta::log_state::inflight) {
             // No need to sample inflight logs
             vlog(
               compaction_log.debug,
@@ -179,7 +179,7 @@ void log_info_collector::populate_log_infos(
             continue;
         }
 
-        if (log.inflight) {
+        if (log.state == log_compaction_meta::log_state::inflight) {
             // Don't step on compaction info that is actively being used.
             continue;
         }
@@ -213,6 +213,11 @@ void log_info_collector::populate_log_infos(
           log.ntp,
           log.info_and_ts->info);
 
+        if (log.state != log_compaction_meta::log_state::idle) {
+            // We don't need to queue an already queued log.
+            continue;
+        }
+
         auto topic_cfg_opt = _topic_metadata_provider->get_topic_cfg(
           model::topic_namespace_view(log.ntp));
 
@@ -225,6 +230,7 @@ void log_info_collector::populate_log_infos(
         if (needs_compaction(log, topic_cfg)) {
             auto ptr_it = logs_set.find(log.tidp);
             if (ptr_it != logs_set.end()) {
+                log.state = log_compaction_meta::log_state::queued;
                 compaction_queue.push(*ptr_it);
             }
         }

--- a/src/v/cloud_topics/level_one/compaction/meta.h
+++ b/src/v/cloud_topics/level_one/compaction/meta.h
@@ -39,12 +39,18 @@ struct log_compaction_meta {
 
     model::topic_id_partition tidp;
     model::ntp ntp;
+    // Whether this log is:
+    // 1. `idle` (not yet queued for compaction)
+    // 2. `queued` (present in the scheduler's `log_compaction_queue`)
+    // 3. `inflight` (currently undergoing a compaction on a worker shard)
+    enum class log_state { idle, queued, inflight } state{log_state::idle};
     // If set, this is cached compaction metadata obtained from the metastore at
-    // the `collected_at` time.
+    // the `collected_at` time. Guaranteed to have a value if `state == queued`
+    // or `state == inflight`.
     std::optional<compaction_info_and_timestamp> info_and_ts{std::nullopt};
     // If set, this is the shard on which the log is currently undergoing an
-    // inflight compaction.
-    std::optional<ss::shard_id> inflight{std::nullopt};
+    // inflight compaction. Guaranteed to have a value if `state == inflight`.
+    std::optional<ss::shard_id> inflight_shard{std::nullopt};
     intrusive_list_hook link;
 };
 

--- a/src/v/cloud_topics/level_one/compaction/scheduling_policies.h
+++ b/src/v/cloud_topics/level_one/compaction/scheduling_policies.h
@@ -40,6 +40,10 @@ private:
         static bool operator()(
           const log_compaction_meta_ptr& a,
           const log_compaction_meta_ptr& b) noexcept {
+            vassert(
+              a->info_and_ts.has_value() && b->info_and_ts.has_value(),
+              "Sorting policy applied to logs without info_and_ts assigned- "
+              "concurrency issue?");
             return a->info_and_ts->info.dirty_ratio
                    > b->info_and_ts->info.dirty_ratio;
         }
@@ -57,6 +61,10 @@ private:
         static bool operator()(
           const log_compaction_meta_ptr& a,
           const log_compaction_meta_ptr& b) noexcept {
+            vassert(
+              a->info_and_ts.has_value() && b->info_and_ts.has_value(),
+              "Sorting policy applied to logs without info_and_ts assigned- "
+              "concurrency issue?");
             return a->info_and_ts->info.earliest_dirty_ts
                    < b->info_and_ts->info.earliest_dirty_ts;
         }

--- a/src/v/cloud_topics/level_one/compaction/tests/worker_manager_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/worker_manager_test.cc
@@ -88,15 +88,19 @@ TEST_F(WorkerManagerTestFixture, AcquireWork) {
     auto meta = ss::make_lw_shared<l1::log_compaction_meta>(
       test_tidp, test_ntp);
     list.push_back(*meta);
+    using state = l1::log_compaction_meta::log_state;
+    meta->state = state::queued;
     pq.emplace(meta);
 
     auto work_opt = manager.try_acquire_work(ss::this_shard_id());
     ASSERT_TRUE(work_opt.has_value());
     ASSERT_EQ(work_opt.value()->ntp, test_ntp);
     ASSERT_EQ(work_opt.value()->tidp, test_tidp);
-    ASSERT_TRUE(work_opt.value()->inflight.has_value());
-    ASSERT_EQ(work_opt.value()->inflight.value(), ss::this_shard_id());
+    ASSERT_TRUE(work_opt.value()->inflight_shard.has_value());
+    ASSERT_EQ(work_opt.value()->state, state::inflight);
+    ASSERT_EQ(work_opt.value()->inflight_shard.value(), ss::this_shard_id());
 
     manager.complete_work(work_opt.value().get());
-    ASSERT_FALSE(work_opt.value()->inflight.has_value());
+    ASSERT_FALSE(work_opt.value()->inflight_shard.has_value());
+    ASSERT_EQ(work_opt.value()->state, state::idle);
 }

--- a/src/v/cloud_topics/level_one/compaction/worker.cc
+++ b/src/v/cloud_topics/level_one/compaction/worker.cc
@@ -52,10 +52,10 @@ ss::future<> compaction_worker::start() {
 ss::future<> compaction_worker::stop() {
     terminate_current_job();
     _worker_state = worker_state::stopped;
-    co_await _worker_update_queue.shutdown();
-
     _as.request_abort();
     _worker_cv.broken();
+
+    co_await _worker_update_queue.shutdown();
 
     auto close_fut = _gate.close();
 

--- a/src/v/cloud_topics/level_one/compaction/worker_manager.cc
+++ b/src/v/cloud_topics/level_one/compaction/worker_manager.cc
@@ -66,7 +66,11 @@ worker_manager::try_acquire_work(ss::shard_id shard) {
         return std::nullopt;
     }
 
-    log->inflight = shard;
+    dassert(
+      log->state == log_compaction_meta::log_state::queued,
+      "Expected log state to be queued when acquiring work");
+    log->state = log_compaction_meta::log_state::inflight;
+    log->inflight_shard = shard;
     return ss::make_foreign(log);
 }
 
@@ -76,7 +80,12 @@ void worker_manager::complete_work(log_compaction_meta* log) {
       "Expected calls to worker_manager::complete_work() to always execute on "
       "shard {}",
       worker_manager_shard);
-    log->inflight.reset();
+    dassert(
+      log->state == log_compaction_meta::log_state::inflight,
+      "Expected log state to be inflight when completing work");
+    log->state = log_compaction_meta::log_state::idle;
+    log->inflight_shard.reset();
+    log->info_and_ts.reset();
 }
 
 ss::future<>
@@ -85,7 +94,7 @@ worker_manager::request_stop_compaction(log_compaction_meta_ptr log) {
         co_return;
     }
 
-    auto shard_opt = log->inflight;
+    auto shard_opt = log->inflight_shard;
     if (!shard_opt.has_value()) {
         co_return;
     }


### PR DESCRIPTION
We could accidentally queue up the same `log` within the `scheduler`'s `log_compaction_queue` multiple times.

When re-sampling a queued (but not inflight) `log`'s compaction info from the `metastore`, we would again push the `log` to the `compaction_queue`.

We still want to resample and re-assign the queued `log`'s updated compaction info, but we don't want multiple of the same `log` in the queue; this is bad in principal, and also can lead to concurrency issues with reseting the `log`'s info after completing a compaction (can lead to crashes/UB, since the `scheduling_policy` of the `log_compaction_queue` requires this optional has a value for ordering).

Add a new `log_state` field to `log_compaction_meta`, and use/assert on this condition in several places to confirm we do not have any concurrency issues with log management. 

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


* none
