### PR TITLE
rpk: support cluster-uuid-override when running WCR

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.65.0
 	github.com/redpanda-data/common-go/proto v0.0.0-20250820120127-9b518fca5ecf
-	github.com/redpanda-data/common-go/rpadmin v0.2.0
+	github.com/redpanda-data/common-go/rpadmin v0.2.1
 	github.com/redpanda-data/common-go/rpsr v0.1.2
 	github.com/redpanda-data/protoc-gen-go-mcp v0.0.0-20250812151819-7e5d5fef8241
 	github.com/rs/xid v1.6.0

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -253,8 +253,8 @@ github.com/redpanda-data/common-go/net v0.1.0 h1:JnJioRJuL961r1QXiJQ1tW9+yEaJfu8
 github.com/redpanda-data/common-go/net v0.1.0/go.mod h1:iOdNkjxM7a1T8F3cYHTaKIPFCHzzp/ia6TN+Z+7Tt5w=
 github.com/redpanda-data/common-go/proto v0.0.0-20250820120127-9b518fca5ecf h1:Oe0Sc3+/37Xgdpze7klkWyvB6eAt/nuUhrn93Rd4ESA=
 github.com/redpanda-data/common-go/proto v0.0.0-20250820120127-9b518fca5ecf/go.mod h1:GMoRcdMz6CIpr+8vKrSJvr8fJDlojETRV45BD6A0DvU=
-github.com/redpanda-data/common-go/rpadmin v0.2.0 h1:s2MyyY+yq7B17mLjjW17RO81wFlzo856K9IuBpsmvv0=
-github.com/redpanda-data/common-go/rpadmin v0.2.0/go.mod h1:qmu76v7RRKgEXLS3UXxZ8KDpObtSNq6RinOIejJNWzw=
+github.com/redpanda-data/common-go/rpadmin v0.2.1 h1:N3GUI3d1h661Nta6Jc4MyaVKWxRIg28yO4MG912gCXQ=
+github.com/redpanda-data/common-go/rpadmin v0.2.1/go.mod h1:qmu76v7RRKgEXLS3UXxZ8KDpObtSNq6RinOIejJNWzw=
 github.com/redpanda-data/common-go/rpsr v0.1.2 h1:DThUeyfBH8fkL9WoP1sEbRhT2NVV22zmsTpcCtzfusQ=
 github.com/redpanda-data/common-go/rpsr v0.1.2/go.mod h1:2j2416onosg5FKaKz52NooRE+q/9EJqQn0kyTcTXWHc=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525 h1:vskZrV6q8W8flL0Ud23AJUYAd8ZgTadO45+loFnG2G0=

--- a/src/go/rpk/pkg/cli/cluster/storage/recovery/start.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/recovery/start.go
@@ -26,16 +26,22 @@ func newStartCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var (
 		wait            bool
 		pollingInterval time.Duration
+		uuidOverride    string
 	)
 
 	cmd := &cobra.Command{
 		Use:   "start",
-		Short: "Start the topic restoration process",
-		Long: `Start the topic restoration process.
+		Short: "Start the cluster restoration process",
+		Long: `Start the cluster restoration process.
 		
-This command starts the process of restoring topics from the archival bucket.
+This command starts the process of restoring data from a failed cluster with
+Tiered Storage enabled, including its metadata, onto a new cluster.
 If the wait flag (--wait/-w) is set, the command will poll the status of the
-recovery process until it's finished.`,
+recovery process until it's finished.
+
+Use --cluster-uuid-override if you want to specify an explicit cluster UUID
+to restore from. For more information, visit https://docs.redpanda.com/current/manage/disaster-recovery/whole-cluster-restore/.
+`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
 			p, err := p.LoadVirtualProfile(fs)
@@ -47,7 +53,7 @@ recovery process until it's finished.`,
 
 			ctx := cmd.Context()
 
-			_, err = client.StartAutomatedRecovery(ctx)
+			_, err = client.StartAutomatedRecovery(ctx, uuidOverride)
 			var he *rpadmin.HTTPResponseError
 			if errors.As(err, &he) {
 				if he.Response.StatusCode == 404 {
@@ -113,6 +119,7 @@ recovery process until it's finished.`,
 	cmd.Flags().MarkDeprecated("topic-name-pattern", "Not supported")
 	cmd.Flags().BoolVarP(&wait, "wait", "w", false, "Wait until auto-restore is complete")
 	cmd.Flags().DurationVar(&pollingInterval, "polling-interval", 5*time.Second, "The status check interval (e.g. '30s', '1.5m'); ignored if --wait is not used")
+	cmd.Flags().StringVar(&uuidOverride, "cluster-uuid-override", "", "Explicit cluster UUID to restore from; uses the latest if unset")
 
 	return cmd
 }


### PR DESCRIPTION
`rpk cluster storage restore start` now supports `--cluster-uuid-override` for a UUID override. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

https://github.com/redpanda-data/common-go/pull/113 is the rpadmin side of things. 
https://github.com/redpanda-data/docs/pull/1513 needs to be updated accordingly once this is merged. 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Features

* rpk: WCR supports `--cluster-uuid-override`