### PR TITLE
[v25.3.x] `kafka`: improve log lines in `produce_validation` (MANUAL BACKPORT)

### DIFF
--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -247,7 +247,9 @@ partition_produce_stages produce_topic_partition(
        .message_timestamp_before_max_ms
        = cfg_ctx.message_timestamp_before_max_ms,
        .message_timestamp_after_max_ms = cfg_ctx.message_timestamp_after_max_ms,
-       .probe = octx.rctx.probe()});
+       .probe = octx.rctx.probe(),
+       .ntp = ntp,
+       .client_id = octx.rctx.header().client_id});
 
     if (validate_batch_res.has_value()) {
         auto dispatch_f = ss::now();

--- a/src/v/kafka/server/handlers/produce_validation.cc
+++ b/src/v/kafka/server/handlers/produce_validation.cc
@@ -34,7 +34,8 @@ std::optional<error_code_and_msg> validate_timestamp(
   model::timestamp_type timestamp_type,
   std::chrono::milliseconds message_timestamp_before_max_ms,
   std::chrono::milliseconds message_timestamp_after_max_ms,
-  kafka::kafka_probe& probe) {
+  kafka::kafka_probe& probe,
+  const model::ntp& ntp) {
     if (timestamp_type == model::timestamp_type::append_time) {
         // These validations are skipped for `APPEND_TIME`.
         // https://kafka.apache.org/documentation/#brokerconfigs_log.message.timestamp.after.max.ms
@@ -49,9 +50,10 @@ std::optional<error_code_and_msg> validate_timestamp(
     if (is_invalid) {
         thread_local static ss::logger::rate_limit rate(validate_rate_interval);
         auto msg = ssx::sformat(
-          "Timestamp {} of message with offset {} is out of range. The "
-          "timestamp should be within [{}, {}] of the broker time.",
+          "Timestamp {} of message for partition {} with offset {} is out of "
+          "range. The timestamp should be within [{}, {}] of the broker time.",
           timestamp,
+          ntp,
           offset,
           message_timestamp_before_max_ms,
           message_timestamp_after_max_ms);
@@ -78,7 +80,8 @@ std::optional<error_code_and_msg> validate_batch_timestamps(
   model::timestamp_type timestamp_type,
   std::chrono::milliseconds message_timestamp_before_max_ms,
   std::chrono::milliseconds message_timestamp_after_max_ms,
-  kafka::kafka_probe& probe) {
+  kafka::kafka_probe& probe,
+  const model::ntp& ntp) {
     if (timestamp_type == model::timestamp_type::append_time) {
         // These validations are skipped for `APPEND_TIME`.
         // https://kafka.apache.org/documentation/#brokerconfigs_log.message.timestamp.after.max.ms
@@ -97,7 +100,8 @@ std::optional<error_code_and_msg> validate_batch_timestamps(
       timestamp_type,
       message_timestamp_before_max_ms,
       message_timestamp_after_max_ms,
-      probe);
+      probe,
+      ntp);
 
     if (res.has_value()) {
         return res;
@@ -111,7 +115,8 @@ std::optional<error_code_and_msg> validate_batch_timestamps(
       timestamp_type,
       message_timestamp_before_max_ms,
       message_timestamp_after_max_ms,
-      probe);
+      probe,
+      ntp);
 
     return res;
 }
@@ -197,7 +202,8 @@ validate_records_and_compute_max_timestamp(
   model::timestamp_type timestamp_type,
   std::chrono::milliseconds message_timestamp_before_max_ms,
   std::chrono::milliseconds message_timestamp_after_max_ms,
-  kafka::kafka_probe& probe) {
+  kafka::kafka_probe& probe,
+  const model::ntp& ntp) {
     std::optional<error_code_and_msg> res;
     int64_t max_timestamp = -1;
     auto iterable_res = iterate_over_records(
@@ -212,7 +218,8 @@ validate_records_and_compute_max_timestamp(
             timestamp_type,
             message_timestamp_before_max_ms,
             message_timestamp_after_max_ms,
-            probe);
+            probe,
+            ntp);
           max_timestamp = std::max(timestamp(), max_timestamp);
 
           return res.has_value() ? ss::stop_iteration::yes
@@ -269,7 +276,9 @@ std::optional<error_code_and_msg> validate_batch(
   model::timestamp_type timestamp_type,
   std::chrono::milliseconds message_timestamp_before_max_ms,
   std::chrono::milliseconds message_timestamp_after_max_ms,
-  kafka::kafka_probe& probe) {
+  kafka::kafka_probe& probe,
+  const model::ntp& ntp,
+  std::optional<std::string_view> client_id) {
     std::optional<error_code_and_msg> res{std::nullopt};
     const auto broker_time = model::timestamp::now();
     const auto has_iterable_batch = iterable_batch_ref.has_value();
@@ -301,7 +310,8 @@ std::optional<error_code_and_msg> validate_batch(
           timestamp_type,
           message_timestamp_before_max_ms,
           message_timestamp_after_max_ms,
-          probe);
+          probe,
+          ntp);
 
         if (res.has_value()) {
             return res;
@@ -315,10 +325,12 @@ std::optional<error_code_and_msg> validate_batch(
             klog.log(
               ss::log_level::warn,
               rate,
-              "Produced batch has max_timestamp left unset ({{-1}}) by "
-              "client. Accepting batch since '{}' is set to '{}'. It is "
-              "strongly recommended that you update your client to set the "
-              "max_timestamp when producing: {}.",
+              "Produced batch for partition {} has max_timestamp left unset "
+              "({{-1}}) by client (client_id: {}). Accepting batch since '{}' "
+              "is set to '{}'. It is strongly recommended that you update your "
+              "client to set the max_timestamp when producing: {}.",
+              ntp,
+              client_id,
               config::shard_local_cfg().kafka_produce_batch_validation.name(),
               validation_mode,
               batch.header());
@@ -343,10 +355,13 @@ std::optional<error_code_and_msg> validate_batch(
             klog.log(
               ss::log_level::warn,
               rate,
-              "Produced batch has max_timestamp left unset ({{-1}}) by "
-              "client. Decompressing batch and setting max_timestamp manually "
-              "since '{}' to set to '{}'. It is strongly recommended that you "
-              "update your client to set the max_timestamp when producing: {}.",
+              "Produced batch for partition {} has max_timestamp left unset "
+              "({{-1}}) by client (client_id: {}). Decompressing batch and "
+              "setting max_timestamp manually since '{}' is set to '{}'. It is "
+              "strongly recommended that you update your client to set the "
+              "max_timestamp when producing: {}.",
+              ntp,
+              client_id,
               config::shard_local_cfg().kafka_produce_batch_validation.name(),
               validation_mode,
               batch.header());
@@ -362,7 +377,8 @@ std::optional<error_code_and_msg> validate_batch(
               timestamp_type,
               message_timestamp_before_max_ms,
               message_timestamp_after_max_ms,
-              probe);
+              probe,
+              ntp);
             if (!max_ts_res.has_value()) {
                 return max_ts_res.error();
             } else {
@@ -382,7 +398,8 @@ std::optional<error_code_and_msg> validate_batch(
               timestamp_type,
               message_timestamp_before_max_ms,
               message_timestamp_after_max_ms,
-              probe);
+              probe,
+              ntp);
         }
 
         if (res.has_value()) {
@@ -413,7 +430,8 @@ std::optional<error_code_and_msg> validate_batch(
           timestamp_type,
           message_timestamp_before_max_ms,
           message_timestamp_after_max_ms,
-          probe);
+          probe,
+          ntp);
 
         if (!max_ts_res.has_value()) {
             return max_ts_res.error();
@@ -458,7 +476,9 @@ std::optional<error_code_and_msg> validate_batch(const validation_args& args) {
       args.timestamp_type,
       args.message_timestamp_before_max_ms,
       args.message_timestamp_after_max_ms,
-      args.probe);
+      args.probe,
+      args.ntp,
+      args.client_id);
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/produce_validation.h
+++ b/src/v/kafka/server/handlers/produce_validation.h
@@ -40,6 +40,8 @@ struct validation_args {
     std::chrono::milliseconds message_timestamp_before_max_ms;
     std::chrono::milliseconds message_timestamp_after_max_ms;
     kafka::kafka_probe& probe;
+    const model::ntp& ntp;
+    std::optional<std::string_view> client_id;
 };
 
 // Entry point for batch validation.

--- a/tests/rptest/tests/compatibility/sarama_produce_test.py
+++ b/tests/rptest/tests/compatibility/sarama_produce_test.py
@@ -90,11 +90,11 @@ class SaramaLegacyProduceTest(RedpandaTest):
     expected_log_lines = defaultdict(dict)
     expected_log_lines[ValidationMode.RELAXED][False] = None
     expected_log_lines[ValidationMode.RELAXED][True] = (
-        "Produced batch has max_timestamp left unset ({-1}) by client. Decompressing batch and setting max_timestamp manually since 'kafka_produce_batch_validation' to set to 'relaxed'. It is strongly recommended that you update your client to set the max_timestamp when producing"
+        "Produced batch for partition {kafka/topic/0} has max_timestamp left unset ({-1}) by client (client_id: {sarama}). Decompressing batch and setting max_timestamp manually since 'kafka_produce_batch_validation' is set to 'relaxed'. It is strongly recommended that you update your client to set the max_timestamp when producing"
     )
     expected_log_lines[ValidationMode.LEGACY][False] = None
     expected_log_lines[ValidationMode.LEGACY][True] = (
-        "Produced batch has max_timestamp left unset ({-1}) by client. Accepting batch since 'kafka_produce_batch_validation' is set to 'legacy'. It is strongly recommended that you update your client to set the max_timestamp when producing"
+        "Produced batch for partition {kafka/topic/0} has max_timestamp left unset ({-1}) by client (client_id: {sarama}). Accepting batch since 'kafka_produce_batch_validation' is set to 'legacy'. It is strongly recommended that you update your client to set the max_timestamp when producing"
     )
     expected_log_lines[ValidationMode.STRICT][False] = None
     expected_log_lines[ValidationMode.STRICT][True] = None
@@ -151,7 +151,7 @@ class SaramaLegacyProduceTest(RedpandaTest):
 
         if expected_log_line is None:
             # We shouldn't see any warning for an unset max_timestamp if it is not expected.
-            pattern = "Produced batch has max_timestamp left unset ({-1}) by client"
+            pattern = "Produced batch for partition {kafka/topic/0} has max_timestamp left unset ({-1}) by client"
             assert not self.redpanda.search_log_all(pattern), (
                 f"Saw unexpected log line in redpanda logs for {validation_mode=}, {compression_type=} when maximum timestamp is unset in a produced batch."
             )


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/28943. `cherry-pick` conflict due to changes in `produce.cc` not present in `v25.3.x`. 

Fixes https://github.com/redpanda-data/redpanda/issues/28968.

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
