### PR TITLE
`ct/l0`: fix heap-use-after-free in `read_debounce`

### DIFF
--- a/src/v/cloud_topics/level_zero/read_debounce/read_debounce.cc
+++ b/src/v/cloud_topics/level_zero/read_debounce/read_debounce.cc
@@ -147,13 +147,15 @@ read_debounce<Clock>::process_single_request(read_request<Clock>* req) {
 
         _pipeline_stage.push_next_stage(*proxy);
 
+        auto holder = _gate.hold();
         proxy->response.get_future()
-          .finally([proxy, u = std::move(u)] {
+          .finally([proxy, u = std::move(u), h = std::move(holder)] mutable {
               // finally is used to capture 'u' and 'proxy'
               // while the request is fulfilled.
               // This call exits shortly but 'proxy' should
               // live until the request is running. The value
               // of 'u' could be 'nullopt'.
+              u.reset();
           })
           .forward_to(std::move(req->response));
         // At this point it's guaranteed that the req->response


### PR DESCRIPTION
Seems like the `finally()` clause here was being invoked long after the owning semaphore was destructed. Add a `_gate` holder to prevent any heap-use-after-free.

```
    #0 0x55f4110f85a7 in seastar::basic_semaphore<ssx::basic_checkpoint_mutex<seastar::lowres_clock>::checkpoint_mutex_exception_factory, seastar::lowres_clock>::available_units() const external/+non_module_dependencies+seastar/include/seastar/core/semaphore.hh:462:55
    #1 0x55f4110f85a7 in ssx::basic_checkpoint_mutex<seastar::lowres_clock>::release() bazel-out/k8-dbg/bin/src/v/ssx/_virtual_includes/checkpoint_mutex/ssx/checkpoint_mutex.h:221:9
    #2 0x55f4110f85a7 in ssx::basic_mutex_units<seastar::lowres_clock>::release() bazel-out/k8-dbg/bin/src/v/ssx/_virtual_includes/checkpoint_mutex/ssx/checkpoint_mutex.h:271:19
    #3 0x55f4110d7cba in ssx::basic_mutex_units<seastar::lowres_clock>::~basic_mutex_units() bazel-out/k8-dbg/bin/src/v/ssx/_virtual_includes/checkpoint_mutex/ssx/checkpoint_mutex.h:247:9
    #4 0x55f4110d7cba in std::__1::__optional_destruct_base<ssx::basic_mutex_units<seastar::lowres_clock>, false>::~__optional_destruct_base[abi:se200100]() external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/optional:300:15
    #5 0x55f4110d7cba in cloud_topics::l0::read_debounce<seastar::lowres_clock>::process_single_request(cloud_topics::l0::read_request<seastar::lowres_clock>*)::'lambda'()::~() src/v/cloud_topics/level_zero/read_debounce/read_debounce.cc:151:20
    #6 0x55f4110fdf23 in seastar::noncopyable_function<seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>> (seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>&&)>::~noncopyable_function() external/+non_module_dependencies+seastar/include/seastar/util/noncopyable_function.hh:200:9
    #7 0x55f4110fdf23 in seastar::continuation<seastar::internal::promise_base_with_type<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>, seastar::noncopyable_function<seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>> (seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>&&)>, seastar::futurize<seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>>::type seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>::then_wrapped_nrvo<seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>, seastar::noncopyable_function<seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>> (seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>&&)>>(seastar::noncopyable_function<seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>> (seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>&&)>&&)::'lambda'(seastar::internal::promise_base_with_type<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>&&, seastar::noncopyable_function<seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>> (seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>&&)>&&, seastar::future_state<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>&&), std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>::~continuation() external/+non_module_dependencies+seastar/include/seastar/core/future.hh:724:8
    #8 0x55f4110fdc82 in seastar::continuation<seastar::internal::promise_base_with_type<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>, seastar::noncopyable_function<seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>> (seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>&&)>, seastar::futurize<seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>>::type seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>::then_wrapped_nrvo<seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>, seastar::noncopyable_function<seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>> (seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>&&)>>(seastar::noncopyable_function<seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>> (seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>&&)>&&)::'lambda'(seastar::internal::promise_base_with_type<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>&&, seastar::noncopyable_function<seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>> (seastar::future<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>&&)>&&, seastar::future_state<std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>&&), std::__1::expected<cloud_topics::l0::dataplane_query_result, cloud_topics::errc>>::run_and_dispose() external/+non_module_dependencies+seastar/include/seastar/core/future.hh:745:9
    #9 0x55f42046b967 in seastar::reactor::task_queue::run_tasks() external/+non_module_dependencies+seastar/src/core/reactor.cc:2747:14
    #10 0x55f42047256c in seastar::reactor::task_queue_group::run_tasks() external/+non_module_dependencies+seastar/src/core/reactor.cc:3251:27
    #11 0x55f420471f91 in seastar::reactor::task_queue_group::run_some_tasks() external/+non_module_dependencies+seastar/src/core/reactor.cc:3235:5
    #12 0x55f4204741e6 in seastar::reactor::do_run() external/+non_module_dependencies+seastar/src/core/reactor.cc:3418:20
    #13 0x55f4204db2e7 in seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_0::operator()() const external/+non_module_dependencies+seastar/src/core/reactor.cc:4732:22
    #14 0x55f4204db2e7 in decltype(std::declval<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_0&>()()) std::__1::__invoke[abi:se200100]<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_0&>(seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_0&) external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__type_traits/invoke.h:179:25
```

Observed here: https://ci-artifacts.dev.vectorized.cloud/production-devprod/redpanda/78400/019b513a-b3fe-4947-b2ba-5188aaca82e2/vbuild/ducktape/results/2025-12-24--001/NodesDecommissioningTest/test_flipping_decommission_recommission/node_is_alive=False.cloud_topic=True/119/

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
