### PR TITLE
CORE-15178 SR Context: store + sharded_store context-aware

### DIFF
--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -203,6 +203,7 @@ redpanda_cc_gtest(
         "//src/v/schema/tests:fake_registry",
         "//src/v/test_utils:gtest",
         "//src/v/utils:vint",
+        "@abseil-cpp//absl/container:flat_hash_map",
         "@googletest//:gtest",
     ],
 )

--- a/src/v/datalake/tests/record_generator.cc
+++ b/src/v/datalake/tests/record_generator.cc
@@ -31,8 +31,9 @@
 
 namespace datalake::tests {
 
-ss::future<
-  checked<pandaproxy::schema_registry::schema_id, record_generator::error>>
+ss::future<checked<
+  pandaproxy::schema_registry::context_schema_id,
+  record_generator::error>>
 record_generator::register_avro_schema(
   std::string_view name, std::string_view schema) {
     using namespace pandaproxy::schema_registry;
@@ -100,11 +101,11 @@ record_generator::add_random_protobuf_record(
     if (it == _id_by_name.end()) {
         co_return error{fmt::format("Schema {} is missing", name)};
     }
-    auto schema_id = it->second;
-    auto schema_def = co_await _sr->get_valid_schema(schema_id);
+    auto ctx_schema_id = it->second;
+    auto schema_def = co_await _sr->get_valid_schema(ctx_schema_id);
     if (!schema_def) {
-        co_return error{
-          fmt::format("Unable to find schema def for id: {}", schema_id)};
+        co_return error{fmt::format(
+          "Unable to find schema def for id: {}", ctx_schema_id.id)};
     }
     if (schema_def->type() != schema_type::protobuf) {
         co_return error{fmt::format(
@@ -132,12 +133,12 @@ record_generator::add_random_protobuf_record(
     if (md_res.has_error()) {
         co_return error{fmt::format(
           "Wasn't able to get descriptor for protobuf def with id: {}",
-          schema_id)};
+          ctx_schema_id.id)};
     }
 
     iobuf val;
     val.append("\0", 1);
-    int32_t encoded_id = ss::cpu_to_be(schema_id());
+    int32_t encoded_id = ss::cpu_to_be(ctx_schema_id.id());
     val.append((const uint8_t*)(&encoded_id), 4);
 
     testing::protobuf_generator pb_gen(config);
@@ -161,10 +162,11 @@ record_generator::add_random_avro_record(
     if (it == _id_by_name.end()) {
         co_return error{fmt::format("Schema {} is missing", name)};
     }
-    auto schema_id = it->second;
-    auto schema_def_res = co_await _sr->get_valid_schema(schema_id);
+    auto ctx_schema_id = it->second;
+    auto schema_def_res = co_await _sr->get_valid_schema(ctx_schema_id);
     if (!schema_def_res.has_value()) {
-        co_return error{fmt::format("Schema {} not in store", schema_id)};
+        co_return error{
+          fmt::format("Schema {} not in store", ctx_schema_id.id)};
     }
     auto& schema_def = schema_def_res.value();
     if (schema_def.type() != schema_type::avro) {
@@ -173,7 +175,7 @@ record_generator::add_random_avro_record(
     }
     iobuf val;
     val.append("\0", 1);
-    int32_t encoded_id = ss::cpu_to_be(schema_id());
+    int32_t encoded_id = ss::cpu_to_be(ctx_schema_id.id());
     val.append((const uint8_t*)(&encoded_id), 4);
 
     avro::NodePtr node_ptr;

--- a/src/v/datalake/tests/record_generator.h
+++ b/src/v/datalake/tests/record_generator.h
@@ -35,7 +35,7 @@ public:
     using error = named_type<ss::sstring, struct error_tag>;
 
     // Registers the given schema with the given name.
-    ss::future<checked<pandaproxy::schema_registry::schema_id, error>>
+    ss::future<checked<pandaproxy::schema_registry::context_schema_id, error>>
     register_avro_schema(std::string_view name, std::string_view schema);
 
     // Registers the given schema with the given name.
@@ -60,7 +60,7 @@ public:
 private:
     chunked_hash_map<
       ss::sstring,
-      pandaproxy::schema_registry::schema_id,
+      pandaproxy::schema_registry::context_schema_id,
       sstring_hash,
       sstring_eq>
       _id_by_name;

--- a/src/v/datalake/tests/record_multiplexer_test.cc
+++ b/src/v/datalake/tests/record_multiplexer_test.cc
@@ -464,19 +464,19 @@ TEST_F(RecordMultiplexerTest, TestBadData) {
     auto reg_res
       = gen.register_avro_schema("avro_v1", avro_schema_v1_str).get();
     EXPECT_FALSE(reg_res.has_error()) << reg_res.error();
-    auto schema_id = reg_res.value();
+    auto ctx_schema_id = reg_res.value();
 
     auto start_offset = model::offset{0};
     record_multiplexer::finished_files files;
     auto res = mux(
       default_param,
       start_offset,
-      [schema_id](storage::record_batch_builder& b) {
+      [ctx_schema_id](storage::record_batch_builder& b) {
           iobuf buf;
           // Append data with a magic bytes that corresponds to the actual
           // schema.
           buf.append("\0", 1);
-          int32_t encoded_id = ss::cpu_to_be(schema_id());
+          int32_t encoded_id = ss::cpu_to_be(ctx_schema_id.id());
           buf.append((const uint8_t*)(&encoded_id), 4);
           buf.append("\1\1\1", 3);
           b.add_raw_kv(std::nullopt, std::move(buf));

--- a/src/v/datalake/tests/record_schema_resolver_test.cc
+++ b/src/v/datalake/tests/record_schema_resolver_test.cc
@@ -21,7 +21,6 @@
 #include <gtest/gtest.h>
 
 #include <exception>
-#include <unordered_map>
 #include <variant>
 
 using namespace pandaproxy::schema_registry;
@@ -536,7 +535,7 @@ namespace {
 struct counting_store : public pandaproxy::schema_registry::schema_getter {
     counting_store(
       schema::fake_registry& registry,
-      std::unordered_map<pandaproxy::schema_registry::schema_id, size_t>&
+      absl::flat_hash_map<pandaproxy::schema_registry::schema_id, size_t>&
         counts)
       : registry(registry)
       , counts(counts) {}
@@ -565,7 +564,7 @@ struct counting_store : public pandaproxy::schema_registry::schema_getter {
     }
 
     schema::fake_registry& registry;
-    std::unordered_map<pandaproxy::schema_registry::schema_id, size_t>& counts;
+    absl::flat_hash_map<pandaproxy::schema_registry::schema_id, size_t>& counts;
 };
 
 class counting_registry : public schema::registry {
@@ -614,7 +613,7 @@ public:
 
 private:
     schema::fake_registry _registry{};
-    std::unordered_map<pandaproxy::schema_registry::schema_id, size_t>
+    absl::flat_hash_map<pandaproxy::schema_registry::schema_id, size_t>
       _counts{};
     mutable counting_store _store{_registry, _counts};
 };

--- a/src/v/datalake/tests/record_schema_resolver_test.cc
+++ b/src/v/datalake/tests/record_schema_resolver_test.cc
@@ -7,6 +7,7 @@
  *
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
+#include "absl/container/flat_hash_map.h"
 #include "base/vassert.h"
 #include "bytes/bytes.h"
 #include "config/property.h"
@@ -97,42 +98,42 @@ public:
                                     schema_definition{
                                       avro_record_schema, schema_type::avro}})
                                 .get();
-        ASSERT_EQ(1, avro_schema_id());
+        ASSERT_EQ(1, avro_schema_id.id());
         auto pb_schema_id = sr->create_schema(
                                 subject_schema{
                                   subject{"foo-value"},
                                   schema_definition{
                                     pb_record_schema, schema_type::protobuf}})
                               .get();
-        ASSERT_EQ(2, pb_schema_id());
+        ASSERT_EQ(2, pb_schema_id.id());
         auto json_schema_id = sr->create_schema(
                                   subject_schema{
                                     subject{"foo-value"},
                                     schema_definition{
                                       json_record_schema, schema_type::json}})
                                 .get();
-        ASSERT_EQ(3, json_schema_id());
+        ASSERT_EQ(3, json_schema_id.id());
         avro_schema_id = sr->create_schema(
                              subject_schema{
                                subject{"latest-avro"},
                                schema_definition{
                                  avro_record_schema, schema_type::avro}})
                            .get();
-        ASSERT_EQ(1, avro_schema_id());
+        ASSERT_EQ(1, avro_schema_id.id());
         pb_schema_id = sr->create_schema(
                            subject_schema{
                              subject{"latest-proto"},
                              schema_definition{
                                pb_record_schema, schema_type::protobuf}})
                          .get();
-        ASSERT_EQ(2, pb_schema_id());
+        ASSERT_EQ(2, pb_schema_id.id());
         json_schema_id = sr->create_schema(
                              subject_schema{
                                subject{"latest-json"},
                                schema_definition{
                                  json_record_schema, schema_type::json}})
                            .get();
-        ASSERT_EQ(3, json_schema_id());
+        ASSERT_EQ(3, json_schema_id.id());
     }
     std::unique_ptr<schema::fake_registry> sr;
 };
@@ -260,7 +261,7 @@ message NestedMessage {
                               schema_definition{
                                 pb_simple_schema, schema_type::protobuf}})
                           .get();
-    ASSERT_EQ(7, pb_schema_id());
+    ASSERT_EQ(7, pb_schema_id.id());
     pb_schema_id = sr->create_schema(
                        subject_schema{
                          subject{"references_schema"},
@@ -273,7 +274,7 @@ message NestedMessage {
                              .version = schema_version{0}}},
                            std::optional<schema_metadata>{}}})
                      .get();
-    ASSERT_EQ(8, pb_schema_id());
+    ASSERT_EQ(8, pb_schema_id.id());
     std::vector<int32_t> pb_offsets{};
     iobuf buf;
     buf.append("\0\0\0\0\10", 5);
@@ -535,13 +536,14 @@ namespace {
 struct counting_store : public pandaproxy::schema_registry::schema_getter {
     counting_store(
       schema::fake_registry& registry,
-      absl::flat_hash_map<pandaproxy::schema_registry::schema_id, size_t>&
-        counts)
+      absl::flat_hash_map<
+        pandaproxy::schema_registry::context_schema_id,
+        size_t>& counts)
       : registry(registry)
       , counts(counts) {}
 
     ss::future<pandaproxy::schema_registry::stored_schema> get_subject_schema(
-      pandaproxy::schema_registry::subject sub,
+      pandaproxy::schema_registry::context_subject sub,
       std::optional<pandaproxy::schema_registry::schema_version> version,
       pandaproxy::schema_registry::include_deleted inc_dec) final {
         auto* getter = co_await registry.getter();
@@ -549,7 +551,8 @@ struct counting_store : public pandaproxy::schema_registry::schema_getter {
     }
 
     ss::future<pandaproxy::schema_registry::schema_definition>
-    get_schema_definition(pandaproxy::schema_registry::schema_id id) final {
+    get_schema_definition(
+      pandaproxy::schema_registry::context_schema_id id) final {
         counts[id] += 1;
         auto* getter = co_await registry.getter();
         co_return co_await getter->get_schema_definition(id);
@@ -557,14 +560,15 @@ struct counting_store : public pandaproxy::schema_registry::schema_getter {
 
     ss::future<std::optional<pandaproxy::schema_registry::schema_definition>>
     maybe_get_schema_definition(
-      pandaproxy::schema_registry::schema_id id) final {
+      pandaproxy::schema_registry::context_schema_id id) final {
         counts[id] += 1;
         auto* getter = co_await registry.getter();
         co_return co_await getter->maybe_get_schema_definition(id);
     }
 
     schema::fake_registry& registry;
-    absl::flat_hash_map<pandaproxy::schema_registry::schema_id, size_t>& counts;
+    absl::flat_hash_map<pandaproxy::schema_registry::context_schema_id, size_t>&
+      counts;
 };
 
 class counting_registry : public schema::registry {
@@ -585,18 +589,18 @@ public:
     }
     ss::future<pandaproxy::schema_registry::schema_definition>
     get_schema_definition(
-      pandaproxy::schema_registry::schema_id id) const override {
+      pandaproxy::schema_registry::context_schema_id id) const override {
         return _store.get_schema_definition(id);
     }
 
     ss::future<pandaproxy::schema_registry::stored_schema> get_subject_schema(
-      pandaproxy::schema_registry::subject sub,
+      pandaproxy::schema_registry::context_subject sub,
       std::optional<pandaproxy::schema_registry::schema_version> version)
       const override {
         return _registry.get_subject_schema(sub, version);
     }
 
-    ss::future<pandaproxy::schema_registry::schema_id> create_schema(
+    ss::future<pandaproxy::schema_registry::context_schema_id> create_schema(
       pandaproxy::schema_registry::subject_schema unparsed) override {
         return _registry.create_schema(std::move(unparsed));
     }
@@ -605,7 +609,7 @@ public:
         return _registry.get_all();
     }
 
-    size_t get_count(pandaproxy::schema_registry::schema_id id) {
+    size_t get_count(pandaproxy::schema_registry::context_schema_id id) {
         return _counts[id];
     }
 
@@ -613,7 +617,7 @@ public:
 
 private:
     schema::fake_registry _registry{};
-    absl::flat_hash_map<pandaproxy::schema_registry::schema_id, size_t>
+    absl::flat_hash_map<pandaproxy::schema_registry::context_schema_id, size_t>
       _counts{};
     mutable counting_store _store{_registry, _counts};
 };
@@ -631,14 +635,14 @@ std::unique_ptr<counting_registry> make_counting_sr() {
                                 schema_definition{
                                   avro_record_schema, schema_type::avro}})
                             .get();
-    vassert(1 == avro_schema_id(), "failed to registry avro schema");
+    vassert(1 == avro_schema_id.id(), "failed to registry avro schema");
     auto pb_schema_id = sr->create_schema(
                             subject_schema{
                               subject{"foo-value"},
                               schema_definition{
                                 pb_record_schema, schema_type::protobuf}})
                           .get();
-    vassert(2 == pb_schema_id(), "failed to register protobuf schema");
+    vassert(2 == pb_schema_id.id(), "failed to register protobuf schema");
 
     auto get_simple_schema = [](int i) {
         constexpr std::string_view schema_temp = R"(
@@ -656,7 +660,7 @@ std::unique_ptr<counting_registry> make_counting_sr() {
                                     get_simple_schema(i),
                                     schema_type::protobuf}})
                               .get();
-        vassert(i == pb_schema_id(), "failed to register protobuf schema");
+        vassert(i == pb_schema_id.id(), "failed to register protobuf schema");
     }
     auto json_schema_id = sr->create_schema(
                               subject_schema{
@@ -664,7 +668,7 @@ std::unique_ptr<counting_registry> make_counting_sr() {
                                 schema_definition{
                                   json_record_schema, schema_type::json}})
                             .get();
-    vassert(10 == json_schema_id(), "failed to register json schema");
+    vassert(10 == json_schema_id.id(), "failed to register json schema");
     return sr;
 }
 } // namespace

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -170,7 +170,9 @@ std::error_code make_error_code(error_code e) {
 }
 
 error_info no_reference_found_for(
-  const subject_schema& schema, const subject& sub, schema_version ver) {
+  const subject_schema& schema,
+  const context_subject& sub,
+  schema_version ver) {
     // fmt v8 doesn't support formatting for elements in a range
     auto fmt_refs = schema.def().refs()
                     | std::views::transform([](const auto& ref) {
@@ -184,13 +186,13 @@ error_info no_reference_found_for(
         "{{subject={},version=0,id=-1,schemaType={},references=[{}],metadata="
         "null,ruleSet=null,schema={}}} with refs [{}] of type {}, details: No "
         "schema reference found for subject \"{}\" and version {}",
-        schema.sub()(),
+        schema.sub(),
         to_string_view(schema.def().type()),
         fmt::join(fmt_refs, ", "),
         parser.read_string(parser.bytes_left()),
         fmt::join(fmt_refs, ", "),
         to_string_view(schema.type()),
-        sub(),
+        sub,
         ver())};
 }
 

--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -68,59 +68,61 @@ inline error_info not_found(schema_id id) {
       fmt::format("Schema {} not found", id())};
 }
 
-inline error_info not_found(const subject& sub) {
+inline error_info not_found(const context_subject& sub) {
     return error_info{
       error_code::subject_not_found,
-      fmt::format("Subject '{}' not found.", sub())};
+      fmt::format("Subject '{}' not found.", sub)};
 }
 
-inline error_info not_found(const subject& sub, mode) {
+inline error_info not_found(const context_subject& sub, mode) {
     return error_info{
       error_code::mode_not_found,
       fmt::format(
-        "Subject '{}' does not have subject-level mode configured.", sub())};
+        "Subject '{}' does not have subject-level mode configured.", sub)};
 }
 
-inline error_info not_found(const subject&, schema_version id) {
+inline error_info not_found(const context_subject&, schema_version version) {
     return error_info{
       error_code::subject_version_not_found,
-      fmt::format("Version {} not found.", id())};
+      fmt::format("Version {} not found.", version())};
 }
 
-inline error_info soft_deleted(const subject& sub) {
+inline error_info soft_deleted(const context_subject& sub) {
     return error_info{
       error_code::subject_soft_deleted,
       fmt::format(
         "Subject '{}' was soft deleted.Set permanent=true to delete "
         "permanently",
-        sub())};
+        sub)};
 }
 
-inline error_info not_deleted(const subject& sub) {
+inline error_info not_deleted(const context_subject& sub) {
     return error_info{
       error_code::subject_not_deleted,
       fmt::format(
         "Subject '{}' was not deleted first before being permanently deleted",
-        sub())};
+        sub)};
 }
 
-inline error_info soft_deleted(const subject& sub, schema_version version) {
+inline error_info
+soft_deleted(const context_subject& sub, schema_version version) {
     return error_info{
       error_code::subject_version_soft_deleted,
       fmt::format(
         "Subject '{}' Version {} was soft deleted.Set permanent=true to "
         "delete permanently",
-        sub(),
+        sub,
         version())};
 }
 
-inline error_info not_deleted(const subject& sub, schema_version version) {
+inline error_info
+not_deleted(const context_subject& sub, schema_version version) {
     return error_info{
       error_code::subject_version_not_deleted,
       fmt::format(
         "Subject '{}' Version {} was not deleted first before being "
         "permanently deleted",
-        sub(),
+        sub,
         version())};
 }
 
@@ -139,10 +141,10 @@ inline error_info schema_version_invalid(ss::sstring v) {
         v)};
 }
 
-inline error_info invalid_subject_schema(const subject& sub) {
+inline error_info invalid_subject_schema(const context_subject& sub) {
     return {
       error_code::subject_schema_invalid,
-      fmt::format("Error while looking up schema under subject {}", sub())};
+      fmt::format("Error while looking up schema under subject {}", sub)};
 }
 
 inline error_info invalid_schema(const subject_schema& schema) {
@@ -154,57 +156,65 @@ inline error_info invalid_schema(std::string msg) {
     return {error_code::schema_invalid, std::move(msg)};
 }
 
-inline error_info has_references(const subject& sub, schema_version ver) {
+inline error_info
+has_references(const context_subject& sub, schema_version ver) {
     return {
       error_code::subject_version_has_references,
       fmt::format(
         "One or more references exist to the schema "
         "{{magic=1,keytype=SCHEMA,subject={},version={}}}",
-        sub(),
+        sub,
         ver())};
 }
 
 error_info no_reference_found_for(
-  const subject_schema& schema, const subject& sub, schema_version ver);
+  const subject_schema& schema, const context_subject& sub, schema_version ver);
 
-inline error_info compatibility_not_found(const subject& sub) {
+inline error_info compatibility_not_found(const context_subject& sub) {
     return error_info{
       error_code::compatibility_not_found,
       fmt::format(
         "Subject '{}' does not have subject-level compatibility configured",
-        sub())};
+        sub)};
 }
 
-inline error_info mode_not_found(const subject& sub) {
+inline error_info mode_not_found(const context_subject& sub) {
     return error_info{
       error_code::mode_not_found,
       fmt::format(
-        "Subject '{}' does not have subject-level mode configured", sub())};
+        "Subject '{}' does not have subject-level mode configured", sub)};
 }
 
-inline error_info mode_not_readwrite(const subject& sub) {
+inline error_info mode_not_readwrite(const context_subject& sub) {
     return error_info{
       error_code::subject_version_operation_not_permitted,
-      fmt::format("Subject {} is not in read-write mode", sub())};
+      fmt::format("Subject {} is not in read-write mode", sub)};
 }
 
-inline error_info mode_not_import(const subject& sub) {
+inline error_info mode_not_import(const context_subject& sub) {
     return error_info{
       error_code::subject_version_operation_not_permitted,
-      fmt::format("Subject {} is not in import mode", sub())};
+      fmt::format("Subject {} is not in import mode", sub)};
 }
 
-inline error_info mode_is_readonly(const std::optional<subject>& sub) {
+inline error_info
+mode_is_readonly(const context& ctx, const std::optional<subject>& sub) {
     return error_info{
       error_code::subject_version_operation_not_permitted,
       fmt::format(
-        "Subject {} is in read-only mode", sub.value_or(subject{"null"}))};
+        "Subject {} in context {} is in read-only mode",
+        sub.value_or(subject{"null"}),
+        ctx)};
 }
 
-inline error_info versions_exhausted(const subject& sub) {
+inline error_info mode_is_readonly(const context_subject& ctx) {
+    return mode_is_readonly(ctx.ctx, ctx.sub);
+}
+
+inline error_info versions_exhausted(const context_subject& sub) {
     return error_info{
       error_code::version_exhausted,
-      fmt::format("Versions exhausted for subject {}", sub())};
+      fmt::format("Versions exhausted for subject {}", sub)};
 }
 
 inline error_info format_not_supported(const output_format f) {

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -50,6 +50,8 @@ namespace pandaproxy::schema_registry {
 
 using server = ctx_server<service>;
 
+namespace {
+
 void parse_accept_header(const server::request_t& rq, server::reply_t& rp) {
     static const std::vector<ppj::serialization_format> headers{
       ppj::serialization_format::schema_registry_v1_json,
@@ -142,6 +144,26 @@ ss::future<subject_schema> make_canonical_schema_with_metadata(
     co_return schema;
 }
 
+chunked_vector<subject>
+to_non_context_subjects(chunked_vector<context_subject> subjects) {
+    // TODO: use context_subject's for authz later, for now, use this
+    // inefficient mapping to help with gradual source migration
+    return std::move(subjects) | std::views::as_rvalue
+           | std::ranges::views::transform(
+             [](context_subject&& ctx_sub) { return std::move(ctx_sub).sub; })
+           | std::ranges::to<chunked_vector<subject>>();
+}
+
+chunked_vector<schema_id>
+to_non_context_schema_ids(const chunked_vector<context_schema_id>& ids) {
+    return ids
+           | std::ranges::views::transform(
+             [](const context_schema_id& ctx_id) { return ctx_id.id; })
+           | std::ranges::to<chunked_vector<schema_id>>();
+}
+
+} // namespace
+
 ss::future<server::reply_t>
 get_config(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
@@ -149,7 +171,8 @@ get_config(server::request_t rq, server::reply_t rp) {
     // Ensure we see latest writes
     co_await rq.service().writer().read_sync();
 
-    auto res = co_await rq.service().schema_store().get_compatibility();
+    auto res = co_await rq.service().schema_store().get_compatibility(
+      default_context);
 
     auto resp = ppj::rjson_serialize_iobuf(get_config_req_rep{.compat = res});
     log_response(*rq.req, resp);
@@ -274,7 +297,7 @@ ss::future<server::reply_t> get_mode(server::request_t rq, server::reply_t rp) {
     // Ensure we see latest writes
     co_await rq.service().writer().read_sync();
 
-    auto res = co_await rq.service().schema_store().get_mode();
+    auto res = co_await rq.service().schema_store().get_mode(default_context);
 
     auto resp = ppj::rjson_serialize_iobuf(mode_req_rep{.mode = res});
     log_response(*rq.req, resp);
@@ -385,8 +408,9 @@ ss::future<server::reply_t> get_schemas_ids_id(
     const auto format = parse_output_format(*rq.req);
 
     co_await rq.service().writer().read_sync();
-    auto subjects = co_await rq.service().schema_store().get_schema_subjects(
-      id, include_deleted::yes);
+    auto subjects = to_non_context_subjects(
+      co_await rq.service().schema_store().get_schema_subjects(
+        id, include_deleted::yes));
 
     enterprise::handle_get_schemas_ids_id_authz(rq, auth_result, subjects);
 
@@ -441,8 +465,10 @@ ss::future<ctx_server<service>::reply_t> get_schemas_ids_id_subjects(
     // Force early 40403 if the schema id isn't found
     co_await rq.service().schema_store().get_schema_definition(id);
 
-    auto resp = ppj::rjson_serialize_iobuf(
+    auto subjects = to_non_context_subjects(
       co_await rq.service().schema_store().get_schema_subjects(id, incl_del));
+
+    auto resp = ppj::rjson_serialize_iobuf(std::move(subjects));
     log_response(*rq.req, resp);
     rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;
@@ -462,8 +488,9 @@ ss::future<server::reply_t> get_subjects(
     // List-type request: must ensure we see latest writes
     co_await rq.service().writer().read_sync();
 
-    auto res = co_await rq.service().schema_store().get_subjects(
-      inc_del, subject_prefix);
+    auto res = to_non_context_subjects(
+      co_await rq.service().schema_store().get_subjects(
+        inc_del, subject_prefix));
 
     // Handle AuthZ - Filters res for the subjects the user is allowed to see
     enterprise::handle_get_subjects_authz(rq, auth_result, res);
@@ -599,7 +626,8 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
     co_await st.validate_schema(schema.schema.share());
 
     // Determine if the definition already exists
-    auto s_id = co_await st.get_schema_id(schema.schema.def().share());
+    auto s_id = co_await st.get_schema_id(
+      default_context, schema.schema.def().share());
 
     vlog(
       srlog.debug, "post_subject_versions: ID for schema definition: {}", s_id);
@@ -767,8 +795,8 @@ get_subject_versions_version_referenced_by(
 
     auto version = parse_schema_version(ver).value();
 
-    auto references = ppj::rjson_serialize_iobuf(
-      co_await rq.service().schema_store().referenced_by(sub, version));
+    auto references = ppj::rjson_serialize_iobuf(to_non_context_schema_ids(
+      co_await rq.service().schema_store().referenced_by(sub, version)));
 
     log_response(*rq.req, references);
     rp.rep->write_body("json", ppj::as_body_writer(std::move(references)));

--- a/src/v/pandaproxy/schema_registry/schema_getter.h
+++ b/src/v/pandaproxy/schema_registry/schema_getter.h
@@ -20,14 +20,14 @@ namespace pandaproxy::schema_registry {
 class schema_getter {
 public:
     virtual ss::future<stored_schema> get_subject_schema(
-      subject sub,
+      context_subject sub,
       std::optional<schema_version> version,
       include_deleted inc_dec)
       = 0;
     virtual ss::future<schema_definition>
-    get_schema_definition(schema_id id) = 0;
+    get_schema_definition(context_schema_id id) = 0;
     virtual ss::future<std::optional<schema_definition>>
-    maybe_get_schema_definition(schema_id id) = 0;
+    maybe_get_schema_definition(context_schema_id id) = 0;
     virtual ~schema_getter() = default;
 };
 

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -125,7 +125,7 @@ ss::future<> seq_writer::read_sync() {
 
 ss::future<> seq_writer::check_mutable(const std::optional<subject>& sub) {
     auto mode = sub ? co_await _store.get_mode(*sub, default_to_global::yes)
-                    : co_await _store.get_mode();
+                    : co_await _store.get_mode(default_context);
     if (mode == mode::read_only) {
         throw as_exception(mode_is_readonly(default_context, sub));
     }
@@ -307,7 +307,7 @@ ss::future<std::optional<bool>> seq_writer::do_write_config(
             existing = co_await _store.get_compatibility(
               sub.value(), default_to_global::no);
         } else {
-            existing = co_await _store.get_compatibility();
+            existing = co_await _store.get_compatibility(default_context);
         }
         if (existing == compat) {
             co_return false;
@@ -383,7 +383,7 @@ ss::future<std::optional<bool>> seq_writer::do_write_mode(
         // Check for no-op case
         mode existing = sub ? co_await _store.get_mode(
                                 sub.value(), default_to_global::no)
-                            : co_await _store.get_mode();
+                            : co_await _store.get_mode(default_context);
         if (existing == m) {
             co_return false;
         }
@@ -400,7 +400,10 @@ ss::future<std::optional<bool>> seq_writer::do_write_mode(
                 error_code::subject_version_operation_not_permitted,
                 "Schema Registry can only move to import mode if empty"});
         };
-        if (!sub && co_await _store.has_subjects(include_deleted::yes)) {
+        if (
+          !sub
+          && co_await _store.has_subjects(
+            default_context, include_deleted::yes)) {
             throw make_exception();
         }
         if (sub) {
@@ -478,7 +481,7 @@ ss::future<std::optional<bool>> seq_writer::do_delete_subject_version(
         throw as_exception(has_references(sub, version));
     }
 
-    schema_id s_id = co_await _store.get_id(sub, version);
+    auto s_id = co_await _store.get_id(sub, version);
     schema_definition schema = co_await _store.get_schema_definition(s_id);
 
     auto key = schema_key{
@@ -487,7 +490,8 @@ ss::future<std::optional<bool>> seq_writer::do_delete_subject_version(
     schema_value value{
       .schema{subject_schema{sub, std::move(schema)}},
       .version{version},
-      .id{s_id},
+      // TODO: use the full s_id here
+      .id{s_id.id},
       .deleted{is_deleted::yes}};
 
     batch_builder rb(write_at);

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -127,7 +127,7 @@ ss::future<> seq_writer::check_mutable(const std::optional<subject>& sub) {
     auto mode = sub ? co_await _store.get_mode(*sub, default_to_global::yes)
                     : co_await _store.get_mode();
     if (mode == mode::read_only) {
-        throw as_exception(mode_is_readonly(sub));
+        throw as_exception(mode_is_readonly(default_context, sub));
     }
     co_return;
 }

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -43,15 +43,23 @@ namespace pandaproxy::schema_registry {
 
 namespace {
 
-constexpr auto shard_for_next_schema_id = ss::shard_id{0};
-
-ss::shard_id shard_for(const subject& sub) {
-    auto hash = xxhash_64(sub().data(), sub().length());
-    return jump_consistent_hash(hash, ss::smp::count);
+ss::shard_id shard_for(const context_subject& sub) {
+    auto hasher = incremental_xxhash64{};
+    hasher.update(sub.ctx());
+    hasher.update(sub.sub());
+    return jump_consistent_hash(hasher.digest(), ss::smp::count);
 }
 
-ss::shard_id shard_for(schema_id id) {
-    return jump_consistent_hash(id(), ss::smp::count);
+ss::shard_id shard_for(const context_schema_id& id) {
+    auto hasher = incremental_xxhash64{};
+    hasher.update(id.ctx());
+    hasher.update(id.id());
+    return jump_consistent_hash(hasher.digest(), ss::smp::count);
+}
+
+ss::shard_id shard_for(const context& ctx) {
+    auto hash = xxhash_64(ctx().data(), ctx().length());
+    return jump_consistent_hash(hash, ss::smp::count);
 }
 
 compatibility_result check_compatible(
@@ -161,19 +169,20 @@ sharded_store::project_ids(stored_schema schema) {
     auto s_id = schema.id;
     if (s_id == invalid_schema_id) {
         // New schema, project an ID for it.
-        s_id = co_await project_schema_id();
+        s_id = co_await project_schema_id(default_context);
         vlog(srlog.debug, "project_ids: projected new ID {}", s_id);
     }
 
-    auto sub_shard{shard_for(sub)};
+    auto ctx_sub = context_subject{default_context, sub};
+    auto sub_shard{shard_for(ctx_sub)};
     auto v_id = co_await _store.invoke_on(
-      sub_shard, _smp_opts, [sub, s_id](store& s) {
-          return s.project_version(sub, s_id);
+      sub_shard, _smp_opts, [ctx_sub, s_id](store& s) {
+          return s.project_version(ctx_sub, s_id);
       });
 
     const bool is_new = v_id.has_value();
     if (is_new && schema.version != invalid_schema_version) {
-        const auto mode = co_await get_mode(sub, default_to_global::yes);
+        const auto mode = co_await get_mode(ctx_sub, default_to_global::yes);
         if (v_id != schema.version && mode != mode::import) {
             throw as_exception(
               error_info{
@@ -206,9 +215,16 @@ ss::future<bool> sharded_store::upsert(
     auto [sub, def] = std::move(schema).destructure();
     // mark schemas that failed to be processed here. They will be given
     // one more chance once we have loaded all the topic to the store.
-    co_await upsert_schema(id, std::move(def), processing_failed);
+    co_await upsert_schema(
+      context_schema_id{default_context, id},
+      std::move(def),
+      processing_failed);
     co_return co_await upsert_subject(
-      marker, std::move(sub), version, id, deleted);
+      marker,
+      context_subject{default_context, std::move(sub)},
+      version,
+      id,
+      deleted);
 }
 
 ss::future<> sharded_store::process_marked_schemas() {
@@ -241,14 +257,14 @@ ss::future<> sharded_store::process_marked_schemas() {
     });
 }
 
-ss::future<bool> sharded_store::has_schema(schema_id id) {
+ss::future<bool> sharded_store::has_schema(context_schema_id id) {
     co_return co_await _store.invoke_on(
       shard_for(id), _smp_opts, [id](store& s) {
           return s.get_schema_definition(id).has_value();
       });
 }
 
-ss::future<> sharded_store::delete_schema(schema_id id) {
+ss::future<> sharded_store::delete_schema(context_schema_id id) {
     return _store.invoke_on(
       shard_for(id), _smp_opts, [id](store& s) { s.delete_schema(id); });
 }
@@ -269,12 +285,13 @@ sharded_store::has_schema(subject_schema schema, include_deleted inc_del) {
     });
     for (auto entry : versions) {
         try {
+            // TODO: deduce the context from the subject/entry.id
             auto def = co_await get_schema_definition(entry.id);
             if (schema.def() == def) {
                 co_return stored_schema{
                   .schema = {schema.sub(), std::move(def)},
                   .version = entry.version,
-                  .id = entry.id,
+                  .id = entry.id.id,
                   .deleted = entry.deleted};
             }
         } catch (const exception& e) {
@@ -297,7 +314,7 @@ sharded_store::has_schema(subject_schema schema, include_deleted inc_del) {
 }
 
 ss::future<std::optional<schema_definition>>
-sharded_store::maybe_get_schema_definition(schema_id id) {
+sharded_store::maybe_get_schema_definition(context_schema_id id) {
     co_return co_await _store.invoke_on(
       shard_for(id),
       _smp_opts,
@@ -313,12 +330,12 @@ sharded_store::maybe_get_schema_definition(schema_id id) {
 }
 
 ss::future<schema_definition>
-sharded_store::get_schema_definition(schema_id id) {
+sharded_store::get_schema_definition(context_schema_id id) {
     return get_schema_definition(id, output_format::none);
 }
 
-ss::future<schema_definition>
-sharded_store::get_schema_definition(schema_id id, output_format format) {
+ss::future<schema_definition> sharded_store::get_schema_definition(
+  context_schema_id id, output_format format) {
     auto def = co_await _store.invoke_on(
       shard_for(id), _smp_opts, [id](store& s) {
           return s.get_schema_definition(id).value();
@@ -328,7 +345,7 @@ sharded_store::get_schema_definition(schema_id id, output_format format) {
 }
 
 ss::future<chunked_vector<subject_version>>
-sharded_store::get_schema_subject_versions(schema_id id) {
+sharded_store::get_schema_subject_versions(context_schema_id id) {
     using subject_versions = chunked_vector<subject_version>;
     auto map = [id](store& s) { return s.get_schema_subject_versions(id); };
     auto reduce = [](subject_versions acc, subject_versions svs) {
@@ -340,7 +357,8 @@ sharded_store::get_schema_subject_versions(schema_id id) {
 }
 
 ss::future<chunked_vector<subject_version_entry>>
-sharded_store::get_subject_versions(subject sub, include_deleted inc_del) {
+sharded_store::get_subject_versions(
+  context_subject sub, include_deleted inc_del) {
     co_return co_await _store.invoke_on(
       shard_for(sub),
       _smp_opts,
@@ -355,9 +373,9 @@ sharded_store::get_subject_versions(subject sub, include_deleted inc_del) {
       });
 }
 
-ss::future<chunked_vector<subject>>
-sharded_store::get_schema_subjects(schema_id id, include_deleted inc_del) {
-    using subjects = chunked_vector<subject>;
+ss::future<chunked_vector<context_subject>> sharded_store::get_schema_subjects(
+  context_schema_id id, include_deleted inc_del) {
+    using subjects = chunked_vector<context_subject>;
     auto map = [id, inc_del](store& s) {
         return s.get_schema_subjects(id, inc_del);
     };
@@ -371,8 +389,8 @@ sharded_store::get_schema_subjects(schema_id id, include_deleted inc_del) {
     co_return subs;
 }
 
-ss::future<schema_id>
-sharded_store::get_id(subject sub, std::optional<schema_version> version) {
+ss::future<context_schema_id> sharded_store::get_id(
+  context_subject sub, std::optional<schema_version> version) {
     auto v_id = co_await _store.invoke_on(
       shard_for(sub), _smp_opts, [sub, version](store& s) {
           return s.get_subject_version_id(sub, version, include_deleted::yes)
@@ -383,7 +401,9 @@ sharded_store::get_id(subject sub, std::optional<schema_version> version) {
 }
 
 ss::future<stored_schema> sharded_store::get_subject_schema(
-  subject sub, std::optional<schema_version> version, include_deleted inc_del) {
+  context_subject sub,
+  std::optional<schema_version> version,
+  include_deleted inc_del) {
     auto sub_shard{shard_for(sub)};
     auto v_id = co_await _store.invoke_on(
       sub_shard, _smp_opts, [sub, version, inc_del](store& s) {
@@ -391,20 +411,21 @@ ss::future<stored_schema> sharded_store::get_subject_schema(
       });
 
     auto def = co_await _store.invoke_on(
-      shard_for(v_id.id), _smp_opts, [id{v_id.id}](store& s) {
+      shard_for(v_id.id), _smp_opts, [id = v_id.id](store& s) {
           return s.get_schema_definition(id).value();
       });
 
     co_return stored_schema{
-      .schema = {sub, std::move(def)},
+      // TODO: pass sub directly instead of sub.sub
+      .schema = {sub.sub, std::move(def)},
       .version = v_id.version,
-      .id = v_id.id,
+      .id = v_id.id.id,
       .deleted = v_id.deleted};
 }
 
-ss::future<chunked_vector<subject>> sharded_store::get_subjects(
+ss::future<chunked_vector<context_subject>> sharded_store::get_subjects(
   include_deleted inc_del, std::optional<ss::sstring> subject_prefix) {
-    using subjects = chunked_vector<subject>;
+    using subjects = chunked_vector<context_subject>;
     auto map = [inc_del, &subject_prefix](store& s) {
         return s.get_subjects(inc_del, subject_prefix);
     };
@@ -416,13 +437,16 @@ ss::future<chunked_vector<subject>> sharded_store::get_subjects(
     co_return co_await _store.map_reduce0(map, subjects{}, reduce);
 }
 
-ss::future<bool> sharded_store::has_subjects(include_deleted inc_del) {
-    auto map = [inc_del](store& s) { return s.has_subjects(inc_del); };
+ss::future<bool>
+sharded_store::has_subjects(context ctx, include_deleted inc_del) {
+    auto map = [ctx, inc_del](store& s) {
+        return s.has_subjects(ctx, inc_del);
+    };
     return _store.map_reduce0(map, false, std::logical_or<>{});
 }
 
 ss::future<chunked_vector<schema_version>>
-sharded_store::get_versions(subject sub, include_deleted inc_del) {
+sharded_store::get_versions(context_subject sub, include_deleted inc_del) {
     auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
       sub_shard, _smp_opts, [sub{std::move(sub)}, inc_del](store& s) {
@@ -430,8 +454,8 @@ sharded_store::get_versions(subject sub, include_deleted inc_del) {
       });
 }
 
-ss::future<bool>
-sharded_store::is_referenced(subject sub, std::optional<schema_version> ver) {
+ss::future<bool> sharded_store::is_referenced(
+  context_subject sub, std::optional<schema_version> ver) {
     // Find all the schema that reference this sub-ver
     auto references = co_await _store.map_reduce0(
       [sub{std::move(sub)}, ver](store& s) {
@@ -449,8 +473,8 @@ sharded_store::is_referenced(subject sub, std::optional<schema_version> ver) {
       std::logical_or<>{});
 }
 
-ss::future<chunked_vector<schema_id>> sharded_store::referenced_by(
-  subject sub, std::optional<schema_version> opt_ver) {
+ss::future<chunked_vector<context_schema_id>> sharded_store::referenced_by(
+  context_subject sub, std::optional<schema_version> opt_ver) {
     schema_version ver;
     // Ensure the subject exists
     auto versions = co_await get_versions(sub, include_deleted::no);
@@ -485,11 +509,12 @@ ss::future<chunked_vector<schema_id>> sharded_store::referenced_by(
       store::schema_id_set{},
       set_accumulator);
 
-    co_return chunked_vector<schema_id>{references.begin(), references.end()};
+    co_return chunked_vector<context_schema_id>{
+      references.begin(), references.end()};
 }
 
 ss::future<chunked_vector<schema_version>> sharded_store::delete_subject(
-  seq_marker marker, subject sub, permanent_delete permanent) {
+  seq_marker marker, context_subject sub, permanent_delete permanent) {
     auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
       sub_shard, _smp_opts, [marker, sub{std::move(sub)}, permanent](store& s) {
@@ -497,7 +522,7 @@ ss::future<chunked_vector<schema_version>> sharded_store::delete_subject(
       });
 }
 
-ss::future<is_deleted> sharded_store::is_subject_deleted(subject sub) {
+ss::future<is_deleted> sharded_store::is_subject_deleted(context_subject sub) {
     auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
       sub_shard, _smp_opts, [sub{std::move(sub)}](store& s) {
@@ -505,8 +530,8 @@ ss::future<is_deleted> sharded_store::is_subject_deleted(subject sub) {
       });
 }
 
-ss::future<is_deleted>
-sharded_store::is_subject_version_deleted(subject sub, schema_version ver) {
+ss::future<is_deleted> sharded_store::is_subject_version_deleted(
+  context_subject sub, schema_version ver) {
     auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
       sub_shard, _smp_opts, [sub{std::move(sub)}, ver](store& s) {
@@ -515,7 +540,7 @@ sharded_store::is_subject_version_deleted(subject sub, schema_version ver) {
 }
 
 ss::future<chunked_vector<seq_marker>>
-sharded_store::get_subject_written_at(subject sub) {
+sharded_store::get_subject_written_at(context_subject sub) {
     auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
       sub_shard, _smp_opts, [sub{std::move(sub)}](store& s) {
@@ -524,7 +549,7 @@ sharded_store::get_subject_written_at(subject sub) {
 }
 
 ss::future<chunked_vector<seq_marker>>
-sharded_store::get_subject_config_written_at(subject sub) {
+sharded_store::get_subject_config_written_at(context_subject sub) {
     auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
       sub_shard, _smp_opts, [sub{std::move(sub)}](store& s) {
@@ -533,7 +558,7 @@ sharded_store::get_subject_config_written_at(subject sub) {
 }
 
 ss::future<chunked_vector<seq_marker>>
-sharded_store::get_subject_mode_written_at(subject sub) {
+sharded_store::get_subject_mode_written_at(context_subject sub) {
     auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
       sub_shard, _smp_opts, [sub{std::move(sub)}](store& s) {
@@ -542,7 +567,8 @@ sharded_store::get_subject_mode_written_at(subject sub) {
 }
 
 ss::future<chunked_vector<seq_marker>>
-sharded_store::get_subject_version_written_at(subject sub, schema_version ver) {
+sharded_store::get_subject_version_written_at(
+  context_subject sub, schema_version ver) {
     auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
       sub_shard, _smp_opts, [sub{std::move(sub)}, ver](store& s) {
@@ -551,7 +577,7 @@ sharded_store::get_subject_version_written_at(subject sub, schema_version ver) {
 }
 
 ss::future<bool> sharded_store::delete_subject_version(
-  subject sub, schema_version ver, force force) {
+  context_subject sub, schema_version ver, force force) {
     auto sub_shard = shard_for(sub);
     auto [schema_id, result] = co_await _store.invoke_on(
       sub_shard, _smp_opts, [sub{std::move(sub)}, ver, force](store& s) {
@@ -578,12 +604,12 @@ ss::future<bool> sharded_store::delete_subject_version(
     co_return result;
 }
 
-ss::future<mode> sharded_store::get_mode() {
-    co_return _store.local().get_mode().value();
+ss::future<mode> sharded_store::get_mode(context ctx) {
+    co_return _store.local().get_mode(ctx).value();
 }
 
 ss::future<mode>
-sharded_store::get_mode(subject sub, default_to_global fallback) {
+sharded_store::get_mode(context_subject sub, default_to_global fallback) {
     auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
       sub_shard, [sub{std::move(sub)}, fallback](store& s) {
@@ -591,14 +617,16 @@ sharded_store::get_mode(subject sub, default_to_global fallback) {
       });
 }
 
-ss::future<bool> sharded_store::set_mode(mode m, force f) {
-    auto map = [m, f](store& s) { return s.set_mode(m, f).value(); };
+ss::future<bool> sharded_store::set_mode(context ctx, mode m, force f) {
+    auto map = [m, f, ctx{std::move(ctx)}](store& s) {
+        return s.set_mode(ctx, m, f).value();
+    };
     auto reduce = std::logical_and<>{};
     co_return co_await _store.map_reduce0(map, true, reduce);
 }
 
-ss::future<bool>
-sharded_store::set_mode(seq_marker marker, subject sub, mode m, force f) {
+ss::future<bool> sharded_store::set_mode(
+  seq_marker marker, context_subject sub, mode m, force f) {
     auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
       sub_shard, _smp_opts, [marker, sub{std::move(sub)}, m, f](store& s) {
@@ -607,7 +635,7 @@ sharded_store::set_mode(seq_marker marker, subject sub, mode m, force f) {
 }
 
 ss::future<bool>
-sharded_store::clear_mode(seq_marker marker, subject sub, force f) {
+sharded_store::clear_mode(seq_marker marker, context_subject sub, force f) {
     auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
       sub_shard, _smp_opts, [marker, sub{std::move(sub)}, f](store& s) {
@@ -615,12 +643,12 @@ sharded_store::clear_mode(seq_marker marker, subject sub, force f) {
       });
 }
 
-ss::future<compatibility_level> sharded_store::get_compatibility() {
-    co_return _store.local().get_compatibility().value();
+ss::future<compatibility_level> sharded_store::get_compatibility(context ctx) {
+    co_return _store.local().get_compatibility(ctx).value();
 }
 
-ss::future<compatibility_level>
-sharded_store::get_compatibility(subject sub, default_to_global fallback) {
+ss::future<compatibility_level> sharded_store::get_compatibility(
+  context_subject sub, default_to_global fallback) {
     auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
       sub_shard, [sub{std::move(sub)}, fallback](store& s) {
@@ -628,17 +656,17 @@ sharded_store::get_compatibility(subject sub, default_to_global fallback) {
       });
 }
 
-ss::future<bool>
-sharded_store::set_compatibility(compatibility_level compatibility) {
-    auto map = [compatibility](store& s) {
-        return s.set_compatibility(compatibility).value();
+ss::future<bool> sharded_store::set_compatibility(
+  context ctx, compatibility_level compatibility) {
+    auto map = [compatibility, ctx{std::move(ctx)}](store& s) {
+        return s.set_compatibility(ctx, compatibility).value();
     };
     auto reduce = std::logical_and<>{};
     co_return co_await _store.map_reduce0(map, true, reduce);
 }
 
 ss::future<bool> sharded_store::set_compatibility(
-  seq_marker marker, subject sub, compatibility_level compatibility) {
+  seq_marker marker, context_subject sub, compatibility_level compatibility) {
     auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
       sub_shard,
@@ -649,7 +677,7 @@ ss::future<bool> sharded_store::set_compatibility(
 }
 
 ss::future<bool>
-sharded_store::clear_compatibility(seq_marker marker, subject sub) {
+sharded_store::clear_compatibility(seq_marker marker, context_subject sub) {
     auto sub_shard{shard_for(sub)};
     co_return co_await _store.invoke_on(
       sub_shard, _smp_opts, [marker, sub{std::move(sub)}](store& s) {
@@ -658,11 +686,11 @@ sharded_store::clear_compatibility(seq_marker marker, subject sub) {
 }
 
 ss::future<bool> sharded_store::upsert_schema(
-  schema_id id, schema_definition def, bool mark_schema) {
-    co_await _store.invoke_on(
-      shard_for_next_schema_id, _smp_opts, [id](store& s) {
-          s.maybe_update_max_schema_id(id);
-      });
+  context_schema_id id, schema_definition def, bool mark_schema) {
+    co_await _store.invoke_on(shard_for(id.ctx), _smp_opts, [id](store& s) {
+        s.maybe_update_max_schema_id(id);
+    });
+
     co_return co_await _store.invoke_on(
       shard_for(id),
       _smp_opts,
@@ -673,7 +701,7 @@ ss::future<bool> sharded_store::upsert_schema(
 
 ss::future<bool> sharded_store::upsert_subject(
   seq_marker marker,
-  subject sub,
+  context_subject sub,
   schema_version version,
   schema_id id,
   is_deleted deleted) {
@@ -686,10 +714,11 @@ ss::future<bool> sharded_store::upsert_subject(
       });
 }
 
-ss::future<schema_id> sharded_store::project_schema_id() {
+/// \brief Get the schema ID to be used for next insert
+ss::future<schema_id> sharded_store::project_schema_id(context ctx) {
     co_return co_await _store.invoke_on(
-      shard_for_next_schema_id, _smp_opts, [](auto& s) {
-          return s.project_schema_id();
+      shard_for(ctx), _smp_opts, [ctx](store& s) {
+          return s.project_schema_id(ctx);
       });
 }
 
@@ -854,8 +883,8 @@ void sharded_store::check_mode_mutability(force f) const {
     _store.local().check_mode_mutability(f).value();
 }
 
-ss::future<bool>
-sharded_store::has_version(subject sub, schema_id id, include_deleted i) {
+ss::future<bool> sharded_store::has_version(
+  context_subject sub, schema_id id, include_deleted i) {
     auto sub_shard{shard_for(sub)};
     auto has_id = co_await _store.invoke_on(
       sub_shard, _smp_opts, [id, sub{std::move(sub)}, i](class store& s) {
@@ -865,11 +894,28 @@ sharded_store::has_version(subject sub, schema_id id, include_deleted i) {
 }
 
 ss::future<std::optional<schema_id>>
-sharded_store::get_schema_id(schema_definition def) const {
-    auto map = [&def](const store& s) { return s.get_schema_id(def); };
+sharded_store::get_schema_id(context ctx, schema_definition def) const {
+    auto map = [&ctx, &def](const store& s) {
+        return s.get_schema_id(ctx, def);
+    };
     auto reduce = [](auto acc, auto s_id) { return std::max(acc, s_id); };
     co_return co_await _store.map_reduce0(
       map, std::optional<schema_id>{}, reduce);
+}
+
+ss::future<chunked_vector<context>> sharded_store::get_contexts() const {
+    using contexts = chunked_vector<context>;
+    auto map = [](const store& s) { return s.get_contexts(); };
+    auto reduce = [](contexts acc, contexts ctxs) {
+        acc.reserve(acc.size() + ctxs.size());
+        std::ranges::move(ctxs, std::back_inserter(acc));
+        return acc;
+    };
+    auto ctxs = co_await _store.map_reduce0(map, contexts{}, reduce);
+    std::ranges::sort(ctxs);
+    auto uniq = std::ranges::unique(ctxs);
+    ctxs.erase_to_end(uniq.begin());
+    co_return ctxs;
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -65,128 +65,129 @@ public:
     // the topic into the store.
     ss::future<> process_marked_schemas();
 
-    ss::future<bool> has_schema(schema_id id);
+    ss::future<bool> has_schema(context_schema_id id);
     ss::future<stored_schema> has_schema(
       subject_schema schema, include_deleted inc_del = include_deleted::no);
 
     ///\brief Return a schema definition by id.
-    ss::future<schema_definition> get_schema_definition(schema_id id) override;
+    ss::future<schema_definition>
+    get_schema_definition(context_schema_id id) override;
 
     ///\brief Return a schema definition by id.
     ss::future<schema_definition>
-    get_schema_definition(schema_id id, output_format format);
+    get_schema_definition(context_schema_id id, output_format format);
 
     ss::future<std::optional<schema_definition>>
-    maybe_get_schema_definition(schema_id id) override;
+    maybe_get_schema_definition(context_schema_id id) override;
 
     ///\brief Return a list of subject-versions for the shema id.
     ss::future<chunked_vector<subject_version>>
-    get_schema_subject_versions(schema_id id);
+    get_schema_subject_versions(context_schema_id id);
 
     ///\brief Return a list of subject-versions for the subject. Returns an
     /// empty vector if the subject does not exist.
     ss::future<chunked_vector<subject_version_entry>>
-    get_subject_versions(subject sub, include_deleted inc_del);
+    get_subject_versions(context_subject sub, include_deleted inc_del);
 
     ///\brief Return a list of subjects for the schema id.
-    ss::future<chunked_vector<subject>>
-    get_schema_subjects(schema_id id, include_deleted inc_del);
+    ss::future<chunked_vector<context_subject>>
+    get_schema_subjects(context_schema_id id, include_deleted inc_del);
 
     ///\brief Return a schema by subject and version (or latest).
     ss::future<stored_schema> get_subject_schema(
-      subject sub,
+      context_subject sub,
       std::optional<schema_version> version,
       include_deleted inc_dec) final;
 
     ///\brief Return the id of a schema by subject and version (or latest).
-    ss::future<schema_id>
-    get_id(subject sub, std::optional<schema_version> version);
+    ss::future<context_schema_id>
+    get_id(context_subject sub, std::optional<schema_version> version);
 
     ///\brief Return a list of subjects.
-    ss::future<chunked_vector<subject>> get_subjects(
+    ss::future<chunked_vector<context_subject>> get_subjects(
       include_deleted inc_del,
       std::optional<ss::sstring> subject_prefix = std::nullopt);
 
     ///\brief Return whether there are any subjects.
-    ss::future<bool> has_subjects(include_deleted inc_del);
+    ss::future<bool> has_subjects(context ctx, include_deleted inc_del);
 
     ///\brief Return a list of versions and associated schema_id.
     ss::future<chunked_vector<schema_version>>
-    get_versions(subject sub, include_deleted inc_del);
-
+    get_versions(context_subject sub, include_deleted inc_del);
     ///\brief Return whether there are any references to a subject version.
     ss::future<bool>
-    is_referenced(subject sub, std::optional<schema_version> ver);
+    is_referenced(context_subject sub, std::optional<schema_version> ver);
 
     ///\brief Return the schema_ids that reference a subject version.
-    ss::future<chunked_vector<schema_id>>
-    referenced_by(subject sub, std::optional<schema_version> ver);
-
+    ss::future<chunked_vector<context_schema_id>>
+    referenced_by(context_subject sub, std::optional<schema_version> ver);
     ///\brief Delete a subject.
-    ss::future<chunked_vector<schema_version>>
-    delete_subject(seq_marker marker, subject sub, permanent_delete permanent);
+    ss::future<chunked_vector<schema_version>> delete_subject(
+      seq_marker marker, context_subject sub, permanent_delete permanent);
 
-    ss::future<is_deleted> is_subject_deleted(subject sub);
+    ss::future<is_deleted> is_subject_deleted(context_subject sub);
 
     ss::future<is_deleted>
-    is_subject_version_deleted(subject sub, schema_version version);
+    is_subject_version_deleted(context_subject sub, schema_version version);
 
     ///\brief Get sequence number history (errors out if not soft-deleted)
-    ss::future<chunked_vector<seq_marker>> get_subject_written_at(subject sub);
+    ss::future<chunked_vector<seq_marker>>
+    get_subject_written_at(context_subject sub);
 
     ///\brief Get sequence number history of subject config. Subject need
     /// not be soft-deleted first
     ss::future<chunked_vector<seq_marker>>
-    get_subject_config_written_at(subject sub);
+    get_subject_config_written_at(context_subject sub);
 
     ///\brief Get sequence number history of subject mode. Subject need
     /// not be soft-deleted first
     ss::future<chunked_vector<seq_marker>>
-    get_subject_mode_written_at(subject sub);
+    get_subject_mode_written_at(context_subject sub);
 
     ///\brief Get sequence number history (errors out if not soft-deleted)
     ss::future<chunked_vector<seq_marker>>
-    get_subject_version_written_at(subject sub, schema_version version);
-
+    get_subject_version_written_at(context_subject sub, schema_version version);
     ///\brief Delete a subject version
     /// \param force Override checks for soft-delete first.
     ss::future<bool> delete_subject_version(
-      subject sub, schema_version version, force f = force::no);
-
+      context_subject sub, schema_version version, force f = force::no);
     ///\brief Get the global mode.
-    ss::future<mode> get_mode();
+    ss::future<mode> get_mode(context ctx);
 
     ///\brief Get the mode for a subject, or fallback to global.
-    ss::future<mode> get_mode(subject sub, default_to_global fallback);
+    ss::future<mode> get_mode(context_subject sub, default_to_global fallback);
 
     ///\brief Set the global mode.
     /// \param force Override checks, always apply action
-    ss::future<bool> set_mode(mode m, force f);
+    ss::future<bool> set_mode(context ctx, mode m, force f);
 
     ///\brief Set the mode for a subject.
     /// \param force Override checks, always apply action
-    ss::future<bool> set_mode(seq_marker marker, subject sub, mode m, force f);
-
+    ss::future<bool>
+    set_mode(seq_marker marker, context_subject sub, mode m, force f);
     ///\brief Clear the mode for a subject.
     /// \param force Override checks, always apply action
-    ss::future<bool> clear_mode(seq_marker marker, subject sub, force f);
+    ss::future<bool>
+    clear_mode(seq_marker marker, context_subject sub, force f);
 
     ///\brief Get the global compatibility level.
-    ss::future<compatibility_level> get_compatibility();
+    ss::future<compatibility_level> get_compatibility(context ctx);
 
     ///\brief Get the compatibility level for a subject, or fallback to global.
     ss::future<compatibility_level>
-    get_compatibility(subject sub, default_to_global fallback);
-
+    get_compatibility(context_subject sub, default_to_global fallback);
     ///\brief Set the global compatibility level.
-    ss::future<bool> set_compatibility(compatibility_level compatibility);
+    ss::future<bool>
+    set_compatibility(context ctx, compatibility_level compatibility);
 
     ///\brief Set the compatibility level for a subject.
     ss::future<bool> set_compatibility(
-      seq_marker marker, subject sub, compatibility_level compatibility);
-
+      seq_marker marker,
+      context_subject sub,
+      compatibility_level compatibility);
     ///\brief Clear the compatibility level for a subject.
-    ss::future<bool> clear_compatibility(seq_marker marker, subject sub);
+    ss::future<bool>
+    clear_compatibility(seq_marker marker, context_subject sub);
 
     ///\brief Check if the provided schema is compatible with the subject and
     /// version, according the the current compatibility.
@@ -205,36 +206,37 @@ public:
     ss::future<compatibility_result> is_compatible(
       schema_version version, subject_schema new_schema, verbose is_verbose);
 
-    ss::future<bool> has_version(subject, schema_id, include_deleted);
+    ss::future<bool> has_version(context_subject, schema_id, include_deleted);
 
     //// \brief Throw if the store is not mutable
     void check_mode_mutability(force f) const;
 
     ///\brief Look up the id of a schema by definition
     ss::future<std::optional<schema_id>>
-    get_schema_id(schema_definition def) const;
+    get_schema_id(context ctx, schema_definition def) const;
+
+    /// \brief List all contexts in the store
+    ss::future<chunked_vector<context>> get_contexts() const;
 
 private:
     ss::future<compatibility_result> do_is_compatible(
       schema_version version, subject_schema new_schema, verbose is_verbose);
 
-    ss::future<bool>
-    upsert_schema(schema_id id, schema_definition def, bool mark_schema);
-    ss::future<> delete_schema(schema_id id);
+    ss::future<bool> upsert_schema(
+      context_schema_id id, schema_definition def, bool mark_schema);
+    ss::future<> delete_schema(context_schema_id id);
 
     ss::future<bool> upsert_subject(
       seq_marker marker,
-      subject sub,
+      context_subject sub,
       schema_version version,
       schema_id id,
       is_deleted deleted);
 
-    ss::future<schema_id> project_schema_id();
+    ss::future<schema_id> project_schema_id(context ctx);
 
     ss::smp_submit_to_options _smp_opts;
     ss::sharded<store> _store;
-
-    ///\brief Access must occur only on shard 0.
 };
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -1631,7 +1631,7 @@ struct consume_to_store {
                       val->compat);
                 }
             } else if (val.has_value()) {
-                co_await _store.set_compatibility(val->compat);
+                co_await _store.set_compatibility(default_context, val->compat);
             } else {
                 vlog(
                   srlog.warn,
@@ -1686,7 +1686,8 @@ struct consume_to_store {
                       force::yes);
                 }
             } else if (val.has_value()) {
-                co_await _store.set_mode(val->mode, force::yes);
+                co_await _store.set_mode(
+                  default_context, val->mode, force::yes);
             } else {
                 vlog(
                   srlog.warn,

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -51,7 +51,7 @@ make_non_const_iterator(T& container, result<typename T::const_iterator> it) {
 
 class store {
 public:
-    using schema_id_set = absl::btree_set<schema_id>;
+    using schema_id_set = absl::btree_set<context_schema_id>;
 
     explicit store()
       : store(is_mutable::no) {}
@@ -75,36 +75,46 @@ public:
     /// return the schema_version and schema_id, and whether it's new.
     insert_result insert(subject_schema schema) {
         auto [sub, def] = std::move(schema).destructure();
-        auto id = insert_schema(std::move(def)).id;
-        auto [version, inserted] = insert_subject(std::move(sub), id);
+        // TODO: deduce the context from the subject
+        auto ctx_sub = context_subject{default_context, std::move(sub)};
+        auto id = insert_schema(ctx_sub.ctx, std::move(def)).id;
+        auto [version, inserted] = insert_subject(std::move(ctx_sub), id);
         return {version, id, inserted};
     }
 
     ///\brief Return a schema definition by id.
-    result<schema_definition> get_schema_definition(const schema_id& id) const {
+    result<schema_definition>
+    get_schema_definition(const context_schema_id& id) const {
         auto it = _schemas.find(id);
         if (it == _schemas.end()) {
-            return not_found(id);
+            return not_found(id.id);
         }
         return {it->second.definition.share()};
     }
 
     ///\brief Return the id of the schema, if it already exists.
-    std::optional<schema_id> get_schema_id(const schema_definition& def) const {
+    std::optional<schema_id>
+    get_schema_id(const context& ctx, const schema_definition& def) const {
         // Iterate in decreasing order to return the maximal matching id
         auto rev = std::views::reverse(_schemas);
-        const auto s_it = std::ranges::find_if(
-          rev, [&](const auto& s) { return def == s.second.definition; });
-        return s_it == rev.end() ? std::optional<schema_id>{} : s_it->first;
+        const auto s_it = std::ranges::find_if(rev, [&](const auto& s) {
+            return ctx == s.first.ctx && def == s.second.definition;
+        });
+        return s_it == rev.end() ? std::optional<schema_id>{} : s_it->first.id;
     }
 
     ///\brief Return a list of subject-versions for the shema id.
-    chunked_vector<subject_version> get_schema_subject_versions(schema_id id) {
+    chunked_vector<subject_version>
+    get_schema_subject_versions(const context_schema_id& id) {
         chunked_vector<subject_version> svs;
         for (const auto& s : _subjects) {
+            if (s.first.ctx != id.ctx) {
+                continue;
+            }
             for (const auto& vs : s.second.versions) {
-                if (vs.id == id && !vs.deleted) {
-                    svs.emplace_back(s.first, vs.version);
+                if (vs.id == id.id && !vs.deleted) {
+                    // TODO: return the full context_subject here
+                    svs.emplace_back(s.first.sub, vs.version);
                 }
             }
         }
@@ -112,13 +122,16 @@ public:
     }
 
     ///\brief Return a list of subjects for the schema id.
-    chunked_vector<subject>
-    get_schema_subjects(schema_id id, include_deleted inc_del) {
-        chunked_vector<subject> subs;
+    chunked_vector<context_subject>
+    get_schema_subjects(const context_schema_id& id, include_deleted inc_del) {
+        chunked_vector<context_subject> subs;
         for (const auto& s : _subjects) {
+            if (s.first.ctx != id.ctx) {
+                continue;
+            }
             if (std::ranges::any_of(
-                  s.second.versions, [id, inc_del](const auto& vs) {
-                      return vs.id == id && (inc_del || !vs.deleted);
+                  s.second.versions, [&id, inc_del](const auto& vs) {
+                      return vs.id == id.id && (inc_del || !vs.deleted);
                   })) {
                 subs.emplace_back(s.first);
             }
@@ -128,7 +141,7 @@ public:
 
     ///\brief Return subject_version_id for a subject and version
     result<subject_version_entry> get_subject_version_id(
-      const subject& sub,
+      const context_subject& sub,
       std::optional<schema_version> version,
       include_deleted inc_del) const {
         auto sub_it = BOOST_OUTCOME_TRYX(get_subject_iter(sub, inc_del));
@@ -152,7 +165,7 @@ public:
 
     ///\brief Return a schema by subject and version.
     result<stored_schema> get_subject_schema(
-      const subject& sub,
+      const context_subject& sub,
       std::optional<schema_version> version,
       include_deleted inc_del) const {
         auto v_id = BOOST_OUTCOME_TRYX(
@@ -161,27 +174,28 @@ public:
         auto def = BOOST_OUTCOME_TRYX(get_schema_definition(v_id.id));
 
         return stored_schema{
-          .schema = {sub, std::move(def)},
+          // TODO: pass sub directly instead of sub.sub
+          .schema = {sub.sub, std::move(def)},
           .version = v_id.version,
-          .id = v_id.id,
+          .id = v_id.id.id,
           .deleted = v_id.deleted};
     }
 
     ///\brief Return a list of subjects.
-    chunked_vector<subject> get_subjects(
+    chunked_vector<context_subject> get_subjects(
       include_deleted inc_del,
       const std::optional<ss::sstring>& subject_prefix = std::nullopt) const {
-        chunked_vector<subject> res;
+        chunked_vector<context_subject> res;
         res.reserve(_subjects.size());
-        for (const auto& sub : _subjects) {
-            if (inc_del || !sub.second.deleted) {
+        for (const auto& ctx_sub : _subjects) {
+            if (inc_del || !ctx_sub.second.deleted) {
                 auto has_version = std::ranges::any_of(
-                  sub.second.versions,
+                  ctx_sub.second.versions,
                   [inc_del](const auto& v) { return inc_del || !v.deleted; });
                 if (
                   has_version
-                  && sub.first().starts_with(subject_prefix.value_or(""))) {
-                    res.push_back(sub.first);
+                  && ctx_sub.first.starts_with(subject_prefix.value_or(""))) {
+                    res.push_back(ctx_sub.first);
                 }
             }
         }
@@ -189,8 +203,11 @@ public:
     }
 
     ///\brief Return if there are subjects.
-    bool has_subjects(include_deleted inc_del) const {
-        return std::ranges::any_of(_subjects, [inc_del](const auto& sub) {
+    bool has_subjects(const context& ctx, include_deleted inc_del) const {
+        return std::ranges::any_of(_subjects, [inc_del, &ctx](const auto& sub) {
+            if (sub.first.ctx != ctx) {
+                return false;
+            }
             return std::ranges::any_of(
               sub.second.versions,
               [inc_del](const auto& v) { return inc_del || !v.deleted; });
@@ -199,7 +216,7 @@ public:
 
     ///\brief Return a list of versions and associated schema_id.
     result<chunked_vector<schema_version>>
-    get_versions(const subject& sub, include_deleted inc_del) const {
+    get_versions(const context_subject& sub, include_deleted inc_del) const {
         auto sub_it = BOOST_OUTCOME_TRYX(get_subject_iter(sub, inc_del));
         const auto& versions = sub_it->second.versions;
         if (versions.empty()) {
@@ -216,7 +233,7 @@ public:
     }
 
     ///\brief Return the value of the 'deleted' field on a subject
-    result<is_deleted> is_subject_deleted(const subject& sub) const {
+    result<is_deleted> is_subject_deleted(const context_subject& sub) const {
         auto sub_it = BOOST_OUTCOME_TRYX(
           get_subject_iter(sub, include_deleted::yes));
         return sub_it->second.deleted;
@@ -224,7 +241,7 @@ public:
 
     ///\brief Return the value of the 'deleted' field on a subject
     result<is_deleted> is_subject_version_deleted(
-      const subject& sub, const schema_version version) const {
+      const context_subject& sub, const schema_version version) const {
         auto sub_it = BOOST_OUTCOME_TRYX(
           get_subject_iter(sub, include_deleted::yes));
         auto v_it = BOOST_OUTCOME_TRYX(
@@ -236,7 +253,7 @@ public:
     ///
     /// \return A vector with at least one element
     result<chunked_vector<seq_marker>>
-    get_subject_written_at(const subject& sub) const {
+    get_subject_written_at(const context_subject& sub) const {
         auto sub_it = BOOST_OUTCOME_TRYX(
           get_subject_iter(sub, include_deleted::yes));
 
@@ -262,7 +279,7 @@ public:
     ///
     /// \return A vector (possibly empty)
     result<chunked_vector<seq_marker>>
-    get_subject_config_written_at(const subject& sub) const {
+    get_subject_config_written_at(const context_subject& sub) const {
         auto sub_it = BOOST_OUTCOME_TRYX(
           get_subject_iter(sub, include_deleted::yes));
 
@@ -290,7 +307,7 @@ public:
     ///
     /// \return A vector (possibly empty)
     result<chunked_vector<seq_marker>>
-    get_subject_mode_written_at(const subject& sub) const {
+    get_subject_mode_written_at(const context_subject& sub) const {
         auto sub_it = BOOST_OUTCOME_TRYX(
           get_subject_iter(sub, include_deleted::yes));
 
@@ -317,7 +334,7 @@ public:
     ///
     /// \return A vector with at least one element
     result<chunked_vector<seq_marker>> get_subject_version_written_at(
-      const subject& sub, schema_version version) const {
+      const context_subject& sub, schema_version version) const {
         auto sub_it = BOOST_OUTCOME_TRYX(
           get_subject_iter(sub, include_deleted::yes));
 
@@ -351,7 +368,7 @@ public:
     ///\brief If this schema ID isn't already in the version list, return
     ///       what the version number will be if it is inserted.
     std::optional<schema_version>
-    project_version(const subject& sub, schema_id sid) const {
+    project_version(const context_subject& sub, schema_id sid) const {
         auto subject_iter = _subjects.find(sub);
         if (subject_iter == _subjects.end()) {
             // Subject doesn't exist yet.  First version will be 1.
@@ -383,7 +400,7 @@ public:
 
     ///\brief Return a list of versions and associated schema_id.
     result<chunked_vector<subject_version_entry>>
-    get_version_ids(const subject& sub, include_deleted inc_del) const {
+    get_version_ids(const context_subject& sub, include_deleted inc_del) const {
         auto sub_it = BOOST_OUTCOME_TRYX(get_subject_iter(sub, inc_del));
         chunked_vector<subject_version_entry> res;
         std::ranges::copy_if(
@@ -398,7 +415,7 @@ public:
     ///\brief Return whether this subject has a version that references the
     /// schema_id.
     result<bool> has_version(
-      const subject& sub, schema_id id, include_deleted inc_del) const {
+      const context_subject& sub, schema_id id, include_deleted inc_del) const {
         auto sub_it = BOOST_OUTCOME_TRYX(get_subject_iter(sub, inc_del));
         const auto& vs = sub_it->second.versions;
         return std::ranges::any_of(vs, [id, inc_del](const auto& entry) {
@@ -406,8 +423,8 @@ public:
         });
     }
 
-    schema_id_set
-    referenced_by(const subject& sub, std::optional<schema_version> ver) {
+    schema_id_set referenced_by(
+      const context_subject& sub, std::optional<schema_version> ver) {
         schema_id_set references;
         for (const auto& s : _schemas) {
             for (const auto& r : s.second.definition.refs()) {
@@ -443,7 +460,9 @@ public:
 
     ///\brief Delete a subject.
     result<chunked_vector<schema_version>> delete_subject(
-      seq_marker marker, const subject& sub, permanent_delete permanent) {
+      seq_marker marker,
+      const context_subject& sub,
+      permanent_delete permanent) {
         auto sub_it = BOOST_OUTCOME_TRYX(
           get_subject_iter(sub, include_deleted::yes));
 
@@ -483,7 +502,9 @@ public:
 
     ///\brief Delete a subject version.
     result<bool> delete_subject_version(
-      const subject& sub, schema_version version, force force = force::no) {
+      const context_subject& sub,
+      schema_version version,
+      force force = force::no) {
         auto sub_it = BOOST_OUTCOME_TRYX(
           get_subject_iter(sub, include_deleted::yes));
         auto& versions = sub_it->second.versions;
@@ -517,30 +538,34 @@ public:
         return true;
     }
 
-    ///\brief Get the global mode.
-    result<mode> get_mode() const { return _mode; }
+    ///\brief Get the global mode of a context.
+    result<mode> get_mode(const context& ctx) const {
+        auto it = _context_stores.find(ctx);
+        return it != _context_stores.end() ? it->second._mode
+                                           : mode::read_write;
+    }
 
     ///\brief Get the mode for a subject, or fallback to global.
     result<mode>
-    get_mode(const subject& sub, default_to_global fallback) const {
+    get_mode(const context_subject& sub, default_to_global fallback) const {
         auto sub_it = get_subject_iter(sub, include_deleted::yes);
         if (sub_it && (sub_it.assume_value())->second.mode.has_value()) {
             return (sub_it.assume_value())->second.mode.value();
         } else if (fallback) {
-            return _mode;
+            return get_mode(sub.ctx);
         }
         return mode_not_found(sub);
     }
 
     ///\brief Set the global mode.
-    result<bool> set_mode(mode m, force f) {
+    result<bool> set_mode(const context& ctx, mode m, force f) {
         BOOST_OUTCOME_TRYX(check_mode_mutability(f));
-        return std::exchange(_mode, m) != m;
+        return std::exchange(_context_stores[ctx]._mode, m) != m;
     }
 
     ///\brief Set the mode for a subject.
     result<bool>
-    set_mode(seq_marker marker, const subject& sub, mode m, force f) {
+    set_mode(seq_marker marker, const context_subject& sub, mode m, force f) {
         BOOST_OUTCOME_TRYX(check_mode_mutability(f));
         auto& sub_entry = get_or_create_subject_entry(sub);
         sub_entry.written_at.push_back(marker);
@@ -549,7 +574,7 @@ public:
 
     ///\brief Clear the mode for a subject.
     result<bool>
-    clear_mode(const seq_marker& marker, const subject& sub, force f) {
+    clear_mode(const seq_marker& marker, const context_subject& sub, force f) {
         BOOST_OUTCOME_TRYX(check_mode_mutability(f));
         auto sub_it = BOOST_OUTCOME_TRYX(
           get_subject_iter(sub, include_deleted::yes));
@@ -558,36 +583,41 @@ public:
         return std::exchange(sub_it->second.mode, std::nullopt) != std::nullopt;
     }
 
-    ///\brief Get the global compatibility level.
-    result<compatibility_level> get_compatibility() const {
-        return _compatibility;
+    ///\brief Get the global compatibility level in a context.
+    result<compatibility_level> get_compatibility(const context& ctx) const {
+        auto it = _context_stores.find(ctx);
+        return it != _context_stores.end() ? it->second._compatibility
+                                           : compatibility_level::backward;
     }
 
     ///\brief Get the compatibility level for a subject, or fallback to global.
-    result<compatibility_level>
-    get_compatibility(const subject& sub, default_to_global fallback) const {
+    result<compatibility_level> get_compatibility(
+      const context_subject& sub, default_to_global fallback) const {
         auto sub_it_res = get_subject_iter(sub, include_deleted::no);
         if (sub_it_res.has_error()) {
             return compatibility_not_found(sub);
         }
         auto sub_it = std::move(sub_it_res).assume_value();
-        if (fallback) {
-            return sub_it->second.compatibility.value_or(_compatibility);
-        } else if (sub_it->second.compatibility) {
-            return sub_it->second.compatibility.value();
+        auto compat = sub_it->second.compatibility;
+        if (compat) {
+            return compat.value();
+        } else if (fallback) {
+            return get_compatibility(sub.ctx);
         }
         return compatibility_not_found(sub);
     }
 
     ///\brief Set the global compatibility level.
-    result<bool> set_compatibility(compatibility_level compatibility) {
-        return std::exchange(_compatibility, compatibility) != compatibility;
+    result<bool>
+    set_compatibility(const context& ctx, compatibility_level compatibility) {
+        return std::exchange(_context_stores[ctx]._compatibility, compatibility)
+               != compatibility;
     }
 
     ///\brief Set the compatibility level for a subject.
     result<bool> set_compatibility(
       seq_marker marker,
-      const subject& sub,
+      const context_subject& sub,
       compatibility_level compatibility) {
         auto& sub_entry = get_or_create_subject_entry(sub);
         sub_entry.written_at.push_back(marker);
@@ -597,7 +627,7 @@ public:
 
     ///\brief Clear the compatibility level for a subject.
     result<bool>
-    clear_compatibility(const seq_marker& marker, const subject& sub) {
+    clear_compatibility(const seq_marker& marker, const context_subject& sub) {
         auto sub_it = BOOST_OUTCOME_TRYX(
           get_subject_iter(sub, include_deleted::yes));
         auto& vec = sub_it->second.written_at;
@@ -610,29 +640,34 @@ public:
         schema_id id;
         bool inserted;
     };
-    insert_schema_result insert_schema(schema_definition def) {
-        if (auto id = get_schema_id(def); id.has_value()) {
+    insert_schema_result
+    insert_schema(const context& ctx, schema_definition def) {
+        if (auto id = get_schema_id(ctx, def); id.has_value()) {
             return {*id, false};
         }
 
-        const auto id = _schemas.empty() ? schema_id{1}
-                                         : std::prev(_schemas.end())->first + 1;
-        auto [_, inserted] = _schemas.try_emplace(id, std::move(def));
+        const auto id = _schemas.empty()
+                          ? schema_id{1}
+                          : std::prev(_schemas.end())->first.id + 1;
+        auto [_, inserted] = _schemas.try_emplace(
+          context_schema_id{ctx, id}, std::move(def));
         return {id, inserted};
     }
 
-    bool upsert_schema(schema_id id, schema_definition def, bool mark_schema) {
+    bool upsert_schema(
+      context_schema_id id, schema_definition def, bool mark_schema) {
         if (mark_schema) {
             _marked_schemas.push_back(id);
         }
-        return _schemas.insert_or_assign(id, schema_entry(std::move(def)))
+        return _schemas
+          .insert_or_assign(std::move(id), schema_entry(std::move(def)))
           .second;
     }
 
-    void delete_schema(schema_id id) { _schemas.erase(id); }
+    void delete_schema(const context_schema_id& id) { _schemas.erase(id); }
 
     // This function returns and unmarkes all marked schemas.
-    chunked_vector<schema_id> extract_marked_schemas() {
+    chunked_vector<context_schema_id> extract_marked_schemas() {
         return std::exchange(_marked_schemas, {});
     }
 
@@ -640,7 +675,7 @@ public:
         schema_version version;
         bool inserted;
     };
-    insert_subject_result insert_subject(subject sub, schema_id id) {
+    insert_subject_result insert_subject(context_subject sub, schema_id id) {
         auto& subject_entry = get_or_create_subject_entry(std::move(sub));
         subject_entry.deleted = is_deleted::no;
         auto& versions = subject_entry.versions;
@@ -661,7 +696,7 @@ public:
 
     bool upsert_subject(
       seq_marker marker,
-      subject sub,
+      context_subject sub,
       schema_version version,
       schema_id id,
       is_deleted deleted) {
@@ -775,21 +810,27 @@ public:
         }
     };
 
+    void maybe_update_max_schema_id(const context_schema_id& id) {
+        auto& nsi = _context_stores[id.ctx]._next_schema_id;
+        auto old = nsi;
+        nsi = std::max(nsi, id.id + schema_id{1});
+        vlog(
+          srlog.debug, "Context {} next_schema_id: {} -> {}", id.ctx, old, nsi);
+    }
+
     /// \brief Get the schema ID to be used for next insert
-    schema_id project_schema_id() {
+    schema_id project_schema_id(const context& ctx) {
         // This is very simple because we only allow one write in
         // flight at a time.  Could be extended to track N in flight
         // operations if needed.  _next_schema_id gets updated
         // if the operation was successful, as a side effect
         // of applying the write to the store.
-        return _next_schema_id;
+        return _context_stores[ctx]._next_schema_id;
     }
 
-    void maybe_update_max_schema_id(schema_id id) {
-        auto& nsi = _next_schema_id;
-        auto old = nsi;
-        nsi = std::max(nsi, id + schema_id{1});
-        vlog(srlog.debug, "next_schema_id: {} -> {}", old, nsi);
+    chunked_vector<context> get_contexts() const {
+        return _context_stores | std::views::keys
+               | std::ranges::to<chunked_vector<context>>();
     }
 
 private:
@@ -802,7 +843,9 @@ private:
 
     class subject_entry {
     public:
-        explicit subject_entry(const subject& sub) { setup_metrics(sub); }
+        explicit subject_entry(const context_subject& sub) {
+            setup_metrics(sub);
+        }
         std::optional<compatibility_level> compatibility;
         std::optional<mode> mode;
         chunked_vector<subject_version_entry> versions;
@@ -814,7 +857,7 @@ private:
         metrics::internal_metric_groups _metrics;
         metrics::public_metric_groups _public_metrics;
 
-        void setup_metrics(const subject& sub) {
+        void setup_metrics(const context_subject& sub) {
             namespace sm = ss::metrics;
             auto group_name = prometheus_sanitize::metrics_name(
               "schema_registry_cache");
@@ -830,7 +873,8 @@ private:
                   },
                   sm::description("The number of versions in the subject"),
                   {
-                    sm::label{"subject"}(sub),
+                    sm::label{"context"}(sub.ctx),
+                    sm::label{"subject"}(sub.sub),
                     sm::label{"deleted"}(deleted),
                   });
             };
@@ -852,22 +896,22 @@ private:
             }
         }
     };
-    using schema_map = absl::btree_map<schema_id, schema_entry>;
-    using subject_map = absl::node_hash_map<subject, subject_entry>;
+    using schema_map = absl::btree_map<context_schema_id, schema_entry>;
+    using subject_map = absl::node_hash_map<context_subject, subject_entry>;
 
-    subject_entry& get_or_create_subject_entry(subject sub) {
+    subject_entry& get_or_create_subject_entry(context_subject sub) {
         return _subjects.try_emplace(sub, sub).first->second;
     }
 
     result<subject_map::iterator>
-    get_subject_iter(const subject& sub, include_deleted inc_del) {
+    get_subject_iter(const context_subject& sub, include_deleted inc_del) {
         const store* const_this = this;
         auto res = const_this->get_subject_iter(sub, inc_del);
         return detail::make_non_const_iterator(_subjects, res);
     }
 
-    result<subject_map::const_iterator>
-    get_subject_iter(const subject& sub, include_deleted inc_del) const {
+    result<subject_map::const_iterator> get_subject_iter(
+      const context_subject& sub, include_deleted inc_del) const {
         auto sub_it = _subjects.find(sub);
         if (sub_it == _subjects.end()) {
             return not_found(sub);
@@ -914,25 +958,32 @@ private:
         return v_it;
     }
 
-    // NOTE: sharded_store shards data into multiple store instances
-    // Sharded fields:
-    //   _schemas: sharded by schema_id
-    //   _subjects: sharded by subject
-    //   _marked_schemas: sharded by schema_id
-    //
-    // Replicated fields (kept on all shards):
-    //   _compatibility
-    //   _mode
-    //
-    // Only on shard 0:
-    //   _next_schema_id
+    struct context_store {
+        compatibility_level _compatibility{compatibility_level::backward};
+        mode _mode{mode::read_write};
+        schema_id _next_schema_id{1};
+    };
+    using context_store_map = absl::node_hash_map<context, context_store>;
+
+    // NOTE: sharded_store shards data into multiple store instances, so some
+    // fields are only present on certain shards.
+    // _schemas: sharded by (context, schema_id)
+    // _subjects: sharded by (context, subject)
+    // _marked_schemas: shard 0 ??
+    // context_store:
+    //  - next_schema_id: sharded by context
+    //  - compatibility: replicated across all shards
+    //  - mode: replicated across all shards
+    // _mutable: replicated across all shards
+
+    // Alternative: Keep the store as is, but key the existing state under a
+    // context. Yet shard state by (context, subject), (context, schema_id)
+    // still.
 
     schema_map _schemas;
     subject_map _subjects;
-    chunked_vector<schema_id> _marked_schemas;
-    compatibility_level _compatibility{compatibility_level::backward};
-    mode _mode{mode::read_write};
-    schema_id _next_schema_id{1};
+    chunked_vector<context_schema_id> _marked_schemas;
+    context_store_map _context_stores;
 
     is_mutable _mutable;
     metrics::internal_metric_groups _metrics;

--- a/src/v/pandaproxy/schema_registry/test/compatibility_3rdparty.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_3rdparty.cc
@@ -138,12 +138,14 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store_3rdparty) {
       c(make_record_batch(schema_key_0, std::nullopt, base_offset++)).get());
 
     // Test mode default
-    BOOST_REQUIRE_EQUAL(c._store.get_mode().get(), pps::mode::read_write);
+    BOOST_REQUIRE_EQUAL(
+      c._store.get_mode(pps::default_context).get(), pps::mode::read_write);
 
     // Test mode READONLY
     BOOST_REQUIRE_NO_THROW(
       c(make_record_batch(mode_key_0, mode_value_ro, base_offset++)).get());
-    BOOST_REQUIRE_EQUAL(c._store.get_mode().get(), pps::mode::read_only);
+    BOOST_REQUIRE_EQUAL(
+      c._store.get_mode(pps::default_context).get(), pps::mode::read_only);
 
     // Test mode no subject, no fallback
     BOOST_REQUIRE_EXCEPTION(
@@ -163,7 +165,8 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store_3rdparty) {
     // test mode READWRITE
     BOOST_REQUIRE_NO_THROW(
       c(make_record_batch(mode_key_0, mode_value_rw, base_offset++)).get());
-    BOOST_REQUIRE_EQUAL(c._store.get_mode().get(), pps::mode::read_write);
+    BOOST_REQUIRE_EQUAL(
+      c._store.get_mode(pps::default_context).get(), pps::mode::read_write);
 
     // test mode subject override
     BOOST_REQUIRE_NO_THROW(

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -39,7 +39,7 @@ bool check_compatible(
   std::string_view reader,
   std::string_view writer) {
     ppstu::store_fixture store;
-    store.store().set_compatibility(lvl).get();
+    store.store().set_compatibility(pps::default_context, lvl).get();
     store.insert(
       pandaproxy::schema_registry::subject_schema{
         pps::subject{"sub"},

--- a/src/v/pandaproxy/schema_registry/test/compatibility_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_store.cc
@@ -29,7 +29,9 @@ SEASTAR_THREAD_TEST_CASE(test_avro_basic_backwards_store_compat) {
 
     pps::seq_marker dummy_marker;
 
-    s.set_compatibility(pps::compatibility_level::backward).get();
+    s.set_compatibility(
+       pps::default_context, pps::compatibility_level::backward)
+      .get();
     auto sub = pps::subject{"sub"};
     s.upsert(
        dummy_marker,
@@ -70,7 +72,9 @@ SEASTAR_THREAD_TEST_CASE(test_avro_basic_backwards_store_compat) {
     BOOST_REQUIRE(
       !s.is_compatible(pps::schema_version{1}, {sub, schema3.share()}).get());
 
-    s.set_compatibility(pps::compatibility_level::backward_transitive).get();
+    s.set_compatibility(
+       pps::default_context, pps::compatibility_level::backward_transitive)
+      .get();
 
     // Test transitive defaulted field to previous - should fail
     BOOST_REQUIRE(

--- a/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
@@ -152,7 +152,8 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
     BOOST_REQUIRE_THROW(c(bad_schema_magic.copy()).get(), pps::exception);
 
     BOOST_REQUIRE(
-      s.get_compatibility().get() == pps::compatibility_level::backward);
+      s.get_compatibility(pps::default_context).get()
+      == pps::compatibility_level::backward);
     BOOST_REQUIRE(
       s.get_compatibility(subject0, pps::default_to_global::yes).get()
       == pps::compatibility_level::backward);

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -61,7 +61,7 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
       = store.referenced_by(referenced_schema.sub(), ver1).get();
 
     BOOST_REQUIRE_EQUAL(referenced_by.size(), 1);
-    BOOST_REQUIRE_EQUAL(referenced_by[0], pps::schema_id{2});
+    BOOST_REQUIRE_EQUAL(referenced_by[0].id, pps::schema_id{2});
 
     BOOST_REQUIRE(
       store.is_referenced(pps::subject{"simple.proto"}, pps::schema_version{1})

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -454,15 +454,20 @@ BOOST_AUTO_TEST_CASE(test_store_global_compat) {
 
     pps::compatibility_level expected{pps::compatibility_level::backward};
     pps::store s;
-    BOOST_REQUIRE(s.get_compatibility().value() == expected);
+    BOOST_REQUIRE(
+      s.get_compatibility(pps::default_context).value() == expected);
 
     // duplicate should return false
-    BOOST_REQUIRE(s.set_compatibility(expected).value() == false);
-    BOOST_REQUIRE(s.get_compatibility().value() == expected);
+    BOOST_REQUIRE(
+      s.set_compatibility(pps::default_context, expected).value() == false);
+    BOOST_REQUIRE(
+      s.get_compatibility(pps::default_context).value() == expected);
 
     expected = pps::compatibility_level::full_transitive;
-    BOOST_REQUIRE(s.set_compatibility(expected).value() == true);
-    BOOST_REQUIRE(s.get_compatibility().value() == expected);
+    BOOST_REQUIRE(
+      s.set_compatibility(pps::default_context, expected).value() == true);
+    BOOST_REQUIRE(
+      s.get_compatibility(pps::default_context).value() == expected);
 }
 
 BOOST_AUTO_TEST_CASE(test_store_subject_compat) {
@@ -475,7 +480,8 @@ BOOST_AUTO_TEST_CASE(test_store_subject_compat) {
     pps::compatibility_level global_expected{
       pps::compatibility_level::backward};
     pps::store s;
-    BOOST_REQUIRE(s.get_compatibility().value() == global_expected);
+    BOOST_REQUIRE(
+      s.get_compatibility(pps::default_context).value() == global_expected);
     s.insert({subject0, string_def0.share()});
 
     auto sub_expected = pps::compatibility_level::backward;
@@ -499,7 +505,8 @@ BOOST_AUTO_TEST_CASE(test_store_subject_compat) {
       == true);
     BOOST_REQUIRE(
       s.get_compatibility(subject0, fallback).value() == sub_expected);
-    BOOST_REQUIRE(s.get_compatibility().value() == global_expected);
+    BOOST_REQUIRE(
+      s.get_compatibility(pps::default_context).value() == global_expected);
 
     // Clearing compatibility should fallback to global
     BOOST_REQUIRE(
@@ -518,7 +525,8 @@ BOOST_AUTO_TEST_CASE(test_store_subject_compat_fallback) {
     BOOST_REQUIRE(s.get_compatibility(subject0, fallback).value() == expected);
 
     expected = pps::compatibility_level::forward;
-    BOOST_REQUIRE(s.set_compatibility(expected).value() == true);
+    BOOST_REQUIRE(
+      s.set_compatibility(pps::default_context, expected).value() == true);
     BOOST_REQUIRE(s.get_compatibility(subject0, fallback).value() == expected);
 }
 
@@ -545,7 +553,8 @@ BOOST_AUTO_TEST_CASE(test_store_delete_subject) {
       {pps::schema_version{1}, pps::schema_version{2}}};
 
     pps::store s;
-    s.set_compatibility(pps::compatibility_level::none).value();
+    s.set_compatibility(pps::default_context, pps::compatibility_level::none)
+      .value();
 
     pps::seq_marker dummy_marker;
 
@@ -664,7 +673,8 @@ BOOST_AUTO_TEST_CASE(test_store_delete_subject_version) {
 
     pps::seq_marker dummy_marker;
     pps::store s;
-    s.set_compatibility(pps::compatibility_level::none).value();
+    s.set_compatibility(pps::default_context, pps::compatibility_level::none)
+      .value();
 
     // Test unknown subject
     BOOST_REQUIRE_EQUAL(
@@ -740,7 +750,8 @@ BOOST_AUTO_TEST_CASE(test_store_delete_subject_version) {
 BOOST_AUTO_TEST_CASE(test_store_subject_version_latest) {
     pps::seq_marker dummy_marker;
     pps::store s;
-    s.set_compatibility(pps::compatibility_level::none).value();
+    s.set_compatibility(pps::default_context, pps::compatibility_level::none)
+      .value();
 
     // First insert, expect id{1}, version{1}
     s.insert({subject0, string_def0.share()});
@@ -786,7 +797,8 @@ BOOST_AUTO_TEST_CASE(test_store_delete_subject_after_delete_version) {
     std::vector<pps::schema_version> expected_vers{{pps::schema_version{2}}};
 
     pps::store s;
-    s.set_compatibility(pps::compatibility_level::none).value();
+    s.set_compatibility(pps::default_context, pps::compatibility_level::none)
+      .value();
 
     pps::seq_marker dummy_marker;
 

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -145,6 +145,18 @@ struct context_subject {
       : ctx{std::move(c)}
       , sub{std::move(s)} {}
 
+    // TODO: remove this, it is only for gradual commit-by-commit source code
+    // migration
+    context_subject(subject sub)
+      : ctx{default_context}
+      , sub{std::move(sub)} {}
+
+    // TODO: remove this, it is only for gradual commit-by-commit source code
+    // migration
+    context_subject(ss::sstring sub)
+      : ctx{default_context}
+      , sub{std::move(sub)} {}
+
     friend auto
     operator<=>(const context_subject& lhs, const context_subject& rhs)
       = default;
@@ -478,6 +490,12 @@ inline constexpr schema_id invalid_schema_id{-1};
 
 // A schema id that is valid within a context.
 struct context_schema_id {
+    // TODO: remove this, it is only for gradual commit-by-commit source code
+    // migration
+    context_schema_id(schema_id id)
+      : ctx{default_context}
+      , id{id} {}
+
     context_schema_id(context c, schema_id s)
       : ctx{std::move(c)}
       , id{s} {}

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -197,6 +197,10 @@ struct context_subject {
         return fmt::format_to(it, ":{}:{}", ctx, sub);
     }
 
+    bool starts_with(const ss::sstring& prefix) const {
+        return to_string().starts_with(prefix);
+    }
+
     context ctx;
     subject sub;
 };
@@ -609,13 +613,13 @@ struct stored_schema {
 ///\brief A mapping of version and schema id for a subject.
 struct subject_version_entry {
     subject_version_entry(
-      schema_version version, schema_id id, is_deleted deleted)
+      schema_version version, context_schema_id id, is_deleted deleted)
       : version{version}
-      , id{id}
+      , id{std::move(id)}
       , deleted(deleted) {}
 
     schema_version version;
-    schema_id id;
+    context_schema_id id;
     is_deleted deleted{is_deleted::no};
 };
 

--- a/src/v/schema/registry.cc
+++ b/src/v/schema/registry.cc
@@ -66,18 +66,18 @@ public:
     }
 
     ss::future<ppsr::schema_definition>
-    get_schema_definition(ppsr::schema_id id) const override {
+    get_schema_definition(ppsr::context_schema_id id) const override {
         auto [reader, _] = co_await service();
         co_return co_await reader->get_schema_definition(id);
     }
     ss::future<ppsr::stored_schema> get_subject_schema(
-      ppsr::subject sub,
+      ppsr::context_subject sub,
       std::optional<ppsr::schema_version> version) const override {
         auto [reader, _] = co_await service();
         co_return co_await reader->get_subject_schema(
           sub, version, ppsr::include_deleted::no);
     }
-    ss::future<ppsr::schema_id>
+    ss::future<ppsr::context_schema_id>
     create_schema(ppsr::subject_schema schema) override {
         auto [reader, writer] = co_await service();
         co_await writer->read_sync();
@@ -118,16 +118,18 @@ public:
           "invalid attempted usage of a disabled schema registry");
     }
     ss::future<ppsr::schema_definition>
-    get_schema_definition(ppsr::schema_id) const override {
+    get_schema_definition(ppsr::context_schema_id) const override {
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");
     }
     ss::future<ppsr::stored_schema> get_subject_schema(
-      ppsr::subject, std::optional<ppsr::schema_version>) const override {
+      ppsr::context_subject,
+      std::optional<ppsr::schema_version>) const override {
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");
     }
-    ss::future<ppsr::schema_id> create_schema(ppsr::subject_schema) override {
+    ss::future<ppsr::context_schema_id>
+    create_schema(ppsr::subject_schema) override {
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");
     }
@@ -135,7 +137,7 @@ public:
 } // namespace
 
 ss::future<std::optional<ppsr::valid_schema>>
-registry::get_valid_schema(ppsr::schema_id schema_id) const {
+registry::get_valid_schema(ppsr::context_schema_id schema_id) const {
     auto reader = co_await getter();
     auto schema_def_opt = co_await reader->maybe_get_schema_definition(
       schema_id);

--- a/src/v/schema/registry.h
+++ b/src/v/schema/registry.h
@@ -58,16 +58,19 @@ public:
     sync(ss::lowres_clock::duration max_age = {}) = 0;
 
     ss::future<std::optional<pandaproxy::schema_registry::valid_schema>>
-    get_valid_schema(pandaproxy::schema_registry::schema_id schema_id) const;
+    get_valid_schema(
+      pandaproxy::schema_registry::context_schema_id schema_id) const;
 
     virtual ss::future<pandaproxy::schema_registry::schema_definition>
-      get_schema_definition(pandaproxy::schema_registry::schema_id) const = 0;
+      get_schema_definition(
+        pandaproxy::schema_registry::context_schema_id) const
+      = 0;
     virtual ss::future<pandaproxy::schema_registry::stored_schema>
       get_subject_schema(
-        pandaproxy::schema_registry::subject,
+        pandaproxy::schema_registry::context_subject,
         std::optional<pandaproxy::schema_registry::schema_version>) const
       = 0;
-    virtual ss::future<pandaproxy::schema_registry::schema_id>
+    virtual ss::future<pandaproxy::schema_registry::context_schema_id>
       create_schema(pandaproxy::schema_registry::subject_schema) = 0;
 };
 } // namespace schema

--- a/src/v/schema/tests/fake_registry.cc
+++ b/src/v/schema/tests/fake_registry.cc
@@ -33,7 +33,7 @@ bool same_schema(
 } // namespace
 
 ss::future<ppsr::stored_schema> schema::fake_store::get_subject_schema(
-  ppsr::subject sub,
+  ppsr::context_subject sub,
   std::optional<ppsr::schema_version> version,
   ppsr::include_deleted) {
     std::optional<ppsr::stored_schema> found;
@@ -56,7 +56,7 @@ ss::future<ppsr::stored_schema> schema::fake_store::get_subject_schema(
 }
 
 ss::future<ppsr::schema_definition>
-schema::fake_store::get_schema_definition(ppsr::schema_id id) {
+schema::fake_store::get_schema_definition(ppsr::context_schema_id id) {
     for (const auto& s : schemas) {
         if (s.id == id) {
             co_return s.schema.def().share();
@@ -66,7 +66,7 @@ schema::fake_store::get_schema_definition(ppsr::schema_id id) {
 }
 
 ss::future<std::optional<ppsr::schema_definition>>
-schema::fake_store::maybe_get_schema_definition(ppsr::schema_id id) {
+schema::fake_store::maybe_get_schema_definition(ppsr::context_schema_id id) {
     for (const auto& s : schemas) {
         if (s.id == id) {
             co_return s.schema.def().share();
@@ -82,12 +82,13 @@ void schema::fake_registry::maybe_throw_injected_failure() const {
 }
 
 ss::future<ppsr::schema_definition>
-schema::fake_registry::get_schema_definition(ppsr::schema_id id) const {
+schema::fake_registry::get_schema_definition(ppsr::context_schema_id id) const {
     maybe_throw_injected_failure();
     return _store.get_schema_definition(id);
 }
 ss::future<ppsr::stored_schema> schema::fake_registry::get_subject_schema(
-  ppsr::subject sub, std::optional<ppsr::schema_version> version) const {
+  ppsr::context_subject sub,
+  std::optional<ppsr::schema_version> version) const {
     maybe_throw_injected_failure();
     return _store.get_subject_schema(sub, version, ppsr::include_deleted::no);
 }
@@ -95,7 +96,7 @@ ss::future<ppsr::schema_getter*> schema::fake_registry::getter() const {
     maybe_throw_injected_failure();
     co_return &_store;
 }
-ss::future<ppsr::schema_id>
+ss::future<ppsr::context_schema_id>
 schema::fake_registry::create_schema(ppsr::subject_schema unparsed) {
     maybe_throw_injected_failure();
     // This is wrong, but simple for our testing.

--- a/src/v/schema/tests/fake_registry.h
+++ b/src/v/schema/tests/fake_registry.h
@@ -20,14 +20,15 @@ namespace schema {
 struct fake_store : public pandaproxy::schema_registry::schema_getter {
 public:
     ss::future<pandaproxy::schema_registry::stored_schema> get_subject_schema(
-      pandaproxy::schema_registry::subject sub,
+      pandaproxy::schema_registry::context_subject sub,
       std::optional<pandaproxy::schema_registry::schema_version> version,
       pandaproxy::schema_registry::include_deleted inc_dec) final;
     ss::future<pandaproxy::schema_registry::schema_definition>
-    get_schema_definition(pandaproxy::schema_registry::schema_id id) final;
+    get_schema_definition(
+      pandaproxy::schema_registry::context_schema_id id) final;
     ss::future<std::optional<pandaproxy::schema_registry::schema_definition>>
     maybe_get_schema_definition(
-      pandaproxy::schema_registry::schema_id id) final;
+      pandaproxy::schema_registry::context_schema_id id) final;
 
     std::vector<pandaproxy::schema_registry::stored_schema> schemas;
 };
@@ -53,14 +54,14 @@ public:
 
     ss::future<pandaproxy::schema_registry::schema_definition>
     get_schema_definition(
-      pandaproxy::schema_registry::schema_id id) const override;
+      pandaproxy::schema_registry::context_schema_id id) const override;
 
     ss::future<pandaproxy::schema_registry::stored_schema> get_subject_schema(
-      pandaproxy::schema_registry::subject sub,
+      pandaproxy::schema_registry::context_subject sub,
       std::optional<pandaproxy::schema_registry::schema_version> version)
       const override;
 
-    ss::future<pandaproxy::schema_registry::schema_id> create_schema(
+    ss::future<pandaproxy::schema_registry::context_schema_id> create_schema(
       pandaproxy::schema_registry::subject_schema unparsed) override;
 
     const std::vector<pandaproxy::schema_registry::stored_schema>& get_all();

--- a/src/v/wasm/schema_registry_module.cc
+++ b/src/v/wasm/schema_registry_module.cc
@@ -198,8 +198,9 @@ ss::future<int32_t> schema_registry_module::create_subject_schema(
     ffi::reader r(buf);
     using namespace pandaproxy::schema_registry;
     try {
-        *out_schema_id = co_await _sr->create_schema(
+        auto ctx_id = co_await _sr->create_schema(
           subject_schema(sub, read_encoded_schema_def(&r)));
+        *out_schema_id = ctx_id.id;
     } catch (const std::exception& ex) {
         vlog(wasm_log.warn, "error registering subject schema: {}", ex);
         co_return SCHEMA_REGISTRY_ERROR;

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -3963,7 +3963,10 @@ class SchemaRegistryModeMutableTest(SchemaRegistryEndpoints):
         result_raw = self.sr_client.set_config(data=compat_back)
         assert result_raw.status_code == 422
         assert result_raw.json()["error_code"] == 42205
-        assert result_raw.json()["message"] == "Subject null is in read-only mode"
+        assert (
+            result_raw.json()["message"]
+            == "Subject null in context . is in read-only mode"
+        )
 
         result_raw = self.sr_client.set_config_subject(
             subject=ro_subject, data=compat_back
@@ -3971,7 +3974,8 @@ class SchemaRegistryModeMutableTest(SchemaRegistryEndpoints):
         assert result_raw.status_code == 422
         assert result_raw.json()["error_code"] == 42205
         assert (
-            result_raw.json()["message"] == f"Subject {ro_subject} is in read-only mode"
+            result_raw.json()["message"]
+            == f"Subject {ro_subject} in context . is in read-only mode"
         )
 
         result_raw = self.sr_client.set_config_subject(
@@ -3984,7 +3988,8 @@ class SchemaRegistryModeMutableTest(SchemaRegistryEndpoints):
         assert result_raw.status_code == 422
         assert result_raw.json()["error_code"] == 42205
         assert (
-            result_raw.json()["message"] == f"Subject {ro_subject} is in read-only mode"
+            result_raw.json()["message"]
+            == f"Subject {ro_subject} in context . is in read-only mode"
         )
 
         result_raw = self.sr_client.delete_config_subject(subject=rw_subject)
@@ -4036,7 +4041,8 @@ class SchemaRegistryModeMutableTest(SchemaRegistryEndpoints):
         assert result_raw.status_code == 422
         assert result_raw.json()["error_code"] == 42205
         assert (
-            result_raw.json()["message"] == f"Subject {ro_subject} is in read-only mode"
+            result_raw.json()["message"]
+            == f"Subject {ro_subject} in context . is in read-only mode"
         )
 
         self.logger.info("Posting schema 2 as rw_subject key")


### PR DESCRIPTION
This PR makes the Schema Registry store layer context-aware in preparation for schema registry context support.

Apart from error-message changes, there are no user-visible changes in this PR. The main changes are only mechanical refactoring / internal-only behaviour changes (memory layout, sharding strategy).

### Types changes
- `context_subject` and `context_schema_id` get implicit constructors from their non-context equivalents. This is to help gradually migrate the source code to be context-aware. For now, many source code locations assume to only act under the hardcoded `default_context`. These will all eventually be migrated and cleaned up, and I have a follow up (CORE-15189) to complete this by removing the implicit constructors.

### Error message changes
- Error messages will now include the context in the message for parity with the reference implementation
- Note: do not focus on the exact error messages too much, as I have a separate follow up ticket to audit and reach parity in the error messages (CORE-15190).

### Store + sharded_store key changes
- Context-scoped configs (mode, compatibility, next schema id) are now stored in an `absl::node_hash_map<context, context_store>` (aka `context_store_map`) that is sharded using `hash(context)`.
- Most endpoints now take `context_subject` instead of `subject` and `context_schema_id` instead of `schema_id` as appropriate.

Fixes https://redpandadata.atlassian.net/browse/CORE-15178

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
