### PR TITLE
[CORE-15053] `rptest`: skip `test_cloud_storage_client_misconfiguration` in FIPS mode

### DIFF
--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -14,6 +14,7 @@ from ducktape.utils.util import wait_until
 
 from rptest.clients.offline_log_viewer import OfflineLogViewer
 from rptest.services.cluster import cluster
+from rptest.utils.mode_checks import skip_fips_mode
 from rptest.services.redpanda import LoggingConfig, RedpandaService, ResourceSettings
 from rptest.tests.redpanda_test import RedpandaTest
 
@@ -347,6 +348,7 @@ class CrashLoopChecksTest(RedpandaTest):
             f"Unexpected crash message: {report['crash_message']}"
         )
 
+    @skip_fips_mode
     @cluster(num_nodes=1, log_allow_list=CLOUD_STORAGE_CLIENT_CONFIG_ERRORS)
     def test_cloud_storage_client_misconfiguration(self):
         """


### PR DESCRIPTION
If in FIPS mode, an assert is triggered when the client fails to configure with `virtual_host` mode, causing the broker to crash. This doesn't align with the test expectations, which expects a different, generic log line for a misconfigured broker.

Alternatively, we could change the check to account for the possibility of running in FIPS mode, but it doesn't feel like thats much of a value add to the test.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
