### PR TITLE
lsm: disambiguate between empty database and applied seqno of 0

### DIFF
--- a/src/v/lsm/db/BUILD
+++ b/src/v/lsm/db/BUILD
@@ -206,6 +206,20 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "snapshot",
+    srcs = [
+        "snapshot.cc",
+    ],
+    hdrs = [
+        "snapshot.h",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/lsm/core/internal:keys",
+    ],
+)
+
+redpanda_cc_library(
     name = "weak_intrusive_list",
     hdrs = ["weak_intrusive_list.h"],
     deps = [

--- a/src/v/lsm/db/impl.cc
+++ b/src/v/lsm/db/impl.cc
@@ -15,6 +15,7 @@
 #include "base/vlog.h"
 #include "lsm/core/exceptions.h"
 #include "lsm/core/internal/files.h"
+#include "lsm/core/internal/iterator.h"
 #include "lsm/core/internal/keys.h"
 #include "lsm/core/internal/logger.h"
 #include "lsm/core/internal/merging_iterator.h"
@@ -35,6 +36,7 @@
 namespace lsm::db {
 
 using internal::operator""_level;
+using internal::operator""_seqno;
 
 impl::impl(ctor, io::persistence p, ss::lw_shared_ptr<internal::options> o)
   : _persistence(std::move(p))
@@ -200,19 +202,27 @@ ss::future<lookup_result> impl::get(internal::key_view key) {
 ss::future<std::unique_ptr<internal::iterator>>
 impl::create_iterator(ss::optimized_optional<ss::lw_shared_ptr<memtable>> wb) {
     auto iter = co_await create_internal_iterator(wb->get());
-    internal::sequence_number iter_seqno = max_applied_seqno();
+    std::optional<internal::sequence_number> iter_seqno = max_applied_seqno();
     if (wb) {
-        auto wb_seqno = (*wb)->last_seqno().value_or(iter_seqno);
+        auto wb_seqno = (*wb)->last_seqno();
         vassert(
           wb_seqno > iter_seqno,
           "write memtable seqno must be greater than the current "
           "max_applied_seqno: {} > {}",
-          wb_seqno,
-          iter_seqno);
+          wb_seqno.value_or(0_seqno),
+          iter_seqno.value_or(0_seqno));
         iter_seqno = wb_seqno;
     }
+    if (!iter_seqno) {
+        // If there is no data in the memtable and the database, then we create
+        // a view of empty data, since we cannot pin before 0.
+        co_return internal::iterator::create_empty();
+    }
     co_return create_db_iterator(
-      std::move(iter), iter_seqno, _opts, [this](internal::key_view key) {
+      std::move(iter),
+      iter_seqno.value(),
+      _opts,
+      [this](internal::key_view key) {
           return _versions->current()->record_read_sample(key).then(
             [this](bool compaction_needed) {
                 if (compaction_needed) {
@@ -374,7 +384,7 @@ ss::future<> impl::run_background_compaction() {
     }
     compaction_state state{
       // TODO: If we support snapshot reads we need to track the last seqno.
-      .smallest_snapshot = _versions->last_seqno(),
+      .smallest_snapshot = _versions->last_seqno().value(),
     };
     auto output_level = compaction.level() + 1_level;
     auto max_file_size = _opts->levels[output_level].max_file_size;
@@ -528,14 +538,20 @@ ss::future<> impl::remove_obsolete_files() {
     }
 }
 
-internal::sequence_number impl::max_persisted_seqno() const {
+std::optional<internal::sequence_number> impl::max_persisted_seqno() const {
     return _versions->last_seqno();
 }
 
-internal::sequence_number impl::max_applied_seqno() const {
-    return _mem->last_seqno()
-      .or_else([this] { return _imm ? (*_imm)->last_seqno() : std::nullopt; })
-      .value_or(max_persisted_seqno());
+std::optional<internal::sequence_number> impl::max_applied_seqno() const {
+    if (auto seqno = _mem->last_seqno()) {
+        return seqno;
+    }
+    if (_imm) {
+        if (auto seqno = (*_imm)->last_seqno()) {
+            return seqno;
+        }
+    }
+    return max_persisted_seqno();
 }
 
 } // namespace lsm::db

--- a/src/v/lsm/db/impl.h
+++ b/src/v/lsm/db/impl.h
@@ -42,10 +42,10 @@ public:
 
     // the maximum sequence number that has been applied to in memory state or
     // durable storage.
-    internal::sequence_number max_applied_seqno() const;
+    std::optional<internal::sequence_number> max_applied_seqno() const;
 
     // The maximum sequence number that has been persisted to durable storage.
-    internal::sequence_number max_persisted_seqno() const;
+    std::optional<internal::sequence_number> max_persisted_seqno() const;
 
     // Open the database
     static ss::future<std::unique_ptr<impl>>

--- a/src/v/lsm/db/manifest.proto
+++ b/src/v/lsm/db/manifest.proto
@@ -23,7 +23,9 @@ message Manifest {
     // The next file ID to be used.
     uint64 next_file_id = 2;
     // The last seqno written.
-    uint64 last_seqno = 4;
+    uint64 last_seqno = 3;
+    // The epoch of the database at which this was written.
+    uint64 database_epoch = 4;
 }
 
 // An immutable version of the database

--- a/src/v/lsm/db/snapshot.cc
+++ b/src/v/lsm/db/snapshot.cc
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "lsm/db/snapshot.h"
+
+#include "lsm/core/internal/keys.h"
+
+namespace lsm::db {
+
+using internal::operator""_seqno;
+
+snapshot::~snapshot() {
+    _prev->_next = _next;
+    _next->_prev = _prev;
+}
+
+std::unique_ptr<snapshot>
+snapshot_list::create(internal::sequence_number seqno) {
+    auto latest_seqno = newest_seqno().value_or(0_seqno);
+    vassert(
+      seqno >= latest_seqno,
+      "snapshots may not be taken on older data: {} >= {}",
+      seqno,
+      latest_seqno);
+    auto snap = std::unique_ptr<snapshot>(new snapshot(seqno));
+    // Insert into our circularly linked list.
+    snap->_next = _head._next;
+    snap->_prev = &_head;
+    _head._next->_prev = snap.get();
+    _head._next = snap.get();
+    return snap;
+}
+
+snapshot_list::snapshot_list()
+  : _head(internal::sequence_number::min()) {
+    // We make this a circularly linked list to simplify the logic (instead of
+    // nullptr as a special sentinel value)
+    _head._next = &_head;
+    _head._prev = &_head;
+}
+
+} // namespace lsm::db

--- a/src/v/lsm/db/snapshot.h
+++ b/src/v/lsm/db/snapshot.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "lsm/core/internal/keys.h"
+
+#include <memory>
+
+namespace lsm::db {
+
+class snapshot_list;
+
+// An explicit snapshot of the database.
+//
+// Currently the database always takes a snapshot for individual reads, but this
+// allows for multiple reads to work on the same snapshot.
+class snapshot {
+    explicit snapshot(internal::sequence_number seqno)
+      : _seqno(seqno) {}
+
+public:
+    snapshot(const snapshot&) = delete;
+    snapshot(snapshot&&) = delete;
+    snapshot& operator=(const snapshot&) = delete;
+    snapshot& operator=(snapshot&&) = delete;
+    ~snapshot();
+
+    // The sequence number that this snapshot was taken at.
+    internal::sequence_number seqno() const { return _seqno; }
+
+private:
+    friend class snapshot_list;
+
+    snapshot* _prev = nullptr;
+    snapshot* _next = nullptr;
+    internal::sequence_number _seqno;
+};
+
+// snapshot_list is a holder for the current list of held snapshots
+class snapshot_list {
+public:
+    snapshot_list();
+    snapshot_list(const snapshot_list&) = delete;
+    snapshot_list(snapshot_list&&) = delete;
+    snapshot_list& operator=(const snapshot_list&) = delete;
+    snapshot_list& operator=(snapshot_list&&) = delete;
+    ~snapshot_list() {
+        vassert(
+          empty(),
+          "all snapshots must be released before the snapshot list is "
+          "destructed");
+    }
+
+    // Create a new explicit snapshot at the given seqno.
+    //
+    // The snapshot will be released when destructed.
+    std::unique_ptr<snapshot> create(internal::sequence_number seqno);
+
+    // Return the newest sequence number of the snapshot held by readers.
+    std::optional<internal::sequence_number> newest_seqno() const {
+        if (empty()) {
+            return std::nullopt;
+        }
+        return _head._next->seqno();
+    }
+
+    // Return the oldest sequence number of the snapshot held by readers.
+    std::optional<internal::sequence_number> oldest_seqno() const {
+        if (empty()) {
+            return std::nullopt;
+        }
+        return _head._prev->seqno();
+    }
+
+    // Returns true if there no explicit snapshots held by readers.
+    bool empty() const { return _head._next == &_head; }
+
+private:
+    friend class snapshot;
+
+    snapshot _head;
+};
+
+} // namespace lsm::db

--- a/src/v/lsm/db/tests/BUILD
+++ b/src/v/lsm/db/tests/BUILD
@@ -46,6 +46,22 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "snapshot_test",
+    timeout = "short",
+    srcs = [
+        "snapshot_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/lsm/core/internal:keys",
+        "//src/v/lsm/db:snapshot",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "weak_intrusive_list_test",
     timeout = "short",
     srcs = [

--- a/src/v/lsm/db/tests/impl_test.cc
+++ b/src/v/lsm/db/tests/impl_test.cc
@@ -25,6 +25,7 @@ namespace {
 
 namespace io = lsm::io;
 using lsm::internal::file_handle;
+using lsm::internal::operator""_seqno;
 
 class proxy_data_persistence : public io::data_persistence {
 public:
@@ -143,7 +144,7 @@ public:
     void write_at_least(size_t size) {
         auto batch = ss::make_lw_shared<lsm::db::memtable>();
         decltype(_shadow) shadow_batch;
-        auto seqno = _db->max_applied_seqno();
+        auto seqno = _db->max_applied_seqno().value_or(0_seqno);
         while (batch->approximate_memory_usage() < size) {
             auto key = lsm::internal::key::encode({
               .key = lsm::user_key_view(
@@ -281,7 +282,7 @@ TEST_F(ImplTest, Randomized) {
 TEST_F(ImplTest, ReadYourOwnWrites) {
     // Write some initial data to the database
     auto batch1 = ss::make_lw_shared<lsm::db::memtable>();
-    auto seqno = _db->max_applied_seqno();
+    auto seqno = _db->max_applied_seqno().value_or(0_seqno);
     auto key1 = lsm::internal::key::encode({
       .key = lsm::user_key_view("key1"),
       .seqno = ++seqno,
@@ -300,7 +301,7 @@ TEST_F(ImplTest, ReadYourOwnWrites) {
 
     // Create a pending write batch with new keys (not yet applied)
     auto pending_batch = ss::make_lw_shared<lsm::db::memtable>();
-    seqno = _db->max_applied_seqno();
+    seqno = _db->max_applied_seqno().value_or(0_seqno);
 
     auto key3 = lsm::internal::key::encode({
       .key = lsm::user_key_view("key3"),
@@ -323,7 +324,7 @@ TEST_F(ImplTest, ReadYourOwnWrites) {
 
     // Create another pending write batch that updates an existing key
     auto update_batch = ss::make_lw_shared<lsm::db::memtable>();
-    seqno = _db->max_applied_seqno();
+    seqno = _db->max_applied_seqno().value_or(0_seqno);
 
     auto key2_updated = lsm::internal::key::encode({
       .key = lsm::user_key_view("key2"),
@@ -405,6 +406,19 @@ TEST_F(ImplTest, Readonly) {
     EXPECT_ANY_THROW(write_at_least(1_KiB));
     EXPECT_TRUE(matches_shadow());
     EXPECT_ANY_THROW(write_at_least(1_KiB));
+}
+
+TEST_F(ImplTest, SnapshotEmpty) {
+    auto it = _db->create_iterator(std::nullopt).get();
+    it->seek_to_first().get();
+    EXPECT_FALSE(it->valid());
+    write_at_least(512_KiB);
+    EXPECT_TRUE(matches_shadow());
+    // Even though there is now data, the DB should be empty
+    it->seek_to_first().get();
+    EXPECT_FALSE(it->valid());
+    it->seek_to_last().get();
+    EXPECT_FALSE(it->valid());
 }
 
 } // namespace

--- a/src/v/lsm/db/tests/snapshot_test.cc
+++ b/src/v/lsm/db/tests/snapshot_test.cc
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "lsm/core/internal/keys.h"
+#include "lsm/db/snapshot.h"
+
+#include <memory>
+#include <optional>
+
+using namespace lsm::db;
+using lsm::internal::operator""_seqno;
+
+TEST(SnapshotListTest, EmptyByDefault) {
+    snapshot_list list;
+    EXPECT_TRUE(list.empty());
+    EXPECT_EQ(list.newest_seqno(), std::nullopt);
+    EXPECT_EQ(list.oldest_seqno(), std::nullopt);
+}
+
+TEST(SnapshotListTest, CreateSingleSnapshot) {
+    snapshot_list list;
+    auto snap = list.create(100_seqno);
+    ASSERT_NE(snap, nullptr);
+    EXPECT_FALSE(list.empty());
+    EXPECT_EQ(snap->seqno(), 100_seqno);
+    EXPECT_EQ(list.newest_seqno(), 100_seqno);
+    EXPECT_EQ(list.oldest_seqno(), 100_seqno);
+}
+
+TEST(SnapshotListTest, CreateMultipleSnapshotsInOrder) {
+    snapshot_list list;
+    auto snap1 = list.create(100_seqno);
+    auto snap2 = list.create(200_seqno);
+    auto snap3 = list.create(300_seqno);
+
+    EXPECT_FALSE(list.empty());
+    EXPECT_EQ(snap1->seqno(), 100_seqno);
+    EXPECT_EQ(snap2->seqno(), 200_seqno);
+    EXPECT_EQ(snap3->seqno(), 300_seqno);
+
+    // Newest should be the most recently created
+    EXPECT_EQ(list.newest_seqno(), 300_seqno);
+    // Oldest should be the first created
+    EXPECT_EQ(list.oldest_seqno(), 100_seqno);
+}
+
+TEST(SnapshotListTest, DestroyingSnapshotRemovesItFromList) {
+    snapshot_list list;
+    auto snap1 = list.create(100_seqno);
+    auto snap2 = list.create(200_seqno);
+    auto snap3 = list.create(300_seqno);
+
+    EXPECT_EQ(list.newest_seqno(), 300_seqno);
+    EXPECT_EQ(list.oldest_seqno(), 100_seqno);
+
+    // Destroy the middle snapshot
+    snap2.reset();
+    EXPECT_EQ(list.newest_seqno(), 300_seqno);
+    EXPECT_EQ(list.oldest_seqno(), 100_seqno);
+
+    // Destroy the oldest
+    snap1.reset();
+    EXPECT_EQ(list.newest_seqno(), 300_seqno);
+    EXPECT_EQ(list.oldest_seqno(), 300_seqno);
+
+    // Destroy the last one
+    snap3.reset();
+    EXPECT_TRUE(list.empty());
+    EXPECT_EQ(list.newest_seqno(), std::nullopt);
+    EXPECT_EQ(list.oldest_seqno(), std::nullopt);
+}
+
+TEST(SnapshotListTest, DestroyingNewestSnapshot) {
+    snapshot_list list;
+    auto snap1 = list.create(100_seqno);
+    auto snap2 = list.create(200_seqno);
+    auto snap3 = list.create(300_seqno);
+
+    // Destroy newest
+    snap3.reset();
+    EXPECT_EQ(list.newest_seqno(), 200_seqno);
+    EXPECT_EQ(list.oldest_seqno(), 100_seqno);
+}
+
+TEST(SnapshotListTest, DestroyingOldestSnapshot) {
+    snapshot_list list;
+    auto snap1 = list.create(100_seqno);
+    auto snap2 = list.create(200_seqno);
+    auto snap3 = list.create(300_seqno);
+
+    // Destroy oldest
+    snap1.reset();
+    EXPECT_EQ(list.newest_seqno(), 300_seqno);
+    EXPECT_EQ(list.oldest_seqno(), 200_seqno);
+}
+
+TEST(SnapshotListTest, CanCreateSnapshotWithSameSeqno) {
+    snapshot_list list;
+    auto snap1 = list.create(100_seqno);
+    auto snap2 = list.create(100_seqno);
+
+    EXPECT_EQ(snap1->seqno(), 100_seqno);
+    EXPECT_EQ(snap2->seqno(), 100_seqno);
+    EXPECT_EQ(list.newest_seqno(), 100_seqno);
+    EXPECT_EQ(list.oldest_seqno(), 100_seqno);
+}
+
+TEST(SnapshotListTest, MultipleSnapshotsWithInterleavedDestruction) {
+    snapshot_list list;
+    auto snap1 = list.create(100_seqno);
+    auto snap2 = list.create(200_seqno);
+    auto snap3 = list.create(300_seqno);
+    auto snap4 = list.create(400_seqno);
+    auto snap5 = list.create(500_seqno);
+
+    EXPECT_EQ(list.newest_seqno(), 500_seqno);
+    EXPECT_EQ(list.oldest_seqno(), 100_seqno);
+
+    // Destroy in non-sequential order
+    snap3.reset();
+    EXPECT_EQ(list.newest_seqno(), 500_seqno);
+    EXPECT_EQ(list.oldest_seqno(), 100_seqno);
+
+    snap1.reset();
+    EXPECT_EQ(list.newest_seqno(), 500_seqno);
+    EXPECT_EQ(list.oldest_seqno(), 200_seqno);
+
+    snap5.reset();
+    EXPECT_EQ(list.newest_seqno(), 400_seqno);
+    EXPECT_EQ(list.oldest_seqno(), 200_seqno);
+
+    snap2.reset();
+    EXPECT_EQ(list.newest_seqno(), 400_seqno);
+    EXPECT_EQ(list.oldest_seqno(), 400_seqno);
+
+    snap4.reset();
+    EXPECT_TRUE(list.empty());
+}

--- a/src/v/lsm/db/tests/version_set_test.cc
+++ b/src/v/lsm/db/tests/version_set_test.cc
@@ -92,6 +92,7 @@ public:
           .smallest = spec.keys.front(),
           .largest = spec.keys.back(),
         });
+        edit.set_last_seqno(0_seqno);
         _version_set->log_and_apply(std::move(edit)).get();
     }
 
@@ -156,6 +157,7 @@ public:
           .oldest_seqno = 0_seqno,
           .newest_seqno = 0_seqno,
         });
+        edit.set_last_seqno(0_seqno);
         _version_set->log_and_apply(std::move(edit)).get();
     }
 
@@ -216,6 +218,7 @@ TEST_F(VersionSetTest, ApplyEdit) {
       .smallest = "a"_key,
       .largest = "z"_key,
     });
+    edit.set_last_seqno(0_seqno);
     vset.log_and_apply(std::move(edit)).get();
     EXPECT_EQ(vset.current()->num_files(0_level), 1);
     EXPECT_EQ(vset.current()->num_files(1_level), 0);
@@ -232,6 +235,7 @@ TEST_F(VersionSetTest, ApplyEditWithDelete) {
           .smallest = "a"_key,
           .largest = "z"_key,
         });
+        edit.set_last_seqno(0_seqno);
         vset.log_and_apply(std::move(edit)).get();
         EXPECT_EQ(vset.current()->num_files(0_level), 1);
         EXPECT_EQ(vset.current()->num_files(1_level), 0);
@@ -276,6 +280,7 @@ TEST_F(VersionSetTest, Recovery) {
           .smallest = "c"_key,
           .largest = "d"_key,
         });
+        edit.set_last_seqno(0_seqno);
         vset.log_and_apply(std::move(edit)).get();
         EXPECT_EQ(vset.current()->num_files(0_level), 2);
         EXPECT_EQ(vset.current()->num_files(1_level), 0);
@@ -310,6 +315,7 @@ TEST_F(VersionSetTest, OverlapInLevel0) {
       .smallest = "b"_key,
       .largest = "e"_key,
     });
+    edit.set_last_seqno(0_seqno);
     vset.log_and_apply(std::move(edit)).get();
     auto current = vset.current();
     EXPECT_TRUE(current->overlap_in_level(0_level, "a"_user_key, "z"_user_key));
@@ -352,6 +358,7 @@ TEST_F(VersionSetTest, OverlapInLevel1) {
       .smallest = "i"_key,
       .largest = "k"_key,
     });
+    edit.set_last_seqno(0_seqno);
     vset.log_and_apply(std::move(edit)).get();
     auto current = vset.current();
     EXPECT_TRUE(current->overlap_in_level(1_level, "a"_user_key, "z"_user_key));

--- a/src/v/lsm/db/version_edit.h
+++ b/src/v/lsm/db/version_edit.h
@@ -105,7 +105,7 @@ private:
     };
     absl::FixedArray<mutation> _mutations_by_level;
     // This is safe because it is applied idempotently.
-    internal::sequence_number _last_seqno = internal::sequence_number::min();
+    std::optional<internal::sequence_number> _last_seqno;
 };
 
 } // namespace lsm::db

--- a/src/v/lsm/db/version_set.cc
+++ b/src/v/lsm/db/version_set.cc
@@ -525,7 +525,10 @@ ss::future<> version_set::log_and_apply(version_edit edit) {
     // deltas, but just snapshot the full manifest. At somepoint we will
     // want delta writes (but that's not possible in the cloud), but for
     // now we will just write full snapshots.
-    auto updated_seqno = std::max(_last_seqno, edit._last_seqno);
+
+    // Invariant: Between the two we must have a seqno, either data exists or
+    // we're writing the first data which must have a seqno
+    auto updated_seqno = std::max(_last_seqno, edit._last_seqno).value();
     auto m = manifest{
       .version = v,
       .next_file_id = _next_file_id,

--- a/src/v/lsm/db/version_set.cc
+++ b/src/v/lsm/db/version_set.cc
@@ -533,6 +533,7 @@ ss::future<> version_set::log_and_apply(version_edit edit) {
       .version = v,
       .next_file_id = _next_file_id,
       .last_seqno = updated_seqno,
+      .epoch = _options->database_epoch,
     };
     co_await write_manifest(std::move(m));
     // Now that the new version is persisted successfully, install the new
@@ -597,6 +598,7 @@ ss::future<> version_set::write_manifest(manifest m) {
     manifest_proto.set_version(std::move(version_proto));
     manifest_proto.set_next_file_id(m.next_file_id());
     manifest_proto.set_last_seqno(m.last_seqno());
+    manifest_proto.set_database_epoch(m.epoch());
     auto serialized = co_await manifest_proto.to_proto();
     co_await _persistence->write_manifest(
       _options->database_epoch, std::move(serialized));
@@ -639,6 +641,7 @@ ss::future<std::optional<version_set::manifest>> version_set::read_manifest() {
     m.version = std::move(v);
     m.next_file_id = internal::file_id(manifest_proto.get_next_file_id());
     m.last_seqno = internal::sequence_number(manifest_proto.get_last_seqno());
+    m.epoch = internal::database_epoch(manifest_proto.get_database_epoch());
     co_return m;
 }
 

--- a/src/v/lsm/db/version_set.h
+++ b/src/v/lsm/db/version_set.h
@@ -161,7 +161,9 @@ public:
     ss::future<> recover();
 
     // The latest seqno applied to the LSM tree.
-    internal::sequence_number last_seqno() const { return _last_seqno; }
+    std::optional<internal::sequence_number> last_seqno() const {
+        return _last_seqno;
+    }
 
     // Returns true iff some level needs compaction.
     bool needs_compaction() const;
@@ -199,7 +201,7 @@ private:
     ss::lw_shared_ptr<version> _current;
     internal::file_id _next_file_id = internal::file_id{2};
     internal::file_id _current_manifest_id;
-    internal::sequence_number _last_seqno;
+    std::optional<internal::sequence_number> _last_seqno;
     absl::FixedArray<std::optional<internal::key>> _compact_pointer;
 };
 

--- a/src/v/lsm/db/version_set.h
+++ b/src/v/lsm/db/version_set.h
@@ -190,6 +190,7 @@ private:
         ss::lw_shared_ptr<version> version;
         internal::file_id next_file_id;
         internal::sequence_number last_seqno;
+        internal::database_epoch epoch;
     };
     // Write this version to a manifest file as a snapshot.
     ss::future<> write_manifest(manifest);

--- a/src/v/lsm/lsm.cc
+++ b/src/v/lsm/lsm.cc
@@ -163,12 +163,14 @@ ss::future<database> database::open(options opts, io::persistence p) {
 
 ss::future<> database::close() { return _impl->close(); }
 
-model::offset database::max_persisted_offset() const {
-    return seqno_cast(_impl->max_persisted_seqno());
+std::optional<model::offset> database::max_persisted_offset() const {
+    return _impl->max_persisted_seqno().transform(
+      [](auto seqno) { return seqno_cast(seqno); });
 }
 
-model::offset database::max_applied_offset() const {
-    return seqno_cast(_impl->max_applied_seqno());
+std::optional<model::offset> database::max_applied_offset() const {
+    return _impl->max_applied_seqno().transform(
+      [](auto seqno) { return seqno_cast(seqno); });
 }
 
 ss::future<> database::flush() { return _impl->flush(); }

--- a/src/v/lsm/lsm.h
+++ b/src/v/lsm/lsm.h
@@ -153,11 +153,11 @@ public:
     ss::future<> close();
 
     // The maximum offset that has been persisted to durable storage.
-    model::offset max_persisted_offset() const;
+    std::optional<model::offset> max_persisted_offset() const;
 
     // The maximum offset that has been applied to the database (persisted or
     // not).
-    model::offset max_applied_offset() const;
+    std::optional<model::offset> max_applied_offset() const;
 
     // Flush existing buffered data such that that `max_persisted_offset()`
     // becomes >= the current `max_applied_offset()`.


### PR DESCRIPTION
Currently 0 was conflated with empty db and that can make replay
hard/annoying.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


* none
