### PR TITLE
ct/l0: Enable batch cache metrics and fix inverted condition

### DIFF
--- a/src/v/cloud_topics/batch_cache/batch_cache.cc
+++ b/src/v/cloud_topics/batch_cache/batch_cache.cc
@@ -98,7 +98,7 @@ ss::future<> batch_cache::cleanup_index_entries() {
     // '_index'  collection to avoid accumulating orphaned entries.
     auto it = _index.begin();
     while (it != _index.end()) {
-        if (!it->second->empty()) {
+        if (it->second->empty()) {
             it = _index.erase(it);
         } else {
             ++it;

--- a/src/v/cloud_topics/batch_cache/probe.cc
+++ b/src/v/cloud_topics/batch_cache/probe.cc
@@ -23,7 +23,6 @@ batch_cache_probe::batch_cache_probe(bool disable_metrics) {
 }
 
 void batch_cache_probe::setup_internal_metrics(bool disable) {
-    return;
     if (disable) {
         return;
     }

--- a/src/v/cloud_topics/batch_cache/tests/batch_cache_test.cc
+++ b/src/v/cloud_topics/batch_cache/tests/batch_cache_test.cc
@@ -24,6 +24,11 @@ struct batch_cache_accessor {
     evict_offset(batch_cache& c, const model::ntp& ntp, model::offset o) {
         c._index[ntp]->testing_evict_from_cache(o);
     }
+    static void reclaim(batch_cache& c, const model::ntp& ntp, size_t size) {
+        // it doesn't really matter what ntp is used, all the indices point to
+        // the same cache.
+        c._index[ntp]->testing_reclaim_from_cache(size);
+    }
     static bool contains_ntp(const batch_cache& c, const model::ntp& ntp) {
         return c._index.contains(ntp);
     }
@@ -49,6 +54,10 @@ public:
 
     void evict_offset(const model::ntp& ntp, model::offset o) {
         cloud_topics::batch_cache_accessor::evict_offset(_cache, ntp, o);
+    }
+
+    void reclaim(const model::ntp& ntp, size_t size) {
+        cloud_topics::batch_cache_accessor::reclaim(_cache, ntp, size);
     }
 };
 
@@ -114,7 +123,7 @@ TEST_F(batch_cache_test_fixture, test_batch_cache_eviction) {
 
     ASSERT_TRUE(contains_ntp(test_ntp));
 
-    evict_offset(test_ntp, model::offset(42));
+    reclaim(test_ntp, 1);
 
     ASSERT_TRUE(contains_ntp(test_ntp));
 

--- a/src/v/storage/batch_cache.h
+++ b/src/v/storage/batch_cache.h
@@ -616,6 +616,13 @@ public:
     }
 
     /*
+     * Testing interface that provides convenient access to the cache. The cache
+     * isn't exposed through storage/log_manager and some tests hook up to that
+     * cache and want to manually run reclaim.
+     */
+    void testing_reclaim_from_cache(size_t size) { _cache->reclaim(size); }
+
+    /*
      * Testing interface used to check if an index range exists even if its
      * associated batch has been evicted from the cache.
      */


### PR DESCRIPTION
The cloud topics batch cache was emptying itself periodically. This really killed its usefulness!

Also the metrics weren't being set up. Didn't see a reason for this, so I turned them on.

I tested both fixes manually. First one is a massive throughput improvement for the reconciler. The batch cache metrics were consistent with other metrics like disk cache metrics and throughput.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
