### PR TITLE
copilot: add lambda coroutine fiasco guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -150,6 +150,19 @@ src/v/base/format_to.h.
   assertion statement (e.g. `vlog(..., fut.get_exception(), ...)`). Instead,
   assign the return value of `get_exception` in a variable and pass the variable.
 
+#### Lambda coroutines, coroutine argument capture, and deducing this
+
+When a lambda coroutine is passed to APIs like `seastar::future::then()`,
+the lambda object is stored in managed memory that gets freed once the
+continuation returns—but the coroutine may still be suspended and later
+access its captures, causing use-after-free. This happens because the
+coroutine frame holds a reference to the lambda's capture storage, which
+becomes dangling. The C++23 "deducing this" syntax
+`([captures...](this auto, args...))` solves this by moving the captures
+directly into the coroutine frame rather than referencing them through the
+lambda object, decoupling capture lifetime from the lambda's lifetime.
+This is distinct from the recursive-lambda use case—here this auto is required
+for memory safety in coroutines, not self-reference.
 
 ### C++ coding style
 


### PR DESCRIPTION
Document the C++23 deducing-this pattern for lambda coroutines to help reviewers understand why `this auto` is used for memory safety in coroutines passed to Seastar APIs, not just for recursion.

Motivated by: https://github.com/redpanda-data/redpanda/pull/29100#discussion_r2641581836
Reference: https://github.com/scylladb/seastar/blob/master/doc/lambda-coroutine-fiasco.md

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
