### PR TITLE
`tree`: Use `performance-move-const-arg.CheckMoveToConstRef` in `clang-tidy`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 ---
 Checks:          'redpanda-*,clang-diagnostic-*,clang-analyzer-*,cert-*,cppcoreguidelines-*,hicpp-*,modernize-*,performance-*,misc-*,bugprone-*,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-hicpp-named-parameter,-misc-include-cleaner,-clang-analyzer-optin.core.EnumCastOutOfRange,-cppcoreguidelines-avoid-reference-coroutine-parameters'
-WarningsAsErrors: 'redpanda-*,bugprone-use-after-move,bugprone-assert-side-effect,bugprone-assignment-in-if-condition,bugprone-dangling-handle,bugprone-sizeof-container,bugprone-stringview-nullptr,bugprone-unused-return-value,bugprone-suspicious-string-compare,misc-unused-using-decls,misc-unused-alias-decls,modernize-redundant-void-arg,performance-implicit-conversion-in-loop,performance-trivially-destructible,performance-no-automatic-move,bugprone-unused-local-non-trivial-variable'
+WarningsAsErrors: 'redpanda-*,bugprone-use-after-move,bugprone-assert-side-effect,bugprone-assignment-in-if-condition,bugprone-dangling-handle,bugprone-sizeof-container,bugprone-stringview-nullptr,bugprone-unused-return-value,bugprone-suspicious-string-compare,misc-unused-using-decls,misc-unused-alias-decls,modernize-redundant-void-arg,performance-implicit-conversion-in-loop,performance-trivially-destructible,performance-no-automatic-move,performance-move-const-arg,bugprone-unused-local-non-trivial-variable'
 HeaderFilterRegex: '^(?!external/.*).*'
 FormatStyle:    file
 CheckOptions:
@@ -34,5 +34,7 @@ CheckOptions:
     value:           seastar::shared_ptr;seastar::lw_shared_ptr;
   - key:             bugprone-unused-local-non-trivial-variable.IncludeTypes
     value:           ::seastar::future
+  - key:             performance-move-const-arg.CheckTriviallyCopyableMove
+    value:           0
 ...
 

--- a/src/v/cloud_storage_clients/xml_sax_parser.cc
+++ b/src/v/cloud_storage_clients/xml_sax_parser.cc
@@ -140,7 +140,7 @@ void aws_parse_impl::consume_characters() {
     switch (_current_tag) {
     case xml_tag::key:
         if (_current_item) {
-            _current_item->key = std::move(characters);
+            _current_item->key = characters;
         } else {
             throw xml_parse_exception{
               "Invalid state: parsing Key when not in Contents tag"};
@@ -164,23 +164,23 @@ void aws_parse_impl::consume_characters() {
         break;
     case xml_tag::etag:
         if (_current_item) {
-            _current_item->etag = std::move(characters);
+            _current_item->etag = characters;
         } else {
             throw xml_parse_exception{
               "Invalid state: parsing ETag when not in Contents tag"};
         }
         break;
     case xml_tag::next_continuation_token:
-        _items.next_continuation_token = std::move(characters);
+        _items.next_continuation_token = characters;
         break;
     case xml_tag::prefix:
         // Parsing prefix at the top level: ListBucketResult -> Prefix
         if (_tags.size() == 2) {
-            _items.prefix = std::move(characters);
+            _items.prefix = characters;
             // Parsing common prefixes: ListBucketResult -> CommonPrefixes ->
             // Prefix
         } else if (_tags.size() == 3 && _tags[1] == aws_tags::common_prefixes) {
-            _items.common_prefixes.push_back(std::move(characters));
+            _items.common_prefixes.push_back(characters);
         }
         break;
     case xml_tag::is_truncated:
@@ -284,11 +284,11 @@ void abs_parse_impl::handle_characters(std::string_view characters) {
 }
 
 void abs_parse_impl::consume_characters() {
-    auto characters = std::exchange(_current_chars, {});
+    std::string characters = std::exchange(_current_chars, {});
     switch (_current_tag) {
     case xml_tag::key:
         if (_current_item) {
-            _current_item->key = std::move(characters);
+            _current_item->key = characters;
         } else {
             throw xml_parse_exception{
               "Invalid state: parsing Name when not in Blob tag"};
@@ -312,24 +312,24 @@ void abs_parse_impl::consume_characters() {
         break;
     case xml_tag::etag:
         if (_current_item) {
-            _current_item->etag = std::move(characters);
+            _current_item->etag = characters;
         } else {
             throw xml_parse_exception{
               "Invalid state: parsing ETag when not in Blob tag"};
         }
         break;
     case xml_tag::next_continuation_token:
-        _items.next_continuation_token = std::move(characters);
+        _items.next_continuation_token = characters;
         _items.is_truncated = true;
         break;
     case xml_tag::prefix:
         // Parsing prefix at the top level: ListBucketResult -> Prefix
         if (_tags.size() == 2) {
-            _items.prefix = std::move(characters);
+            _items.prefix = characters;
             // Parsing common prefixes: EnumerationResults -> Blobs ->
             // BlobPrefix -> Name
         } else if (_tags.size() == 4) {
-            _items.common_prefixes.push_back(std::move(characters));
+            _items.common_prefixes.push_back(characters);
         }
         break;
     case xml_tag::is_truncated:

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -614,8 +614,7 @@ ss::future<> bg_upload_and_replicate(
 
     chunked_vector<model::record_batch_header> headers;
     headers.push_back(header);
-    auto placeholders = co_await convert_to_placeholders(
-      res.value(), std::move(headers));
+    auto placeholders = co_await convert_to_placeholders(res.value(), headers);
 
     vassert(
       placeholders.batches.size() == 1,

--- a/src/v/cloud_topics/level_one/compaction/committer.cc
+++ b/src/v/cloud_topics/level_one/compaction/committer.cc
@@ -183,12 +183,13 @@ compaction_committer::compaction_job::do_upload(
 
     if (!put_res.has_value()) {
         std::ignore = metadata_builder->remove_pending_object(oid);
-        auto err = fmt::format(
-          "Failed to put object {}: {}",
-          oid,
-          static_cast<int>(put_res.error()));
         co_return std::unexpected(
-          error{.t = error::type::io_failure, .msg = std::move(err)});
+          error{
+            .t = error::type::io_failure,
+            .msg = fmt::format(
+              "Failed to put object {}: {}",
+              oid,
+              static_cast<int>(put_res.error()))});
     }
 
     vlog(
@@ -274,10 +275,9 @@ compaction_committer::compaction_job::await_inflight_uploads() {
 ss::future<std::expected<void, metastore::errc>>
 compaction_committer::compaction_job::do_compact_objects(
   metastore::compaction_map_t compact_map) {
-    return l1::retry_metastore_op_with_default_rtc(
-      [this, compact_map = std::move(compact_map)]() {
-          return _metastore->compact_objects(
-            *_metadata_builder, std::move(compact_map));
+    co_return co_await l1::retry_metastore_op_with_default_rtc(
+      [this, &compact_map]() {
+          return _metastore->compact_objects(*_metadata_builder, compact_map);
       },
       _as);
 }

--- a/src/v/cloud_topics/level_one/compaction/log_collector.cc
+++ b/src/v/cloud_topics/level_one/compaction/log_collector.cc
@@ -51,7 +51,7 @@ ss::future<> partition_leader_log_collector::start_collecting_logs() {
     _leader_notify_handle
       = _leaders->local().register_leadership_change_notification(
         [this](const model::ntp& ntp, model::term_id, model::node_id leader) {
-            on_leadership_change(std::move(ntp), leader);
+            on_leadership_change(ntp, leader);
         });
     co_return;
 }
@@ -118,7 +118,7 @@ void partition_leader_log_collector::on_ntp_change(
 }
 
 void partition_leader_log_collector::on_leadership_change(
-  model::ntp ntp, model::node_id leader) {
+  const model::ntp& ntp, model::node_id leader) {
     auto topic_cfg_opt = _topic_table->local().get_topic_cfg(
       model::topic_namespace_view{ntp});
     if (!topic_cfg_opt.has_value()) {
@@ -146,7 +146,7 @@ void partition_leader_log_collector::on_leadership_change(
     }
 
     if (!is_leader && is_managed) {
-        _unmanage_cb(std::move(ntp), "Stepped down as leader");
+        _unmanage_cb(ntp, "Stepped down as leader");
     }
 }
 

--- a/src/v/cloud_topics/level_one/compaction/log_collector.h
+++ b/src/v/cloud_topics/level_one/compaction/log_collector.h
@@ -72,7 +72,7 @@ public:
     using manage_cb_t = ss::noncopyable_function<void(
       const model::ntp&, const model::topic_id_partition&, std::string_view)>;
     using unmanage_cb_t
-      = ss::noncopyable_function<void(const model::ntp&, std::string_view)>;
+      = ss::noncopyable_function<void(model::ntp, std::string_view)>;
     using is_managed_cb_t = ss::noncopyable_function<bool(const model::ntp&)>;
 
     partition_leader_log_collector(
@@ -115,7 +115,7 @@ private:
     // Register operations can be performed synchronously while unregister
     // operations are performed in a backgrounded fiber (see
     // `compaction_scheduler::unmanage_partition()`).
-    void on_leadership_change(model::ntp, model::node_id);
+    void on_leadership_change(const model::ntp&, model::node_id);
 
     // Callback to register a partition with the `compaction_scheduler`.
     manage_cb_t _manage_cb;

--- a/src/v/cloud_topics/level_one/compaction/tests/log_info_collector_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/log_info_collector_test.cc
@@ -71,7 +71,7 @@ TEST_F(LogInfoCollectorTestFixture, TestInfoCollector) {
       .get();
     ASSERT_EQ(cached_metadata.size(), num_topics);
     while (!cached_metadata.empty()) {
-        auto sample = std::move(cached_metadata.top());
+        auto sample = cached_metadata.top();
         cached_metadata.pop();
         ASSERT_TRUE(sample->info_and_ts.has_value());
         ASSERT_FLOAT_EQ(sample->info_and_ts->info.dirty_ratio, 1.0);

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -1834,7 +1834,7 @@ ss::future<ntp_archiver_upload_result> ntp_archiver::upload_segment(
     // the read path will create the index on the fly while downloading the
     // segment, so it is okay to ignore the index upload failure, we still
     // want to advance the offsets because the segment did get uploaded.
-    co_await upload_index(std::move(index_path), std::move(index));
+    co_await upload_index(index_path, std::move(index));
 
     co_return ntp_archiver_upload_result(index_stats);
 

--- a/src/v/cluster/cloud_metadata/cluster_recovery_backend.cc
+++ b/src/v/cluster/cloud_metadata/cluster_recovery_backend.cc
@@ -309,9 +309,9 @@ ss::future<cluster::errc> cluster_recovery_backend::do_action(
                   return _controller_api
                     .wait_for_topic(
                       tp_ns, ss::lowres_clock::now() + permit.delay)
-                    .then([&done, tp_ns](std::error_code ec) {
+                    .then([&done, tp_ns](std::error_code ec) mutable {
                         if (!ec) {
-                            done.emplace_back(std::move(tp_ns));
+                            done.push_back(std::move(tp_ns));
                         } else {
                             vlog(
                               clusterlog.debug,

--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -359,7 +359,7 @@ static void preload_local(
             return;
         }
 
-        return preload_local(key, ss::sstring(std::move(raw_value)), result);
+        return preload_local(key, ss::sstring(raw_value), result);
     } else {
         if (result.has_value()) {
             vlog(clusterlog.info, "Ignoring unknown property: {}", key);

--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -528,7 +528,7 @@ controller_api::get_node_decommission_progress(
     // node but their metadata is update, add them explicitly
     ret.replicas_left += moving_from_node.size();
     auto states = co_await get_partitions_leader_reconfiguration_state(
-      std::move(moving_from_node), timeout);
+      moving_from_node, timeout);
 
     if (states) {
         ret.current_reconfigurations = std::move(states.value());

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -405,7 +405,9 @@ ss::future<> controller_backend::start() {
                 auto snapshot = create_topic_table_snapshot(_topics, _self);
                 ssx::spawn_with_gate(
                   _gate,
-                  [this, bootstrap_revision, snapshot = std::move(snapshot)] {
+                  [this,
+                   bootstrap_revision,
+                   snapshot = std::move(snapshot)] mutable {
                       return clear_orphan_topic_files(
                                bootstrap_revision, std::move(snapshot))
                         .handle_exception([](const std::exception_ptr& err) {

--- a/src/v/cluster/feature_backend.cc
+++ b/src/v/cluster/feature_backend.cc
@@ -138,7 +138,7 @@ ss::future<> feature_backend::save_local_snapshot() {
 }
 
 ss::future<> feature_backend::do_save_local_snapshot(
-  storage::api& storage, const features::feature_table_snapshot& snapshot) {
+  storage::api& storage, features::feature_table_snapshot snapshot) {
     // kvstore is shard-local: must be on a consistent shard every
     // time for snapshot storage to work.
     vassert(ss::this_shard_id() == ss::shard_id{0}, "wrong shard");

--- a/src/v/cluster/feature_backend.h
+++ b/src/v/cluster/feature_backend.h
@@ -47,8 +47,8 @@ public:
     bool has_local_snapshot();
     ss::future<> save_local_snapshot();
 
-    static ss::future<> do_save_local_snapshot(
-      storage::api&, const features::feature_table_snapshot&);
+    static ss::future<>
+    do_save_local_snapshot(storage::api&, features::feature_table_snapshot);
 
     bool is_batch_applicable(const model::record_batch& b) {
         return b.header().type == model::record_batch_type::feature_update;

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -1002,14 +1002,13 @@ void members_manager::join_raft0() {
         return ss::repeat([this] {
                    return dispatch_join_to_seed_server(
                             std::cbegin(_seed_servers),
-                            std::move(
-                              join_node_request{
-                                features::feature_table::
-                                  get_latest_logical_version(),
-                                features::feature_table::
-                                  get_earliest_logical_version(),
-                                _storage.local().node_uuid()().to_vector(),
-                                _self}))
+                            join_node_request{
+                              features::feature_table::
+                                get_latest_logical_version(),
+                              features::feature_table::
+                                get_earliest_logical_version(),
+                              _storage.local().node_uuid()().to_vector(),
+                              _self})
                      .then([this](result<join_node_reply> r) {
                          bool success = r && r.value().success;
                          // stop on success or closed gate
@@ -1477,7 +1476,7 @@ members_manager::dispatch_configuration_update(model::broker broker) {
         auto target = get_update_request_target(
           _raft0->get_leader_id(), brokers);
         auto r = co_await do_dispatch_configuration_update(
-          target.id(), std::move(target.rpc_address()), broker);
+          target.id(), target.rpc_address(), broker);
         if (r.has_error() || r.value().success == false) {
             co_await ss::sleep_abortable(
               _join_retry_jitter.base_duration(), _as.local());

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -1192,8 +1192,7 @@ partition_balancer_planner::request_context::for_each_replica_random_order(
         auto part_visitor = [&visitor, node = repl.node](partition& part) {
             return visitor(part, node);
         };
-        auto stop = do_with_partition(
-          std::move(ntp), *(repl.assignment), part_visitor);
+        auto stop = do_with_partition(ntp, *(repl.assignment), part_visitor);
         if (stop == ss::stop_iteration::yes) {
             co_return;
         }

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -289,7 +289,7 @@ ss::future<consensus_ptr> partition_manager::manage(
     ss::lw_shared_ptr<raft::consensus> c
       = co_await _raft_manager.local().create_group(
         group,
-        std::move(initial_nodes),
+        initial_nodes,
         log,
         enable_learner_recovery_throttle,
         keep_snapshotted_log);

--- a/src/v/cluster/security_manager.cc
+++ b/src/v/cluster/security_manager.cc
@@ -132,7 +132,7 @@ std::error_code do_apply(update_role_cmd cmd, security::role_store& store) {
     if (!removed) {
         return errc::role_does_not_exist;
     }
-    store.put(std::move(data.name), std::move(data.role));
+    store.put(std::move(data.name), data.role);
     return errc::success;
 }
 
@@ -153,7 +153,7 @@ std::error_code do_apply(create_role_cmd cmd, security::role_store& store) {
     if (store.contains(data.name)) {
         return errc::role_exists;
     }
-    store.put(std::move(data.name), std::move(data.role));
+    store.put(std::move(data.name), data.role);
     return errc::success;
 }
 

--- a/src/v/cluster/self_test/cloudcheck.cc
+++ b/src/v/cluster/self_test/cloudcheck.cc
@@ -95,7 +95,7 @@ cloudcheck::run(cloudcheck_opts opts) {
 ss::future<>
 cloudcheck::clear_self_test_folder(cloud_storage_clients::bucket_name bucket) {
     auto rtc = retry_chain_node(_opts.timeout, _opts.backoff, &_rtc);
-    const cloud_storage::remote::list_result object_list
+    cloud_storage::remote::list_result object_list
       = co_await _cloud_storage_api.local().list_objects(
         bucket, rtc, self_test_prefix);
 

--- a/src/v/cluster/self_test_backend.cc
+++ b/src/v/cluster/self_test_backend.cc
@@ -184,19 +184,22 @@ get_status_response self_test_backend::start_test(start_test_request req) {
         _id = req.id;
         vlog(
           clusterlog.debug, "Request to start self-tests with id: {}", req.id);
-        ssx::background
-          = ssx::spawn_with_gate_then(_gate, [this, req = std::move(req)]() {
-                return do_start_test(std::move(req)).then([this](auto results) {
-                    for (auto& r : results) {
-                        r.test_id = _id;
-                    }
-                    _prev_run = get_status_response{
-                      .id = _id,
-                      .status = self_test_status::idle,
-                      .results = std::move(results),
-                      .stage = _stage};
-                });
-            }).finally([units = std::move(units)] {});
+        ssx::background = ssx::spawn_with_gate_then(
+                            _gate,
+                            [this, req = std::move(req)]() mutable {
+                                return do_start_test(std::move(req))
+                                  .then([this](auto results) {
+                                      for (auto& r : results) {
+                                          r.test_id = _id;
+                                      }
+                                      _prev_run = get_status_response{
+                                        .id = _id,
+                                        .status = self_test_status::idle,
+                                        .results = std::move(results),
+                                        .stage = _stage};
+                                  });
+                            })
+                            .finally([units = std::move(units)] {});
     } else {
         vlog(
           clusterlog.info,

--- a/src/v/cluster/self_test_frontend.cc
+++ b/src/v/cluster/self_test_frontend.cc
@@ -197,10 +197,10 @@ ss::future<uuid_t> self_test_frontend::start_test(
           return handle->start_test(
             start_test_request{
               .id = test_id,
-              .dtos = std::move(req.dtos),
-              .ntos = std::move(new_ntos),
-              .unparsed_checks = std::move(req.unparsed_checks),
-              .ctos = std::move(req.ctos),
+              .dtos = req.dtos,
+              .ntos = new_ntos,
+              .unparsed_checks = req.unparsed_checks,
+              .ctos = req.ctos,
             });
       });
     co_return test_id;

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -649,7 +649,7 @@ ss::future<transfer_leadership_reply> service::transfer_leadership(
         auto errc = co_await _partition_manager.invoke_on(
           shard_id.value(),
           [r = std::move(r)](
-            partition_manager& pm) -> ss::future<std::error_code> {
+            partition_manager& pm) mutable -> ss::future<std::error_code> {
               auto partition_ptr = pm.partition_for(r.group);
               if (!partition_ptr) {
                   return ss::make_ready_future<std::error_code>(

--- a/src/v/cluster/tests/leader_balancer_bench.cc
+++ b/src/v/cluster/tests/leader_balancer_bench.cc
@@ -49,7 +49,7 @@ void random_search_eval_bench(bool measure_all) {
 
     random_t rt{index};
     cluster::leader_balancer_types::even_topic_distribution_constraint tdc(
-      std::move(gid_topic), si, mi);
+      gid_topic, si, mi);
     cluster::leader_balancer_types::even_shard_load_constraint slc(si, mi);
 
     if (!measure_all) {

--- a/src/v/cluster/tests/leader_balancer_constraints_test.cc
+++ b/src/v/cluster/tests/leader_balancer_constraints_test.cc
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(even_topic_distribution_empty) {
     auto [shard_index, muted_index] = from_spec({});
 
     auto even_topic_con = lbt::even_topic_distribution_constraint(
-      std::move(gntp_i), shard_index, muted_index);
+      gntp_i, shard_index, muted_index);
 
     BOOST_REQUIRE(even_topic_con.error() == 0);
 }
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(even_topic_distribution_constraint_no_error) {
     auto mute_i = lbt::muted_index({}, {});
 
     auto topic_constraint = lbt::even_topic_distribution_constraint(
-      std::move(g_id_to_t_id), index_cl, mute_i);
+      g_id_to_t_id, index_cl, mute_i);
 
     BOOST_REQUIRE(topic_constraint.error() == 0);
 }
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(even_topic_distributon_constraint_uniform_move) {
     auto mute_i = lbt::muted_index({}, {});
 
     auto topic_constraint = lbt::even_topic_distribution_constraint(
-      std::move(g_id_to_t_id), index_cl, mute_i);
+      g_id_to_t_id, index_cl, mute_i);
     auto reassignment = re(1, 0, 1);
 
     BOOST_REQUIRE(topic_constraint.error() != 0);
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(even_topic_constraint_too_many_replicas) {
     auto mute_i = lbt::muted_index({}, {});
 
     auto topic_constraint = lbt::even_topic_distribution_constraint(
-      std::move(g_id_to_t_id), index_cl, mute_i);
+      g_id_to_t_id, index_cl, mute_i);
 }
 
 BOOST_AUTO_TEST_CASE(even_topic_distributon_constraint_find_reassignment) {
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(even_topic_distributon_constraint_find_reassignment) {
     auto mute_i = lbt::muted_index({}, {});
 
     auto topic_constraint = lbt::even_topic_distribution_constraint(
-      std::move(g_id_to_t_id), index_cl, mute_i);
+      g_id_to_t_id, index_cl, mute_i);
     auto reassignment = re(1, 0, 1);
 
     BOOST_REQUIRE(topic_constraint.error() != 0);
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(even_shard_no_error_even_topic_error) {
     auto even_shard_con = lbt::even_shard_load_constraint(
       shard_index, muted_index);
     auto even_topic_con = lbt::even_topic_distribution_constraint(
-      std::move(g_id_to_t_id), shard_index, muted_index);
+      g_id_to_t_id, shard_index, muted_index);
 
     BOOST_REQUIRE(even_shard_con.error() == 0);
     BOOST_REQUIRE(even_topic_con.error() > 0);
@@ -225,7 +225,7 @@ BOOST_AUTO_TEST_CASE(even_topic_no_error_even_shard_error) {
     auto even_shard_con = lbt::even_shard_load_constraint(
       shard_index, muted_index);
     auto even_topic_con = lbt::even_topic_distribution_constraint(
-      std::move(g_id_to_t_id), shard_index, muted_index);
+      g_id_to_t_id, shard_index, muted_index);
 
     BOOST_REQUIRE(even_shard_con.error() > 0);
 }
@@ -306,7 +306,7 @@ BOOST_AUTO_TEST_CASE(topic_skew_error) {
     auto even_shard_con = lbt::even_shard_load_constraint(
       shard_index, muted_index);
     auto even_topic_con = lbt::even_topic_distribution_constraint(
-      std::move(g_id_to_t_id), shard_index, muted_index);
+      g_id_to_t_id, shard_index, muted_index);
 
     BOOST_REQUIRE(even_shard_con.error() == 0);
     BOOST_REQUIRE(even_topic_con.error() > 0);

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -314,7 +314,7 @@ struct partition_balancer_planner_fixture {
               model::broker_shard{
                 n, random_generators::get_int<uint32_t>(0, 3)});
         }
-        move_partition_replicas(std::move(ntp), std::move(new_replicas));
+        move_partition_replicas(ntp, new_replicas);
     }
 
     void move_partition_replicas(cluster::ntp_reassignment& reassignment) {

--- a/src/v/cluster_link/link_probe.cc
+++ b/src/v/cluster_link/link_probe.cc
@@ -141,8 +141,7 @@ void link_probe::setup_status_metrics() {
 
     std::ranges::copy(statuses | status_to_metric, std::back_inserter(defs));
 
-    _public_status_metrics.emplace().add_group(
-      shadow_link_group, std::move(defs));
+    _public_status_metrics.emplace().add_group(shadow_link_group, defs);
 }
 
 } // namespace cluster_link

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -322,7 +322,7 @@ ss::future<err_info> manager::link_preflight_checks(const model::metadata& md) {
                     // Handle any incompatible API versions or unexpected
                     // errors.
                     if (err.code() != errc::success) {
-                        broker_errors.push_back(std::move(err.message()));
+                        broker_errors.push_back(err.message());
                     }
                 });
           });

--- a/src/v/compaction/filter.cc
+++ b/src/v/compaction/filter.cc
@@ -24,7 +24,7 @@ ss::future<ss::stop_iteration> filter::operator()(model::record_batch b) {
     if (!b.compressed()) {
         co_return co_await filter_and_rewrite_with_sink(comp, std::move(b));
     }
-    auto batch = co_await model::decompress_batch(std::move(b));
+    auto batch = co_await model::decompress_batch(b);
 
     co_return co_await filter_and_rewrite_with_sink(comp, std::move(batch));
 }

--- a/src/v/iceberg/rest_client/json.cc
+++ b/src/v/iceberg/rest_client/json.cc
@@ -26,7 +26,7 @@ oauth_token parse_oauth_token(const json::Document& doc) {
     }
     // token type is defined as enum with the following possible values:
     // "bearer", "mac", "N_A"
-    auto token_type = absl::AsciiStrToLower(
+    ss::sstring token_type = absl::AsciiStrToLower(
       parse_required_str(doc, "token_type"));
 
     if (!(token_type == "bearer" || token_type == "mac"

--- a/src/v/iceberg/tests/transform_utils_test.cc
+++ b/src/v/iceberg/tests/transform_utils_test.cc
@@ -368,7 +368,7 @@ TEST(TestTransformApplication, NumericTruncateTransform) {
           value input_wrapped{
             std::in_place_type<primitive_value>, std::move(input)};
           auto transformed = apply_transform(
-                               std::move(input_wrapped),
+                               input_wrapped,
                                truncate_transform{.length = length})
                                .value();
           ASSERT_TRUE(std::holds_alternative<primitive_value>(transformed));

--- a/src/v/io/persistence.cc
+++ b/src/v/io/persistence.cc
@@ -68,15 +68,15 @@ std::optional<seastar::future<size_t>> check_alignment(
 namespace experimental::io {
 
 void persistence::file::fail_next_read(std::exception_ptr eptr) noexcept {
-    read_ex_ = std::move(eptr);
+    read_ex_ = eptr;
 }
 
 void persistence::file::fail_next_write(std::exception_ptr eptr) noexcept {
-    write_ex_ = std::move(eptr);
+    write_ex_ = eptr;
 }
 
 void persistence::file::fail_next_close(std::exception_ptr eptr) noexcept {
-    close_ex_ = std::move(eptr);
+    close_ex_ = eptr;
 }
 
 seastar::future<> persistence::file::maybe_fail_read() {
@@ -101,11 +101,11 @@ seastar::future<> persistence::file::maybe_fail_close() {
 }
 
 void persistence::fail_next_create(std::exception_ptr eptr) noexcept {
-    create_ex_ = std::move(eptr);
+    create_ex_ = eptr;
 }
 
 void persistence::fail_next_open(std::exception_ptr eptr) noexcept {
-    open_ex_ = std::move(eptr);
+    open_ex_ = eptr;
 }
 
 seastar::future<> persistence::maybe_fail_create() {

--- a/src/v/kafka/client/broker.cc
+++ b/src/v/kafka/client/broker.cc
@@ -425,8 +425,7 @@ remote_broker::send_scram_client_final(
           client_last_resp.data.error_message.value_or("<no error message>")};
     }
 
-    co_return security::server_final_message(
-      std::move(client_last_resp.data.auth_bytes));
+    co_return security::server_final_message(client_last_resp.data.auth_bytes);
 }
 
 template<typename ScramAlgo>

--- a/src/v/kafka/client/brokers.cc
+++ b/src/v/kafka/client/brokers.cc
@@ -86,11 +86,11 @@ ss::future<> brokers::apply(
     chunked_vector<metadata_update::broker> brokers_to_add;
     chunked_vector<model::node_id> brokers_to_remove;
 
-    for (auto& broker : brokers_metadata) {
+    for (const auto& broker : brokers_metadata) {
         auto it = _brokers.find(broker.node_id);
         // not found broker, we need to add it
         if (it == _brokers.end()) {
-            brokers_to_add.push_back(std::move(broker));
+            brokers_to_add.push_back(broker);
             continue;
         }
         auto& existing_broker = it->second;
@@ -99,7 +99,7 @@ ss::future<> brokers::apply(
           != net::unresolved_address(broker.host, broker.port)) {
             // recreate broker with the new address
             brokers_to_remove.push_back(broker.node_id);
-            brokers_to_add.push_back(std::move(broker));
+            brokers_to_add.push_back(broker);
         }
     }
     for (auto& [id, b] : _brokers) {

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -64,7 +64,7 @@ client::client(
       _cluster->get_topics(),
       _cluster->get_brokers(),
       _logger,
-      [this](std::exception_ptr ex) { return mitigate_error(std::move(ex)); }) {
+      [this](std::exception_ptr ex) { return mitigate_error(ex); }) {
     _metadata_callback_id = _cluster->register_metadata_cb(
       [this](const metadata_update& res) { on_metadata_update(res); });
 }
@@ -311,7 +311,7 @@ ss::future<create_topics_response> client::create_topic(
           auto controller = _cluster->get_controller_id().value_or(
             unknown_node_id);
           chunked_vector<kafka::creatable_topic> cv;
-          cv.push_back(std::move(req));
+          cv.push_back(req);
           return _cluster->dispatch_to(
             controller,
             kafka::create_topics_request{
@@ -549,7 +549,7 @@ client::create_consumer(const group_id& group_id, member_id name) {
             _cluster->get_topics(),
             _cluster->get_brokers(),
             std::move(coordinator),
-            std::move(group_id),
+            group_id,
             std::move(name),
             std::move(on_stopped),
             [this](std::exception_ptr ex) { return mitigate_error(ex); },

--- a/src/v/kafka/client/cluster.cc
+++ b/src/v/kafka/client/cluster.cc
@@ -377,7 +377,7 @@ void cluster::set_sasl_configuration(std::optional<sasl_configuration> creds) {
 }
 
 void cluster::update_configuration(connection_configuration config) {
-    _update_config_queue.submit([this, config = std::move(config)] {
+    _update_config_queue.submit([this, config = std::move(config)] mutable {
         return do_update_configuration(std::move(config))
           .handle_exception([this](std::exception_ptr ex) {
               vlog(_logger.warn, "Failed to update broker config: {}", ex);

--- a/src/v/kafka/client/direct_consumer/direct_consumer_probe.cc
+++ b/src/v/kafka/client/direct_consumer/direct_consumer_probe.cc
@@ -45,7 +45,7 @@ void direct_consumer_probe::setup_metrics(configuration config) {
     std::ranges::copy(
       client_metrics | std::views::as_rvalue, std::back_inserter(defs));
 
-    _public_metrics.add_group(config.group_name, std::move(defs));
+    _public_metrics.add_group(config.group_name, defs);
 }
 
 } // namespace client

--- a/src/v/kafka/client/fetcher.cc
+++ b/src/v/kafka/client/fetcher.cc
@@ -54,7 +54,7 @@ fetch_response
 make_fetch_response(const model::topic_partition& tp, std::exception_ptr ex) {
     error_code error;
     try {
-        std::rethrow_exception(std::move(ex));
+        std::rethrow_exception(ex);
     } catch (const partition_error& ex) {
         vlog(kclog.debug, "handling partition_error {}", ex);
         error = ex.error;

--- a/src/v/kafka/client/producer.cc
+++ b/src/v/kafka/client/producer.cc
@@ -51,7 +51,7 @@ produce_response::partition make_produce_response(
       .error_code = error_code::none,
     };
     try {
-        std::rethrow_exception(std::move(ex));
+        std::rethrow_exception(ex);
     } catch (const partition_error& ex) {
         vlog(logger.debug, "handling partition_error {}", ex.what());
         response.error_code = ex.error;
@@ -175,7 +175,7 @@ producer::send(model::topic_partition tp, model::record_batch&& batch) {
     return ss::do_with(
              std::move(batch),
              [this, tp](model::record_batch& batch) mutable {
-                 return ss::with_gate(_gate, [this, tp, &batch]() {
+                 return ss::with_gate(_gate, [this, tp, &batch]() mutable {
                      return retry_with_mitigation(
                        _retries_config.max_retries,
                        _retries_config.retry_base_backoff,
@@ -183,8 +183,8 @@ producer::send(model::topic_partition tp, model::record_batch&& batch) {
                            return do_send(tp, batch.share());
                        },
                        [this](std::exception_ptr ex) {
-                           return _error_handler(std::move(ex))
-                             .handle_exception([this](std::exception_ptr ex) {
+                           return _error_handler(ex).handle_exception(
+                             [this](std::exception_ptr ex) {
                                  vlog(
                                    _logger->trace,
                                    "Error during mitigation: {}",
@@ -196,7 +196,7 @@ producer::send(model::topic_partition tp, model::record_batch&& batch) {
                  });
              })
       .handle_exception([this, p_id](std::exception_ptr ex) {
-          return make_produce_response(p_id, std::move(ex), *_logger);
+          return make_produce_response(p_id, ex, *_logger);
       })
       .then([this, tp, record_count](produce_response::partition res) mutable {
           vlog(

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -687,8 +687,8 @@ connection_context::record_tp_and_calculate_throttle(
     co_return delay_t{.request = delay_request, .enforce = delay_enforce};
 }
 
-ss::future<request_resources> connection_context::throttle_request(
-  const request_data r_data, size_t request_size) {
+ss::future<request_resources>
+connection_context::throttle_request(request_data r_data, size_t request_size) {
     // note that when throttling is first determined, the request is
     // allowed to pass through, and only subsequent requests are
     // delayed. this is a similar strategy used by kafka 2.0: the

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -3665,12 +3665,12 @@ group::delete_offsets(const chunked_vector<model::topic_partition>& offsets) {
      * Delete the requested offsets, unless there is at least one active
      * subscription for an offset.
      */
-    for (auto& offset : offsets) {
+    for (const auto& offset : offsets) {
         if (!subscribed(offset.topic)) {
             vlog(_ctxlog.debug, "Deleting group offset {}", offset);
             _offsets.erase(offset);
             _pending_offset_commits.erase(offset);
-            deleted_offsets.push_back(std::move(offset));
+            deleted_offsets.push_back(offset);
         }
     }
 

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -563,7 +563,7 @@ inline void parse_and_set_bool(
     if (op == config_resource_operation::set && value) {
         try {
             // Ignore case.
-            auto str_value = std::move(*value);
+            auto str_value = *value;
             std::transform(
               str_value.begin(),
               str_value.end(),

--- a/src/v/model/tests/record_batch_test.cc
+++ b/src/v/model/tests/record_batch_test.cc
@@ -129,7 +129,7 @@ TEST_P(RecordBatchCompressionTest, Compression) {
         EXPECT_TRUE(c.compressed());
         EXPECT_EQ(c.header().attrs.compression(), GetParam());
         auto u_copy = model::decompress_batch(c).get();
-        auto u = model::decompress_batch(std::move(c)).get();
+        auto u = model::decompress_batch(c).get();
         EXPECT_FALSE(u.compressed());
         EXPECT_EQ(u.header().attrs.compression(), model::compression::none);
         EXPECT_EQ(u_copy, u);

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -480,7 +480,7 @@ consensus::success_reply consensus::update_follower_index(
     }
 
     if (reply.result == reply_result::success) {
-        successfull_append_entries_reply(idx, std::move(reply));
+        successfull_append_entries_reply(idx, reply);
         return success_reply::yes;
     } else {
         idx.expected_log_end_offset = model::offset{};
@@ -595,7 +595,7 @@ void consensus::process_append_entries_reply(
 }
 
 void consensus::successfull_append_entries_reply(
-  follower_index_metadata& idx, append_entries_reply reply) {
+  follower_index_metadata& idx, const append_entries_reply& reply) {
     // follower and leader logs matches
     idx.last_dirty_log_index = reply.last_dirty_log_index;
     idx.last_flushed_log_index = reply.last_flushed_log_index;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -631,7 +631,7 @@ private:
       model::offset);
 
     void successfull_append_entries_reply(
-      follower_index_metadata&, append_entries_reply);
+      follower_index_metadata&, const append_entries_reply&);
 
     size_t estimate_recovering_followers() const;
     bool needs_recovery(const follower_index_metadata&, model::offset);

--- a/src/v/redpanda/admin/debug.cc
+++ b/src/v/redpanda/admin/debug.cc
@@ -58,8 +58,8 @@ void fill_raft_state(
     auto& src = state.raft_state;
     raft_state.node_id = src.node();
     raft_state.term = src.term();
-    raft_state.offset_translator_state = std::move(src.offset_translator_state);
-    raft_state.group_configuration = std::move(src.group_configuration);
+    raft_state.offset_translator_state = src.offset_translator_state;
+    raft_state.group_configuration = src.group_configuration;
     raft_state.confirmed_term = src.confirmed_term();
     raft_state.flushed_offset = src.flushed_offset();
     raft_state.commit_index = src.commit_index();
@@ -115,9 +115,9 @@ void fill_raft_state(
         ss::httpd::debug_json::follower_recovery_state frs;
         frs.is_active = src.recovery_state->is_active;
         frs.pending_offset_count = src.recovery_state->pending_offset_count;
-        raft_state.follower_recovery_state = std::move(frs);
+        raft_state.follower_recovery_state = frs;
     }
-    replica.raft_state = std::move(raft_state);
+    replica.raft_state = raft_state;
 }
 
 // noinline because this is the characteristic frame we look for the backtrace
@@ -838,7 +838,7 @@ admin_server::sampled_memory_profile_handler(
             ss::httpd::debug_json::allocation_site allocation_site;
             allocation_site.size = allocation_sites.size;
             allocation_site.count = allocation_sites.count;
-            allocation_site.backtrace = std::move(allocation_sites.backtrace);
+            allocation_site.backtrace = allocation_sites.backtrace;
             resp[i].allocation_sites.push(allocation_site);
         }
     }
@@ -933,10 +933,10 @@ admin_server::get_partition_state_handler(
         replica.start_cloud_offset = state.start_cloud_offset;
         replica.next_cloud_offset = state.next_cloud_offset;
         replica.iceberg_mode = state.iceberg_mode;
-        fill_raft_state(replica, std::move(state));
+        fill_raft_state(replica, state);
         response.replicas.push(std::move(replica));
     }
-    co_return ss::json::json_return_type(std::move(response));
+    co_return ss::json::json_return_type(response);
 }
 
 ss::future<ss::json::json_return_type>
@@ -1021,7 +1021,7 @@ admin_server::get_producers_state_handler(
         producers.producers.push(std::move(producer_state));
         co_await ss::coroutine::maybe_yield();
     }
-    co_return ss::json::json_return_type(std::move(producers));
+    co_return ss::json::json_return_type(producers);
 }
 
 ss::future<ss::json::json_return_type> admin_server::get_node_uuid_handler() {
@@ -1033,7 +1033,7 @@ ss::future<ss::json::json_return_type> admin_server::get_node_uuid_handler() {
         uuid.node_id = config::node().node_id().value();
     }
 
-    co_return ss::json::json_return_type(std::move(uuid));
+    co_return ss::json::json_return_type(uuid);
 }
 
 static json::validator make_broker_id_override_validator() {

--- a/src/v/redpanda/admin/partition.cc
+++ b/src/v/redpanda/admin/partition.cc
@@ -37,7 +37,7 @@ using admin::apply_validator;
 
 ss::future<ss::json::json_return_type>
 admin_server::get_transactions_handler(std::unique_ptr<ss::http::request> req) {
-    const model::ntp ntp = parse_ntp_from_request(req->param);
+    model::ntp ntp = parse_ntp_from_request(req->param);
 
     if (need_redirect_to_leader(ntp, _metadata_cache)) {
         throw co_await redirect_to_leader(*req, ntp);
@@ -130,7 +130,7 @@ admin_server::get_transactions_inner_handler(
 ss::future<ss::json::json_return_type>
 admin_server::mark_transaction_expired_handler(
   std::unique_ptr<ss::http::request> req) {
-    const model::ntp ntp = parse_ntp_from_request(req->param);
+    model::ntp ntp = parse_ntp_from_request(req->param);
 
     model::producer_identity pid;
     auto param = req->get_query_param("id");
@@ -828,7 +828,7 @@ void admin_server::register_partition_routes() {
                 result.count = summary.count;
                 result.leaderless = summary.leaderless;
                 result.under_replicated = summary.under_replicated;
-                return ss::json::json_return_type(std::move(result));
+                return ss::json::json_return_type(result);
             });
       });
     register_route<user>(
@@ -1027,7 +1027,7 @@ admin_server::get_partition_handler(std::unique_ptr<ss::http::request> req) {
           .get_reconciliation_state(ntp)
           .then([p](const cluster::ntp_reconciliation_state& state) mutable {
               p.status = ssx::sformat("{}", state.status());
-              return ss::json::json_return_type(std::move(p));
+              return ss::json::json_return_type(p);
           });
     }
 }
@@ -1179,7 +1179,7 @@ admin_server::get_majority_lost_partitions(
             ntp_json.partition = ntp.ntp.tp.partition();
 
             ss::httpd::partition_json::ntp_with_majority_loss result;
-            result.ntp = std::move(ntp_json);
+            result.ntp = ntp_json;
             result.topic_revision = ntp.topic_revision;
             for (auto& replica : ntp.assignment) {
                 ss::httpd::partition_json::assignment assignment;

--- a/src/v/redpanda/admin/security.cc
+++ b/src/v/redpanda/admin/security.cc
@@ -1201,7 +1201,7 @@ generate_kafka_interface_report(
                   kface.name));
             }
 
-            report.supported_sasl_mechanisms = std::move(sasl_mechs);
+            report.supported_sasl_mechanisms = sasl_mechs;
         }
 
         report.authorization_enabled = config::kafka_authz_enabled();
@@ -1514,7 +1514,7 @@ admin_server::get_security_report(std::unique_ptr<ss::http::request>) {
             _audit_mgr.local().get_client_config(),
             ephemeral_credentials::yes);
     }
-    report.interfaces = std::move(interfaces_report);
+    report.interfaces = interfaces_report;
 
     const auto min_secure_tls = config::tls_version::v1_2;
     if (config::shard_local_cfg().tls_min_version < min_secure_tls) {
@@ -1537,7 +1537,7 @@ admin_server::get_security_report(std::unique_ptr<ss::http::request>) {
         alerts.push_back(std::move(alert));
     }
 
-    report.alerts = std::move(alerts);
+    report.alerts = alerts;
 
     return ss::make_ready_future<ss::json::json_return_type>(std::move(report));
 }

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -2076,7 +2076,7 @@ void admin_server::register_cluster_config_routes() {
                     rs.unknown = s.second.unknown;
                 }
 
-                return ss::json::json_return_type(std::move(res));
+                return ss::json::json_return_type(res);
             });
       });
 
@@ -2310,7 +2310,7 @@ admin_server::patch_cluster_config_handler(
         // normal write.
         ss::httpd::cluster_config_json::cluster_config_write_result result;
         result.config_version = current_version;
-        co_return ss::json::json_return_type(std::move(result));
+        co_return ss::json::json_return_type(result);
     }
 
     if (
@@ -2327,7 +2327,7 @@ admin_server::patch_cluster_config_handler(
             [](cluster::config_manager& cm) { return cm.get_version(); });
         ss::httpd::cluster_config_json::cluster_config_write_result result;
         result.config_version = current_version;
-        co_return ss::json::json_return_type(std::move(result));
+        co_return ss::json::json_return_type(result);
     }
 
     vlog(
@@ -2355,7 +2355,7 @@ admin_server::patch_cluster_config_handler(
 
     ss::httpd::cluster_config_json::cluster_config_write_result result;
     result.config_version = patch_result.version;
-    co_return ss::json::json_return_type(std::move(result));
+    co_return ss::json::json_return_type(result);
 }
 
 ss::future<ss::json::json_return_type>
@@ -2839,7 +2839,7 @@ admin_server::get_broker_uuids_handler() {
           }
           return ret;
       });
-    co_return ss::json::json_return_type(std::move(mappings));
+    co_return ss::json::json_return_type(mappings);
 }
 
 ss::future<ss::json::json_return_type> admin_server::decomission_broker_handler(
@@ -3056,9 +3056,9 @@ void admin_server::register_broker_routes() {
 
                 ss::httpd::broker_json::cluster_view ret;
                 ret.version = members_table.version();
-                ret.brokers = std::move(brokers);
+                ret.brokers = brokers;
 
-                return ss::json::json_return_type(std::move(ret));
+                return ss::json::json_return_type(ret);
             });
       });
 
@@ -3067,7 +3067,7 @@ void admin_server::register_broker_routes() {
       [this](std::unique_ptr<ss::http::request>) {
           return get_brokers(_controller)
             .then([](std::vector<ss::httpd::broker_json::broker> brokers) {
-                return ss::json::json_return_type(std::move(brokers));
+                return ss::json::json_return_type(brokers);
             });
       });
     register_route<user>(
@@ -3684,7 +3684,7 @@ admin_server::get_metrics_uuid(std::unique_ptr<ss::http::request>) {
       0, ([](cluster::controller_stm& s) {
           return s.get_metrics_reporter_cluster_info().uuid;
       }));
-    co_return ss::json::json_return_type(std::move(ret));
+    co_return ss::json::json_return_type(ret);
 }
 
 static json::validator make_post_cluster_partitions_validator() {
@@ -4124,7 +4124,7 @@ void admin_server::register_cluster_routes() {
           if (cluster_uuid) {
               ss::httpd::cluster_json::uuid ret;
               ret.cluster_uuid = ssx::sformat("{}", cluster_uuid.value());
-              return ss::json::json_return_type(std::move(ret));
+              return ss::json::json_return_type(ret);
           }
           return ss::json::json_return_type(ss::json::json_void());
       });

--- a/src/v/redpanda/admin/transaction.cc
+++ b/src/v/redpanda/admin/transaction.cc
@@ -169,7 +169,7 @@ admin_server::find_tx_coordinator_handler(
     }
     reply.ec = static_cast<int>(r.ec);
 
-    co_return ss::json::json_return_type(std::move(reply));
+    co_return ss::json::json_return_type(reply);
 }
 
 ss::future<ss::json::json_return_type>

--- a/src/v/redpanda/admin/usage.cc
+++ b/src/v/redpanda/admin/usage.cc
@@ -44,7 +44,7 @@ ss::json::json_return_type raw_data_to_usage_response(
             dl_usage_response.missing_reason = fmt::format(
               "{}", dl_usage.missing_reason);
         }
-        resp.back().datalake_usage = std::move(dl_usage_response);
+        resp.back().datalake_usage = dl_usage_response;
     }
     if (include_open && !resp.empty()) {
         /// Handle case where client does not want to observe

--- a/src/v/redpanda/tests/fixture.cc
+++ b/src/v/redpanda/tests/fixture.cc
@@ -913,8 +913,7 @@ security::server_final_message redpanda_thread_fixture::send_scram_client_final(
             "failed to send scram client final: {}",
             client_last_resp.data.error_code));
     }
-    return security::server_final_message(
-      std::move(client_last_resp.data.auth_bytes));
+    return security::server_final_message(client_last_resp.data.auth_bytes);
 }
 
 template<typename Authenticator>

--- a/src/v/security/tests/authorizer_test.cc
+++ b/src/v/security/tests/authorizer_test.cc
@@ -1492,7 +1492,7 @@ TEST(AUTHORIZER_TEST, role_authz_simple_allow) {
     EXPECT_EQ(r.value(), the_dietrichsons);
     auto r1_members = std::move(r.value()).members();
     r1_members.insert(role_member::from_principal(user3));
-    roles.put(role_name1, std::move(r1_members));
+    roles.put(role_name1, r1_members);
 
     // user3 should now have read permissions
     result = auth.authorized(

--- a/src/v/security/tests/role_store_bench.cc
+++ b/src/v/security/tests/role_store_bench.cc
@@ -66,7 +66,7 @@ role_store make_store(
                 role_mems.insert(m);
             }
         }
-        store.put(std::move(n), std::move(role_mems));
+        store.put(std::move(n), role_mems);
     }
     return store;
 }
@@ -151,7 +151,7 @@ PERF_TEST(role_store_bench, update_role) {
     auto mems = std::move(r).members();
     store.remove(n);
     mems.erase(m);
-    store.put(n, std::move(mems));
+    store.put(n, mems);
     perf_tests::stop_measuring_time();
 }
 
@@ -162,7 +162,7 @@ PERF_TEST(role_store_bench, put_role) {
     all_members.reserve(N_MEMBERS);
     std::ranges::copy(members_data, std::back_inserter(all_members));
     perf_tests::start_measuring_time();
-    store.put(std::move(name), std::move(all_members));
+    store.put(std::move(name), all_members);
     perf_tests::stop_measuring_time();
 }
 

--- a/src/v/security/tests/role_store_test.cc
+++ b/src/v/security/tests/role_store_test.cc
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(role_store_test) {
 
     role_store store;
     BOOST_CHECK(store.put(copied, role0));
-    store.put(moved, std::move(role0_copy));
+    store.put(moved, role0_copy);
 
     BOOST_REQUIRE(store.get(copied).has_value());
     BOOST_CHECK_EQUAL(store.get(copied).value(), role0);
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(role_store_test) {
     BOOST_CHECK(store.remove(copied));
     BOOST_CHECK(store.remove(moved));
     BOOST_CHECK(store.put(copied, role1));
-    store.put(moved, std::move(role1_copy));
+    store.put(moved, role1_copy);
 
     BOOST_REQUIRE(store.get(copied).has_value());
     BOOST_CHECK_EQUAL(store.get(copied).value(), role1);
@@ -310,7 +310,7 @@ BOOST_AUTO_TEST_CASE(role_store_big_store) {
                       role_mems.insert(m);
                   }
               }
-              store.put(std::move(n), std::move(role_mems));
+              store.put(std::move(n), role_mems);
           }
           return store;
       }();

--- a/src/v/storage/tests/batch_cache_reclaim_test.cc
+++ b/src/v/storage/tests/batch_cache_reclaim_test.cc
@@ -91,7 +91,7 @@ TEST(BatchCacheReclaimTest, reclaim) {
     for (size_t i = 0; i < pages_until_reclaim; i++) {
         size_t buf_size = ss::memory::page_size - sizeof(model::record_batch);
         auto batch = make_batch(buf_size);
-        auto e = cache.put(index, std::move(batch), is_dirty_entry::no);
+        auto e = cache.put(index, batch, is_dirty_entry::no);
         ASSERT_TRUE((bool)e.range());
         cache_entries.emplace_back(std::move(e));
     }

--- a/src/v/storage/tests/batch_cache_test.cc
+++ b/src/v/storage/tests/batch_cache_test.cc
@@ -67,7 +67,7 @@ TEST_F(batch_cache_test_fixture, evict) {
     storage::batch_cache_index index(cache);
 
     auto b = make_batch(100);
-    auto w = cache.put(index, std::move(b), is_dirty_entry::no);
+    auto w = cache.put(index, b, is_dirty_entry::no);
     EXPECT_FALSE(cache.empty());
     cache.evict(std::move(w.range()));
     EXPECT_TRUE(cache.empty());
@@ -79,7 +79,7 @@ TEST_F(batch_cache_test_fixture, reclaim_rounds_up) {
     auto b = make_batch(5);
     auto b_size = b.memory_usage();
     SCOPED_TRACE(fmt::format("batch size: {}", b_size));
-    cache.put(index, std::move(b), is_dirty_entry::no);
+    cache.put(index, b, is_dirty_entry::no);
     EXPECT_FALSE(cache.empty());
 
     auto size = cache.reclaim(1);

--- a/src/v/utils/tests/retry_test.cc
+++ b/src/v/utils/tests/retry_test.cc
@@ -72,7 +72,7 @@ SEASTAR_THREAD_TEST_CASE(retry_then_fail_when_cancelled) {
                        .then([](auto) { return false; })
                        .handle_exception([](std::exception_ptr eptr) {
                            try {
-                               std::rethrow_exception(std::move(eptr));
+                               std::rethrow_exception(eptr);
                            } catch (const ss::abort_requested_exception&) {
                                return true;
                            } catch (...) {


### PR DESCRIPTION
Oh dear, what a rabbit hole I have found myself in. What started as a bug fix in an unrelated piece of code in which I accidentally `std::move()`'ed a value into a co-routine that actually takes a `const T&` and ended up shooting myself in the foot via stack-use-after-free, I realized that this issue of `std::move()`'ing not actually `std::move()`'ing something is present throughout the codebase. For a codebase rife with co-routines and lifetime issues, this is a really bad thing.

So, let's enable this `clang-tidy` pass that should make us all a bit safer.

# Common mistakes with `std::move()` in the codebase: 

## 1. Missing mutable on a lambda

This pessimizes to a copy. Every. Time.

### Wrong

```cpp
co_await invoke_on_all_nodes(
      [test_id, ids_set, req, &network_plan](model::node_id nid, auto& handle) {
      [...]
      return handle->start_test(
        start_test_request{
          .id = test_id,
          .dtos = std::move(req.dtos),
          .ntos = std::move(new_ntos),
          .unparsed_checks = std::move(req.unparsed_checks),
          .ctos = std::move(req.ctos),
        });
}
```

### Right

```cpp
co_await invoke_on_all_nodes(
      [test_id, ids_set, req, &network_plan](model::node_id nid, auto& handle) mutable {
      [...]
      return handle->start_test(
        start_test_request{
          .id = test_id,
          .dtos = std::move(req.dtos),
          .ntos = std::move(new_ntos),
          .unparsed_checks = std::move(req.unparsed_checks),
          .ctos = std::move(req.ctos),
        });
}
```

## 2. Moving into a function that takes a `const T&`

Bonus points if the function returns a future and the caller is just doing something entirely unsafe, e.g.

```cpp
ss::future<> invoke_something() {
  something_t v = fetch_something();
  return do_invoke_something(std::move(v));
}

ss::future<> do_invoke_something(const something_t& v){
   ...
}
```

Bonus-bonus points IF `do_invoke_something()` at one point DID take `v` by value, but someone came along and changed it, and now it is a bug because the compiler was happy to accept the change.

## 3. seastar::json is a mess

[No move constructors for elements, just copy constructors](https://github.com/scylladb/seastar/blob/master/include/seastar/json/json_elements.hh).

```cpp
ss::httpd::usage_json::usage_response r{};
r.datalake_usage = std::move(dl_usage_response); // This is a copy.
```

## 4. `std::string` -> `seastar::sstring` is a mess

[No move constructors](https://github.com/scylladb/seastar/blob/master/include/seastar/core/sstring.hh).

```cpp
std::string std_str = "Hello World";
ss::sstring ss_str = std::move(std_str); // This is a copy.
```

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
