### PR TITLE
`rptest`: sort after appending `HEAD` in `upgrade_path_to_head()`

### DIFF
--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -591,9 +591,14 @@ class RedpandaInstaller:
             if line not in latest_version_by_line or v > latest_version_by_line[line]:
                 latest_version_by_line[line] = v
         latest_versions = list(latest_version_by_line.values())
-        latest_versions.sort()
         if self.head_version() not in latest_versions:
             latest_versions.append(self.head_version())
+        latest_versions.sort()
+        # Truncate the `latest_versions` list to `HEAD` so that it is the last
+        # major version in the upgrade path
+        latest_versions = latest_versions[
+            : latest_versions.index(self.head_version()) + 1
+        ]
         self._redpanda.logger.debug(
             f"upgrade path to head from {version} is {latest_versions}"
         )


### PR DESCRIPTION
Occasionally we may mistag a release (e.g with the `rc` suffix), leading to it not appearing in our `released_versions`. If we append `HEAD` _after_ sorting the list, we may end up in a bad situation where the upgrade path is reported as:

```
[DEBUG - 2025-12-15 14:19:31,569 - redpanda_installer - upgrade_path_to_head - lineno:587]: upgrade path to head from (24, 3, 5) is [(24, 3, 18), (25, 1, 12), (25, 2, 12), (25, 3, 2), (25, 2, 13)]
```

This above example was due to a mistag of version `v25.2.13` as `v25.2.13-rc1`.

Also, trim the list to `HEAD` in case it is not the highest major in
the list of `released_versions`. For example, for `v25.2.x` branch, the above
would be corrected from:

```
[(24, 3, 18), (25, 1, 12), (25, 2, 12), (25, 3, 2), (25, 2, 13)]
```

to:

```
[(24, 3, 18), (25, 1, 12), (25, 2, 12), (25, 2, 13), (25, 3, 2)]
```

and with the truncation to `HEAD`:

```
[(24, 3, 18), (25, 1, 12), (25, 2, 12), (25, 2, 13)]
```

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.3.x
- [X] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
