### PR TITLE
[CORE-8780] `rptest`: bump timeout in `write_caching_fi_test`

### DIFF
--- a/tests/rptest/tests/write_caching_fi_test.py
+++ b/tests/rptest/tests/write_caching_fi_test.py
@@ -255,7 +255,7 @@ class WriteCachingFailureInjectionTest(RedpandaTest):
             return next(self.rpk.describe_topic(self.topic)).high_watermark
 
         second_quorum_hwm = wait_until_result(
-            _hwm, timeout_sec=30, backoff_sec=1, retry_on_exc=True
+            _hwm, timeout_sec=120, backoff_sec=1, retry_on_exc=True
         )
 
         lost = 10000 - second_quorum_hwm


### PR DESCRIPTION
This request can take up to 30 seconds to get a response while the quorum is reforming:

```
TRACE 2025-12-17 06:44:32,450 [shard 1:kafk] kafka - handler.h:81 - [client_id: {rpk}] handling list_offsets v6 request {replica_id=-1 isolation_level=0 topics=[{name=test partitions=[{partition_index=0 current_leader_epoch=-1 timestamp={timestamp: -2} max_num_offsets=0}]}]}
DEBUG 2025-12-17 06:45:02,417 [shard 1:main] kafka - connection_context.cc:212 - Connection input_shutdown; aborting operations for 192.168.215.52:50488
DEBUG 2025-12-17 06:45:04,110 [shard 1:kafk] kafka - request_context.h:238 - [192.168.215.52:50488] sending 2:list_offsets for {rpk}, response {throttle_time_ms=0ms topics=[{name=test partitions=[{partition_index=0 error_code={ error_code: not_leader_for_partition [6] } old_style_offsets=[] timestamp={timestamp: missing} offset=-1 leader_epoch=-1}]}]}
```

Bump the timeout to see if that helps deflake the test.


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
