### PR TITLE
rpk: clarify describe regex help text

### DIFF
--- a/src/go/rpk/pkg/cli/group/describe.go
+++ b/src/go/rpk/pkg/cli/group/describe.go
@@ -46,8 +46,8 @@ and describes groups that match any of the expressions.
 Describe groups foo and bar:
   rpk group describe foo bar
 
-Describe any group starting with f and ending in r:
-  rpk group describe -r '^f.*' '.*r$'
+Describe any group starting with f or ending in r:
+  rpk group describe '^f.*' '.*r$' --regex
 
 Describe all groups:
   rpk group describe -r '*'


### PR DESCRIPTION
The --regex flag doesn't accept any argument,
instead, it takes the arguments to `describe` and
parses them as regex (effectively opting into
regex)

This minor help text change aims to clarify that
a bit.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
