### PR TITLE
seastar, security: move some deps to impl deps

### DIFF
--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -595,6 +595,10 @@ cc_library(
             "SEASTAR_BUILD_SHARED_LIBS",
         ],
     }),
+    implementation_deps = [
+        "@c-ares",
+        "@openssl",
+    ],
     includes = [
         "include",
         "src",
@@ -644,11 +648,9 @@ cc_library(
         "@boost//:lockfree",
         "@boost//:program_options",
         "@boost//:thread",
-        "@c-ares",
         "@fmt",
         "@lksctp",
         "@lz4",
-        "@openssl",
         "@protobuf",
         "@yaml-cpp",
     ] + select({

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -36,7 +36,6 @@
 #include <seastar/http/routes.hh>
 #include <seastar/net/api.hh>
 #include <seastar/net/socket_defs.hh>
-#include <seastar/net/tcp.hh>
 #include <seastar/net/tls.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/util/defer.hh>

--- a/src/v/crypto/tests/BUILD
+++ b/src/v/crypto/tests/BUILD
@@ -163,6 +163,7 @@ redpanda_test_cc_library(
         "//src/v/test_utils:gtest",
         "//src/v/test_utils:runfiles",
         "@googletest//:gtest",
+        "@openssl",
     ],
 )
 

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -33,7 +33,6 @@
 #include <seastar/http/httpd.hh>
 #include <seastar/http/routes.hh>
 #include <seastar/net/api.hh>
-#include <seastar/net/tcp.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/defer.hh>
 

--- a/src/v/security/BUILD
+++ b/src/v/security/BUILD
@@ -128,6 +128,7 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         "//src/v/random:secure_random",
+        "//src/v/thirdparty/krb5",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -161,7 +162,6 @@ redpanda_cc_library(
         "//src/v/ssx:thread_worker",
         "//src/v/strings:string_switch",
         "//src/v/strings:utf8",
-        "//src/v/thirdparty/krb5",
         "//src/v/utils:absl_sstring_hash",
         "//src/v/utils:base64",
         "//src/v/utils:log_hist",


### PR DESCRIPTION
During a clean build, there is a long dependency chain through to seastar:

foreign cc bootstrap -> openssl -> seastar

Because openssl is a black box foreign cc compile, seastar cannot even begin to _compile_ until openssl is fully built. Since seastar depends on openssl as a "dep" that applies to all downstream modules too, which for redpanda is basically everything. This leads to long periods where nothing is happening while waiting for openssl to build.

OpenSSL is actually an implementation dep of seastar, so by moving it there all redpanda modules can start compiling without waiting for seastar (seastar is a proper bazel module, which allows this).

Once this is fixes, another similar bottleneck was found in the security module, which depends on krb5 as dep. Same problem, and fixing openssl makes this worse, since krb5 tends to be finished later after that change.

Fixing both of these means that in my informal test there are no more bottlenecks in a 32-lcore build of //src/v/kafka/server: there are 32 jobs running at all times, until there are less than 32 jobs total remaining. This saves about 30 seconds in my non-scientific test.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
