### PR TITLE
Bump java client version to 4.1.x

### DIFF
--- a/tests/java/e2e-verifiers/pom.xml
+++ b/tests/java/e2e-verifiers/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <kafka.clients.version>3.1.2</kafka.clients.version>
+        <kafka.clients.version>4.1.1</kafka.clients.version>
         <commons.lang.version>3.9</commons.lang.version>
         <argparse4j.version>0.8.1</argparse4j.version>
         <slf4j.version>1.7.36</slf4j.version>

--- a/tests/java/kafka-serde/pom.xml
+++ b/tests/java/kafka-serde/pom.xml
@@ -30,7 +30,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <avro.version>1.12.0</avro.version>
-        <confluent.version>7.8.0</confluent.version>
+        <confluent.version>8.1.1</confluent.version>
         <slf4j.version>2.0.16</slf4j.version>
         <buildDir>${project.basedir}/target</buildDir>
     </properties>

--- a/tests/java/verifiers/pom.xml
+++ b/tests/java/verifiers/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.0.2</version>
+            <version>4.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/tests/java/verifiers/src/main/java/io/vectorized/tx_verifier/TxConsumer.java
+++ b/tests/java/verifiers/src/main/java/io/vectorized/tx_verifier/TxConsumer.java
@@ -2,6 +2,7 @@ package io.vectorized.tx_verifier;
 
 import java.lang.Math;
 import java.lang.Thread;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -61,7 +62,8 @@ public class TxConsumer {
 
     while (attempt < attempts) {
       attempt++;
-      ConsumerRecords<String, String> records = consumer.poll(timeout_ms);
+      ConsumerRecords<String, String> records
+          = consumer.poll(Duration.ofMillis(timeout_ms));
       var it = records.iterator();
       while (it.hasNext()) {
         var record = it.next();
@@ -97,7 +99,8 @@ public class TxConsumer {
 
     while (attempt < attempts) {
       attempt++;
-      ConsumerRecords<String, String> records = consumer.poll(timeout_ms);
+      ConsumerRecords<String, String> records
+          = consumer.poll(Duration.ofMillis(timeout_ms));
       var it = records.iterator();
       while (it.hasNext()) {
         read++;

--- a/tests/java/verifiers/src/main/java/io/vectorized/tx_verifier/TxStream.java
+++ b/tests/java/verifiers/src/main/java/io/vectorized/tx_verifier/TxStream.java
@@ -1,12 +1,15 @@
 package io.vectorized.tx_verifier;
 
 import java.lang.Math;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Function;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -96,22 +99,24 @@ public class TxStream {
     producer.beginTransaction();
     offsets = new HashMap<>();
     offsets.put(tp, new OffsetAndMetadata(start));
-    producer.sendOffsetsToTransaction(offsets, groupId);
+    producer.sendOffsetsToTransaction(offsets, consumer.groupMetadata());
     producer.commitTransaction();
   }
 
   public long getGroupOffset() throws Exception {
-    return this.consumer.committed(new TopicPartition(topic, 0)).offset();
+    var tp = new TopicPartition(topic, 0);
+    return this.consumer.committed(Set.of(tp)).get(tp).offset();
   }
 
-  public Map<Long, Long> process(
-      long end, Function<String, String> transform, int batchSize,
-      String target_topic) throws Exception {
+  public Map<Long, Long>
+  process(long end, Function<String, String> transform, String target_topic)
+      throws Exception {
     Map<TopicPartition, OffsetAndMetadata> offsets;
     Map<Long, Long> mapping = new HashMap<>();
 
     while (true) {
-      ConsumerRecords<String, String> records = consumer.poll(batchSize);
+      ConsumerRecords<String, String> records
+          = consumer.poll(Duration.ofMillis(10000));
       var it = records.iterator();
       while (it.hasNext()) {
         var record = it.next();
@@ -126,7 +131,7 @@ public class TxStream {
         long target_offset = future.get().offset();
         offsets = new HashMap<>();
         offsets.put(tp, new OffsetAndMetadata(source_offset + 1));
-        producer.sendOffsetsToTransaction(offsets, groupId);
+        producer.sendOffsetsToTransaction(offsets, consumer.groupMetadata());
         producer.commitTransaction();
 
         mapping.put(target_offset, source_offset);

--- a/tests/java/verifiers/src/main/java/io/vectorized/tx_verifier/Verifier.java
+++ b/tests/java/verifiers/src/main/java/io/vectorized/tx_verifier/Verifier.java
@@ -568,8 +568,7 @@ class Verifier {
           "consumer should observe committed offset; committed offset: "
               + first_offset + ", group offset: " + group_offset);
 
-      var mapping
-          = stream.process(last_offset, x -> x.toUpperCase(), 1, topic2);
+      var mapping = stream.process(last_offset, x -> x.toUpperCase(), topic2);
       stream.close();
       stream = null;
 

--- a/tests/rptest/chaos_tests/README.md
+++ b/tests/rptest/chaos_tests/README.md
@@ -25,7 +25,7 @@ Original test set had the following structure:
 This is translated into the following ducktape test structure:
 * Workloads are ducktape services inheriting from WorkloadServiceBase.
 * Scenarios correspond to test classes. Each class inherits from the base
-  scenario class, but they differ in how the prepare the cluster and topics.
+  scenario class, but they differ in how they prepare the cluster and topics.
 * Suites correspond to test methods of the scenario classes.
 * Each test case corresponds to a case_id parameter passed to a test method.
 * The test method instantiates the workload and the fault (based on the

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -316,7 +316,9 @@ class TestReadReplicaService(EndToEndTest):
     def test_identical_lwms_after_delete_records(
         self, partition_count: int, cloud_storage_type: CloudStorageType
     ) -> None:
-        self._setup_read_replica(partition_count=partition_count, num_messages=1000)
+        self._setup_read_replica(
+            partition_count=partition_count, num_messages=partition_count * 2000
+        )
         rpk = RpkTool(self.redpanda)
 
         def set_lwm(new_lwm):

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -641,7 +641,7 @@ def bg_thread_cm(func) -> Callable[..., ContextManager]:
         while (yield):
             try:
                 # Some action we'd like to repeat
-            catch Exception as e:
+            except Exception as e:
                 # Handle exception, typically just log it.
                 # If we (re-)throw an exception, the background thread stops
         # Some cleanup if needed


### PR DESCRIPTION
To test Redpanda against the new version.

This has nothing about Kafka's Transactions V2: since Redpanda doesn't support it, the clients fall back to the old behaviour.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
