### PR TITLE
tests: Avoid possible out of bound in MTT

### DIFF
--- a/tests/rptest/scale_tests/many_topics_test.py
+++ b/tests/rptest/scale_tests/many_topics_test.py
@@ -322,7 +322,7 @@ class ManyTopicsTest(RedpandaTest):
             return sum(numpy.diff(sorted(numbers_list)) == 1) >= n
 
         # Select random topic from the list
-        target_topic = topic_names[random.randint(0, len(topic_names))]
+        target_topic = random.choice(topic_names)
         # Consumer specific config
         consumer_extra_config = {
             "auto.offset.reset": "smallest",


### PR DESCRIPTION
randint is inclusive on both sides so need to subtract one.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

