### PR TITLE
Bazel build modes: introduce dev mode

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -86,11 +86,9 @@ build:debug --copt -fsanitize=address,undefined,vptr,function,alignment
 build:debug --linkopt -fsanitize=address,undefined,vptr,function,alignment
 build:debug --linkopt -fsanitize-link-c++-runtime
 build:debug --copt -O1
-build:debug --//bazel:has_sanitizers=True
+build:debug --//bazel:sanitizer_mode=all
 # seastar has to be run with system allocator when using sanitizers
 build:debug --@seastar//:system_allocator=True
-# krb5 is a foreign cc build and needs explicit list of sanitizers to build the shared library
-build:debug --@krb5//:sanitizers=address,undefined,vptr,function,alignment
 
 
 # =================================

--- a/.bazelrc
+++ b/.bazelrc
@@ -146,15 +146,26 @@ build:fastbuild --build
 build:dev --config=dev-base --config=dbgsym-lines
 
 # =================================
+# Debugger
+# =================================
+# A mode optimized for running in a debugger, i.e., with no optimization
+# and full symbols. This uses -O0, so Redpanda will run very slowly, which
+# may be unsuitable for some uses. In that case, you might prefer --config=debug.
+# Note that --config=debug is based on this config, so changes to this config
+# will flow through to --config=debug as well.
+build:debugger --compilation_mode=dbg
+build:debugger --config=san-all
+build:debugger --config=dbgsym-all
+
+# =================================
 # Debug
 # =================================
 # Debug mode used in the "debug" CI builds and includes all sanitizers,
-# and full symbols.
-build:debug --compilation_mode=dbg
-build:debug --config=san-all
-build:debug --config=dbgsym-all
+# and full symbols. Runs with -O1 so is faster than --config=debugger,
+# but debugger use more difficult due to optimizations (i.e., many symbols
+# will be missing, etc).
+build:debug --config=debugger
 build:debug --copt=-O1
-
 
 # =================================
 # ODR Finder

--- a/.bazelrc
+++ b/.bazelrc
@@ -79,25 +79,19 @@ build --@seastar//:debug=True
 build:fastbuild --build
 
 # =================================
-# Sanitizer
-# =================================
-build:sanitizer --compilation_mode=dbg
-build:sanitizer --copt -fsanitize=address,undefined,vptr,function,alignment
-build:sanitizer --linkopt -fsanitize=address,undefined,vptr,function,alignment
-build:sanitizer --linkopt -fsanitize-link-c++-runtime
-build:sanitizer --copt -O1
-build:sanitizer --//bazel:has_sanitizers=True
-# seastar has to be run with system allocator when using sanitizers
-build:sanitizer --@seastar//:system_allocator=True
-# krb5 is a foreign cc build and needs explicit list of sanitizers to build the shared library
-build:sanitizer --@krb5//:sanitizers=address,undefined,vptr,function,alignment
-
-# =================================
 # Debug
 # =================================
-# alias to match our legacy cmake debug BUILD_TYPE so we don't have to do any
-# mapping in taskfiles
-build:debug --config=sanitizer
+build:debug --compilation_mode=dbg
+build:debug --copt -fsanitize=address,undefined,vptr,function,alignment
+build:debug --linkopt -fsanitize=address,undefined,vptr,function,alignment
+build:debug --linkopt -fsanitize-link-c++-runtime
+build:debug --copt -O1
+build:debug --//bazel:has_sanitizers=True
+# seastar has to be run with system allocator when using sanitizers
+build:debug --@seastar//:system_allocator=True
+# krb5 is a foreign cc build and needs explicit list of sanitizers to build the shared library
+build:debug --@krb5//:sanitizers=address,undefined,vptr,function,alignment
+
 
 # =================================
 # ODR Finder
@@ -202,6 +196,9 @@ build:coverage --experimental_split_coverage_postprocessing
 build:coverage --experimental_fetch_all_coverage_outputs
 build:coverage --collect_code_coverage
 build:coverage --instrumentation_filter="^//src/v[/:]"
+
+# sanitizer is a deprecated alias for debug
+build:sanitizer --config=debug
 
 # =================================
 # Testing

--- a/.bazelrc
+++ b/.bazelrc
@@ -71,6 +71,66 @@ build --@seastar//:stack_guards=True
 # Debug mode by default. Disabled in release builds.
 build --@seastar//:debug=True
 
+# -base configs generally aren't meant to be used directly but are
+# helpers to DRY later user-facing configs
+
+# base for all sanitizer configs
+# seastar has to be run with system allocator when using ASAN
+build:san-base --@seastar//:system_allocator=True
+build:san-base --linkopt=-fsanitize-link-c++-runtime
+
+# base for dev configs
+build:dev-base --config=san-asan-only
+# Og is similar to O1 but gives slightly better debugging experience
+build:dev-base --copt=-Og
+
+####################################################
+# MIXIN CONFIGS
+#
+# These configurations are ones you can plausibly add to your build
+# command in addition to a single primary build mode in order to
+# opt-in to specific features.
+#
+# That's the idea anyway: in practice not all mixins will work
+# together, nor do all mixins work in all build modes. In those cases
+# we try to note the restrictions below.
+####################################################
+
+#########################
+## debug symbols mixins #
+#########################
+
+# line numbers only: backtrace decoding will work, not good for debugger
+build:dbgsym-lines --copt=-gline-tables-only --strip=never
+# full symbols, great for debugging
+build:dbgsym-all --copt=-g --strip=never
+
+#####################
+## sanitizer mixins #
+#####################
+
+# san-asan-only mixin: only enables address sanitizer
+build:san-asan-only --config=san-base
+build:san-asan-only --//bazel:sanitizer_mode=asan
+build:san-asan-only    --copt=-fsanitize=address
+build:san-asan-only --linkopt=-fsanitize=address
+
+# san-all mixin: enables all sanitizers
+build:san-all  --config=san-base
+build:san-all  --//bazel:sanitizer_mode=all
+build:san-all     --copt=-fsanitize=address,undefined,vptr,function,alignment
+build:san-all  --linkopt=-fsanitize=address,undefined,vptr,function,alignment
+
+################################################
+# PRIMARY BUILD MODES
+#
+# Primary build modes define the overall build configuration. It only makes sense
+# to select one of these in a given bazel invocation (or zero, which is the same
+# as selecting fastbuild).
+#
+# These map directly to BUILD_TYPE in task/cmake #
+##################################################
+
 # =================================
 # Fastbuild
 # =================================
@@ -79,16 +139,21 @@ build --@seastar//:debug=True
 build:fastbuild --build
 
 # =================================
+# Dev
+# =================================
+# Development build mode, intended to be best for non-debugger development.
+# Good build speed, good runtime speed.
+build:dev --config=dev-base --config=dbgsym-lines
+
+# =================================
 # Debug
 # =================================
+# Debug mode used in the "debug" CI builds and includes all sanitizers,
+# and full symbols.
 build:debug --compilation_mode=dbg
-build:debug --copt -fsanitize=address,undefined,vptr,function,alignment
-build:debug --linkopt -fsanitize=address,undefined,vptr,function,alignment
-build:debug --linkopt -fsanitize-link-c++-runtime
-build:debug --copt -O1
-build:debug --//bazel:sanitizer_mode=all
-# seastar has to be run with system allocator when using sanitizers
-build:debug --@seastar//:system_allocator=True
+build:debug --config=san-all
+build:debug --config=dbgsym-all
+build:debug --copt=-O1
 
 
 # =================================
@@ -136,6 +201,9 @@ build:secure --config=relro
 # =================================
 # Release
 # =================================
+# Enables full optimization, and other release features. Simply using
+# --config=release doesn't create a _true_ release binary, that needs at
+# least --stamp=full and PGO-specific compile steps (outside of bazel).
 build:release --compilation_mode opt
 build:release --config=secure
 build:release --copt -mllvm --copt -inline-threshold=2500

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,4 +1,5 @@
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 
 bool_flag(
     name = "gofips",
@@ -12,16 +13,49 @@ config_setting(
     },
 )
 
-bool_flag(
-    name = "has_sanitizers",
-    build_setting_default = False,
+# Selects the sanitizer configuration to use for this build.
+# Note that simply setting this flag is not enough, you also need
+# to enable specific additional flags (see .bazelrc) to actually
+# enable the sanitizers. This flag is set *in addition* to those
+# flags so that downstream build files can made local decisions
+# based on whether sanitizers are enabled or not (e.g., krb5).
+string_flag(
+    name = "sanitizer_mode",
+    build_setting_default = "none",
+    values = [
+        "none",
+        "asan",
+        "all",
+    ],
 )
 
 config_setting(
-    name = "enable_fuzz_testing",
+    name = "sanitizers_none",
     flag_values = {
-        ":has_sanitizers": "true",
+        ":sanitizer_mode": "none",
     },
+)
+
+config_setting(
+    name = "sanitizers_asan",
+    flag_values = {
+        ":sanitizer_mode": "asan",
+    },
+)
+
+config_setting(
+    name = "sanitizers_all",
+    flag_values = {
+        ":sanitizer_mode": "all",
+    },
+)
+
+selects.config_setting_group(
+    name = "enable_fuzz_testing",
+    match_any = [
+        ":sanitizers_asan",
+        ":sanitizers_all",
+    ],
 )
 
 config_setting(

--- a/bazel/thirdparty/krb5.BUILD
+++ b/bazel/thirdparty/krb5.BUILD
@@ -10,12 +10,6 @@ int_flag(
 )
 
 string_flag(
-    name = "sanitizers",
-    build_setting_default = "no",
-    make_variable = "SANITIZERS",
-)
-
-string_flag(
     name = "linker",
     build_setting_default = "lld",
     make_variable = "LINKER",
@@ -52,8 +46,11 @@ configure_make(
         # duplicate symbol error
         "--enable-shared",
         "--disable-static",
-        "--enable-asan=$(SANITIZERS)",
-    ],
+    ] + select({
+        "@com_github_redpanda_data_redpanda//bazel:sanitizers_none": ["--enable-asan=no"],
+        "@com_github_redpanda_data_redpanda//bazel:sanitizers_asan": ["--enable-asan=address"],
+        "@com_github_redpanda_data_redpanda//bazel:sanitizers_all": ["--enable-asan=address,undefined,vptr,function,alignment"],
+    }),
     copts = [
         "-fuse-ld=$LINKER",
     ],
@@ -72,7 +69,6 @@ configure_make(
     ],
     toolchains = [
         ":build_jobs",
-        ":sanitizers",
         ":linker",
     ],
     visibility = [

--- a/tools/build-perf/build-timer.py
+++ b/tools/build-perf/build-timer.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+from dataclasses import dataclass
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import List, Any
+import sys
+import argparse
+import tempfile
+
+# pyright: strict
+
+# Always add type hints unless told otherwise
+
+BAZEL_CMD = "bazel"
+
+
+def info(*args: Any, **kwargs: Any) -> None:
+    print(*args, file=sys.stderr, **kwargs)
+
+
+@dataclass
+class Options:
+    quiet_build: bool
+    target: str
+    skip_delete: bool
+    target2: str
+
+
+@dataclass
+class BuildResult:
+    label: str
+    elapsed: float
+    size_mb: float
+    redpanda_size_mb: float
+    test_elapsed: float
+    test_size_mb: float
+
+
+class Main:
+    def __init__(self, repo_root: Path, options: Options) -> None:
+        self.options: Options = options
+        self.repo_root: Path = repo_root
+        self.logfile_path: str | None = None
+        self.logfile: Any = None
+        self.build_times: List[BuildResult] = []
+        if self.options.quiet_build:
+            self.logfile = tempfile.NamedTemporaryFile(
+                delete=False,
+                mode="w+",
+                prefix="build-timer-bazel-",
+                suffix=".log",
+                dir="/tmp",
+            )
+            self.logfile_path = self.logfile.name
+            info(f"Bazel output will be written to: {self.logfile_path}")
+
+    def run_bazel(
+        self, desc: str, label: str, opts: List[str], target: str | None = None
+    ) -> tuple[float, float]:
+        cmd = (
+            [BAZEL_CMD, "build"] + opts + [(target if target else self.options.target)]
+        )
+        info(f"Running: {' '.join(cmd)}")
+        start: float = time.perf_counter()
+        try:
+            if self.logfile:
+                subprocess.run(
+                    cmd, check=True, stdout=self.logfile, stderr=self.logfile
+                )
+            else:
+                subprocess.run(cmd, check=True)
+        except subprocess.CalledProcessError:
+            if self.logfile is not None:
+                self.logfile.flush()
+                try:
+                    with open(self.logfile.name, "r") as f:
+                        lines = f.readlines()
+                        tail = lines[-50:] if len(lines) > 50 else lines
+                        info("Last 50 lines of Bazel output:")
+                        for line in tail:
+                            info(line.rstrip())
+                except Exception as read_exc:
+                    info(f"Could not read logfile: {read_exc}")
+            raise
+        elapsed: float = time.perf_counter() - start
+        # Calculate size of bazel-bin/src/v
+        output_dir = self.repo_root / "bazel-bin" / "src" / "v"
+        size_bytes: float = 0.0
+        if output_dir.exists():
+            for p in output_dir.rglob("*"):
+                if p.is_file():
+                    size_bytes += p.stat().st_size
+        size_mb: float = size_bytes / 1e6
+        info(f"Output size after build: {size_mb:,.2f} MB")
+        return elapsed, size_mb
+
+    def _run_single_build_option(self, opts: str) -> None:
+        label = "default" if not opts else opts
+        info(f"===== Timing build for label: {label} ======")
+
+        if not self.options.skip_delete:
+            elapsed, size_mb = self.run_bazel("initial build", label, opts.split())
+            print(
+                f"Initial finished: {label} in {elapsed:.2f} seconds, size: {size_mb:,.0f} MB"
+            )
+            # Delete output directory to ensure a clean build
+            output_dir = self.repo_root / "bazel-bin" / "src" / "v"
+            if not output_dir.exists():
+                raise RuntimeError(
+                    f"Output directory {output_dir} does not exist. Aborting."
+                )
+            shutil.rmtree(output_dir)
+            info(f"Deleted output directory: {output_dir}")
+
+        elapsed, size_mb = self.run_bazel("Redpanda rebuild", label, opts.split())
+        # Record redpanda binary size in MB
+        rp_bin = self.repo_root / "bazel-bin/src/v/redpanda/redpanda"
+        redpanda_size_mb = (rp_bin).stat().st_size / 1e6
+        info(f"Redpanda binary size: {redpanda_size_mb:,.2f} MB")
+        print(
+            f"Rebuild finished: {label} in {elapsed:.2f} seconds, size: {size_mb:,.0f} MB, redpanda: {redpanda_size_mb:,.0f} MB"
+        )
+        # Build the test target (no delete)
+        test_elapsed, test_size_mb = self.run_bazel(
+            "Test build", label, opts.split(), target=self.options.target2
+        )
+        print(
+            f"Test build finished: {label} in {test_elapsed:.2f} seconds, size: {test_size_mb:,.0f} MB"
+        )
+        self.build_times.append(
+            BuildResult(
+                label, elapsed, size_mb, redpanda_size_mb, test_elapsed, test_size_mb
+            )
+        )
+
+    def run_bazel_builds(self, build_options_list: List[str]) -> None:
+        for opts in build_options_list:
+            try:
+                self._run_single_build_option(opts)
+            except subprocess.CalledProcessError as e:
+                info(f"=========\nERROR: Build failed for options '{opts}': {e}")
+        if self.logfile:
+            self.logfile.close()
+        info("\nBuild time summary:")
+        for result in self.build_times:
+            print(
+                f"  {result.label:20} {result.elapsed:.2f} seconds, {result.size_mb:,.0f} MB, redpanda: {result.redpanda_size_mb:,.0f} MB, test: {result.test_elapsed:.2f} seconds, test size: {result.test_size_mb:,.0f} MB"
+            )
+        # Output summary as a markdown table
+        print(
+            "\n| Label                  | Time (seconds) | size (MB) | Redpanda size (MB) | Time test (s) | size (MB) |"
+        )
+        print(
+            "|------------------------|---------------:|------------:|--------------:|------------------:|---------------:|"
+        )
+        for result in self.build_times:
+            print(
+                f"| {result.label:22} | {result.elapsed:13.2f} | {result.size_mb:11,.0f} | {result.redpanda_size_mb:13,.0f} | {result.test_elapsed:16.2f} | {result.test_size_mb:13,.0f} |"
+            )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--quiet-build",
+        action="store_true",
+        help="Redirect Bazel output to a logfile in /tmp",
+    )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="//:redpanda",
+        help="Bazel build target (default: //:redpanda)",
+    )
+    parser.add_argument(
+        "--target2",
+        type=str,
+        default="//src/v/kafka/server/tests:fetch_test",
+        help="Second Bazel build target (default: //src/v/kafka/server/tests:fetch_test)",
+    )
+    parser.add_argument(
+        "--skip-delete",
+        action="store_true",
+        help="Skips the warmup + delete + rebuild dance"
+        " and just builds, useful for debugging",
+    )
+    args = parser.parse_args()
+
+    options = Options(
+        quiet_build=args.quiet_build,
+        target=args.target,
+        skip_delete=args.skip_delete,
+        target2=args.target2,
+    )
+
+    repo_root = Path(__file__).resolve().parents[2]
+    user_bazelrc = repo_root / "user.bazelrc"
+    backup_bazelrc = repo_root / "user.bazelrc.backup"
+
+    # Move user.bazelrc out of the way
+    if user_bazelrc.exists():
+        shutil.move(str(user_bazelrc), str(backup_bazelrc))
+        info("Moved user.bazelrc out of the way.")
+    else:
+        info("user.bazelrc not found, continuing.")
+
+    def sanopts(sans: List[str]):
+        sanlist = ",".join(sans)
+        base = "--copt -O1 "
+        sanpart = f"--copt -fsanitize={sanlist} --linkopt -fsanitize={sanlist} --@krb5//:sanitizers={sanlist} --linkopt -fsanitize-link-c++-runtime"
+        return (base + sanpart) if sanlist else base
+
+    try:
+        build_options_list: List[str] = [
+            "--config=release",
+            "",
+            "--strip=never",
+            # "--strip=never --copt -gmlt",
+            # "--strip=never --copt -gline-tables-only",
+            # "--copt -O1",
+            # "--copt -Os",
+            # "--copt -Oz",
+            # "--config=sanitizer",
+            # sanopts(["address"]),
+            # sanopts(["undefined"]),
+            # sanopts(["vptr"]),
+            # sanopts(["function"]),
+            # sanopts(["alignment"]),
+            # sanopts([]),
+            # "--compilation_mode=dbg",
+            # "--copt -fno-function-sections",
+            # "",
+            # "--config=release_base",
+            # "--config=release_base --config=lto",
+            # "--config=release_base --config=full-debug",
+            # "--config=release_base --copt -mllvm --copt -inline-threshold=2500",
+            # "--config=full-debug",
+            # "--config=full-debug --copt -fstandalone-debug",
+            # ""  # default build
+        ]
+        main_obj = Main(repo_root=repo_root, options=options)
+        main_obj.run_bazel_builds(build_options_list)
+    finally:
+        # Restore user.bazelrc
+        if backup_bazelrc.exists():
+            shutil.move(str(backup_bazelrc), str(user_bazelrc))
+            info("Restored user.bazelrc.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Introduces the `dev` build modes and other updates to bazel build modes.

See changes for individual details and also:

https://redpandadata.atlassian.net/wiki/spaces/CORE/pages/1252425745/Build+modes+WIP

For background and build timings.

This shouldn't change either the existing "release" or "debug" builds (I checked that debug binary has identical size before/after the main dev mode change).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
