### PR TITLE
`ct/l1`: deflake `replicated_metastore_test`

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -728,8 +728,13 @@ TEST_F(ReplicatedMetastoreTest, TestBasicRemoveTopics) {
     // Sanity check that all topics exist.
     for (int i = 0; i < topics_count; ++i) {
         auto tp = make_topic_p0(i);
-        auto offsets = meta.get_offsets(tp).get();
-        ASSERT_TRUE(offsets.has_value());
+        std::expected<metastore::offsets_response, metastore::errc> offsets;
+        RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+            return meta.get_offsets(tp).then([&](auto offsets_res) {
+                offsets = std::move(offsets_res);
+                return offsets.has_value();
+            });
+        });
         ASSERT_EQ(offsets->next_offset, o{100});
     }
 


### PR DESCRIPTION
This would flake fairly often with

```
DEBUG 2025-12-11 21:58:05,354 [shard 0:main] cloud_topics - leader_router.cc:255 - Not leader in processing cloud_topics::l1::rpc::get_offsets_request for {kafka_internal/ct_l1_domain/0}
src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc:732: Failure
Value of: offsets.has_value()
  Actual: false
Expected: true
```

Simply add a retry mechanism to deflake the test.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
