### PR TITLE
[CORE-15015] `security` & `kafka`: audit log deflaking

### DIFF
--- a/src/v/kafka/data/rpc/client.cc
+++ b/src/v/kafka/data/rpc/client.cc
@@ -113,6 +113,7 @@ cluster::errc map_errc(std::error_code ec) {
         case ::rpc::errc::disconnected_endpoint:
         case ::rpc::errc::exponential_backoff:
         case ::rpc::errc::shutting_down:
+        case ::rpc::errc::service_unavailable:
             return cluster::errc::timeout;
         default:
             vlog(

--- a/src/v/security/audit/client.cc
+++ b/src/v/security/audit/client.cc
@@ -52,7 +52,7 @@ public:
       audit_probe& probe,
       ss::timer<>::time_point timeout) final {
         constexpr auto map_ec = [](cluster::errc ec) -> kafka::error_code {
-            vlog(adtlog.debug, "Error producing audit data: {}", ec);
+            vlog(adtlog.debug, "Audit data produce result: {}", ec);
             if (ec == cluster::errc::success) {
                 return kafka::error_code::none;
             }


### PR DESCRIPTION
* Removes logging in the `kafka` layer on `rpc::errc::service_unavailable`
* Changes a log line in `security/audit/client.cc`.

Also fixes https://redpandadata.atlassian.net/browse/CORE-15014, https://redpandadata.atlassian.net/browse/CORE-15010, https://redpandadata.atlassian.net/browse/CORE-15009, https://redpandadata.atlassian.net/browse/CORE-15008, https://redpandadata.atlassian.net/browse/CORE-14977, https://redpandadata.atlassian.net/browse/CORE-14976, https://redpandadata.atlassian.net/browse/CORE-14964, https://redpandadata.atlassian.net/browse/CORE-14963, https://redpandadata.atlassian.net/browse/CORE-14943, https://redpandadata.atlassian.net/browse/CORE-14881

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
