### PR TITLE
ct: check l0 reader abort source in materialization

### DIFF
--- a/src/v/cloud_topics/data_plane_api.h
+++ b/src/v/cloud_topics/data_plane_api.h
@@ -76,7 +76,8 @@ public:
       model::ntp ntp,
       size_t output_size_estimate,
       chunked_vector<extent_meta> metadata,
-      model::timeout_clock::time_point timeout)
+      model::timeout_clock::time_point timeout,
+      model::opt_abort_source_t)
       = 0;
 
     /// Return the maximum bytes that may be requested in a single

--- a/src/v/cloud_topics/data_plane_impl.cc
+++ b/src/v/cloud_topics/data_plane_impl.cc
@@ -164,7 +164,8 @@ public:
       model::ntp ntp,
       size_t output_size_estimate,
       chunked_vector<extent_meta> metadata,
-      model::timeout_clock::time_point timeout) override {
+      model::timeout_clock::time_point timeout,
+      model::opt_abort_source_t as) override {
         if (metadata.empty()) {
             co_return chunked_vector<model::record_batch>{};
         }
@@ -183,7 +184,8 @@ public:
             .output_size_estimate = output_size_estimate,
             .meta = std::move(metadata),
           },
-          timeout);
+          timeout,
+          as);
         if (!res) {
             co_return res.error();
         }

--- a/src/v/cloud_topics/frontend/tests/frontend_test.cc
+++ b/src/v/cloud_topics/frontend/tests/frontend_test.cc
@@ -62,7 +62,8 @@ public:
       (model::ntp ntp,
        size_t output_size_estimate,
        chunked_vector<extent_meta> metadata,
-       model::timeout_clock::time_point timeout),
+       model::timeout_clock::time_point timeout,
+       model::opt_abort_source_t),
       (override));
 
     MOCK_METHOD(

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -335,7 +335,11 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
           materialize_count);
         // Ask data layer to bring data from the cloud storage.
         auto mat_res = co_await _ct_api->materialize(
-          _ctp->ntp(), materialize_bytes, std::move(to_materialize), deadline);
+          _ctp->ntp(),
+          materialize_bytes,
+          std::move(to_materialize),
+          deadline,
+          _config.abort_source);
         if (!mat_res.has_value()) {
             if (mat_res.error() == errc::shutting_down) {
                 vlog(_log.debug, "Materialize aborted due to shutdown");
@@ -367,6 +371,9 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
         auto range_to_materialize = std::ranges::subrange(
           _unhydrated.begin(), unhydrated_it);
         for (local_log_batch& local_batch : range_to_materialize) {
+            if (_config.abort_source.has_value()) {
+                _config.abort_source.value().get().check();
+            }
             auto& local_batch_header = local_batch.header;
             model::record_batch batch = ss::visit(
               local_batch.data,

--- a/src/v/cloud_topics/level_zero/pipeline/BUILD
+++ b/src/v/cloud_topics/level_zero/pipeline/BUILD
@@ -157,6 +157,7 @@ redpanda_cc_library(
         ":serializer",
         "//src/v/cloud_topics:logger",
         "//src/v/resource_mgmt:memory_groups",
+        "//src/v/ssx:abort_source",
         "//src/v/ssx:sformat",
         "//src/v/utils:human",
     ],

--- a/src/v/cloud_topics/level_zero/pipeline/read_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/read_pipeline.cc
@@ -17,6 +17,7 @@
 #include "cloud_topics/logger.h"
 #include "config/configuration.h"
 #include "resource_mgmt/memory_groups.h"
+#include "ssx/abort_source.h"
 #include "utils/human.h"
 
 #include <seastar/core/abort_source.hh>
@@ -64,9 +65,25 @@ read_pipeline<Clock>::read_pipeline()
 template<class Clock>
 ss::future<std::expected<dataplane_query_result, std::error_code>>
 read_pipeline<Clock>::make_reader(
-  model::ntp ntp, dataplane_query query, timestamp_t timeout) {
+  model::ntp ntp,
+  dataplane_query query,
+  timestamp_t timeout,
+  model::opt_abort_source_t caller_as) {
     auto h = this->hold_gate();
-    auto& as = this->get_root_rtc().root_abort_source();
+
+    /*
+     * if caller provides an abort source, combine it with rtc
+     */
+    std::optional<ssx::composite_abort_source> combined_as;
+    auto& as = [this, &caller_as, &combined_as] -> ss::abort_source& {
+        auto& rtc_as = this->get_root_rtc().root_abort_source();
+        if (caller_as.has_value()) {
+            combined_as.emplace(caller_as->get(), rtc_as);
+            return combined_as.value().as();
+        }
+        return rtc_as;
+    }();
+
     auto size_estimate = query.output_size_estimate;
     _probe.register_request();
     _probe.set_memory_usage_gauge(_current_size + size_estimate);

--- a/src/v/cloud_topics/level_zero/pipeline/read_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/read_pipeline.h
@@ -48,7 +48,11 @@ public:
     /// The result of the query is a reader that contains the
     /// actual raft_data batches.
     ss::future<std::expected<dataplane_query_result, std::error_code>>
-    make_reader(model::ntp ntp, dataplane_query query, timestamp_t timeout);
+    make_reader(
+      model::ntp ntp,
+      dataplane_query query,
+      timestamp_t timeout,
+      model::opt_abort_source_t as = std::nullopt);
 
     using read_requests_list
       = requests_list<read_pipeline<Clock>, read_request<Clock>>;


### PR DESCRIPTION
I wasn't able to reproduce locally the slow reconciler shutdown, but tracing the reconciler it looks like the most likely candidate for slow shutdown would be the reader, and descending into the reader, this commit addresses what looks like the most likely source of a slow shutdown.

---

The L0 reader takes an abort source via its reader configuration, but it only uses the abort source to configure the local log reader. However, the L0 reader performs other expensive operations besides interacting with the local reader.

One such operation is materialization. Prior to this patch materialization would respect the abort source of the read pipeline. However, when cloud topics is shutting down the pipelines are shutdown last. So during shutdown if the reconciler is materializing batches via an L0 reader it cannot rely on the pipeline abort source for timeline shutdown.

This commit plumbs an abort source from the caller into the pipeline and combines it with the existing pipeline abort source so that both sides can control shutdown behavior.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
