### PR TITLE
bazel: build ragel from source as dev dependency

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -250,7 +250,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "l7k29esR22UzvrnFn7aRUSzHGrWMgmmfdS5lQnKrfGc=",
+        "bzlTransitiveDigest": "3jXppVYKvVDezaAzjtvmVaNF9PAhYbSv2NZW7u4mbf0=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -379,6 +379,15 @@
               "sha256": "0c8fac0a5c66eea339dce6be857101b308ce1064c838b81125b0dde3901e8032",
               "strip_prefix": "lksctp-tools-lksctp-tools-1.0.19",
               "url": "https://vectorized-public.s3.amazonaws.com/dependencies/lksctp-tools-1.0.19.tar.gz"
+            }
+          },
+          "ragel": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//bazel/thirdparty:ragel.BUILD",
+              "sha256": "5f156edb65d20b856d638dd9ee2dfb43285914d9aa2b6ec779dac0270cd56c3f",
+              "strip_prefix": "ragel-6.10",
+              "url": "http://www.colm.net/files/ragel/ragel-6.10.tar.gz"
             }
           },
           "openssl": {

--- a/bazel/install-deps.sh
+++ b/bazel/install-deps.sh
@@ -34,7 +34,6 @@ deb_deps=(
   libtool
   make
   pkgconf
-  ragel
   sudo
 )
 
@@ -47,7 +46,6 @@ fedora_deps=(
   git
   libtool
   perl
-  ragel
   xorg-x11-util-macros
   sudo
 )

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -113,6 +113,14 @@ def data_dependency():
         url = "https://vectorized-public.s3.amazonaws.com/dependencies/lksctp-tools-1.0.19.tar.gz",
     )
 
+    http_archive(
+        name = "ragel",
+        build_file = "//bazel/thirdparty:ragel.BUILD",
+        sha256 = "5f156edb65d20b856d638dd9ee2dfb43285914d9aa2b6ec779dac0270cd56c3f",
+        strip_prefix = "ragel-6.10",
+        url = "http://www.colm.net/files/ragel/ragel-6.10.tar.gz",
+    )
+
     #
     # ** IMPORTANT - OpenSSL and FIPS **
     #

--- a/bazel/thirdparty/ragel.BUILD
+++ b/bazel/thirdparty/ragel.BUILD
@@ -1,0 +1,45 @@
+load("@bazel_skylib//rules:common_settings.bzl", "int_flag")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
+
+# Make this build faster by setting `build --@ragel//:build_jobs=16` in user.bazelrc
+# if you have the cores to spare.
+int_flag(
+    name = "build_jobs",
+    build_setting_default = 8,
+    make_variable = "BUILD_JOBS",
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+)
+
+configure_make(
+    name = "ragel",
+    args = ["-j$RAGEL_BUILD_JOBS"],
+    autoreconf = True,
+    autoreconf_options = ["-ivf"],
+    configure_in_place = True,
+    configure_options = [
+        # Build a static binary for better portability
+        "--disable-shared",
+        "--disable-manual",
+    ],
+    env = {
+        "RAGEL_BUILD_JOBS": "$(BUILD_JOBS)",
+    },
+    lib_source = ":srcs",
+    out_binaries = ["ragel"],
+    targets = ["install-exec"],
+    toolchains = [":build_jobs"],
+    visibility = [
+        "//visibility:public",
+    ],
+)
+
+filegroup(
+    name = "ragel_bin",
+    srcs = [":ragel"],
+    output_group = "ragel",
+    visibility = ["//visibility:public"],
+)

--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -168,21 +168,24 @@ genrule(
     name = "http_request_parser",
     srcs = ["src/http/request_parser.rl"],
     outs = ["include/seastar/http/request_parser.hh"],
-    cmd = "ragel -G2 -o $@ $(SRCS)",
+    cmd = "$(location @ragel//:ragel_bin) -G2 -o $@ $(SRCS)",
+    tools = ["@ragel//:ragel_bin"],
 )
 
 genrule(
     name = "http_response_parser",
     srcs = ["src/http/response_parser.rl"],
     outs = ["include/seastar/http/response_parser.hh"],
-    cmd = "ragel -G2 -o $@ $(SRCS)",
+    cmd = "$(location @ragel//:ragel_bin) -G2 -o $@ $(SRCS)",
+    tools = ["@ragel//:ragel_bin"],
 )
 
 genrule(
     name = "http_chunk_parsers",
     srcs = ["src/http/chunk_parsers.rl"],
     outs = ["include/seastar/http/chunk_parsers.hh"],
-    cmd = "ragel -G2 -o $@ $(SRCS)",
+    cmd = "$(location @ragel//:ragel_bin) -G2 -o $@ $(SRCS)",
+    tools = ["@ragel//:ragel_bin"],
 )
 
 proto_library(


### PR DESCRIPTION
Refactor Bazel build configuration to build ragel 6.10 from source using rules_foreign_cc, removing the need for system installation.

Changes:
- Add ragel 6.10 to bazel/repositories.bzl
- Create ragel.BUILD using configure_make rules
- Update seastar.BUILD genrules to use Bazel-built ragel binary
- Remove ragel installation in install-deps.sh

This makes builds hermetic and reproducible across all environments.

part of https://redpandadata.atlassian.net/browse/DEVPROD-3452

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
