### PR TITLE
cloud_storage_clients: rework client_pool idle client management

### DIFF
--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -144,7 +144,7 @@ ss::future<> remote::stop() {
     vlog(log.debug, "Stopped remote...");
 }
 
-size_t remote::concurrency() const { return _pool.local().max_size(); }
+size_t remote::concurrency() const { return _pool.local().capacity(); }
 
 const provider& remote::provider() const { return _provider; }
 

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -116,7 +116,7 @@ ss::future<> client_pool::client_self_configure(
 
 ss::future<
   std::optional<cloud_storage_clients::client_self_configuration_output>>
-client_pool::do_client_self_configure(http_client_ptr client) {
+client_pool::do_client_self_configure(client_ptr client) {
     try {
         for (auto attempt = 1; attempt <= self_configure_attempts; ++attempt) {
             auto result = co_await client->self_configure();
@@ -282,7 +282,7 @@ ss::future<client_pool::client_lease> client_pool::acquire(
     auto guard = _gate.hold();
 
     std::optional<unsigned int> source_sid;
-    std::optional<http_client_ptr> client;
+    std::optional<client_ptr> client;
 
     auto deadline_reached = [&deadline] {
         return deadline.has_value()
@@ -587,10 +587,10 @@ void client_pool::populate_client_pool() {
     _pool_ready_barrier.signal(_pool_ready_barrier.max_counter());
 }
 
-client_pool::http_client_ptr client_pool::make_client() noexcept {
+client_pool::client_ptr client_pool::make_client() noexcept {
     return ss::visit(
       _config,
-      [this](const s3_configuration& cfg) -> http_client_ptr {
+      [this](const s3_configuration& cfg) -> client_ptr {
           return ss::make_shared<s3_client>(
             weak_from_this(),
             cfg,
@@ -599,7 +599,7 @@ client_pool::http_client_ptr client_pool::make_client() noexcept {
             _as,
             _apply_credentials);
       },
-      [this](const abs_configuration& cfg) -> http_client_ptr {
+      [this](const abs_configuration& cfg) -> client_ptr {
           return ss::make_shared<abs_client>(
             weak_from_this(),
             cfg,
@@ -610,7 +610,7 @@ client_pool::http_client_ptr client_pool::make_client() noexcept {
       });
 }
 
-void client_pool::release(http_client_ptr leased) {
+void client_pool::release(client_ptr leased) {
     vlog(
       pool_log.debug,
       "releasing a client, pool size: {}, capacity: {}",

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -388,7 +388,9 @@ ss::future<client_pool::client_lease> client_pool::acquire(
                     // need to wait in such case.
                     if (_pool.empty()) {
                         co_await ssx::with_timeout_abortable(
-                          _cvar.wait(), model::no_timeout, as);
+                          _cvar.wait(),
+                          deadline.value_or(model::no_timeout),
+                          as);
                         vlog(
                           pool_log.debug,
                           "cvar triggered, pool size: {}",

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -459,7 +459,7 @@ ss::future<client_pool::client_lease> client_pool::acquire(
                   // In the background return the client to the connection pool
                   // of the source shard. The lifetime is guaranteed by the gate
                   // guard.
-                  ssx::spawn_with_gate(pool->_bg_gate, [&pool, source_sid] {
+                  ssx::spawn_with_gate(pool->_bg_gate, [pool, source_sid] {
                       return pool->container().invoke_on(
                         source_sid.value(),
                         [my_sid = ss::this_shard_id()](client_pool& other) {

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -568,7 +568,7 @@ void client_pool::return_one(unsigned other) {
 
 size_t client_pool::size() const noexcept { return _pool.size(); }
 
-size_t client_pool::max_size() const noexcept { return _capacity; }
+size_t client_pool::capacity() const noexcept { return _capacity; }
 
 void client_pool::populate_client_pool() {
     vlog(pool_log.info, "Populating client pool with {} clients", _capacity);

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -566,7 +566,7 @@ void client_pool::return_one(unsigned other) {
     _cvar.signal();
 }
 
-size_t client_pool::size() const noexcept { return _pool.size(); }
+size_t client_pool::idle_count() const noexcept { return _pool.size(); }
 
 size_t client_pool::capacity() const noexcept { return _capacity; }
 

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -193,7 +193,11 @@ ss::future<> client_pool::start(
 }
 
 ss::future<> client_pool::stop() {
-    vlog(pool_log.info, "Stopping client pool: {}", _pool.size());
+    vlog(
+      pool_log.info,
+      "Stopping client pool: {} ({} connections leased)",
+      _idle_clients.size(),
+      _leased.size());
 
     if (!_as.abort_requested()) {
         _as.request_abort();
@@ -208,10 +212,10 @@ ss::future<> client_pool::stop() {
     co_await _gate.close();
 
     std::vector<ss::future<>> stops;
-    stops.reserve(_pool.size());
+    stops.reserve(_idle_clients.size());
 
-    for (auto& it : _pool) {
-        stops.emplace_back(it->stop());
+    for (auto& [_, entry] : _idle_clients) {
+        stops.emplace_back(entry.ptr->stop());
     }
 
     co_await ss::when_all_succeed(stops.begin(), stops.end());
@@ -226,7 +230,7 @@ void client_pool::shutdown_connections() {
     vlog(
       pool_log.info,
       "Shutting down client pool: {} ({} connections leased)",
-      _pool.size(),
+      _idle_clients.size(),
       _leased.size());
 
     _as.request_abort();
@@ -238,8 +242,8 @@ void client_pool::shutdown_connections() {
     for (auto& it : _leased) {
         it.client->shutdown();
     }
-    for (auto& it : _pool) {
-        it->shutdown();
+    for (auto& [_, entry] : _idle_clients) {
+        entry.ptr->shutdown();
     }
 
     vlog(pool_log.info, "Shut down of client pool complete");
@@ -323,9 +327,8 @@ ss::future<client_pool::client_lease> client_pool::acquire(
 
         while (!client.has_value() && !deadline_reached() && !_gate.is_closed()
                && !_as.abort_requested()) {
-            if (likely(!_pool.empty())) {
-                client = _pool.back();
-                _pool.pop_back();
+            if (likely(!_idle_clients.empty())) {
+                client = pop_most_recently_used();
             } else if (
               ss::smp::count == 1
               || _policy == client_pool_overdraft_policy::wait_if_empty
@@ -339,12 +342,12 @@ ss::future<client_pool::client_lease> client_pool::acquire(
                 vlog(
                   pool_log.debug,
                   "cvar triggered, pool size: {}",
-                  _pool.size());
+                  _idle_clients.size());
             } else {
                 // Try borrowing from peer shard.
                 auto clients_in_use = [](client_pool& other) {
                     return std::clamp(
-                      other._capacity - other._pool.size(),
+                      other._capacity - other._idle_clients.size(),
                       0UL,
                       other._capacity);
                 };
@@ -386,7 +389,7 @@ ss::future<client_pool::client_lease> client_pool::acquire(
                     // to borrow from a remote pool (co_await/async-operation),
                     // local pool may have gotten a client back. There is no
                     // need to wait in such case.
-                    if (_pool.empty()) {
+                    if (_idle_clients.empty()) {
                         co_await ssx::with_timeout_abortable(
                           _cvar.wait(),
                           deadline.value_or(model::no_timeout),
@@ -394,7 +397,7 @@ ss::future<client_pool::client_lease> client_pool::acquire(
                         vlog(
                           pool_log.debug,
                           "cvar triggered, pool size: {}",
-                          _pool.size());
+                          _idle_clients.size());
                     }
                 }
             }
@@ -437,14 +440,12 @@ ss::future<client_pool::client_lease> client_pool::acquire(
                   // to the source shard.
                   // Otherwise, we replace the oldest client in the
                   // pool to improve connection reuse.
-                  if (!pool->_pool.empty()) {
+                  if (!pool->_idle_clients.empty()) {
                       vlog(
                         pool_log.debug,
                         "disposing the oldest client connection and "
                         "replacing it with the borrowed one");
-                      pool->_pool.push_back(std::move(client));
-                      client = std::move(pool->_pool.front());
-                      pool->_pool.pop_front();
+                      client = pool->replace_least_recently_used(client);
                   } else {
                       vlog(
                         pool_log.debug,
@@ -466,7 +467,7 @@ ss::future<client_pool::client_lease> client_pool::acquire(
                         });
                   });
               } else {
-                  pool->release(client);
+                  pool->release_most_recently_used(client);
               }
           }
       }),
@@ -523,14 +524,14 @@ size_t client_pool::normalized_num_clients_in_use() const {
     // Here we won't be showing that some clients are available if previously
     // the pool was depleted. This is needed to prevent borrowing from
     // overloaded shards.
-    auto current = _capacity - std::clamp(_pool.size(), 0UL, _capacity);
+    auto current = _capacity - std::clamp(_idle_clients.size(), 0UL, _capacity);
     auto normalized = static_cast<int>(
       100.0 * double(current) / static_cast<double>(_capacity));
     return normalized;
 }
 
-bool client_pool::borrow_one(unsigned other) {
-    if (_pool.empty()) {
+bool client_pool::borrow_one(unsigned other) noexcept {
+    if (_idle_clients.empty()) {
         vlog(pool_log.debug, "declining borrow by {}", other);
         return false;
     }
@@ -538,25 +539,23 @@ bool client_pool::borrow_one(unsigned other) {
       pool_log.debug,
       "approving borrow by {}, pool size {}/{}",
       other,
-      _pool.size(),
+      _idle_clients.size(),
       _capacity);
     // TODO: do not use the bottommost (oldest) element. Find the one
     // with expired connection.
-    auto c = _pool.front();
-    _pool.pop_front();
+    auto c = pop_least_recently_used();
     update_usage_stats();
     c->shutdown();
     ssx::spawn_with_gate(_bg_gate, [c] { return c->stop().finally([c] {}); });
     return true;
 }
 
-void client_pool::return_one(unsigned other) {
+void client_pool::return_one(unsigned other) noexcept {
     vlog(pool_log.debug, "shard {} returns a client", other);
     vassert(
-      _pool.size() < _capacity,
+      _idle_clients.size() < _capacity,
       "tried to return a borrowed client but the pool is full");
-    // Cold clients are at the front. Hot clients are at the back.
-    _pool.emplace_front(make_client());
+    emplace_idle();
     update_usage_stats();
     vlog(
       pool_log.debug,
@@ -566,21 +565,90 @@ void client_pool::return_one(unsigned other) {
     _cvar.signal();
 }
 
-size_t client_pool::idle_count() const noexcept { return _pool.size(); }
+void client_pool::emplace_idle() noexcept {
+    auto new_client = make_client();
+    const client* raw_ptr = new_client.get();
+    auto [it, inserted] = _idle_clients.emplace(
+      raw_ptr, idle_entry(std::move(new_client)));
+    // Cold clients are at the front. Hot clients are at the back.
+    _idle_clients_lru.push_front(it->second);
+}
+
+client_pool::client_ptr client_pool::pop_least_recently_used() noexcept {
+    vassert(
+      !_idle_clients_lru.empty(),
+      "tried to pop from LRU idle list when it's empty");
+    auto& entry = _idle_clients_lru.front();
+    auto client = std::move(entry.ptr);
+    // Automatically removes the entry from the intrusive LRU list.
+    _idle_clients.erase(client.get());
+    return client;
+}
+
+client_pool::client_ptr client_pool::pop_most_recently_used() noexcept {
+    vassert(
+      !_idle_clients_lru.empty(),
+      "tried to pop from LRU idle list when it's empty");
+    auto& entry = _idle_clients_lru.back();
+    auto client = std::move(entry.ptr);
+    // Automatically removes the entry from the intrusive LRU list.
+    _idle_clients.erase(client.get());
+    return client;
+}
+
+void client_pool::release_most_recently_used(client_ptr leased) noexcept {
+    vlog(
+      pool_log.debug,
+      "releasing a client, pool size: {}, capacity: {}",
+      _idle_clients.size(),
+      _capacity);
+    vassert(
+      _idle_clients.size() < _capacity,
+      "tried to release a client but the pool is at capacity");
+    const client* raw_ptr = leased.get();
+    auto [it, inserted] = _idle_clients.emplace(
+      raw_ptr, idle_entry(std::move(leased)));
+    vassert(
+      inserted,
+      "tried to release a client but the client is already in idle clients");
+    // Cold clients are at the front. Hot clients are at the back.
+    _idle_clients_lru.push_back(it->second);
+    _cvar.signal();
+}
+
+client_pool::client_ptr
+client_pool::replace_least_recently_used(client_ptr leased) noexcept {
+    const client* raw_ptr = leased.get();
+    auto [it, inserted] = _idle_clients.emplace(
+      raw_ptr, idle_entry(std::move(leased)));
+    vassert(
+      inserted,
+      "tried to replace LRU client but the client is already in idle clients");
+    _idle_clients_lru.push_back(it->second);
+
+    // Pop the oldest client
+    auto& lru_entry = _idle_clients_lru.front();
+    auto result = std::move(lru_entry.ptr);
+    _idle_clients.erase(result.get());
+    return result;
+}
+
+size_t client_pool::idle_count() const noexcept { return _idle_clients.size(); }
 
 size_t client_pool::capacity() const noexcept { return _capacity; }
 
 void client_pool::populate_client_pool() {
     vlog(pool_log.info, "Populating client pool with {} clients", _capacity);
 
-    _pool.reserve(_capacity);
+    _idle_clients.reserve(_capacity);
     for (size_t i = 0; i < _capacity; i++) {
-        _pool.emplace_back(make_client());
+        emplace_idle();
     }
 
-    // Be defensive in checking that we properly synchronized access to `_pool`
-    // and `_cvar`. Before populate_client_pool() is called, we do not expect
-    // anyone to check the size of the pool or wait on the condition variable.
+    // Be defensive in checking that we properly synchronized access to
+    // `_idle_clients` and `_cvar`. Before populate_client_pool() is called, we
+    // do not expect anyone to check the size of the pool or wait on the
+    // condition variable.
     vassert(
       !_cvar.has_waiters(),
       "This is a bug: _cvar is not expected to have waiters at this point. "
@@ -610,19 +678,6 @@ client_pool::client_ptr client_pool::make_client() noexcept {
             _as,
             _apply_credentials);
       });
-}
-
-void client_pool::release(client_ptr leased) {
-    vlog(
-      pool_log.debug,
-      "releasing a client, pool size: {}, capacity: {}",
-      _pool.size(),
-      _capacity);
-    vassert(
-      _pool.size() < _capacity,
-      "tried to release a client but the pool is at capacity");
-    _pool.emplace_back(std::move(leased));
-    _cvar.signal();
 }
 
 void client_pool::maybe_refresh_credentials() {

--- a/src/v/cloud_storage_clients/client_pool.h
+++ b/src/v/cloud_storage_clients/client_pool.h
@@ -81,6 +81,7 @@ public:
           : client(std::move(other.client))
           , deleter(std::move(other.deleter))
           , as_sub(std::move(other.as_sub))
+          , _track_duration(std::move(other._track_duration))
           , _wd(std::move(other._wd)) {
             _hook.swap_nodes(other._hook);
         }
@@ -90,6 +91,7 @@ public:
             deleter = std::move(other.deleter);
             as_sub = std::move(other.as_sub);
             _hook.swap_nodes(other._hook);
+            _track_duration = std::move(other._track_duration);
             _wd = std::move(other._wd);
             return *this;
         }

--- a/src/v/cloud_storage_clients/client_pool.h
+++ b/src/v/cloud_storage_clients/client_pool.h
@@ -43,9 +43,9 @@ class client_pool
   : public ss::weakly_referencable<client_pool>
   , public ss::peering_sharded_service<client_pool> {
 public:
-    using http_client_ptr = ss::shared_ptr<client>;
+    using client_ptr = ss::shared_ptr<client>;
     struct client_lease {
-        http_client_ptr client;
+        client_ptr client;
         ss::deleter deleter;
         ss::abort_source::subscription as_sub;
         intrusive_list_hook _hook;
@@ -53,7 +53,7 @@ public:
         std::unique_ptr<ssx::watchdog> _wd;
 
         client_lease(
-          http_client_ptr p,
+          client_ptr p,
           ss::abort_source& as,
           ss::deleter deleter,
           std::unique_ptr<client_probe::hist_t::measurement> m)
@@ -181,13 +181,13 @@ private:
         application_stop_signal);
     ss::future<
       std::optional<cloud_storage_clients::client_self_configuration_output>>
-    do_client_self_configure(http_client_ptr client);
+    do_client_self_configure(client_ptr client);
     ss::future<> accept_self_configure_result(
       std::optional<client_self_configuration_output> result);
 
     void populate_client_pool();
-    http_client_ptr make_client() noexcept;
-    void release(http_client_ptr leased);
+    client_ptr make_client() noexcept;
+    void release(client_ptr leased);
 
     /// Return number of clients which wasn't utilized
     size_t normalized_num_clients_in_use() const;
@@ -209,7 +209,7 @@ private:
     ss::shared_ptr<client_probe> _probe;
     client_pool_overdraft_policy _policy;
 
-    ss::circular_buffer<http_client_ptr> _pool;
+    ss::circular_buffer<client_ptr> _pool;
     // List of all connections currently used by clients
     intrusive_list<client_lease, &client_lease::_hook> _leased;
     ss::condition_variable _cvar;

--- a/src/v/cloud_storage_clients/client_pool.h
+++ b/src/v/cloud_storage_clients/client_pool.h
@@ -165,7 +165,10 @@ public:
     /// \brief Get number of connections
     size_t size() const noexcept;
 
-    size_t max_size() const noexcept;
+    /// \brief Configured capacity of the pool. Does not take into account
+    /// connections that may be borrowed from other shards, i.e. when
+    /// `client_pool_overdraft_policy::borrow_if_empty` is used.
+    size_t capacity() const noexcept;
 
     bool has_background_operations() const noexcept {
         return _bg_gate.get_count() > 0;

--- a/src/v/cloud_storage_clients/client_pool.h
+++ b/src/v/cloud_storage_clients/client_pool.h
@@ -162,8 +162,9 @@ public:
       ss::lowres_clock::duration deadline,
       std::optional<ss::sstring> ctx = std::nullopt);
 
-    /// \brief Get number of connections
-    size_t size() const noexcept;
+    /// \brief Idle clients waiting in the pool. If this number is less than
+    /// capacity, some clients are currently leased out, borrowed, or shutdown.
+    size_t idle_count() const noexcept;
 
     /// \brief Configured capacity of the pool. Does not take into account
     /// connections that may be borrowed from other shards, i.e. when

--- a/src/v/cloud_storage_clients/client_pool.h
+++ b/src/v/cloud_storage_clients/client_pool.h
@@ -18,10 +18,11 @@
 #include "ssx/watchdog.h"
 #include "utils/stop_signal.h"
 
-#include <seastar/core/circular_buffer.hh>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
+
+#include <unordered_map>
 
 namespace cloud_storage_clients {
 
@@ -39,7 +40,7 @@ inline constexpr ss::shard_id self_config_shard = ss::shard_id{0};
 
 /// Connection pool implementation
 /// All connections share the same configuration
-class client_pool
+class client_pool final
   : public ss::weakly_referencable<client_pool>
   , public ss::peering_sharded_service<client_pool> {
 public:
@@ -180,6 +181,24 @@ public:
     }
 
 private:
+    /// An entry in the idle clients collection, combining ownership with
+    /// intrusive list membership for LRU ordering.
+    struct idle_entry {
+        explicit idle_entry(client_ptr p)
+          : ptr(std::move(p)) {}
+        idle_entry(const idle_entry&) = delete;
+        idle_entry& operator=(const idle_entry&) = delete;
+        idle_entry(idle_entry&& other) noexcept
+          : ptr(std::move(other.ptr)) {
+            _hook.swap_nodes(other._hook);
+        }
+        idle_entry& operator=(idle_entry&&) = delete;
+        ~idle_entry() = default;
+
+        client_ptr ptr;
+        intrusive_list_hook _hook;
+    };
+
     ss::future<> client_self_configure(
       std::optional<std::reference_wrapper<stop_signal>>
         application_stop_signal);
@@ -191,12 +210,30 @@ private:
 
     void populate_client_pool();
     client_ptr make_client() noexcept;
-    void release(client_ptr leased);
 
-    /// Return number of clients which wasn't utilized
+    /// Return [0, 100] normalized number of clients currently in use by this
+    /// pool (leased locally or lent to other shards) .
     size_t normalized_num_clients_in_use() const;
-    bool borrow_one(unsigned other);
-    void return_one(unsigned other);
+    bool borrow_one(unsigned other) noexcept;
+    void return_one(unsigned other) noexcept;
+
+    /// Add a new idle client to the pool.
+    void emplace_idle() noexcept;
+
+    /// Pop the most recently used idle client from the pool.
+    [[nodiscard]]
+    client_ptr pop_most_recently_used() noexcept;
+
+    /// Pop the least recently used idle client from the pool.
+    [[nodiscard]]
+    client_ptr pop_least_recently_used() noexcept;
+
+    /// Release a leased client back to the pool as most recently used.
+    void release_most_recently_used(client_ptr leased) noexcept;
+
+    /// Replace the least recently used idle client with the provided one.
+    [[nodiscard]] client_ptr
+    replace_least_recently_used(client_ptr leased) noexcept;
 
     void update_usage_stats();
 
@@ -213,9 +250,17 @@ private:
     ss::shared_ptr<client_probe> _probe;
     client_pool_overdraft_policy _policy;
 
-    ss::circular_buffer<client_ptr> _pool;
-    // List of all connections currently used by clients
+    // Authoritative ownership of all idle clients.
+    std::unordered_map<const client*, idle_entry> _idle_clients;
+
+    // Approximately LRU list of idle clients for reuse.
+    // Cold clients are at the front. Hot clients are at the back.
+    intrusive_list<idle_entry, &idle_entry::_hook> _idle_clients_lru;
+
+    // List of all connections currently used by clients, includes borrowed
+    // connections.
     intrusive_list<client_lease, &client_lease::_hook> _leased;
+
     ss::condition_variable _cvar;
     ss::abort_source _as;
     ss::gate _gate;

--- a/src/v/cloud_storage_clients/tests/BUILD
+++ b/src/v/cloud_storage_clients/tests/BUILD
@@ -136,6 +136,7 @@ redpanda_cc_btest(
         ":client_pool_builder",
         "//src/v/base",
         "//src/v/cloud_storage_clients",
+        "//src/v/random:generators",
         "//src/v/test_utils:seastar_boost",
         "@boost//:range",
         "@boost//:test",

--- a/src/v/cloud_storage_clients/tests/client_pool_mt_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_mt_test.cc
@@ -11,11 +11,10 @@
 #include "base/seastarx.h"
 #include "cloud_storage_clients/client_pool.h"
 #include "cloud_storage_clients/tests/client_pool_builder.h"
+#include "random/generators.h"
 
 #include <seastar/core/future.hh>
-#include <seastar/core/loop.hh>
 #include <seastar/core/sharded.hh>
-#include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/timed_out_error.hh>
 #include <seastar/core/with_timeout.hh>
@@ -23,14 +22,15 @@
 #include <seastar/util/defer.hh>
 #include <seastar/util/later.hh>
 
-#include <boost/range/irange.hpp>
 #include <boost/test/tools/old/interface.hpp>
-#include <boost/test/unit_test.hpp>
 
 #include <deque>
+#include <random>
 
 using namespace std::chrono_literals;
 using namespace cloud_storage_clients::tests;
+
+using client_pool = cloud_storage_clients::client_pool;
 
 ss::logger test_log("test-log");
 static const uint16_t httpd_port_number = 4434;
@@ -281,4 +281,131 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_after_leasing_all) {
     } catch (const ss::timed_out_error&) {
         BOOST_FAIL("Timed out");
     }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_client_pool_concurrent_acquire_release) {
+    BOOST_REQUIRE(ss::smp::count == 2);
+
+    constexpr size_t num_connections_per_shard = 4;
+    constexpr size_t num_workers_per_shard = 3;
+    constexpr size_t num_iterations_per_worker = 100;
+    constexpr size_t max_leases_per_worker = 3;
+
+    ss::sharded<client_pool> pool;
+    auto pool_stop = test_pool_builder
+                       .connections_per_shard(num_connections_per_shard)
+                       .overdraft_policy(
+                         cloud_storage_clients::client_pool_overdraft_policy::
+                           borrow_if_empty)
+                       .build(pool)
+                       .get();
+
+    struct shard_state {
+        ss::abort_source as;
+    };
+    ss::sharded<shard_state> state;
+    state.start().get();
+    auto state_stop = ss::defer([&state] { state.stop().get(); });
+
+    using lease_t = client_pool::client_lease;
+    using leases_t = std::vector<lease_t>;
+
+    // Try to acquire a client with timeout. Returns nullopt on timeout.
+    auto try_acquire = [&pool,
+                        &state](this auto, ss::lowres_clock::duration timeout)
+      -> ss::future<std::optional<lease_t>> {
+        auto deadline = ss::lowres_clock::now() + timeout;
+        auto f = co_await ss::coroutine::as_future(
+          pool.local().acquire(state.local().as, deadline));
+        if (f.failed()) {
+            f.ignore_ready_future();
+            co_return std::nullopt;
+        }
+        co_return f.get();
+    };
+
+    // Release random lease(s) from the vector.
+    auto release_random = [](
+                            this auto,
+                            leases_t& leases,
+                            random_generators::rng& gen,
+                            size_t count) {
+        for (size_t i = 0; i < count && !leases.empty(); i++) {
+            auto idx = gen.get_int<size_t>(0, leases.size() - 1);
+            leases.erase(leases.begin() + idx);
+        }
+    };
+
+    // Worker coroutine: repeatedly acquires and releases clients.
+    auto worker = [&](this auto)
+      -> ss::
+        future<> {
+            leases_t leases;
+
+            random_generators::rng gen = random_generators::global();
+            std::bernoulli_distribution acquire_dist(0.7);
+            std::bernoulli_distribution batch_release_dist(0.2);
+
+            for (size_t i = 0; i < num_iterations_per_worker; i++) {
+                bool should_acquire
+              = leases.empty()
+                || (leases.size() < max_leases_per_worker
+                    && acquire_dist(gen.engine()));
+
+                if (!should_acquire) {
+                    size_t count = (batch_release_dist(gen.engine())
+                                    && leases.size() > 1)
+                                     ? 2
+                                     : 1;
+                    release_random(leases, gen, count);
+                    co_await ss::yield();
+                    continue;
+                }
+
+                // Acquire with retry: on timeout, release one lease to relieve
+                // pressure.
+                while (true) {
+                    auto lease = co_await try_acquire(10ms);
+                    if (lease) {
+                        leases.push_back(std::move(*lease));
+                        break;
+                    }
+                    release_random(leases, gen, 1);
+                    co_await ss::sleep(1ms);
+                }
+
+                // Simulate work.
+                auto work_us = gen.get_int<size_t>(0, 200);
+                if (work_us > 0) {
+                    co_await ss::sleep(std::chrono::microseconds(work_us));
+                } else {
+                    co_await ss::yield();
+                }
+            }
+
+            // Drain remaining leases.
+            while (!leases.empty()) {
+                leases.pop_back();
+                co_await ss::yield();
+            }
+        };
+
+    // Run concurrent workers on each shard.
+    pool
+      .invoke_on_all([&](client_pool&) {
+          std::vector<ss::future<>> workers;
+          workers.reserve(num_workers_per_shard);
+          for (size_t w = 0; w < num_workers_per_shard; w++) {
+              workers.push_back(worker());
+          }
+          return ss::when_all_succeed(workers.begin(), workers.end());
+      })
+      .get();
+
+    // Verify all clients returned to the pool.
+    pool
+      .invoke_on_all([&](client_pool& p) {
+          BOOST_CHECK_EQUAL(p.size(), num_connections_per_shard);
+      })
+      .get();
 }

--- a/src/v/cloud_storage_clients/tests/client_pool_mt_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_mt_test.cc
@@ -405,7 +405,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_concurrent_acquire_release) {
     // Verify all clients returned to the pool.
     pool
       .invoke_on_all([&](client_pool& p) {
-          BOOST_CHECK_EQUAL(p.size(), num_connections_per_shard);
+          BOOST_CHECK_EQUAL(p.idle_count(), num_connections_per_shard);
       })
       .get();
 }

--- a/src/v/cloud_storage_clients/tests/client_pool_mt_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_mt_test.cc
@@ -15,7 +15,6 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>
-#include <seastar/core/sleep.hh>
 #include <seastar/core/timed_out_error.hh>
 #include <seastar/core/with_timeout.hh>
 #include <seastar/testing/thread_test_case.hh>

--- a/src/v/cloud_storage_clients/tests/client_pool_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_test.cc
@@ -15,11 +15,9 @@
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
-#include <seastar/core/gate.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/timed_out_error.hh>
-#include <seastar/core/when_all.hh>
 #include <seastar/core/with_timeout.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/defer.hh>

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -921,7 +921,7 @@ FIXTURE_TEST(test_client_pool_wait_strategy, client_pool_fixture) {
         fut.emplace_back(std::move(f));
     }
     ss::when_all_succeed(fut.begin(), fut.end()).get();
-    BOOST_REQUIRE(pool.local().size() == 2);
+    BOOST_REQUIRE(pool.local().idle_count() == 2);
 }
 
 static ss::future<bool> test_client_pool_reconnect_helper(


### PR DESCRIPTION
See individual commits. This is part of the rework leading to https://github.com/redpanda-data/redpanda/pull/28913

claude summary (pretty good)

  Motivation

  This PR refactors the client pool's idle client management from a simple circular buffer to a map + intrusive LRU list structure. This separates ownership (map) from ordering (intrusive list), enabling future support for multiple LRU lists—for example, one per cloud upstream when cross-region bucket support is added.

  As a secondary benefit, lazy client creation simplifies the code and allows the pool to start without a valid configuration—important for future work where configuration may not be available at startup.

  Changes

  The PR builds up through incremental changes:

  1. Cleanup & naming improvements: Renamed client_ptr type alias (typo fix), max_size → capacity(), and size() → idle_count() for clarity
  2. Testing: Added a concurrent acquire/release stress test to exercise the pool under pressure from multiple workers across shards
  3. Refactored idle client management: The core change—switched from circular buffer to map + intrusive LRU list, separating ownership from ordering
  4. Bug fixes: Fixed client_lease move operations that weren't moving _track_duration, and made pool capture in deleter lambda more defensive
  5. Lazy client creation: Clients are now created on-demand when acquired rather than pre-populated

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
