### PR TITLE
[UX-450] buf/rpk: import from BSR and not files for rpk comments

### DIFF
--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -74,12 +74,12 @@ jobs:
         with:
           setup_only: true
       - name: Generate proto files
-        run: buf generate --path proto/redpanda/core/admin/v2/shadow_link.proto --path proto/redpanda/core/common/v1/acl.proto --path proto/redpanda/core/common/v1/tls.proto
+        run: buf generate
       - name: Check for uncommitted changes
         run: |
           if ! git diff --exit-code src/go/rpk/gen/; then
             git diff src/go/rpk/gen/
             echo "Error: Generated proto files are out of date"
-            echo "Run 'buf generate --path proto/redpanda/core/admin/v2/shadow_link.proto --path proto/redpanda/core/common/v1/acl.proto --path proto/redpanda/core/common/v1/tls.proto' and commit the changes"
+            echo "Run 'buf generate' and commit the changes"
             exit 1
           fi

--- a/BUILD
+++ b/BUILD
@@ -63,3 +63,11 @@ filegroup(
     srcs = ["ubsan_suppressions.txt"],
     visibility = ["//visibility:public"],
 )
+
+exports_files(
+    [
+        "MODULE.bazel",
+        "buf.gen.yaml",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,6 +1,12 @@
 version: v2
 managed:
   enabled: false
+inputs:
+  - directory: .
+    paths:
+      - proto/redpanda/core/admin/v2/shadow_link.proto
+      - proto/redpanda/core/common/v1/acl.proto
+      - proto/redpanda/core/common/v1/tls.proto
 plugins:
   # Custom comment extraction plugin - we ONLY generate comments related files,
   # The rest comes from buf.build/gen/go/redpandadata/core/protocolbuffers/go
@@ -9,9 +15,5 @@ plugins:
     opt:
       - paths=import
       - Mproto/redpanda/core/admin/v2/shadow_link.proto=github.com/redpanda-data/redpanda/src/go/rpk/gen/protocomments/admin/v2
-      - Mproto/redpanda/core/admin/v2/broker.proto=github.com/redpanda-data/redpanda/src/go/rpk/gen/protocomments/admin/v2
-      - Mproto/redpanda/core/admin/v2/cluster.proto=github.com/redpanda-data/redpanda/src/go/rpk/gen/protocomments/admin/v2
-      - Mproto/redpanda/core/admin/v2/kafka_connections.proto=github.com/redpanda-data/redpanda/src/go/rpk/gen/protocomments/admin/v2
       - Mproto/redpanda/core/common/v1/acl.proto=github.com/redpanda-data/redpanda/src/go/rpk/gen/protocomments/common/v1
-      - Mproto/redpanda/core/common/v1/ntp.proto=github.com/redpanda-data/redpanda/src/go/rpk/gen/protocomments/common/v1
       - Mproto/redpanda/core/common/v1/tls.proto=github.com/redpanda-data/redpanda/src/go/rpk/gen/protocomments/common/v1

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -2,11 +2,11 @@ version: v2
 managed:
   enabled: false
 inputs:
-  - directory: .
+  - module: buf.build/redpandadata/core:19149a4a2435
     paths:
-      - proto/redpanda/core/admin/v2/shadow_link.proto
-      - proto/redpanda/core/common/v1/acl.proto
-      - proto/redpanda/core/common/v1/tls.proto
+      - redpanda/core/admin/v2/shadow_link.proto
+      - redpanda/core/common/v1/acl.proto
+      - redpanda/core/common/v1/tls.proto
 plugins:
   # Custom comment extraction plugin - we ONLY generate comments related files,
   # The rest comes from buf.build/gen/go/redpandadata/core/protocolbuffers/go
@@ -14,6 +14,6 @@ plugins:
     out: .
     opt:
       - paths=import
-      - Mproto/redpanda/core/admin/v2/shadow_link.proto=github.com/redpanda-data/redpanda/src/go/rpk/gen/protocomments/admin/v2
-      - Mproto/redpanda/core/common/v1/acl.proto=github.com/redpanda-data/redpanda/src/go/rpk/gen/protocomments/common/v1
-      - Mproto/redpanda/core/common/v1/tls.proto=github.com/redpanda-data/redpanda/src/go/rpk/gen/protocomments/common/v1
+      - Mredpanda/core/admin/v2/shadow_link.proto=github.com/redpanda-data/redpanda/src/go/rpk/gen/protocomments/admin/v2
+      - Mredpanda/core/common/v1/acl.proto=github.com/redpanda-data/redpanda/src/go/rpk/gen/protocomments/common/v1
+      - Mredpanda/core/common/v1/tls.proto=github.com/redpanda-data/redpanda/src/go/rpk/gen/protocomments/common/v1

--- a/src/go/rpk/BUILD
+++ b/src/go/rpk/BUILD
@@ -1,0 +1,4 @@
+exports_files(
+    ["go.mod"],
+    visibility = ["//visibility:public"],
+)

--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -9,7 +9,7 @@ require (
 	buf.build/gen/go/redpandadata/cloud/connectrpc/go v1.19.1-20251208213618-d95eb1f5bf36.2
 	buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.10-20251209175915-c155e3b17438.1
 	buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.10-20251106193941-bb850a944663.1
-	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251204205609-c0c7c0a68f89.1
+	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20251218215858-19149a4a2435.1
 	buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251209134521-106822fddcf0.2
 	buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-20251209134521-106822fddcf0.1
 	buf.build/gen/go/redpandadata/gatekeeper/connectrpc/go v1.19.1-20251022210437-a5dd600d04b6.2
@@ -76,7 +76,7 @@ require (
 	golang.org/x/term v0.36.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20251103181224-f26f9409b101
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251029180050-ab9386a59fda
-	google.golang.org/protobuf v1.36.10
+	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.33.3

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -10,8 +10,8 @@ buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.10-20251106193941-
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.10-20251106193941-bb850a944663.1/go.mod h1:EhA16a3hhvTg9rzQ69ch2mJ2ppasEGJFy8ViCc8PYUE=
 buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251125205739-05aa34b3829a.2 h1:gVJAyaNRisvoR2bgYxTLZorChyitt+gpx/FSdP0y2Og=
 buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251125205739-05aa34b3829a.2/go.mod h1:/y8qVz8QQFux6oxVWxu+KeC73QYqygF0wXZEIvaQU5k=
-buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251204205609-c0c7c0a68f89.1 h1:Ya1VBu8W/qJV6ROMI4z5r1gwWDtAQaZavSe6o1o+IQk=
-buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251204205609-c0c7c0a68f89.1/go.mod h1:QenSPzqxZpyo9hHIpRzTetvDchelVDzimnmaggHKenc=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20251218215858-19149a4a2435.1 h1:LLKPTO8tKmB4nIB2WlMWavkVhRV0rWwXluy6mJfdqUM=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20251218215858-19149a4a2435.1/go.mod h1:5sjUVquVwNxt3Q/EhE/UW0BBJ5sgPiaVTw8//wxRULI=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251209134521-106822fddcf0.2 h1:mCwJEx9wqHwQZscE0vuW3szVb5QjlStjae5dr+gx1Lo=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.19.1-20251209134521-106822fddcf0.2/go.mod h1:AUXVi3l4mOkfox1XUVw2U0OdvAK85qPS58RcuLnr7uM=
 buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.10-20251209134521-106822fddcf0.1 h1:xjIO92l2DoT4BRdNeTOH30M+zJGCDY+sYK+t6anhfIk=
@@ -456,8 +456,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20251029180050-ab9386a59fda h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251029180050-ab9386a59fda/go.mod h1:7i2o+ce6H/6BluujYR+kqX3GKH+dChPTQU19wjRPiGk=
 google.golang.org/grpc v1.73.0 h1:VIWSmpI2MegBtTuFt5/JWy2oXxtjJ/e89Z70ImfD2ok=
 google.golang.org/grpc v1.73.0/go.mod h1:50sbHOUqWoCQGI8V2HQLJM0B+LMlIUjNSZmow7EVBQc=
-google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=
-google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
+google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/src/go/rpk/pkg/cli/shadow/BUILD
+++ b/src/go/rpk/pkg/cli/shadow/BUILD
@@ -57,6 +57,11 @@ go_test(
         "types_test.go",
         "update_test.go",
     ],
+    data = [
+        "//:MODULE.bazel",
+        "//:buf.gen.yaml",
+        "//src/go/rpk:go.mod",
+    ],
     embed = [":shadow"],
     deps = [
         "@build_buf_gen_go_redpandadata_cloud_protocolbuffers_go//redpanda/api/controlplane/v1:controlplane",

--- a/src/go/rpk/pkg/cli/shadow/config_test.go
+++ b/src/go/rpk/pkg/cli/shadow/config_test.go
@@ -10,10 +10,32 @@
 package shadow
 
 import (
+	"os"
+	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+// findRedpandaRepoRoot searches upward for the *Redpanda* repository root by
+// looking for the MODULE.bazel file.
+func findRedpandaRepoRoot(t *testing.T) string {
+	// Try from current working directory first. It has to be found from WD to
+	// work with Bazel tests.
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "MODULE.bazel")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("failed to find repo root (MODULE.bazel file)")
+		}
+		dir = parent
+	}
+}
 
 func TestToScreamingSnakeCase(t *testing.T) {
 	tests := []struct {
@@ -36,4 +58,42 @@ func TestToScreamingSnakeCase(t *testing.T) {
 			require.Equal(t, tt.exp, got)
 		})
 	}
+}
+
+// TestBufGenYamlCoreModuleVersion ensures the buf.gen.yaml module version
+// matches the go.mod dependency version for buf.build/gen/go/redpandadata/core.
+// When updating the core proto dependency in go.mod, developers must also run
+// `buf generate` to regenerate the proto comments.
+func TestBufGenYamlCoreModuleVersion(t *testing.T) {
+	repoRoot := findRedpandaRepoRoot(t)
+
+	// Read buf.gen.yaml and extract the commit from:
+	// module: buf.build/redpandadata/core:<commit>
+	bufGenPath := filepath.Join(repoRoot, "buf.gen.yaml")
+	bufGenContent, err := os.ReadFile(bufGenPath)
+	require.NoError(t, err, "failed to read buf.gen.yaml")
+
+	bufGenRe := regexp.MustCompile(`module:\s*buf\.build/redpandadata/core:([a-f0-9]{12})`)
+	bufGenMatch := bufGenRe.FindSubmatch(bufGenContent)
+	require.NotNil(t, bufGenMatch, "failed to find module version in buf.gen.yaml")
+	bufGenCommit := string(bufGenMatch[1])
+
+	// Read go.mod and extract the commit from:
+	// buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20251218215858-<commit>.1
+	goModPath := filepath.Join(repoRoot, "src", "go", "rpk", "go.mod")
+	goModContent, err := os.ReadFile(goModPath)
+	require.NoError(t, err, "failed to read go.mod")
+
+	// The version format is: v<major>.<minor>.<patch>-<timestamp>-<commit>.<build>
+	// We need to extract the 12-char commit hash before the final .<build> suffix.
+	goModRe := regexp.MustCompile(`buf\.build/gen/go/redpandadata/core/protocolbuffers/go\s+v[0-9]+\.[0-9]+\.[0-9]+-[0-9]{14}-([a-f0-9]{12})\.[0-9]+`)
+	goModMatch := goModRe.FindSubmatch(goModContent)
+	require.NotNil(t, goModMatch, "failed to find buf.build/gen/go/redpandadata/core/protocolbuffers/go version in go.mod")
+	goModCommit := string(goModMatch[1])
+
+	require.Equal(t, goModCommit, bufGenCommit,
+		"buf.gen.yaml module version (%s) does not match go.mod dependency version (%s). "+
+			"After updating the buf.build/gen/go/redpandadata/core/protocolbuffers/go dependency in go.mod, "+
+			"update buf.gen.yaml module commit hash and run 'buf generate' from the repo root to regenerate proto comments.",
+		bufGenCommit, goModCommit)
 }


### PR DESCRIPTION
 Refactor buf.gen.yaml to import protos from BSR (buf.build/redpandadata/core) instead of local paths, generating only comment-related files for rpk. This aims to keep go.mod in sync with the generated comments.

This includes a unit test (TestBufGenYamlCoreModuleVersion) to enforce that buf.gen.yaml module version stays in sync with the go.mod core proto dependency.

The only downside is that now `buf generate` requires the user to be authenticated. If we decide to not opt for this, the first commit can be merged, which improves the buf.gen.yaml to now specify which paths are needed for the plugin to be run.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
