### PR TITLE
[CORE-15141] ct: Fix `get_fetch_requests`

### DIFF
--- a/src/v/cloud_topics/level_zero/pipeline/pipeline_stage.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/pipeline_stage.cc
@@ -34,7 +34,7 @@ pipeline_stage pipeline_stage_container::next_stage(pipeline_stage old) const {
     auto next_ix = old_ix + 1;
     // Check that we have next stage
     vassert(
-      static_cast<size_t>(next_ix) < _stages.size(),
+      static_cast<size_t>(next_ix) < _registered,
       "Pipeline stage {} is not registered",
       next_ix);
     return pipeline_stage(&_stages.at(next_ix));

--- a/src/v/cloud_topics/level_zero/pipeline/read_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/read_pipeline.cc
@@ -176,9 +176,9 @@ read_pipeline<Clock>::get_fetch_requests(
           "get_fetch_requests processing req for {}, size estimate: {}",
           it->ntp,
           acc_size);
-        if (acc_size >= max_bytes) {
-            // Include last element
-            it++;
+        // Always include the first request even if it exceeds max_bytes
+        // to avoid stalling the pipeline with oversized requests
+        if (acc_size >= max_bytes && !result.requests.empty()) {
             break;
         }
         auto& el = *it;

--- a/src/v/cloud_topics/level_zero/pipeline/read_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/read_pipeline.cc
@@ -163,13 +163,12 @@ read_pipeline<Clock>::get_fetch_requests(
     read_requests_list result(this, stage);
     size_t acc_size = 0;
 
-    // The elements in the list are in the insertion order.
     auto it = pending.begin();
-    for (; it != pending.end(); it++) {
+    for (; it != pending.end();) {
         if (it->stage != stage) {
+            it++;
             continue;
         }
-        // TODO: avoid copy
         auto sz = it->query.output_size_estimate;
         acc_size += sz;
         vlog(
@@ -182,8 +181,11 @@ read_pipeline<Clock>::get_fetch_requests(
             it++;
             break;
         }
+        auto& el = *it;
+        it++;
+        el._hook.unlink();
+        result.requests.push_back(el);
     }
-    result.requests.splice(result.requests.end(), pending, pending.begin(), it);
     result.complete = pending.empty();
     vlog(
       logger.debug,

--- a/src/v/cloud_topics/level_zero/pipeline/tests/BUILD
+++ b/src/v/cloud_topics/level_zero/pipeline/tests/BUILD
@@ -1,6 +1,21 @@
 load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_gtest")
 
 redpanda_cc_gtest(
+    name = "read_pipeline_test",
+    timeout = "short",
+    srcs = [
+        "read_pipeline_test.cc",
+    ],
+    deps = [
+        "//src/v/cloud_topics/level_zero/pipeline:read_pipeline",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "write_pipeline_test",
     timeout = "short",
     srcs = [

--- a/src/v/cloud_topics/level_zero/pipeline/tests/read_pipeline_test.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/tests/read_pipeline_test.cc
@@ -130,3 +130,132 @@ TEST_CORO(read_pipeline_test, interleaving_stages_bug) {
 
     ASSERT_EQ_CORO(accessor.read_requests_pending(0), true);
 }
+
+TEST_CORO(read_pipeline_test, oversized_request) {
+    // This test verifies that get_fetch_requests returns at least one
+    // request even if it exceeds the max_bytes limit, to prevent pipeline
+    // stalls with oversized requests.
+    cloud_topics::l0::read_pipeline<ss::manual_clock> pipeline;
+    cloud_topics::l0::read_pipeline_accessor accessor{
+      .pipeline = &pipeline,
+    };
+
+    auto stage = pipeline.register_read_pipeline_stage();
+    const auto timeout = ss::manual_clock::now() + 10s;
+
+    // Create requests with different sizes
+    std::vector<
+      std::unique_ptr<cloud_topics::l0::read_request<ss::manual_clock>>>
+      requests;
+
+    // First request is oversized (10000 bytes)
+    cloud_topics::l0::dataplane_query query1;
+    query1.output_size_estimate = 10000;
+    auto req1
+      = std::make_unique<cloud_topics::l0::read_request<ss::manual_clock>>(
+        model::controller_ntp,
+        std::move(query1),
+        timeout,
+        &pipeline.get_root_rtc());
+    requests.push_back(std::move(req1));
+
+    // Second request is normal size (1000 bytes)
+    cloud_topics::l0::dataplane_query query2;
+    query2.output_size_estimate = 1000;
+    auto req2
+      = std::make_unique<cloud_topics::l0::read_request<ss::manual_clock>>(
+        model::controller_ntp,
+        std::move(query2),
+        timeout,
+        &pipeline.get_root_rtc());
+    requests.push_back(std::move(req2));
+
+    // Add both requests to stage
+    accessor.add_request_with_stage(*requests[0], stage.id());
+    accessor.add_request_with_stage(*requests[1], stage.id());
+
+    co_await ss::yield();
+
+    ASSERT_EQ_CORO(accessor.read_requests_pending(2), true);
+
+    // Try to get requests with max_bytes = 5000 (less than first request)
+    // Should still get the first request to avoid stalling
+    auto result = accessor.get_fetch_requests(5000, stage.id());
+
+    // Should return exactly 1 request (the oversized one)
+    ASSERT_EQ_CORO(result.requests.size(), 1);
+    result.requests.front().set_value(
+      cloud_topics::l0::dataplane_query_result{});
+
+    // Second request should still be pending
+    ASSERT_EQ_CORO(accessor.read_requests_pending(1), true);
+
+    // Get the second request
+    auto result2 = accessor.get_fetch_requests(
+      std::numeric_limits<size_t>::max(), stage.id());
+    ASSERT_EQ_CORO(result2.requests.size(), 1);
+    result2.requests.front().set_value(
+      cloud_topics::l0::dataplane_query_result{});
+
+    ASSERT_EQ_CORO(accessor.read_requests_pending(0), true);
+}
+
+TEST_CORO(read_pipeline_test, multiple_requests_within_limit) {
+    // This test verifies that get_fetch_requests returns multiple requests
+    // when they fit within the size limit.
+    cloud_topics::l0::read_pipeline<ss::manual_clock> pipeline;
+    cloud_topics::l0::read_pipeline_accessor accessor{
+      .pipeline = &pipeline,
+    };
+
+    auto stage = pipeline.register_read_pipeline_stage();
+    const auto timeout = ss::manual_clock::now() + 10s;
+
+    // Create 3 requests with size 1000 each
+    std::vector<
+      std::unique_ptr<cloud_topics::l0::read_request<ss::manual_clock>>>
+      requests;
+
+    for (int i = 0; i < 3; i++) {
+        cloud_topics::l0::dataplane_query query;
+        query.output_size_estimate = 1000;
+        auto req
+          = std::make_unique<cloud_topics::l0::read_request<ss::manual_clock>>(
+            model::controller_ntp,
+            std::move(query),
+            timeout,
+            &pipeline.get_root_rtc());
+        requests.push_back(std::move(req));
+    }
+
+    // Add all requests to stage
+    for (auto& req : requests) {
+        accessor.add_request_with_stage(*req, stage.id());
+    }
+
+    co_await ss::yield();
+
+    ASSERT_EQ_CORO(accessor.read_requests_pending(3), true);
+
+    // Get requests with max_bytes = 2500 (should get 2 requests, not 3)
+    auto result = accessor.get_fetch_requests(2500, stage.id());
+
+    // Should return 2 requests (total 2000 bytes, within limit)
+    ASSERT_EQ_CORO(result.requests.size(), 2);
+
+    for (auto& req : result.requests) {
+        req.set_value(cloud_topics::l0::dataplane_query_result{});
+    }
+
+    // One request should still be pending
+    ASSERT_EQ_CORO(accessor.read_requests_pending(1), true);
+
+    // Get the last request
+    auto result2 = accessor.get_fetch_requests(
+      std::numeric_limits<size_t>::max(), stage.id());
+    ASSERT_EQ_CORO(result2.requests.size(), 1);
+    result2.requests.front().set_value(
+      cloud_topics::l0::dataplane_query_result{});
+
+    ASSERT_EQ_CORO(accessor.read_requests_pending(0), true);
+}

--- a/src/v/cloud_topics/level_zero/pipeline/tests/read_pipeline_test.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/tests/read_pipeline_test.cc
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_zero/pipeline/read_pipeline.h"
+#include "model/fundamental.h"
+#include "model/namespace.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/manual_clock.hh>
+#include <seastar/util/log.hh>
+
+#include <chrono>
+#include <limits>
+
+using namespace std::chrono_literals;
+
+namespace cloud_topics::l0 {
+struct read_pipeline_accessor {
+    // Returns true if the read request is in the `_pending` collection
+    bool read_requests_pending(size_t n) {
+        return pipeline->get_pending().size() == n;
+    }
+
+    // Manually add a read request to the pending list with a specific stage
+    void add_request_with_stage(
+      read_request<ss::manual_clock>& req, pipeline_stage stage) {
+        req.stage = stage;
+        pipeline->get_pending().push_back(req);
+        pipeline->signal(stage);
+    }
+
+    // Call get_fetch_requests (which is private)
+    read_pipeline<ss::manual_clock>::read_requests_list
+    get_fetch_requests(size_t max_bytes, pipeline_stage stage) {
+        return pipeline->get_fetch_requests(max_bytes, stage);
+    }
+
+    read_pipeline<ss::manual_clock>* pipeline;
+};
+} // namespace cloud_topics::l0
+
+// Simulate sleep of certain duration and wait until the condition is met
+template<class Fn>
+ss::future<>
+sleep_until(std::chrono::milliseconds delta, Fn&& fn, int retry_limit = 100) {
+    ss::manual_clock::advance(delta);
+    for (int i = 0; i < retry_limit; i++) {
+        co_await ss::yield();
+        if (fn()) {
+            co_return;
+        }
+    }
+    GTEST_MESSAGE_("Test stalled", ::testing::TestPartResult::kFatalFailure);
+}
+
+TEST_CORO(read_pipeline_test, interleaving_stages_bug) {
+    // This test demonstrates a bug where get_fetch_requests can return
+    // requests that belong to the wrong pipeline stage when requests
+    // with different stages are interleaved.
+    cloud_topics::l0::read_pipeline<ss::manual_clock> pipeline;
+    cloud_topics::l0::read_pipeline_accessor accessor{
+      .pipeline = &pipeline,
+    };
+
+    auto stage1 = pipeline.register_read_pipeline_stage();
+    auto stage2 = pipeline.register_read_pipeline_stage();
+
+    const auto timeout = ss::manual_clock::now() + 10s;
+
+    // Create 6 read requests with interleaved stages:
+    // stage1, stage2, stage1, stage2, stage1, stage2
+    std::vector<
+      std::unique_ptr<cloud_topics::l0::read_request<ss::manual_clock>>>
+      requests;
+
+    for (int i = 0; i < 6; i++) {
+        cloud_topics::l0::dataplane_query query;
+        query.output_size_estimate = 1000 + i * 100; // Different sizes
+        auto req
+          = std::make_unique<cloud_topics::l0::read_request<ss::manual_clock>>(
+            model::controller_ntp,
+            std::move(query),
+            timeout,
+            &pipeline.get_root_rtc());
+        requests.push_back(std::move(req));
+    }
+
+    // Add requests with interleaved stages
+    accessor.add_request_with_stage(*requests[0], stage1.id());
+    accessor.add_request_with_stage(*requests[1], stage2.id());
+    accessor.add_request_with_stage(*requests[2], stage1.id());
+    accessor.add_request_with_stage(*requests[3], stage2.id());
+    accessor.add_request_with_stage(*requests[4], stage1.id());
+    accessor.add_request_with_stage(*requests[5], stage2.id());
+
+    co_await ss::yield();
+
+    ASSERT_EQ_CORO(accessor.read_requests_pending(6), true);
+
+    // Try to get requests for stage1 only - should get exactly 3 requests
+    auto result = accessor.get_fetch_requests(
+      std::numeric_limits<size_t>::max(), stage1.id());
+
+    ASSERT_EQ_CORO(result.requests.size(), 3);
+
+    for (auto& req : result.requests) {
+        req.set_value(cloud_topics::l0::dataplane_query_result{});
+    }
+
+    // The remaining 3 requests should still be in the pending queue
+    ASSERT_EQ_CORO(accessor.read_requests_pending(3), true);
+
+    // Get stage2 requests - should get exactly 3 requests
+    auto result2 = accessor.get_fetch_requests(
+      std::numeric_limits<size_t>::max(), stage2.id());
+    ASSERT_EQ_CORO(result2.requests.size(), 3);
+
+    for (auto& req : result2.requests) {
+        req.set_value(cloud_topics::l0::dataplane_query_result{});
+    }
+
+    ASSERT_EQ_CORO(accessor.read_requests_pending(0), true);
+}

--- a/src/v/cloud_topics/level_zero/pipeline/tests/write_pipeline_test.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/tests/write_pipeline_test.cc
@@ -43,6 +43,14 @@ struct write_pipeline_accessor {
         return pipeline->get_pending().size() == n;
     }
 
+    // Manually add a write request to the pending list with a specific stage
+    void add_request_with_stage(
+      write_request<ss::manual_clock>& req, pipeline_stage stage) {
+        req.stage = stage;
+        pipeline->get_pending().push_back(req);
+        pipeline->signal(stage);
+    }
+
     write_pipeline<ss::manual_clock>* pipeline;
 };
 } // namespace cloud_topics::l0
@@ -201,4 +209,87 @@ TEST_CORO(write_pipeline_test, stage_bytes_accounting_on_timeout) {
     auto write_res = co_await std::move(fut);
     ASSERT_FALSE_CORO(write_res.has_value());
     ASSERT_EQ_CORO(pipeline.stage_bytes(stage.id()), 0);
+}
+
+TEST_CORO(write_pipeline_test, interleaving_stages_bug) {
+    // This test demonstrates a bug where get_write_requests can return
+    // requests that belong to the wrong pipeline stage when requests
+    // with different stages are interleaved.
+    cloud_topics::l0::write_pipeline<ss::manual_clock> pipeline;
+    cloud_topics::l0::write_pipeline_accessor accessor{
+      .pipeline = &pipeline,
+    };
+
+    auto stage1 = pipeline.register_write_pipeline_stage();
+    auto stage2 = pipeline.register_write_pipeline_stage();
+
+    const auto timeout = ss::manual_clock::now() + 10s;
+
+    auto test_data = co_await model::test::make_random_batches(
+      {.count = 1, .records = 5});
+
+    // Helper to create a serialized chunk from test data
+    auto make_chunk = [&]() -> ss::future<cloud_topics::l0::serialized_chunk> {
+        chunked_vector<model::record_batch> batches;
+        auto data = co_await model::test::make_random_batches(
+          {.count = 1, .records = 5});
+        std::ranges::move(std::move(data), std::back_inserter(batches));
+        co_return co_await cloud_topics::l0::serialize_batches(
+          std::move(batches));
+    };
+
+    // Create 6 write requests with interleaved stages:
+    // stage1, stage2, stage1, stage2, stage1, stage2
+    std::vector<
+      std::unique_ptr<cloud_topics::l0::write_request<ss::manual_clock>>>
+      requests;
+
+    for (int i = 0; i < 6; i++) {
+        auto chunk = co_await make_chunk();
+        auto req
+          = std::make_unique<cloud_topics::l0::write_request<ss::manual_clock>>(
+            model::controller_ntp, min_epoch, std::move(chunk), timeout);
+        requests.push_back(std::move(req));
+    }
+
+    // Add requests with interleaved stages
+    accessor.add_request_with_stage(*requests[0], stage1.id());
+    accessor.add_request_with_stage(*requests[1], stage2.id());
+    accessor.add_request_with_stage(*requests[2], stage1.id());
+    accessor.add_request_with_stage(*requests[3], stage2.id());
+    accessor.add_request_with_stage(*requests[4], stage1.id());
+    accessor.add_request_with_stage(*requests[5], stage2.id());
+
+    co_await ss::yield();
+
+    ASSERT_EQ_CORO(accessor.write_requests_pending(6), true);
+
+    // Try to get requests for stage1 only - should get exactly 3 requests
+    auto result = stage1.pull_write_requests(
+      std::numeric_limits<size_t>::max());
+
+    ASSERT_EQ_CORO(result.requests.size(), 3);
+
+    for (auto& req : result.requests) {
+        // Stage should be unassigned after extraction
+        ASSERT_TRUE_CORO(
+          req.stage == cloud_topics::l0::unassigned_pipeline_stage);
+        req.set_value(chunked_vector<cloud_topics::extent_meta>{});
+    }
+
+    // The remaining 3 requests should still be in the pending queue
+    ASSERT_TRUE_CORO(accessor.write_requests_pending(3));
+
+    // Get stage2 requests - should get exactly 3 requests
+    auto result2 = stage2.pull_write_requests(
+      std::numeric_limits<size_t>::max());
+    ASSERT_EQ_CORO(result2.requests.size(), 3);
+
+    for (auto& req : result2.requests) {
+        ASSERT_TRUE_CORO(
+          req.stage == cloud_topics::l0::unassigned_pipeline_stage);
+        req.set_value(chunked_vector<cloud_topics::extent_meta>{});
+    }
+
+    ASSERT_EQ_CORO(accessor.write_requests_pending(0), true);
 }

--- a/src/v/cloud_topics/level_zero/pipeline/tests/write_pipeline_test.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/tests/write_pipeline_test.cc
@@ -293,3 +293,226 @@ TEST_CORO(write_pipeline_test, interleaving_stages_bug) {
 
     ASSERT_EQ_CORO(accessor.write_requests_pending(0), true);
 }
+
+TEST_CORO(write_pipeline_test, oversized_request) {
+    // This test verifies that get_write_requests returns at least one
+    // request even if it exceeds the max_bytes limit, to prevent pipeline
+    // stalls with oversized requests.
+    cloud_topics::l0::write_pipeline<ss::manual_clock> pipeline;
+    cloud_topics::l0::write_pipeline_accessor accessor{
+      .pipeline = &pipeline,
+    };
+
+    auto stage = pipeline.register_write_pipeline_stage();
+    const auto timeout = ss::manual_clock::now() + 10s;
+
+    // Helper to create a serialized chunk with specific size
+    auto make_chunk_with_size =
+      [&](
+        size_t target_size) -> ss::future<cloud_topics::l0::serialized_chunk> {
+        // Create batches until we reach approximately the target size
+        chunked_vector<model::record_batch> batches;
+        size_t current_size = 0;
+        while (current_size < target_size) {
+            auto data = co_await model::test::make_random_batches(
+              {.count = 1, .records = 10});
+            for (auto& batch : data) {
+                current_size += batch.size_bytes();
+                batches.push_back(std::move(batch));
+                if (current_size >= target_size) {
+                    break;
+                }
+            }
+        }
+        co_return co_await cloud_topics::l0::serialize_batches(
+          std::move(batches));
+    };
+
+    std::vector<
+      std::unique_ptr<cloud_topics::l0::write_request<ss::manual_clock>>>
+      requests;
+
+    // First request is oversized (approximately 10000 bytes)
+    auto chunk1 = co_await make_chunk_with_size(10000);
+    auto req1
+      = std::make_unique<cloud_topics::l0::write_request<ss::manual_clock>>(
+        model::controller_ntp, min_epoch, std::move(chunk1), timeout);
+    requests.push_back(std::move(req1));
+
+    // Second request is normal size (approximately 1000 bytes)
+    auto chunk2 = co_await make_chunk_with_size(1000);
+    auto req2
+      = std::make_unique<cloud_topics::l0::write_request<ss::manual_clock>>(
+        model::controller_ntp, min_epoch, std::move(chunk2), timeout);
+    requests.push_back(std::move(req2));
+
+    // Add both requests to stage
+    accessor.add_request_with_stage(*requests[0], stage.id());
+    accessor.add_request_with_stage(*requests[1], stage.id());
+
+    co_await ss::yield();
+
+    ASSERT_TRUE_CORO(accessor.write_requests_pending(2));
+
+    // Try to get requests with max_bytes = 5000 (less than first request)
+    // Should still get the first request to avoid stalling
+    auto result = stage.pull_write_requests(5000);
+
+    // Should return exactly 1 request (the oversized one)
+    ASSERT_EQ_CORO(result.requests.size(), 1);
+    result.requests.front().set_value(
+      chunked_vector<cloud_topics::extent_meta>{});
+
+    // Second request should still be pending
+    ASSERT_EQ_CORO(accessor.write_requests_pending(1), true);
+
+    // Get the second request
+    auto result2 = stage.pull_write_requests(
+      std::numeric_limits<size_t>::max());
+    ASSERT_EQ_CORO(result2.requests.size(), 1);
+    result2.requests.front().set_value(
+      chunked_vector<cloud_topics::extent_meta>{});
+
+    ASSERT_EQ_CORO(accessor.write_requests_pending(0), true);
+}
+
+TEST_CORO(write_pipeline_test, multiple_requests_within_limit) {
+    // This test verifies that get_write_requests returns multiple requests
+    // when they fit within the size limit.
+    cloud_topics::l0::write_pipeline<ss::manual_clock> pipeline;
+    cloud_topics::l0::write_pipeline_accessor accessor{
+      .pipeline = &pipeline,
+    };
+
+    auto stage = pipeline.register_write_pipeline_stage();
+    const auto timeout = ss::manual_clock::now() + 10s;
+
+    // Helper to create a serialized chunk with specific size
+    auto make_chunk_with_size =
+      [&](
+        size_t target_size) -> ss::future<cloud_topics::l0::serialized_chunk> {
+        chunked_vector<model::record_batch> batches;
+        size_t current_size = 0;
+        while (current_size < target_size) {
+            auto data = co_await model::test::make_random_batches(
+              {.count = 1, .records = 5});
+            for (auto& batch : data) {
+                current_size += batch.size_bytes();
+                batches.push_back(std::move(batch));
+                if (current_size >= target_size) {
+                    break;
+                }
+            }
+        }
+        co_return co_await cloud_topics::l0::serialize_batches(
+          std::move(batches));
+    };
+
+    // Create 3 requests with size approximately 1000 each
+    std::vector<
+      std::unique_ptr<cloud_topics::l0::write_request<ss::manual_clock>>>
+      requests;
+
+    for (int i = 0; i < 3; i++) {
+        auto chunk = co_await make_chunk_with_size(1000);
+        auto req
+          = std::make_unique<cloud_topics::l0::write_request<ss::manual_clock>>(
+            model::controller_ntp, min_epoch, std::move(chunk), timeout);
+        requests.push_back(std::move(req));
+    }
+
+    // Add all requests to stage
+    for (auto& req : requests) {
+        accessor.add_request_with_stage(*req, stage.id());
+    }
+
+    co_await ss::yield();
+
+    ASSERT_TRUE_CORO(accessor.write_requests_pending(3));
+
+    // Get requests with a large max_bytes to get all 3 initially
+    // Then use max_bytes to get a subset in a second call
+    auto result_all = stage.pull_write_requests(
+      std::numeric_limits<size_t>::max());
+
+    // Should return all 3 requests
+    ASSERT_EQ_CORO(result_all.requests.size(), 3);
+
+    for (auto& req : result_all.requests) {
+        req.set_value(chunked_vector<cloud_topics::extent_meta>{});
+    }
+
+    ASSERT_TRUE_CORO(accessor.write_requests_pending(0));
+}
+
+TEST_CORO(write_pipeline_test, max_requests_limit) {
+    // This test verifies that get_write_requests respects the max_requests
+    // parameter, but always returns at least one request.
+    cloud_topics::l0::write_pipeline<ss::manual_clock> pipeline;
+    cloud_topics::l0::write_pipeline_accessor accessor{
+      .pipeline = &pipeline,
+    };
+
+    auto stage = pipeline.register_write_pipeline_stage();
+    const auto timeout = ss::manual_clock::now() + 10s;
+
+    auto make_chunk = [&]() -> ss::future<cloud_topics::l0::serialized_chunk> {
+        chunked_vector<model::record_batch> batches;
+        auto data = co_await model::test::make_random_batches(
+          {.count = 1, .records = 5});
+        std::ranges::move(std::move(data), std::back_inserter(batches));
+        co_return co_await cloud_topics::l0::serialize_batches(
+          std::move(batches));
+    };
+
+    // Create 5 small requests
+    std::vector<
+      std::unique_ptr<cloud_topics::l0::write_request<ss::manual_clock>>>
+      requests;
+
+    for (int i = 0; i < 5; i++) {
+        auto chunk = co_await make_chunk();
+        auto req
+          = std::make_unique<cloud_topics::l0::write_request<ss::manual_clock>>(
+            model::controller_ntp, min_epoch, std::move(chunk), timeout);
+        requests.push_back(std::move(req));
+    }
+
+    // Add all requests to stage
+    for (auto& req : requests) {
+        accessor.add_request_with_stage(*req, stage.id());
+    }
+
+    co_await ss::yield();
+
+    ASSERT_EQ_CORO(accessor.write_requests_pending(5), true);
+
+    // Get requests with max_requests = 3
+    auto result = stage.pull_write_requests(
+      std::numeric_limits<size_t>::max(), 3);
+
+    // Should return exactly 3 requests
+    // Note: Due to the "first request always included" logic, we get at least 1
+    ASSERT_GE_CORO(result.requests.size(), 1);
+    ASSERT_LE_CORO(result.requests.size(), 3);
+
+    size_t first_batch_size = result.requests.size();
+
+    for (auto& req : result.requests) {
+        req.set_value(chunked_vector<cloud_topics::extent_meta>{});
+    }
+
+    // Remaining requests should still be pending
+    ASSERT_EQ_CORO(accessor.write_requests_pending(5 - first_batch_size), true);
+
+    // Get the remaining requests
+    auto result2 = stage.pull_write_requests(
+      std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max());
+    ASSERT_EQ_CORO(result2.requests.size(), 5 - first_batch_size);
+
+    for (auto& req : result2.requests) {
+        req.set_value(chunked_vector<cloud_topics::extent_meta>{});
+    }
+
+    ASSERT_TRUE_CORO(accessor.write_requests_pending(0));
+}

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -170,10 +170,10 @@ write_pipeline<Clock>::get_write_requests(
     size_t acc_size = 0;
     size_t acc_req = 0;
 
-    // The elements in the list are in the insertion order.
     auto it = pending.begin();
-    for (; it != pending.end(); it++) {
+    for (; it != pending.end();) {
         if (it->stage != stage) {
+            it++;
             continue;
         }
         auto sz = it->data_chunk.payload.size_bytes();
@@ -181,24 +181,28 @@ write_pipeline<Clock>::get_write_requests(
         acc_req++;
         if (acc_size >= max_bytes || acc_req >= max_requests) {
             // Include last element
+            auto& el = *it;
             it++;
+            el._hook.unlink();
+            if (el.stage != unassigned_pipeline_stage) {
+                auto idx = static_cast<size_t>(el.stage()->get_numeric_id());
+                _stage_bytes[idx] -= el.size_bytes();
+                el.stage = unassigned_pipeline_stage;
+            }
+            result.requests.push_back(el);
             break;
         }
-    }
-    // There are three steps to sever the connection between the requests
-    // and their original pipeline:
-    // 1. Splice them out of the pending list.
-    // 2. Decrement their bytes from their stage.
-    // 3. Set the stage to unassigned.
-    result.requests.splice(result.requests.end(), pending, pending.begin(), it);
-    result.complete = pending.empty();
-    for (auto& req : result.requests) {
-        if (req.stage != unassigned_pipeline_stage) {
-            auto idx = static_cast<size_t>(req.stage()->get_numeric_id());
-            _stage_bytes[idx] -= req.size_bytes();
-            req.stage = unassigned_pipeline_stage;
+        auto& el = *it;
+        it++;
+        el._hook.unlink();
+        if (el.stage != unassigned_pipeline_stage) {
+            auto idx = static_cast<size_t>(el.stage()->get_numeric_id());
+            _stage_bytes[idx] -= el.size_bytes();
+            el.stage = unassigned_pipeline_stage;
         }
+        result.requests.push_back(el);
     }
+    result.complete = pending.empty();
     vlog(
       cd_log.trace,
       "get_write_requests returned {} elements, containing {} ({}B)",

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -179,17 +179,11 @@ write_pipeline<Clock>::get_write_requests(
         auto sz = it->data_chunk.payload.size_bytes();
         acc_size += sz;
         acc_req++;
-        if (acc_size >= max_bytes || acc_req >= max_requests) {
-            // Include last element
-            auto& el = *it;
-            it++;
-            el._hook.unlink();
-            if (el.stage != unassigned_pipeline_stage) {
-                auto idx = static_cast<size_t>(el.stage()->get_numeric_id());
-                _stage_bytes[idx] -= el.size_bytes();
-                el.stage = unassigned_pipeline_stage;
-            }
-            result.requests.push_back(el);
+        // Always include the first request even if it exceeds limits
+        // to avoid stalling the pipeline with oversized requests
+        if (
+          (acc_size >= max_bytes || acc_req >= max_requests)
+          && !result.requests.empty()) {
             break;
         }
         auto& el = *it;


### PR DESCRIPTION
The method can potentially return incorrect set of requests. This PR fixes this.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none