### PR TITLE
lsm: support delayed file deletion

### DIFF
--- a/src/v/lsm/BUILD
+++ b/src/v/lsm/BUILD
@@ -21,6 +21,7 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/lsm/io:persistence",
         "//src/v/utils:named_type",
+        "@abseil-cpp//absl/time",
         "@seastar",
     ],
 )

--- a/src/v/lsm/core/internal/BUILD
+++ b/src/v/lsm/core/internal/BUILD
@@ -92,6 +92,7 @@ redpanda_cc_library(
         ":files",
         "//src/v/base",
         "//src/v/lsm/core:compression",
+        "@abseil-cpp//absl/time",
         "@seastar",
     ],
 )

--- a/src/v/lsm/core/internal/options.h
+++ b/src/v/lsm/core/internal/options.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "absl/time/time.h"
 #include "base/format_to.h"
 #include "base/units.h"
 #include "base/vassert.h"
@@ -194,6 +195,12 @@ struct options {
     // Approximate gap in bytes between samples of data read during iteration.
     constexpr static size_t default_read_bytes_period = 10_MiB;
     size_t read_bytes_period = default_read_bytes_period;
+
+    // The delay at which to wait until actually deleting files.
+    //
+    // If set to zero, then files are immediately GC'd after new manifest files
+    // are written.
+    absl::Duration file_deletion_delay;
 
     fmt::iterator format_to(fmt::iterator) const;
 };

--- a/src/v/lsm/core/internal/options.h
+++ b/src/v/lsm/core/internal/options.h
@@ -165,7 +165,7 @@ struct options {
     size_t block_cache_size = default_block_cache_size;
 
     // The size of a single block within an SST file.
-    constexpr static size_t default_sst_block_size = 4_KiB;
+    constexpr static size_t default_sst_block_size = 8_KiB;
     size_t sst_block_size = default_sst_block_size;
 
     // The frequency at which to generate a new bloom filter.

--- a/src/v/lsm/db/BUILD
+++ b/src/v/lsm/db/BUILD
@@ -227,3 +227,26 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "gc_actor",
+    srcs = [
+        "gc_actor.cc",
+    ],
+    hdrs = [
+        "gc_actor.h",
+    ],
+    implementation_deps = [
+        "//src/v/lsm/core/internal:logger",
+    ],
+    deps = [
+        ":table_cache",
+        "//src/v/base",
+        "//src/v/container:chunked_hash_map",
+        "//src/v/lsm/core/internal:files",
+        "//src/v/lsm/core/internal:options",
+        "//src/v/lsm/io:persistence",
+        "//src/v/ssx:actor",
+        "@seastar",
+    ],
+)

--- a/src/v/lsm/db/BUILD
+++ b/src/v/lsm/db/BUILD
@@ -68,6 +68,7 @@ redpanda_cc_library(
         ":version_set",
         "//src/v/base",
         "//src/v/bytes:iobuf",
+        "//src/v/container:chunked_hash_map",
         "//src/v/lsm/core:exceptions",
         "//src/v/lsm/core/internal:files",
         "//src/v/lsm/core/internal:iterator",

--- a/src/v/lsm/db/BUILD
+++ b/src/v/lsm/db/BUILD
@@ -62,6 +62,7 @@ redpanda_cc_library(
         "//src/v/lsm/sst:builder",
     ],
     deps = [
+        ":gc_actor",
         ":memtable",
         ":snapshot",
         ":table_cache",

--- a/src/v/lsm/db/gc_actor.cc
+++ b/src/v/lsm/db/gc_actor.cc
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "lsm/db/gc_actor.h"
+
+#include "base/vlog.h"
+#include "lsm/core/internal/logger.h"
+
+namespace lsm::db {
+
+ss::future<> gc_actor::process(gc_message msg) {
+    auto gen = _persistence->list_files();
+    chunked_hash_set<internal::file_handle> seen_gc_files;
+    while (auto file_handle_opt = co_await gen()) {
+        if (_as.abort_requested()) {
+            co_return;
+        }
+        auto& file_handle = file_handle_opt->get();
+        if (msg.live_files.contains(file_handle)) {
+            // This file is currently apart of the database, don't remove
+            // it.
+            continue;
+        }
+        if (file_handle.epoch > _opts->database_epoch) {
+            // This file was written by a future epoch.
+            continue;
+        }
+        if (
+          file_handle.epoch == _opts->database_epoch
+          && file_handle.id > msg.highest_used_file_id) {
+            // This file is being written concurrently with a compaction.
+            // Or it is for a future version of the database.
+            continue;
+        }
+        // Mark this file as seen, so that we can later remove files that
+        // were deleted by other means.
+        seen_gc_files.insert(file_handle);
+        auto now = ss::lowres_clock::now();
+        auto it = _pending_deletes.find(file_handle);
+        if (it == _pending_deletes.end()) {
+            // This is our first time seeing a pending delete, store the
+            // time at which we want to delete it.
+            it = _pending_deletes.insert_or_assign(
+              it,
+              file_handle,
+              now + absl::ToChronoNanoseconds(_opts->file_deletion_delay));
+        }
+        if (now < it->second) {
+            continue;
+        }
+        co_await _table_cache->evict(file_handle);
+        co_await _persistence->remove_file(file_handle);
+        _pending_deletes.erase(it);
+    }
+}
+
+void gc_actor::on_error(std::exception_ptr ex) noexcept {
+    vlog(log.warn, "error in LSM tree GC: {}", ex);
+}
+
+} // namespace lsm::db

--- a/src/v/lsm/db/gc_actor.cc
+++ b/src/v/lsm/db/gc_actor.cc
@@ -18,9 +18,11 @@ namespace lsm::db {
 
 ss::future<> gc_actor::process(gc_message msg) {
     vlog(log.trace, "gc_actor_process_start");
+
+    auto now = ss::lowres_clock::now();
+
+    // Lookup new files to remove
     auto gen = _persistence->list_files();
-    chunked_hash_set<internal::file_handle> seen_gc_files;
-    int deleted = 0;
     while (auto file_handle_opt = co_await gen()) {
         if (_as.abort_requested()) {
             co_return;
@@ -42,10 +44,6 @@ ss::future<> gc_actor::process(gc_message msg) {
             // Or it is for a future version of the database.
             continue;
         }
-        // Mark this file as seen, so that we can later remove files that
-        // were deleted by other means.
-        seen_gc_files.insert(file_handle);
-        auto now = ss::lowres_clock::now();
         auto it = _pending_deletes.find(file_handle);
         if (it == _pending_deletes.end()) {
             // This is our first time seeing a pending delete, store the
@@ -55,14 +53,22 @@ ss::future<> gc_actor::process(gc_message msg) {
               file_handle,
               now + absl::ToChronoNanoseconds(_opts->file_deletion_delay));
         }
+    }
+
+    // Remove any pending files
+    int deleted = 0;
+    auto it = _pending_deletes.begin();
+    while (it != _pending_deletes.end()) {
         if (now < it->second) {
+            ++it;
             continue;
         }
-        co_await _table_cache->evict(file_handle);
-        co_await _persistence->remove_file(file_handle);
-        _pending_deletes.erase(it);
+        co_await _table_cache->evict(it->first);
+        co_await _persistence->remove_file(it->first);
+        it = _pending_deletes.erase(it);
         ++deleted;
     }
+
     vlog(log.trace, "gc_actor_process_end deleted={}", deleted);
 }
 

--- a/src/v/lsm/db/gc_actor.cc
+++ b/src/v/lsm/db/gc_actor.cc
@@ -17,8 +17,10 @@
 namespace lsm::db {
 
 ss::future<> gc_actor::process(gc_message msg) {
+    vlog(log.trace, "gc_actor_process_start");
     auto gen = _persistence->list_files();
     chunked_hash_set<internal::file_handle> seen_gc_files;
+    int deleted = 0;
     while (auto file_handle_opt = co_await gen()) {
         if (_as.abort_requested()) {
             co_return;
@@ -59,11 +61,13 @@ ss::future<> gc_actor::process(gc_message msg) {
         co_await _table_cache->evict(file_handle);
         co_await _persistence->remove_file(file_handle);
         _pending_deletes.erase(it);
+        ++deleted;
     }
+    vlog(log.trace, "gc_actor_process_end deleted={}", deleted);
 }
 
 void gc_actor::on_error(std::exception_ptr ex) noexcept {
-    vlog(log.warn, "error in LSM tree GC: {}", ex);
+    vlog(log.warn, "gc_actor_process_end error=\"{}\"", ex);
 }
 
 } // namespace lsm::db

--- a/src/v/lsm/db/gc_actor.h
+++ b/src/v/lsm/db/gc_actor.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "container/chunked_hash_map.h"
+#include "lsm/core/internal/files.h"
+#include "lsm/core/internal/options.h"
+#include "lsm/db/table_cache.h"
+#include "lsm/io/persistence.h"
+#include "ssx/actor.h"
+
+namespace lsm::db {
+
+// A request to the GC actor to remove old unused files.
+struct gc_message {
+    // The ID of the highest file that has been committed to the database.
+    // Files with higher IDs are ignored as they could be currently built.
+    internal::file_id highest_used_file_id;
+    // All the of the live files in the database at this time.
+    chunked_hash_set<internal::file_handle> live_files;
+};
+
+// An actor to remove old files from the database that are no longer being used.
+//
+// This actor only has a mailbox size of 1 and drops old requests when new ones
+// come in because new requests will be inclusive of old ones.
+class gc_actor
+  : public ssx::actor<gc_message, 1, ssx::overflow_policy::drop_oldest> {
+public:
+    gc_actor(
+      io::data_persistence* persistence,
+      ss::lw_shared_ptr<internal::options> opts,
+      table_cache* table_cache)
+      : _persistence(persistence)
+      , _opts(std::move(opts))
+      , _table_cache(table_cache) {}
+
+protected:
+    ss::future<> process(gc_message msg) override;
+
+    void on_error(std::exception_ptr ex) noexcept override;
+
+private:
+    io::data_persistence* _persistence;
+    ss::lw_shared_ptr<internal::options> _opts;
+    table_cache* _table_cache;
+    chunked_hash_map<internal::file_handle, ss::lowres_clock::time_point>
+      _pending_deletes;
+};
+
+} // namespace lsm::db

--- a/src/v/lsm/db/gc_actor.h
+++ b/src/v/lsm/db/gc_actor.h
@@ -44,6 +44,8 @@ public:
       , _opts(std::move(opts))
       , _table_cache(table_cache) {}
 
+    size_t pending_delete_count() const { return _pending_deletes.size(); }
+
 protected:
     ss::future<> process(gc_message msg) override;
 

--- a/src/v/lsm/db/impl.cc
+++ b/src/v/lsm/db/impl.cc
@@ -550,9 +550,23 @@ ss::future<> impl::remove_obsolete_files() {
         if (file_handle.epoch > _opts->database_epoch) {
             continue;
         }
+        auto now = ss::lowres_clock::now();
+        auto it = _pending_file_deletes.find(file_handle);
+        if (it == _pending_file_deletes.end()) {
+            it = _pending_file_deletes.insert_or_assign(
+              it,
+              file_handle,
+              now + absl::ToChronoNanoseconds(_opts->file_deletion_delay));
+        }
+        if (now < it->second) {
+            continue;
+        }
+        _pending_file_deletes.erase(it);
         co_await _table_cache->evict(file_handle);
         co_await _persistence.data->remove_file(file_handle);
     }
+    // TODO(rockwood): Also remove files that we don't see anymore (ie. was
+    // deleted by some other process)
 }
 
 std::optional<internal::sequence_number> impl::max_persisted_seqno() const {

--- a/src/v/lsm/db/impl.cc
+++ b/src/v/lsm/db/impl.cc
@@ -49,12 +49,14 @@ impl::impl(ctor, io::persistence p, ss::lw_shared_ptr<internal::options> o)
           _opts->block_cache_size / _opts->sst_block_size)))
   , _versions(
       std::make_unique<version_set>(
-        _persistence.metadata.get(), _table_cache.get(), _opts)) {}
+        _persistence.metadata.get(), _table_cache.get(), _opts))
+  , _gc_actor(_persistence.data.get(), _opts, _table_cache.get()) {}
 
 ss::future<std::unique_ptr<impl>> impl::open(
   ss::lw_shared_ptr<internal::options> opts, io::persistence persistence) {
     auto db = std::make_unique<impl>(
       ctor{}, std::move(persistence), std::move(opts));
+    co_await db->_gc_actor.start();
     auto fut = co_await ss::coroutine::as_future(db->recover());
     if (fut.failed()) {
         auto ex = fut.get_exception();
@@ -268,6 +270,7 @@ ss::future<> impl::close() {
     if (fut) {
         fut = co_await ss::coroutine::as_future(std::move(*fut));
     }
+    co_await _gc_actor.stop();
     co_await _table_cache->close();
     co_await _persistence.data->close();
     co_await _persistence.metadata->close();
@@ -491,7 +494,13 @@ ss::future<> impl::run_background_compaction() {
         });
     }
     co_await _versions->log_and_apply(std::move(*edit));
-    co_await remove_obsolete_files();
+    // Go and cleanup any obsolete files where both the epoch, and file ID is
+    // less than what we have committed, and is not in our working set.
+    co_await _gc_actor.tell(
+      gc_message{
+        .highest_used_file_id = _versions->highest_used_file_id(),
+        .live_files = _versions->get_live_files(),
+      });
 }
 
 ss::future<> impl::flush_memtable() {
@@ -537,36 +546,6 @@ ss::future<> impl::flush_memtable() {
     // reader to pick up both the memtable and the new version with the
     // file. This is OK because all iterators deduplicate already.
     _imm = std::nullopt;
-}
-
-ss::future<> impl::remove_obsolete_files() {
-    chunked_hash_set<internal::file_handle> files = _versions->get_live_files();
-    auto gen = _persistence.data->list_files();
-    while (auto file_handle_opt = co_await gen()) {
-        auto& file_handle = file_handle_opt->get();
-        if (files.contains(file_handle)) {
-            continue;
-        }
-        if (file_handle.epoch > _opts->database_epoch) {
-            continue;
-        }
-        auto now = ss::lowres_clock::now();
-        auto it = _pending_file_deletes.find(file_handle);
-        if (it == _pending_file_deletes.end()) {
-            it = _pending_file_deletes.insert_or_assign(
-              it,
-              file_handle,
-              now + absl::ToChronoNanoseconds(_opts->file_deletion_delay));
-        }
-        if (now < it->second) {
-            continue;
-        }
-        _pending_file_deletes.erase(it);
-        co_await _table_cache->evict(file_handle);
-        co_await _persistence.data->remove_file(file_handle);
-    }
-    // TODO(rockwood): Also remove files that we don't see anymore (ie. was
-    // deleted by some other process)
 }
 
 std::optional<internal::sequence_number> impl::max_persisted_seqno() const {

--- a/src/v/lsm/db/impl.cc
+++ b/src/v/lsm/db/impl.cc
@@ -25,7 +25,6 @@
 #include "lsm/sst/block_cache.h"
 #include "lsm/sst/builder.h"
 
-#include <seastar/core/coroutine.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/coroutine/as_future.hh>
 
@@ -54,6 +53,7 @@ impl::impl(ctor, io::persistence p, ss::lw_shared_ptr<internal::options> o)
 
 ss::future<std::unique_ptr<impl>> impl::open(
   ss::lw_shared_ptr<internal::options> opts, io::persistence persistence) {
+    vlog(log.trace, "open_start");
     auto db = std::make_unique<impl>(
       ctor{}, std::move(persistence), std::move(opts));
     co_await db->_gc_actor.start();
@@ -65,6 +65,7 @@ ss::future<std::unique_ptr<impl>> impl::open(
     }
     // If we're readonly, we don't need to start any compaction loop.
     if (db->_opts->readonly) {
+        vlog(log.trace, "open_end readonly=true");
         co_return db;
     }
     db->_background_work = ss::with_scheduling_group(
@@ -72,14 +73,14 @@ ss::future<std::unique_ptr<impl>> impl::open(
           return ss::do_until(
             [db] { return db->_as.abort_requested(); },
             [db] {
-                vlog(log.trace, "waiting for background work");
                 return db->_start_background_work_signal.wait(db->_as)
                   .then([db] {
                       db->_background_work_running = true;
-                      vlog(log.trace, "start background compaction");
+                      vlog(log.trace, "compaction_loop_start");
                       return db->run_background_compaction();
                   })
                   .then_wrapped([db](ss::future<> fut) {
+                      vlog(log.trace, "compaction_loop_end");
                       db->_background_work_running = false;
                       db->maybe_schedule_compaction();
                       db->_background_work_finished_signal.broadcast();
@@ -89,18 +90,19 @@ ss::future<std::unique_ptr<impl>> impl::open(
                       } catch (const abort_requested_exception& ex) {
                           vlog(
                             log.debug,
-                            "LSM background loop got abort request: {}",
+                            "compaction_loop_error abort=true error=\"{}\"",
                             ex.what());
                       } catch (const io_error_exception& ex) {
                           vlog(
                             log.warn,
-                            "LSM background loop hit IO error: {}",
+                            "compaction_loop_error io=true error=\"{}\"",
                             ex.what());
                       } catch (...) {
                           auto ep = std::current_exception();
                           vlog(
                             log.error,
-                            "Unexpected error in LSM background loop: {}",
+                            "compaction_loop_error unexpected=true "
+                            "error=\"{}\"",
                             ep);
                       }
                       // Signal so that we immediately retry
@@ -110,6 +112,7 @@ ss::future<std::unique_ptr<impl>> impl::open(
                   });
             });
       });
+    vlog(log.trace, "open_end readonly=false");
     co_return db;
 }
 
@@ -133,7 +136,7 @@ ss::future<> impl::make_room_for_write() {
           && _versions->current()->num_files(0_level)
                > _opts->level_zero_slowdown_writes_trigger) {
             // We're in throttling mode
-            vlog(log.debug, "throttling writes due to number of L0 files");
+            vlog(log.debug, "throttling_writes reason=l0_file_count");
             try {
                 co_await ss::sleep_abortable(std::chrono::seconds(1), _as);
             } catch (...) {
@@ -151,7 +154,7 @@ ss::future<> impl::make_room_for_write() {
             co_return;
         }
         if (_imm) {
-            vlog(log.warn, "blocking writes as in memory buffers are full");
+            vlog(log.warn, "blocking_writes reason=memtable_full");
             // We are over the write buffer limit and we have a pending
             // memtable flush, wait for it to finish.
             co_await _background_work_finished_signal.wait(_as);
@@ -160,16 +163,13 @@ ss::future<> impl::make_room_for_write() {
         if (
           _versions->current()->num_files(0_level)
           > _opts->level_zero_stop_writes_trigger) {
-            vlog(
-              log.warn,
-              "too many L0 files, writing for compaction to finish before "
-              "allowing more writes");
+            vlog(log.warn, "blocking_writes reason=l0_full");
             // We've hit out L0 file limit, wait for compaction to finish.
             co_await _background_work_finished_signal.wait(_as);
             continue;
         }
         // We're over our limit, let's make a new memtable
-        vlog(log.trace, "scheduling memtable flush");
+        vlog(log.trace, "scheduling_memtable_flush");
         _imm = std::exchange(_mem, ss::make_lw_shared<memtable>());
         maybe_schedule_compaction();
     }
@@ -265,6 +265,7 @@ ss::future<> impl::flush() {
 }
 
 ss::future<> impl::close() {
+    vlog(log.trace, "close_start");
     _as.request_abort_ex(abort_requested_exception("database closing"));
     auto fut = std::exchange(_background_work, std::nullopt);
     if (fut) {
@@ -274,12 +275,14 @@ ss::future<> impl::close() {
     co_await _table_cache->close();
     co_await _persistence.data->close();
     co_await _persistence.metadata->close();
+    vlog(log.trace, "close_end");
     if (fut && fut->failed()) {
         std::rethrow_exception(fut->get_exception());
     }
 }
 
 ss::future<> impl::recover() {
+    vlog(log.trace, "recover_start");
     co_await _versions->recover();
     // If requested, then pre-open all the files we know about.
     if (auto max_fibers = _opts->max_pre_open_fibers) {
@@ -291,12 +294,15 @@ ss::future<> impl::recover() {
                 all_files.push_back(std::move(file));
             }
         }
+        vlog(log.trace, "recover_pre_open_start files={}", all_files.size());
         co_await ss::max_concurrent_for_each(
           all_files, max_fibers, [this](ss::lw_shared_ptr<file_meta_data> f) {
               return _table_cache->create_iterator(f->handle, f->file_size)
                 .discard_result();
           });
+        vlog(log.trace, "recover_pre_open_end files={}", all_files.size());
     }
+    vlog(log.trace, "recover_end");
 }
 
 void impl::maybe_schedule_compaction() {
@@ -364,6 +370,17 @@ ss::future<> impl::run_background_compaction() {
         co_return;
     }
     auto compaction = *std::move(maybe_compaction);
+    auto input_level = compaction.level();
+    auto output_level = input_level + 1_level;
+    auto num_input_files
+      = compaction.num_input_files(compaction::which::input_level)
+        + compaction.num_input_files(compaction::which::output_level);
+    vlog(
+      log.trace,
+      "compaction_start input_level={} output_level={} input_files={}",
+      input_level,
+      output_level,
+      num_input_files);
     if (compaction.is_trivial_move()) {
         auto input_level_files = compaction.num_input_files(
           compaction::which::input_level);
@@ -382,7 +399,16 @@ ss::future<> impl::run_background_compaction() {
           .oldest_seqno = file->oldest_seqno,
           .newest_seqno = file->newest_seqno,
         });
+        vlog(log.trace, "manifest_write_start");
         co_await _versions->log_and_apply(std::move(*compaction.edit()));
+        vlog(log.trace, "manifest_write_end");
+        vlog(
+          log.trace,
+          "compaction_end input_level={} output_level={} output_files=1 "
+          "output_bytes={} trivial_move=true",
+          input_level,
+          output_level,
+          file->file_size);
         co_return;
     }
     compaction_state state{
@@ -395,7 +421,6 @@ ss::future<> impl::run_background_compaction() {
       .smallest_snapshot = _snapshots.oldest_seqno().value_or(
         _versions->last_seqno().value()),
     };
-    auto output_level = compaction.level() + 1_level;
     auto max_file_size = _opts->levels[output_level].max_file_size;
     sst::builder::options sst_options{
       .block_size = _opts->sst_block_size,
@@ -493,7 +518,9 @@ ss::future<> impl::run_background_compaction() {
           .newest_seqno = output.newest,
         });
     }
+    vlog(log.trace, "manifest_write_start");
     co_await _versions->log_and_apply(std::move(*edit));
+    vlog(log.trace, "manifest_write_end");
     // Go and cleanup any obsolete files where both the epoch, and file ID is
     // less than what we have committed, and is not in our working set.
     co_await _gc_actor.tell(
@@ -501,6 +528,14 @@ ss::future<> impl::run_background_compaction() {
         .highest_used_file_id = _versions->highest_used_file_id(),
         .live_files = _versions->get_live_files(),
       });
+    vlog(
+      log.trace,
+      "compaction_end input_level={} output_level={} output_files={} "
+      "output_bytes={}",
+      input_level,
+      output_level,
+      state.outputs.size(),
+      state.total_bytes);
 }
 
 ss::future<> impl::flush_memtable() {
@@ -512,6 +547,12 @@ ss::future<> impl::flush_memtable() {
                    ? 0_level
                    : v->pick_level_for_memtable_output(
                        imm->min_key().user_key(), imm->max_key().user_key());
+    auto mem_bytes = imm->approximate_memory_usage();
+    vlog(
+      log.trace,
+      "flush_memtable_start level={} mem_bytes={}",
+      level,
+      mem_bytes);
     sst::builder::options sst_options{
       .block_size = _opts->sst_block_size,
       .filter_period = _opts->sst_filter_period,
@@ -525,6 +566,10 @@ ss::future<> impl::flush_memtable() {
       &_as);
     if (!result) {
         _versions->reuse_file_id(id);
+        vlog(
+          log.trace,
+          "flush_memtable_end level={} file_bytes=0 empty=true",
+          level);
         co_return;
     }
     version_edit edit(*_opts);
@@ -538,7 +583,14 @@ ss::future<> impl::flush_memtable() {
       .oldest_seqno = result->oldest_seqno,
       .newest_seqno = result->newest_seqno,
     });
+    vlog(log.trace, "manifest_write_start");
     co_await _versions->log_and_apply(std::move(edit));
+    vlog(log.trace, "manifest_write_end");
+    vlog(
+      log.trace,
+      "flush_memtable_end level={} file_bytes={}",
+      level,
+      result->file_size);
     // Now that the new version has been applied, it's safe to remove the
     // immutable memtable, as readers will pick up the new file instead.
     //

--- a/src/v/lsm/db/impl.h
+++ b/src/v/lsm/db/impl.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "container/chunked_hash_map.h"
 #include "lsm/core/internal/iterator.h"
 #include "lsm/core/internal/keys.h"
 #include "lsm/core/internal/options.h"
@@ -124,6 +125,9 @@ private:
     bool _background_work_running = false;
     std::optional<ss::future<>> _background_work;
     snapshot_list _snapshots;
+
+    chunked_hash_map<internal::file_handle, ss::lowres_clock::time_point>
+      _pending_file_deletes;
 };
 
 } // namespace lsm::db

--- a/src/v/lsm/db/impl.h
+++ b/src/v/lsm/db/impl.h
@@ -16,6 +16,7 @@
 #include "lsm/core/internal/iterator.h"
 #include "lsm/core/internal/keys.h"
 #include "lsm/core/internal/options.h"
+#include "lsm/db/gc_actor.h"
 #include "lsm/db/memtable.h"
 #include "lsm/db/snapshot.h"
 #include "lsm/db/table_cache.h"
@@ -109,8 +110,6 @@ private:
 
     ss::future<> flush_memtable();
 
-    ss::future<> remove_obsolete_files();
-
     io::persistence _persistence;
     ss::lw_shared_ptr<internal::options> _opts;
     // The active in-memory memtable.
@@ -126,8 +125,7 @@ private:
     std::optional<ss::future<>> _background_work;
     snapshot_list _snapshots;
 
-    chunked_hash_map<internal::file_handle, ss::lowres_clock::time_point>
-      _pending_file_deletes;
+    gc_actor _gc_actor;
 };
 
 } // namespace lsm::db

--- a/src/v/lsm/db/table_cache.cc
+++ b/src/v/lsm/db/table_cache.cc
@@ -134,10 +134,7 @@ public:
       , _cache(compute_cache_config(max_entries), eviction(this))
       , _block_cache(std::move(block_cache))
       , _cleanup_queue([](const std::exception_ptr& ex) {
-          vlog(
-            log.error,
-            "expected exception on table cache cleanup queue: {}",
-            ex);
+          vlog(log.error, "table_cache_cleanup_error error=\"{}\"", ex);
       }) {}
 
     ss::future<std::unique_ptr<internal::iterator>>

--- a/src/v/lsm/db/tests/.gitignore
+++ b/src/v/lsm/db/tests/.gitignore
@@ -1,0 +1,1 @@
+trace.json

--- a/src/v/lsm/db/tests/BUILD
+++ b/src/v/lsm/db/tests/BUILD
@@ -178,3 +178,24 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "gc_actor_test",
+    timeout = "short",
+    srcs = [
+        "gc_actor_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/lsm/core/internal:files",
+        "//src/v/lsm/core/internal:options",
+        "//src/v/lsm/db:gc_actor",
+        "//src/v/lsm/db:table_cache",
+        "//src/v/lsm/io:memory_persistence",
+        "//src/v/lsm/sst:block_cache",
+        "//src/v/lsm/sst:builder",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/lsm/db/tests/gc_actor_test.cc
+++ b/src/v/lsm/db/tests/gc_actor_test.cc
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "base/seastarx.h"
+#include "lsm/core/internal/files.h"
+#include "lsm/core/internal/options.h"
+#include "lsm/db/gc_actor.h"
+#include "lsm/db/table_cache.h"
+#include "lsm/io/memory_persistence.h"
+#include "lsm/sst/block_cache.h"
+#include "lsm/sst/builder.h"
+#include "test_utils/async.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace {
+
+using lsm::internal::operator""_db_epoch;
+using lsm::internal::operator""_file_id;
+
+class GcActorTest : public testing::Test {
+public:
+    lsm::internal::file_handle make_sst(
+      lsm::internal::file_id id,
+      lsm::internal::database_epoch epoch = 0_db_epoch) {
+        auto fh = lsm::internal::file_handle{.id = id, .epoch = epoch};
+        auto file = _persistence->open_sequential_writer(fh).get();
+        lsm::sst::builder builder(std::move(file), {});
+        builder.finish().get();
+        builder.close().get();
+        return fh;
+    }
+
+    ss::future<std::vector<lsm::internal::file_handle>> list_files_async() {
+        std::vector<lsm::internal::file_handle> result;
+        auto gen = _persistence->list_files();
+        while (auto fh = co_await gen()) {
+            result.push_back(fh->get());
+        }
+        co_return result;
+    }
+
+    std::vector<lsm::internal::file_handle> list_files() {
+        return list_files_async().get();
+    }
+
+    void start_gc() {
+        _table_cache.emplace(
+          _persistence.get(),
+          10,
+          ss::make_lw_shared<lsm::sst::block_cache>(1_MiB));
+        _gc.emplace(_persistence.get(), _opts, &*_table_cache);
+        _gc->start().get();
+    }
+
+    void TearDown() override {
+        if (_gc) {
+            _gc->stop().get();
+        }
+        if (_table_cache) {
+            _table_cache->close().get();
+        }
+        _persistence->close().get();
+    }
+
+protected:
+    std::unique_ptr<lsm::io::data_persistence> _persistence
+      = lsm::io::make_memory_data_persistence();
+    ss::lw_shared_ptr<lsm::internal::options> _opts
+      = ss::make_lw_shared<lsm::internal::options>();
+    std::optional<lsm::db::table_cache> _table_cache;
+    std::optional<lsm::db::gc_actor> _gc;
+};
+
+} // namespace
+
+TEST_F(GcActorTest, LiveFilesNotDeleted) {
+    auto fh1 = make_sst(1_file_id);
+    auto fh2 = make_sst(2_file_id);
+    auto fh3 = make_sst(3_file_id);
+    ASSERT_EQ(list_files().size(), 3);
+
+    start_gc();
+
+    lsm::db::gc_message msg;
+    msg.highest_used_file_id = 3_file_id;
+    msg.live_files.insert(fh1);
+    msg.live_files.insert(fh2);
+    msg.live_files.insert(fh3);
+    _gc->tell(std::move(msg)).get();
+    tests::drain_task_queue().get();
+
+    EXPECT_EQ(list_files().size(), 3);
+}
+
+TEST_F(GcActorTest, UnusedFilesDeletedImmediatelyWithZeroDelay) {
+    auto fh1 = make_sst(1_file_id);
+    auto fh2 = make_sst(2_file_id);
+    auto fh3 = make_sst(3_file_id);
+    ASSERT_EQ(list_files().size(), 3);
+
+    _opts->file_deletion_delay = absl::ZeroDuration();
+    start_gc();
+
+    lsm::db::gc_message msg;
+    msg.highest_used_file_id = 3_file_id;
+    msg.live_files.insert(fh1);
+    msg.live_files.insert(fh3);
+    _gc->tell(std::move(msg)).get();
+    tests::drain_task_queue().get();
+
+    std::ignore = fh2; // deleted
+    EXPECT_THAT(list_files(), testing::UnorderedElementsAre(fh1, fh3));
+}
+
+TEST_F(GcActorTest, FutureEpochFilesNotDeleted) {
+    auto fh_current = make_sst(1_file_id, 0_db_epoch);
+    auto fh_future = make_sst(2_file_id, 1_db_epoch);
+    ASSERT_EQ(list_files().size(), 2);
+
+    _opts->database_epoch = 0_db_epoch;
+    _opts->file_deletion_delay = absl::ZeroDuration();
+    start_gc();
+
+    lsm::db::gc_message msg;
+    msg.highest_used_file_id = 2_file_id;
+    _gc->tell(std::move(msg)).get();
+    tests::drain_task_queue().get();
+
+    std::ignore = fh_current; // deleted
+    EXPECT_THAT(list_files(), testing::ElementsAre(fh_future));
+}

--- a/src/v/lsm/db/tests/gc_actor_test.cc
+++ b/src/v/lsm/db/tests/gc_actor_test.cc
@@ -100,6 +100,7 @@ TEST_F(GcActorTest, LiveFilesNotDeleted) {
     tests::drain_task_queue().get();
 
     EXPECT_EQ(list_files().size(), 3);
+    EXPECT_EQ(_gc->pending_delete_count(), 0);
 }
 
 TEST_F(GcActorTest, UnusedFilesDeletedImmediatelyWithZeroDelay) {
@@ -120,6 +121,7 @@ TEST_F(GcActorTest, UnusedFilesDeletedImmediatelyWithZeroDelay) {
 
     std::ignore = fh2; // deleted
     EXPECT_THAT(list_files(), testing::UnorderedElementsAre(fh1, fh3));
+    EXPECT_EQ(_gc->pending_delete_count(), 0);
 }
 
 TEST_F(GcActorTest, FutureEpochFilesNotDeleted) {
@@ -138,4 +140,51 @@ TEST_F(GcActorTest, FutureEpochFilesNotDeleted) {
 
     std::ignore = fh_current; // deleted
     EXPECT_THAT(list_files(), testing::ElementsAre(fh_future));
+    EXPECT_EQ(_gc->pending_delete_count(), 0);
+}
+
+TEST_F(GcActorTest, StopTrackingExternalDeletes) {
+    auto fh_1 = make_sst(1_file_id, 0_db_epoch);
+    auto fh_2 = make_sst(2_file_id, 0_db_epoch);
+    auto fh_3 = make_sst(3_file_id, 0_db_epoch);
+    ASSERT_EQ(list_files().size(), 3);
+
+    _opts->database_epoch = 0_db_epoch;
+    // Waiting one nanosecond basically means wait until the next iteration of
+    // the gc actor to delete.
+    _opts->file_deletion_delay = absl::Nanoseconds(1);
+    start_gc();
+
+    lsm::db::gc_message msg;
+    msg.highest_used_file_id = 3_file_id;
+    msg.live_files.insert(fh_2);
+    msg.live_files.insert(fh_3);
+    _gc->tell(std::move(msg)).get();
+    tests::drain_task_queue().get();
+
+    EXPECT_THAT(list_files(), testing::ElementsAre(fh_1, fh_2, fh_3));
+    EXPECT_EQ(_gc->pending_delete_count(), 1);
+
+    // Remove file one out of band
+    _persistence->remove_file(fh_1).get();
+
+    msg = {};
+    msg.highest_used_file_id = 3_file_id;
+    msg.live_files.insert(fh_3);
+    _gc->tell(std::move(msg)).get();
+    tests::drain_task_queue().get();
+
+    EXPECT_THAT(list_files(), testing::ElementsAre(fh_2, fh_3));
+    // We should only have file 2 in the pending delete list
+    EXPECT_EQ(_gc->pending_delete_count(), 1);
+
+    msg = {};
+    msg.highest_used_file_id = 3_file_id;
+    msg.live_files.insert(fh_3);
+    _gc->tell(std::move(msg)).get();
+    tests::drain_task_queue().get();
+
+    EXPECT_THAT(list_files(), testing::ElementsAre(fh_3));
+    // Everything should be deleted now
+    EXPECT_EQ(_gc->pending_delete_count(), 0);
 }

--- a/src/v/lsm/db/tests/logs_to_trace.py
+++ b/src/v/lsm/db/tests/logs_to_trace.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Convert LSM trace logs to Chrome trace JSON format.
+
+Usage:
+    ./logs_to_trace.py < logfile.log > trace.json
+    ./logs_to_trace.py logfile.log > trace.json
+
+Open the output in chrome://tracing or https://ui.perfetto.dev/
+"""
+
+import json
+import re
+import sys
+from datetime import datetime
+
+
+# Log format: LEVEL TIMESTAMP [shard N:CONTEXT] LOGGER - FILE:LINE - MESSAGE
+LOG_PATTERN = re.compile(
+    r"^(?P<level>\w+)\s+"
+    r"(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\s+"
+    r"\[shard (?P<shard>\d+):\w+\]\s+"
+    r"lsm\s+-\s+"
+    r"(?P<file>\w+\.cc):(?P<line>\d+)\s+-\s+"
+    r"(?P<message>.+)$"
+)
+
+
+def parse_timestamp(ts_str: str) -> int:
+    """Parse seastar log timestamp to microseconds since epoch."""
+    dt = datetime.strptime(ts_str, "%Y-%m-%d %H:%M:%S,%f")
+    return int(dt.timestamp() * 1_000_000)
+
+
+def parse_attrs(message: str) -> dict[str, str]:
+    """Parse key=value attributes from message, supporting quoted values."""
+    attrs = {}
+    # Match key=value or key="quoted value"
+    for match in re.finditer(r'(\w+)=(?:"([^"]*)"|(\S+))', message):
+        k = match.group(1)
+        v = match.group(2) if match.group(2) is not None else match.group(3)
+        try:
+            attrs[k] = int(v)
+        except ValueError:
+            attrs[k] = v
+    return attrs
+
+
+def main():
+    # Read input
+    if len(sys.argv) > 1:
+        with open(sys.argv[1]) as f:
+            lines = f.readlines()
+    else:
+        lines = sys.stdin.readlines()
+
+    events = []
+
+    for line in lines:
+        match = LOG_PATTERN.match(line.strip())
+        if not match:
+            continue
+
+        msg = match.group("message")
+        parts = msg.split()
+        if not parts:
+            continue
+
+        op = parts[0]
+
+        # Determine phase: B=begin, E=end, i=instant
+        if op.endswith("_start"):
+            name = op[:-6]
+            ph = "B"
+        elif op.endswith("_end"):
+            name = op[:-4]
+            ph = "E"
+        else:
+            # Instant event for point-in-time operations
+            name = op
+            ph = "i"
+
+        event = {
+            "name": name,
+            "cat": "lsm",
+            "ph": ph,
+            "ts": parse_timestamp(match.group("timestamp")),
+            "pid": 1,
+            "tid": int(match.group("shard")),
+            "args": parse_attrs(msg),
+        }
+
+        # Instant events need a scope (g=global, p=process, t=thread)
+        if ph == "i":
+            event["s"] = "t"  # Thread-scoped instant event
+
+        events.append(event)
+
+    print(json.dumps({"traceEvents": events}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/v/lsm/db/version_set.h
+++ b/src/v/lsm/db/version_set.h
@@ -144,6 +144,13 @@ public:
     // Allocate a new file ID
     internal::file_id new_file_id() { return _next_file_id++; }
 
+    // The highest allocated file ID.
+    internal::file_id highest_used_file_id() {
+        auto fid = _next_file_id;
+        fid--;
+        return fid;
+    }
+
     // Reuse a file ID (for example because a write failed or operation was
     // cancelled).
     void reuse_file_id(internal::file_id id);

--- a/src/v/lsm/lsm.cc
+++ b/src/v/lsm/lsm.cc
@@ -118,6 +118,7 @@ ss::lw_shared_ptr<internal::options> translate_options(options opts) {
     internal_opts->block_cache_size = opts.block_cache_size;
     internal_opts->sst_block_size = opts.sst_block_size;
     internal_opts->sst_filter_period = opts.sst_filter_period;
+    internal_opts->file_deletion_delay = opts.file_deletion_delay;
 
     return internal_opts;
 }

--- a/src/v/lsm/lsm.h
+++ b/src/v/lsm/lsm.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "absl/time/time.h"
 #include "base/seastarx.h"
 #include "lsm/io/persistence.h"
 #include "utils/named_type.h"
@@ -135,6 +136,12 @@ struct options {
     //
     // If empty all levels are uncompressed.
     std::vector<compression_type> compression_by_level;
+
+    // The delay at which to wait until actually deleting files.
+    //
+    // If set to zero, then files are immediately GC'd after new manifest files
+    // are written.
+    absl::Duration file_deletion_delay;
 };
 
 class write_batch;

--- a/src/v/lsm/lsm.h
+++ b/src/v/lsm/lsm.h
@@ -108,7 +108,7 @@ struct options {
     size_t block_cache_size = default_block_cache_size;
 
     // The size of a single block within an SST file.
-    constexpr static size_t default_sst_block_size = 4_KiB;
+    constexpr static size_t default_sst_block_size = 8_KiB;
     size_t sst_block_size = default_sst_block_size;
 
     // The frequency at which to generate a new bloom filter.

--- a/src/v/ssx/BUILD
+++ b/src/v/ssx/BUILD
@@ -299,3 +299,16 @@ redpanda_cc_library(
         "//src/v/base",
     ],
 )
+
+redpanda_cc_library(
+    name = "actor",
+    hdrs = [
+        "actor.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":future_util",
+        "//src/v/base",
+        "@seastar",
+    ],
+)

--- a/src/v/ssx/actor.h
+++ b/src/v/ssx/actor.h
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "ssx/future-util.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+
+#include <array>
+#include <optional>
+
+namespace ssx {
+
+// Policy for handling messages when the mailbox is full
+enum class overflow_policy : uint8_t {
+    // Block the sender until space is available
+    block,
+    // Drop the oldest message in the mailbox to make room
+    drop_oldest,
+};
+
+namespace detail {
+
+// Fixed-size ring buffer with no heap allocation
+template<typename T, size_t Capacity>
+class ring_buffer {
+public:
+    void push_back(T val) {
+        _data[_tail] = std::move(val);
+        _tail = (_tail + 1) % Capacity;
+        ++_size;
+    }
+
+    T pop_front() {
+        auto val = std::move(_data[_head]);
+        _head = (_head + 1) % Capacity;
+        --_size;
+        return val;
+    }
+
+    [[nodiscard]] bool empty() const { return _size == 0; }
+    [[nodiscard]] size_t size() const { return _size; }
+
+private:
+    std::array<T, Capacity> _data;
+    size_t _head{0};
+    size_t _tail{0};
+    size_t _size{0};
+};
+
+// Primary template: use ring_buffer
+template<typename T, size_t MaxSize>
+struct mailbox_storage {
+    using type = ring_buffer<T, MaxSize>;
+
+    static bool is_full(const type& m, size_t max) { return m.size() >= max; }
+    static bool is_empty(const type& m) { return m.empty(); }
+    static void push(type& m, T val) { m.push_back(std::move(val)); }
+    static T pop(type& m) { return m.pop_front(); }
+};
+
+// Specialization for MaxSize=1: use std::optional
+template<typename T>
+struct mailbox_storage<T, 1> {
+    using type = std::optional<T>;
+
+    static bool is_full(const type& m, size_t) { return m.has_value(); }
+    static bool is_empty(const type& m) { return !m.has_value(); }
+    static void push(type& m, T val) { m = std::move(val); }
+    static T pop(type& m) {
+        auto v = std::move(*m);
+        m.reset();
+        return v;
+    }
+};
+
+} // namespace detail
+
+/**
+ * A base class for implementing actors with a message mailbox.
+ *
+ * Derive from this class and implement the process() method to handle
+ * messages of type T. The actor processes messages sequentially on a
+ * single fiber.
+ *
+ * @tparam T The message type
+ * @tparam MaxQueueSize Maximum number of messages in the mailbox
+ * @tparam OverflowPolicy How to handle messages when mailbox is full
+ */
+template<
+  typename T,
+  size_t MaxQueueSize,
+  overflow_policy OverflowPolicy = overflow_policy::block>
+class actor {
+public:
+    actor() = default;
+    actor(const actor&) = delete;
+    actor& operator=(const actor&) = delete;
+    actor(actor&&) = delete;
+    actor& operator=(actor&&) = delete;
+    virtual ~actor() = default;
+
+    // Start the actor's processing loop
+    ss::future<> start() {
+        ssx::background = ss::with_gate(_gate, [this] { return run(); });
+        return ss::now();
+    }
+
+    // Stop the actor, waiting for current message processing to complete
+    ss::future<> stop() {
+        _as.request_abort();
+        _cv.broadcast();
+        co_await _gate.close();
+    }
+
+    // Send a message. Behavior when mailbox is full depends on OverflowPolicy:
+    // - block: waits until space is available
+    // - drop_oldest: drops the oldest message to make room (never blocks)
+    ss::future<> tell(T msg) {
+        if (_as.abort_requested()) {
+            co_return;
+        }
+        auto holder = _gate.hold();
+        if constexpr (OverflowPolicy == overflow_policy::block) {
+            // Wait for space if mailbox is full
+            co_await _cv.wait(
+              [this] { return _as.abort_requested() || !is_full(); });
+            if (_as.abort_requested()) {
+                co_return;
+            }
+        } else {
+            // Drop oldest if full
+            if (is_full()) {
+                storage_traits::pop(_mailbox);
+            }
+        }
+        storage_traits::push(_mailbox, std::move(msg));
+        _cv.signal();
+    }
+
+    // Try to send a message without blocking, returns false if mailbox is full.
+    // Only available when OverflowPolicy is block (with drop_oldest, tell()
+    // never blocks so try_tell is unnecessary).
+    bool try_tell(T msg)
+    requires(OverflowPolicy == overflow_policy::block)
+    {
+        if (_as.abort_requested() || is_full()) {
+            return false;
+        }
+        storage_traits::push(_mailbox, std::move(msg));
+        _cv.signal();
+        return true;
+    }
+
+protected:
+    // Override this to process messages
+    virtual ss::future<> process(T msg) = 0;
+
+    // Override this to handle exceptions thrown by process()
+    virtual void on_error(std::exception_ptr) noexcept = 0;
+
+private:
+    using storage_traits = detail::mailbox_storage<T, MaxQueueSize>;
+    using mailbox_type = typename storage_traits::type;
+
+    bool is_full() const {
+        return storage_traits::is_full(_mailbox, MaxQueueSize);
+    }
+
+    bool is_empty() const { return storage_traits::is_empty(_mailbox); }
+
+    ss::future<> run() {
+        while (true) {
+            co_await _cv.wait(
+              [this] { return _as.abort_requested() || !is_empty(); });
+            if (_as.abort_requested()) {
+                co_return;
+            }
+            auto msg = storage_traits::pop(_mailbox);
+            // Signal waiters that space is available
+            _cv.signal();
+            try {
+                co_await process(std::move(msg));
+            } catch (...) {
+                on_error(std::current_exception());
+            }
+        }
+    }
+
+    mailbox_type _mailbox;
+    ss::condition_variable _cv;
+
+protected:
+    ss::gate _gate;
+    ss::abort_source _as;
+};
+
+} // namespace ssx

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -214,6 +214,22 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "actor_test",
+    timeout = "short",
+    srcs = [
+        "actor_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/ssx:actor",
+        "//src/v/test_utils:async",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "event_test",
     timeout = "short",
     srcs = [

--- a/src/v/ssx/tests/actor_test.cc
+++ b/src/v/ssx/tests/actor_test.cc
@@ -1,0 +1,111 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "ssx/actor.h"
+#include "test_utils/async.h"
+
+#include <seastar/core/future.hh>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <vector>
+
+namespace ssx {
+
+using ::testing::ElementsAre;
+
+namespace {
+
+// Test actor that records messages it processes
+template<size_t MaxSize, overflow_policy Policy = overflow_policy::block>
+class test_actor : public actor<int, MaxSize, Policy> {
+public:
+    ss::future<> process(int msg) override {
+        processed.push_back(msg);
+        co_return;
+    }
+
+    void on_error(std::exception_ptr) noexcept override {}
+
+    std::vector<int> processed;
+};
+
+// Test actor that can throw errors and tracks them
+template<size_t MaxSize>
+class throwing_actor : public actor<int, MaxSize> {
+public:
+    ss::future<> process(int msg) override {
+        processed.push_back(msg);
+        if (msg < 0) {
+            throw std::runtime_error("negative value");
+        }
+        co_return;
+    }
+
+    void on_error(std::exception_ptr ex) noexcept override {
+        errors.push_back(ex);
+    }
+
+    std::vector<int> processed;
+    std::vector<std::exception_ptr> errors;
+};
+
+} // namespace
+
+TEST(Actor, ProcessesMessagesInOrder) {
+    test_actor<10> actor;
+    actor.start().get();
+
+    actor.tell(1).get();
+    actor.tell(2).get();
+    actor.tell(3).get();
+
+    tests::drain_task_queue().get();
+
+    EXPECT_THAT(actor.processed, ElementsAre(1, 2, 3));
+    actor.stop().get();
+}
+
+TEST(Actor, ErrorsDoNotStopProcessing) {
+    throwing_actor<10> actor;
+    actor.start().get();
+
+    actor.tell(1).get();
+    actor.tell(-1).get(); // This will throw
+    actor.tell(2).get();
+
+    tests::drain_task_queue().get();
+
+    EXPECT_THAT(actor.processed, ElementsAre(1, -1, 2));
+    EXPECT_EQ(actor.errors.size(), 1);
+    actor.stop().get();
+}
+
+TEST(Actor, DropOldestPolicy) {
+    test_actor<2, overflow_policy::drop_oldest> actor;
+    actor.start().get();
+
+    // With drop_oldest, tell() never blocks, so we can fill the queue
+    // and subsequent tells will drop the oldest messages
+    actor.tell(1).get();
+    actor.tell(2).get();
+    // Queue is now full, next tell should drop oldest
+    actor.tell(3).get(); // Drops 1, adds 3
+    actor.tell(4).get(); // Drops 2, adds 4
+
+    tests::drain_task_queue().get();
+
+    // Should have processed 3 and 4 (1 and 2 were dropped)
+    EXPECT_THAT(actor.processed, ElementsAre(3, 4));
+    actor.stop().get();
+}
+
+} // namespace ssx


### PR DESCRIPTION
The main purpose of this pr is to introduce the mechanism for delaying when files are deleted from the LSM tree. Any duration can be specified, but the default is 1 hour. Along there way there are a few other notable changes:

* structured logging: the lsm subsystem now uses structured logging for programmatic processing of the logs
* ssx::actor is introduced to hide the boilerplate of starting, stopping and sending messages to a background fiber. I expect to use this in more in the future for flushing and compaction actors as well.
* During performance testing, I noticed doubling the block size helps a lot, so we do this too.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
