### PR TITLE
[CORE-14438] `ct/l1`: hook `compaction_scheduler` up to `app` and add e2e testing of cloud topics compaction

### DIFF
--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -87,6 +87,7 @@ redpanda_cc_library(
     visibility = [
         "//src/v/cloud_topics/frontend:__pkg__",
         "//src/v/cloud_topics/frontend/tests:__pkg__",
+        "//src/v/cloud_topics/level_one/compaction/tests:__pkg__",
         "//src/v/cloud_topics/level_one/metastore/tests:__pkg__",
         "//src/v/cloud_topics/level_zero/reader:__pkg__",
         "//src/v/cloud_topics/reconciler:__pkg__",

--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -99,6 +99,7 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/cloud_topics:state_accessors",
         "//src/v/cloud_topics/level_one/common:file_io",
+        "//src/v/cloud_topics/level_one/compaction:scheduler",
         "//src/v/cloud_topics/level_one/domain:domain_supervisor",
         "//src/v/cloud_topics/level_one/metastore:leader_router",
         "//src/v/cloud_topics/level_one/metastore:replicated_metastore",

--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -14,6 +14,7 @@
 #include "cloud_topics/data_plane_api.h"
 #include "cloud_topics/data_plane_impl.h"
 #include "cloud_topics/housekeeper/manager.h"
+#include "cloud_topics/level_one/compaction/scheduler.h"
 #include "cloud_topics/level_one/metastore/topic_purger.h"
 #include "cloud_topics/level_zero/gc/level_zero_gc.h"
 #include "cloud_topics/manager/manager.h"
@@ -113,6 +114,16 @@ ss::future<> app::construct(
                                    return &replicated_metastore.local();
                                }));
 
+    construct_single_service(
+      compaction_scheduler,
+      l1::compaction_cluster_state{
+        .self = self,
+        .leaders_table = leaders_table,
+        .topic_table = &controller->get_topics_state(),
+        .metadata_cache = metadata_cache},
+      &l1_io,
+      &replicated_metastore);
+
     // Must be last to register so it will be first to be stopped in
     // `app::stop`. This is to ensure that stopped services don't receive
     // callbacks.
@@ -129,6 +140,7 @@ ss::future<> app::start() {
     co_await domain_supervisor.invoke_on_all(
       [](auto& ds) { return ds.start(); });
     co_await housekeeper_manager.invoke_on_all(&housekeeper_manager::start);
+    co_await compaction_scheduler->start();
 
     // When start is called, we must have registered all the callbacks before
     // this as starting the manager will invoke callbacks for partitions already
@@ -226,6 +238,10 @@ ss::sharded<state_accessors>* app::get_state() { return &state; }
 
 ss::sharded<l1::replicated_metastore>* app::get_sharded_replicated_metastore() {
     return &replicated_metastore;
+}
+
+l1::compaction_scheduler* app::get_compaction_scheduler() {
+    return compaction_scheduler.get();
 }
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/app.h
+++ b/src/v/cloud_topics/app.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_topics/level_one/common/file_io.h"
+#include "cloud_topics/level_one/compaction/scheduler.h"
 #include "cloud_topics/level_one/domain/domain_supervisor.h"
 #include "cloud_topics/level_one/metastore/leader_router.h"
 #include "cloud_topics/level_one/metastore/replicated_metastore.h"
@@ -74,6 +75,7 @@ public:
     ss::sharded<l1::domain_supervisor>* get_sharded_l1_domain_supervisor();
     ss::sharded<reconciler::reconciler>* get_reconciler();
     ss::sharded<l1::replicated_metastore>* get_sharded_replicated_metastore();
+    l1::compaction_scheduler* get_compaction_scheduler();
 
     // TODO: add 'get_control_plane_api' etc
 
@@ -92,6 +94,7 @@ private:
     ss::sharded<cloud_topics_manager> manager;
     ss::sharded<level_zero_gc> l0_gc;
     ss::sharded<housekeeper_manager> housekeeper_manager;
+    std::unique_ptr<l1::compaction_scheduler> compaction_scheduler;
 };
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_one/compaction/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/BUILD
@@ -93,6 +93,7 @@ redpanda_cc_library(
         ":committer",
         ":logger",
         ":meta",
+        ":scheduler_probe",
         ":source_and_sink",
         "//src/v/cloud_topics/level_one/common:abstract_io",
         "//src/v/cloud_topics/level_one/common:file_io",
@@ -261,6 +262,7 @@ redpanda_cc_library(
         ":log_info_collector",
         ":logger",
         ":meta",
+        ":scheduler_probe",
         ":scheduling_policies",
         ":worker",
         "//src/v/cloud_topics/level_one/common:file_io",
@@ -269,6 +271,21 @@ redpanda_cc_library(
         "//src/v/container:intrusive",
         "//src/v/model",
         "//src/v/ssx:semaphore",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
+    name = "scheduler_probe",
+    srcs = [
+        "scheduler_probe.cc",
+    ],
+    hdrs = [
+        "scheduler_probe.h",
+    ],
+    deps = [
+        "//src/v/config",
+        "//src/v/metrics",
         "@seastar",
     ],
 )

--- a/src/v/cloud_topics/level_one/compaction/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/BUILD
@@ -55,6 +55,7 @@ redpanda_cc_library(
         ":filter",
         ":logger",
         ":meta",
+        ":worker_probe",
         "//src/v/bytes",
         "//src/v/bytes:iostream",
         "//src/v/cloud_topics:log_reader_config",
@@ -95,6 +96,7 @@ redpanda_cc_library(
         ":meta",
         ":scheduler_probe",
         ":source_and_sink",
+        ":worker_probe",
         "//src/v/cloud_topics/level_one/common:abstract_io",
         "//src/v/cloud_topics/level_one/common:file_io",
         "//src/v/cloud_topics/level_one/metastore",
@@ -286,6 +288,23 @@ redpanda_cc_library(
     deps = [
         "//src/v/config",
         "//src/v/metrics",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
+    name = "worker_probe",
+    srcs = [
+        "worker_probe.cc",
+    ],
+    hdrs = [
+        "worker_probe.h",
+    ],
+    deps = [
+        "//src/v/compaction:types",
+        "//src/v/config",
+        "//src/v/metrics",
+        "//src/v/utils:log_hist",
         "@seastar",
     ],
 )

--- a/src/v/cloud_topics/level_one/compaction/committer.cc
+++ b/src/v/cloud_topics/level_one/compaction/committer.cc
@@ -364,8 +364,14 @@ ss::future<> compaction_committer::compaction_job::do_finalize(
       ssx::with_timeout_abortable(std::move(f), model::no_timeout, _as));
 
     if (_metadata_builder->is_empty()) {
-        fut.ignore_ready_future();
         // There is no update to push.
+        vlog(
+          compaction_log.debug,
+          "No built or uploaded objects for job {}, tidp {}.",
+          _id,
+          _tp);
+
+        fut.ignore_ready_future();
         co_return;
     }
 

--- a/src/v/cloud_topics/level_one/compaction/log_collector.cc
+++ b/src/v/cloud_topics/level_one/compaction/log_collector.cc
@@ -66,7 +66,7 @@ ss::future<> partition_leader_log_collector::stop_collecting_logs() {
 }
 
 void partition_leader_log_collector::on_ntp_change(
-  cluster::topic_table::ntp_delta delta) {
+  const cluster::topic_table::ntp_delta& delta) {
     auto& ntp = delta.ntp;
     auto is_managed = _is_managed_cb(ntp);
 
@@ -75,7 +75,7 @@ void partition_leader_log_collector::on_ntp_change(
     case delta_type::removed: {
         // Partition/possibly topic was removed. Unmanage it if necessary.
         if (is_managed) {
-            _unmanage_cb(std::move(ntp), "Partition removed");
+            _unmanage_cb(ntp, "Partition removed");
         }
         return;
     }
@@ -104,7 +104,7 @@ void partition_leader_log_collector::on_ntp_change(
         if (!is_compacted_cloud_topic && is_managed) {
             // This is likely an existing cloud topic which is no longer
             // `compact` enabled.
-            _unmanage_cb(std::move(ntp), "Disabled compaction");
+            _unmanage_cb(ntp, "Disabled compaction");
         }
         return;
     }

--- a/src/v/cloud_topics/level_one/compaction/log_collector.h
+++ b/src/v/cloud_topics/level_one/compaction/log_collector.h
@@ -102,7 +102,7 @@ private:
     // Register operations can be performed synchronously while unregister
     // operations are performed in a backgrounded fiber (see
     // `compaction_scheduler::unmanage_partition()`).
-    void on_ntp_change(cluster::topic_table::ntp_delta);
+    void on_ntp_change(const cluster::topic_table::ntp_delta&);
 
     // Registers/unregisters `ntp`s with the `compaction_scheduler` using
     // leadership notifications from the `partition_leaders_table`. The

--- a/src/v/cloud_topics/level_one/compaction/logger.h
+++ b/src/v/cloud_topics/level_one/compaction/logger.h
@@ -16,6 +16,6 @@
 
 namespace cloud_topics::l1 {
 
-inline ss::logger compaction_log("cloud_topics::compaction");
+inline ss::logger compaction_log("cloud_topics-compaction");
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/scheduler.cc
+++ b/src/v/cloud_topics/level_one/compaction/scheduler.cc
@@ -34,8 +34,8 @@ compaction_scheduler::compaction_scheduler(
         const model::ntp& ntp,
         const model::topic_id_partition& tidp,
         std::string_view ctx) { manage_partition(ntp, tidp, ctx); },
-      [this](model::ntp ntp, std::string_view ctx) {
-          return unmanage_partition(std::move(ntp), ctx);
+      [this](const model::ntp& ntp, std::string_view ctx) {
+          unmanage_partition(ntp, ctx);
       },
       [this](const model::ntp& ntp) { return is_managed(ntp); },
       state))
@@ -96,8 +96,8 @@ void compaction_scheduler::manage_partition(
     _probe.set_log_count(_logs.size());
 }
 
-ss::future<>
-compaction_scheduler::unmanage_partition(model::ntp ntp, std::string_view ctx) {
+void compaction_scheduler::unmanage_partition(
+  const model::ntp& ntp, std::string_view ctx) {
     auto tidp_entry = _ntp_to_tidp.extract(ntp);
     if (!tidp_entry.has_value()) {
         vassert(
@@ -132,7 +132,7 @@ compaction_scheduler::unmanage_partition(model::ntp ntp, std::string_view ctx) {
     // Request that compaction of this CTP be stopped, if in flight. `handle` is
     // a `lw_shared_ptr`- we can allow it to go out of scope here without fear
     // of UAF elsewhere.
-    co_await _worker_manager.request_stop_compaction(handle);
+    _worker_manager.request_stop_compaction(std::move(handle));
     _probe.set_log_count(_logs.size());
 }
 

--- a/src/v/cloud_topics/level_one/compaction/scheduler.cc
+++ b/src/v/cloud_topics/level_one/compaction/scheduler.cc
@@ -43,7 +43,12 @@ compaction_scheduler::compaction_scheduler(
       &_metastore->local(), &state.metadata_cache->local()))
   , _scheduling_policy(make_default_scheduling_policy())
   , _worker_manager(
-      _compaction_queue, io, metastore, &_committer, state.metadata_cache)
+      _compaction_queue,
+      io,
+      metastore,
+      &_committer,
+      state.metadata_cache,
+      _probe)
   , _compaction_interval(
       config::shard_local_cfg().log_compaction_interval_ms.bind())
   , _compaction_queue(_scheduling_policy->get_comparator()) {
@@ -53,7 +58,8 @@ compaction_scheduler::compaction_scheduler(
 compaction_scheduler::compaction_scheduler(log_info_collector info_collector)
   : _log_info_collector(std::move(info_collector))
   , _scheduling_policy(make_default_scheduling_policy())
-  , _worker_manager(_compaction_queue, nullptr, nullptr, &_committer, nullptr)
+  , _worker_manager(
+      _compaction_queue, nullptr, nullptr, &_committer, nullptr, _probe)
   , _compaction_interval(
       config::shard_local_cfg().log_compaction_interval_ms.bind())
   , _compaction_queue(_scheduling_policy->get_comparator()) {
@@ -87,6 +93,7 @@ void compaction_scheduler::manage_partition(
     _ntp_to_tidp.emplace(ntp, tidp);
     vassert(
       success, "Could not manage compacted CTP {} (concurrency issue?)", ntp);
+    _probe.set_log_count(_logs.size());
 }
 
 ss::future<>
@@ -126,6 +133,7 @@ compaction_scheduler::unmanage_partition(model::ntp ntp, std::string_view ctx) {
     // a `lw_shared_ptr`- we can allow it to go out of scope here without fear
     // of UAF elsewhere.
     co_await _worker_manager.request_stop_compaction(handle);
+    _probe.set_log_count(_logs.size());
 }
 
 void compaction_scheduler::start_bg_loop() {
@@ -160,6 +168,8 @@ ss::future<> compaction_scheduler::scheduling_loop() {
             continue;
         }
 
+        _probe.set_compaction_queue_length(_compaction_queue.size());
+
         co_await _log_info_collector.collect_info_for_logs(
           _logs, _logs_list, _compaction_queue);
 
@@ -168,6 +178,7 @@ ss::future<> compaction_scheduler::scheduling_loop() {
 }
 
 ss::future<> compaction_scheduler::start() {
+    _probe.setup_metrics();
     co_await _committer.start(
       ss::sharded_parameter([] { return make_default_committing_policy(); }),
       ss::sharded_parameter([this] { return &_io->local(); }),

--- a/src/v/cloud_topics/level_one/compaction/scheduler.cc
+++ b/src/v/cloud_topics/level_one/compaction/scheduler.cc
@@ -25,7 +25,6 @@ namespace cloud_topics::l1 {
 
 compaction_scheduler::compaction_scheduler(
   compaction_cluster_state state,
-  std::unique_ptr<scheduling_policy> policy,
   ss::sharded<file_io>* io,
   ss::sharded<l1::replicated_metastore>* metastore)
   : _io(io)
@@ -42,7 +41,7 @@ compaction_scheduler::compaction_scheduler(
       state))
   , _log_info_collector(make_default_log_info_collector(
       &_metastore->local(), &state.metadata_cache->local()))
-  , _scheduling_policy(std::move(policy))
+  , _scheduling_policy(make_default_scheduling_policy())
   , _worker_manager(
       _compaction_queue, io, metastore, &_committer, state.metadata_cache)
   , _compaction_interval(
@@ -51,10 +50,9 @@ compaction_scheduler::compaction_scheduler(
     _compaction_interval.watch([this]() { _sem.signal(); });
 }
 
-compaction_scheduler::compaction_scheduler(
-  log_info_collector info_collector, std::unique_ptr<scheduling_policy> policy)
+compaction_scheduler::compaction_scheduler(log_info_collector info_collector)
   : _log_info_collector(std::move(info_collector))
-  , _scheduling_policy(std::move(policy))
+  , _scheduling_policy(make_default_scheduling_policy())
   , _worker_manager(_compaction_queue, nullptr, nullptr, &_committer, nullptr)
   , _compaction_interval(
       config::shard_local_cfg().log_compaction_interval_ms.bind())
@@ -203,14 +201,6 @@ ss::future<> compaction_scheduler::stop() {
     co_await _committer.stop();
 
     co_await std::move(close_fut);
-}
-
-std::unique_ptr<compaction_scheduler> make_default_compaction_scheduler(
-  compaction_cluster_state state,
-  ss::sharded<file_io>* io,
-  ss::sharded<replicated_metastore>* metastore) {
-    return std::make_unique<compaction_scheduler>(
-      state, make_default_scheduling_policy(), io, metastore);
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/scheduler.h
+++ b/src/v/cloud_topics/level_one/compaction/scheduler.h
@@ -73,9 +73,9 @@ public:
 
     // Removes the `tidp` from the list of managed partitions. No-ops if the
     // provided `tidp` is not managed by this scheduler. Because the `tidp`
-    // may be undergoing an inflight compaction, this function will block until
-    // it is complete (an early stop is requested by this function).
-    ss::future<> unmanage_partition(model::ntp, std::string_view);
+    // may be undergoing an inflight compaction, an early stop is requested by
+    // the `_worker_manager`.
+    void unmanage_partition(const model::ntp&, std::string_view);
 
 private:
     // Starts the backgrounded scheduling loop.

--- a/src/v/cloud_topics/level_one/compaction/scheduler.h
+++ b/src/v/cloud_topics/level_one/compaction/scheduler.h
@@ -15,6 +15,7 @@
 #include "cloud_topics/level_one/compaction/log_collector.h"
 #include "cloud_topics/level_one/compaction/log_info_collector.h"
 #include "cloud_topics/level_one/compaction/meta.h"
+#include "cloud_topics/level_one/compaction/scheduler_probe.h"
 #include "cloud_topics/level_one/compaction/scheduling_policies.h"
 #include "cloud_topics/level_one/compaction/worker_manager.h"
 #include "cloud_topics/level_one/metastore/replicated_metastore.h"
@@ -140,6 +141,8 @@ private:
     chunked_hash_map<model::ntp, model::topic_id_partition> _ntp_to_tidp;
 
 private:
+    compaction_scheduler_probe _probe;
+
     friend class ::SchedulerTestFixture;
 
     // Testing c-tor

--- a/src/v/cloud_topics/level_one/compaction/scheduler.h
+++ b/src/v/cloud_topics/level_one/compaction/scheduler.h
@@ -47,7 +47,6 @@ class compaction_scheduler {
 public:
     compaction_scheduler(
       compaction_cluster_state,
-      std::unique_ptr<scheduling_policy>,
       ss::sharded<file_io>*,
       ss::sharded<l1::replicated_metastore>*);
 
@@ -144,13 +143,7 @@ private:
     friend class ::SchedulerTestFixture;
 
     // Testing c-tor
-    compaction_scheduler(
-      log_info_collector, std::unique_ptr<scheduling_policy>);
+    compaction_scheduler(log_info_collector);
 };
-
-std::unique_ptr<compaction_scheduler> make_default_compaction_scheduler(
-  compaction_cluster_state,
-  ss::sharded<file_io>*,
-  ss::sharded<replicated_metastore>*);
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/scheduler_probe.cc
+++ b/src/v/cloud_topics/level_one/compaction/scheduler_probe.cc
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/compaction/scheduler_probe.h"
+
+#include "config/configuration.h"
+#include "metrics/metrics.h"
+#include "metrics/prometheus_sanitize.h"
+
+#include <seastar/core/metrics.hh>
+
+namespace cloud_topics::l1 {
+
+void compaction_scheduler_probe::setup_metrics() {
+    namespace sm = ss::metrics;
+
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+
+    _metrics.add_group(
+      prometheus_sanitize::metrics_name("cloud_topics:compaction_scheduler"),
+      {
+        sm::make_gauge(
+          "managed_log_count",
+          [this] { return _log_count; },
+          sm::description(
+            "Number of cloud topic logs managed by this compaction scheduler")),
+        sm::make_gauge(
+          "compaction_queue_length",
+          [this] { return _compaction_queue_length; },
+          sm::description(
+            "Length of the compaction queue for this compaction scheduler")),
+        sm::make_gauge(
+          "log_compactions",
+          [this] { return _log_compactions; },
+          sm::description(
+            "Number of compaction rounds performed across all shards")),
+      });
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/scheduler_probe.h
+++ b/src/v/cloud_topics/level_one/compaction/scheduler_probe.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "metrics/metrics.h"
+
+#include <seastar/core/metrics_registration.hh>
+
+#include <cstdint>
+#include <memory>
+
+namespace cloud_topics::l1 {
+
+class compaction_scheduler_probe {
+public:
+    compaction_scheduler_probe() = default;
+
+    compaction_scheduler_probe(const compaction_scheduler_probe&) = delete;
+    compaction_scheduler_probe& operator=(const compaction_scheduler_probe&)
+      = delete;
+    compaction_scheduler_probe(compaction_scheduler_probe&&) = delete;
+    compaction_scheduler_probe& operator=(compaction_scheduler_probe&&)
+      = delete;
+    ~compaction_scheduler_probe() = default;
+
+    void setup_metrics();
+
+    void set_log_count(uint32_t log_count) { _log_count = log_count; }
+    void set_compaction_queue_length(uint32_t compaction_queue_length) {
+        _compaction_queue_length = compaction_queue_length;
+    }
+    void log_compacted() { ++_log_compactions; }
+
+private:
+    uint32_t _log_count{0};
+    uint32_t _compaction_queue_length{0};
+    uint64_t _log_compactions{0};
+
+    metrics::internal_metric_groups _metrics;
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/sink.cc
+++ b/src/v/cloud_topics/level_one/compaction/sink.cc
@@ -256,17 +256,23 @@ ss::future<> compaction_sink::finalize() {
         co_return;
     }
 
-    if (!_processed_extents.empty()) {
-        auto last_offset
-          = _processed_extents.make_reverse_stream().next().last_offset;
-        co_await flush(last_offset);
+    if (_inflight_object) {
+        if (!_processed_extents.empty()) {
+            auto last_offset
+              = _processed_extents.make_reverse_stream().next().last_offset;
+            co_await flush(last_offset);
+        } else {
+            // We started an object but didn't process any extents, which means
+            // no meaningful work has been performed. Discard the inflight
+            // object.
+            auto inflight_object = std::exchange(_inflight_object, nullptr);
+            auto active_staging_file = std::exchange(
+              inflight_object->active_staging_file, nullptr);
+            auto builder = std::exchange(inflight_object->builder, nullptr);
+            co_await active_staging_file->remove();
+            co_await builder->close();
+        }
     }
-
-    // It shouldn't ever be the case that the `_inflight_object` has a value
-    // when `_processed_extents.empty()`, but assert on it here just in case.
-    vassert(
-      !_inflight_object,
-      "Should have called flush() before proceeding to finalize job");
 
     auto removed_tombstone_ranges = get_removed_tombstone_ranges(
       _removable_tombstone_ranges, _processed_extents);

--- a/src/v/cloud_topics/level_one/compaction/source.cc
+++ b/src/v/cloud_topics/level_one/compaction/source.cc
@@ -138,7 +138,8 @@ compaction_source::compaction_source(
   metastore* metastore,
   io* io,
   ss::abort_source& as,
-  compaction_job_state& state)
+  compaction_job_state& state,
+  compaction_worker_probe& probe)
   : _ntp(std::move(ntp))
   , _tp(tp)
   , _dirty_range_intervals(dirty_range_intervals)
@@ -158,7 +159,8 @@ compaction_source::compaction_source(
   , _metastore(metastore)
   , _io(io)
   , _as(as)
-  , _state(state) {}
+  , _state(state)
+  , _probe(probe) {}
 
 ss::future<> compaction_source::initialize() { co_return; }
 
@@ -295,6 +297,8 @@ ss::future<ss::stop_iteration> compaction_source::deduplication_iteration(
               last_offset,
               stats);
         }
+
+        _probe.add_stats(stats);
     }
 
     co_return ss::stop_iteration::no;

--- a/src/v/cloud_topics/level_one/compaction/source.h
+++ b/src/v/cloud_topics/level_one/compaction/source.h
@@ -13,6 +13,7 @@
 #include "cloud_topics/level_one/common/abstract_io.h"
 #include "cloud_topics/level_one/compaction/filter.h"
 #include "cloud_topics/level_one/compaction/meta.h"
+#include "cloud_topics/level_one/compaction/worker_probe.h"
 #include "cloud_topics/level_one/metastore/extent_metadata_reader.h"
 #include "cloud_topics/level_one/metastore/metastore.h"
 #include "cloud_topics/level_one/metastore/offset_interval_set.h"
@@ -36,7 +37,8 @@ public:
       metastore*,
       io*,
       ss::abort_source&,
-      compaction_job_state&);
+      compaction_job_state&,
+      compaction_worker_probe&);
     ss::future<> initialize() final;
     ss::future<ss::stop_iteration> map_building_iteration() final;
     ss::future<ss::stop_iteration>
@@ -92,6 +94,7 @@ private:
 
     ss::abort_source& _as;
     compaction_job_state& _state;
+    compaction_worker_probe& _probe;
 
     // Dirty ranges returned by the `metastore` that were indexed during
     // `map_deduplication_iteration`.

--- a/src/v/cloud_topics/level_one/compaction/tests/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/tests/BUILD
@@ -160,3 +160,21 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "compaction_e2e_test",
+    timeout = "short",
+    srcs = [
+        "compaction_e2e_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/cloud_io/tests:s3_imposter",
+        "//src/v/cloud_topics/level_zero/stm:ctp_stm",
+        "//src/v/cluster",
+        "//src/v/model",
+        "//src/v/redpanda/tests:fixture",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/cloud_topics/level_one/compaction/tests/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/tests/BUILD
@@ -67,6 +67,7 @@ redpanda_cc_gtest(
     ],
     deps = [
         "//src/v/cloud_topics/level_one/compaction:meta",
+        "//src/v/cloud_topics/level_one/compaction:scheduler_probe",
         "//src/v/cloud_topics/level_one/compaction:worker",
         "//src/v/model",
         "//src/v/ssx:semaphore",

--- a/src/v/cloud_topics/level_one/compaction/tests/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/tests/BUILD
@@ -39,6 +39,7 @@ redpanda_cc_gtest(
         "//src/v/cloud_topics/level_one/compaction:filter",
         "//src/v/cloud_topics/level_one/compaction:meta",
         "//src/v/cloud_topics/level_one/compaction:source_and_sink",
+        "//src/v/cloud_topics/level_one/compaction:worker_probe",
         "//src/v/cloud_topics/level_one/frontend_reader/tests:l1_reader_fixture",
         "//src/v/cloud_topics/level_one/metastore",
         "//src/v/cloud_topics/level_one/metastore:simple",

--- a/src/v/cloud_topics/level_one/compaction/tests/compaction_e2e_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/compaction_e2e_test.cc
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_io/tests/s3_imposter.h"
+#include "cloud_topics/level_zero/stm/ctp_stm.h"
+#include "cluster/types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/timeout_clock.h"
+#include "redpanda/tests/fixture.h"
+#include "test_utils/async.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+using namespace cloud_topics;
+using namespace std::chrono_literals;
+
+static const cluster::topic_properties compact_topic_props = [] {
+    cluster::topic_properties props;
+    props.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+    return props;
+}();
+
+class CompactionFixture
+  : public s3_imposter_fixture
+  , public redpanda_thread_fixture
+  , public ::testing::Test {
+public:
+    CompactionFixture()
+      : redpanda_thread_fixture(init_cloud_topics_tag{}, httpd_port_number()) {
+        set_expectations_and_listen({});
+        wait_for_controller_leadership().get();
+    }
+
+    ss::future<>
+    create_cloud_topic(model::ntp ntp, cluster::topic_properties props) {
+        props.cloud_topic_enabled = true;
+        props.shadow_indexing = model::shadow_indexing_mode::disabled;
+
+        co_await add_topic(model::topic_namespace_view{ntp}, 1, props);
+        co_await wait_for_leader(ntp);
+    }
+};
+
+TEST_F(CompactionFixture, ManageAndDeleteCompactedTopic) {
+    // Creating a `compact`-enabled cloud topic should make it appear as managed
+    // in the scheduler.
+    const model::topic topic_name("tapioca");
+    model::ntp ntp(model::kafka_namespace, topic_name, 0);
+    create_cloud_topic(ntp, compact_topic_props).get();
+
+    auto* ct_app = app.cloud_topics_app.get();
+    auto* compaction_scheduler = ct_app->get_compaction_scheduler();
+    RPTEST_REQUIRE_EVENTUALLY(
+      10s, [&] { return compaction_scheduler->is_managed(ntp); });
+
+    app.controller->get_topics_frontend()
+      .local()
+      .delete_topics(
+        {model::topic_namespace{ntp.ns, ntp.tp.topic}}, model::no_timeout)
+      .get();
+
+    // Deleting a managed `compact`-enabled cloud topic should make it unmanaged
+    // in the scheduler.
+    RPTEST_REQUIRE_EVENTUALLY(
+      10s, [&] { return !compaction_scheduler->is_managed(ntp); });
+}
+
+TEST_F(CompactionFixture, AlterAndManageUncompactedTopic) {
+    // Enabling `compact` cleanup policy on an existing cloud topic should make
+    // it managed in the scheduler.
+    const model::topic topic_name("tapioca");
+    model::ntp ntp(model::kafka_namespace, topic_name, 0);
+    create_cloud_topic(ntp, cluster::topic_properties{}).get();
+
+    auto* ct_app = app.cloud_topics_app.get();
+    auto* compaction_scheduler = ct_app->get_compaction_scheduler();
+    ASSERT_FALSE(compaction_scheduler->is_managed(ntp));
+
+    auto property_update = cluster::incremental_topic_updates{};
+    property_update.cleanup_policy_bitflags.op
+      = cluster::incremental_update_operation::set;
+    property_update.cleanup_policy_bitflags.value
+      = model::cleanup_policy_bitflags::compaction;
+    auto custom_update = cluster::incremental_topic_custom_updates{};
+    auto update = cluster::topic_properties_update_vector{
+      cluster::topic_properties_update{
+        model::topic_namespace(ntp.ns, ntp.tp.topic),
+        std::move(property_update),
+        std::move(custom_update)}};
+
+    app.controller->get_topics_frontend()
+      .local()
+      .update_topic_properties(std::move(update), model::no_timeout)
+      .get();
+
+    RPTEST_REQUIRE_EVENTUALLY(
+      10s, [&] { return compaction_scheduler->is_managed(ntp); });
+}
+
+TEST_F(CompactionFixture, ManageAndAlterCompactedTopic) {
+    // Disabling `compact` cleanup policy on a managed cloud topic should make
+    // it unmanaged in the scheduler.
+    const model::topic topic_name("tapioca");
+    model::ntp ntp(model::kafka_namespace, topic_name, 0);
+    create_cloud_topic(ntp, compact_topic_props).get();
+
+    auto* ct_app = app.cloud_topics_app.get();
+    auto* compaction_scheduler = ct_app->get_compaction_scheduler();
+    RPTEST_REQUIRE_EVENTUALLY(
+      10s, [&] { return compaction_scheduler->is_managed(ntp); });
+
+    auto property_update = cluster::incremental_topic_updates{};
+    property_update.cleanup_policy_bitflags.op
+      = cluster::incremental_update_operation::set;
+    property_update.cleanup_policy_bitflags.value
+      = model::cleanup_policy_bitflags::deletion;
+    auto custom_update = cluster::incremental_topic_custom_updates{};
+    auto update = cluster::topic_properties_update_vector{
+      cluster::topic_properties_update{
+        model::topic_namespace(ntp.ns, ntp.tp.topic),
+        std::move(property_update),
+        std::move(custom_update)}};
+
+    app.controller->get_topics_frontend()
+      .local()
+      .update_topic_properties(std::move(update), model::no_timeout)
+      .get();
+
+    RPTEST_REQUIRE_EVENTUALLY(
+      10s, [&] { return !compaction_scheduler->is_managed(ntp); });
+}

--- a/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
@@ -20,6 +20,7 @@
 #include "cloud_topics/level_one/compaction/sink.h"
 #include "cloud_topics/level_one/compaction/source.h"
 #include "cloud_topics/level_one/compaction/tests/in_memory_sink.h"
+#include "cloud_topics/level_one/compaction/worker_probe.h"
 #include "cloud_topics/level_one/frontend_reader/tests/l1_reader_fixture.h"
 #include "cloud_topics/level_one/metastore/metastore.h"
 #include "cloud_topics/level_one/metastore/simple_metastore.h"
@@ -104,6 +105,7 @@ ss::future<> do_compact(
     auto state = l1::compaction_job_state::running;
     auto map = compaction::simple_key_offset_map();
     auto dirty_range_intervals = offsets_response.dirty_ranges.to_vec();
+    l1::compaction_worker_probe probe;
     auto src = std::make_unique<l1::compaction_source>(
       ntp,
       tidp,
@@ -115,7 +117,8 @@ ss::future<> do_compact(
       metastore,
       io,
       as,
-      state);
+      state,
+      probe);
     auto sink = std::make_unique<l1::compaction_sink>(
       tidp,
       dirty_range_intervals,

--- a/src/v/cloud_topics/level_one/compaction/tests/scheduler_fixture.h
+++ b/src/v/cloud_topics/level_one/compaction/tests/scheduler_fixture.h
@@ -49,11 +49,9 @@ public:
     ss::future<> start_scheduler() {
         auto info_collector = l1::log_info_collector(
           &_metastore, std::make_unique<fake_topic_metadata_provider>());
-        auto policy = l1::make_default_scheduling_policy();
         // not `std::make_unique` because private `compaction_scheduler` c-tor.
         scheduler = std::unique_ptr<l1::compaction_scheduler>(
-          new l1::compaction_scheduler(
-            std::move(info_collector), std::move(policy)));
+          new l1::compaction_scheduler(std::move(info_collector)));
         co_await scheduler->_committer.start(
           ss::sharded_parameter(
             [] { return l1::make_default_committing_policy(); }),

--- a/src/v/cloud_topics/level_one/compaction/tests/scheduler_multithread_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/scheduler_multithread_test.cc
@@ -54,7 +54,7 @@ TEST_F(SchedulerTestFixture, TestSchedulerMultithread) {
       };
     auto unmanage_random_partition_func = [this, &managed_ntps]() {
         if (managed_ntps.empty()) {
-            return ss::now();
+            return;
         }
         auto ntp_to_remove
           = random_generators::random_choice(
@@ -62,8 +62,7 @@ TEST_F(SchedulerTestFixture, TestSchedulerMultithread) {
                 managed_ntps.begin(), managed_ntps.end()))
               .first;
         managed_ntps.erase(ntp_to_remove);
-        return scheduler->unmanage_partition(
-          std::move(ntp_to_remove), "unmanage_partition_func");
+        scheduler->unmanage_partition(ntp_to_remove, "unmanage_partition_func");
     };
     auto pause_random_worker_func = [this, &paused_workers]() {
         auto random_shard = random_generators::get_int(ss::smp::count - 1);
@@ -109,8 +108,8 @@ TEST_F(SchedulerTestFixture, TestSchedulerMultithread) {
     auto unmanage_ntp_fut = ss::do_until(
       [&] { return as.abort_requested(); },
       [&]() {
-          return unmanage_random_partition_func().then(
-            [&]() { return ss::sleep(unmanage_sleep); });
+          unmanage_random_partition_func();
+          return ss::sleep(unmanage_sleep);
       });
 
     static constexpr auto pause_worker_sleep = 50ms;

--- a/src/v/cloud_topics/level_one/compaction/tests/scheduler_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/scheduler_test.cc
@@ -56,7 +56,7 @@ TEST_F(SchedulerTestFixture, TestScheduler) {
       };
     auto unmanage_random_partition_func = [this, &managed_ntps]() {
         if (managed_ntps.empty()) {
-            return ss::now();
+            return;
         }
         auto ntp_to_remove
           = random_generators::random_choice(
@@ -64,8 +64,7 @@ TEST_F(SchedulerTestFixture, TestScheduler) {
                 managed_ntps.begin(), managed_ntps.end()))
               .first;
         managed_ntps.erase(ntp_to_remove);
-        return scheduler->unmanage_partition(
-          std::move(ntp_to_remove), "unmanage_partition_func");
+        scheduler->unmanage_partition(ntp_to_remove, "unmanage_partition_func");
     };
     auto pause_random_worker_func = [this, &paused_workers]() {
         auto random_shard = random_generators::get_int(ss::smp::count - 1);
@@ -132,8 +131,8 @@ TEST_F(SchedulerTestFixture, TestScheduler) {
     auto unmanage_ntp_fut = ss::do_until(
       [&] { return as.abort_requested(); },
       [&]() {
-          return unmanage_random_partition_func().then(
-            [&]() { return ss::sleep(unmanage_sleep); });
+          unmanage_random_partition_func();
+          return ss::sleep(unmanage_sleep);
       });
 
     static constexpr auto pause_worker_sleep = 50ms;

--- a/src/v/cloud_topics/level_one/compaction/tests/worker_manager_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/worker_manager_test.cc
@@ -9,6 +9,7 @@
  */
 
 #include "cloud_topics/level_one/compaction/meta.h"
+#include "cloud_topics/level_one/compaction/scheduler_probe.h"
 #include "cloud_topics/level_one/compaction/worker.h"
 #include "cloud_topics/level_one/compaction/worker_manager.h"
 #include "model/fundamental.h"
@@ -48,8 +49,9 @@ public:
 };
 
 TEST_F(WorkerManagerTestFixture, PauseAndResumeWorkers) {
+    l1::compaction_scheduler_probe probe;
     l1::log_compaction_queue pq;
-    l1::worker_manager manager(pq, nullptr, nullptr, nullptr, nullptr);
+    l1::worker_manager manager(pq, nullptr, nullptr, nullptr, nullptr, probe);
     start_workers(manager).get();
     auto stop_manager = ss::defer([&manager] { manager.stop().get(); });
     using worker_state = l1::compaction_worker::worker_state;
@@ -76,9 +78,11 @@ TEST_F(WorkerManagerTestFixture, AcquireWork) {
                       const l1::log_compaction_meta_ptr& b) {
         return a->ntp < b->ntp;
     };
+
+    l1::compaction_scheduler_probe probe;
     l1::log_compaction_queue pq(std::move(cmp_func));
     l1::log_list_t list;
-    l1::worker_manager manager(pq, nullptr, nullptr, nullptr, nullptr);
+    l1::worker_manager manager(pq, nullptr, nullptr, nullptr, nullptr, probe);
     auto stop_manager = ss::defer([&manager] { manager.stop().get(); });
 
     const auto test_ntp = model::ntp(

--- a/src/v/cloud_topics/level_one/compaction/worker.cc
+++ b/src/v/cloud_topics/level_one/compaction/worker.cc
@@ -45,6 +45,7 @@ compaction_worker::compaction_worker(
   , _metadata_cache(metadata_cache) {}
 
 ss::future<> compaction_worker::start() {
+    _probe.setup_metrics();
     start_work_loop();
     co_return;
 }
@@ -207,7 +208,8 @@ ss::future<> compaction_worker::compact_log(log_compaction_meta* log) {
       _metastore,
       _io,
       _as,
-      _job_state);
+      _job_state,
+      _probe);
     auto sink = std::make_unique<compaction_sink>(
       tidp,
       dirty_range_intervals,
@@ -218,6 +220,9 @@ ss::future<> compaction_worker::compact_log(log_compaction_meta* log) {
       _committer);
     auto reducer = compaction::sliding_window_reducer(
       std::move(src), std::move(sink));
+
+    // Start measuring time-to-compact here.
+    auto m = _probe.auto_compaction_measurement();
 
     auto compact_fut = co_await ss::coroutine::as_future(
       std::move(reducer).run());
@@ -232,6 +237,9 @@ ss::future<> compaction_worker::compact_log(log_compaction_meta* log) {
           "Caught exception {} while compacting CTP {}.",
           eptr,
           tidp);
+
+        // Don't let failed compaction runs contribute to the histogram.
+        m->cancel();
     } else {
         vlog(compaction_log.info, "Finished compacting CTP {}", tidp);
     }

--- a/src/v/cloud_topics/level_one/compaction/worker.h
+++ b/src/v/cloud_topics/level_one/compaction/worker.h
@@ -14,6 +14,7 @@
 #include "cloud_topics/level_one/compaction/committer.h"
 #include "cloud_topics/level_one/compaction/meta.h"
 #include "cloud_topics/level_one/compaction/source.h"
+#include "cloud_topics/level_one/compaction/worker_probe.h"
 #include "cloud_topics/level_one/metastore/metastore.h"
 #include "cluster/metadata_cache.h"
 #include "compaction/key_offset_map.h"
@@ -189,6 +190,8 @@ private:
     compaction_committer* _committer;
 
     cluster::metadata_cache* _metadata_cache;
+
+    compaction_worker_probe _probe;
 };
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/worker_manager.cc
+++ b/src/v/cloud_topics/level_one/compaction/worker_manager.cc
@@ -16,6 +16,7 @@
 #include "cloud_topics/level_one/compaction/worker.h"
 #include "cloud_topics/level_one/metastore/replicated_metastore.h"
 #include "model/fundamental.h"
+#include "ssx/future-util.h"
 
 namespace cloud_topics::l1 {
 
@@ -43,7 +44,10 @@ ss::future<> worker_manager::start() {
     co_await _workers.invoke_on_all(&compaction_worker::start);
 }
 
-ss::future<> worker_manager::stop() { co_await _workers.stop(); }
+ss::future<> worker_manager::stop() {
+    co_await _gate.close();
+    co_await _workers.stop();
+}
 
 std::optional<foreign_log_compaction_meta_ptr>
 worker_manager::try_acquire_work(ss::shard_id shard) {
@@ -93,35 +97,39 @@ void worker_manager::complete_work(log_compaction_meta* log) {
     _probe.log_compacted();
 }
 
-ss::future<>
-worker_manager::request_stop_compaction(log_compaction_meta_ptr log) {
+void worker_manager::request_stop_compaction(log_compaction_meta_ptr log) {
     if (!log) {
-        co_return;
+        return;
     }
 
     auto shard_opt = log->inflight_shard;
     if (!shard_opt.has_value()) {
-        co_return;
+        return;
     }
 
     auto shard = shard_opt.value();
 
-    co_await _workers.invoke_on(shard, [](compaction_worker& worker) {
-        return worker.terminate_current_job();
+    ssx::spawn_with_gate(_gate, [this, shard]() {
+        return _workers.invoke_on(shard, [](compaction_worker& worker) {
+            return worker.terminate_current_job();
+        });
     });
 }
 
 ss::future<> worker_manager::alert_workers() {
+    auto guard = _gate.hold();
     co_await _workers.invoke_on_all(
       [](compaction_worker& worker) { worker.alert_worker(); });
 }
 
 ss::future<> worker_manager::pause_worker(ss::shard_id worker) {
+    auto guard = _gate.hold();
     co_await _workers.invoke_on(
       worker, [](compaction_worker& worker) { return worker.pause_worker(); });
 }
 
 ss::future<> worker_manager::resume_worker(ss::shard_id worker) {
+    auto guard = _gate.hold();
     co_await _workers.invoke_on(
       worker, [](compaction_worker& worker) { return worker.resume_worker(); });
 }

--- a/src/v/cloud_topics/level_one/compaction/worker_manager.cc
+++ b/src/v/cloud_topics/level_one/compaction/worker_manager.cc
@@ -24,12 +24,14 @@ worker_manager::worker_manager(
   ss::sharded<file_io>* io,
   ss::sharded<replicated_metastore>* metastore,
   ss::sharded<compaction_committer>* committer,
-  ss::sharded<cluster::metadata_cache>* metadata_cache)
+  ss::sharded<cluster::metadata_cache>* metadata_cache,
+  compaction_scheduler_probe& probe)
   : _work_queue(work_queue)
   , _io(io)
   , _metastore(metastore)
   , _committer(committer)
-  , _metadata_cache(metadata_cache) {}
+  , _metadata_cache(metadata_cache)
+  , _probe(probe) {}
 
 ss::future<> worker_manager::start() {
     co_await _workers.start(
@@ -80,12 +82,15 @@ void worker_manager::complete_work(log_compaction_meta* log) {
       "Expected calls to worker_manager::complete_work() to always execute on "
       "shard {}",
       worker_manager_shard);
+
     dassert(
       log->state == log_compaction_meta::log_state::inflight,
       "Expected log state to be inflight when completing work");
     log->state = log_compaction_meta::log_state::idle;
     log->inflight_shard.reset();
     log->info_and_ts.reset();
+
+    _probe.log_compacted();
 }
 
 ss::future<>

--- a/src/v/cloud_topics/level_one/compaction/worker_manager.h
+++ b/src/v/cloud_topics/level_one/compaction/worker_manager.h
@@ -77,7 +77,7 @@ public:
     // compaction jobs to be ran. This function is ideally used when e.g. a
     // partition is removed or the `cleanup.policy` for a topic is changed and a
     // single compaction job must be stopped.
-    ss::future<> request_stop_compaction(log_compaction_meta_ptr);
+    void request_stop_compaction(log_compaction_meta_ptr);
 
     // Alert all workers that new jobs have become available in the
     // `_work_queue`.
@@ -112,6 +112,8 @@ private:
 
     // A sharded pool of compaction workers.
     ss::sharded<compaction_worker> _workers;
+
+    ss::gate _gate;
 };
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/worker_manager.h
+++ b/src/v/cloud_topics/level_one/compaction/worker_manager.h
@@ -14,6 +14,7 @@
 #include "cloud_topics/level_one/compaction/committer.h"
 #include "cloud_topics/level_one/compaction/logger.h"
 #include "cloud_topics/level_one/compaction/meta.h"
+#include "cloud_topics/level_one/compaction/scheduler_probe.h"
 #include "cloud_topics/level_one/compaction/worker.h"
 #include "cloud_topics/level_one/metastore/replicated_metastore.h"
 #include "cluster/metadata_cache.h"
@@ -44,7 +45,8 @@ public:
       ss::sharded<file_io>*,
       ss::sharded<replicated_metastore>*,
       ss::sharded<compaction_committer>*,
-      ss::sharded<cluster::metadata_cache>*);
+      ss::sharded<cluster::metadata_cache>*,
+      compaction_scheduler_probe&);
 
     // Starts the pool of workers, making them available for compaction jobs.
     ss::future<> start();
@@ -104,6 +106,9 @@ private:
     ss::sharded<compaction_committer>* _committer;
 
     ss::sharded<cluster::metadata_cache>* _metadata_cache;
+
+    // Owned by `scheduler`.
+    compaction_scheduler_probe& _probe;
 
     // A sharded pool of compaction workers.
     ss::sharded<compaction_worker> _workers;

--- a/src/v/cloud_topics/level_one/compaction/worker_probe.cc
+++ b/src/v/cloud_topics/level_one/compaction/worker_probe.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/compaction/worker_probe.h"
+
+#include "config/configuration.h"
+#include "metrics/metrics.h"
+#include "metrics/prometheus_sanitize.h"
+
+#include <seastar/core/metrics.hh>
+
+namespace cloud_topics::l1 {
+
+void compaction_worker_probe::setup_metrics() {
+    namespace sm = ss::metrics;
+
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+
+    _metrics.add_group(
+      prometheus_sanitize::metrics_name("cloud_topics:compaction_worker"),
+      {
+        sm::make_gauge(
+          "batches_removed",
+          [this] { return _batches_removed; },
+          sm::description(
+            "Number of batches removed across all cloud topic partitions on "
+            "this shard")),
+        sm::make_gauge(
+          "records_removed",
+          [this] { return _records_removed; },
+          sm::description(
+            "Number of records removed across all cloud topic partitions on "
+            "this shard")),
+        sm::make_gauge(
+          "tombstones_removed",
+          [this] { return _tombstones_removed; },
+          sm::description(
+            "Number of tombstone records removed across all cloud topic "
+            "partitions on this shard")),
+        sm::make_histogram(
+          "compaction_duration_seconds",
+          [this] { return _compaction_runs.internal_histogram_logform(); },
+          sm::description(
+            "The duration of a compaction run for cloud topic partitions on "
+            "this shard")),
+      });
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/worker_probe.h
+++ b/src/v/cloud_topics/level_one/compaction/worker_probe.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "compaction/types.h"
+#include "metrics/metrics.h"
+#include "utils/log_hist.h"
+
+#include <seastar/core/metrics_registration.hh>
+
+#include <cstdint>
+#include <memory>
+
+namespace cloud_topics::l1 {
+
+class compaction_worker_probe {
+public:
+    using hist_t = log_hist_internal;
+    compaction_worker_probe() = default;
+
+    compaction_worker_probe(const compaction_worker_probe&) = delete;
+    compaction_worker_probe& operator=(const compaction_worker_probe&) = delete;
+    compaction_worker_probe(compaction_worker_probe&&) = delete;
+    compaction_worker_probe& operator=(compaction_worker_probe&&) = delete;
+    ~compaction_worker_probe() = default;
+
+    void setup_metrics();
+
+    std::unique_ptr<hist_t::measurement> auto_compaction_measurement() {
+        return _compaction_runs.auto_measure();
+    }
+
+    void add_stats(const compaction::stats& stats) {
+        _batches_removed += stats.batches_discarded;
+        _records_removed += stats.records_discarded;
+        _tombstones_removed += stats.expired_tombstones_discarded;
+    }
+
+private:
+    hist_t _compaction_runs;
+
+    uint64_t _batches_removed{0};
+    uint64_t _records_removed{0};
+    uint64_t _tombstones_removed{0};
+
+    metrics::internal_metric_groups _metrics;
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/BUILD
@@ -195,6 +195,7 @@ redpanda_cc_library(
         "//src/v/serde",
         "//src/v/serde:map",
         "//src/v/serde:named_type",
+        "//src/v/serde:optional",
         "//src/v/serde:set",
         "//src/v/serde:uuid",
         "//src/v/serde:vector",

--- a/src/v/cloud_topics/level_one/metastore/leader_router.cc
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.cc
@@ -262,15 +262,17 @@ leader_router::process(req_t req, bool local_only) {
     } else if (leader.has_value() && !local_only) {
         vlog(
           cd_log.debug,
-          "Sending remote request for {} as leader of {}",
+          "Sending remote request for {} to broker {} as leader of {}",
           req_name,
+          leader.value(),
           l1_ntp);
         auto ret = co_await remote_dispatch<RemoteFunc>(
           std::move(req), leader.value());
         vlog(
           cd_log.debug,
-          "Sent remote request for {} as leader of {}",
+          "Sent remote request for {} to broker {} as leader of {}",
           req_name,
+          leader.value(),
           l1_ntp);
         co_return ret;
     }

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -759,7 +759,8 @@ replicated_metastore::get_compaction_infos(
             auto& request = partition_and_request.second;
             auto logs = request.logs.copy();
             return fe_.get_compaction_infos(std::move(request))
-              .then([&resp, &logs](rpc::get_compaction_infos_reply reply) {
+              .then([&resp, logs = std::move(logs)](
+                      rpc::get_compaction_infos_reply reply) {
                   if (reply.ec != rpc::errc::ok) {
                       for (const auto& l : logs) {
                           resp[l.tp] = std::unexpected(

--- a/src/v/cloud_topics/level_one/metastore/state.cc
+++ b/src/v/cloud_topics/level_one/metastore/state.cc
@@ -201,6 +201,7 @@ partition_state partition_state::copy() const {
                             ? std::make_optional(compaction_state->copy())
                             : std::nullopt,
       .compaction_epoch = compaction_epoch,
+      .term_starts = term_starts,
     };
     return res;
 }

--- a/src/v/cloud_topics/level_one/metastore/state.h
+++ b/src/v/cloud_topics/level_one/metastore/state.h
@@ -18,6 +18,7 @@
 #include "model/timestamp.h"
 #include "serde/envelope.h"
 #include "serde/rw/envelope.h"
+#include "serde/rw/optional.h"
 #include "serde/rw/set.h"
 
 #include <seastar/core/future.hh>
@@ -190,7 +191,15 @@ struct partition_state
       envelope<partition_state, serde::version<0>, serde::compat_version<0>> {
     friend bool operator==(const partition_state&, const partition_state&)
       = default;
-    auto serde_fields() { return std::tie(extents, start_offset, next_offset); }
+    auto serde_fields() {
+        return std::tie(
+          extents,
+          start_offset,
+          next_offset,
+          compaction_state,
+          compaction_epoch,
+          term_starts);
+    }
 
     partition_state copy() const;
 

--- a/tests/rptest/tests/cloud_topics/e2e_test.py
+++ b/tests/rptest/tests/cloud_topics/e2e_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 from ducktape.utils.util import wait_until
+from ducktape.mark import matrix
 from collections.abc import Iterable
 
 from rptest.clients.kafka_cli_tools import KafkaCliTools
@@ -22,6 +23,7 @@ from rptest.services.kgo_verifier_services import (
 from rptest.services.redpanda import (
     SISettings,
     make_redpanda_service,
+    MetricsEndpoint,
     CLOUD_TOPICS_CONFIG_STR,
 )
 from rptest.tests.end_to_end import EndToEndTest
@@ -86,13 +88,19 @@ class EndToEndCloudTopicsBase(EndToEndTest):
         assert self.redpanda
         self.redpanda.start()
         for topic in self.topics:
+            config = {
+                "redpanda.cloud_topic.enabled": "true",
+                "cleanup.policy": topic.cleanup_policy,
+            }
+            if topic.min_cleanable_dirty_ratio is not None:
+                config["min.cleanable.dirty.ratio"] = topic.min_cleanable_dirty_ratio
+            if topic.delete_retention_ms is not None:
+                config["delete.retention.ms"] = topic.delete_retention_ms
             self.rpk.create_topic(
                 topic=topic.name,
                 partitions=topic.partition_count,
                 replicas=topic.replication_factor,
-                config={
-                    "redpanda.cloud_topic.enabled": "true",
-                },
+                config=config,
             )
 
     def wait_until_reconciled(self, topic: str, partition: int, transactions: bool):
@@ -261,3 +269,163 @@ class EndToEndCloudTopicsTxTest(EndToEndCloudTopicsBase):
         assert cstatus.validator.invalid_reads == 0
         assert cstatus.validator.out_of_scope_invalid_reads == 0
         self.wait_until_all_reconciled(self.topics, transactions=True)
+
+
+class EndToEndCloudTopicsCompactionTest(EndToEndCloudTopicsBase):
+    """Cloud topics end-to-end test with a compacted topic."""
+
+    topics = (
+        TopicSpec(
+            name=EndToEndCloudTopicsBase.s3_topic_name,
+            partition_count=1,
+            replication_factor=3,
+            cleanup_policy=TopicSpec.CLEANUP_COMPACT,
+            min_cleanable_dirty_ratio=0.0,
+            delete_retention_ms=3000,
+        ),
+    )
+    kgo_producer: KgoVerifierProducer
+    kgo_consumer: KgoVerifierSeqConsumer
+
+    def __init__(self, test_context):
+        key_map_memory_kb = test_context.injected_args[
+            "storage_compaction_key_map_memory_kb"
+        ]
+        extra_rp_conf = {
+            "log_compaction_interval_ms": 4000,
+            "storage_compaction_key_map_memory": key_map_memory_kb * 1024,
+        }
+        environment = {"__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"}
+        super(EndToEndCloudTopicsCompactionTest, self).__init__(
+            test_context,
+            extra_rp_conf,
+            environment,
+        )
+        self.msg_size = 4096
+        # Use a smaller message count to prevent timeouts
+        self.msg_count = 1000
+        self.key_set_cardinality = 100
+        self.tombstone_probability = 0.5
+
+    def _metric_sum(self, metric_name):
+        assert self.redpanda
+        return self.redpanda.metric_sum(
+            metric_name=metric_name,
+            metrics_endpoint=MetricsEndpoint.METRICS,
+            expect_metric=True,
+        )
+
+    def get_removed_records(self):
+        return self._metric_sum(
+            "vectorized_cloud_topics_compaction_worker_records_removed"
+        )
+
+    def get_log_compactions(self):
+        return self._metric_sum(
+            "vectorized_cloud_topics_compaction_scheduler_log_compactions"
+        )
+
+    def get_managed_logs(self):
+        return self._metric_sum(
+            "vectorized_cloud_topics_compaction_scheduler_managed_log_count"
+        )
+
+    def produce(self):
+        assert self.redpanda
+        assert self.topic
+        try:
+            self.producer = KgoVerifierProducer(
+                self.test_context,
+                self.redpanda,
+                self.topic,
+                msg_size=self.msg_size,
+                msg_count=self.msg_count,
+                key_set_cardinality=self.key_set_cardinality,
+                tombstone_probability=self.tombstone_probability,
+                validate_latest_values=True,
+                tolerate_failed_produce=True,
+            )
+            self.producer.start()
+            self.producer.wait_for_latest_value_map()
+            self.producer.wait()
+        finally:
+            self.producer.stop()
+
+    def consume(self):
+        assert self.redpanda
+        assert self.topic
+        traffic_node = self.producer.nodes[0]
+        try:
+            self.consumer = KgoVerifierSeqConsumer(
+                self.test_context,
+                self.redpanda,
+                self.topic,
+                self.msg_size,
+                loop=False,
+                compacted=True,
+                validate_latest_values=True,
+                nodes=[traffic_node],
+            )
+            self.consumer.start(clean=False)
+            self.consumer.wait()
+        finally:
+            self.consumer.stop()
+
+    @cluster(num_nodes=4)
+    @matrix(storage_compaction_key_map_memory_kb=[3, 10, 128 * 1024])
+    def test_compact(self, storage_compaction_key_map_memory_kb):
+        def seen_managed_logs():
+            return self.get_managed_logs() > 0
+
+        wait_until(
+            seen_managed_logs,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="Did not see management of compact-enabled CTPs.",
+        )
+
+        num_rounds = 1
+        self.prev_log_compactions = 0
+        self.prev_removed_records = 0
+        for i in range(0, num_rounds):
+            self.produce()
+
+            def seen_compaction():
+                log_compactions = self.get_log_compactions()
+                res = log_compactions > self.prev_log_compactions
+                self.prev_log_compactions = log_compactions
+                return res
+
+            wait_until(
+                seen_compaction,
+                timeout_sec=360,
+                backoff_sec=1,
+                err_msg="Did not see compaction of managed CTPs.",
+            )
+
+            def seen_removed_records():
+                removed_records = self.get_removed_records()
+                res = removed_records > self.prev_removed_records
+                self.prev_removed_records = removed_records
+                return res
+
+            wait_until(
+                seen_removed_records,
+                timeout_sec=60,
+                backoff_sec=1,
+                err_msg="Did not see removed records during compaction of CTPs.",
+            )
+
+            def consumed_latest_values():
+                try:
+                    self.consume()
+                    return True
+                except Exception:
+                    return False
+
+            wait_until(
+                consumed_latest_values,
+                timeout_sec=360,
+                backoff_sec=1,
+                err_msg="Did not see a fully compacted CTP log.",
+            )

--- a/tests/rptest/tests/random_node_operations_smoke_test.py
+++ b/tests/rptest/tests/random_node_operations_smoke_test.py
@@ -279,6 +279,8 @@ class RandomNodeOperationsBase(PreallocNodesTest):
                 auto_assign_node_id=True,
                 omit_seeds_on_idx_one=False,
             )
+            admin = Admin(self.redpanda)
+            admin.set_log_level("cloud_topics-compaction", "trace")
 
     def _alter_local_topic_retention_bytes(self, topic: str, retention_bytes: int):
         rpk = RpkTool(self.redpanda)
@@ -604,10 +606,10 @@ class RandomNodeOperationsBase(PreallocNodesTest):
         )
         fast_producer_consumer.start(clean=True)
 
-        cloud_topics_consumer = RandomNodeOperationsBase.producer_consumer(
+        cloud_topics_delete_consumer = RandomNodeOperationsBase.producer_consumer(
             test_context=self.test_context,
             logger=self.logger,
-            topic_name="tp-workload-ct",
+            topic_name="tp-workload-ct-delete",
             redpanda=self.redpanda,
             nodes=[self.preallocated_nodes[2]],
             msg_size=self.msg_size,
@@ -616,10 +618,24 @@ class RandomNodeOperationsBase(PreallocNodesTest):
             consumers_count=self.consumers_count,
             compaction_enabled=False,
         )
+
+        cloud_topics_compact_consumer = RandomNodeOperationsBase.producer_consumer(
+            test_context=self.test_context,
+            logger=self.logger,
+            topic_name="tp-workload-ct-compact",
+            redpanda=self.redpanda,
+            nodes=[self.preallocated_nodes[2]],
+            msg_size=self.msg_size,
+            rate_limit_bps=self.rate_limit,
+            msg_count=self.msg_count,
+            consumers_count=self.consumers_count,
+            compaction_enabled=True,
+        )
+
         if with_cloud_topics:
             rpk = RpkTool(self.redpanda)
             rpk.create_topic(
-                topic=cloud_topics_consumer.topic,
+                topic=cloud_topics_delete_consumer.topic,
                 partitions=self.max_partitions,
                 replicas=3,
                 config={
@@ -630,7 +646,21 @@ class RandomNodeOperationsBase(PreallocNodesTest):
                     "redpanda.cloud_topic.enabled": "true",
                 },
             )
-            cloud_topics_consumer.start(clean=False)
+            cloud_topics_delete_consumer.start(clean=False)
+
+            rpk.create_topic(
+                topic=cloud_topics_compact_consumer.topic,
+                partitions=self.max_partitions,
+                replicas=3,
+                config={
+                    "segment.bytes": default_segment_size,
+                    "cleanup.policy": "compact",
+                    "redpanda.remote.read": "false",
+                    "redpanda.remote.write": "false",
+                    "redpanda.cloud_topic.enabled": "true",
+                },
+            )
+            cloud_topics_compact_consumer.start(clean=False)
 
         write_caching_enabled = enable_write_caching_testing()
         write_caching_producer_consumer = None
@@ -727,7 +757,8 @@ class RandomNodeOperationsBase(PreallocNodesTest):
         fast_producer_consumer.verify()
 
         if with_cloud_topics:
-            cloud_topics_consumer.verify()
+            cloud_topics_delete_consumer.verify()
+            cloud_topics_compact_consumer.verify()
 
         if mixed_versions:
             self.logger.info("Upgrading cluster with current Redpanda version")


### PR DESCRIPTION
Lots of testing including hooking a `compact` CT topic up in RNOT, which will be great for finding low hanging bugs.

Also, a number of commits with bug fixes that have been found already using these tests.
 
## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
