### PR TITLE
`kgo-verifier`/`rptest`: some small KgoVerifier tweaks 

### DIFF
--- a/tests/go/kgo-verifier/pkg/worker/verifier/validator_status.go
+++ b/tests/go/kgo-verifier/pkg/worker/verifier/validator_status.go
@@ -125,8 +125,8 @@ func (cs *ValidatorStatus) ValidateRecord(r *kgo.Record, validRanges *TopicOffse
 
 	if cs.expectFullyCompacted {
 		latestValue, exists := latestValuesProduced.GetValue(r.Partition, string(r.Key))
-		if !exists || string(latestValue) != string(r.Value) {
-			log.Panicf("Consumed value for key %s does not match the latest produced value in a compacted topic- did compaction for partition %s/%d occur betwen producing and consuming?", r.Key, r.Topic, r.Partition)
+		if exists && string(latestValue) != string(r.Value) {
+			log.Panicf("Consumed value for key %s at offset %d does not match the latest produced value in a compacted topic- did compaction for partition %s/%d occur betwen producing and consuming?", r.Key, r.Offset, r.Topic, r.Partition)
 		}
 	}
 

--- a/tests/rptest/scale_tests/ht_partition_movement_test.py
+++ b/tests/rptest/scale_tests/ht_partition_movement_test.py
@@ -93,6 +93,7 @@ class HighThroughputPartitionMovementTest(PreallocNodesTest, PartitionMovementMi
 
         self.consumer.wait()
         assert self.consumer.consumer_status.validator.invalid_reads == 0
+        self.consumer.stop()
         del self.consumer
 
         # Create a fresh consumer to read the quiescent state from start to finish
@@ -104,6 +105,9 @@ class HighThroughputPartitionMovementTest(PreallocNodesTest, PartitionMovementMi
             >= self.producer.produce_status.acked
         )
         assert self.consumer.consumer_status.validator.invalid_reads == 0
+
+        self.consumer.stop()
+        self.producer.stop()
 
     @cluster(num_nodes=6)
     @parametrize(replication_factor=1)

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -582,6 +582,7 @@ class ManyPartitionsTest(PreallocNodesTest):
             )
             producer.start()
             producer.wait(timeout_sec=expect_transmit_time)
+            producer.stop()
             self.free_preallocated_nodes()
             duration = time.time() - t1
             self.logger.info(
@@ -631,6 +632,7 @@ class ManyPartitionsTest(PreallocNodesTest):
         )
         rand_consumer.start(clean=False)
         rand_consumer.wait()
+        rand_consumer.stop()
 
         fast_producer.stop()
         self.logger.info("Write+randread stress test complete, verifying sequentially")
@@ -672,7 +674,7 @@ class ManyPartitionsTest(PreallocNodesTest):
             ), (
                 f"{verifier.consumer_status.validator.valid_reads} >= {fast_producer.produce_status.acked} + {msg_count_per_topic}"
             )
-
+        verifier.stop()
         self.free_preallocated_nodes()
 
     def _run_omb(self, scale: ScaleParameters):

--- a/tests/rptest/scale_tests/partition_balancer_scale_test.py
+++ b/tests/rptest/scale_tests/partition_balancer_scale_test.py
@@ -85,6 +85,7 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
         # was written before it started.
         self.consumer.wait()
         assert self.consumer.consumer_status.validator.invalid_reads == 0
+        self.consumer.stop()
         del self.consumer
 
         # Start a new consumer to read all data written
@@ -96,6 +97,8 @@ class PartitionBalancerScaleTest(PreallocNodesTest, PartitionMovementMixin):
             >= self.producer.produce_status.acked
         )
         assert self.consumer.consumer_status.validator.invalid_reads == 0
+        self.consumer.stop()
+        self.producer.stop()
 
     def node_replicas(self, topics, node_id):
         topic_descriptions = self.client().describe_topics(topics)

--- a/tests/rptest/scale_tests/tiered_storage_io_stress_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_io_stress_test.py
@@ -149,6 +149,8 @@ class TieredStorageIoStressTest(PreallocNodesTest):
         # mid-run, they'll run to completion.
         for consumer in self._consumers:
             consumer.wait()
+            consumer.stop()
+        self._producer.stop()
 
         assert (
             self._seq_consumer.consumer_status.validator.valid_reads >= wrote_at_least

--- a/tests/rptest/scale_tests/tiered_storage_single_partition_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_single_partition_test.py
@@ -157,6 +157,7 @@ class TieredStorageSinglePartitionTest(RedpandaTest):
             self.redpanda.wait_until(metadata_readable, timeout_sec=30, backoff_sec=1)
 
         producer.wait(timeout_sec=expect_duration)
+        producer.stop()
         producer.free()
 
         produce_duration = time.time() - t1

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -279,7 +279,19 @@ class KgoVerifierService(Service):
             return r.status_code == 200
 
     def _assert_running(self, node: ClusterNode) -> None:
-        node.account.ssh_output(f"ps -p {self._pid}", allow_fail=False)
+        output = node.account.ssh_output(
+            f"test -d /proc/{self._pid} && echo 1 || echo 0"
+        )
+        is_running = output.decode().strip() == "1"
+        assert is_running, f"Process {self._pid} is not running on {node.name}"
+
+    def is_running(self, node: ClusterNode) -> bool:
+        try:
+            self._assert_running(node)
+            return True
+        except Exception as e:
+            self.logger.debug(f"Service is not running, {e}")
+            return False
 
     def stop_node(self, node: ClusterNode, **kwargs: Any) -> None:
         error = None
@@ -346,7 +358,7 @@ class KgoVerifierService(Service):
     def wait_node(self, node: ClusterNode, timeout_sec: float | None = None) -> Any:
         """
         Wrapper to catch timeouts on wait, and send a `/print_stack` to the remote
-        process in case it is experiencing a hang bug.
+        process in case it is experiencing a hang bug (if it is still running).
         """
         assert not self._stopped, (
             f"Can't wait {self.who_am_i()}. It was already stopped. You can either stop() a service or wait() and then stop() it but not the other way around."
@@ -358,7 +370,8 @@ class KgoVerifierService(Service):
             return self._do_wait_node(node, timeout_sec)
         except:
             try:
-                self._remote(node, "print_stack")
+                if self.is_running(node):
+                    self._remote(node, "print_stack")
             except Exception as e:
                 self._redpanda.logger.warning(
                     f"{self.who_am_i()} failed to print stacks during wait failure: {e}"
@@ -423,7 +436,7 @@ class KgoVerifierService(Service):
             f"wait_node {self.who_am_i()}: waiting node={node.name} pid={self._pid} to terminate"
         )
         wait_until(
-            lambda: not node.account.exists(f"/proc/{self._pid}"),
+            lambda: not self.is_running(node),
             timeout_sec=10,
             backoff_sec=0.5,
         )
@@ -538,6 +551,11 @@ class StatusThread(threading.Thread):
         session.mount("http://", HTTPAdapter(max_retries=retry_strategy))
 
         while not self._stop_requested.is_set():
+            if not self._parent.is_running(self._node):
+                raise RuntimeError(
+                    f"Process was terminated early, check logs for {self.who_am_i}"
+                )
+
             drop_out = self._shutdown_requested.is_set()
             r = session.get(
                 url=self._parent._remote_url(self._node, "status"), timeout=5

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -190,6 +190,7 @@ class KgoVerifierService(Service):
         inst = cls(*args, **kwargs)
         inst.start()
         inst.wait(**timeout_kwargs)
+        inst.stop()
         inst.free()
         return inst
 
@@ -320,6 +321,12 @@ class KgoVerifierService(Service):
             if "No such process" not in str(e.msg):
                 raise
 
+        wait_until(
+            lambda: not self.is_running(node),
+            timeout_sec=10,
+            backoff_sec=0.5,
+        )
+
         self._pid = None
         self._release_port()
         if error:
@@ -415,12 +422,10 @@ class KgoVerifierService(Service):
             backoff_sec=5,
             err_msg=f"{self.who_am_i()} didn't complete in {timeout_sec} seconds",
         )
-        self.status_thread.raise_on_error()
 
         # Read final status
         self.logger.debug(f"wait_node {self.who_am_i()}: reading final status")
         self.status_thread.shutdown()
-        self._status_thread = None
 
         # Permit the subprocess to exit, and wait for it to do so
         self.logger.debug(f"wait_node {self.who_am_i()}: requesting shutdown")
@@ -432,22 +437,7 @@ class KgoVerifierService(Service):
             # before shutting down.
             pass
 
-        self.logger.debug(
-            f"wait_node {self.who_am_i()}: waiting node={node.name} pid={self._pid} to terminate"
-        )
-        wait_until(
-            lambda: not self.is_running(node),
-            timeout_sec=10,
-            backoff_sec=0.5,
-        )
-        self._pid = None
-
-        self.logger.debug(
-            f"wait_node {self.who_am_i()}: node={node.name} pid={self._pid} terminated"
-        )
-
-        self._release_port()
-        self._stopped = True
+        self.status_thread.raise_on_error()
 
         return True
 

--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -115,6 +115,7 @@ class CloudRetentionTest(PreallocNodesTest):
             msg_count, timeout_sec=1200, backoff_sec=5, progress_sec=20
         )
         producer.wait()
+        producer.stop()
         self.logger.info("finished producing")
         topics = (TopicSpec(name=self.topic_name, partition_count=num_partitions),)
 
@@ -204,6 +205,7 @@ class CloudRetentionTest(PreallocNodesTest):
         consumer.start(clean=False)
 
         consumer.wait()
+        consumer.stop()
         self.logger.info("finished consuming")
         valid_reads = consumer.consumer_status.validator.valid_reads
         threshold = segment_size * num_partitions / msg_size
@@ -259,6 +261,7 @@ class CloudRetentionTest(PreallocNodesTest):
         )
         producer.start(clean=False)
         producer.wait()
+        producer.stop()
 
         topics = (TopicSpec(name=self.topic_name, partition_count=num_partitions),)
 
@@ -319,6 +322,7 @@ class CloudRetentionTest(PreallocNodesTest):
         )
         producer.start(clean=False)
         producer.wait()
+        producer.stop()
 
 
 class CloudRetentionTimelyGCTest(RedpandaTest):

--- a/tests/rptest/tests/cloud_storage_usage_test.py
+++ b/tests/rptest/tests/cloud_storage_usage_test.py
@@ -99,6 +99,7 @@ class CloudStorageUsageTest(RedpandaTest, PartitionMovementMixin):
 
         for p in producers:
             p.wait(self.target_runtime)
+            p.stop()
             p.free()
 
     def _check_usage(self, timeout_sec):

--- a/tests/rptest/tests/cloud_topics/e2e_test.py
+++ b/tests/rptest/tests/cloud_topics/e2e_test.py
@@ -269,6 +269,8 @@ class EndToEndCloudTopicsTxTest(EndToEndCloudTopicsBase):
         assert cstatus.validator.invalid_reads == 0
         assert cstatus.validator.out_of_scope_invalid_reads == 0
         self.wait_until_all_reconciled(self.topics, transactions=True)
+        self.kgo_consumer.stop()
+        self.kgo_producer.stop()
 
 
 class EndToEndCloudTopicsCompactionTest(EndToEndCloudTopicsBase):

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -1912,6 +1912,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         )
         consumer.start()
         consumer.wait_total_reads(count=9000, timeout_sec=60, backoff_sec=5)
+        consumer.stop()
 
     def _maybe_failure_injector(self, with_failures: bool):
         if with_failures:

--- a/tests/rptest/tests/connection_rate_limit_test.py
+++ b/tests/rptest/tests/connection_rate_limit_test.py
@@ -86,6 +86,7 @@ class ConnectionRateLimitTest(PreallocNodesTest):
     def connection_rate_test(self):
         self._producer.start()
         self._producer.wait()
+        self._producer.stop()
         self._producer.free()
 
         metrics = MetricCheck(

--- a/tests/rptest/tests/datalake/compaction_test.py
+++ b/tests/rptest/tests/datalake/compaction_test.py
@@ -198,6 +198,7 @@ class CompactionTest(RedpandaTest):
 
         producer.start(clean=True)
         producer.wait()
+        producer.stop()
         producer.free()
 
     def wait_for_compaction(self):
@@ -250,6 +251,7 @@ class CompactionTest(RedpandaTest):
 
         consumer.start(clean=False)
         consumer.wait(timeout_sec=120)
+        consumer.stop()
         consumer.free()
 
         verifier = DatalakeVerifier(

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -199,6 +199,7 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
 
         producer.start()
         producer.wait(timeout_sec=60)
+        producer.stop()
         producer.free()
 
         wait_until(
@@ -242,6 +243,7 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
 
         producer.start()
         producer.wait(timeout_sec=30)
+        producer.stop()
         producer.free()
 
         wait_until(
@@ -315,6 +317,7 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
         wait_until(all_partitions_spilled, timeout_sec=180, backoff_sec=10)
 
         producer.wait(timeout_sec=60)
+        producer.stop()
         producer.free()
 
         wait_until(lambda: self._all_uploads_done(), timeout_sec=60, backoff_sec=5)
@@ -418,6 +421,7 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
 
         producer.start()
         producer.wait(timeout_sec=30)
+        producer.stop()
         producer.free()
 
         # wait for uploads from first
@@ -529,6 +533,7 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
             time.sleep(2)
 
         producer.wait(timeout_sec=120)
+        producer.stop()
         producer.free()
 
         self.logger.info(
@@ -1244,6 +1249,7 @@ class EndToEndSpilloverTest(RedpandaTest):
 
         producer.start()
         producer.wait()
+        producer.stop()
         producer.free()
 
         def all_partitions_spilled():
@@ -1268,6 +1274,7 @@ class EndToEndSpilloverTest(RedpandaTest):
         assert consumer.consumer_status.validator.invalid_reads == 0
         assert consumer.consumer_status.validator.valid_reads >= self.msg_count
 
+        consumer.stop()
         consumer.free()
 
     @cluster(num_nodes=4, log_allow_list=[r"cluster.*Can't add segment"])
@@ -1341,6 +1348,7 @@ class EndToEndThrottlingTest(RedpandaTest):
 
         producer.start()
         producer.wait()
+        producer.stop()
         producer.free()
 
         wait_until(self._all_uploads_done, timeout_sec=180, backoff_sec=10)
@@ -1366,7 +1374,7 @@ class EndToEndThrottlingTest(RedpandaTest):
 
         assert consumer.consumer_status.validator.invalid_reads == 0
         assert consumer.consumer_status.validator.valid_reads >= self.msg_count
-
+        consumer.stop()
         consumer.free()
 
         return consume_duration
@@ -1510,6 +1518,7 @@ class EndToEndHydrationTimeoutTest(EndToEndShadowIndexingBase):
         )
         producer.start()
         producer.wait(timeout_sec=300)
+        producer.stop()
         producer.free()
 
         original_snapshot = self.redpanda.storage(

--- a/tests/rptest/tests/follower_fetching_test.py
+++ b/tests/rptest/tests/follower_fetching_test.py
@@ -92,6 +92,7 @@ class FollowerFetchingTest(PreallocNodesTest):
         )
         producer.start()
         producer.wait()
+        producer.stop()
         producer.free()
 
     def get_node_metric(self, node, topic, metric):

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -639,6 +639,7 @@ class LogCompactionEnableSlidingWindow(RedpandaTest):
                 err_msg="Did not see any compacted segments.",
             )
 
+            producer.stop()
             producer.free()
 
             next_sliding_window_config = not next_sliding_window_config

--- a/tests/rptest/tests/offset_for_leader_epoch_archival_test.py
+++ b/tests/rptest/tests/offset_for_leader_epoch_archival_test.py
@@ -163,6 +163,7 @@ class OffsetForLeaderEpochArchivalTest(RedpandaTest):
 
         producer.start()
         producer.wait()
+        producer.stop()
         producer.free()
 
         def all_partitions_spilled():

--- a/tests/rptest/tests/partition_move_interruption_test.py
+++ b/tests/rptest/tests/partition_move_interruption_test.py
@@ -229,6 +229,8 @@ class PartitionMoveInterruption(PartitionMovementMixin, PreallocNodesTest):
 
         self.producer.wait()
         self.consumer.wait()
+        self.producer.stop()
+        self.consumer.stop()
 
     @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
     @matrix(
@@ -282,6 +284,8 @@ class PartitionMoveInterruption(PartitionMovementMixin, PreallocNodesTest):
 
         self.producer.wait()
         self.consumer.wait()
+        self.producer.stop()
+        self.consumer.stop()
 
     def increase_replication_factor(
         self, topic, partition, requested_replication_factor
@@ -374,6 +378,8 @@ class PartitionMoveInterruption(PartitionMovementMixin, PreallocNodesTest):
 
         self.producer.wait()
         self.consumer.wait()
+        self.producer.stop()
+        self.consumer.stop()
 
     @cluster(num_nodes=5)
     def test_cancelling_all_moves_in_cluster(self):
@@ -410,6 +416,8 @@ class PartitionMoveInterruption(PartitionMovementMixin, PreallocNodesTest):
         wait_until(lambda: len(admin.list_reconfigurations()) == 0, 60, 1)
         self.producer.wait()
         self.consumer.wait()
+        self.producer.stop()
+        self.consumer.stop()
 
     def is_moving_to_node(previous_replicas, current_replicas, id):
         return is_in_replica_set(current_replicas, id) and not is_in_replica_set(
@@ -483,6 +491,8 @@ class PartitionMoveInterruption(PartitionMovementMixin, PreallocNodesTest):
 
         self.producer.wait()
         self.consumer.wait()
+        self.producer.stop()
+        self.consumer.stop()
 
     def get_node_by_id(self, id):
         for n in self.redpanda.nodes:
@@ -563,6 +573,8 @@ class PartitionMoveInterruption(PartitionMovementMixin, PreallocNodesTest):
 
         self.producer.wait()
         self.consumer.wait()
+        self.producer.stop()
+        self.consumer.stop()
 
     # TODO: investigate slow startups in debug mode
     @skip_debug_mode
@@ -647,3 +659,5 @@ class PartitionMoveInterruption(PartitionMovementMixin, PreallocNodesTest):
 
         self.producer.wait()
         self.consumer.wait()
+        self.producer.stop()
+        self.consumer.stop()

--- a/tests/rptest/tests/random_node_operations_smoke_test.py
+++ b/tests/rptest/tests/random_node_operations_smoke_test.py
@@ -394,6 +394,7 @@ class RandomNodeOperationsBase(PreallocNodesTest):
             assert self.consumer.consumer_status.validator.invalid_reads == 0, (
                 f"Invalid reads in topic: {self.topic}, invalid reads count: {self.consumer.consumer_status.validator.invalid_reads}"
             )
+            self.consumer.stop()
             del self.consumer
 
             # Start a new consumer to read all data written
@@ -410,6 +411,8 @@ class RandomNodeOperationsBase(PreallocNodesTest):
             assert self.consumer.consumer_status.validator.invalid_reads == 0, (
                 f"Invalid reads in topic: {self.topic}, invalid reads count: {self.consumer.consumer_status.validator.invalid_reads}"
             )
+            self.consumer.stop()
+            self.producer.stop()
 
     def maybe_enable_iceberg_for_topic(
         self, topic_spec: TopicSpec, iceberg_enabled: bool

--- a/tests/rptest/tests/remote_label_test.py
+++ b/tests/rptest/tests/remote_label_test.py
@@ -127,6 +127,7 @@ class RemoteLabelsTest(RedpandaTest):
         )
         producer.start()
         producer.wait(timeout_sec=60)
+        producer.stop()
         producer.free()
 
     @cluster(num_nodes=3)

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -1028,6 +1028,7 @@ class BogusTimestampTest(EndToEndTest):
             )
             producer.start()
             producer.wait()
+            producer.stop()
             producer.free()
 
             # Write the rest of the messages with invalid timestamps
@@ -1042,6 +1043,7 @@ class BogusTimestampTest(EndToEndTest):
             )
             producer.start()
             producer.wait()
+            producer.stop()
         else:
             # Write msg_count messages with timestamps in the future
             producer = KgoVerifierProducer(
@@ -1055,6 +1057,7 @@ class BogusTimestampTest(EndToEndTest):
             )
             producer.start()
             producer.wait()
+            producer.stop()
 
         if not use_broker_timestamps:
             # We should have written the expected number of segments, and nothing can

--- a/tests/rptest/tests/rpk_consume_empty_partition_warning_test.py
+++ b/tests/rptest/tests/rpk_consume_empty_partition_warning_test.py
@@ -56,6 +56,7 @@ class RpkConsumeEmptyPartitionWarningTest(RedpandaTest):
         )
         producer.start()
         producer.wait()
+        producer.stop()
         producer.free()
 
         # Verify initial state

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -259,6 +259,11 @@ class KgoVerifierSelfTest(PreallocNodesTest):
         group_consumer.wait(timeout_sec=60)
         seq_consumer.wait(timeout_sec=60)
 
+        producer.stop()
+        rand_consumer.stop()
+        group_consumer.stop()
+        seq_consumer.stop()
+
     @skip_debug_mode  # Sends meaningful traffic, and not intended to test Redpanda
     @cluster(num_nodes=4)
     def test_kgo_verifier_multi(self):
@@ -339,6 +344,11 @@ class KgoVerifierSelfTest(PreallocNodesTest):
         rand_consumer.wait(timeout_sec=60)
         group_consumer.wait(timeout_sec=60)
 
+        producer.stop()
+        seq_consumer.stop()
+        rand_consumer.stop()
+        group_consumer.stop()
+
 
 class KgoVerifierMultiNodeSelfTest(PreallocNodesTest):
     def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any) -> None:
@@ -407,6 +417,9 @@ class KgoVerifierMultiNodeSelfTest(PreallocNodesTest):
         producer.wait(timeout_sec=60)
         seq_consumer.wait(timeout_sec=60)
 
+        producer.stop()
+        seq_consumer.stop()
+
     @skip_debug_mode
     @cluster(num_nodes=5)
     def test_kgo_verifier_multi_node_autoassign(self) -> None:
@@ -465,6 +478,9 @@ class KgoVerifierMultiNodeSelfTest(PreallocNodesTest):
 
         producer.wait(timeout_sec=60)
         seq_consumer.wait(timeout_sec=60)
+
+        producer.stop()
+        seq_consumer.stop()
 
 
 class BucketScrubSelfTest(RedpandaTest):

--- a/tests/rptest/tests/shadow_linking_rnot_test.py
+++ b/tests/rptest/tests/shadow_linking_rnot_test.py
@@ -161,6 +161,8 @@ class ClusterLinkingWorkloadWorker:
             self.logger.error(f"Workload for topic: {self.spec.topic} failed: {e}")
             success = False
             error = str(e)
+        finally:
+            self.verifier.stop_kgo_services()
         return ClusterLinkingWorkloadResult(self.spec.topic, success, error)
 
 

--- a/tests/rptest/tests/test_si_cache_space_leak.py
+++ b/tests/rptest/tests/test_si_cache_space_leak.py
@@ -127,6 +127,7 @@ class ShadowIndexingCacheSpaceLeakTest(RedpandaTest):
         self._consumer.start(clean=False)
 
         self._producer.wait()
+        self._producer.stop()
 
         # Verify that all files in cache are being closed
         def cache_files_closed():
@@ -156,6 +157,7 @@ class ShadowIndexingCacheSpaceLeakTest(RedpandaTest):
         wait_until(lambda: not cache_files_closed(), timeout_sec=30, backoff_sec=5)
 
         self._consumer.wait()
+        self._consumer.stop()
 
         assert self._producer.produce_status.acked >= num_messages
         assert (

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -331,6 +331,10 @@ class UpgradeBackToBackTest(PreallocNodesTest):
                 controller_snapshot = log_viewer.read_controller_snapshot(node=node)
                 self.logger.info(f"Read controller snapshot: {controller_snapshot}")
 
+        for consumer in self._consumers:
+            consumer.stop()
+        self._producer.stop()
+
 
 class UpgradeWithWorkloadTest(EndToEndTest):
     """
@@ -517,6 +521,7 @@ class UpgradeFromPriorFeatureVersionCloudStorageTest(RedpandaTest):
             )
             producer.start()
             producer.wait()
+            producer.stop()
             producer.free()
             expect_records[partition] += n_records
 

--- a/tests/rptest/tests/write_caching_fi_e2e_test.py
+++ b/tests/rptest/tests/write_caching_fi_e2e_test.py
@@ -125,6 +125,7 @@ class WriteCachingFailureInjectionE2ETest(RedpandaTest):
             assert total_lost == consumer.consumer_status.validator.lost_offsets["0"], (
                 f"kgo reported lost offset count mismatch: expected {total_lost}, got {consumer.consumer_status.validator.lost_offsets['0']}"
             )
+        consumer.stop()
 
     @cluster(num_nodes=5)
     def test_crash_all_with_consumer_group(self):


### PR DESCRIPTION
1. Better validation for compacted logs (avoid any false-negatives for keys produced to a log in a previous round of production)
2. Better detection of a failed/crashed KgoVerifierService (typically due to a `Panic()` call from a validation failure)
3. Go insane over the lack of `stop()` throughout our test suites with `KgoVerifierService`s

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
