### PR TITLE
lsm: allow specifying custom scheduling group for compaction

### DIFF
--- a/src/v/lsm/core/internal/options.h
+++ b/src/v/lsm/core/internal/options.h
@@ -126,11 +126,16 @@ struct options {
     constexpr static size_t default_level_one_compaction_trigger = 4;
     size_t level_one_compaction_trigger = default_level_one_compaction_trigger;
 
+    // Maximum bytes of overlaps in grandparent (i.e., level+2) before we
+    // stop building a single file in a level->level+1 compaction.
     size_t max_grandparent_overlap_bytes(internal::level lvl) const {
         static constexpr size_t multiplier = 10;
         return multiplier * levels[lvl].max_file_size;
     }
 
+    // Maximum number of bytes in all compacted files. We avoid expanding
+    // the lower level file set of a compaction if it would make the
+    // total compaction cover more than this many bytes.
     size_t expanded_compaction_byte_size_limit(internal::level lvl) const {
         static constexpr size_t multiplier = 25;
         return multiplier * levels[lvl].max_file_size;

--- a/src/v/lsm/core/internal/options.h
+++ b/src/v/lsm/core/internal/options.h
@@ -32,6 +32,11 @@ struct options {
     // write operations to fail. However, read operations can be performed.
     bool readonly = false;
 
+    // The scheduling group for background operations in the LSM tree, such as
+    // memtable flushing and compaction. Note that this is unused if the
+    // database is in readonly mode.
+    ss::scheduling_group compaction_scheduling_group;
+
     struct level_config {
         // The level number in the database.
         internal::level number;

--- a/src/v/lsm/db/impl.cc
+++ b/src/v/lsm/db/impl.cc
@@ -64,43 +64,47 @@ ss::future<std::unique_ptr<impl>> impl::open(
     if (db->_opts->readonly) {
         co_return db;
     }
-    db->_background_work = ss::do_until(
-      [db = db.get()] { return db->_as.abort_requested(); },
-      [db = db.get()] {
-          vlog(log.trace, "waiting for background work");
-          return db->_start_background_work_signal.wait(db->_as)
-            .then([db] {
-                db->_background_work_running = true;
-                vlog(log.trace, "start background compaction");
-                return db->run_background_compaction();
-            })
-            .then_wrapped([db](ss::future<> fut) {
-                db->_background_work_running = false;
-                db->maybe_schedule_compaction();
-                db->_background_work_finished_signal.broadcast();
-                try {
-                    fut.get();
-                    return;
-                } catch (const abort_requested_exception& ex) {
-                    vlog(
-                      log.debug,
-                      "LSM background loop got abort request: {}",
-                      ex.what());
-                } catch (const io_error_exception& ex) {
-                    vlog(
-                      log.warn,
-                      "LSM background loop hit IO error: {}",
-                      ex.what());
-                } catch (...) {
-                    auto ep = std::current_exception();
-                    vlog(
-                      log.error,
-                      "Unexpected error in LSM background loop: {}",
-                      ep);
-                }
-                // Signal so that we immediately retry
-                // TODO(lsm): consider some kind of backoff or backpressure?
-                db->_start_background_work_signal.signal();
+    db->_background_work = ss::with_scheduling_group(
+      db->_opts->compaction_scheduling_group, [db = db.get()] {
+          return ss::do_until(
+            [db] { return db->_as.abort_requested(); },
+            [db] {
+                vlog(log.trace, "waiting for background work");
+                return db->_start_background_work_signal.wait(db->_as)
+                  .then([db] {
+                      db->_background_work_running = true;
+                      vlog(log.trace, "start background compaction");
+                      return db->run_background_compaction();
+                  })
+                  .then_wrapped([db](ss::future<> fut) {
+                      db->_background_work_running = false;
+                      db->maybe_schedule_compaction();
+                      db->_background_work_finished_signal.broadcast();
+                      try {
+                          fut.get();
+                          return;
+                      } catch (const abort_requested_exception& ex) {
+                          vlog(
+                            log.debug,
+                            "LSM background loop got abort request: {}",
+                            ex.what());
+                      } catch (const io_error_exception& ex) {
+                          vlog(
+                            log.warn,
+                            "LSM background loop hit IO error: {}",
+                            ex.what());
+                      } catch (...) {
+                          auto ep = std::current_exception();
+                          vlog(
+                            log.error,
+                            "Unexpected error in LSM background loop: {}",
+                            ep);
+                      }
+                      // Signal so that we immediately retry
+                      // TODO(lsm): consider some kind of backoff or
+                      // backpressure?
+                      db->_start_background_work_signal.signal();
+                  });
             });
       });
     co_return db;

--- a/src/v/lsm/lsm.cc
+++ b/src/v/lsm/lsm.cc
@@ -83,6 +83,9 @@ ss::lw_shared_ptr<internal::options> translate_options(options opts) {
       internal::options::default_level_multipler,
       max_level);
     internal_opts->readonly = opts.readonly;
+    internal_opts->compaction_scheduling_group
+      = opts.compaction_scheduling_group.value_or(
+        ss::current_scheduling_group());
     internal_opts->level_zero_slowdown_writes_trigger
       = opts.level_zero_slowdown_writes_trigger;
     internal_opts->level_zero_stop_writes_trigger

--- a/src/v/lsm/lsm.h
+++ b/src/v/lsm/lsm.h
@@ -50,6 +50,12 @@ struct options {
     // write operations to fail. However, read operations can be performed.
     bool readonly = false;
 
+    // The scheduling group for background operations in the LSM tree, such as
+    // memtable flushing and compaction. Note that this is unused if the
+    // database is in readonly mode. Defaults to the scheduling group that
+    // opened the database.
+    std::optional<ss::scheduling_group> compaction_scheduling_group;
+
     // The number of levels in the LSM tree. More levels allow more smaller and
     // faster compactions, but causes more read amplication.
     //


### PR DESCRIPTION
I am sure we want to change the scheduling group for compactions, use this to plumb it in.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
