### PR TITLE
lsm: fix issue with level0 compactions and overlapping files

### DIFF
--- a/src/v/lsm/block/tests/filter_test.cc
+++ b/src/v/lsm/block/tests/filter_test.cc
@@ -30,7 +30,7 @@ lsm::block::filter_reader make_filter(const keys_by_block& keys) {
         builder.start_block(block);
         for (const auto& key : keys_in_block) {
             builder.add_key(
-              lsm::internal::key::encode({.key = ss::sstring(key)}));
+              lsm::internal::key::encode({.key = lsm::user_key_view(key)}));
         }
     }
     auto c = lsm::block::contents::copy_from(builder.finish());

--- a/src/v/lsm/core/BUILD
+++ b/src/v/lsm/core/BUILD
@@ -3,6 +3,14 @@ load("//bazel:build.bzl", "redpanda_cc_library")
 package(default_visibility = ["//src/v/lsm:__subpackages__"])
 
 redpanda_cc_library(
+    name = "keys",
+    hdrs = ["keys.h"],
+    deps = [
+        "//src/v/utils:named_type",
+    ],
+)
+
+redpanda_cc_library(
     name = "compression",
     srcs = ["compression.cc"],
     hdrs = ["compression.h"],

--- a/src/v/lsm/core/internal/BUILD
+++ b/src/v/lsm/core/internal/BUILD
@@ -64,6 +64,7 @@ redpanda_cc_library(
     deps = [
         "//src/v/base",
         "//src/v/bytes:iobuf",
+        "//src/v/lsm/core:keys",
         "//src/v/utils:named_type",
         "@seastar",
     ],

--- a/src/v/lsm/core/internal/keys.cc
+++ b/src/v/lsm/core/internal/keys.cc
@@ -27,15 +27,15 @@ namespace lsm::internal {
 
 key key::encode(parts p) {
     internal::key::underlying_t v(
-      underlying_t::initialized_later{}, p.key.size() + 1 + sizeof(uint64_t));
+      underlying_t::initialized_later{}, p.key().size() + 1 + sizeof(uint64_t));
     dassert(
-      std::ranges::find(p.key, '\0') == p.key.end(),
+      std::ranges::find(p.key(), '\0') == p.key().end(),
       "key must not contain null characters");
     // First we append the user key.
-    std::ranges::copy(p.key, v.data());
+    std::ranges::copy(p.key(), v.data());
     // Then we null terminate, so that keys of different lengths compare
     // lexicographically.
-    v[p.key.size()] = '\0';
+    v[p.key().size()] = '\0';
     // Next we want to encode the sequence number and type, and have them sort
     // in descending order for the same key. Use 7 bytes for the offset, since
     // that should give us plenty of values before overflow.
@@ -44,7 +44,7 @@ key key::encode(parts p) {
     uint64_t encoded = (p.seqno() << CHAR_WIDTH)
                        | static_cast<uint64_t>(p.type);
     encoded = ss::cpu_to_be(~encoded);
-    std::memcpy(&v[p.key.size() + 1], &encoded, sizeof(encoded));
+    std::memcpy(&v[p.key().size() + 1], &encoded, sizeof(encoded));
     return key{v};
 }
 
@@ -90,11 +90,10 @@ fmt::iterator key_view::format_to(fmt::iterator it) const {
       it, "internal_key_view={{user={},suffix=o{:08o}}}", user_key(), encoded);
 }
 
-key::parts key::parts::value(std::string_view key, sequence_number seq_num) {
+key::parts key::parts::value(user_key_view key, sequence_number seq_num) {
     return {.key = key, .seqno = seq_num, .type = value_type::value};
 }
-key::parts
-key::parts::tombstone(std::string_view key, sequence_number seq_num) {
+key::parts key::parts::tombstone(user_key_view key, sequence_number seq_num) {
     return {.key = key, .seqno = seq_num, .type = value_type::tombstone};
 }
 
@@ -106,7 +105,7 @@ key_view::parts key_view::decode() const {
     // The sequence number is the rest of the bytes, which we decode from BE
     // form and invert the bits.
     uint64_t encoded; // NOLINT
-    std::memcpy(&encoded, &_value[p.key.size() + 1], sizeof(encoded));
+    std::memcpy(&encoded, &_value[p.key().size() + 1], sizeof(encoded));
     encoded = ~ss::be_to_cpu(encoded);
     // The last byte is the type.
     p.type = static_cast<value_type>(
@@ -144,7 +143,7 @@ key::operator iobuf() const { return iobuf::from(_value); }
 
 key operator""_seek_key(const char* s, size_t len) {
     return key::encode({
-      .key = ss::sstring(s, len),
+      .key = user_key_view(std::string_view(s, len)),
       .seqno = sequence_number::max(),
       .type = value_type::value,
     });
@@ -159,7 +158,7 @@ key operator""_key(const char* s, size_t len) {
         seq_num = 0; // Default seqno
     }
     return key::encode({
-      .key = k,
+      .key = user_key_view(k),
       .seqno = sequence_number(std::abs(seq_num)),
       .type = seq_num < 0 ? value_type::tombstone : value_type::value,
     });

--- a/src/v/lsm/core/internal/keys.h
+++ b/src/v/lsm/core/internal/keys.h
@@ -96,12 +96,13 @@ public:
     bool empty() const { return _value.empty(); }
 
     // Returns the user portion of the key.
-    std::string_view user_key() const {
+    user_key_view user_key() const {
         dassert(
           _value.size() >= 5,
           "expected key size to be at least 5, got: {}",
           _value.size());
-        return {_value.data(), _value.size() - sizeof(uint64_t) - 1};
+        return user_key_view{
+          _value.data(), _value.size() - sizeof(uint64_t) - 1};
     }
 
     bool operator==(const key& other) const = default;
@@ -149,8 +150,8 @@ public:
           _value.size() >= 5,
           "expected key size to be at least 5, got: {}",
           _value.size());
-        return user_key_view{std::string_view{
-          _value.data(), _value.size() - sizeof(uint64_t) - 1}};
+        return user_key_view{
+          _value.data(), _value.size() - sizeof(uint64_t) - 1};
     }
     // Returns this key's value type
     value_type type() const;

--- a/src/v/lsm/core/internal/keys.h
+++ b/src/v/lsm/core/internal/keys.h
@@ -14,6 +14,7 @@
 #include "base/format_to.h"
 #include "base/seastarx.h"
 #include "base/vassert.h"
+#include "lsm/core/keys.h"
 #include "utils/named_type.h"
 
 #include <seastar/core/sstring.hh>
@@ -57,14 +58,14 @@ class key {
 
 public:
     struct parts {
-        std::string_view key;
+        user_key_view key;
         sequence_number seqno = sequence_number(0);
         value_type type = value_type::value;
 
         // Create a value internal key
-        static parts value(std::string_view key, sequence_number);
+        static parts value(user_key_view key, sequence_number);
         // Create a tombstone internal key
-        static parts tombstone(std::string_view key, sequence_number);
+        static parts tombstone(user_key_view key, sequence_number);
         bool operator==(const parts& other) const = default;
         fmt::iterator format_to(fmt::iterator) const;
     };
@@ -122,7 +123,7 @@ private:
 class key_view {
 public:
     struct parts {
-        std::string_view key;
+        user_key_view key;
         sequence_number seqno = sequence_number(0);
         value_type type = value_type::value;
 
@@ -143,12 +144,13 @@ public:
     bool empty() const { return _value.empty(); }
 
     // The user portion of the key.
-    std::string_view user_key() const {
+    user_key_view user_key() const {
         dassert(
           _value.size() >= 5,
           "expected key size to be at least 5, got: {}",
           _value.size());
-        return {_value.data(), _value.size() - sizeof(uint64_t) - 1};
+        return user_key_view{std::string_view{
+          _value.data(), _value.size() - sizeof(uint64_t) - 1}};
     }
     // Returns this key's value type
     value_type type() const;

--- a/src/v/lsm/core/internal/tests/iterator_test_harness.h
+++ b/src/v/lsm/core/internal/tests/iterator_test_harness.h
@@ -28,7 +28,8 @@ protected:
     std::unique_ptr<lsm::internal::iterator> make_iterator(const data& d) {
         std::map<lsm::internal::key, iobuf> encoded;
         for (const auto& [key, value] : d) {
-            auto encoded_key = lsm::internal::key::encode({.key = key});
+            auto encoded_key = lsm::internal::key::encode(
+              {.key = lsm::user_key_view(key)});
             encoded[std::move(encoded_key)] = iobuf::from(value);
         }
         return _factory.make_iterator(std::move(encoded));

--- a/src/v/lsm/core/internal/tests/keys_bench.cc
+++ b/src/v/lsm/core/internal/tests/keys_bench.cc
@@ -45,7 +45,7 @@ std::vector<key> generate_keys(size_t count, size_t key_length) {
         auto type = i % 2 == 0 ? value_type::value : value_type::tombstone;
         keys.push_back(
           key::encode({
-            .key = user_key,
+            .key = lsm::user_key_view(user_key),
             .seqno = seqno,
             .type = type,
           }));

--- a/src/v/lsm/core/internal/tests/keys_test.cc
+++ b/src/v/lsm/core/internal/tests/keys_test.cc
@@ -17,23 +17,24 @@
 namespace {
 using value_type = lsm::internal::value_type;
 using key = lsm::internal::key;
+using userkey = lsm::user_key_view;
 using seqno = lsm::internal::sequence_number;
 seqno operator""_seqno(unsigned long long seq_num) { return seqno{seq_num}; }
 } // namespace
 
 TEST(Keys, RoundTrip) {
     std::vector<key::parts> key_parts = {
-      {.key = "", .seqno = 999_seqno, .type = value_type::value},
-      {.key = "a", .seqno = 5_seqno, .type = value_type::value},
-      {.key = "a", .seqno = 3_seqno, .type = value_type::value},
-      {.key = "a", .seqno = 1_seqno, .type = value_type::value},
-      {.key = "aa", .seqno = 1_seqno, .type = value_type::value},
-      {.key = "a", .seqno = 1_seqno, .type = value_type::tombstone},
-      {.key = "b", .seqno = 99_seqno, .type = value_type::tombstone},
-      {.key = "b", .seqno = 1_seqno, .type = value_type::tombstone},
-      {.key = "f", .seqno = 0_seqno, .type = value_type::value},
-      {.key = "z", .seqno = 111_seqno, .type = value_type::value},
-      {.key = "z", .seqno = 42_seqno, .type = value_type::tombstone},
+      {.key = userkey(""), .seqno = 999_seqno, .type = value_type::value},
+      {.key = userkey("a"), .seqno = 5_seqno, .type = value_type::value},
+      {.key = userkey("a"), .seqno = 3_seqno, .type = value_type::value},
+      {.key = userkey("a"), .seqno = 1_seqno, .type = value_type::value},
+      {.key = userkey("aa"), .seqno = 1_seqno, .type = value_type::value},
+      {.key = userkey("a"), .seqno = 1_seqno, .type = value_type::tombstone},
+      {.key = userkey("b"), .seqno = 99_seqno, .type = value_type::tombstone},
+      {.key = userkey("b"), .seqno = 1_seqno, .type = value_type::tombstone},
+      {.key = userkey("f"), .seqno = 0_seqno, .type = value_type::value},
+      {.key = userkey("z"), .seqno = 111_seqno, .type = value_type::value},
+      {.key = userkey("z"), .seqno = 42_seqno, .type = value_type::tombstone},
     };
     for (const auto& part : key_parts) {
         auto encoded = key::encode(part);
@@ -42,17 +43,17 @@ TEST(Keys, RoundTrip) {
 }
 TEST(Keys, SortCorrectly) {
     std::vector<key::parts> key_parts = {
-      {.key = "", .seqno = 999_seqno, .type = value_type::value},
-      {.key = "a", .seqno = 5_seqno, .type = value_type::value},
-      {.key = "a", .seqno = 3_seqno, .type = value_type::value},
-      {.key = "a", .seqno = 1_seqno, .type = value_type::tombstone},
-      {.key = "a", .seqno = 1_seqno, .type = value_type::value},
-      {.key = "aa", .seqno = 1_seqno, .type = value_type::value},
-      {.key = "b", .seqno = 99_seqno, .type = value_type::tombstone},
-      {.key = "b", .seqno = 1_seqno, .type = value_type::tombstone},
-      {.key = "f", .seqno = 0_seqno, .type = value_type::value},
-      {.key = "z", .seqno = 111_seqno, .type = value_type::value},
-      {.key = "z", .seqno = 42_seqno, .type = value_type::tombstone},
+      {.key = userkey(""), .seqno = 999_seqno, .type = value_type::value},
+      {.key = userkey("a"), .seqno = 5_seqno, .type = value_type::value},
+      {.key = userkey("a"), .seqno = 3_seqno, .type = value_type::value},
+      {.key = userkey("a"), .seqno = 1_seqno, .type = value_type::tombstone},
+      {.key = userkey("a"), .seqno = 1_seqno, .type = value_type::value},
+      {.key = userkey("aa"), .seqno = 1_seqno, .type = value_type::value},
+      {.key = userkey("b"), .seqno = 99_seqno, .type = value_type::tombstone},
+      {.key = userkey("b"), .seqno = 1_seqno, .type = value_type::tombstone},
+      {.key = userkey("f"), .seqno = 0_seqno, .type = value_type::value},
+      {.key = userkey("z"), .seqno = 111_seqno, .type = value_type::value},
+      {.key = userkey("z"), .seqno = 42_seqno, .type = value_type::tombstone},
     };
     std::vector<key> keys;
     keys.reserve(key_parts.size());
@@ -66,8 +67,9 @@ TEST(Keys, SortCorrectly) {
 
 TEST(Keys, Operator) {
     using lsm::internal::operator""_key;
-    EXPECT_EQ("foo@4"_key.decode(), key::parts::value("foo", 4_seqno));
-    EXPECT_EQ("foo"_key.decode(), key::parts::value("foo", 0_seqno));
-    EXPECT_EQ("bar@"_key.decode(), key::parts::value("bar", 0_seqno));
-    EXPECT_EQ("foo@-9"_key.decode(), key::parts::tombstone("foo", 9_seqno));
+    EXPECT_EQ("foo@4"_key.decode(), key::parts::value(userkey("foo"), 4_seqno));
+    EXPECT_EQ("foo"_key.decode(), key::parts::value(userkey("foo"), 0_seqno));
+    EXPECT_EQ("bar@"_key.decode(), key::parts::value(userkey("bar"), 0_seqno));
+    EXPECT_EQ(
+      "foo@-9"_key.decode(), key::parts::tombstone(userkey("foo"), 9_seqno));
 }

--- a/src/v/lsm/core/internal/tests/merging_iterator_test.cc
+++ b/src/v/lsm/core/internal/tests/merging_iterator_test.cc
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
+#include "lsm/core/internal/keys.h"
 #include "lsm/core/internal/merging_iterator.h"
 #include "lsm/core/internal/tests/iterator_test_harness.h"
 
@@ -93,7 +94,9 @@ std::map<lsm::internal::key, iobuf>
 make_test_data(std::vector<std::pair<std::string, std::string>> data) {
     std::map<lsm::internal::key, iobuf> result;
     for (auto& [k, v] : data) {
-        result.emplace(lsm::internal::key::encode({.key = k}), iobuf::from(v));
+        result.emplace(
+          lsm::internal::key::encode({.key = lsm::user_key_view(k)}),
+          iobuf::from(v));
     }
     return result;
 }
@@ -103,7 +106,7 @@ collect_all_pairs(std::unique_ptr<lsm::internal::iterator>& it) {
     std::vector<std::pair<std::string, std::string>> results;
     it->seek_to_first().get();
     while (it->valid()) {
-        results.emplace_back(it->key().user_key(), to_string(it->value()));
+        results.emplace_back(it->key().user_key()(), to_string(it->value()));
         it->next().get();
     }
     return results;
@@ -114,7 +117,7 @@ collect_all_pairs_reverse(std::unique_ptr<lsm::internal::iterator>& it) {
     std::vector<std::pair<std::string, std::string>> results;
     it->seek_to_last().get();
     while (it->valid()) {
-        results.emplace_back(it->key().user_key(), to_string(it->value()));
+        results.emplace_back(it->key().user_key()(), to_string(it->value()));
         it->prev().get();
     }
     return results;

--- a/src/v/lsm/core/keys.h
+++ b/src/v/lsm/core/keys.h
@@ -19,4 +19,8 @@ namespace lsm {
 // user provided keys (see internal::key for more information).
 using user_key_view = named_type<std::string_view, struct user_key_view_tag>;
 
+consteval user_key_view operator""_user_key(const char* s, size_t len) {
+    return user_key_view{s, len};
+}
+
 } // namespace lsm

--- a/src/v/lsm/core/keys.h
+++ b/src/v/lsm/core/keys.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "utils/named_type.h"
+
+#include <string_view>
+
+namespace lsm {
+
+// User keys are a named type wrapper to distinguish between internal keys and
+// user provided keys (see internal::key for more information).
+using user_key_view = named_type<std::string_view, struct user_key_view_tag>;
+
+} // namespace lsm

--- a/src/v/lsm/db/file_utils.cc
+++ b/src/v/lsm/db/file_utils.cc
@@ -26,15 +26,25 @@ size_t total_file_size(
     return total;
 }
 
-size_t find_file(
-  const chunked_vector<ss::lw_shared_ptr<file_meta_data>>& files,
-  internal::key_view target) {
+namespace {
+
+template<typename Key>
+size_t find_file_impl(
+  const chunked_vector<ss::lw_shared_ptr<file_meta_data>>& files, Key target) {
     size_t left = 0;
     size_t right = files.size();
     while (left < right) {
         size_t mid = (left + right) / 2;
         const auto& f = files[mid];
-        if (f->largest < target) {
+        bool target_after_file = false;
+        if constexpr (std::is_same_v<internal::key_view, Key>) {
+            target_after_file = f->largest < target;
+        } else if constexpr (std::is_same_v<user_key_view, Key>) {
+            target_after_file = f->largest.user_key() < target;
+        } else {
+            static_assert(false, "unsupported type");
+        }
+        if (target_after_file) {
             // kkey at mid.largest is < target. Therefore all files at or before
             // mid are uninteresting.
             left = mid + 1;
@@ -47,16 +57,30 @@ size_t find_file(
     return right;
 }
 
+} // namespace
+
+size_t find_file(
+  const chunked_vector<ss::lw_shared_ptr<file_meta_data>>& files,
+  internal::key_view target) {
+    return find_file_impl(files, target);
+}
+
+size_t find_file(
+  const chunked_vector<ss::lw_shared_ptr<file_meta_data>>& files,
+  user_key_view target) {
+    return find_file_impl(files, target);
+}
+
 namespace {
 
 bool after_file(
-  const file_meta_data& file, const std::optional<internal::key_view>& key) {
-    return key && *key > file.largest;
+  const file_meta_data& file, const std::optional<user_key_view>& key) {
+    return key && *key > file.largest.user_key();
 }
 
 bool before_file(
-  const file_meta_data& file, const std::optional<internal::key_view>& key) {
-    return key && *key < file.smallest;
+  const file_meta_data& file, const std::optional<user_key_view>& key) {
+    return key && *key < file.smallest.user_key();
 }
 
 } // namespace
@@ -64,8 +88,8 @@ bool before_file(
 bool some_file_overlaps_range(
   bool disjoint_sorted_files,
   const chunked_vector<ss::lw_shared_ptr<file_meta_data>>& files,
-  std::optional<internal::key_view> smallest_key,
-  std::optional<internal::key_view> largest_key) {
+  std::optional<user_key_view> smallest_key,
+  std::optional<user_key_view> largest_key) {
     if (!disjoint_sorted_files) {
         // Need to check against all files
         for (const auto& file : files) {

--- a/src/v/lsm/db/file_utils.cc
+++ b/src/v/lsm/db/file_utils.cc
@@ -157,8 +157,8 @@ std::pair<internal::key, internal::key> get_key_range(const Range& r) {
         if (file->smallest < smallest) {
             smallest = file->smallest;
         }
-        if (file->largest < largest) {
-            smallest = file->largest;
+        if (file->largest > largest) {
+            largest = file->largest;
         }
     }
     return std::make_pair(std::move(smallest), std::move(largest));

--- a/src/v/lsm/db/file_utils.h
+++ b/src/v/lsm/db/file_utils.h
@@ -39,6 +39,9 @@ total_file_size(const chunked_vector<ss::lw_shared_ptr<file_meta_data>>& files);
 size_t find_file(
   const chunked_vector<ss::lw_shared_ptr<file_meta_data>>& files,
   internal::key_view target);
+size_t find_file(
+  const chunked_vector<ss::lw_shared_ptr<file_meta_data>>& files,
+  user_key_view target);
 
 // Returns true iff some file in `files` overlaps the user key range
 // [*smallest,*largest].
@@ -49,8 +52,8 @@ size_t find_file(
 bool some_file_overlaps_range(
   bool disjoint_sorted_files,
   const chunked_vector<ss::lw_shared_ptr<file_meta_data>>& files,
-  std::optional<internal::key_view> smallest_key,
-  std::optional<internal::key_view> largest_key);
+  std::optional<user_key_view> smallest_key,
+  std::optional<user_key_view> largest_key);
 
 // Extracts the largest file b1 from `compaction_files` and then searches for a
 // b2 in `level_files` for which user_key(u1) = user_key(l2). If it finds such a

--- a/src/v/lsm/db/impl.cc
+++ b/src/v/lsm/db/impl.cc
@@ -474,9 +474,10 @@ ss::future<> impl::flush_memtable() {
     auto v = _versions->current();
     auto id = _versions->new_file_id();
     auto& imm = *_imm;
-    auto level = imm->empty() ? 0_level
-                              : v->pick_level_for_memtable_output(
-                                  imm->min_key(), imm->max_key());
+    auto level = imm->empty()
+                   ? 0_level
+                   : v->pick_level_for_memtable_output(
+                       imm->min_key().user_key(), imm->max_key().user_key());
     auto result = co_await build_table(
       _persistence.data.get(),
       {.id = id, .epoch = _opts->database_epoch},

--- a/src/v/lsm/db/tests/db_bench.cc
+++ b/src/v/lsm/db/tests/db_bench.cc
@@ -526,7 +526,7 @@ private:
             auto key = ss::sstring(fmt::format("missing{:016d}", i));
 
             auto key_encoded = lsm::internal::key::encode(
-              {.key = key,
+              {.key = lsm::user_key_view(key),
                .seqno = _seqno,
                .type = lsm::internal::value_type::value});
 
@@ -579,7 +579,7 @@ private:
     write_key(ss::sstring key, iobuf value, benchmark_stats& stats) {
         auto batch = ss::make_lw_shared<lsm::db::memtable>();
         auto key_encoded = lsm::internal::key::encode(
-          {.key = key,
+          {.key = lsm::user_key_view(key),
            .seqno = ++_seqno,
            .type = lsm::internal::value_type::value});
 
@@ -597,7 +597,7 @@ private:
     ss::future<> delete_key(const ss::sstring& key, benchmark_stats& stats) {
         auto batch = ss::make_lw_shared<lsm::db::memtable>();
         auto key_encoded = lsm::internal::key::encode(
-          {.key = key,
+          {.key = lsm::user_key_view(key),
            .seqno = ++_seqno,
            .type = lsm::internal::value_type::tombstone});
 
@@ -613,7 +613,7 @@ private:
 
     ss::future<> read_key(const ss::sstring& key, benchmark_stats& stats) {
         auto key_encoded = lsm::internal::key::encode(
-          {.key = key,
+          {.key = lsm::user_key_view(key),
            .seqno = _seqno,
            .type = lsm::internal::value_type::value});
 

--- a/src/v/lsm/db/tests/file_utils_test.cc
+++ b/src/v/lsm/db/tests/file_utils_test.cc
@@ -23,7 +23,6 @@ namespace {
 
 using namespace lsm;
 using lsm::internal::operator""_key;
-using lsm::internal::operator""_seqno;
 using ::testing::ElementsAre;
 
 constexpr static auto default_seqno = internal::sequence_number{100};
@@ -65,24 +64,11 @@ protected:
 
 private:
     bool overlaps(bool disjoint, const char* smallest, const char* largest) {
-        internal::key s, l;
-        if (smallest != nullptr) {
-            s = internal::key::encode({
-              .key = user_key_view(smallest),
-              .seqno = default_seqno,
-            });
-        }
-        if (largest != nullptr) {
-            l = internal::key::encode({
-              .key = user_key_view(largest),
-              .seqno = default_seqno,
-            });
-        }
         return db::some_file_overlaps_range(
           disjoint,
           _files,
-          smallest ? std::make_optional(s) : std::nullopt,
-          largest ? std::make_optional(l) : std::nullopt);
+          smallest ? std::make_optional(user_key_view(smallest)) : std::nullopt,
+          largest ? std::make_optional(user_key_view(largest)) : std::nullopt);
     }
     chunked_vector<ss::lw_shared_ptr<db::file_meta_data>> _files;
 };

--- a/src/v/lsm/db/tests/file_utils_test.cc
+++ b/src/v/lsm/db/tests/file_utils_test.cc
@@ -22,6 +22,7 @@
 namespace {
 
 using namespace lsm;
+using lsm::internal::operator""_key;
 using lsm::internal::operator""_seqno;
 using ::testing::ElementsAre;
 
@@ -307,6 +308,76 @@ TEST_F(AddBoundaryInputsTest, TestDisjointFilePointers) {
     compaction_files.push_back(f1);
     db::add_boundary_inputs(level_files, &compaction_files);
     ASSERT_THAT(compaction_files, ElementsAre(f1, f4, f3));
+}
+
+class GetRangeTest : public testing::Test {
+public:
+    ss::lw_shared_ptr<db::file_meta_data>
+    create_file(uint64_t id, internal::key smallest, internal::key largest) {
+        auto meta_data = ss::make_lw_shared<db::file_meta_data>();
+        meta_data->handle = {.id = internal::file_id{id}};
+        meta_data->file_size = 100;
+        meta_data->smallest = smallest;
+        meta_data->largest = largest;
+        return meta_data;
+    }
+};
+
+TEST_F(GetRangeTest, SingleFile) {
+    chunked_vector<ss::lw_shared_ptr<db::file_meta_data>> files;
+    files.push_back(create_file(1, "a@100"_key, "c@100"_key));
+
+    auto [smallest, largest] = db::get_range(files);
+    EXPECT_EQ(smallest, "a@100"_key);
+    EXPECT_EQ(largest, "c@100"_key);
+}
+
+TEST_F(GetRangeTest, DisjointFiles) {
+    // Regression test for bug where get_key_range() was incorrectly updating
+    // smallest instead of largest when file->largest > largest
+    chunked_vector<ss::lw_shared_ptr<db::file_meta_data>> files;
+    files.push_back(create_file(1, "a@100"_key, "c@100"_key));
+    files.push_back(create_file(2, "d@100"_key, "f@100"_key));
+
+    auto [smallest, largest] = db::get_range(files);
+    EXPECT_EQ(smallest, "a@100"_key);
+    EXPECT_EQ(largest, "f@100"_key);
+}
+
+TEST_F(GetRangeTest, OverlappingFiles) {
+    chunked_vector<ss::lw_shared_ptr<db::file_meta_data>> files;
+    files.push_back(create_file(1, "a@100"_key, "e@100"_key));
+    files.push_back(create_file(2, "c@100"_key, "g@100"_key));
+
+    auto [smallest, largest] = db::get_range(files);
+    EXPECT_EQ(smallest, "a@100"_key);
+    EXPECT_EQ(largest, "g@100"_key);
+}
+
+TEST_F(GetRangeTest, MultipleFiles) {
+    chunked_vector<ss::lw_shared_ptr<db::file_meta_data>> files;
+    files.push_back(create_file(1, "c@100"_key, "e@100"_key));
+    files.push_back(create_file(2, "a@100"_key, "d@100"_key));
+    files.push_back(create_file(3, "f@100"_key, "h@100"_key));
+    files.push_back(create_file(4, "b@100"_key, "g@100"_key));
+
+    auto [smallest, largest] = db::get_range(files);
+    EXPECT_EQ(smallest, "a@100"_key);
+    EXPECT_EQ(largest, "h@100"_key);
+}
+
+TEST_F(GetRangeTest, TwoInputs) {
+    chunked_vector<ss::lw_shared_ptr<db::file_meta_data>> inputs1;
+    chunked_vector<ss::lw_shared_ptr<db::file_meta_data>> inputs2;
+
+    inputs1.push_back(create_file(1, "a@100"_key, "c@100"_key));
+    inputs1.push_back(create_file(2, "d@100"_key, "f@100"_key));
+    inputs2.push_back(create_file(10, "b@100"_key, "e@100"_key));
+    inputs2.push_back(create_file(11, "g@100"_key, "j@100"_key));
+
+    auto [smallest, largest] = db::get_range(inputs1, inputs2);
+    EXPECT_EQ(smallest, "a@100"_key);
+    EXPECT_EQ(largest, "j@100"_key);
 }
 
 } // namespace

--- a/src/v/lsm/db/tests/file_utils_test.cc
+++ b/src/v/lsm/db/tests/file_utils_test.cc
@@ -42,15 +42,15 @@ protected:
             },
             .file_size = 100,
             .smallest = internal::key::encode(
-              {.key = smallest, .seqno = smallest_seq}),
+              {.key = user_key_view(smallest), .seqno = smallest_seq}),
             .largest = internal::key::encode(
-              {.key = largest, .seqno = largest_seq}),
+              {.key = user_key_view(largest), .seqno = largest_seq}),
           }));
     }
 
     size_t find(const std::string& key) {
         auto encoded = internal::key::encode({
-          .key = key,
+          .key = user_key_view(key),
           .seqno = default_seqno,
         });
         return db::find_file(_files, encoded);
@@ -68,13 +68,13 @@ private:
         internal::key s, l;
         if (smallest != nullptr) {
             s = internal::key::encode({
-              .key = smallest,
+              .key = user_key_view(smallest),
               .seqno = default_seqno,
             });
         }
         if (largest != nullptr) {
             l = internal::key::encode({
-              .key = largest,
+              .key = user_key_view(largest),
               .seqno = default_seqno,
             });
         }
@@ -205,15 +205,13 @@ TEST_F(FindFileTest, OverlappingFiles) {
 
 class AddBoundaryInputsTest : public testing::Test {
 public:
-    ss::lw_shared_ptr<db::file_meta_data> create_file(
-      uint64_t id,
-      internal::key::parts smallest,
-      internal::key::parts largest) {
+    ss::lw_shared_ptr<db::file_meta_data>
+    create_file(uint64_t id, internal::key smallest, internal::key largest) {
         auto meta_data = ss::make_lw_shared<db::file_meta_data>();
         meta_data->handle = {.id = internal::file_id{id}};
         meta_data->file_size = 100;
-        meta_data->smallest = internal::key::encode(std::move(smallest));
-        meta_data->largest = internal::key::encode(std::move(largest));
+        meta_data->smallest = std::move(smallest);
+        meta_data->largest = std::move(largest);
         return meta_data;
     }
 
@@ -229,8 +227,7 @@ TEST_F(AddBoundaryInputsTest, TestEmptyFileSets) {
 }
 
 TEST_F(AddBoundaryInputsTest, TestEmptyLevelFiles) {
-    auto f1 = create_file(
-      1, {.key = "100", .seqno = 2_seqno}, {.key = "100", .seqno = 1_seqno});
+    auto f1 = create_file(1, "100@2"_key, "100@1"_key);
     compaction_files.push_back(f1);
     db::add_boundary_inputs(level_files, &compaction_files);
     ASSERT_TRUE(level_files.empty());
@@ -238,8 +235,7 @@ TEST_F(AddBoundaryInputsTest, TestEmptyLevelFiles) {
 }
 
 TEST_F(AddBoundaryInputsTest, TestEmptyCompactionFiles) {
-    auto f1 = create_file(
-      1, {.key = "100", .seqno = 2_seqno}, {.key = "100", .seqno = 1_seqno});
+    auto f1 = create_file(1, "100@2"_key, "100@1"_key);
     level_files.push_back(f1);
     db::add_boundary_inputs(level_files, &compaction_files);
     ASSERT_THAT(level_files, ElementsAre(f1));
@@ -247,12 +243,9 @@ TEST_F(AddBoundaryInputsTest, TestEmptyCompactionFiles) {
 }
 
 TEST_F(AddBoundaryInputsTest, TestNoBoundaryFiles) {
-    auto f1 = create_file(
-      1, {.key = "100", .seqno = 2_seqno}, {.key = "100", .seqno = 1_seqno});
-    auto f2 = create_file(
-      2, {.key = "200", .seqno = 2_seqno}, {.key = "200", .seqno = 1_seqno});
-    auto f3 = create_file(
-      3, {.key = "300", .seqno = 2_seqno}, {.key = "300", .seqno = 1_seqno});
+    auto f1 = create_file(1, "100@2"_key, "100@1"_key);
+    auto f2 = create_file(2, "200@2"_key, "200@1"_key);
+    auto f3 = create_file(3, "300@2"_key, "300@1"_key);
     level_files.push_back(f3);
     level_files.push_back(f2);
     level_files.push_back(f1);
@@ -263,12 +256,9 @@ TEST_F(AddBoundaryInputsTest, TestNoBoundaryFiles) {
 }
 
 TEST_F(AddBoundaryInputsTest, TestOneBoundaryFile) {
-    auto f1 = create_file(
-      1, {.key = "100", .seqno = 3_seqno}, {.key = "100", .seqno = 2_seqno});
-    auto f2 = create_file(
-      2, {.key = "100", .seqno = 1_seqno}, {.key = "200", .seqno = 3_seqno});
-    auto f3 = create_file(
-      3, {.key = "300", .seqno = 2_seqno}, {.key = "300", .seqno = 1_seqno});
+    auto f1 = create_file(1, "100@3"_key, "100@2"_key);
+    auto f2 = create_file(2, "100@1"_key, "200@3"_key);
+    auto f3 = create_file(3, "300@2"_key, "300@1"_key);
     level_files.push_back(f3);
     level_files.push_back(f2);
     level_files.push_back(f1);
@@ -278,12 +268,9 @@ TEST_F(AddBoundaryInputsTest, TestOneBoundaryFile) {
 }
 
 TEST_F(AddBoundaryInputsTest, TestTwoBoundaryFiles) {
-    auto f1 = create_file(
-      1, {.key = "100", .seqno = 6_seqno}, {.key = "100", .seqno = 5_seqno});
-    auto f2 = create_file(
-      2, {.key = "100", .seqno = 2_seqno}, {.key = "300", .seqno = 1_seqno});
-    auto f3 = create_file(
-      3, {.key = "100", .seqno = 4_seqno}, {.key = "100", .seqno = 3_seqno});
+    auto f1 = create_file(1, "100@6"_key, "100@5"_key);
+    auto f2 = create_file(2, "100@2"_key, "300@1"_key);
+    auto f3 = create_file(3, "100@4"_key, "100@3"_key);
     level_files.push_back(f2);
     level_files.push_back(f3);
     level_files.push_back(f1);
@@ -293,15 +280,11 @@ TEST_F(AddBoundaryInputsTest, TestTwoBoundaryFiles) {
 }
 
 TEST_F(AddBoundaryInputsTest, TestDisjointFilePointers) {
-    auto f1 = create_file(
-      1, {.key = "100", .seqno = 6_seqno}, {.key = "100", .seqno = 5_seqno});
-    auto f2 = create_file(
-      2, {.key = "100", .seqno = 6_seqno}, {.key = "300", .seqno = 5_seqno});
-    auto f3 = create_file(
-      3, {.key = "100", .seqno = 2_seqno}, {.key = "100", .seqno = 1_seqno});
+    auto f1 = create_file(1, "100@6"_key, "100@5"_key);
+    auto f2 = create_file(2, "100@6"_key, "300@5"_key);
+    auto f3 = create_file(3, "100@2"_key, "100@1"_key);
     level_files.push_back(f2);
-    auto f4 = create_file(
-      4, {.key = "100", .seqno = 4_seqno}, {.key = "100", .seqno = 3_seqno});
+    auto f4 = create_file(4, "100@4"_key, "100@3"_key);
     level_files.push_back(f2);
     level_files.push_back(f3);
     level_files.push_back(f4);

--- a/src/v/lsm/db/tests/impl_test.cc
+++ b/src/v/lsm/db/tests/impl_test.cc
@@ -146,7 +146,8 @@ public:
         auto seqno = _db->max_applied_seqno();
         while (batch->approximate_memory_usage() < size) {
             auto key = lsm::internal::key::encode({
-              .key = random_generators::gen_alphanum_max_distinct(100'000),
+              .key = lsm::user_key_view(
+                random_generators::gen_alphanum_max_distinct(100'000)),
               .seqno = ++seqno,
             });
             auto value = iobuf::from(
@@ -282,14 +283,14 @@ TEST_F(ImplTest, ReadYourOwnWrites) {
     auto batch1 = ss::make_lw_shared<lsm::db::memtable>();
     auto seqno = _db->max_applied_seqno();
     auto key1 = lsm::internal::key::encode({
-      .key = "key1",
+      .key = lsm::user_key_view("key1"),
       .seqno = ++seqno,
     });
     auto value1 = iobuf::from("value1");
     batch1->put(key1, value1.share());
 
     auto key2 = lsm::internal::key::encode({
-      .key = "key2",
+      .key = lsm::user_key_view("key2"),
       .seqno = ++seqno,
     });
     auto value2 = iobuf::from("value2");
@@ -302,7 +303,7 @@ TEST_F(ImplTest, ReadYourOwnWrites) {
     seqno = _db->max_applied_seqno();
 
     auto key3 = lsm::internal::key::encode({
-      .key = "key3",
+      .key = lsm::user_key_view("key3"),
       .seqno = ++seqno,
     });
     auto value3 = iobuf::from("value3");
@@ -325,7 +326,7 @@ TEST_F(ImplTest, ReadYourOwnWrites) {
     seqno = _db->max_applied_seqno();
 
     auto key2_updated = lsm::internal::key::encode({
-      .key = "key2",
+      .key = lsm::user_key_view("key2"),
       .seqno = ++seqno,
     });
     auto value2_updated = iobuf::from("value2_updated");

--- a/src/v/lsm/db/tests/iter_test.cc
+++ b/src/v/lsm/db/tests/iter_test.cc
@@ -57,7 +57,7 @@ public:
       lsm::internal::sequence_number seqno,
       lsm::internal::value_type type = lsm::internal::value_type::value) {
         auto ikey = lsm::internal::key::encode(
-          {.key = ss::sstring{key}, .seqno = seqno, .type = type});
+          {.key = lsm::user_key_view{key}, .seqno = seqno, .type = type});
         if (type == lsm::internal::value_type::value) {
             _memtable->put(ikey, iobuf::from(value));
         } else {

--- a/src/v/lsm/db/tests/memtable_test.cc
+++ b/src/v/lsm/db/tests/memtable_test.cc
@@ -142,7 +142,7 @@ TEST_F(MemtableTest, GetAtVersion) {
 
     for (const auto& tc : testcases) {
         auto key = lsm::internal::key::encode({
-          .key = tc.key,
+          .key = lsm::user_key_view(tc.key),
           .seqno = lsm::internal::sequence_number(tc.version),
         });
         if (!tc.value) {

--- a/src/v/lsm/db/tests/version_set_test.cc
+++ b/src/v/lsm/db/tests/version_set_test.cc
@@ -19,9 +19,18 @@
 #include "lsm/sst/builder.h"
 
 #include <gmock/gmock-matchers.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 namespace {
+
+using lsm::internal::operator""_level;
+using lsm::internal::operator""_file_id;
+using lsm::internal::operator""_key;
+using lsm::internal::operator""_seqno;
+using testing::ElementsAre;
+using testing::IsEmpty;
+using testing::UnorderedElementsAre;
 
 struct sst_spec {
     lsm::internal::file_id id;
@@ -101,9 +110,91 @@ private:
         _metadata_persistence.get(), &_table_cache, _options);
 };
 
-using lsm::internal::operator""_level;
-using lsm::internal::operator""_file_id;
-using lsm::internal::operator""_key;
+// Fixture for compaction tests that only uses file metadata.
+class CompactionTest : public testing::Test {
+public:
+    constexpr static size_t default_max_entries = 10;
+
+    CompactionTest() {
+        // Use small sizes that are easier to reason about
+        _options->level_one_compaction_trigger = 4;
+        _options->write_buffer_size = 1000;
+        _options->levels = lsm::internal::options::make_levels(
+          /*base_config=*/
+          {
+            .max_total_bytes = 10000, // L0/L1: 10KB total
+            .max_file_size = 1000,    // L0/L1: 1KB per file
+          },
+          /*multiplier=*/10,
+          /*max_level=*/6_level);
+    }
+
+    void TearDown() override {
+        _table_cache.close().get();
+        _data_persistence->close().get();
+        _metadata_persistence->close().get();
+    }
+
+    const lsm::internal::options& options() { return *_options; }
+    lsm::db::version_set& version_set() { return *_version_set; }
+
+    // Add a file to the version using only metadata (no actual SST file).
+    void add_file(
+      lsm::internal::level level,
+      lsm::internal::file_id id,
+      lsm::internal::key smallest,
+      lsm::internal::key largest,
+      uint64_t file_size = 100) {
+        lsm::db::version_edit edit(*_options);
+        edit.add_file({
+          .level = level,
+          .file_handle = {.id = id},
+          .file_size = file_size,
+          .smallest = smallest,
+          .largest = largest,
+          .oldest_seqno = 0_seqno,
+          .newest_seqno = 0_seqno,
+        });
+        _version_set->log_and_apply(std::move(edit)).get();
+    }
+
+    // Extract file IDs from compaction inputs at the specified level.
+    static std::vector<lsm::internal::file_id> input_file_ids(
+      const lsm::db::compaction& c, lsm::db::compaction::which which) {
+        std::vector<lsm::internal::file_id> ids;
+        for (size_t i = 0; i < c.num_input_files(which); ++i) {
+            ids.push_back(c.input(which, i)->handle.id);
+        }
+        return ids;
+    }
+
+    // Extract file IDs from compaction input level.
+    static std::vector<lsm::internal::file_id>
+    input_file_ids(const lsm::db::compaction& c) {
+        return input_file_ids(c, lsm::db::compaction::input_level);
+    }
+
+    // Extract file IDs from compaction output level.
+    static std::vector<lsm::internal::file_id>
+    output_file_ids(const lsm::db::compaction& c) {
+        return input_file_ids(c, lsm::db::compaction::output_level);
+    }
+
+private:
+    ss::lw_shared_ptr<lsm::internal::options> _options
+      = ss::make_lw_shared<lsm::internal::options>();
+    std::unique_ptr<lsm::io::data_persistence> _data_persistence
+      = lsm::io::make_memory_data_persistence();
+    std::unique_ptr<lsm::io::metadata_persistence> _metadata_persistence
+      = lsm::io::make_memory_metadata_persistence();
+    lsm::db::table_cache _table_cache{
+      _data_persistence.get(),
+      default_max_entries,
+      ss::make_lw_shared<lsm::sst::block_cache>(1_MiB)};
+    ss::lw_shared_ptr<lsm::db::version_set> _version_set
+      = ss::make_lw_shared<lsm::db::version_set>(
+        _metadata_persistence.get(), &_table_cache, _options);
+};
 
 } // namespace
 
@@ -314,4 +405,173 @@ TEST_F(VersionSetTest, Get) {
     EXPECT_THAT(result, IsLookupValue("b"_key, 1_level));
     result = vset.current()->get("j"_key, &stats).get();
     EXPECT_THAT(result, IsMissing());
+}
+
+TEST_F(CompactionTest, PickCompactionLevel0ToLevel1) {
+    // Add 4 files to L0 to trigger compaction
+    add_file(0_level, 1_file_id, "a"_key, "d"_key);
+    add_file(0_level, 2_file_id, "e"_key, "h"_key);
+    add_file(0_level, 3_file_id, "i"_key, "m"_key);
+    add_file(0_level, 4_file_id, "n"_key, "z"_key);
+
+    // Add overlapping files in L1
+    add_file(1_level, 10_file_id, "b"_key, "f"_key);
+    add_file(1_level, 11_file_id, "g"_key, "k"_key);
+
+    auto c = version_set().pick_compaction();
+
+    ASSERT_TRUE(c.has_value());
+    EXPECT_EQ(c->level(), 0_level);
+    // L0 compaction includes all overlapping files
+    EXPECT_THAT(input_file_ids(*c), ElementsAre(1_file_id));
+    // L1 files overlapping with the L0 range [a-h]
+    EXPECT_THAT(output_file_ids(*c), ElementsAre(10_file_id));
+}
+
+TEST_F(CompactionTest, TrivialMove) {
+    // Add 4 files to L0 to trigger compaction
+    add_file(0_level, 1_file_id, "a"_key, "d"_key);
+    add_file(0_level, 2_file_id, "e"_key, "h"_key);
+    add_file(0_level, 3_file_id, "i"_key, "m"_key);
+    add_file(0_level, 4_file_id, "n"_key, "z"_key);
+
+    // L1 has no files - first file can be trivially moved
+    auto c = version_set().pick_compaction();
+
+    ASSERT_TRUE(c.has_value());
+    EXPECT_EQ(c->level(), 0_level);
+    EXPECT_THAT(input_file_ids(*c), ElementsAre(1_file_id));
+    EXPECT_THAT(output_file_ids(*c), IsEmpty());
+    EXPECT_TRUE(c->is_trivial_move());
+}
+
+TEST_F(CompactionTest, OverlappingL0Files) {
+    // Add 4 files to L0 with overlapping key ranges.
+    // This tests that when picking files from L0, overlapping files are
+    // properly expanded.
+    add_file(0_level, 1_file_id, "a"_key, "e"_key);
+    add_file(0_level, 2_file_id, "c"_key, "g"_key); // Overlaps with file 1
+    add_file(0_level, 3_file_id, "f"_key, "j"_key); // Overlaps with file 2
+    add_file(0_level, 4_file_id, "m"_key, "z"_key); // Disjoint
+
+    // Add overlapping file in L1
+    add_file(1_level, 10_file_id, "d"_key, "h"_key);
+
+    auto c = version_set().pick_compaction();
+
+    ASSERT_TRUE(c.has_value());
+    EXPECT_EQ(c->level(), 0_level);
+    // Should include all overlapping L0 files: starts with file 1, which
+    // overlaps with file 2, which overlaps with file 3
+    EXPECT_THAT(
+      input_file_ids(*c),
+      UnorderedElementsAre(1_file_id, 2_file_id, 3_file_id));
+    // L1 file overlapping with the selected range
+    EXPECT_THAT(output_file_ids(*c), ElementsAre(10_file_id));
+}
+
+TEST_F(CompactionTest, Level1ToLevel2Compaction) {
+    // L0 is empty, but L1 has enough data to trigger size-based compaction
+    // Each file is 1KB, L1 max is 10KB, so we need >10 files
+    add_file(1_level, 1_file_id, "aa"_key, "ab"_key, 1000);
+    add_file(1_level, 2_file_id, "ac"_key, "ad"_key, 1000);
+    add_file(1_level, 3_file_id, "ae"_key, "af"_key, 1000);
+    add_file(1_level, 4_file_id, "ag"_key, "ah"_key, 1000);
+    add_file(1_level, 5_file_id, "ai"_key, "aj"_key, 1000);
+    add_file(1_level, 6_file_id, "ak"_key, "al"_key, 1000);
+    add_file(1_level, 7_file_id, "am"_key, "an"_key, 1000);
+    add_file(1_level, 8_file_id, "ao"_key, "ap"_key, 1000);
+    add_file(1_level, 9_file_id, "aq"_key, "ar"_key, 1000);
+    add_file(1_level, 10_file_id, "as"_key, "at"_key, 1000);
+    add_file(1_level, 11_file_id, "au"_key, "av"_key, 1000);
+    add_file(1_level, 12_file_id, "aw"_key, "ax"_key, 1000);
+
+    // Add overlapping file in L2
+    add_file(2_level, 100_file_id, "aa"_key, "ac"_key);
+
+    auto c = version_set().pick_compaction();
+
+    ASSERT_TRUE(c.has_value());
+    EXPECT_EQ(c->level(), 1_level); // L1→L2 compaction
+    EXPECT_THAT(input_file_ids(*c), ElementsAre(1_file_id));
+    EXPECT_THAT(output_file_ids(*c), ElementsAre(100_file_id));
+}
+
+TEST_F(CompactionTest, GrandparentOverlapTracking) {
+    // Add files to trigger L0→L1 compaction
+    add_file(0_level, 1_file_id, "a"_key, "d"_key);
+    add_file(0_level, 2_file_id, "e"_key, "h"_key);
+    add_file(0_level, 3_file_id, "i"_key, "m"_key);
+    add_file(0_level, 4_file_id, "n"_key, "z"_key);
+
+    // L1 file
+    add_file(1_level, 10_file_id, "b"_key, "f"_key);
+
+    // Add grandparent files in L2 that overlap with compaction range
+    add_file(2_level, 20_file_id, "a"_key, "c"_key);
+    add_file(2_level, 21_file_id, "d"_key, "e"_key);
+
+    auto c = version_set().pick_compaction();
+
+    ASSERT_TRUE(c.has_value());
+    EXPECT_EQ(c->level(), 0_level);
+    // Compaction should track grandparents to not create too big of compactions
+    // later, this is why file 2 isn't picked up.
+    EXPECT_THAT(input_file_ids(*c), ElementsAre(1_file_id));
+    EXPECT_THAT(output_file_ids(*c), ElementsAre(10_file_id));
+}
+
+TEST_F(CompactionTest, DisjointL0Files) {
+    // Tests compaction with disjoint (non-overlapping) L0 files.
+    // Only the first file is selected even though file 2 is within the
+    // combined L0+L1 range - expansion doesn't occur for disjoint L0 files.
+    add_file(0_level, 1_file_id, "a"_key, "c"_key);
+    add_file(0_level, 2_file_id, "d"_key, "f"_key); // Disjoint from file 1
+    add_file(0_level, 3_file_id, "m"_key, "p"_key);
+    add_file(0_level, 4_file_id, "q"_key, "z"_key);
+
+    // L1 file overlaps with file 1
+    add_file(1_level, 10_file_id, "a"_key, "g"_key);
+
+    auto c = version_set().pick_compaction();
+
+    ASSERT_TRUE(c.has_value());
+    EXPECT_EQ(c->level(), 0_level);
+    // Only picks file 1; file 2 is not included despite being in L1 range
+    EXPECT_THAT(input_file_ids(*c), ElementsAre(1_file_id));
+    EXPECT_THAT(output_file_ids(*c), ElementsAre(10_file_id));
+}
+
+TEST_F(CompactionTest, BoundaryKeyHandling) {
+    // Add files with exact boundary matches to test add_boundary_inputs
+    add_file(0_level, 1_file_id, "a"_key, "d"_key);
+    add_file(0_level, 2_file_id, "e"_key, "h"_key);
+    add_file(0_level, 3_file_id, "i"_key, "m"_key);
+    add_file(0_level, 4_file_id, "n"_key, "z"_key);
+
+    // L1 files where one has a boundary that matches an L0 file's boundary
+    add_file(1_level, 10_file_id, "b"_key, "d"_key); // Ends at 'd' like file 1
+    add_file(
+      1_level, 11_file_id, "e"_key, "g"_key); // Starts at 'e' like file 2
+
+    auto c = version_set().pick_compaction();
+
+    ASSERT_TRUE(c.has_value());
+    EXPECT_EQ(c->level(), 0_level);
+    // Should include file 1 from L0
+    EXPECT_THAT(input_file_ids(*c), ElementsAre(1_file_id));
+    // Should include L1 file with matching boundary
+    EXPECT_THAT(output_file_ids(*c), ElementsAre(10_file_id));
+}
+
+TEST_F(CompactionTest, NoCompactionBelowThreshold) {
+    // Add only 3 files to L0 (below the trigger of 4)
+    add_file(0_level, 1_file_id, "a"_key, "d"_key);
+    add_file(0_level, 2_file_id, "e"_key, "h"_key);
+    add_file(0_level, 3_file_id, "i"_key, "m"_key);
+
+    auto c = version_set().pick_compaction();
+
+    // No compaction should be triggered
+    EXPECT_FALSE(c.has_value());
 }

--- a/src/v/lsm/db/tests/version_set_test.cc
+++ b/src/v/lsm/db/tests/version_set_test.cc
@@ -25,6 +25,7 @@
 namespace {
 
 using lsm::internal::operator""_level;
+using lsm::operator""_user_key;
 using lsm::internal::operator""_file_id;
 using lsm::internal::operator""_key;
 using lsm::internal::operator""_seqno;
@@ -311,21 +312,27 @@ TEST_F(VersionSetTest, OverlapInLevel0) {
     });
     vset.log_and_apply(std::move(edit)).get();
     auto current = vset.current();
-    EXPECT_TRUE(current->overlap_in_level(0_level, "a"_key, "z"_key));
-    EXPECT_TRUE(current->overlap_in_level(0_level, "k"_key, "l"_key));
-    EXPECT_TRUE(current->overlap_in_level(0_level, "f"_key, "h"_key));
-    EXPECT_TRUE(current->overlap_in_level(0_level, "h"_key, "j"_key));
-    EXPECT_TRUE(current->overlap_in_level(0_level, "g"_key, "h"_key));
-    EXPECT_TRUE(current->overlap_in_level(0_level, "h"_key, "i"_key));
+    EXPECT_TRUE(current->overlap_in_level(0_level, "a"_user_key, "z"_user_key));
+    EXPECT_TRUE(current->overlap_in_level(0_level, "k"_user_key, "l"_user_key));
+    EXPECT_TRUE(current->overlap_in_level(0_level, "f"_user_key, "h"_user_key));
+    EXPECT_TRUE(current->overlap_in_level(0_level, "h"_user_key, "j"_user_key));
+    EXPECT_TRUE(current->overlap_in_level(0_level, "g"_user_key, "h"_user_key));
+    EXPECT_TRUE(current->overlap_in_level(0_level, "h"_user_key, "i"_user_key));
     EXPECT_TRUE(current->overlap_in_level(0_level, std::nullopt, std::nullopt));
-    EXPECT_TRUE(current->overlap_in_level(0_level, "k"_key, std::nullopt));
-    EXPECT_TRUE(current->overlap_in_level(0_level, std::nullopt, "d"_key));
-    EXPECT_FALSE(current->overlap_in_level(0_level, std::nullopt, "a"_key));
-    EXPECT_FALSE(current->overlap_in_level(0_level, "l"_key, std::nullopt));
-    EXPECT_FALSE(current->overlap_in_level(0_level, "a"_key, "a"_key));
-    EXPECT_FALSE(current->overlap_in_level(0_level, "y"_key, "z"_key));
-    EXPECT_FALSE(current->overlap_in_level(0_level, "h"_key, "h"_key));
-    EXPECT_FALSE(current->overlap_in_level(1_level, "a"_key, "z"_key));
+    EXPECT_TRUE(current->overlap_in_level(0_level, "k"_user_key, std::nullopt));
+    EXPECT_TRUE(current->overlap_in_level(0_level, std::nullopt, "d"_user_key));
+    EXPECT_FALSE(
+      current->overlap_in_level(0_level, std::nullopt, "a"_user_key));
+    EXPECT_FALSE(
+      current->overlap_in_level(0_level, "l"_user_key, std::nullopt));
+    EXPECT_FALSE(
+      current->overlap_in_level(0_level, "a"_user_key, "a"_user_key));
+    EXPECT_FALSE(
+      current->overlap_in_level(0_level, "y"_user_key, "z"_user_key));
+    EXPECT_FALSE(
+      current->overlap_in_level(0_level, "h"_user_key, "h"_user_key));
+    EXPECT_FALSE(
+      current->overlap_in_level(1_level, "a"_user_key, "z"_user_key));
 }
 
 TEST_F(VersionSetTest, OverlapInLevel1) {
@@ -347,21 +354,27 @@ TEST_F(VersionSetTest, OverlapInLevel1) {
     });
     vset.log_and_apply(std::move(edit)).get();
     auto current = vset.current();
-    EXPECT_TRUE(current->overlap_in_level(1_level, "a"_key, "z"_key));
-    EXPECT_TRUE(current->overlap_in_level(1_level, "k"_key, "l"_key));
-    EXPECT_TRUE(current->overlap_in_level(1_level, "f"_key, "h"_key));
-    EXPECT_TRUE(current->overlap_in_level(1_level, "h"_key, "j"_key));
-    EXPECT_TRUE(current->overlap_in_level(1_level, "g"_key, "h"_key));
-    EXPECT_TRUE(current->overlap_in_level(1_level, "h"_key, "i"_key));
+    EXPECT_TRUE(current->overlap_in_level(1_level, "a"_user_key, "z"_user_key));
+    EXPECT_TRUE(current->overlap_in_level(1_level, "k"_user_key, "l"_user_key));
+    EXPECT_TRUE(current->overlap_in_level(1_level, "f"_user_key, "h"_user_key));
+    EXPECT_TRUE(current->overlap_in_level(1_level, "h"_user_key, "j"_user_key));
+    EXPECT_TRUE(current->overlap_in_level(1_level, "g"_user_key, "h"_user_key));
+    EXPECT_TRUE(current->overlap_in_level(1_level, "h"_user_key, "i"_user_key));
     EXPECT_TRUE(current->overlap_in_level(1_level, std::nullopt, std::nullopt));
-    EXPECT_TRUE(current->overlap_in_level(1_level, "k"_key, std::nullopt));
-    EXPECT_TRUE(current->overlap_in_level(1_level, std::nullopt, "d"_key));
-    EXPECT_FALSE(current->overlap_in_level(1_level, std::nullopt, "c"_key));
-    EXPECT_FALSE(current->overlap_in_level(1_level, "l"_key, std::nullopt));
-    EXPECT_FALSE(current->overlap_in_level(1_level, "a"_key, "b"_key));
-    EXPECT_FALSE(current->overlap_in_level(1_level, "y"_key, "z"_key));
-    EXPECT_FALSE(current->overlap_in_level(1_level, "h"_key, "h"_key));
-    EXPECT_FALSE(current->overlap_in_level(2_level, "a"_key, "z"_key));
+    EXPECT_TRUE(current->overlap_in_level(1_level, "k"_user_key, std::nullopt));
+    EXPECT_TRUE(current->overlap_in_level(1_level, std::nullopt, "d"_user_key));
+    EXPECT_FALSE(
+      current->overlap_in_level(1_level, std::nullopt, "c"_user_key));
+    EXPECT_FALSE(
+      current->overlap_in_level(1_level, "l"_user_key, std::nullopt));
+    EXPECT_FALSE(
+      current->overlap_in_level(1_level, "a"_user_key, "b"_user_key));
+    EXPECT_FALSE(
+      current->overlap_in_level(1_level, "y"_user_key, "z"_user_key));
+    EXPECT_FALSE(
+      current->overlap_in_level(1_level, "h"_user_key, "h"_user_key));
+    EXPECT_FALSE(
+      current->overlap_in_level(2_level, "a"_user_key, "z"_user_key));
 }
 
 TEST_F(VersionSetTest, Get) {
@@ -607,7 +620,7 @@ TEST_F(CompactionTest, NoCompactionBelowThreshold) {
 
 TEST_F(CompactionTest, SameUserKeyDifferentSeqnosOverlap) {
     // Tests overlap detection when the same user key exists at different
-    // sequence numbers across files. This is critical for tombstone
+    // sequence numbers across files. This is needed for tombstone
     // compaction - if we don't detect these as overlapping, tombstones
     // won't compact with older versions of the key and deletions won't work.
     //
@@ -642,7 +655,7 @@ TEST_F(CompactionTest, SameUserKeyDifferentSeqnosOverlap) {
     // includes one L1 file), it means we're not properly detecting overlaps for
     // the same user key at different sequence numbers.
     //
-    // This would be a bug because:
+    // This would be an issue because:
     // 1. Tombstones (deletes) wouldn't compact with older versions
     // 2. Old versions of keys would accumulate
     // 3. Space wouldn't be reclaimed properly

--- a/src/v/lsm/db/tests/version_set_test.cc
+++ b/src/v/lsm/db/tests/version_set_test.cc
@@ -547,6 +547,30 @@ TEST_F(CompactionTest, InputExpansion) {
     EXPECT_THAT(output_file_ids(*c), ElementsAre(10_file_id));
 }
 
+TEST_F(CompactionTest, NoExpansionWhenOutputLevelGrows) {
+    // Tests that expansion is rejected when it would add more output level
+    // files. Initial compaction picks file 1, but expanding to include file 2
+    // would require an additional L1 file, so expansion should not happen.
+    add_file(0_level, 1_file_id, "a"_key, "c"_key, 100);
+    add_file(0_level, 2_file_id, "d"_key, "f"_key, 100);
+    add_file(0_level, 3_file_id, "m"_key, "p"_key, 100);
+    add_file(0_level, 4_file_id, "q"_key, "z"_key, 100);
+
+    // L1 files: file 1 overlaps with L1 file 10, but file 2 would require
+    // adding L1 file 11, so expansion should be rejected
+    add_file(1_level, 10_file_id, "a"_key, "c"_key, 100);
+    add_file(1_level, 11_file_id, "d"_key, "f"_key, 100);
+
+    auto c = version_set().pick_compaction();
+
+    ASSERT_TRUE(c.has_value());
+    EXPECT_EQ(c->level(), 0_level);
+    // Only file 1 should be selected; expansion would add file 2 but also
+    // require adding L1 file 11, so it's rejected
+    EXPECT_THAT(input_file_ids(*c), ElementsAre(1_file_id));
+    EXPECT_THAT(output_file_ids(*c), ElementsAre(10_file_id));
+}
+
 TEST_F(CompactionTest, BoundaryKeyHandling) {
     // Add files with exact boundary matches to test add_boundary_inputs
     add_file(0_level, 1_file_id, "a"_key, "d"_key);
@@ -579,4 +603,41 @@ TEST_F(CompactionTest, NoCompactionBelowThreshold) {
 
     // No compaction should be triggered
     EXPECT_FALSE(c.has_value());
+}
+
+TEST_F(CompactionTest, CompactionPointerRespected) {
+    // Tests that the compaction pointer is respected during compaction
+    // selection. Files before the pointer should not be selected.
+
+    // Set up L1 with multiple files to trigger size-based compaction
+    add_file(1_level, 1_file_id, "a"_key, "b"_key, 1000);
+    add_file(1_level, 2_file_id, "c"_key, "d"_key, 1000);
+    add_file(1_level, 3_file_id, "e"_key, "f"_key, 1000);
+    add_file(1_level, 4_file_id, "g"_key, "h"_key, 1000);
+    add_file(1_level, 5_file_id, "i"_key, "j"_key, 1000);
+    add_file(1_level, 6_file_id, "k"_key, "l"_key, 1000);
+    add_file(1_level, 7_file_id, "m"_key, "n"_key, 1000);
+    add_file(1_level, 8_file_id, "o"_key, "p"_key, 1000);
+    add_file(1_level, 9_file_id, "q"_key, "r"_key, 1000);
+    add_file(1_level, 10_file_id, "s"_key, "t"_key, 1000);
+    add_file(1_level, 11_file_id, "u"_key, "v"_key, 1000);
+    add_file(1_level, 12_file_id, "w"_key, "x"_key, 1000);
+
+    // Add L2 files
+    add_file(2_level, 100_file_id, "c"_key, "d"_key, 100);
+    add_file(2_level, 101_file_id, "e"_key, "f"_key, 100);
+
+    // Set the compaction pointer to after file 2, so next compaction should
+    // start from file 3
+    lsm::db::version_edit edit(options());
+    edit.set_compact_pointer(1_level, "d"_key);
+    version_set().log_and_apply(std::move(edit)).get();
+
+    // Next compaction should pick file 3 or later, not file 1 or 2
+    auto c = version_set().pick_compaction();
+    ASSERT_TRUE(c.has_value());
+    EXPECT_EQ(c->level(), 1_level);
+    // Should pick file 3 (first file after the compact pointer at "d")
+    EXPECT_THAT(input_file_ids(*c), ElementsAre(3_file_id));
+    EXPECT_THAT(output_file_ids(*c), ElementsAre(101_file_id));
 }

--- a/src/v/lsm/db/tests/version_set_test.cc
+++ b/src/v/lsm/db/tests/version_set_test.cc
@@ -493,7 +493,9 @@ TEST_F(CompactionTest, Level1ToLevel2Compaction) {
 
     ASSERT_TRUE(c.has_value());
     EXPECT_EQ(c->level(), 1_level); // L1→L2 compaction
-    EXPECT_THAT(input_file_ids(*c), ElementsAre(1_file_id));
+    // Expansion picks both file 1 and 2 since they both overlap with
+    // the same L2 file and fit within the expansion byte limit
+    EXPECT_THAT(input_file_ids(*c), UnorderedElementsAre(1_file_id, 2_file_id));
     EXPECT_THAT(output_file_ids(*c), ElementsAre(100_file_id));
 }
 
@@ -515,30 +517,33 @@ TEST_F(CompactionTest, GrandparentOverlapTracking) {
 
     ASSERT_TRUE(c.has_value());
     EXPECT_EQ(c->level(), 0_level);
-    // Compaction should track grandparents to not create too big of compactions
-    // later, this is why file 2 isn't picked up.
-    EXPECT_THAT(input_file_ids(*c), ElementsAre(1_file_id));
+    // Expansion picks both file 1 and 2 since they both overlap with
+    // the same L1 file and fit within the expansion byte limit.
+    // Grandparent overlap tracking is verified by checking that the
+    // compaction includes the expected grandparent files.
+    EXPECT_THAT(input_file_ids(*c), UnorderedElementsAre(1_file_id, 2_file_id));
     EXPECT_THAT(output_file_ids(*c), ElementsAre(10_file_id));
 }
 
-TEST_F(CompactionTest, DisjointL0Files) {
-    // Tests compaction with disjoint (non-overlapping) L0 files.
-    // Only the first file is selected even though file 2 is within the
-    // combined L0+L1 range - expansion doesn't occur for disjoint L0 files.
-    add_file(0_level, 1_file_id, "a"_key, "c"_key);
-    add_file(0_level, 2_file_id, "d"_key, "f"_key); // Disjoint from file 1
-    add_file(0_level, 3_file_id, "m"_key, "p"_key);
-    add_file(0_level, 4_file_id, "q"_key, "z"_key);
+TEST_F(CompactionTest, InputExpansion) {
+    // Tests input expansion with disjoint (non-overlapping) L0 files.
+    // When file 1 is picked for compaction against L1 file [a-g],
+    // expansion should also pick file 2 since it doesn't add output files.
+    add_file(0_level, 1_file_id, "a"_key, "c"_key, 100);
+    add_file(0_level, 2_file_id, "d"_key, "f"_key, 100); // Disjoint from file 1
+    add_file(0_level, 3_file_id, "m"_key, "p"_key, 100);
+    add_file(0_level, 4_file_id, "q"_key, "z"_key, 100);
 
-    // L1 file overlaps with file 1
-    add_file(1_level, 10_file_id, "a"_key, "g"_key);
+    // L1 file that covers both file 1 and file 2
+    add_file(1_level, 10_file_id, "a"_key, "g"_key, 100);
 
     auto c = version_set().pick_compaction();
 
     ASSERT_TRUE(c.has_value());
     EXPECT_EQ(c->level(), 0_level);
-    // Only picks file 1; file 2 is not included despite being in L1 range
-    EXPECT_THAT(input_file_ids(*c), ElementsAre(1_file_id));
+    // Expansion should pick both files 1 and 2 since they both overlap with
+    // the same L1 file and fit within the expansion limit
+    EXPECT_THAT(input_file_ids(*c), UnorderedElementsAre(1_file_id, 2_file_id));
     EXPECT_THAT(output_file_ids(*c), ElementsAre(10_file_id));
 }
 

--- a/src/v/lsm/db/tests/version_set_test.cc
+++ b/src/v/lsm/db/tests/version_set_test.cc
@@ -605,6 +605,51 @@ TEST_F(CompactionTest, NoCompactionBelowThreshold) {
     EXPECT_FALSE(c.has_value());
 }
 
+TEST_F(CompactionTest, SameUserKeyDifferentSeqnosOverlap) {
+    // Tests overlap detection when the same user key exists at different
+    // sequence numbers across files. This is critical for tombstone
+    // compaction - if we don't detect these as overlapping, tombstones
+    // won't compact with older versions of the key and deletions won't work.
+    //
+    // In leveldb, get_overlapping_inputs uses user key comparison specifically
+    // to handle this case. If we use internal key comparison instead, we might
+    // miss these overlaps.
+
+    // Add L0 files to trigger compaction
+    // File 1: has "apple" at seqno 200 (newest)
+    add_file(0_level, 1_file_id, "apple@200"_key, "apple@200"_key);
+    add_file(0_level, 2_file_id, "bar"_key, "baz"_key);
+    add_file(0_level, 3_file_id, "qux"_key, "quy"_key);
+    add_file(0_level, 4_file_id, "xyz"_key, "zzz"_key);
+
+    // L1 files: each contains "apple" at different sequence numbers
+    // File 10: "apple" at seqno 100
+    add_file(1_level, 10_file_id, "apple@100"_key, "apple@100"_key);
+
+    // File 11: "apple" at seqno 50 (could be a tombstone)
+    add_file(1_level, 11_file_id, "apple@50"_key, "apple@50"_key);
+
+    auto c = version_set().pick_compaction();
+
+    ASSERT_TRUE(c.has_value());
+    EXPECT_EQ(c->level(), 0_level);
+    // File 1 from L0 should be selected
+    EXPECT_THAT(input_file_ids(*c), ElementsAre(1_file_id));
+
+    // Both L1 files should be included in the output because they
+    // contain the same user key "apple", even though they have different
+    // seqnos. If we're using internal key comparison and this test fails (only
+    // includes one L1 file), it means we're not properly detecting overlaps for
+    // the same user key at different sequence numbers.
+    //
+    // This would be a bug because:
+    // 1. Tombstones (deletes) wouldn't compact with older versions
+    // 2. Old versions of keys would accumulate
+    // 3. Space wouldn't be reclaimed properly
+    EXPECT_THAT(
+      output_file_ids(*c), UnorderedElementsAre(10_file_id, 11_file_id));
+}
+
 TEST_F(CompactionTest, CompactionPointerRespected) {
     // Tests that the compaction pointer is respected during compaction
     // selection. Files before the pointer should not be selected.

--- a/src/v/lsm/db/version_set.cc
+++ b/src/v/lsm/db/version_set.cc
@@ -284,27 +284,27 @@ ss::future<bool> version::record_read_sample(internal::key_view key) {
 chunked_vector<ss::lw_shared_ptr<file_meta_data>>
 version::get_overlapping_inputs(
   internal::level level,
-  std::optional<internal::key_view> begin,
-  std::optional<internal::key_view> end) {
+  std::optional<user_key_view> begin,
+  std::optional<user_key_view> end) {
     chunked_vector<ss::lw_shared_ptr<file_meta_data>> inputs;
     const auto& files = _files[level];
     for (size_t i = 0; i < files.size();) {
         const auto& file = files[i++];
-        if (begin && file->largest < *begin) { // NOLINT(*branch-clone*)
+        if (begin && file->largest.user_key() < *begin) {
             // file is completely before specified range; skip it
-        } else if (end && file->smallest > *end) {
+        } else if (end && file->smallest.user_key() > *end) {
             // file is completely after specified range; skip it
         } else {
             inputs.push_back(file);
             // Level 0 files may overlap each over. So check if the newly added
             // file has expanded the range. If so, restart search.
             if (level == 0_level) {
-                if (begin && file->smallest < *begin) {
-                    begin = file->smallest;
+                if (begin && file->smallest.user_key() < *begin) {
+                    begin = file->smallest.user_key();
                     inputs.clear();
                     i = 0;
-                } else if (end && file->largest > *end) {
-                    end = file->largest;
+                } else if (end && file->largest.user_key() > *end) {
+                    end = file->largest.user_key();
                     inputs.clear();
                     i = 0;
                 }
@@ -378,13 +378,13 @@ version::get(internal::key_view target, get_stats* stats) {
 
 bool version::overlap_in_level(
   internal::level level,
-  std::optional<internal::key_view> begin,
-  std::optional<internal::key_view> end) {
+  std::optional<user_key_view> begin,
+  std::optional<user_key_view> end) {
     return some_file_overlaps_range(level > 0_level, _files[level], begin, end);
 }
 
 internal::level version::pick_level_for_memtable_output(
-  internal::key_view begin, internal::key_view end) {
+  user_key_view begin, user_key_view end) {
     auto level = 0_level;
     if (!overlap_in_level(level, begin, end)) {
         // Push to next level if there is no overlap in next level,
@@ -683,13 +683,13 @@ std::optional<compaction> version_set::pick_compaction() {
     if (level == 0_level) {
         auto [smallest, largest] = get_range(c->_inputs[which::input_level]);
         c->_inputs[which::input_level] = _current->get_overlapping_inputs(
-          0_level, smallest, largest);
+          0_level, smallest.user_key(), largest.user_key());
     }
     add_boundary_inputs(
       _current->_files[level], &c->_inputs[which::input_level]);
     auto [smallest, largest] = get_range(c->_inputs[which::input_level]);
     c->_inputs[which::output_level] = _current->get_overlapping_inputs(
-      level + 1_level, smallest, largest);
+      level + 1_level, smallest.user_key(), largest.user_key());
     add_boundary_inputs(
       _current->_files[level + 1_level], &c->_inputs[which::output_level]);
     // Get entire range covered by compaction
@@ -699,7 +699,7 @@ std::optional<compaction> version_set::pick_compaction() {
     // number of "level+1" files we pick up.
     if (!c->_inputs[which::output_level].empty()) {
         auto expanded0 = _current->get_overlapping_inputs(
-          level, all_smallest, all_largest);
+          level, all_smallest.user_key(), all_largest.user_key());
         add_boundary_inputs(_current->_files[level], &expanded0);
         auto inputs1_size = total_file_size(c->_inputs[which::output_level]);
         auto expanded0_size = total_file_size(expanded0);
@@ -709,7 +709,7 @@ std::optional<compaction> version_set::pick_compaction() {
                < _options->expanded_compaction_byte_size_limit(level)) {
             auto [new_smallest, new_largest] = get_range(expanded0);
             auto expanded1 = _current->get_overlapping_inputs(
-              level + 1_level, new_smallest, new_largest);
+              level + 1_level, new_smallest.user_key(), new_largest.user_key());
             add_boundary_inputs(_current->_files[level + 1_level], &expanded1);
             if (expanded1.size() == c->_inputs[which::output_level].size()) {
                 smallest = new_smallest;
@@ -727,7 +727,7 @@ std::optional<compaction> version_set::pick_compaction() {
     // Compute the set of grandparent files that overlap this compaction.
     if (level() + 2 < _options->levels.size()) {
         c->_grandparents = _current->get_overlapping_inputs(
-          level + 2_level, all_smallest, all_largest);
+          level + 2_level, all_smallest.user_key(), all_largest.user_key());
     }
     // Update the place where we will do the next compaction for this level.
     // We update this immediately instead of waiting for the version_edit

--- a/src/v/lsm/db/version_set.cc
+++ b/src/v/lsm/db/version_set.cc
@@ -288,8 +288,8 @@ version::get_overlapping_inputs(
   std::optional<internal::key_view> end) {
     chunked_vector<ss::lw_shared_ptr<file_meta_data>> inputs;
     const auto& files = _files[level];
-    for (size_t i = 0; i < files.size(); ++i) {
-        const auto& file = files[i];
+    for (size_t i = 0; i < files.size();) {
+        const auto& file = files[i++];
         if (begin && file->largest < *begin) { // NOLINT(*branch-clone*)
             // file is completely before specified range; skip it
         } else if (end && file->smallest > *end) {

--- a/src/v/lsm/db/version_set.cc
+++ b/src/v/lsm/db/version_set.cc
@@ -729,6 +729,10 @@ std::optional<compaction> version_set::pick_compaction() {
         c->_grandparents = _current->get_overlapping_inputs(
           level + 2_level, all_smallest, all_largest);
     }
+    // Update the place where we will do the next compaction for this level.
+    // We update this immediately instead of waiting for the version_edit
+    // to be applied so that if the compaction fails, we will try a different
+    // key range next time.
     _compact_pointer[level] = largest;
     c->_edit.set_compact_pointer(level, largest);
     return c;

--- a/src/v/lsm/db/version_set.h
+++ b/src/v/lsm/db/version_set.h
@@ -69,8 +69,8 @@ public:
     // end==nullptr, means after all keys.
     chunked_vector<ss::lw_shared_ptr<file_meta_data>> get_overlapping_inputs(
       internal::level,
-      std::optional<internal::key_view> begin,
-      std::optional<internal::key_view> end);
+      std::optional<user_key_view> begin,
+      std::optional<user_key_view> end);
 
     // Lookup the value for key.
     ss::future<lookup_result> get(internal::key_view target, get_stats*);
@@ -82,13 +82,13 @@ public:
     // end==nullopt, means after all keys.
     bool overlap_in_level(
       internal::level,
-      std::optional<internal::key_view> begin,
-      std::optional<internal::key_view> end);
+      std::optional<user_key_view> begin,
+      std::optional<user_key_view> end);
 
     // Return the level at which we should place a new memtable compaction
     // result that covers the range [begin,end].
-    internal::level pick_level_for_memtable_output(
-      internal::key_view begin, internal::key_view end);
+    internal::level
+    pick_level_for_memtable_output(user_key_view begin, user_key_view end);
 
     size_t num_files(internal::level level) { return _files[level].size(); }
 

--- a/src/v/lsm/lsm.cc
+++ b/src/v/lsm/lsm.cc
@@ -136,7 +136,7 @@ ss::future<> iterator::seek_to_first() { return _impl->seek_to_first(); }
 ss::future<> iterator::seek_to_last() { return _impl->seek_to_last(); }
 ss::future<> iterator::seek(std::string_view target) {
     auto key = internal::key::encode({
-      .key = target,
+      .key = lsm::user_key_view(target),
       .seqno = internal::sequence_number::max(),
       .type = internal::value_type::value,
     });
@@ -177,7 +177,7 @@ ss::future<> database::apply(write_batch batch) {
 
 ss::future<std::optional<iobuf>> database::get(std::string_view target) {
     auto key = internal::key::encode({
-      .key = target,
+      .key = lsm::user_key_view(target),
       .seqno = internal::sequence_number::max(),
       .type = internal::value_type::value,
     });
@@ -201,7 +201,7 @@ write_batch::~write_batch() noexcept = default;
 
 void write_batch::put(std::string_view key, iobuf value, model::offset offset) {
     auto k = internal::key::encode({
-      .key = key,
+      .key = lsm::user_key_view(key),
       .seqno = seqno_cast(offset),
       .type = internal::value_type::value,
     });
@@ -210,7 +210,7 @@ void write_batch::put(std::string_view key, iobuf value, model::offset offset) {
 
 void write_batch::remove(std::string_view key, model::offset offset) {
     auto k = internal::key::encode({
-      .key = key,
+      .key = lsm::user_key_view(key),
       .seqno = seqno_cast(offset),
       .type = internal::value_type::tombstone,
     });
@@ -219,7 +219,7 @@ void write_batch::remove(std::string_view key, model::offset offset) {
 
 ss::future<std::optional<iobuf>> write_batch::get(std::string_view target) {
     auto key = internal::key::encode({
-      .key = target,
+      .key = lsm::user_key_view(target),
       .seqno = internal::sequence_number::max(),
       .type = internal::value_type::value,
     });

--- a/src/v/lsm/sst/builder.cc
+++ b/src/v/lsm/sst/builder.cc
@@ -108,7 +108,8 @@ ss::future<> builder::finish() {
     // NOTE: if we add more keys here they need to be added lexicographically
     block::builder meta_index_block;
     if (_filter) {
-        auto key = internal::key::encode({.key = "filter.RedpandaBloomV0"});
+        auto key = internal::key::encode(
+          {.key = lsm::user_key_view("filter.RedpandaBloomV0")});
         meta_index_block.add(std::move(key), filter_block_handle.as_iobuf());
     }
     metaindex_block_handle = co_await write_raw_block(

--- a/src/v/lsm/sst/reader.cc
+++ b/src/v/lsm/sst/reader.cc
@@ -70,7 +70,8 @@ read_block(io::random_access_file_reader* file, block::handle handle) {
 ss::future<std::optional<block::filter_reader>> read_filter(
   io::random_access_file_reader* file, block::reader metaindex_block) {
     auto iter = metaindex_block.create_iterator();
-    auto key = internal::key::encode({.key = "filter.RedpandaBloomV0"});
+    auto key = internal::key::encode(
+      {.key = lsm::user_key_view("filter.RedpandaBloomV0")});
     co_await iter->seek(key);
     if (!iter->valid() || iter->key() != key) {
         co_return std::nullopt;


### PR DESCRIPTION
Now there is a very subtle issue in compaction of level0 files in that
if we expand the set of files due to an overlap, that file itself could
have caused an additional overlap, so we need to reset the search and
include the expanded space. This is due to level 0 allowing overlap of
the key space. When we did this reset, we were incrementing the counter
after we set i to 0. The proper fix, is to use the exact logic from
leveldb and only increment the counter after we select the file so the
resetting of `i` works.

This was found while writing a bunch of tests for the compaction picking
logic. So yay! for tests :)

Now this would never effect actual correctness of the LSM tree, but could
mean that compaction could in theory always skip compacting some L0 file.

LevelDB link:
https://github.com/google/leveldb/blob/ac691084fdc5546421a55b25e7653d450e5a25fb/db/version_set.cc#L498

Additionally there were some bugs around tombstones where some keys could be made visible again that were deleted. Originally I had hoped we didn't need some of the messy things leveldb does with user keys, so I had omitted them. Turns out those are actually needed (and there is a test for it now!), but thankfully I was able to find a solution that is a little less clunky IMO

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
