### PR TITLE
[CORE-14954] `cluster`: limit concurrency in `process_delta()`s

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -440,9 +440,9 @@ ss::future<> controller_backend::bootstrap_controller_backend() {
     _topic_table_notify_handle
       = _topics.local().register_ntp_delta_notification(
         [this](topic_table::ntp_delta_range_t deltas_range) {
-            for (const auto& d : deltas_range) {
-                process_delta(d);
-            }
+            chunked_vector<topic_table::ntp_delta> deltas(
+              deltas_range.begin(), deltas_range.end());
+            process_deltas(std::move(deltas));
         });
 
     co_return;
@@ -657,19 +657,32 @@ controller_backend::calculate_learner_initial_offset(
       std::min(max_removable_local_log_offset, *retention_offset));
 }
 
-void controller_backend::process_delta(const topic_table::ntp_delta& d) {
+void controller_backend::process_deltas(
+  chunked_vector<topic_table::ntp_delta> deltas) {
+    ssx::spawn_with_gate(_gate, [this, deltas = std::move(deltas)] mutable {
+        return ss::do_with(
+          std::move(deltas),
+          [this](chunked_vector<topic_table::ntp_delta>& deltas) {
+              return ss::do_for_each(deltas, [this](topic_table::ntp_delta d) {
+                  return _reconciliation_sem.get_units(1).then(
+                    [this, d = std::move(d)](ssx::semaphore_units u) {
+                        ssx::background = process_delta(
+                          std::move(d), std::move(u));
+                    });
+              });
+          });
+    });
+}
+
+ss::future<> controller_backend::process_delta(
+  topic_table::ntp_delta d, ssx::semaphore_units u) {
     vlog(clusterlog.trace, "got delta: {}", d);
 
     // update partition_leaders_table if needed
 
     if (d.type == topic_table_ntp_delta_type::removed) {
-        ssx::spawn_with_gate(
-          _gate, [this, ntp = d.ntp, rev = d.revision] mutable {
-              return ss::do_with(std::move(ntp), [this, rev](const auto& ntp) {
-                  return _partition_leaders_table.local().remove_leader(
-                    ntp, rev);
-              });
-          });
+        co_await _partition_leaders_table.local().remove_leader(
+          d.ntp, d.revision);
     }
 
     // notify reconciliation fiber
@@ -697,7 +710,7 @@ void controller_backend::process_delta(const topic_table::ntp_delta& d) {
 
     rs.wakeup_event.set();
     if (inserted) {
-        ssx::background = reconcile_ntp_fiber(d.ntp, rs_it->second);
+        co_await reconcile_ntp_fiber(d.ntp, rs_it->second, std::move(u));
     }
 }
 
@@ -716,7 +729,14 @@ void controller_backend::notify_reconciliation(const model::ntp& ntp) {
       rs);
     rs.wakeup_event.set();
     if (inserted) {
-        ssx::background = reconcile_ntp_fiber(ntp, rs_it->second);
+        ssx::spawn_with_gate(_gate, [this, ntp = ntp, rs = rs_it->second] {
+            return _reconciliation_sem.get_units(1).then(
+              [this, ntp = std::move(ntp), rs = std::move(rs)](
+                ssx::semaphore_units u) {
+                  return reconcile_ntp_fiber(
+                    std::move(ntp), std::move(rs), std::move(u));
+              });
+        });
     }
 }
 
@@ -879,12 +899,9 @@ ss::future<> controller_backend::clear_orphan_topic_files(
 }
 
 ss::future<> controller_backend::reconcile_ntp_fiber(
-  model::ntp ntp, ss::lw_shared_ptr<ntp_reconciliation_state> rs) {
-    if (_gate.is_closed()) {
-        co_return;
-    }
-    auto gate_holder = _gate.hold();
-
+  model::ntp ntp,
+  ss::lw_shared_ptr<ntp_reconciliation_state> rs,
+  ssx::semaphore_units u) {
     // If we don't switch here, reconciliation will inherit the scheduling group
     // of whoever triggered it (could be e.g. the admin SG).
     co_await ss::coroutine::switch_to(ss::default_scheduling_group());
@@ -896,7 +913,6 @@ ss::future<> controller_backend::reconcile_ntp_fiber(
         }
 
         try {
-            auto sem_units = co_await _reconciliation_sem.get_units(1);
             rs->last_retried_at = ss::lowres_clock::now();
             co_await try_reconcile_ntp(ntp, *rs);
             if (rs->is_reconciled()) {
@@ -914,6 +930,8 @@ ss::future<> controller_backend::reconcile_ntp_fiber(
             }
         }
     }
+
+    u.return_all();
 }
 
 ss::future<> controller_backend::try_reconcile_ntp(

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -270,10 +270,14 @@ private:
       model::revision_id bootstrap_revision,
       absl::flat_hash_map<model::ntp, model::revision_id> topic_table_snapshot);
 
-    void process_delta(const topic_table::ntp_delta&);
+    void process_deltas(chunked_vector<topic_table::ntp_delta>);
+    ss::future<> process_delta(topic_table::ntp_delta, ssx::semaphore_units);
 
+    // Meant to be called with `_gate` already held.
     ss::future<> reconcile_ntp_fiber(
-      model::ntp, ss::lw_shared_ptr<ntp_reconciliation_state>);
+      model::ntp,
+      ss::lw_shared_ptr<ntp_reconciliation_state>,
+      ssx::semaphore_units);
     ss::future<>
     try_reconcile_ntp(const model::ntp&, ntp_reconciliation_state&);
     ss::future<result<ss::stop_iteration>>


### PR DESCRIPTION
We were firing off enough backgrounded jobs with the previous `process_delta()` implementation to cause an oversized allocation in the `seastar::reactor` in the case of many partitions:

```
WARN  2025-12-08 12:50:05,288 [shard 1:clus] seastar_memory - oversized allocation: 262144 bytes. This is non-fatal, but could lead to latency and/or fragmentation issues. Please report: at
[Backtrace #1]
[...]
seastar::memory::cpu_pages::warn_large_allocation(unsigned long) at ./external/+non_module_dependencies+seastar/src/core/memory.cc:859
[...]
(inlined by) seastar::circular_buffer<seastar::task*, std::__1::allocator<seastar::task*>>::push_back(seastar::task*&&) at ./external/+non_module_dependencies+seastar/include/seastar/core/circular_buffer.hh:408
[...]
(inlined by) seastar::reactor::add_task(seastar::task*) at ./external/+non_module_dependencies+seastar/src/core/reactor.cc:3150
(inlined by) seastar::schedule(seastar::task*) at ./external/+non_module_dependencies+seastar/src/core/reactor.cc:3886
cluster::controller_backend::reconcile_ntp_fiber(model::ntp, seastar::lw_shared_ptr<cluster::controller_backend::ntp_reconciliation_state>) at ./src/v/cluster/controller_backend.cc:0
cluster::controller_backend::process_delta(cluster::topic_table_ntp_delta const&) at ./src/v/cluster/controller_backend.cc:700
(inlined by) cluster::controller_backend::bootstrap_controller_backend()::$_0::operator()(boost::iterator_range<chunked_vector<cluster::topic_table_ntp_delta>::iter<true>>) const at ./src/v/cluster/controller_backend.cc:444
```

This is due to the fact we were iterating over the `ntp_delta_range_t` synchronously while processing them (to avoid any concurrent mutations of the underlying `chunked_vector`, since all we really have is a view of the data via `boost::iterator_range`), while immediately spawning background fibers for each delta to process.

Limit the concurrency by:
1. Making an immediate copy of the deltas to process
2. Turning `process_delta()` into an asynchronous function which requires `semaphore_units` be obtained from `_reconciliation_sem` and passed as an argument.
3. Adding a new function `process_deltas()`, which iterates sequential over the copied deltas and waits for units from `_reconciliation_sem` _before_ dispatching background fibers.

Since the previous behavior was also indeterminate with respect to the order in which `ntp_delta`s were processed, the changes here don't invalidate any previously made assumptions.


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Improvements

* Prevent oversized allocations in the `seastar::reactor` when handling many partitions in the `cluster_backend`
