### PR TITLE
lsm: support readonly mode

### DIFF
--- a/src/v/lsm/core/internal/options.h
+++ b/src/v/lsm/core/internal/options.h
@@ -28,6 +28,10 @@ struct options {
     // storage.
     internal::database_epoch database_epoch;
 
+    // If the database is opened in readonly mode. Readonly mode causes all
+    // write operations to fail. However, read operations can be performed.
+    bool readonly = false;
+
     struct level_config {
         // The level number in the database.
         internal::level number;

--- a/src/v/lsm/core/internal/options.h
+++ b/src/v/lsm/core/internal/options.h
@@ -129,8 +129,8 @@ struct options {
 
     // The approximate max number of SST files that should be opened at one
     // time.
-    constexpr static uint32_t default_max_open_files = 1000;
-    uint32_t max_open_files = default_max_open_files;
+    constexpr static size_t default_max_open_files = 1000;
+    size_t max_open_files = default_max_open_files;
 
     // If non-zero, the number of fibers to use to pre-open all the files in the
     // database, which populates the table cache.

--- a/src/v/lsm/db/impl.cc
+++ b/src/v/lsm/db/impl.cc
@@ -27,7 +27,6 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/coroutine/as_future.hh>
-#include <seastar/util/defer.hh>
 
 #include <exception>
 #include <memory>
@@ -60,6 +59,10 @@ ss::future<std::unique_ptr<impl>> impl::open(
         auto ex = fut.get_exception();
         co_await db->close().handle_exception([](const std::exception_ptr&) {});
         std::rethrow_exception(ex);
+    }
+    // If we're readonly, we don't need to start any compaction loop.
+    if (db->_opts->readonly) {
+        co_return db;
     }
     db->_background_work = ss::do_until(
       [db = db.get()] { return db->_as.abort_requested(); },
@@ -104,6 +107,10 @@ ss::future<std::unique_ptr<impl>> impl::open(
 }
 
 ss::future<> impl::apply(ss::lw_shared_ptr<memtable> batch) {
+    if (_opts->readonly) [[unlikely]] {
+        throw invalid_argument_exception(
+          "attempted to write to a readonly database");
+    }
     if (batch->empty()) {
         co_return;
     }
@@ -226,6 +233,10 @@ impl::create_internal_iterator(ss::optimized_optional<memtable*> wb) {
 }
 
 ss::future<> impl::flush() {
+    if (_opts->readonly) [[unlikely]] {
+        throw invalid_argument_exception(
+          "attempted to flush a readonly database");
+    }
     auto applied_seqno = max_applied_seqno();
     while (applied_seqno > max_persisted_seqno()) {
         if (_imm) {

--- a/src/v/lsm/db/tests/impl_test.cc
+++ b/src/v/lsm/db/tests/impl_test.cc
@@ -131,15 +131,7 @@ public:
         _meta_persistence = lsm::io::make_memory_metadata_persistence();
         _tracking_data = std::make_unique<tracking_data_persistence>(
           _underlying_data_persistence.get());
-        _db = lsm::db::impl::open(
-                _options,
-                {
-                  .data = std::make_unique<proxy_data_persistence>(
-                    _tracking_data.get()),
-                  .metadata = std::make_unique<proxy_metadata_persistence>(
-                    _meta_persistence.get()),
-                })
-                .get();
+        open();
     }
 
     void TearDown() override {
@@ -150,6 +142,7 @@ public:
 
     void write_at_least(size_t size) {
         auto batch = ss::make_lw_shared<lsm::db::memtable>();
+        decltype(_shadow) shadow_batch;
         auto seqno = _db->max_applied_seqno();
         while (batch->approximate_memory_usage() < size) {
             auto key = lsm::internal::key::encode({
@@ -158,11 +151,15 @@ public:
             });
             auto value = iobuf::from(
               random_generators::gen_alphanum_string(1_KiB));
-            _shadow.insert_or_assign(
+            shadow_batch.insert_or_assign(
               ss::sstring(key.user_key()), value.share());
             batch->put(key, value.share());
         }
         _db->apply(std::move(batch)).get();
+        // Only apply writes if db write was a success
+        for (auto& [k, v] : shadow_batch) {
+            _shadow.insert_or_assign(k, std::move(v));
+        }
     }
 
     testing::AssertionResult matches_shadow() {
@@ -197,8 +194,14 @@ public:
     }
 
     void restart() {
+        close();
+        open();
+    }
+    void close() {
         _db->close().get();
         _tracking_data->reset_tracking();
+    }
+    void open() {
         _db = lsm::db::impl::open(
                 _options,
                 {
@@ -382,6 +385,25 @@ TEST_F(ImplTest, PreOpenFiles) {
           << "File " << file << " was not pre-opened";
     }
     EXPECT_TRUE(matches_shadow());
+}
+
+TEST_F(ImplTest, Readonly) {
+    // Write some data and flush to create SST files
+    write_at_least(512_KiB);
+    write_at_least(512_KiB);
+    EXPECT_TRUE(matches_shadow());
+    tests::drain_task_queue().get();
+    _db->flush().get();
+
+    // Restart in readonly mode
+    close();
+    _options->readonly = true;
+    open();
+
+    EXPECT_TRUE(matches_shadow());
+    EXPECT_ANY_THROW(write_at_least(1_KiB));
+    EXPECT_TRUE(matches_shadow());
+    EXPECT_ANY_THROW(write_at_least(1_KiB));
 }
 
 } // namespace

--- a/src/v/lsm/lsm.cc
+++ b/src/v/lsm/lsm.cc
@@ -82,6 +82,7 @@ ss::lw_shared_ptr<internal::options> translate_options(options opts) {
       },
       internal::options::default_level_multipler,
       max_level);
+    internal_opts->readonly = opts.readonly;
     internal_opts->level_zero_slowdown_writes_trigger
       = opts.level_zero_slowdown_writes_trigger;
     internal_opts->level_zero_stop_writes_trigger

--- a/src/v/lsm/lsm.h
+++ b/src/v/lsm/lsm.h
@@ -46,6 +46,10 @@ struct options {
     // This value should never decrease.
     uint64_t database_epoch = 0;
 
+    // If the database is opened in readonly mode. Readonly mode causes all
+    // write operations to fail. However, read operations can be performed.
+    bool readonly = false;
+
     // The number of levels in the LSM tree. More levels allow more smaller and
     // faster compactions, but causes more read amplication.
     //

--- a/src/v/lsm/lsm.h
+++ b/src/v/lsm/lsm.h
@@ -77,12 +77,6 @@ struct options {
     constexpr static size_t default_level_one_compaction_trigger = 4;
     size_t level_one_compaction_trigger = default_level_one_compaction_trigger;
 
-    // Write up to this amount of bytes to a file before switching to a new one.
-    // Increasing this provides better file system efficiency with larger files,
-    // but the downside of increasing this is longer compactions and longer
-    // latency/performance hiccups.
-    size_t max_file_size = 2_GiB;
-
     // The approximate max number of SST files that should be opened at one
     // time.
     constexpr static uint32_t default_max_open_files = 1000;

--- a/src/v/lsm/lsm.h
+++ b/src/v/lsm/lsm.h
@@ -79,8 +79,8 @@ struct options {
 
     // The approximate max number of SST files that should be opened at one
     // time.
-    constexpr static uint32_t default_max_open_files = 1000;
-    uint32_t max_open_files = default_max_open_files;
+    constexpr static size_t default_max_open_files = 1000;
+    size_t max_open_files = default_max_open_files;
 
     // If non-zero, the number of fibers to use to pre-open all the files in the
     // database, which populates the table cache.


### PR DESCRIPTION
- **lsm: remove vestigal option**
- **lsm: make max open files size_t**
- **lsm: support readonly mode**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
