### PR TITLE
[CORE-15094] `ct/l0`: shutdown handling in `read_fanout::process_single_request()`

### DIFF
--- a/src/v/cloud_topics/level_zero/pipeline/read_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/read_pipeline.h
@@ -98,6 +98,10 @@ public:
             return _parent->get_root_rtc();
         }
 
+        ss::abort_source& get_abort_source() noexcept {
+            return _parent->get_abort_source();
+        }
+
         void register_pipeline_error(errc e) {
             _parent->register_pipeline_error(e);
         }

--- a/src/v/cloud_topics/level_zero/read_fanout/read_fanout.cc
+++ b/src/v/cloud_topics/level_zero/read_fanout/read_fanout.cc
@@ -11,6 +11,7 @@
 
 #include "cloud_topics/level_zero/pipeline/read_request.h"
 #include "container/chunked_vector.h"
+#include "model/timeout_clock.h"
 #include "ssx/future-util.h"
 
 namespace cloud_topics::l0 {
@@ -134,7 +135,11 @@ ss::future<> read_fanout::process_single_request(l0::read_request<>* req) {
             _pipeline_stage.push_next_stage(*proxy);
             futures.push_back(std::move(fut));
         }
-        auto fut_res = co_await ss::when_all(futures.begin(), futures.end());
+
+        auto& as = _pipeline_stage.get_abort_source();
+        auto fut = ss::when_all(futures.begin(), futures.end());
+        auto fut_res = co_await ssx::with_timeout_abortable(
+          std::move(fut), model::no_timeout, as);
 
         // First process all exception, propagate the first one to the source
         // request Then process error codes, if there are any errors propagate


### PR DESCRIPTION
We were taking a long time to shutdown in `read_fanout`:

```
DEBUG 2025-12-24 20:34:48,111 [shard 0:main] cloud_topics - [fiber5 ct:read_pipeline[pipeline_stage{id:0}]] - read_fanout.cc:55 - Read fanout stopping due to shutdown
DEBUG 2025-12-24 20:34:48,111 [shard 1:main] cloud_topics - [fiber4 ct:read_pipeline[pipeline_stage{id:0}]] - read_fanout.cc:55 - Read fanout stopping due to shutdown
INFO  2025-12-24 20:35:03,111 [shard 0:main] main/cloud_topics::data_plane - sharded_service_container.h:76 - Service cloud_topics::l0::read_fanout is taking more than 15 seconds to shut down.
```

Given that the only thing `read_fanout::stop()` does is await `_gate.close()`, and that the only place other than `bg_process()` (which has obviously shutdown at this point, proven by the above logs) are the backgrounded `process_single_request()` fibers, within which the only awaiting point is `co_await`'ing the built up `futures` container, it seems clear that this is where we are blocking shutdown from completing.

Wrap the request in `ssx::with_timeout_abortable()` using the `_pipeline_stage`'s `abort_source` to properly respect shutdowns in `read_fanout`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
