### PR TITLE
config: don't apply values that fail validation

### DIFF
--- a/src/v/config/config_store.h
+++ b/src/v/config/config_store.h
@@ -94,9 +94,10 @@ public:
                     errors[name] = fmt::format(
                       "Validation error: {}",
                       validation_err.value().error_message());
+                } else {
+                    prop->set_value(node.second);
+                    ok = true;
                 }
-                prop->set_value(node.second);
-                ok = true;
             } catch (const YAML::InvalidNode& e) {
                 errors[name] = fmt::format("Invalid syntax: {}", e);
             } catch (const YAML::ParserException& e) {

--- a/src/v/config/tests/config_store_test.cc
+++ b/src/v/config/tests/config_store_test.cc
@@ -309,9 +309,7 @@ SEASTAR_THREAD_TEST_CASE(validate_with_validator_error) {
     BOOST_TEST(errors.size() > 0);
 
     // Property should retain default value
-    // Surprising but the current behavior is that invalid values actually
-    // update the property.
-    BOOST_TEST(cfg.validated_string() == "invalid_value");
+    BOOST_TEST(cfg.validated_string() == "magic_foo");
 }
 
 SEASTAR_THREAD_TEST_CASE(validate_with_type_mismatch) {
@@ -346,11 +344,7 @@ SEASTAR_THREAD_TEST_CASE(validate_required_with_validator_error) {
       "required_validated_string: invalid_value\n");
 
     // Required property with validation error throws std::invalid_argument
-    // BOOST_CHECK_THROW(cfg.read_yaml(invalid_yaml), std::invalid_argument);
-
-    auto errors = cfg.read_yaml(invalid_yaml);
-    BOOST_TEST(errors.size() > 0);
-    BOOST_TEST(cfg.required_validated_string() == "invalid_value");
+    BOOST_CHECK_THROW(cfg.read_yaml(invalid_yaml), std::invalid_argument);
 }
 
 SEASTAR_THREAD_TEST_CASE(config_json_serialization) {

--- a/src/v/config/tests/config_store_test.cc
+++ b/src/v/config/tests/config_store_test.cc
@@ -13,20 +13,32 @@
 #include "json/writer.h"
 
 #include <seastar/core/sstring.hh>
-#include <seastar/core/thread.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/log.hh>
 
 #include <cstdint>
 #include <iostream>
 #include <iterator>
-#include <random>
 #include <string>
 #include <utility>
 
 namespace {
 
 ss::logger lg("config_test"); // NOLINT
+
+std::optional<ss::sstring> validate_magic_prefix(const ss::sstring& value) {
+    if (!value.starts_with("magic_")) {
+        return fmt::format("value must start with 'magic_', got: {}", value);
+    }
+    return std::nullopt;
+}
+
+std::optional<ss::sstring> validate_throwing(const ss::sstring& value) {
+    if (value == "throw") {
+        throw std::runtime_error("validator threw an exception");
+    }
+    return std::nullopt;
+}
 
 struct test_config : public config::config_store {
     config::property<int> optional_int;
@@ -44,6 +56,8 @@ struct test_config : public config::config_store {
     config::property<ss::sstring> default_secret_string;
     config::property<ss::sstring> secret_string;
     config::property<bool> aliased_bool;
+    config::property<ss::sstring> validated_string;
+    config::property<ss::sstring> throwing_validator_string;
 
     test_config()
       : optional_int(
@@ -113,10 +127,37 @@ struct test_config : public config::config_store {
           "aliased_bool",
           "Property with a compat alias",
           {.aliases = {"aliased_bool_legacy"}},
-          true) {}
+          true)
+      , validated_string(
+          *this,
+          "validated_string",
+          "String that must start with magic_",
+          {},
+          "magic_foo",
+          &validate_magic_prefix)
+      , throwing_validator_string(
+          *this,
+          "throwing_validator_string",
+          "String with a validator that throws",
+          {},
+          "safe",
+          &validate_throwing) {}
 };
 
 struct noop_config : public config::config_store {};
+
+struct required_validated_config : public config::config_store {
+    config::property<ss::sstring> required_validated_string;
+
+    required_validated_config()
+      : required_validated_string(
+          *this,
+          "required_validated_string",
+          "Required string that must start with magic_",
+          {.required = config::required::yes},
+          "magic_bar",
+          &validate_magic_prefix) {}
+};
 
 YAML::Node minimal_valid_configuration() {
     return YAML::Load(
@@ -257,10 +298,59 @@ SEASTAR_THREAD_TEST_CASE(validate_valid_configuration) {
     BOOST_TEST(errors.size() == 0);
 }
 
-SEASTAR_THREAD_TEST_CASE(validate_invalid_configuration) {
+SEASTAR_THREAD_TEST_CASE(validate_with_validator_error) {
     auto cfg = test_config();
-    auto errors = cfg.read_yaml(valid_configuration());
-    BOOST_TEST(errors.size() == 0);
+
+    auto invalid_yaml = YAML::Load("validated_string: invalid_value\n");
+
+    auto errors = cfg.read_yaml(invalid_yaml);
+
+    // Should have error from validator
+    BOOST_TEST(errors.size() > 0);
+
+    // Property should retain default value
+    // Surprising but the current behavior is that invalid values actually
+    // update the property.
+    BOOST_TEST(cfg.validated_string() == "invalid_value");
+}
+
+SEASTAR_THREAD_TEST_CASE(validate_with_type_mismatch) {
+    auto cfg = test_config();
+
+    // Provide string where int is expected
+    auto invalid_yaml = YAML::Load("optional_int: not_an_int\n");
+
+    auto errors = cfg.read_yaml(invalid_yaml);
+
+    BOOST_REQUIRE(!errors.empty());
+    auto& [key, msg] = *errors.begin();
+    BOOST_TEST(key == "optional_int");
+    BOOST_TEST_INFO(msg);
+    BOOST_TEST(msg.contains("bad conversion"));
+
+    BOOST_TEST(cfg.optional_int() == 100); // expect default retained
+}
+
+SEASTAR_THREAD_TEST_CASE(validate_with_throwing_validator) {
+    auto cfg = test_config();
+
+    auto yaml = YAML::Load("throwing_validator_string: throw\n");
+
+    BOOST_CHECK_THROW(cfg.read_yaml(yaml), std::runtime_error);
+}
+
+SEASTAR_THREAD_TEST_CASE(validate_required_with_validator_error) {
+    auto cfg = required_validated_config();
+
+    auto invalid_yaml = YAML::Load(
+      "required_validated_string: invalid_value\n");
+
+    // Required property with validation error throws std::invalid_argument
+    // BOOST_CHECK_THROW(cfg.read_yaml(invalid_yaml), std::invalid_argument);
+
+    auto errors = cfg.read_yaml(invalid_yaml);
+    BOOST_TEST(errors.size() > 0);
+    BOOST_TEST(cfg.required_validated_string() == "invalid_value");
 }
 
 SEASTAR_THREAD_TEST_CASE(config_json_serialization) {

--- a/tests/rptest/tests/adjacent_segment_merging_test.py
+++ b/tests/rptest/tests/adjacent_segment_merging_test.py
@@ -150,6 +150,10 @@ class AdjacentSegmentMergingToggleCompactionTest(AdjacentSegmentMergingTestBase)
             test_context, extra_rp_conf=xtra_conf, num_brokers=1, *args, **kwargs
         )
 
+        self.redpanda.set_environment(
+            {"__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"}
+        )
+
     @cluster(num_nodes=2)
     @matrix(
         acks=[

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -205,6 +205,38 @@ class ClusterConfigBootstrapTest(RedpandaTest):
         )
 
 
+class ClusterConfigBoundedPropertyTest(RedpandaTest):
+    """
+    Test that bounded properties clamp out-of-range values from bootstrap config.
+    """
+
+    def __init__(self, *args, **kwargs):
+        # Set log_segment_size to 100 bytes (below minimum of 1MB)
+        super().__init__(
+            *args,
+            extra_rp_conf={"log_segment_size": 100},
+            **kwargs,
+        )
+
+    @cluster(num_nodes=1)
+    def test_bounded_property_clamped_to_minimum(self):
+        """
+        Verify that bounded properties are clamped to their minimum bound when
+        an out-of-range value is provided in bootstrap config. Setting
+        log_segment_size to 100 should result in the value being clamped to
+        1MB (the minimum bound).
+        """
+        admin = Admin(self.redpanda)
+        config = admin.get_cluster_config()
+
+        # The value should be clamped to 1MB (1048576 bytes)
+        min_segment_size = 1024 * 1024  # 1 MiB
+        assert config["log_segment_size"] == min_segment_size, (
+            f"Expected log_segment_size to be clamped to {min_segment_size} (1MB), "
+            f"but got {config['log_segment_size']}"
+        )
+
+
 class HasRedpandaAndAdmin(Protocol):
     redpanda: RedpandaService
     admin: Admin

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -1232,6 +1232,10 @@ class EndToEndSpilloverTest(RedpandaTest):
         self.msg_size = 1024 * 256
         self.msg_count = 3000
 
+        self.redpanda.set_environment(
+            {"__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"}
+        )
+
     def produce(self):
         topic_name = self.topics[0].name
         producer = KgoVerifierProducer(

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -70,6 +70,10 @@ class NodesDecommissioningTest(PreallocNodesTest):
             extra_rp_conf=extra_rp_conf,
         )
 
+        self.redpanda.set_environment(
+            {"__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"}
+        )
+
     def setup(self):
         # defer starting redpanda to test body
         pass

--- a/tests/rptest/tests/offset_for_leader_epoch_archival_test.py
+++ b/tests/rptest/tests/offset_for_leader_epoch_archival_test.py
@@ -60,6 +60,10 @@ class OffsetForLeaderEpochArchivalTest(RedpandaTest):
             si_settings=si_settings,
         )
 
+        self.redpanda.set_environment(
+            {"__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"}
+        )
+
     def _alter_topic_retention_with_retry(self, topic):
         rpk = RpkTool(self.redpanda)
 

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -1025,7 +1025,10 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         throughput, records, moves, partitions = self._get_scale_params()
         install_opts = InstallOptions(install_previous_version=test_mixed_versions)
         self.start_redpanda(
-            num_nodes=3, install_opts=install_opts, extra_rp_conf=extra_rp_conf
+            num_nodes=3,
+            install_opts=install_opts,
+            extra_rp_conf=extra_rp_conf,
+            environment={"__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"},
         )
 
         self.topic = "topic"
@@ -1094,7 +1097,10 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
 
         install_opts = InstallOptions(install_previous_version=test_mixed_versions)
         self.start_redpanda(
-            num_nodes=3, install_opts=install_opts, extra_rp_conf=extra_rp_conf
+            num_nodes=3,
+            install_opts=install_opts,
+            extra_rp_conf=extra_rp_conf,
+            environment={"__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"},
         )
 
         self.topic = "topic"

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -254,6 +254,10 @@ class ShadowIndexingLocalRetentionTest(RedpandaTest):
         self.rpk = RpkTool(self.redpanda)
         self.s3_bucket_name = si_settings.cloud_storage_bucket
 
+        self.redpanda.set_environment(
+            {"__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"}
+        )
+
     def query_segments(self):
         return self.redpanda.node_storage(self.redpanda.nodes[0]).segments(
             "kafka", self.topic_name, 0
@@ -456,6 +460,10 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
 
         self.rpk = RpkTool(self.redpanda)
         self.s3_bucket_name = si_settings.cloud_storage_bucket
+
+        self.redpanda.set_environment(
+            {"__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"}
+        )
 
     @cluster(num_nodes=3)
     @matrix(cloud_storage_type=get_cloud_storage_type())


### PR DESCRIPTION
`config_store::read_yaml()` would apply property values even when custom
validation failed, only recording the error. This meant invalid configuration
values would silently take effect despite being reported as errors.

This behavior was also inconsistent: conversion exceptions (e.g.,
`YAML::BadConversion`) correctly prevented values from being set, but
custom validator errors did not.

The fix moves `set_value()` inside the else branch so values are only applied
when validation succeeds:

1. Optional properties now correctly retain their default value when validation
   fails.

2. Required properties now correctly throw `std::invalid_argument` when
   validation fails. Previously, the throw logic was bypassed because `ok` was
   set to true even after validation errors.

It's unclear why we don't stop server startup on invalid optional config values.
To avoid breaking something I don't fully understand, this change takes the
conservative approach of retaining defaults.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Bug Fixes

* Fixed config validation to not apply values that fail custom validators, matching the behavior for type conversion errors.