### PR TITLE
[CORE-14983] `ct/l1`: add vectorized `metastore::get_compaction_infos()` implementation

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/log_info_collector.cc
+++ b/src/v/cloud_topics/level_one/compaction/log_info_collector.cc
@@ -79,8 +79,17 @@ ss::future<> log_info_collector::collect_info_for_logs(
 
     auto to_collect = get_logs_to_collect(logs_list, logs_set.size(), now);
 
-    auto compaction_infos = co_await _metastore->get_compaction_infos(
+    auto compaction_infos_res = co_await _metastore->get_compaction_infos(
       to_collect);
+    if (!compaction_infos_res.has_value()) {
+        vlog(
+          compaction_log.warn,
+          "Failed to retrieve compaction info from metastore: {}",
+          compaction_infos_res.error());
+        co_return;
+    }
+
+    auto compaction_infos = std::move(compaction_infos_res).value();
 
     populate_log_infos(
       compaction_infos, logs_set, logs_list, compaction_queue, now);

--- a/src/v/cloud_topics/level_one/domain/BUILD
+++ b/src/v/cloud_topics/level_one/domain/BUILD
@@ -39,6 +39,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics:logger",
         "//src/v/cloud_topics/level_one/metastore:garbage_collector",
         "//src/v/config",
+        "//src/v/container:chunked_hash_map",
         "//src/v/model:batch_builder",
         "//src/v/ssx:future_util",
         "//src/v/ssx:sleep_abortable",

--- a/src/v/cloud_topics/level_one/domain/domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.cc
@@ -14,6 +14,7 @@
 #include "cloud_topics/level_one/metastore/simple_metastore.h"
 #include "cloud_topics/logger.h"
 #include "config/configuration.h"
+#include "container/chunked_hash_map.h"
 #include "model/batch_builder.h"
 #include "ssx/future-util.h"
 #include "ssx/sleep_abortable.h"
@@ -342,6 +343,28 @@ domain_manager::get_offsets(rpc::get_offsets_request req) {
     };
 }
 
+rpc::get_compaction_info_reply domain_manager::do_get_compaction_info(
+  const state& stm_state, rpc::get_compaction_info_request req) {
+    auto get_res = simple_metastore::get_compaction_info(
+      stm_state, req.tp, req.tombstone_removal_upper_bound_ts);
+    if (!get_res.has_value()) {
+        return rpc::get_compaction_info_reply{
+          .ec = convert_metastore_errc(get_res.error()),
+        };
+    }
+    return rpc::get_compaction_info_reply{
+      .ec = rpc::errc::ok,
+      .dirty_ranges = std::move(get_res->offsets_response.dirty_ranges),
+      .removable_tombstone_ranges = std::move(
+        get_res->offsets_response.removable_tombstone_ranges),
+      .dirty_ratio = get_res->dirty_ratio,
+      .earliest_dirty_ts = get_res->earliest_dirty_ts,
+      .extents = meta_to_rpc_extent_metadata(
+        std::move(get_res->offsets_response.extents)),
+      .compaction_epoch = partition_state::compaction_epoch_t{
+        get_res->compaction_epoch()}};
+}
+
 ss::future<rpc::get_compaction_info_reply>
 domain_manager::get_compaction_info(rpc::get_compaction_info_request req) {
     auto gate = maybe_gate();
@@ -357,24 +380,8 @@ domain_manager::get_compaction_info(rpc::get_compaction_info_request req) {
         };
     }
     auto& stm_state = stm_->state();
-    auto get_res = simple_metastore::get_compaction_info(
-      stm_state, req.tp, req.tombstone_removal_upper_bound_ts);
-    if (!get_res.has_value()) {
-        co_return rpc::get_compaction_info_reply{
-          .ec = convert_metastore_errc(get_res.error()),
-        };
-    }
-    co_return rpc::get_compaction_info_reply{
-      .ec = rpc::errc::ok,
-      .dirty_ranges = std::move(get_res->offsets_response.dirty_ranges),
-      .removable_tombstone_ranges = std::move(
-        get_res->offsets_response.removable_tombstone_ranges),
-      .dirty_ratio = get_res->dirty_ratio,
-      .earliest_dirty_ts = get_res->earliest_dirty_ts,
-      .extents = meta_to_rpc_extent_metadata(
-        std::move(get_res->offsets_response.extents)),
-      .compaction_epoch = partition_state::compaction_epoch_t{
-        get_res->compaction_epoch()}};
+
+    co_return do_get_compaction_info(stm_state, std::move(req));
 }
 
 ss::future<rpc::get_term_for_offset_reply>
@@ -547,6 +554,32 @@ domain_manager::remove_topics(rpc::remove_topics_request req) {
       .ec = rpc::errc::ok,
       .not_removed = std::move(not_removed),
     };
+}
+
+ss::future<rpc::get_compaction_infos_reply>
+domain_manager::get_compaction_infos(rpc::get_compaction_infos_request req) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return rpc::get_compaction_infos_reply{
+          .ec = rpc::errc::not_leader,
+        };
+    }
+    auto sync_res = co_await stm_->sync(10s);
+    if (!sync_res.has_value()) {
+        co_return rpc::get_compaction_infos_reply{
+          .ec = convert_stm_errc(sync_res.error()),
+        };
+    }
+    auto& stm_state = stm_->state();
+
+    chunked_hash_map<model::topic_id_partition, rpc::get_compaction_info_reply>
+      compaction_infos;
+    for (auto& log_req : req.logs) {
+        auto log_info = do_get_compaction_info(stm_state, log_req);
+        compaction_infos.insert_or_assign(log_req.tp, std::move(log_info));
+    }
+    co_return rpc::get_compaction_infos_reply{
+      .responses = std::move(compaction_infos)};
 }
 
 ss::lowres_clock::duration domain_manager::gc_interval() const {

--- a/src/v/cloud_topics/level_one/domain/domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.h
@@ -61,10 +61,16 @@ public:
     ss::future<rpc::remove_topics_reply>
       remove_topics(rpc::remove_topics_request);
 
+    ss::future<rpc::get_compaction_infos_reply>
+      get_compaction_infos(rpc::get_compaction_infos_request);
+
 private:
     std::optional<ss::gate::holder> maybe_gate();
     ss::future<> gc_loop();
     ss::lowres_clock::duration gc_interval() const;
+
+    rpc::get_compaction_info_reply
+    do_get_compaction_info(const state&, rpc::get_compaction_info_request);
 
     ss::gate gate_;
     ss::abort_source as_;

--- a/src/v/cloud_topics/level_one/metastore/leader_router.cc
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.cc
@@ -149,6 +149,17 @@ ss::future<rpc::remove_topics_reply> do_remove_topics(
     co_return co_await domain_mgr->remove_topics(std::move(req));
 }
 
+ss::future<rpc::get_compaction_infos_reply> do_get_compaction_infos(
+  domain_supervisor& domain_supervisor,
+  const model::ntp& ntp,
+  rpc::get_compaction_infos_request req) {
+    auto domain_mgr = domain_supervisor.get(ntp);
+    if (!domain_mgr) {
+        co_return rpc::get_compaction_infos_reply{.ec = rpc::errc::not_leader};
+    }
+    co_return co_await domain_mgr->get_compaction_infos(std::move(req));
+}
+
 } // namespace
 
 template<auto Func, typename req_t>
@@ -601,6 +612,27 @@ ss::future<rpc::remove_topics_reply> leader_router::remove_topics(
     co_return co_await process<
       &leader_router::remove_topics_locally,
       &client::remove_topics>(std::move(request), bool(local_only_exec));
+}
+
+ss::future<rpc::get_compaction_infos_reply>
+leader_router::get_compaction_infos_locally(
+  rpc::get_compaction_infos_request request,
+  const model::ntp& metastore_ntp,
+  ss::shard_id shard) {
+    co_return co_await container().invoke_on(
+      shard,
+      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+          return do_get_compaction_infos(
+            *(fe._domain_supervisor), metastore_ntp, std::move(req));
+      });
+}
+
+ss::future<rpc::get_compaction_infos_reply> leader_router::get_compaction_infos(
+  rpc::get_compaction_infos_request request, local_only local_only_exec) {
+    auto holder = _gate.hold();
+    co_return co_await process<
+      &leader_router::get_compaction_infos_locally,
+      &client::get_compaction_infos>(std::move(request), bool(local_only_exec));
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/leader_router.h
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.h
@@ -89,6 +89,9 @@ public:
     ss::future<rpc::remove_topics_reply>
       remove_topics(rpc::remove_topics_request, local_only = local_only::no);
 
+    ss::future<rpc::get_compaction_infos_reply> get_compaction_infos(
+      rpc::get_compaction_infos_request, local_only = local_only::no);
+
     std::optional<model::partition_id>
     metastore_partition(const model::topic_id_partition&) const;
 
@@ -171,6 +174,11 @@ private:
 
     ss::future<rpc::remove_topics_reply> remove_topics_locally(
       rpc::remove_topics_request,
+      const model::ntp& metastore_ntp,
+      ss::shard_id);
+
+    ss::future<rpc::get_compaction_infos_reply> get_compaction_infos_locally(
+      rpc::get_compaction_infos_request,
       const model::ntp& metastore_ntp,
       ss::shard_id);
 

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -425,14 +425,8 @@ public:
       std::expected<compaction_info_response, errc>>;
 
     // Vectorized RPC for obtaining compaction state for a number of partitions.
-    virtual ss::future<compaction_info_map> get_compaction_infos(
-      const chunked_vector<compaction_info_spec>& to_collect) {
-        compaction_info_map ret;
-        for (const auto& log : to_collect) {
-            ret.emplace(log.tidp, co_await get_compaction_info(log));
-        }
-        co_return ret;
-    }
+    virtual ss::future<std::expected<compaction_info_map, errc>>
+    get_compaction_infos(const chunked_vector<compaction_info_spec>&) = 0;
 };
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -693,4 +693,73 @@ replicated_metastore::get_compaction_info(const compaction_info_spec& log) {
     co_return resp;
 }
 
+ss::future<std::expected<metastore::compaction_info_map, metastore::errc>>
+replicated_metastore::get_compaction_infos(
+  const chunked_vector<metastore::compaction_info_spec>& logs) {
+    chunked_hash_map<model::partition_id, rpc::get_compaction_infos_request>
+      partitioned_reqs;
+    metastore::compaction_info_map resp;
+    for (const auto& log : logs) {
+        const auto& tp = log.tidp;
+        auto metastore_partition = fe_.metastore_partition(tp);
+        if (!metastore_partition) {
+            vlog(cd_log.warn, "Unable to get metastore partition for {}", tp);
+            resp.insert_or_assign(tp, std::unexpected(errc::transport_error));
+            continue;
+        }
+        auto [it, inserted] = partitioned_reqs.try_emplace(
+          metastore_partition.value(),
+          rpc::get_compaction_infos_request{
+            .metastore_partition = metastore_partition.value()});
+        auto& req = it->second;
+
+        req.logs.push_back(
+          rpc::get_compaction_info_request{
+            .tp = tp,
+            .tombstone_removal_upper_bound_ts
+            = log.tombstone_removal_upper_bound_ts});
+    }
+
+    static constexpr auto max_rpc_concurrency = 10;
+    auto fut = co_await ss::coroutine::as_future(
+      ss::max_concurrent_for_each(
+        partitioned_reqs,
+        max_rpc_concurrency,
+        [this, &resp](auto& partition_and_request) {
+            auto& request = partition_and_request.second;
+            auto logs = request.logs.copy();
+            return fe_.get_compaction_infos(std::move(request))
+              .then([&resp, &logs](rpc::get_compaction_infos_reply reply) {
+                  if (reply.ec != rpc::errc::ok) {
+                      for (const auto& l : logs) {
+                          resp[l.tp] = std::unexpected(
+                            rpc_to_meta_errc(reply.ec));
+                      }
+                  }
+
+                  for (auto& [log, log_reply] : reply.responses) {
+                      metastore::compaction_info_response log_resp{
+			.dirty_ratio = log_reply.dirty_ratio,
+			.earliest_dirty_ts = log_reply.earliest_dirty_ts,
+			.offsets_response = {
+			  .dirty_ranges = std::move(log_reply.dirty_ranges),
+			  .removable_tombstone_ranges = std::move(log_reply.removable_tombstone_ranges),
+			  .extents = rpc_to_meta_extent_metadata(std::move(log_reply.extents))},
+			.compaction_epoch = metastore::compaction_epoch{log_reply.compaction_epoch()}
+		      };
+                      resp.insert_or_assign(log, std::move(log_resp));
+                  }
+              });
+        }));
+
+    if (fut.failed()) {
+        auto e = fut.get_exception();
+        vlog(
+          cd_log.warn, "Error while sending compaction info requests: {}", e);
+        co_return std::unexpected(metastore::errc::transport_error);
+    }
+
+    co_return resp;
+}
+
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
@@ -68,6 +68,9 @@ public:
     ss::future<std::expected<compaction_info_response, errc>>
     get_compaction_info(const compaction_info_spec&) override;
 
+    ss::future<std::expected<compaction_info_map, errc>>
+    get_compaction_infos(const chunked_vector<compaction_info_spec>&) override;
+
 private:
     leader_router& fe_;
 };

--- a/src/v/cloud_topics/level_one/metastore/rpc.json
+++ b/src/v/cloud_topics/level_one/metastore/rpc.json
@@ -59,6 +59,11 @@
             "name": "remove_topics",
             "input_type": "remove_topics_request",
             "output_type": "remove_topics_reply"
+        },
+        {
+            "name": "get_compaction_infos",
+            "input_type": "get_compaction_infos_request",
+            "output_type": "get_compaction_infos_reply"
         }
     ]
 }

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -330,6 +330,30 @@ struct remove_topics_request
     chunked_vector<model::topic_id> topics;
 };
 
+struct get_compaction_infos_reply
+  : serde::envelope<
+      get_compaction_infos_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    auto serde_fields() { return std::tie(ec, responses); }
+
+    errc ec;
+
+    chunked_hash_map<model::topic_id_partition, get_compaction_info_reply>
+      responses;
+};
+struct get_compaction_infos_request
+  : serde::envelope<
+      get_compaction_infos_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using resp_t = get_compaction_infos_reply;
+    auto serde_fields() { return std::tie(metastore_partition, logs); }
+
+    model::partition_id metastore_partition;
+    chunked_vector<get_compaction_info_request> logs;
+};
+
 } //  namespace cloud_topics::l1::rpc
 
 template<>

--- a/src/v/cloud_topics/level_one/metastore/service.cc
+++ b/src/v/cloud_topics/level_one/metastore/service.cc
@@ -88,4 +88,10 @@ ss::future<get_compaction_info_reply> service::get_compaction_info(
       std::move(request), leader_router::local_only::yes);
 }
 
+ss::future<get_compaction_infos_reply> service::get_compaction_infos(
+  get_compaction_infos_request request, ::rpc::streaming_context&) {
+    return _leader_router->local().get_compaction_infos(
+      std::move(request), leader_router::local_only::yes);
+}
+
 } // namespace cloud_topics::l1::rpc

--- a/src/v/cloud_topics/level_one/metastore/service.h
+++ b/src/v/cloud_topics/level_one/metastore/service.h
@@ -59,6 +59,9 @@ public:
     ss::future<get_compaction_info_reply> get_compaction_info(
       get_compaction_info_request, ::rpc::streaming_context&) override;
 
+    ss::future<get_compaction_infos_reply> get_compaction_infos(
+      get_compaction_infos_request, ::rpc::streaming_context&) override;
+
 private:
     ss::sharded<leader_router>* _leader_router;
 };

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -708,4 +708,14 @@ simple_metastore::get_compaction_info(
       .compaction_epoch = compaction_epoch.value()};
 }
 
+ss::future<std::expected<metastore::compaction_info_map, metastore::errc>>
+simple_metastore::get_compaction_infos(
+  const chunked_vector<compaction_info_spec>& logs) {
+    compaction_info_map infos;
+    for (const auto& log : logs) {
+        infos.emplace(log.tidp, co_await get_compaction_info(log));
+    }
+    co_return infos;
+}
+
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -101,6 +101,9 @@ public:
     ss::future<std::expected<compaction_info_response, errc>>
     get_compaction_info(const compaction_info_spec&) override;
 
+    ss::future<std::expected<compaction_info_map, errc>>
+    get_compaction_infos(const chunked_vector<compaction_info_spec>&) override;
+
 private:
     friend class domain_manager;
     static std::expected<offsets_response, errc>

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -832,3 +832,57 @@ TEST_F(ReplicatedMetastoreTest, TestRemoveTopicsWithShuffleLoop) {
           << "Partition " << i << " still has topics";
     }
 }
+
+TEST_F(ReplicatedMetastoreTest, TestGetCompactionInfos) {
+    auto& app = get_ct_app(model::node_id{0});
+    replicated_metastore meta(app.get_sharded_l1_metastore_router()->local());
+
+    constexpr auto partitions_count = 100;
+    ASSERT_NO_FATAL_FAILURE(
+      add_initial_objects(meta, partitions_count, 999).get());
+    chunked_vector<metastore::compaction_info_spec> info_specs;
+    info_specs.reserve(partitions_count);
+    for (int i = 0; i < partitions_count; ++i) {
+        auto tp = make_tp(i);
+        info_specs.emplace_back(tp, model::timestamp::max());
+    }
+
+    {
+        auto compaction_infos_res = meta.get_compaction_infos(info_specs).get();
+        ASSERT_TRUE(compaction_infos_res.has_value());
+        ASSERT_EQ(compaction_infos_res->size(), partitions_count);
+        for (const auto& [log, info] : compaction_infos_res.value()) {
+            ASSERT_TRUE(info.has_value());
+            ASSERT_DOUBLE_EQ(info->dirty_ratio, 1.0);
+            ASSERT_EQ(info->compaction_epoch, metastore::compaction_epoch{0});
+        }
+    }
+
+    // Compact every partition.
+    std::unique_ptr<metastore::object_metadata_builder> new_objs;
+    ASSERT_NO_FATAL_FAILURE(
+      create_initial_objects(meta, partitions_count, 999, &new_objs));
+    metastore::compaction_map_t cmap;
+    for (int i = 0; i < partitions_count; ++i) {
+        metastore::compaction_update update;
+        update.cleaned_at = model::timestamp::now();
+        update.new_cleaned_ranges.push_back(
+          metastore::compaction_update::cleaned_range{
+            .base_offset = o{0}, .last_offset = o{999}});
+        update.expected_compaction_epoch = metastore::compaction_epoch{0};
+        cmap[make_tp(i)] = std::move(update);
+    }
+    auto cmp_res = meta.compact_objects(*new_objs, cmap).get();
+    ASSERT_TRUE(cmp_res.has_value()) << fmt::to_string(cmp_res.error());
+
+    {
+        auto compaction_infos_res = meta.get_compaction_infos(info_specs).get();
+        ASSERT_TRUE(compaction_infos_res.has_value());
+        ASSERT_EQ(compaction_infos_res->size(), partitions_count);
+        for (const auto& [log, info] : compaction_infos_res.value()) {
+            ASSERT_TRUE(info.has_value());
+            ASSERT_DOUBLE_EQ(info->dirty_ratio, 0.0);
+            ASSERT_EQ(info->compaction_epoch, metastore::compaction_epoch{1});
+        }
+    }
+}


### PR DESCRIPTION
Adds a newly vectorized `get_compaction_infos()` request/handler for the `replicated_metastore` in order to cut down on the number of required RPCs. Previously, N compaction info requests would result in N RPCs, since N logs were being sampled.

A new request type `get_compaction_infos` is added and used to vectorize the operation. The requests are then fanned out according to metastore partition and dispatched concurrently.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
