### PR TITLE
ct: a few simplifications in level zero reader

### DIFF
--- a/src/v/cloud_topics/batch_cache/batch_cache.cc
+++ b/src/v/cloud_topics/batch_cache/batch_cache.cc
@@ -47,6 +47,10 @@ ss::future<> batch_cache::stop() {
 }
 
 void batch_cache::put(const model::ntp& ntp, const model::record_batch& b) {
+    vassert(
+      b.term() > model::term_id{-1},
+      "Batch without term in the cache: {}",
+      b.header());
     if (_lm == nullptr) {
         return;
     }
@@ -81,6 +85,10 @@ batch_cache::get(const model::ntp& ntp, model::offset o) {
     if (auto it = _index.find(ntp); it != _index.end()) {
         auto rb = it->second->get(o);
         if (rb.has_value()) {
+            vassert(
+              rb->term() > model::term_id{-1},
+              "Batch without term in the cache: {}",
+              rb->header());
             _probe.register_get(rb->size_bytes());
         } else {
             _probe.register_miss();

--- a/src/v/cloud_topics/batch_cache/batch_cache.cc
+++ b/src/v/cloud_topics/batch_cache/batch_cache.cc
@@ -89,6 +89,13 @@ batch_cache::get(const model::ntp& ntp, model::offset o) {
               rb->term() > model::term_id{-1},
               "Batch without term in the cache: {}",
               rb->header());
+            vassert(
+              rb->base_offset() <= o && o <= rb->last_offset(),
+              "Unexpected batch for {}, got range: [{},{}] for offset {}",
+              ntp,
+              rb->base_offset(),
+              rb->last_offset(),
+              o);
             _probe.register_get(rb->size_bytes());
         } else {
             _probe.register_miss();

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -257,7 +257,7 @@ level_one_log_reader_impl::read_batches(l1::object_reader& reader) {
                 set_end_of_stream();
                 break;
             }
-            _config.bytes_consumed += batch_size;
+            _bytes_consumed += batch_size;
 
             batches.push_back(std::move(batch));
 
@@ -355,8 +355,8 @@ bool level_one_log_reader_impl::is_end_of_stream() const {
 }
 
 bool level_one_log_reader_impl::is_over_limit_with_bytes(size_t size) const {
-    return (_config.strict_max_bytes || _config.bytes_consumed > 0)
-           && (_config.bytes_consumed + size) > _config.max_bytes;
+    return (_config.strict_max_bytes || _bytes_consumed > 0)
+           && (_bytes_consumed + size) > _config.max_bytes;
 }
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
@@ -135,6 +135,7 @@ private:
     l1::metastore* _metastore;
     l1::io* _io;
     prefix_logger _log;
+    size_t _bytes_consumed{0};
 };
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -51,7 +51,7 @@ level_zero_log_reader_impl::do_load_slice(
     // the 'empty' state. It doesn't make any difference if the reader is in
     // the 'materialized' state. If we're in 'ready' state we risk to go out
     // of sync with cached metadata so it's safer to hydrate.
-    if (auto cached = maybe_load_slices_from_cache(); !cached.empty()) {
+    if (auto cached = maybe_read_batches_from_cache(); !cached.empty()) {
         co_return cached;
     }
 
@@ -86,7 +86,7 @@ level_zero_log_reader_impl::do_load_slice(
 }
 
 chunked_circular_buffer<model::record_batch>
-level_zero_log_reader_impl::maybe_load_slices_from_cache() {
+level_zero_log_reader_impl::maybe_read_batches_from_cache() {
     chunked_circular_buffer<model::record_batch> ret;
     if (!cache_enabled()) {
         return ret;

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -116,7 +116,7 @@ level_zero_log_reader_impl::maybe_read_batches_from_cache() {
         }
 
         ret.push_back(std::move(batch.value()));
-        _config.bytes_consumed += batch_size;
+        _bytes_consumed += batch_size;
         _next_offset = model::offset_cast(
           model::next_offset(ret.back().last_offset()));
     }
@@ -312,7 +312,7 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
                   hydrated_batch_size);
                 break;
             }
-            _config.bytes_consumed += hydrated_batch_size;
+            _bytes_consumed += hydrated_batch_size;
             if (
               auto* meta = std::get_if<cloud_topics::extent_meta>(
                 &unhydrated_it->data)) {
@@ -454,7 +454,7 @@ bool level_zero_log_reader_impl::is_end_of_stream() const {
 }
 
 bool level_zero_log_reader_impl::is_over_limit(size_t size) const {
-    return (_config.strict_max_bytes || _config.bytes_consumed > 0)
-           && (_config.bytes_consumed + size) > _config.max_bytes;
+    return (_config.strict_max_bytes || _bytes_consumed > 0)
+           && (_bytes_consumed + size) > _config.max_bytes;
 }
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -30,6 +30,7 @@ level_zero_log_reader_impl::level_zero_log_reader_impl(
   ss::lw_shared_ptr<cluster::partition> ctp,
   data_plane_api* ct_api)
   : _config(cfg)
+  , _next_offset(_config.start_offset)
   , _ctp(std::move(ctp))
   , _ct_api(ct_api)
   , _log(cd_log, fmt::format("[{}/{}]", fmt::ptr(this), _ctp->ntp())) {
@@ -88,57 +89,61 @@ level_zero_log_reader_impl::do_load_slice(
 
 std::optional<chunked_circular_buffer<model::record_batch>>
 level_zero_log_reader_impl::maybe_load_slices_from_cache() {
+    /*
+     * Fetch batches from the cache starting at `_next_offset` until we hit a
+     * gap or a control batch and must then fetch the data from object storage.
+     */
     chunked_circular_buffer<model::record_batch> ret;
-    auto current = _config.start_offset;
-    while (current <= _config.max_offset) {
+    while (_next_offset <= _config.max_offset) {
         auto batch = _ct_api->cache_get(
-          _ctp->ntp(), kafka::offset_cast(current));
+          _ctp->ntp(), kafka::offset_cast(_next_offset));
         if (!batch.has_value()) {
-            // We hit a gap in the cache and have to download objects
-            // from S3.
-            //
-            // NOTE: this can also happen when transactions are used and
-            // we would encounter reading a control batch from the local log.
             break;
         }
+
         vlog(
           _log.trace,
           "Loaded batch from cache for {}: {} @ term {}",
-          current,
+          _next_offset,
           batch.value().base_offset(),
           batch.value().term());
+
         vassert(
           batch.value().term() > model::term_id{-1},
           "Batch without term in the cache: {}",
           batch.value().header());
+
         auto batch_size = batch.value().size_bytes();
         if (is_over_limit(batch_size)) {
             break;
         }
+
         vassert(
-          batch->base_offset() <= kafka::offset_cast(current)
-            && kafka::offset_cast(current) <= batch->last_offset(),
+          batch->base_offset() <= kafka::offset_cast(_next_offset)
+            && kafka::offset_cast(_next_offset) <= batch->last_offset(),
           "Unexpected batch for {}, got range: [{},{}] for offset {}",
           _ctp->ntp(),
           batch->base_offset(),
           batch->last_offset(),
-          current);
+          _next_offset);
+
         ret.push_back(std::move(batch.value()));
         _config.bytes_consumed += batch_size;
-        current = model::offset_cast(
+        _next_offset = model::offset_cast(
           model::next_offset(ret.back().last_offset()));
     }
-    _config.start_offset = current;
-    if (_config.start_offset > _config.max_offset) {
+
+    if (_next_offset > _config.max_offset) {
         vlog(
           _log.debug,
           "reached end of stream, start offset: {}, max offset: {}, "
-          "current: {}",
+          "next offset: {}",
           _config.start_offset,
           _config.max_offset,
-          current);
+          _next_offset);
         _current = state::end_of_stream_state;
     }
+
     if (!ret.empty()) {
         return ret;
     }
@@ -153,7 +158,7 @@ storage::local_log_reader_config level_zero_log_reader_impl::ctp_read_config() {
      */
     auto ot_state = _ctp->get_offset_translator_state();
     auto start_offset = ot_state->to_log_offset(
-      kafka::offset_cast(_config.start_offset));
+      kafka::offset_cast(_next_offset));
     auto max_offset = ot_state->to_log_offset(
       kafka::offset_cast(_config.max_offset));
 
@@ -450,7 +455,7 @@ void level_zero_log_reader_impl::consume_materialized_batches(
       _hydrated.size(),
       _unhydrated.size());
     *dest = std::exchange(_hydrated, {});
-    _config.start_offset = model::offset_cast(
+    _next_offset = model::offset_cast(
       model::next_offset(dest->back().last_offset()));
     _current = _unhydrated.empty() ? state::empty_state : state::ready_state;
 }

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -51,10 +51,8 @@ level_zero_log_reader_impl::do_load_slice(
     // the 'empty' state. It doesn't make any difference if the reader is in
     // the 'materialized' state. If we're in 'ready' state we risk to go out
     // of sync with cached metadata so it's safer to hydrate.
-    if (cache_enabled()) {
-        if (auto cached = maybe_load_slices_from_cache()) {
-            co_return std::move(cached.value());
-        }
+    if (auto cached = maybe_load_slices_from_cache(); !cached.empty()) {
+        co_return cached;
     }
 
     chunked_circular_buffer<model::record_batch> res;
@@ -87,13 +85,17 @@ level_zero_log_reader_impl::do_load_slice(
     co_return res;
 }
 
-std::optional<chunked_circular_buffer<model::record_batch>>
+chunked_circular_buffer<model::record_batch>
 level_zero_log_reader_impl::maybe_load_slices_from_cache() {
+    chunked_circular_buffer<model::record_batch> ret;
+    if (!cache_enabled()) {
+        return ret;
+    }
+
     /*
      * Fetch batches from the cache starting at `_next_offset` until we hit a
      * gap or a control batch and must then fetch the data from object storage.
      */
-    chunked_circular_buffer<model::record_batch> ret;
     while (_next_offset <= _config.max_offset) {
         auto batch = _ct_api->cache_get(
           _ctp->ntp(), kafka::offset_cast(_next_offset));
@@ -144,10 +146,7 @@ level_zero_log_reader_impl::maybe_load_slices_from_cache() {
         _current = state::end_of_stream_state;
     }
 
-    if (!ret.empty()) {
-        return ret;
-    }
-    return std::nullopt;
+    return ret;
 }
 
 storage::local_log_reader_config level_zero_log_reader_impl::ctp_read_config() {

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -110,11 +110,6 @@ level_zero_log_reader_impl::maybe_read_batches_from_cache() {
           batch.value().base_offset(),
           batch.value().term());
 
-        vassert(
-          batch.value().term() > model::term_id{-1},
-          "Batch without term in the cache: {}",
-          batch.value().header());
-
         auto batch_size = batch.value().size_bytes();
         if (is_over_limit(batch_size)) {
             break;

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -115,15 +115,6 @@ level_zero_log_reader_impl::maybe_read_batches_from_cache() {
             break;
         }
 
-        vassert(
-          batch->base_offset() <= kafka::offset_cast(_next_offset)
-            && kafka::offset_cast(_next_offset) <= batch->last_offset(),
-          "Unexpected batch for {}, got range: [{},{}] for offset {}",
-          _ctp->ntp(),
-          batch->base_offset(),
-          batch->last_offset(),
-          _next_offset);
-
         ret.push_back(std::move(batch.value()));
         _config.bytes_consumed += batch_size;
         _next_offset = model::offset_cast(

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
@@ -136,6 +136,7 @@ private:
     chunked_circular_buffer<model::record_batch> _hydrated;
 
     cloud_topic_log_reader_config _config;
+    kafka::offset _next_offset;
     ss::lw_shared_ptr<cluster::partition> _ctp;
     data_plane_api* _ct_api;
     prefix_logger _log;

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
@@ -101,8 +101,7 @@ private:
     // Return data from the record batch cache.
     // This method could change state of the reader to end_of_stream_state
     // when it reaches committed offset.
-    std::optional<chunked_circular_buffer<model::record_batch>>
-    maybe_load_slices_from_cache();
+    chunked_circular_buffer<model::record_batch> maybe_load_slices_from_cache();
 
     // If adding a batch of `size` would cause this to go over the bytes limit.
     bool is_over_limit(size_t size) const;

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
@@ -140,6 +140,7 @@ private:
     ss::lw_shared_ptr<cluster::partition> _ctp;
     data_plane_api* _ct_api;
     prefix_logger _log;
+    size_t _bytes_consumed{0};
 };
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
@@ -101,7 +101,8 @@ private:
     // Return data from the record batch cache.
     // This method could change state of the reader to end_of_stream_state
     // when it reaches committed offset.
-    chunked_circular_buffer<model::record_batch> maybe_load_slices_from_cache();
+    chunked_circular_buffer<model::record_batch>
+    maybe_read_batches_from_cache();
 
     // If adding a batch of `size` would cause this to go over the bytes limit.
     bool is_over_limit(size_t size) const;

--- a/src/v/cloud_topics/log_reader_config.cc
+++ b/src/v/cloud_topics/log_reader_config.cc
@@ -20,7 +20,7 @@ fmt::iterator cloud_topic_log_reader_config::format_to(fmt::iterator it) const {
       it,
       "start_offset:{}, max_offset:{}, min_bytes:{}, max_bytes:{}, "
       "strict_max_bytes:{}, type_filter: {}, first_timestamp:{}, "
-      "bytes_consumed:{}, skip_cache:{}, abortable:{}, "
+      "skip_cache:{}, abortable:{}, "
       "client_address:{}",
       start_offset,
       max_offset,
@@ -29,7 +29,6 @@ fmt::iterator cloud_topic_log_reader_config::format_to(fmt::iterator it) const {
       strict_max_bytes,
       type_filter,
       first_timestamp,
-      bytes_consumed,
       skip_cache,
       abort_source.has_value(),
       client_address);

--- a/src/v/cloud_topics/log_reader_config.h
+++ b/src/v/cloud_topics/log_reader_config.h
@@ -80,9 +80,6 @@ struct cloud_topic_log_reader_config {
 
     model::opt_client_address_t client_address;
 
-    // used by log reader
-    size_t bytes_consumed{0};
-
     // do not let the lower level readers go over budget even when that means
     // that the reader will return no batches.
     bool strict_max_bytes{false};


### PR DESCRIPTION
Each commit is self contained. Cleaning up a bit of the cache reading code.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
