### PR TITLE
[UX-665] rpk: add RPK_PROFILE env var to set current profile

### DIFF
--- a/src/go/rpk/pkg/cli/profile/create.go
+++ b/src/go/rpk/pkg/cli/profile/create.go
@@ -264,6 +264,7 @@ func CreateFlow(
 		// well.
 		fmt.Printf("Created and switch to profile %q.\n", container.ContainerProfileName)
 		fmt.Println("rpk will now talk to your locally running Redpanda container cluster.")
+		config.MaybePrintProfileEnvOverrideWarning(container.ContainerProfileName)
 		return nil
 
 	case fromCloud != "":
@@ -407,6 +408,7 @@ func CreateFlow(
 		fmt.Println(msg)
 	}
 
+	config.MaybePrintProfileEnvOverrideWarning(p.Name)
 	return nil
 }
 

--- a/src/go/rpk/pkg/cli/profile/profile.go
+++ b/src/go/rpk/pkg/cli/profile/profile.go
@@ -35,6 +35,10 @@ profiles for multiple clusters and swap between them with 'rpk profile use'.
 Multiple profiles may be useful if, for example, you use rpk to talk to
 a localhost cluster, a dev cluster, and a prod cluster, and you want to keep
 your configuration in one place.
+
+You can also use the RPK_PROFILE environment variable to temporarily override
+the current profile without modifying your configuration. The --profile flag
+takes precedence over the environment variable if both are set.
 `,
 	}
 

--- a/src/go/rpk/pkg/cli/profile/set.go
+++ b/src/go/rpk/pkg/cli/profile/set.go
@@ -32,7 +32,7 @@ The key can either be the name of a -X flag or the path to the field in the
 profile's yaml format. For example, using --set tls.enabled=true OR --set
 kafka_api.tls.enabled=true is equivalent. The former corresponds to the -X flag
 tls.enabled, while the latter corresponds to the path kafka_api.tls.enabled in
-the profile's yaml.
+the profile's yaml. To see all available -X fields, run 'rpk -X help'.
 
 This command supports autocompletion of valid keys, suggesting the -X key
 format. If you begin writing a YAML path, this command will suggest the rest of

--- a/src/go/rpk/pkg/cli/profile/use.go
+++ b/src/go/rpk/pkg/cli/profile/use.go
@@ -44,6 +44,7 @@ func newUseCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDieErr(err)
 			fmt.Printf("Set current profile to %q.\n", name)
 			config.MaybePrintAuthSwitchMessage(priorAuth, currentAuth)
+			config.MaybePrintProfileEnvOverrideWarning(name)
 		},
 	}
 

--- a/src/go/rpk/pkg/config/BUILD
+++ b/src/go/rpk/pkg/config/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//src/go/rpk/pkg/os",
         "//src/go/rpk/pkg/out",
         "@build_buf_gen_go_redpandadata_cloud_protocolbuffers_go//redpanda/api/controlplane/v1:controlplane",
+        "@com_github_fatih_color//:color",
         "@com_github_mattn_go_isatty//:go-isatty",
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -88,6 +88,10 @@ const (
 
 const currentRpkYAMLVersion = 7
 
+// ProfileEnvVar is the environment variable used to set the current profile.
+// This can't be a dev override as it is loaded before overrides are applied.
+const ProfileEnvVar = "RPK_PROFILE"
+
 type xflag struct {
 	path        string
 	testExample string
@@ -645,6 +649,11 @@ func ParamsHelp() string {
 	return `The -X flag can be used to override any rpk specific configuration option.
 As an example, -X brokers.tls.enabled=true enables TLS for the Kafka API.
 
+All -X flags can also be set via environment variables. The corresponding
+environment variable is the flag name uppercased, with dots replaced by
+underscores, and prefixed with RPK_. For example, -X brokers becomes
+RPK_BROKERS, and -X tls.enabled becomes RPK_TLS_ENABLED.
+
 The following options are available, with an example value for each option:
 
 brokers=127.0.0.1:9092,localhost:9094
@@ -1186,13 +1195,20 @@ func (p *Params) readRpkConfig(fs afero.Fs, c *Config) error {
 	yaml.Unmarshal(file, &c.rpkYamlActual)
 	c.rpkYamlActual.Version = c.rpkYaml.Version
 
+	overrideProfile := os.Getenv(ProfileEnvVar)
+	overrideSource := ProfileEnvVar + " environment variable"
 	if p.Profile != "" {
-		if c.rpkYaml.Profile(p.Profile) == nil {
-			return fmt.Errorf("selected profile %q does not exist", p.Profile)
-		}
-		c.rpkYaml.CurrentProfile = p.Profile
-		c.rpkYamlActual.CurrentProfile = p.Profile
+		overrideProfile = p.Profile
+		overrideSource = "--profile flag"
 	}
+	if overrideProfile != "" {
+		if c.rpkYaml.Profile(overrideProfile) == nil {
+			return fmt.Errorf("selected profile %q does not exist; check your %s and select an existing profile", overrideProfile, overrideSource)
+		}
+		c.rpkYaml.CurrentProfile = overrideProfile
+		c.rpkYamlActual.CurrentProfile = overrideProfile
+	}
+
 	c.rpkYamlExists = true
 	c.rpkYaml.fileLocation = abs
 	c.rpkYamlActual.fileLocation = abs

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -1587,6 +1587,126 @@ func TestConfig_fixSchemePorts(t *testing.T) {
 	}
 }
 
+func TestProfileEnvVar(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		rpkYaml     string
+		envProfile  string
+		flagProfile string
+		expProfile  string
+		expErr      string
+	}{
+		{
+			name: "env var sets current profile",
+			rpkYaml: `version: 7
+current_profile: default
+profiles:
+    - name: default
+      kafka_api:
+        brokers:
+            - 127.0.0.1:9092
+    - name: myprofile
+      kafka_api:
+        brokers:
+            - 192.168.1.1:9092
+`,
+			envProfile: "myprofile",
+			expProfile: "myprofile",
+		},
+		{
+			name: "flag takes precedence over env var",
+			rpkYaml: `version: 7
+current_profile: default
+profiles:
+    - name: default
+      kafka_api:
+        brokers:
+            - 127.0.0.1:9092
+    - name: envprofile
+      kafka_api:
+        brokers:
+            - 192.168.1.1:9092
+    - name: flagprofile
+      kafka_api:
+        brokers:
+            - 10.0.0.1:9092
+`,
+			envProfile:  "envprofile",
+			flagProfile: "flagprofile",
+			expProfile:  "flagprofile",
+		},
+		{
+			name: "error when env profile does not exist",
+			rpkYaml: `version: 7
+current_profile: default
+profiles:
+    - name: default
+      kafka_api:
+        brokers:
+            - 127.0.0.1:9092
+`,
+			envProfile: "nonexistent",
+			expErr:     `selected profile "nonexistent" does not exist`,
+		},
+		{
+			name: "error when flag profile does not exist",
+			rpkYaml: `version: 7
+current_profile: default
+profiles:
+    - name: default
+      kafka_api:
+        brokers:
+            - 127.0.0.1:9092
+`,
+			flagProfile: "nonexistent",
+			expErr:      `selected profile "nonexistent" does not exist`,
+		},
+		{
+			name: "no env var uses saved current profile",
+			rpkYaml: `version: 7
+current_profile: saved
+profiles:
+    - name: default
+      kafka_api:
+        brokers:
+            - 127.0.0.1:9092
+    - name: saved
+      kafka_api:
+        brokers:
+            - 192.168.1.1:9092
+`,
+			expProfile: "saved",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envProfile != "" {
+				t.Setenv(ProfileEnvVar, tt.envProfile)
+			}
+
+			defaultRpkPath := "/rpk/rpk.yaml"
+			m := make(map[string]testfs.Fmode)
+			m[defaultRpkPath] = testfs.RFile(tt.rpkYaml)
+			fs := testfs.FromMap(m)
+
+			p := &Params{
+				Profile:    tt.flagProfile,
+				ConfigFlag: defaultRpkPath,
+			}
+			cfg, err := p.Load(fs)
+
+			if tt.expErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expErr)
+				return
+			}
+			require.NoError(t, err)
+
+			y := cfg.VirtualRpkYaml()
+			require.Equal(t, tt.expProfile, y.CurrentProfile)
+		})
+	}
+}
+
 func TestProcessOverrides(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/src/go/rpk/pkg/config/rpk_yaml.go
+++ b/src/go/rpk/pkg/config/rpk_yaml.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	controlplanev1 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1"
+	"github.com/fatih/color"
 	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/os"
 	"github.com/spf13/afero"
 	"go.uber.org/zap"
@@ -508,6 +509,15 @@ func (g *RpkGlobals) GetCommandTimeout() time.Duration {
 //////////
 // MISC //
 //////////
+
+// MaybePrintProfileEnvOverrideWarning prints a warning if RPK_PROFILE
+// environment variable is set, which will override the saved profile.
+func MaybePrintProfileEnvOverrideWarning(profileName string) {
+	if os.Getenv(ProfileEnvVar) != "" {
+		yellow := color.New(color.FgHiYellow).SprintFunc()
+		fmt.Fprintf(os.Stderr, "%s environment variable %s is set; it will override the saved profile. Unset it to use %q.\n", yellow("WARNING:"), ProfileEnvVar, profileName)
+	}
+}
 
 // MaybePrintAuthSwitchMessage prints a message if the prior and current
 // auths are different.


### PR DESCRIPTION
Helpful to enable per-session profile, making sure --profile takes precedence as everything in rpk:
  flag > env var > config file

Also, this includes a few doc updates to make the profile section clearer.

### Demo:
![Kapture 2026-01-08 at 15 41 10](https://github.com/user-attachments/assets/f883b3bd-f801-46c3-8cf5-bce91dcf0aa5)

### Error Handling:
The user may select non-existent profiles. Now we hint in case a user forgets the environment variable:
```
$ RPK_PROFILE=AAAA rpk topic list --profile ASDF
rpk unable to load config: selected profile "ASDF" does not exist; check your --profile flag and select an existing profile

$ RPK_PROFILE=AAAA rpk topic list
rpk unable to load config: selected profile "AAAA" does not exist; check your RPK_PROFILE environment variable and select an existing profile
```

There are some commands that modify the current profile (`rpk container`, `rpk profile create`, ...). We now add warnings when they run them and the `RPK_PROFILE` is set:
```
$ RPK_PROFILE=rpk-cloud rpk profile create bar
Created and switched to new profile "bar".
WARNING: environment variable RPK_PROFILE is set; it will override the saved profile. Unset it to use "bar".
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Features

* rpk: supports now RPK_PROFILE environment variable to select your current profile.
