### PR TITLE
[UX-745] rpk shadow create: validate secret existence before request

### DIFF
--- a/src/go/rpk/pkg/cli/security/secret/create.go
+++ b/src/go/rpk/pkg/cli/security/secret/create.go
@@ -70,7 +70,7 @@ redpanda_connect, redpanda_cluster`,
 				SecretData: []byte(secretValue),
 				Scopes:     scopeRequest,
 			}
-			response, err := cl.Secrets.CreateSecret(cmd.Context(), connect.NewRequest(request))
+			response, err := cl.Secret.CreateSecret(cmd.Context(), connect.NewRequest(request))
 			if err != nil {
 				var connectErr *connect.Error
 				if errors.As(err, &connectErr) {

--- a/src/go/rpk/pkg/cli/security/secret/delete.go
+++ b/src/go/rpk/pkg/cli/security/secret/delete.go
@@ -53,7 +53,7 @@ func newDeleteCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			request := &dataplanev1.DeleteSecretRequest{
 				Id: secretName,
 			}
-			_, err = cl.Secrets.DeleteSecret(cmd.Context(), &connect.Request[dataplanev1.DeleteSecretRequest]{Msg: request})
+			_, err = cl.Secret.DeleteSecret(cmd.Context(), &connect.Request[dataplanev1.DeleteSecretRequest]{Msg: request})
 			out.MaybeDie(err, "unable to delete secret: %v", err)
 
 			fmt.Printf("Secret %s deleted successfully \n", secretName)

--- a/src/go/rpk/pkg/cli/security/secret/list.go
+++ b/src/go/rpk/pkg/cli/security/secret/list.go
@@ -53,7 +53,7 @@ func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 					NameContains: nameContains,
 				},
 			}
-			response, err := cl.Secrets.ListSecrets(cmd.Context(), connect.NewRequest(request))
+			response, err := cl.Secret.ListSecrets(cmd.Context(), connect.NewRequest(request))
 			out.MaybeDie(err, "unable to list secrets: %v", err)
 
 			tw := out.NewTable("NAME", "SCOPES")

--- a/src/go/rpk/pkg/cli/security/secret/update.go
+++ b/src/go/rpk/pkg/cli/security/secret/update.go
@@ -72,7 +72,7 @@ overwrite its scopes. Available scope options are: redpanda_connect, redpanda_cl
 				Scopes:     scopeRequest,
 			}
 
-			response, err := cl.Secrets.UpdateSecret(cmd.Context(), connect.NewRequest(request))
+			response, err := cl.Secret.UpdateSecret(cmd.Context(), connect.NewRequest(request))
 			if err != nil {
 				var connectErr *connect.Error
 				if errors.As(err, &connectErr) {

--- a/src/go/rpk/pkg/cli/shadow/create.go
+++ b/src/go/rpk/pkg/cli/shadow/create.go
@@ -19,6 +19,7 @@ import (
 	"buf.build/gen/go/redpandadata/cloud/connectrpc/go/redpanda/api/controlplane/v1/controlplanev1connect"
 	controlplanev1 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1"
 	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
+	dataplanev1 "buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go/redpanda/api/dataplane/v1"
 	"connectrpc.com/connect"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -27,6 +28,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
 )
 
@@ -101,6 +103,9 @@ Create a Shadow Link without confirmation prompt:
 					[]string{prof.CurrentAuth().ClientID},
 				)
 				out.MaybeDieErr(err)
+
+				err = validateCloudSecrets(cmd.Context(), prof, slCfg)
+				out.MaybeDie(err, "unable to validate cloud secrets: %v", err)
 
 				op, err := cloudClient.ShadowLink.CreateShadowLink(cmd.Context(), connect.NewRequest(&controlplanev1.CreateShadowLinkRequest{
 					ShadowLink: shadowLinkConfigToCloudCreate(slCfg),
@@ -274,4 +279,48 @@ func tryShadowLinkErrReason(ctx context.Context, cl controlplanev1connect.Shadow
 		return errMsg
 	}
 	return fmt.Sprintf("%v. Reason: %v", errMsg, link.Msg.GetShadowLink().GetReason())
+}
+
+func validateCloudSecrets(ctx context.Context, prof *config.RpkProfile, slCfg *ShadowLinkConfig) error {
+	// We should only try to validate if pass or key are present in the config.
+	pass, key := authPassword(slCfg.ClientOptions), tlsKey(slCfg.ClientOptions)
+	if pass == "" && key == "" {
+		return nil
+	}
+	// We can't validate the presence of secrets if the Shadow Link is not for
+	// this cluster. In this case we default to the server validation.
+	if slCfg.CloudOptions != nil && slCfg.CloudOptions.ShadowRedpandaID != prof.CloudCluster.ClusterID {
+		zap.L().Sugar().Warn("Shadow Link cluster is different from the current selected cluster in your profile; skipping secrets validation")
+		return nil
+	}
+	dpClient, err := publicapi.DataplaneClientFromRpkProfile(prof)
+	if err != nil {
+		return err
+	}
+	secrets, err := dpClient.Secret.ListSecrets(ctx, connect.NewRequest(&dataplanev1.ListSecretsRequest{
+		PageSize: 500, // 500 is a reasonable upper limit for now.
+		Filter: &dataplanev1.ListSecretsFilter{
+			Scopes: []dataplanev1.Scope{dataplanev1.Scope_SCOPE_REDPANDA_CLUSTER},
+		},
+	}))
+	if err != nil {
+		return fmt.Errorf("unable to list secrets at REDPANDA_CLUSTER scope: %v", err)
+	}
+
+	secretRefs := make(map[string]struct{})
+	for _, secret := range secrets.Msg.GetSecrets() {
+		secretRefs[fmt.Sprintf("%s%s}", secretsPrefix, secret.Id)] = struct{}{}
+	}
+
+	if pass != "" {
+		if _, ok := secretRefs[pass]; !ok {
+			return fmt.Errorf("unable to find authentication password secret %q in the shadow cluster secrets store (REDPANDA_CLUSTER scope)", pass)
+		}
+	}
+	if key != "" {
+		if _, ok := secretRefs[key]; !ok {
+			return fmt.Errorf("unable to find TLS key secret %q in the shadow cluster secrets store (REDPANDA_CLUSTER scope)", key)
+		}
+	}
+	return nil
 }

--- a/src/go/rpk/pkg/cli/shadow/create.go
+++ b/src/go/rpk/pkg/cli/shadow/create.go
@@ -30,6 +30,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// secretsPrefix is the prefix that denotes that a field is referencing a secret
+// in the secrets store. (used in password and TLS key).
+const secretsPrefix = "${secrets."
+
 func newCreateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var (
 		noConfirm   bool
@@ -223,8 +227,11 @@ func validateParsedShadowLinkConfig(slCfg *ShadowLinkConfig) error {
 	if co.TLSSettings != nil && co.TLSSettings.TLSFileSettings != nil {
 		return errors.New("TLS file settings are not supported when using cloud options; use tls_pem_settings instead")
 	}
-	if pw := authPassword(co); pw != "" && !strings.HasPrefix(pw, "${secrets.") {
+	if pw := authPassword(co); pw != "" && !strings.HasPrefix(pw, secretsPrefix) {
 		return errors.New("cloud shadow links don't support plain passwords, you must use secrets from the secrets store. See 'rpk security secret --help' for more details")
+	}
+	if key := tlsKey(slCfg.ClientOptions); key != "" && !strings.HasPrefix(key, secretsPrefix) {
+		return errors.New("cloud shadow links don't support plain TLS keys, you must use secrets from the secrets store. See 'rpk security secret --help' for more details")
 	}
 	return nil
 }
@@ -240,6 +247,17 @@ func authPassword(co *ShadowLinkClientOptions) string {
 	}
 	if auth.PlainConfiguration != nil {
 		return auth.PlainConfiguration.Password
+	}
+	return ""
+}
+
+func tlsKey(co *ShadowLinkClientOptions) string {
+	if co == nil || co.TLSSettings == nil {
+		return ""
+	}
+	tls := co.TLSSettings
+	if pem := tls.TLSPEMSettings; pem != nil {
+		return pem.Key
 	}
 	return ""
 }

--- a/src/go/rpk/pkg/cli/shadow/create_test.go
+++ b/src/go/rpk/pkg/cli/shadow/create_test.go
@@ -283,6 +283,25 @@ func TestValidateParsedShadowLinkConfig(t *testing.T) {
 			expectedErr: "cloud shadow links don't support plain passwords",
 		},
 		{
+			name: "cloud config - plain tls key not allowed",
+			config: &ShadowLinkConfig{
+				Name: "test-link",
+				CloudOptions: &CloudShadowLinkOptions{
+					ShadowRedpandaID: "shadow-cluster",
+				},
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers: []string{"broker1:9092"},
+					TLSSettings: &TLSSettings{
+						Enabled: true,
+						TLSPEMSettings: &TLSPEMSettings{
+							Key: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+						},
+					},
+				},
+			},
+			expectedErr: "cloud shadow links don't support plain TLS keys",
+		},
+		{
 			name: "valid cloud config - with secrets store password",
 			config: &ShadowLinkConfig{
 				Name: "test-link",
@@ -315,7 +334,7 @@ func TestValidateParsedShadowLinkConfig(t *testing.T) {
 						Enabled: true,
 						TLSPEMSettings: &TLSPEMSettings{
 							CA:   "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
-							Key:  "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----",
+							Key:  "${secrets.MY_TLS_KEY}",
 							Cert: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
 						},
 					},

--- a/src/go/rpk/pkg/out/spinner.go
+++ b/src/go/rpk/pkg/out/spinner.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
+	"github.com/fatih/color"
 	"github.com/mattn/go-isatty"
 )
 
@@ -154,12 +155,14 @@ func (s *Spinner) Stop() {
 
 // Success stops the spinner and displays a success message with a ✓ checkmark.
 func (s *Spinner) Success(message string) {
-	s.stopWith(fmt.Sprintf("\u2713 %s\n", message))
+	green := color.New(color.FgGreen).SprintFunc()
+	s.stopWith(fmt.Sprintf("%s %s\n", green("\u2713"), message))
 }
 
 // Fail stops the spinner and displays an error message with an ✗.
 func (s *Spinner) Fail(message string) {
-	s.stopWith(fmt.Sprintf("\u2717 %s\n", message))
+	red := color.New(color.FgRed).SprintFunc()
+	s.stopWith(fmt.Sprintf("%s %s\n", red("\u2717"), message))
 }
 
 // UpdateMessage updates the spinner's message while it's running.

--- a/src/go/rpk/pkg/publicapi/dataplane.go
+++ b/src/go/rpk/pkg/publicapi/dataplane.go
@@ -27,21 +27,20 @@ import (
 // DataPlaneClientSet holds the respective service clients to interact with
 // the data plane endpoints of the Public API.
 type DataPlaneClientSet struct {
-	Transform     *transformServiceClient
-	CloudStorage  dataplanev1connect.CloudStorageServiceClient
-	User          dataplanev1connect.UserServiceClient
-	Secrets       dataplanev1connect.SecretServiceClient
-	MCPServer     dataplanev1alpha3connect.MCPServerServiceClient
-	Topic         dataplanev1connect.TopicServiceClient
-	Pipeline      dataplanev1connect.PipelineServiceClient
 	ACL           dataplanev1connect.ACLServiceClient
+	CloudStorage  dataplanev1connect.CloudStorageServiceClient
 	KafkaConnect  dataplanev1connect.KafkaConnectServiceClient
+	KnowledgeBase dataplanev1alpha3connect.KnowledgeBaseServiceClient
+	MCPServer     dataplanev1alpha3connect.MCPServerServiceClient
+	Monitoring    dataplanev1connect.MonitoringServiceClient
+	Pipeline      dataplanev1connect.PipelineServiceClient
 	Quota         dataplanev1connect.QuotaServiceClient
 	Secret        dataplanev1connect.SecretServiceClient
 	Security      dataplanev1connect.SecurityServiceClient
-	Monitoring    dataplanev1connect.MonitoringServiceClient
-	KnowledgeBase dataplanev1alpha3connect.KnowledgeBaseServiceClient
 	ShadowLink    dataplanev1connect.ShadowLinkServiceClient
+	Topic         dataplanev1connect.TopicServiceClient
+	Transform     *transformServiceClient
+	User          dataplanev1connect.UserServiceClient
 
 	m         sync.RWMutex
 	authToken string
@@ -112,14 +111,13 @@ func NewDataPlaneClientSet(host, authToken string, opts ...connect.ClientOption)
 	dpCl.Transform = newTransformServiceClient(httpCl, host, authToken, opts...)
 	dpCl.CloudStorage = dataplanev1connect.NewCloudStorageServiceClient(httpCl, host, opts...)
 	dpCl.User = dataplanev1connect.NewUserServiceClient(httpCl, host, opts...)
-	dpCl.Secrets = dataplanev1connect.NewSecretServiceClient(httpCl, host, opts...)
+	dpCl.Secret = dataplanev1connect.NewSecretServiceClient(httpCl, host, opts...)
 	dpCl.MCPServer = dataplanev1alpha3connect.NewMCPServerServiceClient(httpCl, host, opts...)
 	dpCl.Topic = dataplanev1connect.NewTopicServiceClient(httpCl, host, opts...)
 	dpCl.Pipeline = dataplanev1connect.NewPipelineServiceClient(httpCl, host, opts...)
 	dpCl.ACL = dataplanev1connect.NewACLServiceClient(httpCl, host, opts...)
 	dpCl.KafkaConnect = dataplanev1connect.NewKafkaConnectServiceClient(httpCl, host, opts...)
 	dpCl.Quota = dataplanev1connect.NewQuotaServiceClient(httpCl, host, opts...)
-	dpCl.Secret = dataplanev1connect.NewSecretServiceClient(httpCl, host, opts...)
 	dpCl.Security = dataplanev1connect.NewSecurityServiceClient(httpCl, host, opts...)
 	dpCl.Monitoring = dataplanev1connect.NewMonitoringServiceClient(httpCl, host, opts...)
 	dpCl.KnowledgeBase = dataplanev1alpha3connect.NewKnowledgeBaseServiceClient(httpCl, host, opts...)


### PR DESCRIPTION
Secret exists in the requested shadow cluster, in
rpk if we are logged in to the shadow cluster we
can validate this upfront.

The create request goes to the dataplane, which
doesn't have access to the secret store, so it
takes a while until the user gets the error back
and is bad UX. So we simplify this by checking
ourselves if we are logged in before submitting
the request.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


### Improvements

* rpk shadow create [cloud]: now rpk validates if the secret exists in the Shadow cluster before sending a request to create 
