### PR TITLE
`ct`: reactor stall improvements

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -99,13 +99,14 @@ static void update_batch_base_offset(
     src.header().reset_size_checksum_metadata(src.data());
 }
 
-static chunked_vector<model::record_batch>
+static ss::future<chunked_vector<model::record_batch>>
 clone_batches(const chunked_vector<model::record_batch>& src) {
     chunked_vector<model::record_batch> res;
     for (auto& s : src) {
         res.push_back(s.copy());
+        co_await ss::coroutine::maybe_yield();
     }
-    return res;
+    co_return res;
 }
 
 /// Write proper offsets into the record batches
@@ -677,7 +678,7 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
 
     chunked_vector<model::record_batch> rb_copy;
     if (cache_enabled()) {
-        rb_copy = clone_batches(batches);
+        rb_copy = co_await clone_batches(batches);
     }
 
     /*
@@ -773,7 +774,7 @@ raft::replicate_stages frontend::replicate(
     chunked_vector<model::record_batch> batch_vec, to_cache;
     batch_vec.push_back(std::move(batch));
     if (cache_enabled()) {
-        to_cache = clone_batches(batch_vec);
+        to_cache.push_back(batch_vec.front().copy());
     }
     raft::replicate_stages out(raft::errc::success);
     ss::promise<result<raft::replicate_result>> result;

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -17,6 +17,8 @@
 #include "config/configuration.h"
 #include "model/timeout_clock.h"
 
+#include <seastar/coroutine/maybe_yield.hh>
+
 #include <chrono>
 #include <exception>
 #include <iterator>
@@ -402,6 +404,7 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
                     model::record_batch::tag_ctor_ng{});
               });
             hydrated.push_back(std::move(batch));
+            co_await ss::coroutine::maybe_yield();
         }
         vassert(
           batches_it == batches.end(),

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -393,7 +393,7 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
                         _ctp->ntp(),
                         batch.base_offset(),
                         batch.term());
-                      _ct_api->cache_put(_ctp->ntp(), batch.copy());
+                      _ct_api->cache_put(_ctp->ntp(), batch);
                   }
                   return batch;
               },


### PR DESCRIPTION
Some reactor stalls and their fixes that I found from my experiments with a `dev_cluster`. Claude was used to find every reactor stall in my logs and export a succinct decoded reactor stall summary for me:

https://gist.github.com/WillemKauf/32ab0cabd0033122fa4a443d1925c2c0

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


* none
