### PR TITLE
CORE-15013 Schema Registry: preparatory refactoring for context support

### DIFF
--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -445,13 +445,8 @@ ss::future<pb::FileDescriptorProto> build_file_with_refs(
         try {
             auto dep_ss = co_await store.get_subject_schema(
               ref.sub, ref.version, include_deleted::yes);
-            auto [_, dep] = std::move(dep_ss.schema).destructure();
             co_await build_file_with_refs(
-              dp,
-              store,
-              ref.name,
-              subject_schema{subject{ref.name}, std::move(dep)},
-              normalize::no);
+              dp, store, ref.name, std::move(dep_ss.schema), normalize::no);
         } catch (const exception& e) {
             if (failed_subject_schema_lookup(e.code())) {
                 throw as_exception(

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -259,8 +259,9 @@ public:
       : _parser{}
       , _fdp{} {}
 
-    const pb::FileDescriptorProto& parse(const subject_schema& schema) {
-        schema_def_input_stream is{schema.def()};
+    const pb::FileDescriptorProto&
+    parse(std::string_view name, const schema_definition& schema_def) {
+        schema_def_input_stream is{schema_def};
         io_error_collector error_collector;
         pb::io::Tokenizer t{&is, &error_collector};
         _parser.RecordErrorsTo(&error_collector);
@@ -269,17 +270,16 @@ public:
         if (!_parser.Parse(&t, &_fdp)) {
             try {
                 // base64 decode the schema
-                iobuf_istream is{base64_to_iobuf(schema.def().raw()())};
+                iobuf_istream iobuf_is{base64_to_iobuf(schema_def.raw()())};
                 // Attempt parse as an encoded FileDescriptorProto.pb
-                if (!_fdp.ParseFromIstream(&is.istream())) {
+                if (!_fdp.ParseFromIstream(&iobuf_is.istream())) {
                     throw as_exception(error_collector.error());
                 }
             } catch (const base64_decoder_exception&) {
                 throw as_exception(error_collector.error());
             }
         }
-        const auto& sub = schema.sub()();
-        _fdp.set_name(std::string_view(sub));
+        _fdp.set_name(name);
         return _fdp;
     }
 
@@ -435,6 +435,7 @@ build_file(pb::DescriptorPool& dp, const pb::FileDescriptorProto& fdp) {
 ss::future<pb::FileDescriptorProto> build_file_with_refs(
   pb::DescriptorPool& dp,
   schema_getter& store,
+  ss::sstring name,
   subject_schema schema,
   normalize norm) {
     for (const auto& ref : schema.def().refs()) {
@@ -448,6 +449,7 @@ ss::future<pb::FileDescriptorProto> build_file_with_refs(
             co_await build_file_with_refs(
               dp,
               store,
+              ref.name,
               subject_schema{subject{ref.name}, std::move(dep)},
               normalize::no);
         } catch (const exception& e) {
@@ -461,7 +463,7 @@ ss::future<pb::FileDescriptorProto> build_file_with_refs(
 
     ss::memory::scoped_system_alloc_fallback fb;
     parser p;
-    auto new_fdp = p.parse(schema);
+    auto new_fdp = p.parse(name, schema.def());
     normalize_imports(new_fdp, norm);
     if (norm) {
         normalize_proto_file(new_fdp);
@@ -479,7 +481,7 @@ ss::future<pb::FileDescriptorProto> import_schema(
   normalize norm) {
     try {
         co_return co_await build_file_with_refs(
-          dp, store, schema.share(), norm);
+          dp, store, schema.sub()(), schema.share(), norm);
     } catch (const exception& e) {
         // Rethrow if the schema is missing references
         if (e.code() == error_code::schema_missing_reference) {

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -37,10 +37,9 @@ namespace pandaproxy::schema_registry {
 namespace {
 
 struct batch_builder : public storage::record_batch_builder {
-    explicit batch_builder(
-      model::offset base_offset, std::optional<subject> sub)
-      : record_batch_builder{model::record_batch_type::raft_data, model::offset{base_offset}}
-      , sub{std::move(sub)} {}
+    explicit batch_builder(model::offset base_offset)
+      : record_batch_builder{
+          model::record_batch_type::raft_data, model::offset{base_offset}} {}
 
     using record_batch_builder::add_raw_kv;
     using record_batch_builder::build;
@@ -60,7 +59,7 @@ struct batch_builder : public storage::record_batch_builder {
           to_json_iobuf(std::forward<V>(value)));
     }
 
-    void operator()(const seq_marker& s) {
+    void add_tombstone(const subject& sub, const seq_marker& s) {
         vlog(
           srlog.debug,
           "Delete {} tombstoning sub={} at {}",
@@ -73,12 +72,12 @@ struct batch_builder : public storage::record_batch_builder {
         switch (s.key_type) {
         case seq_marker_key_type::schema: {
             auto key = schema_key{
-              .seq{s.seq}, .node{s.node}, .sub{*sub}, .version{s.version}};
+              .seq{s.seq}, .node{s.node}, .sub{sub}, .version{s.version}};
             add_raw_kv(to_json_iobuf(std::move(key)), std::nullopt);
         } break;
         case seq_marker_key_type::delete_subject: {
             auto key = delete_subject_key{
-              .seq{s.seq}, .node{s.node}, .sub{*sub}};
+              .seq{s.seq}, .node{s.node}, .sub{sub}};
             add_raw_kv(to_json_iobuf(std::move(key)), std::nullopt);
         } break;
         case seq_marker_key_type::config: {
@@ -95,13 +94,12 @@ struct batch_builder : public storage::record_batch_builder {
         }
     }
 
-    void operator()(const chunked_vector<seq_marker>& sequences) {
+    void add_tombstones(
+      const subject& sub, const chunked_vector<seq_marker>& sequences) {
         for (const seq_marker& s : sequences) {
-            (*this)(s);
+            add_tombstone(sub, s);
         }
     }
-
-    std::optional<subject> sub;
 };
 
 } // namespace
@@ -269,7 +267,7 @@ seq_writer::do_write_subject_version(
           .id{projected.id},
           .deleted = is_deleted::no};
 
-        batch_builder rb(write_at, sub);
+        batch_builder rb(write_at);
         rb(std::move(key), std::move(value));
 
         if (co_await produce_and_apply(write_at, std::move(rb).build())) {
@@ -318,7 +316,7 @@ ss::future<std::optional<bool>> seq_writer::do_write_config(
         // ignore
     }
 
-    batch_builder rb(write_at, sub);
+    batch_builder rb(write_at);
     rb(
       config_key{.seq{write_at}, .node{_node_id}, .sub{sub}},
       config_value{.compat = compat});
@@ -351,8 +349,8 @@ ss::future<std::optional<bool>> seq_writer::do_delete_config(subject sub) {
         co_return false;
     }
 
-    batch_builder rb{model::offset{0}, sub};
-    rb(co_await _store.get_subject_config_written_at(sub));
+    batch_builder rb{model::offset{0}};
+    rb.add_tombstones(sub, co_await _store.get_subject_config_written_at(sub));
 
     if (co_await produce_and_apply(std::nullopt, std::move(rb).build())) {
         co_return true;
@@ -425,7 +423,7 @@ ss::future<std::optional<bool>> seq_writer::do_write_mode(
         // 2. Hard delete them before moving to import mode
     }
 
-    batch_builder rb(write_at, sub);
+    batch_builder rb(write_at);
     rb(
       mode_key{.seq{write_at}, .node{_node_id}, .sub{sub}},
       mode_value{.mode = m});
@@ -454,8 +452,8 @@ seq_writer::do_delete_mode(subject sub, model::offset write_at) {
     co_await _store.get_mode(sub, default_to_global::no);
     _store.check_mode_mutability(force::no);
 
-    batch_builder rb{write_at, sub};
-    rb(co_await _store.get_subject_mode_written_at(sub));
+    batch_builder rb{write_at};
+    rb.add_tombstones(sub, co_await _store.get_subject_mode_written_at(sub));
     if (co_await produce_and_apply(std::nullopt, std::move(rb).build())) {
         co_return true;
     } else {
@@ -492,14 +490,15 @@ ss::future<std::optional<bool>> seq_writer::do_delete_subject_version(
       .id{s_id},
       .deleted{is_deleted::yes}};
 
-    batch_builder rb(write_at, sub);
+    batch_builder rb(write_at);
     rb(std::move(key), std::move(value));
 
     {
         // Clear config if this is a delete of the last version
         auto vec = co_await _store.get_versions(sub, include_deleted::no);
         if (vec.size() == 1 && vec.front() == version) {
-            rb(co_await _store.get_subject_config_written_at(sub));
+            rb.add_tombstones(
+              sub, co_await _store.get_subject_config_written_at(sub));
         }
     }
     if (co_await produce_and_apply(write_at, std::move(rb).build())) {
@@ -536,13 +535,14 @@ seq_writer::do_delete_subject_impermanent(subject sub, model::offset write_at) {
     }
 
     // Proceed to write
-    batch_builder rb{write_at, sub};
+    batch_builder rb{write_at};
     rb(
       delete_subject_key{.seq{write_at}, .node{_node_id}, .sub{sub}},
       delete_subject_value{.sub{sub}});
 
     try {
-        rb(co_await _store.get_subject_mode_written_at(sub));
+        rb.add_tombstones(
+          sub, co_await _store.get_subject_mode_written_at(sub));
     } catch (const exception& e) {
         if (e.code() != error_code::subject_not_found) {
             throw;
@@ -550,7 +550,8 @@ seq_writer::do_delete_subject_impermanent(subject sub, model::offset write_at) {
     }
 
     try {
-        rb(co_await _store.get_subject_config_written_at(sub));
+        rb.add_tombstones(
+          sub, co_await _store.get_subject_config_written_at(sub));
     } catch (const exception& e) {
         if (e.code() != error_code::subject_not_found) {
             throw;
@@ -590,7 +591,7 @@ ss::future<std::optional<chunked_vector<schema_version>>>
 seq_writer::delete_subject_permanent_inner(
   subject sub, std::optional<schema_version> version) {
     chunked_vector<seq_marker> sequences;
-    batch_builder rb{model::offset{0}, sub};
+    batch_builder rb{model::offset{0}};
 
     /// Check for whether our victim is already soft-deleted happens
     /// within these store functions (will throw a 404-equivalent if so)
@@ -609,9 +610,9 @@ seq_writer::delete_subject_permanent_inner(
 
     // Deleting the subject, or the last version, deletes the subject
     if (!version.has_value() || versions.size() == 1) {
-        rb(co_await _store.get_subject_written_at(sub));
+        rb.add_tombstones(sub, co_await _store.get_subject_written_at(sub));
     }
-    rb(sequences);
+    rb.add_tombstones(sub, sequences);
 
     if (co_await produce_and_apply(std::nullopt, std::move(rb).build())) {
         co_return versions;

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -666,16 +666,6 @@ ss::future<bool> sharded_store::upsert_schema(
       });
 }
 
-ss::future<sharded_store::insert_subject_result>
-sharded_store::insert_subject(subject sub, schema_id id) {
-    auto sub_shard{shard_for(sub)};
-    auto [version, inserted] = co_await _store.invoke_on(
-      sub_shard, _smp_opts, [sub{std::move(sub)}, id](store& s) mutable {
-          return s.insert_subject(sub, id);
-      });
-    co_return insert_subject_result{version, inserted};
-}
-
 ss::future<bool> sharded_store::upsert_subject(
   seq_marker marker,
   subject sub,

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -868,11 +868,11 @@ void sharded_store::check_mode_mutability(force f) const {
     _store.local().check_mode_mutability(f).value();
 }
 
-ss::future<bool> sharded_store::has_version(
-  const subject& sub, schema_id id, include_deleted i) {
+ss::future<bool>
+sharded_store::has_version(subject sub, schema_id id, include_deleted i) {
     auto sub_shard{shard_for(sub)};
     auto has_id = co_await _store.invoke_on(
-      sub_shard, _smp_opts, [id, sub, i](class store& s) mutable {
+      sub_shard, _smp_opts, [id, sub{std::move(sub)}, i](class store& s) {
           return s.has_version(sub, id, i);
       });
     co_return has_id.has_value() && has_id.assume_value();

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -43,6 +43,8 @@ namespace pandaproxy::schema_registry {
 
 namespace {
 
+constexpr auto shard_for_next_schema_id = ss::shard_id{0};
+
 ss::shard_id shard_for(const subject& sub) {
     auto hash = xxhash_64(sub().data(), sub().length());
     return jump_consistent_hash(hash, ss::smp::count);
@@ -657,7 +659,10 @@ sharded_store::clear_compatibility(seq_marker marker, subject sub) {
 
 ss::future<bool> sharded_store::upsert_schema(
   schema_id id, schema_definition def, bool mark_schema) {
-    co_await maybe_update_max_schema_id(id);
+    co_await _store.invoke_on(
+      shard_for_next_schema_id, _smp_opts, [id](store& s) {
+          s.maybe_update_max_schema_id(id);
+      });
     co_return co_await _store.invoke_on(
       shard_for(id),
       _smp_opts,
@@ -681,30 +686,11 @@ ss::future<bool> sharded_store::upsert_subject(
       });
 }
 
-/// \brief Get the schema ID to be used for next insert
 ss::future<schema_id> sharded_store::project_schema_id() {
-    // This is very simple because we only allow one write in
-    // flight at a time.  Could be extended to track N in flight
-    // operations if needed.  _next_schema_id gets updated
-    // if the operation was successful, as a side effect
-    // of applying the write to the store.
-    auto fetch = [this] { return _next_schema_id; };
-    co_return co_await ss::smp::submit_to(
-      ss::shard_id{0}, _smp_opts, std::move(fetch));
-}
-
-ss::future<> sharded_store::maybe_update_max_schema_id(schema_id id) {
-    auto update = [this, id] {
-        auto old = _next_schema_id;
-        _next_schema_id = std::max(_next_schema_id, id + 1);
-        vlog(
-          srlog.debug,
-          "maybe_update_max_schema_id: {}->{}",
-          old,
-          _next_schema_id);
-    };
-    co_return co_await ss::smp::submit_to(
-      ss::shard_id{0}, _smp_opts, std::move(update));
+    co_return co_await _store.invoke_on(
+      shard_for_next_schema_id, _smp_opts, [](auto& s) {
+          return s.project_schema_id();
+      });
 }
 
 ss::future<bool> sharded_store::is_compatible(

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -205,7 +205,7 @@ public:
     ss::future<compatibility_result> is_compatible(
       schema_version version, subject_schema new_schema, verbose is_verbose);
 
-    ss::future<bool> has_version(const subject&, schema_id, include_deleted);
+    ss::future<bool> has_version(subject, schema_id, include_deleted);
 
     //// \brief Throw if the store is not mutable
     void check_mode_mutability(force f) const;

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -222,12 +222,6 @@ private:
     upsert_schema(schema_id id, schema_definition def, bool mark_schema);
     ss::future<> delete_schema(schema_id id);
 
-    struct insert_subject_result {
-        schema_version version;
-        bool inserted;
-    };
-    ss::future<insert_subject_result> insert_subject(subject sub, schema_id id);
-
     ss::future<bool> upsert_subject(
       seq_marker marker,
       subject sub,

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -229,15 +229,12 @@ private:
       schema_id id,
       is_deleted deleted);
 
-    ss::future<> maybe_update_max_schema_id(schema_id id);
-
     ss::future<schema_id> project_schema_id();
 
     ss::smp_submit_to_options _smp_opts;
     ss::sharded<store> _store;
 
     ///\brief Access must occur only on shard 0.
-    schema_id _next_schema_id{1};
 };
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -897,11 +897,22 @@ private:
         return v_it;
     }
 
+    // NOTE: sharded_store shards data into multiple store instances
+    // Sharded fields:
+    //   _schemas: sharded by schema_id
+    //   _subjects: sharded by subject
+    //   _marked_schemas: sharded by schema_id
+    //
+    // Replicated fields (kept on all shards):
+    //   _compatibility
+    //   _mode
+
     schema_map _schemas;
     subject_map _subjects;
     chunked_vector<schema_id> _marked_schemas;
     compatibility_level _compatibility{compatibility_level::backward};
     mode _mode{mode::read_write};
+
     is_mutable _mutable;
     metrics::internal_metric_groups _metrics;
     metrics::public_metric_groups _public_metrics;

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -775,6 +775,23 @@ public:
         }
     };
 
+    /// \brief Get the schema ID to be used for next insert
+    schema_id project_schema_id() {
+        // This is very simple because we only allow one write in
+        // flight at a time.  Could be extended to track N in flight
+        // operations if needed.  _next_schema_id gets updated
+        // if the operation was successful, as a side effect
+        // of applying the write to the store.
+        return _next_schema_id;
+    }
+
+    void maybe_update_max_schema_id(schema_id id) {
+        auto& nsi = _next_schema_id;
+        auto old = nsi;
+        nsi = std::max(nsi, id + schema_id{1});
+        vlog(srlog.debug, "next_schema_id: {} -> {}", old, nsi);
+    }
+
 private:
     struct schema_entry {
         explicit schema_entry(schema_definition definition)
@@ -906,12 +923,16 @@ private:
     // Replicated fields (kept on all shards):
     //   _compatibility
     //   _mode
+    //
+    // Only on shard 0:
+    //   _next_schema_id
 
     schema_map _schemas;
     subject_map _subjects;
     chunked_vector<schema_id> _marked_schemas;
     compatibility_level _compatibility{compatibility_level::backward};
     mode _mode{mode::read_write};
+    schema_id _next_schema_id{1};
 
     is_mutable _mutable;
     metrics::internal_metric_groups _metrics;

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -111,6 +111,41 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_failure) {
       });
 }
 
+// Setup: A -> B -> C (missing). Error should mention that the subject
+// "subject-for-B" is missing the reference to C.
+SEASTAR_THREAD_TEST_CASE(test_protobuf_missing_nested_reference_error_subject) {
+    ppstu::store_fixture store;
+
+    auto schema_b = pps::subject_schema{
+      pps::subject{"subject-for-B"},
+      pps::schema_definition{
+        R"(syntax = "proto3"; import "c.proto"; message B { C c = 1; })",
+        pps::schema_type::protobuf,
+        {{"c.proto", pps::subject{"subject-for-C"}, pps::schema_version{1}}},
+        {}}};
+
+    auto schema_a = pps::subject_schema{
+      pps::subject{"subject-for-A"},
+      pps::schema_definition{
+        R"(syntax = "proto3"; import "b.proto"; message A { B b = 1; })",
+        pps::schema_type::protobuf,
+        {{"b.proto", pps::subject{"subject-for-B"}, pps::schema_version{1}}},
+        {}}};
+
+    store.insert(schema_b.share(), pps::schema_version{1});
+
+    BOOST_REQUIRE_EXCEPTION(
+      pps::make_protobuf_schema_definition(store.store(), schema_a.share())
+        .get(),
+      pps::exception,
+      [](const pps::exception& ex) {
+          auto msg = std::string_view(ex.message());
+          return ex.code() == pps::error_code::schema_missing_reference
+                 && msg.contains("subject=b.proto")
+                 && msg.contains("subject \"subject-for-C\"");
+      });
+}
+
 SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_not_referenced) {
     ppstu::store_fixture store;
 

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -141,7 +141,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_missing_nested_reference_error_subject) {
       [](const pps::exception& ex) {
           auto msg = std::string_view(ex.message());
           return ex.code() == pps::error_code::schema_missing_reference
-                 && msg.contains("subject=b.proto")
+                 && msg.contains("subject=subject-for-B")
                  && msg.contains("subject \"subject-for-C\"");
       });
 }


### PR DESCRIPTION
This PR is a set of refactoring changes and a minor fix around protobuf missing transitive dependency error reporting. This splits out some refactoring work that makes implementing schema registry contexts easier.

See the commit messages for details.

Fixes https://redpandadata.atlassian.net/browse/CORE-15013

## Backports Required

* none

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
