### PR TITLE
[CORE-15334] ct: Introduce new scheduling algorithm for lower latency

### DIFF
--- a/src/v/cloud_topics/level_zero/batcher/BUILD
+++ b/src/v/cloud_topics/level_zero/batcher/BUILD
@@ -65,6 +65,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_zero/pipeline:write_request",
         "//src/v/config",
         "//src/v/model",
+        "//src/v/ssx:semaphore",
         "//src/v/utils:retry_chain_node",
         "//src/v/utils:uuid",
         "@abseil-cpp//absl/container:btree",

--- a/src/v/cloud_topics/level_zero/batcher/aggregator.cc
+++ b/src/v/cloud_topics/level_zero/batcher/aggregator.cc
@@ -90,7 +90,7 @@ iobuf aggregator<Clock>::get_stream() {
     iobuf concat;
     for (auto& p : _aggregated) {
         if (p->ref != nullptr) {
-            concat.append(std::move(p->ref->data_chunk.payload));
+            concat.append_fragments(std::move(p->ref->data_chunk.payload));
         }
     }
     return concat;

--- a/src/v/cloud_topics/level_zero/batcher/batcher.cc
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.cc
@@ -256,7 +256,9 @@ ss::future<> batcher<Clock>::bg_controller_loop() {
 
         auto list = _stage.pull_write_requests(
           config::shard_local_cfg()
-            .cloud_topics_produce_batching_size_threshold());
+            .cloud_topics_produce_batching_size_threshold(),
+          config::shard_local_cfg()
+            .cloud_topics_produce_cardinality_threshold());
 
         bool complete = list.complete;
 

--- a/src/v/cloud_topics/level_zero/batcher/batcher.cc
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.cc
@@ -258,6 +258,8 @@ ss::future<> batcher<Clock>::bg_controller_loop() {
           config::shard_local_cfg()
             .cloud_topics_produce_batching_size_threshold());
 
+        bool complete = list.complete;
+
         // We can spawn the work in the background without worrying about memory
         // usage because the pipeline tracks the memory usage for us and will
         // stop accepting new write requests if we go over the limit.
@@ -278,6 +280,12 @@ ss::future<> batcher<Clock>::bg_controller_loop() {
                   }
               });
         });
+
+        // The work is spawned in the background so we can grab data for the
+        // next L0 object. If complete==true, all pending requests were pulled,
+        // so wait for more. If complete==false, there are more pending
+        // requests.
+        more_work = !complete;
     }
 }
 

--- a/src/v/cloud_topics/level_zero/batcher/batcher.cc
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.cc
@@ -51,7 +51,10 @@ batcher<Clock>::batcher(
   , _rtc(_as)
   , _logger(cd_log, _rtc)
   , _stage(std::move(stage))
-  , _probe(config::shard_local_cfg().disable_metrics()) {}
+  , _probe(config::shard_local_cfg().disable_metrics())
+  , _upload_sem(
+      config::shard_local_cfg().cloud_storage_max_connections(), "l0/batcher") {
+}
 
 template<class Clock>
 ss::future<> batcher<Clock>::start() {
@@ -254,6 +257,11 @@ ss::future<> batcher<Clock>::bg_controller_loop() {
             co_return;
         }
 
+        // Acquire semaphore units to limit concurrent background fibers.
+        // This blocks until a slot is available.
+        auto units_fut = co_await ss::coroutine::as_future(
+          ss::get_units(_upload_sem, 1, _as));
+
         auto list = _stage.pull_write_requests(
           config::shard_local_cfg()
             .cloud_topics_produce_batching_size_threshold(),
@@ -262,26 +270,37 @@ ss::future<> batcher<Clock>::bg_controller_loop() {
 
         bool complete = list.complete;
 
+        if (units_fut.failed()) {
+            vlog(
+              _logger.info,
+              "Batcher upload loop is shutting down: {}",
+              units_fut.get_exception());
+            co_return;
+        }
+        auto units = std::move(units_fut.get());
+
         // We can spawn the work in the background without worrying about memory
-        // usage because the pipeline tracks the memory usage for us and will
-        // stop accepting new write requests if we go over the limit.
-        ssx::spawn_with_gate(_gate, [this, list = std::move(list)]() mutable {
-            return run_once(std::move(list))
-              .then([this](std::expected<std::monostate, errc> res) {
-                  if (!res.has_value()) {
-                      if (res.error() == errc::shutting_down) {
-                          vlog(
-                            _logger.info,
-                            "Batcher upload loop is shutting down");
-                      } else {
-                          vlog(
-                            _logger.info,
-                            "Batcher upload loop error: {}",
-                            res.error());
-                      }
-                  }
-              });
-        });
+        // usage because the background fibers is holding units acquired above.
+        ssx::spawn_with_gate(
+          _gate,
+          [this, list = std::move(list), units = std::move(units)]() mutable {
+              return run_once(std::move(list))
+                .then([this](std::expected<std::monostate, errc> res) {
+                    if (!res.has_value()) {
+                        if (res.error() == errc::shutting_down) {
+                            vlog(
+                              _logger.info,
+                              "Batcher upload loop is shutting down");
+                        } else {
+                            vlog(
+                              _logger.info,
+                              "Batcher upload loop error: {}",
+                              res.error());
+                        }
+                    }
+                })
+                .finally([u = std::move(units)] {});
+          });
 
         // The work is spawned in the background so we can grab data for the
         // next L0 object. If complete==true, all pending requests were pulled,

--- a/src/v/cloud_topics/level_zero/batcher/batcher.cc
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.cc
@@ -255,7 +255,8 @@ ss::future<> batcher<Clock>::bg_controller_loop() {
         }
 
         auto list = _stage.pull_write_requests(
-          10_MiB); // TODO: use configuration parameter
+          config::shard_local_cfg()
+            .cloud_topics_produce_batching_size_threshold());
 
         // We can spawn the work in the background without worrying about memory
         // usage because the pipeline tracks the memory usage for us and will

--- a/src/v/cloud_topics/level_zero/batcher/batcher.h
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.h
@@ -24,6 +24,7 @@
 #include "config/property.h"
 #include "model/fundamental.h"
 #include "model/record_batch_reader.h"
+#include "ssx/semaphore.h"
 #include "utils/retry_chain_node.h"
 #include "utils/uuid.h"
 
@@ -121,5 +122,8 @@ private:
     write_pipeline<Clock>::stage _stage;
 
     batcher_probe _probe;
+
+    // Limit the number of concurrent background fibers running run_once
+    ssx::named_semaphore<Clock> _upload_sem;
 };
 } // namespace cloud_topics::l0

--- a/src/v/cloud_topics/level_zero/common/level_zero_probe.cc
+++ b/src/v/cloud_topics/level_zero/common/level_zero_probe.cc
@@ -211,31 +211,16 @@ void write_request_scheduler_probe::setup_internal_metrics(bool disable) {
     _metrics.add_group(
       prometheus_sanitize::metrics_name("cloud_topics_write_request_scheduler"),
       {sm::make_counter(
-         "data_threshold_requests",
-         [this] { return _data_threshold_requests; },
+         "scheduler_requests",
+         [this] { return _scheduler_requests; },
          sm::description(
-           "Number of write requests scheduled by data threshold policy."),
+           "Number of write requests scheduled by the scheduler."),
          labels),
 
        sm::make_counter(
-         "data_threshold_bytes",
-         [this] { return _data_threshold_bytes; },
-         sm::description(
-           "Total number of bytes scheduled by data threshold policy."),
-         labels),
-
-       sm::make_counter(
-         "time_fallback_requests",
-         [this] { return _time_fallback_requests; },
-         sm::description(
-           "Number of write requests scheduled by time based fallback policy."),
-         labels),
-
-       sm::make_counter(
-         "time_fallback_bytes",
-         [this] { return _time_fallback_bytes; },
-         sm::description(
-           "Total number of bytes scheduled by time based fallback policy."),
+         "scheduler_bytes",
+         [this] { return _scheduler_bytes; },
+         sm::description("Total number of bytes scheduled by scheduler."),
          labels),
 
        sm::make_counter(

--- a/src/v/cloud_topics/level_zero/common/level_zero_probe.cc
+++ b/src/v/cloud_topics/level_zero/common/level_zero_probe.cc
@@ -246,6 +246,12 @@ void write_request_scheduler_probe::setup_internal_metrics(bool disable) {
          "rx_bytes_xshard",
          [this] { return _rx_bytes_xshard; },
          sm::description("Total number of bytes received from another shard."),
+         labels),
+
+       sm::make_gauge(
+         "active_groups",
+         [this] { return _active_groups; },
+         sm::description("Number of active upload groups in the scheduler."),
          labels)});
 }
 batcher_probe::batcher_probe(bool disable) { setup_internal_metrics(disable); }

--- a/src/v/cloud_topics/level_zero/common/level_zero_probe.h
+++ b/src/v/cloud_topics/level_zero/common/level_zero_probe.h
@@ -97,14 +97,9 @@ class write_request_scheduler_probe {
 public:
     explicit write_request_scheduler_probe(bool disable);
 
-    void register_data_threshold(size_t bytes) {
-        _data_threshold_requests += 1;
-        _data_threshold_bytes += bytes;
-    }
-
-    void register_time_fallback(size_t bytes) {
-        _time_fallback_requests += 1;
-        _time_fallback_bytes += bytes;
+    void register_request(size_t bytes) {
+        _scheduler_requests += 1;
+        _scheduler_bytes += bytes;
     }
 
     void register_send_xshard(size_t bytes) {
@@ -120,20 +115,16 @@ public:
 private:
     void setup_internal_metrics(bool disable);
 
-    /// Number of write requests and total bytes scheduled by data threshold
-    /// policy.
-    uint64_t _data_threshold_requests{0};
-    uint64_t _data_threshold_bytes{0};
-    /// Number of write requests and total bytes scheduled by time based
-    /// fallback policy.
-    uint64_t _time_fallback_requests{0};
-    uint64_t _time_fallback_bytes{0};
+    /// Number of write requests and total bytes scheduled
+    uint64_t _scheduler_requests{0};
+    uint64_t _scheduler_bytes{0};
     /// Number of requests and total bytes proxied to another shard
     uint64_t _tx_requests_xshard{0};
     uint64_t _tx_bytes_xshard{0};
     /// Number of requests and total bytes received from another shard
     uint64_t _rx_requests_xshard{0};
     uint64_t _rx_bytes_xshard{0};
+
     metrics::internal_metric_groups _metrics;
 };
 

--- a/src/v/cloud_topics/level_zero/common/level_zero_probe.h
+++ b/src/v/cloud_topics/level_zero/common/level_zero_probe.h
@@ -112,6 +112,8 @@ public:
         _rx_bytes_xshard += bytes;
     }
 
+    void set_active_groups(uint64_t count) { _active_groups = count; }
+
 private:
     void setup_internal_metrics(bool disable);
 
@@ -124,6 +126,8 @@ private:
     /// Number of requests and total bytes received from another shard
     uint64_t _rx_requests_xshard{0};
     uint64_t _rx_bytes_xshard{0};
+    /// Number of active upload groups
+    uint64_t _active_groups{0};
 
     metrics::internal_metric_groups _metrics;
 };

--- a/src/v/cloud_topics/level_zero/pipeline/base_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/base_pipeline.h
@@ -191,6 +191,12 @@ protected:
         return _stages.next_stage(s);
     }
 
+    /// Return next stage index without checking if stage is registered.
+    /// This is useful for accessing pre-allocated resources.
+    int next_stage_index(pipeline_stage s) const {
+        return _stages.next_stage_index(s);
+    }
+
     /// Resolve every pending write that matches the predicate with an error.
     template<typename Pred>
     void remove_requests(Pred pred, errc error, std::string_view reason) {

--- a/src/v/cloud_topics/level_zero/pipeline/pipeline_stage.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/pipeline_stage.cc
@@ -50,6 +50,20 @@ pipeline_stage pipeline_stage_container::register_pipeline_stage() noexcept {
     return pipeline_stage(&_stages.at(_registered++));
 }
 
+int pipeline_stage_container::next_stage_index(pipeline_stage old) const {
+    if (old == unassigned_pipeline_stage) {
+        // First stage is index 0
+        return 0;
+    }
+    auto old_ix = old()->get_numeric_id();
+    auto next_ix = old_ix + 1;
+    // Return -1 if we would exceed the allocated stages
+    if (static_cast<size_t>(next_ix) >= _stages.size()) {
+        return -1;
+    }
+    return next_ix;
+}
+
 } // namespace cloud_topics::l0
 
 auto fmt::formatter<cloud_topics::l0::pipeline_stage>::format(

--- a/src/v/cloud_topics/level_zero/pipeline/pipeline_stage.h
+++ b/src/v/cloud_topics/level_zero/pipeline/pipeline_stage.h
@@ -48,6 +48,15 @@ public:
     pipeline_stage first_stage() const;
     pipeline_stage register_pipeline_stage() noexcept;
 
+    /// Get the numeric index of the next stage after the given stage.
+    /// Unlike next_stage(), this method does not check if the next stage
+    /// is registered. It returns the index even if the stage hasn't been
+    /// registered yet. This is useful for accessing pre-allocated resources
+    /// (like counters) that are indexed by stage number.
+    /// \param old The current pipeline stage
+    /// \return The index of the next stage, or -1 if old is unassigned or last
+    int next_stage_index(pipeline_stage old) const;
+
 private:
     std::vector<pipeline_stage_id> _stages;
     size_t _registered{0};

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -401,6 +401,15 @@ write_pipeline<Clock>::stage_bytes_ref(pipeline_stage s) const {
 }
 
 template<class Clock>
+const std::atomic<size_t>*
+write_pipeline<Clock>::stage_bytes_ref_by_index(int index) const {
+    if (index < 0 || static_cast<size_t>(index) >= _stage_bytes.size()) {
+        return nullptr;
+    }
+    return &_stage_bytes[static_cast<size_t>(index)].count;
+}
+
+template<class Clock>
 size_t write_pipeline<Clock>::current_size() const {
     size_t total = 0;
     for (const auto& bytes : _stage_bytes) {

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -270,6 +270,20 @@ void write_pipeline<Clock>::stage::signal_next_stage() {
 }
 
 template<class Clock>
+void write_pipeline<Clock>::stage::enqueue_foreign_request(
+  write_request<Clock>& req, bool signal) {
+    // Foreign requests are proxied from another shard where their bytes
+    // were already accounted for. We place them directly at the next stage
+    // without any byte accounting.
+    auto next = _parent->next_stage(_ps);
+    req.stage = next;
+    _parent->get_pending().push_back(req);
+    if (signal) {
+        _parent->signal(next);
+    }
+}
+
+template<class Clock>
 write_pipeline<Clock>::write_requests_list
 write_pipeline<Clock>::stage::pull_write_requests(
   size_t max_bytes, size_t max_requests) {

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -374,14 +374,23 @@ size_t write_pipeline<Clock>::stage_bytes(pipeline_stage s) const {
     if (s == unassigned_pipeline_stage) {
         return 0;
     }
-    return _stage_bytes[static_cast<size_t>(s()->get_numeric_id())];
+    return _stage_bytes[static_cast<size_t>(s()->get_numeric_id())].count;
+}
+
+template<class Clock>
+const std::atomic<size_t>*
+write_pipeline<Clock>::stage_bytes_ref(pipeline_stage s) const {
+    if (s == unassigned_pipeline_stage) {
+        return nullptr;
+    }
+    return &_stage_bytes[static_cast<size_t>(s()->get_numeric_id())].count;
 }
 
 template<class Clock>
 size_t write_pipeline<Clock>::current_size() const {
     size_t total = 0;
-    for (auto bytes : _stage_bytes) {
-        total += bytes;
+    for (const auto& bytes : _stage_bytes) {
+        total += bytes.count.load(std::memory_order_relaxed);
     }
     return total;
 }

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
@@ -188,6 +188,15 @@ public:
         /// Get pointer to the stage's pending bytes counter
         auto stage_bytes_ref() { return _parent->stage_bytes_ref(_ps); }
 
+        /// Get pointer to the next stage's pending bytes counter.
+        /// Unlike next_stage(), this method returns a valid pointer even if
+        /// the next stage hasn't been registered yet. The counters are
+        /// pre-allocated, so they can be accessed before registration.
+        auto next_stage_bytes_ref() {
+            return _parent->stage_bytes_ref_by_index(
+              _parent->next_stage_index(_ps));
+        }
+
     private:
         /// Pick the right abort source to use.
         ///
@@ -220,6 +229,14 @@ public:
     /// Get the number of bytes at a specific pipeline stage.
     size_t stage_bytes(pipeline_stage s) const;
     const std::atomic<size_t>* stage_bytes_ref(pipeline_stage s) const;
+
+    /// Get pointer to stage bytes counter by index.
+    /// Unlike stage_bytes_ref(pipeline_stage), this method does not require
+    /// the stage to be registered. It returns the pointer to the pre-allocated
+    /// counter at the given index.
+    /// \param index The stage index (0-based)
+    /// \return Pointer to the atomic counter, or nullptr if index is invalid
+    const std::atomic<size_t>* stage_bytes_ref_by_index(int index) const;
 
 private:
     /// Transfer bytes from one stage to another.

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
@@ -97,6 +97,13 @@ public:
         /// to avoid stalling the pipeline.
         void signal_next_stage();
 
+        /// Enqueue a foreign (cross-shard proxied) write request directly to
+        /// the next stage without byte accounting. This is used for requests
+        /// that were accounted for on a different shard.
+        /// \param r Write request to enqueue (must have unassigned stage)
+        /// \param signal If true signal the next stage
+        void enqueue_foreign_request(write_request<Clock>& r, bool signal);
+
         /// Extract write requests out of the pipeline atomically.
         /// The caller is responsible for handling each write request.
         /// The request could be either returned using 'push_next_stage'

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
@@ -178,6 +178,9 @@ public:
             return ss::get_units(_parent->_mem_budget, units);
         }
 
+        /// Get pointer to the stage's pending bytes counter
+        auto stage_bytes_ref() { return _parent->stage_bytes_ref(_ps); }
+
     private:
         /// Pick the right abort source to use.
         ///
@@ -209,6 +212,7 @@ public:
 
     /// Get the number of bytes at a specific pipeline stage.
     size_t stage_bytes(pipeline_stage s) const;
+    const std::atomic<size_t>* stage_bytes_ref(pipeline_stage s) const;
 
 private:
     /// Transfer bytes from one stage to another.
@@ -237,7 +241,17 @@ private:
     void reenqueue(write_request<Clock>& req, bool signal = true);
 
     // Bytes per pipeline stage.
-    std::array<size_t, max_pipeline_stages> _stage_bytes{};
+    struct alignas(std::hardware_destructive_interference_size)
+      padded_atomic_counter {
+        // Always updated on the same shard.
+        // Can be read from any shard.
+        std::atomic<uint64_t> count{0};
+
+        void operator+=(size_t c) { count += c; }
+
+        void operator-=(size_t c) { count -= c; }
+    };
+    std::array<padded_atomic_counter, max_pipeline_stages> _stage_bytes{};
 
     /// Sum of bytes across all pipeline stages.
     size_t current_size() const;

--- a/src/v/cloud_topics/level_zero/tests/l0_object_size_distribution_test.cc
+++ b/src/v/cloud_topics/level_zero/tests/l0_object_size_distribution_test.cc
@@ -41,13 +41,9 @@ static const model::ntp
 
 namespace cloud_topics::l0 {
 struct write_request_balancer_accessor {
-    static void disable_data_threshold_uploads(
-      write_request_scheduler<seastar::manual_clock>* s) {
-        s->_test_only_disable_data_threshold = true;
-    }
-    static void disable_time_based_fallback(
-      write_request_scheduler<seastar::manual_clock>* s) {
-        s->_test_only_disable_time_based_fallback = true;
+    static void
+    disable_background_loop(write_request_scheduler<seastar::manual_clock>* s) {
+        s->_test_only_disable_background_loop = true;
     }
 };
 } // namespace cloud_topics::l0
@@ -112,8 +108,7 @@ public:
 
 class L0ObjectSizeDistFixture : public seastar_test {
 public:
-    ss::future<>
-    start(bool disable_data_threshold, bool disable_time_based_fallback) {
+    ss::future<> start(bool disable_bg_loop) {
         co_await pipeline.start();
 
         /*
@@ -124,13 +119,9 @@ public:
         }));
 
         co_await scheduler.invoke_on_all([&](auto& sched) {
-            if (disable_data_threshold) {
-                l0::write_request_balancer_accessor::
-                  disable_data_threshold_uploads(&sched);
-            }
-            if (disable_time_based_fallback) {
-                l0::write_request_balancer_accessor::
-                  disable_time_based_fallback(&sched);
+            if (disable_bg_loop) {
+                l0::write_request_balancer_accessor::disable_background_loop(
+                  &sched);
             }
         });
 
@@ -205,8 +196,7 @@ TEST_F(L0ObjectSizeDistFixture, ThreeToOne) {
      * uploaded as a single object by the scheduler/batcher.
      */
     ASSERT_EQ(seastar::smp::count, 3);
-
-    start(true, false).get();
+    start(false).get();
 
     const auto timeout = 1s;
     auto deadline = ss::manual_clock::now() + timeout;
@@ -224,17 +214,24 @@ TEST_F(L0ObjectSizeDistFixture, ThreeToOne) {
     }
 
     // upload the built batches from each core
-    pipeline
-      .invoke_on_all([&](auto& p) {
-          return seastar::async([&] {
-              auto data = std::move(batches[seastar::this_shard_id()]);
-              p.write_and_debounce(
-                 test_ntp0, min_epoch, std::move(data), deadline)
-                .discard_result()
-                .get();
-          });
-      })
-      .get();
+    auto write_fut = pipeline.invoke_on_all([&](auto& p) {
+        auto data = std::move(batches[seastar::this_shard_id()]);
+        return p
+          .write_and_debounce(test_ntp0, min_epoch, std::move(data), deadline)
+          .discard_result();
+    });
+
+    // Allow requests to be propagated to the scheduler
+    ss::sleep(5ms).get();
+
+    // Advance time to trigger the scheduler
+    ss::manual_clock::advance(300ms);
+
+    // Give up the shard to allow the background fiber of the scheduler to run
+    ss::sleep(1ms).get();
+
+    // Wait for all write operations to complete
+    std::move(write_fut).get();
 
     // we expect there to have only been one object uploaded for all the data
     ASSERT_EQ(num_uploads().get(), 1);

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/BUILD
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/BUILD
@@ -28,7 +28,11 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_zero/pipeline:write_pipeline",
         "//src/v/cloud_topics/level_zero/pipeline:write_request",
         "//src/v/config",
+        "//src/v/random:time_jitter",
         "//src/v/ssx:future_util",
+        "//src/v/ssx:semaphore",
+        "//src/v/utils:named_type",
+        "@abseil-cpp//absl/container:fixed_array",
         "@seastar",
     ],
 )

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_bench.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_bench.cc
@@ -37,15 +37,14 @@ static cloud_topics::cluster_epoch min_epoch{3840};
 namespace cloud_topics {
 namespace l0 {
 struct write_request_balancer_accessor {
-    static void disable_data_threshold_uploads(write_request_scheduler<>* s) {
-        s->_test_only_disable_data_threshold = true;
+    static void disable_background_loop(write_request_scheduler<>* s) {
+        s->_test_only_disable_background_loop = true;
     }
-    static void disable_time_based_fallback(write_request_scheduler<>* s) {
-        s->_test_only_disable_time_based_fallback = true;
-    }
-    static ss::future<>
-    apply_time_based_fallback(write_request_scheduler<>* s) {
-        return s->apply_time_based_fallback();
+    static ss::future<> run_background_loop_once(
+      write_request_scheduler<>* s, ss::lowres_clock::time_point last_upload) {
+        auto group_id = s->_context->shard_to_group[ss::this_shard_id()].load();
+        s->_context->record_upload_time(group_id, last_upload);
+        co_await s->run_once();
     }
 };
 } // namespace l0
@@ -93,8 +92,7 @@ struct pipeline_sink {
 
 class write_request_scheduler_bench {
 public:
-    ss::future<>
-    start(bool disable_data_threshold, bool disable_time_based_fallback) {
+    ss::future<> start(bool disable_background_loop = true) {
         co_await pipeline.start();
 
         co_await scheduler.start(ss::sharded_parameter([this] {
@@ -102,15 +100,11 @@ public:
         }));
 
         co_await scheduler.invoke_on_all(
-          [disable_data_threshold, disable_time_based_fallback](
+          [disable_background_loop](
             cloud_topics::l0::write_request_scheduler<>& s) {
-              if (disable_data_threshold) {
+              if (disable_background_loop) {
                   cloud_topics::l0::write_request_balancer_accessor::
-                    disable_data_threshold_uploads(&s);
-              }
-              if (disable_time_based_fallback) {
-                  cloud_topics::l0::write_request_balancer_accessor::
-                    disable_time_based_fallback(&s);
+                    disable_background_loop(&s);
               }
           });
 
@@ -143,7 +137,7 @@ PERF_TEST_C(write_request_scheduler_bench, data_threshold) {
     cfg.get("cloud_topics_produce_batching_size_threshold")
       .set_value(size_threshold);
 
-    co_await start(false, true);
+    co_await start(false);
 
     chunked_vector<model::record_batch> batches;
     auto batch = model::test::make_random_batch(
@@ -175,21 +169,21 @@ PERF_TEST_C(write_request_scheduler_bench, data_threshold) {
     co_await stop();
 }
 
-PERF_TEST_C(write_request_scheduler_bench, time_fallback) {
+PERF_TEST_C(write_request_scheduler_bench, cross_shard_upload) {
     // This test measures the time needed to propagate write requests
-    // from all shards.
+    // from all shards to a single target shard for upload.
 
     static constexpr size_t batch_size = 1000;
 
-    // Disable all background activity and invoke time based fallback
+    // Disable all background activity and invoke the cross-shard upload
     // manually.
-    co_await start(true, true);
+    co_await start(true);
 
     auto invoke_fut = pipeline.invoke_on_all(
       [](cloud_topics::l0::write_pipeline<>& p) -> ss::future<> {
           chunked_vector<model::record_batch> batches;
-          // Make shard 1 have more data so the uploads are moved to shard 1.
-          size_t size = ss::this_shard_id() == ss::shard_id(1) ? batch_size * 2
+          // Make shard 0 have more data so the uploads are moved to shard 0.
+          size_t size = ss::this_shard_id() == ss::shard_id(0) ? batch_size * 2
                                                                : batch_size;
           auto batch = model::test::make_random_batch(
             model::test::record_batch_spec{
@@ -209,12 +203,13 @@ PERF_TEST_C(write_request_scheduler_bench, time_fallback) {
             .discard_result();
       });
 
+    auto now = ss::lowres_clock::now() - 10s;
+
     // Make sure requests are enqueued on all shards
     co_await ss::sleep(100ms);
-
     perf_tests::start_measuring_time();
     co_await cloud_topics::l0::write_request_balancer_accessor::
-      apply_time_based_fallback(&scheduler.local());
+      run_background_loop_once(&scheduler.local(), now);
     perf_tests::stop_measuring_time();
 
     co_await std::move(invoke_fut);

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_test.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_test.cc
@@ -27,6 +27,9 @@
 #include <chrono>
 #include <exception>
 #include <limits>
+#include <map>
+#include <random>
+#include <set>
 
 inline ss::logger test_log("balancer_gtest");
 
@@ -39,8 +42,8 @@ namespace cloud_topics {
 // Sink consumes and acknowledges all write requests
 // in the pipeline.
 struct pipeline_sink {
-    explicit pipeline_sink(l0::write_pipeline<>& p)
-      : stage(p.register_write_pipeline_stage()) {
+    explicit pipeline_sink(l0::write_pipeline<>::stage s)
+      : stage(s) {
         vlog(test_log.info, "pipeline_sink stage: {}", stage.id());
     }
 
@@ -109,11 +112,8 @@ struct pipeline_sink {
 
 namespace l0 {
 struct write_request_balancer_accessor {
-    static void disable_data_threshold_uploads(write_request_scheduler<>* s) {
-        s->_test_only_disable_data_threshold = true;
-    }
-    static void disable_time_based_fallback(write_request_scheduler<>* s) {
-        s->_test_only_disable_time_based_fallback = true;
+    static void disable_background_loop(write_request_scheduler<>* s) {
+        s->_test_only_disable_background_loop = true;
     }
 };
 } // namespace l0
@@ -124,38 +124,36 @@ using namespace cloud_topics;
 
 class write_request_balancer_fixture : public seastar_test {
 public:
-    ss::future<>
-    start(bool disable_data_threshold, bool disable_time_based_fallback) {
+    ss::future<> start(bool disable_background_loop) {
         vlog(test_log.info, "Creating pipeline");
         co_await pipeline.start();
 
-        // Start the scheduler
+        // Create the scheduler (registers stage 0 on each shard)
         vlog(test_log.info, "Creating scheduler");
         co_await scheduler.start(ss::sharded_parameter([this] {
             return pipeline.local().register_write_pipeline_stage();
         }));
 
         co_await scheduler.invoke_on_all(
-          [disable_data_threshold,
-           disable_time_based_fallback](l0::write_request_scheduler<>& s) {
-              if (disable_data_threshold) {
-                  l0::write_request_balancer_accessor::
-                    disable_data_threshold_uploads(&s);
-              }
-              if (disable_time_based_fallback) {
-                  l0::write_request_balancer_accessor::
-                    disable_time_based_fallback(&s);
+          [disable_background_loop](l0::write_request_scheduler<>& s) {
+              if (disable_background_loop) {
+                  l0::write_request_balancer_accessor::disable_background_loop(
+                    &s);
               }
           });
 
+        // Start scheduler - can be called before sink is created since
+        // next_stage() now returns unassigned_pipeline_stage when next
+        // stage is not registered
         vlog(test_log.info, "Starting scheduler");
         co_await scheduler.invoke_on_all(
           [](l0::write_request_scheduler<>& sched) { return sched.start(); });
 
-        // Start the sink
+        // Create and start the sink
         vlog(test_log.info, "Creating request_sink");
-        co_await request_sink.start(
-          ss::sharded_parameter([this] { return std::ref(pipeline.local()); }));
+        co_await request_sink.start(ss::sharded_parameter([this] {
+            return pipeline.local().register_write_pipeline_stage();
+        }));
         vlog(test_log.info, "Starting request_sink");
         co_await request_sink.invoke_on_all(
           [](pipeline_sink& sink) { return sink.start(); });
@@ -249,13 +247,12 @@ static auto make_random_batches(size_t num_batches, size_t batch_size) {
     return batches;
 }
 
-TEST_F_CORO(write_request_balancer_fixture, time_based_fallback_test) {
-    // This test produces some batches and expects time based threshold
-    // mechanism to trigger the upload.
+TEST_F_CORO(write_request_balancer_fixture, time_deadline_test) {
+    // This test produces some batches and expects the time deadline
+    // to trigger the upload.
     ASSERT_TRUE_CORO(ss::smp::count > 1);
 
-    co_await start(
-      /*disable_data_threshold=*/true, /*disable_time_based_fallback=*/false);
+    co_await start(false);
 
     auto buf = co_await model::test::make_random_batches();
     chunked_vector<model::record_batch> batches;
@@ -275,17 +272,12 @@ TEST_F_CORO(write_request_balancer_fixture, time_based_fallback_test) {
 
 TEST_F_CORO(write_request_balancer_fixture, test_core_affinity) {
     // This test generates batches on two different shards and expects
-    // time-based-fallback mechanism to trigger the upload. It expects
-    // that write requests to land on one shard. The shard that receives
-    // requests is expected to be the one that produced the most data.
+    // the unified scheduling policy to trigger the upload. It expects
+    // that write requests to land on one shard using round-robin scheduling.
+    // With round-robin, shard 0 will handle the first upload (ix=0).
     ASSERT_TRUE_CORO(ss::smp::count > 1);
 
-    co_await scheduler.invoke_on_all([](l0::write_request_scheduler<>& s) {
-        l0::write_request_balancer_accessor::disable_data_threshold_uploads(&s);
-    });
-
-    co_await start(
-      /*disable_data_threshold=*/true, /*disable_time_based_fallback=*/false);
+    co_await start(false);
 
     static constexpr size_t batch_size = 0x1000;
     static constexpr size_t num_batches_hi = 99;
@@ -313,44 +305,50 @@ TEST_F_CORO(write_request_balancer_fixture, test_core_affinity) {
     auto s1_placeholders = co_await std::move(fut);
 
     // Check that number of upload requests matches expectation.
-    // The shard that has the most data should handle the request.
+    // With round-robin scheduling, shard 0 handles the first upload (ix=0).
+    // Both write requests from shard 0 and shard 1 are forwarded to shard 0.
     auto num_requests = co_await request_sink.invoke_on(
-      ss::shard_id(1), [](auto& s) { return s.write_requests_acked; });
+      ss::shard_id(0), [](auto& s) { return s.write_requests_acked; });
     ASSERT_EQ_CORO(num_requests, 2);
 
     co_await stop();
 }
 
 TEST_F_CORO(write_request_balancer_fixture, data_threshold_test) {
+    // Single shard produces enough data to trigger L0 upload
     ASSERT_TRUE_CORO(ss::smp::count > 1);
     auto size_threshold
       = config::shard_local_cfg()
           .cloud_topics_produce_batching_size_threshold.value();
 
-    co_await start(
-      /*disable_data_threshold=*/false, /*disable_time_based_fallback=*/true);
+    co_await start(false);
 
     auto num_requests_sent = co_await write_until_threshold(
       *this, size_threshold);
 
-    // Check that number of upload requests matches expectation.
+    // With round-robin scheduling, requests can be handled by either shard.
+    // Verify total requests across all shards equals expected.
+    auto total_requests_shard0 = request_sink.local().write_requests_acked;
+    auto total_requests_shard1 = co_await request_sink.invoke_on(
+      1, [](auto& s) { return s.write_requests_acked; });
     ASSERT_EQ_CORO(
-      request_sink.local().write_requests_acked, num_requests_sent);
+      total_requests_shard0 + total_requests_shard1, num_requests_sent);
 
     co_await stop();
 }
 
 TEST_F_CORO(write_request_balancer_fixture, test_data_threshold_with_failover) {
     // On shard zero produce little data on shard 0 and in parallel produce a
-    // lot of data on shard 1. Expect data threshold to be reached on shard 1
-    // and time based threshold to be reached on shard 0.
+    // lot of data on shard 1. With round-robin scheduling, the target shard
+    // alternates between shards. This test verifies that all requests are
+    // eventually acknowledged regardless of which shard handles the upload.
 
     ASSERT_TRUE_CORO(ss::smp::count > 1);
     auto size_threshold
       = config::shard_local_cfg()
           .cloud_topics_produce_batching_size_threshold.value();
 
-    co_await start(false, false);
+    co_await start(false);
 
     // Produce on shard 0
     auto buf = co_await model::test::make_random_batches();
@@ -367,26 +365,28 @@ TEST_F_CORO(write_request_balancer_fixture, test_data_threshold_with_failover) {
           return write_until_threshold(*this, size_threshold);
       });
 
-    ASSERT_EQ_CORO(request_sink.local().write_requests_acked, 1);
-    auto actual_num_requests1 = co_await request_sink.invoke_on(
+    // With round-robin, requests can be handled by either shard.
+    // Verify total requests across all shards equals expected.
+    auto total_requests_shard0 = request_sink.local().write_requests_acked;
+    auto total_requests_shard1 = co_await request_sink.invoke_on(
       1, [](auto& s) { return s.write_requests_acked; });
-    ASSERT_EQ_CORO(expected_num_requests1, actual_num_requests1);
+    ASSERT_EQ_CORO(
+      total_requests_shard0 + total_requests_shard1,
+      1 + expected_num_requests1);
 
     co_await stop();
 }
 
 TEST_F_CORO(
-  write_request_balancer_fixture, test_time_based_fallback_with_failures) {
-    // This test checks different combinations of failures.
+  write_request_balancer_fixture, test_cross_shard_upload_with_failures) {
+    // This test checks different combinations of failures during cross-shard
+    // uploads. With round-robin scheduling, the target shard is selected based
+    // on the ix counter, not on data volume. The test verifies that failures
+    // are correctly propagated regardless of which shard handles the upload.
     ASSERT_TRUE_CORO(ss::smp::count > 1);
     static constexpr size_t batch_size = 0x1000;
 
-    co_await scheduler.invoke_on_all([](l0::write_request_scheduler<>& s) {
-        l0::write_request_balancer_accessor::disable_data_threshold_uploads(&s);
-    });
-
-    co_await start(
-      /*disable_data_threshold=*/true, /*disable_time_based_fallback=*/false);
+    co_await start(false);
 
     co_await request_sink.invoke_on_all([](pipeline_sink& s) {
         // Inject failure on test_ntp1
@@ -401,8 +401,6 @@ TEST_F_CORO(
     auto write_on_shard = [&](ss::shard_id shard, model::ntp ntp, size_t size) {
         return pipeline.invoke_on(
           shard, [ntp, size](l0::write_pipeline<>& pipeline) {
-              // Produce small batch on shard 1 so shard 0 will be
-              // uploading the data.
               chunked_vector<model::record_batch> batches;
               auto batch = model::test::make_random_batch(
                 model::test::record_batch_spec{
@@ -423,11 +421,17 @@ TEST_F_CORO(
           });
     };
 
+    auto get_total_acked = [&]() {
+        auto shard0 = request_sink.local().write_requests_acked;
+        return request_sink.invoke_on(ss::shard_id(1), [shard0](auto& s) {
+            return shard0 + s.write_requests_acked;
+        });
+    };
+
     // This case generates batches on two different shards and expects
-    // time-based-fallback mechanism to trigger the upload. The test
-    // case injects failure on shard 1 and expects the fallback mechanism
-    // to propagate them back to the caller. The target shard in this case
-    // is shard 0 (the shard that makes the upload).
+    // the unified scheduling policy to trigger the upload. The test
+    // case injects failure on test_ntp1 and expects the scheduler
+    // to propagate them back to the caller.
     {
         // Produce on shard 1
         auto fut11 = write_on_shard(ss::shard_id(1), test_ntp1, batch_size);
@@ -440,18 +444,17 @@ TEST_F_CORO(
         auto ph10 = co_await std::move(fut10);
         auto ph11 = co_await std::move(fut11);
 
-        // Check that number of upload requests matches expectation.
-        // The shard that has the most data should handle the request.
-        auto num_requests = request_sink.local().write_requests_acked;
-        ASSERT_EQ_CORO(num_requests, 3);
+        // Check that total upload requests matches expectation.
+        auto total_requests = co_await get_total_acked();
+        ASSERT_EQ_CORO(total_requests, 3);
 
         ASSERT_TRUE_CORO(ph00.has_value());
         ASSERT_TRUE_CORO(!ph11.has_value());
         ASSERT_TRUE_CORO(ph11.error() == cloud_topics::errc::upload_failure);
         ASSERT_TRUE_CORO(ph10.has_value());
     }
-    // This test case is about the same as the previous one with the only
-    // difference that the failure is injected on shard 0 (the uploading shard).
+    // This test case is about the same as the previous one with different
+    // data distribution.
     {
         // Produce on shard 1
         auto fut10 = write_on_shard(ss::shard_id(1), test_ntp0, batch_size);
@@ -465,15 +468,15 @@ TEST_F_CORO(
         auto ph01 = co_await std::move(fut01);
         auto ph10 = co_await std::move(fut10);
 
-        auto num_requests = request_sink.local().write_requests_acked;
-        ASSERT_EQ_CORO(num_requests, 6);
+        auto total_requests = co_await get_total_acked();
+        ASSERT_EQ_CORO(total_requests, 6);
 
         ASSERT_TRUE_CORO(ph00.has_value());
         ASSERT_TRUE_CORO(!ph01.has_value());
         ASSERT_TRUE_CORO(ph01.error() == cloud_topics::errc::upload_failure);
         ASSERT_TRUE_CORO(ph10.has_value());
     }
-    // The data is uploaded on shard 1 and the failure is injected on shard 0.
+    // Another case with different data distribution.
     {
         // Produce on shard 0
         auto fut00 = write_on_shard(ss::shard_id(0), test_ntp0, batch_size);
@@ -486,12 +489,8 @@ TEST_F_CORO(
         auto ph01 = co_await std::move(fut01);
         auto ph10 = co_await std::move(fut10);
 
-        auto num_requests0 = request_sink.local().write_requests_acked;
-        // Nothing is uploaded on this shard
-        ASSERT_EQ_CORO(num_requests0, 6);
-        auto num_requests1 = co_await request_sink.invoke_on(
-          ss::shard_id(1), [](auto& s) { return s.write_requests_acked; });
-        ASSERT_EQ_CORO(num_requests1, 3);
+        auto total_requests = co_await get_total_acked();
+        ASSERT_EQ_CORO(total_requests, 9);
 
         ASSERT_TRUE_CORO(ph00.has_value());
         ASSERT_TRUE_CORO(!ph01.has_value());
@@ -500,4 +499,718 @@ TEST_F_CORO(
     }
 
     co_await stop();
+}
+
+// ============================================================================
+// scheduler_context unit tests
+// ============================================================================
+
+// Helper to create a scheduler_context for testing with mock atomic counters
+class scheduler_context_test : public testing::Test {
+public:
+    using clock_type = ss::manual_clock;
+
+    // Mock backlog counters - one per shard
+    // Using unique_ptr because std::atomic is not movable
+    std::vector<std::unique_ptr<std::atomic<size_t>>> backlog_counters;
+    std::vector<std::unique_ptr<std::atomic<size_t>>> next_stage_counters;
+
+    std::unique_ptr<l0::scheduler_context<clock_type>>
+    make_context(size_t num_shards) {
+        backlog_counters.clear();
+        next_stage_counters.clear();
+
+        for (size_t i = 0; i < num_shards; i++) {
+            backlog_counters.push_back(
+              std::make_unique<std::atomic<size_t>>(0));
+            next_stage_counters.push_back(
+              std::make_unique<std::atomic<size_t>>(0));
+        }
+
+        // FixedArrays are sized at construction time
+        auto ctx = std::make_unique<l0::scheduler_context<clock_type>>(
+          num_shards);
+
+        // Initialize shards with references to our mock counters.
+        // shard_to_group and groups are already default-initialized.
+        for (size_t i = 0; i < num_shards; i++) {
+            ctx->shards[i] = l0::shard_state<clock_type>(
+              std::ref(*backlog_counters[i]),
+              std::ref(
+                static_cast<const std::atomic<size_t>&>(
+                  *next_stage_counters[i])));
+        }
+
+        return ctx;
+    }
+
+    void set_backlog(size_t shard, size_t bytes) {
+        backlog_counters[shard]->store(bytes);
+    }
+
+    void set_next_stage_backlog(size_t shard, size_t bytes) {
+        next_stage_counters[shard]->store(bytes);
+    }
+};
+
+TEST_F(scheduler_context_test, test_initial_state) {
+    // Test that all shards start in group 0
+    auto ctx = make_context(4);
+
+    EXPECT_EQ(ctx->get_group_size(l0::group_id{0}), 4);
+    EXPECT_EQ(ctx->shard_to_group[0].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->shard_to_group[1].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->shard_to_group[2].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->shard_to_group[3].load(), l0::group_id{0});
+}
+
+TEST_F(scheduler_context_test, test_single_split) {
+    // Test splitting a 4-shard group into two 2-shard groups
+    auto ctx = make_context(4);
+
+    // Split group 0
+    bool split = ctx->try_split_group(l0::group_id{0});
+    EXPECT_TRUE(split);
+
+    // After split: shards 0,1 in group 0, shards 2,3 in group 2
+    EXPECT_EQ(ctx->shard_to_group[0].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->shard_to_group[1].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->shard_to_group[2].load(), l0::group_id{2});
+    EXPECT_EQ(ctx->shard_to_group[3].load(), l0::group_id{2});
+
+    EXPECT_EQ(ctx->get_group_size(l0::group_id{0}), 2);
+    EXPECT_EQ(ctx->get_group_size(l0::group_id{2}), 2);
+}
+
+TEST_F(scheduler_context_test, test_full_split_buddy_algorithm) {
+    // Test the full buddy allocator split pattern:
+    // [0,1,2,3] -> [0,1] [2,3] -> [0] [1] [2,3] -> [0] [1] [2] [3]
+    auto ctx = make_context(4);
+
+    // Initial state: all in group 0
+    EXPECT_EQ(ctx->get_group_size(l0::group_id{0}), 4);
+
+    // First split: [0,1,2,3] -> [0,1] + [2,3]
+    EXPECT_TRUE(ctx->try_split_group(l0::group_id{0}));
+    EXPECT_EQ(ctx->shard_to_group[0].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->shard_to_group[1].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->shard_to_group[2].load(), l0::group_id{2});
+    EXPECT_EQ(ctx->shard_to_group[3].load(), l0::group_id{2});
+
+    // Second split: [0,1] -> [0] + [1]
+    EXPECT_TRUE(ctx->try_split_group(l0::group_id{0}));
+    EXPECT_EQ(ctx->shard_to_group[0].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->shard_to_group[1].load(), l0::group_id{1});
+    EXPECT_EQ(ctx->shard_to_group[2].load(), l0::group_id{2});
+    EXPECT_EQ(ctx->shard_to_group[3].load(), l0::group_id{2});
+
+    // Third split: [2,3] -> [2] + [3]
+    EXPECT_TRUE(ctx->try_split_group(l0::group_id{2}));
+    EXPECT_EQ(ctx->shard_to_group[0].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->shard_to_group[1].load(), l0::group_id{1});
+    EXPECT_EQ(ctx->shard_to_group[2].load(), l0::group_id{2});
+    EXPECT_EQ(ctx->shard_to_group[3].load(), l0::group_id{3});
+
+    // Each shard is now in its own group
+    EXPECT_EQ(ctx->get_group_size(l0::group_id{0}), 1);
+    EXPECT_EQ(ctx->get_group_size(l0::group_id{1}), 1);
+    EXPECT_EQ(ctx->get_group_size(l0::group_id{2}), 1);
+    EXPECT_EQ(ctx->get_group_size(l0::group_id{3}), 1);
+
+    // Cannot split single-shard groups
+    EXPECT_FALSE(ctx->try_split_group(l0::group_id{0}));
+    EXPECT_FALSE(ctx->try_split_group(l0::group_id{1}));
+}
+
+TEST_F(scheduler_context_test, test_find_buddy_group) {
+    auto ctx = make_context(4);
+
+    // Split into [0,1] and [2,3]
+    ctx->try_split_group(l0::group_id{0});
+
+    // Group 0's buddy is group 2
+    auto buddy0 = ctx->find_buddy_group(l0::group_id{0});
+    ASSERT_TRUE(buddy0.has_value());
+    EXPECT_EQ(buddy0.value(), l0::group_id{2});
+
+    // Group 2 has no buddy (it's the last group)
+    auto buddy2 = ctx->find_buddy_group(l0::group_id{2});
+    EXPECT_FALSE(buddy2.has_value());
+}
+
+TEST_F(scheduler_context_test, test_merge_buddy_groups) {
+    auto ctx = make_context(4);
+
+    // Split into [0,1] and [2,3]
+    ctx->try_split_group(l0::group_id{0});
+    EXPECT_EQ(ctx->get_group_size(l0::group_id{0}), 2);
+    EXPECT_EQ(ctx->get_group_size(l0::group_id{2}), 2);
+
+    // Merge group 0 with its buddy (group 2)
+    bool merged = ctx->try_merge_group(l0::group_id{0});
+    EXPECT_TRUE(merged);
+
+    // All shards should be back in group 0
+    EXPECT_EQ(ctx->shard_to_group[0].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->shard_to_group[1].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->shard_to_group[2].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->shard_to_group[3].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->get_group_size(l0::group_id{0}), 4);
+}
+
+TEST_F(scheduler_context_test, test_full_merge_buddy_algorithm) {
+    // Test the full buddy allocator merge pattern (reverse of split):
+    // [0] [1] [2] [3] -> [0] [1] [2,3] -> [0,1] [2,3] -> [0,1,2,3]
+    auto ctx = make_context(4);
+
+    // First fully split
+    ctx->try_split_group(l0::group_id{0}); // [0,1] [2,3]
+    ctx->try_split_group(l0::group_id{0}); // [0] [1] [2,3]
+    ctx->try_split_group(l0::group_id{2}); // [0] [1] [2] [3]
+
+    // Verify fully split state
+    EXPECT_EQ(ctx->get_group_size(l0::group_id{0}), 1);
+    EXPECT_EQ(ctx->get_group_size(l0::group_id{1}), 1);
+    EXPECT_EQ(ctx->get_group_size(l0::group_id{2}), 1);
+    EXPECT_EQ(ctx->get_group_size(l0::group_id{3}), 1);
+
+    // Merge [2] with [3] -> [2,3]
+    EXPECT_TRUE(ctx->try_merge_group(l0::group_id{2}));
+    EXPECT_EQ(ctx->shard_to_group[2].load(), l0::group_id{2});
+    EXPECT_EQ(ctx->shard_to_group[3].load(), l0::group_id{2});
+    EXPECT_EQ(ctx->get_group_size(l0::group_id{2}), 2);
+
+    // Merge [0] with [1] -> [0,1]
+    EXPECT_TRUE(ctx->try_merge_group(l0::group_id{0}));
+    EXPECT_EQ(ctx->shard_to_group[0].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->shard_to_group[1].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->get_group_size(l0::group_id{0}), 2);
+
+    // Merge [0,1] with [2,3] -> [0,1,2,3]
+    EXPECT_TRUE(ctx->try_merge_group(l0::group_id{0}));
+    EXPECT_EQ(ctx->get_group_size(l0::group_id{0}), 4);
+    for (size_t i = 0; i < 4; i++) {
+        EXPECT_EQ(ctx->shard_to_group[i].load(), l0::group_id{0});
+    }
+}
+
+TEST_F(scheduler_context_test, test_get_group_bytes) {
+    auto ctx = make_context(4);
+
+    // Set different backlog sizes
+    set_backlog(0, 100);
+    set_backlog(1, 200);
+    set_backlog(2, 300);
+    set_backlog(3, 400);
+
+    // All in group 0, total should be 1000
+    EXPECT_EQ(ctx->get_group_bytes(l0::group_id{0}), 1000);
+
+    // Split into [0,1] and [2,3]
+    ctx->try_split_group(l0::group_id{0});
+
+    // Group 0: 100 + 200 = 300
+    EXPECT_EQ(ctx->get_group_bytes(l0::group_id{0}), 300);
+    // Group 2: 300 + 400 = 700
+    EXPECT_EQ(ctx->get_group_bytes(l0::group_id{2}), 700);
+}
+
+TEST_F(scheduler_context_test, test_get_group_next_stage_bytes) {
+    auto ctx = make_context(4);
+
+    // Set next stage backlog sizes
+    set_next_stage_backlog(0, 1000);
+    set_next_stage_backlog(1, 2000);
+    set_next_stage_backlog(2, 3000);
+    set_next_stage_backlog(3, 4000);
+
+    // All in group 0, total should be 10000
+    EXPECT_EQ(ctx->get_group_next_stage_bytes(l0::group_id{0}), 10000);
+
+    // Split into [0,1] and [2,3]
+    ctx->try_split_group(l0::group_id{0});
+
+    // Group 0: 1000 + 2000 = 3000
+    EXPECT_EQ(ctx->get_group_next_stage_bytes(l0::group_id{0}), 3000);
+    // Group 2: 3000 + 4000 = 7000
+    EXPECT_EQ(ctx->get_group_next_stage_bytes(l0::group_id{2}), 7000);
+}
+
+TEST_F(scheduler_context_test, test_shard_index_in_group) {
+    auto ctx = make_context(4);
+
+    // All in group 0
+    EXPECT_EQ(
+      ctx->get_shard_index_in_group(ss::shard_id(0), l0::group_id{0}), 0);
+    EXPECT_EQ(
+      ctx->get_shard_index_in_group(ss::shard_id(1), l0::group_id{0}), 1);
+    EXPECT_EQ(
+      ctx->get_shard_index_in_group(ss::shard_id(2), l0::group_id{0}), 2);
+    EXPECT_EQ(
+      ctx->get_shard_index_in_group(ss::shard_id(3), l0::group_id{0}), 3);
+
+    // Split into [0,1] and [2,3]
+    ctx->try_split_group(l0::group_id{0});
+
+    // Group 0: shard 0 is index 0, shard 1 is index 1
+    EXPECT_EQ(
+      ctx->get_shard_index_in_group(ss::shard_id(0), l0::group_id{0}), 0);
+    EXPECT_EQ(
+      ctx->get_shard_index_in_group(ss::shard_id(1), l0::group_id{0}), 1);
+
+    // Group 2: shard 2 is index 0, shard 3 is index 1
+    EXPECT_EQ(
+      ctx->get_shard_index_in_group(ss::shard_id(2), l0::group_id{2}), 0);
+    EXPECT_EQ(
+      ctx->get_shard_index_in_group(ss::shard_id(3), l0::group_id{2}), 1);
+}
+
+TEST_F(scheduler_context_test, test_try_schedule_upload_triggers_split) {
+    auto ctx = make_context(4);
+
+    // Group has 4 shards, max_buffer_size = 4 MiB
+    // Split threshold = 4 MiB × 4 = 16 MiB
+    constexpr size_t max_buffer_size = 4 * 1024 * 1024;              // 4 MiB
+    constexpr size_t expected_split_threshold = max_buffer_size * 4; // 16 MiB
+
+    // Set high next stage backlog to trigger split
+    set_next_stage_backlog(0, expected_split_threshold + 1);
+    set_next_stage_backlog(1, expected_split_threshold + 1);
+    set_next_stage_backlog(2, expected_split_threshold + 1);
+    set_next_stage_backlog(3, expected_split_threshold + 1);
+
+    // Set some backlog to trigger upload
+    set_backlog(0, 1000);
+
+    // Advance time past the cooldown period (2 * scheduling_interval = 200ms)
+    ss::manual_clock::advance(250ms);
+
+    // Shard 0 is first in group, should evaluate and trigger split
+    auto result = ctx->try_schedule_upload(
+      ss::shard_id(0), max_buffer_size, 100ms, clock_type::now());
+
+    // After split, shards 0,1 should be in group 0, shards 2,3 in group 2
+    EXPECT_EQ(ctx->shard_to_group[0].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->shard_to_group[1].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->shard_to_group[2].load(), l0::group_id{2});
+    EXPECT_EQ(ctx->shard_to_group[3].load(), l0::group_id{2});
+}
+
+TEST_F(scheduler_context_test, test_try_schedule_upload_triggers_merge) {
+    auto ctx = make_context(4);
+
+    // First split the groups
+    ctx->try_split_group(l0::group_id{0}); // [0,1] [2,3]
+
+    // Set next stage backlog to 0 to trigger merge
+    set_next_stage_backlog(0, 0);
+    set_next_stage_backlog(1, 0);
+    set_next_stage_backlog(2, 0);
+    set_next_stage_backlog(3, 0);
+
+    // Set some backlog
+    set_backlog(0, 1000);
+
+    // Advance time past the cooldown period (2 * scheduling_interval = 200ms)
+    // for both groups (split sets last_modification_time on both)
+    ss::manual_clock::advance(250ms);
+
+    // Shard 0 is first in group 0, should evaluate and trigger merge
+    auto result = ctx->try_schedule_upload(
+      ss::shard_id(0),
+      500, // max_buffer_size
+      100ms,
+      clock_type::now());
+
+    // After merge, all shards should be in group 0
+    EXPECT_EQ(ctx->shard_to_group[0].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->shard_to_group[1].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->shard_to_group[2].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->shard_to_group[3].load(), l0::group_id{0});
+    EXPECT_EQ(ctx->get_group_size(l0::group_id{0}), 4);
+}
+
+TEST_F(scheduler_context_test, test_round_robin_within_group) {
+    auto ctx = make_context(4);
+
+    // Split into [0,1] and [2,3]
+    ctx->try_split_group(l0::group_id{0});
+
+    // Set backlog so upload conditions are met
+    set_backlog(0, 1000);
+    set_backlog(1, 1000);
+
+    // Round-robin counter starts at 0, so shard 0 should be selected first
+    auto result0 = ctx->try_schedule_upload(
+      ss::shard_id(0), 500, 100ms, clock_type::now());
+    EXPECT_EQ(result0.action, l0::schedule_action::upload);
+
+    // Release the lock before checking next shard (simulates upload completion)
+    result0.request.reset();
+
+    // After upload, ix is incremented, so shard 1 should be selected next
+    auto result1_skip = ctx->try_schedule_upload(
+      ss::shard_id(0), 500, 100ms, clock_type::now());
+    EXPECT_EQ(result1_skip.action, l0::schedule_action::skip);
+
+    auto result1 = ctx->try_schedule_upload(
+      ss::shard_id(1), 500, 100ms, clock_type::now());
+    EXPECT_EQ(result1.action, l0::schedule_action::upload);
+}
+
+// ============================================================================
+// Fuzz test for scheduler_context
+// ============================================================================
+
+class scheduler_context_fuzz_test : public testing::Test {
+public:
+    using clock_type = ss::manual_clock;
+
+    static constexpr size_t num_shards = 8;
+    static constexpr size_t max_buffer_size = 4 * 1024 * 1024; // 4 MiB
+    // Split threshold is now dynamic: max_buffer_size × group_size
+    // For initial group of 8 shards: 4 MiB × 8 = 32 MiB
+    static constexpr auto scheduling_interval = 100ms;
+    static constexpr auto iteration_interval = 20ms;
+    static constexpr auto upload_interval = 250ms;
+
+    // Mock backlog counters - one per shard
+    std::vector<std::unique_ptr<std::atomic<size_t>>> backlog_counters;
+    std::vector<std::unique_ptr<std::atomic<size_t>>> next_stage_counters;
+
+    // Random number generator
+    std::mt19937 rng;
+
+    scheduler_context_fuzz_test()
+      : rng(std::random_device{}()) {}
+
+    std::unique_ptr<l0::scheduler_context<clock_type>> make_context() {
+        backlog_counters.clear();
+        next_stage_counters.clear();
+
+        for (size_t i = 0; i < num_shards; i++) {
+            backlog_counters.push_back(
+              std::make_unique<std::atomic<size_t>>(0));
+            next_stage_counters.push_back(
+              std::make_unique<std::atomic<size_t>>(0));
+        }
+
+        // FixedArrays are sized at construction time
+        auto ctx = std::make_unique<l0::scheduler_context<clock_type>>(
+          num_shards);
+
+        // Initialize shards with references to our mock counters.
+        // shard_to_group and groups are already default-initialized.
+        for (size_t i = 0; i < num_shards; i++) {
+            ctx->shards[i] = l0::shard_state<clock_type>(
+              std::ref(*backlog_counters[i]),
+              std::ref(
+                static_cast<const std::atomic<size_t>&>(
+                  *next_stage_counters[i])));
+        }
+
+        return ctx;
+    }
+
+    size_t get_backlog(size_t shard) const {
+        return backlog_counters[shard]->load();
+    }
+
+    void set_backlog(size_t shard, size_t bytes) {
+        backlog_counters[shard]->store(bytes);
+    }
+
+    void add_backlog(size_t shard, size_t bytes) {
+        backlog_counters[shard]->fetch_add(bytes);
+    }
+
+    size_t get_next_stage_backlog(size_t shard) const {
+        return next_stage_counters[shard]->load();
+    }
+
+    void set_next_stage_backlog(size_t shard, size_t bytes) {
+        next_stage_counters[shard]->store(bytes);
+    }
+
+    void add_next_stage_backlog(size_t shard, size_t bytes) {
+        next_stage_counters[shard]->fetch_add(bytes);
+    }
+
+    // Simulate ingestion: add random bytes to current stage backlog
+    void simulate_ingestion() {
+        std::uniform_int_distribution<size_t> bytes_dist(0, 512 * 1024);
+        for (size_t shard = 0; shard < num_shards; shard++) {
+            // 70% chance to add data on each shard
+            if (std::uniform_int_distribution<int>(0, 9)(rng) < 7) {
+                add_backlog(shard, bytes_dist(rng));
+            }
+        }
+    }
+
+    // Simulate upload completion: drain next stage backlog
+    void simulate_upload_drain() {
+        for (size_t shard = 0; shard < num_shards; shard++) {
+            set_next_stage_backlog(shard, 0);
+        }
+    }
+
+    // Simulate partial upload completion: reduce next stage backlog by 10%
+    void simulate_partial_upload_drain() {
+        for (size_t shard = 0; shard < num_shards; shard++) {
+            auto current = get_next_stage_backlog(shard);
+            auto reduction = current / 10;
+            if (reduction > 0) {
+                next_stage_counters[shard]->fetch_sub(reduction);
+            }
+        }
+    }
+
+    // Deposit bytes from current stage to next stage (simulates upload
+    // starting)
+    void deposit_to_next_stage(
+      l0::scheduler_context<clock_type>& ctx, l0::group_id gid) {
+        for (size_t shard = 0; shard < num_shards; shard++) {
+            if (ctx.shard_to_group[shard].load() != gid) {
+                continue;
+            }
+            auto bytes = get_backlog(shard);
+            if (bytes > 0) {
+                set_backlog(shard, 0);
+                add_next_stage_backlog(shard, bytes);
+            }
+        }
+    }
+
+    // Verify invariants
+    void verify_invariants(const l0::scheduler_context<clock_type>& ctx) {
+        // Every shard must belong to a valid group
+        for (size_t shard = 0; shard < num_shards; shard++) {
+            auto gid = ctx.shard_to_group[shard].load();
+            // Group ID must be <= shard ID (buddy allocator invariant)
+            ASSERT_LE(static_cast<size_t>(gid), shard)
+              << "Shard " << shard << " has invalid group_id " << gid;
+        }
+
+        // Groups must be contiguous
+        for (size_t shard = 1; shard < num_shards; shard++) {
+            auto prev_gid = ctx.shard_to_group[shard - 1].load();
+            auto curr_gid = ctx.shard_to_group[shard].load();
+            // Either same group or new group starting at this shard
+            ASSERT_TRUE(
+              prev_gid == curr_gid || static_cast<size_t>(curr_gid) == shard)
+              << "Non-contiguous group at shard " << shard;
+        }
+
+        // Total bytes should be consistent
+        size_t total_backlog = 0;
+        size_t total_next_stage = 0;
+        for (size_t shard = 0; shard < num_shards; shard++) {
+            total_backlog += get_backlog(shard);
+            total_next_stage += get_next_stage_backlog(shard);
+        }
+        // Just verify we can compute these without crash
+        (void)total_backlog;
+        (void)total_next_stage;
+    }
+};
+
+TEST_F(scheduler_context_fuzz_test, test_random_workload) {
+    auto ctx = make_context();
+
+    // Track pending uploads per group (group_id -> lock)
+    std::map<uint32_t, std::optional<std::unique_lock<std::mutex>>>
+      pending_uploads;
+
+    // Advance time past the cooldown period (2 * scheduling_interval = 200ms)
+    // so split/merge can happen in the first iteration
+    ss::manual_clock::advance(250ms);
+    auto simulated_time = clock_type::now();
+    auto last_upload_drain_time = simulated_time;
+
+    // Run for 1000 iterations (20 seconds of simulated time)
+    for (int iteration = 0; iteration < 1000; iteration++) {
+        // Verify invariants at start of each iteration
+        verify_invariants(*ctx);
+
+        // Step 1: Simulate ingestion (add bytes to current stage)
+        simulate_ingestion();
+
+        // Step 2: Randomly modify next stage backlog
+        int next_stage_action = std::uniform_int_distribution<int>(0, 9)(rng);
+        if (next_stage_action == 0) {
+            // 10% chance: drop next stage backlog to 0 (upload completed)
+            simulate_upload_drain();
+        } else if (next_stage_action == 1) {
+            // 10% chance: reduce next stage backlog by 10%
+            simulate_partial_upload_drain();
+        }
+        // 80% chance: keep next stage backlog unchanged
+
+        // Step 3: Run scheduler on every shard
+        for (size_t shard = 0; shard < num_shards; shard++) {
+            auto result = ctx->try_schedule_upload(
+              ss::shard_id(shard),
+              max_buffer_size,
+              scheduling_interval,
+              simulated_time);
+
+            if (result.action == l0::schedule_action::upload) {
+                // Deposit bytes from current stage to next stage
+                deposit_to_next_stage(*ctx, result.gid);
+
+                // Record upload time
+                ctx->record_upload_time(result.gid, simulated_time);
+
+                // Release lock immediately (simulates quick upload)
+                result.request.reset();
+            }
+        }
+
+        // Step 4: Simulate upload drain every 250ms
+        if (simulated_time - last_upload_drain_time >= upload_interval) {
+            simulate_upload_drain();
+            last_upload_drain_time = simulated_time;
+        }
+
+        // Step 5: Advance simulated time
+        ss::manual_clock::advance(iteration_interval);
+        simulated_time = clock_type::now();
+    }
+
+    // Final invariant check
+    verify_invariants(*ctx);
+}
+
+TEST_F(scheduler_context_fuzz_test, test_high_load_causes_splits) {
+    auto ctx = make_context();
+
+    // Verify all shards start in group 0
+    EXPECT_EQ(ctx->get_group_size(l0::group_id{0}), num_shards);
+
+    // Advance time past the cooldown period (2 * scheduling_interval = 200ms)
+    // so splits can happen in the first iteration
+    ss::manual_clock::advance(250ms);
+    auto simulated_time = clock_type::now();
+
+    // Simulate high load: lots of data, slow drain
+    for (int iteration = 0; iteration < 500; iteration++) {
+        verify_invariants(*ctx);
+
+        // Add significant data to all shards
+        for (size_t shard = 0; shard < num_shards; shard++) {
+            add_backlog(shard, 1024 * 1024); // 1 MiB per shard per iteration
+        }
+
+        // Run scheduler on every shard
+        for (size_t shard = 0; shard < num_shards; shard++) {
+            auto result = ctx->try_schedule_upload(
+              ss::shard_id(shard),
+              max_buffer_size,
+              scheduling_interval,
+              simulated_time);
+
+            if (result.action == l0::schedule_action::upload) {
+                deposit_to_next_stage(*ctx, result.gid);
+                ctx->record_upload_time(result.gid, simulated_time);
+                result.request.reset();
+            }
+        }
+
+        // Slow drain: only 5% reduction every iteration
+        for (size_t shard = 0; shard < num_shards; shard++) {
+            auto current = get_next_stage_backlog(shard);
+            auto reduction = current / 20;
+            if (reduction > 0) {
+                next_stage_counters[shard]->fetch_sub(reduction);
+            }
+        }
+
+        ss::manual_clock::advance(iteration_interval);
+        simulated_time = clock_type::now();
+    }
+
+    verify_invariants(*ctx);
+
+    // Under high load with slow drain, groups should have split
+    // Count number of distinct groups
+    std::set<uint32_t> distinct_groups;
+    for (size_t shard = 0; shard < num_shards; shard++) {
+        distinct_groups.insert(
+          static_cast<uint32_t>(ctx->shard_to_group[shard].load()));
+    }
+    EXPECT_GT(distinct_groups.size(), 1)
+      << "Expected groups to split under high load";
+}
+
+TEST_F(scheduler_context_fuzz_test, test_low_load_causes_merges) {
+    auto ctx = make_context();
+
+    // First, force split into individual shards
+    while (ctx->get_group_size(l0::group_id{0}) > 1) {
+        ctx->try_split_group(l0::group_id{0});
+    }
+    // Split remaining groups
+    for (size_t shard = 0; shard < num_shards; shard++) {
+        auto gid = ctx->shard_to_group[shard].load();
+        while (ctx->get_group_size(gid) > 1) {
+            ctx->try_split_group(gid);
+        }
+    }
+
+    // Verify all shards are in their own group
+    for (size_t shard = 0; shard < num_shards; shard++) {
+        EXPECT_EQ(ctx->get_group_size(ctx->shard_to_group[shard].load()), 1);
+    }
+
+    // Advance time past the cooldown period (2 * scheduling_interval = 200ms)
+    // so merges can happen in the first iteration
+    ss::manual_clock::advance(250ms);
+    auto simulated_time = clock_type::now();
+
+    // Simulate low load: minimal data, fast drain
+    for (int iteration = 0; iteration < 500; iteration++) {
+        verify_invariants(*ctx);
+
+        // Add minimal data
+        for (size_t shard = 0; shard < num_shards; shard++) {
+            if (std::uniform_int_distribution<int>(0, 4)(rng) == 0) {
+                add_backlog(shard, 64 * 1024); // 64 KiB occasionally
+            }
+        }
+
+        // Fast drain: clear next stage frequently
+        if (iteration % 5 == 0) {
+            simulate_upload_drain();
+        }
+
+        // Run scheduler on every shard
+        for (size_t shard = 0; shard < num_shards; shard++) {
+            auto result = ctx->try_schedule_upload(
+              ss::shard_id(shard),
+              max_buffer_size,
+              scheduling_interval,
+              simulated_time);
+
+            if (result.action == l0::schedule_action::upload) {
+                deposit_to_next_stage(*ctx, result.gid);
+                ctx->record_upload_time(result.gid, simulated_time);
+                result.request.reset();
+            }
+        }
+
+        ss::manual_clock::advance(iteration_interval);
+        simulated_time = clock_type::now();
+    }
+
+    verify_invariants(*ctx);
+
+    // Under low load with fast drain, groups should have merged
+    // Count number of distinct groups
+    std::set<uint32_t> distinct_groups;
+    for (size_t shard = 0; shard < num_shards; shard++) {
+        distinct_groups.insert(
+          static_cast<uint32_t>(ctx->shard_to_group[shard].load()));
+    }
+    EXPECT_LT(distinct_groups.size(), num_shards)
+      << "Expected groups to merge under low load";
 }

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
@@ -10,16 +10,16 @@
 
 #include "cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.h"
 
+#include "base/vassert.h"
 #include "cloud_topics/level_zero/common/extent_meta.h"
 #include "cloud_topics/level_zero/pipeline/base_pipeline.h"
 #include "cloud_topics/level_zero/pipeline/write_pipeline.h"
 #include "cloud_topics/level_zero/pipeline/write_request.h"
 #include "cloud_topics/logger.h"
 #include "config/configuration.h"
+#include "random/simple_time_jitter.h"
 #include "ssx/future-util.h"
 
-#include <seastar/core/circular_buffer.hh>
-#include <seastar/core/loop.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/shard_id.hh>
 #include <seastar/core/sharded.hh>
@@ -29,11 +29,19 @@
 #include <algorithm>
 #include <chrono>
 #include <cstddef>
-#include <limits>
+
+using namespace std::chrono_literals;
 
 namespace cloud_topics::l0 {
 
 namespace {
+static constexpr auto scheduler_long_sleep_interval = 20ms;
+static constexpr auto scheduler_short_sleep_interval = 5ms;
+static constexpr auto scheduler_sleep_jitter = 2ms;
+
+// Static zero counter used when next stage is not registered yet
+static std::atomic<size_t> zero_counter{0};
+
 // Copy extents and share the payload to use on another shard
 serialized_chunk shallow_copy(serialized_chunk& chunk) {
     serialized_chunk copy;
@@ -42,6 +50,280 @@ serialized_chunk shallow_copy(serialized_chunk& chunk) {
     return copy;
 }
 } // namespace
+
+template<typename Clock>
+size_t scheduler_context<Clock>::count_active_groups() const {
+    if (shard_to_group.empty()) {
+        return 0;
+    }
+    // Groups are monotonically increasing due to buddy algorithm allocation.
+    // Count transitions to new groups by tracking the last seen group.
+    size_t count = 1;
+    group_id last_group = shard_to_group[0].load();
+    for (size_t i = 1; i < shard_to_group.size(); i++) {
+        auto current_group = shard_to_group[i].load();
+        if (current_group != last_group) {
+            count++;
+            last_group = current_group;
+        }
+    }
+    return count;
+}
+
+template<typename Clock>
+size_t scheduler_context<Clock>::get_group_size(group_id gid) const {
+    size_t count = 0;
+    for (const auto& g : shard_to_group) {
+        if (g.load() == gid) {
+            count++;
+        }
+    }
+    return count;
+}
+
+template<typename Clock>
+size_t scheduler_context<Clock>::get_shard_index_in_group(
+  ss::shard_id shard, group_id gid) const {
+    size_t index = 0;
+    for (size_t i = 0; i < static_cast<size_t>(shard); i++) {
+        if (shard_to_group[i].load() == gid) {
+            index++;
+        }
+    }
+    return index;
+}
+
+template<typename Clock>
+uint64_t scheduler_context<Clock>::get_group_bytes(group_id gid) const {
+    uint64_t total_bytes = 0;
+    for (size_t i = 0; i < shards.size(); i++) {
+        if (shard_to_group[i].load() == gid) {
+            total_bytes += shards[i].backlog_size.get().load();
+        }
+    }
+    return total_bytes;
+}
+
+template<typename Clock>
+uint64_t
+scheduler_context<Clock>::get_group_next_stage_bytes(group_id gid) const {
+    uint64_t total_bytes = 0;
+    for (size_t i = 0; i < shards.size(); i++) {
+        if (shard_to_group[i].load() == gid) {
+            const auto& ref = shards[i].next_stage_backlog_size;
+            total_bytes += ref.get().load();
+        }
+    }
+    return total_bytes;
+}
+
+template<typename Clock>
+bool scheduler_context<Clock>::try_split_group(group_id gid) {
+    // Find all shards in this group
+    std::vector<size_t> group_shards;
+    for (size_t i = 0; i < shards.size(); i++) {
+        if (shard_to_group[i].load() == gid) {
+            group_shards.push_back(i);
+        }
+    }
+
+    // Can't split a group with only one shard
+    if (group_shards.size() <= 1) {
+        return false;
+    }
+
+    // Split in half: first half stays, second half moves to new group
+    size_t split_point = group_shards.size() / 2;
+
+    // New group ID = shard ID of first shard in second half
+    group_id new_gid = group_id(group_shards[split_point]);
+
+    // Move second half to the new group
+    for (size_t i = split_point; i < group_shards.size(); i++) {
+        shard_to_group[group_shards[i]].store(new_gid);
+    }
+
+    // Reset the new group's state
+    auto now = Clock::now();
+    groups[static_cast<size_t>(new_gid)].ix.store(0);
+    groups[static_cast<size_t>(new_gid)].last_upload_time.store(now);
+    groups[static_cast<size_t>(new_gid)].last_modification_time.store(now);
+
+    // Update the original group's modification time
+    groups[static_cast<size_t>(gid)].last_modification_time.store(now);
+
+    return true;
+}
+
+template<typename Clock>
+std::optional<group_id>
+scheduler_context<Clock>::find_buddy_group(group_id gid) const {
+    // Find the last shard in this group
+    size_t last_shard_in_group = 0;
+    bool found = false;
+    for (size_t i = 0; i < shards.size(); i++) {
+        if (shard_to_group[i].load() == gid) {
+            last_shard_in_group = i;
+            found = true;
+        }
+    }
+    if (!found) {
+        return std::nullopt;
+    }
+
+    // The buddy group starts at the next shard
+    size_t buddy_first_shard = last_shard_in_group + 1;
+    if (buddy_first_shard >= shards.size()) {
+        return std::nullopt;
+    }
+
+    // Return the group ID of that shard
+    return shard_to_group[buddy_first_shard].load();
+}
+
+template<typename Clock>
+bool scheduler_context<Clock>::try_merge_group(group_id gid) {
+    auto buddy = find_buddy_group(gid);
+    if (!buddy.has_value()) {
+        return false;
+    }
+
+    group_id buddy_gid = buddy.value();
+
+    // Can only merge if buddy is a different group
+    if (buddy_gid == gid) {
+        return false;
+    }
+
+    // Move all shards from buddy group to this group
+    for (size_t i = 0; i < shards.size(); i++) {
+        if (shard_to_group[i].load() == buddy_gid) {
+            shard_to_group[i].store(gid);
+        }
+    }
+
+    // Reset this group's round-robin counter and update modification time
+    auto now = Clock::now();
+    groups[static_cast<size_t>(gid)].ix.store(0);
+    groups[static_cast<size_t>(gid)].last_modification_time.store(now);
+
+    return true;
+}
+
+template<typename Clock>
+schedule_result<Clock> scheduler_context<Clock>::try_schedule_upload(
+  ss::shard_id shard,
+  size_t max_buffer_size,
+  std::chrono::milliseconds scheduling_interval,
+  time_point now) {
+    // Get group info for this shard
+    auto gid = shard_to_group[shard].load();
+    auto& group = groups[static_cast<size_t>(gid)];
+
+    // First check round-robin: is it this shard's turn within the group?
+    auto grp_size = get_group_size(gid);
+    auto current_ix = group.ix.load();
+    auto shard_index_in_group = get_shard_index_in_group(shard, gid);
+
+    if ((current_ix % grp_size) != shard_index_in_group) {
+        // Not this shard's turn - wait for next cycle
+        return {schedule_action::skip, std::nullopt, gid};
+    }
+
+    // Check if this shard should evaluate group splitting or merging.
+    // Only the first shard in the group (shard_index_in_group == 0) checks.
+    // Rate-limit split/merge decisions to avoid group churn - only allow
+    // modifications if enough time has passed since the last split/merge.
+    if (shard_index_in_group == 0) {
+        auto last_mod_time = group.last_modification_time.load();
+        auto cooldown = scheduling_interval * 2;
+        bool can_modify = (now - last_mod_time) >= cooldown;
+
+        if (can_modify) {
+            auto next_stage_bytes = get_group_next_stage_bytes(gid);
+            // Calculate dynamic split threshold based on group size
+            size_t group_split_threshold = max_buffer_size * grp_size;
+            if (grp_size > 1 && next_stage_bytes > group_split_threshold) {
+                // Split: next stage is overloaded, work more independently
+                if (try_split_group(gid)) {
+                    vlog(cd_log.trace, "Split group {}", gid);
+                } else {
+                    vlog(cd_log.info, "Failed to split group {}", gid);
+                }
+            } else if (next_stage_bytes == 0) {
+                // Merge: next stage is empty, can work together with buddy
+                // But only if buddy's next stage is also empty
+                auto buddy = find_buddy_group(gid);
+                if (buddy.has_value()) {
+                    auto buddy_next_stage_bytes = get_group_next_stage_bytes(
+                      buddy.value());
+                    if (buddy_next_stage_bytes == 0) {
+                        if (try_merge_group(gid)) {
+                            // After merge, re-evaluate group info for this
+                            // shard (gid stays the same since we absorbed
+                            // the buddy)
+                            grp_size = get_group_size(gid);
+                            vlog(
+                              cd_log.trace,
+                              "Merged group {}, group size: {}",
+                              gid,
+                              grp_size);
+                        }
+                    } else {
+                        vlog(
+                          cd_log.info,
+                          "Failed to merge group {}, group size: {}",
+                          gid,
+                          grp_size);
+                    }
+                }
+            }
+        }
+    }
+
+    // It's this shard's turn - check upload conditions based on group state
+    auto group_bytes = get_group_bytes(gid);
+    auto last_upload_time
+      = groups[static_cast<size_t>(gid)].last_upload_time.load();
+    auto deadline = last_upload_time + scheduling_interval;
+
+    // Check if upload conditions are met (group size threshold or deadline)
+    if (
+      group_bytes == 0 || (group_bytes < max_buffer_size && deadline >= now)) {
+        return {schedule_action::wait, std::nullopt, gid};
+    }
+
+    // Try to acquire group mutex (non-blocking)
+    std::unique_lock<std::mutex> lock(
+      groups[static_cast<size_t>(gid)].mutex, std::try_to_lock);
+    if (!lock.owns_lock()) {
+        // Some other shard in the group is busy
+        return {schedule_action::wait, std::nullopt, gid};
+    }
+
+    // Re-check conditions after acquiring lock to handle races
+    group_bytes = get_group_bytes(gid);
+    deadline = groups[static_cast<size_t>(gid)].last_upload_time.load()
+               + scheduling_interval;
+    now = Clock::now();
+
+    if (group_bytes < max_buffer_size && deadline >= now) {
+        return {schedule_action::wait, std::nullopt, gid};
+    }
+
+    // Create schedule_request RAII object - it will increment ix when destroyed
+    auto& ix = groups[static_cast<size_t>(gid)].ix;
+    return {
+      schedule_action::upload,
+      schedule_request<Clock>(std::move(lock), ix),
+      gid};
+}
+
+template<typename Clock>
+void scheduler_context<Clock>::record_upload_time(
+  group_id gid, time_point upload_time) {
+    groups[static_cast<size_t>(gid)].last_upload_time.store(upload_time);
+}
 
 template<typename Clock>
 write_request_scheduler<Clock>::write_request_scheduler(
@@ -55,40 +337,64 @@ write_request_scheduler<Clock>::write_request_scheduler(
         .cloud_topics_produce_cardinality_threshold.bind())
   , _scheduling_interval(
       config::shard_local_cfg().cloud_topics_produce_upload_interval.bind())
-  , _probe(config::shard_local_cfg().disable_metrics()) {}
+  , _probe(config::shard_local_cfg().disable_metrics())
+  , _context(nullptr) {}
 
 template<typename Clock>
 ss::future<> write_request_scheduler<Clock>::start() {
     // Collect counters across all shards
     struct counter_shard {
         const std::atomic<size_t>* count;
+        const std::atomic<size_t>* next_stage_count;
         ss::shard_id shard;
     };
-    auto shard_bytes = co_await this->container().map(
-      [](write_request_scheduler<Clock>& s) {
-          return counter_shard{
-            .count = s._stage.stage_bytes_ref(),
-            .shard = ss::this_shard_id(),
-          };
-      });
-    for (unsigned ix = 0; ix < ss::smp::count; ix++) {
-        for (const counter_shard& sc : shard_bytes) {
-            if (sc.shard == ix) {
-                _shard_counters.push_back(std::ref(*sc.count));
-                break;
+
+    if (ss::this_shard_id() == ss::shard_id(0)) {
+        auto shard_bytes = co_await this->container().map(
+          [](write_request_scheduler<Clock>& s) {
+              // Get the next stage bytes reference. This works even if the next
+              // stage hasn't been registered yet because the counters are
+              // pre-allocated.
+              auto next_ref = s._stage.next_stage_bytes_ref();
+              return counter_shard{
+                .count = s._stage.stage_bytes_ref(),
+                .next_stage_count = next_ref ? next_ref : &zero_counter,
+                .shard = ss::this_shard_id(),
+              };
+          });
+        // Create scheduler context on shard 0.
+        // The context is shared between all shards.
+        // FixedArrays are sized at construction time.
+        _shard_zero_context.emplace(ss::smp::count);
+
+        // Initialize shards with their backlog size references.
+        // shard_to_group and groups are already default-initialized by
+        // the FixedArray constructor (padded_atomic_group_id defaults to
+        // group_id{0}, shard_group default-constructs with current time).
+        for (unsigned ix = 0; ix < ss::smp::count; ix++) {
+            for (const counter_shard& sc : shard_bytes) {
+                if (sc.shard == ix) {
+                    _shard_zero_context->shards[ix] = shard_state<Clock>(
+                      std::ref(*sc.count), std::ref(*sc.next_stage_count));
+                    break;
+                }
             }
         }
+
+        auto ref = &_shard_zero_context.value();
+
+        // Install initialized context on all shards
+        co_await this->container().invoke_on_all([ref](auto& service) {
+            service._context = ref;
+            service._init_barrier.signal();
+        });
+    } else {
+        // Wait for shard 0 to initialize _context
+        co_await _init_barrier.wait();
     }
 
-    // Start the background time based fallback loop on shard 0
-    if (
-      ss::this_shard_id() == ss::shard_id(0)
-      && !_test_only_disable_time_based_fallback) {
-        ssx::spawn_with_gate(
-          _gate, [this] { return bg_time_based_fallback(); });
-    }
-    if (!_test_only_disable_data_threshold) {
-        ssx::spawn_with_gate(_gate, [this] { return bg_data_threshold(); });
+    if (!_test_only_disable_background_loop) {
+        ssx::spawn_with_gate(_gate, [this] { return bg_handler(); });
     }
     co_return;
 }
@@ -96,69 +402,105 @@ ss::future<> write_request_scheduler<Clock>::start() {
 template<typename Clock>
 ss::future<> write_request_scheduler<Clock>::stop() {
     _as.request_abort();
+    _init_barrier.broken();
     co_await _gate.close();
 }
 
 template<typename Clock>
-size_t write_request_scheduler<Clock>::shard_bytes() noexcept {
-    // Count bytes but take limits into account. We intentionally don't use
-    // stage_bytes() here because we need to respect _max_cardinality and
-    // _max_buffer_size limits.
-    size_t total_bytes = 0;
-    size_t total_requests = 0;
-    _stage.process(
-      [&total_bytes, &total_requests, this](
-        const l0::write_request<Clock>& req) noexcept
-        -> std::expected<l0::request_processing_result, errc> {
-          total_bytes += req.size_bytes();
-          total_requests++;
-          return total_requests < _max_cardinality()
-                     && total_bytes < _max_buffer_size()
-                   ? request_processing_result::ignore_and_continue
-                   : request_processing_result::ignore_and_stop;
-      });
-    return total_bytes;
+ss::future<typename Clock::time_point>
+write_request_scheduler<Clock>::run_once() {
+    // This is a scheduler's "tick" which happens every
+    // 5-20ms.
+    auto this_shard = ss::this_shard_id();
+    auto now = Clock::now();
+
+    // Update active groups metric (only shard 0 owns the context data)
+    if (this_shard == 0) {
+        _probe.set_active_groups(_context->count_active_groups());
+    }
+
+    // Let scheduler_context make the scheduling decision
+    auto result = _context->try_schedule_upload(
+      this_shard, _max_buffer_size(), _scheduling_interval(), now);
+
+    switch (result.action) {
+    case schedule_action::skip:
+        // Not this shard's turn
+        co_return get_next_wakeup_time(false);
+
+    case schedule_action::wait:
+        // Conditions not met or mutex busy
+        co_return get_next_wakeup_time(true);
+
+    case schedule_action::upload: {
+        // Collect shard info for shards in this group
+        std::vector<shard_info> shard_bytes;
+        shard_bytes.resize(ss::smp::count);
+        _context->get_shard_bytes_vec(shard_bytes, result.gid);
+
+        // Only shutdown exceptions are expected here
+        co_await pull_and_roundtrip(
+          std::move(shard_bytes), std::move(result.request));
+        co_return get_next_wakeup_time(true);
+    }
+    }
+    __builtin_unreachable();
 }
 
 template<typename Clock>
-ss::future<> write_request_scheduler<Clock>::bg_data_threshold() {
-    vassert(
-      !_test_only_disable_data_threshold, "Data threshold is not disabled");
+ss::future<> write_request_scheduler<Clock>::bg_handler() {
+    auto projected_wakeup_time = get_next_wakeup_time(true);
     while (!_as.abort_requested()) {
-        auto req = co_await _stage.wait_until(
-          _max_buffer_size(), Clock::time_point::max(), &_as);
-        if (!req.has_value()) {
-            if (req.error() == errc::shutting_down) {
-                vlog(cd_log.debug, "bg_data_threshold: shutting down");
+        // Wait until max bytes or projected wake up time is reached. Check how
+        // much data we have and was the deadline reached.
+        auto event = co_await _stage.wait_until(
+          _max_buffer_size(), projected_wakeup_time, &_as);
+        if (!event.has_value()) {
+            if (event.error() == errc::shutting_down) {
+                vlog(cd_log.debug, "bg_handler: shutting down");
                 co_return;
             } else {
                 vlog(
                   cd_log.error,
-                  "bg_data_threshold: error waiting for write requests: {}",
-                  req.error());
+                  "bg_handler: error waiting for write requests: {}",
+                  event.error());
             }
             co_return;
         }
-        vlog(
-          cd_log.debug,
-          "bg_data_threshold: pending bytes: {}, total bytes: "
-          "{}",
-          req.value().pending_write_bytes,
-          req.value().total_write_bytes);
-
-        // Propagate to the next stage
-        _stage.process(
-          [this](const l0::write_request<Clock>& r) noexcept
-            -> std::expected<l0::request_processing_result, errc> {
-              _probe.register_data_threshold(r.size_bytes());
-              return l0::request_processing_result::advance_and_continue;
-          });
+        projected_wakeup_time = co_await run_once();
     }
 }
 
 template<typename Clock>
+write_request_scheduler<Clock>::time_point
+write_request_scheduler<Clock>::get_next_wakeup_time(bool long_duration) {
+    simple_time_jitter<Clock> jitter(
+      long_duration ? scheduler_long_sleep_interval
+                    : scheduler_short_sleep_interval,
+      scheduler_sleep_jitter);
+    auto now = Clock::now();
+    auto soft_deadline = now + jitter.next_duration();
+
+    // Use group's last upload time
+    auto gid = _context->shard_to_group[ss::this_shard_id()].load();
+    auto hard_deadline
+      = _context->groups[static_cast<size_t>(gid)].last_upload_time.load()
+        + jitter.next_jitter_duration();
+    auto target = std::min(soft_deadline, hard_deadline);
+    if (target < now) {
+        // Special case. The upload failed so last upload time is
+        // far in the past. If we will use "target" to schedule
+        // next iteration we will be spin waiting for new data.
+        // To avoid this always use soft deadline here.
+        return soft_deadline;
+    }
+    return target;
+}
+
+template<typename Clock>
 ss::future<> write_request_scheduler<Clock>::pull_and_roundtrip(
-  std::vector<shard_info> infos) {
+  std::vector<shard_info> infos,
+  std::optional<schedule_request<Clock>> request) {
     // This method is invoked by the target shard to pull requests from
     // other shards and forward them to its own pipeline.
     std::vector<ss::future<>> in_flight;
@@ -208,12 +550,22 @@ ss::future<> write_request_scheduler<Clock>::pull_and_roundtrip(
     // cloud storage and then it acknowledges the source write requests (which
     // were proxied).
     co_await target_gate.close();
+    auto gid = _context->shard_to_group[ss::this_shard_id()].load();
+    _context->groups[static_cast<size_t>(gid)].last_upload_time.store(
+      Clock::now());
+    if (request.has_value()) {
+        // Unlock will increment ix and release the mutex
+        request.value().unlock();
+    } else {
+        vlog(cd_log.warn, "The cross shard state is not locked");
+    }
+
     // Submit own requests to the pipeline
     bool signaled = false;
     for (const auto& info : infos) {
         if (ss::this_shard_id() == info.shard && info.bytes > 0) {
             // Fast path: process requests locally
-            // This shard is the one that has the most data.
+            // This shard is the target shard selected by round-robin.
             _stage.process(
               [this, &signaled](const write_request<Clock>& r) noexcept {
                   signaled = true;
@@ -224,138 +576,14 @@ ss::future<> write_request_scheduler<Clock>::pull_and_roundtrip(
         }
     }
     if (!signaled) {
-        // It is guaranteed that the shard that has the most data will become
-        // the target shard. But it is also possible that the data threshold
-        // policy will trigger the upload on this shard. In this case the loop
+        // The target shard is selected by round-robin. It is possible that the
+        // selected shard has no local write requests. In this case the loop
         // above will see no write requests. Other shards are depositing their
         // requests to the target shard without signalling the next stage. So we
         // need to signal it here.
         _stage.signal_next_stage();
     }
     co_await ss::when_all_succeed(in_flight.begin(), in_flight.end());
-}
-
-template<typename Clock>
-ss::future<> write_request_scheduler<Clock>::apply_time_based_fallback() {
-    // The time based fallback works in three stages:
-    // 1. Collect information about the requests from every shard.
-    // 2. Decide which shard should handle the requests.
-    // 3. Tell every shard to forward its requests to the target shard.
-    // The whole process is triggered on shard 0. The end to end latency
-    // of the process is relatively high (up to 1ms) but it's fine. The
-    // method is invoked periodically (e.g. every 500ms) so the
-    // additional latency is not significant. If we have very high tput
-    // on some shards they will be excluded from the time based fallback
-    // because they will trigger the data threshold based uploads.
-    std::vector<shard_info> shard_bytes;
-    for (unsigned i = 0; i < _shard_counters.size(); i++) {
-        shard_bytes.push_back({
-          .shard = ss::shard_id(i),
-          .bytes = _shard_counters[i].get().load(),
-        });
-    }
-
-    // NOTE: the heuristic is based on cache behavior. The shard that
-    // uploads the data has to read it. If the write request originates
-    // from the same shard it will be hot in the CPU cache. Otherwise
-    // it will be cold. So the main heuristic is to use the shard
-    // that has the most write requests in the pipeline (by size).
-    // In the future more complex partitioning can be used. E.g. we can
-    // select more than one shard as a target and take NUMA mapping into
-    // account. We can also take into account the load and resources
-    // available for upload. For now it's assumed that the client pool
-    // will always be able to handle the addition L0 upload (e.g. it has
-    // borrowing mechanism to do this).
-
-    if (cd_log.is_enabled(ss::log_level::trace)) {
-        for (auto& req : shard_bytes) {
-            vlog(
-              cd_log.trace,
-              "map result: {} requests, {} bytes",
-              req.shard,
-              req.bytes);
-        }
-    }
-
-    // Find the shard with the most bytes to write
-    auto target_shard = ss::shard_id(0);
-    auto max_shard_bytes = std::numeric_limits<size_t>::min();
-    for (auto& info : shard_bytes) {
-        if (info.bytes > max_shard_bytes) {
-            max_shard_bytes = info.bytes;
-            target_shard = info.shard;
-        }
-    }
-    vlog(
-      cd_log.debug,
-      "bg_time_based_fallback: target shard for write requests: {}, "
-      "bytes: {}",
-      target_shard,
-      max_shard_bytes);
-
-    // We can forward write requests to the target shard now
-    // Every shards forwards its own requests.
-    //
-    // The information flow:
-    // shard 0:      collect information -> decide target shard
-    // target shard: call 'pull_and_roundtrip' and pass the gate holder
-    // target shard: invoke 'forward_to' on every shard that has data
-    // shard[i]:     call 'roundtrip' method on shard[i], pass gate holder
-    // shard[i]:     invoke 'proxy_write_request' on target shard, pass gate
-    //               holder
-    // target shard: enqueue shard[i] requests to the target shard's pipeline
-    //               and dispose the gate holder that belongs to the
-    //               target shard
-    // target shard: wait until all requests are enqueued by waiting
-    //               on the gate
-    // target shard: process own requests and wait until all
-    //               'proxy_write_request' calls are done on all shards
-    //               by waiting on the gate.
-
-    if (max_shard_bytes > 0) {
-        co_await this->container().invoke_on(
-          target_shard,
-          [shard_bytes](write_request_scheduler<Clock>& scheduler) {
-              return scheduler.pull_and_roundtrip(shard_bytes);
-          });
-    }
-}
-
-template<typename Clock>
-ss::future<> write_request_scheduler<Clock>::bg_time_based_fallback() {
-    // This is the background fiber that runs only on shard 0
-    // It is waking up every N ms and forces uploads on all shards
-    // to be aggregated and uploaded to the cloud storage on a single
-    // "target" shard.
-    //
-    // It handles the case when there is not enough updates on every
-    // shards to trigger the upload within N ms.
-    try {
-        vassert(
-          ss::this_shard_id() == ss::shard_id(0),
-          "bg_time_based_fallback: should only run on shard 0");
-        vassert(
-          !_test_only_disable_time_based_fallback,
-          "time based fallback is not disabled");
-        vlog(
-          cd_log.debug,
-          "Starting write_request_scheduler time based fallback background "
-          "loop");
-        while (!_as.abort_requested() && !_stage.stopped()) {
-            // Sleep before next iteration
-            co_await ss::sleep_abortable(_scheduling_interval(), _as);
-            co_await apply_time_based_fallback();
-        }
-    } catch (...) {
-        if (ssx::is_shutdown_exception(std::current_exception())) {
-            vlog(cd_log.debug, "bg_time_based_fallback: shutting down");
-        } else {
-            vlog(
-              cd_log.error,
-              "bg_time_based_fallback: failed: {}",
-              std::current_exception());
-        }
-    }
 }
 
 /// Get a single write request which was created on another shard
@@ -372,13 +600,16 @@ write_request_scheduler<Clock>::proxy_write_request(
     // it will be destroyed on the target shard as well.
     auto h = _gate.hold();
     _probe.register_receive_xshard(req->size_bytes());
+    // Create proxy for the foreign request. The bytes were already accounted
+    // for on the source shard, so we use enqueue_foreign_request to place it
+    // directly at the next stage without byte accounting.
     write_request<Clock> proxy(
       req->ntp,
       req->topic_start_epoch,
       shallow_copy(req->data_chunk),
       req->expiration_time);
     auto fut = proxy.response.get_future();
-    _stage.push_next_stage(proxy, false);
+    _stage.enqueue_foreign_request(proxy, false);
     target_gate_holder.release();
     auto extents_fut = co_await ss::coroutine::as_future(std::move(fut));
     if (extents_fut.failed()) {
@@ -480,5 +711,8 @@ ss::future<> write_request_scheduler<Clock>::forward_to(
 
 template class write_request_scheduler<seastar::lowres_clock>;
 template class write_request_scheduler<seastar::manual_clock>;
+
+template struct scheduler_context<seastar::lowres_clock>;
+template struct scheduler_context<seastar::manual_clock>;
 
 } // namespace cloud_topics::l0

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
@@ -217,7 +217,7 @@ ss::future<> write_request_scheduler<Clock>::pull_and_roundtrip(
             _stage.process(
               [this, &signaled](const write_request<Clock>& r) noexcept {
                   signaled = true;
-                  _probe.register_time_fallback(r.size_bytes());
+                  _probe.register_request(r.size_bytes());
                   return request_processing_result::advance_and_continue;
               });
             break;

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
@@ -59,6 +59,27 @@ write_request_scheduler<Clock>::write_request_scheduler(
 
 template<typename Clock>
 ss::future<> write_request_scheduler<Clock>::start() {
+    // Collect counters across all shards
+    struct counter_shard {
+        const std::atomic<size_t>* count;
+        ss::shard_id shard;
+    };
+    auto shard_bytes = co_await this->container().map(
+      [](write_request_scheduler<Clock>& s) {
+          return counter_shard{
+            .count = s._stage.stage_bytes_ref(),
+            .shard = ss::this_shard_id(),
+          };
+      });
+    for (unsigned ix = 0; ix < ss::smp::count; ix++) {
+        for (const counter_shard& sc : shard_bytes) {
+            if (sc.shard == ix) {
+                _shard_counters.push_back(std::ref(*sc.count));
+                break;
+            }
+        }
+    }
+
     // Start the background time based fallback loop on shard 0
     if (
       ss::this_shard_id() == ss::shard_id(0)
@@ -226,11 +247,13 @@ ss::future<> write_request_scheduler<Clock>::apply_time_based_fallback() {
     // additional latency is not significant. If we have very high tput
     // on some shards they will be excluded from the time based fallback
     // because they will trigger the data threshold based uploads.
-    auto shard_bytes = co_await this->container().map(
-      [](write_request_scheduler<Clock>& s) {
-          return shard_info{
-            .shard = ss::this_shard_id(), .bytes = s.shard_bytes()};
-      });
+    std::vector<shard_info> shard_bytes;
+    for (unsigned i = 0; i < _shard_counters.size(); i++) {
+        shard_bytes.push_back({
+          .shard = ss::shard_id(i),
+          .bytes = _shard_counters[i].get().load(),
+        });
+    }
 
     // NOTE: the heuristic is based on cache behavior. The shard that
     // uploads the data has to read it. If the write request originates

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.h
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.h
@@ -10,42 +10,317 @@
 
 #pragma once
 
+#include "absl/container/fixed_array.h"
 #include "base/seastarx.h"
 #include "cloud_topics/level_zero/common/level_zero_probe.h"
 #include "cloud_topics/level_zero/pipeline/write_pipeline.h"
 #include "cloud_topics/level_zero/pipeline/write_request.h"
 #include "config/property.h"
+#include "ssx/semaphore.h"
+#include "utils/named_type.h"
 
-#include <seastar/core/circular_buffer.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/shard_id.hh>
 #include <seastar/core/sharded.hh>
-#include <seastar/core/weak_ptr.hh>
 
 #include <chrono>
 #include <expected>
+#include <mutex>
+#include <new>
 
 namespace cloud_topics::l0 {
+
+/// Strongly typed group identifier for scheduler groups.
+/// Group ID equals the shard ID of the first shard in the group.
+using group_id = named_type<uint32_t, struct scheduler_context_group_id_t>;
+
+/// Padded atomic group_id to avoid false sharing between shards.
+/// Each shard's group assignment is on its own cache line.
+struct alignas(std::hardware_destructive_interference_size)
+  padded_atomic_group_id {
+    std::atomic<group_id> value{group_id{0}};
+
+    group_id load() const { return value.load(std::memory_order_relaxed); }
+
+    void store(group_id gid) { value.store(gid, std::memory_order_relaxed); }
+};
+
+/// Result of the scheduling decision made by scheduler_context
+enum class schedule_action {
+    /// Not this shard's turn (round-robin)
+    skip,
+    /// This shard's turn but upload conditions not met or mutex busy
+    wait,
+    /// Should perform upload - mutex lock acquired
+    upload,
+};
+
+// Forward declaration
+template<typename Clock>
+class schedule_request;
+
+/// Result returned by try_schedule_upload containing the decision
+/// and associated state
+template<typename Clock>
+struct schedule_result {
+    schedule_action action;
+    /// schedule_request is held when action == upload
+    std::optional<schedule_request<Clock>> request;
+    /// Group ID for this shard (valid for all actions)
+    group_id gid;
+};
+
+template<typename Clock>
+struct shard_state {
+    // Static dummy atomic used only for default construction.
+    // Elements should be reassigned before use.
+    static inline std::atomic<size_t> _dummy_atomic{0};
+
+    shard_state()
+      : backlog_size(_dummy_atomic)
+      , next_stage_backlog_size(_dummy_atomic) {}
+
+    shard_state(
+      std::reference_wrapper<const std::atomic<size_t>> backlog_size, // NOLINT
+      std::reference_wrapper<const std::atomic<size_t>>
+        next_backlog_size) // NOLINT
+      : backlog_size(backlog_size)
+      , next_stage_backlog_size(next_backlog_size) {}
+
+    // Reference to the backlog size counter.
+    std::reference_wrapper<const std::atomic<size_t>> backlog_size;
+
+    // Reference to next stage backlog size counter.
+    std::reference_wrapper<const std::atomic<size_t>> next_stage_backlog_size;
+};
+
+/// This struct stores state shared by all shards in the group.
+/// This includes the mutex, last upload time and an atomic counter.
+/// The counter is used to round-robin uploads between all shards in
+/// the group.
+template<typename Clock>
+struct shard_group {
+    using time_point = Clock::time_point;
+
+    // Round-robin counter - rotates through group members
+    std::atomic<uint32_t> ix{0};
+
+    // Mutex is locked when some shard pulls data from other shards.
+    // It's not locked when the data is uploaded.
+    std::mutex mutex;
+
+    // Last upload time for this group
+    std::atomic<time_point> last_upload_time{Clock::now()};
+
+    // Last time this group was modified by a split or merge operation.
+    // Used to rate-limit split/merge decisions to avoid group churn.
+    std::atomic<time_point> last_modification_time{Clock::now()};
+};
+
+/// RAII object representing a scheduled upload request.
+/// Holds the group mutex lock and increments the round-robin counter
+/// when destroyed.
+template<typename Clock>
+class schedule_request {
+public:
+    /// Construct a schedule_request that manages the lock and ix counter.
+    /// \param lock The acquired mutex lock for the group
+    /// \param ix Reference to the round-robin counter to increment on
+    /// destruction
+    schedule_request(
+      std::unique_lock<std::mutex> lock, std::atomic<uint32_t>& ix) noexcept
+      : _lock(std::move(lock))
+      , _ix(ix) {}
+
+    schedule_request(schedule_request&&) noexcept = default;
+    schedule_request& operator=(schedule_request&&) noexcept = default;
+
+    schedule_request(const schedule_request&) = delete;
+    schedule_request& operator=(const schedule_request&) = delete;
+
+    ~schedule_request() {
+        if (_lock.owns_lock()) {
+            _ix.get().fetch_add(1);
+        }
+    }
+
+    /// Release the lock early (still increments ix)
+    void unlock() {
+        if (_lock.owns_lock()) {
+            _ix.get().fetch_add(1);
+            _lock.unlock();
+        }
+    }
+
+private:
+    std::unique_lock<std::mutex> _lock;
+    std::reference_wrapper<std::atomic<uint32_t>> _ix;
+};
+
+/**
+ Data structure which is created on shard 0 and shared with other shards. It
+ tracks the total amount of outstanding work and contains state shared across
+ all shards.
+
+ The scheduler_context allocates shards to different upload groups. The group
+ contains a set of shards that take turns to upload data from all their
+ backlogs.
+
+ Groups can be either split or merged to scale the throughput. The expectation
+ is that the scheduler is followed by the batcher or some set of components that
+ clean up the pipeline by uploading the data to the cloud storage. Each group
+ tracks the backlog size of the next pipeline component. If the backlog grows
+ the group can be split which will doubles the throughput. This process can
+ continue until there is one group per shard.
+
+ When the group is able to keep up with the workload it can be merged with the
+ next group. The decision is made based on the backlog size. Note that if the
+ shard is not under excessive load the backlog size of the next stage will be
+ equal to zero when the shard checks it. The batcher reacts to pipeline events
+ and pulls enough requests to make N objects almost immediately. So in order
+ for the backlog to grow there should be more data than the batcher can pull
+ in one pass.
+
+ The group allocation uses a spin on a Buddy algorithm.
+
+ Initial state:
+
+ shards: [0, 1, 2, 3, 4, 5, 6, 7]
+ groups: [0, 0, 0, 0, 0, 0, 0, 0]
+
+ All shards are in group 0. Shard 0 plays a special role in group 0. It can act
+ as a leader that may decide to split the group into two sub-groups. Every shard
+ can only make any action when the group's turn counter (shard_group::ix) points
+ to it.
+
+ The group can only be split into two equal parts. After the first split the
+ scheduler state looks like this:
+
+ shards: [0, 1, 2, 3, 4, 5, 6, 7]
+ groups: [0, 0, 0, 0, 4, 4, 4, 4]
+
+ Note that first 4 shards are still assigned to group 0 and the next 4 are
+ assigned to group 4. The shard 4 is a group's leader. Now all shards in [4-7]
+ range will use groups[4] state to make scheduling decision. When the shard #4
+ takes turn to make scheduling decisions it may decide to split the group even
+ further. Same is true for shard 0 (which is in a different group). If the
+ group 0 splits we will have this state:
+
+ shards: [0, 1, 2, 3, 4, 5, 6, 7]
+ groups: [0, 0, 2, 2, 4, 4, 4, 4]
+
+ The splitting is done based on the workload. Every time we split the throughput
+ doubles because evert group uploads independently. The merging of groups is
+ also done based on the backlog size and the workload. The decision to merge two
+ groups can only be done by the group that will become a leader of the group
+ after merging. For instance, in the example above only the group 0 can decide
+ to merge with group
+ 2. Not the other way around. After the merging the state of the scheduler will
+ look like this:
+
+ shards: [0, 1, 2, 3, 4, 5, 6, 7]
+ groups: [0, 0, 0, 0, 4, 4, 4, 4]
+
+ Groups 0 and 4 could be merged next. The groups are split and merged in the
+ same order as in the Buddy algorithm. The use of Buddy algorithm allows us to
+ make splitting/merging without allocating a controller shard.
+*/
+template<typename Clock>
+struct scheduler_context {
+    using time_point = Clock::time_point;
+
+    explicit scheduler_context(size_t num_shards)
+      : shards(num_shards)
+      , shard_to_group(num_shards)
+      , groups(num_shards) {}
+
+    scheduler_context(const scheduler_context&) = delete;
+    scheduler_context& operator=(const scheduler_context&) = delete;
+    scheduler_context(scheduler_context&&) = delete;
+    scheduler_context& operator=(scheduler_context&&) = delete;
+    ~scheduler_context() = default;
+
+    /// Populate vector with per-shard byte counts for shards in the given
+    /// group. This is a template method so it must be defined in the header.
+    template<class Info>
+    size_t get_shard_bytes_vec(std::vector<Info>& vec, group_id gid) {
+        size_t total_size = 0;
+        for (unsigned i = 0; i < shards.size(); i++) {
+            if (shard_to_group[i].load() != gid) {
+                continue;
+            }
+            auto bytes = shards[i].backlog_size.get().load();
+            vec.at(i).shard = ss::shard_id(i);
+            vec.at(i).bytes = bytes;
+            total_size += bytes;
+        }
+        return total_size;
+    }
+
+    /// Count the number of unique active groups.
+    /// Takes advantage of the fact that groups in shard_to_group are
+    /// monotonically increasing (due to buddy algorithm allocation).
+    size_t count_active_groups() const;
+
+    /// Count how many shards belong to a given group
+    size_t get_group_size(group_id gid) const;
+
+    /// Get the index of a shard within its group (0-indexed)
+    size_t get_shard_index_in_group(ss::shard_id shard, group_id gid) const;
+
+    /// Get total bytes across all shards in a given group
+    uint64_t get_group_bytes(group_id gid) const;
+
+    /// Get total next-stage bytes across all shards in a given group
+    uint64_t get_group_next_stage_bytes(group_id gid) const;
+
+    /// Split a group in half. First half stays, second half moves to new group.
+    /// \return true if split was performed, false if group has only one shard
+    bool try_split_group(group_id gid);
+
+    /// Find the buddy group that can be merged with this group.
+    /// The buddy is the next group in shard order (the one that was split off).
+    /// \return The buddy group_id, or nullopt if no buddy exists
+    std::optional<group_id> find_buddy_group(group_id gid) const;
+
+    /// Merge this group with its buddy group (reverse of split).
+    /// The buddy group's shards are absorbed into this group.
+    /// \param gid The group to merge (must be the first group of the pair)
+    /// \return true if merge was performed, false otherwise
+    bool try_merge_group(group_id gid);
+
+    /// Main scheduling decision method. Encapsulates round-robin logic,
+    /// group splitting, upload condition checking, and mutex acquisition.
+    ///
+    /// \param shard The shard making the scheduling decision
+    /// \param max_buffer_size Data threshold for triggering upload
+    /// \param scheduling_interval Time threshold for triggering upload
+    /// \param now Current time
+    /// \return schedule_result with action and optional lock
+    schedule_result<Clock> try_schedule_upload(
+      ss::shard_id shard,
+      size_t max_buffer_size,
+      std::chrono::milliseconds scheduling_interval,
+      time_point now);
+
+    /// Update last upload time for a group after successful upload
+    void record_upload_time(group_id gid, time_point upload_time);
+
+    absl::FixedArray<shard_state<Clock>> shards;
+    // Maps shards to groups. The value at offset N
+    // can be less or equal to N. Padded to avoid false sharing.
+    absl::FixedArray<padded_atomic_group_id> shard_to_group;
+    // State shared by all shards in the group (mutex and last upload time).
+    // Shards are using this state to upload.
+    absl::FixedArray<shard_group<Clock>> groups;
+};
 
 /// The scheduler decides the which shard to use to handle write
 /// requests. It also batches requests.
 ///
-/// The write_request_scheduler is a pipeline component that implements the
-/// "parallel batcher" design. It is placed before the batcher in the pipeline
-/// and acts as a peering_sharded_service, redirecting write requests to
-/// batchers for upload. It can move write requests between shards to maximize
-/// the size of the uploaded objects while keeping the latency bounded.
-///
-/// The scheduler uses two policies to decide when to trigger uploads:
-///
-/// - **Data threshold policy** — Forces a shard to upload immediately once its
-/// local data reaches a set threshold. This operates per shard and does not
-/// cross shard boundaries.
-///
-/// - **Time-based fallback policy** — Runs only on shard 0. After N ms, it
-/// forces all shards to send write requests to a single target shard for
-/// upload. The target shard is chosen based on having the most data in the
-/// pipeline to minimize CPU cache invalidation.
+/// The scheduler pushes data to the next stage of the pipeline based on the
+/// upload interval. It can also aggregate data across shards and funnel
+/// requests from many different shards to the one target shard.
 template<typename Clock = seastar::lowres_clock>
 class write_request_scheduler
   : public ss::peering_sharded_service<write_request_scheduler<Clock>> {
@@ -56,6 +331,8 @@ class write_request_scheduler
         size_t bytes;
     };
 
+    using time_point = Clock::time_point;
+
 public:
     explicit write_request_scheduler(write_pipeline<Clock>::stage s);
 
@@ -64,17 +341,6 @@ public:
     ss::future<> stop();
 
 private:
-    /// The fiber that runs on a shard 0 and schedules
-    /// write requests based on timeout. It works
-    /// across all shards at the same time. When it wakes up
-    /// it collects write requests and triggers
-    /// uploads.
-    ss::future<> bg_time_based_fallback();
-
-    /// This method implements the actual fallback mechanism.
-    /// It is invoked by the 'bg_time_based_fallback' method.
-    ss::future<> apply_time_based_fallback();
-
     /// Target shard pulls write requests from pipelines of
     /// other shards and forwards them to its own pipeline.
     /// Then it propagates the responses back to the original
@@ -84,19 +350,15 @@ private:
     /// \note The method is invoked on the target shard. It communicates
     ///       with other shards to instruct them to forward their requests
     ///       to the target shard to upload.
-    ss::future<> pull_and_roundtrip(std::vector<shard_info> infos);
+    ss::future<> pull_and_roundtrip(
+      std::vector<shard_info> infos, std::optional<schedule_request<Clock>>);
 
-    /// This fiber runs on every shard and is triggered by
-    /// the data accumulation threshold. If enough data is accumulated
-    /// on a shard this shard will trigger the upload without going
-    /// cross shard.
-    ss::future<> bg_data_threshold();
+    /// Unified upload path
+    ss::future<> bg_handler();
 
-    /// Run the load balancing for all available write requests
-    ss::future<checked<bool, errc>> run_once() noexcept;
-
-    /// Simply count number of bytes in the queue
-    size_t shard_bytes() noexcept;
+    /// Run one round of upload
+    /// \return next wake up time
+    ss::future<time_point> run_once();
 
     using foreign_ptr_t
       = ss::foreign_ptr<ss::lw_shared_ptr<chunked_vector<extent_meta>>>;
@@ -145,14 +407,21 @@ private:
       ss::shard_id shard,
       ss::foreign_ptr<gate_holder_ptr> target_shard_gate_holder);
 
+    /// Compute next wake up time for the background fiber.
+    /// The interval could be short or long. If the background fiber expects
+    /// that it will not have enough data for L0 upload for a relatively long
+    /// time it will request long sleep. If the upload conditions are almost met
+    /// it will ask for short sleep interval.
+    /// \param long_sleep indicates that the long sleep interval should be used
+    /// \return Time to wake up the background fiber next time.
+    time_point get_next_wakeup_time(bool long_sleep = false);
+
     write_pipeline<Clock>::stage _stage;
     ss::abort_source _as;
     ss::gate _gate;
 
-    // This field is used in tests to limit the uploads to time based fallback
-    bool _test_only_disable_data_threshold{false};
-    // This field is used in tests to limit the uploads to data threshold
-    bool _test_only_disable_time_based_fallback{false};
+    // This field is used in tests to disable background activit
+    bool _test_only_disable_background_loop{false};
 
     config::binding<size_t> _max_buffer_size;
     config::binding<size_t> _max_cardinality;
@@ -160,9 +429,13 @@ private:
 
     write_request_scheduler_probe _probe;
 
-    // The table of all shard bytes counters (ix = shard id)
-    std::vector<std::reference_wrapper<const std::atomic<size_t>>>
-      _shard_counters;
+    // Field used to allocate scheduler_context. Only initialized
+    // on shard zero. Accessed from all shards.
+    std::optional<scheduler_context<Clock>> _shard_zero_context;
+
+    // Every shard accesses the context through this reference.
+    scheduler_context<Clock>* _context;
+    ssx::named_semaphore<Clock> _init_barrier{0, "l0/write_request_scheduler"};
 };
 
 } // namespace cloud_topics::l0

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.h
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.h
@@ -159,6 +159,10 @@ private:
     config::binding<std::chrono::milliseconds> _scheduling_interval;
 
     write_request_scheduler_probe _probe;
+
+    // The table of all shard bytes counters (ix = shard id)
+    std::vector<std::reference_wrapper<const std::atomic<size_t>>>
+      _shard_counters;
 };
 
 } // namespace cloud_topics::l0


### PR DESCRIPTION
# Write Request Scheduler

## Overview

The `write_request_scheduler` is a component in the L0 write pipeline that coordinates
uploads across shards using a group-based scheduling system with buddy allocator-style
dynamic scaling. It aggregates write requests from multiple shards and funnels them to
a single target shard for upload to cloud storage.

## Dependencies

1. **write_pipeline** - Provides the stage interface for pulling write requests
2. **config::configuration** - Configuration bindings:
3. **seastar sharding** - `peering_sharded_service` for cross-shard communication

## Normal Workflow (Every Tick)

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                           SCHEDULER TICK                                    │
│                      (Every 5-20ms per shard)                               │
└─────────────────────────────────────────────────────────────────────────────┘

bg_handler() loop:
│
├── wait_until(max_bytes, deadline)
│   └── Wakes up when:
│       ├── Stage has >= max_buffer_size bytes, OR
│       └── Deadline reached (soft/hard deadline)
│
└── run_once()
    └── try_schedule_upload()
        ├── Step 1: Check Round-Robin
        │   ├── Get group_id from shard_to_group[this_shard]
        │   ├── Compute shard_index_in_group
        │   └── If (group.ix % group_size) != shard_index_in_group:
        │       └── Return schedule_action::skip
        │
        ├── Step 2: Evaluate Group Split/Merge (leader only)
        │   └── If shard_index_in_group == 0:
        │       ├── Check cooldown: (now - last_modification_time) >= 2 * scheduling_interval
        │       └── If cooldown passed:
        │           ├── Calculate split threshold: max_buffer_size × group_size
        │           ├── If next_stage_bytes > split_threshold AND group_size > 1:
        │           │   └── try_split_group() (updates last_modification_time)
        │           └── If next_stage_bytes == 0 AND buddy exists AND buddy cooldown passed:
        │               └── If buddy_next_stage_bytes == 0:
        │                   └── try_merge_group() (updates last_modification_time)
        │
        ├── Step 3: Check Upload Conditions
        │   ├── group_bytes = sum of backlog across all group shards
        │   ├── deadline = last_upload_time + scheduling_interval
        │   └── If group_bytes == 0 OR (group_bytes < max AND !deadline_passed):
        │       └── Return schedule_action::wait
        │
        └── Step 4: Acquire Lock and Upload
            ├── Try to acquire group mutex (non-blocking)
            ├── If lock acquired:
            │   ├── Increment group.ix for next round
            │   ├── Re-check conditions (handle races)
            │   └── Return schedule_action::upload with lock
            └── If lock busy:
                └── Return schedule_action::wait

Upload Path (schedule_action::upload):
├── pull_and_roundtrip()
│   ├── For each shard in group with bytes > 0:
│   │   └── invoke_on(shard, forward_to(target))
│   │
│   ├── Close target_gate (waits for all forwards to complete)
│   ├── Record upload time
│   ├── Release mutex lock
│   │
│   ├── Process local requests:
│   │   └── stage.process() -> advance to next stage
│   │
│   └── when_all_succeed(in_flight futures)
│
└── Return next wakeup time
```

## Group Splitting and Merging (Buddy Allocator)

### Split Operation

When the next stage (sink) backlog exceeds the dynamic split threshold
(`cloud_topics_produce_batching_size_threshold` × group size), groups split to
increase parallelism. Only the group leader (first shard in the group) can
initiate a split.

```
SPLIT: Group 0 with 4 shards becomes two groups of 2 shards

BEFORE:
┌────────────────────────────────────────┐
│             Group 0                    │
│ ┌──────┐  ┌──────┐  ┌──────┐  ┌──────┐ │
│ │  S0  │  │  S1  │  │  S2  │  │  S3  │ │
│ │leader│  │      │  │      │  │      │ │
│ └──────┘  └──────┘  └──────┘  └──────┘ │
└────────────────────────────────────────┘
shard_to_group: [0, 0, 0, 0]

AFTER:
┌──────────────────┐┌────────────────────┐
│    Group 0       ││     Group 2        │
│ ┌──────┐ ┌──────┐││ ┌──────┐  ┌──────┐ │
│ │  S0  │ │  S1  │││ │  S2  │  │  S3  │ │
│ │leader│ │      │││ │leader│  │      │ │
│ └──────┘ └──────┘││ └──────┘  └──────┘ │
└──────────────────┘└────────────────────┘
shard_to_group: [0, 0, 2, 2]
                      ↑
                      New group ID = first shard in second half


Further splits (8 shards example):

Initial:  [0, 0, 0, 0, 0, 0, 0, 0]   Group 0: all 8 shards

Split 1:  [0, 0, 0, 0, 4, 4, 4, 4]   Group 0: S0-S3, Group 4: S4-S7

Split 2:  [0, 0, 2, 2, 4, 4, 4, 4]   Group 0: S0-S1, Group 2: S2-S3
                                     Group 4: S4-S7

Split 3:  [0, 0, 2, 2, 4, 4, 6, 6]   Group 0: S0-S1, Group 2: S2-S3
                                     Group 4: S4-S5, Group 6: S6-S7

Split 4:  [0, 1, 2, 2, 4, 4, 6, 6]   Group 0: S0, Group 1: S1
                                     Group 2: S2-S3, Group 4: S4-S5
                                     Group 6: S6-S7

Maximum:  [0, 1, 2, 3, 4, 5, 6, 7]   Each shard in its own group
```

### Merge Operation

When the next stage backlog is empty (0 bytes) for **both** the current group and its
buddy group, groups merge to reduce overhead. This ensures we don't merge groups while
one of them still has pending work. Only the lower-numbered group can initiate a merge.

```
MERGE: Group 0 absorbs its buddy Group 2

BEFORE:
┌──────────────────┐┌────────────────────┐
│    Group 0       ││     Group 2        │
│ ┌──────┐ ┌──────┐││ ┌──────┐  ┌──────┐ │
│ │  S0  │ │  S1  │││ │  S2  │  │  S3  │ │
│ │leader│ │      │││ │leader│  │      │ │
│ └──────┘ └──────┘││ └──────┘  └──────┘ │
└──────────────────┘└────────────────────┘
shard_to_group: [0, 0, 2, 2]

AFTER:
┌────────────────────────────────────────┐
│             Group 0                    │
│ ┌──────┐  ┌──────┐  ┌──────┐  ┌──────┐ │
│ │  S0  │  │  S1  │  │  S2  │  │  S3  │ │
│ │leader│  │      │  │      │  │      │ │
│ └──────┘  └──────┘  └──────┘  └──────┘ │
└────────────────────────────────────────┘
shard_to_group: [0, 0, 0, 0]


Buddy relationship:
┌─────────────────────────────────────────────────────────────────┐
│                                                                 │
│   Group 0's buddy is the group starting at (last_shard + 1)     │
│                                                                 │
│   [0, 0, 2, 2, 4, 4, 6, 6]                                      │
│    └──┘  └──┘  └──┘  └──┘                                       │
│     G0    G2    G4    G6                                        │
│      │    ↑     │    ↑                                          │
│      └────┘     └────┘                                          │
│      buddies    buddies                                         │
│                                                                 │
│   G0 can merge with G2, G4 can merge with G6                    │
│   G2 cannot merge with G0 (only lower ID initiates)             │
│                                                                 │
└─────────────────────────────────────────────────────────────────┘
```

### Scaling Behavior

```
Throughput vs Load:

High Load (next_stage > split_threshold)
│
│  Groups split → More parallel uploads → Higher throughput
│
│      ┌──────────────────────────────────────────────────────────┐
│      │     Split threshold: max_buffer_size × group_size        │
│      │                                                          │
│      │     As sink backs up, groups split                       │
│      │     Each group uploads independently                     │
│      │     Threshold scales with group size                     │
│      │     Maximum: 1 group per shard                           │
│      └──────────────────────────────────────────────────────────┘
│
Low Load (next_stage == 0)
│
│  Groups merge → Fewer parallel uploads → Less overhead
│
│      ┌─────────────────────────────────────────┐
│      │     Merge condition: 0 bytes backlog    │
│      │                                         │
│      │     As sink empties, groups merge       │
│      │     Reduces coordination overhead       │
│      │     Minimum: 1 group for all shards     │
│      └─────────────────────────────────────────┘
```


## Configuration Parameters

| Parameter | Default | Description |
|-----------|---------|-------------|
| `cloud_topics_produce_batching_size_threshold` | - | Data threshold to trigger upload |
| `cloud_topics_produce_cardinality_threshold` | - | Max requests per upload batch |
| `cloud_topics_produce_upload_interval` | - | Time threshold to trigger upload |

## Internal Constants

| Constant | Value | Description |
|----------|-------|-------------|
| `scheduler_long_sleep_interval` | 20ms | Long sleep between ticks |
| `scheduler_short_sleep_interval` | 5ms | Short sleep between ticks |
| `scheduler_sleep_jitter` | 2ms | Random jitter to avoid thundering herd |
| Split/merge cooldown | 2 × scheduling_interval | Minimum time between group modifications |

## Dynamic Thresholds

| Threshold | Calculation | Description |
|-----------|-------------|-------------|
| `group_split_threshold` | `cloud_topics_produce_batching_size_threshold` × group size | Next-stage backlog threshold for splitting groups |

## Metrics

The scheduler exposes metrics through `write_request_scheduler_probe`:
- Request counts (send/receive cross-shard)
- Bytes transferred

## Thread Safety

- `scheduler_context` is created on shard 0 and shared read-only (except for atomic operations)
- `shard_group::mutex` coordinates uploads within a group
- `shard_group::ix`, `last_upload_time`, `last_modification_time` are atomics for lock-free reads
- `shard_to_group` modifications only happen while holding the group mutex
- All cross-shard data access uses `std::reference_wrapper<const std::atomic<size_t>>`


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none