### PR TITLE
lsm: update configuration for file/level sizes

### DIFF
--- a/src/v/lsm/core/internal/options.cc
+++ b/src/v/lsm/core/internal/options.cc
@@ -14,7 +14,12 @@
 namespace lsm::internal {
 
 fmt::iterator options::level_config::format_to(fmt::iterator it) const {
-    return fmt::format_to(it, "{{number:{}}}", number);
+    return fmt::format_to(
+      it,
+      "{{number:{},max_total_bytes:{},max_file_size:{}}}",
+      number,
+      max_total_bytes,
+      max_file_size);
 }
 
 fmt::iterator options::format_to(fmt::iterator it) const {

--- a/src/v/lsm/core/internal/options.h
+++ b/src/v/lsm/core/internal/options.h
@@ -13,6 +13,7 @@
 
 #include "base/format_to.h"
 #include "base/units.h"
+#include "base/vassert.h"
 #include "lsm/core/compression.h"
 #include "lsm/core/internal/files.h"
 
@@ -31,21 +32,70 @@ struct options {
         // The level number in the database.
         internal::level number;
 
+        // The maximum number of total bytes in this level.
+        size_t max_total_bytes;
+
+        // Write up to this amount of bytes to a file in this level before
+        // switching to a new one.
+        //
+        // Increasing this provides better file system
+        // efficiency with larger files, but the downside of increasing this is
+        // longer compactions and longer latency/performance hiccups.
+        size_t max_file_size;
+
         fmt::iterator format_to(fmt::iterator) const;
     };
-    constexpr static auto default_max_level = 6_level;
-    static constexpr std::vector<level_config> make_default_levels() {
+
+    // Make a configuration of levels based on the initial level configuration,
+    // and a multiplier between each level.
+    static constexpr std::vector<level_config> make_levels(
+      level_config base_config, size_t multiplier, internal::level max_level) {
+        vassert(
+          max_level >= 1_level,
+          "there must be at least 2 levels in the LSM tree");
         std::vector<level_config> levels;
-        levels.reserve(default_max_level() + 1);
-        for (auto lvl = 0_level; lvl <= default_max_level; ++lvl) {
-            levels.emplace_back(lvl);
+        levels.reserve(max_level + 1_level);
+        // Level0 and level1 we want to be similar in size because usually
+        // compaction between the levels are the bottleneck. This is also the
+        // recommendation in RocksDB. Note that generally level0 is special in
+        // that the system uses the write buffer size and write triggers to
+        // determine the number of files and size of files in level0
+        levels.emplace_back(
+          level_config{
+            .number = 0_level,
+            .max_total_bytes = base_config.max_total_bytes,
+            .max_file_size = base_config.max_file_size,
+          });
+        auto* last_level = &levels.emplace_back(
+          level_config{
+            .number = 1_level,
+            .max_total_bytes = base_config.max_total_bytes,
+            .max_file_size = base_config.max_file_size,
+          });
+        for (auto lvl = 2_level; lvl <= max_level; ++lvl) {
+            last_level = &levels.emplace_back(
+              level_config{
+                .number = lvl,
+                .max_total_bytes = last_level->max_total_bytes * multiplier,
+                .max_file_size = last_level->max_file_size * multiplier,
+              });
         }
         return levels;
     }
     // The levels and their configuration in the database,
     // this will be sorted by level number and also will be monotonically
     // increasing from level 0 to level N (configurable).
-    std::vector<level_config> levels = make_default_levels();
+    constexpr static auto default_max_level = 6_level;
+    // The default size multiplier between levels
+    constexpr static size_t default_level_multipler = 10;
+    std::vector<level_config> levels = make_levels(
+      {
+        .max_total_bytes = default_level_zero_stop_writes_trigger
+                           * default_write_buffer_size,
+        .max_file_size = default_write_buffer_size,
+      },
+      default_level_multipler,
+      default_max_level);
     internal::level max_level() const { return levels.back().number; }
 
     // At what point do we start throttling writes in terms of the number of L0
@@ -67,20 +117,14 @@ struct options {
     constexpr static size_t default_level_one_compaction_trigger = 4;
     size_t level_one_compaction_trigger = default_level_one_compaction_trigger;
 
-    // Write up to this amount of bytes to a file before switching to a new one.
-    // Increasing this provides better file system efficiency with larger files,
-    // but the downside of increasing this is longer compactions and longer
-    // latency/performance hiccups.
-    size_t max_file_size = 2_GiB;
-
-    size_t target_file_size() const { return max_file_size; }
-    size_t max_grandparent_overlap_bytes() const {
+    size_t max_grandparent_overlap_bytes(internal::level lvl) const {
         static constexpr size_t multiplier = 10;
-        return multiplier * target_file_size();
+        return multiplier * levels[lvl].max_file_size;
     }
-    size_t expanded_compaction_byte_size_limit() const {
+
+    size_t expanded_compaction_byte_size_limit(internal::level lvl) const {
         static constexpr size_t multiplier = 25;
-        return multiplier * target_file_size();
+        return multiplier * levels[lvl].max_file_size;
     }
 
     // The approximate max number of SST files that should be opened at one

--- a/src/v/lsm/db/file_utils.cc
+++ b/src/v/lsm/db/file_utils.cc
@@ -17,18 +17,6 @@
 
 namespace lsm::db {
 
-using internal::operator""_level;
-
-size_t max_bytes_for_level(internal::level level) {
-    // NOLINTBEGIN(*magic-number*)
-    size_t result = 10_MiB;
-    while (level > 1_level) {
-        result *= 10;
-        --level;
-    }
-    // NOLINTEND(*magic-number*)
-    return result;
-}
 size_t total_file_size(
   const chunked_vector<ss::lw_shared_ptr<file_meta_data>>& files) {
     size_t total = 0;
@@ -37,6 +25,7 @@ size_t total_file_size(
     }
     return total;
 }
+
 size_t find_file(
   const chunked_vector<ss::lw_shared_ptr<file_meta_data>>& files,
   internal::key_view target) {

--- a/src/v/lsm/db/file_utils.h
+++ b/src/v/lsm/db/file_utils.h
@@ -33,9 +33,6 @@ struct by_smallest_key {
 size_t
 total_file_size(const chunked_vector<ss::lw_shared_ptr<file_meta_data>>& files);
 
-// TODO(lsm): This should be a config knob probably
-size_t max_bytes_for_level(internal::level level);
-
 // Return the smallest index i such that files[i]->largest >= key.
 // Return files.size() if there is no such file.
 // REQUIRES: "files" contains a sorted list of non-overlapping files.

--- a/src/v/lsm/db/impl.cc
+++ b/src/v/lsm/db/impl.cc
@@ -445,18 +445,20 @@ ss::future<> impl::flush_memtable() {
     vassert(_imm, "immutable memtable required in order to flush a memtable");
     auto v = _versions->current();
     auto id = _versions->new_file_id();
+    auto& imm = *_imm;
+    auto level = imm->empty() ? 0_level
+                              : v->pick_level_for_memtable_output(
+                                  imm->min_key(), imm->max_key());
     auto result = co_await build_table(
       _persistence.data.get(),
       {.id = id, .epoch = _opts->database_epoch},
-      (*_imm)->create_iterator(),
+      imm->create_iterator(),
       _opts,
       &_as);
     if (!result) {
         _versions->reuse_file_id(id);
         co_return;
     }
-    auto level = v->pick_level_for_memtable_output(
-      result->smallest, result->largest);
     version_edit edit(*_opts);
     edit.set_last_seqno(result->newest_seqno);
     edit.add_file({

--- a/src/v/lsm/db/impl.cc
+++ b/src/v/lsm/db/impl.cc
@@ -346,6 +346,8 @@ ss::future<> impl::run_background_compaction() {
       // TODO: If we support snapshot reads we need to track the last seqno.
       .smallest_snapshot = _versions->last_seqno(),
     };
+    auto output_level = compaction.level() + 1_level;
+    auto max_file_size = _opts->levels[output_level].max_file_size;
     try {
         auto input = co_await _versions->make_input_iterator(&compaction);
         std::optional<internal::key> current_key;
@@ -408,7 +410,7 @@ ss::future<> impl::run_background_compaction() {
                 current.newest = std::max(key_seqno, current.newest);
                 co_await state.builder->add(internal::key(key), input->value());
                 // Close output file if it is big enough
-                if (state.builder->file_size() >= _opts->target_file_size()) {
+                if (state.builder->file_size() >= max_file_size) {
                     co_await state.finish_current_builder();
                 }
             }

--- a/src/v/lsm/db/memtable.h
+++ b/src/v/lsm/db/memtable.h
@@ -78,6 +78,16 @@ public:
     // If the memtable is empty or not.
     bool empty() const { return _table.empty(); }
 
+    // What is the minimum key in the memtable?
+    //
+    // REQUIRES: !empty()
+    internal::key_view min_key() const { return _table.begin()->first; }
+
+    // What is the maximum key in the memtable?
+    //
+    // REQUIRES: !empty()
+    internal::key_view max_key() const { return _table.rbegin()->first; }
+
     std::optional<internal::sequence_number> last_seqno() const {
         return _last_seqno;
     }

--- a/src/v/lsm/db/tests/impl_test.cc
+++ b/src/v/lsm/db/tests/impl_test.cc
@@ -74,12 +74,17 @@ private:
 class ImplTest : public testing::Test {
 public:
     void SetUp() override {
+        // Make a smaller sized database so we get some actual leveling
+        // happening.
         _options = ss::make_lw_shared<lsm::internal::options>({
+          .levels = lsm::internal::options::make_levels(
+            {.max_total_bytes = 1_MiB, .max_file_size = 256_KiB},
+            /*multiplier=*/2,
+            lsm::internal::options::default_max_level),
           .level_zero_slowdown_writes_trigger = 4,
           .level_zero_stop_writes_trigger = 6,
           .write_buffer_size = 256_KiB,
           .level_one_compaction_trigger = 2,
-          .max_file_size = 2_MiB,
         });
         _data_persistence = lsm::io::make_memory_data_persistence();
         _meta_persistence = lsm::io::make_memory_metadata_persistence();
@@ -198,8 +203,8 @@ TEST_F(ImplTest, MemtableIsFlushed) {
 }
 
 TEST_F(ImplTest, Recovery) {
-    write_at_least(512_KiB);
-    write_at_least(512_KiB);
+    write_at_least(128_KiB);
+    write_at_least(128_KiB);
     EXPECT_TRUE(matches_shadow());
     tests::drain_task_queue().get();
     _db->flush().get();
@@ -215,7 +220,7 @@ TEST_F(ImplTest, Randomized) {
     int rounds = 1000;
 #endif
     for (int i = 0; i < rounds; ++i) {
-        write_at_least(512_KiB);
+        write_at_least(128_KiB);
         EXPECT_TRUE(matches_shadow());
     }
 }

--- a/src/v/lsm/db/version_set.cc
+++ b/src/v/lsm/db/version_set.cc
@@ -401,7 +401,8 @@ internal::level version::pick_level_for_memtable_output(
                 auto files = get_overlapping_inputs(
                   level + 2_level, begin, end);
                 size_t sum = total_file_size(files);
-                if (sum > _vset->_options->max_grandparent_overlap_bytes()) {
+                if (
+                  sum > _vset->_options->max_grandparent_overlap_bytes(level)) {
                     break;
                 }
             }
@@ -559,7 +560,8 @@ void version_set::finalize(version* v) {
     for (auto level = 1_level; level < _options->max_level(); ++level) {
         size_t level_bytes = total_file_size(v->_files[level]);
         double score = static_cast<double>(level_bytes)
-                       / static_cast<double>(max_bytes_for_level(level));
+                       / static_cast<double>(
+                         _options->levels[level].max_total_bytes);
         if (score > best_score) {
             best_level = level;
             best_score = score;
@@ -704,7 +706,7 @@ std::optional<compaction> version_set::pick_compaction() {
         if (
           expanded0.size() > c->_inputs[which::input_level].size()
           && inputs1_size + expanded0_size
-               < _options->expanded_compaction_byte_size_limit()) {
+               < _options->expanded_compaction_byte_size_limit(level)) {
             auto [new_smallest, new_largest] = get_range(expanded0);
             auto expanded1 = _current->get_overlapping_inputs(
               level + 1_level, new_smallest, new_largest);
@@ -793,7 +795,7 @@ bool compaction::is_trivial_move() const {
       num_input_files(which::input_level) == 1
       && num_input_files(which::output_level) == 0
       && total_file_size(_grandparents)
-           <= vset->_options->max_grandparent_overlap_bytes());
+           <= vset->_options->max_grandparent_overlap_bytes(_level));
 }
 
 void compaction::add_input_deletions(version_edit* edit) {
@@ -836,7 +838,9 @@ bool compaction::should_stop_before(internal::key_view key) {
         ++_grandparent_index;
     }
     _seen_key = true;
-    if (_overlapped_bytes > vset->_options->max_grandparent_overlap_bytes()) {
+    if (
+      _overlapped_bytes
+      > vset->_options->max_grandparent_overlap_bytes(_level)) {
         // Too much overlap for current output; start new output
         _overlapped_bytes = 0;
         return true;

--- a/src/v/lsm/lsm.cc
+++ b/src/v/lsm/lsm.cc
@@ -70,13 +70,18 @@ ss::lw_shared_ptr<internal::options> translate_options(options opts) {
     internal_opts->database_epoch = internal::database_epoch{
       opts.database_epoch};
 
-    // Create level configs based on num_levels
-    internal_opts->levels.clear();
-    internal_opts->levels.reserve(opts.num_levels);
-    for (uint8_t i = 0; i < opts.num_levels; ++i) {
-        internal_opts->levels.emplace_back(internal::level{i});
-    }
-
+    // Create level configs based on num_levels, and the level 0 settings.
+    auto max_level = internal::level{
+      static_cast<uint8_t>(opts.num_levels - 1u)};
+    internal_opts->levels = internal::options::make_levels(
+      {
+        .number = internal::level::min(),
+        .max_total_bytes = opts.level_zero_stop_writes_trigger
+                           * opts.write_buffer_size,
+        .max_file_size = opts.write_buffer_size,
+      },
+      internal::options::default_level_multipler,
+      max_level);
     internal_opts->level_zero_slowdown_writes_trigger
       = opts.level_zero_slowdown_writes_trigger;
     internal_opts->level_zero_stop_writes_trigger
@@ -84,7 +89,6 @@ ss::lw_shared_ptr<internal::options> translate_options(options opts) {
     internal_opts->write_buffer_size = opts.write_buffer_size;
     internal_opts->level_one_compaction_trigger
       = opts.level_one_compaction_trigger;
-    internal_opts->max_file_size = opts.max_file_size;
     internal_opts->max_open_files = opts.max_open_files;
     internal_opts->block_cache_size = opts.block_cache_size;
     internal_opts->sst_block_size = opts.sst_block_size;


### PR DESCRIPTION
LevelDB has all the config knobs hardcoded to very small sizes. This
commit removes the last of the hard coding, and now everything is
derived from the configuration knobs. The configuration is now very
similar to both the RocksDB configuration and their recommendations
for default tuning properties.

Reading links:
- https://github.com/facebook/rocksdb/wiki/Leveled-Compaction
- https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide#level-style-compaction

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
