### PR TITLE
[CORE-15091] `ct/l1`: add and use `object_metadata_builder::create_object_for()`

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/BUILD
@@ -217,7 +217,6 @@ redpanda_cc_library(
         "//src/v/container:chunked_circular_buffer",
         "//src/v/container:chunked_hash_map",
         "//src/v/model",
-        "//src/v/ssx:mutex",
         "//src/v/ssx:semaphore",
         "//src/v/ssx:when_all",
         "//src/v/utils:uuid",

--- a/src/v/cloud_topics/level_one/compaction/committer.cc
+++ b/src/v/cloud_topics/level_one/compaction/committer.cc
@@ -100,7 +100,6 @@ void compaction_committer::compaction_job::cancel_job() {
     _as.request_abort();
     _upload_sem.broken();
     _last_upload_scheduled.broken();
-    _metadata_builder_mutex.broken();
 }
 
 ss::future<> compaction_committer::compaction_job::remove_staging_files() {
@@ -157,19 +156,8 @@ compaction_committer::compaction_job::do_upload(
   staging_file* file,
   object_builder::object_info info,
   metastore::object_metadata::ntp_metadata ntp_md) {
-    auto holder_res = co_await ss::coroutine::as_future(
-      _metadata_builder_mutex.get_units());
-    if (holder_res.failed()) {
-        auto e = holder_res.get_exception();
-        co_return std::unexpected(
-          error{
-            .t = error::type::shutdown_failure, .msg = fmt::format("{}", e)});
-    }
-
-    auto holder = std::move(holder_res).get();
-
     auto& metadata_builder = _metadata_builder;
-    auto oid_res = metadata_builder->get_or_create_object_for(_tp);
+    auto oid_res = metadata_builder->create_object_for(_tp);
     if (!oid_res.has_value()) {
         co_return std::unexpected(
           error{

--- a/src/v/cloud_topics/level_one/compaction/committer.h
+++ b/src/v/cloud_topics/level_one/compaction/committer.h
@@ -19,7 +19,6 @@
 #include "container/chunked_circular_buffer.h"
 #include "container/chunked_hash_map.h"
 #include "model/fundamental.h"
-#include "ssx/mutex.h"
 #include "utils/uuid.h"
 
 class ReducerTestFixture;
@@ -158,9 +157,6 @@ public:
 
         compaction_job_id _id;
         model::topic_id_partition _tp;
-        // TODO: remove when we have better primitives around "one tidp,
-        // multiple objects" for the `metadata_builder`.
-        ssx::mutex _metadata_builder_mutex{"metadata_builder_mutex"};
         // The `metadata_builder` that is receiving a stream of L1 objects
         // as they are pushed to the `committer` and continually building up
         // an update for the `metastore`.

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -110,6 +110,17 @@ public:
         virtual std::expected<object_id, error>
         get_or_create_object_for(const model::topic_id_partition&) = 0;
 
+        // Creates a new object for the given partition. It is guaranteed that
+        // this object is brand new/unused. It is not guaranteed, however, that
+        // it cannot be accessed concurrently by other users of this
+        // `object_metadata_builder` who call `get_or_create_object_for()`. If
+        // complete isolation of objects is required, ensure that all users of
+        // this particular `object_metadata_builder` only invoke
+        // `create_object_for()` and `finish()` for the provided `object_id`
+        // within a tightly bounded scope.
+        virtual std::expected<object_id, error>
+        create_object_for(const model::topic_id_partition&) = 0;
+
         // Removes a pending object from the builder. The object must be in the
         // pending state. Further calls to get_or_create_object_for() will not
         // return the object id. Any other call that references the object id

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -101,6 +101,8 @@ public:
 
     std::expected<object_id, error>
     get_or_create_object_for(const model::topic_id_partition&) override;
+    std::expected<object_id, error>
+    create_object_for(const model::topic_id_partition&) override;
     std::expected<void, error> remove_pending_object(object_id) override;
     std::expected<void, error>
       add(object_id, metastore::object_metadata::ntp_metadata) override;
@@ -139,6 +141,22 @@ replicated_object_builder::get_or_create_object_for(
         return oid;
     }
     return partition_objects.pending_objects_.begin()->first;
+}
+
+std::expected<object_id, replicated_object_builder::error>
+replicated_object_builder::create_object_for(
+  const model::topic_id_partition& tidp) {
+    auto metastore_pid = fe_.metastore_partition(tidp);
+    if (!metastore_pid) {
+        return std::unexpected(
+          error{
+            "could not determine metastore partition for create_object_for()"});
+    }
+    auto& partition_objects = partitions_[*metastore_pid];
+
+    auto oid = create_object_id();
+    partition_objects.pending_objects_[oid] = {};
+    return oid;
 }
 
 std::expected<void, replicated_object_builder::error>

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -49,6 +49,13 @@ simple_object_builder::get_or_create_object_for(
     return pending_objects_.begin()->first;
 }
 
+std::expected<object_id, simple_object_builder::error>
+simple_object_builder::create_object_for(const model::topic_id_partition&) {
+    auto oid = create_object_id();
+    pending_objects_[oid] = {};
+    return oid;
+}
+
 std::expected<void, simple_object_builder::error>
 simple_object_builder::remove_pending_object(object_id oid) {
     auto it = pending_objects_.find(oid);

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -31,6 +31,8 @@ public:
 
     std::expected<object_id, error>
     get_or_create_object_for(const model::topic_id_partition&) override;
+    std::expected<object_id, error>
+    create_object_for(const model::topic_id_partition&) override;
     std::expected<void, error> remove_pending_object(object_id) override;
     std::expected<void, error>
       add(object_id, metastore::object_metadata::ntp_metadata) override;

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -999,6 +999,24 @@ TEST(SimpleMetastoreTest, TestObjectBuilder) {
     ASSERT_EQ(0, release_res.value()[1].ntp_metas.size());
 }
 
+TEST(SimpleMetastoreTest, TestObjectBuilderCreatesNewObjects) {
+    simple_metastore m;
+    auto ob = m.object_builder().get().value();
+    auto tp = model::topic_id_partition::from(tid_a);
+
+    chunked_hash_set<object_id> oids;
+    static constexpr size_t num_objects = 1000;
+    // Creating objects for the same partition will result in a different object
+    // everytime.
+    for (size_t i = 0; i < num_objects; ++i) {
+        auto oid_opt = ob->create_object_for(tp);
+        ASSERT_TRUE(oid_opt.has_value());
+        auto [_, inserted] = oids.insert(oid_opt.value());
+        ASSERT_TRUE(inserted);
+    }
+    ASSERT_EQ(oids.size(), num_objects);
+}
+
 TEST(SimpleMetastoreTest, TestObjectBuilderBadObjects) {
     // Test calls for objects that don't exist in the builder.
     simple_metastore m;


### PR DESCRIPTION
In compaction, we need to be able to create individual L1 objects from the same `object_metadata_builder` for the same partition concurrently.

Currently, the only interface provided is `get_or_create_object_for()`, which can result in reuse of the same `object_id`, by design. This has forced the `compaction_committer` to use a `mutex` around the `object_metadata_builder` during concurrent constructions of L1 objects to ensure isolation of objects.

Add `create_object_for()` for this specific use-case, with possible footguns/unexpected behavior noted in an inline comment above the function declaration.

Finally, amend the `compaction_committer` to use this new API.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
