### PR TITLE
cluster/health_overview: report high disk usage in health reports

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -1194,17 +1194,28 @@ health_monitor_backend::get_cluster_health_overview(
             }
         }
         auto report_it = reports().find(id);
-        if (
-          report_it != reports().end()
-          && report_it->second->local_state.recovery_mode_enabled) {
+        if (report_it == reports().end()) {
+            continue;
+        }
+        const auto& report = report_it->second;
+        if (report->local_state.recovery_mode_enabled) {
             ret.nodes_in_recovery_mode.push_back(id);
+        }
+        auto disk_usage_alert = report->local_state.get_disk_alert();
+        switch (disk_usage_alert) {
+        case storage::disk_space_alert::ok:
+            break;
+        case storage::disk_space_alert::low_space:
+        case storage::disk_space_alert::degraded:
+            ret.high_disk_usage_nodes.push_back(id);
+            break;
         }
     }
 
-    std::sort(ret.all_nodes.begin(), ret.all_nodes.end());
-    std::sort(ret.nodes_down.begin(), ret.nodes_down.end());
-    std::sort(
-      ret.nodes_in_recovery_mode.begin(), ret.nodes_in_recovery_mode.end());
+    std::ranges::sort(ret.all_nodes);
+    std::ranges::sort(ret.nodes_down);
+    std::ranges::sort(ret.nodes_in_recovery_mode);
+    std::ranges::sort(ret.high_disk_usage_nodes);
 
     auto aggr_report = aggregate_reports(reports());
     co_await fill_aggregate_with_offline_partitions(
@@ -1226,6 +1237,12 @@ health_monitor_backend::get_cluster_health_overview(
     // cluster is not healthy if some nodes are down
     if (!ret.nodes_down.empty()) {
         ret.unhealthy_reasons.emplace_back("nodes_down");
+    }
+
+    // disk usage on a subset of nodes exceeds configured storage
+    // alert thresholds
+    if (!ret.high_disk_usage_nodes.empty()) {
+        ret.unhealthy_reasons.emplace_back("high_disk_usage_nodes");
     }
 
     // cluster is not healthy if some partitions do not have leaders

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -366,13 +366,15 @@ std::ostream& operator<<(std::ostream& o, const cluster_health_overview& ho) {
     fmt::print(
       o,
       "{{controller_id: {}, nodes: {}, unhealthy_reasons: {}, nodes_down: {}, "
-      "nodes_in_recovery_mode: {}, bytes_in_cloud_storage: {}, "
-      "leaderless_count: {}, under_replicated_count: {}, "
-      "leaderless_partitions: {}, under_replicated_partitions: {}}}",
+      "high_disk_usage_nodes: {}, nodes_in_recovery_mode: {}, "
+      "bytes_in_cloud_storage: {}, leaderless_count: {}, "
+      "under_replicated_count: {}, leaderless_partitions: {}, "
+      "under_replicated_partitions: {}}}",
       ho.controller_id,
       ho.all_nodes,
       ho.unhealthy_reasons,
       ho.nodes_down,
+      ho.high_disk_usage_nodes,
       ho.nodes_in_recovery_mode,
       ho.bytes_in_cloud_storage,
       ho.leaderless_count,

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -421,6 +421,10 @@ struct cluster_health_overview {
     // A list of known nodes which are down from the point of view of the health
     // subsystem.
     std::vector<model::node_id> nodes_down;
+    // A list of nodes that exceed disk usage alerts defined by
+    // storage_space_alert_free_threshold_percent and
+    // storage_space_alert_free_threshold_bytes
+    std::vector<model::node_id> high_disk_usage_nodes;
     // A list of nodes that have been booted up in recovery mode.
     std::vector<model::node_id> nodes_in_recovery_mode;
     std::vector<model::ntp> leaderless_partitions;

--- a/src/v/redpanda/admin/api-doc/cluster.json
+++ b/src/v/redpanda/admin/api-doc/cluster.json
@@ -250,6 +250,13 @@
                     },
                     "description": "ids of all nodes being recognized as down"
                 },
+                "high_disk_usage_nodes": {
+                    "type": "array",
+                    "items": {
+                        "type": "int"
+                    },
+                    "description": "ids of all nodes with disk usage exceeding storage alert thresholds"
+                },
                 "nodes_in_recovery_mode": {
                     "type": "array",
                     "items": {

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -4058,12 +4058,15 @@ void admin_server::register_cluster_routes() {
                 ret.unhealthy_reasons._set = true;
                 ret.all_nodes._set = true;
                 ret.nodes_down._set = true;
+                ret.high_disk_usage_nodes._set = true;
                 ret.leaderless_partitions._set = true;
                 ret.under_replicated_partitions._set = true;
 
                 ret.unhealthy_reasons = health_overview.unhealthy_reasons;
                 ret.all_nodes = health_overview.all_nodes;
                 ret.nodes_down = health_overview.nodes_down;
+                ret.high_disk_usage_nodes
+                  = health_overview.high_disk_usage_nodes;
                 ret.nodes_in_recovery_mode
                   = health_overview.nodes_in_recovery_mode;
 

--- a/tests/rptest/tests/cluster_health_overview_test.py
+++ b/tests/rptest/tests/cluster_health_overview_test.py
@@ -11,6 +11,7 @@ import random
 
 from ducktape.utils.util import wait_until
 
+from ducktape.cluster.cluster import ClusterNode
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
@@ -30,6 +31,7 @@ class ClusterHealthOverviewTest(RedpandaTest):
                 # https://github.com/redpanda-data/redpanda/issues/5253
                 "enable_leader_balancer": False,
             },
+            environment={"__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"},
         )
 
         self.admin = Admin(self.redpanda)
@@ -47,11 +49,11 @@ class ClusterHealthOverviewTest(RedpandaTest):
         self.client().create_topic(topics)
         return topics
 
-    def get_health(self):
+    def get_health(self, node: ClusterNode | None = None):
         """Wrapper around admin.get_cluster_health_overview which validates some invariants
         about each health report"""
 
-        hov = self.admin.get_cluster_health_overview()
+        hov = self.admin.get_cluster_health_overview(node=node)
 
         # these invariants should always hold
         if hov["is_healthy"]:
@@ -60,6 +62,7 @@ class ClusterHealthOverviewTest(RedpandaTest):
             assert hov["leaderless_count"] == 0
             assert len(hov["under_replicated_partitions"]) == 0
             assert hov["under_replicated_count"] == 0
+            assert len(hov["high_disk_usage_nodes"]) == 0
             assert len(hov["unhealthy_reasons"]) == 0
             assert len(hov["all_nodes"]) > 0
         else:
@@ -151,4 +154,39 @@ class ClusterHealthOverviewTest(RedpandaTest):
         self.redpanda.start_node(first_down)
         self.redpanda.start_node(second_down)
 
+        self.wait_until_healthy()
+
+    @cluster(
+        num_nodes=5, log_allow_list=[".*cluster - storage space alert: free space.*"]
+    )
+    def cluster_health_overview_disk_usage_alert_test(self):
+        # Test that high_disk_usage_nodes is reported correctly
+        self.create_topics()
+        self.wait_until_healthy()
+
+        # Fake alert
+        self.redpanda.set_cluster_config(
+            {"storage_space_alert_free_threshold_percent": 100}
+        )
+
+        def ensure_high_disk_usage_reported(node: ClusterNode):
+            hov = self.get_health(node=node)
+            return (
+                not hov["is_healthy"]
+                and "high_disk_usage_nodes" in hov["unhealthy_reasons"]
+                and len(hov["high_disk_usage_nodes"]) == 5
+            )
+
+        def ensure_unhealthy_report():
+            return all(
+                ensure_high_disk_usage_reported(node)
+                for node in self.redpanda.started_nodes()
+            )
+
+        wait_until(ensure_unhealthy_report, 30, 2)
+
+        # Disable disk usage alert
+        self.redpanda.set_cluster_config(
+            {"storage_space_alert_free_threshold_percent": 5}
+        )
         self.wait_until_healthy()


### PR DESCRIPTION
With this change the cluster health report has the following additions

* A list of nodes that exceed storage alert thresholds
* Overall health is marked unhealthy if there are any nodes that exceed ^^ reports

This came out of an incident where it was hard to tell which nodes were running out of disk since we didn’t have access to metrics. When a node starts running low on disk, it tends to cause weird issues, so it’s better to surface that in the cluster health reporting.

A follow-up will be to surface this in rpk (that needs a change in a different repo, so it’ll be handled separately).

Fixes: https://redpandadata.atlassian.net/browse/INC-1048

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x


## Release Notes
### Features
* Cluster health report now includes node IDs of nodes that exceed the disk usage reporting thresholds.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
