### PR TITLE
[CORE-14926] `ct/l1`: add `extent_metadata_reader` and paginate extents requests in `compaction` subsystem

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/BUILD
@@ -62,6 +62,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_one/common:object",
         "//src/v/cloud_topics/level_one/frontend_reader:reader",
         "//src/v/cloud_topics/level_one/metastore",
+        "//src/v/cloud_topics/level_one/metastore:extent_metadata_reader",
         "//src/v/cloud_topics/level_one/metastore:offset_interval_set",
         "//src/v/compaction:key",
         "//src/v/compaction:key_offset_map",

--- a/src/v/cloud_topics/level_one/compaction/committer.cc
+++ b/src/v/cloud_topics/level_one/compaction/committer.cc
@@ -99,7 +99,7 @@ ss::future<> compaction_committer::compaction_job::finalize(
 void compaction_committer::compaction_job::cancel_job() {
     _as.request_abort();
     _upload_sem.broken();
-    _upload_cv.broken();
+    _last_upload_scheduled.broken();
     _metadata_builder_mutex.broken();
 }
 
@@ -135,7 +135,7 @@ ss::future<> compaction_committer::compaction_job::upload_loop() {
         }
     }
 
-    _upload_cv.signal();
+    _last_upload_scheduled.signal();
 }
 
 void compaction_committer::compaction_job::start_upload_loop() {
@@ -246,7 +246,7 @@ void compaction_committer::compaction_job::upload_some() {
 
 ss::future<std::optional<ss::sstring>>
 compaction_committer::compaction_job::await_inflight_uploads() {
-    co_await _upload_cv.wait();
+    co_await _last_upload_scheduled.wait();
 
     auto inflight_uploads = std::exchange(_inflight_uploads, {});
 

--- a/src/v/cloud_topics/level_one/compaction/committer.h
+++ b/src/v/cloud_topics/level_one/compaction/committer.h
@@ -169,7 +169,9 @@ public:
         // or when the job is marked as `finalized`.
         ssx::semaphore _upload_sem;
         ss::abort_source _as;
-        ss::condition_variable _upload_cv;
+        // Condition variable that is signalled when the last L1 object has been
+        // uploaded, and awaited upon within `await_inflight_uploads()`.
+        ss::condition_variable _last_upload_scheduled;
 
         compaction_committer* _committer;
         io* _io;

--- a/src/v/cloud_topics/level_one/compaction/sink.cc
+++ b/src/v/cloud_topics/level_one/compaction/sink.cc
@@ -100,8 +100,7 @@ compaction_sink::initialize(compaction::sliding_window_reducer::source& src) {
 
     bool has_removable_tombstones = !_removable_tombstone_ranges.empty();
     bool has_dirty_ranges = !_dirty_range_intervals.empty();
-    bool should_compact = !ct_src._extents.empty()
-                          && (has_removable_tombstones || has_dirty_ranges);
+    bool should_compact = has_removable_tombstones || has_dirty_ranges;
 
     if (!should_compact) {
         co_return false;

--- a/src/v/cloud_topics/level_one/compaction/sink.h
+++ b/src/v/cloud_topics/level_one/compaction/sink.h
@@ -82,7 +82,7 @@ private:
     const metastore::compaction_epoch _expected_compaction_epoch;
 
     // The start offset of the log.
-    kafka::offset _start_offset{0};
+    kafka::offset _start_offset;
 
     // The compaction job, if initialized, as returned by the `_committer`.
     compaction_committer::compaction_job* _job{nullptr};

--- a/src/v/cloud_topics/level_one/compaction/source.cc
+++ b/src/v/cloud_topics/level_one/compaction/source.cc
@@ -14,6 +14,7 @@
 #include "cloud_topics/level_one/compaction/logger.h"
 #include "cloud_topics/level_one/compaction/sink.h"
 #include "cloud_topics/level_one/frontend_reader/level_one_reader.h"
+#include "cloud_topics/level_one/metastore/extent_metadata_reader.h"
 #include "cloud_topics/level_one/metastore/offset_interval_set.h"
 #include "cloud_topics/log_reader_config.h"
 #include "compaction/key.h"
@@ -99,32 +100,18 @@ private:
     std::optional<model::offset> _max_indexed_offset{std::nullopt};
 };
 
-// Returns extent regions that bound the provided `dirty_range`.
-// For example, if the passed `dirty_range` is `[10,100]` and the provided
+// Aligns the passed extent to the provided dirty range.
+// For example, if the passed `dirty_range` is `[10,100]`, and some example
 // `extents` are `[[0, 20], [21, 39], [40, 71], [72, 93], [94, 110]]`, the
-// container returned would be expected to hold `[[10, 20], [21, 39], [40, 71],
-// [72, 93], [94, 100]]`.
-chunked_vector<offset_interval_set::interval> intervals_for_dirty_range(
+// return value would be expected to be `[[10, 20], [21, 39], [40, 71], [72,
+// 93], [94, 100]]` (respectively).
+void align_extent_to_dirty_range(
   const offset_interval_set::interval& dirty_range,
-  const metastore::extent_metadata_vec& extents) {
-    chunked_vector<offset_interval_set::interval> result;
-    for (const auto& extent : extents) {
-        if (extent.base_offset > dirty_range.last_offset) {
-            break;
-        }
-
-        auto base = kafka::offset{
-          std::max(dirty_range.base_offset(), extent.base_offset())};
-        auto last = kafka::offset{
-          std::min(dirty_range.last_offset(), extent.last_offset())};
-
-        if (base <= last) {
-            result.push_back({.base_offset = base, .last_offset = last});
-        }
-    }
-
-    result.shrink_to_fit();
-    return result;
+  metastore::extent_metadata& extent) {
+    extent.base_offset = kafka::offset{
+      std::max(dirty_range.base_offset(), extent.base_offset())};
+    extent.last_offset = kafka::offset{
+      std::min(dirty_range.last_offset(), extent.last_offset())};
 }
 
 bool should_compact_extent(
@@ -145,7 +132,6 @@ compaction_source::compaction_source(
   model::topic_id_partition tp,
   const chunked_vector<offset_interval_set::interval>& dirty_range_intervals,
   const offset_interval_set& removable_tombstone_ranges,
-  metastore::extent_metadata_vec extents,
   kafka::offset start_offset,
   compaction::key_offset_map* map,
   std::chrono::milliseconds min_compaction_lag_ms,
@@ -157,8 +143,16 @@ compaction_source::compaction_source(
   , _tp(tp)
   , _dirty_range_intervals(dirty_range_intervals)
   , _removable_tombstone_ranges(removable_tombstone_ranges)
-  , _extents(std::move(extents))
   , _start_offset(start_offset)
+  , _dirty_range_it(_dirty_range_intervals.crbegin())
+  , _extent_reader(
+      metastore,
+      tp,
+      _start_offset,
+      kafka::offset::max(),
+      extent_metadata_reader::iteration_direction::forwards,
+      as)
+  , _extent_iterator(_extent_reader.generator())
   , _map(map)
   , _min_compaction_lag_ms(min_compaction_lag_ms)
   , _metastore(metastore)
@@ -166,12 +160,7 @@ compaction_source::compaction_source(
   , _as(as)
   , _state(state) {}
 
-ss::future<> compaction_source::initialize() {
-    _dirty_range_it = _dirty_range_intervals.crbegin();
-    _extents_it = _extents.cbegin();
-    _extents_end_it = _extents.cend();
-    co_return;
-}
+ss::future<> compaction_source::initialize() { co_return; }
 
 ss::future<ss::stop_iteration> compaction_source::map_building_iteration() {
     if (preempted()) {
@@ -184,18 +173,35 @@ ss::future<ss::stop_iteration> compaction_source::map_building_iteration() {
 
     const auto& dirty_range = *_dirty_range_it;
 
-    auto extent_aligned_ranges = intervals_for_dirty_range(
-      dirty_range, _extents);
+    auto dirty_range_extent_reader = extent_metadata_reader(
+      _metastore,
+      _tp,
+      dirty_range.base_offset,
+      dirty_range.last_offset,
+      extent_metadata_reader::iteration_direction::backwards,
+      _as);
+    auto gen = dirty_range_extent_reader.generator();
     bool map_is_full = false;
     // Worth noting that iteration over these extent aligned intervals is not
     // necessary for correctness- however, it provides a natural chunking of the
     // offset ranges for our reads, and also provides fine-grained intervals
     // over which we can indicate `has_tombstones` for the ranges.
-    for (auto it = extent_aligned_ranges.crbegin();
-         it != extent_aligned_ranges.crend();
-         ++it) {
-        const auto& start_offset = it->base_offset;
-        const auto& max_offset = it->last_offset;
+    while (auto extent_res_opt = co_await gen()) {
+        auto& extent_res = extent_res_opt->get();
+        if (!extent_res.has_value()) {
+            vlog(
+              compaction_log.warn,
+              "Error fetching extent metadata during map building iteration: "
+              "{}",
+              extent_res.error());
+            co_return ss::stop_iteration::yes;
+        }
+
+        auto extent = std::move(extent_res).value();
+
+        align_extent_to_dirty_range(dirty_range, extent);
+        const auto& start_offset = extent.base_offset;
+        const auto& max_offset = extent.last_offset;
 
         cloud_topic_log_reader_config config(start_offset, max_offset, _as);
         auto rdr = model::record_batch_reader(
@@ -223,12 +229,8 @@ ss::future<ss::stop_iteration> compaction_source::map_building_iteration() {
         }
 
         if (map_is_full) {
-            break;
+            co_return ss::stop_iteration::yes;
         }
-    }
-
-    if (map_is_full) {
-        co_return ss::stop_iteration::yes;
     }
 
     ++_dirty_range_it;
@@ -242,11 +244,25 @@ ss::future<ss::stop_iteration> compaction_source::deduplication_iteration(
         co_return ss::stop_iteration::yes;
     }
 
-    if (_extents_it == _extents_end_it) {
+    auto extent_res_opt = co_await _extent_iterator();
+    if (!extent_res_opt.has_value()) {
+        // We finished iterating.
         co_return ss::stop_iteration::yes;
     }
 
-    auto& extent = *_extents_it;
+    auto& extent_res = extent_res_opt->get();
+
+    if (!extent_res.has_value()) {
+        // We received an error from the metastore.
+        vlog(
+          compaction_log.warn,
+          "Error fetching extent metadata during deduplication iteration: {}",
+          extent_res.error());
+        co_return ss::stop_iteration::yes;
+    }
+
+    auto extent = std::move(extent_res).value();
+
     if (should_compact_extent(extent, _min_compaction_lag_ms)) {
         kafka::offset start_offset{extent.base_offset};
         kafka::offset last_offset{extent.last_offset};
@@ -280,8 +296,6 @@ ss::future<ss::stop_iteration> compaction_source::deduplication_iteration(
               stats);
         }
     }
-
-    ++_extents_it;
 
     co_return ss::stop_iteration::no;
 }

--- a/src/v/cloud_topics/level_one/compaction/source.h
+++ b/src/v/cloud_topics/level_one/compaction/source.h
@@ -13,6 +13,7 @@
 #include "cloud_topics/level_one/common/abstract_io.h"
 #include "cloud_topics/level_one/compaction/filter.h"
 #include "cloud_topics/level_one/compaction/meta.h"
+#include "cloud_topics/level_one/metastore/extent_metadata_reader.h"
 #include "cloud_topics/level_one/metastore/metastore.h"
 #include "cloud_topics/level_one/metastore/offset_interval_set.h"
 #include "compaction/key_offset_map.h"
@@ -29,7 +30,6 @@ public:
       model::topic_id_partition,
       const chunked_vector<offset_interval_set::interval>&,
       const offset_interval_set&,
-      metastore::extent_metadata_vec,
       kafka::offset,
       compaction::key_offset_map*,
       std::chrono::milliseconds,
@@ -58,22 +58,25 @@ private:
     const interval_vec& _dirty_range_intervals;
     const offset_interval_set& _removable_tombstone_ranges;
 
+    // The start offset of the CTP.
+    kafka::offset _start_offset;
+
     // Iterator used during `map_building_iteration()` which points into the
     // above vector `_dirty_range_intervals`. Iterating backwards over extents
     // to fill the key-offset map used for de-duplication can allow for more
     // efficient compaction runs when compacting the log.
     interval_vec::const_reverse_iterator _dirty_range_it;
 
-    // The extents of the CTP, as returned from the `metastore`. The
-    // de-duplication pass _must_ be extent aligned as part of a requirement of
-    // the `metastore`'s internal state and rules around replacing or compacting
-    // existing extents.
-    metastore::extent_metadata_vec _extents;
-    metastore::extent_metadata_vec::const_iterator _extents_it;
-    metastore::extent_metadata_vec::const_iterator _extents_end_it;
+    // The extent metadata reader, which is constructed and immediately used to
+    // produce the `_extent_iterator` generator. This object must be kept alive
+    // while `_extent_iterator` is in use, but it should not be used directly.
+    extent_metadata_reader _extent_reader;
 
-    // The start offset of the CTP.
-    [[maybe_unused]] kafka::offset _start_offset;
+    // The generated constructed from the forward reader for extents of
+    // the CTP during `deduplication_iteration()`. The de-duplication pass
+    // _must_ be extent aligned as part of a requirement of the `metastore`'s
+    // internal state and rules around replacing or compacting existing extents.
+    extent_metadata_reader::extent_metadata_generator _extent_iterator;
 
     // The key-offset map for this run of compaction. Built up from existing
     // data during `map_building_iteration()` by iterating over `_dirty_ranges`

--- a/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
@@ -109,7 +109,7 @@ ss::future<> do_compact(
       tidp,
       dirty_range_intervals,
       offsets_response.removable_tombstone_ranges,
-      std::move(offsets_response.extents),
+      l1::metastore::extent_metadata_vec{},
       start_offset,
       &map,
       min_compaction_lag_ms,

--- a/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
@@ -109,7 +109,6 @@ ss::future<> do_compact(
       tidp,
       dirty_range_intervals,
       offsets_response.removable_tombstone_ranges,
-      l1::metastore::extent_metadata_vec{},
       start_offset,
       &map,
       min_compaction_lag_ms,

--- a/src/v/cloud_topics/level_one/compaction/worker.cc
+++ b/src/v/cloud_topics/level_one/compaction/worker.cc
@@ -167,8 +167,7 @@ ss::future<> compaction_worker::compact_log(log_compaction_meta* log) {
     auto compaction_offsets = metastore::compaction_offsets_response{
       .dirty_ranges = log->info_and_ts->info.offsets_response.dirty_ranges,
       .removable_tombstone_ranges
-      = log->info_and_ts->info.offsets_response.removable_tombstone_ranges,
-      .extents = log->info_and_ts->info.offsets_response.extents.copy()};
+      = log->info_and_ts->info.offsets_response.removable_tombstone_ranges};
     auto expected_compaction_epoch = log->info_and_ts->info.compaction_epoch;
     auto start_offset = log->info_and_ts->info.start_offset;
 
@@ -202,7 +201,7 @@ ss::future<> compaction_worker::compact_log(log_compaction_meta* log) {
       tidp,
       dirty_range_intervals,
       compaction_offsets.removable_tombstone_ranges,
-      std::move(compaction_offsets.extents),
+      metastore::extent_metadata_vec{},
       start_offset,
       _map.get(),
       min_lag_ms,

--- a/src/v/cloud_topics/level_one/compaction/worker.cc
+++ b/src/v/cloud_topics/level_one/compaction/worker.cc
@@ -201,7 +201,6 @@ ss::future<> compaction_worker::compact_log(log_compaction_meta* log) {
       tidp,
       dirty_range_intervals,
       compaction_offsets.removable_tombstone_ranges,
-      metastore::extent_metadata_vec{},
       start_offset,
       _map.get(),
       min_lag_ms,

--- a/src/v/cloud_topics/level_one/domain/domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.cc
@@ -359,8 +359,6 @@ rpc::get_compaction_info_reply domain_manager::do_get_compaction_info(
         get_res->offsets_response.removable_tombstone_ranges),
       .dirty_ratio = get_res->dirty_ratio,
       .earliest_dirty_ts = get_res->earliest_dirty_ts,
-      .extents = meta_to_rpc_extent_metadata(
-        std::move(get_res->offsets_response.extents)),
       .compaction_epoch
       = partition_state::compaction_epoch_t{get_res->compaction_epoch()},
       .start_offset = get_res->start_offset};

--- a/src/v/cloud_topics/level_one/metastore/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/BUILD
@@ -267,3 +267,20 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "extent_metadata_reader",
+    srcs = [
+        "extent_metadata_reader.cc",
+    ],
+    hdrs = [
+        "extent_metadata_reader.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":metastore",
+        ":retry",
+        "//src/v/model",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_one/metastore/extent_metadata_reader.cc
+++ b/src/v/cloud_topics/level_one/metastore/extent_metadata_reader.cc
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/metastore/extent_metadata_reader.h"
+
+#include "cloud_topics/level_one/metastore/metastore.h"
+#include "cloud_topics/level_one/metastore/retry.h"
+
+namespace cloud_topics::l1 {
+
+extent_metadata_reader::extent_metadata_reader(
+  metastore* metastore,
+  model::topic_id_partition tp,
+  kafka::offset min_offset,
+  kafka::offset max_offset,
+  iteration_direction iter_dir,
+  ss::abort_source& as,
+  std::optional<size_t> num_extents_per_request)
+  : _metastore(metastore)
+  , _tp(std::move(tp))
+  , _min_offset(min_offset)
+  , _max_offset(max_offset)
+  , _iter_dir(iter_dir)
+  , _as(as)
+  , _num_extents_per_request(
+      num_extents_per_request.value_or(default_num_extents_per_request)) {}
+
+extent_metadata_reader::extent_metadata_generator
+extent_metadata_reader::generator() {
+    switch (_iter_dir) {
+    case iteration_direction::forwards:
+        return forward_generator();
+    case iteration_direction::backwards:
+        return backward_generator();
+    }
+}
+
+extent_metadata_reader::extent_metadata_generator
+extent_metadata_reader::forward_generator() {
+    kafka::offset next_offset = _min_offset;
+    kafka::offset end_offset = _max_offset;
+    while (next_offset <= end_offset) {
+        auto extent_md_res = co_await retry_metastore_op_with_default_rtc(
+          [this, next_offset] {
+              return _metastore->get_extent_metadata_forwards(
+                _tp, next_offset, _max_offset, _num_extents_per_request);
+          },
+          _as);
+
+        if (!extent_md_res.has_value()) {
+            // Return the error to the user. Allow them to decide what
+            // to do with the generator.
+            co_yield std::unexpected(extent_md_res.error());
+        } else {
+            // Yield extents.
+            auto extents = std::move(extent_md_res->extents);
+
+            if (extents.empty()) {
+                break;
+            }
+
+            for (const auto& extent : extents) {
+                co_yield extent;
+            }
+
+            next_offset = kafka::next_offset(extents.back().last_offset);
+        }
+    }
+}
+
+extent_metadata_reader::extent_metadata_generator
+extent_metadata_reader::backward_generator() {
+    kafka::offset next_offset = _max_offset;
+    kafka::offset end_offset = _min_offset;
+    while (next_offset >= end_offset) {
+        auto extent_md_res = co_await retry_metastore_op_with_default_rtc(
+          [this, next_offset] {
+              return _metastore->get_extent_metadata_backwards(
+                _tp, _min_offset, next_offset, _num_extents_per_request);
+          },
+          _as);
+
+        if (!extent_md_res.has_value()) {
+            // Return the error to the user. Allow them to decide what
+            // to do with the generator.
+            co_yield std::unexpected(extent_md_res.error());
+        } else {
+            // Yield extents.
+            auto extents = std::move(extent_md_res->extents);
+
+            if (extents.empty()) {
+                break;
+            }
+
+            for (const auto& extent : extents) {
+                co_yield extent;
+            }
+
+            next_offset = kafka::prev_offset(extents.back().base_offset);
+        }
+    }
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/extent_metadata_reader.h
+++ b/src/v/cloud_topics/level_one/metastore/extent_metadata_reader.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_topics/level_one/metastore/metastore.h"
+#include "model/fundamental.h"
+
+#include <seastar/coroutine/generator.hh>
+
+#include <expected>
+
+namespace cloud_topics::l1 {
+
+// Fetches extents from the `metastore` for the provided `tp` within the range
+// `[min_offset, max_offset]` inclusively. Iteration (and thereby the order in
+// which extents are provided) can be forwards or backwards.
+// For example, for an extent state of `[[0,9],[10,19],[20,29]]` and a
+// construction like `extent_metadata_reader([0,15,forwards])`, the generator
+// is expected to yield the extents `[[0,9],[10,19]]`. For a construction like
+// `extent_metadata_reader([0,15,backwards])`, the generator is expected to
+// yield `[[10,19],[0,9]]`.
+// If an error from the `metastore` is received, this error is yielded to the
+// user. The `extent_metadata_generator` will be left in a valid state if the
+// user wishes to continue retrying.
+class extent_metadata_reader {
+public:
+    // The direction of iteration. Dictates which extent metadata request to the
+    // `metastore` is made and the order in which extents are yielded.
+    enum class iteration_direction { forwards, backwards };
+
+    using extent_metadata_generator = ss::coroutine::experimental::generator<
+      std::expected<metastore::extent_metadata, metastore::errc>>;
+
+    // Some sane default for the max number of extents returned per RPC request
+    // to the `metastore`. Can be overridden with argument to
+    // `extent_metadata_reader` constructor.
+    static constexpr size_t default_num_extents_per_request = 100;
+
+    extent_metadata_reader(
+      metastore*,
+      model::topic_id_partition,
+      kafka::offset,
+      kafka::offset,
+      iteration_direction,
+      ss::abort_source&,
+      std::optional<size_t> = std::nullopt);
+
+    // Creates an `extent_metadata_generator`, which can be iterated over or
+    // `co_await`'ed directly to retrieve extents.
+    extent_metadata_generator generator();
+
+private:
+    // Implementation for `iteration_direction::forwards`.
+    extent_metadata_generator forward_generator();
+    // Implementation for `iteration_direction::backwards`.
+    extent_metadata_generator backward_generator();
+
+    metastore* _metastore{nullptr};
+
+    model::topic_id_partition _tp;
+    kafka::offset _min_offset;
+    kafka::offset _max_offset;
+    iteration_direction _iter_dir;
+    ss::abort_source& _as;
+    size_t _num_extents_per_request;
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -308,22 +308,6 @@ public:
     using compaction_map_t
       = chunked_hash_map<model::topic_id_partition, compaction_update>;
 
-    struct extent_metadata {
-        kafka::offset base_offset;
-        kafka::offset last_offset;
-        model::timestamp max_timestamp;
-
-        fmt::iterator format_to(fmt::iterator it) const {
-            return fmt::format_to(
-              it,
-              "{{offsets:({}~{}), max_timestamp:{}}}",
-              base_offset,
-              last_offset,
-              max_timestamp);
-        }
-    };
-    using extent_metadata_vec = chunked_vector<extent_metadata>;
-
     struct compaction_offsets_response {
         // Offset ranges whose keys have not been fully deduplicated from the
         // start of the log.
@@ -336,15 +320,12 @@ public:
         // consult this to determine if the tombstone should be removed.
         offset_interval_set removable_tombstone_ranges;
 
-        extent_metadata_vec extents;
-
         fmt::iterator format_to(fmt::iterator it) const {
             return fmt::format_to(
               it,
-              "{{dirty_ranges:{}, removable_tombstone_ranges:{}, extents:{}}}",
+              "{{dirty_ranges:{}, removable_tombstone_ranges:{}}}",
               dirty_ranges,
-              removable_tombstone_ranges,
-              extents);
+              removable_tombstone_ranges);
         }
     };
     // Similar to replace_objects(), but with additional constraints based on
@@ -437,6 +418,23 @@ public:
     // Vectorized RPC for obtaining compaction state for a number of partitions.
     virtual ss::future<std::expected<compaction_info_map, errc>>
     get_compaction_infos(const chunked_vector<compaction_info_spec>&) = 0;
+
+    struct extent_metadata {
+        kafka::offset base_offset;
+        kafka::offset last_offset;
+        model::timestamp max_timestamp;
+
+        fmt::iterator format_to(fmt::iterator it) const {
+            return fmt::format_to(
+              it,
+              "{{offsets:({}~{}), max_timestamp:{}}}",
+              base_offset,
+              last_offset,
+              max_timestamp);
+        }
+    };
+
+    using extent_metadata_vec = chunked_vector<extent_metadata>;
 
     struct extent_metadata_response {
         extent_metadata_vec extents{};

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -696,8 +696,8 @@ replicated_metastore::get_compaction_info(const compaction_info_spec& log) {
     resp.earliest_dirty_ts = reply.earliest_dirty_ts;
     resp.offsets_response = {
       .dirty_ranges = std::move(reply.dirty_ranges),
-      .removable_tombstone_ranges = std::move(reply.removable_tombstone_ranges),
-      .extents = rpc_to_meta_extent_metadata(std::move(reply.extents))};
+      .removable_tombstone_ranges = std::move(
+        reply.removable_tombstone_ranges)};
     resp.compaction_epoch = metastore::compaction_epoch{
       reply.compaction_epoch()};
     resp.start_offset = reply.start_offset;
@@ -755,8 +755,7 @@ replicated_metastore::get_compaction_infos(
                         .earliest_dirty_ts = log_reply.earliest_dirty_ts,
                         .offsets_response = {
                           .dirty_ranges = std::move(log_reply.dirty_ranges),
-                          .removable_tombstone_ranges = std::move(log_reply.removable_tombstone_ranges),
-                          .extents = rpc_to_meta_extent_metadata(std::move(log_reply.extents))},
+                          .removable_tombstone_ranges = std::move(log_reply.removable_tombstone_ranges)},
                         .compaction_epoch = metastore::compaction_epoch{log_reply.compaction_epoch()},
                         .start_offset = log_reply.start_offset};
                       resp.insert_or_assign(log, std::move(log_resp));

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -213,7 +213,6 @@ struct get_compaction_info_reply
           removable_tombstone_ranges,
           dirty_ratio,
           earliest_dirty_ts,
-          extents,
           compaction_epoch,
           start_offset);
     }
@@ -223,7 +222,6 @@ struct get_compaction_info_reply
     offset_interval_set removable_tombstone_ranges;
     double dirty_ratio;
     std::optional<model::timestamp> earliest_dirty_ts;
-    chunked_vector<extent_metadata> extents;
     partition_state::compaction_epoch_t compaction_epoch;
     kafka::offset start_offset;
 };

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -540,14 +540,6 @@ simple_metastore::get_compaction_offsets(
     auto& prt = prt_ref->get();
     compaction_offsets_response resp;
 
-    resp.extents.reserve(prt.extents.size());
-    for (const auto& extent : prt.extents) {
-        resp.extents.push_back(
-          {.base_offset = extent.base_offset,
-           .last_offset = extent.last_offset,
-           .max_timestamp = extent.max_timestamp});
-    }
-
     if (prt.start_offset >= prt.next_offset) {
         // The log is empty, nothing to compact.
         return resp;

--- a/src/v/cloud_topics/level_one/metastore/tests/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/tests/BUILD
@@ -138,3 +138,19 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "extent_metadata_reader_test",
+    timeout = "short",
+    srcs = [
+        "extent_metadata_reader_test.cc",
+    ],
+    deps = [
+        ":builders",
+        "//src/v/cloud_topics/level_one/common:object_id",
+        "//src/v/cloud_topics/level_one/metastore:extent_metadata_reader",
+        "//src/v/cloud_topics/level_one/metastore:simple",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/cloud_topics/level_one/metastore/tests/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/tests/BUILD
@@ -1,4 +1,16 @@
-load("//bazel:test.bzl", "redpanda_cc_gtest")
+load("//bazel:test.bzl", "redpanda_cc_gtest", "redpanda_test_cc_library")
+
+redpanda_test_cc_library(
+    name = "builders",
+    hdrs = [
+        "builders.h",
+    ],
+    deps = [
+        "//src/v/cloud_topics/level_one/common:object_id",
+        "//src/v/cloud_topics/level_one/metastore",
+        "@seastar",
+    ],
+)
 
 redpanda_cc_gtest(
     name = "simple_metastore_test",
@@ -7,6 +19,7 @@ redpanda_cc_gtest(
         "simple_metastore_test.cc",
     ],
     deps = [
+        ":builders",
         "//src/v/cloud_topics/level_one/common:object_id",
         "//src/v/cloud_topics/level_one/metastore:simple",
         "//src/v/test_utils:gtest",

--- a/src/v/cloud_topics/level_one/metastore/tests/builders.h
+++ b/src/v/cloud_topics/level_one/metastore/tests/builders.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_topics/level_one/common/object_id.h"
+#include "cloud_topics/level_one/metastore/metastore.h"
+
+namespace cloud_topics::l1::test_utils {
+
+using term_map_t = metastore::term_offset_map_t;
+class terms_builder {
+public:
+    terms_builder&
+    add(std::string_view tp_str, model::term_id t, kafka::offset o) {
+        auto tp = model::topic_id_partition::from(tp_str);
+        out[tp].emplace_back(
+          metastore::term_offset{.term = t, .first_offset = o});
+        return *this;
+    }
+    term_map_t build() { return std::move(out); }
+
+private:
+    term_map_t out;
+};
+
+using om_list_t = chunked_vector<metastore::object_metadata>;
+using cmap_t = metastore::compaction_map_t;
+class om_builder {
+public:
+    om_builder(object_id oid, size_t footer_pos, size_t object_size) {
+        out.oid = oid;
+        out.footer_pos = footer_pos;
+        out.object_size = object_size;
+    }
+    om_builder& add(
+      std::string_view tpr_str,
+      kafka::offset base_o,
+      kafka::offset last_o,
+      model::timestamp last_t,
+      size_t first_pos,
+      size_t last_pos) {
+        out.ntp_metas.emplace_back(
+          metastore::object_metadata::ntp_metadata{
+            .tidp = model::topic_id_partition::from(tpr_str),
+            .base_offset = base_o,
+            .last_offset = last_o,
+            .max_timestamp = last_t,
+            .pos = first_pos,
+            .size = last_pos - first_pos,
+          });
+        return *this;
+    }
+    metastore::object_metadata build() { return std::move(out); }
+
+private:
+    metastore::object_metadata out;
+};
+class cm_builder {
+public:
+    cm_builder& clean(
+      std::string_view tpr_str,
+      kafka::offset base,
+      kafka::offset last,
+      std::optional<model::timestamp> with_tombstones_ts = std::nullopt) {
+        auto tp = model::topic_id_partition::from(tpr_str);
+        auto& cmp_meta = out[tp];
+        cmp_meta.new_cleaned_ranges.push_back(
+          metastore::compaction_update::cleaned_range{
+            .base_offset = base,
+            .last_offset = last,
+            .has_tombstones = with_tombstones_ts.has_value(),
+          });
+        if (with_tombstones_ts) {
+            cmp_meta.cleaned_at = *with_tombstones_ts;
+        }
+        return *this;
+    }
+    cm_builder& remove_tombstones(
+      std::string_view tpr_str, kafka::offset base, kafka::offset last) {
+        auto tp = model::topic_id_partition::from(tpr_str);
+        auto& cmp_meta = out[tp];
+        cmp_meta.removed_tombstones_ranges.insert(base, last);
+        cmp_meta.cleaned_at = model::timestamp::now();
+        return *this;
+    }
+    cm_builder& set_expected_epoch(
+      std::string_view tpr_str, metastore::compaction_epoch epoch) {
+        auto tp = model::topic_id_partition::from(tpr_str);
+        auto& cmp_meta = out[tp];
+        cmp_meta.expected_compaction_epoch = epoch;
+        return *this;
+    }
+    cmap_t build() { return std::move(out); }
+
+private:
+    cmap_t out;
+};
+
+} // namespace cloud_topics::l1::test_utils

--- a/src/v/cloud_topics/level_one/metastore/tests/extent_metadata_reader_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/extent_metadata_reader_test.cc
@@ -1,0 +1,352 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/common/object_id.h"
+#include "cloud_topics/level_one/metastore/extent_metadata_reader.h"
+#include "cloud_topics/level_one/metastore/simple_metastore.h"
+#include "cloud_topics/level_one/metastore/tests/builders.h"
+#include "gmock/gmock.h"
+#include "test_utils/test_macros.h"
+
+#include <gtest/gtest.h>
+
+using namespace cloud_topics;
+using namespace cloud_topics::l1;
+using namespace cloud_topics::l1::test_utils;
+
+using iter_dir = extent_metadata_reader::iteration_direction;
+
+namespace {
+
+const object_id oid1 = l1::create_object_id();
+const object_id oid2 = l1::create_object_id();
+const object_id oid3 = l1::create_object_id();
+
+const std::string_view tid_a = "deadbeef-aaaa-0000-0000-000000000000/0";
+
+static ss::abort_source as;
+
+kafka::offset operator""_o(unsigned long long o) {
+    return kafka::offset{static_cast<int64_t>(o)};
+}
+
+model::timestamp operator""_t(unsigned long long t) {
+    return model::timestamp{static_cast<int64_t>(t)};
+}
+
+model::term_id operator""_tm(unsigned long long t) {
+    return model::term_id{static_cast<int64_t>(t)};
+}
+
+MATCHER_P2(MatchesRange, base, last, "") {
+    return arg.base_offset == base && arg.last_offset == last;
+}
+
+ss::future<metastore::extent_metadata_vec>
+consume_reader_to_extent_metadata_vec(extent_metadata_reader rdr) {
+    metastore::extent_metadata_vec vec;
+    auto gen = rdr.generator();
+    while (auto extent_res_opt = co_await gen()) {
+        auto& extent_res = extent_res_opt->get();
+        auto extent_md = std::move(extent_res).value();
+        vec.push_back(std::move(extent_md));
+    }
+    co_return vec;
+}
+
+} // namespace
+
+TEST(SimpleMetastoreTest, TestReadExtentMetadataForwards) {
+    simple_metastore m;
+    om_list_t os;
+    constexpr size_t data_size = 99;
+    os.emplace_back(om_builder(oid1, 100, 1100)
+                      .add(tid_a, 0_o, 9_o, 2000_t, 0, data_size)
+                      .build());
+    os.emplace_back(om_builder(oid2, 100, 1100)
+                      .add(tid_a, 10_o, 19_o, 2000_t, 0, data_size)
+                      .build());
+    os.emplace_back(om_builder(oid3, 100, 1100)
+                      .add(tid_a, 20_o, 29_o, 2000_t, 0, data_size)
+                      .build());
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    auto tp = model::topic_id_partition::from(tid_a);
+
+    // A few basic test cases with an expanding `max_offset`.
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{9};
+        auto rdr = extent_metadata_reader(
+          &m, tp, min_offset, max_offset, iter_dir::forwards, as);
+        auto read_extents
+          = consume_reader_to_extent_metadata_vec(std::move(rdr)).get();
+        EXPECT_THAT(read_extents, testing::ElementsAre(MatchesRange(0_o, 9_o)));
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{15};
+        auto rdr = extent_metadata_reader(
+          &m, tp, min_offset, max_offset, iter_dir::forwards, as);
+        auto read_extents
+          = consume_reader_to_extent_metadata_vec(std::move(rdr)).get();
+        EXPECT_THAT(
+          read_extents,
+          testing::ElementsAre(
+            MatchesRange(0_o, 9_o), MatchesRange(10_o, 19_o)));
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{19};
+        auto rdr = extent_metadata_reader(
+          &m, tp, min_offset, max_offset, iter_dir::forwards, as);
+        auto read_extents
+          = consume_reader_to_extent_metadata_vec(std::move(rdr)).get();
+        EXPECT_THAT(
+          read_extents,
+          testing::ElementsAre(
+            MatchesRange(0_o, 9_o), MatchesRange(10_o, 19_o)));
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{20};
+        auto rdr = extent_metadata_reader(
+          &m, tp, min_offset, max_offset, iter_dir::forwards, as);
+        auto read_extents
+          = consume_reader_to_extent_metadata_vec(std::move(rdr)).get();
+        EXPECT_THAT(
+          read_extents,
+          testing::ElementsAre(
+            MatchesRange(0_o, 9_o),
+            MatchesRange(10_o, 19_o),
+            MatchesRange(20_o, 29_o)));
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{100};
+        auto rdr = extent_metadata_reader(
+          &m, tp, min_offset, max_offset, iter_dir::forwards, as);
+        auto read_extents
+          = consume_reader_to_extent_metadata_vec(std::move(rdr)).get();
+        EXPECT_THAT(
+          read_extents,
+          testing::ElementsAre(
+            MatchesRange(0_o, 9_o),
+            MatchesRange(10_o, 19_o),
+            MatchesRange(20_o, 29_o)));
+    }
+
+    // Non zero min_offset test cases.
+    {
+        auto min_offset = kafka::offset{5};
+        auto max_offset = kafka::offset{9};
+        auto rdr = extent_metadata_reader(
+          &m, tp, min_offset, max_offset, iter_dir::forwards, as);
+        auto read_extents
+          = consume_reader_to_extent_metadata_vec(std::move(rdr)).get();
+        EXPECT_THAT(read_extents, testing::ElementsAre(MatchesRange(0_o, 9_o)));
+    }
+    {
+        auto min_offset = kafka::offset{9};
+        auto max_offset = kafka::offset{29};
+        auto rdr = extent_metadata_reader(
+          &m, tp, min_offset, max_offset, iter_dir::forwards, as);
+        auto read_extents
+          = consume_reader_to_extent_metadata_vec(std::move(rdr)).get();
+        EXPECT_THAT(
+          read_extents,
+          testing::ElementsAre(
+            MatchesRange(0_o, 9_o),
+            MatchesRange(10_o, 19_o),
+            MatchesRange(20_o, 29_o)));
+    }
+
+    // Edge case when returning one extent (max_offset is on the boundary of an
+    // extent).
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{10};
+        auto rdr = extent_metadata_reader(
+          &m, tp, min_offset, max_offset, iter_dir::forwards, as, 1);
+        auto read_extents
+          = consume_reader_to_extent_metadata_vec(std::move(rdr)).get();
+        EXPECT_THAT(
+          read_extents,
+          testing::ElementsAre(
+            MatchesRange(0_o, 9_o), MatchesRange(10_o, 19_o)));
+    }
+}
+
+TEST(SimpleMetastoreTest, TestReadExtentMetadataBackwards) {
+    simple_metastore m;
+    om_list_t os;
+    constexpr size_t data_size = 99;
+    os.emplace_back(om_builder(oid1, 100, 1100)
+                      .add(tid_a, 0_o, 9_o, 2000_t, 0, data_size)
+                      .build());
+    os.emplace_back(om_builder(oid2, 100, 1100)
+                      .add(tid_a, 10_o, 19_o, 2000_t, 0, data_size)
+                      .build());
+    os.emplace_back(om_builder(oid3, 100, 1100)
+                      .add(tid_a, 20_o, 29_o, 2000_t, 0, data_size)
+                      .build());
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    auto tp = model::topic_id_partition::from(tid_a);
+
+    // A few basic test cases with an expanding `max_offset`.
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{9};
+        auto rdr = extent_metadata_reader(
+          &m, tp, min_offset, max_offset, iter_dir::backwards, as);
+        auto read_extents
+          = consume_reader_to_extent_metadata_vec(std::move(rdr)).get();
+        EXPECT_THAT(read_extents, testing::ElementsAre(MatchesRange(0_o, 9_o)));
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{15};
+        auto rdr = extent_metadata_reader(
+          &m, tp, min_offset, max_offset, iter_dir::backwards, as);
+        auto read_extents
+          = consume_reader_to_extent_metadata_vec(std::move(rdr)).get();
+        EXPECT_THAT(
+          read_extents,
+          testing::ElementsAre(
+            MatchesRange(10_o, 19_o), MatchesRange(0_o, 9_o)));
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{19};
+        auto rdr = extent_metadata_reader(
+          &m, tp, min_offset, max_offset, iter_dir::backwards, as);
+        auto read_extents
+          = consume_reader_to_extent_metadata_vec(std::move(rdr)).get();
+        EXPECT_THAT(
+          read_extents,
+          testing::ElementsAre(
+            MatchesRange(10_o, 19_o), MatchesRange(0_o, 9_o)));
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{20};
+        auto rdr = extent_metadata_reader(
+          &m, tp, min_offset, max_offset, iter_dir::backwards, as);
+        auto read_extents
+          = consume_reader_to_extent_metadata_vec(std::move(rdr)).get();
+        EXPECT_THAT(
+          read_extents,
+          testing::ElementsAre(
+            MatchesRange(20_o, 29_o),
+            MatchesRange(10_o, 19_o),
+            MatchesRange(0_o, 9_o)));
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{100};
+        auto rdr = extent_metadata_reader(
+          &m, tp, min_offset, max_offset, iter_dir::backwards, as);
+        auto read_extents
+          = consume_reader_to_extent_metadata_vec(std::move(rdr)).get();
+        EXPECT_THAT(
+          read_extents,
+          testing::ElementsAre(
+            MatchesRange(20_o, 29_o),
+            MatchesRange(10_o, 19_o),
+            MatchesRange(0_o, 9_o)));
+    }
+
+    // Non zero min_offset test cases.
+    {
+        auto min_offset = kafka::offset{5};
+        auto max_offset = kafka::offset{9};
+        auto rdr = extent_metadata_reader(
+          &m, tp, min_offset, max_offset, iter_dir::backwards, as);
+        auto read_extents
+          = consume_reader_to_extent_metadata_vec(std::move(rdr)).get();
+        EXPECT_THAT(read_extents, testing::ElementsAre(MatchesRange(0_o, 9_o)));
+    }
+    {
+        auto min_offset = kafka::offset{9};
+        auto max_offset = kafka::offset{29};
+        auto rdr = extent_metadata_reader(
+          &m, tp, min_offset, max_offset, iter_dir::backwards, as);
+        auto read_extents
+          = consume_reader_to_extent_metadata_vec(std::move(rdr)).get();
+        EXPECT_THAT(
+          read_extents,
+          testing::ElementsAre(
+            MatchesRange(20_o, 29_o),
+            MatchesRange(10_o, 19_o),
+            MatchesRange(0_o, 9_o)));
+    }
+
+    // Edge case when returning one extent (min_offset is on the boundary of an
+    // extent).
+    {
+        auto min_offset = kafka::offset{9};
+        auto max_offset = kafka::offset{15};
+        auto rdr = extent_metadata_reader(
+          &m, tp, min_offset, max_offset, iter_dir::backwards, as, 1);
+        auto read_extents
+          = consume_reader_to_extent_metadata_vec(std::move(rdr)).get();
+        EXPECT_THAT(
+          read_extents,
+          testing::ElementsAre(
+            MatchesRange(10_o, 19_o), MatchesRange(0_o, 9_o)));
+    }
+}
+
+TEST(SimpleMetastoreTest, TestGetExtentMetadataEmpty) {
+    simple_metastore m;
+    om_list_t os;
+    constexpr size_t data_size = 99;
+    os.emplace_back(om_builder(oid1, 100, 1100)
+                      .add(tid_a, 0_o, 9_o, 2000_t, 0, data_size)
+                      .build());
+    os.emplace_back(om_builder(oid2, 100, 1100)
+                      .add(tid_a, 10_o, 19_o, 2000_t, 0, data_size)
+                      .build());
+    os.emplace_back(om_builder(oid3, 100, 1100)
+                      .add(tid_a, 20_o, 29_o, 2000_t, 0, data_size)
+                      .build());
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    auto tp = model::topic_id_partition::from(tid_a);
+
+    auto set_start_res = m.set_start_offset(tp, 30_o).get();
+    ASSERT_TRUE(set_start_res.has_value());
+
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{100};
+        auto rdr = extent_metadata_reader(
+          &m, tp, min_offset, max_offset, iter_dir::forwards, as);
+        auto read_extents
+          = consume_reader_to_extent_metadata_vec(std::move(rdr)).get();
+        ASSERT_TRUE(read_extents.empty());
+    }
+    {
+        auto min_offset = kafka::offset{0};
+        auto max_offset = kafka::offset{100};
+        auto rdr = extent_metadata_reader(
+          &m, tp, min_offset, max_offset, iter_dir::backwards, as);
+        auto read_extents
+          = consume_reader_to_extent_metadata_vec(std::move(rdr)).get();
+        ASSERT_TRUE(read_extents.empty());
+    }
+}

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -7,14 +7,18 @@
  *
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
+
 #include "cloud_topics/level_one/common/object_id.h"
 #include "cloud_topics/level_one/metastore/simple_metastore.h"
+#include "cloud_topics/level_one/metastore/tests/builders.h"
 #include "gmock/gmock.h"
 
 #include <gtest/gtest.h>
 
 using namespace cloud_topics;
 using namespace cloud_topics::l1;
+using namespace cloud_topics::l1::test_utils;
+
 using ::testing::Field;
 using ::testing::IsEmpty;
 using ::testing::Optional;
@@ -46,96 +50,6 @@ model::term_id operator""_tm(unsigned long long t) {
 MATCHER_P2(MatchesRange, base, last, "") {
     return arg.base_offset == base && arg.last_offset == last;
 }
-
-using term_list_t = chunked_vector<metastore::term_offset>;
-using term_map_t = metastore::term_offset_map_t;
-class terms_builder {
-public:
-    terms_builder&
-    add(std::string_view tp_str, model::term_id t, kafka::offset o) {
-        auto tp = model::topic_id_partition::from(tp_str);
-        out[tp].emplace_back(
-          metastore::term_offset{.term = t, .first_offset = o});
-        return *this;
-    }
-    term_map_t build() { return std::move(out); }
-
-private:
-    term_map_t out;
-};
-
-using om_list_t = chunked_vector<metastore::object_metadata>;
-using cmap_t = metastore::compaction_map_t;
-class om_builder {
-public:
-    om_builder(object_id oid, size_t footer_pos, size_t object_size) {
-        out.oid = oid;
-        out.footer_pos = footer_pos;
-        out.object_size = object_size;
-    }
-    om_builder& add(
-      std::string_view tpr_str,
-      kafka::offset base_o,
-      kafka::offset last_o,
-      model::timestamp last_t,
-      size_t first_pos,
-      size_t last_pos) {
-        out.ntp_metas.emplace_back(
-          metastore::object_metadata::ntp_metadata{
-            .tidp = model::topic_id_partition::from(tpr_str),
-            .base_offset = base_o,
-            .last_offset = last_o,
-            .max_timestamp = last_t,
-            .pos = first_pos,
-            .size = last_pos - first_pos,
-          });
-        return *this;
-    }
-    metastore::object_metadata build() { return std::move(out); }
-
-private:
-    metastore::object_metadata out;
-};
-class cm_builder {
-public:
-    cm_builder& clean(
-      std::string_view tpr_str,
-      kafka::offset base,
-      kafka::offset last,
-      std::optional<model::timestamp> with_tombstones_ts = std::nullopt) {
-        auto tp = model::topic_id_partition::from(tpr_str);
-        auto& cmp_meta = out[tp];
-        cmp_meta.new_cleaned_ranges.push_back(
-          metastore::compaction_update::cleaned_range{
-            .base_offset = base,
-            .last_offset = last,
-            .has_tombstones = with_tombstones_ts.has_value(),
-          });
-        if (with_tombstones_ts) {
-            cmp_meta.cleaned_at = *with_tombstones_ts;
-        }
-        return *this;
-    }
-    cm_builder& remove_tombstones(
-      std::string_view tpr_str, kafka::offset base, kafka::offset last) {
-        auto tp = model::topic_id_partition::from(tpr_str);
-        auto& cmp_meta = out[tp];
-        cmp_meta.removed_tombstones_ranges.insert(base, last);
-        cmp_meta.cleaned_at = model::timestamp::now();
-        return *this;
-    }
-    cm_builder& set_expected_epoch(
-      std::string_view tpr_str, metastore::compaction_epoch epoch) {
-        auto tp = model::topic_id_partition::from(tpr_str);
-        auto& cmp_meta = out[tp];
-        cmp_meta.expected_compaction_epoch = epoch;
-        return *this;
-    }
-    cmap_t build() { return std::move(out); }
-
-private:
-    cmap_t out;
-};
 
 } // namespace
 


### PR DESCRIPTION
Right now, all extents in a partition have their extent_metadata (two offsets and a timestamp, 24 bytes) returned as part of the `compaction_info_response` from the `metastore`, as they are iterated over during compaction of a cloud topic partition in the read path of compaction.

As topics scale, the number of extents will grow (by default, for an uncompacted log, the number of extents in a topic is effectively `topic_size / l1_object_size`), and while compaction can do an okay job of keeping the number of extents bounded, we do not want to continue to provide all the extents up front like this.

Use the previously implemented `get_extent_metadata_{forwards/backwards}` metastore functions to build an `extent_metadata_reader`, which can be used to iterate over extents in the `metastore` for a given CTP while transparently retrieving them via RPCs.

Both backwards and forwards iteration is supported as required for compaction (during the `map_building_iteration()` and `deduplication_iteration()` respectively).

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
