### PR TITLE
`ct/l0`: use `chunked_vector` in `level_zero_gc`

### DIFF
--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -94,7 +94,7 @@ public:
     }
 
     size_t delete_objects(
-      std::vector<cloud_storage_clients::client::list_bucket_item> objects,
+      chunked_vector<cloud_storage_clients::client::list_bucket_item> objects,
       size_t keys_total_bytes) {
         auto n_objects = objects.size();
         if (n_objects > 0) {
@@ -116,7 +116,7 @@ public:
     }
 
     seastar::future<> do_delete_objects(
-      std::vector<cloud_storage_clients::client::list_bucket_item>
+      chunked_vector<cloud_storage_clients::client::list_bucket_item>
         eligible_objects,
       ssx::semaphore_units page_u) noexcept {
         auto u_fut = co_await ss::coroutine::as_future(
@@ -213,14 +213,15 @@ public:
     seastar::future<std::expected<void, cloud_io::upload_result>>
     delete_objects(
       seastar::abort_source* asrc,
-      std::vector<cloud_storage_clients::client::list_bucket_item> objects)
+      chunked_vector<cloud_storage_clients::client::list_bucket_item> objects)
       override {
         retry_chain_node rtc(*asrc, timeout, backoff);
-        auto keys
-          = objects | std::views::transform([](auto& obj) { return obj.key; })
-            | std::ranges::to<std::vector<cloud_storage_clients::object_key>>();
+        auto keys = objects
+                    | std::views::transform([](auto& obj) { return obj.key; })
+                    | std::ranges::to<
+                      chunked_vector<cloud_storage_clients::object_key>>();
         auto res = co_await remote_->delete_objects(
-          bucket_, keys, rtc, [](auto) {});
+          bucket_, std::move(keys), rtc, [](auto) {});
         if (res == cloud_io::upload_result::success) {
             co_return std::expected<void, cloud_io::upload_result>();
         }
@@ -665,7 +666,7 @@ level_zero_gc::do_try_to_collect(std::optional<cluster_epoch>& max_gc_epoch) {
       max_gc_birthday);
 
     // objects that can be safely deleted
-    std::vector<cloud_storage_clients::client::list_bucket_item>
+    chunked_vector<cloud_storage_clients::client::list_bucket_item>
       eligible_objects;
     // total size of eligible keys
     size_t object_keys_total_bytes = 0;

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
@@ -170,7 +170,7 @@ public:
         virtual seastar::future<std::expected<void, cloud_io::upload_result>>
         delete_objects(
           seastar::abort_source*,
-          std::vector<cloud_storage_clients::client::list_bucket_item>)
+          chunked_vector<cloud_storage_clients::client::list_bucket_item>)
           = 0;
     };
 

--- a/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
+++ b/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
@@ -29,7 +29,7 @@ class object_storage_test_impl
   : public cloud_topics::level_zero_gc::object_storage {
 public:
     object_storage_test_impl(
-      std::vector<cloud_storage_clients::client::list_bucket_item>* listed,
+      chunked_vector<cloud_storage_clients::client::list_bucket_item>* listed,
       std::unordered_set<ss::sstring>* deleted,
       gc_test_config* cfg)
       : listed_(listed)
@@ -82,7 +82,7 @@ public:
     seastar::future<std::expected<void, cloud_io::upload_result>>
     delete_objects(
       seastar::abort_source* as,
-      std::vector<cloud_storage_clients::client::list_bucket_item> objects)
+      chunked_vector<cloud_storage_clients::client::list_bucket_item> objects)
       override {
         co_await seastar::sleep(cfg_->delete_cost);
         auto u = co_await delete_mtx_.get_units(*as);
@@ -92,7 +92,7 @@ public:
         co_return std::expected<void, cloud_io::upload_result>();
     }
 
-    std::vector<cloud_storage_clients::client::list_bucket_item>* listed_;
+    chunked_vector<cloud_storage_clients::client::list_bucket_item>* listed_;
     std::unordered_set<ss::sstring>* deleted_;
     gc_test_config* cfg_;
 
@@ -177,7 +177,7 @@ public:
         listed.push_back(item);
     }
 
-    std::vector<cloud_storage_clients::client::list_bucket_item> listed;
+    chunked_vector<cloud_storage_clients::client::list_bucket_item> listed;
     std::unordered_set<ss::sstring> deleted;
     std::optional<int64_t> max_epoch;
     cloud_topics::level_zero_gc gc;


### PR DESCRIPTION
Backtrace from a local oversized allocation:

```
[Backtrace #0]
seastar::guarded_backtrace(void**, int) at ??:0
void seastar::backtrace<seastar::current_backtrace_tasklocal()::$_0>(seastar::current_backtrace_tasklocal()::$_0&&, bool) at backtrace.cc:0
seastar::current_backtrace_tasklocal() at ??:0
seastar::current_tasktrace() at ??:0
seastar::current_backtrace() at ??:0
seastar::memory::cpu_pages::warn_large_allocation(unsigned long) at ??:0
seastar::memory::allocate_slowpath(unsigned long) at ??:0
operator new(unsigned long) at ??:0
void* std::__1::__libcpp_operator_new[abi:se200100]<unsigned long>(unsigned long) at main.cc:0
cloud_storage_clients::client::list_bucket_item* std::__1::__libcpp_allocate[abi:se200100]<cloud_storage_clients::client::list_bucket_item>(std::__1::__element_count, unsigned long) at level_zero_gc.cc:0
std::__1::allocator<cloud_storage_clients::client::list_bucket_item>::allocate[abi:se200100](unsigned long) at level_zero_gc.cc:0
std::__1::allocator<cloud_storage_clients::client::list_bucket_item>::allocate_at_least[abi:se200100](unsigned long) at level_zero_gc.cc:0
std::__1::allocation_result<cloud_storage_clients::client::list_bucket_item*, unsigned long> std::__1::allocator_traits<std::__1::allocator<cloud_storage_clients::client::list_bucket_item>>::allocate_at_least[abi:se200100]<std::__1::allocator<cloud_storage_clients::client::list_bucket_item>>(std::__1::allocator<cloud_storage_clients::client::list_bucket_item>&, unsigned long) at ??:0
auto std::__1::__allocate_at_least[abi:se200100]<std::__1::allocator<cloud_storage_clients::client::list_bucket_item>>(std::__1::allocator<cloud_storage_clients::client::list_bucket_item>&, unsigned long) at level_zero_gc.cc:0
std::__1::__split_buffer<cloud_storage_clients::client::list_bucket_item, std::__1::allocator<cloud_storage_clients::client::list_bucket_item>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<cloud_storage_clients::client::list_bucket_item>&) at level_zero_gc.cc:0
cloud_storage_clients::client::list_bucket_item* std::__1::vector<cloud_storage_clients::client::list_bucket_item, std::__1::allocator<cloud_storage_clients::client::list_bucket_item>>::__emplace_back_slow_path<cloud_storage_clients::client::list_bucket_item const&>(cloud_storage_clients::client::list_bucket_item const&) at ??:0
cloud_storage_clients::client::list_bucket_item& std::__1::vector<cloud_storage_clients::client::list_bucket_item, std::__1::allocator<cloud_storage_clients::client::list_bucket_item>>::emplace_back<cloud_storage_clients::client::list_bucket_item const&>(cloud_storage_clients::client::list_bucket_item const&) at ??:0
std::__1::vector<cloud_storage_clients::client::list_bucket_item, std::__1::allocator<cloud_storage_clients::client::list_bucket_item>>::push_back[abi:se200100](cloud_storage_clients::client::list_bucket_item const&) at level_zero_gc.cc:0
cloud_topics::level_zero_gc::do_try_to_collect(std::__1::optional<detail::base_named_type<long, cloud_topics::cloud_topics_epoch, std::__1::integral_constant<bool, true>>>&) (.resume) at level_zero_gc.cc:0
std::__1::coroutine_handle<seastar::internal::coroutine_traits_base<std::__1::expected<unsigned long, cloud_topics::level_zero_gc::collection_error>>::promise_type>::resume[abi:se200100]() const at level_zero_gc.cc:0
seastar::internal::coroutine_traits_base<std::__1::expected<unsigned long, cloud_topics::level_zero_gc::collection_error>>::promise_type::run_and_dispose() at ??:0
seastar::reactor::task_queue::run_tasks() at ??:0
seastar::reactor::task_queue_group::run_tasks() at ??:0
seastar::reactor::task_queue_group::run_some_tasks() at ??:0
seastar::reactor::do_run() at ??:0
seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_0::operator()() const at reactor.cc:0
decltype(std::declval<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_0&>()()) std::__1::__invoke[abi:se200100]<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_0&>(seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_0&) at reactor.cc:0
void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:se200100]<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_0&>(seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_0&) at reactor.cc:0
void std::__1::__invoke_r[abi:se200100]<void, seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_0&>(seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_0&) at reactor.cc:0
std::__1::__function::__alloc_func<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_0, std::__1::allocator<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_0>, void ()>::operator()[abi:se200100]() at reactor.cc:0
std::__1::__function::__func<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_0, std::__1::allocator<seastar::smp::configure(seastar::smp_options const&, seastar::reactor_options const&)::$_0>, void ()>::operator()() at reactor.cc:0
std::__1::__function::__value_func<void ()>::operator()[abi:se200100]() const at application.cc:0
std::__1::function<void ()>::operator()() const at application.cc:0
seastar::posix_thread::start_routine(void*) at ??:0
/lib64/libc.so.6: ELF 64-bit LSB shared object, x86-64, version 1 (GNU/Linux), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=48c4b9b1efb1df15da8e787f489128bf31893317, for GNU/Linux 3.2.0, not stripped
```

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


* none
