### PR TITLE
[backport] [25.3.x] cl/scale_tests: deflake cluster linking verifier

### DIFF
--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -7,7 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from collections import defaultdict
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager, nullcontext
 import time
@@ -52,10 +51,7 @@ from rptest.services.multi_cluster_services import (
 from rptest.services.redpanda import LoggingConfig, TLSProvider
 from rptest.services.tls import CertificateAuthority, Certificate, TLSCertManager
 from rptest.tests.prealloc_nodes import PreallocNodesTest
-from rptest.util import (
-    bg_thread_cm,
-    contextmanager,
-)
+from rptest.util import bg_thread_cm, contextmanager, wait_until_result
 from rptest.utils.node_operations import FailureInjectorBackgroundThread
 from threading import Lock
 from urllib3.exceptions import ProtocolError
@@ -264,36 +260,49 @@ class ClusterLinkingProgressVerifier:
             and self.target_consumer_finished()
         )
 
-    def _calculate_partition_lag(self):
-        ret = defaultdict(dict)
-
+    def check_topic_hwms(self, timeout: int = 120, debug_only: bool = False):
         # describe target first to make sure the lag is always greater than or equal to 0
-        target = list(self.target_rpk.describe_topic(self.topic))
-        source = list(self.source_rpk.describe_topic(self.topic))
+        def describe_topics():
+            def describe_once():
+                target = list(self.target_rpk.describe_topic(self.topic))
+                source = list(self.source_rpk.describe_topic(self.topic))
+                if len(source) != len(target):
+                    return False, None
+                return True, (target, source)
 
-        if len(source) != len(target):
-            return None
-        for source_partition, target_partition in zip(source, target):
-            if source_partition.id != target_partition.id:
-                return None
-            assert source_partition.high_watermark >= target_partition.high_watermark, (
-                f"Source partition high watermark must be greater than or equal to target partition high watermark (source: {source_partition.high_watermark}, target: {target_partition.high_watermark})"
+            return wait_until_result(
+                describe_once,
+                timeout_sec=timeout,
+                backoff_sec=0.5,
+                err_msg=f"Failed to describe topics for lag calculation in {timeout} seconds",
             )
-            lag = source_partition.high_watermark - target_partition.high_watermark
-            self.logger.debug(
-                f"Partition {self.topic}/{source_partition.id} - source: ({source_partition}), target: ({target_partition}) lag: {lag}"
+
+        try:
+            (target, source) = describe_topics()
+            assert len(target) == len(source), (
+                "Verification failed, Topic partitions count mismatch between source and target"
             )
-            ret[source_partition.id] = lag
-
-        return ret
-
-    def total_lag(self, partition_lags) -> float:
-        if partition_lags is None:
-            return float("inf")
-        total = 0
-        for lag in partition_lags.values():
-            total += lag
-        return total
+            partitions_with_lag = 0
+            for source_partition, target_partition in zip(source, target):
+                assert source_partition.id == target_partition.id, (
+                    f"Partition id mismatch {source_partition.id} != {target_partition.id}"
+                )
+                if target_partition.high_watermark != source_partition.high_watermark:
+                    lag = (
+                        source_partition.high_watermark
+                        - target_partition.high_watermark
+                    )
+                    self.logger.debug(
+                        f"Partition {self.topic}/{source_partition.id} - source: ({source_partition}), target: ({target_partition}) lag: {lag}"
+                    )
+                    partitions_with_lag += 1
+                assert debug_only or partitions_with_lag == 0, (
+                    f"Verification failed, {partitions_with_lag} partitions do not have synced high watermarks"
+                )
+        except Exception as e:
+            self.logger.warning(f"Verification failed: {e}")
+            if not debug_only:
+                raise
 
     def stop_kgo_services(self):
         self.source_consumer.stop()
@@ -301,26 +310,13 @@ class ClusterLinkingProgressVerifier:
         self.producer.stop()
 
     def validate_progress(self, progress_timeout=60, backoff_delay=5):
-        total_last_lag = float("inf")
-        replication_last_progress = time.time()
-
         workload_last_progress = time.time()
         source_consumer_last_reads = 0
         target_consumer_last_reads = 0
         producer_last_acked = 0
 
-        while True:
-            # Check replication progress
-            current_lag = self._calculate_partition_lag()
-            total_current_lag = self.total_lag(current_lag)
+        while not self.workload_finished():
             now = time.time()
-            # track replication progress
-            if total_current_lag < total_last_lag or total_current_lag == 0:
-                self.logger.debug(
-                    f"Replication making progress - current_lag: {total_current_lag}, last_lag: {total_last_lag}"
-                )
-                replication_last_progress = now
-
             producer_acked = self.producer.produce_status.acked
             source_reads = self.source_consumer.consumer_status.validator.total_reads
             target_reads = self.target_consumer.consumer_status.validator.total_reads
@@ -336,26 +332,17 @@ class ClusterLinkingProgressVerifier:
                 target_consumer_last_reads = target_reads
                 producer_last_acked = producer_acked
 
-            if not self.workload_finished() and (
-                now - workload_last_progress > progress_timeout
-            ):
+            if now - workload_last_progress > progress_timeout:
                 self.logger.error(
                     f"No workload progress for {progress_timeout}s, source reads: {source_reads} (last: {source_consumer_last_reads}), target reads: {target_reads} (last: {target_consumer_last_reads}), producer acks: {producer_acked} (last: {producer_last_acked})"
                 )
+                self.check_topic_hwms(debug_only=True)
                 raise Exception("Workload stalled")
 
-            total_last_lag = total_current_lag
-            if time.time() - replication_last_progress > progress_timeout:
-                self.logger.error(
-                    f"No replication progress for {progress_timeout}s, last lag: {total_last_lag}, current lag: {total_current_lag}"
-                )
-                raise Exception("Replication stalled")
+            if not self.workload_finished():
+                time.sleep(backoff_delay)
 
-            if self.workload_finished() and total_current_lag == 0:
-                self.logger.info("Replication finished")
-                break
-
-            time.sleep(backoff_delay)
+        self.check_topic_hwms()
 
     def consumer_groups_state_consistent(self):
         source_groups = self.source_rpk.group_list()


### PR DESCRIPTION
The verifier is inherently flaky due to how it computes replication lag.

It snapshots source partition HWMs and target partition HWMs, then computes total lag as the sum of per-partition differences. This works at small scales, but with trickling data and many partitions it runs into issues:

1. Multiple retries are required to obtain a consistent snapshot due to interference from the leader balancer.

2. The lag computation can falsely suggest no progress depending on how HWM snapshots interleave with produce operations. If data is produced to the source but not yet replicated to the target at snapshot time, the result can appear as though lag has not improved—even when the target HWM has advanced from previous snapshot. This behavior is more pronounced in scale tests.

This change decouples replication lag tracking from the verification loop. The verifier already ensures progress by checkpointing total records consumed from both source and target. This naturally captures replication progress because consumption cannot move unless HWMs move.

By removing the inline replication-lag checks, the verification becomes far more stable at scale. A final replication check now compares HWMs directly to ensure everything is fully synced.

(cherry picked from commit 406eba23757efec577d96085b8ff655285db8e0e)

Fixes https://github.com/redpanda-data/redpanda/issues/28867


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
