### PR TITLE
ct/l0: Introduce accurate per-stage write pipeline accounting

### DIFF
--- a/src/v/cloud_topics/level_zero/pipeline/base_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/base_pipeline.h
@@ -37,6 +37,8 @@ public:
     }
 };
 
+static constexpr size_t max_pipeline_stages = 10;
+
 /// Result of the processing of the single request
 enum class request_processing_result {
     /// Advance current request to the next pipeline stage and
@@ -87,8 +89,6 @@ struct requests_list {
 /// The base_pipeline contains code which is reused by both pipelines.
 template<class Request, class Derived, class Clock = ss::lowres_clock>
 class base_pipeline {
-    static constexpr size_t max_pipeline_stages = 10;
-
 public:
     base_pipeline()
       : _root_rtc(_as)

--- a/src/v/cloud_topics/level_zero/pipeline/tests/BUILD
+++ b/src/v/cloud_topics/level_zero/pipeline/tests/BUILD
@@ -11,6 +11,7 @@ redpanda_cc_gtest(
         "//src/v/cloud_topics/level_zero/pipeline:write_pipeline",
         "//src/v/container:chunked_circular_buffer",
         "//src/v/model",
+        "//src/v/model/tests:random",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
         "@seastar",

--- a/src/v/cloud_topics/level_zero/pipeline/tests/write_pipeline_test.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/tests/write_pipeline_test.cc
@@ -14,6 +14,7 @@
 #include "model/fundamental.h"
 #include "model/namespace.h"
 #include "model/record_batch_reader.h"
+#include "model/tests/random_batch.h"
 #include "test_utils/test.h"
 
 #include <seastar/core/abort_source.hh>
@@ -27,6 +28,8 @@
 #include <seastar/util/noncopyable_function.hh>
 
 #include <chrono>
+#include <iterator>
+#include <limits>
 #include <tuple>
 
 using namespace std::chrono_literals;
@@ -125,4 +128,77 @@ TEST_CORO(batcher_test, expired_write_request) {
     ASSERT_TRUE_CORO(!fail_result.has_value());
 
     ASSERT_TRUE_CORO(pass_result.has_value());
+}
+
+TEST_CORO(write_pipeline_test, stage_bytes_accounting) {
+    cloud_topics::l0::write_pipeline<ss::manual_clock> pipeline;
+    cloud_topics::l0::write_pipeline_accessor accessor{
+      .pipeline = &pipeline,
+    };
+
+    auto stage = pipeline.register_write_pipeline_stage();
+
+    ASSERT_EQ_CORO(pipeline.stage_bytes(stage.id()), 0);
+
+    const auto timeout = ss::manual_clock::now() + 1s;
+    auto test_data = co_await model::test::make_random_batches(
+      {.count = 1, .records = 5});
+    chunked_vector<model::record_batch> batches;
+    std::ranges::move(std::move(test_data), std::back_inserter(batches));
+
+    auto fut = pipeline.write_and_debounce(
+      model::controller_ntp, min_epoch, std::move(batches), timeout);
+
+    co_await sleep_until(
+      10ms, [&] { return accessor.write_requests_pending(1); });
+
+    // Bytes in the stage.
+    ASSERT_GT_CORO(pipeline.stage_bytes(stage.id()), 0);
+
+    // Pull requests -- bytes leave the stage.
+    auto res = stage.pull_write_requests(std::numeric_limits<size_t>::max());
+    ASSERT_EQ_CORO(pipeline.stage_bytes(stage.id()), 0);
+
+    res.requests.front().set_value(chunked_vector<cloud_topics::extent_meta>{});
+    auto write_res = co_await std::move(fut);
+    ASSERT_TRUE_CORO(write_res.has_value());
+}
+
+TEST_CORO(write_pipeline_test, stage_bytes_accounting_on_timeout) {
+    cloud_topics::l0::write_pipeline<ss::manual_clock> pipeline;
+    cloud_topics::l0::write_pipeline_accessor accessor{
+      .pipeline = &pipeline,
+    };
+
+    auto stage = pipeline.register_write_pipeline_stage();
+
+    ASSERT_EQ_CORO(pipeline.stage_bytes(stage.id()), 0);
+
+    static constexpr auto timeout_duration = 1s;
+    const auto timeout = ss::manual_clock::now() + timeout_duration;
+    auto test_data = co_await model::test::make_random_batches(
+      {.count = 1, .records = 5});
+    chunked_vector<model::record_batch> batches;
+    std::ranges::move(std::move(test_data), std::back_inserter(batches));
+
+    auto fut = pipeline.write_and_debounce(
+      model::controller_ntp, min_epoch, std::move(batches), timeout);
+
+    co_await sleep_until(
+      10ms, [&] { return accessor.write_requests_pending(1); });
+
+    // Bytes in the stage.
+    ASSERT_GT_CORO(pipeline.stage_bytes(stage.id()), 0);
+
+    // "Wait" until the requests time out.
+    ss::manual_clock::advance(timeout_duration);
+
+    // Trigger timeout detection by pulling requests.
+    auto res = stage.pull_write_requests(std::numeric_limits<size_t>::max());
+    ASSERT_EQ_CORO(res.requests.size(), 0);
+
+    // Stage bytes are released when the future resolves.
+    auto write_res = co_await std::move(fut);
+    ASSERT_FALSE_CORO(write_res.has_value());
+    ASSERT_EQ_CORO(pipeline.stage_bytes(stage.id()), 0);
 }

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -80,7 +80,7 @@ write_pipeline<Clock>::write_and_debounce(
 
     // Register data influx
     _probe.register_bytes_in(sz);
-    _probe.set_memory_usage_gauge(_current_size + sz);
+    _probe.set_memory_usage_gauge(current_size() + sz);
     _probe.register_request();
     auto lat_measure = _probe.register_request_processing_time();
     auto err_probe = ss::defer([this] { _probe.register_request_error(); });
@@ -94,12 +94,14 @@ write_pipeline<Clock>::write_and_debounce(
         units = co_await ss::get_units(
           _mem_budget, sz, this->get_root_rtc().root_abort_source());
     }
-    _current_size += sz;
     _bytes_total += sz;
-    auto d = ss::defer([this, sz] { _current_size -= sz; });
     auto stage = this->first_stage();
     l0::write_request<Clock> request(
       std::move(ntp), min_epoch, std::move(data_chunk), timeout, stage);
+    transfer_stage_bytes(unassigned_pipeline_stage, stage, sz);
+    auto stage_cleanup = ss::defer([this, &request, sz] {
+        transfer_stage_bytes(request.stage, unassigned_pipeline_stage, sz);
+    });
     vlog(
       cd_log.trace,
       "write_pipeline.write_and_debounce, created write_request(size={}, "
@@ -142,7 +144,7 @@ void write_pipeline<Clock>::reenqueue(write_request<Clock>& r, bool signal) {
           r.stage);
         // Move all re-enqueued requests to the next stage automatically
         // and notify the corresponding event filter.
-        r.stage = this->next_stage(r.stage);
+        advance_request_stage(r);
         this->get_pending().push_back(r);
         if (signal) {
             this->signal(r.stage);
@@ -187,8 +189,20 @@ write_pipeline<Clock>::get_write_requests(
             break;
         }
     }
+    // There are three steps to sever the connection between the requests
+    // and their original pipeline:
+    // 1. Splice them out of the pending list.
+    // 2. Decrement their bytes from their stage.
+    // 3. Set the stage to unassigned.
     result.requests.splice(result.requests.end(), pending, pending.begin(), it);
     result.complete = pending.empty();
+    for (auto& req : result.requests) {
+        if (req.stage != unassigned_pipeline_stage) {
+            auto idx = static_cast<size_t>(req.stage()->get_numeric_id());
+            _stage_bytes[idx] -= req.size_bytes();
+            req.stage = unassigned_pipeline_stage;
+        }
+    }
     vlog(
       cd_log.trace,
       "get_write_requests returned {} elements, containing {} ({}B)",
@@ -207,7 +221,7 @@ write_pipeline<Clock>::register_write_pipeline_stage() noexcept {
 template<class Clock>
 void write_pipeline<Clock>::signal(pipeline_stage stage) {
     this->do_signal(
-      stage, event_type::new_write_request, _current_size, _bytes_total);
+      stage, event_type::new_write_request, stage_bytes(stage), _bytes_total);
 }
 
 template<class Clock>
@@ -215,7 +229,7 @@ event write_pipeline<Clock>::trigger_event(pipeline_stage stage) {
     return event{
       .stage = stage,
       .type = event_type::new_write_request,
-      .pending_write_bytes = _current_size,
+      .pending_write_bytes = stage_bytes(stage),
       .total_write_bytes = _bytes_total,
     };
 }
@@ -316,6 +330,41 @@ write_pipeline<Clock>::stage::choose_abort_source(ss::abort_source* maybe_as) {
         }
     }
     return std::make_pair(std::move(sub), as);
+}
+
+template<class Clock>
+void write_pipeline<Clock>::transfer_stage_bytes(
+  pipeline_stage from, pipeline_stage to, size_t bytes) {
+    if (from != unassigned_pipeline_stage) {
+        _stage_bytes[static_cast<size_t>(from()->get_numeric_id())] -= bytes;
+    }
+    if (to != unassigned_pipeline_stage) {
+        _stage_bytes[static_cast<size_t>(to()->get_numeric_id())] += bytes;
+    }
+}
+
+template<class Clock>
+void write_pipeline<Clock>::advance_request_stage(write_request<Clock>& req) {
+    auto next = this->next_stage(req.stage);
+    transfer_stage_bytes(req.stage, next, req.size_bytes());
+    req.stage = next;
+}
+
+template<class Clock>
+size_t write_pipeline<Clock>::stage_bytes(pipeline_stage s) const {
+    if (s == unassigned_pipeline_stage) {
+        return 0;
+    }
+    return _stage_bytes[static_cast<size_t>(s()->get_numeric_id())];
+}
+
+template<class Clock>
+size_t write_pipeline<Clock>::current_size() const {
+    size_t total = 0;
+    for (auto bytes : _stage_bytes) {
+        total += bytes;
+    }
+    return total;
 }
 
 template class write_pipeline<ss::lowres_clock>;

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -95,12 +95,11 @@ write_pipeline<Clock>::write_and_debounce(
           _mem_budget, sz, this->get_root_rtc().root_abort_source());
     }
     _bytes_total += sz;
-    auto stage = this->first_stage();
     l0::write_request<Clock> request(
-      std::move(ntp), min_epoch, std::move(data_chunk), timeout, stage);
-    transfer_stage_bytes(unassigned_pipeline_stage, stage, sz);
-    auto stage_cleanup = ss::defer([this, &request, sz] {
-        transfer_stage_bytes(request.stage, unassigned_pipeline_stage, sz);
+      std::move(ntp), min_epoch, std::move(data_chunk), timeout);
+    auto stage_cleanup = ss::defer([this, &request] {
+        transfer_stage_bytes(
+          request.stage, unassigned_pipeline_stage, request.size_bytes());
     });
     vlog(
       cd_log.trace,
@@ -111,10 +110,7 @@ write_pipeline<Clock>::write_and_debounce(
         timeout - Clock::now())
         .count());
     auto fut = request.response.get_future();
-    this->get_pending().push_back(request);
-
-    // Notify all active event_filter instances
-    this->signal(stage);
+    reenqueue(request, /*signal=*/true);
 
     auto res = co_await std::move(fut);
     if (!res.has_value()) {

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
@@ -24,6 +24,7 @@
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/util/optimized_optional.hh>
 
+#include <array>
 #include <exception>
 #include <expected>
 #include <functional>
@@ -128,11 +129,11 @@ public:
                     }
                     switch (r.value()) {
                     case request_processing_result::advance_and_continue:
-                        req.stage = _parent->next_stage(req.stage);
+                        _parent->advance_request_stage(req);
                         count++;
                         continue;
                     case request_processing_result::advance_and_stop:
-                        req.stage = _parent->next_stage(req.stage);
+                        _parent->advance_request_stage(req);
                         count++;
                         break;
                     case request_processing_result::ignore_and_continue:
@@ -187,7 +188,18 @@ public:
 
     event trigger_event(pipeline_stage stage);
 
+    /// Advance a request to the next stage, updating per-stage byte accounting.
+    /// This is the canonical way to change a request's stage.
+    void advance_request_stage(write_request<Clock>& req);
+
+    /// Get the number of bytes at a specific pipeline stage.
+    size_t stage_bytes(pipeline_stage s) const;
+
 private:
+    /// Transfer bytes from one stage to another.
+    void
+    transfer_stage_bytes(pipeline_stage from, pipeline_stage to, size_t bytes);
+
     /// Get write requests atomically.
     /// The total size of returned write requests and the stage to which they
     /// belong to should be specified.
@@ -209,8 +221,12 @@ private:
     /// available
     void reenqueue(write_request<Clock>& req, bool signal = true);
 
-    // Current bytes (gauge)
-    size_t _current_size{0};
+    // Bytes per pipeline stage.
+    std::array<size_t, max_pipeline_stages> _stage_bytes{};
+
+    /// Sum of bytes across all pipeline stages.
+    size_t current_size() const;
+
     // Total bytes went through the pipeline
     size_t _bytes_total{0};
     // Semaphore that represents memory budget that we have

--- a/src/v/cloud_topics/level_zero/pipeline/write_request.h
+++ b/src/v/cloud_topics/level_zero/pipeline/write_request.h
@@ -44,6 +44,7 @@ struct write_request : ss::weakly_referencable<write_request<Clock>> {
     /// with timeout error
     timestamp_t expiration_time;
     /// Current pipeline stage
+    /// Use write_pipeline::advance_next_stage to change stage.
     pipeline_stage stage;
     /// List of all write requests
     intrusive_list_hook _hook;

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
@@ -193,10 +193,12 @@ ss::future<> write_request_scheduler<Clock>::pull_and_roundtrip(
         if (ss::this_shard_id() == info.shard && info.bytes > 0) {
             // Fast path: process requests locally
             // This shard is the one that has the most data.
-            _stage.process([&signaled](write_request<Clock>&) noexcept {
-                signaled = true;
-                return request_processing_result::advance_and_continue;
-            });
+            _stage.process(
+              [this, &signaled](const write_request<Clock>& r) noexcept {
+                  signaled = true;
+                  _probe.register_time_fallback(r.size_bytes());
+                  return request_processing_result::advance_and_continue;
+              });
             break;
         }
     }
@@ -346,7 +348,6 @@ write_request_scheduler<Clock>::proxy_write_request(
     // the holder was created on the target shard and
     // it will be destroyed on the target shard as well.
     auto h = _gate.hold();
-    _probe.register_time_fallback(req->size_bytes());
     _probe.register_receive_xshard(req->size_bytes());
     write_request<Clock> proxy(
       req->ntp,

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
@@ -80,7 +80,9 @@ ss::future<> write_request_scheduler<Clock>::stop() {
 
 template<typename Clock>
 size_t write_request_scheduler<Clock>::shard_bytes() noexcept {
-    // Count bytes but take limits into account.
+    // Count bytes but take limits into account. We intentionally don't use
+    // stage_bytes() here because we need to respect _max_cardinality and
+    // _max_buffer_size limits.
     size_t total_bytes = 0;
     size_t total_requests = 0;
     _stage.process(
@@ -350,8 +352,7 @@ write_request_scheduler<Clock>::proxy_write_request(
       req->ntp,
       req->topic_start_epoch,
       shallow_copy(req->data_chunk),
-      req->expiration_time,
-      _stage.id());
+      req->expiration_time);
     auto fut = proxy.response.get_future();
     _stage.push_next_stage(proxy, false);
     target_gate_holder.release();


### PR DESCRIPTION
Previously, the write pipeline maintained a _current_sz member that counted the size of all write requests in the pipeline. It was incremented just before the write was added to the pipeline and decremented when request finished and its owning write_and_debounce call returned. The big problem with _current_sz is that it was being used for the data threshold, despite counting, e.g., bytes being uploaded, instead of just bytes waiting to be batched in the scheduler stage.

This change introduces careful accounting of write request bytes by stage, and uses this accurate accounting in the data threshold. A write request belongs to the pipeline whose pending request list it is linked into, and to the stage in its stage member. This means, for example, that a write request that is being proxied belongs to no pipeline and no stage, and isn't counted. The proxy request created from it does count. This differs from _current_sz accounting.

Note that the bytes of write request a shard holds in memory is not the same thing as the bytes owned by the pipeline, because proxied requests are still held and accounted for in memory on the source shard, but not on the target shard. It's the opposite for pipeline stage byte accounting. It's OK not to count the proxied request because the batch payload stays in memory on the source shard.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
