### PR TITLE
[CORE-14555] ct/l0: Fix shutdown deadlock in read_debounce

### DIFF
--- a/src/v/cloud_topics/level_zero/pipeline/base_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/base_pipeline.h
@@ -160,18 +160,19 @@ public:
     void shutdown() {
         _as.request_abort_ex(
           std::make_exception_ptr(pipeline_abort_requested()));
+        remove_requests_for_shutdown();
     }
 
     ss::future<> stop() {
         if (!_as.abort_requested()) {
             _as.request_abort_ex(
               std::make_exception_ptr(pipeline_abort_requested()));
+            remove_requests_for_shutdown();
         }
         auto fut = _gate.close();
         for (auto& f : _filters) {
             f.cancel();
         }
-        remove_requests_for_shutdown();
         co_await std::move(fut);
     }
 


### PR DESCRIPTION
During shutdown, `read_debounce` could hang indefinitely waiting for its gate to close. The deadlock occurred as follows:

0. `read_debounce::process_single_request()` creates proxy requests,
   capturing a gate holder in a `finally()` callback that runs when
   `proxy->response` resolves.
1. `data_plane_impl::stop()` calls `_read_pipeline.shutdown()`, then shuts stops the fetch handler, then the read debouncer.
2. When `read_debounce::stop()` calls `_gate.close()`, it waits for all gate holders to be released
3. The proxy responses come from the fetch handler, which is stopped, so the futures never resolve and the gate never closes.

The fix is to call `remove_requests_for_shutdown()` in `shutdown()` rather than in `stop()`. This cancels all pending requests, allowing their futures to resolve with `errc::shutting_down`.

Fixes CORE-14555

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
