### PR TITLE
`ct/l1`: fix UAF in `file_io::read_object()`

### DIFF
--- a/src/v/cloud_topics/level_one/common/file_io.cc
+++ b/src/v/cloud_topics/level_one/common/file_io.cc
@@ -156,10 +156,10 @@ file_io::put_object(object_id oid, staging_file* file, ss::abort_source* as) {
 
 ss::future<uint64_t> file_io::save_to_cache(
   ss::input_stream<char> stream,
-  cloud_io::space_reservation_guard* reservation,
+  cloud_io::space_reservation_guard reservation,
   std::filesystem::path cache_key,
   uint64_t content_length) {
-    co_await _cache->put(std::move(cache_key), stream, *reservation);
+    co_await _cache->put(std::move(cache_key), stream, reservation);
     co_return content_length;
 }
 
@@ -211,10 +211,13 @@ file_io::read_object(object_extent extent, ss::abort_source* as) {
             co_return std::unexpected(io::errc::file_io_error);
         }
         cloud_io::try_consume_stream consumer =
-          [this, r = reservation_fut.get(), &cache_key](
+          [this, r = reservation_fut.get(), cache_key](
             uint64_t content_length, ss::input_stream<char> stream) mutable {
               return save_to_cache(
-                std::move(stream), &r, cache_key, content_length);
+                std::move(stream),
+                std::move(r),
+                std::move(cache_key),
+                content_length);
           };
         auto result_fut
           = co_await ss::coroutine::as_future<cloud_io::download_result>(

--- a/src/v/cloud_topics/level_one/common/file_io.h
+++ b/src/v/cloud_topics/level_one/common/file_io.h
@@ -47,7 +47,7 @@ public:
 private:
     ss::future<uint64_t> save_to_cache(
       ss::input_stream<char>,
-      cloud_io::space_reservation_guard*,
+      cloud_io::space_reservation_guard,
       std::filesystem::path,
       uint64_t content_length);
 


### PR DESCRIPTION
This is dangerous because capturing `r = reservation_fut.get()` and then passing a pointer to it to `save_to_cache()` will result in a use-after-free should the future be resolved after the `consumer` lambda is destructed.

Change the lambda signature to only capture values that will be moved or copied into `save_to_cache()` to ensure lifetime safety.

Relevant Backtrace:

```
Backtrace:
[Backtrace #0]
seastar::guarded_backtrace(void**, int) at ./external/+non_module_dependencies+seastar/src/util/backtrace.cc:102
void seastar::backtrace<seastar::backtrace_buffer::append_backtrace()::'lambda'(seastar::frame)>(seastar::backtrace_buffer::append_backtrace()::'lambda'(seastar::frame)&&, bool) at ./external/+non_module_dependencies+seastar/include/seastar/util/backtrace.hh:89
 (inlined by) seastar::backtrace_buffer::append_backtrace() at ./external/+non_module_dependencies+seastar/src/core/reactor.cc:801
 (inlined by) seastar::print_with_backtrace(seastar::backtrace_buffer&, bool) at ./external/+non_module_dependencies+seastar/src/core/reactor.cc:839
seastar::print_with_backtrace(char const*, bool, bool) at ./external/+non_module_dependencies+seastar/src/core/reactor.cc:859
 (inlined by) seastar::sigsegv_action(siginfo_t*, ucontext_t*) at ./external/+non_module_dependencies+seastar/src/core/reactor.cc:4260
 (inlined by) void seastar::install_oneshot_signal_handler<11, (void (*)(siginfo_t*, ucontext_t*))(&seastar::sigsegv_action(siginfo_t*, ucontext_t*))>()::'lambda'(int, siginfo_t*, void*)::operator()(int, siginfo_t*, void*) const at ./external/+non_module_dependencies+seastar/src/core/reactor.cc:4194
 (inlined by) void seastar::install_oneshot_signal_handler<11, (void (*)(siginfo_t*, ucontext_t*))(&seastar::sigsegv_action(siginfo_t*, ucontext_t*))>()::'lambda'(int, siginfo_t*, void*)::__invoke(int, siginfo_t*, void*) at ./external/+non_module_dependencies+seastar/src/core/reactor.cc:4189
/home/willem/redpanda/vbuild/bazel-out/redpanda/bin/../lib/libc.so.6: ELF 64-bit LSB shared object, x86-64, version 1 (GNU/Linux), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=cd410b710f0f094c6832edd95931006d883af48e, for GNU/Linux 3.2.0, stripped
?? at ??:0
cloud_io::remote::download_stream(cloud_io::basic_transfer_details<seastar::lowres_clock>, seastar::noncopyable_function<seastar::future<unsigned long> (unsigned long, seastar::input_stream<char>)> const&, std::__1::basic_string_view<char, std::__1::char_traits<char>>, bool, std::__1::optional<std::__1::pair<unsigned long, unsigned long>>, std::__1::function<void (unsigned long)>)::$_0::operator()() const at ./src/v/cloud_io/remote.cc:316
 (inlined by) cloud_io::remote::download_stream(cloud_io::basic_transfer_details<seastar::lowres_clock>, seastar::noncopyable_function<seastar::future<unsigned long> (unsigned long, seastar::input_stream<char>)> const&, std::__1::basic_string_view<char, std::__1::char_traits<char>>, bool, std::__1::optional<std::__1::pair<unsigned long, unsigned long>>, std::__1::function<void (unsigned long)>) at ./src/v/cloud_io/remote.cc:314
cloud_topics::l1::file_io::read_object(cloud_topics::l1::object_extent, seastar::abort_source*) (.resume) at ./src/v/cloud_topics/level_one/common/file_io.cc:221
std::__1::coroutine_handle<seastar::internal::coroutine_traits_base<std::__1::expected<seastar::input_stream<char>, cloud_topics::l1::io::errc>>::promise_type>::resume[abi:ne200100]() const at ./external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__coroutine/coroutine_handle.h:144
 (inlined by) seastar::internal::coroutine_traits_base<std::__1::expected<seastar::input_stream<char>, cloud_topics::l1::io::errc>>::promise_type::run_and_dispose() at ./external/+non_module_dependencies+seastar/include/seastar/core/coroutine.hh:129
seastar::reactor::task_queue::run_tasks() at ./external/+non_module_dependencies+seastar/src/core/reactor.cc:2747
seastar::reactor::task_queue_group::run_tasks() at ./external/+non_module_dependencies+seastar/src/core/reactor.cc:3251
 (inlined by) seastar::reactor::task_queue_group::run_some_tasks() at ./external/+non_module_dependencies+seastar/src/core/reactor.cc:3235
 (inlined by) seastar::reactor::do_run() at ./external/+non_module_dependencies+seastar/src/core/reactor.cc:3418
seastar::reactor::run() at ./external/+non_module_dependencies+seastar/src/core/reactor.cc:3295
seastar::app_template::run_deprecated(int, char**, std::__1::function<void ()>&&) at ./external/+non_module_dependencies+seastar/src/core/app-template.cc:266
seastar::app_template::run(int, char**, std::__1::function<seastar::future<int> ()>&&) at ./external/+non_module_dependencies+seastar/src/core/app-template.cc:160
application::run(int, char**) at ./src/v/redpanda/application.cc:305
main at ./src/v/redpanda/main.cc:22
?? at ??:0
__libc_start_main at ??:0
_start at ??:0
```

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
