### PR TITLE
cloud_storage: make subscription available immediately

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -279,6 +279,7 @@ void remote::notify_external_subscribers(
           "Filter object is not initialized properly");
         flt._promise->set_value(event);
         flt._promise = std::nullopt;
+        flt._gate_holder.release();
         // NOTE: the filter object can be reused by the owner
     }
 
@@ -616,13 +617,11 @@ ss::future<upload_result> remote::upload_object(upload_request req) {
 ss::future<api_activity_notification>
 remote::subscribe(remote::event_filter& filter) {
     _as.check();
-    auto holder = _gate.hold();
     vassert(filter._hook.is_linked() == false, "Filter is already in use");
     _filters.push_back(filter);
+    filter._gate_holder = _gate.hold();
     filter._promise.emplace();
-    return filter._promise->get_future().then(
-      [h = std::move(holder)](api_activity_notification r) { return r; });
-    ;
+    return filter._promise->get_future();
 }
 
 std::function<void(size_t)>

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -448,12 +448,14 @@ public:
             if (_promise.has_value()) {
                 _hook.unlink();
                 _promise.reset();
+                _gate_holder.release();
             }
         }
 
     private:
         absl::node_hash_set<const retry_chain_node*> _sources_to_ignore;
         std::unordered_set<api_activity_type> _events_to_ignore;
+        ss::gate::holder _gate_holder;
         std::optional<ss::promise<api_activity_notification>> _promise;
         intrusive_list_hook _hook;
     };


### PR DESCRIPTION
In tests we we assert that once the operation concluded the subscription future is available. That assertion began to fail.

Judging by implementation that is not guaranteed (since 2mo bold change d1eb7f781463d963bacc2b970fa457c41bf30b16).

I _think_ recent changes to client pool does add some noise to reactor and slightly changed the task scheduling and made the test flaky as result.

Build failure example
https://github.com/redpanda-data/redpanda/pull/28933#:~:text=build%2Drelease%2Dclang%2Damd64

Restore the original subscribe/promise availability (deterministic) semantics by storing the gate on the promise object and avoiding an intermediate task.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
