### PR TITLE
Precursor changes for 26.1 seastar rebase

### DIFF
--- a/src/v/cloud_topics/level_one/common/object.h
+++ b/src/v/cloud_topics/level_one/common/object.h
@@ -20,6 +20,7 @@
 #include "model/timestamp.h"
 #include "serde/envelope.h"
 
+#include <seastar/core/file.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
 

--- a/src/v/cloud_topics/level_one/compaction/meta.h
+++ b/src/v/cloud_topics/level_one/compaction/meta.h
@@ -20,6 +20,7 @@
 #include "model/timestamp.h"
 
 #include <seastar/core/gate.hh>
+#include <seastar/core/sharded.hh>
 
 #include <memory>
 

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -264,7 +264,8 @@ ss::future<ss::temporary_buffer<char>> client::receive() {
     // Protect the receive operation with the dispatch gate to prevent
     // the input stream from being invalidated while reads are in flight
     auto holder = _dispatch_gate.hold();
-    return _in.read()
+    return in()
+      .read()
       .then([this](ss::temporary_buffer<char>&& tmpbuf) {
           _probe->add_inbound_bytes(tmpbuf.size());
           return std::move(tmpbuf);

--- a/src/v/kafka/client/transport.cc
+++ b/src/v/kafka/client/transport.cc
@@ -81,7 +81,7 @@ void transport::request_entry::set_error(errc ec) {
 
 ss::future<> transport::read_loop() {
     while (is_valid()) {
-        auto reply_sz = co_await protocol::parse_size(_in);
+        auto reply_sz = co_await protocol::parse_size(in());
 
         if (!reply_sz) {
             // If we can't read the size, we are disconnected.
@@ -90,7 +90,7 @@ ss::future<> transport::read_loop() {
         auto bytes_remaining = reply_sz.value();
 
         // TODO: add validation for correlation id here
-        auto correlation_id = co_await read_correlation_id(_in);
+        auto correlation_id = co_await read_correlation_id(in());
         bytes_remaining -= sizeof(correlation_id);
         auto it = _pending_requests.find(correlation_id);
 
@@ -107,7 +107,7 @@ ss::future<> transport::read_loop() {
         _pending_requests.erase(it);
         std::optional<tagged_fields> reply_tags;
         if (entry->is_flexible) {
-            auto [tags, bytes_read] = co_await parse_tags(_in);
+            auto [tags, bytes_read] = co_await parse_tags(in());
             reply_tags = std::move(tags);
             bytes_remaining -= bytes_read;
         }
@@ -116,7 +116,7 @@ ss::future<> transport::read_loop() {
           "reading response for correlation_id: {}, bytes_remaining: {}",
           correlation_id,
           bytes_remaining);
-        auto reply_buffer = co_await read_iobuf_exactly(_in, bytes_remaining);
+        auto reply_buffer = co_await read_iobuf_exactly(in(), bytes_remaining);
 
         entry->response_promise.set_value(
           response_data{

--- a/src/v/net/transport.cc
+++ b/src/v/net/transport.cc
@@ -131,6 +131,11 @@ ss::future<> base_transport::stop() {
     // it isn't dropping an un-stopped output stream when it
     // assigns to _out
     _out = {};
+
+    if (_in.has_value()) {
+        co_await _in->close();
+        _in = std::nullopt;
+    }
 }
 
 void base_transport::shutdown() noexcept {

--- a/src/v/net/transport.cc
+++ b/src/v/net/transport.cc
@@ -107,30 +107,30 @@ base_transport::connect(clock_type::time_point connection_timeout) {
         return do_connect(connection_timeout);
     });
 }
+
 ss::future<> base_transport::stop() {
     fail_outstanding_futures();
 
-    return _dispatch_gate.close().then([this]() {
-        // We must call stop() on our output stream, because
-        // seastar::output_stream may not be safely destroyed without a call to
-        // close(), and this class may be destroyed after stop() is called.
-        return _out.stop().then_wrapped([this](ss::future<> f) {
-            // Invalidate _out here, so that do_connect can assert that
-            // it isn't dropping an un-stopped output stream when it
-            // assigns to _out
-            try {
-                f.get();
-            } catch (...) {
-                // Closing the output stream can throw bad pipe if
-                // it had unflushed bytes, as we already closed FD.
-                vlog(
-                  _log->debug,
-                  "Exception while stopping transport: {}",
-                  std::current_exception());
-            }
-            _out = {};
-        });
-    });
+    co_await _dispatch_gate.close();
+
+    // We must call stop() on our output stream, because
+    // seastar::output_stream may not be safely destroyed without a call to
+    // close(), and this class may be destroyed after stop() is called.
+
+    try {
+        co_await _out.stop();
+    } catch (...) {
+        // Closing the output stream can throw bad pipe if
+        // it had unflushed bytes, as we already closed FD.
+        vlog(
+          _log->debug,
+          "Exception while stopping transport: {}",
+          std::current_exception());
+    }
+    // Invalidate _out here, so that do_connect can assert that
+    // it isn't dropping an un-stopped output stream when it
+    // assigns to _out
+    _out = {};
 }
 
 void base_transport::shutdown() noexcept {

--- a/src/v/net/transport.h
+++ b/src/v/net/transport.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 #include "base/seastarx.h"
+#include "base/vassert.h"
 #include "net/batched_output_stream.h"
 #include "net/client_probe.h"
 #include "net/types.h"
@@ -83,7 +84,7 @@ public:
     void set_keepalive(bool);
 
     [[gnu::always_inline]] bool is_valid() const {
-        return _fd && !_shutdown && !_in.eof();
+        return _fd && !_shutdown && (_in && !in().eof());
     }
 
     const unresolved_address& server_address() const { return _server_addr; }
@@ -96,7 +97,18 @@ public:
 protected:
     virtual void fail_outstanding_futures() {}
 
-    ss::input_stream<char> _in;
+    // Return the input stream associated with the transport.
+    // The transport must not be in initial/stopped state.
+    const ss::input_stream<char>& in() const {
+        vassert(_in.has_value(), "input stream not initialized");
+        return *_in;
+    }
+
+    ss::input_stream<char>& in() {
+        vassert(_in.has_value(), "input stream not initialized");
+        return *_in;
+    }
+
     net::batched_output_stream _out;
     ss::gate _dispatch_gate;
 
@@ -104,6 +116,8 @@ private:
     ss::future<> do_connect(clock_type::time_point);
 
     std::unique_ptr<ss::connected_socket> _fd;
+    std::optional<ss::input_stream<char>> _in;
+
     unresolved_address _server_addr;
     ss::shared_ptr<ss::tls::certificate_credentials> _creds;
     std::optional<ss::sstring> _tls_sni_hostname;

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -697,20 +697,17 @@ get_integer_query_param(const ss::http::request& req, std::string_view name) {
 } // namespace
 
 void admin_server::configure_metrics_route() {
-    ss::prometheus::add_prometheus_routes(
-      _server,
-      {.metric_help = "redpanda metrics",
-       .prefix = "vectorized",
-       .handle = ss::metrics::default_handle(),
-       .route = "/metrics"})
-      .get();
-    ss::prometheus::add_prometheus_routes(
-      _server,
-      {.metric_help = "redpanda metrics",
-       .prefix = "redpanda",
-       .handle = metrics::public_metrics_handle,
-       .route = "/public_metrics"})
-      .get();
+    ss::prometheus::config private_config;
+    private_config.prefix = "vectorized";
+    private_config.handle = ss::metrics::default_handle();
+    private_config.route = "/metrics";
+    ss::prometheus::add_prometheus_routes(_server, private_config).get();
+
+    ss::prometheus::config public_config;
+    public_config.prefix = "redpanda";
+    public_config.handle = metrics::public_metrics_handle;
+    public_config.route = "/public_metrics";
+    ss::prometheus::add_prometheus_routes(_server, public_config).get();
 }
 
 ss::future<> admin_server::configure_listeners() {

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -393,7 +393,7 @@ ss::future<> transport::do_reads() {
     return ss::do_until(
       [this] { return !is_valid(); },
       [this] {
-          return parse_header(_in).then([this](std::optional<header> h) {
+          return parse_header(in()).then([this](std::optional<header> h) {
               if (!h) {
                   vlog(
                     rpclog.debug,
@@ -421,7 +421,7 @@ ss::future<> transport::dispatch(header h) {
           h.correlation_id);
         // we have to skip received bytes to make input stream
         // state correct
-        return _in.skip(h.payload_size);
+        return in().skip(h.payload_size);
     }
     _probe->add_bytes_received(size_of_rpc_header + h.payload_size);
     auto ctx = std::make_unique<client_context_impl>(*this, h);

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -445,7 +445,7 @@ transport::send_typed_versioned(
           }
           const auto version = sctx.value()->get_header().version;
           return internal::parse_result<Output>(
-                   _in, std::move(sctx.value()), req_ver)
+                   in(), std::move(sctx.value()), req_ver)
             .then([version](result<client_context<Output>> r) {
                 return ret_t(result_context<Output>{version, std::move(r)});
             });

--- a/src/v/storage/tests/backlog_controller_test.cc
+++ b/src/v/storage/tests/backlog_controller_test.cc
@@ -36,9 +36,12 @@ struct simple_backlog_sampler : storage::backlog_controller::sampler {
 };
 
 class backlog_controller_fixture : public ::testing::Test {
+    using labels_type = ss::metrics::impl::labels_type;
+    using label_value = labels_type::mapped_type;
+    const labels_type sch_group_label = {
+      {"group", label_value{"sch_control_gr"}}, {"shard", label_value{"0"}}};
+
 public:
-    const std::map<ss::sstring, ss::sstring> sch_group_label = {
-      {"group", "sch_control_gr"}, {"shard", "0"}};
     backlog_controller_fixture() {
         sg = ss::create_scheduling_group("sch_control_gr", 100).get();
         /**

--- a/src/v/test_utils/metrics.h
+++ b/src/v/test_utils/metrics.h
@@ -40,7 +40,7 @@ std::optional<T> find_metric_value(
     }
 
     ss::metrics::impl::labels_type label_set{
-      {ss::metrics::shard_label.name(), std::to_string(ss::this_shard_id())}};
+      {ss::metrics::shard_label.name(), ss::metrics::impl::shard()}};
     for (const auto& [key, value] : labels) {
         label_set.emplace(key, value);
     }


### PR DESCRIPTION
These are changes which can go in now which fix compile issues related to the 26.1 seastar rebase. 

When we actually flip the switch there will be additional compile fixes which aren't as easily made backwards compatible.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
