### PR TITLE
`ct/l1`: fix logic error in `get_contiguous_range_with_tombstones()`

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/state.cc
+++ b/src/v/cloud_topics/level_one/metastore/state.cc
@@ -173,6 +173,7 @@ compaction_state::get_contiguous_range_with_tombstones(
         }
         cur_tombstone_range_last = std::max(
           it->last_offset, cur_tombstone_range_last);
+        contiguous_next_offset = kafka::next_offset(it->last_offset);
         if (cur_tombstone_range_last >= last) {
             return tombstone_range_iters{
               .begin = last_le_base,

--- a/src/v/cloud_topics/level_one/metastore/tests/state_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_test.cc
@@ -367,3 +367,58 @@ TEST(CompactionStateTest, TestTruncateCleanedRanges) {
     };
     EXPECT_EQ(s.cleaned_ranges_with_tombstones, expected);
 }
+
+TEST(CompactionStateTest, TestContiguousTombstoneRangeMany) {
+    compaction_state s;
+    // Create many contiguous ranges:
+    // [0, 9], [10, 19], [20, 29], ..., [90, 99]
+    for (int i = 0; i < 10; ++i) {
+        s.cleaned_ranges_with_tombstones.insert(
+          tombstone_range(i * 10, i * 10 + 9, 1000));
+    }
+
+    // The full range [0, 99] should be contiguous.
+    ASSERT_TRUE(s.has_contiguous_range_with_tombstones(o{0}, o{99}));
+
+    // Any sub-range should also be contiguous.
+    ASSERT_TRUE(s.has_contiguous_range_with_tombstones(o{0}, o{50}));
+    ASSERT_TRUE(s.has_contiguous_range_with_tombstones(o{25}, o{75}));
+    ASSERT_TRUE(s.has_contiguous_range_with_tombstones(o{50}, o{99}));
+
+    // Erasing the full range should work.
+    ASSERT_TRUE(s.erase_contiguous_range_with_tombstones(o{0}, o{99}));
+    EXPECT_TRUE(s.cleaned_ranges_with_tombstones.empty());
+}
+
+TEST(CompactionStateTest, TestContiguousTombstoneRangeManyNonUniform) {
+    compaction_state s;
+    // Ranges with varying sizes, similar to real compaction output.
+    s.cleaned_ranges_with_tombstones = {
+      tombstone_range(120198, 120282, 1000),
+      tombstone_range(120283, 120383, 1000),
+      tombstone_range(120384, 120495, 1000),
+      tombstone_range(120496, 120597, 1000),
+      tombstone_range(120598, 120707, 1000),
+      tombstone_range(120708, 120796, 1000),
+      tombstone_range(120797, 120893, 1000),
+      tombstone_range(120894, 120992, 1000),
+      tombstone_range(120993, 121091, 1000),
+      tombstone_range(121092, 121184, 1000),
+      tombstone_range(121185, 121187, 1000),
+      tombstone_range(121188, 121268, 1000),
+      tombstone_range(121269, 121374, 1000),
+      tombstone_range(121375, 121485, 1000),
+      tombstone_range(121486, 121587, 1000),
+      tombstone_range(121588, 121693, 1000),
+      tombstone_range(121694, 121785, 1000),
+      tombstone_range(121786, 121881, 1000),
+      tombstone_range(121882, 121979, 1000),
+    };
+
+    // The full range [120198, 121979] should be contiguous.
+    ASSERT_TRUE(s.has_contiguous_range_with_tombstones(o{120198}, o{121979}));
+
+    // Erasing should work.
+    ASSERT_TRUE(s.erase_contiguous_range_with_tombstones(o{120198}, o{121979}));
+    EXPECT_TRUE(s.cleaned_ranges_with_tombstones.empty());
+}


### PR DESCRIPTION
From my `dev_cluster` run, I saw:

```
node-0: DEBUG 2026-01-07 22:34:33,118 [shard 4:main] cloud_topics - domain_manager.cc:181 - Rejecting request to replace objects: Tombstone-removed range [120198, 121979] for {5e23c7db-494e-4ea0-b5f7-eb4f91c95a14/13} is not tracked as having tombstones
node-0: DEBUG 2026-01-07 22:33:17,017 [shard 2:main] cloud_topics - leader_router.cc:259 - Processed local request for cloud_topics::l1::rpc::replace_objects_request as leader of {kafka_internal/ct_l1_domain/2}
node-2: WARN  2026-01-07 22:34:33,121 [shard 0:main] cloud_topics-compaction - committer.cc:335 - Could not commit metadata update {new_cleaned_ranges:[], removed_tombstone_ranges:{{120198 -> 121980}}, cleaned_at:{timestamp: 1767843273116}, expected_compaction_epoch: 30} for compaction of tidp {5e23c7db-494e-4ea0-b5f7-eb4f91c95a14/13}, job id a394d514-a933-4f46-a684-86a825a75271: metastore::errc::invalid_request. Retrying object update without metadata.
```

which seemed troubling, so I had Claude write an `l1_simple_stm` decoder, from which:

```
python deserialize_l1_snapshot.py --json /home/willem/redpanda/data/node0/data/kafka_internal/ct_l1_domain/2_40/l1_simple_stm.snapshot
```

and the relevant output from partition `13` is shown below:

https://gist.github.com/WillemKauf/a5093937f461907aa71279cc96def207

Clearly, this update was valid (all those cleaned ranges form a contiguous set from `[120198~121979]`). Turns out we were forgetting to re-assign `contiguous_next_offset` in `compaction_state::get_contiguous_range_with_tombstones()`. After fixing it and rebooting my dev cluster,

```
node-1: INFO  2026-01-07 23:09:30,734 [shard 4:main] cloud_topics-compaction - committer.cc:326 - Finalized compaction of tidp {5e23c7db-494e-4ea0-b5f7-eb4f91c95a14/13}, job id c8da3ada-e7fe-4c0c-9408-1fbfd946416f with compaction metadata update {new_cleaned_ranges:[], removed_tombstone_ranges:{{120198 -> 121980}}, cleaned_at:{timestamp: 1767845370721}, expected_compaction_epoch: 31}
```

:partying_face: 

Fix the bug and add two test cases Claude wrote (using the data provided above, no less) to prevent regressions

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
