### PR TITLE
`ct/l1`: `committer`: add `compaction_epoch` to empty update

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/committer.cc
+++ b/src/v/cloud_topics/level_one/compaction/committer.cc
@@ -283,9 +283,17 @@ compaction_committer::compaction_job::do_compact_objects(
 }
 
 ss::future<>
-compaction_committer::compaction_job::compact_objects_without_update() {
-    auto replace_res = co_await do_compact_objects(
-      metastore::compaction_map_t{});
+compaction_committer::compaction_job::compact_objects_without_update(
+  metastore::compaction_epoch expected_compaction_epoch) {
+    auto compaction_update = metastore::compaction_update{
+      .new_cleaned_ranges = {},
+      .removed_tombstones_ranges = {},
+      .cleaned_at = model::timestamp::missing(),
+      .expected_compaction_epoch = expected_compaction_epoch};
+
+    metastore::compaction_map_t compact_map;
+    compact_map.emplace(_tp, std::move(compaction_update));
+    auto replace_res = co_await do_compact_objects(std::move(compact_map));
     if (replace_res.has_value()) {
         vlog(
           compaction_log.info,
@@ -339,7 +347,8 @@ ss::future<> compaction_committer::compaction_job::compact_objects_with_update(
           commit_res.error());
         // We couldn't commit the metastore update, but we should at least try
         // to replace the objects so as not to discard our hard IO work.
-        co_return co_await compact_objects_without_update();
+        co_return co_await compact_objects_without_update(
+          expected_compaction_epoch);
     }
 }
 
@@ -392,7 +401,8 @@ ss::future<> compaction_committer::compaction_job::do_finalize(
         // If an error was encountered during committing, don't attempt to
         // make a compaction update for `compact_objects` with the
         // `metastore`- just replace the objects.
-        co_return co_await compact_objects_without_update();
+        co_return co_await compact_objects_without_update(
+          expected_compaction_epoch);
     }
 
     auto res = std::move(fut).get();
@@ -403,7 +413,8 @@ ss::future<> compaction_committer::compaction_job::do_finalize(
           "storage: {}",
           _id,
           res.value());
-        co_return co_await compact_objects_without_update();
+        co_return co_await compact_objects_without_update(
+          expected_compaction_epoch);
     }
 
     co_return co_await compact_objects_with_update(

--- a/src/v/cloud_topics/level_one/compaction/committer.h
+++ b/src/v/cloud_topics/level_one/compaction/committer.h
@@ -138,7 +138,8 @@ public:
         // Essentially a call to `metastore->replace_objects()`. Used when we
         // were unable to put all the compaction updates in object storage, or
         // when the formed compaction update was rejected.
-        ss::future<> compact_objects_without_update();
+        ss::future<>
+          compact_objects_without_update(metastore::compaction_epoch);
 
         // Finalizes the compaction job through a request to
         // `metastore->compact_objects()`, using the provided cleaned ranges and


### PR DESCRIPTION
We still need to specify the `compaction_epoch` in a `compact_objects()` request that only replaces objects.

We weren't doing this in the `compaction_committer`. Amend the call site to fix this.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
