### PR TITLE
[v25.2.x] `misc`: skip death tests

### DIFF
--- a/src/v/compression/tests/lz4_buf_tests.cc
+++ b/src/v/compression/tests/lz4_buf_tests.cc
@@ -83,6 +83,8 @@ TEST(MixedAllocations, CustomAllocator) {
 }
 
 TEST(MaxBufSizeDeathTest, CustomAllocator) {
+    GTEST_SKIP()
+      << "TODO(death_tests): re-enable when death tests are made stable in CI.";
     auto b = compression::lz4_decompression_buffers{4_MiB, 128_KiB + 1};
     auto allocator = b.custom_mem_alloc();
     ASSERT_DEATH(

--- a/src/v/storage/mvlog/tests/file_test.cc
+++ b/src/v/storage/mvlog/tests/file_test.cc
@@ -148,6 +148,8 @@ TEST_F_CORO(FileTest, TestAppend) {
 
 using FileDeathTest = FileTest;
 TEST_F(FileDeathTest, TestAppendAfterClose) {
+    GTEST_SKIP()
+      << "TODO(death_tests): re-enable when death tests are made stable in CI.";
     const auto path = test_path("foo");
     auto created = file_mgr_->create_file(path).get();
     created->close().get();
@@ -160,6 +162,8 @@ TEST_F(FileDeathTest, TestAppendAfterClose) {
 }
 
 TEST_F(FileDeathTest, TestStreamAfterClose) {
+    GTEST_SKIP()
+      << "TODO(death_tests): re-enable when death tests are made stable in CI.";
     const auto path = test_path("foo");
     auto created = file_mgr_->create_file(path).get();
     auto buf = tests::random_iobuf();

--- a/src/v/test_utils/tests/test_utils_test.cc
+++ b/src/v/test_utils/tests/test_utils_test.cc
@@ -30,6 +30,8 @@ TEST(test_utils_test, test_macros_pass) {
 }
 
 TEST(test_utils_test, test_macros_fail) {
+    GTEST_SKIP()
+      << "TODO(death_tests): re-enable when death tests are made stable in CI.";
     ASSERT_DEATH(RPTEST_FAIL("fail message"), "fail message");
     ASSERT_DEATH(RPTEST_ADD_FAIL("fail message"), "fail message");
     ASSERT_DEATH(RPTEST_FAIL_CORO("fail message"), "fail message");


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28566 