### PR TITLE
cloud_io/cache: Add get_stream_range for reading byte ranges

### DIFF
--- a/src/v/cloud_io/basic_cache_service_api.h
+++ b/src/v/cloud_io/basic_cache_service_api.h
@@ -113,6 +113,21 @@ public:
       unsigned int read_ahead = default_read_ahead)
       = 0;
 
+    /// Get a range of a cached value as a stream if it exists
+    ///
+    /// \param key is a cache key
+    /// \param offset is the byte offset to start reading from
+    /// \param length is the number of bytes to read
+    /// \param read_buffer_size is a read buffer size for the iostream
+    /// \param read_ahead number of pages that can be read asynchronously
+    virtual ss::future<std::optional<cache_item_stream>> get_stream_range(
+      std::filesystem::path key,
+      uint64_t offset,
+      uint64_t length,
+      size_t read_buffer_size = default_read_buffer_size,
+      unsigned int read_ahead = default_read_ahead)
+      = 0;
+
     /// Add new value to the cache, overwrite if it's already exist
     ///
     /// \param key is a cache key

--- a/src/v/cloud_io/cache_service.cc
+++ b/src/v/cloud_io/cache_service.cc
@@ -1133,6 +1133,28 @@ ss::future<std::optional<cloud_io::cache_item_stream>> cache::get_stream(
     };
 }
 
+ss::future<std::optional<cloud_io::cache_item_stream>> cache::get_stream_range(
+  std::filesystem::path key,
+  uint64_t offset,
+  uint64_t length,
+  size_t read_buffer_size,
+  unsigned int read_ahead) {
+    auto get_res = co_await get(key);
+    if (!get_res.has_value()) {
+        co_return std::nullopt;
+    }
+
+    ss::file_input_stream_options options{};
+    options.buffer_size = read_buffer_size;
+    options.read_ahead = read_ahead;
+    auto stream = ss::make_file_input_stream(
+      std::move(get_res->body), offset, length, std::move(options));
+    co_return cloud_io::cache_item_stream{
+      .body = std::move(stream),
+      .size = length,
+    };
+}
+
 ss::future<std::optional<cache_item>> cache::_get(std::filesystem::path key) {
     auto guard = _gate.hold();
     vlog(log.debug, "Trying to get {} from archival cache.", key.native());

--- a/src/v/cloud_io/cache_service.h
+++ b/src/v/cloud_io/cache_service.h
@@ -89,6 +89,13 @@ public:
       size_t read_buffer_size = cloud_io::default_read_buffer_size,
       unsigned int read_ahead = cloud_io::default_read_ahead) override;
 
+    ss::future<std::optional<cloud_io::cache_item_stream>> get_stream_range(
+      std::filesystem::path key,
+      uint64_t offset,
+      uint64_t length,
+      size_t read_buffer_size = cloud_io::default_read_buffer_size,
+      unsigned int read_ahead = cloud_io::default_read_ahead) override;
+
     /// Add new value to the cache, overwrite if it's already exist
     ///
     /// \param key is a cache key

--- a/src/v/cloud_topics/level_zero/reader/materialized_extent.cc
+++ b/src/v/cloud_topics/level_zero/reader/materialized_extent.cc
@@ -119,6 +119,8 @@ model::record_batch make_raft_data_batch(materialized_extent ext) {
 
 ss::future<result<iobuf>> materialize_from_cache(
   std::filesystem::path cache_file_name,
+  uint64_t offset,
+  uint64_t length,
   cloud_io::basic_cache_service_api<>* cache,
   micro_probe* probe);
 
@@ -186,11 +188,18 @@ ss::future<result<bool>> materialize(
 
     if (status.value() == cloud_io::cache_element_status::available) {
         auto res = co_await materialize_from_cache(
-          cache_file_name, cache, probe);
+          cache_file_name,
+          ext->meta.first_byte_offset(),
+          ext->meta.byte_range_size(),
+          cache,
+          probe);
         if (!res.has_value()) {
             co_return res.error();
         }
         ext->object = std::move(res.value());
+        // Object now contains just the extent range, so reset offset to 0
+        ext->meta.first_byte_offset = cloud_topics::first_byte_offset_t{0};
+        hydrated = true; // Indicates range read from cache
     } else {
         auto res = co_await materialize_from_cloud_storage(
           cache_file_name, bucket, api, cache, rtc, probe);
@@ -204,14 +213,18 @@ ss::future<result<bool>> materialize(
 
 ss::future<result<iobuf>> materialize_from_cache(
   std::filesystem::path cache_file_name,
+  uint64_t offset,
+  uint64_t length,
   cloud_io::basic_cache_service_api<>* cache,
   micro_probe* probe) {
     iobuf result_buf;
     probe->num_cache_reads++;
     auto buffer_size = config::shard_local_cfg().storage_read_buffer_size();
-    auto read_ahead = config::shard_local_cfg().storage_read_readahead_count();
-    auto fut = co_await ss::coroutine::as_future(
-      cache->get_stream(cache_file_name, buffer_size, read_ahead));
+    // Disable readahead: we're reading a specific extent range where
+    // neighboring bytes belong to different partitions and won't be useful.
+    constexpr unsigned int read_ahead = 0;
+    auto fut = co_await ss::coroutine::as_future(cache->get_stream_range(
+      cache_file_name, offset, length, buffer_size, read_ahead));
     auto sz_stream_result = result_from_ready_future<errc::cache_read_error>(
       std::move(fut));
     if (!sz_stream_result.has_value()) {

--- a/src/v/cloud_topics/level_zero/reader/materialized_extent_reader.cc
+++ b/src/v/cloud_topics/level_zero/reader/materialized_extent_reader.cc
@@ -56,9 +56,10 @@ ss::future<result<chunked_vector<materialized_extent>>> materialize_sorted_run(
             if (!res.has_value()) {
                 co_return res.error();
             }
-            // Only cache the full object for sharing if it wasn't a range read.
-            // Range reads (res.value() == true) only contain the extent's data,
-            // not the full L0 object.
+            // If reading from cache (res.value() == true), only the
+            // required range was returned. Otherwise, the object
+            // was hydrated and we can place it into the `hydrated`
+            // collection.
             if (!res.value()) {
                 hydrated.insert(
                   std::make_pair(

--- a/src/v/cloud_topics/level_zero/reader/materialized_extent_reader.cc
+++ b/src/v/cloud_topics/level_zero/reader/materialized_extent_reader.cc
@@ -56,9 +56,15 @@ ss::future<result<chunked_vector<materialized_extent>>> materialize_sorted_run(
             if (!res.has_value()) {
                 co_return res.error();
             }
-            hydrated.insert(
-              std::make_pair(
-                back.meta.id, back.object.share(0, back.object.size_bytes())));
+            // Only cache the full object for sharing if it wasn't a range read.
+            // Range reads (res.value() == true) only contain the extent's data,
+            // not the full L0 object.
+            if (!res.value()) {
+                hydrated.insert(
+                  std::make_pair(
+                    back.meta.id,
+                    back.object.share(0, back.object.size_bytes())));
+            }
         }
     }
     co_return std::move(extents);

--- a/src/v/cloud_topics/level_zero/reader/tests/materialized_extent_fixture.cc
+++ b/src/v/cloud_topics/level_zero/reader/tests/materialized_extent_fixture.cc
@@ -84,12 +84,21 @@ void materialized_extent_fixture::produce_placeholders(
         }
         return std::move(builder).build();
     };
+    // Per-batch metadata for setting up cache range expectations
+    struct batch_cache_info {
+        std::filesystem::path path;
+        uint64_t offset;
+        uint64_t size;
+        iobuf data;
+    };
     // List of placeholder batches alongside the list of L0 objects
     // that has to be added to the cloud storage mock and (optionally) cache
     // mock
     struct placeholders_and_uploads {
         chunked_vector<model::record_batch> placeholders;
         std::map<std::filesystem::path, iobuf> uploads;
+        // Per-batch info for cache range reads
+        std::vector<batch_cache_info> batch_infos;
     };
     // Produce data for the partition and the cloud/cache. Group data
     // together using 'group_by' parameter.
@@ -99,26 +108,38 @@ void materialized_extent_fixture::produce_placeholders(
         std::queue<iobuf> serialized_batches) -> placeholders_and_uploads {
         chunked_vector<model::record_batch> placeholders;
         std::map<std::filesystem::path, iobuf> uploads;
+        std::vector<batch_cache_info> batch_infos;
         while (!sources.empty()) {
             iobuf current;
             auto id = cloud_topics::object_id::create(
               cloud_topics::cluster_epoch(1));
+            auto fname = cloud_topics::object_path_factory::level_zero_path(id);
             for (int i = 0; i < group_by; i++) {
                 auto buf = std::move(serialized_batches.front());
                 serialized_batches.pop();
                 auto batch = std::move(sources.front());
                 sources.pop();
+                auto offset = current.size_bytes();
+                auto size = buf.size_bytes();
                 auto placeholder = generate_placeholder(
-                  id, current.size_bytes(), buf.size_bytes(), batch);
+                  id, offset, size, batch);
                 placeholders.push_back(std::move(placeholder));
+                // Track per-batch info for cache expectations
+                batch_infos.push_back(
+                  batch_cache_info{
+                    .path = fname,
+                    .offset = offset,
+                    .size = size,
+                    .data = buf.copy(),
+                  });
                 current.append(std::move(buf));
             }
-            auto fname = cloud_topics::object_path_factory::level_zero_path(id);
             uploads[fname] = std::move(current);
         }
         return {
           .placeholders = std::move(placeholders),
           .uploads = std::move(uploads),
+          .batch_infos = std::move(batch_infos),
         };
     };
     std::queue<model::record_batch> sources;
@@ -147,34 +168,34 @@ void materialized_extent_fixture::produce_placeholders(
         serialized_batches.push(buf.copy());
         sources.push(b.copy());
     }
-    auto [placeholders, uploads] = generate_placeholders_and_uploads(
-      std::move(sources), std::move(serialized_batches));
+    auto [placeholders, uploads, batch_infos]
+      = generate_placeholders_and_uploads(
+        std::move(sources), std::move(serialized_batches));
     vlog(
       test_log.info,
       "Generated {} placeholders and {} L0 objects",
       placeholders.size(),
       uploads.size());
 
-    for (auto&& kv : uploads) {
-        auto sz = kv.second.size_bytes();
-        injected_failure failure = {};
-        if (!injected_failures.empty()) {
-            failure = injected_failures.back();
-            injected_failures.pop();
-        }
-        if (use_cache) {
-            // Simplified event flow:
-            // cache.is_cached() -> available
-            // cache.get() -> payload
-
+    if (use_cache) {
+        // For cache reads, set up per-batch expectations for range reads
+        // Simplified event flow per batch:
+        // cache.is_cached() -> available
+        // cache.get_stream_range() -> payload for this batch's range
+        for (auto&& info : batch_infos) {
+            injected_failure failure = {};
+            if (!injected_failures.empty()) {
+                failure = injected_failures.back();
+                injected_failures.pop();
+            }
             switch (failure.is_cached) {
             case injected_is_cached_failure::none:
                 cache.expect_is_cached(
-                  kv.first, cloud_io::cache_element_status::available);
+                  info.path, cloud_io::cache_element_status::available);
                 break;
             case injected_is_cached_failure::stall_then_ok:
                 cache.expect_is_cached(
-                  kv.first,
+                  info.path,
                   std::vector<cloud_io::cache_element_status>{
                     cloud_io::cache_element_status::in_progress,
                     cloud_io::cache_element_status::available});
@@ -187,39 +208,56 @@ void materialized_extent_fixture::produce_placeholders(
                 throw std::runtime_error("Not implemented");
             case injected_is_cached_failure::throw_error:
                 cache.expect_is_cached_throws(
-                  kv.first,
+                  info.path,
                   std::make_exception_ptr(std::runtime_error("dummy")));
                 continue;
             case injected_is_cached_failure::throw_shutdown:
                 cache.expect_is_cached_throws(
-                  kv.first,
+                  info.path,
                   std::make_exception_ptr(ss::gate_closed_exception()));
                 continue;
             };
 
             cloud_io::cache_item_stream s{
-              .body = make_iobuf_input_stream(kv.second.copy()),
-              .size = sz,
+              .body = make_iobuf_input_stream(std::move(info.data)),
+              .size = info.size,
             };
             switch (failure.cache_get) {
             case injected_cache_get_failure::none:
-                cache.expect_get_stream(kv.first, std::move(s));
+                cache.expect_get_stream_range(
+                  info.path, info.offset, info.size, std::move(s));
                 break;
             case injected_cache_get_failure::return_error:
-                cache.expect_get_stream(kv.first, std::nullopt);
+                cache.expect_get_stream_range(
+                  info.path, info.offset, info.size, std::nullopt);
                 break;
             case injected_cache_get_failure::throw_error:
-                cache.expect_get_stream_throws(
-                  kv.first,
+                cache.expect_get_stream_range_throws(
+                  info.path,
+                  info.offset,
+                  info.size,
                   std::make_exception_ptr(std::runtime_error("dummy")));
                 break;
             case injected_cache_get_failure::throw_shutdown:
-                cache.expect_get_stream_throws(
-                  kv.first,
+                cache.expect_get_stream_range_throws(
+                  info.path,
+                  info.offset,
+                  info.size,
                   std::make_exception_ptr(ss::gate_closed_exception()));
                 break;
             };
-        } else {
+        }
+    }
+
+    // For cloud storage reads (not cached), set up expectations per L0 object
+    if (!use_cache) {
+        for (auto&& kv : uploads) {
+            auto sz = kv.second.size_bytes();
+            injected_failure failure = {};
+            if (!injected_failures.empty()) {
+                failure = injected_failures.back();
+                injected_failures.pop();
+            }
             // Simplified event flow:
             // cache.is_cached() -> not_available
             // remote.download_object() -> payload

--- a/src/v/cloud_topics/level_zero/reader/tests/mocks.h
+++ b/src/v/cloud_topics/level_zero/reader/tests/mocks.h
@@ -209,6 +209,35 @@ public:
           .WillOnce(::testing::Return(std::move(fut)));
     }
 
+    void expect_get_stream_range(
+      std::filesystem::path p,
+      uint64_t offset,
+      uint64_t length,
+      std::optional<cloud_io::cache_item_stream> item) {
+        auto fut
+          = ss::make_ready_future<std::optional<cloud_io::cache_item_stream>>(
+            std::move(item));
+        EXPECT_CALL(
+          *this,
+          get_stream_range(p, offset, length, ::testing::_, ::testing::_))
+          .Times(1)
+          .WillOnce(::testing::Return(std::move(fut)));
+    }
+
+    void expect_get_stream_range_throws(
+      std::filesystem::path p,
+      uint64_t offset,
+      uint64_t length,
+      std::exception_ptr e) {
+        auto fut = ss::make_exception_future<
+          std::optional<cloud_io::cache_item_stream>>(e);
+        EXPECT_CALL(
+          *this,
+          get_stream_range(p, offset, length, ::testing::_, ::testing::_))
+          .Times(1)
+          .WillOnce(::testing::Return(std::move(fut)));
+    }
+
     void expect_put(std::filesystem::path p, std::exception_ptr e = nullptr) {
         ss::future<> result = ss::now();
         if (e != nullptr) {

--- a/src/v/cloud_topics/level_zero/reader/tests/mocks.h
+++ b/src/v/cloud_topics/level_zero/reader/tests/mocks.h
@@ -128,6 +128,16 @@ public:
       ());
 
     MOCK_METHOD(
+      ss::future<std::optional<cloud_io::cache_item_stream>>,
+      get_stream_range,
+      (std::filesystem::path key,
+       uint64_t offset,
+       uint64_t length,
+       size_t read_buffer_size,
+       unsigned int read_ahead),
+      ());
+
+    MOCK_METHOD(
       ss::future<>,
       put,
       (std::filesystem::path key,


### PR DESCRIPTION
L0 objects contain extents from multiple partitions. When reading a cached L0 object, we previously loaded the entire object into memory even though only a specific extent's byte range was needed.

This adds get_stream_range() to the cache API which reads only the requested byte range. The L0 reader now uses this to read just the extent data.

In testing, this helped reduce cloud cache I/O significantly. It also helps estimated memory usage more closely match actual memory usage in the L0 fetch path.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

