### PR TITLE
[UX-747] rpk shadow: enable --print-template for cloud

### DIFF
--- a/src/go/rpk/pkg/cli/shadow/config.go
+++ b/src/go/rpk/pkg/cli/shadow/config.go
@@ -84,7 +84,7 @@ Save the template with documentation to a file:
 		Run: func(_ *cobra.Command, _ []string) {
 			var outputData, successMsg string
 			if printTemplate {
-				template := generateConfigTemplate()
+				template := generateConfigTemplate(cloud)
 				outputData = template
 				successMsg = "Template file generated successfully: %s\n"
 			} else {
@@ -225,10 +225,28 @@ func generateSampleConfig(cloud bool) *ShadowLinkConfig {
 	return slCfg
 }
 
-func generateConfigTemplate() string {
+func generateConfigTemplate(cloud bool) string {
 	var sb strings.Builder
 
-	sb.WriteString("# Shadow Link Configuration Template\n")
+	if cloud {
+		sb.WriteString("# Shadow Link Configuration Template for Redpanda Cloud\n")
+	} else {
+		sb.WriteString("# Shadow Link Configuration Template\n")
+	}
+
+	// Manually add name field (not in ShadowLinkConfigurations proto, but in ShadowLink)
+	sb.WriteString("# The name of the shadow link\n")
+	sb.WriteString("name: \"\"\n")
+
+	// Inject cloud_options manually (not in admin/v2 proto)
+	if cloud {
+		sb.WriteString("# Configurations for Shadow Link in Redpanda Cloud\n")
+		sb.WriteString("cloud_options:\n")
+		sb.WriteString("  # The ID of the source Redpanda Cloud cluster (optional)\n")
+		sb.WriteString("  source_redpanda_id: \"\"\n")
+		sb.WriteString("  # The ID of the shadow Redpanda Cloud cluster\n")
+		sb.WriteString("  shadow_redpanda_id: \"\"\n\n")
+	}
 
 	// Get the message descriptor from the global registry
 	cfg := &v2.ShadowLinkConfigurations{}
@@ -252,7 +270,7 @@ func generateConfigTemplate() string {
 			continue
 		}
 
-		writeFieldTemplate(&sb, field, 0)
+		writeFieldTemplate(&sb, field, 0, cloud)
 	}
 
 	return sb.String()
@@ -331,7 +349,12 @@ func toScreamingSnakeCase(s string) string {
 	return strings.ToUpper(result.String())
 }
 
-func writeFieldTemplate(sb *strings.Builder, field protoreflect.FieldDescriptor, indent int) {
+func writeFieldTemplate(sb *strings.Builder, field protoreflect.FieldDescriptor, indent int, cloud bool) {
+	// Skip tls_file_settings for Cloud (only tls_pem_settings is valid)
+	if cloud && string(field.Name()) == "tls_file_settings" {
+		return
+	}
+
 	indentStr := strings.Repeat("  ", indent)
 
 	// Get field comment using the appropriate package registry
@@ -373,7 +396,7 @@ func writeFieldTemplate(sb *strings.Builder, field protoreflect.FieldDescriptor,
 					continue
 				}
 
-				writeFieldTemplate(sb, nestedField, indent+2)
+				writeFieldTemplate(sb, nestedField, indent+2, cloud)
 			}
 		} else {
 			// List of scalars
@@ -409,7 +432,7 @@ func writeFieldTemplate(sb *strings.Builder, field protoreflect.FieldDescriptor,
 					continue
 				}
 
-				writeFieldTemplate(sb, nestedField, indent+1)
+				writeFieldTemplate(sb, nestedField, indent+1, cloud)
 			}
 		}
 	} else {

--- a/src/go/rpk/pkg/cli/shadow/types.go
+++ b/src/go/rpk/pkg/cli/shadow/types.go
@@ -31,7 +31,10 @@ type ShadowLinkConfig struct {
 }
 
 type CloudShadowLinkOptions struct {
+	// Source Redpanda cluster ID. This field is optional. If provided, fetches
+	// bootstrap server information.
 	SourceRedpandaID string `json:"source_redpanda_id,omitempty" yaml:"source_redpanda_id,omitempty"`
+	// Shadow Redpanda cluster ID where the shadow link will be created.
 	ShadowRedpandaID string `json:"shadow_redpanda_id,omitempty" yaml:"shadow_redpanda_id,omitempty"`
 }
 


### PR DESCRIPTION
We chose to manually inject the string instead of
generating a full comment registry for just 2
fields. If the configuration for cloud expands we
can revisit this mechanism.

### Sample
```yaml
# Shadow Link Configuration Template for Redpanda Cloud
# The name of the shadow link
name: ""
# Configurations for Shadow Link in Redpanda Cloud
cloud_options:
  # The ID of the source Redpanda Cloud cluster (optional)
  source_redpanda_id: ""
  # The ID of the shadow Redpanda Cloud cluster
  shadow_redpanda_id: ""

# Configuration for the internal kafka client
client_options:
  # The bootstrap servers to use
  bootstrap_servers: []
  # If provided, this is the expected ID of the source cluster.  If it does
  # not match then the connection will be rejected.  If provided, this value
  # must match the `ClusterId` field returned in the Kafka Metadata response
  # message
  source_cluster_id: ""
  # TLS settings
  tls_settings:
    # Whether or not TLS is enabled
    enabled: false
    # Certificates and keys are provided in PEM format
    tls_pem_settings:
      # The CA
      ca: ""
      # Key and Cert are optional but if one is provided, then both must be
      # The key
      key: ""
      # The cert
      cert: ""
    # If true, the SNI hostname will not be provided when TLS is used
    do_not_set_sni_hostname: false
  # Authentication settings
  authentication_configuration:
    # SASL/SCRAM configuration
    scram_configuration:
      # SCRAM username
      username: ""
      # Password
      password: ""
      # The SCRAM mechanism to use
      scram_mechanism: SCRAM_SHA_256  # SCRAM-SHA-256
    # SASL/PLAIN configuration
    plain_configuration:
      # PLAIN username
      username: ""
      # Password
      password: ""
  # Max metadata age.
  # If 0 is provided, defaults to 10 seconds
  metadata_max_age_ms: 0
  # Connection timeout.
  # If 0 is provided, defaults to 1 second
  connection_timeout_ms: 0
  # Retry base backoff.
  # If 0 is provided, defaults to 100ms
  retry_backoff_ms: 0
  # Fetch request timeout.
  # If 0 is provided, defaults to 500ms
  fetch_wait_max_ms: 0
  # Fetch min bytes.
  # If 0 is provided, defaults to 5 MiB
  fetch_min_bytes: 0
  # Fetch max bytes.
  # If 0 is provided, defaults to 20 MiB
  fetch_max_bytes: 0
  # Fetch partition max bytes.
  # If 0 is provided, defaults to 5 MiB
  fetch_partition_max_bytes: 0

# Topic metadata sync options
topic_metadata_sync_options:
  # How often to sync metadata
  # If 0 provided, defaults to 30 seconds
  interval: 30s  # duration (e.g., 30s, 1m, 1h)
  # List of filters that indicate which topics should be automatically
  # created as shadow topics on the shadow cluster.  This only controls
  # automatic creation of shadow topics and does not effect the state of the
  # mirror topic once it is created.
  # Literal filters for __consumer_offsets, _redpanda.audit_log and _schemas
  # will be rejected as well as prefix filters to match topics prefixed with
  # _redpanda or __redpanda.
  # Wildcard `*` is permitted only for literal filters and will _not_ match
  # any topics that start with _redpanda or __redpanda.  If users wish to
  # shadow topics that start with _redpanda or __redpanda, they should
  # provide a literal filter for those topics.
  auto_create_shadow_topic_filters:
      # Literal or prefix
      pattern_type: LITERAL  # Must match the filter exactly
      # Include or exclude
      filter_type: INCLUDE  # Include the items that match the filter
      # The resource name, or "*"
      # Note if "*", must be the _only_ character
      # and `pattern_type` must be `PATTERN_TYPE_LITERAL`
      name: ""
  # List of topic properties that should be synced from the source topic.
  # The following properties will always be replicated
  # - Partition count
  # - `max.message.bytes`
  # - `cleanup.policy`
  # - `timestamp.type`
  # The following properties are not allowed to be replicated and adding them
  # to this list will result in an error:
  # - `redpanda.remote.readreplica`
  # - `redpanda.remote.recovery`
  # - `redpanda.remote.allowgaps`
  # - `redpanda.virtual.cluster.id`
  # - `redpanda.leaders.preference`
  # - `redpanda.cloud_topic.enabled`
  # This list is a list of properties in addition to the default properties
  # that will be synced.  See `exclude_default`.
  synced_shadow_topic_properties: []
  # If false, then the following topic properties will be synced by default:
  # - `compression.type`
  # - `retention.bytes`
  # - `retention.ms`
  # - `delete.retention.ms`
  # - Replication Factor
  # - `min.compaction.lag.ms`
  # - `max.compaction.lag.ms`
  # If this is true, then only the properties listed in
  # `synced_shadow_topic_properties` will be synced.
  exclude_default: false
  # Enables data replication from the earliest offset
  # on the source topic/partition.
  start_at_earliest:
  # Enables data replication from the latest offset
  # on the source topic/partition.
  start_at_latest:
  # Enables data replication from the first offset on the
  # source topic/partition where the record's timestamp is
  # at or after the specified timestamp.
  start_at_timestamp: "2024-01-01T00:00:00Z"  # RFC3339 timestamp
  # Allows user to pause the topic sync task.  If paused, then
  # the task will enter the 'paused' state and not sync topics or their
  # properties from the source cluster
  paused: false

# Consumer offset sync options
consumer_offset_sync_options:
  # Sync interval
  # If 0 provided, defaults to 30 seconds
  interval: 30s  # duration (e.g., 30s, 1m, 1h)
  # Allows user to pause the consumer offset sync task.  If paused, then
  # the task will enter the 'paused' state and not sync consumer offsets from
  # the source cluster
  paused: false
  # The filters
  group_filters:
      # Literal or prefix
      pattern_type: LITERAL  # Must match the filter exactly
      # Include or exclude
      filter_type: INCLUDE  # Include the items that match the filter
      # The resource name, or "*"
      # Note if "*", must be the _only_ character
      # and `pattern_type` must be `PATTERN_TYPE_LITERAL`
      name: ""

# Security settings sync options
security_sync_options:
  # Sync interval
  # If 0 provided, defaults to 30 seconds
  interval: 30s  # duration (e.g., 30s, 1m, 1h)
  # Allows user to pause the security settings sync task.  If paused,
  # then the task will enter the 'paused' state and will not sync security
  # settings from the source cluster
  paused: false
  # ACL filters
  acl_filters:
      # The resource filter
      resource_filter:
        # The ACL resource type to match
        resource_type: ANY
        # The pattern to apply to name
        pattern_type: ANY
        # Name, if not given will default to match all items in `resource_type`.
        # Note that asterisk `*` is literal and matches resource ACLs
        # that are named `*`
        name: ""
      # The access filter
      access_filter:
        # The name of the principal, if not set will default to match
        # all principals with the specified `operation` and `permission_type`
        principal: ""
        # The ACL operation to match
        operation: ANY
        # The permission type
        permission_type: ANY
        # The host to match.  If not set, will default to match all hosts
        # with the specified `operation` and `permission_type`. Note that
        # the asterisk `*` is literal and matches hosts that are set to `*`
        host: ""

# Schema Registry sync options
schema_registry_sync_options:
  shadow_schema_registry_topic:
```
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


### Features

* rpk shadow config generate: now supports --print-template along with --for-cloud
