### PR TITLE
ct/reconciler: Add priority-order processing and fast-follow

### DIFF
--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -215,9 +215,9 @@ ss::future<> reconciler::reconciliation_loop() {
          *   except for shutdown
          */
         // clang-format on
-        chunked_vector<model::ntp> processed_ntps;
+        reconcile_result result;
         try {
-            processed_ntps = co_await reconcile();
+            result = co_await reconcile();
         } catch (...) {
             const auto is_shutdown = ssx::is_shutdown_exception(
               std::current_exception());
@@ -230,7 +230,7 @@ ss::future<> reconciler::reconciliation_loop() {
 
         // Update priority counters based on what was processed.
         chunked_hash_set<model::ntp> processed_set(
-          processed_ntps.begin(), processed_ntps.end());
+          result.processed_ntps.begin(), result.processed_ntps.end());
         for (auto& [ntp, entry] : _sources) {
             if (processed_set.contains(ntp)) {
                 entry.rounds_waiting = 0;
@@ -239,11 +239,21 @@ ss::future<> reconciler::reconciliation_loop() {
             }
         }
 
-        next_wait = _scheduler.current_interval();
+        // If we filled an object to max size, re-reconcile immediately.
+        // The reconciler tries to stay on the batch cache aggressively
+        // when throughput is high.
+        const auto max_object_size
+          = config::shard_local_cfg()
+              .cloud_topics_reconciliation_max_object_size();
+        if (result.max_object_bytes >= max_object_size) {
+            next_wait = ss::lowres_clock::duration::zero();
+        } else {
+            next_wait = _scheduler.current_interval();
+        }
     }
 }
 
-ss::future<chunked_vector<model::ntp>> reconciler::reconcile() {
+ss::future<reconcile_result> reconciler::reconcile() {
     _probe.increment_rounds();
 
     chunked_vector<source_entry> entries;
@@ -256,7 +266,7 @@ ss::future<chunked_vector<model::ntp>> reconciler::reconcile() {
       "Reconciliation loop tick with {} attached partitions",
       entries.size());
     if (entries.empty()) {
-        co_return chunked_vector<model::ntp>{};
+        co_return reconcile_result{};
     }
 
     auto source_sets = partition_sources_into_sets(std::move(entries));
@@ -264,19 +274,18 @@ ss::future<chunked_vector<model::ntp>> reconciler::reconcile() {
     // Adapt scheduling interval based on max object size produced.
     // Note that we slow down if there's nothing to reconcile or if all
     // objects failed. This is a sort of retry with backoff mechanism.
-    size_t max_bytes_produced = 0;
-    chunked_vector<model::ntp> all_processed;
+    reconcile_result result;
     for (auto& source_set : source_sets) {
-        auto [bytes, processed] = co_await reconcile_source_set(
-          std::move(source_set));
-        max_bytes_produced = std::max(max_bytes_produced, bytes);
-        for (auto& ntp : processed) {
-            all_processed.push_back(std::move(ntp));
+        auto set_result = co_await reconcile_source_set(std::move(source_set));
+        result.max_object_bytes = std::max(
+          result.max_object_bytes, set_result.max_object_bytes);
+        for (auto& ntp : set_result.processed_ntps) {
+            result.processed_ntps.push_back(std::move(ntp));
         }
     }
 
-    _scheduler.adapt(max_bytes_produced);
-    co_return all_processed;
+    _scheduler.adapt(result.max_object_bytes);
+    co_return result;
 }
 
 chunked_vector<chunked_vector<ss::shared_ptr<source>>>
@@ -309,11 +318,10 @@ reconciler::partition_sources_into_sets(chunked_vector<source_entry> entries) {
     return result;
 }
 
-ss::future<std::pair<size_t, chunked_vector<model::ntp>>>
-reconciler::reconcile_source_set(
+ss::future<reconcile_result> reconciler::reconcile_source_set(
   chunked_vector<ss::shared_ptr<source>> sources) {
     if (sources.empty()) {
-        co_return std::pair{size_t{0}, chunked_vector<model::ntp>{}};
+        co_return reconcile_result{};
     }
 
     // Begin by creating the set of objects to be built.
@@ -340,7 +348,7 @@ reconciler::reconcile_source_set(
           "Could not create object metadata builder: {}",
           metadata_builder_res.error());
         _probe.increment_rounds_failed();
-        co_return std::pair{size_t{0}, chunked_vector<model::ntp>{}};
+        co_return reconcile_result{};
     }
     auto& metadata_builder = metadata_builder_res.value();
     chunked_hash_map<l1::object_id, chunked_vector<ss::shared_ptr<source>>>
@@ -351,7 +359,7 @@ reconciler::reconcile_source_set(
         if (!oid.has_value()) {
             vlog(lg.warn, "Could not get object: {}", oid.error());
             _probe.increment_rounds_failed();
-            co_return std::pair{size_t{0}, chunked_vector<model::ntp>{}};
+            co_return reconcile_result{};
         }
         oid_to_sources[oid.value()].push_back(src);
     }
@@ -387,7 +395,7 @@ reconciler::reconcile_source_set(
               oid,
               ex);
             if (is_shutdown) {
-                co_return std::pair{size_t{0}, chunked_vector<model::ntp>{}};
+                co_return reconcile_result{};
             }
             failed_objects.push_back(oid);
             continue;
@@ -432,7 +440,7 @@ reconciler::reconcile_source_set(
         // NB: This doesn't count as failing the round because it may be that
         // all sources are fully reconciled.
         vlog(lg.debug, "No successful objects to commit to metastore");
-        co_return std::pair{size_t{0}, chunked_vector<model::ntp>{}};
+        co_return reconcile_result{};
     }
 
     // Commit all successful objects to the metastore.
@@ -443,18 +451,19 @@ reconciler::reconcile_source_set(
           "Abandoning reconciliation run because the L1 metastore operation "
           "failed"));
         _probe.increment_rounds_failed();
-        co_return std::pair{size_t{0}, chunked_vector<model::ntp>{}};
+        co_return reconcile_result{};
     }
 
     // Collect the NTPs that were successfully processed.
-    chunked_vector<model::ntp> processed_ntps;
+    reconcile_result result;
+    result.max_object_bytes = max_bytes_produced;
     for (const auto& obj : successful_objects) {
         for (const auto& commit : obj.commits) {
-            processed_ntps.push_back(commit.source->ntp());
+            result.processed_ntps.push_back(commit.source->ntp());
         }
     }
 
-    co_return std::pair{max_bytes_produced, std::move(processed_ntps)};
+    co_return result;
 }
 
 ss::future<std::expected<reconciler::built_object_metadata, reconcile_error>>

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -25,6 +25,7 @@
 #include "cluster/partition.h"
 #include "config/configuration.h"
 #include "model/fundamental.h"
+#include "random/generators.h"
 #include "ssx/future-util.h"
 #include "utils/retry_chain_node.h"
 
@@ -95,12 +96,13 @@ void reconciler::attach_source(ss::shared_ptr<source> src) {
     if (_sources.contains(src->ntp())) {
         return;
     }
+    auto ntp = src->ntp();
     vlog(
       lg.debug,
       "Attaching partition {} (tidp: {})",
-      src->ntp(),
+      ntp,
       src->topic_id_partition());
-    _sources.emplace(src->ntp(), src);
+    _sources.emplace(std::move(ntp), source_entry{.src = std::move(src)});
 }
 
 void reconciler::detach(const model::ntp& ntp) {
@@ -113,6 +115,26 @@ void reconciler::detach(const model::ntp& ntp) {
          * _sources collection.
          */
         _sources.erase(it);
+    }
+}
+
+void reconciler::prioritize_sources(chunked_vector<source_entry>& entries) {
+    // Sort entries by rounds waiting (descending) so starved partitions
+    // get priority.
+    std::sort(entries.begin(), entries.end(), [](auto& a, auto& b) {
+        return a.rounds_waiting > b.rounds_waiting;
+    });
+
+    // Shuffle within groups of same rounds_waiting value for fairness.
+    auto& rng = random_generators::global().engine();
+    auto it = entries.begin();
+    while (it != entries.end()) {
+        auto group_start = it;
+        auto group_waiting = it->rounds_waiting;
+        while (it != entries.end() && it->rounds_waiting == group_waiting) {
+            ++it;
+        }
+        std::shuffle(group_start, it, rng);
     }
 }
 
@@ -193,8 +215,9 @@ ss::future<> reconciler::reconciliation_loop() {
          *   except for shutdown
          */
         // clang-format on
+        chunked_vector<model::ntp> processed_ntps;
         try {
-            co_await reconcile();
+            processed_ntps = co_await reconcile();
         } catch (...) {
             const auto is_shutdown = ssx::is_shutdown_exception(
               std::current_exception());
@@ -204,67 +227,93 @@ ss::future<> reconciler::reconciliation_loop() {
               "Recoverable error during reconciliation: {}",
               std::current_exception());
         }
+
+        // Update priority counters based on what was processed.
+        chunked_hash_set<model::ntp> processed_set(
+          processed_ntps.begin(), processed_ntps.end());
+        for (auto& [ntp, entry] : _sources) {
+            if (processed_set.contains(ntp)) {
+                entry.rounds_waiting = 0;
+            } else {
+                ++entry.rounds_waiting;
+            }
+        }
+
         next_wait = _scheduler.current_interval();
     }
 }
 
-ss::future<> reconciler::reconcile() {
+ss::future<chunked_vector<model::ntp>> reconciler::reconcile() {
     _probe.increment_rounds();
 
-    chunked_vector<ss::shared_ptr<source>> sources;
+    chunked_vector<source_entry> entries;
     // Make a copy of the sources to not worry about concurrent modification.
-    for (auto& [_, src] : _sources) {
-        sources.push_back(src);
+    for (auto& [_, entry] : _sources) {
+        entries.push_back(entry);
     }
     vlog(
       lg.debug,
       "Reconciliation loop tick with {} attached partitions",
-      sources.size());
-    if (sources.empty()) {
-        co_return;
+      entries.size());
+    if (entries.empty()) {
+        co_return chunked_vector<model::ntp>{};
     }
 
-    auto source_sets = partition_sources_into_sets(std::move(sources));
+    auto source_sets = partition_sources_into_sets(std::move(entries));
 
     // Adapt scheduling interval based on max object size produced.
     // Note that we slow down if there's nothing to reconcile or if all
     // objects failed. This is a sort of retry with backoff mechanism.
     size_t max_bytes_produced = 0;
+    chunked_vector<model::ntp> all_processed;
     for (auto& source_set : source_sets) {
-        auto bytes = co_await reconcile_source_set(std::move(source_set));
+        auto [bytes, processed] = co_await reconcile_source_set(
+          std::move(source_set));
         max_bytes_produced = std::max(max_bytes_produced, bytes);
+        for (auto& ntp : processed) {
+            all_processed.push_back(std::move(ntp));
+        }
     }
 
     _scheduler.adapt(max_bytes_produced);
+    co_return all_processed;
 }
 
 chunked_vector<chunked_vector<ss::shared_ptr<source>>>
-reconciler::partition_sources_into_sets(
-  chunked_vector<ss::shared_ptr<source>> sources) {
-    chunked_hash_map<model::topic_id, chunked_vector<ss::shared_ptr<source>>>
-      topic_id_to_sources;
-    for (auto& src : sources) {
-        auto& src_vec = topic_id_to_sources[src->topic_id_partition().topic_id];
-        src_vec.push_back(std::move(src));
+reconciler::partition_sources_into_sets(chunked_vector<source_entry> entries) {
+    chunked_hash_map<model::topic_id, chunked_vector<source_entry>>
+      topic_id_to_entries;
+    for (auto& entry : entries) {
+        auto& entry_vec
+          = topic_id_to_entries[entry.src->topic_id_partition().topic_id];
+        entry_vec.push_back(std::move(entry));
     }
 
     vlog(
       lg.debug,
       "Partitioned sources into {} sets by topic_id",
-      topic_id_to_sources.size());
+      topic_id_to_entries.size());
 
+    // Prioritize within each set and extract sources.
     chunked_vector<chunked_vector<ss::shared_ptr<source>>> result;
-    result.reserve(topic_id_to_sources.size());
-    for (auto& [_, src_vec] : topic_id_to_sources) {
-        result.push_back(std::move(src_vec));
+    result.reserve(topic_id_to_entries.size());
+    for (auto& [_, entry_vec] : topic_id_to_entries) {
+        prioritize_sources(entry_vec);
+        chunked_vector<ss::shared_ptr<source>> sources;
+        sources.reserve(entry_vec.size());
+        for (auto& entry : entry_vec) {
+            sources.push_back(std::move(entry.src));
+        }
+        result.push_back(std::move(sources));
     }
     return result;
 }
 
-ss::future<size_t> reconciler::reconcile_source_set(
+ss::future<std::pair<size_t, chunked_vector<model::ntp>>>
+reconciler::reconcile_source_set(
   chunked_vector<ss::shared_ptr<source>> sources) {
     if (sources.empty()) {
-        co_return 0;
+        co_return std::pair{size_t{0}, chunked_vector<model::ntp>{}};
     }
 
     // Begin by creating the set of objects to be built.
@@ -291,7 +340,7 @@ ss::future<size_t> reconciler::reconcile_source_set(
           "Could not create object metadata builder: {}",
           metadata_builder_res.error());
         _probe.increment_rounds_failed();
-        co_return 0;
+        co_return std::pair{size_t{0}, chunked_vector<model::ntp>{}};
     }
     auto& metadata_builder = metadata_builder_res.value();
     chunked_hash_map<l1::object_id, chunked_vector<ss::shared_ptr<source>>>
@@ -302,7 +351,7 @@ ss::future<size_t> reconciler::reconcile_source_set(
         if (!oid.has_value()) {
             vlog(lg.warn, "Could not get object: {}", oid.error());
             _probe.increment_rounds_failed();
-            co_return 0;
+            co_return std::pair{size_t{0}, chunked_vector<model::ntp>{}};
         }
         oid_to_sources[oid.value()].push_back(src);
     }
@@ -338,7 +387,7 @@ ss::future<size_t> reconciler::reconcile_source_set(
               oid,
               ex);
             if (is_shutdown) {
-                co_return 0;
+                co_return std::pair{size_t{0}, chunked_vector<model::ntp>{}};
             }
             failed_objects.push_back(oid);
             continue;
@@ -383,7 +432,7 @@ ss::future<size_t> reconciler::reconcile_source_set(
         // NB: This doesn't count as failing the round because it may be that
         // all sources are fully reconciled.
         vlog(lg.debug, "No successful objects to commit to metastore");
-        co_return 0;
+        co_return std::pair{size_t{0}, chunked_vector<model::ntp>{}};
     }
 
     // Commit all successful objects to the metastore.
@@ -394,10 +443,18 @@ ss::future<size_t> reconciler::reconcile_source_set(
           "Abandoning reconciliation run because the L1 metastore operation "
           "failed"));
         _probe.increment_rounds_failed();
-        co_return 0;
+        co_return std::pair{size_t{0}, chunked_vector<model::ntp>{}};
     }
 
-    co_return max_bytes_produced;
+    // Collect the NTPs that were successfully processed.
+    chunked_vector<model::ntp> processed_ntps;
+    for (const auto& obj : successful_objects) {
+        for (const auto& commit : obj.commits) {
+            processed_ntps.push_back(commit.source->ntp());
+        }
+    }
+
+    co_return std::pair{max_bytes_produced, std::move(processed_ntps)};
 }
 
 ss::future<std::expected<reconciler::built_object_metadata, reconcile_error>>

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -85,6 +85,11 @@ struct reconcile_error {
  * the L1 metastore. Finally, it updates the LRO, based on either
  * its own progress, or a corrected LRO returned from the metastore.
  */
+struct reconcile_result {
+    size_t max_object_bytes{0};
+    chunked_vector<model::ntp> processed_ntps;
+};
+
 class reconciler {
 public:
     reconciler(l1::io*, l1::metastore*);
@@ -114,11 +119,11 @@ public:
      * may be reconciled into an L1 object. Operates on the set of currently
      * attached partitions.
      *
-     * Returns the set of NTPs that were processed this round.
-     * An NTP is processed if it contributes an extent to an object
-     * accepted by the metastore and its LRO advances.
+     * Returns the max object size produced and the set of NTPs that were
+     * processed this round. An NTP is processed if it contributes an extent
+     * to an object accepted by the metastore and its LRO advances.
      */
-    ss::future<chunked_vector<model::ntp>> reconcile();
+    ss::future<reconcile_result> reconcile();
 
 private:
     struct source_entry {
@@ -275,7 +280,7 @@ private:
      * Returns the max object size produced (or 0 if none committed) and the
      * NTPs that were successfully processed.
      */
-    ss::future<std::pair<size_t, chunked_vector<model::ntp>>>
+    ss::future<reconcile_result>
     reconcile_source_set(chunked_vector<ss::shared_ptr<source>> sources);
 
     /*

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -113,13 +113,23 @@ public:
      * One round of reconciliation in which data from one or more sources
      * may be reconciled into an L1 object. Operates on the set of currently
      * attached partitions.
+     *
+     * Returns the set of NTPs that were processed this round.
+     * An NTP is processed if it contributes an extent to an object
+     * accepted by the metastore and its LRO advances.
      */
-    ss::future<> reconcile();
+    ss::future<chunked_vector<model::ntp>> reconcile();
 
 private:
+    struct source_entry {
+        ss::shared_ptr<source> src;
+        // Number of rounds since last processed.
+        uint32_t rounds_waiting{0};
+    };
+
     // NB: Partition attachment is the only part using ntps instead of
     //     topic id partitions.
-    chunked_hash_map<model::ntp, ss::shared_ptr<source>> _sources;
+    chunked_hash_map<model::ntp, source_entry> _sources;
 
 private:
     /*
@@ -250,19 +260,30 @@ private:
       std::unique_ptr<l1::metastore::object_metadata_builder> meta_builder);
 
     /*
-     * Partition sources into sets for reconciliation.
+     * Partition source entries into sets for reconciliation, grouped by
+     * topic_id. Within each set, entries are sorted by priority (sources
+     * waiting longer get higher priority) with shuffling for fairness among
+     * equal priorities. Returns the prioritized sources with entry metadata
+     * stripped.
      */
     chunked_vector<chunked_vector<ss::shared_ptr<source>>>
-    partition_sources_into_sets(chunked_vector<ss::shared_ptr<source>> sources);
+    partition_sources_into_sets(chunked_vector<source_entry> entries);
 
     /*
      * Reconcile a set of sources. Creates a metadata builder, maps sources to
      * objects, builds and uploads objects, and commits them to the metastore.
-     * Returns the max object size produced, or 0 if no objects were
-     * successfully committed.
+     * Returns the max object size produced (or 0 if none committed) and the
+     * NTPs that were successfully processed.
      */
-    ss::future<size_t>
+    ss::future<std::pair<size_t, chunked_vector<model::ntp>>>
     reconcile_source_set(chunked_vector<ss::shared_ptr<source>> sources);
+
+    /*
+     * Sort source entries by priority for reconciliation. Sources that have
+     * been waiting longer (more rounds skipped) get higher priority. Sources
+     * with equal priority are shuffled for fairness.
+     */
+    static void prioritize_sources(chunked_vector<source_entry>& entries);
 
     l1::io* _l1_io;
     l1::metastore* _metastore;

--- a/src/v/cloud_topics/tests/leader_epoch_test.cc
+++ b/src/v/cloud_topics/tests/leader_epoch_test.cc
@@ -251,7 +251,9 @@ TEST_F(LeaderEpochTest, TestGetLeaderEpochWhileReconciling) {
                 auto& ct_app = get_ct_app(node_id);
                 ct_app.get_reconciler()
                   ->invoke_on_all(
-                    [](auto& reconciler) { return reconciler.reconcile(); })
+                    [](auto& reconciler) {
+                        return reconciler.reconcile().discard_result();
+                    })
                   .get();
             }
             auto l1_o = get_last_l1_offset().get();

--- a/src/v/cloud_topics/tests/leader_epoch_test.cc
+++ b/src/v/cloud_topics/tests/leader_epoch_test.cc
@@ -250,10 +250,9 @@ TEST_F(LeaderEpochTest, TestGetLeaderEpochWhileReconciling) {
             for (auto node_id : instance_ids()) {
                 auto& ct_app = get_ct_app(node_id);
                 ct_app.get_reconciler()
-                  ->invoke_on_all(
-                    [](auto& reconciler) {
-                        return reconciler.reconcile().discard_result();
-                    })
+                  ->invoke_on_all([](auto& reconciler) {
+                      return reconciler.reconcile().discard_result();
+                  })
                   .get();
             }
             auto l1_o = get_last_l1_offset().get();


### PR DESCRIPTION
The reconciler batches partitions into L1 objects with a size budget. When the budget is exceeded, remaining partitions are skipped. This change tracks how many rounds each partition has been waiting and prioritizes those that have waited longest. Within equal-priority groups, partitions are shuffled. This helps more fairly reconcile partitions.

When any partitions are skipped, the next reconciliation round starts immediately (fast-follow) rather than waiting for the normal interval. This helps the reconciler keep up with high throughput writes. Empirically, these changes together were very helpful in keeping the reconciler following close behind the HWM of partitions, reading from the batch cache.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
