### PR TITLE
lsm: add tests for cloud persistence

### DIFF
--- a/src/v/lsm/io/BUILD
+++ b/src/v/lsm/io/BUILD
@@ -57,6 +57,7 @@ redpanda_cc_library(
         "//src/v/bytes:ioarray",
         "//src/v/bytes:iobuf",
         "//src/v/cloud_io:io_result",
+        "//src/v/config",
         "//src/v/lsm/core:exceptions",
         "//src/v/lsm/core/internal:files",
         "//src/v/utils:retry_chain_node",

--- a/src/v/lsm/io/cloud_persistence.cc
+++ b/src/v/lsm/io/cloud_persistence.cc
@@ -523,6 +523,14 @@ ss::future<std::unique_ptr<data_persistence>> open_cloud_data_persistence(
   cloud_io::remote* remote,
   cloud_storage_clients::bucket_name bucket,
   cloud_storage_clients::object_key prefix) {
+    try {
+        co_await ss::recursive_touch_directory(staging_directory.native());
+    } catch (const std::system_error& e) {
+        throw io_error_exception(e.code(), "io error touching db dir: {}", e);
+    } catch (...) {
+        throw io_error_exception(
+          "io error touching db dir: {}", std::current_exception());
+    }
     co_return std::make_unique<cloud_data_persistence>(
       std::move(staging_directory),
       remote,

--- a/src/v/lsm/io/cloud_persistence.cc
+++ b/src/v/lsm/io/cloud_persistence.cc
@@ -12,6 +12,7 @@
 
 #include "cloud_io/io_result.h"
 #include "cloud_storage_clients/types.h"
+#include "config/configuration.h"
 #include "lsm/core/exceptions.h"
 #include "lsm/core/internal/files.h"
 #include "lsm/io/file_io.h"
@@ -22,11 +23,21 @@
 #include <seastar/core/reactor.hh>
 
 #include <memory>
-#include <ranges>
 
 namespace lsm::io {
 
 namespace {
+
+retry_chain_node make_rtc(ss::abort_source& as) {
+    constexpr auto timeout = std::chrono::seconds(10);
+    auto backoff
+      = config::shard_local_cfg().cloud_storage_initial_backoff_ms.value();
+    return retry_chain_node{
+      as,
+      timeout,
+      backoff,
+    };
+}
 
 bool check_result(cloud_io::download_result result) {
     switch (result) {
@@ -128,7 +139,7 @@ public:
 
 private:
     ss::future<> upload() {
-        retry_chain_node root(*_as);
+        auto root = make_rtc(*_as);
         lazy_abort_source las{[this] {
             return _as->abort_requested()
                      ? std::make_optional("abort requested")
@@ -187,7 +198,7 @@ public:
         if (reader) {
             co_return reader;
         }
-        retry_chain_node root{_as};
+        auto root = make_rtc(_as);
         cloud_io::download_result result{};
         try {
             result = co_await _remote->download_stream(
@@ -252,7 +263,7 @@ public:
     ss::future<> remove_file(internal::file_handle h) override {
         _as.check();
         auto _ = _gate.hold();
-        retry_chain_node rtc(_as);
+        auto rtc = make_rtc(_as);
         auto filename = internal::sst_file_name(h);
         cloud_io::upload_result result{};
         try {
@@ -278,7 +289,7 @@ public:
     list_files() override {
         _as.check();
         auto _ = _gate.hold();
-        retry_chain_node rtc(_as);
+        auto rtc = make_rtc(_as);
         // TODO: Consider merging with on disk file listing.
         cloud_io::list_result result
           = cloud_storage_clients::error_outcome::fail;
@@ -399,7 +410,7 @@ public:
     read_manifest(internal::database_epoch epoch) override {
         _as.check();
         auto _ = _gate.hold();
-        retry_chain_node root{_as};
+        auto rtc = make_rtc(_as);
         auto max_key = manifest_key(epoch);
         auto keys = co_await list_manifests();
         // list_manifests gives you biggest to smallest key, so find the first
@@ -414,7 +425,7 @@ public:
           .transfer_details = {
             .bucket = _bucket,
             .key = std::move(*it),
-            .parent_rtc = root,
+            .parent_rtc = rtc,
           },
           .display_str = "LSM Manifest download",
           .payload = b,
@@ -428,13 +439,13 @@ public:
     write_manifest(internal::database_epoch epoch, iobuf b) override {
         _as.check();
         auto _ = _gate.hold();
-        retry_chain_node root{_as};
+        auto rtc = make_rtc(_as);
         auto my_key = manifest_key(epoch);
         auto result = co_await _remote->upload_object({
           .transfer_details = {
             .bucket = _bucket,
             .key = my_key,
-            .parent_rtc = root,
+            .parent_rtc = rtc,
           },
           .display_str = "LSM Manifest upload",
           .payload = std::move(b),
@@ -449,7 +460,7 @@ public:
             keys_to_delete.push_back(key);
         }
         result = co_await _remote->delete_objects(
-          _bucket, std::move(keys_to_delete), root, [](size_t) {});
+          _bucket, std::move(keys_to_delete), rtc, [](size_t) {});
     }
 
     ss::future<> close() override {
@@ -462,9 +473,9 @@ private:
     ss::future<chunked_vector<cloud_storage_clients::object_key>>
     list_manifests() {
         using namespace cloud_storage_clients;
-        retry_chain_node root{_as};
+        auto rtc = make_rtc(_as);
         auto list_result = co_await _remote->list_objects(
-          _bucket, root, manifest_prefix());
+          _bucket, rtc, manifest_prefix());
         if (list_result.has_error()) {
             switch (list_result.error()) {
             case error_outcome::fail:

--- a/src/v/lsm/io/tests/BUILD
+++ b/src/v/lsm/io/tests/BUILD
@@ -6,9 +6,15 @@ redpanda_cc_gtest(
     srcs = [
         "persistence_test.cc",
     ],
+    cpu = 1,
     deps = [
         "//src/v/base",
+        "//src/v/cloud_io:remote",
+        "//src/v/cloud_io/tests:s3_imposter",
+        "//src/v/cloud_io/tests:scoped_remote",
+        "//src/v/cloud_storage_clients",
         "//src/v/lsm/core/internal:files",
+        "//src/v/lsm/io:cloud_persistence",
         "//src/v/lsm/io:disk_persistence",
         "//src/v/lsm/io:memory_persistence",
         "//src/v/lsm/io:persistence",

--- a/src/v/lsm/io/tests/persistence_test.cc
+++ b/src/v/lsm/io/tests/persistence_test.cc
@@ -9,7 +9,12 @@
  * by the Apache License, Version 2.0
  */
 
+#include "cloud_io/remote.h"
+#include "cloud_io/tests/s3_imposter.h"
+#include "cloud_io/tests/scoped_remote.h"
+#include "cloud_storage_clients/types.h"
 #include "lsm/core/internal/files.h"
+#include "lsm/io/cloud_persistence.h"
 #include "lsm/io/disk_persistence.h"
 #include "lsm/io/memory_persistence.h"
 #include "lsm/io/persistence.h"
@@ -22,9 +27,9 @@
 #include <gtest/gtest.h>
 
 using namespace lsm::io;
-using lsm::internal::file_handle;
-using lsm::internal::operator""_file_id;
-using lsm::internal::operator""_db_epoch;
+namespace lsm_internal = lsm::internal;
+using lsm_internal::operator""_file_id;
+using lsm_internal::operator""_db_epoch;
 
 using data_persistence_factory
   = std::function<ss::future<std::unique_ptr<data_persistence>>()>;
@@ -40,9 +45,9 @@ protected:
         }
     }
 
-    ss::future<std::vector<file_handle>> list_files() {
+    ss::future<std::vector<lsm_internal::file_handle>> list_files() {
         auto gen = persistence->list_files();
-        std::vector<file_handle> files;
+        std::vector<lsm_internal::file_handle> files;
         while (auto file = co_await gen()) {
             files.push_back(*file);
         }
@@ -73,7 +78,7 @@ TEST_P(PersistenceTest, CanWriteAndReadAFile) {
 }
 
 TEST_P(PersistenceTest, ListFiles) {
-    std::vector<file_handle> files;
+    std::vector<lsm_internal::file_handle> files;
     {
         for (auto i = 0_file_id; i < 25_file_id; ++i) {
             files.emplace_back(i, 0_db_epoch);
@@ -245,6 +250,49 @@ TEST_P(PersistenceTest, RandomAccessReaderComprehensive) {
     persistence->remove_file({}).get();
 }
 
+// Mock cloud data persistence that owns s3_imposter and proxies to the real
+// cloud_data_persistence implementation. This allows cloud persistence to be
+// tested within the parameterized test framework.
+class mock_cloud_data_persistence : public data_persistence {
+public:
+    mock_cloud_data_persistence(
+      std::unique_ptr<s3_imposter_fixture> fixture,
+      std::unique_ptr<cloud_io::scoped_remote> sr,
+      std::unique_ptr<data_persistence> impl)
+      : fixture_(std::move(fixture))
+      , sr_(std::move(sr))
+      , impl_(std::move(impl)) {}
+
+    ss::future<std::unique_ptr<sequential_file_writer>>
+    open_sequential_writer(lsm_internal::file_handle handle) override {
+        return impl_->open_sequential_writer(handle);
+    }
+
+    ss::future<optional_pointer<random_access_file_reader>>
+    open_random_access_reader(lsm_internal::file_handle handle) override {
+        return impl_->open_random_access_reader(handle);
+    }
+
+    ss::future<> remove_file(lsm_internal::file_handle handle) override {
+        co_await impl_->remove_file(handle);
+        // We also need to remove the expectation from the s3 imposter as well
+        fixture_->remove_expectations(
+          {fmt::format("test-prefix/{}", lsm_internal::sst_file_name(handle))});
+    }
+
+    ss::coroutine::experimental::generator<lsm_internal::file_handle>
+    list_files() override {
+        return impl_->list_files();
+    }
+
+    ss::future<> close() override { return impl_->close(); }
+
+private:
+    std::unique_ptr<s3_imposter_fixture> fixture_;
+    std::unique_ptr<cloud_io::scoped_remote> sr_;
+    std::unique_ptr<data_persistence> impl_;
+};
+
 INSTANTIATE_TEST_SUITE_P(
   PersistenceSuite,
   PersistenceTest,
@@ -255,6 +303,24 @@ INSTANTIATE_TEST_SUITE_P(
         // Ensure each testcase has it's own directory.
         auto subdir = ss::sstring(uuid_t::create());
         return open_disk_data_persistence(tmpdir / std::string_view(subdir));
+    },
+    []() -> ss::future<std::unique_ptr<data_persistence>> {
+        std::filesystem::path tmpdir = std::getenv("TEST_TMPDIR");
+        auto staging_subdir = ss::sstring(uuid_t::create());
+        auto staging = tmpdir / std::string_view(staging_subdir);
+
+        auto fixture = std::make_unique<s3_imposter_fixture>();
+        fixture->set_expectations_and_listen({});
+        auto sr = cloud_io::scoped_remote::create(10, fixture->conf);
+
+        auto impl = co_await open_cloud_data_persistence(
+          staging,
+          &sr->remote.local(),
+          fixture->bucket_name,
+          cloud_storage_clients::object_key("test-prefix"));
+
+        co_return std::make_unique<mock_cloud_data_persistence>(
+          std::move(fixture), std::move(sr), std::move(impl));
     }),
   [](const testing::TestParamInfo<data_persistence_factory>& info) {
       switch (info.index) {
@@ -262,6 +328,8 @@ INSTANTIATE_TEST_SUITE_P(
           return "memory";
       case 1:
           return "disk";
+      case 2:
+          return "cloud";
       default:
           return "unknown";
       }


### PR DESCRIPTION
- **lsm/io: add backoff to cloud persistence**
- **lsm/io: add tests for cloud persistence**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
