### PR TITLE
bazel: Don't build openssl docs

### DIFF
--- a/bazel/thirdparty/openssl.BUILD
+++ b/bazel/thirdparty/openssl.BUILD
@@ -59,6 +59,7 @@ configure_make(
         "--openssldir=/etc/ssl",
         "--libdir=lib",
         "no-tests",
+        "no-docs",
     ] + select({
         ":debug_mode": ["--debug"],
         ":release_mode": ["--release"],


### PR DESCRIPTION
We are now on an a newer openssl version which supports this flag.

Disabling the docs build speeds up the "Building openssl_foreign_cc" step from about 60s to 25s on my machine.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


* none


