### PR TITLE
[UX-755] rpk: add spinner for long-running operations

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -266,6 +266,7 @@ use_repo(
     "com_github_avast_retry_go",
     "com_github_aws_aws_sdk_go",
     "com_github_beevik_ntp",
+    "com_github_briandowns_spinner",
     "com_github_bufbuild_protocompile",
     "com_github_cespare_xxhash",
     "com_github_containerd_errdefs",

--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.55.6
 	github.com/beevik/ntp v1.5.0
+	github.com/briandowns/spinner v1.23.2
 	github.com/bufbuild/protocompile v0.14.1
 	github.com/cespare/xxhash v1.1.0
 	github.com/containerd/errdefs v1.0.0

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -44,6 +44,8 @@ github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPn
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/beevik/ntp v1.5.0 h1:y+uj/JjNwlY2JahivxYvtmv4ehfi3h74fAuABB9ZSM4=
 github.com/beevik/ntp v1.5.0/go.mod h1:mJEhBrwT76w9D+IfOEGvuzyuudiW9E52U2BaTrMOYow=
+github.com/briandowns/spinner v1.23.2 h1:Zc6ecUnI+YzLmJniCfDNaMbW0Wid1d5+qcTq4L2FW8w=
+github.com/briandowns/spinner v1.23.2/go.mod h1:LaZeM4wm2Ywy6vO571mvhQNRcWfRUnXOs0RcKV0wYKM=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=

--- a/src/go/rpk/pkg/cli/shadow/create.go
+++ b/src/go/rpk/pkg/cli/shadow/create.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"buf.build/gen/go/redpandadata/cloud/connectrpc/go/redpanda/api/controlplane/v1/controlplanev1connect"
@@ -86,7 +87,6 @@ Create a Shadow Link without confirmation prompt:
 					out.Exit("Shadow Link creation cancelled")
 				}
 			}
-			fmt.Println()
 
 			successMsgTmpl := "Successfully created shadow link %q with ID %q. To query the status, run:\n  'rpk shadow status %[1]v'"
 			if prof.CheckFromCloud() {
@@ -103,24 +103,31 @@ Create a Shadow Link without confirmation prompt:
 				}))
 				out.MaybeDie(err, "unable to create Shadow Link: %v", err)
 
+				spinner := out.NewSpinner(cmd.Context(), "Creating Shadow Link...", out.WithElapsedTime())
 				isComplete, err := waitForOperation(cmd.Context(), cloudClient, op.Msg.GetOperation().GetId())
 				if err != nil {
 					if oErr := new(OperationFailedError); errors.As(err, &oErr) {
-						out.Die(tryShadowLinkErrReason(cmd.Context(), cloudClient.ShadowLink, oErr))
+						spinner.Fail(tryShadowLinkErrReason(cmd.Context(), cloudClient.ShadowLink, oErr))
+						os.Exit(1)
 					}
-					out.Die("unable to confirm Shadow Link creation: %v", err)
+					spinner.Fail(fmt.Sprintf("unable to confirm Shadow Link creation: %v", err))
+					os.Exit(1)
 				}
 				if isComplete {
-					out.Exit(successMsgTmpl, slCfg.Name, op.Msg.GetOperation().GetResourceId())
+					spinner.Success(fmt.Sprintf(successMsgTmpl, slCfg.Name, op.Msg.GetOperation().GetResourceId()))
+					os.Exit(0)
 				}
+				spinner.Stop()
 				out.Exit("Shadow link creation is taking longer than expected. Please check the state of the shadow link using 'rpk shadow describe %v' and 'rpk shadow status %v'", slCfg.Name, slCfg.Name)
 			}
 			cl, err := adminapi.NewClient(cmd.Context(), fs, prof)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
+			spinner := out.NewSpinner(cmd.Context(), "Creating Shadow Link...")
 			link, err := cl.ShadowLinkService().CreateShadowLink(cmd.Context(), connect.NewRequest(&adminv2.CreateShadowLinkRequest{
 				ShadowLink: shadowLinkConfigToProto(slCfg),
 			}))
+			spinner.Stop()
 			out.MaybeDie(err, "unable to create shadow link: %v", handleConnectError(err, "create", slCfg.Name))
 
 			out.Exit(successMsgTmpl, link.Msg.GetShadowLink().GetName(), link.Msg.GetShadowLink().GetUid())

--- a/src/go/rpk/pkg/cli/shadow/delete.go
+++ b/src/go/rpk/pkg/cli/shadow/delete.go
@@ -11,6 +11,7 @@ package shadow
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	controlplanev1 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1"
@@ -100,28 +101,35 @@ Force delete a Shadow Link with active shadow topics:
 				}))
 				out.MaybeDie(err, "unable to delete Shadow Link: %v", err)
 
+				spinner := out.NewSpinner(cmd.Context(), "Deleting Shadow Link...", out.WithElapsedTime())
 				isComplete, err := waitForOperation(cmd.Context(), cloudClient, op.Msg.GetOperation().GetId())
-				out.MaybeDie(err, "unable to confirm Shadow Link deletion: %v", err)
+				if err != nil {
+					spinner.Fail(fmt.Sprintf("unable to confirm Shadow Link deletion: %v", err))
+					os.Exit(1)
+				}
 				if !isComplete {
+					spinner.Stop()
 					out.Exit("Shadow link deletion is taking longer than expected. Please check the status of the shadow link using 'rpk shadow status %q'", linkName)
 				}
-			} else {
-				cl, err := adminapi.NewClient(cmd.Context(), fs, prof)
-				out.MaybeDie(err, "unable to initialize admin client: %v", err)
-
-				link, err := cl.ShadowLinkService().GetShadowLink(cmd.Context(), connect.NewRequest(&adminv2.GetShadowLinkRequest{
-					Name: linkName,
-				}))
-				out.MaybeDie(err, "unable to get Redpanda Shadow Link information: %v", handleConnectError(err, "get", linkName))
-				printShadowLinkInfo(link.Msg.GetShadowLink())
-				promptConfirm(false)
-
-				_, err = cl.ShadowLinkService().DeleteShadowLink(cmd.Context(), connect.NewRequest(&adminv2.DeleteShadowLinkRequest{
-					Name:  linkName,
-					Force: forceDelete,
-				}))
-				out.MaybeDie(err, "unable to delete Redpanda Shadow Link %q: %v", linkName, handleConnectError(err, "delete", linkName))
+				spinner.Success(fmt.Sprintf("Shadow Link %q deleted successfully", linkName))
+				os.Exit(0)
 			}
+			// Self-hosted path
+			cl, err := adminapi.NewClient(cmd.Context(), fs, prof)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			link, err := cl.ShadowLinkService().GetShadowLink(cmd.Context(), connect.NewRequest(&adminv2.GetShadowLinkRequest{
+				Name: linkName,
+			}))
+			out.MaybeDie(err, "unable to get Redpanda Shadow Link information: %v", handleConnectError(err, "get", linkName))
+			printShadowLinkInfo(link.Msg.GetShadowLink())
+			promptConfirm(false)
+
+			_, err = cl.ShadowLinkService().DeleteShadowLink(cmd.Context(), connect.NewRequest(&adminv2.DeleteShadowLinkRequest{
+				Name:  linkName,
+				Force: forceDelete,
+			}))
+			out.MaybeDie(err, "unable to delete Redpanda Shadow Link %q: %v", linkName, handleConnectError(err, "delete", linkName))
 
 			fmt.Printf("Shadow Link %q deleted successfully\n", linkName)
 		},

--- a/src/go/rpk/pkg/cli/shadow/update.go
+++ b/src/go/rpk/pkg/cli/shadow/update.go
@@ -11,6 +11,7 @@ package shadow
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 
@@ -142,23 +143,30 @@ Update a Shadow Link configuration:
 					UpdateMask: fm,
 				}))
 				out.MaybeDie(err, "unable to update Shadow Link: %v", handleConnectError(err, "update", linkName))
+				spinner := out.NewSpinner(cmd.Context(), "Updating Shadow Link...")
 				isComplete, err := waitForOperation(cmd.Context(), cloudClient, op.Msg.GetOperation().GetId())
-				out.MaybeDie(err, "unable to confirm Shadow Link update: %v", err)
+				if err != nil {
+					spinner.Fail(fmt.Sprintf("unable to confirm Shadow Link update: %v", err))
+					os.Exit(1)
+				}
 				if !isComplete {
+					spinner.Stop()
 					out.Exit("Shadow link update is taking longer than expected. Please check the status of the shadow link using 'rpk shadow status %q'", linkName)
 				}
-			} else {
-				updatedSL := shadowLinkConfigToProto(updatedCfg)
-				fm, err := fieldmaskpb.New(updatedSL, diff...)
-				out.MaybeDie(err, "unrecognized changed fields: %v; please report this with Redpanda Support", err)
-
-				zap.L().Sugar().Debugf("Requesting configuration update for: %v", strings.Join(diff, ", "))
-				_, err = adminClient.ShadowLinkService().UpdateShadowLink(cmd.Context(), connect.NewRequest(&adminv2.UpdateShadowLinkRequest{
-					ShadowLink: updatedSL,
-					UpdateMask: fm,
-				}))
-				out.MaybeDie(err, "unable to update Shadow Link: %v", handleConnectError(err, "update", linkName))
+				spinner.Success(fmt.Sprintf("Successfully updated shadow link %q", linkName))
+				os.Exit(0)
 			}
+			// Self-hosted path
+			updatedSL := shadowLinkConfigToProto(updatedCfg)
+			fm, err := fieldmaskpb.New(updatedSL, diff...)
+			out.MaybeDie(err, "unrecognized changed fields: %v; please report this with Redpanda Support", err)
+
+			zap.L().Sugar().Debugf("Requesting configuration update for: %v", strings.Join(diff, ", "))
+			_, err = adminClient.ShadowLinkService().UpdateShadowLink(cmd.Context(), connect.NewRequest(&adminv2.UpdateShadowLinkRequest{
+				ShadowLink: updatedSL,
+				UpdateMask: fm,
+			}))
+			out.MaybeDie(err, "unable to update Shadow Link: %v", handleConnectError(err, "update", linkName))
 			fmt.Printf("Successfully updated shadow link %q.\n", linkName)
 		},
 	}

--- a/src/go/rpk/pkg/out/BUILD
+++ b/src/go/rpk/pkg/out/BUILD
@@ -6,12 +6,15 @@ go_library(
         "color.go",
         "in.go",
         "out.go",
+        "spinner.go",
     ],
     importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/out",
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_alecaivazis_survey_v2//:survey",
+        "@com_github_briandowns_spinner//:spinner",
         "@com_github_fatih_color//:color",
+        "@com_github_mattn_go_isatty//:go-isatty",
         "@com_github_spf13_afero//:afero",
         "@com_github_twmb_franz_go_pkg_kadm//:kadm",
         "@in_gopkg_yaml_v3//:yaml_v3",
@@ -24,6 +27,7 @@ go_test(
     srcs = [
         "in_test.go",
         "out_test.go",
+        "spinner_test.go",
     ],
     embed = [":out"],
     deps = [

--- a/src/go/rpk/pkg/out/spinner.go
+++ b/src/go/rpk/pkg/out/spinner.go
@@ -1,0 +1,205 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package out
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/mattn/go-isatty"
+)
+
+// Spinner provides animated progress indication for long-running operations.
+// In TTY environments, it displays an animated spinner with elapsed time.
+// In non-TTY environments, it gracefully degrades to simple text output.
+type Spinner struct {
+	spinner     *spinner.Spinner
+	mu          sync.Mutex
+	isTTY       bool
+	output      io.Writer
+	stopped     bool
+	startTime   time.Time
+	showElapsed bool
+	message     string
+	cancel      context.CancelFunc
+}
+
+// spinnerConfig holds configuration options for the spinner.
+type spinnerConfig struct {
+	output      io.Writer
+	showElapsed bool
+}
+
+// SpinnerOption configures a Spinner.
+type SpinnerOption func(*spinnerConfig)
+
+// WithOutput sets the output writer for the spinner.
+// Defaults to os.Stdout.
+func WithOutput(w io.Writer) SpinnerOption {
+	return func(c *spinnerConfig) {
+		c.output = w
+	}
+}
+
+// WithElapsedTime enables showing elapsed time in the spinner message.
+// When enabled, the spinner displays "(Xs elapsed)" after the message.
+func WithElapsedTime() SpinnerOption {
+	return func(c *spinnerConfig) {
+		c.showElapsed = true
+	}
+}
+
+// isTerminal checks if the given writer is a terminal.
+func isTerminal(w io.Writer) bool {
+	if f, ok := w.(*os.File); ok {
+		return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
+	}
+	return false
+}
+
+// NewSpinner creates and starts a new spinner with the given message.
+// The spinner runs in a background goroutine until Stop(), Success(),
+// or Fail() is called. The context is used for cancellation, if the
+// context is cancelled, the spinner will stop automatically.
+//
+// In non-TTY environments, the spinner degrades gracefully - no animation
+// is shown, only the final message when stopped.
+//
+// Example:
+//
+//	spinner := out.NewSpinner(ctx, "Creating shadow link...")
+//	defer spinner.Stop()
+//	// ... do work ...
+//	spinner.Success("Shadow link created")
+func NewSpinner(ctx context.Context, message string, opts ...SpinnerOption) *Spinner {
+	cfg := &spinnerConfig{
+		output: os.Stdout,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	s := &Spinner{
+		output:      cfg.output,
+		isTTY:       isTerminal(cfg.output),
+		startTime:   time.Now(),
+		showElapsed: cfg.showElapsed,
+		message:     message,
+	}
+
+	if !s.isTTY {
+		// Non-TTY: print message once, no animation
+		fmt.Fprintln(s.output, message)
+		return s
+	}
+
+	// TTY: start animated spinner
+	// CharSets[11] is the dot spinner (⣾)
+	sp := spinner.New(spinner.CharSets[11], 100*time.Millisecond, spinner.WithWriter(cfg.output))
+	sp.Suffix = " " + message
+	s.spinner = sp
+	sp.Start()
+
+	// If elapsed time is enabled, start a goroutine to update the suffix.
+	// We create a child context so we can cancel the goroutine when the
+	// spinner stops, without affecting the parent context.
+	if s.showElapsed {
+		ctx, cancel := context.WithCancel(ctx)
+		s.cancel = cancel
+		go s.updateElapsedTime(ctx)
+	}
+
+	return s
+}
+
+// updateElapsedTime periodically updates the spinner suffix with elapsed time.
+func (s *Spinner) updateElapsedTime(ctx context.Context) {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.mu.Lock()
+			if s.stopped || s.spinner == nil {
+				s.mu.Unlock()
+				return
+			}
+			elapsed := time.Since(s.startTime).Truncate(time.Second)
+			s.spinner.Suffix = fmt.Sprintf(" %s (%v elapsed)", s.message, elapsed)
+			s.mu.Unlock()
+		}
+	}
+}
+
+// Stop stops the spinner without displaying a final message.
+// Safe to call multiple times.
+func (s *Spinner) Stop() {
+	s.stopWith("")
+}
+
+// Success stops the spinner and displays a success message with a ✓ checkmark.
+func (s *Spinner) Success(message string) {
+	s.stopWith(fmt.Sprintf("\u2713 %s\n", message))
+}
+
+// Fail stops the spinner and displays an error message with an ✗.
+func (s *Spinner) Fail(message string) {
+	s.stopWith(fmt.Sprintf("\u2717 %s\n", message))
+}
+
+// UpdateMessage updates the spinner's message while it's running.
+func (s *Spinner) UpdateMessage(message string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.stopped || s.spinner == nil {
+		return
+	}
+
+	s.message = message
+	if s.showElapsed {
+		elapsed := time.Since(s.startTime).Truncate(time.Second)
+		s.spinner.Suffix = fmt.Sprintf(" %s (%v elapsed)", message, elapsed)
+	} else {
+		s.spinner.Suffix = " " + message
+	}
+}
+
+// stopWith stops the spinner and displays the given final message.
+func (s *Spinner) stopWith(finalMsg string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.stopped {
+		return
+	}
+	s.stopped = true
+
+	// Cancel context to stop elapsed time updater
+	if s.cancel != nil {
+		s.cancel()
+	}
+
+	if s.spinner != nil {
+		s.spinner.FinalMSG = finalMsg
+		s.spinner.Stop()
+	} else if finalMsg != "" {
+		// Non-TTY mode: just print the final message
+		fmt.Fprint(s.output, finalMsg)
+	}
+}

--- a/src/go/rpk/pkg/out/spinner_test.go
+++ b/src/go/rpk/pkg/out/spinner_test.go
@@ -1,0 +1,93 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package out
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests use bytes.Buffer which is detected as non-TTY,
+// so they test the graceful degradation path.
+
+func TestSpinner_NonTTY_Success(t *testing.T) {
+	buf := new(bytes.Buffer)
+	spinner := NewSpinner(context.Background(), "Working...", WithOutput(buf))
+	spinner.Success("Done successfully")
+
+	output := buf.String()
+	require.Contains(t, output, "Working...")
+	require.Contains(t, output, "\u2713 Done successfully")
+}
+
+func TestSpinner_NonTTY_Fail(t *testing.T) {
+	buf := new(bytes.Buffer)
+	spinner := NewSpinner(context.Background(), "Working...", WithOutput(buf))
+	spinner.Fail("Something went wrong")
+
+	output := buf.String()
+	require.Contains(t, output, "Working...")
+	require.Contains(t, output, "\u2717 Something went wrong")
+}
+
+func TestSpinner_NonTTY_Stop(t *testing.T) {
+	buf := new(bytes.Buffer)
+	spinner := NewSpinner(context.Background(), "Working...", WithOutput(buf))
+	spinner.Stop()
+
+	output := buf.String()
+	require.Contains(t, output, "Working...")
+	// Stop without message should not add extra output
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	require.Len(t, lines, 1)
+}
+
+func TestSpinner_MultipleStops(t *testing.T) {
+	buf := new(bytes.Buffer)
+	spinner := NewSpinner(context.Background(), "Working...", WithOutput(buf))
+
+	// Multiple stops should be safe
+	spinner.Stop()
+	spinner.Stop()
+	spinner.Success("This should not print")
+
+	output := buf.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	require.Len(t, lines, 1) // Only the initial message
+}
+
+func TestSpinner_SuccessThenFail(t *testing.T) {
+	buf := new(bytes.Buffer)
+	spinner := NewSpinner(context.Background(), "Working...", WithOutput(buf))
+
+	spinner.Success("Done")
+	spinner.Fail("This should not print") // Already stopped
+
+	output := buf.String()
+	require.Contains(t, output, "\u2713 Done")
+	require.NotContains(t, output, "\u2717")
+}
+
+func TestSpinner_UpdateMessage_NonTTY(t *testing.T) {
+	buf := new(bytes.Buffer)
+	spinner := NewSpinner(context.Background(), "Initial message...", WithOutput(buf))
+
+	// UpdateMessage in non-TTY mode is a no-op (no program running)
+	spinner.UpdateMessage("Updated message")
+	spinner.Success("Done")
+
+	output := buf.String()
+	require.Contains(t, output, "Initial message...")
+	require.Contains(t, output, "\u2713 Done")
+}


### PR DESCRIPTION
Introduce a spinner component for visual feedback during long-running operations. The spinner:

- Supports context cancellation
- Gracefully degrades to simple text output in non-TTY environments
- Allows Ctrl+C to terminate the command properly

Add WithElapsedTime option to display elapsed time for operations that may take more than ~5 seconds, such as Shadow Link create, update, and delete in cloud environments where we poll for operation completion.

![Kapture 2025-12-18 at 11 14 46](https://github.com/user-attachments/assets/993a9728-4918-4f16-a8c8-c3f0a069f47f)


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


### Improvements

* `rpk shadow` now has visual feedback on long-running operations.