### PR TITLE
ct/l0: Share, don't copy, downloaded object when caching

### DIFF
--- a/src/v/cloud_topics/level_zero/reader/materialized_extent.cc
+++ b/src/v/cloud_topics/level_zero/reader/materialized_extent.cc
@@ -268,7 +268,6 @@ ss::future<result<iobuf>> materialize_from_cloud_storage(
         co_return conv(dl_result.value());
     }
 
-    auto buf_str = make_iobuf_input_stream(payload.copy());
     // TODO: use circuit-breaker here, if the operation fails
     // repeatedly it can be temporarily short-circuited to avoid
     // burning cycles.
@@ -290,6 +289,7 @@ ss::future<result<iobuf>> materialize_from_cloud_storage(
     if (sr_guard.has_value()) {
         // TODO: use proper priority class
         probe->num_cache_writes++;
+        auto buf_str = make_iobuf_input_stream(payload.share());
         auto put_future = co_await ss::coroutine::as_future(
           cache->put(cache_file_name, buf_str, sr_guard.value()));
 


### PR DESCRIPTION
Use iobuf::share not iobuf::copy to obtain an iobuf to read into the cloud storage cache. This eliminates an extra copy of a fairly hefty (~4MiB usually) buffer, reducing peak memory usage of the L0 fetch.

Very minor: I moved the creation of the input stream so it happens after we obtain the space reservation for the object.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
