### PR TITLE
`config`: improve `deprecated_property` feedback

### DIFF
--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -305,13 +305,13 @@ static void preload_local(
             // but for strings it's not (the literal value in the cache is
             // "\"foo\"").
             auto decoded = YAML::Load(raw_value);
-            property.set_value(decoded);
+            bool set = property.set_value(decoded);
 
             // Because we are in preload, it doesn't matter if the property
             // requires restart.  We are setting it before anything else
             // can be using it.
 
-            if (result.has_value()) {
+            if (result.has_value() && set) {
                 vlog(
                   clusterlog.trace,
                   "Loaded property {}={} from local cache",

--- a/src/v/config/config_store.h
+++ b/src/v/config/config_store.h
@@ -80,7 +80,11 @@ public:
             }();
 
             if (prop == nullptr) {
-                vlog(configlog.warn, "Unknown property {}", name);
+                vlog(
+                  configlog.warn,
+                  "Unknown property {} for {} config store",
+                  name,
+                  store_name());
                 continue;
             }
             bool ok = false;
@@ -232,6 +236,8 @@ public:
     }
 
     virtual ~config_store() noexcept = default;
+
+    virtual ss::sstring store_name() const { return "config_store"; }
 
 private:
     friend class base_property;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -857,6 +857,8 @@ private:
         return !enable_developmental_unrecoverable_data_corrupting_features()
                   .empty();
     }
+
+    ss::sstring store_name() const override { return "cluster"; }
 };
 
 template<typename T>

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -192,6 +192,8 @@ public:
         return _cfg_file_path;
     }
 
+    ss::sstring store_name() const override { return "node"; }
+
 private:
     property<std::optional<net::unresolved_address>> _advertised_rpc_api;
     one_or_many_property<model::broker_endpoint> _advertised_kafka_api;

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -13,6 +13,7 @@
 #include "base/oncore.h"
 #include "base/type_traits.h"
 #include "config/base_property.h"
+#include "config/logger.h"
 #include "config/rjson_serialization.h"
 #include "config/tls_config.h"
 #include "config/types.h"
@@ -873,7 +874,21 @@ public:
     deprecated_property(config_store& conf, std::string_view name)
       : property(conf, name, "", {.visibility = visibility::deprecated}) {}
 
-    void set_value(std::any) override { return; }
+    ss::sstring deprecated_property_log_line() const {
+        return fmt::format(
+          "{} is a deprecated property and will be ignored. It is recommended "
+          "that you update your configurations to avoid setting it.",
+          name());
+    }
+    void set_value(std::any) override {
+        vlog(configlog.warn, "{}", deprecated_property_log_line());
+        return;
+    }
+
+    bool set_value(YAML::Node) override {
+        vlog(configlog.warn, "{}", deprecated_property_log_line());
+        return false;
+    }
 };
 
 template<typename T>


### PR DESCRIPTION
Some small changes to improve user feedback around deprecated and unknown properties in the `config` subsystem.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
