### PR TITLE
`.github`: add some protobuf instructions to `copilot_instructions.md`

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -119,7 +119,7 @@ Follow the guidelines provided in `proto/redpanda/README.md` for basic Protobuf 
 - **Compiler Standard:** C++23 is required. Some SDK components (e.g., `src/transform-sdk/cpp/`) use C++23 and specific flags like `-Wall`, `-fno-exceptions`, and for some targets, `-stdlib=libc++`.
 - **Sanitizers:** Some components and test builds use sanitizers (address, leak, undefined) via `-fsanitize=address,leak,undefined` for both compile and link.
 - **Suppression Files:** Leak, undefined, and other sanitizer suppressions can be found in the root as `lsan_suppressions.txt`, `ubsan_suppressions.txt`.
-- **C++ Linting:** `.clang-format` and `.clang-tidy` in the root directory are enforced. Always run formatting tools before submitting a PR:
+- **C++ Linting:** `.clang-format` and `.clang-tidy` in the root directory are enforced. Always run `clang-format` before committing changes or submitting a PR:
   ```bash
   bazel run //tools:clang_format
   ```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,7 @@ It uses extensively the thread-per-core model and asynchronous (coroutines, futu
   - `tools/`: Development and helper scripts
   - `tests/`: Test suites
   - `conf/`: Configuration files
+  - `proto/`: Protobuf definitions for Redpanda services and APIs
   - `.github/`, `.buildkite/`: CI/workflow automation
 - **Documentation:** [Docs site](https://redpanda.com/documentation) and `docs/`.
 
@@ -95,6 +96,19 @@ It uses extensively the thread-per-core model and asynchronous (coroutines, futu
 - `.bazelignore`, `.bazelrc`, `.bazelversion`, `BUILD`, `MODULE.bazel`, `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `LICENSES/`, `bazel/`, `src/`, `tests/`, `conf/`, `tools/`, `.github/`, `.buildkite/`, etc.
 
 ---
+
+## Protobuf-Specific Instructions
+
+### Protobuf Coding Guidelines
+
+Follow the guidelines provided in `proto/redpanda/README.md` for basic Protobuf standards.
+
+### Protobuf Build & Environment
+- **Primary Protobuf code lives in `proto/`.**
+- **Formatting:** `.clang-format` in the root directory is enforced. Always run `clang-format` before committing changes or submitting a PR:
+  ```bash
+  bazel run //tools:clang_format
+  ```
 
 ## C++-Specific Instructions
 


### PR DESCRIPTION
And also re-enforce use of `clang-format` before committing C++ changes.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
