### PR TITLE
DEVPROD-3695

### DIFF
--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -1747,3 +1747,148 @@ class CloudCluster:
             f"did not reach {target_state} within {timeout_sec // 60} minutes."
         )
         return False
+
+    def update_cluster_node_count(
+        self,
+        cluster_id: str,
+        node_count: int,
+        wait_for_completion: bool = True,
+        timeout_sec: int = 1200,  # 20 minutes for horizontal scaling
+    ) -> dict:
+        """
+        Scale cluster horizontally using PATCH /v1/clusters/{id}.
+        Horizontal scaling (within or across tier) adds/removes nodes to existing pool.
+        Cluster transitions to STATE_UPGRADING during operation.
+
+        Returns operation response dict containing operation.id and operation.state.
+        """
+        self._logger.warning(
+            f"Scaling cluster {cluster_id} to {node_count} nodes (horizontal)"
+        )
+        payload = {"redpanda_node_count": node_count}
+
+        self._logger.debug(
+            f"PATCH /v1/clusters/{cluster_id} body: {json.dumps(payload)}"
+        )
+
+        try:
+            response = self.public_api._http_patch(
+                base_url=self.config.public_api_url,
+                endpoint=f"/v1/clusters/{cluster_id}",
+                json=payload,
+            )
+
+            if wait_for_completion and "operation" in response:
+                operation_id = response["operation"]["id"]
+                self._logger.info(
+                    f"Waiting for horizontal scaling operation {operation_id} to complete"
+                )
+                success = self.wait_for_operation_complete(
+                    cluster_id, operation_id, timeout_sec
+                )
+                if not success:
+                    raise RuntimeError(
+                        f"Horizontal scaling operation {operation_id} did not complete"
+                    )
+
+            return response
+        except Exception as e:
+            self._logger.error(
+                f"Error scaling cluster {cluster_id} to {node_count} nodes: {e}"
+            )
+            raise
+
+    def update_cluster_tier(
+        self,
+        cluster_id: str,
+        tier_name: str,
+        wait_for_completion: bool = True,
+        timeout_sec: int = 2400,  # 40 minutes for vertical scaling
+    ) -> dict:
+        """
+        Change cluster tier using PATCH /v1/clusters/{id}.
+        Tier changes can be horizontal (same instance type, adds/removes nodes)
+        or vertical (different instance type, rolling node replacement).
+        Cluster transitions to STATE_UPGRADING during operation.
+
+        Returns operation response dict containing operation.id and operation.state.
+        """
+        self._logger.warning(f"Changing cluster {cluster_id} tier to {tier_name}")
+        payload = {"throughput_tier": tier_name}
+
+        self._logger.debug(
+            f"PATCH /v1/clusters/{cluster_id} body: {json.dumps(payload)}"
+        )
+
+        try:
+            response = self.public_api._http_patch(
+                base_url=self.config.public_api_url,
+                endpoint=f"/v1/clusters/{cluster_id}",
+                json=payload,
+            )
+
+            if wait_for_completion and "operation" in response:
+                operation_id = response["operation"]["id"]
+                self._logger.info(
+                    f"Waiting for tier change operation {operation_id} to complete"
+                )
+                success = self.wait_for_operation_complete(
+                    cluster_id, operation_id, timeout_sec
+                )
+                if not success:
+                    raise RuntimeError(
+                        f"Tier change operation {operation_id} did not complete"
+                    )
+
+            return response
+        except Exception as e:
+            self._logger.error(
+                f"Error changing cluster {cluster_id} tier to {tier_name}: {e}"
+            )
+            raise
+
+    def get_cluster_with_node_count(self, cluster_id: str) -> dict:
+        """
+        Get cluster info including redpanda_node_count using GET /v1/clusters/{id}.
+        During scaling, this shows the NEW desired values (state, throughput_tier,
+        redpanda_node_count).
+
+        Returns cluster dict with redpanda_node_count, state, throughput_tier fields.
+        """
+        try:
+            response = self.public_api._http_get(
+                endpoint=f"/v1/clusters/{cluster_id}",
+                base_url=self.config.public_api_url,
+            )
+            return response.get("cluster", {})
+        except Exception as e:
+            self._logger.error(f"Error getting cluster {cluster_id}: {e}")
+            raise
+
+    def list_throughput_tiers(
+        self,
+        cloud_provider: str | None = None,
+        cluster_type: str | None = None,
+        region: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        List available throughput tiers using GET /v1beta2/tiers.
+        Optional filters: cloud_provider (e.g., 'CLOUD_PROVIDER_AWS'),
+        cluster_type (e.g., 'TYPE_BYOC'), region (e.g., 'us-west-2').
+
+        Returns list of tier dictionaries.
+        """
+        params = {}
+        if cloud_provider:
+            params["filter.cloud_provider"] = cloud_provider
+        if cluster_type:
+            params["filter.cluster_type"] = cluster_type
+        if region:
+            params["filter.region"] = region
+
+        try:
+            tiers = self.public_api._http_get(endpoint="/v1beta2/tiers", params=params)
+            return tiers.get("throughput_tiers", [])
+        except Exception as e:
+            self._logger.error(f"Error listing throughput tiers: {e}")
+            raise


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


## Add Data Plane Scaling APIs to CloudCluster

### Overview

This PR adds helper methods to the `CloudCluster` class in `redpanda_cloud.py` to enable testing of Redpanda Cloud's data plane scaling capabilities. These methods wrap the new public REST API endpoints for cluster scaling, tier changes, and status checks.

### New Methods Added

| Method | Description | API Endpoint |
|--------|-------------|--------------|
| `update_cluster_node_count()` | Horizontal scaling - add/remove nodes | `PATCH /v1/clusters/{id}` |
| `update_cluster_tier()` | Vertical scaling - change throughput tier | `PATCH /v1/clusters/{id}` |
| `get_cluster_with_node_count()` | Get cluster info including node count | `GET /v1/clusters/{id}` |
| `list_throughput_tiers()` | List available tiers with optional filters | `GET /v1beta2/tiers` |


### Testing Performed

**Environment**: Integration 
**Cluster**: AWS BYOC cluster 

| Test | Result |
|------|--------|
| `get_cluster_with_node_count()` | ✅ Successfully retrieved cluster info with node count |
| `list_throughput_tiers()` (unfiltered) | ✅ Returned 258 tiers |
| `list_throughput_tiers()` (AWS + BYOC + us-east-1) | ✅ Returned 18 filtered tiers |
| **Horizontal Scaling**: 3 → 6 nodes | ✅ Completed successfully, cluster reached `STATE_READY` |
| **Horizontal Scaling**: 6 → 3 nodes | ✅ Completed successfully, cluster reached `STATE_READY` |
| **Vertical Scaling**: tier-1-aws → tier-2-aws | ✅ Completed successfully, rolling replacement worked |
| **Vertical Scaling**: tier-2-aws → tier-1-aws | ✅ Completed successfully, reverted to original tier |



### Files Changed

- `tests/rptest/services/redpanda_cloud.py` - Added 4 new methods to `CloudCluster` class