### PR TITLE
iceberg: support bucket names with dots in URIs

### DIFF
--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -677,7 +677,6 @@ redpanda_cc_gtest(
     ],
     cpu = 1,
     deps = [
-        ":test_schemas",
         "//src/v/cloud_io:provider",
         "//src/v/iceberg:uri",
         "//src/v/test_utils:gtest",

--- a/src/v/iceberg/tests/uri_test.cc
+++ b/src/v/iceberg/tests/uri_test.cc
@@ -10,34 +10,37 @@
 
 #include "cloud_io/provider.h"
 #include "iceberg/uri.h"
-#include "test_utils/test.h"
+
+#include <gtest/gtest.h>
 
 #include <variant>
 
+namespace {
 using namespace iceberg;
 
 template<auto Start, auto End, auto Inc, class F>
 constexpr void constexpr_for(F&& f) {
     if constexpr (Start < End) {
         f(std::integral_constant<decltype(Start), Start>());
-        constexpr_for<Start + Inc, End, Inc>(f);
+        constexpr_for<Start + Inc, End, Inc>(std::forward<F>(f));
     }
 }
 
-auto valid_paths = std::vector{
-  std::filesystem::path("a"),
-  std::filesystem::path("foo/bar/baz/manifest.avro"),
-};
+constexpr auto valid_paths = std::to_array({"a", "foo/bar/baz/manifest.avro"});
 
 template<typename V>
 void test_uri_conversion();
 
 template<>
 void test_uri_conversion<cloud_io::s3_compat_provider>() {
-    auto bucket = cloud_storage_clients::bucket_name("testbucket1");
-    auto other_bucket = cloud_storage_clients::bucket_name("testbucket2");
+    const std::vector<cloud_storage_clients::bucket_name> examples = {
+      cloud_storage_clients::bucket_name{"testbucket1"},
+      cloud_storage_clients::bucket_name{"test.bucket.name"}};
 
-    auto other_converter = uri_converter(
+    const auto unrelated_bucket = cloud_storage_clients::bucket_name(
+      "testbucket2");
+
+    const auto other_converter = uri_converter(
       cloud_io::s3_compat_provider{"otherscheme"});
 
     auto s3_compat_provider_schemes = std::vector{"s3", "gcs"};
@@ -45,24 +48,26 @@ void test_uri_conversion<cloud_io::s3_compat_provider>() {
         uri_converter convertor(
           cloud_io::provider{cloud_io::s3_compat_provider{scheme}});
 
-        for (const auto& path : valid_paths) {
-            auto uri = convertor.to_uri(bucket, path);
+        for (const auto& b : examples) {
+            for (const auto& path : valid_paths) {
+                auto uri = convertor.to_uri(b, path);
 
-            // Forward
-            ASSERT_EQ(
-              uri, fmt::format("{}://testbucket1/{}", scheme, path.native()));
+                // Forward
+                ASSERT_EQ(uri, fmt::format("{}://{}/{}", scheme, b, path));
 
-            // Backward
-            auto path_res = convertor.from_uri(bucket, uri);
-            ASSERT_TRUE(path_res.has_value())
-              << "Failed to get path from URI: " << uri;
-            ASSERT_EQ(path_res.value(), path);
+                // Backward
+                auto path_res = convertor.from_uri(b, uri);
+                ASSERT_TRUE(path_res.has_value())
+                  << "Failed to get path from URI: " << uri;
+                ASSERT_EQ(path_res.value(), path);
 
-            // Should fail with different bucket.
-            ASSERT_FALSE(convertor.from_uri(other_bucket, uri).has_value());
+                // Should fail with different bucket.
+                ASSERT_FALSE(
+                  convertor.from_uri(unrelated_bucket, uri).has_value());
 
-            // Should fail with other converter.
-            ASSERT_FALSE(other_converter.from_uri(bucket, uri).has_value());
+                // Should fail with other converter.
+                ASSERT_FALSE(other_converter.from_uri(b, uri).has_value());
+            }
         }
     }
 }
@@ -83,7 +88,7 @@ void test_uri_conversion<cloud_io::abs_provider>() {
           uri,
           fmt::format(
             "abfss://testbucket1@testaccount123.dfs.core.windows.net/{}",
-            path.native()));
+            path));
 
         // Backward
         auto path_res = convertor.from_uri(bucket, uri);
@@ -107,5 +112,7 @@ constexpr void test_uri_conversion_all_providers() {
           std::variant_alternative_t<i.value, cloud_io::provider>>();
     });
 }
+
+} // namespace
 
 TEST(IcebergUriTest, Test) { test_uri_conversion_all_providers(); }

--- a/src/v/iceberg/uri.cc
+++ b/src/v/iceberg/uri.cc
@@ -73,15 +73,13 @@ std::optional<std::filesystem::path> uri_converter::from_uri(
             || protocol.back() != ':') {
               return std::nullopt;
           }
-          auto dotpos = uri.get_host().find('.');
-          if (dotpos == std::string::npos) {
-              // Host is the bucket name.
-              if (uri.get_host() != bucket()) {
-                  return std::nullopt;
-              }
-          } else {
+          if (uri.get_host() != bucket()) {
               // We are not generating yet virtual host style URIs so don't
               // parse them yet.
+              //
+              // We also exclude the possibility of URI looking like
+              // s3://bucket.s3.amazonaws.com/path/to/object. I haven't seen
+              // such examples so assume they do no exist.
               return std::nullopt;
           }
           // Ensure that minimum path length is at least enough to cover the


### PR DESCRIPTION
Previously, the URI parser would reject bucket names containing dots by treating any host with a dot as an unsupported virtual host-style URI. This prevented using S3 buckets with dots in their names.

We also change slightly the behavior to reject uris like `s3://bucket.s3.amazonaws.com/path/to/object`. I never seen them in the wild and I think it is unsafe to accept them without additional checks.

Fixes https://redpandadata.atlassian.net/browse/CORE-15069

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x

## Release Notes

### Bug Fixes

* Iceberg: Allow bucket names with dots. Also, reject URIs returned by catalog that look like `s3://bucket.s3.amazonaws.com/path/to/object`.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
