### PR TITLE
.clangd: analyze angled includes

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,5 +1,7 @@
 Diagnostics:
   ClangTidy:
     Remove: bugprone-unchecked-optional-access
+  Includes:
+    AnalyzeAngledIncludes: true
 CompileFlags:
   Remove: [-ferror-limit=*]


### PR DESCRIPTION
Tell .clangd to analyze angled includes, which includes things like seastar includes. This means that unused seastar headers will be flagged.

Only affects .clangd, not clang-tidy, etc.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
