### PR TITLE
[CORE-14957] minor adjustments

### DIFF
--- a/src/v/cluster/cluster_link/frontend.cc
+++ b/src/v/cluster/cluster_link/frontend.cc
@@ -1089,7 +1089,7 @@ errc frontend::validator::validate_metadata_mirroring_config(
 }
 
 ss::future<errc> frontend::failover_link_topics(
-  ::cluster_link::model::id_t id, model::timeout_clock::time_point timeout) {
+  ::cluster_link::model::id_t id, model::timeout_clock::duration timeout) {
     auto meta = _table->find_link_by_id(id);
     if (!meta.has_value()) {
         co_return errc::does_not_exist;
@@ -1136,7 +1136,7 @@ ss::future<errc> frontend::failover_link_topics(
                    {.topic = t,
                     .status
                     = ::cluster_link::model::mirror_topic_status::failing_over},
-                   timeout)
+                   model::timeout_clock::now() + timeout)
             .then([&errors](errc err_code) {
                 if (err_code != errc::success) {
                     errors.push_back(err_code);

--- a/src/v/cluster/cluster_link/frontend.h
+++ b/src/v/cluster/cluster_link/frontend.h
@@ -78,7 +78,7 @@ public:
       model::timeout_clock::time_point);
 
     ss::future<errc> failover_link_topics(
-      ::cluster_link::model::id_t, model::timeout_clock::time_point);
+      ::cluster_link::model::id_t, model::timeout_clock::duration);
 
     bool cluster_link_active() const;
 

--- a/src/v/cluster_link/deps.h
+++ b/src/v/cluster_link/deps.h
@@ -94,7 +94,7 @@ public:
     shadow_topic_report(const model::id_t&, const ::model::topic&) = 0;
 
     virtual ss::future<::cluster::cluster_link::errc>
-      failover_link_topics(model::id_t, ::model::timeout_clock::time_point) = 0;
+      failover_link_topics(model::id_t, ::model::timeout_clock::duration) = 0;
 
     virtual ss::future<::cluster::cluster_link::errc> delete_shadow_topic(
       model::id_t,

--- a/src/v/cluster_link/link_status_reconciler.cc
+++ b/src/v/cluster_link/link_status_reconciler.cc
@@ -15,7 +15,7 @@
 #include "cluster_link/logger.h"
 #include "ssx/future-util.h"
 
-static constexpr auto reconciliation_interval = std::chrono::seconds{5};
+static constexpr auto reconciliation_interval = std::chrono::seconds{1};
 static constexpr auto mutation_timeout = std::chrono::seconds{5};
 
 namespace cluster_link {

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -523,7 +523,7 @@ ss::future<cl_result<model::metadata>> manager::update_mirror_topic_status(
 
 ss::future<cl_result<model::metadata>>
 manager::failover_link_topics(model::name_t link_name) {
-    static constexpr auto model_timeout = 30s;
+    static constexpr auto failover_command_timeout = 5s;
     auto hold = _g.hold();
     vlog(
       cllog.info,
@@ -536,7 +536,7 @@ manager::failover_link_topics(model::name_t link_name) {
           ssx::sformat("Unable to find link by name '{}'", link_name)};
     }
     auto ec = co_await _registry->failover_link_topics(
-      *link_id, ::model::timeout_clock::now() + model_timeout);
+      *link_id, failover_command_timeout);
     auto err = map_cluster_errc(ec);
     if (err != errc::success) {
         co_return err_info(

--- a/src/v/cluster_link/replication/mux_remote_consumer.cc
+++ b/src/v/cluster_link/replication/mux_remote_consumer.cc
@@ -290,7 +290,7 @@ ss::future<> mux_remote_consumer::fetch_loop() {
 }
 
 void mux_remote_consumer::update_configuration(const configuration& cfg) {
-    vlog(cllog.info, "Updating mux consumer configuration: {}", cfg);
+    vlog(cllog.trace, "Updating mux consumer configuration: {}", cfg);
     _consumer->update_configuration(cfg.direct_consumer_configuration);
     _partition_max_buffered = cfg.partition_max_buffered;
     _fetch_max_wait = cfg.fetch_max_wait;

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -216,7 +216,7 @@ public:
     }
 
     ss::future<::cluster::cluster_link::errc> failover_link_topics(
-      model::id_t id, ::model::timeout_clock::time_point timeout) override {
+      model::id_t id, ::model::timeout_clock::duration timeout) override {
         return _plf->failover_link_topics(id, timeout);
     }
 

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -206,7 +206,7 @@ public:
     }
 
     ss::future<::cluster::cluster_link::errc> failover_link_topics(
-      model::id_t id, ::model::timeout_clock::time_point timeout) override {
+      model::id_t id, ::model::timeout_clock::duration timeout) override {
         auto link = _table->find_link_by_id(id);
         if (!link) {
             co_return ::cluster::cluster_link::errc::does_not_exist;
@@ -222,7 +222,7 @@ public:
             auto err = co_await update_mirror_topic_state(
               id,
               {.topic = t, .status = model::mirror_topic_status::failing_over},
-              timeout);
+              ::model::timeout_clock::now() + timeout);
             if (err != ::cluster::cluster_link::errc::success) {
                 co_return err;
             }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

* Adjust a logger to be `trace` rather than `info` to clean up log output
* Switch failover command to use a duration as a parameter rather than timepoint
* Adjust link reconciliation period from `5s` to `1s`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements

* Improve timeout logic for failover link to not timeout when processing thousands of shadow topics
* Reduce log noise
* Increase frequency of topic reconciliation loop to reduce time it takes to failover topics
