### PR TITLE
Add fuzz tests to nightly test suite

### DIFF
--- a/tests/rptest/test_suite_nightly.yml
+++ b/tests/rptest/test_suite_nightly.yml
@@ -13,3 +13,4 @@
 import:
   - test_suite_quick.yml
   - test_suite_chaos.yml
+  - test_suite_fuzz.yml

--- a/tests/rptest/test_suite_nightly.yml
+++ b/tests/rptest/test_suite_nightly.yml
@@ -1,0 +1,15 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+# This suite is used by the nightly re-test of dev, see e.g.:
+# https://buildkite.com/redpanda/redpanda/settings/schedules/607aec04-b4a7-4504-ac0b-d3b5fdc4ab15
+
+import:
+  - test_suite_quick.yml
+  - test_suite_chaos.yml


### PR DESCRIPTION
Add a "nightly" suite reflecting what we run in nightly re-test, and add fuzz tests to it. See details in commits.

After this goes in, we need to update the schedule `DUCKTAPE_ARGS` to point to this new suite.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
