### PR TITLE
shadowing/usage: wire up shadowing bytes in usage accounting

### DIFF
--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -194,6 +194,10 @@ public:
         return _instances[id]->app.id_allocator_frontend.local();
     }
 
+    kafka::usage_manager& get_local_usage_manager(model::node_id id) {
+        return _instances[id]->app.usage_manager.local();
+    }
+
     ss::sharded<cluster::partition_manager>&
     get_partition_manager(model::node_id id) {
         return _instances[id]->app.partition_manager;

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -37,6 +37,7 @@
 #include "kafka/data/partition_proxy.h"
 #include "kafka/server/group_router.h"
 #include "kafka/server/snc_quota_manager.h"
+#include "kafka/server/usage_manager.h"
 #include "kafka/server/write_at_offset_stm.h"
 
 #include <seastar/coroutine/switch_to.hh>
@@ -397,10 +398,12 @@ public:
     explicit local_partition_sink(
       ss::lw_shared_ptr<cluster::partition> partition,
       const cluster::metadata_cache& md_cache,
-      cluster::id_allocator_frontend& id_alloc)
+      cluster::id_allocator_frontend& id_alloc,
+      kafka::usage_manager& usage_mgr)
       : _partition(std::move(partition))
       , _metadata_cache{md_cache}
       , _id_allocator_frontend(id_alloc)
+      , _usage_mgr(usage_mgr)
       , _stm(_partition->raft()
                ->stm_manager()
                ->get<kafka::write_at_offset_stm>()) {
@@ -599,6 +602,7 @@ private:
     ss::lw_shared_ptr<cluster::partition> _partition;
     const cluster::metadata_cache& _metadata_cache;
     cluster::id_allocator_frontend& _id_allocator_frontend;
+    [[maybe_unused]] kafka::usage_manager& _usage_mgr;
     ss::shared_ptr<kafka::write_at_offset_stm> _stm;
     // set in start();
     std::optional<kafka::offset> _last_replicated_offset;
@@ -612,10 +616,12 @@ public:
     explicit local_partition_data_sink_factory(
       ss::sharded<cluster::partition_manager>& pm,
       ss::sharded<cluster::metadata_cache>& md_cache,
-      ss::sharded<cluster::id_allocator_frontend>& id_alloc)
+      ss::sharded<cluster::id_allocator_frontend>& id_alloc,
+      ss::sharded<kafka::usage_manager>& usage_mgr)
       : _partition_manager(pm)
       , _metadata_cache{md_cache}
-      , _id_allocator_frontend(id_alloc) {}
+      , _id_allocator_frontend(id_alloc)
+      , _usage_mgr(usage_mgr) {}
 
     std::unique_ptr<replication::data_sink>
     make_sink(const ::model::ntp& ntp) final {
@@ -627,13 +633,15 @@ public:
         return make_default_data_sink(
           std::move(partition),
           _metadata_cache.local(),
-          _id_allocator_frontend.local());
+          _id_allocator_frontend.local(),
+          _usage_mgr.local());
     }
 
 private:
     ss::sharded<cluster::partition_manager>& _partition_manager;
     ss::sharded<cluster::metadata_cache>& _metadata_cache;
     ss::sharded<cluster::id_allocator_frontend>& _id_allocator_frontend;
+    ss::sharded<kafka::usage_manager>& _usage_mgr;
 };
 
 std::unique_ptr<replication::data_source> make_default_data_source(
@@ -645,9 +653,10 @@ std::unique_ptr<replication::data_source> make_default_data_source(
 std::unique_ptr<replication::data_sink> make_default_data_sink(
   ss::lw_shared_ptr<cluster::partition> partition,
   const cluster::metadata_cache& md_cache,
-  cluster::id_allocator_frontend& id_allocator) {
+  cluster::id_allocator_frontend& id_allocator,
+  kafka::usage_manager& usage_mgr) {
     return std::make_unique<local_partition_sink>(
-      std::move(partition), md_cache, id_allocator);
+      std::move(partition), md_cache, id_allocator, usage_mgr);
 }
 
 class default_link_config_provider
@@ -855,12 +864,14 @@ public:
       ss::sharded<cluster::partition_manager>* partition_manager,
       ss::sharded<kafka::snc_quota_manager>* snc_quota_mgr,
       ss::sharded<cluster::metadata_cache>* md_cache,
-      ss::sharded<cluster::id_allocator_frontend>* id_alloc)
+      ss::sharded<cluster::id_allocator_frontend>* id_alloc,
+      ss::sharded<kafka::usage_manager>* usage_mgr)
       : link_factory()
       , _partition_manager(partition_manager)
       , _snc_quota_mgr(snc_quota_mgr)
       , _metadata_cache(md_cache)
-      , _id_allocator_frontend(id_alloc) {}
+      , _id_allocator_frontend(id_alloc)
+      , _usage_mgr(usage_mgr) {}
 
     static constexpr auto link_reconciler_period = 5min;
     std::unique_ptr<link> create_link(
@@ -892,7 +903,10 @@ public:
               make_remote_consumer_configuration(config.connection),
               std::move(probe_cfg))),
           std::make_unique<local_partition_data_sink_factory>(
-            *_partition_manager, *_metadata_cache, *_id_allocator_frontend));
+            *_partition_manager,
+            *_metadata_cache,
+            *_id_allocator_frontend,
+            *_usage_mgr));
     }
 
 private:
@@ -900,6 +914,7 @@ private:
     ss::sharded<kafka::snc_quota_manager>* _snc_quota_mgr;
     ss::sharded<cluster::metadata_cache>* _metadata_cache;
     ss::sharded<cluster::id_allocator_frontend>* _id_allocator_frontend;
+    ss::sharded<kafka::usage_manager>* _usage_mgr;
 };
 
 class kafka_consumer_groups_router : public consumer_groups_router {
@@ -987,6 +1002,7 @@ service::service(
   ss::sharded<cluster::security_frontend>* security_fe,
   ss::sharded<kafka::data::rpc::client>* kafka_data_rpc_client,
   ss::sharded<cluster::id_allocator_frontend>* id_alloc,
+  ss::sharded<kafka::usage_manager>* usage_mgr,
   ss::smp_service_group smp_group,
   ss::scheduling_group scheduling_group)
   : _self(self)
@@ -1005,6 +1021,7 @@ service::service(
   , _security_fe(security_fe)
   , _kafka_data_rpc_client(kafka_data_rpc_client)
   , _id_allocator_frontend(id_alloc)
+  , _usage_mgr(usage_mgr)
   , _smp_group(smp_group)
   , _scheduling_group(scheduling_group)
   , _queue(_scheduling_group, [](const std::exception_ptr& ex) {
@@ -1201,7 +1218,8 @@ ss::future<> service::maybe_start_manager() {
         _partition_manager,
         _snc_quota_mgr,
         _metadata_cache,
-        _id_allocator_frontend),
+        _id_allocator_frontend,
+        _usage_mgr),
       std::make_unique<cluster_factory>(),
       std::make_unique<kafka_consumer_groups_router>(_group_router),
       std::make_unique<health_monitor_based_partition_metadata_provider>(

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -467,12 +467,14 @@ public:
 
         chunked_vector<kafka::offset> expected_offsets;
         expected_offsets.reserve(batches.size());
+        uint64_t total_bytes = 0;
         for (const auto& batch : batches) {
             _highest_seen_pid = std::max(
               _highest_seen_pid,
               ::model::producer_id{batch.header().producer_id});
             expected_offsets.push_back(
               ::model::offset_cast(batch.base_offset()));
+            total_bytes += batch.size_bytes();
         }
         auto new_last_replicated_begin = ::model::offset_cast(
           batches.front().base_offset());
@@ -514,6 +516,15 @@ public:
           timeout,
           as);
         _last_replicated_offset = new_last_replicated_end;
+        stages.replicate_finished = stages.replicate_finished.then(
+          [this, total_bytes](result<raft::replicate_result> result) {
+              if (result.has_error()) {
+                  return result;
+              }
+              // Update usage manager with the number of bytes replicated
+              _usage_mgr.add_shadow_bytes_recv(total_bytes);
+              return result;
+          });
         return stages;
     }
 
@@ -602,7 +613,7 @@ private:
     ss::lw_shared_ptr<cluster::partition> _partition;
     const cluster::metadata_cache& _metadata_cache;
     cluster::id_allocator_frontend& _id_allocator_frontend;
-    [[maybe_unused]] kafka::usage_manager& _usage_mgr;
+    kafka::usage_manager& _usage_mgr;
     ss::shared_ptr<kafka::write_at_offset_stm> _stm;
     // set in start();
     std::optional<kafka::offset> _last_replicated_offset;

--- a/src/v/cluster_link/service.h
+++ b/src/v/cluster_link/service.h
@@ -57,6 +57,7 @@ public:
       ss::sharded<cluster::security_frontend>* security_fe,
       ss::sharded<kafka::data::rpc::client>* kafka_data_rpc_client,
       ss::sharded<cluster::id_allocator_frontend>* id_alloc,
+      ss::sharded<kafka::usage_manager>* usage_mgr,
       ss::smp_service_group smp_group,
       ss::scheduling_group scheduling_group);
 
@@ -228,6 +229,7 @@ private:
     ss::sharded<cluster::security_frontend>* _security_fe;
     ss::sharded<kafka::data::rpc::client>* _kafka_data_rpc_client;
     ss::sharded<cluster::id_allocator_frontend>* _id_allocator_frontend;
+    ss::sharded<kafka::usage_manager>* _usage_mgr;
     ss::smp_service_group _smp_group;
     ss::scheduling_group _scheduling_group;
     std::unique_ptr<manager> _manager;
@@ -246,5 +248,6 @@ std::unique_ptr<replication::data_source> make_default_data_source(
 std::unique_ptr<replication::data_sink> make_default_data_sink(
   ss::lw_shared_ptr<cluster::partition> partition,
   const cluster::metadata_cache&,
-  cluster::id_allocator_frontend&);
+  cluster::id_allocator_frontend&,
+  kafka::usage_manager&);
 } // namespace cluster_link

--- a/src/v/cluster_link/tests/partition_replicator_fixture_tests.cc
+++ b/src/v/cluster_link/tests/partition_replicator_fixture_tests.cc
@@ -56,7 +56,8 @@ public:
         auto sink = cluster_link::make_default_data_sink(
           partition,
           get_local_cache(model::node_id{0}),
-          get_local_id_allocator_frontend(model::node_id{0}));
+          get_local_id_allocator_frontend(model::node_id{0}),
+          get_local_usage_manager(model::node_id{0}));
         _replicator
           = std::make_unique<cluster_link::replication::partition_replicator>(
             _source,

--- a/src/v/kafka/server/usage_aggregator.cc
+++ b/src/v/kafka/server/usage_aggregator.cc
@@ -97,12 +97,15 @@ static ss::future<> clear_persisted_state(storage::kvstore& kvstore) {
 usage usage::operator+(const usage& other) const {
     return usage{
       .bytes_sent = bytes_sent + other.bytes_sent,
-      .bytes_received = bytes_received + other.bytes_received};
+      .bytes_received = bytes_received + other.bytes_received,
+      .shadow_bytes_received = shadow_bytes_received
+                               + other.shadow_bytes_received};
 }
 
 usage& usage::operator+=(const usage& other) {
     bytes_sent += other.bytes_sent;
     bytes_received += other.bytes_received;
+    shadow_bytes_received += other.shadow_bytes_received;
     return *this;
 }
 
@@ -120,6 +123,7 @@ void usage_window::reset(uint64_t now) {
     u.bytes_received = 0;
     u.bytes_cloud_storage = std::nullopt;
     u.datalake_usage = {};
+    u.shadow_bytes_received = 0;
 }
 
 template<typename clock_type>

--- a/src/v/kafka/server/usage_aggregator.h
+++ b/src/v/kafka/server/usage_aggregator.h
@@ -59,28 +59,36 @@ std::chrono::time_point<clock_type, duration> round_to_interval(
 /// periodically serialized to disk, hence why the struct inherits from the
 /// serde::envelope
 struct usage
-  : serde::envelope<usage, serde::version<1>, serde::compat_version<0>> {
+  : serde::envelope<usage, serde::version<2>, serde::compat_version<0>> {
     uint64_t bytes_sent{0};
     uint64_t bytes_received{0};
     std::optional<uint64_t> bytes_cloud_storage;
     datalake_usage_api::usage_stats datalake_usage;
+    // Total bytes replicated as a part of shadowing. This is
+    // not accounted under (Kafka) bytes_received.
+    uint64_t shadow_bytes_received{0};
     usage operator+(const usage&) const;
     usage& operator+=(const usage&);
     auto serde_fields() {
         return std::tie(
-          bytes_sent, bytes_received, bytes_cloud_storage, datalake_usage);
+          bytes_sent,
+          bytes_received,
+          bytes_cloud_storage,
+          datalake_usage,
+          shadow_bytes_received);
     }
     friend bool operator==(const usage&, const usage&) = default;
     friend std::ostream& operator<<(std::ostream& os, const usage& u) {
         fmt::print(
           os,
           "{{ bytes_sent: {} bytes_received: {} bytes_cloud_storage: {} "
-          "datalake_usage: {} }}",
+          "datalake_usage: {} shadow_bytes_received: {}}}",
           u.bytes_sent,
           u.bytes_received,
           u.bytes_cloud_storage ? std::to_string(*u.bytes_cloud_storage)
                                 : "n/a",
-          u.datalake_usage);
+          u.datalake_usage,
+          u.shadow_bytes_received);
         return os;
     }
 };

--- a/src/v/kafka/server/usage_manager.h
+++ b/src/v/kafka/server/usage_manager.h
@@ -91,6 +91,14 @@ public:
     /// kafka port
     void add_bytes_recv(size_t recv) { _current_bucket.bytes_received += recv; }
 
+    /// Adds shadow traffic bytes received to current open window
+    ///
+    /// Should be called at the shadowing layer to account for bytes received
+    /// via shadowing replication
+    void add_shadow_bytes_recv(size_t recv) {
+        _current_bucket.shadow_bytes_received += recv;
+    }
+
     /// Obtain all current stats - for all shards
     ///
     ss::future<std::vector<usage_window>> get_usage_stats() const;

--- a/src/v/redpanda/admin/api-doc/usage.json
+++ b/src/v/redpanda/admin/api-doc/usage.json
@@ -89,6 +89,10 @@
                 "datalake_usage": {
                     "type": "datalake_usage",
                     "description": "Datalake feature usage metrics."
+                },
+                "shadowing_bytes_received_count": {
+                    "type": "long",
+                    "description": "Number of bytes received by Redpanda for shadowing related replication"
                 }
             }
         }

--- a/src/v/redpanda/admin/usage.cc
+++ b/src/v/redpanda/admin/usage.cc
@@ -45,6 +45,7 @@ ss::json::json_return_type raw_data_to_usage_response(
               "{}", dl_usage.missing_reason);
         }
         resp.back().datalake_usage = std::move(dl_usage_response);
+        resp.back().shadowing_bytes_received_count = e.u.shadow_bytes_received;
     }
     if (include_open && !resp.empty()) {
         /// Handle case where client does not want to observe

--- a/src/v/redpanda/application_runtime.cc
+++ b/src/v/redpanda/application_runtime.cc
@@ -281,6 +281,7 @@ void application::wire_up_runtime_services(
       &controller->get_security_frontend(),
       &_kafka_data_rpc_client,
       &id_allocator_frontend,
+      &usage_manager,
       smp_service_groups.cluster_link_smp_sg(),
       scheduling_groups::instance().cluster_linking_sg())
       .get();

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1776,7 +1776,9 @@ class Admin:
             self._request("GET", "debug/cloud_storage_usage?retries_allowed=10").json()
         )
 
-    def get_usage(self, node: ClusterNode, include_open: bool = True) -> dict[str, Any]:
+    def get_usage(
+        self, node: ClusterNode, include_open: bool = True
+    ) -> list[dict[str, Any]]:
         return self._request(
             "GET", f"usage?include_open_bucket={str(include_open)}", node=node
         ).json()

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -3739,3 +3739,97 @@ class ShadowLinkCustomStartOffsetSelectionTests(ShadowLinkPreAllocTestBase):
             assert source_offsets == target_offsets, (
                 f"Expected source and target offsets to match, got {target_offsets} vs {source_offsets}"
             )
+
+
+class ShadowLinkingUsageTest(ShadowLinkPreAllocTestBase):
+    """
+    Tests that the usage endpoint is tracking shadowing metrics
+    """
+
+    def __init__(self, test_context, *args, **kwargs):
+        # Enable usage tracking with reasonable window settings
+        # The windows are chosen so the entire history of windows
+        # are returned in each usage query. This way we can easily
+        # sum across all windows to get total shadowing bytes received
+        # and compute deltas as needed.
+        extra_rp_conf = {
+            "enable_usage": True,
+            "usage_num_windows": 30,
+            "usage_window_width_interval_sec": 3,
+            "usage_disk_persistance_interval_sec": 3,
+        }
+        super(ShadowLinkingUsageTest, self).__init__(
+            test_context=test_context, extra_rp_conf=extra_rp_conf, *args, **kwargs
+        )
+
+    def _get_shadowing_bytes_received(self, cluster: RedpandaService) -> int:
+        """
+        Get the total shadowing_bytes_received_count across all windows for a cluster
+        """
+        admin = cluster._admin
+        total_bytes = 0
+
+        for node in cluster.started_nodes():
+            try:
+                usage_response = admin.get_usage(node, include_open=True)
+                for window in usage_response:
+                    shadow_bytes = window.get("shadowing_bytes_received_count", 0)
+                    total_bytes += shadow_bytes
+            except Exception as e:
+                self.logger.warning(f"Failed to get usage from node {node.name}: {e}")
+
+        return total_bytes
+
+    @cluster(num_nodes=7)
+    def test_shadowing_bytes_received_tracking(self):
+        """
+        Test that shadowing_bytes_received_count is properly tracked when
+        data is replicated via shadowing
+        """
+        # Create topic on source cluster
+        source_topic = TopicSpec(name="test-topic")
+        self.source_default_client().create_topic(source_topic)
+
+        # Create shadow link
+        self.create_link("test-link")
+
+        prev_shadow_bytes = self._get_shadowing_bytes_received(
+            self.target_cluster_service
+        )
+        iterations = 5
+        total_produced = 0
+        for _ in range(iterations):
+            # Produce data to source cluster
+            records = 10000
+            record_size = 512
+            KgoVerifierProducer.oneshot(
+                self.test_context,
+                self.source_cluster_service,
+                topic=source_topic.name,
+                msg_size=record_size,
+                msg_count=records,
+            )
+            total_produced += records * record_size
+            self.logger.debug(f"Produced {total_produced} bytes to source cluster")
+
+            # Wait for data to be replicated via shadowing
+            def shadowing_bytes_increased():
+                current_bytes = self._get_shadowing_bytes_received(
+                    self.target_cluster_service
+                )
+                self.logger.debug(
+                    f"Current shadowing bytes received: {current_bytes}, "
+                    f"prev: {prev_shadow_bytes}, "
+                    f"total produced: {total_produced}"
+                )
+                made_progress = current_bytes > prev_shadow_bytes and current_bytes > (
+                    total_produced * 0.5
+                )
+                return (made_progress, current_bytes)
+
+            prev_shadow_bytes = wait_until_result(
+                shadowing_bytes_increased,
+                timeout_sec=60,
+                backoff_sec=3,
+                err_msg="Shadowing bytes received count did not increase as expected",
+            )


### PR DESCRIPTION
Hooks up shadowing ingress bytes to the usage endpoint (see example below). It uses a different entry than Kafka ingress so it’s easy to tell the traffic types apart (if we may choose to bill differently).

```
[
  {
    "begin_timestamp": 1766086683,
    "end_timestamp": 1766086683,
    "open": true,
    "kafka_bytes_sent_count": 0,
    "kafka_bytes_received_count": 0,
    "cloud_storage_bytes_gauge": 0,
    "datalake_usage": {
      "missing_reason": "feature_disabled"
    },
    "shadowing_bytes_received_count": 0
  },
  {
    "begin_timestamp": 1766086680,
    "end_timestamp": 1766086683,
    "open": false,
    "kafka_bytes_sent_count": 0,
    "kafka_bytes_received_count": 0,
    "cloud_storage_bytes_gauge": 0,
    "datalake_usage": {
      "missing_reason": "feature_disabled"
    },
    "shadowing_bytes_received_count": 0
  },
  {
    "begin_timestamp": 1766086677,
    "end_timestamp": 1766086680,
    "open": false,
    "kafka_bytes_sent_count": 0,
    "kafka_bytes_received_count": 0,
    "cloud_storage_bytes_gauge": 0,
    "datalake_usage": {
      "missing_reason": "feature_disabled"
    },
    "shadowing_bytes_received_count": 5959970
  },
  {
    "begin_timestamp": 1766086674,
    "end_timestamp": 1766086677,
    "open": false,
    "kafka_bytes_sent_count": 0,
    "kafka_bytes_received_count": 0,
    "cloud_storage_bytes_gauge": 0,
    "datalake_usage": {
      "missing_reason": "feature_disabled"
    },
    "shadowing_bytes_received_count": 0
  },
  {
    "begin_timestamp": 1766086671,
    "end_timestamp": 1766086674,
    "open": false,
    "kafka_bytes_sent_count": 0,
    "kafka_bytes_received_count": 0,
    "cloud_storage_bytes_gauge": 0,
    "datalake_usage": {
      "missing_reason": "feature_disabled"
    },
    "shadowing_bytes_received_count": 467261
  },
....
```
Fixes: https://redpandadata.atlassian.net/browse/CORE-15048
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
