### PR TITLE
ct/l0: Fix materialize request exceeding memory quota

### DIFF
--- a/src/v/cloud_topics/data_plane_api.h
+++ b/src/v/cloud_topics/data_plane_api.h
@@ -70,12 +70,20 @@ public:
       model::timeout_clock::time_point deadline)
       = 0;
 
+    // Materialize extents from the L0 read pipeline.
+    // `output_size_estimate` must not exceed `materialize_max_bytes()`.
     virtual ss::future<result<chunked_vector<model::record_batch>>> materialize(
       model::ntp ntp,
       size_t output_size_estimate,
       chunked_vector<extent_meta> metadata,
       model::timeout_clock::time_point timeout)
       = 0;
+
+    /// Return the maximum bytes that may be requested in a single
+    /// materialize() call. This reflects the read pipeline's memory quota.
+    /// Callers of `materialize` must limit their requests to stay within this
+    /// bound.
+    virtual size_t materialize_max_bytes() const = 0;
 
     /// Cache materialized record batch
     virtual void cache_put(const model::ntp&, const model::record_batch& b) = 0;

--- a/src/v/cloud_topics/data_plane_impl.cc
+++ b/src/v/cloud_topics/data_plane_impl.cc
@@ -168,6 +168,15 @@ public:
         if (metadata.empty()) {
             co_return chunked_vector<model::record_batch>{};
         }
+        // Callers must respect materialize_max_bytes() to avoid blocking
+        // forever on the read pipeline's memory semaphore.
+        auto max_bytes = materialize_max_bytes();
+        vassert(
+          output_size_estimate <= max_bytes,
+          "materialize request size {} exceeds limit {}; caller must "
+          "respect materialize_max_bytes()",
+          output_size_estimate,
+          max_bytes);
         auto res = co_await _read_pipeline.local().make_reader(
           ntp,
           {
@@ -188,6 +197,10 @@ public:
     std::optional<model::record_batch>
     cache_get(const model::ntp& ntp, model::offset o) final {
         return _batch_cache.local().get(ntp, o);
+    }
+
+    size_t materialize_max_bytes() const final {
+        return _read_pipeline.local().memory_quota_capacity();
     }
 
 private:

--- a/src/v/cloud_topics/frontend/tests/frontend_test.cc
+++ b/src/v/cloud_topics/frontend/tests/frontend_test.cc
@@ -77,6 +77,8 @@ public:
       (const model::ntp&, model::offset o),
       (override));
 
+    MOCK_METHOD(size_t, materialize_max_bytes, (), (const, override));
+
     MOCK_METHOD(ss::future<>, start, (), (override));
 
     MOCK_METHOD(ss::future<>, stop, (), (override));

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -32,7 +32,12 @@ level_zero_log_reader_impl::level_zero_log_reader_impl(
   : _config(cfg)
   , _ctp(std::move(ctp))
   , _ct_api(ct_api)
-  , _log(cd_log, fmt::format("[{}/{}]", fmt::ptr(this), _ctp->ntp())) {}
+  , _log(cd_log, fmt::format("[{}/{}]", fmt::ptr(this), _ctp->ntp())) {
+    // Cap the reader's max_bytes at the read pipeline's memory quota to prevent
+    // a single materialize call from exceeding what the pipeline can handle.
+    _config.max_bytes = std::min(
+      _config.max_bytes, _ct_api->materialize_max_bytes());
+}
 
 ss::future<model::record_batch_reader::storage_t>
 level_zero_log_reader_impl::do_load_slice(

--- a/src/v/cloud_topics/level_zero/pipeline/read_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/read_pipeline.cc
@@ -52,7 +52,8 @@ void read_pipeline<Clock>::stage::push_next_stage(
 
 template<class Clock>
 read_pipeline<Clock>::read_pipeline()
-  : _mem_quota(get_cloud_topics_l0_read_path_memory(), "read-pipeline")
+  : _mem_quota_capacity(get_cloud_topics_l0_read_path_memory())
+  , _mem_quota(_mem_quota_capacity, "read-pipeline")
   // TODO: use config parameter
   , _breaker(10, std::chrono::seconds(1))
   , _probe(

--- a/src/v/cloud_topics/level_zero/pipeline/read_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/read_pipeline.h
@@ -133,6 +133,11 @@ public:
 
     event trigger_event(pipeline_stage stage);
 
+    /// Return the memory quota capacity for the read pipeline.
+    size_t memory_quota_capacity() const noexcept {
+        return _mem_quota_capacity;
+    }
+
 private:
     ss::abort_source& get_abort_source() {
         return this->get_root_rtc().root_abort_source();
@@ -160,6 +165,7 @@ private:
     // Total bytes went through the pipeline
     size_t _bytes_total{0};
 
+    size_t _mem_quota_capacity;
     ssx::named_semaphore<Clock> _mem_quota;
 
     circuit_breaker<Clock> _breaker;


### PR DESCRIPTION
A materialize request could exceed the read pipeline's memory quota, causing an infinite wait at the semaphore. This happened when the caller's max_bytes (e.g., 64 MiB from reconciler) exceeded the read pipeline's quota (~41 MB with 2GB memory).

Fix by exposing the quota via materialize_max_bytes() and:
1. Capping the reader's max_bytes at the quota in the constructor
2. Adding a vassert in materialize() to catch violations

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
