### PR TITLE
PGO train improvements

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -469,7 +469,7 @@ http_archive(
     name = "omb",
     add_prefix = "omb",
     build_file = "//bazel/thirdparty:omb.BUILD",
-    sha256 = "8b4cb43d5092cb76d43d6a3e3d58a9ad513d08cb5a87ff56ec609fff28b8e2ba",
+    sha256 = "9d1f651d98a624dcfb09c213a8b77732bd08e037d32922b06c06e6027841e8ee",
     strip_prefix = "openmessaging-benchmark-0.0.1-SNAPSHOT",
-    urls = ["https://perf-team-public.s3.us-west-2.amazonaws.com/tmp/omb_minimal_test.tar.gz"],
+    urls = ["https://vectorized-public.s3.amazonaws.com/dependencies/omb/omb_minimal_3c624daad47f16ae7036b67142c384d3e59150bf.tar.gz"],
 )

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -68,25 +68,6 @@ py_binary(
     deps = DEV_CLUSTER_PYTHON_DEPS,
 )
 
-# dev cluster target for the pgo genrule. We need dev_cluster as a tool
-# dependency such that it provides the deps/runfiles. That however makes it
-# dependencies (redpanda) built in "host-config" which is not what we want.
-py_binary(
-    name = "dev_cluster_for_pgo",
-    testonly = True,
-    srcs = [
-        "dev_cluster.py",
-    ],
-    data = [
-        "//bazel/thirdparty:grafana",
-        "//bazel/thirdparty:minio",
-        "//bazel/thirdparty:prometheus",
-    ],
-    main = "dev_cluster.py",
-    visibility = ["//visibility:private"],
-    deps = DEV_CLUSTER_PYTHON_DEPS,
-)
-
 # Package redpanda binary into a tarball alongside with all needed runfiles. We
 # can't make a redpanda a "tool" dependency as otherwise it will run under
 # "host-config"
@@ -101,18 +82,33 @@ pkg_tar(
     visibility = ["//visibility:private"],
 )
 
+# pgo training script used as a tool target which also sets up the python deps
+# for dev_cluster.py such that we can run dev_cluster from within train_pgo
+py_binary(
+    name = "train_pgo",
+    testonly = True,
+    srcs = [
+        "pgo_bolt/train_pgo.py",
+    ],
+    data = [
+        "dev_cluster.py",
+    ],
+    visibility = ["//visibility:private"],
+    deps = DEV_CLUSTER_PYTHON_DEPS,
+)
+
 genrule(
     name = "pgo_profile",
     testonly = True,
     srcs = [
         "//bazel/thirdparty:omb_minimal",
         "@current_llvm_toolchain//:llvm-profdata",
-        "pgo_bolt/train_pgo.py",
+        "dev_cluster.py",
         ":redpanda_package_for_pgo",
     ],
     outs = ["pgo_profile.profdata"],
-    cmd = "$(execpath pgo_bolt/train_pgo.py) " +
-          "--dev-cluster-py $(execpath :dev_cluster_for_pgo) " +
+    cmd = "$(execpath :train_pgo) " +
+          "--dev-cluster-py $(location dev_cluster.py) " +
           "--llvm-profdata-bin $(execpath @current_llvm_toolchain//:llvm-profdata) " +
           "--redpanda-tar $(location :redpanda_package_for_pgo) " +
           "--omb-benchmark $(execpath //bazel/thirdparty:omb_minimal) " +
@@ -123,7 +119,7 @@ genrule(
         "supports-graceful-termination",
     ],
     tools = [
-        ":dev_cluster_for_pgo",
+        ":train_pgo",
     ],
     visibility = ["//visibility:public"],
 )

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -115,7 +115,6 @@ genrule(
           "--combined-profile-file $(RULEDIR)/pgo_profile.profdata",
     tags = [
         "manual",
-        "no-sandbox",
         "supports-graceful-termination",
     ],
     tools = [

--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -756,9 +756,13 @@ async def main():
 
     asyncio.get_event_loop().add_signal_handler(signal.SIGINT, stop)
 
+    def failed_exit_code(rc: int):
+        # ignore -2/SIGINT, natural way to stop the dev cluster.
+        return rc not in [0, -2]
+
     failed = False
     return_codes = await asyncio.gather(*all_coros)
-    if any(rc != 0 for rc in return_codes):
+    if any(failed_exit_code(rc) for rc in return_codes):
         print(f"Redpanda nodes exited with non-zero return codes: {return_codes}")
         failed = True
 
@@ -767,19 +771,19 @@ async def main():
     if minio_task and minio:
         minio.stop()
         minio_ret_code = await minio_task
-        if minio_ret_code != 0:
+        if failed_exit_code(minio_ret_code):
             print(f"Minio exited with non-zero return code: {minio_ret_code}")
             failed = True
     if prometheus_task and prometheus:
         prometheus.stop()
         prom_ret_code = await prometheus_task
-        if prom_ret_code != 0:
+        if failed_exit_code(prom_ret_code):
             print(f"Prometheus exited with non-zero return code: {prom_ret_code}")
             failed = True
     if grafana_task and grafana:
         grafana.stop()
         grafana_ret_code = await grafana_task
-        if grafana_ret_code != 0:
+        if failed_exit_code(grafana_ret_code):
             print(f"Grafana exited with non-zero return code: {grafana_ret_code}")
             failed = True
 

--- a/tools/pgo_bolt/omb_config/driver.yaml
+++ b/tools/pgo_bolt/omb_config/driver.yaml
@@ -1,4 +1,4 @@
-name: bolt-training
+name: pgo-bl3-like
 driverClass: io.openmessaging.benchmark.driver.redpanda.RedpandaBenchmarkDriver
 
 replicationFactor: 3

--- a/tools/pgo_bolt/omb_config/workload.yaml
+++ b/tools/pgo_bolt/omb_config/workload.yaml
@@ -17,7 +17,7 @@ producerRate: 20000
 
 consumerBacklogSizeGB: 0
 
-warmupDurationMinutes: 1
+warmupDurationMinutes: 0
 testDurationMinutes: 1
 
 keyDistributor: NO_KEY

--- a/tools/pgo_bolt/omb_config/workload.yaml
+++ b/tools/pgo_bolt/omb_config/workload.yaml
@@ -1,4 +1,4 @@
-name: poc-aw
+name: pgo-bl3-like
 
 topics: 1
 

--- a/tools/pgo_bolt/omb_config/workload.yaml
+++ b/tools/pgo_bolt/omb_config/workload.yaml
@@ -13,7 +13,7 @@ subscriptionsPerTopic: 1
 producersPerTopic: 10
 consumerPerSubscription: 10
 
-producerRate: 100000
+producerRate: 20000
 
 consumerBacklogSizeGB: 0
 

--- a/tools/pgo_bolt/train_pgo.py
+++ b/tools/pgo_bolt/train_pgo.py
@@ -200,7 +200,7 @@ def extra_rp_tar(rp_tar: str, temp_dir: str):
 
     with tarfile.open(rp_tar, "r") as tar:
         for member in tar.getmembers():
-            tar.extract(member, path=extract_path)
+            tar.extract(member, path=extract_path, filter="fully_trusted")
 
     # Find the redpanda binary (to avoid hardcoding the a little bit brittle path)
     for root, _, files in os.walk(extract_path):

--- a/tools/pgo_bolt/train_pgo.py
+++ b/tools/pgo_bolt/train_pgo.py
@@ -7,6 +7,7 @@ import subprocess
 import os
 import signal
 import asyncio
+import sys
 import tarfile
 import tempfile
 from typing import Any
@@ -131,21 +132,25 @@ def check_omb(omb_target: OmbTarget):
         raise RuntimeError("OMB consumed too few messages")
 
 
-async def terminate(proc: asyncio.subprocess.Process, name: str):
+async def terminate(proc: asyncio.subprocess.Process, name: str) -> int:
     if not proc:
-        return
+        return 0
     try:
         print(f"Terminating {name} (pid {proc.pid})")
         os.killpg(proc.pid, signal.SIGINT)
-        await proc.wait()
+    except ProcessLookupError:
+        # process might have already exited (naturally or not)
+        pass
     except Exception as e:
         print(f"Error terminating {name}: {e}")
+    return await proc.wait()
 
 
 async def profile(args: argparse.Namespace, tmpdir: str, redpanda_bin: str):
     cluster_proc: asyncio.subprocess.Process | None = None
     omb_proc: asyncio.subprocess.Process | None = None
     cluster_task: asyncio.Task[None] | None = None
+    failed = False
     try:
         cluster_proc = await start_dev_cluster(
             args.dev_cluster_py,
@@ -161,11 +166,16 @@ async def profile(args: argparse.Namespace, tmpdir: str, redpanda_bin: str):
 
     finally:
         if omb_proc:
-            await terminate(omb_proc, "omb")
+            omb_status = await terminate(omb_proc, "omb")
+            failed = failed or omb_status != 0
         if cluster_proc:
-            await terminate(cluster_proc, "cluster")
+            cluster_status = await terminate(cluster_proc, "cluster")
+            failed = failed or cluster_status != 0
         if cluster_task:
             await cluster_task
+
+    if failed:
+        sys.exit(1)
 
 
 def combine_profiles(

--- a/tools/pgo_bolt/train_pgo.py
+++ b/tools/pgo_bolt/train_pgo.py
@@ -45,8 +45,8 @@ async def continue_stream(proc: asyncio.subprocess.Process, tag: str):
         print(f"[{tag}] - {line}")
 
 
-async def start_dev_cluster(dev_cluster_py: str, redpanda_bin: str):
-    data_dir = "/dev/shm/rp_data/"
+async def start_dev_cluster(dev_cluster_py: str, redpanda_bin: str, tmpdir: str):
+    data_dir = os.path.join(tmpdir, "rp_data")
     os.makedirs(data_dir, exist_ok=True)
     cmd = [
         sys.executable,
@@ -152,6 +152,7 @@ async def profile(args: argparse.Namespace, tmpdir: str, redpanda_bin: str):
         cluster_proc = await start_dev_cluster(
             args.dev_cluster_py,
             redpanda_bin,
+            tmpdir,
         )
         await read_until(cluster_proc, CLUSTER_STARTUP_MARKER, "cluster")
         cluster_task = asyncio.create_task(continue_stream(cluster_proc, "cluster"))
@@ -211,7 +212,9 @@ def extra_rp_tar(rp_tar: str, temp_dir: str):
 
 
 def main(args: argparse.Namespace):
-    with tempfile.TemporaryDirectory(prefix="redpanda_pgo_") as tmpdirname:
+    with tempfile.TemporaryDirectory(
+        prefix="redpanda_pgo_", dir="/dev/shm"
+    ) as tmpdirname:
         profile_dir = os.path.join(tmpdirname, "profile_dir")
         os.makedirs(profile_dir)
         os.environ["LLVM_PROFILE_FILE"] = f"{profile_dir}/data-%p.profraw"

--- a/tools/pgo_bolt/train_pgo.py
+++ b/tools/pgo_bolt/train_pgo.py
@@ -15,7 +15,6 @@ import yaml
 
 CLUSTER_STARTUP_MARKER = "Successfully started Redpanda"
 BENCH_START_MARKER = "Starting benchmark traffic"
-PERF_PROFILE_FILE = "perf.data"
 
 # Helper script to run PGO training workloads against a RP dev cluster
 # We use the devcluster to launch a basic rf=3 cluster and run OMB against it.
@@ -133,8 +132,6 @@ def check_omb(omb_target: OmbTarget):
 
 
 async def terminate(proc: asyncio.subprocess.Process, name: str) -> int:
-    if not proc:
-        return 0
     try:
         print(f"Terminating {name} (pid {proc.pid})")
         os.killpg(proc.pid, signal.SIGINT)

--- a/tools/pgo_bolt/train_pgo.py
+++ b/tools/pgo_bolt/train_pgo.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import argparse
+from dataclasses import dataclass
 import glob
+import json
 import subprocess
 import os
 import signal
@@ -8,6 +10,7 @@ import asyncio
 import tarfile
 import tempfile
 from typing import Any
+import yaml
 
 CLUSTER_STARTUP_MARKER = "Successfully started Redpanda"
 BENCH_START_MARKER = "Starting benchmark traffic"
@@ -68,16 +71,32 @@ async def start_dev_cluster(dev_cluster_py: str, redpanda_bin: str):
     return proc
 
 
-async def start_omb(omb_benchmark: str):
+@dataclass
+class OmbTarget:
+    results_path: str
+    total_messages: int
+
+
+async def start_omb(
+    tmpdir: str, omb_benchmark: str
+) -> tuple[asyncio.subprocess.Process, OmbTarget]:
+    workload_path = (
+        f"{os.path.dirname(os.path.realpath(__file__))}/omb_config/workload.yaml"
+    )
+    driver_path = (
+        f"{os.path.dirname(os.path.realpath(__file__))}/omb_config/driver.yaml"
+    )
+    results_path = os.path.join(tmpdir, "results.json")
+
     bench_cmd: list[str] = [
         omb_benchmark,
         "--drivers",
-        f"{os.path.dirname(os.path.realpath(__file__))}/omb_config/driver.yaml",
+        driver_path,
         "--output",
-        "/tmp/ombout",
+        results_path,
         "--service-version",
         "unknown_version",
-        f"{os.path.dirname(os.path.realpath(__file__))}/omb_config/workload.yaml",
+        workload_path,
     ]
     print(f"Launching omb: {' '.join(bench_cmd)}")
     proc = await asyncio.create_subprocess_exec(
@@ -86,7 +105,30 @@ async def start_omb(omb_benchmark: str):
         stderr=asyncio.subprocess.STDOUT,
         start_new_session=True,
     )
-    return proc
+
+    with open(workload_path, "r") as workload_yaml:
+        workload = yaml.safe_load(workload_yaml)
+
+    omb_target = OmbTarget(
+        results_path=results_path,
+        total_messages=workload["producerRate"]
+        * (workload["warmupDurationMinutes"] + workload["testDurationMinutes"])
+        * 60,
+    )
+    return proc, omb_target
+
+
+def check_omb(omb_target: OmbTarget):
+    with open(omb_target.results_path, "r") as results_f:
+        results = json.load(results_f)
+
+    # OMB will always overshoot but just avoid flakiness
+    leeway_factor = 0.95
+
+    if sum(results["sent"]) < omb_target.total_messages * leeway_factor:
+        raise RuntimeError("OMB sent too few messages")
+    if sum(results["consumed"]) < omb_target.total_messages * leeway_factor:
+        raise RuntimeError("OMB consumed too few messages")
 
 
 async def terminate(proc: asyncio.subprocess.Process, name: str):
@@ -100,7 +142,7 @@ async def terminate(proc: asyncio.subprocess.Process, name: str):
         print(f"Error terminating {name}: {e}")
 
 
-async def profile(args: argparse.Namespace, redpanda_bin: str):
+async def profile(args: argparse.Namespace, tmpdir: str, redpanda_bin: str):
     cluster_proc: asyncio.subprocess.Process | None = None
     omb_proc: asyncio.subprocess.Process | None = None
     cluster_task: asyncio.Task[None] | None = None
@@ -112,9 +154,10 @@ async def profile(args: argparse.Namespace, redpanda_bin: str):
         await read_until(cluster_proc, CLUSTER_STARTUP_MARKER, "cluster")
         cluster_task = asyncio.create_task(continue_stream(cluster_proc, "cluster"))
 
-        omb_proc = await start_omb(args.omb_benchmark)
+        omb_proc, omb_target = await start_omb(tmpdir, args.omb_benchmark)
         await read_until(omb_proc, BENCH_START_MARKER, "omb")
         await asyncio.create_task(continue_stream(omb_proc, "omb"))
+        check_omb(omb_target)
 
     finally:
         if omb_proc:
@@ -168,7 +211,7 @@ def main(args: argparse.Namespace):
 
         redpanda_bin = extra_rp_tar(args.redpanda_tar, tmpdirname)
 
-        asyncio.run(profile(args, redpanda_bin))
+        asyncio.run(profile(args, tmpdirname, redpanda_bin))
         combine_profiles(args, profile_dir, args.combined_profile_file)
 
 

--- a/tools/pgo_bolt/train_pgo.py
+++ b/tools/pgo_bolt/train_pgo.py
@@ -183,6 +183,9 @@ def combine_profiles(
 
     assert len(profiles) > 0, f"No profiles found in {base_profile_dir}"
 
+    for profile in profiles:
+        print(f"Profile: {profile} size: {os.path.getsize(profile)} bytes")
+
     llvm_profdata_cmd: list[str] = [
         args.llvm_profdata_bin,
         "merge",

--- a/tools/pgo_bolt/train_pgo.py
+++ b/tools/pgo_bolt/train_pgo.py
@@ -46,6 +46,7 @@ async def start_dev_cluster(dev_cluster_py: str, redpanda_bin: str):
     data_dir = "/dev/shm/rp_data/"
     os.makedirs(data_dir, exist_ok=True)
     cmd = [
+        sys.executable,
         dev_cluster_py,
         "--cores",
         "2",


### PR DESCRIPTION
A few minor pgo train improvements:

 - pgo: Skip warmup in OMB training
 - Fix workload/driver names
 - Lower rate in OMB run
 - Forward negative exit codes
 - Check omb message count


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
