### PR TITLE
CORE-15177 SR Context: add context types 

### DIFF
--- a/src/v/datalake/record_multiplexer.h
+++ b/src/v/datalake/record_multiplexer.h
@@ -16,6 +16,7 @@
 #include "datalake/partitioning_writer.h"
 #include "datalake/schema_identifier.h"
 #include "datalake/translation/translation_probe.h"
+#include "model/metadata.h"
 #include "model/record.h"
 #include "model/record_batch_reader.h"
 #include "model/timestamp.h"

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -246,7 +246,8 @@ std::string_view as_string_view(const json::Value& v) {
 ss::future<> check_references(sharded_store& store, subject_schema schema) {
     for (const auto& ref : schema.def().refs()) {
         co_await store.get_id(ref.sub, ref.version)
-          .handle_exception_type([&](const exception& e) -> schema_id {
+          .discard_result()
+          .handle_exception_type([&](const exception& e) {
               if (failed_subject_schema_lookup(e.code())) {
                   throw as_exception(
                     no_reference_found_for(schema, ref.sub, ref.version));

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -303,7 +303,7 @@ private:
     int _ref_units{max_recursion_depth};
 };
 
-struct context {
+struct compatibility_context {
     schema_context older;
     schema_context newer;
 };
@@ -502,7 +502,7 @@ result<document_context> parse_json(iobuf buf) {
 // for N is also valid for O. precondition: older and newer are both valid
 // schemas
 json_compatibility_result is_superset(
-  context ctx,
+  compatibility_context ctx,
   const json::Value& older,
   const json::Value& newer,
   std::filesystem::path p);
@@ -1033,7 +1033,7 @@ json_compatibility_result is_numeric_property_value_superset(
 enum class additional_field_for { object, array };
 
 json_compatibility_result is_additional_superset(
-  const context& ctx,
+  const compatibility_context& ctx,
   const json::Value& older,
   const json::Value& newer,
   additional_field_for field_type,
@@ -1349,7 +1349,7 @@ json_compatibility_result is_numeric_superset(
 }
 
 json_compatibility_result is_array_superset(
-  const context& ctx,
+  const compatibility_context& ctx,
   const json::Value& older,
   const json::Value& newer,
   std::filesystem::path p) {
@@ -1536,7 +1536,7 @@ json_compatibility_result is_array_superset(
 }
 
 json_compatibility_result is_object_properties_superset(
-  const context& ctx,
+  const compatibility_context& ctx,
   const json::Value& older,
   const json::Value& newer,
   std::filesystem::path p) {
@@ -1678,7 +1678,7 @@ json_compatibility_result is_object_required_superset(
 }
 
 json_compatibility_result is_object_dependencies_superset(
-  const context& ctx,
+  const compatibility_context& ctx,
   const json::Value& older,
   const json::Value& newer,
   std::filesystem::path p) {
@@ -1771,7 +1771,7 @@ json_compatibility_result is_object_dependencies_superset(
 }
 
 json_compatibility_result is_object_superset(
-  const context& ctx,
+  const compatibility_context& ctx,
   const json::Value& older,
   const json::Value& newer,
   std::filesystem::path p) {
@@ -1878,7 +1878,7 @@ json_compatibility_result is_enum_superset(
 }
 
 json_compatibility_result is_not_combinator_superset(
-  const context& ctx,
+  const compatibility_context& ctx,
   const json::Value& older,
   const json::Value& newer,
   std::filesystem::path p) {
@@ -1929,7 +1929,7 @@ json::Value to_keyword(p_combinator c) {
 }
 
 json_compatibility_result is_positive_combinator_superset(
-  const context& ctx,
+  const compatibility_context& ctx,
   const json::Value& older,
   const json::Value& newer,
   std::filesystem::path p) {
@@ -2120,7 +2120,7 @@ using namespace is_superset_impl;
 // for N is also valid for O. precondition: older and newer are both valid
 // schemas
 json_compatibility_result is_superset(
-  context ctx,
+  compatibility_context ctx,
   const json::Value& older_schema,
   const json::Value& newer_schema,
   std::filesystem::path p) {
@@ -2433,7 +2433,7 @@ compatibility_result check_compatible(
     auto raw_compat_result = [&]() {
         // reader is a superset of writer iff every schema that is valid for
         // writer is also valid for reader
-        context ctx{.older{reader()}, .newer{writer()}};
+        compatibility_context ctx{.older{reader()}, .newer{writer()}};
         return is_superset(ctx, reader().ctx.doc, writer().ctx.doc, "#/");
     }();
 

--- a/src/v/pandaproxy/schema_registry/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/test/BUILD
@@ -321,6 +321,19 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "context_subject_test",
+    timeout = "short",
+    srcs = [
+        "context_subject.cc",
+    ],
+    deps = [
+        "//src/v/pandaproxy/schema_registry:types",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
 redpanda_cc_btest(
     name = "test_json_schema",
     timeout = "short",

--- a/src/v/pandaproxy/schema_registry/test/context_subject.cc
+++ b/src/v/pandaproxy/schema_registry/test/context_subject.cc
@@ -1,0 +1,69 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/schema_registry/types.h"
+
+#include <gtest/gtest.h>
+
+namespace pandaproxy::schema_registry {
+
+TEST(ContextSubjectTest, FromString) {
+    // Unqualified subjects use default context
+    EXPECT_EQ(
+      context_subject::from_string("my-topic"),
+      (context_subject{default_context, subject{"my-topic"}}));
+
+    // Qualified syntax: ":.context:subject"
+    EXPECT_EQ(
+      context_subject::from_string(":.my-ctx:my-topic"),
+      (context_subject{context{".my-ctx"}, subject{"my-topic"}}));
+
+    // Explicit default context ":.:subject"
+    EXPECT_EQ(
+      context_subject::from_string(":.:my-topic"),
+      (context_subject{default_context, subject{"my-topic"}}));
+
+    // Context-only form ":.ctx:" (empty subject, used for context-level config)
+    EXPECT_EQ(
+      context_subject::from_string(":.my-ctx:"),
+      (context_subject{context{".my-ctx"}, subject{""}}));
+
+    // Colons in subject after context are preserved
+    EXPECT_EQ(
+      context_subject::from_string(":.ctx:a:b:c"),
+      (context_subject{context{".ctx"}, subject{"a:b:c"}}));
+
+    // Invalid qualified syntax falls back to unqualified
+    EXPECT_EQ(
+      context_subject::from_string(":no-dot"),
+      (context_subject{default_context, subject{":no-dot"}}));
+    EXPECT_EQ(
+      context_subject::from_string(":.no-second-colon"),
+      (context_subject{default_context, subject{":.no-second-colon"}}));
+}
+
+TEST(ContextSubjectTest, ToStringAndRoundTrip) {
+    // Default context: just the subject
+    auto unqualified = context_subject{default_context, subject{"my-topic"}};
+    EXPECT_EQ(unqualified.to_string(), "my-topic");
+    EXPECT_EQ(
+      context_subject::from_string(unqualified.to_string()), unqualified);
+
+    // Non-default context: qualified format
+    auto qualified = context_subject{context{".my-ctx"}, subject{"my-topic"}};
+    EXPECT_EQ(qualified.to_string(), ":.my-ctx:my-topic");
+    EXPECT_EQ(context_subject::from_string(qualified.to_string()), qualified);
+
+    // Context-only (empty subject): qualified format
+    auto ctx_only = context_subject{context{".my-ctx"}, subject{""}};
+    EXPECT_EQ(ctx_only.to_string(), ":.my-ctx:");
+    EXPECT_EQ(context_subject::from_string(ctx_only.to_string()), ctx_only);
+}
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -16,7 +16,7 @@
 #include "base/seastarx.h"
 #include "container/chunked_vector.h"
 #include "kafka/protocol/errors.h"
-#include "model/metadata.h"
+#include "model/fundamental.h"
 #include "strings/string_switch.h"
 #include "utils/named_type.h"
 

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -154,6 +154,37 @@ struct context_subject {
         return H::combine(std::move(h), ctx_sub.ctx, ctx_sub.sub);
     }
 
+    /// Parse from qualified subject ":.context:subject" or unqualified
+    /// "subject" (which uses the default context)
+    static context_subject from_string(std::string_view input) {
+        // Check for qualified syntax: starts with ":."
+        if (input.starts_with(":.")) {
+            // Find the second colon that separates context from subject
+            auto second_colon = input.find(':', 2);
+
+            if (second_colon != std::string_view::npos) {
+                auto ctx_str = input.substr(1, second_colon - 1);
+                auto sub_str = input.substr(second_colon + 1);
+
+                return context_subject{context{ctx_str}, subject{sub_str}};
+            }
+        }
+
+        // Default case: unqualified subject or invalid qualified syntax
+        return context_subject{default_context, subject{input}};
+    }
+
+    /// Format as qualified subject ":.context:subject" or "subject" if in the
+    /// default context
+    ss::sstring to_string() const { return ssx::sformat("{}", *this); }
+
+    fmt::iterator format_to(fmt::iterator it) const {
+        if (ctx == pandaproxy::schema_registry::default_context) {
+            return fmt::format_to(it, "{}", sub);
+        }
+        return fmt::format_to(it, ":{}:{}", ctx, sub);
+    }
+
     context ctx;
     subject sub;
 };

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -131,6 +131,33 @@ using registry_resource = named_type<ss::sstring, struct registry_resource_tag>;
 using subject = named_type<ss::sstring, struct subject_tag>;
 inline const subject invalid_subject{};
 
+/// \brief A schema context, used for namespacing schemas and schema ids. Can be
+/// used to implement multi-tenancy, environment (e.g., dev, staging, prod)
+/// separation, and so on. By default, schemas are stored under the "." context.
+using context = named_type<ss::sstring, struct context_tag>;
+inline const context default_context{"."};
+
+// A subject bound to a context
+struct context_subject {
+    constexpr context_subject() = default;
+
+    context_subject(context c, subject s)
+      : ctx{std::move(c)}
+      , sub{std::move(s)} {}
+
+    friend auto
+    operator<=>(const context_subject& lhs, const context_subject& rhs)
+      = default;
+
+    template<typename H>
+    friend H AbslHashValue(H h, const context_subject& ctx_sub) {
+        return H::combine(std::move(h), ctx_sub.ctx, ctx_sub.sub);
+    }
+
+    context ctx;
+    subject sub;
+};
+
 ///\brief The version of the schema registered with a subject.
 ///
 /// A subject may evolve its schema over time. Each version is associated with a
@@ -417,6 +444,25 @@ private:
 ///\brief Globally unique identifier for a schema.
 using schema_id = named_type<int32_t, struct schema_id_tag>;
 inline constexpr schema_id invalid_schema_id{-1};
+
+// A schema id that is valid within a context.
+struct context_schema_id {
+    context_schema_id(context c, schema_id s)
+      : ctx{std::move(c)}
+      , id{s} {}
+
+    friend auto
+    operator<=>(const context_schema_id& lhs, const context_schema_id& rhs)
+      = default;
+
+    template<typename H>
+    friend H AbslHashValue(H h, const context_schema_id& ctx_id) {
+        return H::combine(std::move(h), ctx_id.ctx, ctx_id.id);
+    }
+
+    context ctx;
+    schema_id id;
+};
 
 struct subject_version {
     subject_version(subject s, schema_version v)

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -129,14 +129,14 @@ using registry_resource = named_type<ss::sstring, struct registry_resource_tag>;
 ///
 /// Typically it will be "<topic>-key" or "<topic>-value".
 using subject = named_type<ss::sstring, struct subject_tag>;
-static const subject invalid_subject{};
+inline const subject invalid_subject{};
 
 ///\brief The version of the schema registered with a subject.
 ///
 /// A subject may evolve its schema over time. Each version is associated with a
 /// schema_id.
 using schema_version = named_type<int32_t, struct schema_version_tag>;
-static constexpr schema_version invalid_schema_version{-1};
+inline constexpr schema_version invalid_schema_version{-1};
 
 struct schema_reference {
     friend bool
@@ -416,7 +416,7 @@ private:
 
 ///\brief Globally unique identifier for a schema.
 using schema_id = named_type<int32_t, struct schema_id_tag>;
-static constexpr schema_id invalid_schema_id{-1};
+inline constexpr schema_id invalid_schema_id{-1};
 
 struct subject_version {
     subject_version(subject s, schema_version v)


### PR DESCRIPTION
Add core types for schema registry contexts: `context`, `context_subject`, and `context_schema_id`. These will be used to namespace schemas and subjects across tenants or environments.

Also includes:
  - Parsing and formatting for qualified subjects (`:.ctx:subject`)
  - Rename of `context` → `compatibility_context` in json.cc to avoid collision
  - Minor refactors to prepare for context support

See commit messages for details.

Fixes https://redpandadata.atlassian.net/browse/CORE-15177

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
