### PR TITLE
k/group_mgr: use quorum_ack replication for group tombstone replication

### DIFF
--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -376,9 +376,9 @@ ss::future<size_t> group_manager::delete_offsets(
     }
 
     /*
-     * replicate tombstone records to the group's partition. avoid acks=all
-     * because the process is largely best-effort and the in-memory state was
-     * already cleaned up.
+     * replicate tombstone records to the group's partition. It is fine to use
+     * quorum_ack as even though this operation is not critical it is
+     * interleaved with quorum ack replicate calls.
      */
     auto batch = std::move(builder).build();
 
@@ -386,7 +386,7 @@ ss::future<size_t> group_manager::delete_offsets(
         auto result = co_await group->partition()->raft()->replicate(
           std::move(batch),
           raft::replicate_options(
-            raft::consistency_level::leader_ack, group->term()));
+            raft::consistency_level::quorum_ack, group->term()));
 
         if (result) {
             vlog(


### PR DESCRIPTION
When group tombstone is replicated previously we were using `leader_ack` consistency. It is optimization that is not really relevant in this case as leader acks are there to increase the throughput by minimizing the latency of request handling.

Another point is that it is very likely the tombstone replicate request will be immediately followed by `offset_commit` request that will fore flush either way.

Changed the consistency level used to replicate the tombstones with `quorum_acks`

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none