### PR TITLE
ct: introduce producer queue

### DIFF
--- a/src/v/cloud_topics/data_plane_api.h
+++ b/src/v/cloud_topics/data_plane_api.h
@@ -21,7 +21,26 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
 
+#include <expected>
+#include <system_error>
+
 namespace cloud_topics {
+
+// staged_write is a write operation that has been reserved in the pipeline.
+// it is decoupled from uploading so that we can provide backpressure before
+// accepting more batches into the pipeline
+struct staged_write {
+    struct batch_data {
+        batch_data() = default;
+        batch_data(const batch_data&) = default;
+        batch_data(batch_data&&) = delete;
+        batch_data& operator=(const batch_data&) = default;
+        batch_data& operator=(batch_data&&) = delete;
+        virtual ~batch_data() = default;
+    };
+
+    std::unique_ptr<batch_data> staged;
+};
 
 /// Dataplane API
 class data_plane_api {
@@ -37,11 +56,17 @@ public:
     virtual ss::future<> start() = 0;
     virtual ss::future<> stop() = 0;
 
-    /// Write data batches and get back placeholder batches
-    virtual ss::future<result<chunked_vector<extent_meta>>> write_and_debounce(
+    // Reserve the space needed for this write.
+    virtual ss::future<std::expected<staged_write, std::error_code>>
+    stage_write(chunked_vector<model::record_batch> batches) = 0;
+
+    // Execute this write using the reservation.
+    virtual ss::future<
+      std::expected<chunked_vector<extent_meta>, std::error_code>>
+    execute_write(
       model::ntp ntp,
       cluster_epoch min_epoch,
-      chunked_vector<model::record_batch> batches,
+      staged_write reservation,
       model::timeout_clock::time_point deadline)
       = 0;
 

--- a/src/v/cloud_topics/data_plane_impl.cc
+++ b/src/v/cloud_topics/data_plane_impl.cc
@@ -36,6 +36,10 @@
 
 namespace cloud_topics {
 
+struct staged_pipeline_write : public staged_write::batch_data {
+    l0::write_pipeline<>::prepared_data data;
+};
+
 class impl
   : public data_plane_api
   , public ssx::sharded_service_container {
@@ -132,17 +136,28 @@ public:
         co_return;
     }
 
-    ss::future<result<chunked_vector<extent_meta>>> write_and_debounce(
+    ss::future<std::expected<staged_write, std::error_code>>
+    stage_write(chunked_vector<model::record_batch> batches) override {
+        auto reservation = co_await _write_pipeline.local().prepare_write(
+          std::move(batches));
+        if (!reservation.has_value()) {
+            co_return std::unexpected(reservation.error());
+        }
+        auto staged = std::make_unique<staged_pipeline_write>();
+        staged->data = std::move(reservation.value());
+        co_return staged_write{.staged = std::move(staged)};
+    }
+
+    ss::future<std::expected<chunked_vector<extent_meta>, std::error_code>>
+    execute_write(
       model::ntp ntp,
       cluster_epoch min_epoch,
-      chunked_vector<model::record_batch> r,
-      model::timeout_clock::time_point timeout) override {
-        auto res = co_await _write_pipeline.local().write_and_debounce(
-          std::move(ntp), min_epoch, std::move(r), timeout);
-        if (res.has_value()) {
-            co_return std::move(res.value());
-        }
-        co_return res.error();
+      staged_write reservation,
+      model::timeout_clock::time_point deadline) override {
+        auto staged = std::unique_ptr<staged_pipeline_write>(
+          static_cast<staged_pipeline_write*>(reservation.staged.release()));
+        co_return co_await _write_pipeline.local().execute_write(
+          std::move(ntp), min_epoch, std::move(staged->data), deadline);
     }
 
     ss::future<result<chunked_vector<model::record_batch>>> materialize(

--- a/src/v/cloud_topics/frontend/BUILD
+++ b/src/v/cloud_topics/frontend/BUILD
@@ -26,6 +26,7 @@ redpanda_cc_library(
         "//src/v/cloud_storage:types",
         "//src/v/cloud_topics:logger",
         "//src/v/cloud_topics/level_one/metastore",
+        "//src/v/cloud_topics/level_zero/common:producer_queue",
         "//src/v/cloud_topics/level_zero/stm:ctp_stm",
         "//src/v/cloud_topics/level_zero/stm:placeholder",
         "//src/v/cluster",

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -15,6 +15,7 @@
 #include "cloud_topics/level_one/frontend_reader/level_one_reader.h"
 #include "cloud_topics/level_one/metastore/metastore.h"
 #include "cloud_topics/level_zero/common/extent_meta.h"
+#include "cloud_topics/level_zero/common/producer_queue.h"
 #include "cloud_topics/level_zero/frontend_reader/level_zero_reader.h"
 #include "cloud_topics/level_zero/stm/ctp_stm.h"
 #include "cloud_topics/level_zero/stm/placeholder.h"
@@ -529,32 +530,17 @@ struct upload_and_replicate_stages {
       , batch_id(batch_id)
       , opts(opts)
       , timeout(timeout) {}
-
-    ss::promise<> request_enqueued;
-    ss::promise<result<raft::replicate_result>> replicate_finished;
 };
 
-ss::future<> bg_upload_and_replicate(
+ss::future<result<raft::replicate_result>> do_upload_and_replicate(
   data_plane_api* api,
   ss::lw_shared_ptr<cluster::partition> partition,
+  l0::producer_ticket ticket,
   model::record_batch_header header,
   ss::lw_shared_ptr<upload_and_replicate_stages> op,
   bool cache_enabled) {
-    vassert(api != nullptr, "cloud topics api is not initialized");
-
-    auto ticket = op->ctp_stm_api->producer_queue().reserve(
-      op->batch_id.pid.get_id());
-    // Now that we've acquired our ticket and determined our ordering, we can
-    // say that the request is enqueued and get more produce requests.
-    op->request_enqueued.set_value();
-
-    auto fallback = ss::defer([op] {
-        // This guarantees that the promises are set.
-        // The error code used here does not represent the
-        // actual error.
-        op->replicate_finished.set_value(raft::errc::timeout);
-    });
-
+    // The default errc that will cause the client to retry to operation
+    constexpr auto default_errc = raft::errc::timeout;
     /*
      * L0 GC relies on a minimum epoch associated with each NTP for calculating
      * the name of an L0 object. The minimum is based on the topic revision, but
@@ -568,59 +554,66 @@ ss::future<> bg_upload_and_replicate(
       "Unexpected invalid min epoch {} for {}",
       min_epoch,
       op->ntp);
-
     chunked_vector<model::record_batch> rb_copy;
     if (cache_enabled) {
         rb_copy = clone_batches(op->batches);
     }
 
     auto timeout = op->timeout == 0ms ? L0_upload_default_timeout : op->timeout;
-    auto res = co_await api->write_and_debounce(
+    auto upload_fut = co_await ss::coroutine::as_future(api->write_and_debounce(
       op->ntp,
       min_epoch,
       std::move(op->batches),
-      model::timeout_clock::now() + timeout);
+      model::timeout_clock::now() + timeout));
 
-    if (res.has_error()) {
-        vlog(
-          cd_log.debug,
-          "LO object upload has failed: {}",
-          res.error().message());
-        co_return;
+    if (upload_fut.failed()) {
+        auto ex = upload_fut.get_exception();
+        vlog(cd_log.debug, "LO object upload has failed: {}", ex);
+        co_return default_errc;
     }
 
-    if (res.value().empty()) {
+    auto upload_res = upload_fut.get();
+
+    if (upload_res.has_error()) {
+        vlog(
+          cd_log.debug,
+          "LO object upload has errored: {}",
+          upload_res.error().message());
+        co_return default_errc;
+    }
+    if (upload_res.value().empty()) {
         vlog(
           cd_log.warn,
           "LO object upload returned empty result, nothing to replicate");
-        co_return;
+        co_return default_errc;
     }
 
     auto fence_fut = co_await ss::coroutine::as_future(
-      op->ctp_stm_api->fence_epoch(res.value().front().id.epoch));
+      op->ctp_stm_api->fence_epoch(upload_res.value().front().id.epoch));
     if (fence_fut.failed()) {
         auto e = fence_fut.get_exception();
         vlog(
           cd_log.warn,
           "Failed to fence epoch {} for ntp {}, error: {}",
-          res.value().front().id.epoch,
+          upload_res.value().front().id.epoch,
           op->ntp,
           e);
-        co_return;
+        co_return default_errc;
     }
     auto fence = std::move(fence_fut.get());
     if (!fence.unit.has_value()) {
         vlog(
           cd_log.warn,
           "Failed to fence epoch {} for ntp {}, fence unit is empty",
-          res.value().front().id.epoch,
+          upload_res.value().front().id.epoch,
           op->ntp);
-        co_return;
+        co_return default_errc;
     }
 
     chunked_vector<model::record_batch_header> headers;
     headers.push_back(header);
-    auto placeholders = co_await convert_to_placeholders(res.value(), headers);
+    auto placeholders = co_await convert_to_placeholders(
+      upload_res.value(), headers);
 
     vassert(
       placeholders.batches.size() == 1,
@@ -632,66 +625,61 @@ ss::future<> bg_upload_and_replicate(
     op->opts = update_replicate_options(op->opts, fence.term);
     auto replicate_stages = partition->replicate_in_stages(
       op->batch_id, std::move(placeholders.batches.front()), op->opts);
-
-    fallback.cancel();
-
     // Once the request is enqueued in raft and our order is guaranteed we can
     // release our ticket and further requests can be enqueued into the raft
     // layer.
-    ssx::background = replicate_stages.request_enqueued.then_wrapped(
-      [t = std::move(ticket)](ss::future<> fut) mutable {
-          t.release();
-          fut.ignore_ready_future();
-      });
+    auto enqueued_fut = co_await ss::coroutine::as_future(
+      std::move(replicate_stages.request_enqueued));
 
-    auto replicate_fut
-      = std::move(replicate_stages.replicate_finished)
-          .then(
-            [api,
-             cache_enabled,
-             inp = std::move(rb_copy),
-             ntp = partition->ntp(),
-             fence_unit = std::move(fence.unit)](
-              result<cluster::kafka_result> res) mutable
-              -> result<raft::replicate_result> {
-                if (res.has_error()) {
-                    return res.error();
-                }
-                if (cache_enabled) {
-                    // The term_id is not guaranteed to be set if the request
-                    // was served from the list of finished requests. This might
-                    // happen if the request is coming from the snapshot (in
-                    // which case it's not stored) or from the log replay. The
-                    // simplest solution in this case is to skip caching.
-                    if (res.value().last_term >= model::term_id{0}) {
-                        update_batches(
-                          inp,
-                          kafka::offset_cast(res.value().last_offset),
-                          res.value().last_term);
-                        for (const auto& b : inp) {
-                            vlog(
-                              cd_log.trace,
-                              "Putting batch to cache: {}, term: {}",
-                              b.base_offset(),
-                              b.term());
-                            api->cache_put(ntp, b);
-                        }
-                    } else {
-                        vlog(
-                          cd_log.debug,
-                          "Skipping cache put for ntp {} at offset {} with "
-                          "unset term",
-                          ntp,
-                          res.value().last_offset);
-                    }
-                }
-                return raft::replicate_result{
-                  .last_offset = kafka::offset_cast(res.value().last_offset),
-                  .last_term = res.value().last_term,
-                };
-            });
+    ticket.release(); // always release the ticket
 
-    replicate_fut.forward_to(std::move(op->replicate_finished));
+    if (enqueued_fut.failed()) {
+        auto ex = enqueued_fut.get_exception();
+        vlog(
+          cd_log.trace,
+          "failed to enqueue replicate request into raft ({}): {}",
+          op->ntp,
+          ex);
+        // fallthrough - we expect the finish command to throw if this one did
+        // and we don't want to abandon the replicate_finished future
+    }
+
+    auto res = co_await std::move(replicate_stages.replicate_finished);
+    if (res.has_error()) {
+        co_return res.error();
+    }
+    if (cache_enabled) {
+        // The term_id is not guaranteed to be set if the request
+        // was served from the list of finished requests. This might
+        // happen if the request is coming from the snapshot (in
+        // which case it's not stored) or from the log replay. The
+        // simplest solution in this case is to skip caching.
+        if (res.value().last_term >= model::term_id{0}) {
+            update_batches(
+              rb_copy,
+              kafka::offset_cast(res.value().last_offset),
+              res.value().last_term);
+            for (const auto& b : rb_copy) {
+                vlog(
+                  cd_log.trace,
+                  "Putting batch to cache: {}, term: {}",
+                  b.base_offset(),
+                  b.term());
+                api->cache_put(op->ntp, b);
+            }
+        } else {
+            vlog(
+              cd_log.debug,
+              "Skipping cache put for ntp {} at offset {} with "
+              "unset term",
+              op->ntp,
+              res.value().last_offset);
+        }
+    }
+    co_return raft::replicate_result{
+      .last_offset = kafka::offset_cast(res.value().last_offset),
+      .last_term = res.value().last_term,
+    };
 }
 } // namespace
 
@@ -805,10 +793,18 @@ raft::replicate_stages frontend::replicate(
       opts.timeout.value_or(L0_replicate_default_timeout));
 
     raft::replicate_stages out(raft::errc::success);
-    out.request_enqueued = op_state->request_enqueued.get_future();
-    out.replicate_finished = op_state->replicate_finished.get_future();
-    ssx::background = bg_upload_and_replicate(
-      _data_plane, _partition, header, op_state, cache_enabled());
+    auto ticket = op_state->ctp_stm_api->producer_queue().reserve(
+      batch_id.pid.get_id());
+    // Now that we've acquired our ticket and determined our ordering, we can
+    // say that the request is enqueued and get more produce requests.
+    out.request_enqueued = ss::now();
+    out.replicate_finished = do_upload_and_replicate(
+      _data_plane,
+      _partition,
+      std::move(ticket),
+      header,
+      op_state,
+      cache_enabled());
     return out;
 }
 

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -542,11 +542,16 @@ ss::future<> bg_upload_and_replicate(
   bool cache_enabled) {
     vassert(api != nullptr, "cloud topics api is not initialized");
 
+    auto ticket = op->ctp_stm_api->producer_queue().reserve(
+      op->batch_id.pid.get_id());
+    // Now that we've acquired our ticket and determined our ordering, we can
+    // say that the request is enqueued and get more produce requests.
+    op->request_enqueued.set_value();
+
     auto fallback = ss::defer([op] {
         // This guarantees that the promises are set.
         // The error code used here does not represent the
         // actual error.
-        op->request_enqueued.set_value();
         op->replicate_finished.set_value(raft::errc::timeout);
     });
 
@@ -568,6 +573,7 @@ ss::future<> bg_upload_and_replicate(
     if (cache_enabled) {
         rb_copy = clone_batches(op->batches);
     }
+
     auto timeout = op->timeout == 0ms ? L0_upload_default_timeout : op->timeout;
     auto res = co_await api->write_and_debounce(
       op->ntp,
@@ -620,19 +626,23 @@ ss::future<> bg_upload_and_replicate(
       placeholders.batches.size() == 1,
       "Expected single batch, got {}",
       placeholders.batches.size());
-
-    // Replicate
+    // Wait for all previous requests from this producer to be processed
+    co_await ticket.redeem();
+    // Replicate now that our ticket is redeemed
     op->opts = update_replicate_options(op->opts, fence.term);
     auto replicate_stages = partition->replicate_in_stages(
       op->batch_id, std::move(placeholders.batches.front()), op->opts);
 
     fallback.cancel();
 
-    // Forward future result to the 'op'. The expectation is that at this point
-    // the target promises (inside 'op') are used to generate futures and these
-    // futures are awaited.
-    replicate_stages.request_enqueued.forward_to(
-      std::move(op->request_enqueued));
+    // Once the request is enqueued in raft and our order is guaranteed we can
+    // release our ticket and further requests can be enqueued into the raft
+    // layer.
+    ssx::background = replicate_stages.request_enqueued.then_wrapped(
+      [t = std::move(ticket)](ss::future<> fut) mutable {
+          t.release();
+          fut.ignore_ready_future();
+      });
 
     auto replicate_fut
       = std::move(replicate_stages.replicate_finished)

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -508,38 +508,18 @@ raft::replicate_options update_replicate_options(
     return opts;
 }
 
-struct upload_and_replicate_stages {
-    model::ntp ntp;
-    ss::lw_shared_ptr<cluster::partition> partition;
-    ss::lw_shared_ptr<cloud_topics::ctp_stm_api> ctp_stm_api;
-    chunked_vector<model::record_batch> batches;
-    model::batch_identity batch_id;
-    raft::replicate_options opts;
-    std::chrono::milliseconds timeout;
-
-    upload_and_replicate_stages(
-      ss::lw_shared_ptr<cluster::partition> partition,
-      chunked_vector<model::record_batch> batches,
-      model::batch_identity batch_id,
-      raft::replicate_options opts,
-      std::chrono::milliseconds timeout)
-      : ntp(partition->ntp())
-      , partition(std::move(partition))
-      , ctp_stm_api(make_ctp_stm_api(this->partition))
-      , batches(std::move(batches))
-      , batch_id(batch_id)
-      , opts(opts)
-      , timeout(timeout) {}
-};
-
 ss::future<result<raft::replicate_result>> do_upload_and_replicate(
   data_plane_api* api,
   ss::lw_shared_ptr<cluster::partition> partition,
+  ss::lw_shared_ptr<cloud_topics::ctp_stm_api> ctp_stm_api,
   l0::producer_ticket ticket,
+  model::batch_identity batch_id,
   model::record_batch_header header,
-  ss::lw_shared_ptr<upload_and_replicate_stages> op,
-  bool cache_enabled) {
-    // The default errc that will cause the client to retry to operation
+  staged_write staged,
+  chunked_vector<model::record_batch> cache_batches,
+  raft::replicate_options opts) {
+    const auto& ntp = partition->ntp();
+    // The default errc that will cause the client to retry the operation
     constexpr auto default_errc = raft::errc::timeout;
     /*
      * L0 GC relies on a minimum epoch associated with each NTP for calculating
@@ -553,17 +533,16 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
       min_epoch() > 0L,
       "Unexpected invalid min epoch {} for {}",
       min_epoch,
-      op->ntp);
-    chunked_vector<model::record_batch> rb_copy;
-    if (cache_enabled) {
-        rb_copy = clone_batches(op->batches);
-    }
+      ntp);
 
-    auto timeout = op->timeout == 0ms ? L0_upload_default_timeout : op->timeout;
-    auto upload_fut = co_await ss::coroutine::as_future(api->write_and_debounce(
-      op->ntp,
+    auto timeout = opts.timeout.value_or(0ms);
+    if (timeout == 0ms) {
+        timeout = L0_upload_default_timeout;
+    }
+    auto upload_fut = co_await ss::coroutine::as_future(api->execute_write(
+      ntp,
       min_epoch,
-      std::move(op->batches),
+      std::move(staged),
       model::timeout_clock::now() + timeout));
 
     if (upload_fut.failed()) {
@@ -574,7 +553,7 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
 
     auto upload_res = upload_fut.get();
 
-    if (upload_res.has_error()) {
+    if (!upload_res.has_value()) {
         vlog(
           cd_log.debug,
           "LO object upload has errored: {}",
@@ -589,14 +568,14 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
     }
 
     auto fence_fut = co_await ss::coroutine::as_future(
-      op->ctp_stm_api->fence_epoch(upload_res.value().front().id.epoch));
+      ctp_stm_api->fence_epoch(upload_res.value().front().id.epoch));
     if (fence_fut.failed()) {
         auto e = fence_fut.get_exception();
         vlog(
           cd_log.warn,
           "Failed to fence epoch {} for ntp {}, error: {}",
           upload_res.value().front().id.epoch,
-          op->ntp,
+          ntp,
           e);
         co_return default_errc;
     }
@@ -606,7 +585,7 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
           cd_log.warn,
           "Failed to fence epoch {} for ntp {}, fence unit is empty",
           upload_res.value().front().id.epoch,
-          op->ntp);
+          ntp);
         co_return default_errc;
     }
 
@@ -622,9 +601,9 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
     // Wait for all previous requests from this producer to be processed
     co_await ticket.redeem();
     // Replicate now that our ticket is redeemed
-    op->opts = update_replicate_options(op->opts, fence.term);
+    opts = update_replicate_options(opts, fence.term);
     auto replicate_stages = partition->replicate_in_stages(
-      op->batch_id, std::move(placeholders.batches.front()), op->opts);
+      batch_id, std::move(placeholders.batches.front()), opts);
     // Once the request is enqueued in raft and our order is guaranteed we can
     // release our ticket and further requests can be enqueued into the raft
     // layer.
@@ -638,7 +617,7 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
         vlog(
           cd_log.trace,
           "failed to enqueue replicate request into raft ({}): {}",
-          op->ntp,
+          ntp,
           ex);
         // fallthrough - we expect the finish command to throw if this one did
         // and we don't want to abandon the replicate_finished future
@@ -648,7 +627,7 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
     if (res.has_error()) {
         co_return res.error();
     }
-    if (cache_enabled) {
+    if (!cache_batches.empty()) {
         // The term_id is not guaranteed to be set if the request
         // was served from the list of finished requests. This might
         // happen if the request is coming from the snapshot (in
@@ -656,23 +635,23 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
         // simplest solution in this case is to skip caching.
         if (res.value().last_term >= model::term_id{0}) {
             update_batches(
-              rb_copy,
+              cache_batches,
               kafka::offset_cast(res.value().last_offset),
               res.value().last_term);
-            for (const auto& b : rb_copy) {
+            for (const auto& b : cache_batches) {
                 vlog(
                   cd_log.trace,
                   "Putting batch to cache: {}, term: {}",
                   b.base_offset(),
                   b.term());
-                api->cache_put(op->ntp, b);
+                api->cache_put(ntp, b);
             }
         } else {
             vlog(
               cd_log.debug,
               "Skipping cache put for ntp {} at offset {} with "
               "unset term",
-              op->ntp,
+              ntp,
               res.value().last_offset);
         }
     }
@@ -710,15 +689,18 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
       min_epoch,
       ntp());
 
-    // Dataplane.
-    auto res = co_await _data_plane->write_and_debounce(
+    auto staged = co_await _data_plane->stage_write(std::move(batches));
+    if (!staged.has_value()) {
+        co_return std::unexpected(staged.error());
+    }
+    auto res = co_await _data_plane->execute_write(
       ntp(),
       min_epoch,
-      std::move(batches),
+      std::move(staged.value()),
       model::timeout_clock::now()
         + opts.timeout.value_or(L0_replicate_default_timeout));
 
-    if (res.has_error()) {
+    if (!res.has_value()) {
         co_return std::unexpected(res.error());
     }
 
@@ -782,29 +764,48 @@ raft::replicate_stages frontend::replicate(
   model::batch_identity batch_id,
   model::record_batch batch,
   raft::replicate_options opts) {
+    auto ctp_stm_api = make_ctp_stm_api(_partition);
     auto header = batch.header();
-    chunked_vector<model::record_batch> batch_vec;
+    chunked_vector<model::record_batch> batch_vec, to_cache;
     batch_vec.push_back(std::move(batch));
-    auto op_state = ss::make_lw_shared<upload_and_replicate_stages>(
-      _partition,
-      std::move(batch_vec),
-      batch_id,
-      opts,
-      opts.timeout.value_or(L0_replicate_default_timeout));
-
+    if (cache_enabled()) {
+        to_cache = clone_batches(batch_vec);
+    }
     raft::replicate_stages out(raft::errc::success);
-    auto ticket = op_state->ctp_stm_api->producer_queue().reserve(
-      batch_id.pid.get_id());
-    // Now that we've acquired our ticket and determined our ordering, we can
-    // say that the request is enqueued and get more produce requests.
-    out.request_enqueued = ss::now();
-    out.replicate_finished = do_upload_and_replicate(
-      _data_plane,
-      _partition,
-      std::move(ticket),
-      header,
-      op_state,
-      cache_enabled());
+    ss::promise<result<raft::replicate_result>> result;
+    out.replicate_finished = result.get_future();
+    out.request_enqueued = _data_plane->stage_write(std::move(batch_vec))
+                             .then_wrapped([this,
+                                            p = std::move(result),
+                                            cloned = std::move(to_cache),
+                                            batch_id,
+                                            header,
+                                            opts](auto fut) mutable {
+                                 if (fut.failed()) {
+                                     p.set_exception(fut.get_exception());
+                                     return;
+                                 }
+                                 auto reserve_result = std::move(fut.get());
+                                 if (!reserve_result.has_value()) {
+                                     p.set_value(raft::errc::timeout);
+                                     return;
+                                 }
+                                 auto ctp_stm = make_ctp_stm_api(_partition);
+                                 auto ticket
+                                   = ctp_stm->producer_queue().reserve(
+                                     batch_id.pid.get_id());
+                                 do_upload_and_replicate(
+                                   _data_plane,
+                                   _partition,
+                                   ctp_stm,
+                                   std::move(ticket),
+                                   batch_id,
+                                   header,
+                                   std::move(reserve_result.value()),
+                                   std::move(cloned),
+                                   opts)
+                                   .forward_to(std::move(p));
+                             });
     return out;
 }
 

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -599,7 +599,11 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
       "Expected single batch, got {}",
       placeholders.batches.size());
     // Wait for all previous requests from this producer to be processed
-    co_await ticket.redeem();
+    if (opts.as) {
+        co_await ticket.redeem(opts.as->get());
+    } else {
+        co_await ticket.redeem();
+    }
     // Replicate now that our ticket is redeemed
     opts = update_replicate_options(opts, fence.term);
     auto replicate_stages = partition->replicate_in_stages(

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -580,12 +580,13 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
         co_return default_errc;
     }
     auto fence = std::move(fence_fut.get());
-    if (!fence.unit.has_value()) {
+    if (!fence.has_value()) {
         vlog(
           cd_log.warn,
-          "Failed to fence epoch {} for ntp {}, fence unit is empty",
+          "Failed to fence epoch {} for ntp {}, ctp latest seen epoch is {}",
           upload_res.value().front().id.epoch,
-          ntp);
+          ntp,
+          fence.error().latest_seen);
         co_return default_errc;
     }
 
@@ -605,7 +606,7 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
         co_await ticket.redeem();
     }
     // Replicate now that our ticket is redeemed
-    opts = update_replicate_options(opts, fence.term);
+    opts = update_replicate_options(opts, fence->term);
     auto replicate_stages = partition->replicate_in_stages(
       batch_id, std::move(placeholders.batches.front()), opts);
     // Once the request is enqueued in raft and our order is guaranteed we can
@@ -722,14 +723,13 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
         std::rethrow_exception(e);
     }
     auto fence = std::move(fence_fut.get());
-    if (!fence.unit.has_value()) {
+    if (!fence.has_value()) {
         vlog(
           cd_log.warn,
-          "Failed to fence epoch {} for ntp {}, fence unit is empty",
+          "Failed to fence epoch {} for ntp {}, ctp latest seen epoch is {}",
           res.value().front().id.epoch,
-          ntp());
-
-        /// TODO: Maybe return different error code here?
+          ntp(),
+          fence.error().latest_seen);
         co_return std::unexpected(
           kafka::make_error_code(kafka::error_code::request_timed_out));
     }
@@ -741,7 +741,7 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
         placeholder_batches.push_back(std::move(batch));
     }
 
-    opts = update_replicate_options(opts, fence.term);
+    opts = update_replicate_options(opts, fence->term);
     auto result = co_await _partition->replicate(
       std::move(placeholder_batches), opts);
 

--- a/src/v/cloud_topics/frontend/tests/frontend_test.cc
+++ b/src/v/cloud_topics/frontend/tests/frontend_test.cc
@@ -33,6 +33,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <expected>
+
 static ss::logger e2e_test_log("e2e_test");
 using namespace cloud_topics;
 using namespace testing;
@@ -40,11 +42,17 @@ using namespace testing;
 class mock_api : public data_plane_api {
 public:
     MOCK_METHOD(
-      ss::future<result<chunked_vector<extent_meta>>>,
-      write_and_debounce,
+      (ss::future<std::expected<staged_write, std::error_code>>),
+      stage_write,
+      (chunked_vector<model::record_batch>),
+      (override));
+
+    MOCK_METHOD(
+      (ss::future<std::expected<chunked_vector<extent_meta>, std::error_code>>),
+      execute_write,
       (model::ntp,
        cluster_epoch,
-       chunked_vector<model::record_batch>,
+       staged_write,
        model::timeout_clock::time_point),
       (override));
 
@@ -84,7 +92,8 @@ auto make_extent_fut(model::offset o, cluster_epoch epoch) {
 
     chunked_vector<extent_meta> vec;
     vec.push_back(std::move(m));
-    return ss::make_ready_future<result<chunked_vector<extent_meta>>>(
+    return ss::make_ready_future<
+      std::expected<chunked_vector<extent_meta>, std::error_code>>(
       std::move(vec));
 }
 
@@ -124,7 +133,12 @@ TEST_F(frontend_fixture, test_replicate_epoch) {
     cloud_topics::frontend frontend(std::move(partition), _data_plane.get());
 
     EXPECT_CALL(*_data_plane, cache_put(_, _)).Times(2);
-    EXPECT_CALL(*_data_plane, write_and_debounce(_, _, _, _))
+    using stage_result = std::expected<staged_write, std::error_code>;
+    EXPECT_CALL(*_data_plane, stage_write(_))
+      .WillOnce(Return(ss::as_ready_future(stage_result{})))
+      .WillOnce(Return(ss::as_ready_future(stage_result{})))
+      .WillOnce(Return(ss::as_ready_future(stage_result{})));
+    EXPECT_CALL(*_data_plane, execute_write(_, _, _, _))
       .WillOnce(Return(make_extent_fut(model::offset(0), cluster_epoch(0))))
       .WillOnce(Return(make_extent_fut(model::offset(1), cluster_epoch(1))))
       .WillOnce(Return(make_extent_fut(model::offset(2), cluster_epoch(0))));

--- a/src/v/cloud_topics/level_zero/common/BUILD
+++ b/src/v/cloud_topics/level_zero/common/BUILD
@@ -8,6 +8,7 @@ package(
         "//src/v/cloud_topics/frontend/tests:__pkg__",
         "//src/v/cloud_topics/level_zero/batcher:__pkg__",
         "//src/v/cloud_topics/level_zero/batcher/tests:__pkg__",
+        "//src/v/cloud_topics/level_zero/common/tests:__pkg__",
         "//src/v/cloud_topics/level_zero/frontend_reader:__pkg__",
         "//src/v/cloud_topics/level_zero/pipeline:__pkg__",
         "//src/v/cloud_topics/level_zero/pipeline/tests:__pkg__",
@@ -54,6 +55,24 @@ redpanda_cc_library(
         "//src/v/utils:hdr_hist",
         "//src/v/utils:log_hist",
         "@fmt",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
+    name = "producer_queue",
+    srcs = [
+        "producer_queue.cc",
+    ],
+    hdrs = [
+        "producer_queue.h",
+    ],
+    implementation_deps = [
+        "//src/v/container:chunked_hash_map",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/model",
         "@seastar",
     ],
 )

--- a/src/v/cloud_topics/level_zero/common/producer_queue.cc
+++ b/src/v/cloud_topics/level_zero/common/producer_queue.cc
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_zero/common/producer_queue.h"
+
+#include "container/chunked_hash_map.h"
+#include "model/record.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+
+namespace cloud_topics::l0 {
+
+namespace {
+class ticket_impl;
+}
+
+using producer_state_map = chunked_hash_map<model::producer_id, ticket_impl*>;
+
+class producer_ticket::impl {
+public:
+    virtual ~impl() = default;
+    virtual ss::future<> redeem() = 0;
+    virtual void release() = 0;
+};
+
+namespace {
+
+/// A noop ticket that doesn't enforce any ordering. Used for no_producer_id.
+class noop_ticket_impl final : public producer_ticket::impl {
+public:
+    ~noop_ticket_impl() override = default;
+
+    ss::future<> redeem() override { return ss::now(); }
+
+    void release() override {}
+};
+
+/// A real ticket that enforces ordering by chaining futures.
+class ticket_impl final : public producer_ticket::impl {
+public:
+    ticket_impl(
+      ticket_impl* prev,
+      model::producer_id pid,
+      ss::lw_shared_ptr<producer_state_map> map)
+      : _prev(prev)
+      , _pid(pid)
+      , _map(std::move(map)) {
+        if (_prev != nullptr) {
+            // If we're waiting for a previous ticket to be released
+            // tell it who to notify next.
+            _prev->_next = this;
+        } else {
+            // Otherwise we're at the head of the queue we can resolve ourself.
+            _p.set_value();
+        }
+    }
+
+    ~ticket_impl() override { release(); }
+
+    ss::future<> redeem() override { return _p.get_future(); }
+
+    void release() override {
+        // Use the null map to signify a released ticket.
+        if (!_map) {
+            return;
+        }
+        // If we are waiting on something, then change it to be waiting on the
+        // next element instead.
+        if (_prev != nullptr) {
+            _prev->_next = _next;
+        }
+        if (_next != nullptr) {
+            // If we have no previous node, then we can set the next as
+            // resolved.
+            if (_prev == nullptr) {
+                _next->_p.set_value();
+            }
+            _next->_prev = _prev;
+        } else if (_prev != nullptr) {
+            // If we have no next node, but there is a previous node,
+            // update it to be the tail of the list
+            _map->insert_or_assign(_pid, _prev);
+        } else {
+            // There is no next or previous state, we can cleanup.
+            _map->erase(_pid);
+        }
+        _map = nullptr;
+    }
+
+private:
+    ticket_impl* _prev;
+    ticket_impl* _next = nullptr;
+
+    model::producer_id _pid;
+    ss::lw_shared_ptr<producer_state_map> _map;
+    ss::promise<> _p;
+};
+
+} // namespace
+
+class producer_queue::impl {
+public:
+    producer_ticket reserve(model::producer_id pid) {
+        if (pid == model::no_producer_id) {
+            return producer_ticket{std::make_unique<noop_ticket_impl>()};
+        }
+        auto it = _producer_states->find(pid);
+        ticket_impl* prev = nullptr;
+        if (it != _producer_states->end()) {
+            prev = it->second;
+        }
+        auto ticket = std::make_unique<ticket_impl>(
+          prev, pid, _producer_states);
+        _producer_states->insert_or_assign(it, pid, ticket.get());
+        return producer_ticket{std::move(ticket)};
+    }
+
+    size_t size() const { return _producer_states->size(); }
+
+private:
+    ss::lw_shared_ptr<producer_state_map> _producer_states
+      = ss::make_lw_shared<producer_state_map>();
+};
+
+producer_ticket::producer_ticket() = default;
+
+producer_ticket::producer_ticket(std::unique_ptr<impl> ticket_impl)
+  : _impl(std::move(ticket_impl)) {}
+
+producer_ticket::~producer_ticket() = default;
+
+producer_ticket::producer_ticket(producer_ticket&&) noexcept = default;
+
+producer_ticket& producer_ticket::operator=(producer_ticket&&) noexcept
+  = default;
+
+ss::future<> producer_ticket::redeem() { return _impl->redeem(); }
+
+void producer_ticket::release() { _impl->release(); }
+
+// producer_queue wrapper implementation
+producer_queue::producer_queue()
+  : _impl(std::make_unique<impl>()) {}
+
+producer_queue::~producer_queue() = default;
+
+producer_queue::producer_queue(producer_queue&&) noexcept = default;
+
+producer_queue& producer_queue::operator=(producer_queue&&) noexcept = default;
+
+producer_ticket producer_queue::reserve(model::producer_id pid) {
+    return _impl->reserve(pid);
+}
+
+size_t producer_queue::size() const { return _impl->size(); }
+
+} // namespace cloud_topics::l0

--- a/src/v/cloud_topics/level_zero/common/producer_queue.cc
+++ b/src/v/cloud_topics/level_zero/common/producer_queue.cc
@@ -76,6 +76,9 @@ public:
         // next element instead.
         if (_prev != nullptr) {
             _prev->_next = _next;
+            // We also resolve our own future if we were waiting on something
+            // but were released early.
+            _p.set_value();
         }
         if (_next != nullptr) {
             // If we have no previous node, then we can set the next as
@@ -93,6 +96,8 @@ public:
             _map->erase(_pid);
         }
         _map = nullptr;
+        _prev = nullptr;
+        _next = nullptr;
     }
 
 private:
@@ -143,6 +148,22 @@ producer_ticket& producer_ticket::operator=(producer_ticket&&) noexcept
   = default;
 
 ss::future<> producer_ticket::redeem() { return _impl->redeem(); }
+ss::future<> producer_ticket::redeem(ss::abort_source& as) {
+    std::exception_ptr ep;
+    auto sub = as.subscribe(
+      [this, &as, &ep](const std::optional<std::exception_ptr>& e) noexcept {
+          ep = e.value_or(as.get_default_exception());
+          _impl->release(); // this will trigger the waiting future to resolve
+      });
+    if (!sub) {
+        co_await ss::coroutine::return_exception_ptr(
+          as.abort_requested_exception_ptr());
+    }
+    co_await _impl->redeem();
+    if (ep) {
+        co_await ss::coroutine::return_exception_ptr(ep);
+    }
+}
 
 void producer_ticket::release() { _impl->release(); }
 

--- a/src/v/cloud_topics/level_zero/common/producer_queue.h
+++ b/src/v/cloud_topics/level_zero/common/producer_queue.h
@@ -86,8 +86,12 @@ public:
     // Redeem the ticket for usage, this waits for all previous tickets to be
     // released.
     ss::future<> redeem();
+    ss::future<> redeem(ss::abort_source&);
 
     // Release the ticket so that other later tickets in the queue can proceed.
+    //
+    // Can be called concurrently with `redeem`, which will cause it to return
+    // immediately.
     void release();
 
 private:

--- a/src/v/cloud_topics/level_zero/common/producer_queue.h
+++ b/src/v/cloud_topics/level_zero/common/producer_queue.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "model/record.h"
+
+#include <memory>
+
+namespace cloud_topics::l0 {
+
+class producer_ticket;
+
+// A producer queue is a linearization point for producers within cloud topics.
+//
+// In cloud topics we accept requests in order to the batcher from the kafka
+// layer, and post upload we also need to release requests into raft in the same
+// order we recieved them. However we don't want to limit in flight requests to
+// one request per partition, we want to allow multiple per producer. So the
+// producer queue is the mechanism to enforce this ordering.
+//
+// Expected usage looks like this:
+//
+// ```
+// ss::promise<> enqueued_promise = ...;
+// ss::promise<> finished_promise = ...;
+// auto ticket = producer_queue.reserve(my_pid);
+// enqueued_promise.set_value();
+// co_await write_and_debounce(...);
+// co_await ticket.redeem(); // wait for previous replicate calls
+// auto stages = partition->replicate(...);
+// // the next request/ticket can be redeemed after the request is in raft
+// stages.request_enqueued.then([&ticket] { ticket.release(); });
+// stages.request_finished.forward_to(finished_promise);
+// ```
+//
+// NOTE: This class' memory usage is bounded by the concurrency of in flight
+// requests and should scale ~linearly with the number of concurrent produce
+// requests.
+class producer_queue {
+public:
+    producer_queue();
+    ~producer_queue();
+    producer_queue(const producer_queue&) = delete;
+    producer_queue(producer_queue&&) noexcept;
+    producer_queue& operator=(const producer_queue&) = delete;
+    producer_queue& operator=(producer_queue&&) noexcept;
+
+    // Reserve a position within the queue for a given producer.
+    // The ticket can be redeemed later on to wait for previous tickets to be
+    // released. This creates a queuing effect per producer id.
+    //
+    // NOTE: If the producer id is model::no_producer_id, then this ticket
+    // is basically a noop and doesn't wait or preserve any ordering.
+    producer_ticket reserve(model::producer_id);
+
+    /// Returns the number of producers currently tracked in the queue.
+    /// Used for testing to verify proper cleanup.
+    size_t size() const;
+
+private:
+    class impl;
+    std::unique_ptr<impl> _impl;
+};
+
+// A ticket within the producer queue.
+class producer_ticket {
+public:
+    class impl;
+
+    producer_ticket();
+    ~producer_ticket();
+    producer_ticket(const producer_ticket&) = delete;
+    producer_ticket(producer_ticket&&) noexcept;
+    producer_ticket& operator=(const producer_ticket&) = delete;
+    producer_ticket& operator=(producer_ticket&&) noexcept;
+
+    // Redeem the ticket for usage, this waits for all previous tickets to be
+    // released.
+    ss::future<> redeem();
+
+    // Release the ticket so that other later tickets in the queue can proceed.
+    void release();
+
+private:
+    explicit producer_ticket(std::unique_ptr<impl> impl);
+    friend class producer_queue;
+
+    std::unique_ptr<impl> _impl;
+};
+
+} // namespace cloud_topics::l0

--- a/src/v/cloud_topics/level_zero/common/tests/BUILD
+++ b/src/v/cloud_topics/level_zero/common/tests/BUILD
@@ -1,0 +1,17 @@
+load("//bazel:test.bzl", "redpanda_cc_gtest")
+
+redpanda_cc_gtest(
+    name = "producer_queue_test",
+    timeout = "short",
+    srcs = [
+        "producer_queue_test.cc",
+    ],
+    deps = [
+        "//src/v/cloud_topics/level_zero/common:producer_queue",
+        "//src/v/model",
+        "//src/v/random:generators",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_zero/common/tests/producer_queue_test.cc
+++ b/src/v/cloud_topics/level_zero/common/tests/producer_queue_test.cc
@@ -168,6 +168,44 @@ TEST_CORO(producer_queue_test, continuation_cleanup) {
     co_return;
 }
 
+TEST_CORO(producer_queue_test, redeem_with_abort_source) {
+    producer_queue queue;
+    model::producer_id pid{1};
+
+    // Test 1: Abort while waiting for previous ticket
+    auto ticket1 = queue.reserve(pid);
+    auto ticket2 = queue.reserve(pid);
+
+    co_await ticket1.redeem();
+
+    ss::abort_source as;
+    auto redeem_fut = ticket2.redeem(as);
+
+    // Give it a moment to start waiting
+    co_await ss::sleep(std::chrono::milliseconds(10));
+
+    // Trigger abort while ticket2 is waiting
+    as.request_abort();
+
+    // Should get an exception
+    ASSERT_THROW_CORO(
+      co_await std::move(redeem_fut), ss::abort_requested_exception);
+
+    // ticket2 should have auto-released due to abort
+    ticket1.release();
+
+    // Test 2: Successful redeem followed by abort (should be no-op)
+    auto ticket3 = queue.reserve(pid);
+    ss::abort_source as2;
+    co_await ticket3.redeem(as2);
+
+    // Abort after successful redeem - should not affect anything
+    as2.request_abort();
+    ticket3.release();
+
+    ASSERT_EQ_CORO(queue.size(), 0);
+}
+
 namespace {
 
 ss::future<> random_sleep() {
@@ -244,8 +282,9 @@ TEST_CORO(producer_queue_test, concurrent_operations_with_drops) {
                 queue.reserve(pid),
                 i,
                 completion_order,
-                [pid](auto& ticket, int request_id, auto& order) {
-                    auto n = random_generators::get_int(0, 3);
+                ss::abort_source{},
+                [pid](auto& ticket, int request_id, auto& order, auto& as) {
+                    auto n = random_generators::get_int(0, 5);
                     if (n == 0) {
                         // Explicit release
                         return random_sleep().then(
@@ -253,9 +292,45 @@ TEST_CORO(producer_queue_test, concurrent_operations_with_drops) {
                     } else if (n == 1) {
                         // No release, just destructor
                         return random_sleep();
+                    } else if (n == 2) {
+                        // Abort before redeem completes
+                        auto redeem_fut = ticket.redeem(as);
+                        as.request_abort();
+                        return std::move(redeem_fut)
+                          .then([&ticket, request_id, &order, pid] {
+                              (*order)[pid].push_back(request_id);
+                              ticket.release();
+                          })
+                          .handle_exception([](auto) {
+                              // Abort exception is expected, ignore
+                          });
+                    } else if (n == 3) {
+                        // Random abort during operation
+                        auto redeem_fut = ticket.redeem(as);
+                        return random_sleep().then(
+                          [&as,
+                           redeem_fut = std::move(redeem_fut),
+                           &ticket,
+                           request_id,
+                           &order,
+                           pid]() mutable {
+                              // Maybe abort, maybe not
+                              if (random_generators::get_int(0, 1) == 0) {
+                                  as.request_abort();
+                              }
+                              return std::move(redeem_fut)
+                                .then([&ticket, request_id, &order, pid] {
+                                    return random_sleep().then(
+                                      [&ticket, request_id, &order, pid] {
+                                          (*order)[pid].push_back(request_id);
+                                          ticket.release();
+                                      });
+                                })
+                                .handle_exception([](auto) {});
+                          });
                     } else {
-                        // happy path
-                        return ticket.redeem().then(
+                        // Happy path with abort source (but no abort)
+                        return ticket.redeem(as).then(
                           [&ticket, request_id, &order, pid] {
                               // Add random sleep to encourage interleaving
                               return random_sleep().then(

--- a/src/v/cloud_topics/level_zero/common/tests/producer_queue_test.cc
+++ b/src/v/cloud_topics/level_zero/common/tests/producer_queue_test.cc
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_zero/common/producer_queue.h"
+#include "model/record.h"
+#include "random/generators.h"
+#include "test_utils/async.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/sleep.hh>
+
+#include <gtest/gtest.h>
+
+#include <map>
+
+using namespace cloud_topics::l0;
+
+TEST_CORO(producer_queue_test, basic_reserve_redeem_release) {
+    producer_queue queue;
+    model::producer_id pid{1};
+
+    auto ticket = queue.reserve(pid);
+
+    // First ticket should redeem immediately
+    co_await ticket.redeem();
+
+    // Release the ticket
+    ticket.release();
+}
+
+TEST_CORO(producer_queue_test, ordering_enforced) {
+    producer_queue queue;
+    model::producer_id pid{1};
+
+    // Reserve two tickets for the same producer
+    auto ticket1 = queue.reserve(pid);
+    auto ticket2 = queue.reserve(pid);
+
+    // First ticket redeems immediately
+    co_await ticket1.redeem();
+
+    // Second ticket should not redeem until first is released
+    bool ticket2_redeemed = false;
+    auto ticket2_fut = ticket2.redeem().then(
+      [&ticket2_redeemed] { ticket2_redeemed = true; });
+
+    // Give it a moment to potentially redeem (it shouldn't)
+    co_await ss::sleep(std::chrono::milliseconds(10));
+    ASSERT_FALSE_CORO(ticket2_redeemed);
+
+    // Release ticket1, which should allow ticket2 to redeem
+    ticket1.release();
+
+    co_await std::move(ticket2_fut);
+    ASSERT_TRUE_CORO(ticket2_redeemed);
+
+    ticket2.release();
+}
+
+TEST_CORO(producer_queue_test, no_producer_id_is_noop) {
+    producer_queue queue;
+
+    // Reserve multiple tickets with no_producer_id
+    auto ticket1 = queue.reserve(model::no_producer_id);
+    auto ticket2 = queue.reserve(model::no_producer_id);
+    auto ticket3 = queue.reserve(model::no_producer_id);
+
+    // All should redeem immediately without waiting
+    co_await ticket1.redeem();
+    co_await ticket2.redeem();
+    co_await ticket3.redeem();
+
+    // Release is also a noop
+    ticket1.release();
+    ticket2.release();
+    ticket3.release();
+}
+
+TEST_CORO(producer_queue_test, multiple_producers_no_cross_blocking) {
+    producer_queue queue;
+    model::producer_id pid1{1};
+    model::producer_id pid2{2};
+
+    // Reserve tickets for two different producers
+    auto ticket1_p1 = queue.reserve(pid1);
+    auto ticket1_p2 = queue.reserve(pid2);
+
+    // Both should redeem immediately (different producers)
+    co_await ticket1_p1.redeem();
+    co_await ticket1_p2.redeem();
+
+    // Reserve second tickets while first are still held
+    auto ticket2_p1 = queue.reserve(pid1);
+    auto ticket2_p2 = queue.reserve(pid2);
+
+    // Neither second ticket should be redeemable yet
+    bool ticket2_p1_redeemed = false;
+    bool ticket2_p2_redeemed = false;
+
+    auto fut_p1 = ticket2_p1.redeem().then(
+      [&ticket2_p1_redeemed] { ticket2_p1_redeemed = true; });
+    auto fut_p2 = ticket2_p2.redeem().then(
+      [&ticket2_p2_redeemed] { ticket2_p2_redeemed = true; });
+
+    co_await ss::sleep(std::chrono::milliseconds(10));
+    ASSERT_FALSE_CORO(ticket2_p1_redeemed);
+    ASSERT_FALSE_CORO(ticket2_p2_redeemed);
+
+    // Release producer 1's first ticket
+    ticket1_p1.release();
+    co_await std::move(fut_p1);
+    ASSERT_TRUE_CORO(ticket2_p1_redeemed);
+
+    // Producer 2's second ticket should still be blocked
+    ASSERT_FALSE_CORO(ticket2_p2_redeemed);
+
+    // Release producer 2's first ticket
+    ticket1_p2.release();
+    co_await std::move(fut_p2);
+    ASSERT_TRUE_CORO(ticket2_p2_redeemed);
+
+    ticket2_p1.release();
+    ticket2_p2.release();
+}
+
+TEST_CORO(producer_queue_test, auto_release_on_destruction) {
+    producer_queue queue;
+    model::producer_id pid{1};
+
+    auto ticket1 = queue.reserve(pid);
+    auto ticket2 = queue.reserve(pid);
+    auto ticket3 = queue.reserve(pid);
+
+    {
+        // an exception or some error happends and ticket2 is released early
+        auto temp = std::move(ticket2);
+    }
+
+    // but that should not make ticket3 available because ticket1 is still
+    // not yet redeemed.
+    auto ticket3_redeem = ticket3.redeem();
+    co_await tests::drain_task_queue();
+    ASSERT_FALSE_CORO(ticket3_redeem.available());
+
+    co_await ticket1.redeem();
+    ticket1.release();
+    co_await std::move(ticket3_redeem);
+    ticket3.release();
+}
+
+TEST_CORO(producer_queue_test, continuation_cleanup) {
+    producer_queue queue;
+    model::producer_id pid{1};
+    auto ticket1 = queue.reserve(pid);
+    auto ticket2 = queue.reserve(pid);
+    {
+        auto temp = std::move(ticket2);
+    }
+    ticket1.release();
+    co_return;
+}
+
+namespace {
+
+ss::future<> random_sleep() {
+    auto sleep_ms = std::chrono::milliseconds(random_generators::get_int(5));
+    return ss::sleep(sleep_ms);
+}
+
+} // namespace
+
+TEST_CORO(producer_queue_test, concurrent_operations) {
+    producer_queue queue;
+    model::producer_id pid1{1};
+    model::producer_id pid2{2};
+    model::producer_id pid3{3};
+
+    // Track completion order per producer
+    using completion_order_t = std::map<model::producer_id, std::vector<int>>;
+    auto completion_order = ss::make_lw_shared<completion_order_t>();
+
+    std::vector<ss::future<>> operations;
+
+    // Spawn concurrent operations for multiple producers
+    constexpr int requests_per_producer = 50;
+    for (int i = 0; i < requests_per_producer; ++i) {
+        for (auto pid : {pid1, pid2, pid3}) {
+            operations.push_back(
+              ss::do_with(
+                queue.reserve(pid),
+                i,
+                completion_order,
+                [pid](auto& ticket, int request_id, auto& order) {
+                    return ticket.redeem().then(
+                      [&ticket, request_id, &order, pid] {
+                          return random_sleep().then(
+                            [&ticket, request_id, &order, pid] {
+                                (*order)[pid].push_back(request_id);
+                                ticket.release();
+                            });
+                      });
+                }));
+        }
+    }
+
+    co_await ss::when_all_succeed(operations.begin(), operations.end());
+
+    // Verify each producer saw monotonically increasing request IDs
+    for (const auto& [pid, requests] : *completion_order) {
+        ASSERT_EQ_CORO(requests.size(), requests_per_producer);
+        for (size_t i = 0; i < requests.size(); ++i) {
+            ASSERT_EQ_CORO(requests[i], static_cast<int>(i));
+        }
+    }
+    ASSERT_EQ_CORO(queue.size(), 0);
+}
+
+TEST_CORO(producer_queue_test, concurrent_operations_with_drops) {
+    producer_queue queue;
+    model::producer_id pid1{1};
+    model::producer_id pid2{2};
+    model::producer_id pid3{3};
+
+    // Track completion order per producer
+    using completion_order_t = std::map<model::producer_id, std::vector<int>>;
+    auto completion_order = ss::make_lw_shared<completion_order_t>();
+
+    std::vector<ss::future<>> operations;
+
+    // Spawn concurrent operations for multiple producers
+    constexpr int requests_per_producer = 500;
+    for (int i = 0; i < requests_per_producer; ++i) {
+        for (auto pid : {pid1, pid2, pid3}) {
+            operations.push_back(
+              ss::do_with(
+                queue.reserve(pid),
+                i,
+                completion_order,
+                [pid](auto& ticket, int request_id, auto& order) {
+                    auto n = random_generators::get_int(0, 3);
+                    if (n == 0) {
+                        // Explicit release
+                        return random_sleep().then(
+                          [&ticket] { ticket.release(); });
+                    } else if (n == 1) {
+                        // No release, just destructor
+                        return random_sleep();
+                    } else {
+                        // happy path
+                        return ticket.redeem().then(
+                          [&ticket, request_id, &order, pid] {
+                              // Add random sleep to encourage interleaving
+                              return random_sleep().then(
+                                [&ticket, request_id, &order, pid] {
+                                    (*order)[pid].push_back(request_id);
+                                    ticket.release();
+                                });
+                          });
+                    }
+                }));
+        }
+    }
+
+    co_await ss::when_all_succeed(operations.begin(), operations.end());
+
+    // Verify each producer saw monotonically increasing request IDs
+    for (const auto& [pid, requests] : *completion_order) {
+        ASSERT_TRUE_CORO(std::ranges::is_sorted(requests))
+          << fmt::format("pid={}, requests={}", pid, requests);
+    }
+    ASSERT_EQ_CORO(queue.size(), 0);
+}

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -13,10 +13,12 @@
 #include "base/units.h"
 #include "cloud_topics/level_zero/pipeline/event_filter.h"
 #include "cloud_topics/level_zero/pipeline/pipeline_stage.h"
+#include "cloud_topics/level_zero/pipeline/serializer.h"
 #include "cloud_topics/level_zero/pipeline/write_request.h"
 #include "cloud_topics/logger.h"
 #include "config/configuration.h"
 #include "resource_mgmt/memory_groups.h"
+#include "ssx/semaphore.h"
 #include "utils/human.h"
 
 #include <seastar/core/abort_source.hh>
@@ -70,21 +72,24 @@ write_pipeline<Clock>::write_and_debounce(
   cluster_epoch min_epoch,
   chunked_vector<model::record_batch> batches,
   Clock::time_point timeout) {
+    auto staged = co_await prepare_write(std::move(batches));
+    if (!staged.has_value()) {
+        co_return std::unexpected(staged.error());
+    }
+    co_return co_await execute_write(
+      std::move(ntp), min_epoch, std::move(staged.value()), timeout);
+}
+
+template<class Clock>
+auto write_pipeline<Clock>::prepare_write(
+  chunked_vector<model::record_batch> batches)
+  -> ss::future<std::expected<prepared_data, std::error_code>> {
     auto h = this->hold_gate();
-    // The write request is stored on the stack of the
-    // fiber until the 'response' promise is set. The
-    // promise can be set by any fiber that completed
-    // the request processing.
     auto data_chunk = co_await l0::serialize_batches(std::move(batches));
     auto sz = data_chunk.payload.size_bytes();
-
     // Register data influx
     _probe.register_bytes_in(sz);
     _probe.set_memory_usage_gauge(current_size() + sz);
-    _probe.register_request();
-    auto lat_measure = _probe.register_request_processing_time();
-    auto err_probe = ss::defer([this] { _probe.register_request_error(); });
-
     // Grab the semaphore after the size of the write request
     // is known. It's impossible to do this in advance because
     // the memory is actually allocated before this call.
@@ -94,9 +99,29 @@ write_pipeline<Clock>::write_and_debounce(
         units = co_await ss::get_units(
           _mem_budget, sz, this->get_root_rtc().root_abort_source());
     }
+    co_return prepared_data(std::move(data_chunk), std::move(units.value()));
+}
+
+template<class Clock>
+ss::future<std::expected<chunked_vector<extent_meta>, std::error_code>>
+write_pipeline<Clock>::execute_write(
+  model::ntp ntp,
+  cluster_epoch min_epoch,
+  prepared_data prepped,
+  Clock::time_point timeout) {
+    auto h = this->hold_gate();
+    // The write request is stored on the stack of the
+    // fiber until the 'response' promise is set. The
+    // promise can be set by any fiber that completed
+    // the request processing.
+    auto sz = prepped.data_chunk.payload.size_bytes();
+
+    _probe.register_request();
+    auto lat_measure = _probe.register_request_processing_time();
+    auto err_probe = ss::defer([this] { _probe.register_request_error(); });
     _bytes_total += sz;
     l0::write_request<Clock> request(
-      std::move(ntp), min_epoch, std::move(data_chunk), timeout);
+      std::move(ntp), min_epoch, std::move(prepped.data_chunk), timeout);
     auto stage_cleanup = ss::defer([this, &request] {
         transfer_stage_bytes(
           request.stage, unassigned_pipeline_stage, request.size_bytes());

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
@@ -62,6 +62,21 @@ public:
       chunked_vector<model::record_batch> batches,
       Clock::time_point timeout);
 
+    struct prepared_data {
+        serialized_chunk data_chunk;
+        ss::semaphore_units<ss::named_semaphore_exception_factory, Clock> units;
+    };
+
+    ss::future<std::expected<prepared_data, std::error_code>>
+    prepare_write(chunked_vector<model::record_batch> batches);
+
+    ss::future<std::expected<chunked_vector<extent_meta>, std::error_code>>
+    execute_write(
+      model::ntp ntp,
+      cluster_epoch min_epoch,
+      prepared_data prepped,
+      Clock::time_point timeout);
+
     using write_requests_list
       = requests_list<write_pipeline<Clock>, write_request<Clock>>;
 

--- a/src/v/cloud_topics/level_zero/stm/BUILD
+++ b/src/v/cloud_topics/level_zero/stm/BUILD
@@ -106,6 +106,7 @@ redpanda_cc_library(
         "//src/v/serde:uuid",
         "//src/v/serde:vector",
         "//src/v/ssx:future_util",
+        "//src/v/ssx:watchdog",
         "//src/v/storage",
     ],
     visibility = ["//visibility:public"],

--- a/src/v/cloud_topics/level_zero/stm/BUILD
+++ b/src/v/cloud_topics/level_zero/stm/BUILD
@@ -111,6 +111,7 @@ redpanda_cc_library(
     deps = [
         ":ctp_stm_state",
         ":types",
+        "//src/v/cloud_topics/level_zero/common:producer_queue",
         "//src/v/raft",
         "@seastar",
     ],
@@ -135,6 +136,7 @@ redpanda_cc_library(
         ":dl_snapshot",
         ":dl_version",
         "//src/v/base",
+        "//src/v/cloud_topics/level_zero/common:producer_queue",
         "//src/v/model",
         "//src/v/ssx:future_util",
         "//src/v/utils:retry_chain_node",

--- a/src/v/cloud_topics/level_zero/stm/BUILD
+++ b/src/v/cloud_topics/level_zero/stm/BUILD
@@ -63,6 +63,7 @@ redpanda_cc_library(
     hdrs = ["types.h"],
     visibility = [":__subpackages__"],
     deps = [
+        "//src/v/cloud_topics:types",
         "//src/v/model",
         "@fmt",
         "@seastar",

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -18,6 +18,7 @@
 #include "raft/consensus.h"
 #include "raft/persisted_stm.h"
 #include "ssx/future-util.h"
+#include "ssx/watchdog.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/sleep.hh>
@@ -61,7 +62,8 @@ private:
 } // namespace
 
 ctp_stm::ctp_stm(ss::logger& logger, raft::consensus* raft)
-  : raft::persisted_stm<>(name, logger, raft) {}
+  : raft::persisted_stm<>(name, logger, raft)
+  , _lock(ss::semaphore::max_counter()) {}
 
 ss::future<> ctp_stm::start() {
     ssx::spawn_with_gate(_gate, [this] { return prefix_truncate_below_lro(); });
@@ -71,7 +73,26 @@ ss::future<> ctp_stm::start() {
 ss::future<> ctp_stm::stop() {
     _lro_advanced.broken();
     _as.request_abort();
+    // We can't break the lock because that could cause UAF
+    // as the units are held outside of this class.
+    // however lock acquisition uses the above abort_source so
+    // we should not be acquiring new waiters.
+    // _lock.broken();
     co_await raft::persisted_stm<>::stop();
+    static constexpr auto epoch_fence_lock_timeout = 10s;
+    ssx::watchdog wd(epoch_fence_lock_timeout, [this] {
+        // This is basically the number of produce requests still in flight
+        auto num_read_locks_held = ss::semaphore::max_counter()
+                                   - _lock.available_units();
+        vlog(
+          _log.debug,
+          "timeout waiting for epoch fencing lock units to be returned: {} "
+          "units outstanding",
+          num_read_locks_held);
+    });
+    // Wait for all the units to be returned otherwise when the units are
+    // destructed we could get a UAF.
+    co_await _lock.wait(ss::semaphore::max_counter());
 }
 
 ss::future<> ctp_stm::prefix_truncate_below_lro() {
@@ -126,7 +147,8 @@ ss::future<> ctp_stm::prefix_truncate_below_lro() {
         // truncating it again so if LRO is making lots of rapid but small
         // progress we aren't snapshotting too much.
         if (_raft->last_snapshot_index() > snapshot_index) {
-            co_await ss::sleep_abortable(min_truncate_period, _as);
+            co_await ss::sleep_abortable<ss::lowres_clock>(
+              min_truncate_period, _as);
         }
     }
 }
@@ -335,7 +357,7 @@ ss::future<iobuf> ctp_stm::take_raft_snapshot(model::offset snapshot_at) {
 ss::future<std::expected<cluster_epoch_fence, stale_cluster_epoch>>
 ctp_stm::fence_epoch(cluster_epoch e) {
     auto holder = _gate.hold();
-    if (!co_await sync(sync_timeout)) {
+    if (!co_await sync(sync_timeout, _as)) {
         vlog(_log.warn, "ctp_stm::fence_epoch sync timeout");
         throw std::runtime_error(fmt_with_ctx(fmt::format, "Sync timeout"));
     }
@@ -347,7 +369,7 @@ ctp_stm::fence_epoch(cluster_epoch e) {
     auto fence_epoch = _state.get_max_seen_epoch().or_else(get_applied_epoch);
     if (fence_epoch.has_value() && fence_epoch.value() == e) {
         // Case 1. Same epoch, need to acquire read-lock.
-        auto unit = co_await _lock.hold_read_lock();
+        auto unit = co_await ss::get_units(_lock, 1, _as);
         if (_state.get_max_seen_epoch().or_else(get_applied_epoch) == e) {
             // The max_seen_epoch didn't advance after the scheduling point
             co_return cluster_epoch_fence{
@@ -355,7 +377,8 @@ ctp_stm::fence_epoch(cluster_epoch e) {
         }
     } else {
         // Case 2. New epoch, need to acquire write-lock.
-        auto unit = co_await _lock.hold_write_lock();
+        auto unit = co_await ss::get_units(
+          _lock, ss::semaphore::max_counter(), _as);
         auto current_epoch = _state.get_max_seen_epoch().or_else(
           get_applied_epoch);
         if (!current_epoch.has_value() || current_epoch.value() <= e) {

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -372,4 +372,7 @@ ss::future<cluster_epoch_fence> ctp_stm::fence_epoch(cluster_epoch e) {
 model::offset ctp_stm::max_removable_local_log_offset() {
     return _state.get_max_collectible_offset();
 }
+
+l0::producer_queue& ctp_stm::producer_queue() { return _producer_queue; }
+
 }; // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -332,7 +332,8 @@ ss::future<iobuf> ctp_stm::take_raft_snapshot(model::offset snapshot_at) {
     co_return serde::to_iobuf(_state);
 }
 
-ss::future<cluster_epoch_fence> ctp_stm::fence_epoch(cluster_epoch e) {
+ss::future<std::expected<cluster_epoch_fence, stale_cluster_epoch>>
+ctp_stm::fence_epoch(cluster_epoch e) {
     auto holder = _gate.hold();
     if (!co_await sync(sync_timeout)) {
         vlog(_log.warn, "ctp_stm::fence_epoch sync timeout");
@@ -366,7 +367,10 @@ ss::future<cluster_epoch_fence> ctp_stm::fence_epoch(cluster_epoch e) {
         }
     }
     // If we reach here, it means that we need to discard the batch.
-    co_return cluster_epoch_fence{};
+    co_return std::unexpected(
+      stale_cluster_epoch(_state.get_max_seen_epoch()
+                            .or_else(get_applied_epoch)
+                            .value_or(cluster_epoch{-1})));
 }
 
 model::offset ctp_stm::max_removable_local_log_offset() {

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -15,7 +15,7 @@
 #include "cloud_topics/level_zero/stm/types.h"
 #include "raft/persisted_stm.h"
 
-#include <seastar/core/rwlock.hh>
+#include <seastar/core/semaphore.hh>
 
 #include <expected>
 
@@ -114,7 +114,7 @@ private:
     /// Lock to protect the state from concurrent access.
     /// When the new epoch is applied we need to acquire a write lock.
     /// Otherwise, we need to acquire a read lock.
-    ss::rwlock _lock;
+    ss::semaphore _lock;
     /// Current in-memory state of the STM
     ctp_stm_state _state;
 

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "cloud_topics/level_zero/common/producer_queue.h"
 #include "cloud_topics/level_zero/stm/ctp_stm_state.h"
 #include "cloud_topics/level_zero/stm/types.h"
 #include "raft/persisted_stm.h"
@@ -80,6 +81,11 @@ public:
     ss::future<bool> sync_in_term(
       model::timeout_clock::time_point deadline, ss::abort_source& as);
 
+    // The producer queue for this CTP.
+    //
+    // This is used to preserve ordering of concurrently uploading requests.
+    l0::producer_queue& producer_queue();
+
 private:
     ss::future<> do_apply(const model::record_batch&) override;
     void apply_placeholder(const model::record_batch&);
@@ -101,6 +107,7 @@ private:
     ss::future<> prefix_truncate_below_lro();
 
 private:
+    l0::producer_queue _producer_queue;
     /// Lock to protect the state from concurrent access.
     /// When the new epoch is applied we need to acquire a write lock.
     /// Otherwise, we need to acquire a read lock.

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -17,6 +17,8 @@
 
 #include <seastar/core/rwlock.hh>
 
+#include <expected>
+
 namespace cloud_topics {
 
 class ctp_stm_api;
@@ -54,7 +56,8 @@ public:
         _state.advance_max_seen_epoch(epoch);
     }
 
-    ss::future<cluster_epoch_fence> fence_epoch(cluster_epoch e);
+    ss::future<std::expected<cluster_epoch_fence, stale_cluster_epoch>>
+    fence_epoch(cluster_epoch e);
 
     /// Return inactive epoch of the CTP
     ///

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
@@ -193,4 +193,8 @@ std::optional<cluster_epoch> ctp_stm_api::get_max_seen_epoch() const {
     return _stm->state().get_max_seen_epoch();
 }
 
+l0::producer_queue& ctp_stm_api::producer_queue() {
+    return _stm->producer_queue();
+}
+
 }; // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
@@ -174,14 +174,15 @@ ss::future<bool> ctp_stm_api::sync_in_term(
     co_return co_await _stm->sync_in_term(deadline, as);
 }
 
-ss::future<cluster_epoch_fence> ctp_stm_api::fence_epoch(cluster_epoch e) {
+ss::future<std::expected<cluster_epoch_fence, stale_cluster_epoch>>
+ctp_stm_api::fence_epoch(cluster_epoch e) {
     vlog(_log.debug, "Fencing epoch {} in term {}", e, _stm->_raft->term());
     auto res = co_await _stm->fence_epoch(e);
     vlog(
       _log.debug,
       "Fence acquired = {} in term {}",
-      res.unit.has_value(),
-      res.term);
+      res.has_value(),
+      res.has_value() ? res->term : model::term_id{-1});
     co_return std::move(res);
 }
 

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "cloud_topics/level_zero/common/producer_queue.h"
 #include "cloud_topics/level_zero/stm/types.h"
 #include "cloud_topics/types.h"
 #include "model/fundamental.h"
@@ -95,6 +96,8 @@ public:
     std::optional<cluster_epoch> get_max_epoch() const;
 
     std::optional<cluster_epoch> get_max_seen_epoch() const;
+
+    l0::producer_queue& producer_queue();
 
 private:
     /// Replicate a record batch and wait for it to be applied to the ctp_stm.

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
@@ -91,7 +91,8 @@ public:
     sync_in_term(model::timeout_clock::time_point deadline, ss::abort_source&);
 
     /// Fence writes
-    ss::future<cluster_epoch_fence> fence_epoch(cluster_epoch e);
+    ss::future<std::expected<cluster_epoch_fence, stale_cluster_epoch>>
+    fence_epoch(cluster_epoch e);
 
     std::optional<cluster_epoch> get_max_epoch() const;
 

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -158,20 +158,20 @@ TEST_F_CORO(ctp_stm_fixture, test_fencing) {
     {
         auto fence
           = co_await api(node(*get_leader())).fence_epoch(ct::cluster_epoch{2});
-        ASSERT_TRUE_CORO(fence.unit.has_value());
+        ASSERT_TRUE_CORO(fence.has_value());
     }
 
     // Acquire the fence for epoch 1 (should fail)
     {
         auto fence
           = co_await api(node(*get_leader())).fence_epoch(ct::cluster_epoch{1});
-        ASSERT_FALSE_CORO(fence.unit.has_value());
+        ASSERT_FALSE_CORO(fence.has_value());
     }
 
     // Advance max_seen_epoch to 3.
     auto write_fence
       = co_await api(node(*get_leader())).fence_epoch(ct::cluster_epoch{3});
-    ASSERT_TRUE_CORO(write_fence.unit.has_value());
+    ASSERT_TRUE_CORO(write_fence.has_value());
 
     // Out of order fence for epoch 2 (should be waiting for the fence to be
     // released)
@@ -182,7 +182,7 @@ TEST_F_CORO(ctp_stm_fixture, test_fencing) {
     write_fence = {};
 
     auto read_fence = co_await std::move(fut);
-    ASSERT_FALSE_CORO(read_fence.unit.has_value());
+    ASSERT_FALSE_CORO(read_fence.has_value());
 }
 
 TEST_F_CORO(ctp_stm_fixture, test_last_reconciled_offset) {
@@ -457,6 +457,6 @@ TEST_F_CORO(ctp_stm_fixture, test_snapshot) {
     // Acquire the fence for epoch 1 (should fail)
     {
         auto fence = co_await api(leader).fence_epoch(ct::cluster_epoch{1});
-        ASSERT_FALSE_CORO(fence.unit.has_value());
+        ASSERT_FALSE_CORO(fence.has_value());
     }
 }

--- a/src/v/cloud_topics/level_zero/stm/types.h
+++ b/src/v/cloud_topics/level_zero/stm/types.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "cloud_topics/types.h"
 #include "model/fundamental.h"
 
 #include <seastar/core/rwlock.hh>
@@ -23,12 +24,18 @@ enum class ctp_stm_key : uint8_t {
 
 struct [[nodiscard]] cluster_epoch_fence {
     // Units protecting the epoch state.
-    // If it's set to nullopt the batch has to be discarded
-    // because of the out of order epoch.
-    std::optional<ss::rwlock::holder> unit;
+    ss::rwlock::holder unit;
     // Term in which the batch is replicated.
     model::term_id term;
 };
+
+// The error returned when the CTP STM has seen a newer epoch than the one
+// attempting to be used.
+struct [[nodiscard]] stale_cluster_epoch {
+    // The latest cluster epoch
+    cluster_epoch latest_seen;
+};
+
 } // namespace cloud_topics
 
 template<>

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -594,6 +594,7 @@ ss::future<> partition::stop() {
     }
 
     _probe.clear_metrics();
+    _cloud_storage_probe->clear_metrics();
     vlog(clusterlog.debug, "Stopped partition {}", partition_ntp);
 }
 

--- a/src/v/raft/group_manager.cc
+++ b/src/v/raft/group_manager.cc
@@ -189,7 +189,7 @@ ss::future<xshard_transfer_state> group_manager::do_shutdown(
         co_await c->remove_persistent_state();
     }
     co_await _heartbeats.deregister_group(group_id);
-    auto it = std::find(_groups.begin(), _groups.end(), c);
+    auto it = std::ranges::find(_groups, c);
     vassert(
       it != _groups.end(),
       "A consensus instance with group id: {} that is requested to be removed "


### PR DESCRIPTION
- **ct/l0: add a producer queue**
- **ct/l0/stm: wire in producer queue**
- **ct/frontend: allow concurrent requests per producer**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
