### PR TITLE
[CORE-15023] Supporting code for multipart request/response

### DIFF
--- a/src/v/cloud_storage_clients/tests/BUILD
+++ b/src/v/cloud_storage_clients/tests/BUILD
@@ -88,7 +88,7 @@ redpanda_cc_btest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "util_test",
     timeout = "short",
     srcs = [
@@ -96,8 +96,8 @@ redpanda_cc_btest(
     ],
     deps = [
         "//src/v/cloud_storage_clients",
-        "//src/v/test_utils:seastar_boost",
-        "@boost//:test",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
     ],
 )
 

--- a/src/v/cloud_storage_clients/tests/BUILD
+++ b/src/v/cloud_storage_clients/tests/BUILD
@@ -95,6 +95,8 @@ redpanda_cc_gtest(
         "util_test.cc",
     ],
     deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
         "//src/v/cloud_storage_clients",
         "@googletest//:gtest",
         "@googletest//:gtest_main",

--- a/src/v/cloud_storage_clients/tests/util_test.cc
+++ b/src/v/cloud_storage_clients/tests/util_test.cc
@@ -495,3 +495,313 @@ TEST(FullMultipartParsing, WithErrors) {
     EXPECT_EQ(content_ids[2].value(), 2);
     EXPECT_TRUE(is_ok_results[2]);
 }
+
+// ----------------------------------------------------------------------------
+// Malformed MIME header tests
+// ----------------------------------------------------------------------------
+
+TEST(MimeHeaderMalformed, MalformedHeaders) {
+    using namespace cloud_storage_clients;
+
+    // Header without colon separator
+    std::string_view mime_data = "Content-Type application/http\r\n"
+                                 "\r\n";
+
+    auto buf = iobuf::from(mime_data);
+    iobuf_parser parser(std::move(buf));
+
+    // Missing separator, parser will throw
+    EXPECT_THROW(util::mime_header::from(parser), std::runtime_error);
+}
+
+TEST(MimeHeaderMalformed, MissingSeparatorSpace) {
+    using namespace cloud_storage_clients;
+
+    // Header with colon but missing space after it
+    std::string_view mime_data = "Content-Type:application/http\r\n"
+                                 "\r\n";
+
+    auto buf = iobuf::from(mime_data);
+    iobuf_parser parser(std::move(buf));
+
+    // Should parse but the value won't match due to missing space
+    auto header = util::mime_header::from(parser);
+    auto content_type = header.get(boost::beast::http::field::content_type);
+    // The field won't be found because we look for ": " separator
+    EXPECT_FALSE(content_type.has_value());
+}
+
+TEST(MimeHeaderMalformed, OnlyLfLineEndings) {
+    using namespace cloud_storage_clients;
+
+    // Using LF only instead of CRLF (malformed per HTTP spec)
+    std::string_view mime_data = "Content-Type: application/http\n"
+                                 "Content-ID: 10\n"
+                                 "\n";
+
+    auto buf = iobuf::from(mime_data);
+    iobuf_parser parser(std::move(buf));
+
+    // Should throw because parser expects CRLF
+    EXPECT_THROW(util::mime_header::from(parser), std::runtime_error);
+}
+
+TEST(MimeHeaderMalformed, MixedLineEndings) {
+    using namespace cloud_storage_clients;
+
+    // Mix of CRLF and LF
+    std::string_view mime_data = "Content-Type: application/http\r\n"
+                                 "Content-ID: 10\n" // LF only
+                                 "\r\n";
+
+    auto buf = iobuf::from(mime_data);
+    iobuf_parser parser(std::move(buf));
+
+    // Should throw due to inconsistent line endings
+    EXPECT_THROW(util::mime_header::from(parser), std::runtime_error);
+}
+
+TEST(MimeHeaderMalformed, ExceedsMaxBuffer) {
+    using namespace cloud_storage_clients;
+
+    // Create a header that exceeds max_buf (1024 bytes)
+    std::string long_value(1100, 'x');
+    std::string mime_data = fmt::format(
+      "Content-Type: {}\r\n"
+      "\r\n",
+      long_value);
+
+    auto buf = iobuf::from(mime_data);
+    iobuf_parser parser(std::move(buf));
+
+    // Should throw due to exceeding buffer size
+    EXPECT_THROW(util::mime_header::from(parser), std::runtime_error);
+}
+
+TEST(MimeHeaderMalformed, MissingFinalCrlf) {
+    using namespace cloud_storage_clients;
+
+    // Header without final CRLF CRLF (truncated)
+    std::string_view mime_data = "Content-Type: application/http\r\n"
+                                 "Content-ID: 5\r\n";
+
+    auto buf = iobuf::from(mime_data);
+    iobuf_parser parser(std::move(buf));
+
+    // Parser consumes all data but doesn't find the final CRLF CRLF
+    EXPECT_THROW(util::mime_header::from(parser), std::runtime_error);
+    EXPECT_EQ(parser.bytes_left(), 0);
+}
+
+TEST(MimeHeaderMalformed, CrWithoutLf) {
+    using namespace cloud_storage_clients;
+
+    // CR not followed by LF
+    std::string_view mime_data = "Content-Type: application/http\rX\n"
+                                 "\r\n";
+
+    auto buf = iobuf::from(mime_data);
+    iobuf_parser parser(std::move(buf));
+
+    // Should throw due to malformed line ending
+    EXPECT_THROW(util::mime_header::from(parser), std::runtime_error);
+}
+
+TEST(MimeHeaderMalformed, LfWithoutCr) {
+    using namespace cloud_storage_clients;
+
+    // LF not preceded by CR
+    std::string_view mime_data = "Content-Type: application/http\n\r\n";
+
+    auto buf = iobuf::from(mime_data);
+    iobuf_parser parser(std::move(buf));
+
+    // Should throw due to malformed line ending
+    EXPECT_THROW(util::mime_header::from(parser), std::runtime_error);
+}
+
+TEST(MimeHeaderMalformed, MultipleColons) {
+    using namespace cloud_storage_clients;
+
+    // Header with multiple colons (valid HTTP - should take first)
+    std::string_view mime_data = "Content-Type: text/plain: with: colons\r\n"
+                                 "\r\n";
+
+    auto buf = iobuf::from(mime_data);
+    iobuf_parser parser(std::move(buf));
+
+    auto header = util::mime_header::from(parser);
+    auto content_type = header.get(boost::beast::http::field::content_type);
+    EXPECT_TRUE(content_type.has_value());
+    // Should include everything after first ": "
+    EXPECT_TRUE(content_type.value().contains("text/plain: with: colons"));
+}
+
+TEST(MimeHeaderMalformed, ParseEmpty) {
+    using namespace cloud_storage_clients;
+
+    std::string_view mime_data = "\r\n";
+
+    auto buf = iobuf::from(mime_data);
+    iobuf_parser parser(std::move(buf));
+
+    EXPECT_THROW(util::mime_header::from(parser), std::runtime_error);
+}
+
+TEST(MimeHeaderMalformed, ParseLeadingCrlf) {
+    using namespace cloud_storage_clients;
+
+    std::string_view mime_data = "\r\n"
+                                 "Content-Type: application/http\r\n"
+                                 "\r\n";
+
+    auto buf = iobuf::from(mime_data);
+    iobuf_parser parser(std::move(buf));
+
+    EXPECT_THROW(util::mime_header::from(parser), std::runtime_error);
+}
+
+// ----------------------------------------------------------------------------
+// Malformed multipart boundary tests
+// ----------------------------------------------------------------------------
+
+TEST(MultipartMalformed, MissingStartBoundary) {
+    using namespace cloud_storage_clients;
+
+    // Content without opening boundary
+    std::string_view multipart_data = "Content-Type: text/plain\r\n"
+                                      "\r\n"
+                                      "Some content\r\n"
+                                      "--boundary--\r\n";
+
+    auto buf = iobuf::from(multipart_data);
+
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--boundary"));
+
+    // Should not find any parts without start boundary
+    auto part = parser.get_part();
+    EXPECT_FALSE(part.has_value());
+}
+
+TEST(MultipartMalformed, TruncatedBoundary) {
+    using namespace cloud_storage_clients;
+
+    // Boundary cut off in the middle
+    std::string_view multipart_data = "--boundary\r\n"
+                                      "Content\r\n"
+                                      "\r\n"
+                                      "--boun"; // Truncated
+
+    auto buf = iobuf::from(multipart_data);
+
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--boundary"));
+
+    // Should return nullopt due to truncation
+    auto part = parser.get_part();
+    EXPECT_FALSE(part.has_value());
+}
+
+TEST(MultipartMalformed, BoundaryWithExtraDashes) {
+    using namespace cloud_storage_clients;
+
+    // Boundary with extra dashes
+    std::string_view multipart_data = "---boundary\r\n" // Three dashes
+                                      "Content\r\n"
+                                      "\r\n"
+                                      "--boundary--\r\n";
+
+    auto buf = iobuf::from(multipart_data);
+
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--boundary"));
+
+    // Parser expects exactly "--boundary" at the very start of the buffer
+    auto part = parser.get_part();
+    EXPECT_FALSE(part.has_value());
+}
+
+TEST(MultipartMalformed, MissingCrlfBeforeBoundary) {
+    using namespace cloud_storage_clients;
+
+    // Missing CRLF before boundary delimiter
+    std::string_view multipart_data = "--boundary\r\n"
+                                      "First part\r\n"
+                                      "--boundary\r\n" // No CRLF before this
+                                      "Second part\r\n"
+                                      "\r\n"
+                                      "--boundary--\r\n";
+
+    auto buf = iobuf::from(multipart_data);
+
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--boundary"));
+
+    // Missing CRLF before boundary is equivalent to finding the boundary in the
+    // message, which is illegal per RFC 2046
+    auto part1 = parser.get_part();
+    EXPECT_FALSE(part1.has_value());
+}
+
+TEST(MultipartMalformed, BoundaryInContent) {
+    using namespace cloud_storage_clients;
+
+    // Boundary string appears in content
+    // NOTE: Multipart parsers cannot distinguish between boundary delimiters
+    // and boundary strings in content. This is why RFC 2046 requires that
+    // boundaries must not appear in the content, or content must be encoded.
+    std::string_view multipart_data = "--boundary\r\n"
+                                      "Content-Type: text/plain\r\n"
+                                      "\r\n"
+                                      "This contains --boundary in text\r\n"
+                                      "--boundary--\r\n";
+
+    auto buf = iobuf::from(multipart_data);
+
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--boundary"));
+
+    // Parser should fail when the boundary appears in the message
+    EXPECT_FALSE(parser.get_part().has_value());
+}
+
+TEST(MultipartMalformed, EmptyBoundary) {
+    using namespace cloud_storage_clients;
+
+    std::string_view multipart_data = "--boundary\r\n"
+                                      "Content\r\n"
+                                      "--boundary--\r\n";
+
+    auto buf = iobuf::from(multipart_data);
+
+    // Empty boundary string
+    util::multipart_response_parser parser(std::move(buf), ss::sstring(""));
+
+    // Should not find parts with empty boundary
+    auto part = parser.get_part();
+    EXPECT_FALSE(part.has_value());
+}
+
+TEST(MultipartMalformed, OnlyEndBoundary) {
+    using namespace cloud_storage_clients;
+
+    // Only end boundary, no opening boundary
+    std::string_view multipart_data = "--boundary--\r\n";
+
+    auto buf = iobuf::from(multipart_data);
+
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--boundary"));
+
+    // Should not find any parts
+    auto part = parser.get_part();
+    EXPECT_FALSE(part.has_value());
+}
+
+// NOTE: multipart_subresponse is effectively a thin wrapper around beast
+// request parsers, so we rely on the correctness (and known limitations) of
+// their implementation rather than any limited edge case testing we could
+// accomplish here. As long as multipart_response_parser returns iobuf parts
+// that themselves contain properly trimmed HTTP responses (header + body w/
+// correct line endings), then multipart_subresponse should work as expected.

--- a/src/v/cloud_storage_clients/tests/util_test.cc
+++ b/src/v/cloud_storage_clients/tests/util_test.cc
@@ -1,8 +1,8 @@
 #include "cloud_storage_clients/util.h"
 
-#include <boost/test/unit_test.hpp>
+#include <gtest/gtest.h>
 
-BOOST_AUTO_TEST_CASE(test_all_paths_to_file) {
+TEST(Util, AllPathsToFile) {
     using namespace cloud_storage_clients;
 
     auto result1 = util::all_paths_to_file(object_key{"a/b/c/log.txt"});
@@ -11,14 +11,14 @@ BOOST_AUTO_TEST_CASE(test_all_paths_to_file) {
       object_key{"a/b"},
       object_key{"a/b/c"},
       object_key{"a/b/c/log.txt"}};
-    BOOST_REQUIRE_EQUAL(result1, expected1);
+    EXPECT_EQ(result1, expected1);
 
     auto result2 = util::all_paths_to_file(object_key{"a/b/c/"});
-    BOOST_REQUIRE_EQUAL(result2, std::vector<object_key>{});
+    EXPECT_EQ(result2, std::vector<object_key>{});
 
     auto result3 = util::all_paths_to_file(object_key{""});
-    BOOST_REQUIRE_EQUAL(result3, std::vector<object_key>{});
+    EXPECT_EQ(result3, std::vector<object_key>{});
 
     auto result4 = util::all_paths_to_file(object_key{"foo"});
-    BOOST_REQUIRE_EQUAL(result4, std::vector<object_key>{object_key{"foo"}});
+    EXPECT_EQ(result4, std::vector<object_key>{object_key{"foo"}});
 }

--- a/src/v/cloud_storage_clients/tests/util_test.cc
+++ b/src/v/cloud_storage_clients/tests/util_test.cc
@@ -1,3 +1,5 @@
+#include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
 #include "cloud_storage_clients/util.h"
 
 #include <gtest/gtest.h>
@@ -21,4 +23,475 @@ TEST(Util, AllPathsToFile) {
 
     auto result4 = util::all_paths_to_file(object_key{"foo"});
     EXPECT_EQ(result4, std::vector<object_key>{object_key{"foo"}});
+}
+
+// ============================================================================
+// mime_header tests
+// ============================================================================
+
+namespace {
+constexpr auto convert_cid = [](std::string_view raw) {
+    return std::make_optional<int>(std::stoi(std::string{raw}));
+};
+} // namespace
+
+TEST(MimeHeader, ParseBasic) {
+    using namespace cloud_storage_clients;
+
+    std::string_view mime_data = "Content-Type: application/http\r\n"
+                                 "Content-ID: 42\r\n"
+                                 "\r\n";
+
+    auto buf = iobuf::from(mime_data);
+    iobuf_parser parser(std::move(buf));
+
+    auto header = util::mime_header::from(parser);
+
+    // Check Content-Type
+    auto content_type = header.get(boost::beast::http::field::content_type);
+    EXPECT_TRUE(content_type.has_value());
+    EXPECT_EQ(content_type.value(), "application/http");
+
+    // Check Content-ID
+    auto content_id = header.content_id<int>(convert_cid);
+    EXPECT_TRUE(content_id.has_value());
+    EXPECT_EQ(content_id.value(), 42);
+
+    // Nonexistent header returns nullopt
+    auto xfer_encoding = header.get(
+      boost::beast::http::field::content_transfer_encoding);
+    EXPECT_FALSE(xfer_encoding.has_value());
+}
+
+TEST(MimeHeader, ParseNoContentId) {
+    using namespace cloud_storage_clients;
+
+    std::string_view mime_data = "Content-Type: text/plain\r\n"
+                                 "\r\n";
+
+    auto buf = iobuf::from(mime_data);
+    iobuf_parser parser(std::move(buf));
+
+    auto header = util::mime_header::from(parser);
+
+    // Content-ID should be absent, but nothing blows up
+    auto content_id = header.content_id<int>(convert_cid);
+    EXPECT_FALSE(content_id.has_value());
+}
+
+TEST(MimeHeader, ParseExtraHeaders) {
+    using namespace cloud_storage_clients;
+
+    std::string_view mime_data = "Content-Type: application/http\r\n"
+                                 "Content-ID: 5\r\n"
+                                 "X-Custom-Header: custom-value\r\n"
+                                 "\r\n";
+
+    auto buf = iobuf::from(mime_data);
+    iobuf_parser parser(std::move(buf));
+
+    auto header = util::mime_header::from(parser);
+
+    // Standard fields should still work
+    auto content_type = header.get(boost::beast::http::field::content_type);
+    EXPECT_TRUE(content_type.has_value());
+    EXPECT_EQ(content_type.value(), "application/http");
+
+    auto content_id = header.content_id<int>(convert_cid);
+    EXPECT_TRUE(content_id.has_value());
+    EXPECT_EQ(content_id.value(), 5);
+}
+
+TEST(MimeHeader, MixedCaseName) {
+    using namespace cloud_storage_clients;
+    std::string_view mime_data = "cOnTeNt-TyPe: application/http\r\n"
+                                 "CONTENT-id: BIGTEXT-5\r\n"
+                                 "\r\n";
+    auto buf = iobuf::from(mime_data);
+    iobuf_parser parser(std::move(buf));
+
+    auto header = util::mime_header::from(parser);
+
+    // fields should still be legible
+    EXPECT_TRUE(
+      header.get(boost::beast::http::field::content_type).has_value());
+    EXPECT_TRUE(header.get(boost::beast::http::field::content_id).has_value());
+
+    // but the case of the _value_ should be untouched
+    EXPECT_EQ(
+      header.get(boost::beast::http::field::content_id).value(), "BIGTEXT-5");
+}
+
+// ============================================================================
+// multipart_response_parser tests
+// ============================================================================
+
+TEST(MultipartParser, SinglePart) {
+    using namespace cloud_storage_clients;
+
+    std::string_view multipart_data = "--boundary\r\n"
+                                      "Content-Type: text/plain\r\n"
+                                      "\r\n"
+                                      "Hello World\r\n"
+                                      "\r\n"
+                                      "--boundary--\r\n";
+
+    auto buf = iobuf::from(multipart_data);
+
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--boundary"));
+
+    // Get first part
+    auto part1 = parser.get_part();
+    EXPECT_TRUE(part1.has_value());
+
+    auto content = part1.value().linearize_to_string();
+    EXPECT_TRUE(content.contains("Content-Type: text/plain"));
+    EXPECT_TRUE(content.contains("Hello World"));
+
+    // Should be no more parts
+    auto part2 = parser.get_part();
+    EXPECT_FALSE(part2.has_value());
+}
+
+TEST(MultipartParser, MultipleParts) {
+    using namespace cloud_storage_clients;
+
+    std::string_view multipart_data = "--boundary\r\n"
+                                      "Content-ID: 0\r\n"
+                                      "\r\n"
+                                      "First part\r\n"
+                                      "\r\n"
+                                      "--boundary\r\n"
+                                      "Content-ID: 1\r\n"
+                                      "\r\n"
+                                      "Second part\r\n"
+                                      "\r\n"
+                                      "--boundary\r\n"
+                                      "Content-ID: 2\r\n"
+                                      "\r\n"
+                                      "Third part\r\n"
+                                      "\r\n"
+                                      "--boundary--\r\n";
+
+    auto buf = iobuf::from(multipart_data);
+
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--boundary"));
+
+    // Get all three parts
+    auto part1 = parser.get_part();
+    EXPECT_TRUE(part1.has_value());
+
+    auto part2 = parser.get_part();
+    EXPECT_TRUE(part2.has_value());
+
+    auto part3 = parser.get_part();
+    EXPECT_TRUE(part3.has_value());
+
+    // Verify content
+    EXPECT_TRUE(part1.value().linearize_to_string().contains("First part"));
+    EXPECT_TRUE(part2.value().linearize_to_string().contains("Second part"));
+    EXPECT_TRUE(part3.value().linearize_to_string().contains("Third part"));
+
+    // Should be no more parts
+    auto part4 = parser.get_part();
+    EXPECT_FALSE(part4.has_value());
+}
+
+TEST(MultipartParser, EmptyParts) {
+    using namespace cloud_storage_clients;
+
+    std::string_view multipart_data = "--boundary\r\n"
+                                      "\r\n"
+                                      "--boundary\r\n"
+                                      "\r\n"
+                                      "--boundary--\r\n";
+
+    auto buf = iobuf::from(multipart_data);
+
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--boundary"));
+
+    // Even with empty parts, parser should handle gracefully
+    auto part1 = parser.get_part();
+    EXPECT_FALSE(part1.has_value());
+
+    auto part2 = parser.get_part();
+    EXPECT_FALSE(part2.has_value());
+
+    EXPECT_FALSE(parser.get_part().has_value());
+}
+
+TEST(MultipartParser, NoEndBoundary) {
+    using namespace cloud_storage_clients;
+
+    std::string_view multipart_data = "--boundary\r\n"
+                                      "Content-ID: 0\r\n"
+                                      "\r\n"
+                                      "Data without end"
+                                      "--bound";
+
+    auto buf = iobuf::from(multipart_data);
+
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--boundary"));
+
+    // Should handle missing/incomplete end boundary gracefully
+    auto part1 = parser.get_part();
+    EXPECT_FALSE(part1.has_value());
+}
+
+TEST(MultipartParser, EmptyBuffer) {
+    using namespace cloud_storage_clients;
+
+    iobuf buf;
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--boundary"));
+
+    // Empty buffer should return no parts
+    auto part = parser.get_part();
+    EXPECT_FALSE(part.has_value());
+}
+
+// ============================================================================
+// multipart_subresponse tests
+// ============================================================================
+
+TEST(MultipartSubresponse, ParseSuccess) {
+    using namespace cloud_storage_clients;
+
+    std::string_view http_response = "HTTP/1.1 202 Accepted\r\n"
+                                     "x-ms-request-id: abc-123\r\n"
+                                     "x-ms-version: 2023-01-03\r\n"
+                                     "Content-Length: 0\r\n"
+                                     "\r\n";
+
+    auto buf = iobuf::from(http_response);
+    iobuf_parser parser(std::move(buf));
+
+    auto subresponse = util::multipart_subresponse::from(parser);
+
+    // Check status
+    EXPECT_EQ(subresponse.result(), boost::beast::http::status::accepted);
+    EXPECT_TRUE(subresponse.is_ok());
+
+    // Should have no error
+    auto error = subresponse.error("x-ms-error-code");
+    EXPECT_FALSE(error.has_value());
+    error = subresponse.error([](iobuf b) { return b.linearize_to_string(); });
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(MultipartSubresponse, ParseNotFound) {
+    using namespace cloud_storage_clients;
+
+    std::string_view http_response = "HTTP/1.1 404 Not Found\r\n"
+                                     "x-ms-error-code: BlobNotFound\r\n"
+                                     "Content-Length: 0\r\n"
+                                     "\r\n";
+
+    auto buf = iobuf::from(http_response);
+    iobuf_parser parser(std::move(buf));
+
+    auto subresponse = util::multipart_subresponse::from(parser);
+
+    EXPECT_EQ(subresponse.result(), boost::beast::http::status::not_found);
+    // 404 is considered "ok" for delete operations
+    EXPECT_TRUE(subresponse.is_ok());
+
+    // So error() should return nullopt, regardless of header contents
+    auto error = subresponse.error("x-ms-error-code");
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(MultipartSubresponse, ParseErrorHeader) {
+    using namespace cloud_storage_clients;
+
+    std::string_view http_response = "HTTP/1.1 403 Forbidden\r\n"
+                                     "x-ms-error-code: AuthenticationFailed\r\n"
+                                     "Content-Length: 0\r\n"
+                                     "\r\n";
+
+    auto buf = iobuf::from(http_response);
+    iobuf_parser parser(std::move(buf));
+
+    auto subresponse = util::multipart_subresponse::from(parser);
+
+    EXPECT_EQ(subresponse.result(), boost::beast::http::status::forbidden);
+    EXPECT_FALSE(subresponse.is_ok());
+
+    // Should extract error message
+    auto error = subresponse.error("x-ms-error-code");
+    EXPECT_TRUE(error.has_value());
+    EXPECT_TRUE(error.value().contains("403"));
+    EXPECT_TRUE(
+      error.value().contains(fmt::format("{}", subresponse.result())));
+    EXPECT_TRUE(error.value().contains("AuthenticationFailed"));
+}
+
+TEST(MultipartSubresponse, ParseErrorNoMessage) {
+    using namespace cloud_storage_clients;
+
+    std::string_view http_response = "HTTP/1.1 500 Internal Server Error\r\n"
+                                     "Content-Length: 0\r\n"
+                                     "\r\n";
+
+    auto buf = iobuf::from(http_response);
+    iobuf_parser parser(std::move(buf));
+
+    auto subresponse = util::multipart_subresponse::from(parser);
+
+    EXPECT_EQ(
+      subresponse.result(), boost::beast::http::status::internal_server_error);
+    EXPECT_FALSE(subresponse.is_ok());
+
+    // Error should still be returned with "Unknown" reason
+    auto error = subresponse.error("x-ms-error-code");
+    EXPECT_TRUE(error.has_value());
+    EXPECT_TRUE(error.value().contains("500"));
+    EXPECT_TRUE(
+      error.value().contains(fmt::format("{}", subresponse.result())));
+    EXPECT_TRUE(error.value().contains("Unknown"));
+}
+
+TEST(MultipartSubresponse, ParseErrorInBody) {
+    using namespace cloud_storage_clients;
+
+    std::string_view http_response = "HTTP/1.1 500 Internal Server Error\r\n"
+                                     "Content-Length: 4\r\n"
+                                     "\r\n"
+                                     "OOPS\r\n"
+                                     "\r\n";
+
+    auto buf = iobuf::from(http_response);
+    iobuf_parser parser(std::move(buf));
+
+    auto subresponse = util::multipart_subresponse::from(parser);
+
+    EXPECT_EQ(
+      subresponse.result(), boost::beast::http::status::internal_server_error);
+    EXPECT_FALSE(subresponse.is_ok());
+
+    // Error should still be returned with "Unknown" reason
+    auto error = subresponse.error(
+      [](iobuf b) { return b.linearize_to_string(); });
+    EXPECT_TRUE(error.has_value());
+    EXPECT_TRUE(error.value().contains("500"));
+    EXPECT_TRUE(
+      error.value().contains(fmt::format("{}", subresponse.result())));
+    EXPECT_TRUE(error.value().contains("OOPS"));
+}
+
+// ============================================================================
+// Integration tests - full multipart response parsing
+// ============================================================================
+
+TEST(FullMultipartParsing, Success) {
+    using namespace cloud_storage_clients;
+
+    // Simulate Azure Batch API response with multiple successful deletes
+    std::string_view batch_response = "--batch_boundary\r\n"
+                                      "Content-Type: application/http\r\n"
+                                      "Content-ID: 0\r\n"
+                                      "\r\n"
+                                      "HTTP/1.1 202 Accepted\r\n"
+                                      "x-ms-request-id: req-0\r\n"
+                                      "\r\n"
+                                      "--batch_boundary\r\n"
+                                      "Content-Type: application/http\r\n"
+                                      "Content-ID: 1\r\n"
+                                      "\r\n"
+                                      "HTTP/1.1 202 Accepted\r\n"
+                                      "x-ms-request-id: req-1\r\n"
+                                      "\r\n"
+                                      "--batch_boundary--\r\n";
+
+    auto buf = iobuf::from(batch_response);
+
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--batch_boundary"));
+
+    int successful_parts = 0;
+
+    std::optional<iobuf> part;
+    while ((part = parser.get_part()).has_value()) {
+        iobuf_parser part_parser(std::move(part).value());
+
+        // Parse MIME headers
+        auto mime = util::mime_header::from(part_parser);
+        auto content_id = mime.content_id<int>(convert_cid);
+        EXPECT_TRUE(content_id.has_value());
+
+        // Parse HTTP response
+        auto subresponse = util::multipart_subresponse::from(part_parser);
+        EXPECT_TRUE(subresponse.is_ok());
+        EXPECT_EQ(subresponse.result(), boost::beast::http::status::accepted);
+
+        successful_parts++;
+    }
+
+    EXPECT_EQ(successful_parts, 2);
+}
+
+TEST(FullMultipartParsing, WithErrors) {
+    using namespace cloud_storage_clients;
+
+    // Simulate response with mixed success and errors
+    std::string_view batch_response = "--batch_boundary\r\n"
+                                      "Content-Type: application/http\r\n"
+                                      "Content-ID: 0\r\n"
+                                      "\r\n"
+                                      "HTTP/1.1 202 Accepted\r\n"
+                                      "x-ms-request-id: req-0\r\n"
+                                      "\r\n"
+                                      "--batch_boundary\r\n"
+                                      "Content-Type: application/http\r\n"
+                                      "Content-ID: 1\r\n"
+                                      "\r\n"
+                                      "HTTP/1.1 403 Forbidden\r\n"
+                                      "x-ms-error-code: InvalidCredentials\r\n"
+                                      "\r\n"
+                                      "--batch_boundary\r\n"
+                                      "Content-Type: application/http\r\n"
+                                      "Content-ID: 2\r\n"
+                                      "\r\n"
+                                      "HTTP/1.1 404 Not Found\r\n"
+                                      "x-ms-error-code: BlobNotFound\r\n"
+                                      "\r\n"
+                                      "--batch_boundary--\r\n";
+
+    auto buf = iobuf::from(batch_response);
+
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--batch_boundary"));
+
+    std::vector<bool> is_ok_results;
+    std::vector<std::optional<size_t>> content_ids;
+
+    std::optional<iobuf> part;
+    while ((part = parser.get_part()).has_value()) {
+        iobuf_parser part_parser(std::move(part).value());
+
+        auto mime = util::mime_header::from(part_parser);
+        content_ids.push_back(mime.content_id<int>(convert_cid));
+
+        auto subresponse = util::multipart_subresponse::from(part_parser);
+        is_ok_results.push_back(subresponse.is_ok());
+    }
+
+    EXPECT_EQ(is_ok_results.size(), 3);
+    EXPECT_EQ(content_ids.size(), 3);
+
+    // First one should be successful
+    EXPECT_EQ(content_ids[0].value(), 0);
+    EXPECT_TRUE(is_ok_results[0]);
+
+    // Second one should be error
+    EXPECT_EQ(content_ids[1].value(), 1);
+    EXPECT_FALSE(is_ok_results[1]);
+
+    // Third one (404) should be ok for deletes
+    EXPECT_EQ(content_ids[2].value(), 2);
+    EXPECT_TRUE(is_ok_results[2]);
 }

--- a/src/v/cloud_storage_clients/util.cc
+++ b/src/v/cloud_storage_clients/util.cc
@@ -440,4 +440,76 @@ void multipart_response_parser::advance_to_first_boundary() {
     }
 }
 
+auto multipart_subresponse::result() const -> status {
+    vassert(!_ec, "Parser had errored: {}", _ec.message());
+    vassert(_response.has_value(), "Response missing");
+    vassert(_header_done, "Header not done");
+    return _response.value().result();
+}
+
+bool multipart_subresponse::is_ok() const {
+    auto st = result();
+    return st == status::ok || st == status::accepted
+           || st == status::no_content || st == status::not_found;
+}
+
+std::optional<ss::sstring>
+multipart_subresponse::error(std::string_view error_code_name) const {
+    if (is_ok()) {
+        return std::nullopt;
+    }
+    auto st = result();
+    auto it = _response.value().find(error_code_name);
+    std::string_view reason = "Unknown";
+    if (it != _response.value().end()) {
+        reason = it->value();
+    }
+    return ssx::sformat(
+      "HTTP {} {} - {}", static_cast<unsigned>(st), st, reason);
+}
+
+std::optional<ss::sstring>
+multipart_subresponse::error(const std::function<ss::sstring(iobuf)>& parser) {
+    if (is_ok()) {
+        return std::nullopt;
+    }
+    auto st = result();
+    auto reason = parser(_body.share());
+    return ssx::sformat(
+      "HTTP {} {} - {}", static_cast<unsigned>(st), st, reason);
+}
+
+multipart_subresponse multipart_subresponse::from(iobuf_parser& in) {
+    multipart_subresponse result{};
+    auto buf = in.share(in.bytes_left());
+    parser_t parser;
+    parser.eager(true);
+    parser.get().body().set_temporary_source(buf);
+    auto bufseq = iobuf_to_constbufseq(buf);
+    result._noctets = parser.put(bufseq, result._ec);
+    if (result._ec) {
+        throw std::runtime_error(
+          ssx::sformat(
+            "failed to parse multipart response part: {}, remaining bytes: "
+            "{}, n octets parsed: {}",
+            result._ec.message(),
+            buf.size_bytes(),
+            result._noctets));
+    }
+    result._header_done = parser.is_header_done();
+    result._body = parser.get().body().consume();
+    result._response.emplace(parser.release());
+    return result;
+}
+
+std::vector<boost::asio::const_buffer>
+multipart_subresponse::iobuf_to_constbufseq(const iobuf& buf) {
+    std::vector<boost::asio::const_buffer> seq;
+    for (const auto& fragm : buf) {
+        boost::asio::const_buffer cbuf{fragm.get(), fragm.size()};
+        seq.push_back(cbuf);
+    }
+    return seq;
+};
+
 } // namespace cloud_storage_clients::util

--- a/src/v/cloud_storage_clients/util.cc
+++ b/src/v/cloud_storage_clients/util.cc
@@ -368,4 +368,76 @@ std::optional<ss::sstring> mime_header::get(field f) const {
     return std::nullopt;
 }
 
+multipart_response_parser::multipart_response_parser(iobuf b, ss::sstring delim)
+  : _buffer(std::move(b))
+  , _parser(std::cref(_buffer))
+  , _delim(std::move(delim)) {}
+
+std::optional<iobuf> multipart_response_parser::get_part() {
+    advance_to_first_boundary();
+    if (!_found_first || _done) {
+        return std::nullopt;
+    }
+    size_t delim_idx = 0;
+    std::optional<size_t> part_start{};
+    size_t part_len = 0;
+    crlf_stack line_feed;
+    while (delim_idx < _delim.size() && _parser.bytes_left()) {
+        auto c = _parser.consume_type<char>();
+        if (c == _delim[delim_idx]) {
+            ++delim_idx;
+            continue;
+        }
+        // unlikely, but we may have skipped some bytes that appeared to be
+        // part of a delimiter.
+        part_len += delim_idx + 1;
+        delim_idx = 0;
+        auto [is_lf, _] = line_feed.try_put(c);
+        // eat up any leading CRLFs so the resulting part starts on text
+        if (!part_start.has_value()) [[unlikely]] {
+            if (is_lf) {
+                part_len = 0;
+                continue;
+            }
+            part_start = _parser.bytes_consumed() - 1;
+            part_len = 1;
+        }
+    }
+    // we ran out of bytes before reaching the end delimiter OR/AND the complete
+    // boundary string appeared in the sub-response body (illegal per multipart
+    // grammar laid out in RFC 2046)
+    if (
+      delim_idx != _delim.size() || line_feed.count() != 2
+      || _parser.bytes_left() < 2) {
+        _done = true;
+        return std::nullopt;
+    }
+    // check for end delimiter
+    // in the common case (not the end), the next two chars will hold a CRLF,
+    // which will be stripped off by the next call to get_part.
+    auto maybe_end = _parser.peek_bytes(2);
+    if (maybe_end[0] == '-' && maybe_end[1] == '-') {
+        _done = true;
+    }
+    if (part_len == 0 || !part_start.has_value()) {
+        return std::nullopt;
+    }
+    return std::make_optional<iobuf>(
+      _buffer.share(part_start.value(), part_len));
+}
+
+void multipart_response_parser::advance_to_first_boundary() {
+    size_t delim_idx = 0;
+    while (!_found_first && _parser.bytes_left()) {
+        auto c = _parser.consume_type<char>();
+        if (c == _delim[delim_idx]) {
+            ++delim_idx;
+            _found_first = delim_idx == _delim.size();
+        } else {
+            // TODO(oren): I think ABS might actually put something here
+            break;
+        }
+    }
+}
+
 } // namespace cloud_storage_clients::util

--- a/src/v/cloud_storage_clients/util.cc
+++ b/src/v/cloud_storage_clients/util.cc
@@ -12,8 +12,10 @@
 
 #include "base/vlog.h"
 #include "bytes/streambuf.h"
+#include "container/chunked_vector.h"
 #include "http/utils.h"
 #include "net/connection.h"
+#include "strings/string_switch.h"
 #include "utils/retry_chain_node.h"
 
 #include <seastar/core/future.hh>
@@ -245,6 +247,125 @@ get_response_content_type(const http::client::response_header& headers) {
     }
 
     return response_content_type::unknown;
+}
+
+namespace {
+
+/// \brief Helper struct for tracking CRLF sequences in raw HTTP response data.
+struct crlf_stack {
+    crlf_stack() { stk.reserve(4); }
+    /// \brief Try to push a character onto the stack
+    ///
+    /// \return Whether the character is a carriage return or line feed, AND
+    ///         whether the character might be part of a CRLF sequence
+    std::pair<bool, bool> try_put(char c) {
+        if (
+          (c == '\r' && stk.size() % 2 == 0)
+          || (c == '\n' && stk.size() % 2 == 1)) {
+            stk.push_back(c);
+        } else {
+            stk.clear();
+        }
+        return std::make_pair(c == '\r' || c == '\n', stk.size() > 0);
+    }
+    /// \brief Return the number of complete CRLF sequences on the stack
+    ///
+    /// If the top of the stack is a carriage return, return 0. In general, only
+    /// complete CRLFs have any meaning in parsing logic.
+    size_t count() const {
+        if (stk.size() % 2) {
+            return 0;
+        }
+        return stk.size() / 2;
+    }
+
+private:
+    chunked_vector<char> stk;
+};
+} // namespace
+
+mime_header mime_header::from(iobuf_parser& in) {
+    mime_header result;
+    crlf_stack line_feed;
+    chunked_vector<std::pair<std::string, ssize_t>> raw_headers;
+    static constexpr size_t max_buf = 1024;
+    std::string buf;
+    // track whether we reached the name/value separator (':')
+    std::optional<ssize_t> sep_pos{};
+    // read the buffer, char by char, splitting lines on CRLF and break when we
+    // reach CRLF CRLF or run out of bytes
+    while (in.bytes_left()) {
+        auto c = in.consume_type<char>();
+        auto [is_nl, is_crlf_part] = line_feed.try_put(c);
+        if (is_nl && !is_crlf_part) {
+            // For our limited use case, we expect to see newline chars ONLY as
+            // part of a CRLF sequence
+            throw std::runtime_error(
+              "Failed to parse MIME header: Misplaced newline");
+        } else if (buf.size() >= max_buf) {
+            throw std::runtime_error(
+              fmt::format(
+                "Failed to parse MIME header: Exceeded max header size {}",
+                max_buf));
+        }
+        // only the first colon separates name from value, and every character
+        // up to that point (i.e. the header name) is case insensitive per
+        // RFC 5234
+        if (!sep_pos.has_value()) {
+            if (c == ':') {
+                sep_pos = buf.size();
+            }
+            c = static_cast<char>(std::tolower(c));
+        }
+        buf.push_back(c);
+        if (line_feed.count() == 1) {
+            if (buf.size() <= 2) {
+                throw std::runtime_error(
+                  "Failed to parse MIME header: Unexpected leading CRLF");
+            } else if (!sep_pos.has_value()) {
+                throw std::runtime_error(
+                  "Failed to parse MIME header: Missing name/value separator");
+            } else {
+                raw_headers.emplace_back(
+                  std::make_pair(std::move(buf), sep_pos.value() + 2));
+                buf = {};
+                sep_pos.reset();
+            }
+        } else if (line_feed.count() == 2) {
+            break;
+        }
+    }
+    if (line_feed.count() != 2 && !raw_headers.empty()) {
+        throw std::runtime_error(
+          "Failed to parse MIME header: missing trailing 'CRLF CRLF'");
+    }
+    for (const auto& [hdr, val_start] : raw_headers) {
+        std::optional<field> f{};
+        if (hdr.starts_with("content-type: ")) {
+            f = field::content_type;
+        } else if (hdr.starts_with("content-id: ")) {
+            f = field::content_id;
+        } else if (hdr.starts_with("content-length: ")) {
+            f = field::content_length;
+        } else if (hdr.starts_with("content-transfer-encoding: ")) {
+            f = field::content_transfer_encoding;
+        }
+        if (f.has_value()) {
+            // assume trailing CRLF is always present and strip it off
+            auto n = hdr.size() - val_start - 2;
+            std::ignore = result._fields.try_emplace(
+              f.value(), hdr.substr(val_start, n));
+        }
+        // quietly ignore anything we don't match for and/or anything malformed
+    }
+    return result;
+}
+
+std::optional<ss::sstring> mime_header::get(field f) const {
+    if (auto it = _fields.find(f); it != _fields.end()) {
+        return std::make_optional(it->second);
+    }
+    return std::nullopt;
 }
 
 } // namespace cloud_storage_clients::util

--- a/src/v/cloud_storage_clients/util.h
+++ b/src/v/cloud_storage_clients/util.h
@@ -142,4 +142,64 @@ private:
     bool _done{false};
 };
 
+/// \brief Individual HTTP response from a multipart response body
+///
+/// Represents a single HTTP response extracted from a multipart response.
+/// Each subresponse contains its own HTTP status code, headers, and body,
+/// allowing batch operations to return individual results for each operation
+/// within a single HTTP response. This is used to parse individual delete
+/// results from cloud storage batch operations.
+struct multipart_subresponse {
+    using status = boost::beast::http::status;
+
+    /// \brief Get the HTTP status code of this subresponse
+    ///
+    /// \return The HTTP status code (e.g., 200 OK, 404 Not Found)
+    status result() const;
+
+    /// \brief Check if this subresponse indicates success
+    ///
+    /// \return True if the status code is in the 2xx range or 404
+    bool is_ok() const;
+
+    /// \brief Extract an error message from the response headers if one is
+    /// present.
+    ///
+    /// \param error_code_name The name of the error code field to extract
+    ///        (e.g., "x-ms-error-code" in an ABS response)
+    /// \return The error message, or nullopt if not found or not an error
+    std::optional<ss::sstring> error(std::string_view error_code_name) const;
+
+    /// \brief Extract an error message from the response body if one is present
+    ///
+    /// Note that this function is non-const because the transformation requires
+    /// a share from a stored body.
+    ///
+    /// \param Transformation function to extract some string from the body,
+    ///        (e.g. a known field from a raw json object)
+    ///  \return The extracted error message, or nullopt if not an error
+    std::optional<ss::sstring> error(const std::function<ss::sstring(iobuf)>&);
+
+    /// \brief Parse a subresponse from an iobuf
+    ///
+    /// Parses a single HTTP response (with headers and body) from the given
+    /// parser. The parser should be positioned at the start of an HTTP
+    /// response within a multipart response part.
+    ///
+    /// \param in Parser positioned at the start of an HTTP response
+    /// \return Parsed subresponse structure
+    static multipart_subresponse from(iobuf_parser& in);
+
+private:
+    static std::vector<boost::asio::const_buffer>
+    iobuf_to_constbufseq(const iobuf& buf);
+    using parser_t = boost::beast::http::response_parser<http::iobuf_body>;
+    using response_t = parser_t::value_type;
+    std::optional<response_t> _response{};
+    size_t _noctets{0};
+    boost::beast::error_code _ec{};
+    bool _header_done{false};
+    iobuf _body;
+};
+
 } // namespace cloud_storage_clients::util

--- a/src/v/cloud_storage_clients/util.h
+++ b/src/v/cloud_storage_clients/util.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
 #include "cloud_storage_clients/types.h"
 #include "http/client.h"
 
@@ -50,5 +51,64 @@ void url_encode_target(http::client::request_header& header);
 
 response_content_type
 get_response_content_type(const http::client::response_header& headers);
+
+/// \brief MIME header representation for multipart response parts
+///
+/// Represents MIME-style headers found in individual parts of a multipart
+/// HTTP response. Each part in a multipart response can have its own headers
+/// (Content-Type, Content-ID, etc.) that describe the part's metadata.
+/// This is commonly used in batch operations where cloud storage APIs return
+/// multiple subresponses in a single HTTP response.
+///
+/// NOTE: We need a special parser for this because those included w/
+/// boost::beast expect a status line at the front of response, no exceptions.
+/// In principle, we could stick the status line at the front buffer and hand
+/// off to beast, but we would still need to search forward for the first blank
+/// line, besides which just getting the resulting slice ready for beast would
+/// probably be even more code.
+struct mime_header {
+    using field = boost::beast::http::field;
+    using field_map_t = std::unordered_map<field, ss::sstring>;
+
+    /// \brief Retrieve and transform the Content-ID field
+    ///
+    /// Retrieves the Content-ID field value and applies the provided
+    /// transformation function to convert it to the desired type.
+    /// This is useful for parsing structured Content-IDs that may contain
+    /// object keys or other identifiers.
+    ///
+    /// \param f Transformation function to parse the Content-ID string
+    /// \return Transformed Content-ID value, or nullopt if field is missing
+    ///         or transformation fails
+    template<typename T>
+    std::optional<T> content_id(
+      const std::function<std::optional<T>(std::string_view)> f) const {
+        return get(field::content_id).and_then(f);
+    }
+
+    /// \brief Get the value of a MIME header field
+    ///
+    /// \param f The header field to retrieve
+    /// \return The field value, or nullopt if not present
+    std::optional<ss::sstring> get(field f) const;
+
+    /// \brief Find a header field in the collection
+    field_map_t::const_iterator find(field f) const { return _fields.find(f); }
+
+    /// \brief Get iterator to end of header fields
+    field_map_t::const_iterator end() const { return _fields.end(); }
+
+    /// \brief Parse MIME headers from an iobuf
+    ///
+    /// Reads MIME-style headers from the parser until an empty line is
+    /// encountered. Headers are expected in "Field-Name: value" format.
+    ///
+    /// \param in Parser positioned at the start of MIME headers
+    /// \return Parsed MIME header structure
+    static mime_header from(iobuf_parser& in);
+
+private:
+    field_map_t _fields;
+};
 
 } // namespace cloud_storage_clients::util

--- a/src/v/cloud_storage_clients/util.h
+++ b/src/v/cloud_storage_clients/util.h
@@ -111,4 +111,35 @@ private:
     field_map_t _fields;
 };
 
+/// \brief Parser for multipart HTTP response bodies
+///
+/// Parses HTTP responses with multipart content encoding, where multiple
+/// subresponses are separated by boundary delimiters. This is used by cloud
+/// storage APIs (like ABS batch delete) to return multiple operation results
+/// in a single HTTP response. The parser extracts individual parts between
+/// boundaries, allowing each subresponse to be processed independently.
+struct multipart_response_parser {
+    /// \param b The complete multipart response body
+    /// \param delim The boundary delimiter string (with leading dashes)
+    explicit multipart_response_parser(iobuf b, ss::sstring delim);
+
+    /// \brief Extract the next part from the multipart response
+    ///
+    /// Returns the content of the next part in the multipart response,
+    /// excluding the boundary markers. Call repeatedly to iterate through
+    /// all parts in the response.
+    ///
+    /// \return The next part's content, or nullopt if all parts have been
+    ///         consumed or the final boundary has been reached
+    std::optional<iobuf> get_part();
+
+private:
+    void advance_to_first_boundary();
+    iobuf _buffer;
+    iobuf_const_parser _parser;
+    ss::sstring _delim;
+    bool _found_first{false};
+    bool _done{false};
+};
+
 } // namespace cloud_storage_clients::util

--- a/src/v/strings/string_switch.h
+++ b/src/v/strings/string_switch.h
@@ -78,6 +78,20 @@ public:
         return *this;
     }
 
+    constexpr string_switch& starts_with(std::string_view S, T value) {
+        if (!result && view.starts_with(S)) {
+            result = std::move(value);
+        }
+        return *this;
+    }
+
+    constexpr string_switch& ends_with(std::string_view S, T value) {
+        if (!result && view.ends_with(S)) {
+            result = std::move(value);
+        }
+        return *this;
+    }
+
     constexpr string_switch&
     match_all(std::string_view S0, std::string_view S1, T value) {
         return match(S0, value).match(S1, value);

--- a/src/v/strings/tests/BUILD
+++ b/src/v/strings/tests/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_btest_no_seastar")
+load("//bazel:test.bzl", "redpanda_cc_btest_no_seastar", "redpanda_cc_gtest")
 
 redpanda_cc_btest_no_seastar(
     name = "strings_test",
@@ -6,7 +6,6 @@ redpanda_cc_btest_no_seastar(
     srcs = [
         "constexpr_string_switch.cc",
         "static_str_test.cc",
-        "string_switch_test.cc",
         "utf8_control_chars.cc",
         "utf8_substring.cc",
     ],
@@ -14,5 +13,18 @@ redpanda_cc_btest_no_seastar(
         "//src/v/strings:static_str",
         "//src/v/strings:string_switch",
         "//src/v/strings:utf8",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "string_switch_gtest",
+    timeout = "short",
+    srcs = [
+        "string_switch_test.cc",
+    ],
+    deps = [
+        "//src/v/strings:string_switch",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
     ],
 )

--- a/src/v/strings/tests/string_switch_test.cc
+++ b/src/v/strings/tests/string_switch_test.cc
@@ -9,35 +9,56 @@
 
 #include "strings/string_switch.h"
 
-#include <boost/test/unit_test.hpp>
+#include <gtest/gtest.h>
 
 #include <stdexcept>
 
-BOOST_AUTO_TEST_CASE(string_switch_match_one) {
-    BOOST_REQUIRE_EQUAL(
+TEST(StringSwitch, MatchOne) {
+    EXPECT_EQ(
       int8_t(42),
       string_switch<int8_t>("hello")
         .match("world", -1)
         .match("hello", 42)
         .default_match(0));
 }
-BOOST_AUTO_TEST_CASE(string_switch_default) {
-    BOOST_REQUIRE_EQUAL(
+
+TEST(StringSwitch, StartsWithOne) {
+    EXPECT_EQ(
+      int8_t(42),
+      string_switch<int8_t>("hello, world!")
+        .starts_with("world", -1)
+        .starts_with("hello", 42)
+        .default_match(0));
+}
+
+TEST(StringSwitch, EndsWithOne) {
+    EXPECT_EQ(
+      int8_t(42),
+      string_switch<int8_t>("hello, world!")
+        .ends_with("hello", -1)
+        .ends_with("world!", 42)
+        .default_match(0));
+}
+
+TEST(StringSwitch, Default) {
+    EXPECT_EQ(
       int8_t(-66),
       string_switch<int8_t>("hello")
         .match("x", -1)
         .match("y", 42)
         .default_match(-66));
 }
-BOOST_AUTO_TEST_CASE(string_switch_match_all) {
-    BOOST_REQUIRE_EQUAL(
+
+TEST(StringSwitch, MatchAll) {
+    EXPECT_EQ(
       int8_t(42),
       string_switch<int8_t>("hello")
         .match_all("x", "y", "hello", 42)
         .default_match(-66));
 }
-BOOST_AUTO_TEST_CASE(string_switch_match_all_max) {
-    BOOST_REQUIRE_EQUAL(
+
+TEST(StringSwitch, MatchAllMax) {
+    EXPECT_EQ(
       int8_t(42),
       string_switch<int8_t>("hello")
         .match_all(
@@ -54,18 +75,20 @@ BOOST_AUTO_TEST_CASE(string_switch_match_all_max) {
         .default_match(-66));
 }
 
-BOOST_AUTO_TEST_CASE(string_switch_no_match) {
-    BOOST_CHECK_EXCEPTION(
-      string_switch<int8_t>("ccc").match("a", 0).match("b", 1).
-      operator int8_t(),
-      std::runtime_error,
-      [](const std::runtime_error& e) {
-          // check that the error string includes the string we were searching
-          // for as a weak hint to where the error occurred
-          if (!std::string(e.what()).ends_with("ccc")) {
-              BOOST_TEST_FAIL(
-                "Expected error message to end with ccc but was: " << e.what());
-          };
-          return true;
-      });
+TEST(StringSwitch, NoMatch) {
+    EXPECT_THROW(
+      {
+          try {
+              string_switch<int8_t>("ccc").match("a", 0).match("b", 1).
+              operator int8_t();
+          } catch (const std::runtime_error& e) {
+              // check that the error string includes the string we were
+              // searching for as a weak hint to where the error occurred
+              EXPECT_TRUE(std::string(e.what()).ends_with("ccc"))
+                << "Expected error message to end with 'ccc' but was: "
+                << e.what();
+              throw;
+          }
+      },
+      std::runtime_error);
 }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR introduces some support code for parsing multipart MIME responses (e.g. from ABS or GCS batch APIs).

- `mime_header` - a crude line parser for standalone mime headers. we need to strip these off the front of multipart sub-responses to prepare them for boost::beast response parsers. very narrow in scope.
- `multipart_response_parser` - split an buffer on a provided boundary string
- `multipart_subresponse` - thin wrapper around boost::beast response parser.

A general goal here is to avoid linearizing a whole multipart response buffer in one go, since it might include hundreds of sub-responses of indeterminate length (e.g. GCS includes a whole JSON response body with metadata and such). The overall theme is finding prescribed boundaries between textual elements by characterwise inspection of some iobuf. Perfect generality is a non-goal.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
