### PR TITLE
ct: use short term for configs instead of L0

### DIFF
--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -342,11 +342,12 @@ level_zero_gc::level_zero_gc(
       level_zero_gc_config{
         .deletion_grace_period
         = config::shard_local_cfg()
-            .cloud_topics_l0_gc_minimum_object_age.bind(),
+            .cloud_topics_short_term_gc_minimum_object_age.bind(),
         .throttle_progress
-        = config::shard_local_cfg().cloud_topics_l0_gc_interval.bind(),
+        = config::shard_local_cfg().cloud_topics_short_term_gc_interval.bind(),
         .throttle_no_progress
-        = config::shard_local_cfg().cloud_topics_l0_gc_backoff_interval.bind(),
+        = config::shard_local_cfg()
+            .cloud_topics_short_term_gc_backoff_interval.bind(),
       },
       std::make_unique<object_storage_remote_impl>(remote, std::move(bucket)),
       std::make_unique<epoch_source_impl>(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4523,23 +4523,23 @@ configuration::configuration()
       "The local cache duration of a cluster wide epoch.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1min)
-  , cloud_topics_l0_gc_minimum_object_age(
+  , cloud_topics_short_term_gc_minimum_object_age(
       *this,
-      "cloud_topics_l0_gc_minimum_object_age",
+      "cloud_topics_short_term_gc_minimum_object_age",
       "The minimum age of an L0 object before it becomes eligible for garbage "
       "collection.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       12h)
-  , cloud_topics_l0_gc_interval(
+  , cloud_topics_short_term_gc_interval(
       *this,
-      "cloud_topics_l0_gc_interval",
+      "cloud_topics_short_term_gc_interval",
       "The interval between invocations of the L0 garbage collection work loop "
       "when progress is being made.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10s)
-  , cloud_topics_l0_gc_backoff_interval(
+  , cloud_topics_short_term_gc_backoff_interval(
       *this,
-      "cloud_topics_l0_gc_backoff_interval",
+      "cloud_topics_short_term_gc_backoff_interval",
       "The interval between invocations of the L0 garbage collection work loop "
       "when no progress is being made or errors are occurring.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -823,9 +823,11 @@ public:
     property<std::chrono::milliseconds>
       cloud_topics_epoch_service_local_epoch_cache_duration;
 
-    property<std::chrono::milliseconds> cloud_topics_l0_gc_minimum_object_age;
-    property<std::chrono::milliseconds> cloud_topics_l0_gc_interval;
-    property<std::chrono::milliseconds> cloud_topics_l0_gc_backoff_interval;
+    property<std::chrono::milliseconds>
+      cloud_topics_short_term_gc_minimum_object_age;
+    property<std::chrono::milliseconds> cloud_topics_short_term_gc_interval;
+    property<std::chrono::milliseconds>
+      cloud_topics_short_term_gc_backoff_interval;
 
     development_feature_property<int> development_feature_property_testing_only;
 

--- a/tests/rptest/tests/cloud_topics/l0_gc_test.py
+++ b/tests/rptest/tests/cloud_topics/l0_gc_test.py
@@ -38,9 +38,9 @@ class CloudTopicsL0GCTest(RedpandaTest):
             "cloud_topics_reconciliation_interval": 2000,
             "cloud_topics_epoch_service_epoch_increment_interval": 5000,
             "cloud_topics_epoch_service_local_epoch_cache_duration": 5000,
-            "cloud_topics_l0_gc_minimum_object_age": 10000,
-            "cloud_topics_l0_gc_interval": 2000,
-            "cloud_topics_l0_gc_backoff_interval": 10000,
+            "cloud_topics_short_term_gc_minimum_object_age": 10000,
+            "cloud_topics_short_term_gc_interval": 2000,
+            "cloud_topics_short_term_gc_backoff_interval": 10000,
         }
         super(CloudTopicsL0GCTest, self).__init__(
             test_context=test_context,


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
