### PR TITLE
dt: Add detailed logging for storage consistency check

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -4592,9 +4592,11 @@ class RedpandaService(Service, RedpandaServiceABC):
                 max_node = node
             diff = result.observed_total - result.reported_total
             for file, size in result.observed:
-                self.logger.debug(f"Observed file [{node_name}]: {size:7} {file}")
+                self.logger.debug(f"Observed file [{node_name}]: {size:12} {file}")
+            for key, value in result.reported.items():
+                self.logger.debug(f"Reported [{node_name}]: {key}={value:12}")
             self.logger.warning(
-                f"Storage usage [{node_name}]: obs {result.observed_total:7} rep {result.reported_total:7} diff {diff:7} pct {result.diff_ratio} reclaimable_pct {result.reclaimable_ratio}"
+                f"Storage usage [{node_name}]: obs {result.observed_total:12} rep {result.reported_total:12} diff {diff:12} pct {result.diff_ratio} reclaimable_pct {result.reclaimable_ratio}"
             )
 
         max_node_name = f"{self.idx(max_node)}:{max_node.account.hostname}"


### PR DESCRIPTION
When the storage usage consistency check fails, log the breakdown of reported storage from the node's admin API. This helps diagnose discrepancies between observed filesystem usage and reported usage.

Also widen the format width from 7 to 12 to accommodate larger byte values.

I was investigating CORE-14985, a test failure due to reported vs. gathered size mismatch, but not making much progress.
This change might help if it happens again.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
