### PR TITLE
[CORE-15021] Cloud Topics: Level Zero GC delete pipeline

### DIFF
--- a/src/v/cloud_topics/level_zero/gc/BUILD
+++ b/src/v/cloud_topics/level_zero/gc/BUILD
@@ -29,6 +29,8 @@ redpanda_cc_library(
         "//src/v/cloud_topics:logger",
         "//src/v/cloud_topics:object_utils",
         "//src/v/cluster",
+        "//src/v/ssx:semaphore",
+        "//src/v/ssx:work_queue",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -488,12 +488,13 @@ level_zero_gc::level_zero_gc(
   std::unique_ptr<object_storage> storage,
   std::unique_ptr<epoch_source> epoch_source)
   : config_(std::move(config))
-  , storage_(std::move(storage))
   , epoch_source_(std::move(epoch_source))
   , should_run_(false) // begin in a stopped state
   , should_shutdown_(false)
   , worker_(worker())
-  , probe_(config::shard_local_cfg().disable_metrics()) {}
+  , probe_(config::shard_local_cfg().disable_metrics())
+  , delete_worker_(
+      std::make_unique<list_delete_worker>(std::move(storage), probe_)) {}
 
 level_zero_gc::level_zero_gc(
   cloud_io::remote* remote,
@@ -516,8 +517,11 @@ level_zero_gc::level_zero_gc(
       std::make_unique<epoch_source_impl>(
         health_monitor, controller_stm, topic_table)) {}
 
+level_zero_gc::~level_zero_gc() = default;
+
 void level_zero_gc::start() {
     vlog(cd_log.info, "Starting cloud topics L0 GC worker");
+    delete_worker_->start();
     should_run_ = true;
     worker_cv_.signal();
 }
@@ -526,6 +530,7 @@ void level_zero_gc::pause() {
     vlog(cd_log.info, "Pausing cloud topics L0 GC worker");
     should_run_ = false;
     asrc_.request_abort();
+    delete_worker_->pause();
 }
 
 seastar::future<> level_zero_gc::stop() {
@@ -533,7 +538,9 @@ seastar::future<> level_zero_gc::stop() {
     should_shutdown_ = true;
     asrc_.request_abort();
     worker_cv_.signal();
+    co_await delete_worker_->stop();
     co_await std::exchange(worker_, seastar::make_ready_future<>());
+    vlog(cd_log.info, "Stopped cloud_topics L0 GC worker");
 }
 
 // internal error codes used between the worker fiber and the main GC function
@@ -600,7 +607,10 @@ seastar::future<> level_zero_gc::worker() {
 
 seastar::future<std::expected<size_t, level_zero_gc::collection_error>>
 level_zero_gc::try_to_collect() {
-    const auto candidate_objects = co_await storage_->list_objects(&asrc_);
+    if (!delete_worker_->has_capacity()) {
+        co_return 0;
+    }
+    auto candidate_objects = co_await delete_worker_->next_page();
     if (!candidate_objects.has_value()) {
         vlog(
           cd_log.debug,
@@ -637,6 +647,8 @@ level_zero_gc::try_to_collect() {
     // objects that can be safely deleted
     std::vector<cloud_storage_clients::client::list_bucket_item>
       eligible_objects;
+    // total size of eligible keys
+    size_t object_keys_total_bytes = 0;
 
     // used to detect unsorted object listings
     seastar::sstring last_key;
@@ -686,7 +698,8 @@ level_zero_gc::try_to_collect() {
               cd_log,
               seastar::log_level::error,
               rate,
-              "Non-lexicographic object listing detected during L0 GC {} < {}",
+              "Non-lexicographic object listing detected during L0 GC {} < "
+              "{}",
               object.key,
               last_key);
         }
@@ -716,27 +729,12 @@ level_zero_gc::try_to_collect() {
             continue;
         }
 
+        object_keys_total_bytes += object.key.size();
         eligible_objects.push_back(object);
     }
 
-    const auto num_eligible = eligible_objects.size();
-
-    auto res = co_await storage_->delete_objects(
-      &asrc_, std::move(eligible_objects));
-    if (!res.has_value()) {
-        vlog(
-          cd_log.info,
-          "Received an error deleting L0 data objects: {}",
-          res.error());
-        co_return std::unexpected(collection_error::service_error);
-    }
-
-    probe_.objects_deleted(num_eligible);
-
-    vlog(
-      cd_log.debug, "Deleted {} L0 data objects eligible for GC", num_eligible);
-
-    co_return num_eligible;
+    co_return delete_worker_->delete_objects(
+      std::move(eligible_objects), object_keys_total_bytes);
 }
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -607,9 +607,27 @@ seastar::future<> level_zero_gc::worker() {
 
 seastar::future<std::expected<size_t, level_zero_gc::collection_error>>
 level_zero_gc::try_to_collect() {
-    if (!delete_worker_->has_capacity()) {
-        co_return 0;
+    // Ultra-temporary cache to avoid repeatedly querying for max gc-able epoch.
+    // Since the result will always be valid clusterwide, compute exactly once
+    // per collection loop.
+    std::optional<cluster_epoch> max_gc_epoch;
+    size_t total_eligible{0};
+    while (delete_worker_->has_capacity()) {
+        auto res = co_await do_try_to_collect(std::ref(max_gc_epoch));
+        if (!res.has_value()) {
+            co_return res;
+        }
+        if (res.value() == 0) {
+            break;
+        }
+        total_eligible += res.value();
     }
+
+    co_return total_eligible;
+}
+
+seastar::future<std::expected<size_t, level_zero_gc::collection_error>>
+level_zero_gc::do_try_to_collect(std::optional<cluster_epoch>& max_gc_epoch) {
     auto candidate_objects = co_await delete_worker_->next_page();
     if (!candidate_objects.has_value()) {
         vlog(
@@ -619,17 +637,19 @@ level_zero_gc::try_to_collect() {
         co_return std::unexpected(collection_error::service_error);
     }
 
-    const auto maybe_max_gc_epoch
-      = co_await epoch_source_->max_gc_eligible_epoch(&asrc_);
-    if (!maybe_max_gc_epoch.has_value()) {
-        vlog(
-          cd_log.debug,
-          "Received error retrieving GC eligible epoch: {}",
-          maybe_max_gc_epoch.error());
-        co_return std::unexpected(collection_error::service_error);
+    if (!max_gc_epoch.has_value()) {
+        const auto maybe_max_gc_epoch
+          = co_await epoch_source_->max_gc_eligible_epoch(&asrc_);
+        if (!maybe_max_gc_epoch.has_value()) {
+            vlog(
+              cd_log.debug,
+              "Received error retrieving GC eligible epoch: {}",
+              maybe_max_gc_epoch.error());
+            co_return std::unexpected(collection_error::service_error);
+        }
+        max_gc_epoch = maybe_max_gc_epoch.value();
     }
 
-    const auto max_gc_epoch = maybe_max_gc_epoch.value();
     if (!max_gc_epoch.has_value()) {
         vlog(cd_log.info, "No GC eligible epoch currently exists");
         co_return std::unexpected(collection_error::no_collectible_epoch);

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -15,12 +15,167 @@
 #include "cloud_topics/object_utils.h"
 #include "cluster/health_monitor_frontend.h"
 #include "cluster/topic_table.h"
+#include "ssx/semaphore.h"
+#include "ssx/work_queue.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/gate.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/coroutine/as_future.hh>
 
 namespace cloud_topics {
+
+class level_zero_gc::list_delete_worker {
+public:
+    explicit list_delete_worker(
+      std::unique_ptr<object_storage> storage, level_zero_gc_probe& probe)
+      : storage_(std::move(storage))
+      , probe_(&probe)
+      , worker_([](std::exception_ptr eptr) {
+          vlog(cd_log.warn, "Exception from delete worker: {}", eptr);
+      }) {}
+    void start() {
+        vlog(cd_log.info, "Starting cloud topics list/delete worker");
+        if (as_.abort_requested()) {
+            as_ = {};
+        }
+        if (gate_.is_closed()) {
+            gate_ = {};
+        }
+    }
+    void pause() {
+        as_.request_abort();
+        continuation_token_.reset();
+    }
+    seastar::future<> stop() {
+        if (gate_.is_closed()) {
+            co_return;
+        }
+        vlog(cd_log.info, "Stopping cloud topics list/delete worker");
+        as_.request_abort();
+        delete_sem_.broken();
+        page_sem_.broken();
+        co_await worker_.shutdown();
+        co_await gate_.close();
+        vlog(cd_log.info, "Stopped cloud topics list/delete worker");
+    }
+
+    seastar::future<std::expected<size_t, level_zero_gc::collection_error>>
+    collect() {
+        throw std::runtime_error("not implemented");
+    }
+
+    bool has_capacity() const { return page_sem_.available_units() > 0; }
+
+    seastar::future<std::expected<
+      cloud_storage_clients::client::list_bucket_result,
+      cloud_storage_clients::error_outcome>>
+    next_page() {
+        // cached continuation is single use. pass it to list_objects and null
+        // it out immediately.
+        auto objects = co_await storage_->list_objects(
+          &as_, std::exchange(continuation_token_, std::nullopt));
+
+        // fairly naive approach to caching the token. if the list request
+        // failed, we leave the cached token empty, but if some other error
+        // occurs while processing a page, we keep the token and "skip" that
+        // page. with lexicographically ordered list results and monotonic
+        // epochs, any eligible keys in a skipped page are guaranteed to appear
+        // in a subsequent round. given the volume of L0 objects at higher
+        // throughput rates, we're going to err on the side of making progress
+        // (vs performing a perfect sweep of outstanding objects).
+        if (
+          objects.has_value()
+          && !objects.value().next_continuation_token.empty()) {
+            continuation_token_.emplace(
+              std::move(objects.value().next_continuation_token));
+        }
+        co_return objects;
+    }
+
+    size_t delete_objects(
+      std::vector<cloud_storage_clients::client::list_bucket_item> objects,
+      size_t keys_total_bytes) {
+        auto n_objects = objects.size();
+        if (n_objects > 0) {
+            auto u = seastar::try_get_units(page_sem_, keys_total_bytes);
+            if (!u.has_value()) {
+                vlog(cd_log.trace, "Delete pipeline saturated");
+                // take the units unsafely. we don't really care about the
+                // memory limit in particular, just don't want to grow
+                // unbounded.
+                u.emplace(seastar::consume_units(page_sem_, keys_total_bytes));
+            }
+            worker_.submit([this,
+                            o = std::move(objects),
+                            u = std::move(u).value()]() mutable {
+                return do_delete_objects(std::move(o), std::move(u));
+            });
+        }
+        return n_objects;
+    }
+
+    seastar::future<> do_delete_objects(
+      std::vector<cloud_storage_clients::client::list_bucket_item>
+        eligible_objects,
+      ssx::semaphore_units page_u) noexcept {
+        auto u_fut = co_await ss::coroutine::as_future(
+          seastar::get_units(delete_sem_, 1, as_));
+        if (u_fut.failed()) {
+            vlog(
+              cd_log.debug,
+              "Failed to get units in delete worker: {}",
+              u_fut.get_exception());
+            co_return;
+        }
+        if (gate_.is_closed()) {
+            vlog(cd_log.trace, "Gate closed");
+            co_return;
+        }
+        ssx::spawn_with_gate(
+          gate_,
+          [this,
+           u = std::move(u_fut.get()),
+           pu = std::move(page_u),
+           eo = std::move(eligible_objects)]() mutable {
+              const auto num_eligible = eo.size();
+              return storage_->delete_objects(&as_, std::move(eo))
+                .then([this, num_eligible](
+                        std::expected<void, cloud_io::upload_result> res) {
+                    if (!res.has_value()) {
+                        vlog(
+                          cd_log.info,
+                          "Received an error deleting L0 data objects: {}",
+                          res.error());
+                    } else {
+                        probe_->objects_deleted(num_eligible);
+                        vlog(
+                          cd_log.debug,
+                          "Deleted {} L0 data objects eligible for GC",
+                          num_eligible);
+                    }
+                })
+                .finally([u = std::move(u), pu = std::move(pu)] {})
+                .handle_exception([](std::exception_ptr eptr) {
+                    vlog(cd_log.debug, "Delete objects failed: {}", eptr);
+                });
+          });
+    }
+
+private:
+    std::unique_ptr<object_storage> storage_;
+    level_zero_gc_probe* probe_;
+    ssx::work_queue worker_;
+    // TODO: configurable limits?
+    // max number of in-flight delete ops
+    ssx::semaphore delete_sem_{5, "ct/gc/delete"};
+    // control (approximate) total memory held by gc-eligible list pages in
+    // flight (these may be queued depending on delete concurrency)
+    ssx::semaphore page_sem_{1_MiB, "ct/gc/page"};
+    seastar::abort_source as_{};
+    seastar::gate gate_{};
+    std::optional<ss::sstring> continuation_token_{};
+};
 
 class object_storage_remote_impl : public level_zero_gc::object_storage {
 public:

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -37,10 +37,18 @@ public:
     seastar::future<std::expected<
       cloud_storage_clients::client::list_bucket_result,
       cloud_storage_clients::error_outcome>>
-    list_objects(seastar::abort_source* asrc) override {
+    list_objects(
+      seastar::abort_source* asrc,
+      std::optional<ss::sstring> continuation_token) override {
         retry_chain_node rtc(*asrc, timeout, backoff);
         auto res = co_await remote_->list_objects(
-          bucket_, rtc, object_path_factory::level_zero_data_dir());
+          bucket_,
+          rtc,
+          object_path_factory::level_zero_data_dir(),
+          std::nullopt /*delimiter*/,
+          std::nullopt /*item_filter*/,
+          std::nullopt /*max_keys*/,
+          std::move(continuation_token));
         if (res.has_value()) {
             co_return std::move(res).assume_value();
         }

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
@@ -247,6 +247,8 @@ public:
       seastar::sharded<cluster::controller_stm>*,
       seastar::sharded<cluster::topic_table>*);
 
+    ~level_zero_gc();
+
     /*
      * Request that GC be started or paused. These can be called multiple times
      * and in any order. The last invocation will eventually take effect.
@@ -262,7 +264,6 @@ public:
 
 private:
     level_zero_gc_config config_;
-    std::unique_ptr<object_storage> storage_;
     std::unique_ptr<epoch_source> epoch_source_;
 
     bool should_run_;
@@ -278,6 +279,7 @@ private:
     level_zero_gc_probe probe_;
 
     class list_delete_worker;
+    std::unique_ptr<list_delete_worker> delete_worker_{};
 };
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
@@ -162,7 +162,10 @@ public:
         virtual seastar::future<std::expected<
           cloud_storage_clients::client::list_bucket_result,
           cloud_storage_clients::error_outcome>>
-        list_objects(seastar::abort_source*) = 0;
+        list_objects(
+          seastar::abort_source*,
+          std::optional<ss::sstring> continuation_token = std::nullopt)
+          = 0;
 
         virtual seastar::future<std::expected<void, cloud_io::upload_result>>
         delete_objects(

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
@@ -276,6 +276,8 @@ private:
     seastar::future<std::expected<size_t, collection_error>> try_to_collect();
 
     level_zero_gc_probe probe_;
+
+    class list_delete_worker;
 };
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
@@ -275,6 +275,8 @@ private:
     seastar::future<> worker();
     enum class collection_error : int8_t;
     seastar::future<std::expected<size_t, collection_error>> try_to_collect();
+    seastar::future<std::expected<size_t, collection_error>>
+    do_try_to_collect(std::optional<cluster_epoch>&);
 
     level_zero_gc_probe probe_;
 

--- a/src/v/cloud_topics/level_zero/gc/tests/BUILD
+++ b/src/v/cloud_topics/level_zero/gc/tests/BUILD
@@ -9,6 +9,7 @@ redpanda_cc_gtest(
     deps = [
         "//src/v/cloud_topics:object_utils",
         "//src/v/cloud_topics/level_zero/gc:level_zero_gc",
+        "//src/v/ssx:mutex",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
         "@seastar",

--- a/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
+++ b/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
@@ -42,11 +42,19 @@ public:
     seastar::future<std::expected<
       cloud_storage_clients::client::list_bucket_result,
       cloud_storage_clients::error_outcome>>
-    list_objects(seastar::abort_source* as) override {
+    list_objects(
+      seastar::abort_source* as,
+      std::optional<ss::sstring> continuation_token) override {
         chunked_vector<cloud_storage_clients::client::list_bucket_item> keep;
         co_await seastar::sleep(cfg_->list_cost);
         auto lu = co_await list_mtx_.get_units(*as);
         for (const auto& object : *listed_) {
+            if (continuation_token.has_value()) {
+                if (object.key == continuation_token) {
+                    continuation_token.reset();
+                }
+                continue;
+            }
             auto not_deleted = true;
             {
                 auto du = co_await delete_mtx_.get_units(*as);
@@ -60,7 +68,10 @@ public:
             }
         }
 
+        auto continuation = keep.empty() ? ss::sstring{} : keep.back().key;
+
         co_return cloud_storage_clients::client::list_bucket_result{
+          .next_continuation_token = std::move(continuation),
           .contents = std::move(keep),
         };
     }

--- a/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
+++ b/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
@@ -390,3 +390,34 @@ TEST_F(LevelZeroGCScaleOutTest, CleanShutdown) {
     // then immediately shutdown gc
     gc.stop().get();
 }
+
+TEST_F(LevelZeroGCScaleOutTest, ConcurrentDeletes) {
+    static constexpr size_t list_page_size{20};
+    int n = list_page_size * 20;
+    for (int i = 0; i < n; i++) {
+        add_listed(i, 24h);
+    }
+    this->max_epoch = n;
+    this->cfg.list_page_size = list_page_size;
+    this->cfg.delete_cost = 100ms;
+    gc.start();
+    EXPECT_TRUE(Eventually(
+      [this, expected = (size_t)n] { return deleted.size() == expected; }));
+}
+
+// make sure we make progress when the total size of eligible keys exceeds the
+// in-flight limit
+// i.e. 50 * 500 * len(key)=72 ~= 1.5MiB > 1MiB
+TEST_F(LevelZeroGCScaleOutTest, ConcurrentDeletesPipelineSaturation) {
+    static constexpr size_t list_page_size{500};
+    int n = list_page_size * 50;
+    for (int i = 0; i < n; i++) {
+        add_listed(i, 24h);
+    }
+    this->max_epoch = n;
+    this->cfg.list_page_size = list_page_size;
+    this->cfg.delete_cost = 50ms;
+    gc.start();
+    EXPECT_TRUE(Eventually(
+      [this, expected = (size_t)n] { return deleted.size() == expected; }));
+}

--- a/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
+++ b/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
@@ -355,3 +355,38 @@ TEST_F(LevelZeroGCMaxEpochTest, EmptySnapshotNonEmptyReport) {
     ASSERT_TRUE(max_gc().has_value());
     ASSERT_FALSE(max_gc().value().has_value());
 }
+
+class LevelZeroGCScaleOutTest : public LevelZeroGCTest {
+public:
+    LevelZeroGCScaleOutTest()
+      : LevelZeroGCTest(1s, 2s) {}
+};
+
+TEST_F(LevelZeroGCScaleOutTest, MultiPageDelete) {
+    static constexpr size_t list_page_size{100};
+    int n = list_page_size * 4;
+    for (int i = 0; i < n; i++) {
+        add_listed(i, 24h);
+    }
+    this->max_epoch = n;
+    this->cfg.list_page_size = list_page_size;
+    gc.start();
+    EXPECT_TRUE(Eventually(
+      [this, expected = (size_t)n] { return deleted.size() == expected; }));
+}
+
+TEST_F(LevelZeroGCScaleOutTest, CleanShutdown) {
+    static constexpr size_t list_page_size{10};
+    int n = list_page_size * 10;
+    for (int i = 0; i < n; i++) {
+        add_listed(i, 24h);
+    }
+    this->max_epoch = n;
+    this->cfg.list_page_size = list_page_size;
+    this->cfg.delete_cost = 200ms;
+    gc.start();
+    // wait until we process one page
+    EXPECT_TRUE(Eventually([this] { return !deleted.empty(); }));
+    // then immediately shutdown gc
+    gc.stop().get();
+}

--- a/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
+++ b/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
@@ -9,6 +9,7 @@
  */
 #include "cloud_topics/level_zero/gc/level_zero_gc.h"
 #include "cloud_topics/object_utils.h"
+#include "ssx/mutex.h"
 
 #include <seastar/core/sleep.hh>
 
@@ -16,14 +17,24 @@
 
 using namespace std::chrono_literals;
 
+namespace {
+struct gc_test_config {
+    size_t list_page_size{std::numeric_limits<int>::max()};
+    std::chrono::milliseconds list_cost{0ms};
+    std::chrono::milliseconds delete_cost{0ms};
+};
+} // namespace
+
 class object_storage_test_impl
   : public cloud_topics::level_zero_gc::object_storage {
 public:
     object_storage_test_impl(
       std::vector<cloud_storage_clients::client::list_bucket_item>* listed,
-      std::vector<cloud_storage_clients::client::list_bucket_item>* deleted)
+      std::unordered_set<ss::sstring>* deleted,
+      gc_test_config* cfg)
       : listed_(listed)
-      , deleted_(deleted) {}
+      , deleted_(deleted)
+      , cfg_(cfg) {}
 
     /*
      * Returns objects in `listed_` that aren't in `deleted_`.
@@ -31,18 +42,21 @@ public:
     seastar::future<std::expected<
       cloud_storage_clients::client::list_bucket_result,
       cloud_storage_clients::error_outcome>>
-    list_objects(seastar::abort_source*) override {
+    list_objects(seastar::abort_source* as) override {
         chunked_vector<cloud_storage_clients::client::list_bucket_item> keep;
+        co_await seastar::sleep(cfg_->list_cost);
+        auto lu = co_await list_mtx_.get_units(*as);
         for (const auto& object : *listed_) {
             auto not_deleted = true;
-            for (const auto& deleted : *deleted_) {
-                if (object.key == deleted.key) {
-                    not_deleted = false;
-                    break;
-                }
+            {
+                auto du = co_await delete_mtx_.get_units(*as);
+                not_deleted = !deleted_->contains(object.key);
             }
             if (not_deleted) {
                 keep.push_back(object);
+            }
+            if (keep.size() >= cfg_->list_page_size) {
+                break;
             }
         }
 
@@ -56,15 +70,23 @@ public:
      */
     seastar::future<std::expected<void, cloud_io::upload_result>>
     delete_objects(
-      seastar::abort_source*,
+      seastar::abort_source* as,
       std::vector<cloud_storage_clients::client::list_bucket_item> objects)
       override {
-        deleted_->append_range(objects);
+        co_await seastar::sleep(cfg_->delete_cost);
+        auto u = co_await delete_mtx_.get_units(*as);
+        deleted_->insert_range(
+          std::move(objects)
+          | std::views::transform([](auto& s) { return std::move(s.key); }));
         co_return std::expected<void, cloud_io::upload_result>();
     }
 
     std::vector<cloud_storage_clients::client::list_bucket_item>* listed_;
-    std::vector<cloud_storage_clients::client::list_bucket_item>* deleted_;
+    std::unordered_set<ss::sstring>* deleted_;
+    gc_test_config* cfg_;
+
+    ssx::mutex list_mtx_{"object-store-impl-list"};
+    ssx::mutex delete_mtx_{"object-store-impl-delete"};
 };
 
 class epoch_source_test_impl
@@ -107,17 +129,21 @@ private:
 
 class LevelZeroGCTest : public testing::Test {
 public:
-    LevelZeroGCTest()
+    LevelZeroGCTest(
+      std::chrono::milliseconds throttle_progress = 10ms,
+      std::chrono::milliseconds throttle_no_progress = 10ms)
       : gc(
           cloud_topics::level_zero_gc_config{
             .deletion_grace_period
             = config::mock_binding<std::chrono::milliseconds>(12h),
             .throttle_progress
-            = config::mock_binding<std::chrono::milliseconds>(10ms),
+            = config::mock_binding<std::chrono::milliseconds>(
+              throttle_progress),
             .throttle_no_progress
-            = config::mock_binding<std::chrono::milliseconds>(10ms),
+            = config::mock_binding<std::chrono::milliseconds>(
+              throttle_no_progress),
           },
-          std::make_unique<object_storage_test_impl>(&listed, &deleted),
+          std::make_unique<object_storage_test_impl>(&listed, &deleted, &cfg),
           std::make_unique<epoch_source_test_impl>(&max_epoch)) {}
 
     void TearDown() override { gc.stop().get(); }
@@ -141,14 +167,14 @@ public:
     }
 
     std::vector<cloud_storage_clients::client::list_bucket_item> listed;
-    std::vector<cloud_storage_clients::client::list_bucket_item> deleted;
+    std::unordered_set<ss::sstring> deleted;
     std::optional<int64_t> max_epoch;
     cloud_topics::level_zero_gc gc;
+    gc_test_config cfg{};
 };
 
 template<typename Func>
-::testing::AssertionResult Eventually(Func func) {
-    int retries = 50;
+::testing::AssertionResult Eventually(Func func, int retries = 50) {
     while (retries-- > 0) {
         if (func()) {
             return ::testing::AssertionSuccess();


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR adds a work_queue for delete operation in level_zero_gc, with the general goal of overlapping list & delete. Napkin math suggests that sequential paging list operations will dominate GC latency at low to moderate throughput, so we want to hide any additional delete latency behind the usually more expensive list.

Request concurrency & memory usage of the pipeline are governed by a pair of semaphores - one to limit the memory consumption of outstanding GC-eligible object keys, the other to limit the number of in-flight delete operations going on in the background. 

Since work_queue tasks are processed sequentially, if a particular task blocks waiting for the request semaphore (i.e. before being pushed to the background), subsequent tasks will stay in the queue rather than stacking up on the semaphore. 

Similarly, each iteration of the GC loop will try to page through the entire level_zero/data prefix, queueing up pages of work as it goes. If the page semaphore is exhausted before we reach the last page of list results, the iteration ends and we reenter the loop after a configurable delay, giving the delete worker a chance to burn down some of the outstanding work.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
