### PR TITLE
Sesatar rebase 26.1 precusors, round II

### DIFF
--- a/src/v/base/BUILD
+++ b/src/v/base/BUILD
@@ -6,6 +6,7 @@ redpanda_cc_library(
         "vassert.cc",
     ],
     hdrs = [
+        "compiler_utils.h",
         "format_to.h",
         "likely.h",
         "oncore.h",

--- a/src/v/base/compiler_utils.h
+++ b/src/v/base/compiler_utils.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+// Start ignoring deprecations from this line, should be paired with
+// REDPANDA_END_IGNORE_DEPRECATIONS after the region you want to ignore
+// Use of this macro is ideally paired with a comment/JIRA reference
+// indicating the plan for removing the ignored deprecations.
+#define REDPANDA_BEGIN_IGNORE_DEPRECATIONS                                     \
+    _Pragma("GCC diagnostic push")                                             \
+      _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+
+#define REDPANDA_END_IGNORE_DEPRECATIONS _Pragma("GCC diagnostic pop")

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -298,25 +298,25 @@ remote_segment::offset_data_stream(
     options.read_ahead
       = config::shard_local_cfg().storage_read_readahead_count();
 
-    ss::input_stream<char> data_stream;
-    if (is_legacy_mode_engaged()) {
-        data_stream = ss::make_file_input_stream(
-          _data_file, pos.file_pos, std::move(options));
-    } else {
-        auto chunk_ds = std::make_unique<chunk_data_source_impl>(
-          _chunks_api.value(),
-          *this,
-          pos.kaf_offset,
-          end,
-          pos.file_pos,
-          std::move(options),
-          prefetch_override);
-        data_stream = ss::input_stream<char>{
-          ss::data_source{std::move(chunk_ds)}};
-    }
+    auto make_stream = [&]() -> ss::input_stream<char> {
+        if (is_legacy_mode_engaged()) {
+            return ss::make_file_input_stream(
+              _data_file, pos.file_pos, std::move(options));
+        } else {
+            auto chunk_ds = std::make_unique<chunk_data_source_impl>(
+              _chunks_api.value(),
+              *this,
+              pos.kaf_offset,
+              end,
+              pos.file_pos,
+              std::move(options),
+              prefetch_override);
+            return ss::input_stream<char>{ss::data_source{std::move(chunk_ds)}};
+        }
+    };
 
     co_return input_stream_with_offsets{
-      .stream = std::move(data_stream),
+      .stream = make_stream(),
       .rp_offset = pos.rp_offset,
       .kafka_offset = pos.kaf_offset,
     };

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -309,7 +309,7 @@ ss::future<> client::send(ss::scattered_message<char> msg) {
     // the output stream from being invalidated while writes are in flight
     auto holder = _dispatch_gate.hold();
     try {
-        co_await _out.write(std::move(msg));
+        co_await out().write(std::move(msg));
     } catch (...) {
         _probe->register_transport_error();
         throw;

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -485,12 +485,12 @@ private:
         int it = 0;
         const int max_iter = 1000;
         while (it++ < max_iter) {
-            auto tmpbuf = _fin.read().get();
+            auto tmpbuf = _fin->read().get();
             buffer.append(std::move(tmpbuf));
             if (buffer.size_bytes() > _expected_data.size()) {
                 ss::sstring body = buffer.linearize_to_string();
                 if (body.find(_expected_data) != ss::sstring::npos) {
-                    _fin.close().get();
+                    _fin->close().get();
                     return buffer;
                 }
             }
@@ -501,17 +501,17 @@ private:
 
     void do_send_response() {
         for (const auto& buf : _response) {
-            _fout.write(buf).get();
-            _fout.flush().get();
+            _fout->write(buf).get();
+            _fout->flush().get();
             ss::sleep(std::chrono::milliseconds(1)).get();
         }
-        _fout.close().get();
+        _fout->close().get();
     }
 
     ss::server_socket _server_socket;
     ss::connected_socket _socket;
-    ss::input_stream<char> _fin;
-    ss::output_stream<char> _fout;
+    std::optional<ss::input_stream<char>> _fin;
+    std::optional<ss::output_stream<char>> _fout;
     ss::sstring _expected_data;
     std::vector<ss::sstring> _response;
     ss::gate _gate;

--- a/src/v/kafka/client/transport.h
+++ b/src/v/kafka/client/transport.h
@@ -249,10 +249,10 @@ private:
           std::make_unique<request_entry>(
             this, correlation, is_flexible, timeout));
         auto response_future = it->second->response_promise.get_future();
-        co_await _out.write(iobuf_as_scattered(std::move(buf)));
+        co_await out().write(iobuf_as_scattered(std::move(buf)));
         // return all units to the semaphore before flushing the output
         u.return_all();
-        co_await _out.flush();
+        co_await out().flush();
         auto response_data = co_await std::move(response_future);
         if (response_data.has_error()) {
             co_return ret_t(response_data.error());

--- a/src/v/net/batched_output_stream.h
+++ b/src/v/net/batched_output_stream.h
@@ -49,7 +49,10 @@ class batched_output_stream {
 public:
     static constexpr size_t default_max_unflushed_bytes = 1024 * 1024;
 
-    batched_output_stream() = default;
+    // default-constructed ss::output_streams are deprecated so don't offer
+    // default constructor here either - if you need deferred construction
+    // consider std::optional<batched_output_stream>.
+    batched_output_stream() = delete;
     explicit batched_output_stream(
       ss::output_stream<char>, size_t cache = default_max_unflushed_bytes);
     ~batched_output_stream() noexcept = default;

--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -146,6 +146,19 @@ bool is_invalid_character_error(std::exception_ptr e) {
     }
 }
 
+namespace {
+ss::input_stream<char> get_input_stream(
+  ss::connected_socket& fd, std::optional<size_t> in_max_buffer_size) {
+    if (in_max_buffer_size.has_value()) {
+        auto in_config = ss::connected_socket_input_stream_config{};
+        in_config.max_buffer_size = in_max_buffer_size.value();
+        return fd.input(in_config);
+    } else {
+        return fd.input();
+    }
+}
+} // namespace
+
 connection::connection(
   boost::intrusive::list<connection>& hook,
   ss::sstring name,
@@ -160,19 +173,11 @@ connection::connection(
   , _name(std::move(name))
   , _fd(std::move(f))
   , _local_addr(_fd.local_address())
-  , _in(_fd.input())
+  , _in(get_input_stream(_fd, in_max_buffer_size))
   , _out(_fd.output())
   , _probe(p)
   , _tls_enabled(tls_enabled)
   , _log(log) {
-    if (in_max_buffer_size.has_value()) {
-        auto in_config = ss::connected_socket_input_stream_config{};
-        in_config.max_buffer_size = in_max_buffer_size.value();
-        _in = _fd.input(in_config);
-    } else {
-        _in = _fd.input();
-    }
-
     _hook.push_back(*this);
     _probe.connection_established();
 }

--- a/src/v/net/transport.cc
+++ b/src/v/net/transport.cc
@@ -1,5 +1,6 @@
 #include "net/transport.h"
 
+#include "base/compiler_utils.h"
 #include "base/vassert.h"
 #include "base/vlog.h"
 #include "net/dns.h"
@@ -53,12 +54,15 @@ ss::future<> base_transport::do_connect(clock_type::time_point timeout) {
           resolved_address, timeout, _log);
 
         if (_creds) {
+            // CORE-14958
+            REDPANDA_BEGIN_IGNORE_DEPRECATIONS
             fd = co_await ss::tls::wrap_client(
               _creds,
               std::move(fd),
               ss::tls::tls_options{
                 .wait_for_eof_on_shutdown = _wait_for_tls_server_eof,
                 .server_name = _tls_sni_hostname.value_or("")});
+            REDPANDA_END_IGNORE_DEPRECATIONS
         }
         _fd = std::make_unique<ss::connected_socket>(std::move(fd));
         if (auto* p = _probe.value_or(nullptr); p != nullptr) {

--- a/src/v/net/transport.cc
+++ b/src/v/net/transport.cc
@@ -72,7 +72,9 @@ ss::future<> base_transport::do_connect(clock_type::time_point timeout) {
 
         // Never implicitly destroy a live output stream here: output streams
         // are only safe to destroy after/during stop()
-        vassert(!_out.is_valid(), "destroyed output_stream without stopping");
+        vassert(
+          !_out.has_value() || !_out->is_valid(),
+          "destroyed output_stream without stopping");
         _out = net::batched_output_stream(_fd->output());
     } catch (...) {
         auto e = std::current_exception();
@@ -123,7 +125,9 @@ ss::future<> base_transport::stop() {
     // close(), and this class may be destroyed after stop() is called.
 
     try {
-        co_await _out.stop();
+        if (_out.has_value()) {
+            co_await _out->stop();
+        }
     } catch (...) {
         // Closing the output stream can throw bad pipe if
         // it had unflushed bytes, as we already closed FD.
@@ -132,10 +136,15 @@ ss::future<> base_transport::stop() {
           "Exception while stopping transport: {}",
           std::current_exception());
     }
-    // Invalidate _out here, so that do_connect can assert that
+
+    // Set _out to nullopt here, so that do_connect can assert that
     // it isn't dropping an un-stopped output stream when it
-    // assigns to _out
-    _out = {};
+    // assigns to _out. Note that this happens even if _out->stop()
+    // above throws: because the most common case is that the flush
+    // implied by stop(), but close() still closes the stream in that
+    // case using a finally. So though we don't *know* if stop() closed
+    // the underlying stream, we *hope* it did.
+    _out = std::nullopt;
 
     if (_in.has_value()) {
         co_await _in->close();

--- a/src/v/net/transport.h
+++ b/src/v/net/transport.h
@@ -111,7 +111,16 @@ protected:
         return *_in;
     }
 
-    net::batched_output_stream _out;
+    const net::batched_output_stream& out() const {
+        vassert(_out.has_value(), "output stream not initialized");
+        return *_out;
+    }
+
+    net::batched_output_stream& out() {
+        vassert(_out.has_value(), "output stream not initialized");
+        return *_out;
+    }
+
     ss::gate _dispatch_gate;
 
 private:
@@ -119,6 +128,7 @@ private:
 
     std::unique_ptr<ss::connected_socket> _fd;
     std::optional<ss::input_stream<char>> _in;
+    std::optional<net::batched_output_stream> _out;
 
     unresolved_address _server_addr;
     ss::shared_ptr<ss::tls::certificate_credentials> _creds;

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -346,7 +346,7 @@ ss::future<> transport::do_dispatch_send() {
           auto units = std::move(resp_entry->resource_units);
           auto msg_size = v.size();
 
-          auto f = _out.write(std::move(v));
+          auto f = out().write(std::move(v));
           resp_entry->timing.dispatched_at = clock_type::now();
           vlog(
             rpclog.trace,


### PR DESCRIPTION
An additional (and likely last) round of changes needed for the seastar rebase, but which don't depend
on the rebase.

Details in each change.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
