### PR TITLE
metrics: add optional pass-through metrics injected by kubernetes

### DIFF
--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -91,6 +91,41 @@ ss::future<std::vector<ss::sstring>> get_fqdns(std::string_view hostname) {
 } // namespace
 
 namespace cluster {
+std::optional<metrics_reporter::kubernetes_metrics> get_kubernetes_metrics() {
+    cluster::metrics_reporter::kubernetes_metrics km;
+    bool any = false;
+
+    if (auto v = std::getenv("REDPANDA_METRICS_K8S_DEPLOYMENT_TYPE"); v && *v) {
+        km.deployment_type.emplace(v);
+        any = true;
+    }
+    if (auto v = std::getenv("REDPANDA_METRICS_K8S_CHART_VERSION"); v && *v) {
+        km.chart_version.emplace(v);
+        any = true;
+    }
+    if (auto v = std::getenv("REDPANDA_METRICS_K8S_OPERATOR_IMAGE_VERSION");
+        v && *v) {
+        km.operator_image_version.emplace(v);
+        any = true;
+    }
+    if (auto v = std::getenv("REDPANDA_METRICS_K8S_VERSION"); v && *v) {
+        km.k8s_version.emplace(v);
+        any = true;
+    }
+    if (auto v = std::getenv("REDPANDA_METRICS_K8S_ENVIRONMENT"); v && *v) {
+        km.k8s_environment.emplace(v);
+        any = true;
+    }
+    if (auto v = std::getenv("REDPANDA_METRICS_K8S_CLUSTER_ID"); v && *v) {
+        km.k8s_cluster_id.emplace(v);
+        any = true;
+    }
+
+    if (any) {
+        return km;
+    }
+    return std::nullopt;
+}
 
 namespace details {
 address parse_url(const ss::sstring& url) {
@@ -375,6 +410,10 @@ metrics_reporter::build_metrics_snapshot() {
     // Check if schema registry is shadowed
     snapshot.schema_registry_shadowed
       = _clfe->local().schema_registry_shadowing_active();
+
+    if (auto km = get_kubernetes_metrics(); km) {
+        snapshot.kubernetes.emplace(std::move(*km));
+    }
 
     co_return snapshot;
 }
@@ -686,6 +725,11 @@ void rjson_serialize(
     w.Key("fqdns");
     rjson_serialize(w, snapshot.fqdns);
 
+    if (snapshot.kubernetes.has_value()) {
+        w.Key("kubernetes");
+        rjson_serialize(w, snapshot.kubernetes.value());
+    }
+
     w.Key("number_of_active_shadow_links");
     w.Uint64(snapshot.number_of_active_shadow_links);
 
@@ -706,6 +750,37 @@ void rjson_serialize(
     w.Uint64(ds.free);
     w.Key("total");
     w.Uint64(ds.total);
+    w.EndObject();
+}
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w,
+  const cluster::metrics_reporter::kubernetes_metrics& km) {
+    w.StartObject();
+    if (km.deployment_type.has_value()) {
+        w.Key("deployment_type");
+        w.String(km.deployment_type.value());
+    }
+    if (km.chart_version.has_value()) {
+        w.Key("chart");
+        w.String(km.chart_version.value());
+    }
+    if (km.operator_image_version.has_value()) {
+        w.Key("operator_image");
+        w.String(km.operator_image_version.value());
+    }
+    if (km.k8s_version.has_value()) {
+        w.Key("version");
+        w.String(km.k8s_version.value());
+    }
+    if (km.k8s_environment.has_value()) {
+        w.Key("environment");
+        w.String(km.k8s_environment.value());
+    }
+    if (km.k8s_cluster_id.has_value()) {
+        w.Key("cluster_id");
+        w.String(km.k8s_cluster_id.value());
+    }
     w.EndObject();
 }
 

--- a/src/v/cluster/metrics_reporter.h
+++ b/src/v/cluster/metrics_reporter.h
@@ -87,6 +87,15 @@ public:
         std::vector<net::unresolved_address> advertised_listeners;
     };
 
+    struct kubernetes_metrics {
+        std::optional<ss::sstring> deployment_type;
+        std::optional<ss::sstring> chart_version;
+        std::optional<ss::sstring> operator_image_version;
+        std::optional<ss::sstring> k8s_version;
+        std::optional<ss::sstring> k8s_environment;
+        std::optional<ss::sstring> k8s_cluster_id;
+    };
+
     struct metrics_snapshot {
         ss::sstring cluster_uuid;
         ss::sstring storage_uuid;
@@ -123,6 +132,8 @@ public:
         uint32_t number_of_active_shadow_links{0};
         uint32_t number_of_shadow_topics{0};
         bool schema_registry_shadowed{false};
+
+        std::optional<kubernetes_metrics> kubernetes;
     };
     static constexpr ss::shard_id shard = 0;
 
@@ -177,6 +188,9 @@ private:
     ss::lowres_clock::time_point _last_success
       = ss::lowres_clock::time_point::min();
 };
+
+std::optional<metrics_reporter::kubernetes_metrics> get_kubernetes_metrics();
+
 } // namespace cluster
 namespace json {
 void rjson_serialize(
@@ -188,4 +202,7 @@ void rjson_serialize(
 void rjson_serialize(
   json::Writer<json::StringBuffer>& w,
   const cluster::metrics_reporter::node_metrics& v);
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w,
+  const cluster::metrics_reporter::kubernetes_metrics& v);
 } // namespace json

--- a/src/v/cluster/tests/metrics_reporter_test.cc
+++ b/src/v/cluster/tests/metrics_reporter_test.cc
@@ -63,3 +63,78 @@ BOOST_AUTO_TEST_CASE(test_invalid_url) {
     BOOST_REQUIRE_THROW(
       cluster::details::parse_url("vectorized.io"), std::invalid_argument);
 }
+
+void unset_all_kubernetes_env_vars() {
+    unsetenv("REDPANDA_METRICS_K8S_DEPLOYMENT_TYPE");
+    unsetenv("REDPANDA_METRICS_K8S_CHART_VERSION");
+    unsetenv("REDPANDA_METRICS_K8S_OPERATOR_IMAGE_VERSION");
+    unsetenv("REDPANDA_METRICS_K8S_VERSION");
+    unsetenv("REDPANDA_METRICS_K8S_ENVIRONMENT");
+    unsetenv("REDPANDA_METRICS_K8S_CLUSTER_ID");
+}
+
+BOOST_AUTO_TEST_CASE(test_kubernetes_metrics) {
+    unset_all_kubernetes_env_vars();
+    {
+        auto km = cluster::get_kubernetes_metrics();
+        BOOST_REQUIRE(!km.has_value());
+    }
+    // empty check
+    setenv("REDPANDA_METRICS_K8S_DEPLOYMENT_TYPE", "", 1);
+    setenv("REDPANDA_METRICS_K8S_CHART_VERSION", "", 1);
+    setenv("REDPANDA_METRICS_K8S_OPERATOR_IMAGE_VERSION", "", 1);
+    setenv("REDPANDA_METRICS_K8S_VERSION", "", 1);
+    setenv("REDPANDA_METRICS_K8S_ENVIRONMENT", "", 1);
+    setenv("REDPANDA_METRICS_K8S_CLUSTER_ID", "", 1);
+    {
+        auto km = cluster::get_kubernetes_metrics();
+        BOOST_REQUIRE(!km.has_value());
+    }
+    unset_all_kubernetes_env_vars();
+    setenv("REDPANDA_METRICS_K8S_DEPLOYMENT_TYPE", "operator", 1);
+    {
+        auto km = cluster::get_kubernetes_metrics();
+        BOOST_REQUIRE(km.has_value());
+        BOOST_REQUIRE_EQUAL(km->deployment_type.value(), "operator");
+    }
+    unset_all_kubernetes_env_vars();
+    setenv("REDPANDA_METRICS_K8S_CHART_VERSION", "1.2.3", 1);
+    {
+        auto km = cluster::get_kubernetes_metrics();
+        BOOST_REQUIRE(km.has_value());
+        BOOST_REQUIRE_EQUAL(km->chart_version.value(), "1.2.3");
+    }
+    unset_all_kubernetes_env_vars();
+    setenv(
+      "REDPANDA_METRICS_K8S_OPERATOR_IMAGE_VERSION",
+      "redpanda/operator:latest",
+      1);
+    {
+        auto km = cluster::get_kubernetes_metrics();
+        BOOST_REQUIRE(km.has_value());
+        BOOST_REQUIRE_EQUAL(
+          km->operator_image_version.value(), "redpanda/operator:latest");
+    }
+    unset_all_kubernetes_env_vars();
+    setenv("REDPANDA_METRICS_K8S_VERSION", "v1.24.0", 1);
+    {
+        auto km = cluster::get_kubernetes_metrics();
+        BOOST_REQUIRE(km.has_value());
+        BOOST_REQUIRE_EQUAL(km->k8s_version.value(), "v1.24.0");
+    }
+    unset_all_kubernetes_env_vars();
+    setenv("REDPANDA_METRICS_K8S_ENVIRONMENT", "azure", 1);
+    {
+        auto km = cluster::get_kubernetes_metrics();
+        BOOST_REQUIRE(km.has_value());
+        BOOST_REQUIRE_EQUAL(km->k8s_environment.value(), "azure");
+    }
+    unset_all_kubernetes_env_vars();
+    setenv("REDPANDA_METRICS_K8S_CLUSTER_ID", "cluster-1234", 1);
+    {
+        auto km = cluster::get_kubernetes_metrics();
+        BOOST_REQUIRE(km.has_value());
+        BOOST_REQUIRE_EQUAL(km->k8s_cluster_id.value(), "cluster-1234");
+    }
+    unset_all_kubernetes_env_vars();
+}


### PR DESCRIPTION
In order to track kubernetes usage metrics better that are tied to specific brokers, this patch adds the ability to specify environment variables set by Operator or Helm-based deployments that will be propagated in broker telemetry.

Environment variables were chosen for compatibility with older versions of Redpanda where the variables will silently be ignored.

The metrics published here are explicitly not tied directly to metrics that the operator itself will publish about resource utilization of particular Kubernetes primitives, rather the additional metrics involved are only related to the ecosystem in which the broker is run and tied directly to broker operation (i.e. including things like operator version which corresponds to sidecars run with each broker pod).

Related internal ticket: https://redpandadata.atlassian.net/browse/K8S-402

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
