### PR TITLE
ct: add L0 GC workloop control configuration options

### DIFF
--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -324,7 +324,7 @@ level_zero_gc::level_zero_gc(
   level_zero_gc_config config,
   std::unique_ptr<object_storage> storage,
   std::unique_ptr<epoch_source> epoch_source)
-  : config_(config)
+  : config_(std::move(config))
   , storage_(std::move(storage))
   , epoch_source_(std::move(epoch_source))
   , should_run_(false) // begin in a stopped state
@@ -337,10 +337,17 @@ level_zero_gc::level_zero_gc(
   cloud_storage_clients::bucket_name bucket,
   seastar::sharded<cluster::health_monitor_frontend>* health_monitor,
   seastar::sharded<cluster::controller_stm>* controller_stm,
-  seastar::sharded<cluster::topic_table>* topic_table,
-  level_zero_gc_config config)
+  seastar::sharded<cluster::topic_table>* topic_table)
   : level_zero_gc(
-      config,
+      level_zero_gc_config{
+        .deletion_grace_period
+        = config::shard_local_cfg()
+            .cloud_topics_l0_gc_minimum_object_age.bind(),
+        .throttle_progress
+        = config::shard_local_cfg().cloud_topics_l0_gc_interval.bind(),
+        .throttle_no_progress
+        = config::shard_local_cfg().cloud_topics_l0_gc_backoff_interval.bind(),
+      },
       std::make_unique<object_storage_remote_impl>(remote, std::move(bucket)),
       std::make_unique<epoch_source_impl>(
         health_monitor, controller_stm, topic_table)) {}
@@ -402,16 +409,16 @@ seastar::future<> level_zero_gc::worker() {
             auto res = co_await try_to_collect();
             if (res.has_value()) {
                 if (res.value() > 0) {
-                    backoff = config_.throttle_progress;
+                    backoff = config_.throttle_progress();
                 } else {
-                    backoff = config_.throttle_no_progress;
+                    backoff = config_.throttle_no_progress();
                 }
             } else {
                 switch (res.error()) {
                 case collection_error::service_error:
                 case collection_error::invalid_object_name:
                 case collection_error::no_collectible_epoch:
-                    backoff = config_.throttle_no_progress;
+                    backoff = config_.throttle_no_progress();
                 }
             }
 
@@ -420,7 +427,7 @@ seastar::future<> level_zero_gc::worker() {
               cd_log.info,
               "Level zero GC restarting after error: {}",
               std::current_exception());
-            backoff = config_.throttle_no_progress;
+            backoff = config_.throttle_no_progress();
         }
     }
 
@@ -455,7 +462,7 @@ level_zero_gc::try_to_collect() {
     }
 
     const auto max_gc_birthday = std::chrono::system_clock::now()
-                                 - config_.deletion_grace_period;
+                                 - config_.deletion_grace_period();
 
     vlog(
       cd_log.debug,

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
@@ -136,16 +136,9 @@ namespace cloud_topics {
  * epochs starting at 0.
  */
 struct level_zero_gc_config {
-    /*
-     * TODO(noah): the grace period controls the minimum age of objects before
-     * they are eligible for removal, and likely deserves to be a proper
-     * configuration tunable. The throttling parameters are for preventing the
-     * polling worker from spinning. The throttling policy is very crude, and
-     * will need to be revisited, but should keep things in check for now.
-     */
-    std::chrono::milliseconds deletion_grace_period{10s};
-    std::chrono::milliseconds throttle_progress{2s};
-    std::chrono::milliseconds throttle_no_progress{10s};
+    config::binding<std::chrono::milliseconds> deletion_grace_period;
+    config::binding<std::chrono::milliseconds> throttle_progress;
+    config::binding<std::chrono::milliseconds> throttle_no_progress;
 };
 
 class level_zero_gc {
@@ -249,8 +242,7 @@ public:
       cloud_storage_clients::bucket_name,
       seastar::sharded<cluster::health_monitor_frontend>*,
       seastar::sharded<cluster::controller_stm>*,
-      seastar::sharded<cluster::topic_table>*,
-      level_zero_gc_config = {});
+      seastar::sharded<cluster::topic_table>*);
 
     /*
      * Request that GC be started or paused. These can be called multiple times

--- a/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
+++ b/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
@@ -110,9 +110,12 @@ public:
     LevelZeroGCTest()
       : gc(
           cloud_topics::level_zero_gc_config{
-            .deletion_grace_period = 12h,
-            .throttle_progress = 10ms,
-            .throttle_no_progress = 10ms,
+            .deletion_grace_period
+            = config::mock_binding<std::chrono::milliseconds>(12h),
+            .throttle_progress
+            = config::mock_binding<std::chrono::milliseconds>(10ms),
+            .throttle_no_progress
+            = config::mock_binding<std::chrono::milliseconds>(10ms),
           },
           std::make_unique<object_storage_test_impl>(&listed, &deleted),
           std::make_unique<epoch_source_test_impl>(&max_epoch)) {}

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4523,6 +4523,27 @@ configuration::configuration()
       "The local cache duration of a cluster wide epoch.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1min)
+  , cloud_topics_l0_gc_minimum_object_age(
+      *this,
+      "cloud_topics_l0_gc_minimum_object_age",
+      "The minimum age of an L0 object before it becomes eligible for garbage "
+      "collection.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      12h)
+  , cloud_topics_l0_gc_interval(
+      *this,
+      "cloud_topics_l0_gc_interval",
+      "The interval between invocations of the L0 garbage collection work loop "
+      "when progress is being made.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      10s)
+  , cloud_topics_l0_gc_backoff_interval(
+      *this,
+      "cloud_topics_l0_gc_backoff_interval",
+      "The interval between invocations of the L0 garbage collection work loop "
+      "when no progress is being made or errors are occurring.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      1min)
   , development_feature_property_testing_only(
       *this,
       "development_feature_property_testing_only",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -823,6 +823,10 @@ public:
     property<std::chrono::milliseconds>
       cloud_topics_epoch_service_local_epoch_cache_duration;
 
+    property<std::chrono::milliseconds> cloud_topics_l0_gc_minimum_object_age;
+    property<std::chrono::milliseconds> cloud_topics_l0_gc_interval;
+    property<std::chrono::milliseconds> cloud_topics_l0_gc_backoff_interval;
+
     development_feature_property<int> development_feature_property_testing_only;
 
 private:

--- a/tests/rptest/tests/cloud_topics/l0_gc_test.py
+++ b/tests/rptest/tests/cloud_topics/l0_gc_test.py
@@ -38,6 +38,9 @@ class CloudTopicsL0GCTest(RedpandaTest):
             "cloud_topics_reconciliation_interval": 2000,
             "cloud_topics_epoch_service_epoch_increment_interval": 5000,
             "cloud_topics_epoch_service_local_epoch_cache_duration": 5000,
+            "cloud_topics_l0_gc_minimum_object_age": 10000,
+            "cloud_topics_l0_gc_interval": 2000,
+            "cloud_topics_l0_gc_backoff_interval": 10000,
         }
         super(CloudTopicsL0GCTest, self).__init__(
             test_context=test_context,


### PR DESCRIPTION
Add some configuration options to control l0 gc work loop. Not the final form for GA, but for control in beta version of GC.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
