### PR TITLE
tests: Increase bazel timeout in iobuf_mt_test

### DIFF
--- a/src/v/bytes/tests/BUILD
+++ b/src/v/bytes/tests/BUILD
@@ -28,7 +28,7 @@ redpanda_cc_btest(
 
 redpanda_cc_gtest(
     name = "iobuf_mt_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "iobuf_tests_mt.cc",
     ],


### PR DESCRIPTION
This test is a lot slower on arm debug so we are running into timeouts.

Bump the timeout.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [ ] v25.1.x

## Release Notes


* none


