### PR TITLE
`ct/l1`: two compaction bug fixes

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -766,18 +766,25 @@ replicated_metastore::get_compaction_infos(
                           resp[l.tp] = std::unexpected(
                             rpc_to_meta_errc(reply.ec));
                       }
+                      return;
                   }
 
                   for (auto& [log, log_reply] : reply.responses) {
-                      metastore::compaction_info_response log_resp{
-                        .dirty_ratio = log_reply.dirty_ratio,
-                        .earliest_dirty_ts = log_reply.earliest_dirty_ts,
-                        .offsets_response = {
-                          .dirty_ranges = std::move(log_reply.dirty_ranges),
-                          .removable_tombstone_ranges = std::move(log_reply.removable_tombstone_ranges)},
-                        .compaction_epoch = metastore::compaction_epoch{log_reply.compaction_epoch()},
-                        .start_offset = log_reply.start_offset};
-                      resp.insert_or_assign(log, std::move(log_resp));
+                      if (log_reply.ec == rpc::errc::ok) {
+                          metastore::compaction_info_response log_resp{
+                            .dirty_ratio = log_reply.dirty_ratio,
+                            .earliest_dirty_ts = log_reply.earliest_dirty_ts,
+                            .offsets_response = {
+                              .dirty_ranges = std::move(log_reply.dirty_ranges),
+                              .removable_tombstone_ranges = std::move(log_reply.removable_tombstone_ranges)},
+                            .compaction_epoch = metastore::compaction_epoch{log_reply.compaction_epoch()},
+                            .start_offset = log_reply.start_offset};
+                          resp.insert_or_assign(log, std::move(log_resp));
+                      } else {
+                          resp.insert_or_assign(
+                            log,
+                            std::unexpected(rpc_to_meta_errc(log_reply.ec)));
+                      }
                   }
               });
         }));

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -572,7 +572,7 @@ simple_metastore::get_compaction_offsets(
         dirty_base_candidate = kafka::next_offset(cleaned_range.last_offset);
     }
     auto prt_last_offset = kafka::prev_offset(prt.next_offset);
-    if (dirty_base_candidate < prt_last_offset) {
+    if (dirty_base_candidate <= prt_last_offset) {
         resp.dirty_ranges.insert(dirty_base_candidate, prt_last_offset);
     }
 

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -1573,6 +1573,48 @@ TEST(SimpleMetastoreTest, TestDirtyRatio) {
     ASSERT_EQ(compaction_info->start_offset, 0_o);
 }
 
+TEST(SimpleMetastoreTest, TestCompactionOffsetsSingleDirtyAtEnd) {
+    simple_metastore m;
+    om_list_t os;
+    auto tp = model::topic_id_partition::from(tid_a);
+
+    // Create a log with offsets [0, 100] (next_offset = 101).
+    os.emplace_back(om_builder(oid1, 100, 1010)
+                      .add(tid_a, 0_o, 100_o, 1000_t, 0, 1009)
+                      .build());
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    // Clean all offsets except the last one: clean [0, 99].
+    // This leaves only offset 100 dirty.
+    {
+        om_list_t new_os;
+        new_os.emplace_back(om_builder(oid2, 100, 1010)
+                              .add(tid_a, 0_o, 100_o, 1000_t, 0, 1009)
+                              .build());
+
+        auto cmb = cm_builder();
+        cmb.clean(tid_a, 0_o, 99_o, 3000_t);
+        cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{0});
+        auto compact_res = m.compact_objects(new_os, cmb.build()).get();
+        ASSERT_TRUE(compact_res.has_value());
+    }
+
+    auto to_collect = metastore::compaction_info_spec{
+      .tidp = tp, .tombstone_removal_upper_bound_ts = 3000_t};
+    auto compaction_info = m.get_compaction_info(to_collect).get();
+    ASSERT_TRUE(compaction_info.has_value());
+
+    // The dirty ratio should be non-zero
+    EXPECT_GT(compaction_info->dirty_ratio, 0.0);
+
+    // The dirty_ranges should contain [100, 100]
+    EXPECT_THAT(
+      compaction_info->offsets_response.dirty_ranges.to_vec(),
+      testing::ElementsAre(MatchesRange(100_o, 100_o)));
+}
+
 TEST(SimpleMetastoreTest, TestAddGetOffsetAfterBytes) {
     simple_metastore m;
     om_list_t os;


### PR DESCRIPTION
1. Properly respect `compaction_info_response`s that have `ec` set instead of the compaction info.
2. Fix a bug in `simple_metastore::get_compaction_offsets()` for computing the dirty ranges.

For 2, I had Claude investigate and write a test. Relevant session output is included in commit message.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
