### PR TITLE
lsm: support per level compression

### DIFF
--- a/src/v/bytes/ioarray.cc
+++ b/src/v/bytes/ioarray.cc
@@ -21,6 +21,7 @@
 
 #include <cstring>
 #include <iterator>
+#include <stdexcept>
 
 ioarray::ioarray(size_t size)
   : ioarray(uninitialized_t{}, size) {
@@ -260,4 +261,28 @@ void ioarray::trim_back(size_t n) {
     auto* buffers_ptr = &_buffers;
     buffers_ptr->~FixedArray();
     new (buffers_ptr) absl::FixedArray(std::move(replacement));
+}
+
+ioarray
+ioarray::from_sized_buffers(std::span<ss::temporary_buffer<char>> bufs) {
+    if (bufs.empty()) {
+        return {};
+    }
+    ioarray out(uninitialized_t{}, bufs.size() * max_chunk_size);
+    size_t i = 0, size = 0;
+    for (auto& buf : bufs.subspan(0, bufs.size() - 1)) {
+        if (buf.size() != max_chunk_size) {
+            throw std::invalid_argument(
+              fmt::format(
+                "inner chunk size must be {}, got {}",
+                max_chunk_size,
+                buf.size()));
+        }
+        size += buf.size();
+        out._buffers[i++] = buf.share();
+    }
+    size += bufs.back().size();
+    out._buffers[i] = bufs.back().share();
+    out._size = size;
+    return out;
 }

--- a/src/v/bytes/ioarray.h
+++ b/src/v/bytes/ioarray.h
@@ -75,7 +75,13 @@ public:
         std::array<std::string_view, 2> _views;
     };
 
-    // Create an uninitialized iovector where all the chunks are aligned.
+    // Create an ioarray by sharing the passed in to be buffers into
+    // a new ioarray.
+    //
+    // REQUIRES: All but the last buffer must be `max_chunk_size` in length.
+    static ioarray from_sized_buffers(std::span<ss::temporary_buffer<char>>);
+
+    // Create an uninitialized ioarray where all the chunks are aligned.
     // It's assumed that the alignment is a power of two less than
     // `max_chunk_size` and that size is a multiple of alignment.
     static ioarray aligned(size_t alignment, size_t size);

--- a/src/v/bytes/tests/ioarray_test.cc
+++ b/src/v/bytes/tests/ioarray_test.cc
@@ -355,4 +355,113 @@ TEST(IOArray, ReadFixed32) {
     EXPECT_EQ(0x04030201, contents2.read_fixed32(1));
 }
 
+TEST(IOArray, FromSizedBuffers) {
+    // Test empty input
+    {
+        std::vector<ss::temporary_buffer<char>> bufs;
+        auto arr = ioarray::from_sized_buffers(bufs);
+        EXPECT_TRUE(arr.empty());
+        EXPECT_EQ(0, arr.size());
+    }
+
+    // Test single buffer (can be any size since it's the last one)
+    {
+        std::vector<ss::temporary_buffer<char>> bufs;
+        bufs.emplace_back(1024);
+        for (size_t i = 0; i < 1024; ++i) {
+            bufs[0].get_write()[i] = 'A' + (i % 26);
+        }
+
+        auto arr = ioarray::from_sized_buffers(bufs);
+        EXPECT_EQ(1024, arr.size());
+        for (size_t i = 0; i < 1024; ++i) {
+            EXPECT_EQ('A' + (i % 26), arr[i]);
+        }
+    }
+
+    // Test multiple buffers with correct sizes
+    {
+        std::vector<ss::temporary_buffer<char>> bufs;
+        // Two full chunks
+        bufs.emplace_back(128_KiB);
+        bufs.emplace_back(128_KiB);
+        // Last chunk can be smaller
+        bufs.emplace_back(64_KiB);
+
+        // Fill with pattern
+        for (size_t buf_idx = 0; buf_idx < bufs.size(); ++buf_idx) {
+            for (size_t i = 0; i < bufs[buf_idx].size(); ++i) {
+                bufs[buf_idx].get_write()[i] = static_cast<char>(
+                  (buf_idx * 128_KiB + i) & 0xFF);
+            }
+        }
+
+        auto arr = ioarray::from_sized_buffers(bufs);
+        EXPECT_EQ(128_KiB + 128_KiB + 64_KiB, arr.size());
+
+        // Verify data is accessible
+        for (size_t i = 0; i < arr.size(); ++i) {
+            EXPECT_EQ(static_cast<char>(i & 0xFF), arr[i])
+              << "Mismatch at index " << i;
+        }
+    }
+
+    // Test that buffers are shared (not copied)
+    {
+        std::vector<ss::temporary_buffer<char>> bufs;
+        bufs.emplace_back(128_KiB);
+        bufs.emplace_back(100);
+
+        // Fill with initial pattern
+        std::memset(bufs[0].get_write(), 'X', 128_KiB);
+        std::memset(bufs[1].get_write(), 'Y', 100);
+
+        auto arr = ioarray::from_sized_buffers(bufs);
+
+        // Modify original buffer
+        bufs[0].get_write()[0] = 'Z';
+
+        // Verify array sees the change (proving sharing)
+        EXPECT_EQ('Z', arr[0]);
+        EXPECT_EQ('X', arr[1]);
+        EXPECT_EQ('Y', arr[128_KiB]);
+    }
+
+    // Test conversion to iobuf
+    {
+        std::vector<ss::temporary_buffer<char>> bufs;
+        bufs.emplace_back(128_KiB);
+        bufs.emplace_back(50_KiB);
+
+        for (size_t buf_idx = 0; buf_idx < bufs.size(); ++buf_idx) {
+            for (size_t i = 0; i < bufs[buf_idx].size(); ++i) {
+                bufs[buf_idx].get_write()[i] = static_cast<char>(
+                  (buf_idx * 128_KiB + i) & 0xFF);
+            }
+        }
+
+        auto arr = ioarray::from_sized_buffers(bufs);
+
+        EXPECT_EQ(128_KiB + 50_KiB, arr.size());
+
+        // Verify contents
+        char expected = 0;
+        for (char c : arr.as_range()) {
+            EXPECT_EQ(expected++, c);
+        }
+    }
+
+    // Test invalid case: middle buffer not max_chunk_size
+    {
+        std::vector<ss::temporary_buffer<char>> bufs;
+        bufs.emplace_back(128_KiB);
+        bufs.emplace_back(64_KiB); // Wrong size!
+        bufs.emplace_back(100);
+
+        EXPECT_THROW(
+          { auto arr = ioarray::from_sized_buffers(bufs); },
+          std::invalid_argument);
+    }
+}
+
 // NOLINTEND(*magic-numbers*)

--- a/src/v/compression/BUILD
+++ b/src/v/compression/BUILD
@@ -30,6 +30,7 @@ redpanda_cc_library(
     deps = [
         "//src/v/base",
         "//src/v/bytes",
+        "//src/v/bytes:ioarray",
         "//src/v/bytes:iobuf",
         "//src/v/utils:object_pool",
         "//src/v/utils:static_deleter_fn",

--- a/src/v/compression/async_stream_zstd.cc
+++ b/src/v/compression/async_stream_zstd.cc
@@ -15,11 +15,13 @@
 #include "base/vlog.h"
 #include "bytes/bytes.h"
 #include "bytes/details/io_allocation_size.h"
+#include "bytes/ioarray.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
 #include <fmt/format.h>
+#include <sys/uio.h>
 
 #include <array>
 #include <zstd.h>
@@ -256,6 +258,71 @@ ss::future<iobuf> async_stream_zstd::uncompress(iobuf i_buf) {
     }
 
     co_return ret_buf;
+}
+
+ss::future<ioarray> async_stream_zstd::uncompress(ioarray i_arr) {
+    if (unlikely(i_arr.empty())) {
+        throw std::runtime_error(
+          "Asked to stream_zstd::uncompress empty array");
+    }
+
+    ss::abort_source as;
+    auto ctx_scope = co_await _decompression_ctx_pool.allocate_scoped_object(
+      as);
+    auto& ctx = *ctx_scope;
+
+    ZSTD_DCtx_reset(ctx._decompress_ctx, ZSTD_reset_session_only);
+
+    size_t last_zstd_ret = 0;
+
+    std::vector<ss::temporary_buffer<char>> obufs;
+    size_t osize = 0;
+    auto append = [&obufs, &osize](std::span<const char> decompressed) {
+        constexpr size_t max_chunk_size = ioarray::max_chunk_size;
+        while (!decompressed.empty()) {
+            auto written_in_buffer = osize % max_chunk_size;
+            if (written_in_buffer == 0) {
+                obufs.emplace_back(max_chunk_size);
+            }
+            auto remaining = max_chunk_size - written_in_buffer;
+            auto n = std::min(decompressed.size(), remaining);
+            auto& buf = obufs.back();
+            // NOLINTNEXTLINE(*pointer-arithmetic*)
+            char* write = buf.get_write() + written_in_buffer;
+            std::memcpy(write, decompressed.data(), n);
+            decompressed = decompressed.subspan(n);
+            osize += n;
+        }
+    };
+
+    for (auto& ibuf : i_arr.as_iovec()) {
+        ZSTD_inBuffer in = {
+          .src = ibuf.iov_base, .size = ibuf.iov_len, .pos = 0};
+
+        while (in.pos < in.size) {
+            ZSTD_outBuffer out = {
+              .dst = ctx._d_buffer.get_write(),
+              .size = ctx._d_buffer.size(),
+              .pos = 0};
+
+            const auto zstd_ret = ZSTD_decompressStream(
+              ctx._decompress_ctx, &out, &in);
+            throw_if_error(zstd_ret);
+
+            append({ctx._d_buffer.get(), out.pos});
+            last_zstd_ret = zstd_ret;
+
+            co_await ss::coroutine::maybe_yield();
+        }
+    }
+
+    if (last_zstd_ret != 0) {
+        throw std::runtime_error("Input truncated before reading epilog");
+    }
+
+    auto out = ioarray::from_sized_buffers(obufs);
+    out.trim_back(out.size() - osize);
+    co_return out;
 }
 
 } // namespace compression

--- a/src/v/compression/async_stream_zstd.h
+++ b/src/v/compression/async_stream_zstd.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "bytes/ioarray.h"
 #include "bytes/iobuf.h"
 #include "utils/object_pool.h"
 
@@ -34,6 +35,7 @@ public:
 
     ss::future<iobuf> compress(iobuf);
     ss::future<iobuf> uncompress(iobuf);
+    ss::future<ioarray> uncompress(ioarray);
 
     size_t decompression_size() const;
 

--- a/src/v/compression/tests/zstd_tests.cc
+++ b/src/v/compression/tests/zstd_tests.cc
@@ -102,9 +102,11 @@ SEASTAR_THREAD_TEST_CASE(async_stream_zstd_test) {
         iobuf buf = gen(i);
 
         auto cbuf = fn.compress(buf.share(0, i)).get();
+        auto darr = fn.uncompress(ioarray::copy_from(cbuf)).get();
         auto dbuf = fn.uncompress(std::move(cbuf)).get();
 
         BOOST_CHECK_EQUAL(dbuf, buf);
+        BOOST_CHECK_EQUAL(dbuf, darr.as_iobuf());
     }
 }
 

--- a/src/v/lsm/core/compression.cc
+++ b/src/v/lsm/core/compression.cc
@@ -11,11 +11,13 @@
 
 #include "lsm/core/compression.h"
 
+#include "compression/async_stream_zstd.h"
 #include "compression/compression.h"
 #include "lsm/core/exceptions.h"
 
 #include <seastar/core/coroutine.hh>
 
+#include <exception>
 #include <utility>
 
 namespace lsm {
@@ -40,10 +42,20 @@ ss::future<iobuf> compress(iobuf buf, compression_type type) {
 }
 
 ss::future<ioarray> uncompress(ioarray array, compression_type type) {
-    // TODO(lsm): support uncompression directly into ioarray?
-    auto iobuf = co_await compression::stream_compressor::uncompress(
-      array.as_iobuf(), convert_type(type));
-    co_return ioarray::copy_from(iobuf);
+    switch (type) {
+    case compression_type::none:
+        throw invalid_argument_exception(
+          "attempted to compress with type none");
+    case compression_type::zstd: {
+        try {
+            co_return co_await compression::async_stream_zstd_instance()
+              .uncompress(std::move(array));
+        } catch (const std::exception& ex) {
+            throw invalid_argument_exception(
+              "failed to uncompress: {}", ex.what());
+        }
+    }
+    }
 }
 
 compression_type compression_type_from_raw(uint8_t v) {

--- a/src/v/lsm/core/internal/options.cc
+++ b/src/v/lsm/core/internal/options.cc
@@ -11,15 +11,18 @@
 
 #include "lsm/core/internal/options.h"
 
+#include <utility>
+
 namespace lsm::internal {
 
 fmt::iterator options::level_config::format_to(fmt::iterator it) const {
     return fmt::format_to(
       it,
-      "{{number:{},max_total_bytes:{},max_file_size:{}}}",
+      "{{number:{},max_total_bytes:{},max_file_size:{},compression:{}}}",
       number,
       max_total_bytes,
-      max_file_size);
+      max_file_size,
+      std::to_underlying(compression));
 }
 
 fmt::iterator options::format_to(fmt::iterator it) const {

--- a/src/v/lsm/core/internal/options.h
+++ b/src/v/lsm/core/internal/options.h
@@ -52,6 +52,12 @@ struct options {
         // longer compactions and longer latency/performance hiccups.
         size_t max_file_size;
 
+        // The compression type for SST blocks created in this level. In some
+        // cases this setting may be ignored, for example if there is a trivial
+        // compaction move and a file moves between levels without needing to be
+        // rewritten.
+        compression_type compression = compression_type::none;
+
         fmt::iterator format_to(fmt::iterator) const;
     };
 
@@ -168,9 +174,6 @@ struct options {
     // REQUIRED: this value must be a power of two
     constexpr static size_t default_sst_filter_period = 2_KiB;
     size_t sst_filter_period = default_sst_filter_period;
-
-    // The compression to use for SST blocks.
-    compression_type compression = compression_type::none;
 
     // We arrange to automatically compact after a file after a certain
     // number of seeks. Let's assume:

--- a/src/v/lsm/db/impl.cc
+++ b/src/v/lsm/db/impl.cc
@@ -323,10 +323,10 @@ struct compaction_state {
     ss::future<> open_current_builder(
       internal::file_handle h,
       io::data_persistence* p,
-      ss::lw_shared_ptr<internal::options> opts) {
+      sst::builder::options opts) {
         outputs.emplace_back(h);
         auto w = co_await p->open_sequential_writer(h);
-        builder.emplace(std::move(w), std::move(opts));
+        builder.emplace(std::move(w), opts);
     }
     ss::future<> finish_current_builder() {
         auto b = std::exchange(builder, std::nullopt);
@@ -394,6 +394,11 @@ ss::future<> impl::run_background_compaction() {
     };
     auto output_level = compaction.level() + 1_level;
     auto max_file_size = _opts->levels[output_level].max_file_size;
+    sst::builder::options sst_options{
+      .block_size = _opts->sst_block_size,
+      .filter_period = _opts->sst_filter_period,
+      .compression = _opts->levels[output_level].compression,
+    };
     try {
         auto input = co_await _versions->make_input_iterator(&compaction);
         std::optional<internal::key> current_key;
@@ -443,7 +448,7 @@ ss::future<> impl::run_background_compaction() {
                         .epoch = _opts->database_epoch,
                       },
                       _persistence.data.get(),
-                      _opts);
+                      sst_options);
                 }
                 auto& current = state.current_output();
                 if (state.builder->num_entries() == 0) {
@@ -498,11 +503,16 @@ ss::future<> impl::flush_memtable() {
                    ? 0_level
                    : v->pick_level_for_memtable_output(
                        imm->min_key().user_key(), imm->max_key().user_key());
+    sst::builder::options sst_options{
+      .block_size = _opts->sst_block_size,
+      .filter_period = _opts->sst_filter_period,
+      .compression = _opts->levels[level].compression,
+    };
     auto result = co_await build_table(
       _persistence.data.get(),
       {.id = id, .epoch = _opts->database_epoch},
       imm->create_iterator(),
-      _opts,
+      sst_options,
       &_as);
     if (!result) {
         _versions->reuse_file_id(id);

--- a/src/v/lsm/db/table_builder.cc
+++ b/src/v/lsm/db/table_builder.cc
@@ -66,10 +66,10 @@ ss::future<std::optional<build_table_result>> build_table(
   io::data_persistence* persistence,
   internal::file_handle handle,
   std::unique_ptr<internal::iterator> iter,
-  ss::lw_shared_ptr<internal::options> opts,
+  sst::builder::options opts,
   ss::abort_source* as) {
     auto writer = co_await persistence->open_sequential_writer(handle);
-    sst::builder builder{std::move(writer), std::move(opts)};
+    sst::builder builder{std::move(writer), opts};
     auto result = co_await write_sst_file(std::move(iter), &builder, as)
                     .finally([&builder] { return builder.close(); });
     if (!result) {

--- a/src/v/lsm/db/table_builder.h
+++ b/src/v/lsm/db/table_builder.h
@@ -15,8 +15,8 @@
 #include "lsm/core/internal/files.h"
 #include "lsm/core/internal/iterator.h"
 #include "lsm/core/internal/keys.h"
-#include "lsm/core/internal/options.h"
 #include "lsm/io/persistence.h"
+#include "lsm/sst/builder.h"
 
 #include <seastar/core/future.hh>
 
@@ -39,7 +39,7 @@ ss::future<std::optional<build_table_result>> build_table(
   io::data_persistence* persistence,
   internal::file_handle handle,
   std::unique_ptr<internal::iterator> iter,
-  ss::lw_shared_ptr<internal::options> opts,
+  sst::builder::options opts,
   ss::abort_source*);
 
 } // namespace lsm::db

--- a/src/v/lsm/db/tests/db_bench.cc
+++ b/src/v/lsm/db/tests/db_bench.cc
@@ -177,9 +177,12 @@ public:
               lsm::internal::options::default_level_multipler,
               lsm::internal::options::default_max_level),
             .write_buffer_size = _cfg.write_buffer_size,
-            .compression = _cfg.compression ? lsm::compression_type::zstd
-                                            : lsm::compression_type::none,
           });
+        if (_cfg.compression) {
+            for (auto& level : opts->levels) {
+                level.compression = lsm::compression_type::zstd;
+            }
+        }
 
         std::unique_ptr<lsm::io::data_persistence> data;
         std::unique_ptr<lsm::io::metadata_persistence> metadata;

--- a/src/v/lsm/db/tests/table_cache_test.cc
+++ b/src/v/lsm/db/tests/table_cache_test.cc
@@ -11,7 +11,6 @@
 
 #include "base/seastarx.h"
 #include "lsm/core/internal/files.h"
-#include "lsm/core/internal/options.h"
 #include "lsm/db/table_cache.h"
 #include "lsm/io/memory_persistence.h"
 #include "lsm/sst/builder.h"
@@ -32,8 +31,7 @@ public:
     std::pair<lsm::internal::file_handle, size_t> make_sst() {
         auto filename = file_handle{.id = ++_latest_id, .epoch = 0_db_epoch};
         auto file = _persistence->open_sequential_writer(filename).get();
-        lsm::sst::builder builder(
-          std::move(file), ss::make_lw_shared<lsm::internal::options>());
+        lsm::sst::builder builder(std::move(file), {});
         // Just make empty SST files - the cache doesn't care about the contents
         builder.finish().get();
         builder.close().get();

--- a/src/v/lsm/db/tests/version_set_test.cc
+++ b/src/v/lsm/db/tests/version_set_test.cc
@@ -70,8 +70,7 @@ public:
     void add_sst(sst_spec spec) {
         auto writer
           = _data_persistence->open_sequential_writer({.id = spec.id}).get();
-        lsm::sst::builder builder(
-          std::move(writer), ss::make_lw_shared<lsm::internal::options>());
+        lsm::sst::builder builder(std::move(writer), {});
         std::ranges::sort(spec.keys);
         for (const auto& key : spec.keys) {
             builder

--- a/src/v/lsm/lsm.cc
+++ b/src/v/lsm/lsm.cc
@@ -11,6 +11,7 @@
 
 #include "lsm/lsm.h"
 
+#include "base/vassert.h"
 #include "lsm/core/internal/iterator.h"
 #include "lsm/core/internal/keys.h"
 #include "lsm/core/internal/options.h"
@@ -20,10 +21,21 @@
 #include <seastar/core/coroutine.hh>
 
 #include <stdexcept>
+#include <utility>
 
 namespace lsm {
 
 namespace {
+
+compression_type translate_compression(options::compression_type type) {
+    switch (type) {
+    case options::compression_type::none:
+        return compression_type::none;
+    case options::compression_type::zstd:
+        return compression_type::zstd;
+    }
+    vunreachable("unknown compression type {}", std::to_underlying(type));
+}
 
 ss::lw_shared_ptr<internal::options> translate_options(options opts) {
     if (opts.num_levels < 2) {
@@ -82,6 +94,14 @@ ss::lw_shared_ptr<internal::options> translate_options(options opts) {
       },
       internal::options::default_level_multipler,
       max_level);
+    compression_type c = compression_type::none;
+    for (uint8_t i = 0; i < opts.num_levels; ++i) {
+        if (i < opts.compression_by_level.size()) {
+            c = translate_compression(opts.compression_by_level[i]);
+        }
+        internal_opts->levels[i].compression = c;
+    }
+
     internal_opts->readonly = opts.readonly;
     internal_opts->compaction_scheduling_group
       = opts.compaction_scheduling_group.value_or(
@@ -98,15 +118,6 @@ ss::lw_shared_ptr<internal::options> translate_options(options opts) {
     internal_opts->block_cache_size = opts.block_cache_size;
     internal_opts->sst_block_size = opts.sst_block_size;
     internal_opts->sst_filter_period = opts.sst_filter_period;
-
-    switch (opts.compression) {
-    case options::compression_type::none:
-        internal_opts->compression = compression_type::none;
-        break;
-    case options::compression_type::zstd:
-        internal_opts->compression = compression_type::zstd;
-        break;
-    }
 
     return internal_opts;
 }

--- a/src/v/lsm/lsm.h
+++ b/src/v/lsm/lsm.h
@@ -127,10 +127,14 @@ struct options {
     };
     // The compression to use for SST blocks.
     //
-    // This value may be changed between different opens of the database.
+    // This value may be changed between different opens of the database (old
+    // data is left as is).
     //
-    // TODO: support different compression types per level
-    compression_type compression = compression_type::none;
+    // More elements in this vector are ignored, and if there are more levels
+    // than elements, the last element is repeated for the rest of the levels.
+    //
+    // If empty all levels are uncompressed.
+    std::vector<compression_type> compression_by_level;
 };
 
 class write_batch;

--- a/src/v/lsm/sst/builder.cc
+++ b/src/v/lsm/sst/builder.cc
@@ -18,15 +18,13 @@
 
 namespace lsm::sst {
 
-builder::builder(
-  std::unique_ptr<io::sequential_file_writer> w,
-  ss::lw_shared_ptr<internal::options> opts)
+builder::builder(std::unique_ptr<io::sequential_file_writer> w, options opts)
   : _writer(std::move(w))
-  , _opts(std::move(opts)) {
-    if (_opts->sst_filter_period > 0) {
+  , _opts(opts) {
+    if (_opts.filter_period > 0) {
         _filter.emplace(
           block::filter_builder::options{
-            .filter_period = _opts->sst_filter_period,
+            .filter_period = _opts.filter_period,
           });
     }
 }
@@ -52,7 +50,7 @@ ss::future<> builder::add(internal::key key, iobuf value) {
     _last_key = key;
     _data_block.add(std::move(key), std::move(value));
     ++_added_entries;
-    if (_data_block.current_size_estimate() > _opts->sst_block_size) {
+    if (_data_block.current_size_estimate() > _opts.block_size) {
         co_await flush();
     }
 }
@@ -63,7 +61,7 @@ ss::future<> builder::flush() {
     }
     auto buf = _data_block.finish();
     _pending_handle = co_await write_raw_block(
-      std::move(buf), _opts->compression);
+      std::move(buf), _opts.compression);
     _pending_index_entry = true;
     if (_filter) {
         _filter->start_block(_written_bytes);
@@ -113,7 +111,7 @@ ss::future<> builder::finish() {
         meta_index_block.add(std::move(key), filter_block_handle.as_iobuf());
     }
     metaindex_block_handle = co_await write_raw_block(
-      meta_index_block.finish(), _opts->compression);
+      meta_index_block.finish(), _opts.compression);
 
     if (_pending_index_entry) {
         // TODO(lsm): See the TODO in builder::add

--- a/src/v/lsm/sst/builder.h
+++ b/src/v/lsm/sst/builder.h
@@ -20,18 +20,20 @@
 #include "lsm/core/internal/options.h"
 #include "lsm/io/persistence.h"
 
-#include <seastar/core/iostream.hh>
-
 namespace lsm::sst {
 
 // builder provides the interface used to build a Sorted String Table (SST),
 // which is an immutable and sorted map from keys to values.
 class builder {
 public:
+    struct options {
+        size_t block_size = internal::options::default_sst_block_size;
+        size_t filter_period = internal::options::default_sst_filter_period;
+        compression_type compression = compression_type::none;
+    };
+
     // Construct a new builder that will write to the given file.
-    builder(
-      std::unique_ptr<io::sequential_file_writer>,
-      ss::lw_shared_ptr<internal::options> o);
+    builder(std::unique_ptr<io::sequential_file_writer>, options);
 
     // Add key, value to the table being constructed.
     // REQUIRES: key is after any previously added key according to comparator.
@@ -63,7 +65,7 @@ private:
     block::handle _pending_handle;
     internal::key _last_key;
     std::unique_ptr<io::sequential_file_writer> _writer;
-    ss::lw_shared_ptr<internal::options> _opts;
+    options _opts;
     std::optional<block::filter_builder> _filter;
     bool _pending_index_entry = false;
 };

--- a/src/v/lsm/sst/tests/iterator_test.cc
+++ b/src/v/lsm/sst/tests/iterator_test.cc
@@ -32,8 +32,8 @@ public:
         {
             auto file
               = _persistence->open_sequential_writer({.id = filename}).get();
-            auto opts = ss::make_lw_shared<lsm::internal::options>();
-            opts->compression = CompressionType;
+            lsm::sst::builder::options opts;
+            opts.compression = CompressionType;
             lsm::sst::builder builder(std::move(file), opts);
             for (auto& [key, value] : map) {
                 builder.add(key, std::move(value)).get();

--- a/src/v/lsm/sst/tests/sst_test.cc
+++ b/src/v/lsm/sst/tests/sst_test.cc
@@ -42,8 +42,7 @@ TEST_P(SSTTest, CanCreateAndReadFile) {
     size_t file_size = 0;
     {
         auto file = _persistence->open_sequential_writer({}).get();
-        auto opts = ss::make_lw_shared<lsm::internal::options>();
-        lsm::sst::builder builder(std::move(file), opts);
+        lsm::sst::builder builder(std::move(file), {});
         builder.add("abc"_key, iobuf::from("value1")).get();
         builder.add("abcd"_key, iobuf::from("value2")).get();
         builder.add("abc123"_key, iobuf::from("value3")).get();


### PR DESCRIPTION
Support per level compression settings, as well as supporting direct decompression for ioarray

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
