### PR TITLE
ct/reconciler: Introduce adaptive reconciler scheduling

### DIFF
--- a/src/v/cloud_topics/reconciler/BUILD
+++ b/src/v/cloud_topics/reconciler/BUILD
@@ -65,11 +65,13 @@ redpanda_cc_library(
         "//src/v/cloud_topics:logger",
         "//src/v/cloud_topics/frontend",
         "//src/v/cloud_topics/level_zero/stm:ctp_stm_api",
+        "//src/v/config",
         "//src/v/kafka/utils:txn_reader",
         "//src/v/utils:retry_chain_node",
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":adaptive_interval",
         ":reconciler_probe",
         ":reconciliation_consumer",
         "//src/v/base",

--- a/src/v/cloud_topics/reconciler/BUILD
+++ b/src/v/cloud_topics/reconciler/BUILD
@@ -3,6 +3,21 @@ load("//bazel:build.bzl", "redpanda_cc_library")
 package(default_visibility = [":__subpackages__"])
 
 redpanda_cc_library(
+    name = "adaptive_interval",
+    srcs = [
+        "adaptive_interval.cc",
+    ],
+    hdrs = [
+        "adaptive_interval.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/config",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "reconciliation_consumer",
     srcs = [
         "reconciliation_consumer.cc",

--- a/src/v/cloud_topics/reconciler/adaptive_interval.cc
+++ b/src/v/cloud_topics/reconciler/adaptive_interval.cc
@@ -20,17 +20,17 @@ adaptive_interval::adaptive_interval(
   config::binding<double> target_fill_ratio,
   config::binding<double> speedup_blend,
   config::binding<double> slowdown_blend,
-  size_t max_object_size)
+  config::binding<size_t> max_object_size)
   : _min_interval(std::move(min_interval))
   , _max_interval(std::move(max_interval))
   , _target_fill_ratio(std::move(target_fill_ratio))
   , _speedup_blend(std::move(speedup_blend))
   , _slowdown_blend(std::move(slowdown_blend))
-  , _max_object_size(max_object_size)
+  , _max_object_size(std::move(max_object_size))
   , _current_interval(_min_interval()) {}
 
 void adaptive_interval::adapt(size_t max_bytes_produced) {
-    auto target_object_size = static_cast<double>(_max_object_size)
+    auto target_object_size = static_cast<double>(_max_object_size())
                               * _target_fill_ratio();
 
     // Compute ideal interval based on how far off we were from target.

--- a/src/v/cloud_topics/reconciler/adaptive_interval.cc
+++ b/src/v/cloud_topics/reconciler/adaptive_interval.cc
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/reconciler/adaptive_interval.h"
+
+#include <algorithm>
+
+namespace cloud_topics::reconciler {
+
+adaptive_interval::adaptive_interval(
+  config::binding<std::chrono::milliseconds> min_interval,
+  config::binding<std::chrono::milliseconds> max_interval,
+  config::binding<double> target_fill_ratio,
+  config::binding<double> speedup_blend,
+  config::binding<double> slowdown_blend,
+  size_t max_object_size)
+  : _min_interval(std::move(min_interval))
+  , _max_interval(std::move(max_interval))
+  , _target_fill_ratio(std::move(target_fill_ratio))
+  , _speedup_blend(std::move(speedup_blend))
+  , _slowdown_blend(std::move(slowdown_blend))
+  , _max_object_size(max_object_size)
+  , _current_interval(_min_interval()) {}
+
+void adaptive_interval::adapt(size_t max_bytes_produced) {
+    auto target_object_size = static_cast<double>(_max_object_size)
+                              * _target_fill_ratio();
+
+    // Compute ideal interval based on how far off we were from target.
+    ss::lowres_clock::duration ideal_interval;
+    if (max_bytes_produced == 0) {
+        ideal_interval = _max_interval();
+    } else {
+        // If actual < target, ratio > 1, so interval increases.
+        // If actual > target, ratio < 1, so interval decreases.
+        double ratio = target_object_size
+                       / static_cast<double>(max_bytes_produced);
+        auto current_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+          _current_interval);
+        ideal_interval = std::chrono::duration_cast<ss::lowres_clock::duration>(
+          std::chrono::duration<double, std::milli>(
+            current_ms.count() * ratio));
+    }
+
+    // Asymmetric blending: fast to speed up, slow to slow down.
+    double blend = _slowdown_blend();
+    if (ideal_interval < _current_interval) {
+        blend = _speedup_blend();
+    }
+
+    auto current_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+      _current_interval);
+    auto ideal_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+      ideal_interval);
+    auto blended_ms = std::chrono::duration<double, std::milli>(
+      (1.0 - blend) * current_ms.count() + blend * ideal_ms.count());
+    _current_interval = std::chrono::duration_cast<ss::lowres_clock::duration>(
+      blended_ms);
+
+    auto min = ss::lowres_clock::duration(_min_interval());
+    auto max = ss::lowres_clock::duration(_max_interval());
+    _current_interval = std::clamp(_current_interval, min, max);
+}
+
+ss::lowres_clock::duration adaptive_interval::current_interval() const {
+    return _current_interval;
+}
+
+} // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/adaptive_interval.h
+++ b/src/v/cloud_topics/reconciler/adaptive_interval.h
@@ -43,7 +43,7 @@ public:
       config::binding<double> target_fill_ratio,
       config::binding<double> speedup_blend,
       config::binding<double> slowdown_blend,
-      size_t max_object_size);
+      config::binding<size_t> max_object_size);
 
     /**
      * Update the interval based on the result of a reconciliation round.
@@ -64,7 +64,7 @@ private:
     config::binding<double> _target_fill_ratio;
     config::binding<double> _speedup_blend;
     config::binding<double> _slowdown_blend;
-    size_t _max_object_size;
+    config::binding<size_t> _max_object_size;
 
     ss::lowres_clock::duration _current_interval;
 };

--- a/src/v/cloud_topics/reconciler/adaptive_interval.h
+++ b/src/v/cloud_topics/reconciler/adaptive_interval.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "config/property.h"
+
+#include <seastar/core/lowres_clock.hh>
+
+#include <chrono>
+
+namespace cloud_topics::reconciler {
+
+/**
+ * Adaptive interval calculator for reconciliation scheduling.
+ *
+ * This class implements an adaptive scheduling algorithm that adjusts the
+ * reconciliation interval based on observed object fill ratios. The goal is
+ * to produce well-sized objects (target ~80% of max size) while adapting to
+ * varying data rates.
+ *
+ * Key properties:
+ * - Asymmetric response: fast to shorten interval and slow to lengthen it.
+ *   This helps because adjustment happens once per interval, so long
+ *   intervals have an inherent slowness to how they adjust.
+ * - Bounded: interval always stays within [min_interval, max_interval]
+ * - Self-correcting: errors in rate estimation correct each round
+ *
+ * To disable adaptive scheduling, set min_interval == max_interval.
+ */
+class adaptive_interval {
+public:
+    adaptive_interval(
+      config::binding<std::chrono::milliseconds> min_interval,
+      config::binding<std::chrono::milliseconds> max_interval,
+      config::binding<double> target_fill_ratio,
+      config::binding<double> speedup_blend,
+      config::binding<double> slowdown_blend,
+      size_t max_object_size);
+
+    /**
+     * Update the interval based on the result of a reconciliation round.
+     *
+     * @param max_bytes_produced The size of the largest object produced in
+     *        this round. Use 0 if no objects were produced.
+     */
+    void adapt(size_t max_bytes_produced);
+
+    /**
+     * Get the current interval to use for the next sleep.
+     */
+    ss::lowres_clock::duration current_interval() const;
+
+private:
+    config::binding<std::chrono::milliseconds> _min_interval;
+    config::binding<std::chrono::milliseconds> _max_interval;
+    config::binding<double> _target_fill_ratio;
+    config::binding<double> _speedup_blend;
+    config::binding<double> _slowdown_blend;
+    size_t _max_object_size;
+
+    ss::lowres_clock::duration _current_interval;
+};
+
+} // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -23,6 +23,7 @@
 #include "cloud_topics/reconciler/reconciliation_consumer.h"
 #include "cloud_topics/reconciler/reconciliation_source.h"
 #include "cluster/partition.h"
+#include "config/configuration.h"
 #include "model/fundamental.h"
 #include "ssx/future-util.h"
 #include "utils/retry_chain_node.h"
@@ -58,7 +59,17 @@ void log_error(
 
 reconciler::reconciler(l1::io* l1_io, l1::metastore* metastore)
   : _l1_io(l1_io)
-  , _metastore(metastore) {}
+  , _metastore(metastore)
+  , _scheduler(
+      config::shard_local_cfg().cloud_topics_reconciliation_min_interval.bind(),
+      config::shard_local_cfg().cloud_topics_reconciliation_max_interval.bind(),
+      config::shard_local_cfg()
+        .cloud_topics_reconciliation_target_fill_ratio.bind(),
+      config::shard_local_cfg()
+        .cloud_topics_reconciliation_speedup_blend.bind(),
+      config::shard_local_cfg()
+        .cloud_topics_reconciliation_slowdown_blend.bind(),
+      max_object_size) {}
 
 ss::future<> reconciler::start() {
     _probe.setup_metrics();
@@ -104,10 +115,6 @@ void reconciler::detach(const model::ntp& ntp) {
     }
 }
 
-ss::lowres_clock::duration reconciler::reconciliation_interval() const {
-    return config::shard_local_cfg().cloud_topics_reconciliation_interval();
-}
-
 ss::future<> reconciler::reconciliation_loop() {
     /*
      * Polling is not particularly efficient, and in practice, we'll probably
@@ -118,7 +125,7 @@ ss::future<> reconciler::reconciliation_loop() {
 
     auto deferred = ss::defer(
       [] { vlog(lg.debug, "Reconciliation loop exiting"); });
-    ss::lowres_clock::duration next_wait = reconciliation_interval();
+    ss::lowres_clock::duration next_wait = _scheduler.current_interval();
     while (!_gate.is_closed()) {
         try {
             co_await ss::sleep_abortable(next_wait, _as);
@@ -130,7 +137,8 @@ ss::future<> reconciler::reconciliation_loop() {
         if (config::shard_local_cfg()
               .cloud_topics_disable_reconciliation_loop()) {
             vlog(lg.debug, "Reconciliation loop disabled, skipping iteration");
-            next_wait = reconciliation_interval();
+            next_wait = config::shard_local_cfg()
+                          .cloud_topics_reconciliation_max_interval.value();
             continue;
         }
 
@@ -184,7 +192,6 @@ ss::future<> reconciler::reconciliation_loop() {
          *   except for shutdown
          */
         // clang-format on
-        auto round_start = ss::lowres_clock::now();
         try {
             co_await reconcile();
         } catch (...) {
@@ -196,10 +203,7 @@ ss::future<> reconciler::reconciliation_loop() {
               "Recoverable error during reconciliation: {}",
               std::current_exception());
         }
-        auto round_duration = ss::lowres_clock::now() - round_start;
-        next_wait = std::max(
-          reconciliation_interval() - round_duration,
-          ss::lowres_clock::duration(0));
+        next_wait = _scheduler.current_interval();
     }
 }
 
@@ -322,6 +326,16 @@ ss::future<> reconciler::reconcile() {
         vassert(
           rm_ret.has_value(), "Removing object {} in non-pending state", oid);
     }
+
+    // Adapt scheduling interval based on max object size produced.
+    // Note that we slow down if there's nothing to reconcile or if all
+    // objects failed. This is a sort of retry with backoff mechanism.
+    size_t max_bytes_produced = 0;
+    for (const auto& obj : successful_objects) {
+        max_bytes_produced = std::max(
+          max_bytes_produced, obj.object_info.size_bytes);
+    }
+    _scheduler.adapt(max_bytes_produced);
 
     // Check if we have any successful objects to commit.
     if (successful_objects.empty()) {

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -69,7 +69,8 @@ reconciler::reconciler(l1::io* l1_io, l1::metastore* metastore)
         .cloud_topics_reconciliation_speedup_blend.bind(),
       config::shard_local_cfg()
         .cloud_topics_reconciliation_slowdown_blend.bind(),
-      max_object_size) {}
+      config::shard_local_cfg()
+        .cloud_topics_reconciliation_max_object_size.bind()) {}
 
 ss::future<> reconciler::start() {
     _probe.setup_metrics();
@@ -476,6 +477,8 @@ reconciler::make_context() {
     auto output_stream = stream_fut.get();
     ctx.builder = l1::object_builder::create(
       std::move(output_stream), l1::object_builder::options{});
+    ctx.size_budget
+      = config::shard_local_cfg().cloud_topics_reconciliation_max_object_size();
 
     co_return ctx;
 }
@@ -483,6 +486,8 @@ reconciler::make_context() {
 ss::future<std::expected<reconciler::built_object_metadata, reconcile_error>>
 reconciler::build_object(
   builder_context& ctx, const chunked_vector<ss::shared_ptr<source>>& sources) {
+    const auto max_size = ctx.size_budget;
+
     chunked_vector<commit_info> metas;
     metas.reserve(sources.size());
     for (const auto& src : sources) {
@@ -493,19 +498,18 @@ reconciler::build_object(
 
         // Enforce the size limit, but always allow one partition in.
         auto current_size = ctx.builder->file_size();
-        if (!metas.empty() && current_size >= max_object_size) {
+        if (!metas.empty() && current_size >= max_size) {
             vlog(
               lg.debug,
               "Stopping object build: size {} >= max {}",
               current_size,
-              max_object_size);
+              max_size);
             break;
         }
         // Beware underflow if the first partition sneaks a batch in over the
         // size limit.
-        ctx.size_budget = current_size >= max_object_size
-                            ? 0
-                            : max_object_size - current_size;
+        ctx.size_budget = current_size >= max_size ? 0
+                                                   : max_size - current_size;
         auto start_offset = kafka::next_offset(src->last_reconciled_offset());
         auto read_result = co_await add_source_to_object(
           ctx, src, start_offset);

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -15,6 +15,7 @@
 #include "cloud_topics/level_one/common/object.h"
 #include "cloud_topics/level_one/common/object_id.h"
 #include "cloud_topics/level_one/metastore/metastore.h"
+#include "cloud_topics/reconciler/adaptive_interval.h"
 #include "cloud_topics/reconciler/reconciler_probe.h"
 #include "cloud_topics/reconciler/reconciliation_consumer.h"
 #include "cluster/partition.h"
@@ -121,7 +122,9 @@ private:
     chunked_hash_map<model::ntp, ss::shared_ptr<source>> _sources;
 
 private:
-    static constexpr size_t max_object_size = 64_MiB;
+    // Maximum size of an L1 object. With target fill ratio of 0.8, this gives
+    // an effective target object size of 64 MiB.
+    static constexpr size_t max_object_size = 80_MiB;
 
     /*
      * A container for an object in the process of being built.
@@ -172,7 +175,6 @@ private:
 
     // Top-level background worker that drives reconciliation.
     ss::future<> reconciliation_loop();
-    ss::lowres_clock::duration reconciliation_interval() const;
 
     /*
      * Reconcile a set of sources into an object with id `oid`.
@@ -256,6 +258,7 @@ private:
     ss::gate _gate;
     ss::abort_source _as;
     reconciler_probe _probe;
+    adaptive_interval _scheduler;
 };
 
 } // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -122,10 +122,6 @@ private:
     chunked_hash_map<model::ntp, ss::shared_ptr<source>> _sources;
 
 private:
-    // Maximum size of an L1 object. With target fill ratio of 0.8, this gives
-    // an effective target object size of 64 MiB.
-    static constexpr size_t max_object_size = 80_MiB;
-
     /*
      * A container for an object in the process of being built.
      * Always requires cleanup via close_builder() and cleanup_staging().
@@ -133,7 +129,7 @@ private:
     struct builder_context {
         std::unique_ptr<l1::staging_file> staging;
         std::unique_ptr<l1::object_builder> builder;
-        size_t size_budget{max_object_size};
+        size_t size_budget{0};
 
         // Close the builder.
         // Should be called before cleanup_staging.

--- a/src/v/cloud_topics/reconciler/tests/BUILD
+++ b/src/v/cloud_topics/reconciler/tests/BUILD
@@ -66,6 +66,7 @@ redpanda_cc_gtest(
         "//src/v/storage:record_batch_builder",
         "//src/v/test_utils:gtest",
         "//src/v/test_utils:random_bytes",
+        "//src/v/test_utils:scoped_config",
         "@googletest//:gtest",
         "@seastar",
     ],

--- a/src/v/cloud_topics/reconciler/tests/BUILD
+++ b/src/v/cloud_topics/reconciler/tests/BUILD
@@ -1,5 +1,19 @@
 load("//bazel:test.bzl", "redpanda_cc_gtest", "redpanda_test_cc_library")
 
+redpanda_cc_gtest(
+    name = "adaptive_interval_test",
+    timeout = "short",
+    srcs = [
+        "adaptive_interval_test.cc",
+    ],
+    deps = [
+        "//src/v/cloud_topics/reconciler:adaptive_interval",
+        "//src/v/config",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
 redpanda_test_cc_library(
     name = "test_utils",
     hdrs = [

--- a/src/v/cloud_topics/reconciler/tests/adaptive_interval_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/adaptive_interval_test.cc
@@ -44,7 +44,7 @@ adaptive_interval make_test_scheduler(
       config::mock_binding<double>(target_fill),
       config::mock_binding<double>(speedup_blend),
       config::mock_binding<double>(slowdown_blend),
-      max_object_size};
+      config::mock_binding<size_t>(max_object_size)};
 }
 
 double interval_ms(const adaptive_interval& scheduler) {
@@ -60,7 +60,8 @@ void stabilize(adaptive_interval& scheduler, double data_rate_mib_per_sec) {
     for (int i = 0; i < many_rounds; i++) {
         double interval_sec = interval_ms(scheduler) / 1000.0;
         double bytes_mib = data_rate_mib_per_sec * interval_sec;
-        size_t bytes = static_cast<size_t>(std::min(bytes_mib, 80.0) * MiB);
+        double max_mib = static_cast<double>(max_object_size) / MiB;
+        size_t bytes = static_cast<size_t>(std::min(bytes_mib, max_mib) * MiB);
         scheduler.adapt(bytes);
     }
 }

--- a/src/v/cloud_topics/reconciler/tests/adaptive_interval_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/adaptive_interval_test.cc
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/reconciler/adaptive_interval.h"
+#include "config/property.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+using namespace cloud_topics::reconciler;
+using namespace std::chrono_literals;
+
+namespace {
+
+// Default test parameters.
+// These come from some ad hoc simulations testing the algorithm.
+constexpr size_t max_object_size = 80_MiB;
+constexpr auto default_min_interval = 250ms;
+constexpr auto default_max_interval = 60000ms;
+constexpr double default_target_fill = 0.8;
+constexpr double default_speedup_blend = 0.9;
+constexpr double default_slowdown_blend = 0.4;
+
+// Number of rounds to run when expecting the interval to stabilize.
+constexpr int many_rounds = 10000;
+
+adaptive_interval make_test_scheduler(
+  std::chrono::milliseconds min_interval = default_min_interval,
+  std::chrono::milliseconds max_interval = default_max_interval,
+  double target_fill = default_target_fill,
+  double speedup_blend = default_speedup_blend,
+  double slowdown_blend = default_slowdown_blend) {
+    return {
+      config::mock_binding<std::chrono::milliseconds>(min_interval),
+      config::mock_binding<std::chrono::milliseconds>(max_interval),
+      config::mock_binding<double>(target_fill),
+      config::mock_binding<double>(speedup_blend),
+      config::mock_binding<double>(slowdown_blend),
+      max_object_size};
+}
+
+double interval_ms(const adaptive_interval& scheduler) {
+    return std::chrono::duration<double, std::milli>(
+             scheduler.current_interval())
+      .count();
+}
+
+// Run many adaptation rounds at a fixed data rate until interval stabilizes.
+// Each round produces bytes = data_rate * interval, capped at max_object_size.
+void stabilize(adaptive_interval& scheduler, double data_rate_mib_per_sec) {
+    constexpr double MiB = 1024 * 1024;
+    for (int i = 0; i < many_rounds; i++) {
+        double interval_sec = interval_ms(scheduler) / 1000.0;
+        double bytes_mib = data_rate_mib_per_sec * interval_sec;
+        size_t bytes = static_cast<size_t>(std::min(bytes_mib, 80.0) * MiB);
+        scheduler.adapt(bytes);
+    }
+}
+
+} // namespace
+
+TEST(AdaptiveIntervalTest, BasicAdaptation) {
+    auto scheduler = make_test_scheduler();
+
+    // 1. Should start at min_interval
+    EXPECT_NEAR(interval_ms(scheduler), 250.0, 1.0);
+
+    // 2. Interval increases when objects are below target fill.
+    // Target size is 80MiB * 0.8 = 64MiB. Produce 32MiB (half of target).
+    size_t half_target = static_cast<size_t>(
+      max_object_size * default_target_fill / 2);
+    for (int i = 0; i < 5; i++) {
+        auto prev = interval_ms(scheduler);
+        scheduler.adapt(half_target);
+        EXPECT_GT(interval_ms(scheduler), prev);
+    }
+
+    // 3. Interval decreases when objects are above target fill.
+    // Produce full-size objects (80MiB > 64MiB target).
+    for (int i = 0; i < 5; i++) {
+        auto prev = interval_ms(scheduler);
+        scheduler.adapt(max_object_size);
+        EXPECT_LT(interval_ms(scheduler), prev);
+    }
+
+    // 4. Stabilizes at max_interval with zero data rate.
+    stabilize(scheduler, 0.0);
+    EXPECT_NEAR(interval_ms(scheduler), 60000.0, 10.0);
+
+    // 5. Stabilizes at min_interval with very high data rate.
+    // At 1000MiB/s, even at min_interval (250ms), we produce 250MiB > 80MiB.
+    stabilize(scheduler, 1000.0);
+    EXPECT_NEAR(interval_ms(scheduler), 250.0, 10.0);
+}
+
+TEST(AdaptiveIntervalTest, ConvergesToIdealInterval) {
+    auto scheduler = make_test_scheduler();
+
+    constexpr double target_object_size_mib = 80.0 * default_target_fill;
+
+    // Data rate of 10MiB/s -> ideal interval = 64MiB / 10MiB/s = 6.4s
+    constexpr double data_rate_1 = 10.0;
+    constexpr double ideal_interval_1 = target_object_size_mib / data_rate_1
+                                        * 1000.0;
+
+    stabilize(scheduler, data_rate_1);
+    EXPECT_NEAR(interval_ms(scheduler), ideal_interval_1, 100.0);
+
+    // Change to data rate of 20MiB/s -> ideal interval = 64MiB / 20MiB/s = 3.2s
+    constexpr double data_rate_2 = 20.0;
+    constexpr double ideal_interval_2 = target_object_size_mib / data_rate_2
+                                        * 1000.0;
+
+    stabilize(scheduler, data_rate_2);
+    EXPECT_NEAR(interval_ms(scheduler), ideal_interval_2, 100.0);
+
+    // Change to data rate of 5MiB/s -> ideal interval = 64MiB / 5MiB/s = 12.8s
+    constexpr double data_rate_3 = 5.0;
+    constexpr double ideal_interval_3 = target_object_size_mib / data_rate_3
+                                        * 1000.0;
+
+    stabilize(scheduler, data_rate_3);
+    EXPECT_NEAR(interval_ms(scheduler), ideal_interval_3, 100.0);
+}
+
+TEST(AdaptiveIntervalTest, NonAdaptiveMode) {
+    // When min == max, interval should stay fixed regardless of data rate.
+    auto fixed_interval = 5000ms;
+    auto scheduler = make_test_scheduler(fixed_interval, fixed_interval);
+
+    EXPECT_NEAR(interval_ms(scheduler), 5000.0, 1.0);
+
+    // Zero data rate should not change interval.
+    scheduler.adapt(0);
+    EXPECT_NEAR(interval_ms(scheduler), 5000.0, 1.0);
+
+    // Full objects should not change interval.
+    scheduler.adapt(max_object_size);
+    EXPECT_NEAR(interval_ms(scheduler), 5000.0, 1.0);
+
+    // Half-full objects should not change interval.
+    scheduler.adapt(max_object_size / 2);
+    EXPECT_NEAR(interval_ms(scheduler), 5000.0, 1.0);
+
+    // Many rounds at various data rates should not change interval.
+    stabilize(scheduler, 0.0);
+    EXPECT_NEAR(interval_ms(scheduler), 5000.0, 1.0);
+
+    stabilize(scheduler, 100.0);
+    EXPECT_NEAR(interval_ms(scheduler), 5000.0, 1.0);
+
+    stabilize(scheduler, 1000.0);
+    EXPECT_NEAR(interval_ms(scheduler), 5000.0, 1.0);
+}

--- a/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
@@ -18,6 +18,7 @@
 #include "model/record_batch_reader.h"
 #include "model/tests/random_batch.h"
 #include "model/tests/randoms.h"
+#include "test_utils/scoped_config.h"
 
 #include <seastar/util/defer.hh>
 
@@ -161,14 +162,18 @@ TEST_F(ReconcilerTest, MultipleSources) {
 }
 
 TEST_F(ReconcilerTest, ObjectSizeLimit) {
+    // Use a small max object size for fast tests.
+    scoped_config cfg;
+    cfg.get("cloud_topics_reconciliation_max_object_size")
+      .set_value(size_t{1_MiB});
+
     auto src = add_source();
 
-    // Total size = 50 * 4 * 512KiB = 100MiB, which is greater than the 80MiB
-    // max object size.
+    // Total size = 20 * 1 * 64KiB = 1.25MiB, which exceeds the 1MiB limit.
     // Disable compression to ensure predictable sizes.
-    constexpr auto batch_count = 50;
-    constexpr auto record_count = 4;
-    constexpr auto record_size = 512_KiB;
+    constexpr auto batch_count = 20;
+    constexpr auto record_count = 1;
+    constexpr auto record_size = 64_KiB;
     for (size_t i = 0; i < batch_count; ++i) {
         src->add_batch(
           {.allow_compression = false,
@@ -192,14 +197,19 @@ TEST_F(ReconcilerTest, ObjectSizeLimit) {
 }
 
 TEST_F(ReconcilerTest, ObjectSizeLimitMultipleSources) {
+    // Use a small max object size for fast tests.
+    scoped_config cfg;
+    cfg.get("cloud_topics_reconciliation_max_object_size")
+      .set_value(size_t{1_MiB});
+
     auto src1 = add_source();
     auto src2 = add_source();
 
-    // 75MiB in source 1.
+    // 960KiB in source 1 (15 * 64KiB).
     // Disable compression to ensure predictable sizes.
-    constexpr auto batch_count_1 = 75;
+    constexpr auto batch_count_1 = 15;
     constexpr auto record_count = 1;
-    constexpr auto record_size = 1_MiB;
+    constexpr auto record_size = 64_KiB;
     for (size_t i = 0; i < batch_count_1; ++i) {
         src1->add_batch(
           {.allow_compression = false,
@@ -207,8 +217,8 @@ TEST_F(ReconcilerTest, ObjectSizeLimitMultipleSources) {
            .record_sizes = std::vector<size_t>(record_count, record_size)});
     }
 
-    // 50 in source 2, total 100MiB > 80MiB object limit.
-    constexpr auto batch_count_2 = 50;
+    // 640KiB in source 2 (10 * 64KiB), total 1.6MiB > 1MiB limit.
+    constexpr auto batch_count_2 = 10;
     for (size_t i = 0; i < batch_count_2; ++i) {
         src2->add_batch(
           {.allow_compression = false,
@@ -240,17 +250,22 @@ TEST_F(ReconcilerTest, ObjectSizeLimitMultipleSources) {
       metastore_next_offset(src2), Optional(kafka::offset{last_offset_2 + 1}));
 }
 
-// Test that when two sources each exceed max_object_size (64MiB), only one
+// Test that when two sources each exceed max_object_size, only one
 // is processed per reconciliation round. This verifies that the size_budget
 // calculation doesn't underflow (which would allow both to be processed).
 TEST_F(ReconcilerTest, ObjectSizeLimitOneSourcePerRound) {
+    // Use a small max object size for fast tests.
+    scoped_config cfg;
+    cfg.get("cloud_topics_reconciliation_max_object_size")
+      .set_value(size_t{1_MiB});
+
     auto src1 = add_source();
     auto src2 = add_source();
 
-    // Each source: 13 batches of 5MiB = 65MiB, exceeding the 64MiB limit.
-    constexpr auto batch_count = 13;
+    // Each source: 25 batches of 64KiB = 1.6MiB > 1MiB limit.
+    constexpr auto batch_count = 25;
     constexpr auto record_count = 1;
-    constexpr auto record_size = 5_MiB;
+    constexpr auto record_size = 64_KiB;
     for (size_t i = 0; i < batch_count; ++i) {
         src1->add_batch(
           {.allow_compression = false,
@@ -264,15 +279,14 @@ TEST_F(ReconcilerTest, ObjectSizeLimitOneSourcePerRound) {
 
     reconcile();
 
-    constexpr auto last_offset = batch_count * record_count - 1;
     auto lro1 = src1->last_reconciled_offset();
     auto lro2 = src2->last_reconciled_offset();
 
-    // Exactly one source should be fully processed, the other should not
-    // advance. We're agnostic to which one goes first.
-    bool src1_done = lro1 == kafka::offset{last_offset};
-    bool src2_done = lro2 == kafka::offset{last_offset};
-    EXPECT_TRUE(src1_done != src2_done)
+    // Exactly one source should make progress, the other should not advance.
+    // The size budget prevents processing multiple sources in one round.
+    bool src1_started = lro1 >= kafka::offset{0};
+    bool src2_started = lro2 >= kafka::offset{0};
+    EXPECT_TRUE(src1_started != src2_started)
       << "Expected exactly one source to be processed per round. "
       << "src1 LRO: " << lro1 << ", src2 LRO: " << lro2;
 }
@@ -324,7 +338,7 @@ TEST_F(ReconcilerTest, MetastoreAddObjectsTransientFailure) {
     src1->add_batch({.count = 10});
     src2->add_batch({.count = 10});
 
-    metastore().fail_add_objects_transiently(3);
+    metastore().fail_add_objects_transiently(2);
 
     reconcile();
 

--- a/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
@@ -163,11 +163,11 @@ TEST_F(ReconcilerTest, MultipleSources) {
 TEST_F(ReconcilerTest, ObjectSizeLimit) {
     auto src = add_source();
 
-    // Total size = 50 * 3 * 512KiB = 75MiB, which is greater than the 64MiB
+    // Total size = 50 * 4 * 512KiB = 100MiB, which is greater than the 80MiB
     // max object size.
     // Disable compression to ensure predictable sizes.
     constexpr auto batch_count = 50;
-    constexpr auto record_count = 3;
+    constexpr auto record_count = 4;
     constexpr auto record_size = 512_KiB;
     for (size_t i = 0; i < batch_count; ++i) {
         src->add_batch(
@@ -195,9 +195,9 @@ TEST_F(ReconcilerTest, ObjectSizeLimitMultipleSources) {
     auto src1 = add_source();
     auto src2 = add_source();
 
-    // 50MiB in source 1.
+    // 75MiB in source 1.
     // Disable compression to ensure predictable sizes.
-    constexpr auto batch_count_1 = 50;
+    constexpr auto batch_count_1 = 75;
     constexpr auto record_count = 1;
     constexpr auto record_size = 1_MiB;
     for (size_t i = 0; i < batch_count_1; ++i) {
@@ -207,8 +207,8 @@ TEST_F(ReconcilerTest, ObjectSizeLimitMultipleSources) {
            .record_sizes = std::vector<size_t>(record_count, record_size)});
     }
 
-    // 25MiB in source 2, total 75MiB > 64MiB object limit.
-    constexpr auto batch_count_2 = 25;
+    // 50 in source 2, total 100MiB > 80MiB object limit.
+    constexpr auto batch_count_2 = 50;
     for (size_t i = 0; i < batch_count_2; ++i) {
         src2->add_batch(
           {.allow_compression = false,

--- a/src/v/cloud_topics/tests/end_to_end_test.cc
+++ b/src/v/cloud_topics/tests/end_to_end_test.cc
@@ -98,6 +98,10 @@ TEST_F(e2e_fixture, test_create_cloud_topic) {
 }
 
 TEST_F(e2e_fixture, test_l0_path) {
+    // Disable reconciliation to ensure we test the L0 path exclusively.
+    test_local_cfg.get("cloud_topics_disable_reconciliation_loop")
+      .set_value(true);
+
     auto* producer = make_producer();
     size_t total_records = 100;
     size_t records_per_batch = 5;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4571,6 +4571,14 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       0.4,
       validate_0_to_1_ratio)
+  , cloud_topics_reconciliation_max_object_size(
+      *this,
+      "cloud_topics_reconciliation_max_object_size",
+      "Maximum size in bytes for L1 objects produced by the reconciler. "
+      "With the default target fill ratio of 0.8, this gives an effective "
+      "target object size of 64 MiB.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      80_MiB)
   , cloud_topics_long_term_garbage_collection_interval(
       *this,
       "cloud_topics_long_term_garbage_collection_interval",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4530,13 +4530,47 @@ configuration::configuration()
       "negatively impact performance and stability of the cluster.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
-  , cloud_topics_reconciliation_interval(
+  , cloud_topics_reconciliation_min_interval(
       *this,
-      "cloud_topics_reconciliation_interval",
-      "Time interval after which data is moved from short term storage "
-      "to long term storage.",
+      "cloud_topics_reconciliation_min_interval",
+      "Minimum reconciliation interval for adaptive scheduling. The "
+      "reconciler will not run more frequently than this.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      250ms)
+  , cloud_topics_reconciliation_max_interval(
+      *this,
+      "cloud_topics_reconciliation_max_interval",
+      "Maximum reconciliation interval for adaptive scheduling.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10s)
+  , cloud_topics_reconciliation_target_fill_ratio(
+      *this,
+      "cloud_topics_reconciliation_target_fill_ratio",
+      "Target fill ratio for L1 objects. The reconciler adapts its interval "
+      "to produce objects at approximately this fill level (0.0 to 1.0).",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      0.8,
+      validate_0_to_1_ratio)
+  , cloud_topics_reconciliation_speedup_blend(
+      *this,
+      "cloud_topics_reconciliation_speedup_blend",
+      "Blend factor for speeding up reconciliation (0.0 to 1.0). Higher "
+      "values mean reconciliation increases its frequency faster when trying "
+      "to find a frequency that produces well-sized objects.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      0.9,
+      validate_0_to_1_ratio)
+  , cloud_topics_reconciliation_slowdown_blend(
+      *this,
+      "cloud_topics_reconciliation_slowdown_blend",
+      "Blend factor for slowing down reconciliation (0.0 to 1.0). Higher "
+      "values mean reconciliation lowers its frequency faster when trying to "
+      "find a frequency that produces well-sized objects. Generally this "
+      "should be lower than the speedup blend, because reconciliation has less "
+      "opportunities to adapt its frequency when it runs less frequently.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      0.4,
+      validate_0_to_1_ratio)
   , cloud_topics_long_term_garbage_collection_interval(
       *this,
       "cloud_topics_long_term_garbage_collection_interval",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -828,6 +828,7 @@ public:
     property<double> cloud_topics_reconciliation_target_fill_ratio;
     property<double> cloud_topics_reconciliation_speedup_blend;
     property<double> cloud_topics_reconciliation_slowdown_blend;
+    property<size_t> cloud_topics_reconciliation_max_object_size;
     property<std::chrono::milliseconds>
       cloud_topics_long_term_garbage_collection_interval;
     property<std::chrono::milliseconds>

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -821,7 +821,13 @@ public:
     property<std::chrono::milliseconds> cloud_topics_produce_upload_interval;
     property<size_t> cloud_topics_produce_cardinality_threshold;
     property<bool> cloud_topics_disable_reconciliation_loop;
-    property<std::chrono::milliseconds> cloud_topics_reconciliation_interval;
+    property<std::chrono::milliseconds>
+      cloud_topics_reconciliation_min_interval;
+    property<std::chrono::milliseconds>
+      cloud_topics_reconciliation_max_interval;
+    property<double> cloud_topics_reconciliation_target_fill_ratio;
+    property<double> cloud_topics_reconciliation_speedup_blend;
+    property<double> cloud_topics_reconciliation_slowdown_blend;
     property<std::chrono::milliseconds>
       cloud_topics_long_term_garbage_collection_interval;
     property<std::chrono::milliseconds>

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -423,4 +423,20 @@ validate_cloud_storage_cluster_name(const std::optional<ss::sstring>& input) {
     return std::nullopt;
 }
 
+std::optional<ss::sstring>
+validate_cloud_topics_reconciliation_intervals(const configuration& config) {
+    auto min_interval = config.cloud_topics_reconciliation_min_interval();
+    auto max_interval = config.cloud_topics_reconciliation_max_interval();
+
+    if (min_interval > max_interval) {
+        return fmt::format(
+          "cloud_topics_reconciliation_min_interval ({}) must be less than or "
+          "equal to cloud_topics_reconciliation_max_interval ({})",
+          min_interval.count(),
+          max_interval.count());
+    }
+
+    return std::nullopt;
+}
+
 }; // namespace config

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -78,4 +78,7 @@ validate_consumer_group_metrics(const std::vector<ss::sstring>& metrics);
 std::optional<ss::sstring>
 validate_cloud_storage_cluster_name(const std::optional<ss::sstring>&);
 
+std::optional<ss::sstring>
+validate_cloud_topics_reconciliation_intervals(const configuration& config);
+
 }; // namespace config

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -2036,6 +2036,15 @@ void config_multi_property_validation(
           updated_config.iceberg_rest_catalog_authentication_mode.name()}]
           = opt_err.value();
     }
+
+    // Validate cloud topics reconciliation intervals
+    auto interval_err
+      = config::validate_cloud_topics_reconciliation_intervals(updated_config);
+    if (interval_err.has_value()) {
+        errors[ss::sstring{
+          updated_config.cloud_topics_reconciliation_min_interval.name()}]
+          = interval_err.value();
+    }
 }
 } // namespace
 

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -2038,8 +2038,8 @@ void config_multi_property_validation(
     }
 
     // Validate cloud topics reconciliation intervals
-    auto interval_err
-      = config::validate_cloud_topics_reconciliation_intervals(updated_config);
+    auto interval_err = config::validate_cloud_topics_reconciliation_intervals(
+      updated_config);
     if (interval_err.has_value()) {
         errors[ss::sstring{
           updated_config.cloud_topics_reconciliation_min_interval.name()}]

--- a/tests/rptest/tests/cloud_topics/l0_gc_test.py
+++ b/tests/rptest/tests/cloud_topics/l0_gc_test.py
@@ -35,7 +35,8 @@ class CloudTopicsL0GCTest(RedpandaTest):
         )
         extra_rp_conf = {
             CLOUD_TOPICS_CONFIG_STR: True,
-            "cloud_topics_reconciliation_interval": 2000,
+            "cloud_topics_reconciliation_min_interval": 2000,
+            "cloud_topics_reconciliation_max_interval": 2000,
             "cloud_topics_epoch_service_epoch_increment_interval": 5000,
             "cloud_topics_epoch_service_local_epoch_cache_duration": 5000,
             "cloud_topics_short_term_gc_minimum_object_age": 10000,

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -775,6 +775,15 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                 # Do this instead.
                 valid_value = 10000
 
+            if name in (
+                "cloud_topics_reconciliation_target_fill_ratio",
+                "cloud_topics_reconciliation_speedup_blend",
+                "cloud_topics_reconciliation_slowdown_blend",
+            ):
+                # Doubling the default puts it out of the valid range.
+                # Do this instead.
+                valid_value = 0.5
+
             if name == "tls_v1_2_cipher_suites":
                 valid_value = ":".join(
                     random.sample(


### PR DESCRIPTION
This adds adaptive scheduling to the reconciler. Individual commit message have more detail, but the main points are

1. The adaptive scheduler's purpose is to create nice-sized objects when throughput is steady and reconciliation can keep up with it.
2. Its purpose is not to handle very-high throughput situations or to address the latency cliff of falling off the batch cache and having to read from S3 or the on-disk cache. A follow-up will try to address that.
3. I also allowed configuring the max object size, which may be useful in some cases to improve reconciler throughput, but also lets me make the tests fast.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none