### PR TITLE
`ct/l1`: add `start_offset` to `metastore::compaction_info_response`

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/sink.cc
+++ b/src/v/cloud_topics/level_one/compaction/sink.cc
@@ -81,6 +81,7 @@ compaction_sink::compaction_sink(
   const chunked_vector<offset_interval_set::interval>& dirty_range_intervals,
   const offset_interval_set& removable_tombstone_ranges,
   metastore::compaction_epoch expected_compaction_epoch,
+  kafka::offset start_offset,
   io* io,
   compaction_committer* committer,
   object_builder::options opts)
@@ -88,6 +89,7 @@ compaction_sink::compaction_sink(
   , _dirty_range_intervals(dirty_range_intervals)
   , _removable_tombstone_ranges(removable_tombstone_ranges)
   , _expected_compaction_epoch(expected_compaction_epoch)
+  , _start_offset(start_offset)
   , _io(io)
   , _committer(committer)
   , _opts(opts) {}
@@ -104,8 +106,6 @@ compaction_sink::initialize(compaction::sliding_window_reducer::source& src) {
     if (!should_compact) {
         co_return false;
     }
-
-    _start_offset = ct_src._extents.front().base_offset;
 
     _job = co_await _committer->begin_compaction_job(_tp);
 

--- a/src/v/cloud_topics/level_one/compaction/sink.h
+++ b/src/v/cloud_topics/level_one/compaction/sink.h
@@ -28,6 +28,7 @@ public:
       const chunked_vector<offset_interval_set::interval>&,
       const offset_interval_set&,
       metastore::compaction_epoch,
+      kafka::offset,
       l1::io*,
       compaction_committer*,
       object_builder::options = {});
@@ -76,7 +77,12 @@ private:
     using interval_vec = chunked_vector<offset_interval_set::interval>;
     const interval_vec& _dirty_range_intervals;
     const offset_interval_set& _removable_tombstone_ranges;
+
+    // The expected compaction epoch for the log.
     const metastore::compaction_epoch _expected_compaction_epoch;
+
+    // The start offset of the log.
+    kafka::offset _start_offset{0};
 
     // The compaction job, if initialized, as returned by the `_committer`.
     compaction_committer::compaction_job* _job{nullptr};
@@ -96,9 +102,6 @@ private:
     };
 
     std::unique_ptr<compacted_object> _inflight_object{nullptr};
-
-    // The start offset of the log.
-    kafka::offset _start_offset{0};
 
     // The interval set that is populated by extents which have been read by the
     // `source` and written by the `sink`. This is important to know in order to

--- a/src/v/cloud_topics/level_one/compaction/source.cc
+++ b/src/v/cloud_topics/level_one/compaction/source.cc
@@ -146,6 +146,7 @@ compaction_source::compaction_source(
   const chunked_vector<offset_interval_set::interval>& dirty_range_intervals,
   const offset_interval_set& removable_tombstone_ranges,
   metastore::extent_metadata_vec extents,
+  kafka::offset start_offset,
   compaction::key_offset_map* map,
   std::chrono::milliseconds min_compaction_lag_ms,
   metastore* metastore,
@@ -157,6 +158,7 @@ compaction_source::compaction_source(
   , _dirty_range_intervals(dirty_range_intervals)
   , _removable_tombstone_ranges(removable_tombstone_ranges)
   , _extents(std::move(extents))
+  , _start_offset(start_offset)
   , _map(map)
   , _min_compaction_lag_ms(min_compaction_lag_ms)
   , _metastore(metastore)

--- a/src/v/cloud_topics/level_one/compaction/source.h
+++ b/src/v/cloud_topics/level_one/compaction/source.h
@@ -30,6 +30,7 @@ public:
       const chunked_vector<offset_interval_set::interval>&,
       const offset_interval_set&,
       metastore::extent_metadata_vec,
+      kafka::offset,
       compaction::key_offset_map*,
       std::chrono::milliseconds,
       metastore*,
@@ -70,6 +71,9 @@ private:
     metastore::extent_metadata_vec _extents;
     metastore::extent_metadata_vec::const_iterator _extents_it;
     metastore::extent_metadata_vec::const_iterator _extents_end_it;
+
+    // The start offset of the CTP.
+    [[maybe_unused]] kafka::offset _start_offset;
 
     // The key-offset map for this run of compaction. Built up from existing
     // data during `map_building_iteration()` by iterating over `_dirty_ranges`

--- a/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
@@ -94,6 +94,7 @@ ss::future<> do_compact(
   model::ntp ntp,
   l1::metastore::compaction_offsets_response offsets_response,
   l1::metastore::compaction_epoch expected_compaction_epoch,
+  kafka::offset start_offset,
   l1::compaction_committer& committer,
   l1::metastore* metastore,
   l1::io* io,
@@ -109,6 +110,7 @@ ss::future<> do_compact(
       dirty_range_intervals,
       offsets_response.removable_tombstone_ranges,
       std::move(offsets_response.extents),
+      start_offset,
       &map,
       min_compaction_lag_ms,
       metastore,
@@ -120,6 +122,7 @@ ss::future<> do_compact(
       dirty_range_intervals,
       offsets_response.removable_tombstone_ranges,
       expected_compaction_epoch,
+      start_offset,
       io,
       &committer);
     auto reducer = compaction::sliding_window_reducer(
@@ -258,6 +261,7 @@ TEST_F(ReducerTestFixture, LinearKeyValueReducer) {
       ntp,
       std::move(compaction_info->offsets_response),
       compaction_info->compaction_epoch,
+      compaction_info->start_offset,
       committer,
       &_metastore,
       &_io)
@@ -328,6 +332,7 @@ TEST_F(ReducerTestFixture, LinearKeyValueReducerSetStartOffset) {
       ntp,
       std::move(compaction_info->offsets_response),
       compaction_info->compaction_epoch,
+      compaction_info->start_offset,
       committer,
       &_metastore,
       &_io)
@@ -392,6 +397,7 @@ TEST_F(ReducerTestFixture, TombstoneReducer) {
           ntp,
           std::move(compaction_info->offsets_response),
           compaction_info->compaction_epoch,
+          compaction_info->start_offset,
           committer,
           &_metastore,
           &_io)
@@ -419,6 +425,7 @@ TEST_F(ReducerTestFixture, TombstoneReducer) {
           ntp,
           std::move(compaction_info->offsets_response),
           compaction_info->compaction_epoch,
+          compaction_info->start_offset,
           committer,
           &_metastore,
           &_io)
@@ -512,6 +519,7 @@ TEST_F(ReducerTestFixture, MinCompactionLagMsReducerIncreasingTimestamps) {
           ntp,
           std::move(compaction_info->offsets_response),
           compaction_info->compaction_epoch,
+          compaction_info->start_offset,
           committer,
           &_metastore,
           &_io,
@@ -629,6 +637,7 @@ TEST_F(ReducerTestFixture, MinCompactionLagMsReducerDecreasingTimestamps) {
           ntp,
           std::move(compaction_info->offsets_response),
           compaction_info->compaction_epoch,
+          compaction_info->start_offset,
           committer,
           &_metastore,
           &_io,
@@ -759,6 +768,7 @@ TEST_F(ReducerTestFixture, MinCompactionLagMsReducerInterleavedTimestamps) {
           ntp,
           std::move(compaction_info->offsets_response),
           compaction_info->compaction_epoch,
+          compaction_info->start_offset,
           committer,
           &_metastore,
           &_io,

--- a/src/v/cloud_topics/level_one/compaction/worker.cc
+++ b/src/v/cloud_topics/level_one/compaction/worker.cc
@@ -170,6 +170,7 @@ ss::future<> compaction_worker::compact_log(log_compaction_meta* log) {
       = log->info_and_ts->info.offsets_response.removable_tombstone_ranges,
       .extents = log->info_and_ts->info.offsets_response.extents.copy()};
     auto expected_compaction_epoch = log->info_and_ts->info.compaction_epoch;
+    auto start_offset = log->info_and_ts->info.start_offset;
 
     // Lazy initialization of offset map.
     if (!_map) {
@@ -202,6 +203,7 @@ ss::future<> compaction_worker::compact_log(log_compaction_meta* log) {
       dirty_range_intervals,
       compaction_offsets.removable_tombstone_ranges,
       std::move(compaction_offsets.extents),
+      start_offset,
       _map.get(),
       min_lag_ms,
       _metastore,
@@ -213,6 +215,7 @@ ss::future<> compaction_worker::compact_log(log_compaction_meta* log) {
       dirty_range_intervals,
       compaction_offsets.removable_tombstone_ranges,
       expected_compaction_epoch,
+      start_offset,
       _io,
       _committer);
     auto reducer = compaction::sliding_window_reducer(

--- a/src/v/cloud_topics/level_one/domain/domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.cc
@@ -361,8 +361,9 @@ rpc::get_compaction_info_reply domain_manager::do_get_compaction_info(
       .earliest_dirty_ts = get_res->earliest_dirty_ts,
       .extents = meta_to_rpc_extent_metadata(
         std::move(get_res->offsets_response.extents)),
-      .compaction_epoch = partition_state::compaction_epoch_t{
-        get_res->compaction_epoch()}};
+      .compaction_epoch
+      = partition_state::compaction_epoch_t{get_res->compaction_epoch()},
+      .start_offset = get_res->start_offset};
 }
 
 ss::future<rpc::get_compaction_info_reply>

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -371,16 +371,20 @@ public:
         compaction_offsets_response offsets_response;
         // The log's current compaction epoch.
         compaction_epoch compaction_epoch;
+        // The log's current start_offset. Can be expected to be == 0 for
+        // `compact` only topics, might be > 0 for `compact,delete` topics.
+        kafka::offset start_offset;
 
         fmt::iterator format_to(fmt::iterator it) const {
             return fmt::format_to(
               it,
               "{{dirty_ratio:{}, earliest_dirty_ts:{}, offsets_response:{}, "
-              "compaction_epoch:{}}}",
+              "compaction_epoch:{}, start_offset:{}}}",
               dirty_ratio,
               earliest_dirty_ts,
               offsets_response,
-              compaction_epoch);
+              compaction_epoch,
+              start_offset);
         }
     };
 

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -700,6 +700,7 @@ replicated_metastore::get_compaction_info(const compaction_info_spec& log) {
       .extents = rpc_to_meta_extent_metadata(std::move(reply.extents))};
     resp.compaction_epoch = metastore::compaction_epoch{
       reply.compaction_epoch()};
+    resp.start_offset = reply.start_offset;
 
     co_return resp;
 }
@@ -756,7 +757,8 @@ replicated_metastore::get_compaction_infos(
                           .dirty_ranges = std::move(log_reply.dirty_ranges),
                           .removable_tombstone_ranges = std::move(log_reply.removable_tombstone_ranges),
                           .extents = rpc_to_meta_extent_metadata(std::move(log_reply.extents))},
-                        .compaction_epoch = metastore::compaction_epoch{log_reply.compaction_epoch()}};
+                        .compaction_epoch = metastore::compaction_epoch{log_reply.compaction_epoch()},
+                        .start_offset = log_reply.start_offset};
                       resp.insert_or_assign(log, std::move(log_resp));
                   }
               });

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -214,7 +214,8 @@ struct get_compaction_info_reply
           dirty_ratio,
           earliest_dirty_ts,
           extents,
-          compaction_epoch);
+          compaction_epoch,
+          start_offset);
     }
 
     errc ec;
@@ -224,6 +225,7 @@ struct get_compaction_info_reply
     std::optional<model::timestamp> earliest_dirty_ts;
     chunked_vector<extent_metadata> extents;
     partition_state::compaction_epoch_t compaction_epoch;
+    kafka::offset start_offset;
 };
 struct get_compaction_info_request
   : serde::envelope<

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -699,9 +699,9 @@ simple_metastore::get_compaction_info(
         return std::unexpected(earliest_dirty_ts.error());
     }
 
-    auto offsets = get_compaction_offsets(state, tidp, ts);
-    if (!offsets.has_value()) {
-        return std::unexpected(offsets.error());
+    auto compact_offsets = get_compaction_offsets(state, tidp, ts);
+    if (!compact_offsets.has_value()) {
+        return std::unexpected(compact_offsets.error());
     }
 
     auto compaction_epoch = get_compaction_epoch(state, tidp);
@@ -709,11 +709,17 @@ simple_metastore::get_compaction_info(
         return std::unexpected(compaction_epoch.error());
     }
 
+    auto log_offsets = get_offsets(state, tidp);
+    if (!log_offsets.has_value()) {
+        return std::unexpected(log_offsets.error());
+    }
+
     return compaction_info_response{
       .dirty_ratio = dirty_ratio.value(),
       .earliest_dirty_ts = earliest_dirty_ts.value(),
-      .offsets_response = std::move(offsets).value(),
-      .compaction_epoch = compaction_epoch.value()};
+      .offsets_response = std::move(compact_offsets).value(),
+      .compaction_epoch = compaction_epoch.value(),
+      .start_offset = log_offsets.value().start_offset};
 }
 
 ss::future<std::expected<metastore::compaction_info_map, metastore::errc>>

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -327,6 +327,7 @@ TEST_F(ReplicatedMetastoreTest, TestBasicAdd) {
         EXPECT_FLOAT_EQ(cmp_info->dirty_ratio, 1.0);
         EXPECT_TRUE(cmp_info->earliest_dirty_ts.has_value());
         EXPECT_EQ(cmp_info->compaction_epoch, metastore::compaction_epoch{0});
+        EXPECT_EQ(cmp_info->start_offset, o{0});
     }
 }
 
@@ -420,6 +421,7 @@ TEST_F(ReplicatedMetastoreTest, TestBasicCompact) {
         EXPECT_FLOAT_EQ(cmp_info->dirty_ratio, 0.0);
         EXPECT_TRUE(!cmp_info->earliest_dirty_ts.has_value());
         EXPECT_EQ(cmp_info->compaction_epoch, metastore::compaction_epoch{1});
+        EXPECT_EQ(cmp_info->start_offset, o{0});
     }
 }
 
@@ -684,6 +686,15 @@ TEST_F(ReplicatedMetastoreTest, TestSetStartOffset) {
           ASSERT_TRUE(offsets.has_value());
           ASSERT_EQ(expected_start, offsets->start_offset);
           ASSERT_EQ(expected_next, offsets->next_offset);
+
+          // Sanity check the start offset returned by get_compaction_info() as
+          // well.
+          auto spec = metastore::compaction_info_spec{
+            .tidp = tp,
+            .tombstone_removal_upper_bound_ts = model::timestamp::now()};
+          auto cmp_info = meta.get_compaction_info(spec).get();
+          ASSERT_TRUE(cmp_info.has_value());
+          ASSERT_EQ(cmp_info->start_offset, expected_start);
       };
 
     // Get initial offsets
@@ -855,6 +866,7 @@ TEST_F(ReplicatedMetastoreTest, TestGetCompactionInfos) {
             ASSERT_TRUE(info.has_value());
             ASSERT_DOUBLE_EQ(info->dirty_ratio, 1.0);
             ASSERT_EQ(info->compaction_epoch, metastore::compaction_epoch{0});
+            ASSERT_EQ(info->start_offset, o{0});
         }
     }
 
@@ -883,6 +895,7 @@ TEST_F(ReplicatedMetastoreTest, TestGetCompactionInfos) {
             ASSERT_TRUE(info.has_value());
             ASSERT_DOUBLE_EQ(info->dirty_ratio, 0.0);
             ASSERT_EQ(info->compaction_epoch, metastore::compaction_epoch{1});
+            ASSERT_EQ(info->start_offset, o{0});
         }
     }
 }

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -1550,17 +1550,23 @@ TEST(SimpleMetastoreTest, TestSetStartWithCompactionState) {
     ASSERT_EQ(21_o, offsets_res->next_offset);
 
     // Only the [16, 20] should remain dirty.
-    auto cmp_after = m.get_compaction_offsets(tp, 3000_t).get();
+    auto to_collect = metastore::compaction_info_spec{
+      .tidp = tp, .tombstone_removal_upper_bound_ts = 3000_t};
+    auto cmp_after = m.get_compaction_info(to_collect).get();
     ASSERT_TRUE(cmp_after.has_value());
     EXPECT_THAT(
-      cmp_after->dirty_ranges.to_vec(),
+      cmp_after->offsets_response.dirty_ranges.to_vec(),
       testing::ElementsAre(MatchesRange(16_o, 20_o)));
 
     // Removable tombstone ranges should also be adjusted to reflect the new
     // start.
     EXPECT_THAT(
-      cmp_after->removable_tombstone_ranges.to_vec(),
+      cmp_after->offsets_response.removable_tombstone_ranges.to_vec(),
       testing::ElementsAre(MatchesRange(10_o, 15_o)));
+
+    // Assert that the new start offset is reported correctly in the compaction
+    // info as well.
+    ASSERT_EQ(cmp_after->start_offset, 10_o);
 }
 
 TEST(SimpleMetastoreTest, TestDirtyRatio) {
@@ -1594,6 +1600,7 @@ TEST(SimpleMetastoreTest, TestDirtyRatio) {
     auto compaction_info = m.get_compaction_info(to_collect).get();
     ASSERT_TRUE(compaction_info.has_value());
     ASSERT_FLOAT_EQ(compaction_info->dirty_ratio, 1.0);
+    ASSERT_EQ(compaction_info->start_offset, 0_o);
 
     // Clean range is now [0, 9]. Only one extent still has dirty offsets.
     {
@@ -1612,6 +1619,7 @@ TEST(SimpleMetastoreTest, TestDirtyRatio) {
     compaction_info = m.get_compaction_info(to_collect).get();
     ASSERT_TRUE(compaction_info.has_value());
     ASSERT_FLOAT_EQ(compaction_info->dirty_ratio, 0.5);
+    ASSERT_EQ(compaction_info->start_offset, 0_o);
 
     // Clean range is now [0, 19], the entire log is clean.
     {
@@ -1630,6 +1638,7 @@ TEST(SimpleMetastoreTest, TestDirtyRatio) {
     compaction_info = m.get_compaction_info(to_collect).get();
     ASSERT_TRUE(compaction_info.has_value());
     ASSERT_FLOAT_EQ(compaction_info->dirty_ratio, 0.0);
+    ASSERT_EQ(compaction_info->start_offset, 0_o);
 }
 
 TEST(SimpleMetastoreTest, TestAddGetOffsetAfterBytes) {


### PR DESCRIPTION
It will be good to know the log start offset during compaction. In most cases (`compact` only topics) it should be == 0, but for `compact,delete` topics it can be >= 0.


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
