### PR TITLE
[v25.2.x] bazel: Update c-ares to v1.34.6

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -220,7 +220,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "9H54sxIOd7u/Ivr+b8+5whhn+NPZL4WXpBg1Wkh6rn4=",
+        "bzlTransitiveDigest": "3hcsEjq1m6FoiDIWfZ+VGFA3ODPdgfrrsUW3YeriF3g=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -262,9 +262,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:c-ares.BUILD",
-              "sha256": "7d935790e9af081c25c495fd13c2cfcda4792983418e96358ef6e7320ee06346",
-              "strip_prefix": "c-ares-1.34.5",
-              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.5.tar.gz"
+              "sha256": "912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5",
+              "strip_prefix": "c-ares-1.34.6",
+              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.6.tar.gz"
             }
           },
           "hdrhistogram": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -40,9 +40,9 @@ def data_dependency():
     http_archive(
         name = "c-ares",
         build_file = "//bazel/thirdparty:c-ares.BUILD",
-        sha256 = "7d935790e9af081c25c495fd13c2cfcda4792983418e96358ef6e7320ee06346",
-        strip_prefix = "c-ares-1.34.5",
-        url = "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.5.tar.gz",
+        sha256 = "912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5",
+        strip_prefix = "c-ares-1.34.6",
+        url = "https://vectorized-public.s3.amazonaws.com/dependencies/c-ares-1.34.6.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/29036 