### PR TITLE
[CORE-14971] rptest: allowed log line for slow TS test

### DIFF
--- a/tests/rptest/tests/datalake/cluster_restore_test.py
+++ b/tests/rptest/tests/datalake/cluster_restore_test.py
@@ -31,6 +31,10 @@ from rptest.utils.si_utils import NTP, BucketView
 KiB = 1024
 MiB = KiB * KiB
 
+DISABLED_WRITES_ALLOWED_LOGS = [
+    "Adjacent segment merging refusing to run on topic with remote.write disabled",
+]
+
 
 class DatalakeClusterRestoreTest(RedpandaTest):
     segment_size = 1 * MiB
@@ -441,7 +445,7 @@ class DatalakeClusterRestoreTest(RedpandaTest):
                 "Expected one table per topic (i.e. no DLQ tables)"
             )
 
-    @cluster(num_nodes=6)
+    @cluster(num_nodes=6, log_allow_list=DISABLED_WRITES_ALLOWED_LOGS)
     @matrix(
         cloud_storage_type=supported_storage_types(),
         catalog_type=supported_catalog_types(),
@@ -555,7 +559,7 @@ class DatalakeClusterRestoreTest(RedpandaTest):
                 rpk.alter_topic_config(t, "redpanda.remote.write", "true")
             rpk.alter_topic_config("_schemas", "redpanda.remote.write", "true")
 
-    @cluster(num_nodes=6)
+    @cluster(num_nodes=6, log_allow_list=DISABLED_WRITES_ALLOWED_LOGS)
     @matrix(
         cloud_storage_type=supported_storage_types(),
         catalog_type=supported_catalog_types(),


### PR DESCRIPTION
Some of the test cases in cluster_restore_test use remote.write=false to simulate slow tiered storage. This results in a log line like:

ERROR 2025-12-11 09:53:10,570 [shard 1:au  ] archival - [fiber15 kafka/unstructured_tp_0/0] - adjacent_segment_merger.cc:119 - Adjacent segment merging refusing to run on topic with remote.write disabled

Added to the allowed list for these test cases.

Fixes CORE-14971

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
