### PR TITLE
[v25.3.x] [CORE-14503] s/appender_bench: change the test to be of moderate size

### DIFF
--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -1022,6 +1022,7 @@ redpanda_cc_bench(
 
 redpanda_cc_bench(
     name = "segment_appender_rpbench",
+    timeout = "moderate",
     srcs = ["segment_appender_bench.cc"],
     deps = [
         "//src/v/model",


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28821
