### PR TITLE
`ct/l1`: add `metastore::get_extent_metadata_{forwards/backwards}`

### DIFF
--- a/src/v/cloud_topics/level_one/domain/domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.cc
@@ -582,6 +582,51 @@ domain_manager::get_compaction_infos(rpc::get_compaction_infos_request req) {
       .responses = std::move(compaction_infos)};
 }
 
+ss::future<rpc::get_extent_metadata_reply>
+domain_manager::get_extent_metadata(rpc::get_extent_metadata_request req) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return rpc::get_extent_metadata_reply{
+          .ec = rpc::errc::not_leader,
+        };
+    }
+    auto sync_res = co_await stm_->sync(10s);
+    if (!sync_res.has_value()) {
+        co_return rpc::get_extent_metadata_reply{
+          .ec = convert_stm_errc(sync_res.error()),
+        };
+    }
+    auto& stm_state = stm_->state();
+
+    auto get_res = [&]() {
+        switch (req.o) {
+        case rpc::get_extent_metadata_request::order::forwards:
+            return simple_metastore::get_extent_metadata_forwards(
+              stm_state,
+              req.tp,
+              req.min_offset,
+              req.max_offset,
+              req.max_num_extents);
+        case rpc::get_extent_metadata_request::order::backwards:
+            return simple_metastore::get_extent_metadata_backwards(
+              stm_state,
+              req.tp,
+              req.min_offset,
+              req.max_offset,
+              req.max_num_extents);
+        }
+    }();
+
+    if (!get_res.has_value()) {
+        co_return rpc::get_extent_metadata_reply{
+          .ec = convert_metastore_errc(get_res.error()),
+        };
+    }
+    co_return rpc::get_extent_metadata_reply{
+      .ec = rpc::errc::ok,
+      .extents = meta_to_rpc_extent_metadata(std::move(get_res->extents))};
+}
+
 ss::lowres_clock::duration domain_manager::gc_interval() const {
     return config::shard_local_cfg()
       .cloud_topics_long_term_garbage_collection_interval();

--- a/src/v/cloud_topics/level_one/domain/domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.h
@@ -64,6 +64,9 @@ public:
     ss::future<rpc::get_compaction_infos_reply>
       get_compaction_infos(rpc::get_compaction_infos_request);
 
+    ss::future<rpc::get_extent_metadata_reply>
+      get_extent_metadata(rpc::get_extent_metadata_request);
+
 private:
     std::optional<ss::gate::holder> maybe_gate();
     ss::future<> gc_loop();

--- a/src/v/cloud_topics/level_one/metastore/leader_router.cc
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.cc
@@ -160,6 +160,17 @@ ss::future<rpc::get_compaction_infos_reply> do_get_compaction_infos(
     co_return co_await domain_mgr->get_compaction_infos(std::move(req));
 }
 
+ss::future<rpc::get_extent_metadata_reply> do_get_extent_metadata(
+  domain_supervisor& domain_supervisor,
+  const model::ntp& ntp,
+  rpc::get_extent_metadata_request req) {
+    auto domain_mgr = domain_supervisor.get(ntp);
+    if (!domain_mgr) {
+        co_return rpc::get_extent_metadata_reply{.ec = rpc::errc::not_leader};
+    }
+    co_return co_await domain_mgr->get_extent_metadata(std::move(req));
+}
+
 } // namespace
 
 template<auto Func, typename req_t>
@@ -633,6 +644,27 @@ ss::future<rpc::get_compaction_infos_reply> leader_router::get_compaction_infos(
     co_return co_await process<
       &leader_router::get_compaction_infos_locally,
       &client::get_compaction_infos>(std::move(request), bool(local_only_exec));
+}
+
+ss::future<rpc::get_extent_metadata_reply>
+leader_router::get_extent_metadata_locally(
+  rpc::get_extent_metadata_request request,
+  const model::ntp& metastore_ntp,
+  ss::shard_id shard) {
+    co_return co_await container().invoke_on(
+      shard,
+      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+          return do_get_extent_metadata(
+            *(fe._domain_supervisor), metastore_ntp, std::move(req));
+      });
+}
+
+ss::future<rpc::get_extent_metadata_reply> leader_router::get_extent_metadata(
+  rpc::get_extent_metadata_request request, local_only local_only_exec) {
+    auto holder = _gate.hold();
+    co_return co_await process<
+      &leader_router::get_extent_metadata_locally,
+      &client::get_extent_metadata>(std::move(request), bool(local_only_exec));
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/leader_router.h
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.h
@@ -92,6 +92,9 @@ public:
     ss::future<rpc::get_compaction_infos_reply> get_compaction_infos(
       rpc::get_compaction_infos_request, local_only = local_only::no);
 
+    ss::future<rpc::get_extent_metadata_reply> get_extent_metadata(
+      rpc::get_extent_metadata_request, local_only = local_only::no);
+
     std::optional<model::partition_id>
     metastore_partition(const model::topic_id_partition&) const;
 
@@ -179,6 +182,11 @@ private:
 
     ss::future<rpc::get_compaction_infos_reply> get_compaction_infos_locally(
       rpc::get_compaction_infos_request,
+      const model::ntp& metastore_ntp,
+      ss::shard_id);
+
+    ss::future<rpc::get_extent_metadata_reply> get_extent_metadata_locally(
+      rpc::get_extent_metadata_request,
       const model::ntp& metastore_ntp,
       ss::shard_id);
 

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -433,6 +433,32 @@ public:
     // Vectorized RPC for obtaining compaction state for a number of partitions.
     virtual ss::future<std::expected<compaction_info_map, errc>>
     get_compaction_infos(const chunked_vector<compaction_info_spec>&) = 0;
+
+    struct extent_metadata_response {
+        extent_metadata_vec extents{};
+    };
+
+    // Returns a number of extents in the offset range `[start, end]`
+    // inclusively, and in ascending offset order. Useful for forward
+    // iteration over an extent-aligned offset range- that is, for an extent
+    // metastore state of `[[0, 9],[10,19],[20,29]]`, and a request like
+    // `get_extent_metadata_ge([0, 15])`, the returned extents will be `[[0, 9],
+    // [10, 19]]`.
+    virtual ss::future<std::expected<extent_metadata_response, errc>>
+    get_extent_metadata_forwards(
+      const model::topic_id_partition&, kafka::offset, kafka::offset, size_t)
+      = 0;
+
+    // Returns a number of extents in the offset range `[start, end]`
+    // inclusively, and in descending offset order. Useful for backward
+    // iteration over an extent-aligned offset range- that is, for an extent
+    // metastore state of `[[0, 9],[10,19],[20,29]]`, and a request like
+    // `get_extent_metadata_le([0, 15])`, the returned extents will be `[[10,
+    // 19], [0, 9]]`.
+    virtual ss::future<std::expected<extent_metadata_response, errc>>
+    get_extent_metadata_backwards(
+      const model::topic_id_partition&, kafka::offset, kafka::offset, size_t)
+      = 0;
 };
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -772,4 +772,73 @@ replicated_metastore::get_compaction_infos(
     co_return resp;
 }
 
+ss::future<std::expected<metastore::extent_metadata_response, metastore::errc>>
+replicated_metastore::get_extent_metadata_forwards(
+  const model::topic_id_partition& tidp,
+  kafka::offset min_offset,
+  kafka::offset max_offset,
+  size_t max_num_extents) {
+    static constexpr auto o = rpc::get_extent_metadata_request::order::forwards;
+
+    rpc::get_extent_metadata_request req;
+    req.tp = tidp;
+    req.min_offset = min_offset;
+    req.max_offset = max_offset;
+    req.max_num_extents = max_num_extents;
+    req.o = o;
+
+    auto reply_fut = co_await ss::coroutine::as_future(
+      fe_.get_extent_metadata(std::move(req)));
+    if (reply_fut.failed()) {
+        auto ex = reply_fut.get_exception();
+        vlog(cd_log.warn, "Error while sending request: {}", ex);
+        co_return std::unexpected(metastore::errc::transport_error);
+    }
+    auto reply = reply_fut.get();
+
+    if (reply.ec != rpc::errc::ok) {
+        co_return std::unexpected(rpc_to_meta_errc(reply.ec));
+    }
+
+    metastore::extent_metadata_response resp;
+    resp.extents = rpc_to_meta_extent_metadata(std::move(reply.extents));
+
+    co_return resp;
+}
+
+ss::future<std::expected<metastore::extent_metadata_response, metastore::errc>>
+replicated_metastore::get_extent_metadata_backwards(
+  const model::topic_id_partition& tidp,
+  kafka::offset min_offset,
+  kafka::offset max_offset,
+  size_t max_num_extents) {
+    static constexpr auto o
+      = rpc::get_extent_metadata_request::order::backwards;
+
+    rpc::get_extent_metadata_request req;
+    req.tp = tidp;
+    req.min_offset = min_offset;
+    req.max_offset = max_offset;
+    req.max_num_extents = max_num_extents;
+    req.o = o;
+
+    auto reply_fut = co_await ss::coroutine::as_future(
+      fe_.get_extent_metadata(std::move(req)));
+    if (reply_fut.failed()) {
+        auto ex = reply_fut.get_exception();
+        vlog(cd_log.warn, "Error while sending request: {}", ex);
+        co_return std::unexpected(metastore::errc::transport_error);
+    }
+    auto reply = reply_fut.get();
+
+    if (reply.ec != rpc::errc::ok) {
+        co_return std::unexpected(rpc_to_meta_errc(reply.ec));
+    }
+
+    metastore::extent_metadata_response resp;
+    resp.extents = rpc_to_meta_extent_metadata(std::move(reply.extents));
+
+    co_return resp;
+}
+
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
@@ -71,6 +71,20 @@ public:
     ss::future<std::expected<compaction_info_map, errc>>
     get_compaction_infos(const chunked_vector<compaction_info_spec>&) override;
 
+    ss::future<std::expected<extent_metadata_response, errc>>
+    get_extent_metadata_forwards(
+      const model::topic_id_partition&,
+      kafka::offset,
+      kafka::offset,
+      size_t) override;
+
+    ss::future<std::expected<extent_metadata_response, errc>>
+    get_extent_metadata_backwards(
+      const model::topic_id_partition&,
+      kafka::offset,
+      kafka::offset,
+      size_t) override;
+
 private:
     leader_router& fe_;
 };

--- a/src/v/cloud_topics/level_one/metastore/rpc.json
+++ b/src/v/cloud_topics/level_one/metastore/rpc.json
@@ -64,6 +64,11 @@
             "name": "get_compaction_infos",
             "input_type": "get_compaction_infos_request",
             "output_type": "get_compaction_infos_reply"
+        },
+        {
+            "name": "get_extent_metadata",
+            "input_type": "get_extent_metadata_request",
+            "output_type": "get_extent_metadata_reply"
         }
     ]
 }

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -354,6 +354,36 @@ struct get_compaction_infos_request
     chunked_vector<get_compaction_info_request> logs;
 };
 
+struct get_extent_metadata_reply
+  : serde::envelope<
+      get_extent_metadata_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    auto serde_fields() { return std::tie(ec, extents); }
+
+    errc ec;
+    chunked_vector<extent_metadata> extents;
+};
+struct get_extent_metadata_request
+  : serde::envelope<
+      get_extent_metadata_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using resp_t = get_extent_metadata_reply;
+
+    enum class order { forwards, backwards };
+
+    auto serde_fields() {
+        return std::tie(tp, min_offset, max_offset, o, max_num_extents);
+    }
+
+    model::topic_id_partition tp;
+    kafka::offset min_offset;
+    kafka::offset max_offset;
+    order o;
+    size_t max_num_extents;
+};
+
 } //  namespace cloud_topics::l1::rpc
 
 template<>

--- a/src/v/cloud_topics/level_one/metastore/service.cc
+++ b/src/v/cloud_topics/level_one/metastore/service.cc
@@ -94,4 +94,10 @@ ss::future<get_compaction_infos_reply> service::get_compaction_infos(
       std::move(request), leader_router::local_only::yes);
 }
 
+ss::future<get_extent_metadata_reply> service::get_extent_metadata(
+  get_extent_metadata_request request, ::rpc::streaming_context&) {
+    return _leader_router->local().get_extent_metadata(
+      std::move(request), leader_router::local_only::yes);
+}
+
 } // namespace cloud_topics::l1::rpc

--- a/src/v/cloud_topics/level_one/metastore/service.h
+++ b/src/v/cloud_topics/level_one/metastore/service.h
@@ -62,6 +62,9 @@ public:
     ss::future<get_compaction_infos_reply> get_compaction_infos(
       get_compaction_infos_request, ::rpc::streaming_context&) override;
 
+    ss::future<get_extent_metadata_reply> get_extent_metadata(
+      get_extent_metadata_request, ::rpc::streaming_context&) override;
+
 private:
     ss::sharded<leader_router>* _leader_router;
 };

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -592,6 +592,7 @@ std::expected<double, metastore::errc> simple_metastore::get_dirty_ratio(
     auto prt_ref = state.partition_state(tp);
 
     if (!prt_ref.has_value()) {
+        vlog(cd_log.debug, "Partition {} not tracked", tp);
         return std::unexpected(errc::missing_ntp);
     }
 
@@ -631,6 +632,7 @@ simple_metastore::get_earliest_dirty_ts(
     auto prt_ref = state.partition_state(tp);
 
     if (!prt_ref.has_value()) {
+        vlog(cd_log.debug, "Partition {} not tracked", tp);
         return std::unexpected(errc::missing_ntp);
     }
 
@@ -671,6 +673,7 @@ simple_metastore::get_compaction_epoch(
     auto prt_ref = state.partition_state(tp);
 
     if (!prt_ref.has_value()) {
+        vlog(cd_log.debug, "Partition {} not tracked", tp);
         return std::unexpected(errc::missing_ntp);
     }
 

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -729,4 +729,113 @@ simple_metastore::get_compaction_infos(
     co_return infos;
 }
 
+ss::future<std::expected<metastore::extent_metadata_response, metastore::errc>>
+simple_metastore::get_extent_metadata_forwards(
+  const model::topic_id_partition& tp,
+  kafka::offset min_offset,
+  kafka::offset max_offset,
+  size_t max_num_extents) {
+    co_return get_extent_metadata_forwards(
+      state_, tp, min_offset, max_offset, max_num_extents);
+}
+
+std::expected<metastore::extent_metadata_response, metastore::errc>
+simple_metastore::get_extent_metadata_forwards(
+  const state& state,
+  const model::topic_id_partition& tp,
+  kafka::offset min_offset,
+  kafka::offset max_offset,
+  size_t max_num_extents) {
+    auto prt_ref = state.partition_state(tp);
+
+    if (!prt_ref.has_value()) {
+        vlog(cd_log.debug, "Partition {} not tracked", tp);
+        return std::unexpected(errc::missing_ntp);
+    }
+
+    const auto& prt = prt_ref->get();
+
+    extent_metadata_vec extents;
+
+    auto min_it = std::ranges::lower_bound(
+      prt.extents, min_offset, std::less<>{}, &extent::last_offset);
+    for (auto it = min_it; it != prt.extents.end(); ++it) {
+        auto& extent = *it;
+        if (extent.base_offset > max_offset) {
+            break;
+        }
+
+        if (extents.size() >= max_num_extents) {
+            break;
+        }
+
+        extents.push_back(
+          {.base_offset = extent.base_offset,
+           .last_offset = extent.last_offset,
+           .max_timestamp = extent.max_timestamp});
+    }
+
+    return extent_metadata_response{.extents = std::move(extents)};
+}
+
+ss::future<std::expected<metastore::extent_metadata_response, metastore::errc>>
+simple_metastore::get_extent_metadata_backwards(
+  const model::topic_id_partition& tp,
+  kafka::offset min_offset,
+  kafka::offset max_offset,
+  size_t max_num_extents) {
+    co_return get_extent_metadata_backwards(
+      state_, tp, min_offset, max_offset, max_num_extents);
+}
+
+std::expected<metastore::extent_metadata_response, metastore::errc>
+simple_metastore::get_extent_metadata_backwards(
+  const state& state,
+  const model::topic_id_partition& tp,
+  kafka::offset min_offset,
+  kafka::offset max_offset,
+  size_t max_num_extents) {
+    auto prt_ref = state.partition_state(tp);
+
+    if (!prt_ref.has_value()) {
+        vlog(cd_log.debug, "Partition {} not tracked", tp);
+        return std::unexpected(errc::missing_ntp);
+    }
+
+    const auto& prt = prt_ref->get();
+
+    extent_metadata_vec extents;
+
+    auto max_it = std::ranges::lower_bound(
+      prt.extents, max_offset, std::less<>{}, &extent::last_offset);
+    if (max_it != prt.extents.end() && max_it->base_offset > max_offset) {
+        if (max_it != prt.extents.begin()) {
+            --max_it;
+        } else {
+            // No extents.
+            return extent_metadata_response{};
+        }
+    }
+    auto max_rit = max_it == prt.extents.end()
+                     ? std::make_reverse_iterator(prt.extents.end())
+                     : std::make_reverse_iterator(std::next(max_it));
+    for (auto it = max_rit; it != prt.extents.rend(); ++it) {
+        auto& extent = *it;
+        if (extent.last_offset < min_offset) {
+            break;
+        }
+
+        if (extents.size() >= max_num_extents) {
+            break;
+        }
+
+        extents.push_back(
+          {.base_offset = extent.base_offset,
+           .last_offset = extent.last_offset,
+           .max_timestamp = extent.max_timestamp});
+    }
+
+    return extent_metadata_response{.extents = std::move(extents)};
+}
+
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -105,6 +105,20 @@ public:
     ss::future<std::expected<compaction_info_map, errc>>
     get_compaction_infos(const chunked_vector<compaction_info_spec>&) override;
 
+    ss::future<std::expected<extent_metadata_response, errc>>
+    get_extent_metadata_forwards(
+      const model::topic_id_partition&,
+      kafka::offset,
+      kafka::offset,
+      size_t) override;
+
+    ss::future<std::expected<extent_metadata_response, errc>>
+    get_extent_metadata_backwards(
+      const model::topic_id_partition&,
+      kafka::offset,
+      kafka::offset,
+      size_t) override;
+
 private:
     friend class domain_manager;
     static std::expected<offsets_response, errc>
@@ -133,6 +147,20 @@ private:
       const state&, const model::topic_id_partition&, model::term_id);
     static std::expected<model::term_id, errc> get_term_for_offset(
       const state&, const model::topic_id_partition&, kafka::offset);
+    static std::expected<extent_metadata_response, errc>
+    get_extent_metadata_forwards(
+      const state&,
+      const model::topic_id_partition&,
+      kafka::offset,
+      kafka::offset,
+      size_t);
+    static std::expected<extent_metadata_response, errc>
+    get_extent_metadata_backwards(
+      const state&,
+      const model::topic_id_partition&,
+      kafka::offset,
+      kafka::offset,
+      size_t);
 
     state state_;
 };

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -1735,3 +1735,345 @@ TEST(SimpleMetastoreTest, TestCompactionMultipleDirtyRangesMadeClean) {
           testing::ElementsAre(MatchesRange(0_o, 20_o)));
     }
 }
+
+TEST(SimpleMetastoreTest, TestGetExtentMetadataForwards) {
+    simple_metastore m;
+    om_list_t os;
+    constexpr size_t data_size = 99;
+    os.emplace_back(om_builder(oid1, 100, 1100)
+                      .add(tid_a, 0_o, 9_o, 2000_t, 0, data_size)
+                      .build());
+    os.emplace_back(om_builder(oid2, 100, 1100)
+                      .add(tid_a, 10_o, 19_o, 2000_t, 0, data_size)
+                      .build());
+    os.emplace_back(om_builder(oid3, 100, 1100)
+                      .add(tid_a, 20_o, 29_o, 2000_t, 0, data_size)
+                      .build());
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    auto tp = model::topic_id_partition::from(tid_a);
+
+    // A few basic test cases with an expanding `max_offset`.
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{9};
+        auto extent_metadata_res = m.get_extent_metadata_forwards(
+                                      tp, min_offset, max_offset, 10)
+                                     .get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        EXPECT_THAT(
+          extent_metadata_res->extents,
+          testing::ElementsAre(MatchesRange(0_o, 9_o)));
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{15};
+        auto extent_metadata_res = m.get_extent_metadata_forwards(
+                                      tp, min_offset, max_offset, 10)
+                                     .get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        EXPECT_THAT(
+          extent_metadata_res->extents,
+          testing::ElementsAre(
+            MatchesRange(0_o, 9_o), MatchesRange(10_o, 19_o)));
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{19};
+        auto extent_metadata_res = m.get_extent_metadata_forwards(
+                                      tp, min_offset, max_offset, 10)
+                                     .get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        EXPECT_THAT(
+          extent_metadata_res->extents,
+          testing::ElementsAre(
+            MatchesRange(0_o, 9_o), MatchesRange(10_o, 19_o)));
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{20};
+        auto extent_metadata_res = m.get_extent_metadata_forwards(
+                                      tp, min_offset, max_offset, 10)
+                                     .get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        EXPECT_THAT(
+          extent_metadata_res->extents,
+          testing::ElementsAre(
+            MatchesRange(0_o, 9_o),
+            MatchesRange(10_o, 19_o),
+            MatchesRange(20_o, 29_o)));
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{100};
+        auto extent_metadata_res = m.get_extent_metadata_forwards(
+                                      tp, min_offset, max_offset, 10)
+                                     .get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        EXPECT_THAT(
+          extent_metadata_res->extents,
+          testing::ElementsAre(
+            MatchesRange(0_o, 9_o),
+            MatchesRange(10_o, 19_o),
+            MatchesRange(20_o, 29_o)));
+    }
+
+    // A few test cases where the number of extents is limited.
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{9};
+        auto extent_metadata_res
+          = m.get_extent_metadata_forwards(tp, min_offset, max_offset, 0).get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        ASSERT_TRUE(extent_metadata_res->extents.empty());
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{15};
+        auto extent_metadata_res
+          = m.get_extent_metadata_forwards(tp, min_offset, max_offset, 1).get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        EXPECT_THAT(
+          extent_metadata_res->extents,
+          testing::ElementsAre(MatchesRange(0_o, 9_o)));
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{20};
+        auto extent_metadata_res
+          = m.get_extent_metadata_forwards(tp, min_offset, max_offset, 2).get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        EXPECT_THAT(
+          extent_metadata_res->extents,
+          testing::ElementsAre(
+            MatchesRange(0_o, 9_o), MatchesRange(10_o, 19_o)));
+    }
+
+    // Non zero min_offset test cases.
+    {
+        auto min_offset = kafka::offset{5};
+        auto max_offset = kafka::offset{9};
+        auto extent_metadata_res = m.get_extent_metadata_forwards(
+                                      tp, min_offset, max_offset, 10)
+                                     .get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        EXPECT_THAT(
+          extent_metadata_res->extents,
+          testing::ElementsAre(MatchesRange(0_o, 9_o)));
+    }
+    {
+        auto min_offset = kafka::offset{9};
+        auto max_offset = kafka::offset{29};
+        auto extent_metadata_res = m.get_extent_metadata_forwards(
+                                      tp, min_offset, max_offset, 10)
+                                     .get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        EXPECT_THAT(
+          extent_metadata_res->extents,
+          testing::ElementsAre(
+            MatchesRange(0_o, 9_o),
+            MatchesRange(10_o, 19_o),
+            MatchesRange(20_o, 29_o)));
+    }
+}
+
+TEST(SimpleMetastoreTest, TestGetExtentMetadataBackwards) {
+    simple_metastore m;
+    om_list_t os;
+    constexpr size_t data_size = 99;
+    os.emplace_back(om_builder(oid1, 100, 1100)
+                      .add(tid_a, 0_o, 9_o, 2000_t, 0, data_size)
+                      .build());
+    os.emplace_back(om_builder(oid2, 100, 1100)
+                      .add(tid_a, 10_o, 19_o, 2000_t, 0, data_size)
+                      .build());
+    os.emplace_back(om_builder(oid3, 100, 1100)
+                      .add(tid_a, 20_o, 29_o, 2000_t, 0, data_size)
+                      .build());
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    auto tp = model::topic_id_partition::from(tid_a);
+
+    // A few basic test cases with an expanding `max_offset`.
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{9};
+        auto extent_metadata_res = m.get_extent_metadata_backwards(
+                                      tp, min_offset, max_offset, 10)
+                                     .get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        EXPECT_THAT(
+          extent_metadata_res->extents,
+          testing::ElementsAre(MatchesRange(0_o, 9_o)));
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{15};
+        auto extent_metadata_res = m.get_extent_metadata_backwards(
+                                      tp, min_offset, max_offset, 10)
+                                     .get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        EXPECT_THAT(
+          extent_metadata_res->extents,
+          testing::ElementsAre(
+            MatchesRange(10_o, 19_o), MatchesRange(0_o, 9_o)));
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{19};
+        auto extent_metadata_res = m.get_extent_metadata_backwards(
+                                      tp, min_offset, max_offset, 10)
+                                     .get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        EXPECT_THAT(
+          extent_metadata_res->extents,
+          testing::ElementsAre(
+            MatchesRange(10_o, 19_o), MatchesRange(0_o, 9_o)));
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{20};
+        auto extent_metadata_res = m.get_extent_metadata_backwards(
+                                      tp, min_offset, max_offset, 10)
+                                     .get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        EXPECT_THAT(
+          extent_metadata_res->extents,
+          testing::ElementsAre(
+            MatchesRange(20_o, 29_o),
+            MatchesRange(10_o, 19_o),
+            MatchesRange(0_o, 9_o)));
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{100};
+        auto extent_metadata_res = m.get_extent_metadata_backwards(
+                                      tp, min_offset, max_offset, 10)
+                                     .get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        EXPECT_THAT(
+          extent_metadata_res->extents,
+          testing::ElementsAre(
+            MatchesRange(20_o, 29_o),
+            MatchesRange(10_o, 19_o),
+            MatchesRange(0_o, 9_o)));
+    }
+
+    // A few test cases where the number of extents is limited.
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{9};
+        auto extent_metadata_res = m.get_extent_metadata_backwards(
+                                      tp, min_offset, max_offset, 0)
+                                     .get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        ASSERT_TRUE(extent_metadata_res->extents.empty());
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{15};
+        auto extent_metadata_res = m.get_extent_metadata_backwards(
+                                      tp, min_offset, max_offset, 1)
+                                     .get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        EXPECT_THAT(
+          extent_metadata_res->extents,
+          testing::ElementsAre(MatchesRange(10_o, 19_o)));
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{21};
+        auto extent_metadata_res = m.get_extent_metadata_backwards(
+                                      tp, min_offset, max_offset, 1)
+                                     .get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        EXPECT_THAT(
+          extent_metadata_res->extents,
+          testing::ElementsAre(MatchesRange(20_o, 29_o)));
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{20};
+        auto extent_metadata_res = m.get_extent_metadata_backwards(
+                                      tp, min_offset, max_offset, 2)
+                                     .get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        EXPECT_THAT(
+          extent_metadata_res->extents,
+          testing::ElementsAre(
+            MatchesRange(20_o, 29_o), MatchesRange(10_o, 19_o)));
+    }
+
+    // Non zero min_offset test cases.
+    {
+        auto min_offset = kafka::offset{5};
+        auto max_offset = kafka::offset{9};
+        auto extent_metadata_res = m.get_extent_metadata_backwards(
+                                      tp, min_offset, max_offset, 10)
+                                     .get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        EXPECT_THAT(
+          extent_metadata_res->extents,
+          testing::ElementsAre(MatchesRange(0_o, 9_o)));
+    }
+    {
+        auto min_offset = kafka::offset{9};
+        auto max_offset = kafka::offset{29};
+        auto extent_metadata_res = m.get_extent_metadata_backwards(
+                                      tp, min_offset, max_offset, 10)
+                                     .get();
+        ASSERT_TRUE(extent_metadata_res.has_value());
+        EXPECT_THAT(
+          extent_metadata_res->extents,
+          testing::ElementsAre(
+            MatchesRange(20_o, 29_o),
+            MatchesRange(10_o, 19_o),
+            MatchesRange(0_o, 9_o)));
+    }
+}
+
+TEST(SimpleMetastoreTest, TestGetExtentMetadataEmpty) {
+    simple_metastore m;
+    om_list_t os;
+    constexpr size_t data_size = 99;
+    os.emplace_back(om_builder(oid1, 100, 1100)
+                      .add(tid_a, 0_o, 9_o, 2000_t, 0, data_size)
+                      .build());
+    os.emplace_back(om_builder(oid2, 100, 1100)
+                      .add(tid_a, 10_o, 19_o, 2000_t, 0, data_size)
+                      .build());
+    os.emplace_back(om_builder(oid3, 100, 1100)
+                      .add(tid_a, 20_o, 29_o, 2000_t, 0, data_size)
+                      .build());
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    auto tp = model::topic_id_partition::from(tid_a);
+
+    auto set_start_res = m.set_start_offset(tp, 30_o).get();
+    ASSERT_TRUE(set_start_res.has_value());
+
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{100};
+        auto extent_metadata_ge_res = m.get_extent_metadata_forwards(
+                                         tp, min_offset, max_offset, 10)
+                                        .get();
+        ASSERT_TRUE(extent_metadata_ge_res.has_value());
+        ASSERT_TRUE(extent_metadata_ge_res->extents.empty());
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{100};
+        auto extent_metadata_le_res = m.get_extent_metadata_backwards(
+                                         tp, min_offset, max_offset, 10)
+                                        .get();
+        ASSERT_TRUE(extent_metadata_le_res.has_value());
+        ASSERT_TRUE(extent_metadata_le_res->extents.empty());
+    }
+}


### PR DESCRIPTION
Returns a number of extents in the offset range `[start, end]` inclusively, and in ascending or descending offset order (for `forwards()`/`backwards()` respectively).

`forwards()` is obviously useful for forward iteration over an extent-aligned offset range- that is, for an extent metastore state of `[[0, 9],[10,19],[20,29]]` and a request like `get_extent_metadata_forwards([0, 15])`, the returned extents will be `[[0, 9], [10, 19]]`.

`backwards()` is obviously useful for backward iteration over an extent-aligned offset range- that is, for an extent metastore state of `[[0, 9],[10,19],[20,29]]` and a request like `get_extent_metadata_backwards([0, 15])`, the returned extents will be `[[10, 19], [0, 9]]`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
