### PR TITLE
[UX-746] rpk shadow (cloud): add failure reason

### DIFF
--- a/src/go/rpk/pkg/cli/shadow/BUILD
+++ b/src/go/rpk/pkg/cli/shadow/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//src/go/rpk/pkg/os",
         "//src/go/rpk/pkg/out",
         "//src/go/rpk/pkg/publicapi",
+        "@build_buf_gen_go_redpandadata_cloud_connectrpc_go//redpanda/api/controlplane/v1/controlplanev1connect",
         "@build_buf_gen_go_redpandadata_cloud_protocolbuffers_go//redpanda/api/controlplane/v1:controlplane",
         "@build_buf_gen_go_redpandadata_core_protocolbuffers_go//redpanda/core/admin/v2:admin",
         "@build_buf_gen_go_redpandadata_core_protocolbuffers_go//redpanda/core/common/v1:common",

--- a/src/go/rpk/pkg/cli/shadow/create.go
+++ b/src/go/rpk/pkg/cli/shadow/create.go
@@ -10,10 +10,12 @@
 package shadow
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 
+	"buf.build/gen/go/redpandadata/cloud/connectrpc/go/redpanda/api/controlplane/v1/controlplanev1connect"
 	controlplanev1 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1"
 	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
 	"connectrpc.com/connect"
@@ -102,11 +104,16 @@ Create a Shadow Link without confirmation prompt:
 				out.MaybeDie(err, "unable to create Shadow Link: %v", err)
 
 				isComplete, err := waitForOperation(cmd.Context(), cloudClient, op.Msg.GetOperation().GetId())
-				out.MaybeDie(err, "unable to confirm Shadow Link creation: %v", err)
+				if err != nil {
+					if oErr := new(OperationFailedError); errors.As(err, &oErr) {
+						out.Die(tryShadowLinkErrReason(cmd.Context(), cloudClient.ShadowLink, oErr))
+					}
+					out.Die("unable to confirm Shadow Link creation: %v", err)
+				}
 				if isComplete {
 					out.Exit(successMsgTmpl, slCfg.Name, op.Msg.GetOperation().GetResourceId())
 				}
-				out.Exit("Shadow link creation is taking longer than expected. Please check the status of the shadow link using 'rpk shadow status %q'", slCfg.Name)
+				out.Exit("Shadow link creation is taking longer than expected. Please check the state of the shadow link using 'rpk shadow describe %v' and 'rpk shadow status %v'", slCfg.Name, slCfg.Name)
 			}
 			cl, err := adminapi.NewClient(cmd.Context(), fs, prof)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
@@ -228,4 +235,18 @@ func authPassword(co *ShadowLinkClientOptions) string {
 		return auth.PlainConfiguration.Password
 	}
 	return ""
+}
+
+// tryShadowLinkErrReason attempts to extract a more specific error reason from
+// the Shadow Link response, defaulting to a generic error message if the call
+// fails or there is no additional information.
+func tryShadowLinkErrReason(ctx context.Context, cl controlplanev1connect.ShadowLinkServiceClient, oErr *OperationFailedError) string {
+	errMsg := oErr.Error()
+	link, err := cl.GetShadowLink(ctx, connect.NewRequest(&controlplanev1.GetShadowLinkRequest{
+		Id: oErr.Operation.GetResourceId(),
+	}))
+	if err != nil || link.Msg.GetShadowLink().GetReason() == "" {
+		return errMsg
+	}
+	return fmt.Sprintf("%v. Reason: %v", errMsg, link.Msg.GetShadowLink().GetReason())
 }

--- a/src/go/rpk/pkg/cli/shadow/describe.go
+++ b/src/go/rpk/pkg/cli/shadow/describe.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	controlplanev1 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1"
-
 	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
 	corecommonv1 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/common/v1"
 	"connectrpc.com/connect"
@@ -216,6 +215,9 @@ func printCloudOverview(link *controlplanev1.ShadowLink) {
 	tw.Print("NAME", link.GetName())
 	tw.Print("ID", link.GetId())
 	tw.Print("STATE", strings.TrimPrefix(link.GetState().String(), "STATE_"))
+	if link.GetReason() != "" {
+		tw.Print("REASON", link.GetReason())
+	}
 	tw.Print("SHADOW REDPANDA ID", link.GetShadowRedpandaId())
 	if createdAt := link.GetCreatedAt(); createdAt != nil {
 		tw.Print("CREATED AT", createdAt.AsTime().Format(time.RFC3339))

--- a/src/go/rpk/pkg/cli/shadow/shadow.go
+++ b/src/go/rpk/pkg/cli/shadow/shadow.go
@@ -70,7 +70,7 @@ func waitForOperation(ctx context.Context, cloudClient *publicapi.CloudClientSet
 		time.Sleep(time.Duration(sleepTime) * time.Millisecond)
 	}
 	for i := range maxOpRetries {
-		shadowLink, err := cloudClient.Operations.GetOperation(ctx, connect.NewRequest(&controlplanev1.GetOperationRequest{
+		slOp, err := cloudClient.Operations.GetOperation(ctx, connect.NewRequest(&controlplanev1.GetOperationRequest{
 			Id: opID,
 		}))
 		if err != nil {
@@ -81,11 +81,11 @@ func waitForOperation(ctx context.Context, cloudClient *publicapi.CloudClientSet
 			}
 			return false, fmt.Errorf("unable to get Shadow Link Operation: %v", err)
 		}
-		switch shadowLink.Msg.GetOperation().GetState() {
+		switch slOp.Msg.GetOperation().GetState() {
 		case controlplanev1.Operation_STATE_COMPLETED:
 			return true, nil
 		case controlplanev1.Operation_STATE_FAILED:
-			return false, fmt.Errorf("an error occurred while attempting to perform the operation. %v", shadowLink.Msg.GetOperation().GetError().GetMessage())
+			return false, &OperationFailedError{Operation: slOp.Msg.GetOperation()}
 		default:
 			if i < maxOpRetries-1 {
 				backoff(i)
@@ -95,4 +95,12 @@ func waitForOperation(ctx context.Context, cloudClient *publicapi.CloudClientSet
 		}
 	}
 	return false, nil
+}
+
+type OperationFailedError struct {
+	Operation *controlplanev1.Operation
+}
+
+func (e *OperationFailedError) Error() string {
+	return fmt.Sprintf("operation %q failed: %s", e.Operation.GetId(), e.Operation.GetError().GetMessage())
 }


### PR DESCRIPTION
Reason field will only be populated when the
state != ready.

We will attempt to get this reason as well if the
creation failed to provide a better UX as the
operation response does not contain any info on
why it failed

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

