### PR TITLE
rpk: add --ignore-profile flag to bypass cfg files

### DIFF
--- a/src/go/rpk/pkg/cli/root.go
+++ b/src/go/rpk/pkg/cli/root.go
@@ -89,8 +89,12 @@ func Execute() {
 
 	pf.StringVar(&p.ConfigFlag, "config", "", fmt.Sprintf("Redpanda or rpk config file; default search paths are %q, $PWD/redpanda.yaml, and /etc/redpanda/redpanda.yaml", searchLocal))
 	pf.StringVar(&p.Profile, "profile", "", "rpk profile to use")
+	pf.BoolVar(&p.IgnoreProfile, "ignore-profile", false, "Ignore rpk.yaml and redpanda.yaml; use default settings")
 	pf.StringArrayVarP(&p.FlagOverrides, "config-opt", "X", nil, "Override rpk configuration settings; '-X help' for detail or '-X list' for terser detail")
 	pf.BoolVarP(&p.DebugLogs, "verbose", "v", false, "Enable verbose logging")
+
+	root.MarkFlagsMutuallyExclusive("ignore-profile", "profile")
+	root.MarkFlagsMutuallyExclusive("ignore-profile", "config")
 
 	root.RegisterFlagCompletionFunc("config-opt", func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		var opts []string

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -607,6 +607,10 @@ type Params struct {
 	// Profile is any flag-specified profile name.
 	Profile string
 
+	// IgnoreProfile skips loading rpk.yaml and redpanda.yaml, using default
+	// settings instead.
+	IgnoreProfile bool
+
 	// DebugLogs opts into debug logging.
 	//
 	// This field only for setting, to actually get a logger after the
@@ -1142,6 +1146,9 @@ func readFile(fs afero.Fs, path string) (string, []byte, error) {
 }
 
 func (p *Params) readRpkConfig(fs afero.Fs, c *Config) error {
+	if p.IgnoreProfile {
+		return nil // Skip reading rpk.yaml, use defaults
+	}
 	def, err := DefaultRpkYamlPath()
 	path := def
 	if p.ConfigFlag != "" {
@@ -1202,6 +1209,9 @@ func (p *Params) readRpkConfig(fs afero.Fs, c *Config) error {
 }
 
 func (p *Params) readRedpandaConfig(fs afero.Fs, c *Config) error {
+	if p.IgnoreProfile {
+		return nil // Skip reading redpanda.yaml, use defaults
+	}
 	paths := []string{p.ConfigFlag}
 	if p.ConfigFlag == "" {
 		paths = paths[:0]

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -1821,3 +1821,121 @@ func TestProcessOverrides(t *testing.T) {
 		})
 	}
 }
+
+func TestIgnoreProfile(t *testing.T) {
+	defaultRpkPath, err := DefaultRpkYamlPath()
+	require.NoError(t, err)
+
+	t.Run("ignores rpk.yaml and redpanda.yaml, uses defaults", func(t *testing.T) {
+		// Set up files that would normally be loaded
+		fs := testfs.FromMap(map[string]testfs.Fmode{
+			defaultRpkPath: testfs.RFile(`version: 7
+current_profile: custom
+profiles:
+    - name: custom
+      kafka_api:
+        brokers:
+            - remote-host:9092
+`),
+			DefaultRedpandaYamlPath: testfs.RFile(`redpanda:
+    kafka_api:
+        - address: 10.0.0.1
+          port: 9092
+`),
+		})
+
+		p := &Params{IgnoreProfile: true}
+		cfg, err := p.Load(fs)
+		require.NoError(t, err)
+
+		// Should use default localhost settings, not the config file values.
+		profile := cfg.VirtualProfile()
+		require.Equal(t, []string{"127.0.0.1:9092"}, profile.KafkaAPI.Brokers)
+		require.Equal(t, []string{"127.0.0.1:9644"}, profile.AdminAPI.Addresses)
+		require.Equal(t, []string{"127.0.0.1:8081"}, profile.SR.Addresses)
+	})
+
+	t.Run("allows environment variable overrides", func(t *testing.T) {
+		fs := testfs.FromMap(map[string]testfs.Fmode{
+			defaultRpkPath: testfs.RFile(`version: 7
+current_profile: custom
+profiles:
+    - name: custom
+      kafka_api:
+        brokers:
+            - remote-host:9092
+`),
+		})
+
+		t.Setenv("RPK_BROKERS", "env-host:9092")
+
+		p := &Params{IgnoreProfile: true}
+		cfg, err := p.Load(fs)
+		require.NoError(t, err)
+
+		// Should use the env var override, not defaults or config file values.
+		profile := cfg.VirtualProfile()
+		require.Equal(t, []string{"env-host:9092"}, profile.KafkaAPI.Brokers)
+	})
+
+	t.Run("allows -X overrides", func(t *testing.T) {
+		fs := testfs.FromMap(map[string]testfs.Fmode{
+			defaultRpkPath: testfs.RFile(`version: 7
+current_profile: custom
+profiles:
+    - name: custom
+      kafka_api:
+        brokers:
+            - remote-host:9092
+`),
+		})
+
+		p := &Params{
+			IgnoreProfile: true,
+			FlagOverrides: []string{"brokers=override-host:9092"},
+		}
+		cfg, err := p.Load(fs)
+		require.NoError(t, err)
+
+		// Should use the override value, not defaults or config file values.
+		profile := cfg.VirtualProfile()
+		require.Equal(t, []string{"override-host:9092"}, profile.KafkaAPI.Brokers)
+	})
+
+	t.Run("don't ignore rpk.yaml and redpanda.yaml", func(t *testing.T) {
+		fs := testfs.FromMap(map[string]testfs.Fmode{
+			defaultRpkPath: testfs.RFile(`version: 7
+current_profile: custom
+profiles:
+    - name: custom
+      kafka_api:
+        brokers:
+            - remote-host:9092
+`),
+			DefaultRedpandaYamlPath: testfs.RFile(`redpanda:
+    kafka_api:
+        - address: 10.0.0.1
+          port: 9092
+rpk:
+  kafka_api:
+    brokers: 100.100.100.1:9092
+  admin_api:
+    addresses: from-redpanda:9644
+      
+`),
+		})
+
+		p := &Params{IgnoreProfile: false} // The default
+		cfg, err := p.Load(fs)
+		require.NoError(t, err)
+
+		profile := cfg.VirtualProfile()
+		// Should use what's in the profile (not in the redpanda.yaml).
+		require.Equal(t, []string{"remote-host:9092"}, profile.KafkaAPI.Brokers)
+		// Should use what's in the redpanda.yaml as the profile doesn't have anything.
+		require.Equal(t, []string{"from-redpanda:9644"}, profile.AdminAPI.Addresses)
+		// Should 'guess' the host from kafka's host in the profile. SR is not
+		// set anywhere.
+		require.Equal(t, []string{"remote-host:8081"}, profile.SR.Addresses)
+	})
+}


### PR DESCRIPTION
This is particularly useful for CI environments. Users can still provide their setup through flags or environment variables when using this flag. This is a niche use case, but useful nonetheless

```
# Useful in CI scripts where a profile might be configured, but you want localhost
$ rpk topic list --ignore-profile

# Combine with -X overrides to connect to a specific cluster without using profiles
$ rpk cluster health --ignore-profile -X brokers=10.0.0.1:9092

# Use environment variables with --ignore-profile
$ RPK_BROKERS=rp-container-1:9092 rpk topic describe my-topic --ignore-profile
```

Fixes UX-75

**Note:** We didn't use `--no-profile` since it's already used in other commands to prevent automatically creating a profile. 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Features

* rpk: now have --ignore-profile that makes rpk ignore the rpk.yaml and redpanda.yaml config files.