### PR TITLE
[v25.2.x] [CORE-15047] kafka/client: Enhance connection errors

### DIFF
--- a/src/v/kafka/client/broker.cc
+++ b/src/v/kafka/client/broker.cc
@@ -76,7 +76,8 @@ ss::future<shared_broker_t> broker_factory::create_broker(
         co_await broker_transport->connect();
     } catch (const std::system_error& ex) {
         if (net::is_reconnect_error(ex) || is_dns_failure_error(ex)) {
-            throw broker_error(node_id, error_code::network_exception);
+            throw broker_error(
+              node_id, error_code::network_exception, ex.what());
         }
         vlog(_logger->warn, "std::system_error: {}", ex.what());
         throw;

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -83,19 +83,23 @@ ss::future<> client::connect() {
       _seeds.begin(), _seeds.end(), random_generators::internal::gen);
 
     return ss::do_with(size_t{0}, [this](size_t& retries) {
+        const auto seed = [this, &retries]() {
+            return _seeds[retries % _seeds.size()];
+        };
         return retry_with_mitigation(
           _config.retries_cfg.max_retries,
           _config.retries_cfg.retry_base_backoff,
-          [this, retries]() {
-              return do_connect(_seeds[retries % _seeds.size()]);
-          },
-          [this, &retries](std::exception_ptr ex) {
-              ++retries;
+          [this, seed]() { return do_connect(seed()); },
+          [this, seed, &retries](std::exception_ptr ex) {
+              auto address = seed();
               vlog(
                 _logger.info,
-                "Failed to connect to seed {}: {}, retrying",
-                retries,
+                "Failed to connect {} to seed @ {}:{} - {}, retrying",
+                _config.connection_cfg.client_id.value_or("redpanda-client"),
+                address.host(),
+                address.port(),
                 ex);
+              ++retries;
               return external_mitigate_error(ex);
           },
           _as);


### PR DESCRIPTION
* Improve retry to logic to properly rotate all provided seed servers.
* Improve logging when connect fails.

In combination with https://github.com/redpanda-data/redpanda/pull/29204

Example:
```
INFO  2026-01-09 09:47:44,960 [shard 0:main] kafka/client - schema_registry_client - client.cc:99 - Failed to connect schema_registry_client to seed @ nohost:19092 - kafka::client::broker_error ({ node: -1 }, { error_code: network_exception [13] }: connection to 192.168.0.189:19092: No route to host), retrying
WARN  2026-01-09 09:47:44,960 [shard 0:main] schemaregistry - service.cc:427 - mitigate_error: kafka::client::broker_error ({ node: -1 }, { error_code: network_exception [13] }: connection to 192.168.0.189:19092: No route to host)
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Improvements

* kafka/client: Improve retry to logic to properly rotate all provided seed servers.
