### PR TITLE
aio-limit-test: Force node id 0

### DIFF
--- a/tests/rptest/tests/aio_limit_test.py
+++ b/tests/rptest/tests/aio_limit_test.py
@@ -22,7 +22,7 @@ class AioLimitTest(RedpandaTest):
     TARGET_IOCBS = 100
 
     def __init__(self, ctx: TestContext):
-        super().__init__(test_context=ctx)
+        super().__init__(test_context=ctx, num_brokers=1)
 
     def setUp(self):
         aio_arg = f"--max-networking-io-control-blocks={self.TARGET_IOCBS}"


### PR DESCRIPTION
I don't fully understand the mechanics but while this passes 100% consistently on normal CI it does sometimes fail with manual /cdt (fewer nodes) and RP fails to start with the wrong node id.

Force the node id to avoid that.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


* none
