### PR TITLE
ssx: introduce time and clock

### DIFF
--- a/src/v/ssx/BUILD
+++ b/src/v/ssx/BUILD
@@ -312,3 +312,35 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "time",
+    srcs = [
+        "time.cc",
+    ],
+    hdrs = [
+        "time.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "@abseil-cpp//absl/time",
+        "@fmt",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
+    name = "clock",
+    srcs = [
+        "clock.cc",
+    ],
+    hdrs = [
+        "clock.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":time",
+        "@seastar",
+    ],
+)

--- a/src/v/ssx/clock.cc
+++ b/src/v/ssx/clock.cc
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "ssx/clock.h"
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/manual_clock.hh>
+
+#include <chrono>
+
+namespace ssx {
+
+// ============================================================================
+// Clock Implementation Classes
+// ============================================================================
+
+// High-resolution steady clock (monotonic)
+class hires_steady_clock_impl final : public steady_clock {
+public:
+    instant now() const noexcept override {
+        return instant::from_chrono(seastar::steady_clock_type::now());
+    }
+
+    const char* name() const noexcept override {
+        return "seastar::steady_clock";
+    }
+};
+
+// Low-resolution steady clock (monotonic)
+class lowres_steady_clock_impl final : public steady_clock {
+public:
+    instant now() const noexcept override {
+        return instant::from_chrono(seastar::lowres_clock::now());
+    }
+
+    const char* name() const noexcept override {
+        return "seastar::lowres_clock";
+    }
+};
+
+// High-resolution wall clock (system time)
+class hires_wall_clock_impl final : public wall_clock {
+public:
+    wall_time now() const noexcept override {
+        return wall_time::from_chrono(std::chrono::system_clock::now());
+    }
+
+    const char* name() const noexcept override {
+        return "std::chrono::system_clock";
+    }
+};
+
+// Low-resolution wall clock (system time)
+class lowres_wall_clock_impl final : public wall_clock {
+public:
+    wall_time now() const noexcept override {
+        return wall_time::from_chrono(seastar::lowres_system_clock::now());
+    }
+
+    const char* name() const noexcept override {
+        return "seastar::lowres_system_clock";
+    }
+};
+
+// Wrapper for seastar::manual_clock as wall_clock (testing)
+class manual_wall_clock_impl final : public wall_clock {
+public:
+    wall_time now() const noexcept override {
+        return wall_time::from_chrono(seastar::manual_clock::now());
+    }
+
+    const char* name() const noexcept override {
+        return "seastar::manual_clock";
+    }
+};
+
+// Wrapper for seastar::manual_clock as steady_clock (testing)
+class manual_steady_clock_impl final : public steady_clock {
+public:
+    instant now() const noexcept override {
+        return instant::from_chrono(seastar::manual_clock::now());
+    }
+
+    const char* name() const noexcept override {
+        return "seastar::manual_clock";
+    }
+};
+
+// ============================================================================
+// Singleton Clock Accessors
+// ============================================================================
+
+ssx::steady_clock& hires_steady_clock() noexcept {
+    static hires_steady_clock_impl instance;
+    return instance;
+}
+
+ssx::steady_clock& lowres_steady_clock() noexcept {
+    static lowres_steady_clock_impl instance;
+    return instance;
+}
+
+ssx::wall_clock& hires_wall_clock() noexcept {
+    static hires_wall_clock_impl instance;
+    return instance;
+}
+
+ssx::wall_clock& lowres_wall_clock() noexcept {
+    static lowres_wall_clock_impl instance;
+    return instance;
+}
+
+ssx::wall_clock& manual_wall_clock() {
+    static manual_wall_clock_impl instance;
+    return instance;
+}
+
+ssx::steady_clock& manual_steady_clock() {
+    static manual_steady_clock_impl instance;
+    return instance;
+}
+
+} // namespace ssx

--- a/src/v/ssx/clock.h
+++ b/src/v/ssx/clock.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "ssx/time.h"
+
+/*
+ * SSX Temporal Library - Clock Virtual Interfaces
+ * ================================================
+ *
+ * This library provides virtual clock interfaces that enable dependency
+ * injection and testing without template-based code. Instead of templating
+ * all your types on clock (e.g., `MyClass<Clock>`), you can now use
+ * references to clock interfaces (e.g., `MyClass(wall_clock& clock)`).
+ *
+ * Two clock types are provided:
+ * - `steady_clock`: Monotonic clock that never goes backwards
+ * - `wall_clock`: Real-world time clock (can jump due to NTP/DST)
+ *
+ * Usage in production code:
+ *   void my_function(ssx::wall_clock& clock) {
+ *       auto now = clock.now();
+ *       auto deadline = now + ssx::duration(1'000'000'000);
+ *   }
+ *
+ * Usage in tests:
+ *   auto& test_clock = ssx::manual_wall_clock();
+ *   my_function(test_clock);
+ *   ss::manual_clock::advance(1s);
+ *   // Verify timeout behavior...
+ */
+
+namespace ssx {
+
+/// Virtual interface for monotonic steady clocks
+/// Monotonic clocks never go backwards and are not affected by system time
+/// changes
+class steady_clock {
+public:
+    virtual ~steady_clock() = default;
+
+    /// Get current instant from the steady clock
+    virtual instant now() const noexcept = 0;
+
+    /// Get a descriptive name for this clock (for debugging/logging)
+    virtual const char* name() const noexcept = 0;
+};
+
+/// Virtual interface for wall clocks
+/// Wall clocks represent real-world time and can jump due to NTP adjustments,
+/// DST changes, or manual system time changes
+class wall_clock {
+public:
+    virtual ~wall_clock() = default;
+
+    /// Get current wall time from the clock
+    virtual wall_time now() const noexcept = 0;
+
+    /// Get a descriptive name for this clock (for debugging/logging)
+    virtual const char* name() const noexcept = 0;
+};
+
+// Get the high-resolution steady clock (seastar::steady_clock)
+// Returns a singleton instance - use for precise monotonic time
+steady_clock& hires_steady_clock() noexcept;
+
+// Get the low-resolution steady clock (seastar::lowres_clock)
+// Returns a singleton instance - more efficient for coarse monotonic time
+steady_clock& lowres_steady_clock() noexcept;
+
+// Get the high-resolution wall clock (std::chrono::system_clock)
+// Returns a singleton instance - use for precise system time
+wall_clock& hires_wall_clock() noexcept;
+
+// Get the low-resolution wall clock (seastar::lowres_system_clock)
+// Returns a singleton instance - more efficient for coarse system time
+wall_clock& lowres_wall_clock() noexcept;
+
+// Create a manual wall clock for testing
+// Control time with seastar::manual_clock::advance()
+wall_clock& manual_wall_clock();
+
+// Create a manual steady clock for testing
+// Control time with seastar::manual_clock::advance()
+steady_clock& manual_steady_clock();
+
+} // namespace ssx

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -349,3 +349,31 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "time_test",
+    timeout = "short",
+    srcs = [
+        "time_test.cc",
+    ],
+    deps = [
+        "//src/v/ssx:time",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "clock_test",
+    timeout = "short",
+    srcs = [
+        "clock_test.cc",
+    ],
+    deps = [
+        "//src/v/ssx:clock",
+        "//src/v/ssx:time",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/ssx/tests/clock_test.cc
+++ b/src/v/ssx/tests/clock_test.cc
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "ssx/clock.h"
+#include "ssx/time.h"
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/manual_clock.hh>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+namespace ssx {
+
+using namespace std::chrono_literals;
+
+TEST(ClockSingleton, SteadyClock) {
+    auto& clock1 = hires_steady_clock();
+    auto& clock2 = hires_steady_clock();
+
+    // Should return the same instance (singleton)
+    EXPECT_EQ(&clock1, &clock2);
+
+    // Should return valid instants
+    auto now = clock1.now();
+    EXPECT_GT(
+      now.to_chrono<std::chrono::steady_clock>().time_since_epoch().count(), 0);
+
+    // Clock should have a name
+    EXPECT_NE(clock1.name(), nullptr);
+}
+
+TEST(ClockSingleton, WallClock) {
+    auto& clock1 = lowres_wall_clock();
+    auto& clock2 = lowres_wall_clock();
+
+    // Should return the same instance (singleton)
+    EXPECT_EQ(&clock1, &clock2);
+
+    // Should return valid wall times
+    auto now = clock1.now();
+    // Wall clock should be reasonably close to current time (not zero)
+    EXPECT_GT(
+      now.to_chrono<std::chrono::system_clock>().time_since_epoch().count(), 0);
+
+    // Clock should have a name
+    EXPECT_NE(clock1.name(), nullptr);
+}
+
+TEST(ClockSingleton, ManualWallClock) {
+    auto& clock1 = manual_wall_clock();
+    auto& clock2 = manual_wall_clock();
+
+    // Should return the same instance (singleton)
+    EXPECT_EQ(&clock1, &clock2);
+
+    // Should support polymorphism
+    wall_clock& clock_ref = clock1;
+    auto now = clock_ref.now();
+    EXPECT_EQ(
+      now.to_chrono<std::chrono::system_clock>().time_since_epoch().count(), 0);
+}
+
+TEST(ClockSingleton, ManualSteadyClock) {
+    auto& clock1 = manual_steady_clock();
+    auto& clock2 = manual_steady_clock();
+
+    // Should return the same instance (singleton)
+    EXPECT_EQ(&clock1, &clock2);
+
+    // Should support polymorphism
+    steady_clock& clock_ref = clock1;
+    auto now = clock_ref.now();
+    EXPECT_EQ(
+      now.to_chrono<std::chrono::steady_clock>().time_since_epoch().count(), 0);
+}
+
+TEST(ManualClock, TimeAdvances) {
+    auto& clock = manual_wall_clock();
+
+    auto t1 = clock.now();
+    seastar::manual_clock::advance(100ms);
+    auto t2 = clock.now();
+
+    auto elapsed = t2 - t1;
+    EXPECT_GE(elapsed.to_nanoseconds(), 100'000'000); // At least 100ms
+}
+
+TEST(ManualClock, SteadyClockAdvances) {
+    auto& clock = manual_steady_clock();
+
+    auto t1 = clock.now();
+    seastar::manual_clock::advance(50ms);
+    auto t2 = clock.now();
+
+    auto elapsed = t2 - t1;
+    EXPECT_GE(elapsed.to_nanoseconds(), 50'000'000); // At least 50ms
+}
+
+TEST(ClockPolymorphism, WallClockReference) {
+    wall_clock& clock_ref = manual_wall_clock();
+
+    // Should work through base class reference
+    auto now1 = clock_ref.now();
+
+    seastar::manual_clock::advance(10ms);
+
+    auto now2 = clock_ref.now();
+    EXPECT_GT(now2, now1);
+}
+
+TEST(ClockPolymorphism, SteadyClockReference) {
+    steady_clock& clock_ref = manual_steady_clock();
+
+    // Should work through base class reference
+    auto now1 = clock_ref.now();
+
+    seastar::manual_clock::advance(10ms);
+
+    auto now2 = clock_ref.now();
+    EXPECT_GT(now2, now1);
+}
+
+TEST(Conversions, DurationToChronoRoundTrip) {
+    auto original = duration::nanoseconds(123456789);
+    auto chrono_dur = original.to_chrono<std::chrono::nanoseconds>();
+    auto roundtrip = duration::from_chrono(chrono_dur);
+
+    EXPECT_EQ(original, roundtrip);
+}
+
+TEST(Conversions, ChronoSecondsToDuration) {
+    auto chrono_dur = 5s;
+    auto ssx_dur = duration::from_chrono(chrono_dur);
+
+    EXPECT_EQ(ssx_dur.to_nanoseconds(), 5'000'000'000);
+}
+
+TEST(Conversions, ChronoMillisecondsToDuration) {
+    auto chrono_dur = 250ms;
+    auto ssx_dur = duration::from_chrono(chrono_dur);
+
+    EXPECT_EQ(ssx_dur.to_nanoseconds(), 250'000'000);
+}
+
+} // namespace ssx

--- a/src/v/ssx/tests/time_test.cc
+++ b/src/v/ssx/tests/time_test.cc
@@ -1,0 +1,365 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "ssx/time.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <limits>
+
+namespace ssx {
+
+constexpr int64_t int64_max = std::numeric_limits<int64_t>::max();
+constexpr int64_t int64_min = std::numeric_limits<int64_t>::min();
+
+// ============================================================================
+// Duration Tests
+// ============================================================================
+
+TEST(Duration, Construction) {
+    // Default construction
+    constexpr duration d1;
+    EXPECT_EQ(d1.to_nanoseconds(), 0);
+
+    // From nanoseconds
+    auto d2 = duration::nanoseconds(1000);
+    EXPECT_EQ(d2.to_nanoseconds(), 1000);
+
+    // Static factory methods
+    constexpr auto zero = duration::zero();
+    constexpr auto inf = duration::infinite();
+    EXPECT_EQ(zero.to_nanoseconds(), 0);
+    EXPECT_EQ(inf.to_nanoseconds(), int64_max);
+    EXPECT_TRUE(inf.is_infinite());
+}
+
+TEST(Duration, Addition) {
+    EXPECT_EQ(
+      (duration::nanoseconds(100) + duration::nanoseconds(200))
+        .to_nanoseconds(),
+      300);
+    EXPECT_EQ(
+      (duration::nanoseconds(-100) + duration::nanoseconds(-200))
+        .to_nanoseconds(),
+      -300);
+    EXPECT_EQ(
+      (duration::nanoseconds(100) + duration::nanoseconds(-50))
+        .to_nanoseconds(),
+      50);
+
+    // Saturating overflow
+    auto d1 = duration::nanoseconds(int64_max - 10);
+    auto d2 = duration::nanoseconds(20);
+    auto result = d1 + d2;
+    EXPECT_EQ(result.to_nanoseconds(), int64_max);
+    EXPECT_EQ(
+      result.to_chrono<std::chrono::nanoseconds>(),
+      std::chrono::nanoseconds::max());
+    EXPECT_LT(
+      result.to_chrono<std::chrono::microseconds>(),
+      std::chrono::microseconds::max());
+}
+
+TEST(Duration, Subtraction) {
+    EXPECT_EQ(
+      (duration::nanoseconds(200) - duration::nanoseconds(100))
+        .to_nanoseconds(),
+      100);
+    EXPECT_EQ(
+      (duration::nanoseconds(-100) - duration::nanoseconds(-200))
+        .to_nanoseconds(),
+      100);
+
+    // Saturating underflow
+    auto d1 = duration::nanoseconds(int64_min + 10);
+    auto d2 = duration::nanoseconds(20);
+    auto result = d1 - d2;
+    EXPECT_EQ(result.to_nanoseconds(), int64_min);
+    EXPECT_EQ(
+      result.to_chrono<std::chrono::nanoseconds>(),
+      std::chrono::nanoseconds::min());
+    EXPECT_GT(
+      result.to_chrono<std::chrono::microseconds>(),
+      std::chrono::microseconds::min());
+}
+
+TEST(Duration, Multiplication) {
+    EXPECT_EQ((duration::nanoseconds(100) * 3).to_nanoseconds(), 300);
+    EXPECT_EQ((duration::nanoseconds(100) * -2).to_nanoseconds(), -200);
+    EXPECT_EQ(
+      (3 * duration::nanoseconds(100)).to_nanoseconds(), 300); // Commutative
+
+    // Saturating overflow
+    auto d = duration::nanoseconds(int64_max / 2);
+    auto result = d * 3;
+    EXPECT_EQ(
+      result.to_chrono<std::chrono::nanoseconds>(),
+      std::chrono::nanoseconds::max());
+}
+
+TEST(Duration, Division) {
+    EXPECT_EQ((duration::nanoseconds(300) / 3).to_nanoseconds(), 100);
+    EXPECT_EQ((duration::nanoseconds(100) / -2).to_nanoseconds(), -50);
+
+    // Saturating division: INT64_MIN / -1 should saturate to INT64_MAX
+    auto d_min = duration::nanoseconds(int64_min);
+    auto result = d_min / -1;
+    EXPECT_EQ(result.to_nanoseconds(), int64_max);
+}
+
+TEST(Duration, Negation) {
+    EXPECT_EQ((-duration::nanoseconds(100)).to_nanoseconds(), -100);
+    EXPECT_EQ((-duration::nanoseconds(-100)).to_nanoseconds(), 100);
+
+    // Negating INT64_MIN saturates to MAX
+    auto d_min = duration::nanoseconds(int64_min);
+    auto neg = -d_min;
+    EXPECT_EQ(neg.to_nanoseconds(), int64_max);
+
+    // Negating infinite saturates to MIN
+    auto d_inf = duration::infinite();
+    auto neg_inf = -d_inf;
+    EXPECT_TRUE(neg_inf.to_nanoseconds() == int64_min || neg_inf.is_infinite());
+}
+
+TEST(Duration, CompoundAssignment) {
+    duration d = duration::nanoseconds(100);
+    d += duration::nanoseconds(50);
+    EXPECT_EQ(d.to_nanoseconds(), 150);
+
+    d -= duration::nanoseconds(25);
+    EXPECT_EQ(d.to_nanoseconds(), 125);
+
+    d *= 2;
+    EXPECT_EQ(d.to_nanoseconds(), 250);
+
+    d /= 5;
+    EXPECT_EQ(d.to_nanoseconds(), 50);
+
+    // Saturating division assignment
+    duration d_min = duration::nanoseconds(int64_min);
+    d_min /= -1;
+    EXPECT_EQ(d_min.to_nanoseconds(), int64_max);
+}
+
+TEST(Duration, Comparison) {
+    EXPECT_TRUE(duration::nanoseconds(100) == duration::nanoseconds(100));
+    EXPECT_FALSE(duration::nanoseconds(100) == duration::nanoseconds(200));
+
+    EXPECT_TRUE(duration::nanoseconds(100) < duration::nanoseconds(200));
+    EXPECT_TRUE(duration::nanoseconds(100) <= duration::nanoseconds(100));
+    EXPECT_TRUE(duration::nanoseconds(200) > duration::nanoseconds(100));
+    EXPECT_TRUE(duration::nanoseconds(200) >= duration::nanoseconds(200));
+}
+
+TEST(Duration, SpecialValues) {
+    auto inf = duration::infinite();
+    auto zero = duration::zero();
+
+    // Infinite + anything = infinite
+    EXPECT_EQ(inf + duration::nanoseconds(1000), inf);
+    EXPECT_EQ(inf + zero, inf);
+
+    // Infinite is the maximum
+    EXPECT_TRUE(inf > duration::nanoseconds(int64_max - 1));
+}
+
+// ============================================================================
+// Instant Tests
+// ============================================================================
+
+TEST(Instant, Construction) {
+    // Default construction (epoch)
+    constexpr instant i1;
+    EXPECT_EQ(i1, instant());
+
+    // Static factory methods
+    constexpr auto future = instant::infinite_future();
+    constexpr auto past = instant::infinite_past();
+    EXPECT_TRUE(future.is_infinite_future());
+    EXPECT_TRUE(past.is_infinite_past());
+}
+
+TEST(Instant, AddDuration) {
+    auto i = instant() + duration::nanoseconds(1000);
+    auto d = duration::nanoseconds(500);
+    auto result = i + d;
+    auto expected = instant() + duration::nanoseconds(1500);
+    EXPECT_EQ(result, expected);
+
+    // Adding to infinite_future stays at infinite_future
+    auto i_max = instant::infinite_future();
+    auto result2 = i_max + duration::nanoseconds(20);
+    EXPECT_EQ(result2, instant::infinite_future());
+}
+
+TEST(Instant, SubtractDuration) {
+    auto i = instant() + duration::nanoseconds(1000);
+    auto d = duration::nanoseconds(300);
+    auto result = i - d;
+    auto expected = instant() + duration::nanoseconds(700);
+    EXPECT_EQ(result, expected);
+
+    // Subtracting from infinite_past stays at infinite_past
+    auto i_min = instant::infinite_past();
+    auto result2 = i_min - duration::nanoseconds(20);
+    EXPECT_EQ(result2, instant::infinite_past());
+}
+
+TEST(Instant, SubtractInstants) {
+    auto i1 = instant() + duration::nanoseconds(2000);
+    auto i2 = instant() + duration::nanoseconds(500);
+    auto elapsed = i1 - i2;
+    EXPECT_EQ(elapsed.to_nanoseconds(), 1500);
+
+    // Saturating when result would overflow
+    auto max_i = instant::infinite_future();
+    auto min_i = instant::infinite_past();
+    auto huge_duration = max_i - min_i;
+    EXPECT_TRUE(huge_duration.is_infinite()); // Saturated
+}
+
+TEST(Instant, CompoundAssignment) {
+    instant i = instant() + duration::nanoseconds(1000);
+    i += duration::nanoseconds(500);
+    EXPECT_EQ(i, instant() + duration::nanoseconds(1500));
+
+    i -= duration::nanoseconds(300);
+    EXPECT_EQ(i, instant() + duration::nanoseconds(1200));
+}
+
+TEST(Instant, Comparison) {
+    auto i100 = instant() + duration::nanoseconds(100);
+    auto i200 = instant() + duration::nanoseconds(200);
+
+    EXPECT_TRUE(i100 == i100);
+    EXPECT_FALSE(i100 == i200);
+
+    EXPECT_TRUE(i100 < i200);
+    EXPECT_TRUE(i100 <= i100);
+    EXPECT_TRUE(i200 > i100);
+    EXPECT_TRUE(i200 >= i200);
+}
+
+TEST(Instant, SpecialValues) {
+    auto future = instant::infinite_future();
+    auto past = instant::infinite_past();
+
+    // Future + duration = still future (saturated)
+    EXPECT_EQ(future + duration::nanoseconds(1000), future);
+
+    // Past - duration = still past (saturated)
+    EXPECT_EQ(past - duration::nanoseconds(1000), past);
+
+    // Future is maximum, past is minimum
+    auto almost_max = instant() + duration::nanoseconds(int64_max - 1);
+    auto almost_min = instant() + duration::nanoseconds(int64_min + 1);
+    EXPECT_TRUE(future > almost_max);
+    EXPECT_TRUE(past < almost_min);
+}
+
+// ============================================================================
+// Wall Time Tests
+// ============================================================================
+
+TEST(WallTime, Construction) {
+    // Default construction (epoch)
+    constexpr wall_time wt1;
+    EXPECT_EQ(wt1, wall_time());
+
+    // Static factory methods
+    constexpr auto future = wall_time::infinite_future();
+    constexpr auto past = wall_time::infinite_past();
+    EXPECT_TRUE(future.is_infinite_future());
+    EXPECT_TRUE(past.is_infinite_past());
+}
+
+TEST(WallTime, AddDuration) {
+    auto wt = wall_time() + duration::nanoseconds(1000);
+    auto d = duration::nanoseconds(500);
+    auto result = wt + d;
+    auto expected = wall_time() + duration::nanoseconds(1500);
+    EXPECT_EQ(result, expected);
+
+    // Adding to infinite_future stays at infinite_future
+    auto wt_max = wall_time::infinite_future();
+    auto result2 = wt_max + duration::nanoseconds(20);
+    EXPECT_EQ(result2, wall_time::infinite_future());
+}
+
+TEST(WallTime, SubtractDuration) {
+    auto wt = wall_time() + duration::nanoseconds(1000);
+    auto d = duration::nanoseconds(300);
+    auto result = wt - d;
+    auto expected = wall_time() + duration::nanoseconds(700);
+    EXPECT_EQ(result, expected);
+
+    // Subtracting from infinite_past stays at infinite_past
+    auto wt_min = wall_time::infinite_past();
+    auto result2 = wt_min - duration::nanoseconds(20);
+    EXPECT_EQ(result2, wall_time::infinite_past());
+}
+
+TEST(WallTime, SubtractWallTimes) {
+    auto wt1 = wall_time() + duration::nanoseconds(2000);
+    auto wt2 = wall_time() + duration::nanoseconds(500);
+    auto elapsed = wt1 - wt2;
+    EXPECT_EQ(elapsed.to_nanoseconds(), 1500);
+
+    // Saturating when result would overflow
+    auto max_wt = wall_time::infinite_future();
+    auto min_wt = wall_time::infinite_past();
+    auto huge_duration = max_wt - min_wt;
+    EXPECT_TRUE(huge_duration.is_infinite()); // Saturated
+}
+
+TEST(WallTime, CompoundAssignment) {
+    wall_time wt = wall_time() + duration::nanoseconds(1000);
+    wt += duration::nanoseconds(500);
+    EXPECT_EQ(wt, wall_time() + duration::nanoseconds(1500));
+
+    wt -= duration::nanoseconds(300);
+    EXPECT_EQ(wt, wall_time() + duration::nanoseconds(1200));
+}
+
+TEST(WallTime, Comparison) {
+    auto wt100 = wall_time() + duration::nanoseconds(100);
+    auto wt200 = wall_time() + duration::nanoseconds(200);
+
+    EXPECT_TRUE(wt100 == wt100);
+    EXPECT_FALSE(wt100 == wt200);
+
+    EXPECT_TRUE(wt100 < wt200);
+    EXPECT_TRUE(wt100 <= wt100);
+    EXPECT_TRUE(wt200 > wt100);
+    EXPECT_TRUE(wt200 >= wt200);
+}
+
+TEST(WallTime, SpecialValues) {
+    auto future = wall_time::infinite_future();
+    auto past = wall_time::infinite_past();
+
+    // Future + duration = still future (saturated)
+    EXPECT_EQ(future + duration::nanoseconds(1000), future);
+
+    // Past - duration = still past (saturated)
+    EXPECT_EQ(past - duration::nanoseconds(1000), past);
+
+    // Future is maximum, past is minimum
+    auto almost_max = wall_time() + duration::nanoseconds(int64_max - 1);
+    auto almost_min = wall_time() + duration::nanoseconds(int64_min + 1);
+    EXPECT_TRUE(future > almost_max);
+    EXPECT_TRUE(past < almost_min);
+}
+
+} // namespace ssx

--- a/src/v/ssx/time.cc
+++ b/src/v/ssx/time.cc
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "ssx/time.h"
+
+namespace ssx {
+
+fmt::format_context::iterator
+duration::format_to(fmt::format_context::iterator out) const {
+    return fmt::format_to(out, "{}", absl::FormatDuration(_dur));
+}
+
+fmt::format_context::iterator
+instant::format_to(fmt::format_context::iterator out) const {
+    return fmt::format_to(out, "{{duration={}}}", *this - instant());
+}
+
+fmt::format_context::iterator
+wall_time::format_to(fmt::format_context::iterator out) const {
+    return fmt::format_to(out, "{}", absl::FormatTime(_time));
+}
+
+} // namespace ssx

--- a/src/v/ssx/time.h
+++ b/src/v/ssx/time.h
@@ -1,0 +1,408 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "absl/time/time.h"
+#include "base/format_to.h"
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/manual_clock.hh>
+
+#include <chrono>
+#include <cstdint>
+#include <type_traits>
+
+/*
+ * SSX Temporal Library - Type-Safe Time Value Types
+ * ==================================================
+ *
+ * This library provides strong time value types with saturating arithmetic:
+ *
+ * - `duration`: Represents a time interval (can be negative)
+ * - `instant`: Monotonic clock instant (steady, cannot go backwards)
+ * - `wall_time`: Wall clock instant (can jump due to NTP/DST adjustments)
+ *
+ * All types use int64_t nanoseconds internally and employ saturating
+ * arithmetic to prevent overflow/underflow bugs. Type safety prevents
+ * mixing instant and wall_time incorrectly.
+ *
+ * Usage:
+ *   ssx::duration d = ssx::duration::seconds(1);
+ *   ssx::instant t1 = clock.now();
+ *   ssx::instant t2 = t1 + d;
+ *   ssx::duration elapsed = t2 - t1;
+ *
+ * Special Values:
+ *   ssx::duration::infinite()
+ *   ssx::instant::infinite_future()
+ *   ssx::instant::infinite_past()
+ */
+
+namespace ssx {
+
+// Forward declarations
+class duration;
+class instant;
+class wall_time;
+
+// Time duration value type with saturating arithmetic
+// Represents a time interval in nanoseconds (can be negative)
+class duration {
+public:
+    // Create infinite duration
+    static constexpr duration infinite() noexcept {
+        return duration(absl::InfiniteDuration());
+    }
+
+    // Create zero duration
+    static constexpr duration zero() noexcept {
+        return duration(absl::ZeroDuration());
+    }
+
+    // Saturating factory methods
+    static constexpr duration hours(int64_t s) noexcept {
+        return duration(absl::Hours(s));
+    }
+    static constexpr duration minutes(int64_t s) noexcept {
+        return duration(absl::Minutes(s));
+    }
+    static constexpr duration seconds(int64_t s) noexcept {
+        return duration(absl::Seconds(s));
+    }
+    static constexpr duration milliseconds(int64_t ms) noexcept {
+        return duration(absl::Milliseconds(ms));
+    }
+    static constexpr duration microseconds(int64_t us) noexcept {
+        return duration(absl::Microseconds(us));
+    }
+    static constexpr duration nanoseconds(int64_t ns) noexcept {
+        return duration(absl::Nanoseconds(ns));
+    }
+
+    static duration from_chrono(std::chrono::hours s) noexcept {
+        return duration::hours(s.count());
+    }
+    static duration from_chrono(std::chrono::minutes s) noexcept {
+        return duration::minutes(s.count());
+    }
+    static duration from_chrono(std::chrono::seconds s) noexcept {
+        return duration::seconds(s.count());
+    }
+    static duration from_chrono(std::chrono::milliseconds ms) noexcept {
+        return duration::milliseconds(ms.count());
+    }
+    static duration from_chrono(std::chrono::microseconds us) noexcept {
+        return duration::microseconds(us.count());
+    }
+    static duration from_chrono(std::chrono::nanoseconds ns) noexcept {
+        return duration::nanoseconds(ns.count());
+    }
+
+    // Construct from nanoseconds
+    explicit constexpr duration(absl::Duration duration) noexcept
+      : _dur(duration) {}
+
+    // Default construction = zero
+    constexpr duration() noexcept
+      : _dur(absl::ZeroDuration()) {}
+
+    constexpr bool is_infinite() const noexcept {
+        return _dur == absl::InfiniteDuration();
+    }
+
+    // Convert to std::chrono duration
+    template<typename Duration>
+    Duration to_chrono() const noexcept {
+        if constexpr (std::is_same_v<Duration, std::chrono::nanoseconds>) {
+            return absl::ToChronoNanoseconds(_dur);
+        } else if constexpr (std::
+                               is_same_v<Duration, std::chrono::microseconds>) {
+            return absl::ToChronoMicroseconds(_dur);
+        } else if constexpr (std::
+                               is_same_v<Duration, std::chrono::milliseconds>) {
+            return absl::ToChronoMilliseconds(_dur);
+        } else if constexpr (std::is_same_v<Duration, std::chrono::seconds>) {
+            return absl::ToChronoSeconds(_dur);
+        } else if constexpr (std::is_same_v<Duration, std::chrono::minutes>) {
+            return absl::ToChronoMinutes(_dur);
+        } else if constexpr (std::is_same_v<Duration, std::chrono::hours>) {
+            return absl::ToChronoHours(_dur);
+        } else {
+            static_assert(false, "unsupported type");
+        }
+    }
+
+    // Conversion helpers (truncating)
+    constexpr int64_t to_hours() const noexcept {
+        return absl::ToInt64Hours(_dur);
+    }
+    constexpr int64_t to_minutes() const noexcept {
+        return absl::ToInt64Minutes(_dur);
+    }
+    constexpr int64_t to_seconds() const noexcept {
+        return absl::ToInt64Seconds(_dur);
+    }
+    constexpr int64_t to_milliseconds() const noexcept {
+        return absl::ToInt64Milliseconds(_dur);
+    }
+    constexpr int64_t to_microseconds() const noexcept {
+        return absl::ToInt64Microseconds(_dur);
+    }
+    constexpr int64_t to_nanoseconds() const noexcept {
+        return absl::ToInt64Nanoseconds(_dur);
+    }
+
+    // Saturating addition
+    constexpr duration operator+(duration other) const noexcept {
+        return duration(_dur + other._dur);
+    }
+
+    // Saturating subtraction
+    constexpr duration operator-(duration other) const noexcept {
+        return duration(_dur - other._dur);
+    }
+
+    // Saturating multiplication by scalar
+    constexpr duration operator*(int64_t scalar) const noexcept {
+        return duration(_dur * scalar);
+    }
+
+    // Division by scalar (saturating)
+    constexpr duration operator/(int64_t scalar) const noexcept {
+        return duration(_dur / scalar);
+    }
+
+    // Negation (saturating)
+    constexpr duration operator-() const noexcept { return duration(-_dur); }
+
+    // Compound assignment operators
+    constexpr duration& operator+=(duration other) noexcept {
+        _dur += other._dur;
+        return *this;
+    }
+
+    constexpr duration& operator-=(duration other) noexcept {
+        _dur -= other._dur;
+        return *this;
+    }
+
+    constexpr duration& operator*=(int64_t scalar) noexcept {
+        _dur *= scalar;
+        return *this;
+    }
+
+    constexpr duration& operator/=(int64_t scalar) noexcept {
+        _dur /= scalar;
+        return *this;
+    }
+
+    // Comparison operators
+    constexpr bool operator==(const duration& other) const noexcept = default;
+    constexpr auto operator<=>(const duration& other) const noexcept = default;
+
+    // Formatting support
+    fmt::format_context::iterator
+    format_to(fmt::format_context::iterator out) const;
+
+    explicit operator absl::Duration() const { return _dur; }
+
+private:
+    absl::Duration _dur;
+};
+
+// Monotonic clock instant value type with saturating arithmetic
+// Cannot move backwards in time (steady/monotonic)
+class instant {
+public:
+    // Create infinite future instant
+    static constexpr instant infinite_future() noexcept {
+        return instant(absl::InfiniteFuture());
+    }
+
+    // Create infinite past instant
+    static constexpr instant infinite_past() noexcept {
+        return instant(absl::InfinitePast());
+    }
+
+    static instant from_chrono(seastar::lowres_clock::time_point tp) noexcept {
+        return instant() + duration::from_chrono(tp.time_since_epoch());
+    }
+    static instant from_chrono(seastar::manual_clock::time_point tp) noexcept {
+        return instant() + duration::from_chrono(tp.time_since_epoch());
+    }
+    static instant
+    from_chrono(std::chrono::steady_clock::time_point tp) noexcept {
+        return instant() + duration::from_chrono(tp.time_since_epoch());
+    }
+
+    // Construct from nanoseconds since epoch
+    explicit constexpr instant(absl::Time time) noexcept
+      : _time(time) {}
+
+    // Default construction = (zero instant)
+    constexpr instant() noexcept = default;
+
+    // Check if infinite future
+    constexpr bool is_infinite_future() const noexcept {
+        return _time == absl::InfiniteFuture();
+    }
+
+    // Check if infinite past
+    constexpr bool is_infinite_past() const noexcept {
+        return _time == absl::InfinitePast();
+    }
+
+    template<typename Clock>
+    typename Clock::time_point to_chrono() const noexcept {
+        auto diff = *this - instant();
+        return typename Clock::time_point(
+          diff.to_chrono<typename Clock::duration>());
+    }
+
+    // Add duration to instant (saturating)
+    constexpr instant operator+(duration d) const noexcept {
+        return instant(_time + absl::Duration(d));
+    }
+
+    // Subtract duration from instant (saturating)
+    constexpr instant operator-(duration d) const noexcept {
+        return instant(_time - absl::Duration(d));
+    }
+
+    // Subtract two instants to get duration (saturating)
+    constexpr duration operator-(instant other) const noexcept {
+        return duration(_time - other._time);
+    }
+
+    // Compound assignment
+    constexpr instant& operator+=(duration d) noexcept {
+        _time += absl::Duration(d);
+        return *this;
+    }
+
+    constexpr instant& operator-=(duration d) noexcept {
+        _time -= absl::Duration(d);
+        return *this;
+    }
+
+    // Comparison operators
+    constexpr bool operator==(const instant& other) const noexcept = default;
+    constexpr auto operator<=>(const instant& other) const noexcept = default;
+
+    // Formatting support
+    fmt::format_context::iterator
+    format_to(fmt::format_context::iterator out) const;
+
+private:
+    // Time since boot
+    absl::Time _time;
+};
+
+// Wall clock instant value type with saturating arithmetic
+// Represents real-world time, can jump (NTP adjustments, DST, etc.)
+class wall_time {
+public:
+    // Create infinite future wall_time
+    static constexpr wall_time infinite_future() noexcept {
+        return wall_time(absl::InfiniteFuture());
+    }
+
+    // Create infinite past wall_time
+    static constexpr wall_time infinite_past() noexcept {
+        return wall_time(absl::InfinitePast());
+    }
+
+    static wall_time
+    from_chrono(std::chrono::system_clock::time_point tp) noexcept {
+        return wall_time(absl::FromChrono(tp));
+    }
+    static wall_time
+    from_chrono(seastar::lowres_system_clock::time_point tp) noexcept {
+        return wall_time() + duration::from_chrono(tp.time_since_epoch());
+    }
+    static wall_time
+    from_chrono(seastar::manual_clock::time_point tp) noexcept {
+        return wall_time() + duration::from_chrono(tp.time_since_epoch());
+    }
+
+    // Construct from nanoseconds since Unix epoch
+    explicit constexpr wall_time(absl::Time t) noexcept
+      : _time(t) {}
+
+    // Default construction = Unix epoch (zero)
+    constexpr wall_time() noexcept
+      : _time(absl::UnixEpoch()) {}
+
+    // Check if infinite future
+    constexpr bool is_infinite_future() const noexcept {
+        return _time == absl::InfiniteFuture();
+    }
+
+    // Check if infinite past
+    constexpr bool is_infinite_past() const noexcept {
+        return _time == absl::InfinitePast();
+    }
+
+    template<typename Clock>
+    typename Clock::time_point to_chrono() const noexcept {
+        if constexpr (std::is_same_v<std::chrono::system_clock, Clock>) {
+            return absl::ToChronoTime(_time);
+        }
+        auto diff = *this - wall_time();
+        return typename Clock::time_point(
+          diff.to_chrono<typename Clock::duration>());
+    }
+
+    // Add duration to wall_time (saturating)
+    constexpr wall_time operator+(duration d) const noexcept {
+        return wall_time(_time + absl::Duration(d));
+    }
+
+    // Subtract duration from wall_time (saturating)
+    constexpr wall_time operator-(duration d) const noexcept {
+        return wall_time(_time - absl::Duration(d));
+    }
+
+    // Subtract two wall_times to get duration (saturating)
+    constexpr duration operator-(wall_time other) const noexcept {
+        return duration(_time - other._time);
+    }
+
+    // Compound assignment
+    constexpr wall_time& operator+=(duration d) noexcept {
+        _time += absl::Duration(d);
+        return *this;
+    }
+
+    constexpr wall_time& operator-=(duration d) noexcept {
+        _time -= absl::Duration(d);
+        return *this;
+    }
+
+    // Comparison operators
+    constexpr bool operator==(const wall_time& other) const noexcept = default;
+    constexpr auto operator<=>(const wall_time& other) const noexcept = default;
+
+    // Formatting support
+    fmt::format_context::iterator
+    format_to(fmt::format_context::iterator out) const;
+
+private:
+    absl::Time _time;
+};
+
+// Allow duration * scalar (commutative, saturating)
+constexpr duration operator*(int64_t scalar, duration d) noexcept {
+    return d * scalar;
+}
+
+} // namespace ssx


### PR DESCRIPTION
This adds a new temporal library to our seastar extentions with type-safe time handling and saturating arithmetic.

Core types:
- duration - time span in nanoseconds
- instant - monotonic time point (from steady clocks)
- wall_time - system time point (from wall clocks)

All types use int64_t internally with saturating arithmetic to prevent overflow. Special values: INT64_MAX = infinite future, INT64_MIN = infinite past.

Clock interfaces:
Virtual clock interfaces replace template-based clock usage:
- steady_clock - monotonic clocks that never go backwards
- wall_clock - system time clocks (can jump due to NTP/DST)

Clock implementations provided:
- hires_steady_clock() - high-resolution monotonic (seastar::steady_clock)
- lowres_steady_clock() - low-resolution monotonic (seastar::lowres_clock)
- hires_wall_clock() - high-resolution system time (std::chrono::system_clock)
- lowres_wall_clock() - low-resolution system time (seastar::lowres_system_clock)

Plus manual_steady_clock() and manual_wall_clock() for testing.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
