### PR TITLE
[v25.3.x] [CORE-15015] `security` & `kafka`: audit log deflaking

### DIFF
--- a/src/v/kafka/data/rpc/client.cc
+++ b/src/v/kafka/data/rpc/client.cc
@@ -113,6 +113,7 @@ cluster::errc map_errc(std::error_code ec) {
         case ::rpc::errc::disconnected_endpoint:
         case ::rpc::errc::exponential_backoff:
         case ::rpc::errc::shutting_down:
+        case ::rpc::errc::service_unavailable:
             return cluster::errc::timeout;
         default:
             vlog(

--- a/src/v/security/audit/client.cc
+++ b/src/v/security/audit/client.cc
@@ -52,7 +52,7 @@ public:
       audit_probe& probe,
       ss::timer<>::time_point timeout) final {
         constexpr auto map_ec = [](cluster::errc ec) -> kafka::error_code {
-            vlog(adtlog.debug, "Error producing audit data: {}", ec);
+            vlog(adtlog.debug, "Audit data produce result: {}", ec);
             if (ec == cluster::errc::success) {
                 return kafka::error_code::none;
             }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/29019
