### PR TITLE
[CORE-14846] `ct/l1`: add `file_arena`

### DIFF
--- a/src/v/cloud_topics/level_one/common/BUILD
+++ b/src/v/cloud_topics/level_one/common/BUILD
@@ -120,3 +120,30 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "file_arena",
+    srcs = [
+        "file_arena.cc",
+        "file_arena_probe.cc",
+    ],
+    hdrs = [
+        "file_arena.h",
+        "file_arena_probe.h",
+    ],
+    implementation_deps = [
+        "//src/v/ssx:future_util",
+        "//src/v/utils:human",
+    ],
+    visibility = [
+        "//src/v/cloud_topics:__pkg__",
+        "//src/v/cloud_topics/level_one:__subpackages__",
+    ],
+    deps = [
+        ":abstract_io",
+        "//src/v/config",
+        "//src/v/metrics",
+        "//src/v/ssx:semaphore",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_one/common/file_arena.cc
+++ b/src/v/cloud_topics/level_one/common/file_arena.cc
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/common/file_arena.h"
+
+#include "cloud_topics/level_one/common/file_arena_probe.h"
+#include "ssx/future-util.h"
+#include "ssx/semaphore.h"
+#include "utils/human.h"
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+namespace cloud_topics::l1 {
+
+staging_file_with_reservation::staging_file_with_reservation(
+  std::unique_ptr<staging_file> file, ssx::semaphore_units disk_reservation)
+  : _file(std::move(file))
+  , _disk_reservation(std::move(disk_reservation)) {}
+
+ss::future<size_t> staging_file_with_reservation::size() {
+    return _file->size();
+}
+
+ss::future<ss::output_stream<char>>
+staging_file_with_reservation::output_stream() {
+    return _file->output_stream();
+}
+
+void staging_file_with_reservation::finalize(size_t file_size) {
+    size_t units = _disk_reservation.count();
+    if (units > file_size) {
+        // We asked for more units than we used. Return the excess to the
+        // arena's local pool.
+        size_t excess = units - file_size;
+        _disk_reservation.return_units(excess);
+    }
+}
+
+ss::future<> staging_file_with_reservation::remove() {
+    co_await _file->remove();
+    _disk_reservation.return_all();
+}
+
+file_arena_manager::file_arena_manager(
+  config::binding<size_t> scratch_space_size_bytes,
+  config::binding<double> scratch_space_soft_limit_size_percent,
+  config::binding<size_t> block_size,
+  std::string_view arena_ctx,
+  ss::logger& logger)
+  : _scratch_space_size_bytes(scratch_space_size_bytes)
+  , _scratch_space_soft_limit_size_percent(
+      scratch_space_soft_limit_size_percent)
+  , _block_size(block_size)
+  , _disk_bytes_reservable(0, fmt::format("file_arena::{}::global", arena_ctx))
+  , _logger(logger) {
+    // Set up watch functions on bindings
+    _scratch_space_size_bytes.watch([this] { update_disk_limits(); });
+    _scratch_space_soft_limit_size_percent.watch(
+      [this] { update_disk_limits(); });
+
+    // Initialize
+    update_disk_limits();
+}
+
+ss::future<> file_arena_manager::start(ss::sharded<file_arena>* arena) {
+    _arena = arena;
+    ssx::spawn_with_gate(_gate, [this] { return disk_space_monitor(); });
+    co_return;
+}
+
+ss::future<> file_arena_manager::stop() {
+    _as.request_abort();
+    _disk_space_monitor_cv.broken();
+    _disk_bytes_reservable.broken();
+    co_await _gate.close();
+}
+
+bool file_arena_manager::disk_space_soft_limit_exceeded() const {
+    // we use the available_units semaphore interface which is adjusted to
+    // reflect any deficits (cores owe us units), and might be negative.
+    const auto used = static_cast<ssize_t>(_disk_bytes_reservable_total)
+                      - _disk_bytes_reservable.available_units();
+    return used > static_cast<ssize_t>(_disk_bytes_reservable_soft_limit);
+}
+
+ss::future<> file_arena_manager::disk_space_monitor() {
+    while (!_gate.is_closed()) {
+        co_await _disk_space_monitor_cv.wait(
+          [this] { return disk_space_soft_limit_exceeded(); });
+
+        try {
+            co_await reclaim_disk_space();
+        } catch (...) {
+            vlog(
+              _logger.info,
+              "Recoverable error reclaiming scratch space: {}",
+              std::current_exception());
+        }
+
+        /*
+         * even when we the system is driven to high disk space utilization
+         * frequently, we don't want to go too hard with the reclaim loop.
+         */
+        co_await ss::sleep_abortable(1s, _as);
+    }
+}
+
+ss::future<> file_arena_manager::reclaim_disk_space() {
+    auto excess_units = co_await _arena->map_reduce0(
+      [](file_arena& a) { return a.release_unused_disk_units(); },
+      size_t{0},
+      [](size_t acc, size_t units) { return acc + units; });
+
+    if (excess_units > 0) {
+        _disk_bytes_reservable.signal(excess_units);
+    }
+
+    vlog(
+      _logger.debug,
+      "Collected {} unused shard-local disk reservation units for the global "
+      "pool, new reservable total: {}",
+      human::bytes(excess_units),
+      human::bytes(_disk_bytes_reservable.current()));
+}
+
+void file_arena_manager::update_disk_limits() {
+    const auto new_total_size = _scratch_space_size_bytes();
+    const auto new_soft_percent = _scratch_space_soft_limit_size_percent();
+
+    // current settings
+    const auto prev_total_size = _disk_bytes_reservable_total;
+    const auto prev_soft_limit = _disk_bytes_reservable_soft_limit;
+    const auto prev_available = _disk_bytes_reservable.available_units();
+
+    _disk_bytes_reservable_soft_limit = static_cast<size_t>(
+      static_cast<double>(new_total_size) * (new_soft_percent / 100.0));
+
+    if (new_total_size > prev_total_size) {
+        auto delta = new_total_size - prev_total_size;
+        _disk_bytes_reservable_total = new_total_size;
+        _disk_bytes_reservable.signal(delta);
+    } else if (new_total_size < prev_total_size) {
+        auto delta = prev_total_size - new_total_size;
+        _disk_bytes_reservable_total = new_total_size;
+        _disk_bytes_reservable.consume(delta);
+    }
+
+    // Alert the disk space monitor in case there is any work to be done due to
+    // the new configurations.
+    _disk_space_monitor_cv.signal();
+
+    auto format_reservable = [](auto v) {
+        if (v >= 0) {
+            return fmt::format("{}", human::bytes(v));
+        }
+        return fmt::format("{} ({})", human::bytes(0), v);
+    };
+
+    vlog(
+      _logger.info,
+      "Setting file arena scratch space total reservation: {}, soft limit: {}, "
+      "available: {} (previous total: {}, soft limit: {}, available: {})",
+      human::bytes(new_total_size),
+      human::bytes(_disk_bytes_reservable_soft_limit),
+      format_reservable(_disk_bytes_reservable.available_units()),
+      human::bytes(prev_total_size),
+      human::bytes(prev_soft_limit),
+      format_reservable(prev_available));
+}
+
+file_arena::file_arena(
+  io* io,
+  config::binding<size_t> scratch_space_size_bytes,
+  config::binding<double> scratch_space_soft_limit_size_percent,
+  config::binding<size_t> block_size,
+  std::string_view arena_ctx,
+  ss::logger& logger)
+  : _io(io)
+  , _local_disk_bytes_reservable(
+      0, fmt::format("file_arena::{}::local", arena_ctx))
+  , _logger(logger)
+  , _probe(std::make_unique<file_arena_probe>(this, arena_ctx)) {
+    if (ss::this_shard_id() == manager_shard) {
+        _core0_arena_manager = std::make_unique<file_arena_manager>(
+          scratch_space_size_bytes,
+          scratch_space_soft_limit_size_percent,
+          block_size,
+          arena_ctx,
+          logger);
+    }
+}
+
+ss::future<> file_arena::start() {
+    if (ss::this_shard_id() == manager_shard) {
+        co_await _core0_arena_manager->start(&container());
+    }
+    _probe->setup_metrics();
+}
+
+ss::future<> file_arena::stop() {
+    _local_disk_bytes_reservable.broken();
+    if (_core0_arena_manager) {
+        co_await _core0_arena_manager->stop();
+    }
+    _probe.reset(nullptr);
+}
+
+ss::future<std::expected<staging_file_with_reservation, io::errc>>
+file_arena::create_tmp_file(size_t required_file_size, ss::abort_source& as) {
+    auto units = co_await reserve_units(required_file_size, as);
+    auto file_res = co_await _io->create_tmp_file();
+    if (!file_res.has_value()) {
+        co_return std::unexpected(file_res.error());
+    }
+
+    co_return staging_file_with_reservation(
+      std::move(file_res).value(), std::move(units));
+}
+
+ss::future<ssx::semaphore_units>
+file_arena::reserve_units(size_t required_file_size, ss::abort_source& as) {
+    static const auto init_backoff = 100ms;
+    static const auto max_backoff = 1000ms;
+
+    auto backoff = init_backoff;
+    while (true) {
+        auto local_opt_units = ss::try_get_units(
+          _local_disk_bytes_reservable, required_file_size);
+        if (local_opt_units.has_value()) {
+            if (_logger.is_enabled(ss::log_level::trace)) {
+                vlog(
+                  _logger.trace,
+                  "Allocated {} disk reservation from shard-local pool. Total "
+                  "available {}",
+                  human::bytes(local_opt_units.value().count()),
+                  human::bytes(_local_disk_bytes_reservable.current()));
+            }
+            co_return std::move(local_opt_units).value();
+        }
+
+        auto units = co_await request_units_from_core0_manager();
+        if (units > 0) {
+            _local_disk_bytes_reservable.signal(units);
+            if (_logger.is_enabled(ss::log_level::debug)) {
+                vlog(
+                  _logger.debug,
+                  "Received {} disk reservation from global pool for this "
+                  "shard. New total available {}",
+                  human::bytes(units),
+                  human::bytes(_local_disk_bytes_reservable.current()));
+            }
+        }
+
+        backoff = std::min(backoff, max_backoff);
+
+        co_await ss::sleep_abortable(backoff, as);
+
+        backoff *= 2;
+    }
+}
+
+size_t file_arena::release_unused_disk_units() {
+    const auto units = _local_disk_bytes_reservable.current();
+    if (units > 0) {
+        _local_disk_bytes_reservable.consume(units);
+    }
+    return units;
+}
+
+size_t file_arena_manager::get_units(ss::shard_id shard) {
+    const auto units = std::min(
+      _disk_bytes_reservable.current(), _block_size());
+
+    if (units > 0) {
+        _disk_bytes_reservable.consume(units);
+    }
+
+    if (disk_space_soft_limit_exceeded()) {
+        _disk_space_monitor_cv.signal();
+    }
+
+    vlog(
+      _logger.debug,
+      "Allocated {} disk reservation for shard {} from global pool. New total "
+      "available {}",
+      human::bytes(units),
+      shard,
+      human::bytes(_disk_bytes_reservable.current()));
+
+    return units;
+}
+
+ss::future<size_t> file_arena::request_units_from_core0_manager() {
+    auto from = ss::this_shard_id();
+    return container().invoke_on(manager_shard, [from](file_arena& a) {
+        return a._core0_arena_manager->get_units(from);
+    });
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/file_arena.h
+++ b/src/v/cloud_topics/level_one/common/file_arena.h
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_topics/level_one/common/abstract_io.h"
+#include "cloud_topics/level_one/common/file_arena_probe.h"
+#include "config/property.h"
+#include "ssx/semaphore.h"
+
+#include <seastar/core/sharded.hh>
+
+struct FileArenaTestFixture;
+
+namespace cloud_topics::l1 {
+
+// A thin wrapper around a `staging_file` which also holds on to some semaphore
+// units. These units are obtained from a `file_arena` and are held until
+// `finalize()` & `remove()` are called, or the `staging_file_with_reservation`
+// goes out of scope. `staging_file_with_reservation`s must not outlive the
+// `file_arena` from which they are created.
+class staging_file_with_reservation {
+public:
+    staging_file_with_reservation(
+      std::unique_ptr<staging_file>, ssx::semaphore_units);
+
+    // Returns `_file->size()`.
+    ss::future<size_t> size();
+    // Returns `_file->output_stream()`.
+    ss::future<ss::output_stream<char>> output_stream();
+
+    // Intended to be called when `_file` is no longer going to be written to
+    // (but is still in use/present on disk otherwise). This can help in
+    // proactively freeing any unused units in `_disk_reservation`, if the size
+    // of `_file` on disk if smaller than what was originally requested.
+    void finalize(size_t);
+
+    // Calls `_file->remove()` and returns all remaining units in
+    // `_disk_reservation`.
+    ss::future<> remove();
+
+private:
+    std::unique_ptr<staging_file> _file;
+    ssx::semaphore_units _disk_reservation;
+};
+
+class file_arena_manager;
+
+// A file arena which has a disk reservation allocated to it. Memory is
+// managed both shard-locally and globally in a work-stealing fashion via the
+// `file_arena_manager` (which exists only on shard 0).
+// When memory is first requested on any shard, a cross-core retrieval of units
+// from the global pool is made and added to the available shard-local
+// resources. A soft limit (which is some percentage
+// of the overall reservation) is used to trigger memory reclamation from the
+// shard-local pools to return them to the global pool.
+class file_arena : public ss::peering_sharded_service<file_arena> {
+public:
+    static constexpr ss::shard_id manager_shard = 0;
+
+    file_arena(
+      io*,
+      config::binding<size_t>,
+      config::binding<double>,
+      config::binding<size_t>,
+      std::string_view,
+      ss::logger&);
+
+    // Starts the `file_arena_manager`'s resource management.
+    ss::future<> start();
+
+    // Stops the `file_arena_manager`'s disk management.
+    ss::future<> stop();
+
+    // Waits for available resources via `reserve_units()` per the requested
+    // number of bytes, and returns either a `staging_file_with_reservation`
+    // with the units held or an `io::errc` detailing the error.
+    ss::future<std::expected<staging_file_with_reservation, io::errc>>
+    create_tmp_file(size_t, ss::abort_source&);
+
+private:
+    friend file_arena_manager;
+    friend file_arena_probe;
+    friend ::FileArenaTestFixture;
+
+    // Tries to obtain units from the shard-local resources. If not enough are
+    // available per the requested file size, they are requested from the
+    // global pool held in `file_arena_manager` on core0 (which will actively
+    // try to reclaim memory from other shards until enough are available on
+    // this shard).
+    ss::future<ssx::semaphore_units> reserve_units(size_t, ss::abort_source&);
+
+    // Releases all unused units available in `_local_disk_bytes_reservable` and
+    // returns that count.
+    size_t release_unused_disk_units();
+
+    // Requests units from the global pool held in the `file_arena_manager`.
+    ss::future<size_t> request_units_from_core0_manager();
+
+private:
+    // Generates our `staging_files` for us.
+    io* _io;
+
+    // The number of bytes available for reservation on this shard.
+    ssx::semaphore _local_disk_bytes_reservable;
+
+    ss::logger& _logger;
+
+    // The manager of the file arena. Exists only on the shard0 instance
+    // of this object. Responsible for providing access to the global pool of
+    // memory allocated for this file arena, and managing memory across all
+    // shards of the `file_arena`.
+    std::unique_ptr<file_arena_manager> _core0_arena_manager{nullptr};
+
+    std::unique_ptr<file_arena_probe> _probe{nullptr};
+};
+
+// A manager of the global and shard-local memory reservation in a `file_arena`.
+// Owns the global pool of bytes from which users across all shards request
+// units, and is responsible for actively reclaiming unused units when necessary
+// across all shards.
+class file_arena_manager {
+public:
+    file_arena_manager(
+      config::binding<size_t>,
+      config::binding<double>,
+      config::binding<size_t>,
+      std::string_view,
+      ss::logger&);
+
+    // Starts resource management for the provided `file_arena`.
+    ss::future<> start(ss::sharded<file_arena>*);
+
+    // Stops resource management.
+    ss::future<> stop();
+
+    // Gets units from the global pool. May trigger reclamation in case the soft
+    // limit is exceeded.
+    size_t get_units(ss::shard_id);
+
+private:
+    // Check if the total use (including outstanding reservations) on the global
+    // memory pool has exceeded the soft limit.
+    bool disk_space_soft_limit_exceeded() const;
+
+    // A backgrounded task which calls `manage_disk_space()` when
+    // `_disk_space_monitor_cv` is triggered, typically when the soft limit has
+    // been exceeded.
+    ss::future<> disk_space_monitor();
+
+    // Attempts to reclaim memory from shard-local reservation pools for use in
+    // the global memory pool.
+    ss::future<> reclaim_disk_space();
+
+    // Updates internal disk limits per changes in configuration parameters.
+    void update_disk_limits();
+
+private:
+    friend file_arena_probe;
+    friend ::FileArenaTestFixture;
+
+    // The upper limit of reservable disk space. At most times equivalent to
+    // `_scratch_space_size_bytes`- it is duplicated in order to make
+    // required changes to the number of bytes accessible from
+    // `_disk_bytes_reservable` when the configuration for
+    // `_scratch_space_size_bytes` is altered.
+    size_t _disk_bytes_reservable_total{0};
+
+    // The soft limit of reservable disk space. When this limit is breached, the
+    // `file_arena_manager` will begin to attempt to reclaim memory in
+    // shard-local reservation pools for use in the global memory pool.
+    size_t _disk_bytes_reservable_soft_limit{0};
+
+    // The config binding for the amount of scratch space allocated for this
+    // arena.
+    config::binding<size_t> _scratch_space_size_bytes;
+
+    // The config binding for the percentage of the total scratch space that
+    // forms the soft limit.
+    config::binding<double> _scratch_space_soft_limit_size_percent;
+
+    // The expected number of units that will be returned by a call to
+    // `get_units()`.
+    config::binding<size_t> _block_size;
+
+    // The total number of bytes currently available for reservation across
+    // all shards.
+    ssx::semaphore _disk_bytes_reservable;
+
+    ss::logger& _logger;
+
+    ss::sharded<file_arena>* _arena{nullptr};
+
+    // Used to alert `disk_space_monitor()` that it should attempt to reclaim
+    // memory for the global pool.
+    ss::condition_variable _disk_space_monitor_cv;
+
+    ss::gate _gate;
+    ss::abort_source _as;
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/file_arena_probe.cc
+++ b/src/v/cloud_topics/level_one/common/file_arena_probe.cc
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/common/file_arena_probe.h"
+
+#include "cloud_topics/level_one/common/file_arena.h"
+#include "config/configuration.h"
+#include "metrics/metrics.h"
+#include "metrics/prometheus_sanitize.h"
+
+namespace cloud_topics::l1 {
+
+void file_arena_probe::setup_metrics() {
+    namespace sm = ss::metrics;
+
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+
+    _metrics.add_group(
+      prometheus_sanitize::metrics_name(
+        fmt::format("cloud_topics::file_arena:{}", _ctx)),
+      {
+        sm::make_gauge(
+          "shard_local_available",
+          [this] {
+              return _arena->_local_disk_bytes_reservable.available_units();
+          },
+          sm::description(
+            "Number of bytes available in the shard-local pool, including "
+            "outstanding reservations")),
+        sm::make_gauge(
+          "global_pool_available",
+          [this] {
+              if (ss::this_shard_id() == file_arena::manager_shard) {
+                  if (_arena->_core0_arena_manager) {
+                      return _arena->_core0_arena_manager
+                        ->_disk_bytes_reservable.available_units();
+                  }
+              }
+              return ssize_t{0};
+          },
+          sm::description(
+            "Number of bytes available in the global pool, including "
+            "outstanding reservations (expected to be empty on all shards "
+            "except shard 0).")),
+      });
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/file_arena_probe.h
+++ b/src/v/cloud_topics/level_one/common/file_arena_probe.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "metrics/metrics.h"
+
+namespace cloud_topics::l1 {
+
+class file_arena;
+
+class file_arena_probe {
+public:
+    file_arena_probe(file_arena* arena, std::string_view ctx)
+      : _arena(arena)
+      , _ctx(ctx) {}
+
+    void setup_metrics();
+
+private:
+    metrics::internal_metric_groups _metrics;
+
+    file_arena* _arena;
+    ss::sstring _ctx;
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/tests/BUILD
+++ b/src/v/cloud_topics/level_one/common/tests/BUILD
@@ -30,3 +30,22 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "file_arena_test",
+    timeout = "short",
+    srcs = [
+        "file_arena_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/cloud_topics/level_one/common:abstract_io",
+        "//src/v/cloud_topics/level_one/common:fake_io",
+        "//src/v/cloud_topics/level_one/common:file_arena",
+        "//src/v/config",
+        "//src/v/ssx:semaphore",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_one/common/tests/file_arena_test.cc
+++ b/src/v/cloud_topics/level_one/common/tests/file_arena_test.cc
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/common/abstract_io.h"
+#include "cloud_topics/level_one/common/fake_io.h"
+#include "cloud_topics/level_one/common/file_arena.h"
+#include "config/property.h"
+#include "ssx/semaphore.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/sharded.hh>
+
+#include <gtest/gtest.h>
+
+using namespace cloud_topics::l1;
+
+static const ss::sstring test_arena_str = "test_arena";
+static ss::logger test_log(test_arena_str);
+
+struct FileArenaTestFixture : public seastar_test {
+    ss::future<> set_up_file_arena(
+      size_t global_scratch_space,
+      double soft_limit_percent,
+      size_t block_size) {
+        co_await sharded_arena.start(
+          ss::sharded_parameter([&]() { return &io; }),
+          ss::sharded_parameter([&]() {
+              return config::mock_binding<size_t>(global_scratch_space);
+          }),
+          ss::sharded_parameter(
+            [&]() { return config::mock_binding<double>(soft_limit_percent); }),
+          ss::sharded_parameter(
+            [&]() { return config::mock_binding<size_t>(block_size); }),
+          ss::sharded_parameter([&]() { return test_arena_str; }),
+          std::ref(test_log));
+        co_await sharded_arena.invoke_on_all(&file_arena::start);
+    }
+
+    ss::future<> TearDownAsync() override { co_await sharded_arena.stop(); }
+
+    ss::future<file_arena_manager*> get_core0_manager() {
+        co_return co_await sharded_arena.invoke_on(
+          file_arena::manager_shard,
+          [](const auto& a) { return a._core0_arena_manager.get(); });
+    }
+
+    ssx::semaphore& local_disk_bytes_reservable(file_arena& a) {
+        return a._local_disk_bytes_reservable;
+    }
+
+    size_t disk_bytes_reservable_total(file_arena_manager* m) {
+        return m->_disk_bytes_reservable_total;
+    }
+
+    ssx::semaphore& disk_bytes_reservable(file_arena_manager* m) {
+        return m->_disk_bytes_reservable;
+    }
+
+    ss::future<> reclaim_disk_space(file_arena_manager* m) {
+        return m->reclaim_disk_space();
+    }
+
+    fake_io io{};
+    ss::sharded<file_arena> sharded_arena;
+};
+
+TEST_F(FileArenaTestFixture, TrackedFileMemoryManagement) {
+    static constexpr auto global_scratch_space = 100;
+    static constexpr auto soft_limit_percent = 80.0;
+    static constexpr auto block_size = 64;
+    set_up_file_arena(global_scratch_space, soft_limit_percent, block_size)
+      .get();
+
+    auto& arena = sharded_arena.local();
+    auto* m = get_core0_manager().get();
+    ssx::semaphore& global_sem = disk_bytes_reservable(m);
+    ssx::semaphore& local_sem = local_disk_bytes_reservable(arena);
+    ss::abort_source as;
+
+    static constexpr auto file_bytes = block_size;
+    auto tracked_file_res = arena.create_tmp_file(file_bytes, as).get();
+    ASSERT_TRUE(tracked_file_res.has_value());
+    auto tracked_file = std::move(tracked_file_res).value();
+
+    // The global reservable total hasn't changed, but the available number of
+    // units has.
+    ASSERT_EQ(disk_bytes_reservable_total(m), global_scratch_space);
+    ASSERT_EQ(global_sem.current(), global_scratch_space - file_bytes);
+    // Though, there is no excess in the local pool yet.
+    ASSERT_EQ(local_sem.current(), 0);
+
+    // Write some data to the staging file.
+    auto output_stream = tracked_file.output_stream().get();
+    static const ss::sstring str = "Hello, world!";
+    output_stream.write(str.data(), str.size()).get();
+
+    // Finalize the file (indicate there will be no more future writes). The
+    // excess disk reservation will be returned to the local shard pool.
+    tracked_file.finalize(str.size());
+
+    // After finalizing, the difference between the allocated block size and the
+    // size of the tracked_file on disk has been returned to the local pool.
+    ASSERT_EQ(local_sem.current(), block_size - str.size());
+    // Global pool has not changed.
+    ASSERT_EQ(global_sem.current(), global_scratch_space - file_bytes);
+
+    tracked_file.remove().get();
+
+    // After removing, all units have been returned to the local pool.
+    ASSERT_EQ(local_sem.current(), block_size);
+    // Global pool has not changed.
+    ASSERT_EQ(global_sem.current(), global_scratch_space - file_bytes);
+
+    // Though, if we force a reclaim of disk space...
+    reclaim_disk_space(m).get();
+
+    // ...Local pool has its unused memory reclaimed...
+    ASSERT_EQ(local_sem.current(), 0);
+
+    //...and global pool is full again.
+    ASSERT_EQ(global_sem.current(), global_scratch_space);
+}
+
+TEST_F(FileArenaTestFixture, MultipleTrackedFiles) {
+    static constexpr auto global_scratch_space = 100;
+    static constexpr auto soft_limit_percent = 80.0;
+    static constexpr auto block_size = 64;
+    set_up_file_arena(global_scratch_space, soft_limit_percent, block_size)
+      .get();
+
+    auto& arena = sharded_arena.local();
+    auto* m = get_core0_manager().get();
+    ssx::semaphore& global_sem = disk_bytes_reservable(m);
+    ssx::semaphore& local_sem = local_disk_bytes_reservable(arena);
+    ss::abort_source as;
+
+    static constexpr auto file_bytes = block_size;
+    auto tracked_file_res = arena.create_tmp_file(file_bytes, as).get();
+    ASSERT_TRUE(tracked_file_res.has_value());
+    auto tracked_file = std::move(tracked_file_res).value();
+
+    // Write some data to the staging file.
+    auto output_stream = tracked_file.output_stream().get();
+    static const ss::sstring str = "Hello, world, here is 36 more bytes!";
+    output_stream.write(str.data(), str.size()).get();
+
+    // Issue a request for another file. It won't be able to resolve, as there
+    // isn't enough space in the global pool.
+    auto next_file_fut = arena.create_tmp_file(file_bytes, as);
+
+    // Finalize the existing file, though, and there will be just enough space
+    // for the next file in the local pool.
+    tracked_file.finalize(str.size());
+
+    auto next_file_res = std::move(next_file_fut).get();
+    ASSERT_TRUE(next_file_res.has_value());
+    auto next_tracked_file = std::move(next_file_res).value();
+
+    ASSERT_EQ(local_sem.current(), 0);
+    ASSERT_EQ(global_sem.current(), 0);
+
+    tracked_file.remove().get();
+    next_tracked_file.remove().get();
+
+    // All the units are returned to the local pool.
+    ASSERT_EQ(local_sem.current(), global_scratch_space);
+    ASSERT_EQ(global_sem.current(), 0);
+}


### PR DESCRIPTION
To be used as a scratch space manager for L1 objects in `cloud_topics`.

A ~~very~~ somewhat faithful copy-paste/rework of the `datalake` manager- the work stealing approach with shard-local pools and a global memory reservation is reproduced here. The same approach of a soft-limit and a manager on core0 which reclaims unused reservations from each shard is utilized.

The `file_arena` acts as a wrapper around the `cloud_topics::l1::io` layer, in which users request `staging_file`s with their expected maximum file size up front.

The user is returned a `staging_file_with_reservation` object, which is also a thin wrapper, this time around a `staging_file` and some semaphore units. The `staging_file` can be utilized as expected, and after the user is finished writing to it, can call `finalize()` in order to return any unused space (the delta between the file size on disk and the up front memory reservation) to the shard-local pool. Finally, when the file is no longer required, the `remove()` function invokes `staging_file::remove()` and also returns all semaphore units back to the shard-local pool. This two-stage return approach is helpful for `cloud_topics`- both the `reconciler` and compaction use L1 files of an target maximum size, but have an interdeterminate amount of time between finalizing their writes to the file (which may end up being smaller than the expected maximum) and uploading/removing the files from disk.

Obviously, this means a `file_arena` must outlive all `staging_file_with_reservation` objects.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
