### PR TITLE
[v25.3.x] when lowering recovery rate with recoveries in flight don't wait for available bytes to converge

### DIFF
--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -184,13 +184,17 @@ class NodesDecommissioningTest(PreallocNodesTest):
 
         wait_until(requested_status, timeout_sec=timeout_sec, backoff_sec=1)
 
-    def _set_recovery_rate(self, new_rate: int):
+    def _set_recovery_rate(self, new_rate: int, await_rehabilitation: bool = True):
         # use admin API to leverage the retry policy when controller returns 503
         patch_result = self.admin.patch_cluster_config(
             upsert={"raft_learner_recovery_rate": new_rate}
         )
         self.logger.debug(f"setting recovery rate to {new_rate} result: {patch_result}")
-        wait_for_recovery_throttle_rate(redpanda=self.redpanda, new_rate=new_rate)
+        wait_for_recovery_throttle_rate(
+            redpanda=self.redpanda,
+            new_rate=new_rate,
+            await_rehabilitation=await_rehabilitation,
+        )
 
     # after node was removed the state should be consistent on all other not removed nodes
     def _check_state_consistent(self, decommissioned_id: int):
@@ -812,7 +816,7 @@ class NodesDecommissioningTest(PreallocNodesTest):
         # throttle recovery
         self.redpanda.clean_node(self.redpanda.nodes[-1], preserve_current_install=True)
         self.redpanda.start_node(self.redpanda.nodes[-1])
-        self._set_recovery_rate(10)
+        self._set_recovery_rate(0, await_rehabilitation=False)
 
         # wait for rebalancing to start
         to_decommission = self.redpanda.nodes[-1]

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -518,12 +518,26 @@ def search_logs_with_timeout(redpanda, pattern: str, timeout_s: int = 5):
     )
 
 
-def wait_for_recovery_throttle_rate(redpanda, new_rate: int):
+def wait_for_recovery_throttle_rate(
+    redpanda, new_rate: int, await_rehabilitation: bool = True
+):
     # Recovery rate activates in the next coordinator tick, wait for it
     # to happen.
     def wait_for_throttle_update():
         def check_throttle_rate(node):
             try:
+                config = redpanda._admin.get_cluster_config(node, include_defaults=True)
+                current_rate = int(config["raft_learner_recovery_rate"])
+                redpanda.logger.debug(
+                    f"Node {node.name} has recovery throttle rate: {current_rate}, expecting: {new_rate}"
+                )
+                if current_rate != new_rate:
+                    return False
+                if not await_rehabilitation:
+                    # when recovery rate is set to low ongoing recoveries may
+                    # constantly overuse the allowance so that it never reaches
+                    # the set rate
+                    return True
                 metrics = list(redpanda.metrics(node))
                 family = filter(
                     lambda fam: fam.name

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -562,7 +562,7 @@ def wait_for_recovery_throttle_rate(
                 )
             except Exception:
                 redpanda.logger.debug(
-                    f"Error getting throttle rate for {node}", exc_info=True
+                    f"Error getting throttle rate for {node.name}", exc_info=True
                 )
                 return False
 
@@ -573,7 +573,7 @@ def wait_for_recovery_throttle_rate(
             n for n in redpanda.started_nodes() if redpanda.node_id(n) in active_brokers
         ]
         assert filtered
-        return all([check_throttle_rate(n) for n in filtered])
+        return all(check_throttle_rate(n) for n in filtered)
 
     wait_until(
         wait_for_throttle_update,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28926
