### PR TITLE
CORE-14619 rpk: fix version check logic for semver

### DIFF
--- a/src/go/rpk/pkg/redpanda/version.go
+++ b/src/go/rpk/pkg/redpanda/version.go
@@ -47,12 +47,13 @@ func (v Version) Less(b Version) bool {
 
 // IsAtLeast returns true if the version is greater than or equal to the passed version.
 func (v Version) IsAtLeast(b Version) bool {
-	if v.Major >= b.Major {
-		if v.Feature >= b.Feature {
-			return v.Patch >= b.Patch
-		}
+	if v.Major != b.Major {
+		return v.Major > b.Major
 	}
-	return false
+	if v.Feature != b.Feature {
+		return v.Feature > b.Feature
+	}
+	return v.Patch >= b.Patch
 }
 
 func (v Version) String() string {

--- a/src/go/rpk/pkg/redpanda/version_test.go
+++ b/src/go/rpk/pkg/redpanda/version_test.go
@@ -79,6 +79,7 @@ func TestVersion_IsAtLeast(t *testing.T) {
 		{"lower year", Version{23, 1, 1}, Version{22, 1, 1}, true},
 		{"lower feature", Version{22, 3, 23}, Version{22, 2, 23}, true},
 		{"lower patch", Version{23, 4, 23}, Version{23, 4, 22}, true},
+		{"next major with lower minor and patch", Version{26, 1, 1}, Version{25, 3, 2}, true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			require.Equal(t, test.a.IsAtLeast(test.b), test.exp)


### PR DESCRIPTION
Fixes a bug in the rpk version comparison logic to correctly account for semantic versioning.

This check is currently only used in the `rpk cluster connections list` command, and has only been working for checking if the version is at least `25.3.x`, hence the bug was not visible to users. But in CI some tests are now running as 26.1.0 and so this bug surfaced a CI failure.

Fixes https://redpandadata.atlassian.net/browse/CORE-14619

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
