### PR TITLE
rpk: add SR sync to shadow describe

### DIFF
--- a/src/go/rpk/pkg/cli/shadow/describe.go
+++ b/src/go/rpk/pkg/cli/shadow/describe.go
@@ -34,6 +34,7 @@ const (
 	secTopicSync      = "Topic Sync"
 	secConsumerOffset = "Consumer Offset Sync"
 	secSecurity       = "Security Sync"
+	secSchemaRegistry = "Schema Registry Sync"
 )
 
 func newDescribeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
@@ -109,6 +110,7 @@ Display only the client configuration:
 	cmd.Flags().BoolVarP(&opts.topic, "print-topic", "t", false, "Print the detailed topic configuration section")
 	cmd.Flags().BoolVarP(&opts.co, "print-consumer", "r", false, "Print the detailed consumer offset configuration section")
 	cmd.Flags().BoolVarP(&opts.sec, "print-security", "s", false, "Print the detailed security configuration section")
+	cmd.Flags().BoolVarP(&opts.sr, "print-registry", "y", false, "Print the detailed schema registry configuration section")
 	cmd.Flags().BoolVarP(&opts.all, "print-all", "a", false, "Print all sections")
 	return cmd
 }
@@ -120,16 +122,17 @@ type slDescribeOptions struct {
 	topic    bool
 	co       bool // consumer offset
 	sec      bool // security
+	sr       bool // schema registry
 }
 
 // If no flags are set, default to overview and client sections.
 func (o *slDescribeOptions) defaultOrAll() {
-	if !o.all && !o.overview && !o.client && !o.topic && !o.co && !o.sec {
+	if !o.all && !o.overview && !o.client && !o.topic && !o.co && !o.sec && !o.sr {
 		o.overview, o.client = true, true
 	}
 
 	if o.all {
-		o.overview, o.client, o.topic, o.co, o.sec = true, true, true, true, true
+		o.overview, o.client, o.topic, o.co, o.sec, o.sr = true, true, true, true, true, true
 	}
 }
 
@@ -141,6 +144,7 @@ func printShadowLinkDescription(link *adminv2.ShadowLink, opts slDescribeOptions
 			secTopicSync:      opts.topic,
 			secConsumerOffset: opts.co,
 			secSecurity:       opts.sec,
+			secSchemaRegistry: opts.sr,
 		})...,
 	)
 
@@ -164,6 +168,10 @@ func printShadowLinkDescription(link *adminv2.ShadowLink, opts slDescribeOptions
 
 	sections.Add(secSecurity, func() {
 		printSecuritySync(cfg.GetSecuritySyncOptions())
+	})
+
+	sections.Add(secSchemaRegistry, func() {
+		printSchemaRegistrySync(cfg.GetSchemaRegistrySyncOptions())
 	})
 }
 
@@ -196,6 +204,10 @@ func printCloudShadowLinkDescription(link *controlplanev1.ShadowLink, opts slDes
 
 	sections.Add(secSecurity, func() {
 		printSecuritySync(link.GetSecuritySyncOptions())
+	})
+
+	sections.Add(secSchemaRegistry, func() {
+		printSchemaRegistrySync(link.GetSchemaRegistrySyncOptions())
 	})
 }
 
@@ -446,6 +458,16 @@ func printSecuritySync(opts *adminv2.SecuritySettingsSyncOptions) {
 			)
 		}
 	}
+}
+
+func printSchemaRegistrySync(opts *adminv2.SchemaRegistrySyncOptions) {
+	tw := out.NewTabWriter()
+	defer tw.Flush()
+	if opts == nil {
+		tw.Print("No schema registry sync configuration")
+		return
+	}
+	tw.Print("SHADOWING MODE", strings.ReplaceAll(opts.WhichSchemaRegistryShadowingMode().String(), "_", " "))
 }
 
 func formatScramMechanism(m adminv2.ScramMechanism) string {


### PR DESCRIPTION
Schema registry section was missing from the
original describe output.


### Sample Output:

```
SCHEMA REGISTRY SYNC
====================
SHADOWING MODE  shadow schema registry topic

SCHEMA REGISTRY SYNC
====================
SHADOWING MODE  not set
```

Fixes UX-761

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Improvements

* rpk shadow describe now shows Schema Registry sync mode.
