### PR TITLE
[v25.3.x] tests: Increase bazel timeout in iobuf_mt_test

### DIFF
--- a/src/v/bytes/tests/BUILD
+++ b/src/v/bytes/tests/BUILD
@@ -28,7 +28,7 @@ redpanda_cc_btest(
 
 redpanda_cc_gtest(
     name = "iobuf_mt_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "iobuf_tests_mt.cc",
     ],


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28955
