### PR TITLE
[CORE-15047] net/transport: Enhance connection errors with resolved address

### DIFF
--- a/src/v/net/transport.cc
+++ b/src/v/net/transport.cc
@@ -9,7 +9,19 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/core/with_timeout.hh>
 
+#include <system_error>
+
 namespace {
+
+class timed_out_error : public ss::timed_out_error {
+public:
+    explicit timed_out_error(ss::sstring msg)
+      : _msg{std::move(msg)} {}
+    const char* what() const noexcept override { return _msg.c_str(); }
+
+private:
+    ss::sstring _msg;
+};
 
 ss::future<ss::connected_socket> connect_with_timeout(
   const seastar::socket_address& address,
@@ -19,9 +31,23 @@ ss::future<ss::connected_socket> connect_with_timeout(
     auto f = socket->connect(address).finally([socket] {});
     return ss::with_timeout(timeout, std::move(f))
       .handle_exception([socket, address, log](const std::exception_ptr& e) {
-          vlog(log->trace, "error connecting to {} - {}", address, e);
-          socket->shutdown();
-          return ss::make_exception_future<ss::connected_socket>(e);
+          try {
+              std::rethrow_exception(e);
+          } catch (const ss::timed_out_error& ex) {
+              socket->shutdown();
+              return ss::make_exception_future<ss::connected_socket>(
+                timed_out_error(
+                  ssx::sformat("connection to {} - {}", address, e)));
+          } catch (const std::system_error& ex) {
+              socket->shutdown();
+              return ss::make_exception_future<ss::connected_socket>(
+                std::system_error(
+                  ex.code(), fmt::format("connection to {}", address)));
+          } catch (...) {
+              vlog(log->trace, "error connecting to {} - {}", address, e);
+              socket->shutdown();
+              return ss::make_exception_future<ss::connected_socket>(e);
+          }
       });
 }
 


### PR DESCRIPTION
Enhance the exception with the resolved address if the underlying error is of a known type.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x

## Release Notes

### Improvements

* Connection errors now report the resolved address where possible.
