### PR TITLE
CORE-15017 dt: allowlist ASan stacktraces in signal crash tests

### DIFF
--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -30,6 +30,13 @@ SIGNAL_CRASH_LOG = [
     "Segmentation fault:",
     "Illegal instruction on",
     "Illegal instruction:",
+    # ASan stack trace lines (e.g. "#4 0x... in seastar::promise_base::assert_task_shard")
+    # and summary lines (e.g. "SUMMARY: AddressSanitizer: SEGV ... in ...::assert_task_shard")
+    # In debug mode, the ASan output may include function names with 'assert' in them depending
+    # on what is on the stack when the signal is received by the process. This 'assert' text
+    # would trigger the bad log lines check. To avoid that, we exclude ASan output lines here.
+    r"#\d+ 0x[0-9a-f]+ in ",
+    "SUMMARY: AddressSanitizer:",
 ]
 
 ASSERT_CRASH_LOG = ["assert - "]


### PR DESCRIPTION
Tests that intentionally send fatal signals (SIGSEGV, SIGABRT, SIGILL)
to redpanda can trigger the ASan's signal handler, which prints a stack
trace. This output may contain function names like "assert_task_shard"
that match the "[Aa]ssert" bad log pattern, causing false positive test
failures.

The chain of events:
1. Test sends SIGSEGV to redpanda
2. Redpanda's signal handler records the crash
3. Redpanda's signal handler re-raises to the original handler
4. ASan's signal handler runs and prints a diagnostic stack trace
5. Log scanner sees "assert" in a function name and flags it as bad

Added patterns to SIGNAL_CRASH_LOG to exclude ASan stack trace lines
(e.g. `https://github.com/redpanda-data/redpanda/pull/4 0x... in function_name`) and summary lines (e.g. `SUMMARY:
AddressSanitizer: SEGV ... in ...::assert_task_shard`) from bad log
detection.

### Example:
```
Segmentation fault:
0x00000000180b80d5 in 
...
0x000000001806f564 in 
Recorded crash reason to crash file on shard 0 (SIGSEGV)
AddressSanitizer:DEADLYSIGNAL
=================================================================
==830==ERROR: AddressSanitizer: SEGV on unknown address 0x00000000033e (pc 0x56534b3036c0 bp 0x000000000047 sp 0x7fff8bd32ee0 T0)
==830==The signal is caused by a READ memory access.
==830==Hint: address points to the zero page.
exec llvm-symbolizer shim, cmd: '--demangle --inlines --default-arch=x86_64', ASAN_OPTIONS=abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1, UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1:abort_on_error=1:suppressions=/opt/ubsan_suppressions.txt
    #0 0x56534b3036c0 in __asan::FakeStack::GC(unsigned long) /src/llvm-project/compiler-rt/lib/asan/asan_fake_stack.cpp:160:11
    #1 0x56534b303f37 in Allocate /src/llvm-project/compiler-rt/lib/asan/asan_fake_stack.cpp:92:5
    #2 0x56534b303f37 in OnMalloc /src/llvm-project/compiler-rt/lib/asan/asan_fake_stack.cpp:229:11
    #3 0x56534b303f37 in __asan_stack_malloc_1 /src/llvm-project/compiler-rt/lib/asan/asan_fake_stack.cpp:274:1
    #4 0x56535b938edd in seastar::internal::promise_base::assert_task_shard() const external/+non_module_dependencies+seastar/src/core/future.cc:119
    #5 0x56535b93c1f6 in void seastar::internal::promise_base::make_ready<(seastar::internal::promise_base::urgent)1>() external/+non_module_dependencies+seastar/src/core/future.cc:130:9
...
SUMMARY: AddressSanitizer: SEGV external/+non_module_dependencies+seastar/src/core/future.cc:119 in seastar::internal::promise_base::assert_task_shard() const
==830==ABORTING

...

rptest.services.utils.BadLogLines: <BadLogLines nodes=docker-rp-21(2) example="#4 0x56535b938edd in seastar::internal::promise_base::assert_task_shard() const external/+non_module_dependencies+seastar/src/core/future.cc:119">
```

Note that the ASan is triggered by the SEGV signal, and the fact that ASAN-related code is currently on the stack (FakeStack::GC) is just happenstance.

Fixes https://redpandadata.atlassian.net/browse/CORE-15017


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
