### PR TITLE
Add comparison operators to iobuf fuzz test (and other enchancements)

### DIFF
--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -78,7 +78,7 @@ def _test_options():
         "ASAN_OPTIONS": "disable_coredump=0:abort_on_error=1",
         "ASAN_SYMBOLIZER_PATH": "$(rootpath @current_llvm_toolchain//:llvm-symbolizer)",
         "LSAN_OPTIONS": "suppressions=$(rootpath //:lsan_suppressions)",
-        "UBSAN_OPTIONS": "halt_on_error=1:abort_on_error=1:report_error_type=1:suppressions=$(rootpath //:ubsan_suppressions)",
+        "UBSAN_OPTIONS": "symbolize=1:print_stacktrace=1:halt_on_error=1:abort_on_error=1:report_error_type=1:suppressions=$(rootpath //:ubsan_suppressions)",
         # see https://redpandadata.atlassian.net/wiki/x/BwDSUw
         "REDPANDA_RNG_SEEDING_MODE_DEFAULT": "fixed",
     }
@@ -189,6 +189,7 @@ def _redpanda_cc_fuzz_test(
       env: environment variables
       data: data file dependencies
     """
+    test_data, test_env = _test_options()
     cc_test(
         name = name,
         timeout = timeout,
@@ -203,8 +204,8 @@ def _redpanda_cc_fuzz_test(
         tags = [
             "fuzz",
         ],
-        env = env,
-        data = data,
+        env = env | test_env,
+        data = data + test_data,
         linkopts = [
             "-fsanitize=fuzzer",
         ],

--- a/src/v/bytes/tests/BUILD
+++ b/src/v/bytes/tests/BUILD
@@ -101,6 +101,8 @@ redpanda_cc_fuzz_test(
     args = [
         "-max_total_time=30",
         "-rss_limit_mb=8192",
+        "-max_len=1048576",
+        "-len_control=15",
     ],
     deps = [
         "//src/v/base",

--- a/src/v/bytes/tests/iobuf_fuzz.cc
+++ b/src/v/bytes/tests/iobuf_fuzz.cc
@@ -23,6 +23,167 @@
 #include <deque>
 #include <exception>
 #include <numeric>
+#include <ranges>
+#include <stdexcept>
+#include <string_view>
+
+/*
+ * All fuzz operations on an iobuf object are also applied to an object of this
+ * reference type. The reference type's operations are considered correct and
+ * therefore it is expected that the iobuf object ends up in a similar state as
+ * the reference object if the iobuf operations are implemented correctly.
+ */
+using reference_t = std::deque<std::string_view>;
+
+namespace {
+/*
+ * Compare contents of iobuf and reference container.
+ */
+void check_equals(const iobuf& buf, const reference_t& ref) {
+    const auto ref_size = std::accumulate(
+      ref.begin(), ref.end(), size_t(0), [](size_t acc, std::string_view sv) {
+          return acc + sv.size();
+      });
+
+    if (buf.empty() != (ref_size == 0)) {
+        throw std::runtime_error(
+          fmt::format(
+            "Iobuf empty state {} != reference empty state {}",
+            buf.empty(),
+            ref_size == 0));
+    }
+
+    if (buf.size_bytes() != ref_size) {
+        throw std::runtime_error(
+          fmt::format(
+            "Iobuf size {} != reference size {}", buf.size_bytes(), ref_size));
+    }
+
+    struct ref_ctx {
+        reference_t::const_iterator it, end;
+        std::string_view sv;
+
+        explicit ref_ctx(const reference_t& ref)
+          : it(ref.cbegin())
+          , end(ref.cend()) {
+            if (it != end) {
+                sv = *it;
+            }
+        }
+
+        std::string_view next(size_t limit) {
+            vassert(it != end, "");
+            auto ret = sv.substr(0, limit);
+            vassert(ret.size() <= sv.size(), "");
+            sv.remove_prefix(ret.size());
+            if (sv.empty()) {
+                ++it;
+                if (it != end) {
+                    sv = *it;
+                }
+            }
+            return ret;
+        }
+    };
+
+    // for string_view operators. skip if the buffer is big.
+    std::optional<std::string> s;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    if (buf.size_bytes() < (1ULL << 18ULL)) {
+        s.emplace();
+    }
+
+    ref_ctx ctx(ref);
+    auto in = iobuf::iterator_consumer(buf.cbegin(), buf.cend());
+    in.consume(buf.size_bytes(), [&s, &ctx](const char* data, size_t size) {
+        if (s.has_value()) {
+            s.value().append(data, size);
+        }
+        std::string_view in(data, size);
+        while (!in.empty()) {
+            auto ref = ctx.next(in.size());
+            if (std::memcmp(in.data(), ref.data(), ref.size()) != 0) {
+                throw std::runtime_error(
+                  fmt::format("Iobuf contents differ from reference contents"));
+            }
+            in.remove_prefix(ref.size());
+        }
+        return ss::stop_iteration::no;
+    });
+
+    if (s.has_value()) {
+        // coverage for iobuf::operator==(std:string_view) (equal)
+        if (!(buf == std::string_view(s.value()))) {
+            throw std::runtime_error(
+              "Iobuf contents are not identical for "
+              "string_view comparison");
+        }
+        // coverage for iobuf::operator==(std:string_view) (not-equal)
+        if (!s.value().empty()) {
+            s.value().back()++;
+            if (buf == std::string_view(s.value())) {
+                throw std::runtime_error(
+                  "Iobuf contents are not identical for "
+                  "string_view comparison");
+            }
+            s.value().back()--;
+        }
+        // coverage for iobuf::operator!=(std:string_view) (size difference)
+        s.value().append("a");
+        if (!(buf != std::string_view(s.value()))) {
+            throw std::runtime_error(
+              "Iobuf contents are identical for string_view comparison");
+        }
+    }
+}
+
+struct iobuf_and_ref {
+    iobuf buf;
+    reference_t ref;
+
+    void check() const {
+        try {
+            ::check_equals(buf, ref);
+        } catch (const std::exception& e) {
+            throw std::runtime_error(
+              fmt::format("iobuf_and_ref: {}", e.what()));
+        }
+    }
+};
+
+/*
+ * A repeatable way of generating an iobuf with many fragments from a
+ * string_view.
+ */
+iobuf_and_ref generate_many_frag_iobuf(std::string_view v) {
+    iobuf_and_ref o;
+    while (!v.empty()) {
+        auto frag_size = std::min<size_t>(v[0], v.size() - 1);
+        v.remove_prefix(1);
+
+        o.buf.append_fragments(iobuf::from(v.substr(0, frag_size)));
+        o.ref.push_back(v.substr(0, frag_size));
+        v.remove_prefix(frag_size);
+    }
+    o.check();
+    return o;
+}
+
+/*
+ * Does an unsigned byte-wise lexicographical comparison between two reference
+ * objects.
+ */
+std::strong_ordering
+compare_reference(const reference_t& a, const reference_t& b) {
+    auto to_unsigned_char = std::views::transform(
+      [](char c) { return static_cast<unsigned char>(c); });
+    auto a_chars = a | std::views::join | to_unsigned_char;
+    auto b_chars = b | std::views::join | to_unsigned_char;
+
+    return std::lexicographical_compare_three_way(
+      a_chars.begin(), a_chars.end(), b_chars.begin(), b_chars.end());
+}
+} // namespace
 
 /*
  * Holds an iobuf and a reference container. When an operation (e.g. append)
@@ -32,7 +193,7 @@
  */
 class iobuf_ops {
     iobuf buf;
-    std::deque<std::string_view> ref;
+    reference_t ref;
 
 public:
     void moves() {
@@ -100,6 +261,52 @@ public:
         tmp.append(payload.data(), payload.size());
         buf.prepend(std::move(tmp));
         ref.push_front(payload);
+    }
+
+    void compare_iobufs(std::string_view v, bool use_small_frags) {
+        iobuf o_buf;
+        reference_t o_ref;
+        if (use_small_frags) {
+            auto r = generate_many_frag_iobuf(v);
+            o_buf = std::move(r.buf);
+            o_ref = std::move(r.ref);
+        } else {
+            o_buf = iobuf::from(v);
+            o_ref.push_back(v);
+            check_equals(o_buf, o_ref);
+        }
+
+        // Test iobuf::operator<=>
+        {
+            auto iobuf_res = buf <=> o_buf;
+            auto ref_res = compare_reference(ref, o_ref);
+            if (iobuf_res != ref_res) {
+                throw std::runtime_error("(buf <=> o_buf) != (ref <=> o_ref)");
+            }
+
+            iobuf_res = o_buf <=> buf;
+            ref_res = compare_reference(o_ref, ref);
+            if (iobuf_res != ref_res) {
+                throw std::runtime_error("(o_buf <=> buf) != (o_ref <=> ref)");
+            }
+        }
+
+        // Test iobuf::operator==
+        {
+            auto iobuf_res = buf == o_buf;
+            auto ref_res = compare_reference(ref, o_ref)
+                           == std::strong_ordering::equal;
+            if (iobuf_res != ref_res) {
+                throw std::runtime_error("(buf == o_buf) != (ref == o_ref)");
+            }
+
+            iobuf_res = o_buf == buf;
+            ref_res = compare_reference(o_ref, ref)
+                      == std::strong_ordering::equal;
+            if (iobuf_res != ref_res) {
+                throw std::runtime_error("(o_buf == buf) != (o_ref == ref)");
+            }
+        }
     }
 
     void trim_front(size_t size) {
@@ -194,117 +401,14 @@ public:
         }
     }
 
-public:
     /*
      * Check consistency of iobuf with reference.
      */
     void check() const {
-        const auto ref_size = std::accumulate(
-          ref.begin(),
-          ref.end(),
-          size_t(0),
-          [](size_t acc, std::string_view sv) { return acc + sv.size(); });
-
-        if (buf.empty() != (ref_size == 0)) {
-            throw std::runtime_error(
-              fmt::format(
-                "Iobuf empty state {} != reference empty state {}",
-                buf.empty(),
-                ref_size == 0));
-        }
-
-        if (buf.size_bytes() != ref_size) {
-            throw std::runtime_error(
-              fmt::format(
-                "Iobuf size {} != reference size {}",
-                buf.size_bytes(),
-                ref_size));
-        }
-
-        check_equals();
-    }
-
-private:
-    /*
-     * Compare contents of iobuf and reference container.
-     */
-    void check_equals() const {
-        struct ref_ctx {
-            std::deque<std::string_view>::const_iterator it, end;
-            std::string_view sv;
-
-            explicit ref_ctx(const std::deque<std::string_view>& ref)
-              : it(ref.cbegin())
-              , end(ref.cend()) {
-                if (it != end) {
-                    sv = *it;
-                }
-            }
-
-            std::string_view next(size_t limit) {
-                vassert(it != end, "");
-                auto ret = sv.substr(0, limit);
-                vassert(ret.size() <= sv.size(), "");
-                sv.remove_prefix(ret.size());
-                if (sv.empty()) {
-                    ++it;
-                    if (it != end) {
-                        sv = *it;
-                    }
-                }
-                return ret;
-            }
-        };
-
-        // for string_view operators. skip if the buffer is big.
-        std::optional<std::string> s;
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-        if (buf.size_bytes() < (1ULL << 18ULL)) {
-            s.emplace();
-        }
-
-        ref_ctx ctx(ref);
-        auto in = iobuf::iterator_consumer(buf.cbegin(), buf.cend());
-        in.consume(buf.size_bytes(), [&s, &ctx](const char* data, size_t size) {
-            if (s.has_value()) {
-                s.value().append(data, size);
-            }
-            std::string_view in(data, size);
-            while (!in.empty()) {
-                auto ref = ctx.next(in.size());
-                if (std::memcmp(in.data(), ref.data(), ref.size()) != 0) {
-                    throw std::runtime_error(
-                      fmt::format(
-                        "Iobuf contents differ from reference contents"));
-                }
-                in.remove_prefix(ref.size());
-            }
-            return ss::stop_iteration::no;
-        });
-
-        if (s.has_value()) {
-            // coverage for iobuf::operator==(std:string_view) (equal)
-            if (!(buf == std::string_view(s.value()))) {
-                throw std::runtime_error(
-                  "Iobuf contents are not identical for "
-                  "string_view comparison");
-            }
-            // coverage for iobuf::operator==(std:string_view) (not-equal)
-            if (!s.value().empty()) {
-                s.value().back()++;
-                if (buf == std::string_view(s.value())) {
-                    throw std::runtime_error(
-                      "Iobuf contents are not identical for "
-                      "string_view comparison");
-                }
-                s.value().back()--;
-            }
-            // coverage for iobuf::operator!=(std:string_view) (size difference)
-            s.value().append("a");
-            if (!(buf != std::string_view(s.value()))) {
-                throw std::runtime_error(
-                  "Iobuf contents are identical for string_view comparison");
-            }
+        try {
+            ::check_equals(buf, ref);
+        } catch (const std::exception& e) {
+            throw std::runtime_error(fmt::format("iobuf_ops: {}", e.what()));
         }
     }
 };
@@ -319,6 +423,8 @@ enum class op_type : uint8_t {
     iobuf_as_scattered,
     hexdump,
     reserve_memory,
+    compare,
+    compare_small_fragments,
     prepend_temporary_buffer,
     prepend_iobuf,
     append_iobuf,
@@ -334,6 +440,10 @@ struct fmt::formatter<op_type> : formatter<std::string_view> {
     auto format(op_type t, format_context& ctx) const {
         auto name = [](auto t) {
             switch (t) {
+            case op_type::compare:
+                return "compare";
+            case op_type::compare_small_fragments:
+                return "compare_small_fragments";
             case op_type::copy:
                 return "copy";
             case op_type::append_fragments:
@@ -461,6 +571,14 @@ private:
         vassert(op.size.has_value(), "Op {} requires size operands", op.op);
 
         switch (op.op) {
+        case op_type::compare:
+            m_.compare_iobufs(op.data, false);
+            return;
+
+        case op_type::compare_small_fragments:
+            m_.compare_iobufs(op.data, true);
+            return;
+
         case op_type::append_fragments:
             m_.append_fragments(op.data);
             return;
@@ -533,6 +651,8 @@ private:
 
         // size operand
         switch (op.op) {
+        case op_type::compare:
+        case op_type::compare_small_fragments:
         case op_type::trim_front:
         case op_type::trim_back:
         case op_type::prepend_iobuf:
@@ -553,6 +673,8 @@ private:
 
         // data operand
         switch (op.op) {
+        case op_type::compare:
+        case op_type::compare_small_fragments:
         case op_type::append_fragments:
         case op_type::prepend_iobuf:
         case op_type::prepend_temporary_buffer:

--- a/src/v/bytes/tests/iobuf_fuzz.cc
+++ b/src/v/bytes/tests/iobuf_fuzz.cc
@@ -16,6 +16,7 @@
  * llvm-cov show src/v/bytes/tests/fuzz_iobuf -instr-profile=default.profdata
  * -format=html ../src/v/bytes/iobuf.h ../src/v/bytes/iobuf.cc > cov.html
  */
+#include "base/units.h"
 #include "base/vassert.h"
 #include "bytes/iobuf.h"
 #include "bytes/scattered_message.h"
@@ -40,18 +41,10 @@ namespace {
  * Compare contents of iobuf and reference container.
  */
 void check_equals(const iobuf& buf, const reference_t& ref) {
-    const auto ref_size = std::accumulate(
-      ref.begin(), ref.end(), size_t(0), [](size_t acc, std::string_view sv) {
+    const auto ref_size = std::ranges::fold_left(
+      ref, size_t(0), [](size_t acc, std::string_view sv) {
           return acc + sv.size();
       });
-
-    if (buf.empty() != (ref_size == 0)) {
-        throw std::runtime_error(
-          fmt::format(
-            "Iobuf empty state {} != reference empty state {}",
-            buf.empty(),
-            ref_size == 0));
-    }
 
     if (buf.size_bytes() != ref_size) {
         throw std::runtime_error(
@@ -59,82 +52,45 @@ void check_equals(const iobuf& buf, const reference_t& ref) {
             "Iobuf size {} != reference size {}", buf.size_bytes(), ref_size));
     }
 
-    struct ref_ctx {
-        reference_t::const_iterator it, end;
-        std::string_view sv;
+    auto buf_begin = iobuf::byte_iterator(buf.cbegin(), buf.cend());
+    auto buf_end = iobuf::byte_iterator(buf.cend(), buf.cend());
+    auto ref_range = ref | std::views::join;
 
-        explicit ref_ctx(const reference_t& ref)
-          : it(ref.cbegin())
-          , end(ref.cend()) {
-            if (it != end) {
-                sv = *it;
-            }
-        }
-
-        std::string_view next(size_t limit) {
-            vassert(it != end, "");
-            auto ret = sv.substr(0, limit);
-            vassert(ret.size() <= sv.size(), "");
-            sv.remove_prefix(ret.size());
-            if (sv.empty()) {
-                ++it;
-                if (it != end) {
-                    sv = *it;
-                }
-            }
-            return ret;
-        }
-    };
-
-    // for string_view operators. skip if the buffer is big.
-    std::optional<std::string> s;
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    if (buf.size_bytes() < (1ULL << 18ULL)) {
-        s.emplace();
+    if (!std::equal(buf_begin, buf_end, ref_range.begin())) {
+        throw std::runtime_error("buf != ref");
     }
 
-    ref_ctx ctx(ref);
-    auto in = iobuf::iterator_consumer(buf.cbegin(), buf.cend());
-    in.consume(buf.size_bytes(), [&s, &ctx](const char* data, size_t size) {
-        if (s.has_value()) {
-            s.value().append(data, size);
-        }
-        std::string_view in(data, size);
-        while (!in.empty()) {
-            auto ref = ctx.next(in.size());
-            if (std::memcmp(in.data(), ref.data(), ref.size()) != 0) {
-                throw std::runtime_error(
-                  fmt::format("Iobuf contents differ from reference contents"));
-            }
-            in.remove_prefix(ref.size());
-        }
-        return ss::stop_iteration::no;
-    });
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    if (buf.size_bytes() > 128_KiB) {
+        // Skip the string_view operator checks if the iobuf is too large to
+        // linearize.
+        return;
+    }
 
-    if (s.has_value()) {
-        // coverage for iobuf::operator==(std:string_view) (equal)
-        if (!(buf == std::string_view(s.value()))) {
+    auto s = buf.linearize_to_string();
+    // coverage for iobuf::operator==(std:string_view) (equal)
+    if (!(buf == std::string_view(s))) {
+        throw std::runtime_error(
+          "Iobuf contents are not identical for "
+          "string_view comparison");
+    }
+    // coverage for iobuf::operator==(std:string_view) (not-equal)
+    if (!s.empty()) {
+        s.back()++;
+        if (buf == std::string_view(s)) {
             throw std::runtime_error(
               "Iobuf contents are not identical for "
               "string_view comparison");
         }
-        // coverage for iobuf::operator==(std:string_view) (not-equal)
-        if (!s.value().empty()) {
-            s.value().back()++;
-            if (buf == std::string_view(s.value())) {
-                throw std::runtime_error(
-                  "Iobuf contents are not identical for "
-                  "string_view comparison");
-            }
-            s.value().back()--;
-        }
-        // coverage for iobuf::operator!=(std:string_view) (size difference)
-        s.value().append("a");
-        if (!(buf != std::string_view(s.value()))) {
-            throw std::runtime_error(
-              "Iobuf contents are identical for string_view comparison");
-        }
+        s.back()--;
     }
+    // coverage for iobuf::operator!=(std:string_view) (size difference)
+    s.append("a", 1);
+    if (!(buf != std::string_view(s))) {
+        throw std::runtime_error(
+          "Iobuf contents are identical for string_view comparison");
+    }
+    return;
 }
 
 struct iobuf_and_ref {

--- a/src/v/bytes/tests/iobuf_fuzz.cc
+++ b/src/v/bytes/tests/iobuf_fuzz.cc
@@ -234,7 +234,7 @@ public:
         ref.push_back(payload);
     }
 
-    void append_fragments(std::string_view payload) {
+    void append_fragments(std::string_view payload, bool use_small_frags) {
         /*
          * footgun alert: if you append from an iobuf share then the backing
          * memory is also shared. so if you do something like this:
@@ -245,10 +245,18 @@ public:
          * overwrite data at the front of the buffer. this same scenario can
          * probably be created when combining ops with iobuf::share.
          */
-        iobuf tmp;
-        tmp.append(payload.data(), payload.size());
-        buf.append_fragments(std::move(tmp));
-        ref.push_back(payload);
+        if (!use_small_frags) {
+            iobuf tmp;
+            tmp.append(payload.data(), payload.size());
+            buf.append_fragments(std::move(tmp));
+            ref.push_back(payload);
+        } else {
+            auto g_buf = generate_many_frag_iobuf(payload);
+            buf.append_fragments(std::move(g_buf.buf));
+            for (auto v : g_buf.ref) {
+                ref.push_back(v);
+            }
+        }
     }
 
     void prepend_temporary_buffer(std::string_view payload) {
@@ -430,6 +438,7 @@ enum class op_type : uint8_t {
     append_iobuf,
     append_temporary_buffer,
     append_fragments,
+    append_small_fragments,
     append_uint8_array,
     append_char_array,
     max = append_char_array,
@@ -448,6 +457,8 @@ struct fmt::formatter<op_type> : formatter<std::string_view> {
                 return "copy";
             case op_type::append_fragments:
                 return "append_fragments";
+            case op_type::append_small_fragments:
+                return "append_small_fragments";
             case op_type::moves:
                 return "moves";
             case op_type::clear:
@@ -580,7 +591,11 @@ private:
             return;
 
         case op_type::append_fragments:
-            m_.append_fragments(op.data);
+            m_.append_fragments(op.data, false);
+            return;
+
+        case op_type::append_small_fragments:
+            m_.append_fragments(op.data, true);
             return;
 
         case op_type::trim_front:
@@ -660,6 +675,7 @@ private:
         case op_type::hexdump:
         case op_type::prepend_temporary_buffer:
         case op_type::append_fragments:
+        case op_type::append_small_fragments:
         case op_type::append_iobuf:
         case op_type::append_temporary_buffer:
         case op_type::append_uint8_array:
@@ -676,6 +692,7 @@ private:
         case op_type::compare:
         case op_type::compare_small_fragments:
         case op_type::append_fragments:
+        case op_type::append_small_fragments:
         case op_type::prepend_iobuf:
         case op_type::prepend_temporary_buffer:
         case op_type::append_iobuf:


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
A follow-up to https://github.com/redpanda-data/redpanda/pull/29179 . This PR adds coverage for iobuf comparison operators to the iobuf fuzz test.  This addition allows for the issues of the prior PR to be detected in the fuzz test. I.e,
```
$ bazel test //src/v/bytes/tests:iobuf_fuzz --config=sanitizer --runs_per_test=100                                                                                                                                                                   00:17:56 [8/1855]
INFO: Invocation ID: ed80b7dc-a90c-495f-a647-22d11fc5c38c
INFO: Analyzed target //src/v/bytes/tests:iobuf_fuzz (0 packages loaded, 0 targets configured).
FAIL: //src/v/bytes/tests:iobuf_fuzz (run 18 of 100) (Exit 1) (see /home/brandonallard/data/.cache/bazel/_bazel_brandonallard/50acd7c106e570e66c6351a7103182f1/execroot/_main/bazel-out/k8-dbg/testlogs/src/v/bytes/tests/iobuf_fuzz/run_18_of_100/test.log)
INFO: From Testing //src/v/bytes/tests:iobuf_fuzz (run 18 of 100):
==================== Test output for //src/v/bytes/tests:iobuf_fuzz (run 18 of 100):
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 2773365366
INFO: A corpus is not provided, starting from an empty corpus
#2      INITED exec/s: 0 rss: 130Mb
WARNING: no interesting inputs were found so far. Is the code instrumented for coverage?
This may also happen if the target rejected all inputs we tried so far
#32768  pulse  corp: 1/1b lim: 2105 exec/s: 8192 rss: 254Mb
src/v/bytes/iobuf.cc:192:52: runtime error: null pointer passed as argument 2, which is declared to never be null
external/+non_module_dependencies+x86_64_sysroot/usr/include/string.h:65:33: note: nonnull attribute specified here
    #0 0x7ff296ec461d in iobuf::operator<=>(iobuf const&) const src/v/bytes/iobuf.cc:192:28
    #1 0x55d29d4a27b4 in iobuf_ops::compare_iobufs(std::__1::basic_string_view<char, std::__1::char_traits<char>>, bool) src/v/bytes/tests/iobuf_fuzz.cc:281:31
    #2 0x55d29d49e171 in driver::handle_op(driver::op_spec) src/v/bytes/tests/iobuf_fuzz.cc:576:16
    #3 0x55d29d49abbb in driver::operator()() src/v/bytes/tests/iobuf_fuzz.cc:513:13
    #4 0x55d29d49abbb in LLVMFuzzerTestOneInput src/v/bytes/tests/iobuf_fuzz.cc:719:16
    #5 0x55d29d3385db in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:619:13
    #6 0x55d29d337c05 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:516:7
    #7 0x55d29d339935 in fuzzer::Fuzzer::MutateAndTestOne() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:765:19
    #8 0x55d29d33a595 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, std::__Fuzzer::allocator<fuzzer::SizedFile>>&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:910:5
    #9 0x55d29d327ff5 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:915:6
    #10 0x55d29d354bb2 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #11 0x7ff28d010247 in __libc_start_call_main (/lib64/libc.so.6+0x3247) (BuildId: 515c33a35f41020661fea8ac4eb995e26ccd6b00)
    #12 0x7ff28d01030a in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x330a) (BuildId: 515c33a35f41020661fea8ac4eb995e26ccd6b00)
    #13 0x55d29d31a704 in _start (/home/brandonallard/data/.cache/bazel/_bazel_brandonallard/50acd7c106e570e66c6351a7103182f1/execroot/_main/bazel-out/k8-dbg/bin/src/v/bytes/tests/iobuf_fuzz+0x2f0704) (BuildId: 4de8a27cc512a4a32db2efcd62d94228)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/v/bytes/iobuf.cc:192:52
MS: 5 CMP-CrossOver-InsertRepeatedBytes-ChangeBit-InsertByte- DE: "\000\000\000\000"-; base unit: adc83b19e793491b1c6ea0fd8b46cd9f32e592fc
0x23,0xa,0x0,0x0,0x0,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0xa,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8
,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0xa,0x0,
#\012\000\000\000\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\012\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\01
0\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\010\012\000
artifact_prefix='./'; Test unit written to ./crash-87234361ff2513f61e8eba73f82676d022d60e42
Base64: IwoAAAAICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgKCAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgKAA==
================================================================================
FAIL: //src/v/bytes/tests:iobuf_fuzz (run 76 of 100) (Exit 77) (see /home/brandonallard/data/.cache/bazel/_bazel_brandonallard/50acd7c106e570e66c6351a7103182f1/execroot/_main/bazel-out/k8-dbg/testlogs/src/v/bytes/tests/iobuf_fuzz/run_76_of_100/test.log)
INFO: From Testing //src/v/bytes/tests:iobuf_fuzz (run 76 of 100):
==================== Test output for //src/v/bytes/tests:iobuf_fuzz (run 76 of 100):
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 2867371789
INFO: A corpus is not provided, starting from an empty corpus
#2      INITED exec/s: 0 rss: 127Mb
WARNING: no interesting inputs were found so far. Is the code instrumented for coverage?
This may also happen if the target rejected all inputs we tried so far
#32768  pulse  corp: 1/1b lim: 2105 exec/s: 8192 rss: 245Mb
#65536  pulse  corp: 1/1b lim: 4228 exec/s: 6553 rss: 248Mb
libc++abi: terminating due to uncaught exception of type std::runtime_error: (buf <=> o_buf) != (ref <=> o_ref)
==12== ERROR: libFuzzer: deadly signal
    #0 0x55a6e61329f1 in __sanitizer_print_stack_trace /src/llvm-project/compiler-rt/lib/asan/asan_stack.cpp:87:3
    #1 0x55a6e6027228 in fuzzer::PrintStackTrace() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerUtil.cpp:210:5
    #2 0x55a6e6009e73 in fuzzer::Fuzzer::CrashCallback() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:231:3
    #3 0x7f980b02704f  (/lib64/libc.so.6+0x1a04f) (BuildId: 515c33a35f41020661fea8ac4eb995e26ccd6b00)
    #4 0x7f980b080113 in __pthread_kill_implementation (/lib64/libc.so.6+0x73113) (BuildId: 515c33a35f41020661fea8ac4eb995e26ccd6b00)
    #5 0x7f980b026f9d in gsignal (/lib64/libc.so.6+0x19f9d) (BuildId: 515c33a35f41020661fea8ac4eb995e26ccd6b00)
    #6 0x7f980b00e941 in abort (/lib64/libc.so.6+0x1941) (BuildId: 515c33a35f41020661fea8ac4eb995e26ccd6b00)
    #7 0x55a6e616d985 in __abort_message abort_message.cpp
    #8 0x55a6e61d3288 in demangling_terminate_handler() cxa_default_handlers.cpp
    #9 0x55a6e61d3172 in std::__terminate(void (*)()) cxa_handlers.cpp
    #10 0x55a6e61d1d98 in __cxa_rethrow (/home/brandonallard/data/.cache/bazel/_bazel_brandonallard/50acd7c106e570e66c6351a7103182f1/execroot/_main/bazel-out/k8-dbg/bin/src/v/bytes/tests/iobuf_fuzz+0x4d4d98) (BuildId: 4de8a27cc512a4a32db2efcd62d94228)
    #11 0x55a6e616dd28 in LLVMFuzzerTestOneInput src/v/bytes/tests/iobuf_fuzz.cc:724:9
    #12 0x55a6e600b5db in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:619:13
    #13 0x55a6e600ac05 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:516:7
    #14 0x55a6e600c935 in fuzzer::Fuzzer::MutateAndTestOne() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:765:19
    #15 0x55a6e600d595 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, std::__Fuzzer::allocator<fuzzer::SizedFile>>&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:910:5
    #16 0x55a6e5ffaff5 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:915:6
    #17 0x55a6e6027bb2 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #18 0x7f980b010247 in __libc_start_call_main (/lib64/libc.so.6+0x3247) (BuildId: 515c33a35f41020661fea8ac4eb995e26ccd6b00)
    #19 0x7f980b01030a in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x330a) (BuildId: 515c33a35f41020661fea8ac4eb995e26ccd6b00)
    #20 0x55a6e5fed704 in _start (/home/brandonallard/data/.cache/bazel/_bazel_brandonallard/50acd7c106e570e66c6351a7103182f1/execroot/_main/bazel-out/k8-dbg/bin/src/v/bytes/tests/iobuf_fuzz+0x2f0704) (BuildId: 4de8a27cc512a4a32db2efcd62d94228)

NOTE: libFuzzer has rudimentary signal handlers.
      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
SUMMARY: libFuzzer: deadly signal
MS: 4 CopyPart-ChangeBit-CMP-CMP- DE: "\000\000\000\000\000\000\000\000"-"\377\377\377\377\377\377\377\377\377\377?\377\377\377\377\377\377\377\377\377\377\377\012\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\000\000\000\000\000\000\000\011\377\377\
377\377\377\377\377\377\377"-; base unit: adc83b19e793491b1c6ea0fd8b46cd9f32e592fc
0x4a,0xa,0x0,0x0,0x0,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x3f,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xa,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x9,0xff,0xff,0xf
f,0xff,0xff,0xff,0xff,0xff,0xff,0x0,0x0,0x0,0x0,0x0,
J\012\000\000\000\377\377\377\377\377\377\377\377\377\377?\377\377\377\377\377\377\377\377\377\377\377\012\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\000\000\000\000\000\000\000\011\377\377\377\377\377\377\377\377\377\000\000\000\000\000
artifact_prefix='./'; Test unit written to ./crash-b93c506ce3bec14322fc8cabc8898af768226160
Base64: SgoAAAD/////////////P///////////////Cv///////////////////////////////wAAAAAAAAAJ////////////AAAAAAA=
================================================================================
```

The PR also increases coverage of iobufs with many small fragments in the fuzz test.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
