### PR TITLE
Fix an UB in group blocking

### DIFF
--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -727,7 +727,9 @@ ss::future<result<model::offset>> group_manager::set_blocked_for_groups(
     // in case we return early with an exception or another error
     auto revert_blocking = ss::defer([p, &affected_gids, to_block] {
         if (to_block) {
-            p->blocked_groups.erase(affected_gids.begin(), affected_gids.end());
+            for (const auto& gid : affected_gids) {
+                p->blocked_groups.erase(gid);
+            }
         }
     });
     if (to_block) {
@@ -771,7 +773,9 @@ ss::future<result<model::offset>> group_manager::set_blocked_for_groups(
 
     // unblock only when replicated
     if (!to_block) {
-        p->blocked_groups.erase(affected_gids.cbegin(), affected_gids.cend());
+        for (const auto& gid : affected_gids) {
+            p->blocked_groups.erase(gid);
+        }
     }
 
     revert_blocking.cancel();

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -277,6 +277,7 @@ redpanda_cc_btest(
     cpu = 1,
     deps = [
         "//src/v/cluster",
+        "//src/v/container:chunked_vector",
         "//src/v/kafka/client:transport",
         "//src/v/kafka/protocol",
         "//src/v/kafka/protocol:describe_groups",

--- a/src/v/kafka/server/tests/consumer_groups_test.cc
+++ b/src/v/kafka/server/tests/consumer_groups_test.cc
@@ -10,6 +10,7 @@
 #include "cluster/controller.h"
 #include "cluster/controller_api.h"
 #include "cluster/security_frontend.h"
+#include "container/chunked_vector.h"
 #include "kafka/client/transport.h"
 #include "kafka/protocol/describe_groups.h"
 #include "kafka/protocol/errors.h"
@@ -377,6 +378,8 @@ FIXTURE_TEST(block_test, consumer_offsets_fixture) {
     model::topic t{"topic"};
     kafka::group_id g{"group"};
     kafka::group_instance_id gi("group-instance");
+    kafka::group_id ug1{"unrelated_group1"};
+    kafka::group_id ug2{"unrelated_group2"};
 
     add_topic(model::topic_namespace_view{model::kafka_namespace, t}).get();
     wait_for_consumer_offsets_topic(gi);
@@ -425,7 +428,12 @@ FIXTURE_TEST(block_test, consumer_offsets_fixture) {
 
     auto set_blocked = [&](bool blocked) {
         auto res = app._group_manager.local()
-                     .set_blocked_for_groups(gntp, {g}, blocked)
+                     .set_blocked_for_groups(
+                       gntp,
+                       // triggering a bug where the wrong group gets unblocked
+                       blocked ? chunked_vector<kafka::group_id>{ug1, g, ug2}
+                               : chunked_vector<kafka::group_id>{g},
+                       blocked)
                      .get();
         BOOST_REQUIRE(res.has_value());
     };


### PR DESCRIPTION
Not only chunked_hash_set and chunked_vector have mutually convertible iterators, but also using the wrong ones often works as expected!

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
