### PR TITLE
`cloud_storage`: tweak `segment_meta_cstore_test` parameters

### DIFF
--- a/src/v/cloud_storage/tests/BUILD
+++ b/src/v/cloud_storage/tests/BUILD
@@ -65,7 +65,7 @@ redpanda_test_cc_library(
 
 redpanda_cc_btest(
     name = "segment_meta_cstore_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "segment_meta_cstore_test.cc",
     ],

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -39,8 +39,8 @@ static ss::logger test("test-logger-s");
 // have to use smaller dataset. It's important to actually run the tests in
 // debug to detect potential memory bugs using ASan.
 #ifdef NDEBUG
-static constexpr size_t short_test_size = 10000;
-static constexpr size_t long_test_size = 100000;
+static constexpr size_t short_test_size = 3000;
+static constexpr size_t long_test_size = 20'000;
 #else
 static constexpr size_t short_test_size = 1500;
 static constexpr size_t long_test_size = 10'000;


### PR DESCRIPTION
This test was often timing out in CI. Tweak test size parameters and bump its timeout to `moderate` to avoid flakes.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
