### PR TITLE
Fix bug in `iobuf::operator<=>`

### DIFF
--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -197,8 +197,8 @@ std::strong_ordering iobuf::operator<=>(const iobuf& o) const {
                 rhs.remove_prefix(n);
                 if (rhs.empty()) {
                     rhs = other_next_view();
-                    if (o_it == o.cend()) {
-                        break;
+                    if (rhs.empty()) {
+                        return _size <=> o._size;
                     }
                 }
             }

--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -107,47 +107,8 @@ bool iobuf::operator==(const iobuf& o) const {
     if (_size != o._size) {
         return false;
     }
-    if (!_frags.empty() && !o._frags.empty()) {
-        std::string_view lhs{_frags.front()};
-        std::string_view rhs{o._frags.front()};
-        constexpr static size_t max_byte_for_byte_cmp = 4;
-        auto n = std::min({lhs.size(), rhs.size(), max_byte_for_byte_cmp});
-        for (size_t i = 0; i < n; ++i) {
-            if (lhs[i] != rhs[i]) {
-                return false;
-            }
-        }
-    }
-    // We know these have the same amount of bytes in them, but they might
-    // be chunked differently.
-    auto o_it = o.cbegin();
-    auto other_next_view = [&o, &o_it] -> std::string_view {
-        while (o_it != o.cend() && o_it->is_empty()) {
-            ++o_it;
-        }
-        if (o_it == o.cend()) {
-            return {};
-        }
-        std::string_view s{o_it->get(), o_it->size()};
-        ++o_it;
-        return s;
-    };
-    std::string_view rhs = other_next_view();
-    for (const auto& frag : *this) {
-        std::string_view lhs{frag.get(), frag.size()};
-        while (!lhs.empty()) {
-            auto n = std::min(lhs.size(), rhs.size());
-            if (lhs.substr(0, n) != rhs.substr(0, n)) {
-                return false;
-            }
-            lhs.remove_prefix(n);
-            rhs.remove_prefix(n);
-            if (rhs.empty()) {
-                rhs = other_next_view();
-            }
-        }
-    }
-    return true;
+
+    return (*this <=> o) == std::strong_ordering::equal;
 }
 
 bool iobuf::operator<(const iobuf& o) const {

--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -155,55 +155,63 @@ bool iobuf::operator<(const iobuf& o) const {
 }
 
 std::strong_ordering iobuf::operator<=>(const iobuf& o) const {
+    const auto next_view_fn = [](const iobuf& c) {
+        return [c_it = c.cbegin(), end_it = c.cend()] mutable {
+            while (c_it != end_it && c_it->is_empty()) {
+                ++c_it;
+            }
+            if (c_it == end_it) {
+                return std::string_view{};
+            }
+            std::string_view s{*c_it};
+            ++c_it;
+            return s;
+        };
+    };
+    auto this_next_view{next_view_fn(*this)};
+    auto other_next_view{next_view_fn(o)};
+
+    std::string_view lhs{this_next_view()};
+    std::string_view rhs{other_next_view()};
+
+    if (lhs.empty() || rhs.empty()) {
+        return _size <=> o._size;
+    }
+
     // Always check the first few bytes using byte for byte comparison,
     // this allows the case of relatively randomized data to be done quickly
     // but we still preserve the chunked checks that are faster if there is
     // a matching prefix.
-    if (!_frags.empty() && !o._frags.empty()) {
-        std::string_view lhs{_frags.front()};
-        std::string_view rhs{o._frags.front()};
-        constexpr static size_t max_byte_for_byte_cmp = 4;
-        auto n = std::min({lhs.size(), rhs.size(), max_byte_for_byte_cmp});
-        for (size_t i = 0; i < n; ++i) {
-            auto cmp = lhs[i] <=> rhs[i];
-            if (cmp != std::strong_ordering::equal) {
-                return cmp;
-            }
+    constexpr static size_t max_byte_for_byte_cmp = 4;
+    const auto n = std::min({lhs.size(), rhs.size(), max_byte_for_byte_cmp});
+    for (size_t i = 0; i < n; ++i) {
+        const auto cmp = lhs[i] <=> rhs[i];
+        if (cmp != std::strong_ordering::equal) {
+            return cmp;
         }
     }
-    auto o_it = o.cbegin();
-    auto other_next_view = [&o, &o_it] -> std::string_view {
-        while (o_it != o.cend() && o_it->is_empty()) {
-            ++o_it;
+
+    for (;;) {
+        const auto n = std::min(lhs.size(), rhs.size());
+        if (n == 0) {
+            break;
         }
-        if (o_it == o.cend()) {
-            return {};
+
+        const auto cmp = std::memcmp(lhs.data(), rhs.data(), n) <=> 0;
+        if (cmp != std::strong_ordering::equal) {
+            return cmp;
         }
-        std::string_view s{*o_it};
-        ++o_it;
-        return s;
-    };
-    std::string_view rhs = other_next_view();
-    if (!rhs.empty()) { // This prevents UB by using memcmp with nullptr
-        for (const auto& frag : *this) {
-            std::string_view lhs{frag};
-            while (!lhs.empty()) {
-                auto n = std::min(lhs.size(), rhs.size());
-                auto cmp = std::memcmp(lhs.data(), rhs.data(), n) <=> 0;
-                if (cmp != std::strong_ordering::equal) {
-                    return cmp;
-                }
-                lhs.remove_prefix(n);
-                rhs.remove_prefix(n);
-                if (rhs.empty()) {
-                    rhs = other_next_view();
-                    if (rhs.empty()) {
-                        return _size <=> o._size;
-                    }
-                }
-            }
+
+        lhs.remove_prefix(n);
+        if (lhs.empty()) {
+            lhs = this_next_view();
+        }
+        rhs.remove_prefix(n);
+        if (rhs.empty()) {
+            rhs = other_next_view();
         }
     }
+
     return _size <=> o._size;
 }
 

--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <iostream>
 #include <limits>
+#include <string_view>
 
 std::ostream& operator<<(std::ostream& o, const iobuf& io) {
     return o << "{bytes=" << io.size_bytes()
@@ -116,6 +117,25 @@ bool iobuf::operator<(const iobuf& o) const {
 }
 
 std::strong_ordering iobuf::operator<=>(const iobuf& o) const {
+    if (empty() || o.empty()) {
+        return _size <=> o._size;
+    }
+
+    // Always check the first few bytes using byte for byte comparison,
+    // this allows the case of relatively randomized data to be done quickly
+    // but we still preserve the chunked checks that are faster if there is
+    // a matching prefix.
+    std::string_view lhs{_frags.front()};
+    std::string_view rhs{o._frags.front()};
+    constexpr static size_t max_byte_for_byte_cmp = 4;
+    const auto n = std::min({lhs.size(), rhs.size(), max_byte_for_byte_cmp});
+    for (size_t i = 0; i < n; ++i) {
+        const auto cmp = lhs[i] <=> rhs[i];
+        if (cmp != std::strong_ordering::equal) {
+            return cmp;
+        }
+    }
+
     const auto next_view_fn = [](const iobuf& c) {
         return [c_it = c.cbegin(), end_it = c.cend()] mutable {
             while (c_it != end_it && c_it->is_empty()) {
@@ -132,32 +152,10 @@ std::strong_ordering iobuf::operator<=>(const iobuf& o) const {
     auto this_next_view{next_view_fn(*this)};
     auto other_next_view{next_view_fn(o)};
 
-    std::string_view lhs{this_next_view()};
-    std::string_view rhs{other_next_view()};
-
-    if (lhs.empty() || rhs.empty()) {
-        return _size <=> o._size;
-    }
-
-    // Always check the first few bytes using byte for byte comparison,
-    // this allows the case of relatively randomized data to be done quickly
-    // but we still preserve the chunked checks that are faster if there is
-    // a matching prefix.
-    constexpr static size_t max_byte_for_byte_cmp = 4;
-    const auto n = std::min({lhs.size(), rhs.size(), max_byte_for_byte_cmp});
-    for (size_t i = 0; i < n; ++i) {
-        const auto cmp = lhs[i] <=> rhs[i];
-        if (cmp != std::strong_ordering::equal) {
-            return cmp;
-        }
-    }
-
+    lhs = this_next_view();
+    rhs = other_next_view();
     for (;;) {
         const auto n = std::min(lhs.size(), rhs.size());
-        if (n == 0) {
-            break;
-        }
-
         const auto cmp = std::memcmp(lhs.data(), rhs.data(), n) <=> 0;
         if (cmp != std::strong_ordering::equal) {
             return cmp;
@@ -166,10 +164,16 @@ std::strong_ordering iobuf::operator<=>(const iobuf& o) const {
         lhs.remove_prefix(n);
         if (lhs.empty()) {
             lhs = this_next_view();
+            if (lhs.empty()) {
+                break;
+            }
         }
         rhs.remove_prefix(n);
         if (rhs.empty()) {
             rhs = other_next_view();
+            if (rhs.empty()) {
+                break;
+            }
         }
     }
 

--- a/src/v/bytes/tests/iobuf_tests.cc
+++ b/src/v/bytes/tests/iobuf_tests.cc
@@ -99,6 +99,10 @@ SEASTAR_THREAD_TEST_CASE(test_cmp_str_view) {
       std::strong_ordering::equal, (multiple_frags.share(0, 3) <=> "cat"));
     BOOST_CHECK_LT(iobuf::from(""), iobuf::from("cat"));
     BOOST_CHECK_GT(iobuf::from("cat"), iobuf::from(""));
+    auto multi_frags = iobuf::from("ab");
+    multi_frags.append_fragments(iobuf::from("d"));
+    BOOST_CHECK_EQUAL(
+      true, (iobuf::from("abc") <=> multi_frags) == std::strong_ordering::less);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_appended_data_is_retained) {


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Currently `iobuf::operator<=>(const iobuf& rhs)` will always skip the last `rhs` fragment in cases where `rhs` has more than one fragment. This PR fixes that and tries to simplify the logic in both the `<=>` operator and the `==` operator in an attempt to make the code more readable and less error-prone.

A follow-up PR will enhance the iobuf fuzzer to better test the `<=>` operator along with a few other iobuf methods.
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
