### PR TITLE
tests: block learner recovery in reassignment tests

### DIFF
--- a/tests/rptest/tests/partition_reassignments_test.py
+++ b/tests/rptest/tests/partition_reassignments_test.py
@@ -463,7 +463,7 @@ class PartitionReassignmentsTest(RedpandaTest):
             },
             # Set a low throttle to slowdown partition move enough that there is
             # something to cancel
-            recovery_rate=10,
+            recovery_rate=0,
         )
 
         self.wait_producers(producers, num_messages=10000)
@@ -514,7 +514,7 @@ class PartitionReassignmentsTest(RedpandaTest):
             producer_config={"topics": all_topic_names, "throughput": 1024},
             # Slow down partition move enough that the reassignment is in-progress
             # when we execute add-partitions
-            recovery_rate=10,
+            recovery_rate=0,
         )
 
         self.wait_producers(producers, num_messages=100000)


### PR DESCRIPTION
Reassignment cancellation tests rely on the fact that recovery will not finish before the test tries to cancel it. Setting recovery throttle to `0` fully blocks the recovery.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none