### PR TITLE
[v25.3.x] The Great TX Compaction Backport

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -257,7 +257,8 @@ std::optional<shard_placement_target> placement_target_on_node(
 
 partition_state get_partition_state(ss::lw_shared_ptr<partition> partition) {
     partition_state state{};
-    if (unlikely(!partition)) {
+    if (!partition || !partition->log() || !partition->log()->stm_manager())
+      [[unlikely]] {
         return state;
     }
     state.start_offset = partition->raft_start_offset();
@@ -270,6 +271,8 @@ partition_state get_partition_state(ss::lw_shared_ptr<partition> partition) {
     state.revision_id = partition->get_revision_id();
     state.log_size_bytes = partition->size_bytes();
     state.non_log_disk_size_bytes = partition->non_log_disk_size_bytes();
+    state.max_tombstone_removable_offset
+      = partition->log()->stm_manager()->max_removable_local_log_offset();
     state.is_read_replica_mode_enabled
       = partition->is_read_replica_mode_enabled();
     state.is_remote_fetch_enabled = partition->is_remote_fetch_enabled();
@@ -379,6 +382,8 @@ std::vector<partition_stm_state> get_partition_stm_state(consensus_ptr ptr) {
         state.last_applied_offset = stm->last_applied();
         state.max_removable_local_log_offset
           = stm->max_removable_local_log_offset();
+        state.last_local_snapshot_offset
+          = stm->last_locally_snapshotted_offset();
         result.push_back(std::move(state));
     }
     return result;

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1852,6 +1852,7 @@ model::offset rm_stm::to_log_offset(kafka::offset k_offset) const {
 
 ss::future<raft::local_snapshot_applied>
 rm_stm::apply_local_snapshot(raft::stm_snapshot_header hdr, iobuf&& tx_ss_buf) {
+    auto data_buf = std::move(tx_ss_buf);
     auto units = co_await _state_lock.hold_write_lock();
 
     vlog(
@@ -1859,7 +1860,7 @@ rm_stm::apply_local_snapshot(raft::stm_snapshot_header hdr, iobuf&& tx_ss_buf) {
       "applying snapshot with last included offset: {}",
       hdr.offset);
     tx_snapshot_v6 data;
-    iobuf_parser data_parser(std::move(tx_ss_buf));
+    iobuf_parser data_parser(std::move(data_buf));
     if (hdr.version == tx_snapshot_v4::version) {
         tx_snapshot_v4 data_v4
           = co_await reflection::async_adl<tx_snapshot_v4>{}.from(data_parser);

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1264,6 +1264,9 @@ ss::future<result<kafka_result>> rm_stm::replicate_msg(
 }
 
 model::offset rm_stm::last_stable_offset() {
+    if (_as.abort_requested()) [[unlikely]] {
+        return model::invalid_lso;
+    }
     // There are two main scenarios we deal with here.
     // 1. stm is still bootstrapping
     // 2. stm is past bootstrapping.

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -738,7 +738,7 @@ ss::future<tx::errc> rm_stm::do_abort_tx(
             // Or it may mean that a tx coordinator
             //   - lost its state
             //   - rolled back to previous op
-            //   - the previous op happend to be an abort
+            //   - the previous op happened to be an abort
             //   - the coordinator retried it
             //
             // In the first case the least impactful way to reject the request.
@@ -1281,6 +1281,8 @@ model::offset rm_stm::last_stable_offset() {
     // We optimize for the case where there are no inflight transactional
     // batch to return the high water mark.
     auto last_applied = last_applied_offset();
+
+    // scenario 1: still bootstrapping
     if (unlikely(
           !_bootstrap_committed_offset
           || last_applied < _bootstrap_committed_offset.value())) {
@@ -1290,6 +1292,7 @@ model::offset rm_stm::last_stable_offset() {
         return model::invalid_lso;
     }
 
+    // scenario 2: past bootstrapping
     // Check for any in-flight transactions.
     auto first_tx_start = model::offset::max();
     if (_is_tx_enabled && !_active_tx_producers.empty()) {

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1331,6 +1331,39 @@ model::offset rm_stm::last_stable_offset() {
         // transactions.
         lso = std::min(first_tx_start, next_to_apply);
     } else if (synced_leader) {
+        ////////////////  WARNING ///////////
+        // there is a real bug lurking here that overestimates the LSO beyond
+        // an open transaction.
+        //
+
+        // The problem manifests when the LSO is requested after successful
+        // replication of begin_tx batch but before the stm has applied it.
+        // In this case the LSO may be advanced beyond the begin_tx batch offset
+        // because the leader doesn't yet 'know' about the begin_tx batch and
+        // may not consider it in LSO calculation.
+
+        // Another problem is we do not let lso move backwards once
+        // computed (see _last_known_lso update below), So even if the
+        // stm has applied the begin_tx later, we will not correct
+        // the LSO to reflect the begin_tx presence.
+
+        // There is a test that caught this issue in rm_stm_tests which
+        // is disabled for now until we can fix the underlying problem.
+
+        // The impact of this overestimation is that compaction may compact
+        // away open transaction begin marker as it relies on LSO. The
+        // chances are rare but not impossible :(. if at that point the replica
+        // restarts and there are no further updates in the transaction, the
+        // transaction has no record of ever beginning.
+
+        // We need a better way to track in-flight transactions for the purposes
+        // of LSO calculation.
+
+        // An obvious solution is to clamp LSO to next_to_apply in all cases
+        // but it was tried in the past and caused performance regressions
+        // in non transaction workloads like write_caching, acks=0/1. So that
+        // is not a viable solution.
+
         // no inflight transactions in (last_applied, last_visible_index]
         lso = model::next_offset(last_visible_index);
     } else {

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -257,6 +257,7 @@ ss::future<checked<model::term_id, tx::errc>> rm_stm::begin_tx(
   std::chrono::milliseconds transaction_timeout_ms,
   model::partition_id tm) {
     auto state_lock = co_await _state_lock.hold_read_lock();
+    auto lso_lock_holder = co_await _lso_lock.hold_write_lock();
     if (!co_await sync(_sync_timeout())) {
         vlog(
           _ctx_log.trace,
@@ -1301,6 +1302,16 @@ model::offset rm_stm::last_stable_offset() {
         vlog(
           _ctx_log.trace,
           "state machine is resetting, last_known_lso: {}, last_applied: {}",
+          _last_known_lso,
+          last_applied);
+        return _last_known_lso;
+    }
+    auto lso_read_units = _lso_lock.try_hold_read_lock();
+    if (!lso_read_units) {
+        // LSO calculation is in progress, return last known LSO
+        vlog(
+          _ctx_log.trace,
+          "lso update in progress, last_known_lso: {}, last_applied: {}",
           _last_known_lso,
           last_applied);
         return _last_known_lso;

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1293,6 +1293,18 @@ model::offset rm_stm::last_stable_offset() {
     }
 
     // scenario 2: past bootstrapping
+    auto read_units = _state_lock.try_hold_read_lock();
+    if (!read_units) {
+        // A reset in progress means the stm may not be in a consistent state
+        // for LSO calculation. In this case we return the last known LSO to be
+        // conservative.
+        vlog(
+          _ctx_log.trace,
+          "state machine is resetting, last_known_lso: {}, last_applied: {}",
+          _last_known_lso,
+          last_applied);
+        return _last_known_lso;
+    }
     // Check for any in-flight transactions.
     auto first_tx_start = model::offset::max();
     if (_is_tx_enabled && !_active_tx_producers.empty()) {

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -435,6 +435,15 @@ private:
     model::producer_id _highest_producer_id;
     // for monotonicity of computed LSO.
     model::offset _last_known_lso{-1};
+    /**
+     * LSO lock protects the LSO from being exposed before transaction begin
+     * batch is applied.
+     *
+     * The lock is acquired in write mode when a begin transaction batch is
+     * being handled protecting exposure of potentially invalid LSO until the
+     * begin batch is applied.
+     */
+    ss::rwlock _lso_lock;
 
     friend struct ::rm_stm_test_fixture;
 };

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -117,7 +117,7 @@ namespace cluster {
  * This stm periodically checks if there is any pending transaction for
  * expiration. The expiration kicks in the transaction is not committed/aborted
  * within the user set transaction timeout. A producer with an active
- * transaction cannot be evicted, so exipration ensures that with timely
+ * transaction cannot be evicted, so expiration ensures that with timely
  * expiration of open transactions, the producer states are candidates for
  * eviction.
  */

--- a/src/v/cluster/tests/rm_stm_test_fixture.h
+++ b/src/v/cluster/tests/rm_stm_test_fixture.h
@@ -20,11 +20,13 @@
 static ss::logger logger{"rm_stm-test"};
 static prefix_logger ctx_logger{logger, ""};
 
+static constexpr auto large_timeout = std::chrono::minutes(30);
+
 struct rm_stm_test_fixture : simple_raft_fixture {
     void create_stm_and_start_raft(
       storage::ntp_config::default_overrides overrides = {}) {
         max_concurent_producers.start(std::numeric_limits<size_t>::max()).get();
-        producer_expiration_ms.start(std::chrono::milliseconds::max()).get();
+        producer_expiration_ms.start(large_timeout).get();
         producer_state_manager
           .start(
             ss::sharded_parameter(

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -981,3 +981,91 @@ FIXTURE_TEST(test_concurrent_producer_evictions, rm_stm_test_fixture) {
     ss::when_all_succeed(std::move(replicate_f), std::move(reset_f)).get();
     gate.close().get();
 }
+
+FIXTURE_TEST(test_lso_bound_by_open_tx, rm_stm_test_fixture) {
+    create_stm_and_start_raft();
+    auto& stm = *_stm;
+    auto raft = _raft;
+    stm.start().get();
+    stm.testing_only_disable_auto_abort();
+
+    wait_for_confirmed_leader();
+    wait_for_meta_initialized();
+
+    auto pid = model::producer_identity{0, 0};
+
+    auto random_sleep = []() {
+        auto sleep_ms = std::chrono::milliseconds{
+          random_generators::get_int(0, 5)};
+        return ss::sleep(sleep_ms);
+    };
+
+    auto snapshot_and_apply = [&] {
+        return local_snapshot(cluster::tx::tx_snapshot::version)
+          .then([&](auto snapshot) {
+              return random_sleep().then(
+                [this, snapshot = std::move(snapshot)]() mutable {
+                    return apply_snapshot(
+                             snapshot.header, std::move(snapshot.data))
+                      .discard_result();
+                });
+          });
+    };
+
+    std::optional<model::offset> open_tx_start_offset;
+    auto tx_and_snapshot = [&](model::tx_seq tx_seq) {
+        auto timeout = std::chrono::milliseconds(
+          std::numeric_limits<int32_t>::max());
+        // begin tx
+        BOOST_REQUIRE(
+          stm.begin_tx(pid, tx_seq, timeout, model::partition_id(0)).get());
+
+        open_tx_start_offset = raft->committed_offset();
+
+        if (tests::random_bool()) {
+            // snapshot
+            snapshot_and_apply().get();
+        }
+        // replicate some batches
+        random_sleep().get();
+        auto result = replicate_all(stm, make_batches(pid, 0, 5, true)).get();
+        BOOST_REQUIRE(result.has_value());
+
+        if (tests::random_bool()) {
+            // snapshot
+            snapshot_and_apply().get();
+        }
+        random_sleep().get();
+
+        open_tx_start_offset.reset();
+        // commit
+        BOOST_REQUIRE_EQUAL(
+          stm.commit_tx(pid, tx_seq, timeout).get(), cluster::tx::errc::none);
+    };
+
+    ss::abort_source as;
+    auto lso_bound_checker_f = ss::do_until(
+      [&as] { return as.abort_requested(); },
+      [&] {
+          auto current_lso = stm.last_stable_offset();
+          bool lso_bound = !open_tx_start_offset
+                           || current_lso == open_tx_start_offset;
+          if (!lso_bound) {
+              vlog(
+                logger.error,
+                "LSO {} exceeded earliest open tx offset {}",
+                current_lso,
+                earliest_open_tx);
+          }
+          BOOST_REQUIRE(lso_bound);
+          return ss::now();
+      });
+
+    auto deadline = ss::lowres_clock::now() + 10s;
+    model::tx_seq tx_seq{0};
+    while (ss::lowres_clock::now() < deadline) {
+        tx_and_snapshot(tx_seq++);
+    }
+    as.request_abort();
+    std::move(lso_bound_checker_f).get();
+}

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -945,6 +945,10 @@ FIXTURE_TEST(test_concurrent_producer_evictions, rm_stm_test_fixture) {
 }
 
 FIXTURE_TEST(test_lso_bound_by_open_tx, rm_stm_test_fixture) {
+    // disabled, this test exposed a real bug in bounded LSO computation and
+    // hence disabled until it is fixed. check comment in
+    // rm_stm::last_stable_offset() for more details.
+    return;
     create_stm_and_start_raft();
     auto& stm = *_stm;
     auto raft = _raft;

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -37,6 +37,8 @@ using namespace std::chrono_literals;
 static const failure_type<cluster::errc>
   invalid_producer_epoch(cluster::errc::invalid_producer_epoch);
 
+static constexpr auto timeout = 30min;
+
 struct batches_with_identity {
     model::batch_identity id;
     chunked_vector<model::record_batch> batches;
@@ -141,14 +143,8 @@ FIXTURE_TEST(test_tx_happy_tx, rm_stm_test_fixture) {
     }).get();
 
     auto pid2 = model::producer_identity{2, 0};
-    auto term_op = stm
-                     .begin_tx(
-                       pid2,
-                       tx_seq,
-                       std::chrono::milliseconds(
-                         std::numeric_limits<int32_t>::max()),
-                       model::partition_id(0))
-                     .get();
+    auto term_op
+      = stm.begin_tx(pid2, tx_seq, timeout, model::partition_id(0)).get();
     BOOST_REQUIRE((bool)term_op);
     BOOST_REQUIRE_EQUAL(stm.highest_producer_id(), pid2.get_id());
 
@@ -208,14 +204,8 @@ FIXTURE_TEST(test_tx_aborted_tx_1, rm_stm_test_fixture) {
     }).get();
 
     auto pid2 = model::producer_identity{2, 0};
-    auto term_op = stm
-                     .begin_tx(
-                       pid2,
-                       tx_seq,
-                       std::chrono::milliseconds(
-                         std::numeric_limits<int32_t>::max()),
-                       model::partition_id(0))
-                     .get();
+    auto term_op
+      = stm.begin_tx(pid2, tx_seq, timeout, model::partition_id(0)).get();
     BOOST_REQUIRE((bool)term_op);
     BOOST_REQUIRE_EQUAL(stm.highest_producer_id(), pid2.get_id());
 
@@ -284,14 +274,8 @@ FIXTURE_TEST(test_tx_aborted_tx_2, rm_stm_test_fixture) {
     }).get();
 
     auto pid2 = model::producer_identity{2, 0};
-    auto term_op = stm
-                     .begin_tx(
-                       pid2,
-                       tx_seq,
-                       std::chrono::milliseconds(
-                         std::numeric_limits<int32_t>::max()),
-                       model::partition_id(0))
-                     .get();
+    auto term_op
+      = stm.begin_tx(pid2, tx_seq, timeout, model::partition_id(0)).get();
     BOOST_REQUIRE_EQUAL(stm.highest_producer_id(), pid2.get_id());
     BOOST_REQUIRE((bool)term_op);
 
@@ -370,14 +354,12 @@ FIXTURE_TEST(test_stale_begin_tx_fenced, rm_stm_test_fixture) {
     auto tx_seq_old = model::tx_seq(9);
     auto tx_seq_new = model::tx_seq(11);
     auto pid1 = model::producer_identity{1, 0};
-    auto timeout = std::chrono::milliseconds(
-      std::numeric_limits<int32_t>::max());
 
-    auto begin_tx = [&stm, &pid1, timeout](model::tx_seq seq) {
+    auto begin_tx = [&stm, &pid1](model::tx_seq seq) {
         return stm.begin_tx(pid1, seq, timeout, model::partition_id(0)).get();
     };
 
-    auto commit_tx = [&stm, &pid1, timeout](model::tx_seq seq) {
+    auto commit_tx = [&stm, &pid1](model::tx_seq seq) {
         return stm.commit_tx(pid1, seq, timeout).get();
     };
 
@@ -421,25 +403,13 @@ FIXTURE_TEST(test_tx_begin_fences_produce, rm_stm_test_fixture) {
     BOOST_REQUIRE((bool)offset_r);
 
     auto pid20 = model::producer_identity{2, 0};
-    auto term_op = stm
-                     .begin_tx(
-                       pid20,
-                       tx_seq,
-                       std::chrono::milliseconds(
-                         std::numeric_limits<int32_t>::max()),
-                       model::partition_id(0))
-                     .get();
+    auto term_op
+      = stm.begin_tx(pid20, tx_seq, timeout, model::partition_id(0)).get();
     BOOST_REQUIRE((bool)term_op);
 
     auto pid21 = model::producer_identity{2, 1};
-    term_op = stm
-                .begin_tx(
-                  pid21,
-                  tx_seq,
-                  std::chrono::milliseconds(
-                    std::numeric_limits<int32_t>::max()),
-                  model::partition_id(0))
-                .get();
+    term_op
+      = stm.begin_tx(pid21, tx_seq, timeout, model::partition_id(0)).get();
     BOOST_REQUIRE((bool)term_op);
 
     rreader = make_batches(pid20, 0, 5, true);
@@ -468,14 +438,8 @@ FIXTURE_TEST(test_tx_post_aborted_produce, rm_stm_test_fixture) {
     BOOST_REQUIRE((bool)offset_r);
 
     auto pid20 = model::producer_identity{2, 0};
-    auto term_op = stm
-                     .begin_tx(
-                       pid20,
-                       tx_seq,
-                       std::chrono::milliseconds(
-                         std::numeric_limits<int32_t>::max()),
-                       model::partition_id(0))
-                     .get();
+    auto term_op
+      = stm.begin_tx(pid20, tx_seq, timeout, model::partition_id(0)).get();
     BOOST_REQUIRE((bool)term_op);
 
     rreader = make_batches(pid20, 0, 5, true);
@@ -512,8 +476,6 @@ FIXTURE_TEST(test_aborted_transactions, rm_stm_test_fixture) {
 
     static int64_t pid_counter = 0;
     const auto tx_seq = model::tx_seq(0);
-    const auto timeout = std::chrono::milliseconds(
-      std::numeric_limits<int32_t>::max());
     size_t segment_count = 1;
 
     auto& segments = disk_log->segments();
@@ -1014,8 +976,6 @@ FIXTURE_TEST(test_lso_bound_by_open_tx, rm_stm_test_fixture) {
 
     std::optional<model::offset> open_tx_start_offset;
     auto tx_and_snapshot = [&](model::tx_seq tx_seq) {
-        auto timeout = std::chrono::milliseconds(
-          std::numeric_limits<int32_t>::max());
         // begin tx
         BOOST_REQUIRE(
           stm.begin_tx(pid, tx_seq, timeout, model::partition_id(0)).get());
@@ -1055,7 +1015,7 @@ FIXTURE_TEST(test_lso_bound_by_open_tx, rm_stm_test_fixture) {
                 logger.error,
                 "LSO {} exceeded earliest open tx offset {}",
                 current_lso,
-                earliest_open_tx);
+                open_tx_start_offset);
           }
           BOOST_REQUIRE(lso_bound);
           return ss::now();

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -945,10 +945,6 @@ FIXTURE_TEST(test_concurrent_producer_evictions, rm_stm_test_fixture) {
 }
 
 FIXTURE_TEST(test_lso_bound_by_open_tx, rm_stm_test_fixture) {
-    // disabled, this test exposed a real bug in bounded LSO computation and
-    // hence disabled until it is fixed. check comment in
-    // rm_stm::last_stable_offset() for more details.
-    return;
     create_stm_and_start_raft();
     auto& stm = *_stm;
     auto raft = _raft;

--- a/src/v/cluster/tests/tx_compaction_tests.cc
+++ b/src/v/cluster/tests/tx_compaction_tests.cc
@@ -53,6 +53,7 @@ FIXTURE_TEST(test_tx_compaction_combinations, rm_stm_test_fixture) {
     scoped_config cfg;
     cfg.get("log_disable_housekeeping_for_tests").set_value(true);
     cfg.get("log_segment_ms_min").set_value(1ms);
+    cfg.get("log_compaction_tx_batch_removal_enabled").set_value(true);
     for (auto num_tx : {10, 20, 30}) {
         for (auto num_rolls : {0, 1, 2, 3, 5}) {
             for (auto type :

--- a/src/v/cluster/tests/tx_compaction_utils.h
+++ b/src/v/cluster/tests/tx_compaction_utils.h
@@ -138,7 +138,7 @@ public:
         auto batches = co_await copy_to_mem(reader);
 
         // Ensure there are no aborted keys (tracked in _aborted_xxx)
-        // int fence_batch_count = 0;
+        int fence_batch_count = 0;
         for (auto& batch : batches) {
             auto type = batch.header().type;
             RPTEST_REQUIRE_NE_CORO(type, model::record_batch_type::tx_prepare);
@@ -153,14 +153,13 @@ public:
                 RPTEST_REQUIRE_CORO(_committed_pids.contains(pid));
                 RPTEST_REQUIRE_CORO(!_aborted_pids.contains(pid));
             }
-            // if (type == model::record_batch_type::tx_fence) {
-            //     fence_batch_count++;
-            // }
+            if (type == model::record_batch_type::tx_fence) {
+                fence_batch_count++;
+            }
         }
 
-        // TODO(tx_compact): Re-enable this when transactional control batch
-        // feature is added. Fence batches should be removed.
-        // RPTEST_REQUIRE_CORO(fence_batch_count == 0);
+        // Fence batches should be removed.
+        RPTEST_REQUIRE_CORO(fence_batch_count == 0);
     }
 
     void run_random_workload(

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -28,6 +28,20 @@
 #include <ranges>
 namespace cluster {
 
+namespace {
+template<typename F>
+auto handle_shutdown_exceptions(F fut) {
+    using fut_value_t = F::value_type;
+    return std::move(fut).handle_exception([](const std::exception_ptr& e) {
+        if (ssx::is_shutdown_exception(e)) {
+            // map shutdown exception to timeout error as we cannot be
+            // certain about the operation outcome.
+            return ssx::now<fut_value_t>(tm_stm::op_status::timeout);
+        }
+        return ss::make_exception_future<fut_value_t>(e);
+    });
+}
+} // namespace
 ss::future<result<raft::replicate_result>>
 tm_stm::replicate_quorum_ack(model::term_id term, model::record_batch&& batch) {
     auto opts = raft::replicate_options{
@@ -94,7 +108,8 @@ tm_stm::get_tx(kafka::transactional_id tx_id) {
 }
 
 ss::future<checked<model::term_id, tm_stm::op_status>> tm_stm::barrier() {
-    return ss::with_gate(_gate, [this] { return do_barrier(); });
+    return handle_shutdown_exceptions(
+      ss::with_gate(_gate, [this] { return do_barrier(); }));
 }
 
 ss::future<checked<model::term_id, tm_stm::op_status>> tm_stm::do_barrier() {
@@ -167,7 +182,8 @@ ss::future<ss::basic_rwlock<>::holder> tm_stm::prepare_transfer_leadership() {
 
 ss::future<checked<model::term_id, tm_stm::op_status>>
 tm_stm::sync(model::timeout_clock::duration timeout) {
-    return ss::with_gate(_gate, [this, timeout] { return do_sync(timeout); });
+    return handle_shutdown_exceptions(
+      ss::with_gate(_gate, [this, timeout] { return do_sync(timeout); }));
 }
 
 ss::future<checked<model::term_id, tm_stm::op_status>>
@@ -186,9 +202,10 @@ tm_stm::do_sync(model::timeout_clock::duration timeout) {
 
 ss::future<checked<tx_metadata, tm_stm::op_status>>
 tm_stm::update_tx(tx_metadata tx, model::term_id term) {
-    return ss::with_gate(_gate, [this, tx = std::move(tx), term]() mutable {
-        return do_update_tx(std::move(tx), term);
-    });
+    return handle_shutdown_exceptions(
+      ss::with_gate(_gate, [this, tx = std::move(tx), term]() mutable {
+          return do_update_tx(std::move(tx), term);
+      }));
 }
 
 ss::future<checked<tx_metadata, tm_stm::op_status>>

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2760,15 +2760,19 @@ struct partition_state_request
 struct partition_stm_state
   : serde::envelope<
       partition_stm_state,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     ss::sstring name;
     model::offset last_applied_offset;
     model::offset max_removable_local_log_offset;
+    model::offset last_local_snapshot_offset;
 
     auto serde_fields() {
         return std::tie(
-          name, last_applied_offset, max_removable_local_log_offset);
+          name,
+          last_applied_offset,
+          max_removable_local_log_offset,
+          last_local_snapshot_offset);
     }
 };
 
@@ -2901,7 +2905,7 @@ struct partition_raft_state
 
 struct partition_state
   : serde::
-      envelope<partition_state, serde::version<1>, serde::compat_version<0>> {
+      envelope<partition_state, serde::version<2>, serde::compat_version<0>> {
     model::offset start_offset;
     model::offset committed_offset;
     model::offset last_stable_offset;
@@ -2919,6 +2923,7 @@ struct partition_state
     ss::sstring read_replica_bucket;
     ss::sstring iceberg_mode;
     partition_raft_state raft_state;
+    model::offset max_tombstone_removable_offset;
 
     auto serde_fields() {
         return std::tie(
@@ -2938,7 +2943,8 @@ struct partition_state
           is_cloud_data_available,
           read_replica_bucket,
           raft_state,
-          iceberg_mode);
+          iceberg_mode,
+          max_tombstone_removable_offset);
     }
 
     friend bool operator==(const partition_state&, const partition_state&)

--- a/src/v/compaction/types.cc
+++ b/src/v/compaction/types.cc
@@ -23,11 +23,13 @@ std::ostream& operator<<(std::ostream& o, const compaction_config& c) {
       o,
       "{{max_removable_local_log_offset:{}, "
       "max_tombstone_remove_offset:{}, "
+      "max_tx_remove_offset:{}, "
       "should_sanitize:{}, "
       "tombstone_retention_ms:{}, "
       "tx_retention_ms:{}}}",
       c.max_removable_local_log_offset,
       c.max_tombstone_remove_offset,
+      c.max_tx_remove_offset,
       c.sanitizer_config,
       c.tombstone_retention_ms,
       c.tx_retention_ms);

--- a/src/v/compaction/types.h
+++ b/src/v/compaction/types.h
@@ -51,6 +51,9 @@ struct compaction_config {
     // Cannot remove tombstones past this offset
     model::offset max_tombstone_remove_offset;
 
+    // Cannot remove transactional control batches past this offset
+    model::offset max_tx_remove_offset;
+
     // The retention time for tombstones. Tombstone removal occurs only for
     // "clean" compacted segments past the tombstone deletion horizon timestamp,
     // which is a segment's `clean_compact_timestamp + tombstone_retention_ms`.

--- a/src/v/compaction/utils.cc
+++ b/src/v/compaction/utils.cc
@@ -20,6 +20,16 @@
 
 namespace compaction {
 
+bool is_tx_batch_compaction_enabled(
+  ss::sharded<features::feature_table>& feature_table) {
+    if (!config::shard_local_cfg().log_compaction_tx_batch_removal_enabled()) {
+        // Safety hatch for disabling control batch removal
+        return false;
+    }
+    return feature_table.local().is_active(
+      features::feature::coordinated_compaction);
+}
+
 bool is_removable_control_batch(
   const model::ntp& ntp,
   const model::record_batch_type batch_type,
@@ -29,7 +39,7 @@ bool is_removable_control_batch(
     // Fence batches can also be immediately removed when seen in the
     // `__consumer_offsets` topic or safely removed from a user topic. However,
     // removal in a user topic is gated by
-    // `log_compaction_disable_tx_batch_removal()`.
+    // `log_compaction_tx_batch_removal_enabled()`.
     auto is_co_topic = model::is_consumer_offsets_topic(ntp);
     auto remove_user_tx_fence_enabled
       = config::shard_local_cfg().log_compaction_tx_batch_removal_enabled()

--- a/src/v/compaction/utils.cc
+++ b/src/v/compaction/utils.cc
@@ -23,7 +23,7 @@ namespace compaction {
 bool is_removable_control_batch(
   const model::ntp& ntp,
   const model::record_batch_type batch_type,
-  [[maybe_unused]] ss::sharded<features::feature_table>& feature_table) {
+  ss::sharded<features::feature_table>& feature_table) {
     // Control batches in consumer offsets are special compared to
     // the ones in data partitions can be safely compacted away.
     // Fence batches can also be immediately removed when seen in the
@@ -31,13 +31,10 @@ bool is_removable_control_batch(
     // removal in a user topic is gated by
     // `log_compaction_disable_tx_batch_removal()`.
     auto is_co_topic = model::is_consumer_offsets_topic(ntp);
-    // TODO(tx_compact): Re-enable this when transactional control batch feature
-    // is added.
-    auto remove_user_tx_fence_enabled = false;
-    // auto remove_user_tx_fence_enabled
-    //   = !config::shard_local_cfg().log_compaction_disable_tx_batch_removal()
-    //     && feature_table.local().is_active(
-    //       features::feature::coordinated_compaction);
+    auto remove_user_tx_fence_enabled
+      = !config::shard_local_cfg().log_compaction_disable_tx_batch_removal()
+        && feature_table.local().is_active(
+          features::feature::coordinated_compaction);
     auto tx_fence_removable = batch_type == model::record_batch_type::tx_fence
                               && (is_co_topic || remove_user_tx_fence_enabled);
     return tx_fence_removable

--- a/src/v/compaction/utils.cc
+++ b/src/v/compaction/utils.cc
@@ -33,7 +33,7 @@ bool is_tx_batch_compaction_enabled(
 bool is_removable_control_batch(
   const model::ntp& ntp,
   const model::record_batch_type batch_type,
-  ss::sharded<features::feature_table>& feature_table) {
+  bool remove_user_tx_fence_enabled) {
     // Control batches in consumer offsets are special compared to
     // the ones in data partitions can be safely compacted away.
     // Fence batches can also be immediately removed when seen in the
@@ -41,10 +41,6 @@ bool is_removable_control_batch(
     // removal in a user topic is gated by
     // `log_compaction_tx_batch_removal_enabled()`.
     auto is_co_topic = model::is_consumer_offsets_topic(ntp);
-    auto remove_user_tx_fence_enabled
-      = config::shard_local_cfg().log_compaction_tx_batch_removal_enabled()
-        && feature_table.local().is_active(
-          features::feature::coordinated_compaction);
     auto tx_fence_removable = batch_type == model::record_batch_type::tx_fence
                               && (is_co_topic || remove_user_tx_fence_enabled);
     return tx_fence_removable

--- a/src/v/compaction/utils.cc
+++ b/src/v/compaction/utils.cc
@@ -32,7 +32,7 @@ bool is_removable_control_batch(
     // `log_compaction_disable_tx_batch_removal()`.
     auto is_co_topic = model::is_consumer_offsets_topic(ntp);
     auto remove_user_tx_fence_enabled
-      = !config::shard_local_cfg().log_compaction_disable_tx_batch_removal()
+      = config::shard_local_cfg().log_compaction_tx_batch_removal_enabled()
         && feature_table.local().is_active(
           features::feature::coordinated_compaction);
     auto tx_fence_removable = batch_type == model::record_batch_type::tx_fence

--- a/src/v/compaction/utils.h
+++ b/src/v/compaction/utils.h
@@ -31,7 +31,7 @@ bool is_tx_batch_compaction_enabled(
 bool is_removable_control_batch(
   const model::ntp& ntp,
   const model::record_batch_type batch_type,
-  ss::sharded<features::feature_table>& feature_table);
+  bool remove_user_tx_fence_enabled);
 
 // Returns `true` or `false` indicating whether the batch type of the header
 // passed contains records that may be removed by compaction- whether that is by

--- a/src/v/compaction/utils.h
+++ b/src/v/compaction/utils.h
@@ -20,6 +20,9 @@
 
 namespace compaction {
 
+bool is_tx_batch_compaction_enabled(
+  ss::sharded<features::feature_table>& feature_table);
+
 // Returns `true` if the provided `record_batch_type` is a control batch that is
 // immediately removable during compaction. This means we do not need to
 // consider either deduplication (compactible) or `delete.retention.ms` (a form

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1158,11 +1158,14 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::nullopt)
   , log_compaction_disable_tx_batch_removal(
+      *this, "log_compaction_disable_tx_batch_removal")
+  , log_compaction_tx_batch_removal_enabled(
       *this,
-      "log_compaction_disable_tx_batch_removal",
-      "Disable removal of transactional control batches. This should only be "
-      "toggled to `true` in extreme cases of proven instability due to issues "
-      "with transactional control batch removal.",
+      "log_compaction_tx_batch_removal_enabled",
+      "Enables removal of transactional control batches during compaction. "
+      "These batches are removed according to a topic's configured "
+      "delete.retention.ms, and only if the topic's cleanup.policy "
+      "allows compaction.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
   , retention_bytes(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -273,7 +273,8 @@ struct configuration final : public config_store {
     property<std::optional<uint32_t>>
       log_compaction_merge_max_segments_per_range;
     property<std::optional<uint32_t>> log_compaction_merge_max_ranges;
-    property<bool> log_compaction_disable_tx_batch_removal;
+    deprecated_property log_compaction_disable_tx_batch_removal;
+    property<bool> log_compaction_tx_batch_removal_enabled;
     // same as retention.size in kafka - TODO: size not implemented
     property<std::optional<size_t>> retention_bytes;
     property<int32_t> group_topic_partitions;

--- a/src/v/kafka/server/tests/group_tx_compaction_test.cc
+++ b/src/v/kafka/server/tests/group_tx_compaction_test.cc
@@ -380,21 +380,19 @@ ss::future<> run_workload(
     });
 
     struct batch_validator {
-        bool do_validate_batch([[maybe_unused]] const model::record_batch& b) {
-            // TODO(tx_compact): Re-enable this when transactional control batch
-            // feature is added.
-            // auto batch_type = b.header().type;
-            //  if (
-            //    batch_type == model::record_batch_type::group_fence_tx
-            //    || batch_type == model::record_batch_type::group_prepare_tx
-            //    || batch_type == model::record_batch_type::group_commit_tx
-            //    || batch_type == model::record_batch_type::group_abort_tx
-            //    || batch_type == model::record_batch_type::tx_fence) {
-            //      return true;
-            //  }
-            //  if (b.header().attrs.is_control()) {
-            //      return true;
-            //  }
+        bool do_validate_batch(const model::record_batch& b) {
+            auto batch_type = b.header().type;
+            if (
+              batch_type == model::record_batch_type::group_fence_tx
+              || batch_type == model::record_batch_type::group_prepare_tx
+              || batch_type == model::record_batch_type::group_commit_tx
+              || batch_type == model::record_batch_type::group_abort_tx
+              || batch_type == model::record_batch_type::tx_fence) {
+                return true;
+            }
+            if (b.header().attrs.is_control()) {
+                return true;
+            }
 
             return false;
         }

--- a/src/v/kafka/server/tests/group_tx_compaction_test.cc
+++ b/src/v/kafka/server/tests/group_tx_compaction_test.cc
@@ -346,18 +346,19 @@ ss::future<> run_workload(
             return ss::make_ready_future<>();
         }
         return log->apply_segment_ms().then([&] {
-            return log
-              ->housekeeping(
-                storage::housekeeping_config{
-                  model::timestamp::max(),
-                  std::nullopt,
-                  log->stm_manager()->max_removable_local_log_offset(),
-                  log->stm_manager()->max_removable_local_log_offset(),
-                  std::nullopt,
-                  std::chrono::milliseconds{0},
-                  std::chrono::milliseconds{0},
-                  dummy_as,
-                })
+            auto collect_offset
+              = log->stm_manager()->max_removable_local_log_offset();
+            auto cfg = storage::housekeeping_config::make_config(
+              model::timestamp::max(),
+              std::nullopt,
+              collect_offset,
+              collect_offset,
+              collect_offset,
+              std::nullopt,
+              std::chrono::milliseconds{0},
+              std::chrono::milliseconds{0},
+              dummy_as);
+            return log->housekeeping(std::move(cfg))
               .handle_exception_type(
                 [](const storage::segment_closed_exception&) {});
         });

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -223,6 +223,10 @@ public:
 
     const prefix_logger& log() const { return _log; }
 
+    model::offset last_locally_snapshotted_offset() const override {
+        return _last_snapshot_offset;
+    }
+
 protected:
     ss::future<> start() override;
 

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -1193,6 +1193,10 @@
                 "max_removable_local_log_offset": {
                     "type": "long",
                     "description": "Max removable offset"
+                },
+                "last_local_snapshot_offset": {
+                    "type": "long",
+                    "description": "Last local snapshot offset"
                 }
             }
         },
@@ -1389,6 +1393,10 @@
                 "iceberg_mode": {
                     "type": "string",
                     "description": "Iceberg enablement mode for the topic"
+                },
+                "max_tombstone_removable_offset": {
+                    "type": "long",
+                    "description": "Maximum offset up to which tombstones/transaction end markers can be removed."
                 },
                 "raft_state": {
                     "type": "raft_replica_state",

--- a/src/v/redpanda/admin/debug.cc
+++ b/src/v/redpanda/admin/debug.cc
@@ -108,6 +108,7 @@ void fill_raft_state(
         state.last_applied_offset = stm.last_applied_offset;
         state.max_removable_local_log_offset
           = stm.max_removable_local_log_offset;
+        state.last_local_snapshot_offset = stm.last_local_snapshot_offset;
         raft_state.stms.push(std::move(state));
     }
     if (src.recovery_state) {
@@ -922,6 +923,8 @@ admin_server::get_partition_state_handler(
         replica.revision_id = state.revision_id;
         replica.log_size_bytes = state.log_size_bytes;
         replica.non_log_disk_size_bytes = state.non_log_disk_size_bytes;
+        replica.max_tombstone_removable_offset
+          = state.max_tombstone_removable_offset;
         replica.is_read_replica_mode_enabled
           = state.is_read_replica_mode_enabled;
         replica.read_replica_bucket = state.read_replica_bucket;

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -471,7 +471,7 @@ bool tx_reducer::can_discard_consumer_offsets_batch(
     // batches, so no need to retain originally written group_prepare_tx
     // batches while the transaction is in progress.
     return compaction::is_removable_control_batch(
-      _ntp, b.header().type, _feature_table);
+      _ntp, b.header().type, _tx_batch_compaction_enabled);
 }
 
 ss::future<ss::stop_iteration> tx_reducer::operator()(model::record_batch&& b) {

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -252,13 +252,13 @@ public:
       ss::lw_shared_ptr<storage::stm_manager> stm_mgr,
       chunked_vector<model::tx_range>&& txs,
       compacted_index_writer* w,
-      ss::sharded<features::feature_table>& feature_table) noexcept
+      bool tx_batch_compaction_enabled) noexcept
       : _ntp(std::move(ntp))
       , _delegate(index_rebuilder_reducer(w))
       , _aborted_txs(model::tx_range_cmp(), std::move(txs))
       , _stm_mgr(stm_mgr)
       , _transactional_stm_type(stm_mgr->transactional_stm_type())
-      , _feature_table(feature_table) {
+      , _tx_batch_compaction_enabled(tx_batch_compaction_enabled) {
         _stats.num_aborted_txes = _aborted_txs.size();
     }
     ss::future<ss::stop_iteration> operator()(model::record_batch&&);
@@ -309,7 +309,7 @@ private:
     // Set if a transactional stm is attached to this partition.
     std::optional<storage::stm_type> _transactional_stm_type;
 
-    ss::sharded<features::feature_table>& _feature_table;
+    bool _tx_batch_compaction_enabled;
 };
 
 // Builds up a key_offset_map for a segment, starting from the offset

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -872,7 +872,10 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
 
         const bool segment_needs_rewrite
           = internal::may_have_removable_tombstones(seg, cfg)
-            || internal::has_removable_transaction_batches(seg, cfg)
+            || internal::has_removable_transaction_batches(
+              seg,
+              cfg,
+              compaction::is_tx_batch_compaction_enabled(_feature_table))
             || co_await segment_needs_rewrite_with_offset_map(cfg, seg, map);
         if (!segment_needs_rewrite) {
             vlog(
@@ -1514,7 +1517,10 @@ ss::future<bool> disk_log_impl::chunked_sliding_window_compact(
 
             const bool segment_needs_rewrite
               = internal::may_have_removable_tombstones(s, compact_cfg)
-                || internal::has_removable_transaction_batches(s, compact_cfg)
+                || internal::has_removable_transaction_batches(
+                  s,
+                  compact_cfg,
+                  compaction::is_tx_batch_compaction_enabled(_feature_table))
                 || co_await segment_needs_rewrite_with_offset_map(
                   compact_cfg, s, map);
             if (!segment_needs_rewrite) {

--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -348,8 +348,9 @@ std::ostream& operator<<(std::ostream& o, const index_state& s) {
              << ", clean_compact_timestamp:" << s.clean_compact_timestamp
              << ", may_have_tombstone_records:" << s.may_have_tombstone_records
              << ", self_compact_timestamp:" << s.self_compact_timestamp
-             << ", may_have_transaction_batches:"
-             << s.may_have_transaction_batches << ", " << s.index << "}";
+             << ", may_have_transaction_control_batches:"
+             << s.may_have_transaction_control_batches << ", " << s.index
+             << "}";
 }
 
 void index_state::serde_write(iobuf& out) const {
@@ -372,7 +373,7 @@ void index_state::serde_write(iobuf& out) const {
     write(tmp, clean_compact_timestamp);
     write(tmp, may_have_tombstone_records);
     write(tmp, self_compact_timestamp);
-    write(tmp, may_have_transaction_batches);
+    write(tmp, may_have_transaction_control_batches);
 
     crc::crc32c crc;
     crc_extend_iobuf(crc, tmp);
@@ -490,10 +491,12 @@ void read_nested(
     } else {
         st.self_compact_timestamp = std::nullopt;
     }
-    if (hdr._version >= index_state::may_have_transaction_batches_version) {
-        read_nested(p, st.may_have_transaction_batches, 0U);
+    if (
+      hdr._version
+      >= index_state::may_have_transaction_control_batches_version) {
+        read_nested(p, st.may_have_transaction_control_batches, 0U);
     } else {
-        st.may_have_transaction_batches = true;
+        st.may_have_transaction_control_batches = true;
     }
 }
 
@@ -562,7 +565,8 @@ index_state::index_state(const index_state& o) noexcept
   , clean_compact_timestamp(o.clean_compact_timestamp)
   , may_have_tombstone_records(o.may_have_tombstone_records)
   , self_compact_timestamp(o.self_compact_timestamp)
-  , may_have_transaction_batches(o.may_have_transaction_batches) {}
+  , may_have_transaction_control_batches(
+      o.may_have_transaction_control_batches) {}
 
 namespace serde_compat {
 uint64_t index_state_serde::checksum(const index_state& r) {

--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -350,8 +350,9 @@ std::ostream& operator<<(std::ostream& o, const index_state& s) {
              << ", self_compact_timestamp:" << s.self_compact_timestamp
              << ", may_have_transaction_control_batches:"
              << s.may_have_transaction_control_batches
-             << ", may_have_transaction_data_batches:"
-             << s.may_have_transaction_data_batches << ", " << s.index << "}";
+             << ", may_have_transaction_data_or_fence_batches:"
+             << s.may_have_transaction_data_or_fence_batches << ", " << s.index
+             << "}";
 }
 
 void index_state::serde_write(iobuf& out) const {
@@ -375,7 +376,7 @@ void index_state::serde_write(iobuf& out) const {
     write(tmp, may_have_tombstone_records);
     write(tmp, self_compact_timestamp);
     write(tmp, may_have_transaction_control_batches);
-    write(tmp, may_have_transaction_data_batches);
+    write(tmp, may_have_transaction_data_or_fence_batches);
 
     crc::crc32c crc;
     crc_extend_iobuf(crc, tmp);
@@ -501,10 +502,11 @@ void read_nested(
         st.may_have_transaction_control_batches = true;
     }
     if (
-      hdr._version >= index_state::may_have_transaction_data_batches_version) {
-        read_nested(p, st.may_have_transaction_data_batches, 0U);
+      hdr._version
+      >= index_state::may_have_transaction_data_or_fence_batches_version) {
+        read_nested(p, st.may_have_transaction_data_or_fence_batches, 0U);
     } else {
-        st.may_have_transaction_data_batches = true;
+        st.may_have_transaction_data_or_fence_batches = true;
     }
 }
 
@@ -574,7 +576,8 @@ index_state::index_state(const index_state& o) noexcept
   , may_have_tombstone_records(o.may_have_tombstone_records)
   , self_compact_timestamp(o.self_compact_timestamp)
   , may_have_transaction_control_batches(o.may_have_transaction_control_batches)
-  , may_have_transaction_data_batches(o.may_have_transaction_data_batches) {}
+  , may_have_transaction_data_or_fence_batches(
+      o.may_have_transaction_data_or_fence_batches) {}
 
 namespace serde_compat {
 uint64_t index_state_serde::checksum(const index_state& r) {

--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -349,8 +349,9 @@ std::ostream& operator<<(std::ostream& o, const index_state& s) {
              << ", may_have_tombstone_records:" << s.may_have_tombstone_records
              << ", self_compact_timestamp:" << s.self_compact_timestamp
              << ", may_have_transaction_control_batches:"
-             << s.may_have_transaction_control_batches << ", " << s.index
-             << "}";
+             << s.may_have_transaction_control_batches
+             << ", may_have_transaction_data_batches:"
+             << s.may_have_transaction_data_batches << ", " << s.index << "}";
 }
 
 void index_state::serde_write(iobuf& out) const {
@@ -374,6 +375,7 @@ void index_state::serde_write(iobuf& out) const {
     write(tmp, may_have_tombstone_records);
     write(tmp, self_compact_timestamp);
     write(tmp, may_have_transaction_control_batches);
+    write(tmp, may_have_transaction_data_batches);
 
     crc::crc32c crc;
     crc_extend_iobuf(crc, tmp);
@@ -498,6 +500,12 @@ void read_nested(
     } else {
         st.may_have_transaction_control_batches = true;
     }
+    if (
+      hdr._version >= index_state::may_have_transaction_data_batches_version) {
+        read_nested(p, st.may_have_transaction_data_batches, 0U);
+    } else {
+        st.may_have_transaction_data_batches = true;
+    }
 }
 
 index_state index_state::copy() const { return *this; }
@@ -565,8 +573,8 @@ index_state::index_state(const index_state& o) noexcept
   , clean_compact_timestamp(o.clean_compact_timestamp)
   , may_have_tombstone_records(o.may_have_tombstone_records)
   , self_compact_timestamp(o.self_compact_timestamp)
-  , may_have_transaction_control_batches(
-      o.may_have_transaction_control_batches) {}
+  , may_have_transaction_control_batches(o.may_have_transaction_control_batches)
+  , may_have_transaction_data_batches(o.may_have_transaction_data_batches) {}
 
 namespace serde_compat {
 uint64_t index_state_serde::checksum(const index_state& r) {

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -140,7 +140,8 @@ struct index_state
     // Added in the same version.
     static constexpr auto self_compact_timestamp_version = 10;
     static constexpr auto may_have_transaction_control_batches_version = 10;
-    static constexpr auto may_have_transaction_data_batches_version = 11;
+    static constexpr auto may_have_transaction_data_or_fence_batches_version
+      = 11;
 
     static index_state
     make_empty_index(model::offset base_offset, offset_delta_time with_offset);
@@ -237,11 +238,12 @@ struct index_state
     // control batches (abort/commit batches, as well as tx_fence markers).
     bool may_have_transaction_control_batches{true};
 
-    // may_have_transaction_data_batches is `true` by default. It remains
-    // `true` until compaction deduplication/segment data copying is performed
-    // and it is proven that the segment does not contain any transactional
-    // data batches (i.e raft data batches with a transactional bit set).
-    bool may_have_transaction_data_batches{true};
+    // `may_have_transaction_data_or_fence_batches` is `true` by default. It
+    // remains `true` until compaction deduplication/segment data copying is
+    // performed and it is proven that the segment does not contain any
+    // transactional data batches (i.e raft data batches with a transactional
+    // bit set) or tx_fence markers.
+    bool may_have_transaction_data_or_fence_batches{true};
 
     size_t size() const;
 

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -131,7 +131,7 @@ private:
    1 byte  - non_data_timestamps
  */
 struct index_state
-  : serde::envelope<index_state, serde::version<10>, serde::compat_version<4>> {
+  : serde::envelope<index_state, serde::version<11>, serde::compat_version<4>> {
     static constexpr auto monotonic_timestamps_version = 5;
     static constexpr auto broker_timestamp_version = 6;
     static constexpr auto num_compactible_records_version = 7;
@@ -140,6 +140,7 @@ struct index_state
     // Added in the same version.
     static constexpr auto self_compact_timestamp_version = 10;
     static constexpr auto may_have_transaction_control_batches_version = 10;
+    static constexpr auto may_have_transaction_data_batches_version = 11;
 
     static index_state
     make_empty_index(model::offset base_offset, offset_delta_time with_offset);
@@ -235,6 +236,12 @@ struct index_state
     // and it is proven that the segment does not contain any transactional
     // control batches (abort/commit batches, as well as tx_fence markers).
     bool may_have_transaction_control_batches{true};
+
+    // may_have_transaction_data_batches is `true` by default. It remains
+    // `true` until compaction deduplication/segment data copying is performed
+    // and it is proven that the segment does not contain any transactional
+    // data batches (i.e raft data batches with a transactional bit set).
+    bool may_have_transaction_data_batches{true};
 
     size_t size() const;
 

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -139,7 +139,7 @@ struct index_state
     static constexpr auto may_have_tombstone_records_version = 9;
     // Added in the same version.
     static constexpr auto self_compact_timestamp_version = 10;
-    static constexpr auto may_have_transaction_batches_version = 10;
+    static constexpr auto may_have_transaction_control_batches_version = 10;
 
     static index_state
     make_empty_index(model::offset base_offset, offset_delta_time with_offset);
@@ -230,10 +230,11 @@ struct index_state
     // delete horizon is set by `self_compact_timestamp + delete.retention.ms`.
     std::optional<model::timestamp> self_compact_timestamp{std::nullopt};
 
-    // may_have_transaction_batches is `true` by default. It remains `true`
-    // until compaction deduplication/segment data copying is performed and and
-    // it is proven that the segment does not contain any transactional batches.
-    bool may_have_transaction_batches{true};
+    // may_have_transaction_control_batches is `true` by default. It remains
+    // `true` until compaction deduplication/segment data copying is performed
+    // and it is proven that the segment does not contain any transactional
+    // control batches (abort/commit batches, as well as tx_fence markers).
+    bool may_have_transaction_control_batches{true};
 
     size_t size() const;
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -433,18 +433,19 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
           = current_log.handle->stm_manager()->max_tombstone_remove_offset();
         model::offset tx_snapshot_offset
           = current_log.handle->stm_manager()->tx_snapshot_offset();
-        // We clamp the offset up to which we can remove tombstones to the
-        // last snapshot taken by the transactional stm. This ensures that we
-        // do not remove tombstones that may be needed to reconstruct the
-        // state machine during recovery.
+        // We clamp the offset up to which we can remove transactional control
+        // batches to the last snapshot taken by the transactional stm. This
+        // ensures that we do not remove control batches that may be needed to
+        // reconstruct the state machine during recovery.
+        model::offset max_tx_remove_offset = std::min(
+          max_tombstone_remove_offset, tx_snapshot_offset);
+
         vlog(
           gclog.trace,
-          "{}: max tombstone remove offset: {}, tx snapshot offset: {}",
+          "{}: max tombstone remove offset: {}, max tx remove offset: {}",
           ntp,
           max_tombstone_remove_offset,
-          tx_snapshot_offset);
-        max_tombstone_remove_offset = std::min(
-          max_tombstone_remove_offset, tx_snapshot_offset);
+          max_tx_remove_offset);
         if (
           max_unpinned_offset
           && *max_unpinned_offset < max_compactible_offset) {
@@ -458,17 +459,19 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
               max_compactible_offset);
             max_compactible_offset = *max_unpinned_offset;
         }
-        co_await current_log.handle->housekeeping(housekeeping_config(
-          collection_threshold,
-          _config.retention_bytes(),
-          max_compactible_offset,
-          max_tombstone_remove_offset,
-          current_log.handle->config().tombstone_retention_ms(),
-          current_log.handle->config().tx_retention_ms(),
-          current_log.handle->config().min_compaction_lag_ms(),
-          _abort_source,
-          std::move(ntp_sanitizer_cfg),
-          _compaction_hash_key_map.get()));
+        co_await current_log.handle->housekeeping(
+          housekeeping_config::make_config(
+            collection_threshold,
+            _config.retention_bytes(),
+            max_compactible_offset,
+            max_tombstone_remove_offset,
+            max_tx_remove_offset,
+            current_log.handle->config().tombstone_retention_ms(),
+            current_log.handle->config().tx_retention_ms(),
+            current_log.handle->config().min_compaction_lag_ms(),
+            _abort_source,
+            std::move(ntp_sanitizer_cfg),
+            _compaction_hash_key_map.get()));
         _probe->housekeeping_log_processed();
     }
 }

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -431,6 +431,20 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
           = current_log.handle->stm_manager()->max_removable_local_log_offset();
         model::offset max_tombstone_remove_offset
           = current_log.handle->stm_manager()->max_tombstone_remove_offset();
+        model::offset tx_snapshot_offset
+          = current_log.handle->stm_manager()->tx_snapshot_offset();
+        // We clamp the offset up to which we can remove tombstones to the
+        // last snapshot taken by the transactional stm. This ensures that we
+        // do not remove tombstones that may be needed to reconstruct the
+        // state machine during recovery.
+        vlog(
+          gclog.trace,
+          "{}: max tombstone remove offset: {}, tx snapshot offset: {}",
+          ntp,
+          max_tombstone_remove_offset,
+          tx_snapshot_offset);
+        max_tombstone_remove_offset = std::min(
+          max_tombstone_remove_offset, tx_snapshot_offset);
         if (
           max_unpinned_offset
           && *max_unpinned_offset < max_compactible_offset) {

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -208,8 +208,10 @@ ss::future<index_state> deduplicate_segment(
     auto segment_last_offset = seg->offsets().get_committed_offset();
     auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
-    auto unset_transactional_bit_enabled = feature_table.local().is_active(
-      features::feature::coordinated_compaction);
+    auto unset_transactional_bit_enabled
+      = feature_table.local().is_active(
+          features::feature::coordinated_compaction)
+        && !config::shard_local_cfg().log_compaction_disable_tx_batch_removal();
     const bool past_tombstone_delete_horizon
       = internal::is_past_tombstone_delete_horizon(seg, cfg);
     bool may_have_tombstone_records = false;

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -215,7 +215,7 @@ ss::future<index_state> deduplicate_segment(
     bool may_have_tombstone_records = false;
     const bool past_tx_delete_horizon
       = internal::is_past_transaction_batch_delete_horizon(seg, cfg);
-    bool may_have_transaction_batches = false;
+    bool may_have_transaction_control_batches = false;
 
     auto is_latest_record = [&map](
                               const model::record_batch& b,
@@ -232,7 +232,7 @@ ss::future<index_state> deduplicate_segment(
                           &may_have_tombstone_records,
                           &probe,
                           past_tx_delete_horizon,
-                          &may_have_transaction_batches](
+                          &may_have_transaction_control_batches](
                            const model::record_batch& b,
                            const model::record& r,
                            bool is_last_record_in_batch) {
@@ -248,7 +248,7 @@ ss::future<index_state> deduplicate_segment(
           past_tombstone_delete_horizon,
           may_have_tombstone_records,
           past_tx_delete_horizon,
-          may_have_transaction_batches);
+          may_have_transaction_control_batches);
     };
 
     auto copy_reducer = internal::copy_data_segment_reducer(
@@ -292,8 +292,9 @@ ss::future<index_state> deduplicate_segment(
     // Set may_have_tombstone_records
     new_idx.may_have_tombstone_records = may_have_tombstone_records;
 
-    // Set may_have_transaction_batches
-    new_idx.may_have_transaction_batches = may_have_transaction_batches;
+    // Set may_have_transaction_control_batches
+    new_idx.may_have_transaction_control_batches
+      = may_have_transaction_control_batches;
 
     if (
       seg->index().may_have_tombstone_records()

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -216,6 +216,7 @@ ss::future<index_state> deduplicate_segment(
     const bool past_tx_delete_horizon
       = internal::is_past_transaction_batch_delete_horizon(seg, cfg);
     bool may_have_transaction_control_batches = false;
+    bool may_have_transaction_data_batches = false;
 
     auto is_latest_record = [&map](
                               const model::record_batch& b,
@@ -232,7 +233,8 @@ ss::future<index_state> deduplicate_segment(
                           &may_have_tombstone_records,
                           &probe,
                           past_tx_delete_horizon,
-                          &may_have_transaction_control_batches](
+                          &may_have_transaction_control_batches,
+                          &may_have_transaction_data_batches](
                            const model::record_batch& b,
                            const model::record& r,
                            bool is_last_record_in_batch) {
@@ -248,7 +250,8 @@ ss::future<index_state> deduplicate_segment(
           past_tombstone_delete_horizon,
           may_have_tombstone_records,
           past_tx_delete_horizon,
-          may_have_transaction_control_batches);
+          may_have_transaction_control_batches,
+          may_have_transaction_data_batches);
     };
 
     auto copy_reducer = internal::copy_data_segment_reducer(
@@ -295,6 +298,10 @@ ss::future<index_state> deduplicate_segment(
     // Set may_have_transaction_control_batches
     new_idx.may_have_transaction_control_batches
       = may_have_transaction_control_batches;
+
+    // Set may_have_transaction_data_batches
+    new_idx.may_have_transaction_data_batches
+      = may_have_transaction_data_batches;
 
     if (
       seg->index().may_have_tombstone_records()

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -208,13 +208,8 @@ ss::future<index_state> deduplicate_segment(
     auto segment_last_offset = seg->offsets().get_committed_offset();
     auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
-    // TODO(tx_compact): Re-enable this when transactional control batch feature
-    // is added.
-    auto unset_transactional_bit_enabled = false;
-    // auto unset_transactional_bit_enabled
-    //   = !config::shard_local_cfg().log_compaction_disable_tx_batch_removal()
-    //     && feature_table.local().is_active(
-    //       features::feature::coordinated_compaction);
+    auto unset_transactional_bit_enabled = feature_table.local().is_active(
+      features::feature::coordinated_compaction);
     const bool past_tombstone_delete_horizon
       = internal::is_past_tombstone_delete_horizon(seg, cfg);
     bool may_have_tombstone_records = false;

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -156,7 +156,7 @@ ss::future<model::offset> build_offset_map(
               read_lock,
               resources,
               probe,
-              feature_table);
+              compaction::is_tx_batch_compaction_enabled(feature_table));
         } catch (const segment_closed_exception& e) {
             // Stop early if the segment e.g. has been prefix truncated.
             // We'll make do with the offset map we have so far.
@@ -208,15 +208,14 @@ ss::future<index_state> deduplicate_segment(
     auto segment_last_offset = seg->offsets().get_committed_offset();
     auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
-    auto unset_transactional_bit_enabled
-      = feature_table.local().is_active(
-          features::feature::coordinated_compaction)
-        && config::shard_local_cfg().log_compaction_tx_batch_removal_enabled();
+    auto tx_batch_compaction_enabled
+      = compaction::is_tx_batch_compaction_enabled(feature_table);
     const bool past_tombstone_delete_horizon
       = internal::is_past_tombstone_delete_horizon(seg, cfg);
     bool may_have_tombstone_records = false;
     const bool past_tx_delete_horizon
-      = internal::is_past_transaction_batch_delete_horizon(seg, cfg);
+      = internal::is_past_transaction_batch_delete_horizon(
+        seg, cfg, tx_batch_compaction_enabled);
     bool may_have_transaction_control_batches = false;
     bool may_have_transaction_data_or_fence_batches = false;
 
@@ -236,7 +235,8 @@ ss::future<index_state> deduplicate_segment(
                           &probe,
                           past_tx_delete_horizon,
                           &may_have_transaction_control_batches,
-                          &may_have_transaction_data_or_fence_batches](
+                          &may_have_transaction_data_or_fence_batches,
+                          tx_batch_compaction_enabled](
                            const model::record_batch& b,
                            const model::record& r,
                            bool is_last_record_in_batch) {
@@ -253,7 +253,8 @@ ss::future<index_state> deduplicate_segment(
           may_have_tombstone_records,
           past_tx_delete_horizon,
           may_have_transaction_control_batches,
-          may_have_transaction_data_or_fence_batches);
+          may_have_transaction_data_or_fence_batches,
+          tx_batch_compaction_enabled);
     };
 
     auto copy_reducer = internal::copy_data_segment_reducer(
@@ -265,7 +266,7 @@ ss::future<index_state> deduplicate_segment(
       seg->index().base_offset(),
       segment_last_offset,
       compaction_placeholder_enabled,
-      unset_transactional_bit_enabled,
+      tx_batch_compaction_enabled,
       &cmp_idx_writer,
       inject_reader_failure,
       cfg.asrc);

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -211,7 +211,7 @@ ss::future<index_state> deduplicate_segment(
     auto unset_transactional_bit_enabled
       = feature_table.local().is_active(
           features::feature::coordinated_compaction)
-        && !config::shard_local_cfg().log_compaction_disable_tx_batch_removal();
+        && config::shard_local_cfg().log_compaction_tx_batch_removal_enabled();
     const bool past_tombstone_delete_horizon
       = internal::is_past_tombstone_delete_horizon(seg, cfg);
     bool may_have_tombstone_records = false;

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -218,7 +218,7 @@ ss::future<index_state> deduplicate_segment(
     const bool past_tx_delete_horizon
       = internal::is_past_transaction_batch_delete_horizon(seg, cfg);
     bool may_have_transaction_control_batches = false;
-    bool may_have_transaction_data_batches = false;
+    bool may_have_transaction_data_or_fence_batches = false;
 
     auto is_latest_record = [&map](
                               const model::record_batch& b,
@@ -236,7 +236,7 @@ ss::future<index_state> deduplicate_segment(
                           &probe,
                           past_tx_delete_horizon,
                           &may_have_transaction_control_batches,
-                          &may_have_transaction_data_batches](
+                          &may_have_transaction_data_or_fence_batches](
                            const model::record_batch& b,
                            const model::record& r,
                            bool is_last_record_in_batch) {
@@ -253,7 +253,7 @@ ss::future<index_state> deduplicate_segment(
           may_have_tombstone_records,
           past_tx_delete_horizon,
           may_have_transaction_control_batches,
-          may_have_transaction_data_batches);
+          may_have_transaction_data_or_fence_batches);
     };
 
     auto copy_reducer = internal::copy_data_segment_reducer(
@@ -301,9 +301,9 @@ ss::future<index_state> deduplicate_segment(
     new_idx.may_have_transaction_control_batches
       = may_have_transaction_control_batches;
 
-    // Set may_have_transaction_data_batches
-    new_idx.may_have_transaction_data_batches
-      = may_have_transaction_data_batches;
+    // Set may_have_transaction_data_or_fence_batches
+    new_idx.may_have_transaction_data_or_fence_batches
+      = may_have_transaction_data_or_fence_batches;
 
     if (
       seg->index().may_have_tombstone_records()

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -41,7 +41,7 @@ segment_index::segment_index(
   bool may_have_tombstone_records,
   std::optional<model::timestamp> self_compact_timestamp,
   bool may_have_transaction_control_batches,
-  bool may_have_transaction_data_batches)
+  bool may_have_transaction_data_or_fence_batches)
   : _path(std::move(path))
   , _step(step)
   , _feature_table(std::ref(feature_table))
@@ -56,8 +56,8 @@ segment_index::segment_index(
     _state.self_compact_timestamp = self_compact_timestamp;
     _state.may_have_transaction_control_batches
       = may_have_transaction_control_batches;
-    _state.may_have_transaction_data_batches
-      = may_have_transaction_data_batches;
+    _state.may_have_transaction_data_or_fence_batches
+      = may_have_transaction_data_or_fence_batches;
 }
 
 segment_index::segment_index(
@@ -97,8 +97,8 @@ void segment_index::reset() {
     auto may_have_tombstone_records = _state.may_have_tombstone_records;
     auto may_have_transaction_control_batches
       = _state.may_have_transaction_control_batches;
-    auto may_have_transaction_data_batches
-      = _state.may_have_transaction_data_batches;
+    auto may_have_transaction_data_or_fence_batches
+      = _state.may_have_transaction_data_or_fence_batches;
 
     _state = index_state::make_empty_index(
       base, storage::internal::should_apply_delta_time_offset(_feature_table));
@@ -108,8 +108,8 @@ void segment_index::reset() {
     _state.may_have_tombstone_records = may_have_tombstone_records;
     _state.may_have_transaction_control_batches
       = may_have_transaction_control_batches;
-    _state.may_have_transaction_data_batches
-      = may_have_transaction_data_batches;
+    _state.may_have_transaction_data_or_fence_batches
+      = may_have_transaction_data_or_fence_batches;
 
     _acc = 0;
 }

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -40,7 +40,7 @@ segment_index::segment_index(
   std::optional<model::timestamp> clean_compact_timestamp,
   bool may_have_tombstone_records,
   std::optional<model::timestamp> self_compact_timestamp,
-  bool may_have_transaction_batches)
+  bool may_have_transaction_control_batches)
   : _path(std::move(path))
   , _step(step)
   , _feature_table(std::ref(feature_table))
@@ -53,7 +53,8 @@ segment_index::segment_index(
     _state.clean_compact_timestamp = clean_compact_timestamp;
     _state.may_have_tombstone_records = may_have_tombstone_records;
     _state.self_compact_timestamp = self_compact_timestamp;
-    _state.may_have_transaction_batches = may_have_transaction_batches;
+    _state.may_have_transaction_control_batches
+      = may_have_transaction_control_batches;
 }
 
 segment_index::segment_index(
@@ -91,7 +92,8 @@ void segment_index::reset() {
     auto self_compact_timestamp = _state.self_compact_timestamp;
     auto clean_compact_timestamp = _state.clean_compact_timestamp;
     auto may_have_tombstone_records = _state.may_have_tombstone_records;
-    auto may_have_transaction_batches = _state.may_have_transaction_batches;
+    auto may_have_transaction_control_batches
+      = _state.may_have_transaction_control_batches;
 
     _state = index_state::make_empty_index(
       base, storage::internal::should_apply_delta_time_offset(_feature_table));
@@ -99,7 +101,8 @@ void segment_index::reset() {
     _state.self_compact_timestamp = self_compact_timestamp;
     _state.clean_compact_timestamp = clean_compact_timestamp;
     _state.may_have_tombstone_records = may_have_tombstone_records;
-    _state.may_have_transaction_batches = may_have_transaction_batches;
+    _state.may_have_transaction_control_batches
+      = may_have_transaction_control_batches;
 
     _acc = 0;
 }

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -40,7 +40,8 @@ segment_index::segment_index(
   std::optional<model::timestamp> clean_compact_timestamp,
   bool may_have_tombstone_records,
   std::optional<model::timestamp> self_compact_timestamp,
-  bool may_have_transaction_control_batches)
+  bool may_have_transaction_control_batches,
+  bool may_have_transaction_data_batches)
   : _path(std::move(path))
   , _step(step)
   , _feature_table(std::ref(feature_table))
@@ -55,6 +56,8 @@ segment_index::segment_index(
     _state.self_compact_timestamp = self_compact_timestamp;
     _state.may_have_transaction_control_batches
       = may_have_transaction_control_batches;
+    _state.may_have_transaction_data_batches
+      = may_have_transaction_data_batches;
 }
 
 segment_index::segment_index(
@@ -94,6 +97,8 @@ void segment_index::reset() {
     auto may_have_tombstone_records = _state.may_have_tombstone_records;
     auto may_have_transaction_control_batches
       = _state.may_have_transaction_control_batches;
+    auto may_have_transaction_data_batches
+      = _state.may_have_transaction_data_batches;
 
     _state = index_state::make_empty_index(
       base, storage::internal::should_apply_delta_time_offset(_feature_table));
@@ -103,6 +108,8 @@ void segment_index::reset() {
     _state.may_have_tombstone_records = may_have_tombstone_records;
     _state.may_have_transaction_control_batches
       = may_have_transaction_control_batches;
+    _state.may_have_transaction_data_batches
+      = may_have_transaction_data_batches;
 
     _acc = 0;
 }

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -160,7 +160,7 @@ public:
       bool may_have_tombstone_records = true,
       std::optional<model::timestamp> self_compact_timestamp = std::nullopt,
       bool may_have_transaction_control_batches = true,
-      bool may_have_transaction_data_batches = true);
+      bool may_have_transaction_data_or_fence_batches = true);
 
     ~segment_index() noexcept = default;
     segment_index(segment_index&&) noexcept = default;
@@ -292,8 +292,8 @@ public:
         return _state.may_have_transaction_control_batches;
     }
 
-    bool may_have_transaction_data_batches() const {
-        return _state.may_have_transaction_data_batches;
+    bool may_have_transaction_data_or_fence_batches() const {
+        return _state.may_have_transaction_data_or_fence_batches;
     }
 
     ss::future<bool> materialize_index();

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -159,7 +159,7 @@ public:
       std::optional<model::timestamp> clean_compact_timestamp = std::nullopt,
       bool may_have_tombstone_records = true,
       std::optional<model::timestamp> self_compact_timestamp = std::nullopt,
-      bool may_have_transaction_batches = true);
+      bool may_have_transaction_control_batches = true);
 
     ~segment_index() noexcept = default;
     segment_index(segment_index&&) noexcept = default;
@@ -287,15 +287,8 @@ public:
         return _state.self_compact_timestamp;
     }
 
-    void set_may_have_transaction_batches(bool b) {
-        if (_state.may_have_transaction_batches != b) {
-            _needs_persistence = true;
-        }
-        _state.may_have_transaction_batches = b;
-    }
-
-    bool may_have_transaction_batches() const {
-        return _state.may_have_transaction_batches;
+    bool may_have_transaction_control_batches() const {
+        return _state.may_have_transaction_control_batches;
     }
 
     ss::future<bool> materialize_index();

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -159,7 +159,8 @@ public:
       std::optional<model::timestamp> clean_compact_timestamp = std::nullopt,
       bool may_have_tombstone_records = true,
       std::optional<model::timestamp> self_compact_timestamp = std::nullopt,
-      bool may_have_transaction_control_batches = true);
+      bool may_have_transaction_control_batches = true,
+      bool may_have_transaction_data_batches = true);
 
     ~segment_index() noexcept = default;
     segment_index(segment_index&&) noexcept = default;
@@ -289,6 +290,10 @@ public:
 
     bool may_have_transaction_control_batches() const {
         return _state.may_have_transaction_control_batches;
+    }
+
+    bool may_have_transaction_data_batches() const {
+        return _state.may_have_transaction_data_batches;
     }
 
     ss::future<bool> materialize_index();

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -390,13 +390,8 @@ ss::future<storage::index_state> do_copy_segment_data(
     auto segment_last_offset = seg->offsets().get_committed_offset();
     auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
-    // TODO(tx_compact): Re-enable this when transactional control batch feature
-    // is added.
-    auto unset_transactional_bit_enabled = false;
-    // auto unset_transactional_bit_enabled
-    //   = !config::shard_local_cfg().log_compaction_disable_tx_batch_removal()
-    //     && feature_table.local().is_active(
-    //       features::feature::coordinated_compaction);
+    auto unset_transactional_bit_enabled = feature_table.local().is_active(
+      features::feature::coordinated_compaction);
     const bool past_tombstone_delete_horizon
       = internal::is_past_tombstone_delete_horizon(seg, cfg);
     bool may_have_tombstone_records = false;
@@ -1379,9 +1374,6 @@ ss::future<bool> mark_segment_as_finished_self_compaction(
 
 bool is_past_transaction_batch_delete_horizon(
   ss::lw_shared_ptr<segment> seg, const compaction::compaction_config& cfg) {
-    // TODO(tx_compact): Re-enable this when transactional control batch feature
-    // is added.
-    return false;
     if (config::shard_local_cfg().log_compaction_disable_tx_batch_removal()) {
         // Safety hatch for disabling control batch removal
         return false;

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -1381,8 +1381,7 @@ bool is_past_transaction_batch_delete_horizon(
 
     if (
       seg->has_self_compact_timestamp() && cfg.tx_retention_ms.has_value()
-      && seg->offsets().get_stable_offset()
-           <= cfg.max_tombstone_remove_offset) {
+      && seg->offsets().get_stable_offset() <= cfg.max_tx_remove_offset) {
         const auto now = model::to_time_point(model::timestamp::now());
         return (now
                 - model::to_time_point(

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -397,7 +397,7 @@ ss::future<storage::index_state> do_copy_segment_data(
     bool may_have_tombstone_records = false;
     const bool past_tx_delete_horizon
       = internal::is_past_transaction_batch_delete_horizon(seg, cfg);
-    bool may_have_transaction_batches = false;
+    bool may_have_transaction_control_batches = false;
 
     auto offset_in_compacted_list =
       [compacted_offsets = std::move(compacted_offsets)](
@@ -417,7 +417,7 @@ ss::future<storage::index_state> do_copy_segment_data(
                           &may_have_tombstone_records,
                           &pb,
                           past_tx_delete_horizon,
-                          &may_have_transaction_batches](
+                          &may_have_transaction_control_batches](
                            const model::record_batch& b,
                            const model::record& r,
                            bool is_last_record_in_batch) {
@@ -433,7 +433,7 @@ ss::future<storage::index_state> do_copy_segment_data(
           past_tombstone_delete_horizon,
           may_have_tombstone_records,
           past_tx_delete_horizon,
-          may_have_transaction_batches);
+          may_have_transaction_control_batches);
     };
 
     auto copy_reducer = copy_data_segment_reducer(
@@ -487,8 +487,9 @@ ss::future<storage::index_state> do_copy_segment_data(
     // Set may_have_tombstone_records
     new_index.may_have_tombstone_records = may_have_tombstone_records;
 
-    // Set may_have_transaction_batches
-    new_index.may_have_transaction_batches = may_have_transaction_batches;
+    // Set may_have_transaction_control_batches
+    new_index.may_have_transaction_control_batches
+      = may_have_transaction_control_batches;
 
     if (
       seg->index().may_have_tombstone_records()
@@ -969,9 +970,10 @@ make_concatenated_segment(
 
     // If any of the segments contain a transactional batch, then the new index
     // should reflect that.
-    auto new_may_have_transaction_batches = std::ranges::any_of(
-      segments,
-      [](const auto& s) { return s->index().may_have_transaction_batches(); });
+    auto new_may_have_transaction_control_batches = std::ranges::any_of(
+      segments, [](const auto& s) {
+          return s->index().may_have_transaction_control_batches();
+      });
 
     segment_index index(
       index_path,
@@ -983,7 +985,7 @@ make_concatenated_segment(
       new_clean_compact_timestamp,
       new_may_have_tombstone_records,
       new_self_compact_timestamp,
-      new_may_have_transaction_batches);
+      new_may_have_transaction_control_batches);
 
     co_return std::make_tuple(
       ss::make_lw_shared<segment>(
@@ -1394,7 +1396,7 @@ bool is_past_transaction_batch_delete_horizon(
 
 bool has_removable_transaction_batches(
   ss::lw_shared_ptr<segment> seg, const compaction::compaction_config& cfg) {
-    return seg->index().may_have_transaction_batches()
+    return seg->index().may_have_transaction_control_batches()
            && is_past_transaction_batch_delete_horizon(seg, cfg);
 }
 

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -398,6 +398,7 @@ ss::future<storage::index_state> do_copy_segment_data(
     const bool past_tx_delete_horizon
       = internal::is_past_transaction_batch_delete_horizon(seg, cfg);
     bool may_have_transaction_control_batches = false;
+    bool may_have_transaction_data_batches = false;
 
     auto offset_in_compacted_list =
       [compacted_offsets = std::move(compacted_offsets)](
@@ -417,7 +418,8 @@ ss::future<storage::index_state> do_copy_segment_data(
                           &may_have_tombstone_records,
                           &pb,
                           past_tx_delete_horizon,
-                          &may_have_transaction_control_batches](
+                          &may_have_transaction_control_batches,
+                          &may_have_transaction_data_batches](
                            const model::record_batch& b,
                            const model::record& r,
                            bool is_last_record_in_batch) {
@@ -433,7 +435,8 @@ ss::future<storage::index_state> do_copy_segment_data(
           past_tombstone_delete_horizon,
           may_have_tombstone_records,
           past_tx_delete_horizon,
-          may_have_transaction_control_batches);
+          may_have_transaction_control_batches,
+          may_have_transaction_data_batches);
     };
 
     auto copy_reducer = copy_data_segment_reducer(
@@ -490,6 +493,10 @@ ss::future<storage::index_state> do_copy_segment_data(
     // Set may_have_transaction_control_batches
     new_index.may_have_transaction_control_batches
       = may_have_transaction_control_batches;
+
+    // Set may_have_transaction_data_batches
+    new_index.may_have_transaction_data_batches
+      = may_have_transaction_data_batches;
 
     if (
       seg->index().may_have_tombstone_records()
@@ -968,11 +975,18 @@ make_concatenated_segment(
           .self_compact_timestamp()
           .value();
 
-    // If any of the segments contain a transactional batch, then the new index
-    // should reflect that.
+    // If any of the segments contain a transactional control batch, then the
+    // new index should reflect that.
     auto new_may_have_transaction_control_batches = std::ranges::any_of(
       segments, [](const auto& s) {
           return s->index().may_have_transaction_control_batches();
+      });
+
+    // If any of the segments contain a transactional data batch, then the new
+    // index should reflect that.
+    auto new_may_have_transaction_data_batches = std::ranges::any_of(
+      segments, [](const auto& s) {
+          return s->index().may_have_transaction_data_batches();
       });
 
     segment_index index(
@@ -985,7 +999,8 @@ make_concatenated_segment(
       new_clean_compact_timestamp,
       new_may_have_tombstone_records,
       new_self_compact_timestamp,
-      new_may_have_transaction_control_batches);
+      new_may_have_transaction_control_batches,
+      new_may_have_transaction_data_batches);
 
     co_return std::make_tuple(
       ss::make_lw_shared<segment>(
@@ -1396,8 +1411,15 @@ bool is_past_transaction_batch_delete_horizon(
 
 bool has_removable_transaction_batches(
   ss::lw_shared_ptr<segment> seg, const compaction::compaction_config& cfg) {
-    return seg->index().may_have_transaction_control_batches()
-           && is_past_transaction_batch_delete_horizon(seg, cfg);
+    // If there are transactional data batches, we will unset the transactional
+    // bit during compaction.
+    auto has_data_batches = seg->index().may_have_transaction_data_batches();
+    // If there are removable control batches, they will be removed during
+    // compaction.
+    auto has_removable_control_batches
+      = seg->index().may_have_transaction_control_batches()
+        && is_past_transaction_batch_delete_horizon(seg, cfg);
+    return has_data_batches || has_removable_control_batches;
 }
 
 } // namespace storage::internal

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -352,7 +352,8 @@ ss::future<storage::index_state> do_copy_segment_data(
   ss::rwlock::holder rw_lock_holder,
   storage_resources& resources,
   offset_delta_time apply_offset,
-  ss::sharded<features::feature_table>& feature_table) {
+  ss::sharded<features::feature_table>& feature_table,
+  bool tx_batch_compaction_enabled) {
     // preserve base_offset, broker_timestamp, and clean_compact_timestamp from
     // the segment's index
     auto old_base_offset = seg->index().base_offset();
@@ -390,15 +391,12 @@ ss::future<storage::index_state> do_copy_segment_data(
     auto segment_last_offset = seg->offsets().get_committed_offset();
     auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
-    auto unset_transactional_bit_enabled
-      = feature_table.local().is_active(
-          features::feature::coordinated_compaction)
-        && config::shard_local_cfg().log_compaction_tx_batch_removal_enabled();
     const bool past_tombstone_delete_horizon
       = internal::is_past_tombstone_delete_horizon(seg, cfg);
     bool may_have_tombstone_records = false;
     const bool past_tx_delete_horizon
-      = internal::is_past_transaction_batch_delete_horizon(seg, cfg);
+      = internal::is_past_transaction_batch_delete_horizon(
+        seg, cfg, tx_batch_compaction_enabled);
     bool may_have_transaction_control_batches = false;
     bool may_have_transaction_data_or_fence_batches = false;
 
@@ -421,7 +419,8 @@ ss::future<storage::index_state> do_copy_segment_data(
                           &pb,
                           past_tx_delete_horizon,
                           &may_have_transaction_control_batches,
-                          &may_have_transaction_data_or_fence_batches](
+                          &may_have_transaction_data_or_fence_batches,
+                          tx_batch_compaction_enabled](
                            const model::record_batch& b,
                            const model::record& r,
                            bool is_last_record_in_batch) {
@@ -438,7 +437,8 @@ ss::future<storage::index_state> do_copy_segment_data(
           may_have_tombstone_records,
           past_tx_delete_horizon,
           may_have_transaction_control_batches,
-          may_have_transaction_data_or_fence_batches);
+          may_have_transaction_data_or_fence_batches,
+          tx_batch_compaction_enabled);
     };
 
     auto copy_reducer = copy_data_segment_reducer(
@@ -450,7 +450,7 @@ ss::future<storage::index_state> do_copy_segment_data(
       old_base_offset,
       segment_last_offset,
       compaction_placeholder_enabled,
-      unset_transactional_bit_enabled,
+      tx_batch_compaction_enabled,
       /*cidx=*/nullptr,
       /*inject_failure=*/false,
       cfg.asrc);
@@ -576,7 +576,8 @@ ss::future<compaction_result> do_self_compact_segment(
   storage_resources& resources,
   offset_delta_time apply_offset,
   ss::rwlock::holder read_holder,
-  ss::sharded<features::feature_table>& feature_table) {
+  ss::sharded<features::feature_table>& feature_table,
+  bool tx_batch_compaction_enabled) {
     auto size_before = s->size_bytes();
 
     if (cfg.asrc) {
@@ -609,7 +610,8 @@ ss::future<compaction_result> do_self_compact_segment(
       std::move(read_holder),
       resources,
       apply_offset,
-      feature_table);
+      feature_table,
+      tx_batch_compaction_enabled);
     vlog(
       gclog.trace, "finished copying segment data for {}", s->reader().path());
 
@@ -653,11 +655,15 @@ ss::future<> build_compaction_index(
   const segment_full_path& p,
   compaction::compaction_config cfg,
   storage_resources& resources,
-  ss::sharded<features::feature_table>& feature_table) {
+  bool tx_batch_compaction_enabled) {
     auto w = storage::make_file_backed_compacted_index(
       p, false, resources, cfg.sanitizer_config);
     auto reducer = tx_reducer(
-      p.get_ntp(), stm_manager, std::move(aborted_txs), w.get(), feature_table);
+      p.get_ntp(),
+      stm_manager,
+      std::move(aborted_txs),
+      w.get(),
+      tx_batch_compaction_enabled);
     auto index_builder = co_await ss::coroutine::as_future<tx_reducer::stats>(
       std::move(rdr)
         .consume(std::move(reducer), model::no_timeout)
@@ -696,7 +702,7 @@ ss::future<> rebuild_compaction_index(
   compaction::compaction_config cfg,
   storage::probe& pb,
   storage_resources& resources,
-  ss::sharded<features::feature_table>& feature_table) {
+  bool tx_batch_compaction_enabled) {
     segment_full_path idx_path = s->path().to_compacted_index();
     vlog(gclog.info, "Rebuilding index file... ({})", idx_path);
     pb.corrupted_compaction_index();
@@ -714,7 +720,7 @@ ss::future<> rebuild_compaction_index(
       idx_path,
       cfg,
       resources,
-      feature_table);
+      tx_batch_compaction_enabled);
     vlog(
       gclog.info, "rebuilt index: {}, attempting compaction again", idx_path);
 }
@@ -726,7 +732,7 @@ ss::future<compacted_index::recovery_state> maybe_rebuild_compaction_index(
   ss::rwlock::holder& read_holder,
   storage_resources& resources,
   storage::probe& pb,
-  ss::sharded<features::feature_table>& feature_table) {
+  bool tx_batch_compaction_enabled) {
     segment_full_path idx_path = s->path().to_compacted_index();
 
     compacted_index::recovery_state state;
@@ -760,7 +766,7 @@ ss::future<compacted_index::recovery_state> maybe_rebuild_compaction_index(
         }
 
         co_await rebuild_compaction_index(
-          s, stm_manager, cfg, pb, resources, feature_table);
+          s, stm_manager, cfg, pb, resources, tx_batch_compaction_enabled);
 
         // Take the lock again before proceeding.
         read_holder = co_await s->read_lock();
@@ -789,9 +795,11 @@ ss::future<compaction_result> self_compact_segment(
             "Cannot compact an active segment. cfg:{} - segment:{}", cfg, s));
     }
 
+    const bool tx_batch_compaction_enabled
+      = compaction::is_tx_batch_compaction_enabled(feature_table);
     const bool may_remove_tombstones = may_have_removable_tombstones(s, cfg);
     const bool will_remove_transaction_batches
-      = has_removable_transaction_batches(s, cfg);
+      = has_removable_transaction_batches(s, cfg, tx_batch_compaction_enabled);
 
     auto should_force_compaction = force_compaction || may_remove_tombstones
                                    || will_remove_transaction_batches;
@@ -807,7 +815,13 @@ ss::future<compaction_result> self_compact_segment(
     auto read_holder = co_await s->read_lock();
     compacted_index::recovery_state state
       = co_await maybe_rebuild_compaction_index(
-        s, stm_manager, cfg, read_holder, resources, pb, feature_table);
+        s,
+        stm_manager,
+        cfg,
+        read_holder,
+        resources,
+        pb,
+        tx_batch_compaction_enabled);
 
     const bool is_valid_index_state
       = (state == compacted_index::recovery_state::index_recovered)
@@ -823,7 +837,8 @@ ss::future<compaction_result> self_compact_segment(
       resources,
       apply_offset,
       std::move(read_holder),
-      feature_table);
+      feature_table,
+      tx_batch_compaction_enabled);
 
     if (res.did_compact()) {
         pb.add_compaction_removed_bytes(
@@ -1392,9 +1407,10 @@ ss::future<bool> mark_segment_as_finished_self_compaction(
 }
 
 bool is_past_transaction_batch_delete_horizon(
-  ss::lw_shared_ptr<segment> seg, const compaction::compaction_config& cfg) {
-    if (!config::shard_local_cfg().log_compaction_tx_batch_removal_enabled()) {
-        // Safety hatch for disabling control batch removal
+  ss::lw_shared_ptr<segment> seg,
+  const compaction::compaction_config& cfg,
+  bool tx_batch_compaction_enabled) {
+    if (!tx_batch_compaction_enabled) {
         return false;
     }
 
@@ -1412,7 +1428,9 @@ bool is_past_transaction_batch_delete_horizon(
 }
 
 bool has_removable_transaction_batches(
-  ss::lw_shared_ptr<segment> seg, const compaction::compaction_config& cfg) {
+  ss::lw_shared_ptr<segment> seg,
+  const compaction::compaction_config& cfg,
+  bool tx_batch_compaction_enabled) {
     // If there are transactional data batches, we will unset the transactional
     // bit during compaction.
     auto has_data_batches
@@ -1421,7 +1439,8 @@ bool has_removable_transaction_batches(
     // compaction.
     auto has_removable_control_batches
       = seg->index().may_have_transaction_control_batches()
-        && is_past_transaction_batch_delete_horizon(seg, cfg);
+        && is_past_transaction_batch_delete_horizon(
+          seg, cfg, tx_batch_compaction_enabled);
     return has_data_batches || has_removable_control_batches;
 }
 

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -400,7 +400,7 @@ ss::future<storage::index_state> do_copy_segment_data(
     const bool past_tx_delete_horizon
       = internal::is_past_transaction_batch_delete_horizon(seg, cfg);
     bool may_have_transaction_control_batches = false;
-    bool may_have_transaction_data_batches = false;
+    bool may_have_transaction_data_or_fence_batches = false;
 
     auto offset_in_compacted_list =
       [compacted_offsets = std::move(compacted_offsets)](
@@ -421,7 +421,7 @@ ss::future<storage::index_state> do_copy_segment_data(
                           &pb,
                           past_tx_delete_horizon,
                           &may_have_transaction_control_batches,
-                          &may_have_transaction_data_batches](
+                          &may_have_transaction_data_or_fence_batches](
                            const model::record_batch& b,
                            const model::record& r,
                            bool is_last_record_in_batch) {
@@ -438,7 +438,7 @@ ss::future<storage::index_state> do_copy_segment_data(
           may_have_tombstone_records,
           past_tx_delete_horizon,
           may_have_transaction_control_batches,
-          may_have_transaction_data_batches);
+          may_have_transaction_data_or_fence_batches);
     };
 
     auto copy_reducer = copy_data_segment_reducer(
@@ -496,9 +496,9 @@ ss::future<storage::index_state> do_copy_segment_data(
     new_index.may_have_transaction_control_batches
       = may_have_transaction_control_batches;
 
-    // Set may_have_transaction_data_batches
-    new_index.may_have_transaction_data_batches
-      = may_have_transaction_data_batches;
+    // Set may_have_transaction_data_or_fence_batches
+    new_index.may_have_transaction_data_or_fence_batches
+      = may_have_transaction_data_or_fence_batches;
 
     if (
       seg->index().may_have_tombstone_records()
@@ -986,9 +986,9 @@ make_concatenated_segment(
 
     // If any of the segments contain a transactional data batch, then the new
     // index should reflect that.
-    auto new_may_have_transaction_data_batches = std::ranges::any_of(
+    auto new_may_have_transaction_data_or_fence_batches = std::ranges::any_of(
       segments, [](const auto& s) {
-          return s->index().may_have_transaction_data_batches();
+          return s->index().may_have_transaction_data_or_fence_batches();
       });
 
     segment_index index(
@@ -1002,7 +1002,7 @@ make_concatenated_segment(
       new_may_have_tombstone_records,
       new_self_compact_timestamp,
       new_may_have_transaction_control_batches,
-      new_may_have_transaction_data_batches);
+      new_may_have_transaction_data_or_fence_batches);
 
     co_return std::make_tuple(
       ss::make_lw_shared<segment>(
@@ -1415,7 +1415,8 @@ bool has_removable_transaction_batches(
   ss::lw_shared_ptr<segment> seg, const compaction::compaction_config& cfg) {
     // If there are transactional data batches, we will unset the transactional
     // bit during compaction.
-    auto has_data_batches = seg->index().may_have_transaction_data_batches();
+    auto has_data_batches
+      = seg->index().may_have_transaction_data_or_fence_batches();
     // If there are removable control batches, they will be removed during
     // compaction.
     auto has_removable_control_batches

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -390,8 +390,10 @@ ss::future<storage::index_state> do_copy_segment_data(
     auto segment_last_offset = seg->offsets().get_committed_offset();
     auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
-    auto unset_transactional_bit_enabled = feature_table.local().is_active(
-      features::feature::coordinated_compaction);
+    auto unset_transactional_bit_enabled
+      = feature_table.local().is_active(
+          features::feature::coordinated_compaction)
+        && !config::shard_local_cfg().log_compaction_disable_tx_batch_removal();
     const bool past_tombstone_delete_horizon
       = internal::is_past_tombstone_delete_horizon(seg, cfg);
     bool may_have_tombstone_records = false;

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -393,7 +393,7 @@ ss::future<storage::index_state> do_copy_segment_data(
     auto unset_transactional_bit_enabled
       = feature_table.local().is_active(
           features::feature::coordinated_compaction)
-        && !config::shard_local_cfg().log_compaction_disable_tx_batch_removal();
+        && config::shard_local_cfg().log_compaction_tx_batch_removal_enabled();
     const bool past_tombstone_delete_horizon
       = internal::is_past_tombstone_delete_horizon(seg, cfg);
     bool may_have_tombstone_records = false;
@@ -1393,7 +1393,7 @@ ss::future<bool> mark_segment_as_finished_self_compaction(
 
 bool is_past_transaction_batch_delete_horizon(
   ss::lw_shared_ptr<segment> seg, const compaction::compaction_config& cfg) {
-    if (config::shard_local_cfg().log_compaction_disable_tx_batch_removal()) {
+    if (!config::shard_local_cfg().log_compaction_tx_batch_removal_enabled()) {
         // Safety hatch for disabling control batch removal
         return false;
     }

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "compaction/key_offset_map.h"
 #include "compaction/utils.h"
+#include "model/record.h"
 #include "model/record_batch_reader.h"
 #include "model/record_batch_types.h"
 #include "storage/compacted_index.h"
@@ -358,12 +359,16 @@ ss::future<bool> should_keep(
   bool past_tombstone_delete_horizon,
   bool& may_have_tombstone_records,
   bool past_tx_delete_horizon,
-  bool& has_tx_batches) {
+  bool& has_tx_control_batches,
+  bool& has_tx_data_batches) {
     const auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
     const auto is_compactible = compaction::is_compactible(b.header());
     const auto is_last_batch = b.last_offset() == segment_last_offset;
-    const auto is_control_batch = b.header().attrs.is_control();
+    const auto is_tx_control_batch = b.header().attrs.is_control();
+    const auto is_tx_data_batch = b.header().type
+                                    == model::record_batch_type::raft_data
+                                  && b.header().attrs.is_transactional();
     const auto is_tombstone = r.is_tombstone();
     // once compaction placeholder feature is enabled, we are not
     // worried about empty batches as the reducer then installs a
@@ -380,8 +385,12 @@ ss::future<bool> should_keep(
             may_have_tombstone_records = true;
         }
 
-        if (is_control_batch) {
-            has_tx_batches = true;
+        if (is_tx_control_batch) {
+            has_tx_control_batches = true;
+        }
+
+        if (is_tx_data_batch) {
+            has_tx_data_batches = true;
         }
 
         co_return true;
@@ -400,15 +409,15 @@ ss::future<bool> should_keep(
         if (is_tombstone) {
             pb.add_removed_tombstone();
         }
-        if (is_control_batch) {
+        if (is_tx_control_batch) {
             pb.add_removed_control_batch();
         }
         co_return false;
     }
 
     if (!is_compactible) {
-        if (is_control_batch) {
-            has_tx_batches = true;
+        if (is_tx_control_batch) {
+            has_tx_control_batches = true;
         }
         co_return true;
     }
@@ -417,6 +426,10 @@ ss::future<bool> should_keep(
 
     if (is_tombstone && keep) {
         may_have_tombstone_records = true;
+    }
+
+    if (is_tx_data_batch && keep) {
+        has_tx_data_batches = true;
     }
 
     co_return keep;

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -50,7 +50,7 @@ ss::future<compacted_index::recovery_state> maybe_rebuild_compaction_index(
   ss::rwlock::holder& read_holder,
   storage_resources& resources,
   storage::probe& pb,
-  ss::sharded<features::feature_table>& feature_table);
+  bool tx_batch_compaction_enabled);
 
 /// \brief, this method will acquire it's own locks on the segment
 ///
@@ -72,7 +72,7 @@ ss::future<> rebuild_compaction_index(
   compaction::compaction_config cfg,
   storage::probe& pb,
   storage_resources& resources,
-  ss::sharded<features::feature_table>&);
+  bool tx_batch_compaction_enabled);
 
 /*
  * Concatentate segments into a minimal new segment.
@@ -277,10 +277,14 @@ bool may_have_removable_tombstones(
   ss::lw_shared_ptr<segment> seg, const compaction::compaction_config& cfg);
 
 bool is_past_transaction_batch_delete_horizon(
-  ss::lw_shared_ptr<segment> seg, const compaction::compaction_config& cfg);
+  ss::lw_shared_ptr<segment> seg,
+  const compaction::compaction_config& cfg,
+  bool tx_batch_compaction_enabled);
 
 bool has_removable_transaction_batches(
-  ss::lw_shared_ptr<segment> seg, const compaction::compaction_config& cfg);
+  ss::lw_shared_ptr<segment> seg,
+  const compaction::compaction_config& cfg,
+  bool tx_batch_compaction_enabled);
 
 // Mark a segment as completed window compaction, and whether it is "clean" (in
 // which case the `clean_compact_timestamp` is set in the segment's index).
@@ -318,7 +322,7 @@ auto with_segment_reader_handle(segment_reader_handle handle, Func func) {
 //      __consumer_offsets topic).
 //   2. Expired tombstone records past the removal horizon set by
 //      `delete.retention.ms`
-//   2. Expired control batches past the removal horizon set by
+//   3. Expired control batches past the removal horizon set by
 //      `delete.retention.ms`
 // In all other cases, return `false`.
 inline bool can_discard(
@@ -327,9 +331,9 @@ inline bool can_discard(
   const model::ntp& ntp,
   bool past_tombstone_delete_horizon,
   bool past_tx_delete_horizon,
-  ss::sharded<features::feature_table>& feature_table) {
+  bool tx_batch_compaction_enabled) {
     if (compaction::is_removable_control_batch(
-          ntp, b.header().type, feature_table)) {
+          ntp, b.header().type, tx_batch_compaction_enabled)) {
         return true;
     }
 
@@ -338,7 +342,9 @@ inline bool can_discard(
         return true;
     }
 
-    // Deal with transactional control batch removal
+    // Deal with transactional control batch removal.
+    // `tx_batch_compaction_enabled` is already considered in the variable
+    // `past_tx_delete_horizon`, so it does not need to be queried again here.
     if (b.header().attrs.is_control() && past_tx_delete_horizon) {
         return true;
     }
@@ -360,7 +366,8 @@ ss::future<bool> should_keep(
   bool& may_have_tombstone_records,
   bool past_tx_delete_horizon,
   bool& has_tx_control_batches,
-  bool& has_tx_data_or_fence_batches) {
+  bool& has_tx_data_or_fence_batches,
+  bool tx_batch_compaction_enabled) {
     const auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
     const auto is_compactible = compaction::is_compactible(b.header());
@@ -406,7 +413,7 @@ ss::future<bool> should_keep(
           ntp,
           past_tombstone_delete_horizon,
           past_tx_delete_horizon,
-          feature_table)) {
+          tx_batch_compaction_enabled)) {
         if (is_tombstone) {
             pb.add_removed_tombstone();
         }

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -360,15 +360,16 @@ ss::future<bool> should_keep(
   bool& may_have_tombstone_records,
   bool past_tx_delete_horizon,
   bool& has_tx_control_batches,
-  bool& has_tx_data_batches) {
+  bool& has_tx_data_or_fence_batches) {
     const auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
     const auto is_compactible = compaction::is_compactible(b.header());
     const auto is_last_batch = b.last_offset() == segment_last_offset;
     const auto is_tx_control_batch = b.header().attrs.is_control();
-    const auto is_tx_data_batch = b.header().type
-                                    == model::record_batch_type::raft_data
-                                  && b.header().attrs.is_transactional();
+    const auto is_tx_data_batch = (b.header().type == model::record_batch_type::raft_data
+         && b.header().attrs.is_transactional());
+    const auto is_tx_fence_batch = b.header().type
+                                   == model::record_batch_type::tx_fence;
     const auto is_tombstone = r.is_tombstone();
     // once compaction placeholder feature is enabled, we are not
     // worried about empty batches as the reducer then installs a
@@ -389,8 +390,8 @@ ss::future<bool> should_keep(
             has_tx_control_batches = true;
         }
 
-        if (is_tx_data_batch) {
-            has_tx_data_batches = true;
+        if (is_tx_data_batch || is_tx_fence_batch) {
+            has_tx_data_or_fence_batches = true;
         }
 
         co_return true;
@@ -419,6 +420,9 @@ ss::future<bool> should_keep(
         if (is_tx_control_batch) {
             has_tx_control_batches = true;
         }
+        if (is_tx_fence_batch) {
+            has_tx_data_or_fence_batches = true;
+        }
         co_return true;
     }
 
@@ -429,7 +433,7 @@ ss::future<bool> should_keep(
     }
 
     if (is_tx_data_batch && keep) {
-        has_tx_data_batches = true;
+        has_tx_data_or_fence_batches = true;
     }
 
     co_return keep;

--- a/src/v/storage/tests/compaction_e2e_multinode_test.cc
+++ b/src/v/storage/tests/compaction_e2e_multinode_test.cc
@@ -72,9 +72,10 @@ FIXTURE_TEST(replicate_after_compaction, compaction_multinode_test) {
     first_log->force_roll().get();
     BOOST_REQUIRE_EQUAL(first_log->segment_count(), 2);
     ss::abort_source as;
-    storage::housekeeping_config conf(
+    auto conf = storage::housekeeping_config::make_config(
       model::timestamp::min(),
       std::nullopt,
+      first_log->stm_manager()->max_removable_local_log_offset(),
       first_log->stm_manager()->max_removable_local_log_offset(),
       first_log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
@@ -125,9 +126,10 @@ FIXTURE_TEST(replicate_after_compaction, compaction_multinode_test) {
 
     // The segments should maintain their last records.
     // {[3]} {[5]} {[0 1 2 3 4 5]}
-    storage::housekeeping_config conf2(
+    auto conf2 = storage::housekeeping_config::make_config(
       model::timestamp::min(),
       std::nullopt,
+      new_log->stm_manager()->max_removable_local_log_offset(),
       new_log->stm_manager()->max_removable_local_log_offset(),
       new_log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
@@ -200,11 +202,14 @@ FIXTURE_TEST(compact_transactions_and_replicate, compaction_multinode_test) {
     first_log->flush().get();
     first_log->force_roll().get();
     ss::abort_source as;
-    storage::housekeeping_config conf(
+    auto collect_offset
+      = first_log->stm_manager()->max_removable_local_log_offset();
+    auto conf = storage::housekeeping_config::make_config(
       model::timestamp::min(),
       std::nullopt,
-      first_log->stm_manager()->max_removable_local_log_offset(),
-      first_log->stm_manager()->max_removable_local_log_offset(),
+      collect_offset,
+      collect_offset,
+      collect_offset,
       std::nullopt,
       std::nullopt,
       std::chrono::milliseconds{0},
@@ -231,9 +236,10 @@ FIXTURE_TEST(compact_transactions_and_replicate, compaction_multinode_test) {
     new_log->flush().get();
     new_log->force_roll().get();
 
-    storage::housekeeping_config conf2(
+    auto conf2 = storage::housekeeping_config::make_config(
       model::timestamp::min(),
       std::nullopt,
+      new_log->stm_manager()->max_removable_local_log_offset(),
       new_log->stm_manager()->max_removable_local_log_offset(),
       new_log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,

--- a/src/v/storage/tests/compaction_e2e_multinode_test.cc
+++ b/src/v/storage/tests/compaction_e2e_multinode_test.cc
@@ -367,7 +367,6 @@ FIXTURE_TEST(segment_tx_flags, compaction_multinode_test) {
 
 FIXTURE_TEST(segment_tx_flags_compaction_disabled, compaction_multinode_test) {
     scoped_config cfg;
-    cfg.get("log_compaction_disable_tx_batch_removal").set_value(true);
     cfg.get("log_compaction_merge_max_segments_per_range")
       .set_value(std::make_optional<uint32_t>(0));
     cfg.get("log_compaction_merge_max_ranges")
@@ -432,7 +431,7 @@ FIXTURE_TEST(segment_tx_flags_compaction_disabled, compaction_multinode_test) {
     ss::abort_source as;
     auto collect_offset = log->stm_manager()->max_removable_local_log_offset();
     {
-        // Compact while `log_compaction_disable_tx_batch_removal` is `true`,
+        // Compact while `log_compaction_tx_batch_removal_enabled` is `false`,
         // preventing unsetting of transactional bits or removal of any control
         // batches.
         auto conf = storage::housekeeping_config::make_config(
@@ -466,7 +465,7 @@ FIXTURE_TEST(segment_tx_flags_compaction_disabled, compaction_multinode_test) {
     BOOST_REQUIRE(segments[2]->index().may_have_transaction_control_batches());
 
     {
-        cfg.get("log_compaction_disable_tx_batch_removal").set_value(false);
+        cfg.get("log_compaction_tx_batch_removal_enabled").set_value(true);
         // Compact twice to remove transactional batches and unset bits.
         auto conf = storage::housekeeping_config::make_config(
           model::timestamp::min(),

--- a/src/v/storage/tests/compaction_e2e_multinode_test.cc
+++ b/src/v/storage/tests/compaction_e2e_multinode_test.cc
@@ -148,6 +148,8 @@ FIXTURE_TEST(replicate_after_compaction, compaction_multinode_test) {
 }
 
 FIXTURE_TEST(compact_transactions_and_replicate, compaction_multinode_test) {
+    scoped_config cfg;
+    cfg.get("log_compaction_tx_batch_removal_enabled").set_value(true);
     const model::topic topic{"mocha"};
     model::node_id id{0};
     auto* app = create_node_application(id);
@@ -251,6 +253,8 @@ FIXTURE_TEST(compact_transactions_and_replicate, compaction_multinode_test) {
 }
 
 FIXTURE_TEST(segment_tx_flags, compaction_multinode_test) {
+    scoped_config cfg;
+    cfg.get("log_compaction_tx_batch_removal_enabled").set_value(true);
     const model::topic topic{"tapioca"};
     model::node_id id{0};
     create_node_application(id);

--- a/src/v/storage/tests/compaction_e2e_multinode_test.cc
+++ b/src/v/storage/tests/compaction_e2e_multinode_test.cc
@@ -249,3 +249,117 @@ FIXTURE_TEST(compact_transactions_and_replicate, compaction_multinode_test) {
     new_log->housekeeping(conf2).get();
     exec.validate(new_log).get();
 }
+
+FIXTURE_TEST(segment_tx_flags, compaction_multinode_test) {
+    const model::topic topic{"tapioca"};
+    model::node_id id{0};
+    create_node_application(id);
+    auto* rp = instance(id);
+    wait_for_controller_leadership(id).get();
+
+    cluster::topic_properties props;
+    props.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+    rp->add_topic({model::kafka_namespace, topic}, 1, props).get();
+    model::partition_id pid{0};
+    auto ntp = model::ntp(model::kafka_namespace, topic, pid);
+    RPTEST_REQUIRE_EVENTUALLY(5s, [&] {
+        auto [_, prt] = get_leader(ntp);
+        return prt != nullptr;
+    });
+    auto [_, partition] = get_leader(ntp);
+    auto log = partition->log();
+    using cluster::tx_executor;
+    tx_executor exec;
+    auto make_ctx = [&](int64_t id, model::term_id term) {
+        model::producer_identity pid{id, 0};
+        return tx_executor::tx_op_ctx{
+          exec.data_gen(), partition->rm_stm(), log, pid, term};
+    };
+    // Produce transactional records.
+    tx_executor::sorted_tx_ops_t ops;
+    auto term = partition->raft()->term();
+
+    int weight = 1;
+    ops.emplace(
+      ss::make_shared(tx_executor::begin_op(make_ctx(1, term), weight++)));
+    ops.emplace(
+      ss::make_shared(tx_executor::roll_op(make_ctx(1, term), weight++)));
+    ops.emplace(
+      ss::make_shared(tx_executor::data_op(make_ctx(1, term), weight++, 1)));
+    ops.emplace(
+      ss::make_shared(tx_executor::roll_op(make_ctx(1, term), weight++)));
+
+    ops.emplace(
+      ss::make_shared(tx_executor::abort_op(make_ctx(1, term), weight++)));
+    ops.emplace(
+      ss::make_shared(tx_executor::begin_op(make_ctx(2, term), weight++)));
+    ops.emplace(
+      ss::make_shared(tx_executor::data_op(make_ctx(2, term), weight++, 1)));
+    ops.emplace(
+      ss::make_shared(tx_executor::abort_op(make_ctx(2, term), weight++)));
+
+    exec.execute(std::move(ops)).get();
+    partition->log()->flush().get();
+    partition->log()->force_roll().get();
+
+    // Before compaction, segments should by default have these flags as `true`.
+    for (const auto& segment : log->segments()) {
+        BOOST_REQUIRE(segment->index().may_have_transaction_control_batches());
+        BOOST_REQUIRE(segment->index().may_have_transaction_data_batches());
+    }
+
+    ss::abort_source as;
+    auto collect_offset = log->stm_manager()->max_removable_local_log_offset();
+    {
+        auto conf = storage::housekeeping_config::make_config(
+          model::timestamp::min(),
+          std::nullopt,
+          collect_offset,
+          collect_offset,
+          collect_offset,
+          std::nullopt,
+          std::nullopt,
+          std::chrono::milliseconds{0},
+          as);
+        log->housekeeping(conf).get();
+    }
+
+    // After the first compaction, control batches are still present, but data
+    // batches have had their bit unset (due to being compacted twice over
+    // during self compaction -> sliding window compaction)
+    for (const auto& segment : log->segments()) {
+        if (segment->has_self_compact_timestamp()) {
+            BOOST_REQUIRE(
+              segment->index().may_have_transaction_control_batches());
+            BOOST_REQUIRE(
+              !segment->index().may_have_transaction_data_batches());
+        }
+    }
+
+    {
+        auto conf = storage::housekeeping_config::make_config(
+          model::timestamp::min(),
+          std::nullopt,
+          collect_offset,
+          collect_offset,
+          collect_offset,
+          std::nullopt,
+          std::chrono::milliseconds{0},
+          std::chrono::milliseconds{0},
+          as);
+        log->housekeeping(conf).get();
+    }
+
+    // `may_have_transaction_data_batches` will be false after the previous
+    // compaction, as transactional bits were unset.
+    // `may_have_transaction_control_batches` will also be false due to
+    // compacting with `tx_retention_ms` set.
+    for (const auto& segment : log->segments()) {
+        if (segment->has_self_compact_timestamp()) {
+            BOOST_REQUIRE(
+              !segment->index().may_have_transaction_control_batches());
+            BOOST_REQUIRE(
+              !segment->index().may_have_transaction_data_batches());
+        }
+    }
+}

--- a/src/v/storage/tests/compaction_e2e_multinode_test.cc
+++ b/src/v/storage/tests/compaction_e2e_multinode_test.cc
@@ -351,16 +351,153 @@ FIXTURE_TEST(segment_tx_flags, compaction_multinode_test) {
         log->housekeeping(conf).get();
     }
 
-    // `may_have_transaction_data_batches` will be false after the previous
-    // compaction, as transactional bits were unset.
-    // `may_have_transaction_control_batches` will also be false due to
+    // `may_have_transaction_data_or_fence_batches` will be false after the
+    // previous compaction, as transactional bits were unset and fences were
+    // removed. `may_have_transaction_control_batches` will also be false due to
     // compacting with `tx_retention_ms` set.
     for (const auto& segment : log->segments()) {
         if (segment->has_self_compact_timestamp()) {
             BOOST_REQUIRE(
               !segment->index().may_have_transaction_control_batches());
             BOOST_REQUIRE(
-              !segment->index().may_have_transaction_data_batches());
+              !segment->index().may_have_transaction_data_or_fence_batches());
         }
     }
+}
+
+FIXTURE_TEST(segment_tx_flags_compaction_disabled, compaction_multinode_test) {
+    scoped_config cfg;
+    cfg.get("log_compaction_disable_tx_batch_removal").set_value(true);
+    cfg.get("log_compaction_merge_max_segments_per_range")
+      .set_value(std::make_optional<uint32_t>(0));
+    cfg.get("log_compaction_merge_max_ranges")
+      .set_value(std::make_optional<uint32_t>(0));
+
+    const model::topic topic{"tapioca"};
+    model::node_id id{0};
+    create_node_application(id);
+    auto* rp = instance(id);
+    wait_for_controller_leadership(id).get();
+
+    cluster::topic_properties props;
+    props.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+    rp->add_topic({model::kafka_namespace, topic}, 1, props).get();
+    model::partition_id pid{0};
+    auto ntp = model::ntp(model::kafka_namespace, topic, pid);
+    RPTEST_REQUIRE_EVENTUALLY(5s, [&] {
+        auto [_, prt] = get_leader(ntp);
+        return prt != nullptr;
+    });
+    auto [_, partition] = get_leader(ntp);
+    auto log = partition->log();
+    using cluster::tx_executor;
+    tx_executor exec;
+    auto make_ctx = [&](int64_t id, model::term_id term) {
+        model::producer_identity pid{id, 0};
+        return tx_executor::tx_op_ctx{
+          exec.data_gen(), partition->rm_stm(), log, pid, term};
+    };
+    // Produce transactional records.
+    tx_executor::sorted_tx_ops_t ops;
+    auto term = partition->raft()->term();
+
+    auto num_segments = 3;
+    int weight = 1;
+    ops.emplace(
+      ss::make_shared(tx_executor::begin_op(make_ctx(1, term), weight++)));
+    ops.emplace(
+      ss::make_shared(tx_executor::roll_op(make_ctx(1, term), weight++)));
+    ops.emplace(
+      ss::make_shared(tx_executor::data_op(make_ctx(1, term), weight++, 1)));
+    ops.emplace(
+      ss::make_shared(tx_executor::roll_op(make_ctx(1, term), weight++)));
+    ops.emplace(
+      ss::make_shared(tx_executor::commit_op(make_ctx(1, term), weight++)));
+
+    exec.execute(std::move(ops)).get();
+    partition->log()->flush().get();
+    partition->log()->force_roll().get();
+
+    // num_segments + 1 for active segment
+    BOOST_REQUIRE_EQUAL(log->segment_count(), num_segments + 1);
+    auto& segments = log->segments();
+
+    // Before compaction, segments should by default have these flags as `true`.
+    for (const auto& segment : segments) {
+        BOOST_REQUIRE(segment->index().may_have_transaction_control_batches());
+        BOOST_REQUIRE(
+          segment->index().may_have_transaction_data_or_fence_batches());
+    }
+
+    ss::abort_source as;
+    auto collect_offset = log->stm_manager()->max_removable_local_log_offset();
+    {
+        // Compact while `log_compaction_disable_tx_batch_removal` is `true`,
+        // preventing unsetting of transactional bits or removal of any control
+        // batches.
+        auto conf = storage::housekeeping_config::make_config(
+          model::timestamp::min(),
+          std::nullopt,
+          collect_offset,
+          collect_offset,
+          collect_offset,
+          std::nullopt,
+          std::nullopt,
+          std::chrono::milliseconds{0},
+          as);
+        log->housekeeping(conf).get();
+    }
+
+    BOOST_REQUIRE_EQUAL(segments.size(), num_segments + 1);
+
+    // First segment has a `tx_fence` batch.
+    BOOST_REQUIRE(
+      segments[0]->index().may_have_transaction_data_or_fence_batches());
+    BOOST_REQUIRE(segments[0]->index().may_have_transaction_control_batches());
+
+    // Second segment has a transactional raft batch.
+    BOOST_REQUIRE(
+      segments[1]->index().may_have_transaction_data_or_fence_batches());
+    BOOST_REQUIRE(!segments[1]->index().may_have_transaction_control_batches());
+
+    // Third segment has a control (commit) batch.
+    BOOST_REQUIRE(
+      !segments[2]->index().may_have_transaction_data_or_fence_batches());
+    BOOST_REQUIRE(segments[2]->index().may_have_transaction_control_batches());
+
+    {
+        cfg.get("log_compaction_disable_tx_batch_removal").set_value(false);
+        // Compact twice to remove transactional batches and unset bits.
+        auto conf = storage::housekeeping_config::make_config(
+          model::timestamp::min(),
+          std::nullopt,
+          collect_offset,
+          collect_offset,
+          collect_offset,
+          std::nullopt,
+          std::chrono::milliseconds{0},
+          std::chrono::milliseconds{0},
+          as);
+        log->housekeeping(conf).get();
+        log->housekeeping(conf).get();
+    }
+
+    BOOST_REQUIRE_EQUAL(segments.size(), num_segments + 1);
+
+    // All segments have a self compact timestamp, and no remaining
+    // transactional control batches or raft data/fence batches.
+    BOOST_REQUIRE(segments[0]->has_self_compact_timestamp());
+    BOOST_REQUIRE(!segments[0]->index().may_have_transaction_control_batches());
+    BOOST_REQUIRE(
+      !segments[0]->index().may_have_transaction_data_or_fence_batches());
+
+    BOOST_REQUIRE(segments[1]->has_self_compact_timestamp());
+    BOOST_REQUIRE(!segments[1]->index().may_have_transaction_control_batches());
+    BOOST_REQUIRE(
+      !segments[1]->index().may_have_transaction_data_or_fence_batches());
+
+    BOOST_REQUIRE(segments[2]->has_self_compact_timestamp());
+    BOOST_REQUIRE(!segments[2]->index().may_have_transaction_control_batches());
+    BOOST_REQUIRE(
+      !segments[2]->index().may_have_transaction_data_or_fence_batches());
 }

--- a/src/v/storage/tests/compaction_e2e_multinode_test.cc
+++ b/src/v/storage/tests/compaction_e2e_multinode_test.cc
@@ -305,7 +305,8 @@ FIXTURE_TEST(segment_tx_flags, compaction_multinode_test) {
     // Before compaction, segments should by default have these flags as `true`.
     for (const auto& segment : log->segments()) {
         BOOST_REQUIRE(segment->index().may_have_transaction_control_batches());
-        BOOST_REQUIRE(segment->index().may_have_transaction_data_batches());
+        BOOST_REQUIRE(
+          segment->index().may_have_transaction_data_or_fence_batches());
     }
 
     ss::abort_source as;
@@ -332,7 +333,7 @@ FIXTURE_TEST(segment_tx_flags, compaction_multinode_test) {
             BOOST_REQUIRE(
               segment->index().may_have_transaction_control_batches());
             BOOST_REQUIRE(
-              !segment->index().may_have_transaction_data_batches());
+              !segment->index().may_have_transaction_data_or_fence_batches());
         }
     }
 

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -2327,9 +2327,6 @@ TEST_F(CompactionFixtureTest, SuperfluousPlaceholderRemoval) {
 }
 
 TEST_F(CompactionFixtureTest, AbortTransactions) {
-    // TODO(tx_compact): Re-enable this when transactional control batch feature
-    // is added.
-    return;
     using cluster::tx_executor;
     tx_executor exec;
     auto term = partition->raft()->term();
@@ -2403,9 +2400,6 @@ TEST_F(CompactionFixtureTest, AbortTransactions) {
 }
 
 TEST_F(CompactionFixtureTest, CommitTransactions) {
-    // TODO(tx_compact): Re-enable this when transactional control batch feature
-    // is added.
-    return;
     using cluster::tx_executor;
     tx_executor exec;
     auto term = partition->raft()->term();

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -2328,6 +2328,8 @@ TEST_F(CompactionFixtureTest, SuperfluousPlaceholderRemoval) {
 }
 
 TEST_F(CompactionFixtureTest, AbortTransactions) {
+    test_local_cfg.get("log_compaction_tx_batch_removal_enabled")
+      .set_value(true);
     using cluster::tx_executor;
     tx_executor exec;
     auto term = partition->raft()->term();
@@ -2401,6 +2403,8 @@ TEST_F(CompactionFixtureTest, AbortTransactions) {
 }
 
 TEST_F(CompactionFixtureTest, CommitTransactions) {
+    test_local_cfg.get("log_compaction_tx_batch_removal_enabled")
+      .set_value(true);
     using cluster::tx_executor;
     tx_executor exec;
     auto term = partition->raft()->term();

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -257,6 +257,7 @@ public:
           std::chrono::milliseconds{0},
           nullptr,
           nullptr);
+        cfg.max_tx_remove_offset = max_collect_offset;
         auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
         // sliding_window_compact takes cfg by const&, so return will be a
         // use-after-free

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -36,6 +36,13 @@ model::offset stm_manager::max_removable_local_log_offset() {
     return result;
 }
 
+model::offset stm_manager::tx_snapshot_offset() const {
+    if (_tx_stm) {
+        return _tx_stm->last_locally_snapshotted_offset();
+    }
+    return model::offset::max();
+}
+
 std::optional<kafka::offset> stm_manager::lowest_pinned_data_offset() const {
     std::optional<kafka::offset> result;
     for (const auto& stm : _stms) {

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -481,6 +481,31 @@ struct housekeeping_config {
     compaction::compaction_config compact;
     gc_config gc;
 
+    static housekeeping_config make_config(
+      model::timestamp upper,
+      std::optional<size_t> max_bytes_in_log,
+      model::offset max_collect_offset,
+      model::offset max_tombstone_remove_offset,
+      std::optional<std::chrono::milliseconds> tombstone_retention_ms,
+      std::optional<std::chrono::milliseconds> tx_retention_ms,
+      std::chrono::milliseconds min_lag_ms,
+      ss::abort_source& as,
+      std::optional<ntp_sanitizer_config> san_cfg = std::nullopt,
+      compaction::hash_key_offset_map* key_map = nullptr) {
+        auto cfg = housekeeping_config(
+          upper,
+          max_bytes_in_log,
+          max_collect_offset,
+          max_tombstone_remove_offset,
+          tombstone_retention_ms,
+          tx_retention_ms,
+          min_lag_ms,
+          as,
+          san_cfg,
+          key_map);
+        return cfg;
+    }
+
     friend std::ostream& operator<<(std::ostream&, const housekeeping_config&);
 };
 

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -76,6 +76,8 @@ public:
     // equal to the high watermark.
     virtual std::optional<kafka::offset> lowest_pinned_data_offset() const = 0;
 
+    virtual model::offset last_locally_snapshotted_offset() const = 0;
+
     virtual model::offset last_applied() const = 0;
 
     virtual const ss::sstring& name() = 0;
@@ -181,6 +183,12 @@ public:
     const ss::shared_ptr<snapshotable_stm> transactional_stm() const {
         return _tx_stm;
     }
+
+    /**
+     * Returns the offset of the last snapshot taken by the transactional state
+     * machine. if no transactional stm is registered, returns max offset.
+     */
+    model::offset tx_snapshot_offset() const;
 
 private:
     ss::shared_ptr<snapshotable_stm> _tx_stm;

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -486,6 +486,7 @@ struct housekeeping_config {
       std::optional<size_t> max_bytes_in_log,
       model::offset max_collect_offset,
       model::offset max_tombstone_remove_offset,
+      model::offset max_tx_remove_offset,
       std::optional<std::chrono::milliseconds> tombstone_retention_ms,
       std::optional<std::chrono::milliseconds> tx_retention_ms,
       std::chrono::milliseconds min_lag_ms,
@@ -503,6 +504,7 @@ struct housekeeping_config {
           as,
           san_cfg,
           key_map);
+        cfg.compact.max_tx_remove_offset = max_tx_remove_offset;
         return cfg;
     }
 

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -29,6 +29,7 @@ from rptest.tests.partition_movement import PartitionMovementMixin
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.utils.mode_checks import skip_debug_mode
+from rptest.util import wait_until_result
 
 
 class LogCompactionTestBase(PartitionMovementMixin):
@@ -678,6 +679,9 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
             "log_compaction_interval_ms": 1000,
             "log_segment_size": 2 * 1024**2,  # 2 MiB
             "compacted_log_segment_size": 1024**2,  # 1 MiB
+            # Trigger tombstone removal quickly
+            "storage_target_replay_bytes": 100,
+            "log_segment_ms": 60,
         }
         self.transaction_timeout_ms = 2000
 
@@ -711,12 +715,14 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
         producer.wait(timeout_sec=180)
         producer.stop()
 
-    def check_tx_batches(self):
+    def all_tx_batches_removed(self):
         viewer = OfflineLogViewer(self.redpanda)
+        node_results = []
         for node in self.redpanda.nodes:
             num_control_batches = 0
             num_fence_batches = 0
             partitions = viewer.read_kafka_records(node, self.topic_spec.name)
+            partition_results = []
             for partition in partitions:
                 for record_or_batch in partition:
                     if "expanded_attrs" not in record_or_batch:
@@ -726,12 +732,104 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
                     if record_or_batch["type_name"] == "tx_fence":
                         num_fence_batches += 1
 
-                assert num_control_batches == 0, (
-                    f"expected 0 control batches (abort/commit batches), saw {num_control_batches} on node {node.name}"
+                partition_results.append((num_control_batches, num_fence_batches))
+            self.redpanda.logger.debug(
+                f"Node {node.name} compaction results {partition_results}"
+            )
+            node_results.append(
+                all(
+                    [
+                        num_control_batches == 0 and num_fence_batches == 0
+                        for num_control_batches, num_fence_batches in partition_results
+                    ]
                 )
-                assert num_fence_batches == 0, (
-                    f"expected 0 tx_fence batches, saw {num_fence_batches}  on node {node.name}"
+            )
+        return all(node_results)
+
+    def wait_until_stms_caught_up(self):
+        # grab the debug partition dump for each partition ensure
+        # committed index matches last applied offset
+        def stms_caught_up(partition_id: int):
+            state = self.redpanda._admin.get_partition_state(
+                namespace="kafka", topic=self.topic_spec.name, partition=partition_id
+            )
+            raft_states = [r["raft_state"] for r in state["replicas"]]
+            commit_indexes = []
+            commit_and_applied = []
+            for s in raft_states:
+                commit_index = s["commit_index"]
+                commit_indexes.append(commit_index)
+                last_applied = -1
+                for stm in s["stms"]:
+                    if stm["name"] == "tx.snapshot":
+                        last_applied = stm["last_applied_offset"]
+                commit_and_applied.append(commit_index == last_applied)
+            synced = all(commit_and_applied) and len(set(commit_indexes)) == 1
+            # Returns whether all STMs are caught up, and the commit index
+            # at which they are caught up.
+            return (synced, commit_indexes[0])
+
+        def all_partition_stms_caught_up():
+            stm_results = [
+                stms_caught_up(partition_id)
+                for partition_id in range(self.partition_count)
+            ]
+            synced, commit_indexes = map(list, zip(*stm_results))
+            return all(synced), commit_indexes
+
+        return wait_until_result(
+            all_partition_stms_caught_up,
+            timeout_sec=120,
+            backoff_sec=5,
+            err_msg="STMs did not catch up for all partitions.",
+            retry_on_exc=True,
+        )
+
+    def wait_for_local_snaphot_catchup(self, offsets: list[int]):
+        def stms_snaphotted(partition_id: int, target_offset: int):
+            state = self.redpanda._admin.get_partition_state(
+                namespace="kafka", topic=self.topic_spec.name, partition=partition_id
+            )
+            raft_states = [r["raft_state"] for r in state["replicas"]]
+            snapshotted = []
+            for s in raft_states:
+                for stm in s["stms"]:
+                    if stm["name"] == "tx.snapshot":
+                        last_snapshot = stm["last_local_snapshot_offset"]
+                        snapshotted.append(last_snapshot >= target_offset)
+            return all(snapshotted) and len(snapshotted) == len(raft_states)
+
+        def all_partition_stms_snaphotted():
+            return all(
+                [
+                    stms_snaphotted(partition_id, offsets[partition_id])
+                    for partition_id in range(self.partition_count)
+                ]
+            )
+
+        deadline = time.time() + 120
+        while True:
+            if time.time() > deadline:
+                raise TimeoutError(
+                    "Not all STMs have local snapshots at target offsets."
                 )
+            try:
+                if all_partition_stms_snaphotted():
+                    return
+                # Produce some garbage to force snapshots
+                KgoVerifierProducer.oneshot(
+                    context=self.test_context,
+                    redpanda=self.redpanda,
+                    topic=self.topic_spec.name,
+                    msg_size=1024,
+                    msg_count=10000,
+                    custom_node=self.preallocated_nodes,
+                )
+            except Exception as e:
+                self.redpanda.logger.warning(
+                    f"Exception while checking STM snapshots, retrying... {e}"
+                )
+            time.sleep(5)
 
     def do_test_tx_control_batch_removal(self, test_case_name, test_case):
         self.logger.info(
@@ -751,8 +849,19 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
 
         self.stop_partition_movement()
 
+        commit_idxs = self.wait_until_stms_caught_up()
+        self.logger.debug(
+            f"STMs caught up at commit indexes {commit_idxs}, waiting for local snapshots to catchup"
+        )
+        self.wait_for_local_snaphot_catchup(commit_idxs)
         # Check that no tx batches are seen after compaction settles
-        self.check_tx_batches()
+        self.redpanda.wait_until(
+            self.all_tx_batches_removed,
+            timeout_sec=240,
+            backoff_sec=5,
+            err_msg="Transactional batches were not removed after compaction.",
+            retry_on_exc=True,
+        )
 
 
 class LogCompactionTxRemovalTest(LogCompactionTxRemovalTestBase):

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -637,7 +637,149 @@ class LogCompactionEnableSlidingWindow(RedpandaTest):
             )
 
 
-class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
+class LogCompactionTxRemovalMixin:
+    def wait_for_all_tx_batches_removed(
+        self, produce_func, timeout_sec=240, backoff_sec=5
+    ):
+        assert self.redpanda, (
+            "Must set self.redpanda before calling wait_for_all_tx_batches_removed()"
+        )
+        assert self.topic_spec, (
+            "Must set self.topic_spec before calling wait_for_all_tx_batches_removed()"
+        )
+        assert self.partition_count, (
+            "Must set self.partition_count before calling wait_for_all_tx_batches_removed()"
+        )
+
+        commit_idxs = self.wait_until_stms_caught_up()
+        self.logger.debug(
+            f"STMs caught up at commit indexes {commit_idxs}, waiting for local snapshots to catchup"
+        )
+
+        self.wait_for_local_snapshot_catchup(commit_idxs, produce_func)
+
+        # Check that no tx batches are seen after compaction settles
+        self.redpanda.wait_until(
+            self.all_tx_batches_removed,
+            timeout_sec=timeout_sec,
+            backoff_sec=backoff_sec,
+            err_msg="Transactional batches were not removed after compaction.",
+            retry_on_exc=True,
+        )
+
+    def all_tx_batches_removed(self):
+        viewer = OfflineLogViewer(self.redpanda)
+        node_results = []
+        for node in self.redpanda.nodes:
+            num_control_batches = 0
+            num_fence_batches = 0
+            partitions = viewer.read_kafka_records(node, self.topic_spec.name)
+            partition_results = []
+            for partition in partitions:
+                for record_or_batch in partition:
+                    if "expanded_attrs" not in record_or_batch:
+                        continue
+                    if record_or_batch["expanded_attrs"]["control_batch"]:
+                        num_control_batches += 1
+                    if record_or_batch["type_name"] == "tx_fence":
+                        num_fence_batches += 1
+
+                partition_results.append((num_control_batches, num_fence_batches))
+            self.redpanda.logger.debug(
+                f"Node {node.name} compaction results {partition_results}"
+            )
+            node_results.append(
+                all(
+                    [
+                        num_control_batches == 0 and num_fence_batches == 0
+                        for num_control_batches, num_fence_batches in partition_results
+                    ]
+                )
+            )
+        return all(node_results)
+
+    def wait_until_stms_caught_up(self):
+        # grab the debug partition dump for each partition ensure
+        # committed index matches last applied offset
+        def stms_caught_up(partition_id: int):
+            state = self.redpanda._admin.get_partition_state(
+                namespace="kafka", topic=self.topic_spec.name, partition=partition_id
+            )
+            raft_states = [r["raft_state"] for r in state["replicas"]]
+            commit_indexes = []
+            commit_and_applied = []
+            for s in raft_states:
+                commit_index = s["commit_index"]
+                commit_indexes.append(commit_index)
+                last_applied = -1
+                for stm in s["stms"]:
+                    if stm["name"] == "tx.snapshot":
+                        last_applied = stm["last_applied_offset"]
+                commit_and_applied.append(commit_index == last_applied)
+            synced = all(commit_and_applied) and len(set(commit_indexes)) == 1
+            # Returns whether all STMs are caught up, and the commit index
+            # at which they are caught up.
+            return (synced, commit_indexes[0])
+
+        def all_partition_stms_caught_up():
+            stm_results = [
+                stms_caught_up(partition_id)
+                for partition_id in range(self.partition_count)
+            ]
+            synced, commit_indexes = map(list, zip(*stm_results))
+            return all(synced), commit_indexes
+
+        return wait_until_result(
+            all_partition_stms_caught_up,
+            timeout_sec=120,
+            backoff_sec=5,
+            err_msg="STMs did not catch up for all partitions.",
+            retry_on_exc=True,
+        )
+
+    def wait_for_local_snapshot_catchup(self, offsets: list[int], produce_func):
+        def stms_snapshotted(partition_id: int, target_offset: int):
+            state = self.redpanda._admin.get_partition_state(
+                namespace="kafka", topic=self.topic_spec.name, partition=partition_id
+            )
+            raft_states = [r["raft_state"] for r in state["replicas"]]
+            snapshotted = []
+            for s in raft_states:
+                for stm in s["stms"]:
+                    if stm["name"] == "tx.snapshot":
+                        last_snapshot = stm["last_local_snapshot_offset"]
+                        snapshotted.append(last_snapshot >= target_offset)
+            return all(snapshotted) and len(snapshotted) == len(raft_states)
+
+        def all_partition_stms_snapshotted():
+            return all(
+                [
+                    stms_snapshotted(partition_id, offsets[partition_id])
+                    for partition_id in range(self.partition_count)
+                ]
+            )
+
+        deadline = time.time() + 120
+        while True:
+            if time.time() > deadline:
+                raise TimeoutError(
+                    "Not all STMs have local snapshots at target offsets."
+                )
+            try:
+                if all_partition_stms_snapshotted():
+                    return
+                # Produce some garbage to force snapshots
+                produce_func()
+            except Exception as e:
+                self.redpanda.logger.warning(
+                    f"Exception while checking STM snapshots, retrying... {e}"
+                )
+            time.sleep(5)
+
+
+class LogCompactionTxRemovalTestBase(
+    LogCompactionTestBase, LogCompactionTxRemovalMixin, PreallocNodesTest
+):
     @dataclass
     class TestCase:
         msg_size: int
@@ -715,122 +857,6 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
         producer.wait(timeout_sec=180)
         producer.stop()
 
-    def all_tx_batches_removed(self):
-        viewer = OfflineLogViewer(self.redpanda)
-        node_results = []
-        for node in self.redpanda.nodes:
-            num_control_batches = 0
-            num_fence_batches = 0
-            partitions = viewer.read_kafka_records(node, self.topic_spec.name)
-            partition_results = []
-            for partition in partitions:
-                for record_or_batch in partition:
-                    if "expanded_attrs" not in record_or_batch:
-                        continue
-                    if record_or_batch["expanded_attrs"]["control_batch"]:
-                        num_control_batches += 1
-                    if record_or_batch["type_name"] == "tx_fence":
-                        num_fence_batches += 1
-
-                partition_results.append((num_control_batches, num_fence_batches))
-            self.redpanda.logger.debug(
-                f"Node {node.name} compaction results {partition_results}"
-            )
-            node_results.append(
-                all(
-                    [
-                        num_control_batches == 0 and num_fence_batches == 0
-                        for num_control_batches, num_fence_batches in partition_results
-                    ]
-                )
-            )
-        return all(node_results)
-
-    def wait_until_stms_caught_up(self):
-        # grab the debug partition dump for each partition ensure
-        # committed index matches last applied offset
-        def stms_caught_up(partition_id: int):
-            state = self.redpanda._admin.get_partition_state(
-                namespace="kafka", topic=self.topic_spec.name, partition=partition_id
-            )
-            raft_states = [r["raft_state"] for r in state["replicas"]]
-            commit_indexes = []
-            commit_and_applied = []
-            for s in raft_states:
-                commit_index = s["commit_index"]
-                commit_indexes.append(commit_index)
-                last_applied = -1
-                for stm in s["stms"]:
-                    if stm["name"] == "tx.snapshot":
-                        last_applied = stm["last_applied_offset"]
-                commit_and_applied.append(commit_index == last_applied)
-            synced = all(commit_and_applied) and len(set(commit_indexes)) == 1
-            # Returns whether all STMs are caught up, and the commit index
-            # at which they are caught up.
-            return (synced, commit_indexes[0])
-
-        def all_partition_stms_caught_up():
-            stm_results = [
-                stms_caught_up(partition_id)
-                for partition_id in range(self.partition_count)
-            ]
-            synced, commit_indexes = map(list, zip(*stm_results))
-            return all(synced), commit_indexes
-
-        return wait_until_result(
-            all_partition_stms_caught_up,
-            timeout_sec=120,
-            backoff_sec=5,
-            err_msg="STMs did not catch up for all partitions.",
-            retry_on_exc=True,
-        )
-
-    def wait_for_local_snapshot_catchup(self, offsets: list[int]):
-        def stms_snapshotted(partition_id: int, target_offset: int):
-            state = self.redpanda._admin.get_partition_state(
-                namespace="kafka", topic=self.topic_spec.name, partition=partition_id
-            )
-            raft_states = [r["raft_state"] for r in state["replicas"]]
-            snapshotted = []
-            for s in raft_states:
-                for stm in s["stms"]:
-                    if stm["name"] == "tx.snapshot":
-                        last_snapshot = stm["last_local_snapshot_offset"]
-                        snapshotted.append(last_snapshot >= target_offset)
-            return all(snapshotted) and len(snapshotted) == len(raft_states)
-
-        def all_partition_stms_snapshotted():
-            return all(
-                [
-                    stms_snapshotted(partition_id, offsets[partition_id])
-                    for partition_id in range(self.partition_count)
-                ]
-            )
-
-        deadline = time.time() + 120
-        while True:
-            if time.time() > deadline:
-                raise TimeoutError(
-                    "Not all STMs have local snapshots at target offsets."
-                )
-            try:
-                if all_partition_stms_snapshotted():
-                    return
-                # Produce some garbage to force snapshots
-                KgoVerifierProducer.oneshot(
-                    context=self.test_context,
-                    redpanda=self.redpanda,
-                    topic=self.topic_spec.name,
-                    msg_size=1024,
-                    msg_count=10000,
-                    custom_node=self.preallocated_nodes,
-                )
-            except Exception as e:
-                self.redpanda.logger.warning(
-                    f"Exception while checking STM snapshots, retrying... {e}"
-                )
-            time.sleep(5)
-
     def do_test_tx_control_batch_removal(self, test_case_name, test_case):
         self.logger.info(
             f"Running test case {test_case_name} with topic {self.topic_spec.name}"
@@ -849,19 +875,17 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
 
         self.stop_partition_movement()
 
-        commit_idxs = self.wait_until_stms_caught_up()
-        self.logger.debug(
-            f"STMs caught up at commit indexes {commit_idxs}, waiting for local snapshots to catchup"
-        )
-        self.wait_for_local_snapshot_catchup(commit_idxs)
-        # Check that no tx batches are seen after compaction settles
-        self.redpanda.wait_until(
-            self.all_tx_batches_removed,
-            timeout_sec=240,
-            backoff_sec=5,
-            err_msg="Transactional batches were not removed after compaction.",
-            retry_on_exc=True,
-        )
+        def produce_func():
+            KgoVerifierProducer.oneshot(
+                context=self.test_context,
+                redpanda=self.redpanda,
+                topic=self.topic_spec.name,
+                msg_size=1024,
+                msg_count=10000,
+                custom_node=self.preallocated_nodes,
+            )
+
+        self.wait_for_all_tx_batches_removed(produce_func)
 
 
 class LogCompactionTxRemovalTest(LogCompactionTxRemovalTestBase):

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -930,6 +930,16 @@ class LogCompactionTxRemovalUpgradeTest(LogCompactionTxRemovalTestBase):
         self.redpanda._installer.install(self.redpanda.nodes, version)
         self.redpanda.restart_nodes(self.redpanda.nodes)
 
+        wait_until(
+            self.redpanda.healthy,
+            timeout_sec=20,
+            backoff_sec=2,
+            err_msg="Cluster did not become healthy after restart/upgrade",
+        )
+        self.redpanda._admin.await_stable_leader(
+            namespace="redpanda", topic="controller", partition=0
+        )
+
     @cluster(num_nodes=4)
     @matrix(test_case_name=list(LogCompactionTxRemovalTestBase.test_cases.keys()))
     def test_tx_control_batch_removal_with_upgrade(self, test_case_name):

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -21,6 +21,9 @@ from rptest.services.kgo_verifier_services import (
     KgoVerifierProducer,
     KgoVerifierSeqConsumer,
 )
+from rptest.services.redpanda_installer import (
+    RedpandaVersionLine,
+)
 from rptest.services.redpanda import MetricsEndpoint
 from rptest.tests.partition_movement import PartitionMovementMixin
 from rptest.tests.prealloc_nodes import PreallocNodesTest
@@ -752,76 +755,74 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
         self.check_tx_batches()
 
 
-# TODO(tx_compact): Re-enable this when transactional control batch feature
-# is added.
-# class LogCompactionTxRemovalTest(LogCompactionTxRemovalTestBase):
-#    def __init__(self, test_context):
-#        super().__init__(test_context)
-#
-#    @cluster(num_nodes=4)
-#    def test_tx_control_batch_removal(self):
-#        failed_test_cases = []
-#        for name, test_case in LogCompactionTxRemovalTestBase.test_cases.items():
-#            self.topic_setup(
-#                cleanup_policy=TopicSpec.CLEANUP_COMPACT,
-#                replication_factor=3,
-#                key_set_cardinality=100,
-#                partition_count=1,
-#            )
-#
-#            try:
-#                self.do_test_tx_control_batch_removal(name, test_case)
-#            except Exception as e:
-#                self.logger.info(f"Test case {name} failed with exception {e}")
-#
-#                failed_test_cases.append(e)
-#        assert len(failed_test_cases) == 0, (
-#            f"Expected 0 failed test cases, got {len(failed_test_cases)}"
-#        )
-#
-#
-# class LogCompactionTxRemovalUpgradeTest(LogCompactionTxRemovalTestBase):
-#    def __init__(self, test_context):
-#        super().__init__(test_context)
-#        # Version before `may_have_transactional_batches` was added.
-#        self.initial_version: RedpandaVersionLine = (25, 1)
-#        # Version before tx removal was added to compaction.
-#        self.may_have_tx_batch_version: RedpandaVersionLine = (25, 2)
-#
-#    def setUp(self):
-#        self.redpanda._installer.install(self.redpanda.nodes, self.initial_version)
-#        self.redpanda.start()
-#
-#    def upgrade_to_version(self, version):
-#        self.redpanda._installer.install(self.redpanda.nodes, version)
-#        self.redpanda.restart_nodes(self.redpanda.nodes)
-#
-#    @cluster(num_nodes=4)
-#    @matrix(test_case_name=list(LogCompactionTxRemovalTestBase.test_cases.keys()))
-#    def test_tx_control_batch_removal_with_upgrade(self, test_case_name):
-#        test_case = LogCompactionTxRemovalTestBase.test_cases[test_case_name]
-#
-#        self.topic_setup(
-#            cleanup_policy=TopicSpec.CLEANUP_COMPACT,
-#            replication_factor=3,
-#            key_set_cardinality=100,
-#            partition_count=1,
-#        )
-#
-#        # Produce some transactional data
-#        self.produce(test_case)
-#
-#        # Upgrade to `may_have_transactional_batch` version.
-#        self.upgrade_to_version(self.may_have_tx_batch_version)
-#
-#        # Produce more transactional data.
-#        self.produce(test_case)
-#
-#        # Upgrade to `HEAD`.
-#        for version in self.redpanda._installer.upgrade_path_to_head(
-#            self.may_have_tx_batch_version
-#        ):
-#            self.upgrade_to_version(version)
-#
-#        # Perform rest of test
-#        self.do_test_tx_control_batch_removal(test_case_name, test_case)
+class LogCompactionTxRemovalTest(LogCompactionTxRemovalTestBase):
+    def __init__(self, test_context):
+        super().__init__(test_context)
+
+    @cluster(num_nodes=4)
+    def test_tx_control_batch_removal(self):
+        failed_test_cases = []
+        for name, test_case in LogCompactionTxRemovalTestBase.test_cases.items():
+            self.topic_setup(
+                cleanup_policy=TopicSpec.CLEANUP_COMPACT,
+                replication_factor=3,
+                key_set_cardinality=100,
+                partition_count=1,
+            )
+
+            try:
+                self.do_test_tx_control_batch_removal(name, test_case)
+            except Exception as e:
+                self.logger.info(f"Test case {name} failed with exception {e}")
+
+                failed_test_cases.append(e)
+        assert len(failed_test_cases) == 0, (
+            f"Expected 0 failed test cases, got {len(failed_test_cases)}"
+        )
+
+
+class LogCompactionTxRemovalUpgradeTest(LogCompactionTxRemovalTestBase):
+    def __init__(self, test_context):
+        super().__init__(test_context)
+        # Version before `may_have_transactional_batches` was added.
+        self.initial_version: RedpandaVersionLine = (25, 1)
+        # Version before tx removal was added to compaction.
+        self.may_have_tx_batch_version: RedpandaVersionLine = (25, 2)
+
+    def setUp(self):
+        self.redpanda._installer.install(self.redpanda.nodes, self.initial_version)
+        self.redpanda.start()
+
+    def upgrade_to_version(self, version):
+        self.redpanda._installer.install(self.redpanda.nodes, version)
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+
+    @cluster(num_nodes=4)
+    @matrix(test_case_name=list(LogCompactionTxRemovalTestBase.test_cases.keys()))
+    def test_tx_control_batch_removal_with_upgrade(self, test_case_name):
+        test_case = LogCompactionTxRemovalTestBase.test_cases[test_case_name]
+
+        self.topic_setup(
+            cleanup_policy=TopicSpec.CLEANUP_COMPACT,
+            replication_factor=3,
+            key_set_cardinality=100,
+            partition_count=1,
+        )
+
+        # Produce some transactional data
+        self.produce(test_case)
+
+        # Upgrade to `may_have_transactional_batch` version.
+        self.upgrade_to_version(self.may_have_tx_batch_version)
+
+        # Produce more transactional data.
+        self.produce(test_case)
+
+        # Upgrade to `HEAD`.
+        for version in self.redpanda._installer.upgrade_path_to_head(
+            self.may_have_tx_batch_version
+        ):
+            self.upgrade_to_version(version)
+
+        # Perform rest of test
+        self.do_test_tx_control_batch_removal(test_case_name, test_case)

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -814,9 +814,10 @@ class LogCompactionTxRemovalTestBase(
         ),
     }
 
-    def __init__(self, test_context):
+    def __init__(self, test_context, extra_rp_conf=None):
         self.test_context = test_context
         # Run with small segments and a very frequent compaction interval.
+
         self.extra_rp_conf = {
             "log_compaction_interval_ms": 1000,
             "log_segment_size": 2 * 1024**2,  # 2 MiB
@@ -825,6 +826,8 @@ class LogCompactionTxRemovalTestBase(
             "storage_target_replay_bytes": 100,
             "log_segment_ms": 60,
         }
+        if extra_rp_conf:
+            self.extra_rp_conf.update(extra_rp_conf)
         self.transaction_timeout_ms = 2000
 
         super().__init__(
@@ -890,7 +893,8 @@ class LogCompactionTxRemovalTestBase(
 
 class LogCompactionTxRemovalTest(LogCompactionTxRemovalTestBase):
     def __init__(self, test_context):
-        super().__init__(test_context)
+        extra_rp_conf = {"log_compaction_tx_batch_removal_enabled": True}
+        super().__init__(test_context, extra_rp_conf=extra_rp_conf)
 
     @cluster(num_nodes=4)
     def test_tx_control_batch_removal(self):
@@ -966,6 +970,11 @@ class LogCompactionTxRemovalUpgradeTest(LogCompactionTxRemovalTestBase):
             self.may_have_tx_batch_version
         ):
             self.upgrade_to_version(version)
+
+        # Once we have upgraded to the newest version, enable tx batch removal.
+        self.redpanda.set_cluster_config(
+            {"log_compaction_tx_batch_removal_enabled": True}
+        )
 
         # Perform rest of test
         self.do_test_tx_control_batch_removal(test_case_name, test_case)

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -785,8 +785,8 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
             retry_on_exc=True,
         )
 
-    def wait_for_local_snaphot_catchup(self, offsets: list[int]):
-        def stms_snaphotted(partition_id: int, target_offset: int):
+    def wait_for_local_snapshot_catchup(self, offsets: list[int]):
+        def stms_snapshotted(partition_id: int, target_offset: int):
             state = self.redpanda._admin.get_partition_state(
                 namespace="kafka", topic=self.topic_spec.name, partition=partition_id
             )
@@ -799,10 +799,10 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
                         snapshotted.append(last_snapshot >= target_offset)
             return all(snapshotted) and len(snapshotted) == len(raft_states)
 
-        def all_partition_stms_snaphotted():
+        def all_partition_stms_snapshotted():
             return all(
                 [
-                    stms_snaphotted(partition_id, offsets[partition_id])
+                    stms_snapshotted(partition_id, offsets[partition_id])
                     for partition_id in range(self.partition_count)
                 ]
             )
@@ -814,7 +814,7 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
                     "Not all STMs have local snapshots at target offsets."
                 )
             try:
-                if all_partition_stms_snaphotted():
+                if all_partition_stms_snapshotted():
                     return
                 # Produce some garbage to force snapshots
                 KgoVerifierProducer.oneshot(
@@ -853,7 +853,7 @@ class LogCompactionTxRemovalTestBase(LogCompactionTestBase, PreallocNodesTest):
         self.logger.debug(
             f"STMs caught up at commit indexes {commit_idxs}, waiting for local snapshots to catchup"
         )
-        self.wait_for_local_snaphot_catchup(commit_idxs)
+        self.wait_for_local_snapshot_catchup(commit_idxs)
         # Check that no tx batches are seen after compaction settles
         self.redpanda.wait_until(
             self.all_tx_batches_removed,

--- a/tests/rptest/transactions/tx_upgrade_test.py
+++ b/tests/rptest/transactions/tx_upgrade_test.py
@@ -18,7 +18,6 @@ import confluent_kafka as ck
 from ducktape.errors import TimeoutError
 from ducktape.utils.util import wait_until
 
-from rptest.clients.offline_log_viewer import OfflineLogViewer
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
@@ -37,6 +36,7 @@ from rptest.services.redpanda_installer import (
 )
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.utils.mode_checks import skip_debug_mode
+from rptest.tests.log_compaction_test import LogCompactionTxRemovalMixin
 
 
 class TxUpgradeTestBase(RedpandaTest):
@@ -149,7 +149,7 @@ class TxUpgradeTest(TxUpgradeTestBase):
         )
 
 
-class TxUpgradeCompactionTest(TxUpgradeTestBase):
+class TxUpgradeCompactionTest(TxUpgradeTestBase, LogCompactionTxRemovalMixin):
     """
     Test validating interaction between compaction and transactions during rolling-restart upgrades (including mixed-version node cluster interaction)
     """
@@ -159,6 +159,9 @@ class TxUpgradeCompactionTest(TxUpgradeTestBase):
             "log_compaction_interval_ms": 4000,
             "log_segment_size": 2 * 1024**2,  # 2 MiB
             "compacted_log_segment_size": 1024**2,  # 1 MiB
+            # Trigger tombstone removal quickly
+            "storage_target_replay_bytes": 100,
+            "log_segment_ms": 60,
         }
 
         super(TxUpgradeCompactionTest, self).__init__(
@@ -197,28 +200,6 @@ class TxUpgradeCompactionTest(TxUpgradeTestBase):
             backoff_sec=self.extra_rp_conf["log_compaction_interval_ms"] / 1000 * 4,
             err_msg="Compaction did not stabilize.",
         )
-
-    def check_tx_batches(self):
-        viewer = OfflineLogViewer(self.redpanda)
-        for node in self.redpanda.nodes:
-            num_control_batches = 0
-            num_fence_batches = 0
-            partitions = viewer.read_kafka_records(node, self.topic_spec.name)
-            for partition in partitions:
-                for record_or_batch in partition:
-                    if "expanded_attrs" not in record_or_batch:
-                        continue
-                    if record_or_batch["expanded_attrs"]["control_batch"]:
-                        num_control_batches += 1
-                    if record_or_batch["type_name"] == "tx_fence":
-                        num_fence_batches += 1
-
-            assert num_control_batches == 0, (
-                f"expected 0 control batches (abort/commit batches), saw {num_control_batches} on node {node.name}"
-            )
-            assert num_fence_batches == 0, (
-                f"expected 0 tx_fence batches, saw {num_fence_batches}  on node {node.name}"
-            )
 
     @skip_debug_mode
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
@@ -272,7 +253,22 @@ class TxUpgradeCompactionTest(TxUpgradeTestBase):
         self.redpanda.restart_nodes(self.redpanda.nodes)
 
         self.wait_for_sliding_window_compaction()
-        self.check_tx_batches()
+
+        def produce_func():
+            producer = ck.Producer({"bootstrap.servers": self.redpanda.brokers()})
+
+            def random_string(n=5):
+                return "".join(random.choice(string.ascii_letters) for _ in range(n))
+
+            for i in range(0, 10000):
+                producer.produce(
+                    topic=self.topic_spec.name,
+                    key=random_string(),
+                    value=random_string(1024),
+                )
+            producer.flush()
+
+        self.wait_for_all_tx_batches_removed(produce_func)
 
 
 class TxUpgradeRevertTest(RedpandaTest):

--- a/tests/rptest/transactions/tx_upgrade_test.py
+++ b/tests/rptest/transactions/tx_upgrade_test.py
@@ -12,7 +12,7 @@ import random
 import string
 from enum import Enum
 from threading import Lock, Semaphore, Thread
-from time import sleep
+from time import sleep, time
 
 import confluent_kafka as ck
 from ducktape.errors import TimeoutError
@@ -85,6 +85,22 @@ class TxUpgradeTestBase(RedpandaTest):
                 )
             producer.commit_transaction()
             producer.flush()
+
+    def _produce_with_transactions(self, topic, retries=10, timeout_sec=300):
+        deadline = time() + timeout_sec
+        while retries > 0 and time() < deadline:
+            retries -= 1
+            try:
+                self._populate_tx_coordinator(topic)
+                break
+            except Exception as e:
+                self.logger.debug(
+                    f"Caught exception {e} while trying to produce to topic {topic}. {retries} retries left."
+                )
+                pass
+            sleep(1)
+        else:
+            assert False, f"Failed to produce to topic {topic}"
 
     def _get_tx_id_mapping(self):
         mapping = {}
@@ -217,7 +233,7 @@ class TxUpgradeCompactionTest(TxUpgradeTestBase, LogCompactionTxRemovalMixin):
         assert prev_version_str in unique_versions, unique_versions
 
         for new_version in self.installer.upgrade_path_to_head(self.initial_version):
-            self._populate_tx_coordinator(topic=self.topic_spec.name)
+            self._produce_with_transactions(topic=self.topic_spec.name)
             initial_mapping = self._get_tx_id_mapping()
             self.logger.info(f"Initial mapping {initial_mapping}")
 
@@ -234,7 +250,7 @@ class TxUpgradeCompactionTest(TxUpgradeTestBase, LogCompactionTxRemovalMixin):
             )
 
             # verify if txs are handled correctly with mixed versions
-            self._populate_tx_coordinator(topic=self.topic_spec.name)
+            self._produce_with_transactions(topic=self.topic_spec.name)
 
             # Only once we upgrade the rest of the nodes do we converge on the new
             # version.
@@ -247,7 +263,7 @@ class TxUpgradeCompactionTest(TxUpgradeTestBase, LogCompactionTxRemovalMixin):
             prev_version_str = ver_string(new_version)
 
         # One last round of producing
-        self._populate_tx_coordinator(topic=self.topic_spec.name)
+        self._produce_with_transactions(topic=self.topic_spec.name)
 
         # Restart the redpanda broker to roll segments
         self.redpanda.restart_nodes(self.redpanda.nodes)

--- a/tests/rptest/transactions/tx_upgrade_test.py
+++ b/tests/rptest/transactions/tx_upgrade_test.py
@@ -262,6 +262,11 @@ class TxUpgradeCompactionTest(TxUpgradeTestBase, LogCompactionTxRemovalMixin):
             )
             prev_version_str = ver_string(new_version)
 
+        # Once we have upgraded to the newest version, enable tx batch removal.
+        self.redpanda.set_cluster_config(
+            {"log_compaction_tx_batch_removal_enabled": True}
+        )
+
         # One last round of producing
         self._produce_with_transactions(topic=self.topic_spec.name)
 

--- a/tests/rptest/transactions/tx_upgrade_test.py
+++ b/tests/rptest/transactions/tx_upgrade_test.py
@@ -18,6 +18,7 @@ import confluent_kafka as ck
 from ducktape.errors import TimeoutError
 from ducktape.utils.util import wait_until
 
+from rptest.clients.offline_log_viewer import OfflineLogViewer
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
@@ -25,9 +26,12 @@ from rptest.services.cluster import cluster
 from rptest.services.redpanda import (
     RESTART_LOG_ALLOW_LIST,
     RedpandaService,
+    MetricsEndpoint,
 )
 from rptest.services.redpanda_installer import (
     RedpandaInstaller,
+    RedpandaVersionLine,
+    RedpandaVersionTriple,
     wait_for_num_versions,
     ver_string,
 )
@@ -145,132 +149,130 @@ class TxUpgradeTest(TxUpgradeTestBase):
         )
 
 
-# TODO(tx_compact): Re-enable this when transactional control batch feature
-# is added.
-# class TxUpgradeCompactionTest(TxUpgradeTestBase):
-#    """
-#    Test validating interaction between compaction and transactions during rolling-restart upgrades (including mixed-version node cluster interaction)
-#    """
-#
-#    def __init__(self, test_context):
-#        self.extra_rp_conf = {
-#            "log_compaction_interval_ms": 4000,
-#            "log_segment_size": 2 * 1024**2,  # 2 MiB
-#            "compacted_log_segment_size": 1024**2,  # 1 MiB
-#        }
-#
-#        super(TxUpgradeCompactionTest, self).__init__(
-#            test_context=test_context, extra_rp_conf=self.extra_rp_conf
-#        )
-#
-#        self.transaction_timeout_ms = 2000
-#
-#    def setUp(self):
-#        # Version before `may_have_transactional_batches` was added.
-#        self.initial_version: RedpandaVersionTriple = self.installer.latest_for_line(
-#            RedpandaVersionLine((25, 1))
-#        )[0]
-#        self.installer.install(self.redpanda.nodes, self.initial_version)
-#        super(TxUpgradeCompactionTest, self).setUp()
-#
-#    def get_complete_sliding_window_rounds(self):
-#        return self.redpanda.metric_sum(
-#            metric_name="vectorized_storage_log_complete_sliding_window_rounds_total",
-#            metrics_endpoint=MetricsEndpoint.METRICS,
-#            topic=self.topic_spec.name,
-#        )
-#
-#    def wait_for_sliding_window_compaction(self):
-#        self.prev_sliding_window_rounds = None
-#
-#        def compaction_has_completed():
-#            new_sliding_window_rounds = self.get_complete_sliding_window_rounds()
-#            res = self.prev_sliding_window_rounds == new_sliding_window_rounds
-#            self.prev_sliding_window_rounds = new_sliding_window_rounds
-#            return res
-#
-#        wait_until(
-#            compaction_has_completed,
-#            timeout_sec=120,
-#            backoff_sec=self.extra_rp_conf["log_compaction_interval_ms"] / 1000 * 4,
-#            err_msg="Compaction did not stabilize.",
-#        )
-#
-#    def check_tx_batches(self):
-#        viewer = OfflineLogViewer(self.redpanda)
-#        for node in self.redpanda.nodes:
-#            num_control_batches = 0
-#            num_fence_batches = 0
-#            partitions = viewer.read_kafka_records(node, self.topic_spec.name)
-#            for partition in partitions:
-#                for record_or_batch in partition:
-#                    if "expanded_attrs" not in record_or_batch:
-#                        continue
-#                    if record_or_batch["expanded_attrs"]["control_batch"]:
-#                        num_control_batches += 1
-#                    if record_or_batch["type_name"] == "tx_fence":
-#                        num_fence_batches += 1
-#
-#            assert num_control_batches == 0, (
-#                f"expected 0 control batches (abort/commit batches), saw {num_control_batches} on node {node.name}"
-#            )
-#            assert num_fence_batches == 0, (
-#                f"expected 0 tx_fence batches, saw {num_fence_batches}  on node {node.name}"
-#            )
-#
-#    @skip_debug_mode
-#    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
-#    def upgrade_with_compaction_test(self):
-#        self.topic_spec = TopicSpec(
-#            partition_count=self.partition_count,
-#            delete_retention_ms=3000,
-#            cleanup_policy=TopicSpec.CLEANUP_COMPACT,
-#            min_cleanable_dirty_ratio=0.0,
-#        )
-#        self.client().create_topic(self.topic_spec)
-#
-#        prev_version_str = ver_string(self.initial_version)
-#        unique_versions = wait_for_num_versions(self.redpanda, 1)
-#        assert prev_version_str in unique_versions, unique_versions
-#
-#        for new_version in self.installer.upgrade_path_to_head(self.initial_version):
-#            self._populate_tx_coordinator(topic=self.topic_spec.name)
-#            initial_mapping = self._get_tx_id_mapping()
-#            self.logger.info(f"Initial mapping {initial_mapping}")
-#
-#            first_node = self.redpanda.nodes[0]
-#
-#            self.installer.install(self.redpanda.nodes, new_version)
-#
-#            # Upgrade & restart one node to the new version.
-#            self.redpanda.restart_nodes([first_node])
-#            unique_versions = wait_for_num_versions(self.redpanda, 2)
-#            assert prev_version_str in unique_versions, unique_versions
-#            assert self._get_tx_id_mapping() == initial_mapping, (
-#                "Mapping changed after upgrading one of the nodes"
-#            )
-#
-#            # verify if txs are handled correctly with mixed versions
-#            self._populate_tx_coordinator(topic=self.topic_spec.name)
-#
-#            # Only once we upgrade the rest of the nodes do we converge on the new
-#            # version.
-#            self.redpanda.restart_nodes(self.redpanda.nodes)
-#            unique_versions = wait_for_num_versions(self.redpanda, 1)
-#            assert prev_version_str not in unique_versions, unique_versions
-#            assert self._get_tx_id_mapping() == initial_mapping, (
-#                "Mapping changed after full upgrade"
-#            )
-#            prev_version_str = ver_string(new_version)
-#
-#        # One last round of producing
-#        self._populate_tx_coordinator(topic=self.topic_spec.name)
-#
-#        # Restart the redpanda broker to roll segments
-#        self.redpanda.restart_nodes(self.redpanda.nodes)
-#
-#        self.wait_for_sliding_window_compaction()
-#        self.check_tx_batches()
+class TxUpgradeCompactionTest(TxUpgradeTestBase):
+    """
+    Test validating interaction between compaction and transactions during rolling-restart upgrades (including mixed-version node cluster interaction)
+    """
+
+    def __init__(self, test_context):
+        self.extra_rp_conf = {
+            "log_compaction_interval_ms": 4000,
+            "log_segment_size": 2 * 1024**2,  # 2 MiB
+            "compacted_log_segment_size": 1024**2,  # 1 MiB
+        }
+
+        super(TxUpgradeCompactionTest, self).__init__(
+            test_context=test_context, extra_rp_conf=self.extra_rp_conf
+        )
+
+        self.transaction_timeout_ms = 2000
+
+    def setUp(self):
+        # Version before `may_have_transactional_batches` was added.
+        self.initial_version: RedpandaVersionTriple = self.installer.latest_for_line(
+            RedpandaVersionLine((25, 1))
+        )[0]
+        self.installer.install(self.redpanda.nodes, self.initial_version)
+        super(TxUpgradeCompactionTest, self).setUp()
+
+    def get_complete_sliding_window_rounds(self):
+        return self.redpanda.metric_sum(
+            metric_name="vectorized_storage_log_complete_sliding_window_rounds_total",
+            metrics_endpoint=MetricsEndpoint.METRICS,
+            topic=self.topic_spec.name,
+        )
+
+    def wait_for_sliding_window_compaction(self):
+        self.prev_sliding_window_rounds = None
+
+        def compaction_has_completed():
+            new_sliding_window_rounds = self.get_complete_sliding_window_rounds()
+            res = self.prev_sliding_window_rounds == new_sliding_window_rounds
+            self.prev_sliding_window_rounds = new_sliding_window_rounds
+            return res
+
+        wait_until(
+            compaction_has_completed,
+            timeout_sec=120,
+            backoff_sec=self.extra_rp_conf["log_compaction_interval_ms"] / 1000 * 4,
+            err_msg="Compaction did not stabilize.",
+        )
+
+    def check_tx_batches(self):
+        viewer = OfflineLogViewer(self.redpanda)
+        for node in self.redpanda.nodes:
+            num_control_batches = 0
+            num_fence_batches = 0
+            partitions = viewer.read_kafka_records(node, self.topic_spec.name)
+            for partition in partitions:
+                for record_or_batch in partition:
+                    if "expanded_attrs" not in record_or_batch:
+                        continue
+                    if record_or_batch["expanded_attrs"]["control_batch"]:
+                        num_control_batches += 1
+                    if record_or_batch["type_name"] == "tx_fence":
+                        num_fence_batches += 1
+
+            assert num_control_batches == 0, (
+                f"expected 0 control batches (abort/commit batches), saw {num_control_batches} on node {node.name}"
+            )
+            assert num_fence_batches == 0, (
+                f"expected 0 tx_fence batches, saw {num_fence_batches}  on node {node.name}"
+            )
+
+    @skip_debug_mode
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def upgrade_with_compaction_test(self):
+        self.topic_spec = TopicSpec(
+            partition_count=self.partition_count,
+            delete_retention_ms=3000,
+            cleanup_policy=TopicSpec.CLEANUP_COMPACT,
+            min_cleanable_dirty_ratio=0.0,
+        )
+        self.client().create_topic(self.topic_spec)
+
+        prev_version_str = ver_string(self.initial_version)
+        unique_versions = wait_for_num_versions(self.redpanda, 1)
+        assert prev_version_str in unique_versions, unique_versions
+
+        for new_version in self.installer.upgrade_path_to_head(self.initial_version):
+            self._populate_tx_coordinator(topic=self.topic_spec.name)
+            initial_mapping = self._get_tx_id_mapping()
+            self.logger.info(f"Initial mapping {initial_mapping}")
+
+            first_node = self.redpanda.nodes[0]
+
+            self.installer.install(self.redpanda.nodes, new_version)
+
+            # Upgrade & restart one node to the new version.
+            self.redpanda.restart_nodes([first_node])
+            unique_versions = wait_for_num_versions(self.redpanda, 2)
+            assert prev_version_str in unique_versions, unique_versions
+            assert self._get_tx_id_mapping() == initial_mapping, (
+                "Mapping changed after upgrading one of the nodes"
+            )
+
+            # verify if txs are handled correctly with mixed versions
+            self._populate_tx_coordinator(topic=self.topic_spec.name)
+
+            # Only once we upgrade the rest of the nodes do we converge on the new
+            # version.
+            self.redpanda.restart_nodes(self.redpanda.nodes)
+            unique_versions = wait_for_num_versions(self.redpanda, 1)
+            assert prev_version_str not in unique_versions, unique_versions
+            assert self._get_tx_id_mapping() == initial_mapping, (
+                "Mapping changed after full upgrade"
+            )
+            prev_version_str = ver_string(new_version)
+
+        # One last round of producing
+        self._populate_tx_coordinator(topic=self.topic_spec.name)
+
+        # Restart the redpanda broker to roll segments
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        self.wait_for_sliding_window_compaction()
+        self.check_tx_batches()
 
 
 class TxUpgradeRevertTest(RedpandaTest):


### PR DESCRIPTION
## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Features

* Enable compaction of transactional control batches per `delete.retention.ms`. This feature cannot be enabled at the same time as any tiered storage topic properties (i.e this feature is only accessible for local topics).