### PR TITLE
cloud_storage_clients: parse bucket DSN parameters

### DIFF
--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -14,6 +14,7 @@
 #include "cloud_io/logger.h"
 #include "cloud_io/provider.h"
 #include "cloud_io/transfer_details.h"
+#include "cloud_storage_clients/bucket_name_parts.h"
 #include "cloud_storage_clients/client_pool.h"
 #include "cloud_storage_clients/configuration.h"
 #include "cloud_storage_clients/types.h"
@@ -184,6 +185,15 @@ ss::future<upload_result> remote::upload_stream(
   std::optional<size_t> max_retries) {
     const auto& path = transfer_details.key;
     const auto& bucket = transfer_details.bucket;
+    const auto bucket_parts = cloud_storage_clients::parse_bucket_name(bucket);
+    if (!bucket_parts) {
+        vlog(
+          log.warn,
+          "Failed to parse bucket name {}: {}",
+          bucket,
+          bucket_parts.error());
+        co_return upload_result::failed;
+    }
     auto guard = _gate.hold();
     retry_chain_node fib(&transfer_details.parent_rtc);
     retry_chain_logger ctxlog(log, fib);
@@ -202,7 +212,7 @@ ss::future<upload_result> remote::upload_stream(
         }
         auto fut = co_await ss::coroutine::as_future(
           _pool.local().acquire_with_timeout(
-            fib.root_abort_source(), _lease_timeout(), fib()));
+            *bucket_parts, fib.root_abort_source(), _lease_timeout(), fib()));
         if (fut.failed()) {
             co_return throw_if_not_timeout(
               fut.get_exception(), upload_result::timedout);
@@ -226,7 +236,7 @@ ss::future<upload_result> remote::upload_stream(
         auto reader_handle = co_await reset_str();
         // Segment upload attempt
         auto res = co_await lease.client->put_object(
-          bucket,
+          bucket_parts->name,
           path,
           content_length,
           reader_handle->take_stream(),
@@ -306,15 +316,24 @@ ss::future<download_result> remote::download_stream(
   std::function<void(size_t)> throttle_metric_ms_cb) {
     const auto& path = transfer_details.key;
     const auto& bucket = transfer_details.bucket;
+    const auto bucket_parts = cloud_storage_clients::parse_bucket_name(bucket);
+    if (!bucket_parts) {
+        vlog(
+          log.warn,
+          "Failed to parse bucket name {}: {}",
+          bucket,
+          bucket_parts.error());
+        co_return download_result::failed;
+    }
 
     auto guard = _gate.hold();
     retry_chain_node fib(&transfer_details.parent_rtc);
     retry_chain_logger ctxlog(log, fib);
 
-    auto fut = co_await [this, &fib, &transfer_details] {
+    auto fut = co_await [this, &fib, &transfer_details, &bucket_parts] {
         transfer_details.on_client_acquire();
         return ss::coroutine::as_future(_pool.local().acquire_with_timeout(
-          fib.root_abort_source(), _lease_timeout(), fib()));
+          *bucket_parts, fib.root_abort_source(), _lease_timeout(), fib()));
     }();
     if (fut.failed()) {
         co_return throw_if_not_timeout(
@@ -331,7 +350,7 @@ ss::future<download_result> remote::download_stream(
         auto download_latency_measure
           = transfer_details.scoped_latency_measurement();
         auto resp = co_await lease.client->get_object(
-          bucket, path, fib.get_timeout(), false, byte_range);
+          bucket_parts->name, path, fib.get_timeout(), false, byte_range);
 
         if (resp) {
             vlog(ctxlog.debug, "Receive OK response from {}", path);
@@ -436,11 +455,20 @@ remote::download_object(download_request download_request) {
 
     const auto path = transfer_details.key;
     const auto bucket = transfer_details.bucket;
+    const auto bucket_parts = cloud_storage_clients::parse_bucket_name(bucket);
+    if (!bucket_parts) {
+        vlog(
+          log.warn,
+          "Failed to parse bucket name {}: {}",
+          bucket,
+          bucket_parts.error());
+        co_return download_result::failed;
+    }
     const auto object_type = download_request.display_str;
 
     auto fut = co_await ss::coroutine::as_future(
       _pool.local().acquire_with_timeout(
-        fib.root_abort_source(), _lease_timeout(), fib()));
+        *bucket_parts, fib.root_abort_source(), _lease_timeout(), fib()));
     if (fut.failed()) {
         co_return throw_if_not_timeout(
           fut.get_exception(), download_result::timedout);
@@ -454,7 +482,10 @@ remote::download_object(download_request download_request) {
     while (!_gate.is_closed() && permit.is_allowed && !result) {
         download_request.transfer_details.on_request(fib.retry_count());
         auto resp = co_await lease.client->get_object(
-          bucket, path, fib.get_timeout(), download_request.expect_missing);
+          bucket_parts->name,
+          path,
+          fib.get_timeout(),
+          download_request.expect_missing);
 
         if (resp) {
             vlog(ctxlog.debug, "Receive OK response from {}", path);
@@ -527,12 +558,22 @@ ss::future<download_result> remote::object_exists(
   const cloud_storage_clients::object_key& path,
   retry_chain_node& parent,
   std::string_view object_type) {
+    const auto bucket_parts = cloud_storage_clients::parse_bucket_name(bucket);
+    if (!bucket_parts) {
+        vlog(
+          log.warn,
+          "Failed to parse bucket name {}: {}",
+          bucket,
+          bucket_parts.error());
+        co_return download_result::failed;
+    }
+
     ss::gate::holder gh{_gate};
     retry_chain_node fib(&parent);
     retry_chain_logger ctxlog(log, fib);
     auto fut = co_await ss::coroutine::as_future(
       _pool.local().acquire_with_timeout(
-        fib.root_abort_source(), _lease_timeout(), fib()));
+        *bucket_parts, fib.root_abort_source(), _lease_timeout(), fib()));
     if (fut.failed()) {
         co_return throw_if_not_timeout(
           fut.get_exception(), download_result::timedout);
@@ -543,7 +584,7 @@ ss::future<download_result> remote::object_exists(
     std::optional<download_result> result;
     while (!_gate.is_closed() && permit.is_allowed && !result) {
         auto resp = co_await lease.client->head_object(
-          bucket, path, fib.get_timeout());
+          bucket_parts->name, path, fib.get_timeout());
         if (resp) {
             vlog(
               ctxlog.debug,
@@ -605,6 +646,15 @@ ss::future<download_result> remote::object_exists(
 ss::future<upload_result>
 remote::delete_object(transfer_details transfer_details) {
     const auto& bucket = transfer_details.bucket;
+    const auto bucket_parts = cloud_storage_clients::parse_bucket_name(bucket);
+    if (!bucket_parts) {
+        vlog(
+          log.warn,
+          "Failed to parse bucket name {}: {}",
+          bucket,
+          bucket_parts.error());
+        co_return upload_result::failed;
+    }
     const auto& path = transfer_details.key;
     auto& parent = transfer_details.parent_rtc;
     ss::gate::holder gh{_gate};
@@ -612,7 +662,7 @@ remote::delete_object(transfer_details transfer_details) {
     retry_chain_logger ctxlog(log, fib);
     auto fut = co_await ss::coroutine::as_future(
       _pool.local().acquire_with_timeout(
-        fib.root_abort_source(), _lease_timeout(), fib()));
+        *bucket_parts, fib.root_abort_source(), _lease_timeout(), fib()));
     if (fut.failed()) {
         co_return throw_if_not_timeout(
           fut.get_exception(), upload_result::timedout);
@@ -629,7 +679,7 @@ remote::delete_object(transfer_details transfer_details) {
         // represents any mutable operation.
         transfer_details.on_request(fib.retry_count());
         auto res = co_await lease.client->delete_object(
-          bucket, path, fib.get_timeout());
+          bucket_parts->name, path, fib.get_timeout());
 
         if (res) {
             co_return upload_result::success;
@@ -768,13 +818,23 @@ ss::future<upload_result> remote::delete_object_batch(
   chunked_vector<cloud_storage_clients::object_key> keys,
   retry_chain_node& parent,
   std::function<void(size_t)> req_cb) {
+    const auto bucket_parts = cloud_storage_clients::parse_bucket_name(bucket);
+    if (!bucket_parts) {
+        vlog(
+          log.warn,
+          "Failed to parse bucket name {}: {}",
+          bucket,
+          bucket_parts.error());
+        co_return upload_result::failed;
+    }
+
     ss::gate::holder gh{_gate};
 
     retry_chain_node fib(&parent);
     retry_chain_logger ctxlog(log, fib);
     auto fut = co_await ss::coroutine::as_future(
       _pool.local().acquire_with_timeout(
-        fib.root_abort_source(), _lease_timeout(), fib()));
+        *bucket_parts, fib.root_abort_source(), _lease_timeout(), fib()));
     if (fut.failed()) {
         co_return throw_if_not_timeout(
           fut.get_exception(), upload_result::timedout);
@@ -786,7 +846,7 @@ ss::future<upload_result> remote::delete_object_batch(
     while (!_gate.is_closed() && permit.is_allowed && !result) {
         req_cb(fib.retry_count());
         auto res = co_await lease.client->delete_objects(
-          bucket, keys, fib.get_timeout());
+          bucket_parts->name, keys, fib.get_timeout());
 
         if (res) {
             if (!res.value().undeleted_keys.empty()) {
@@ -964,12 +1024,22 @@ ss::future<list_result> remote::list_objects(
   std::optional<cloud_storage_clients::client::item_filter> item_filter,
   std::optional<size_t> max_keys,
   std::optional<ss::sstring> continuation_token) {
+    const auto bucket_parts = cloud_storage_clients::parse_bucket_name(bucket);
+    if (!bucket_parts) {
+        vlog(
+          log.warn,
+          "Failed to parse bucket name {}: {}",
+          bucket,
+          bucket_parts.error());
+        co_return cloud_storage_clients::error_outcome::fail;
+    }
+
     ss::gate::holder gh{_gate};
     retry_chain_node fib(&parent);
     retry_chain_logger ctxlog(log, fib);
     auto fut = co_await ss::coroutine::as_future(
       _pool.local().acquire_with_timeout(
-        fib.root_abort_source(), _lease_timeout(), fib()));
+        *bucket_parts, fib.root_abort_source(), _lease_timeout(), fib()));
     if (fut.failed()) {
         co_return throw_if_not_timeout(
           fut.get_exception(), cloud_storage_clients::error_outcome::retry);
@@ -993,7 +1063,7 @@ ss::future<list_result> remote::list_objects(
     // Keep iterating while the ListObjectsV2 calls has more items to return
     while (!_gate.is_closed() && permit.is_allowed && !result) {
         auto res = co_await lease.client->list_objects(
-          bucket,
+          bucket_parts->name,
           prefix,
           std::nullopt,
           max_keys,
@@ -1090,6 +1160,18 @@ ss::future<upload_result> remote::upload_object(upload_request upload_request) {
     auto guard = _gate.hold();
 
     auto& transfer_details = upload_request.transfer_details;
+
+    auto& bucket = transfer_details.bucket;
+    const auto bucket_parts = cloud_storage_clients::parse_bucket_name(bucket);
+    if (!bucket_parts) {
+        vlog(
+          log.warn,
+          "Failed to parse bucket name {}: {}",
+          bucket,
+          bucket_parts.error());
+        co_return upload_result::failed;
+    }
+
     retry_chain_node fib(&transfer_details.parent_rtc);
     retry_chain_logger ctxlog(log, fib);
     auto permit = fib.retry();
@@ -1102,7 +1184,7 @@ ss::future<upload_result> remote::upload_object(upload_request upload_request) {
     while (!_gate.is_closed() && permit.is_allowed && !result) {
         auto fut = co_await ss::coroutine::as_future(
           _pool.local().acquire_with_timeout(
-            fib.root_abort_source(), _lease_timeout(), fib()));
+            *bucket_parts, fib.root_abort_source(), _lease_timeout(), fib()));
         if (fut.failed()) {
             co_return throw_if_not_timeout(
               fut.get_exception(), upload_result::timedout);
@@ -1119,7 +1201,7 @@ ss::future<upload_result> remote::upload_object(upload_request upload_request) {
 
         auto to_upload = upload_request.payload.copy();
         auto res = co_await lease.client->put_object(
-          transfer_details.bucket,
+          bucket_parts->name,
           path,
           content_length,
           make_iobuf_input_stream(std::move(to_upload)),

--- a/src/v/cloud_io/tests/s3_imposter.h
+++ b/src/v/cloud_io/tests/s3_imposter.h
@@ -30,6 +30,12 @@ inline cloud_storage_clients::bucket_name random_test_bucket_name() {
       "test-bucket-" + ss::sstring{uuid_t::create()}};
 }
 
+inline cloud_storage_clients::plain_bucket_name
+random_test_plain_bucket_name() {
+    return cloud_storage_clients::plain_bucket_name{
+      "test-bucket-" + ss::sstring{uuid_t::create()}};
+}
+
 static constexpr cloud_storage_clients::s3_url_style default_url_style
   = cloud_storage_clients::s3_url_style::virtual_host;
 

--- a/src/v/cloud_storage_clients/BUILD
+++ b/src/v/cloud_storage_clients/BUILD
@@ -5,6 +5,7 @@ redpanda_cc_library(
     srcs = [
         "abs_client.cc",
         "abs_error.cc",
+        "bucket_name_parts.cc",
         "client_pool.cc",
         "client_probe.cc",
         "configuration.cc",
@@ -17,6 +18,7 @@ redpanda_cc_library(
     hdrs = [
         "abs_client.h",
         "abs_error.h",
+        "bucket_name_parts.h",
         "client.h",
         "client_pool.h",
         "client_probe.h",
@@ -64,6 +66,7 @@ redpanda_cc_library(
         "//src/v/utils:named_type",
         "//src/v/utils:retry_chain_node",
         "//src/v/utils:stop_signal",
+        "@ada",
         "@boost//:beast",
         "@boost//:lexical_cast",
         "@boost//:property_tree",

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -192,7 +192,7 @@ abs_request_creator::abs_request_creator(
   , _apply_credentials{std::move(apply_credentials)} {}
 
 result<http::client::request_header> abs_request_creator::make_get_blob_request(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   const object_key& key,
   std::optional<http_byte_range> byte_range) {
     // GET /{container-id}/{blob-id} HTTP/1.1
@@ -224,7 +224,9 @@ result<http::client::request_header> abs_request_creator::make_get_blob_request(
 }
 
 result<http::client::request_header> abs_request_creator::make_put_blob_request(
-  const bucket_name& name, const object_key& key, size_t payload_size_bytes) {
+  const plain_bucket_name& name,
+  const object_key& key,
+  size_t payload_size_bytes) {
     // PUT /{container-id}/{blob-id} HTTP/1.1
     // Host: {storage-account-id}.blob.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
@@ -255,7 +257,7 @@ result<http::client::request_header> abs_request_creator::make_put_blob_request(
 
 result<http::client::request_header>
 abs_request_creator::make_get_blob_metadata_request(
-  const bucket_name& name, const object_key& key) {
+  const plain_bucket_name& name, const object_key& key) {
     // HEAD /{container-id}/{blob-id}?comp=metadata HTTP/1.1
     // Host: {storage-account-id}.blob.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
@@ -280,7 +282,7 @@ abs_request_creator::make_get_blob_metadata_request(
 
 result<http::client::request_header>
 abs_request_creator::make_delete_blob_request(
-  const bucket_name& name, const object_key& key) {
+  const plain_bucket_name& name, const object_key& key) {
     // DELETE /{container-id}/{blob-id} HTTP/1.1
     // Host: {storage-account-id}.blob.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
@@ -306,7 +308,7 @@ abs_request_creator::make_delete_blob_request(
 
 result<http::client::request_header>
 abs_request_creator::make_list_blobs_request(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   bool files_only,
   std::optional<object_key> prefix,
   std::optional<size_t> max_results,
@@ -384,7 +386,7 @@ abs_request_creator::make_get_account_info_request() {
 
 result<http::client::request_header>
 abs_request_creator::make_set_expiry_to_blob_request(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   const object_key& key,
   ss::lowres_clock::duration expires_in) const {
     // https://learn.microsoft.com/en-us/rest/api/storageservices/set-blob-expiry?tabs=microsoft-entra-id
@@ -418,7 +420,7 @@ abs_request_creator::make_set_expiry_to_blob_request(
 result<http::client::request_header>
 abs_request_creator::make_delete_file_request(
   const access_point_uri& adls_ap,
-  const bucket_name& name,
+  const plain_bucket_name& name,
   const object_key& path) {
     // DELETE /{container-id}/{path} HTTP/1.1
     // Host: {storage-account-id}.dfs.core.windows.net
@@ -622,7 +624,7 @@ ss::future<result<T, error_outcome>> abs_client::send_request(
 
 ss::future<result<http::client::response_stream_ref, error_outcome>>
 abs_client::get_object(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   const object_key& key,
   ss::lowres_clock::duration timeout,
   bool expect_no_such_key,
@@ -635,7 +637,7 @@ abs_client::get_object(
 }
 
 ss::future<http::client::response_stream_ref> abs_client::do_get_object(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   const object_key& key,
   ss::lowres_clock::duration timeout,
   bool expect_no_such_key,
@@ -688,7 +690,7 @@ ss::future<http::client::response_stream_ref> abs_client::do_get_object(
 
 ss::future<result<abs_client::no_response, error_outcome>>
 abs_client::put_object(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   const object_key& key,
   size_t payload_size,
   ss::input_stream<char> body,
@@ -704,7 +706,7 @@ abs_client::put_object(
 }
 
 ss::future<> abs_client::do_put_object(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   const object_key& key,
   size_t payload_size,
   ss::input_stream<char> body,
@@ -743,14 +745,14 @@ ss::future<> abs_client::do_put_object(
 
 ss::future<result<abs_client::head_object_result, error_outcome>>
 abs_client::head_object(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   const object_key& key,
   ss::lowres_clock::duration timeout) {
     return send_request(do_head_object(name, key, timeout), key);
 }
 
 ss::future<abs_client::head_object_result> abs_client::do_head_object(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   const object_key& key,
   ss::lowres_clock::duration timeout) {
     auto header = _requestor.make_get_blob_metadata_request(name, key);
@@ -784,7 +786,7 @@ ss::future<abs_client::head_object_result> abs_client::do_head_object(
 
 ss::future<result<abs_client::no_response, error_outcome>>
 abs_client::delete_object(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   const object_key& key,
   ss::lowres_clock::duration timeout) {
     using ret_t = result<no_response, error_outcome>;
@@ -830,7 +832,7 @@ abs_client::delete_object(
 }
 
 ss::future<> abs_client::do_delete_object(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   const object_key& key,
   ss::lowres_clock::duration timeout) {
     auto header = _requestor.make_delete_blob_request(name, key);
@@ -859,7 +861,7 @@ ss::future<> abs_client::do_delete_object(
 
 ss::future<result<abs_client::delete_objects_result, error_outcome>>
 abs_client::delete_objects(
-  const bucket_name& bucket,
+  const plain_bucket_name& bucket,
   const chunked_vector<object_key>& keys,
   ss::lowres_clock::duration timeout) {
     abs_client::delete_objects_result delete_objects_result;
@@ -879,7 +881,7 @@ abs_client::delete_objects(
 
 ss::future<result<abs_client::list_bucket_result, error_outcome>>
 abs_client::list_objects(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   std::optional<object_key> prefix,
   [[maybe_unused]] std::optional<object_key> start_after,
   std::optional<size_t> max_keys,
@@ -900,7 +902,7 @@ abs_client::list_objects(
 }
 
 ss::future<abs_client::list_bucket_result> abs_client::do_list_objects(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   std::optional<object_key> prefix,
   std::optional<size_t> max_results,
   std::optional<ss::sstring> marker,
@@ -958,6 +960,11 @@ abs_client::get_account_info(ss::lowres_clock::duration timeout) {
 ss::future<abs_client::storage_account_info>
 abs_client::do_test_set_expiry_on_dummy_file(
   ss::lowres_clock::duration timeout) {
+    // TODO: Review this code. It is likely buggy when Remote Read Replicas are
+    // used. We are testing HNS on default storage account, but in RRR setup, we
+    // actually use a different storage account for reads.
+    // A similar issue exists in S3 client.
+
     // since this is one-off operation at startup, it's easier to read directly
     // cloud_storage_azure_container than to wire it in. this is ok because if
     // we are in abs_client it means that the required properties, like
@@ -970,7 +977,7 @@ abs_client::do_test_set_expiry_on_dummy_file(
         throw std::runtime_error("cloud_storage_azure_container is not set");
     }
 
-    auto bucket = bucket_name{container_name.value()};
+    auto bucket = plain_bucket_name{container_name.value()};
     auto test_file = object_key{set_expiry_test_file};
 
     // try set expiry
@@ -1053,7 +1060,7 @@ abs_client::do_get_account_info(ss::lowres_clock::duration timeout) {
 }
 
 ss::future<> abs_client::do_delete_file(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   object_key path,
   ss::lowres_clock::duration timeout) {
     vassert(
@@ -1091,7 +1098,7 @@ ss::future<> abs_client::do_delete_file(
 
 ss::future<result<abs_client::no_response, error_outcome>>
 abs_client::delete_path(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   object_key path,
   ss::lowres_clock::duration timeout) {
     return send_request(
@@ -1102,7 +1109,7 @@ abs_client::delete_path(
 }
 
 ss::future<> abs_client::do_delete_path(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   object_key path,
   ss::lowres_clock::duration timeout) {
     std::vector<object_key> blobs_to_delete = util::all_paths_to_file(path);

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -35,7 +35,7 @@ public:
     /// \param payload_size_bytes is a size of the object in bytes
     /// \return initialized and signed http header or error
     result<http::client::request_header> make_put_blob_request(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       size_t payload_size_bytes);
 
@@ -45,7 +45,7 @@ public:
     /// \param key is the blob identifier
     /// \return initialized and signed http header or error
     result<http::client::request_header> make_get_blob_request(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       std::optional<http_byte_range> byte_range = std::nullopt);
 
@@ -55,15 +55,15 @@ public:
     /// \param key is a blob name
     /// \return initialized and signed http header or error
     result<http::client::request_header> make_get_blob_metadata_request(
-      const bucket_name& name, const object_key& key);
+      const plain_bucket_name& name, const object_key& key);
 
     /// \brief Create a 'Delete Blob' request header
     ///
     /// \param name is a container
     /// \param key is an blob name
     /// \return initialized and signed http header or error
-    result<http::client::request_header>
-    make_delete_blob_request(const bucket_name& name, const object_key& key);
+    result<http::client::request_header> make_delete_blob_request(
+      const plain_bucket_name& name, const object_key& key);
 
     // clang-format off
     /// \brief Initialize http header for 'List Blobs' request
@@ -77,7 +77,7 @@ public:
     /// \return initialized and signed http header or error
     // clang-format on
     result<http::client::request_header> make_list_blobs_request(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       bool files_only,
       std::optional<object_key> prefix,
       std::optional<size_t> max_results,
@@ -90,7 +90,7 @@ public:
     /// \brief Init http header for 'Set Expiry' request. the object will be
     /// expired in `expires_in` ms after the request is received
     result<http::client::request_header> make_set_expiry_to_blob_request(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       ss::lowres_clock::duration expires_in) const;
 
@@ -103,7 +103,7 @@ public:
     /// \return initialized and signed http header or error
     result<http::client::request_header> make_delete_file_request(
       const access_point_uri& adls_ap,
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& path);
 
 private:
@@ -152,7 +152,7 @@ public:
     /// \return future that becomes ready after request was sent
     ss::future<result<http::client::response_stream_ref, error_outcome>>
     get_object(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       ss::lowres_clock::duration timeout,
       bool expect_no_such_key = false,
@@ -164,7 +164,7 @@ public:
     /// \param timeout is a timeout of the operation
     /// \return future that becomes ready when the request is completed
     ss::future<result<head_object_result, error_outcome>> head_object(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       ss::lowres_clock::duration timeout) override;
 
@@ -176,7 +176,7 @@ public:
     /// \param timeout is a timeout of the operation
     /// \return future that becomes ready when the upload is completed
     ss::future<result<no_response, error_outcome>> put_object(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       size_t payload_size,
       ss::input_stream<char> body,
@@ -191,7 +191,7 @@ public:
     /// \param timeout is a timeout of the operation
     /// \return future that becomes ready when the request is completed
     ss::future<result<list_bucket_result, error_outcome>> list_objects(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       std::optional<object_key> prefix = std::nullopt,
       std::optional<object_key> start_after = std::nullopt,
       std::optional<size_t> max_keys = std::nullopt,
@@ -205,7 +205,7 @@ public:
     /// \param key is an id of the blob
     /// \param timeout is a timeout of the operation
     ss::future<result<no_response, error_outcome>> delete_object(
-      const bucket_name& bucket,
+      const plain_bucket_name& bucket,
       const object_key& key,
       ss::lowres_clock::duration timeout) override;
 
@@ -217,7 +217,7 @@ public:
     /// \param keys is a list of blob ids
     /// \param timeout is a timeout of the operation
     ss::future<result<delete_objects_result, error_outcome>> delete_objects(
-      const bucket_name& bucket,
+      const plain_bucket_name& bucket,
       const chunked_vector<object_key>& keys,
       ss::lowres_clock::duration timeout) override;
 
@@ -246,7 +246,7 @@ public:
     /// \param key is the path to be deleted
     /// \param timeout is a timeout of the operation
     ss::future<result<no_response, error_outcome>> delete_path(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       object_key path,
       ss::lowres_clock::duration timeout);
 
@@ -258,14 +258,14 @@ private:
       std::optional<op_type_tag> op_type = std::nullopt);
 
     ss::future<http::client::response_stream_ref> do_get_object(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       ss::lowres_clock::duration timeout,
       bool expect_no_such_key = false,
       std::optional<http_byte_range> byte_range = std::nullopt);
 
     ss::future<> do_put_object(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       size_t payload_size,
       ss::input_stream<char> body,
@@ -273,17 +273,17 @@ private:
       bool accept_no_content = false);
 
     ss::future<head_object_result> do_head_object(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       ss::lowres_clock::duration timeout);
 
     ss::future<> do_delete_object(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       ss::lowres_clock::duration timeout);
 
     ss::future<list_bucket_result> do_list_objects(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       std::optional<object_key> prefix,
       std::optional<size_t> max_results,
       std::optional<ss::sstring> marker,
@@ -302,12 +302,12 @@ private:
     do_test_set_expiry_on_dummy_file(ss::lowres_clock::duration timeout);
 
     ss::future<> do_delete_path(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       object_key path,
       ss::lowres_clock::duration timeout);
 
     ss::future<> do_delete_file(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       object_key path,
       ss::lowres_clock::duration timeout);
 

--- a/src/v/cloud_storage_clients/bucket_name_parts.cc
+++ b/src/v/cloud_storage_clients/bucket_name_parts.cc
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage_clients/bucket_name_parts.h"
+
+#include <ada.h>
+
+namespace cloud_storage_clients {
+
+std::expected<bucket_name_parts, std::string>
+parse_bucket_name(const bucket_name& bucket) {
+    const auto& bucket_str = bucket();
+
+    auto query_pos = bucket_str.find('?');
+    if (bucket_str.empty() || query_pos == 0) {
+        return std::unexpected("bucket: name cannot be empty");
+    }
+
+    if (query_pos == ss::sstring::npos) {
+        return bucket_name_parts{.name = plain_bucket_name{bucket_str}};
+    }
+
+    bucket_name_parts parts{
+      .name = plain_bucket_name{bucket_str.substr(0, query_pos)},
+    };
+
+    auto query = std::string_view{bucket_str}.substr(query_pos + 1);
+    if (query.empty()) {
+        return parts;
+    }
+
+    ada::url_search_params search_params(query);
+    for (const auto& [key, value] : search_params) {
+        parts.params.emplace_back(ss::sstring{key}, ss::sstring{value});
+    }
+
+    return parts;
+}
+
+} // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/bucket_name_parts.h
+++ b/src/v/cloud_storage_clients/bucket_name_parts.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "model/fundamental.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <expected>
+#include <vector>
+
+namespace cloud_storage_clients {
+
+/// Components extracted from parsing a bucket_name (which may be a DSN).
+///
+/// This struct is the result of parsing a bucket_name and provides the
+/// components needed for cloud storage API calls and client routing.
+///
+/// See `cloud_storage_clients::bucket_name` documentation in
+/// model/fundamental.h for DSN format details.
+struct bucket_name_parts {
+    plain_bucket_name name;
+
+    /// Connection parameters extracted from DSN query string.
+    /// Empty if no parameters were specified. Vector is efficient here since
+    /// the number of parameters is small.
+    std::vector<std::pair<ss::sstring, ss::sstring>> params;
+};
+
+/// Parses a bucket_name (which may be a DSN) into its component parts.
+///
+/// Accepts both plain bucket names ("my-bucket") and DSN-format names with
+/// query parameters
+/// ("my-bucket?region=us-west-2&endpoint=http://localhost:9000").
+std::expected<bucket_name_parts, std::string>
+parse_bucket_name(const bucket_name& bucket);
+
+} // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -61,7 +61,7 @@ public:
     /// \return future that becomes ready after request was sent
     virtual ss::future<result<http::client::response_stream_ref, error_outcome>>
     get_object(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       ss::lowres_clock::duration timeout,
       bool expect_no_such_key = false,
@@ -80,7 +80,7 @@ public:
     /// \param timeout is a timeout of the operation
     /// \return future that becomes ready when the request is completed
     virtual ss::future<result<head_object_result, error_outcome>> head_object(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       ss::lowres_clock::duration timeout)
       = 0;
@@ -95,7 +95,7 @@ public:
     /// \param accept_no_content accepts a 204 response as valid
     /// \return future that becomes ready when the upload is completed
     virtual ss::future<result<no_response, error_outcome>> put_object(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       size_t payload_size,
       ss::input_stream<char> body,
@@ -135,7 +135,7 @@ public:
     /// collected.
     /// \return future that becomes ready when the request is completed
     virtual ss::future<result<list_bucket_result, error_outcome>> list_objects(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       std::optional<object_key> prefix = std::nullopt,
       std::optional<object_key> start_after = std::nullopt,
       std::optional<size_t> max_keys = std::nullopt,
@@ -152,7 +152,7 @@ public:
     /// \param timeout is a timeout of the operation
     /// \return future that becomes ready when the request is completed
     virtual ss::future<result<no_response, error_outcome>> delete_object(
-      const bucket_name& bucket,
+      const plain_bucket_name& bucket,
       const object_key& key,
       ss::lowres_clock::duration timeout)
       = 0;
@@ -182,7 +182,7 @@ public:
     /// considered as successfully deleted)
     virtual ss::future<result<delete_objects_result, error_outcome>>
     delete_objects(
-      const bucket_name& bucket,
+      const plain_bucket_name& bucket,
       const chunked_vector<object_key>& keys,
       ss::lowres_clock::duration timeout)
       = 0;

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -278,8 +278,13 @@ std::tuple<unsigned int, unsigned int> pick_two_random_shards() {
 /// \return client pointer (via future that can wait if all clients
 ///         are in use)
 ss::future<client_pool::client_lease> client_pool::acquire(
-  ss::abort_source& as, std::optional<ss::lowres_clock::time_point> deadline) {
+  const bucket_name_parts& bucket,
+  ss::abort_source& as,
+  std::optional<ss::lowres_clock::time_point> deadline) {
     auto guard = _gate.hold();
+
+    // Support for bucket_name_parts connection parameters is currently a no-op.
+    std::ignore = bucket;
 
     std::optional<unsigned int> source_sid;
     std::optional<http_client_ptr> client;
@@ -475,10 +480,11 @@ ss::future<client_pool::client_lease> client_pool::acquire(
 }
 
 auto client_pool::acquire_with_timeout(
+  const bucket_name_parts& bucket,
   ss::abort_source& as,
   ss::lowres_clock::duration timeout,
   std::optional<ss::sstring> ctx) -> ss::future<client_lease> {
-    auto lease = co_await acquire(as);
+    auto lease = co_await acquire(bucket, as);
     if (timeout < ss::lowres_clock::duration::max()) {
         // take a copy of the shared_ptr held by the lease to avoid racing with
         // client_pool teardown

--- a/src/v/cloud_storage_clients/client_pool.h
+++ b/src/v/cloud_storage_clients/client_pool.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_roles/apply_credentials.h"
+#include "cloud_storage_clients/bucket_name_parts.h"
 #include "cloud_storage_clients/client.h"
 #include "cloud_storage_clients/client_probe.h"
 #include "cloud_storage_clients/credential_manager.h"
@@ -139,6 +140,7 @@ public:
     /// \return client pointer (via future that can wait if all clients
     ///         are in use)
     ss::future<client_lease> acquire(
+      const bucket_name_parts& bucket,
       ss::abort_source& as,
       std::optional<ss::lowres_clock::time_point> deadline = std::nullopt);
 
@@ -158,6 +160,7 @@ public:
     /// \param ctx - Optional context for the log message. e.g. the string
     ///              representation of a retry_chain_node.
     ss::future<client_lease> acquire_with_timeout(
+      const bucket_name_parts& bucket,
       ss::abort_source& as,
       ss::lowres_clock::duration deadline,
       std::optional<ss::sstring> ctx = std::nullopt);

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -84,7 +84,7 @@ request_creator::request_creator(
   , _apply_credentials{std::move(apply_credentials)} {}
 
 result<http::client::request_header> request_creator::make_get_object_request(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   const object_key& key,
   std::optional<http_byte_range> byte_range) {
     http::client::request_header header{};
@@ -123,7 +123,7 @@ result<http::client::request_header> request_creator::make_get_object_request(
 }
 
 result<http::client::request_header> request_creator::make_head_object_request(
-  const bucket_name& name, const object_key& key) {
+  const plain_bucket_name& name, const object_key& key) {
     http::client::request_header header{};
     // Virtual Style:
     // HEAD /{object-id} HTTP/1.1
@@ -153,7 +153,9 @@ result<http::client::request_header> request_creator::make_head_object_request(
 
 result<http::client::request_header>
 request_creator::make_unsigned_put_object_request(
-  const bucket_name& name, const object_key& key, size_t payload_size_bytes) {
+  const plain_bucket_name& name,
+  const object_key& key,
+  size_t payload_size_bytes) {
     // Virtual Style:
     // PUT /my-image.jpg HTTP/1.1
     // Host: {bucket-name}.s3.{region}.amazonaws.com
@@ -192,7 +194,7 @@ request_creator::make_unsigned_put_object_request(
 
 result<http::client::request_header>
 request_creator::make_list_objects_v2_request(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   std::optional<object_key> prefix,
   std::optional<object_key> start_after,
   std::optional<size_t> max_keys,
@@ -260,7 +262,7 @@ request_creator::make_list_objects_v2_request(
 
 result<http::client::request_header>
 request_creator::make_delete_object_request(
-  const bucket_name& name, const object_key& key) {
+  const plain_bucket_name& name, const object_key& key) {
     http::client::request_header header{};
     // Virtual Style:
     // DELETE /{object-id} HTTP/1.1
@@ -292,7 +294,7 @@ request_creator::make_delete_object_request(
 
 result<std::tuple<http::client::request_header, ss::input_stream<char>>>
 request_creator::make_delete_objects_request(
-  const bucket_name& name, const chunked_vector<object_key>& keys) {
+  const plain_bucket_name& name, const chunked_vector<object_key>& keys) {
     // https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html
     // will generate this request:
     //
@@ -382,7 +384,7 @@ request_creator::make_delete_objects_request(
     return {std::move(header), make_iobuf_input_stream(std::move(body))};
 }
 
-std::string request_creator::make_host(const bucket_name& name) const {
+std::string request_creator::make_host(const plain_bucket_name& name) const {
     switch (_ap_style) {
     case s3_url_style::virtual_host:
         // Host: bucket-name.s3.region-code.amazonaws.com
@@ -394,7 +396,7 @@ std::string request_creator::make_host(const bucket_name& name) const {
 }
 
 std::string request_creator::make_target(
-  const bucket_name& name, const object_key& key) const {
+  const plain_bucket_name& name, const object_key& key) const {
     switch (_ap_style) {
     case s3_url_style::virtual_host:
         // Target: /homepage.html
@@ -543,7 +545,7 @@ ss::future<ResultT> parse_head_error_response(
 template<typename T>
 ss::future<result<T, error_outcome>> s3_client::send_request(
   ss::future<T> request_future,
-  const bucket_name& bucket,
+  const plain_bucket_name& bucket,
   const object_key& key) {
     auto outcome = error_outcome::retry;
 
@@ -692,7 +694,11 @@ s3_client::self_configure() {
         co_return result;
     }
 
-    const auto bucket = cloud_storage_clients::bucket_name{
+    // TODO: Review this code. It is likely buggy when Remote Read Replicas are
+    // used. We are testing HNS on default storage account, but in RRR setup, we
+    // actually use a different storage account for reads.
+    // A similar issue exists in ABS client.
+    const auto bucket = cloud_storage_clients::plain_bucket_name{
       bucket_config.value().value()};
 
     // Test virtual_host style.
@@ -729,7 +735,8 @@ s3_client::self_configure() {
     co_return error_outcome::fail;
 }
 
-ss::future<bool> s3_client::self_configure_test(const bucket_name& bucket) {
+ss::future<bool>
+s3_client::self_configure_test(const plain_bucket_name& bucket) {
     // Check that the current addressing-style works by issuing a ListObjects
     // request.
     auto list_objects_result = co_await list_objects(
@@ -743,7 +750,7 @@ void s3_client::shutdown() { _client.shutdown_now(); }
 
 ss::future<result<http::client::response_stream_ref, error_outcome>>
 s3_client::get_object(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   const object_key& key,
   ss::lowres_clock::duration timeout,
   bool expect_no_such_key,
@@ -756,7 +763,7 @@ s3_client::get_object(
 }
 
 ss::future<http::client::response_stream_ref> s3_client::do_get_object(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   const object_key& key,
   ss::lowres_clock::duration timeout,
   bool expect_no_such_key,
@@ -827,14 +834,14 @@ ss::future<http::client::response_stream_ref> s3_client::do_get_object(
 
 ss::future<result<s3_client::head_object_result, error_outcome>>
 s3_client::head_object(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   const object_key& key,
   ss::lowres_clock::duration timeout) {
     return send_request(do_head_object(name, key, timeout), name, key);
 }
 
 ss::future<s3_client::head_object_result> s3_client::do_head_object(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   const object_key& key,
   ss::lowres_clock::duration timeout) {
     auto header = _requestor.make_head_object_request(name, key);
@@ -888,7 +895,7 @@ ss::future<s3_client::head_object_result> s3_client::do_head_object(
 }
 
 ss::future<result<s3_client::no_response, error_outcome>> s3_client::put_object(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   const object_key& key,
   size_t payload_size,
   ss::input_stream<char> body,
@@ -904,7 +911,7 @@ ss::future<result<s3_client::no_response, error_outcome>> s3_client::put_object(
 }
 
 ss::future<> s3_client::do_put_object(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   const object_key& id,
   size_t payload_size,
   ss::input_stream<char> body,
@@ -980,7 +987,7 @@ ss::future<> s3_client::do_put_object(
 
 ss::future<result<s3_client::list_bucket_result, error_outcome>>
 s3_client::list_objects(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   std::optional<object_key> prefix,
   std::optional<object_key> start_after,
   std::optional<size_t> max_keys,
@@ -1004,7 +1011,7 @@ s3_client::list_objects(
 }
 
 ss::future<s3_client::list_bucket_result> s3_client::do_list_objects_v2(
-  const bucket_name& name,
+  const plain_bucket_name& name,
   std::optional<object_key> prefix,
   std::optional<object_key> start_after,
   std::optional<size_t> max_keys,
@@ -1056,7 +1063,7 @@ ss::future<s3_client::list_bucket_result> s3_client::do_list_objects_v2(
 
 ss::future<result<s3_client::no_response, error_outcome>>
 s3_client::delete_object(
-  const bucket_name& bucket,
+  const plain_bucket_name& bucket,
   const object_key& key,
   ss::lowres_clock::duration timeout) {
     using ret_t = result<s3_client::no_response, error_outcome>;
@@ -1090,7 +1097,7 @@ s3_client::delete_object(
 }
 
 ss::future<> s3_client::do_delete_object(
-  const bucket_name& bucket,
+  const plain_bucket_name& bucket,
   const object_key& key,
   ss::lowres_clock::duration timeout) {
     auto header = _requestor.make_delete_object_request(bucket, key);
@@ -1181,7 +1188,7 @@ iobuf_to_delete_objects_result(iobuf&& buf) {
 }
 
 auto s3_client::do_delete_objects(
-  const bucket_name& bucket,
+  const plain_bucket_name& bucket,
   const chunked_vector<object_key>& keys,
   ss::lowres_clock::duration timeout)
   -> ss::future<client::delete_objects_result> {
@@ -1223,7 +1230,7 @@ auto s3_client::do_delete_objects(
 }
 
 auto s3_client::delete_objects(
-  const bucket_name& bucket,
+  const plain_bucket_name& bucket,
   const chunked_vector<object_key>& keys,
   ss::lowres_clock::duration timeout)
   -> ss::future<result<delete_objects_result, error_outcome>> {

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -45,7 +45,7 @@ public:
     /// \param payload_size_bytes is a size of the object in bytes
     /// \return initialized and signed http header or error
     result<http::client::request_header> make_unsigned_put_object_request(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       size_t payload_size_bytes);
 
@@ -56,7 +56,7 @@ public:
     /// \param key is an object name
     /// \return initialized and signed http header or error
     result<http::client::request_header> make_get_object_request(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       std::optional<http_byte_range> byte_range = std::nullopt);
 
@@ -65,16 +65,16 @@ public:
     /// \param name is a bucket that has the object
     /// \param key is an object name
     /// \return initialized and signed http header or error
-    result<http::client::request_header>
-    make_head_object_request(const bucket_name& name, const object_key& key);
+    result<http::client::request_header> make_head_object_request(
+      const plain_bucket_name& name, const object_key& key);
 
     /// \brief Create a 'DeleteObject' request header
     ///
     /// \param name is a bucket that has the object
     /// \param key is an object name
     /// \return initialized and signed http header or error
-    result<http::client::request_header>
-    make_delete_object_request(const bucket_name& name, const object_key& key);
+    result<http::client::request_header> make_delete_object_request(
+      const plain_bucket_name& name, const object_key& key);
 
     /// \brief Create a 'DeleteObjects' request header and body
     ///
@@ -83,7 +83,7 @@ public:
     /// \return the header and an the body as an input_stream
     result<std::tuple<http::client::request_header, ss::input_stream<char>>>
     make_delete_objects_request(
-      const bucket_name& name, const chunked_vector<object_key>& keys);
+      const plain_bucket_name& name, const chunked_vector<object_key>& keys);
 
     /// \brief Initialize http header for 'ListObjectsV2' request
     ///
@@ -95,7 +95,7 @@ public:
     /// \param delimiter used to group results with common prefixes
     /// \return initialized and signed http header or error
     result<http::client::request_header> make_list_objects_v2_request(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       std::optional<object_key> prefix,
       std::optional<object_key> start_after,
       std::optional<size_t> max_keys,
@@ -104,10 +104,10 @@ public:
 
 private:
     friend class s3_client;
-    std::string make_host(const bucket_name& name) const;
+    std::string make_host(const plain_bucket_name& name) const;
 
     std::string
-    make_target(const bucket_name& name, const object_key& key) const;
+    make_target(const plain_bucket_name& name, const object_key& key) const;
 
     access_point_uri _ap;
 
@@ -154,7 +154,7 @@ public:
     /// \return future that gets ready after request was sent
     ss::future<result<http::client::response_stream_ref, error_outcome>>
     get_object(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       ss::lowres_clock::duration timeout,
       bool expect_no_such_key = false,
@@ -165,7 +165,7 @@ public:
     /// \param key is an id of the object
     /// \return future that becomes ready when the request is completed
     ss::future<result<head_object_result, error_outcome>> head_object(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       ss::lowres_clock::duration timeout) override;
 
@@ -176,7 +176,7 @@ public:
     /// \param body is an input_stream that can be used to read body
     /// \return future that becomes ready when the upload is completed
     ss::future<result<no_response, error_outcome>> put_object(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       size_t payload_size,
       ss::input_stream<char> body,
@@ -184,7 +184,7 @@ public:
       bool accept_no_content = false) override;
 
     ss::future<result<list_bucket_result, error_outcome>> list_objects(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       std::optional<object_key> prefix = std::nullopt,
       std::optional<object_key> start_after = std::nullopt,
       std::optional<size_t> max_keys = std::nullopt,
@@ -194,30 +194,30 @@ public:
       std::optional<item_filter> collect_item_if = std::nullopt) override;
 
     ss::future<result<no_response, error_outcome>> delete_object(
-      const bucket_name& bucket,
+      const plain_bucket_name& bucket,
       const object_key& key,
       ss::lowres_clock::duration timeout) override;
 
     ss::future<result<delete_objects_result, error_outcome>> delete_objects(
-      const bucket_name& bucket,
+      const plain_bucket_name& bucket,
       const chunked_vector<object_key>& keys,
       ss::lowres_clock::duration timeout) override;
 
 private:
     ss::future<head_object_result> do_head_object(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       ss::lowres_clock::duration timeout);
 
     ss::future<http::client::response_stream_ref> do_get_object(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       ss::lowres_clock::duration timeout,
       bool expect_no_such_key = false,
       std::optional<http_byte_range> byte_range = std::nullopt);
 
     ss::future<> do_put_object(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       const object_key& key,
       size_t payload_size,
       ss::input_stream<char> body,
@@ -225,7 +225,7 @@ private:
       bool accept_no_content = false);
 
     ss::future<list_bucket_result> do_list_objects_v2(
-      const bucket_name& name,
+      const plain_bucket_name& name,
       std::optional<object_key> prefix = std::nullopt,
       std::optional<object_key> start_after = std::nullopt,
       std::optional<size_t> max_keys = std::nullopt,
@@ -235,26 +235,26 @@ private:
       std::optional<item_filter> collect_item_if = std::nullopt);
 
     ss::future<> do_delete_object(
-      const bucket_name& bucket,
+      const plain_bucket_name& bucket,
       const object_key& key,
       ss::lowres_clock::duration timeout);
 
     ss::future<delete_objects_result> do_delete_objects(
-      const bucket_name& bucket,
+      const plain_bucket_name& bucket,
       const chunked_vector<object_key>& keys,
       ss::lowres_clock::duration timeout);
 
     template<typename T>
     ss::future<result<T, error_outcome>> send_request(
       ss::future<T> request_future,
-      const bucket_name& bucket,
+      const plain_bucket_name& bucket,
       const object_key& key);
 
     // Performs testing as part of the self-configuration step. Returns true if
     // the test was successful (indicating that the current addressing style is
     // compatible with the configured cloud storage provider), and false
     // otherwise.
-    ss::future<bool> self_configure_test(const bucket_name& bucket);
+    ss::future<bool> self_configure_test(const plain_bucket_name& bucket);
 
 private:
     request_creator _requestor;

--- a/src/v/cloud_storage_clients/tests/BUILD
+++ b/src/v/cloud_storage_clients/tests/BUILD
@@ -114,6 +114,19 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "bucket_name_parts_test",
+    timeout = "short",
+    srcs = [
+        "bucket_name_parts_test.cc",
+    ],
+    deps = [
+        "//src/v/cloud_storage_clients",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
 redpanda_test_cc_library(
     name = "client_pool_builder",
     hdrs = [

--- a/src/v/cloud_storage_clients/tests/bucket_name_parts_test.cc
+++ b/src/v/cloud_storage_clients/tests/bucket_name_parts_test.cc
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage_clients/bucket_name_parts.h"
+
+#include <gtest/gtest.h>
+
+using cloud_storage_clients::bucket_name;
+using cloud_storage_clients::parse_bucket_name;
+using cloud_storage_clients::plain_bucket_name;
+
+TEST(ParseBucketName, PlainBucketName) {
+    auto result = parse_bucket_name(bucket_name{"my-bucket"});
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->name, plain_bucket_name{"my-bucket"});
+    EXPECT_TRUE(result->params.empty());
+}
+
+TEST(ParseBucketName, EmptyBucketNameRejected) {
+    auto result = parse_bucket_name(bucket_name{""});
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), "bucket: name cannot be empty");
+}
+
+TEST(ParseBucketName, WithParams) {
+    auto result = parse_bucket_name(bucket_name{"my-bucket?region=us-west-2"});
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->name, plain_bucket_name{"my-bucket"});
+    ASSERT_EQ(result->params.size(), 1);
+    EXPECT_EQ(result->params[0].first, "region");
+    EXPECT_EQ(result->params[0].second, "us-west-2");
+}
+
+TEST(ParseBucketName, TrailingQuestionMark) {
+    auto result = parse_bucket_name(bucket_name{"my-bucket?"});
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->name, plain_bucket_name{"my-bucket"});
+    EXPECT_TRUE(result->params.empty());
+}
+
+TEST(ParseBucketName, EmptyBucketWithParamsRejected) {
+    auto result = parse_bucket_name(bucket_name{"?region=us-west-2"});
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), "bucket: name cannot be empty");
+}

--- a/src/v/cloud_storage_clients/tests/client_pool_mt_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_mt_test.cc
@@ -29,6 +29,10 @@
 
 #include <deque>
 
+static const cloud_storage_clients::bucket_name_parts test_bucket{
+  .name = cloud_storage_clients::plain_bucket_name("test-bucket"),
+};
+
 using namespace std::chrono_literals;
 using namespace cloud_storage_clients::tests;
 
@@ -72,20 +76,20 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_blocked_on_another_shard) {
     // deplete own connections
     std::deque<cloud_storage_clients::client_pool::client_lease> leases;
     for (size_t i = 0; i < num_connections_per_shard; i++) {
-        leases.push_back(pool.local().acquire(as).get());
+        leases.push_back(pool.local().acquire(test_bucket, as).get());
     }
 
     vlog(test_log.debug, "borrow connections from others");
     // deplete others connections
     for (size_t i = 0; i < num_connections_per_shard; i++) {
-        leases.push_back(pool.local().acquire(as).get());
+        leases.push_back(pool.local().acquire(test_bucket, as).get());
     }
 
     auto fut = ss::smp::invoke_on_others([&pool] {
         return ss::async([&pool] {
             ss::abort_source local_as;
             vlog(test_log.debug, "acquire extra connection on the other shard");
-            std::ignore = pool.local().acquire(local_as).get();
+            std::ignore = pool.local().acquire(test_bucket, local_as).get();
             vlog(test_log.debug, "connection acquired");
         });
     });
@@ -160,7 +164,8 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_blocked_on_this_shard) {
       .invoke_on_all([&pool](shard_leases& sl) mutable {
           return ss::async([&] {
               for (size_t i = 0; i < num_connections_per_shard; i++) {
-                  sl.leases.push_back(pool.local().acquire(sl.as).get());
+                  sl.leases.push_back(
+                    pool.local().acquire(test_bucket, sl.as).get());
               }
           });
       })
@@ -175,7 +180,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_blocked_on_this_shard) {
 
     // Free local resources which should become available to the prevoiusly
     // created future.
-    auto fut = pool.local().acquire(leases.local().as);
+    auto fut = pool.local().acquire(test_bucket, leases.local().as);
     try {
         ss::with_timeout(ss::lowres_clock::now() + 1s, std::move(fut)).get();
     } catch (const ss::timed_out_error&) {
@@ -219,7 +224,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_after_leasing_all) {
     // Lease all connections from all the shards.
     for (size_t i = 0; i < ss::smp::count * num_connections_per_shard; i++) {
         leases.local().leases.push_back(
-          pool.local().acquire(leases.local().as).get());
+          pool.local().acquire(test_bucket, leases.local().as).get());
     }
 
     vlog(test_log.debug, "connections depleted");
@@ -238,7 +243,8 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_after_leasing_all) {
         [&pool](shard_leases& sl) {
             return ss::async([&sl, &pool] {
                 for (size_t i = 0; i < num_connections_per_shard; i++) {
-                    sl.leases.push_back(pool.local().acquire(sl.as).get());
+                    sl.leases.push_back(
+                      pool.local().acquire(test_bucket, sl.as).get());
                 }
             });
         })
@@ -246,7 +252,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_after_leasing_all) {
 
     vlog(test_log.debug, "done borrowing leases");
 
-    auto pending_acquire = pool.local().acquire(as);
+    auto pending_acquire = pool.local().acquire(test_bucket, as);
     ss::yield().get();
 
     if (pending_acquire.available()) {

--- a/src/v/cloud_storage_clients/tests/client_pool_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_test.cc
@@ -30,6 +30,10 @@
 using namespace std::chrono_literals;
 using namespace cloud_storage_clients::tests;
 
+static const cloud_storage_clients::bucket_name_parts test_bucket{
+  .name = cloud_storage_clients::plain_bucket_name("test-bucket"),
+};
+
 ss::logger test_log("test-log");
 static const uint16_t httpd_port_number = 4434;
 static constexpr const char* httpd_host_name = "localhost";
@@ -62,7 +66,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_abortable) {
                         .get();
     ss::abort_source as;
 
-    auto f = pool.local().acquire(as);
+    auto f = pool.local().acquire(test_bucket, as);
     while (!pool.local().has_waiters()) {
         ss::yield().get();
     }
@@ -92,13 +96,15 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_with_timeout) {
     using namespace std::chrono_literals;
 
     {
-        auto lease = pool.local().acquire_with_timeout(as, 100ms).get();
+        auto lease
+          = pool.local().acquire_with_timeout(test_bucket, as, 100ms).get();
 
         // The request should fail w/in 500ms due to lease expiry
         // Note that the default timeout for the request itself is 5s
         auto res = ss::with_timeout(
                      ss::lowres_clock::now() + 500ms,
-                     lease.client->list_objects(random_test_bucket_name()))
+                     lease.client->list_objects(
+                       random_test_plain_bucket_name()))
                      .get();
 
         BOOST_REQUIRE(res.has_error());
@@ -109,11 +115,11 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_with_timeout) {
     }
 
     {
-        auto lease = pool.local().acquire(as).get();
+        auto lease = pool.local().acquire(test_bucket, as).get();
 
         auto f = ss::with_timeout(
           ss::lowres_clock::now() + 500ms,
-          lease.client->list_objects(random_test_bucket_name()));
+          lease.client->list_objects(random_test_plain_bucket_name()));
 
         // This time the lease never expires, so internally we should keep
         // trying to connect for at least 500ms.
@@ -126,7 +132,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_with_timeout) {
 
         auto lease = pool.local()
                        .acquire_with_timeout(
-                         as, ss::lowres_clock::duration::max())
+                         test_bucket, as, ss::lowres_clock::duration::max())
                        .get();
 
         BOOST_REQUIRE_EQUAL(lease._wd, nullptr);
@@ -148,7 +154,8 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_timeout) {
         // acquire should time out. no abort required.
         ss::abort_source as;
 
-        auto f = pool.local().acquire(as, ss::lowres_clock::now() + 100ms);
+        auto f = pool.local().acquire(
+          test_bucket, as, ss::lowres_clock::now() + 100ms);
         while (!pool.local().has_waiters()) {
             ss::yield().get();
         }
@@ -164,7 +171,8 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_timeout) {
         // soon.
         ss::abort_source as;
 
-        auto f = pool.local().acquire(as, ss::lowres_clock::time_point::max());
+        auto f = pool.local().acquire(
+          test_bucket, as, ss::lowres_clock::time_point::max());
         while (!pool.local().has_waiters()) {
             ss::yield().get();
         }
@@ -186,7 +194,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_timeout) {
         // client acquisition.
 
         ss::abort_source as;
-        auto f = pool.local().acquire_with_timeout(as, 100ms);
+        auto f = pool.local().acquire_with_timeout(test_bucket, as, 100ms);
         ss::sleep(500ms).get();
         as.request_abort();
         BOOST_REQUIRE_THROW(f.get(), ss::abort_requested_exception);
@@ -196,7 +204,9 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_timeout) {
         // passing a deadline in the past should behave sanely
         ss::abort_source as;
         BOOST_REQUIRE_THROW(
-          pool.local().acquire(as, ss::lowres_clock::time_point::min()).get(),
+          pool.local()
+            .acquire(test_bucket, as, ss::lowres_clock::time_point::min())
+            .get(),
           ss::timed_out_error);
     }
 }
@@ -208,7 +218,8 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_self_configure_deadline) {
     auto stop_guard = test_pool_builder.skip_start(true).build(pool).get();
 
     ss::abort_source as;
-    auto f = pool.local().acquire(as, ss::lowres_clock::now() - 100ms);
+    auto f = pool.local().acquire(
+      test_bucket, as, ss::lowres_clock::now() - 100ms);
 
     ss::with_timeout(
       ss::lowres_clock::now() + 1s,
@@ -227,7 +238,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_self_configure_abortable) {
     auto stop_guard = test_pool_builder.skip_start(true).build(pool).get();
 
     ss::abort_source as;
-    auto f = pool.local().acquire(as);
+    auto f = pool.local().acquire(test_bucket, as);
 
     while (!pool.local().has_waiters()) {
         ss::yield().get();

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -26,7 +26,6 @@
 #include <seastar/core/iostream.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sleep.hh>
-#include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/http/function_handlers.hh>
@@ -34,23 +33,24 @@
 #include <seastar/http/httpd.hh>
 #include <seastar/http/request.hh>
 #include <seastar/http/routes.hh>
-#include <seastar/net/api.hh>
 #include <seastar/net/socket_defs.hh>
 #include <seastar/net/tls.hh>
 #include <seastar/testing/test_case.hh>
-#include <seastar/util/defer.hh>
 
-#include <boost/algorithm/string.hpp>
-#include <boost/beast/http/field.hpp>
 #include <boost/property_tree/ptree_fwd.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/test/tools/old/interface.hpp>
-#include <boost/test/unit_test.hpp>
 
 #include <chrono>
 
+namespace {
+
 using namespace std::chrono_literals;
 using namespace cloud_storage_clients::tests;
+
+static const cloud_storage_clients::bucket_name_parts test_bucket{
+  .name = cloud_storage_clients::plain_bucket_name("test-bucket"),
+};
 
 static const uint16_t httpd_port_number = 4434;
 static constexpr const char* httpd_host_name = "localhost";
@@ -397,6 +397,8 @@ started_client_and_server(const cloud_storage_clients::s3_configuration& conf) {
     };
 }
 
+} // namespace
+
 SEASTAR_TEST_CASE(test_put_object_success) {
     return ss::async([] {
         auto conf = client_configuration();
@@ -406,7 +408,7 @@ SEASTAR_TEST_CASE(test_put_object_success) {
         auto payload_stream = make_iobuf_input_stream(std::move(payload));
         client
           ->put_object(
-            cloud_storage_clients::bucket_name("test-bucket"),
+            cloud_storage_clients::plain_bucket_name("test-bucket"),
             cloud_storage_clients::object_key("test"),
             expected_payload_size,
             std::move(payload_stream),
@@ -428,7 +430,7 @@ SEASTAR_TEST_CASE(test_put_object_failure) {
         auto payload_stream = make_iobuf_input_stream(std::move(payload));
         const auto result = client
                               ->put_object(
-                                cloud_storage_clients::bucket_name(
+                                cloud_storage_clients::plain_bucket_name(
                                   "test-bucket"),
                                 cloud_storage_clients::object_key("test-error"),
                                 expected_payload_size,
@@ -452,7 +454,7 @@ SEASTAR_TEST_CASE(test_put_object_unexpected) {
         const auto result
           = client
               ->put_object(
-                cloud_storage_clients::bucket_name("test-bucket"),
+                cloud_storage_clients::plain_bucket_name("test-bucket"),
                 cloud_storage_clients::object_key("test-unexpected"),
                 expected_payload_size,
                 std::move(payload_stream),
@@ -471,7 +473,7 @@ SEASTAR_TEST_CASE(test_get_object_success) {
         auto payload_stream = make_iobuf_ref_output_stream(payload);
         const auto result = client
                               ->get_object(
-                                cloud_storage_clients::bucket_name(
+                                cloud_storage_clients::plain_bucket_name(
                                   "test-bucket"),
                                 cloud_storage_clients::object_key("test"),
                                 100ms)
@@ -494,7 +496,7 @@ SEASTAR_TEST_CASE(test_get_object_failure) {
         auto [server, client] = started_client_and_server(conf);
         const auto result = client
                               ->get_object(
-                                cloud_storage_clients::bucket_name(
+                                cloud_storage_clients::plain_bucket_name(
                                   "test-bucket"),
                                 cloud_storage_clients::object_key("test-error"),
                                 100ms)
@@ -512,7 +514,7 @@ SEASTAR_TEST_CASE(test_delete_object_success) {
         auto [server, client] = started_client_and_server(conf);
         const auto result = client
                               ->delete_object(
-                                cloud_storage_clients::bucket_name(
+                                cloud_storage_clients::plain_bucket_name(
                                   "test-bucket"),
                                 cloud_storage_clients::object_key("test"),
                                 100ms)
@@ -530,7 +532,7 @@ SEASTAR_TEST_CASE(test_delete_object_failure) {
 
         const auto result = client
                               ->delete_object(
-                                cloud_storage_clients::bucket_name(
+                                cloud_storage_clients::plain_bucket_name(
                                   "test-bucket"),
                                 cloud_storage_clients::object_key("test-error"),
                                 100ms)
@@ -557,7 +559,7 @@ SEASTAR_TEST_CASE(test_delete_object_not_found) {
         const auto result
           = client
               ->delete_object(
-                cloud_storage_clients::bucket_name("test-bucket"),
+                cloud_storage_clients::plain_bucket_name("test-bucket"),
                 cloud_storage_clients::object_key("test-key-not-found"),
                 100ms)
               .get();
@@ -575,7 +577,7 @@ SEASTAR_TEST_CASE(test_delete_bucket_not_found) {
         const auto result
           = client
               ->delete_object(
-                cloud_storage_clients::bucket_name("test-bucket"),
+                cloud_storage_clients::plain_bucket_name("test-bucket"),
                 cloud_storage_clients::object_key("test-bucket-not-found"),
                 100ms)
               .get();
@@ -594,7 +596,7 @@ SEASTAR_TEST_CASE(test_unexpected_error_message) {
         const auto result
           = client
               ->get_object(
-                cloud_storage_clients::bucket_name("test-bucket"),
+                cloud_storage_clients::plain_bucket_name("test-bucket"),
                 cloud_storage_clients::object_key("test-unexpected"),
                 100ms)
               .get();
@@ -619,7 +621,7 @@ SEASTAR_TEST_CASE(test_list_objects_success) {
         auto payload_stream = make_iobuf_ref_output_stream(payload);
         const auto result = client
                               ->list_objects(
-                                cloud_storage_clients::bucket_name(
+                                cloud_storage_clients::plain_bucket_name(
                                   "test-bucket"),
                                 cloud_storage_clients::object_key("test"))
                               .get();
@@ -661,7 +663,7 @@ SEASTAR_TEST_CASE(test_list_objects_with_filter) {
         const auto result
           = client
               ->list_objects(
-                cloud_storage_clients::bucket_name("test-bucket"),
+                cloud_storage_clients::plain_bucket_name("test-bucket"),
                 cloud_storage_clients::object_key("test"),
                 std::nullopt,
                 std::nullopt,
@@ -696,7 +698,7 @@ SEASTAR_TEST_CASE(test_list_objects_failure) {
         auto [server, client] = started_client_and_server(conf);
         const auto result = client
                               ->list_objects(
-                                cloud_storage_clients::bucket_name(
+                                cloud_storage_clients::plain_bucket_name(
                                   "test-bucket"),
                                 cloud_storage_clients::object_key("test-error"))
                               .get();
@@ -714,7 +716,7 @@ SEASTAR_TEST_CASE(test_list_objects_with_continuation) {
         auto [server, client] = started_client_and_server(conf);
         const auto result = client
                               ->list_objects(
-                                cloud_storage_clients::bucket_name{
+                                cloud_storage_clients::plain_bucket_name{
                                   "test-bucket"},
                                 cloud_storage_clients::object_key{"test-cont"},
                                 {},
@@ -732,7 +734,7 @@ SEASTAR_TEST_CASE(test_delete_objects_success) {
           client_configuration());
         auto result = client
                         ->delete_objects(
-                          cloud_storage_clients::bucket_name{"oknoerror"},
+                          cloud_storage_clients::plain_bucket_name{"oknoerror"},
                           {cloud_storage_clients::object_key{"key1"},
                            cloud_storage_clients::object_key{"key2"},
                            cloud_storage_clients::object_key{"key3"}},
@@ -755,7 +757,7 @@ SEASTAR_TEST_CASE(test_delete_objects_errors) {
 
         auto result = client
                         ->delete_objects(
-                          cloud_storage_clients::bucket_name{"okerror"},
+                          cloud_storage_clients::plain_bucket_name{"okerror"},
                           {keys.begin(), keys.end()},
                           http::default_connect_timeout)
                         .get();
@@ -780,7 +782,8 @@ SEASTAR_TEST_CASE(test_delete_object_retry) {
           client_configuration());
         auto result = client
                         ->delete_objects(
-                          cloud_storage_clients::bucket_name{"empty-body"},
+                          cloud_storage_clients::plain_bucket_name{
+                            "empty-body"},
                           {cloud_storage_clients::object_key{"key1"}},
                           http::default_connect_timeout)
                         .get();
@@ -802,7 +805,7 @@ ss::future<> do_test_put_object_no_response(bool acceptable) {
         const auto response
           = client
               ->put_object(
-                cloud_storage_clients::bucket_name("test-bucket"),
+                cloud_storage_clients::plain_bucket_name("test-bucket"),
                 cloud_storage_clients::object_key("test-put-no-content"),
                 expected_payload_size,
                 std::move(payload_stream),
@@ -833,7 +836,7 @@ ss::future<> do_test_no_such_configuration(bool acceptable) {
         auto [server, client] = started_client_and_server(conf);
         const auto result = client
                               ->get_object(
-                                cloud_storage_clients::bucket_name(
+                                cloud_storage_clients::plain_bucket_name(
                                   "test-bucket"),
                                 cloud_storage_clients::object_key("no-config"),
                                 100ms,
@@ -895,7 +898,7 @@ static ss::future<> test_client_pool_payload(
     iobuf payload;
     auto payload_stream = make_iobuf_ref_output_stream(payload);
     auto result = co_await client->get_object(
-      cloud_storage_clients::bucket_name("test-bucket"),
+      cloud_storage_clients::plain_bucket_name("test-bucket"),
       cloud_storage_clients::object_key("test"),
       100ms);
     BOOST_REQUIRE(result);
@@ -913,7 +916,7 @@ FIXTURE_TEST(test_client_pool_wait_strategy, client_pool_fixture) {
     for (size_t i = 0; i < 20; i++) {
         auto f
           = pool.local()
-              .acquire(never_abort)
+              .acquire(test_bucket, never_abort)
               .then([server = server](
                       cloud_storage_clients::client_pool::client_lease lease) {
                   return test_client_pool_payload(server, std::move(lease));
@@ -933,7 +936,7 @@ static ss::future<bool> test_client_pool_reconnect_helper(
     auto payload_stream = make_iobuf_ref_output_stream(payload);
     try {
         auto result = co_await client->get_object(
-          cloud_storage_clients::bucket_name("test-bucket"),
+          cloud_storage_clients::plain_bucket_name("test-bucket"),
           cloud_storage_clients::object_key("test"),
           100ms);
         BOOST_REQUIRE(result);
@@ -956,7 +959,7 @@ FIXTURE_TEST(test_client_pool_reconnect, client_pool_fixture) {
     std::vector<ss::future<bool>> fut;
     for (size_t i = 0; i < 20; i++) {
         auto f = pool.local()
-                   .acquire(never_abort)
+                   .acquire(test_bucket, never_abort)
                    .then(
                      [server = server](
                        cloud_storage_clients::client_pool::client_lease lease) {

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -79,7 +79,31 @@ inline constexpr offset operator-(offset o, offset_delta d) { return o + (-d); }
 
 namespace cloud_storage_clients {
 
-using bucket_name = named_type<ss::sstring, struct s3_bucket_name>;
+/// Bucket name type stores a plain cloud storage bucket name or a data source
+/// name (DSN) that includes bucket name and optional connection parameters
+/// overriding cluster configuration.
+///
+/// No secret information is stored in this type. It can be logged or displayed
+/// to the user as is.
+///
+/// Examples:
+///   - my-bucket
+///   - my-bucket?region=us-west-2&endpoint=http://localhost:9000
+///
+/// History note: The connection parameters in DSN format were introduced to
+/// support cross-region bucket access for Remote Read Replicas feature
+/// (https://redpandadata.atlassian.net/browse/CORE-12797). In general, the new
+/// format can be used by any feature that requires overriding cluster-level
+/// connection settings on per-bucket basis.
+using bucket_name = named_type<ss::sstring, struct bucket_name_tag>;
+
+/// Plain bucket name is the actual bucket name without any connection
+/// parameters.
+///
+/// Examples:
+///   - my-bucket
+///   - another-bucket
+using plain_bucket_name = named_type<ss::sstring, struct plain_bucket_name_tag>;
 
 } // namespace cloud_storage_clients
 


### PR DESCRIPTION
Introduce type distinction between bucket_name and plain_bucket_name:

- bucket_name: Can store either a plain bucket name OR a DSN (Data Source Name) with connection parameters (e.g., "my-bucket?region=us-west-2"). This type was introduced to support cross-region bucket access for Remote Read Replicas.

- plain_bucket_name: Always contains just the bucket name without any parameters (e.g., "my-bucket"). This is the actual bucket name used for cloud storage API calls.

Also introduce bucket_name_parts struct and parse_bucket_name() to extract the plain bucket name and connection parameters from a DSN. The parser follows application/x-www-form-urlencoded conventions with stricter validation: empty keys, duplicate keys, and empty parameters are rejected.

Parameters are stored as a vector of key-value pairs rather than a typed struct. This keeps the parser decoupled from provider-specific semantics (e.g., "account" is required for Azure but invalid for S3). Validation of which parameters are valid/required belongs in the cloud client factories, not in the generic parser. A vector is also cache-friendly for the small number of parameters typical in a DSN (usually 1-3).

This type safety prevents accidentally using a DSN string where only the plain bucket name is expected.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
