### PR TITLE
ct: Support out of order epochs in ctp_stm

### DIFF
--- a/src/v/cloud_topics/frontend/tests/frontend_test.cc
+++ b/src/v/cloud_topics/frontend/tests/frontend_test.cc
@@ -142,26 +142,12 @@ TEST_F(frontend_fixture, test_replicate_epoch) {
       .WillOnce(Return(ss::as_ready_future(stage_result{})))
       .WillOnce(Return(ss::as_ready_future(stage_result{})));
     EXPECT_CALL(*_data_plane, execute_write(_, _, _, _))
-      .WillOnce(Return(make_extent_fut(model::offset(0), cluster_epoch(0))))
-      .WillOnce(Return(make_extent_fut(model::offset(1), cluster_epoch(1))))
+      .WillOnce(Return(make_extent_fut(model::offset(0), cluster_epoch(1))))
+      .WillOnce(Return(make_extent_fut(model::offset(1), cluster_epoch(2))))
       .WillOnce(Return(make_extent_fut(model::offset(2), cluster_epoch(0))));
 
     {
-        // First batch with offset 0
-        auto batch = model::test::make_random_batch(model::offset{0}, false);
-        chunked_vector<model::record_batch> buf;
-        buf.push_back(std::move(batch));
-        auto res = frontend
-                     .replicate(
-                       std::move(buf),
-                       raft::replicate_options(
-                         raft::consistency_level::quorum_ack))
-                     .get();
-        ASSERT_TRUE(res.has_value());
-    }
-
-    {
-        // First batch with offset 1
+        // First batch with offset 0 (epoch 1)
         auto batch = model::test::make_random_batch(model::offset{1}, false);
         chunked_vector<model::record_batch> buf;
         buf.push_back(std::move(batch));
@@ -175,7 +161,21 @@ TEST_F(frontend_fixture, test_replicate_epoch) {
     }
 
     {
-        // First batch with offset 2 (breaks invariant)
+        // First batch with offset 1 (epoch 2)
+        auto batch = model::test::make_random_batch(model::offset{2}, false);
+        chunked_vector<model::record_batch> buf;
+        buf.push_back(std::move(batch));
+        auto res = frontend
+                     .replicate(
+                       std::move(buf),
+                       raft::replicate_options(
+                         raft::consistency_level::quorum_ack))
+                     .get();
+        ASSERT_TRUE(res.has_value());
+    }
+
+    {
+        // First batch with offset 2 (epoch 0, breaks invariant)
         auto batch = model::test::make_random_batch(model::offset{2}, false);
         chunked_vector<model::record_batch> buf;
         buf.push_back(std::move(batch));

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -201,9 +201,7 @@ ss::future<bool> ctp_stm::sync_in_term(
 }
 
 std::optional<cluster_epoch> ctp_stm::estimate_inactive_epoch() const noexcept {
-    auto estimate = _state.estimate_min_epoch().transform(prev_cluster_epoch);
-    auto prev = _state.get_previous_epoch().transform(prev_cluster_epoch);
-    return std::min(estimate, prev); // returning nullopt here is safe
+    return _state.estimate_inactive_epoch();
 }
 
 ss::future<std::optional<cluster_epoch>> ctp_stm::get_inactive_epoch() {

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -50,8 +50,18 @@ cluster_epoch extract_epoch(model::record_batch&& batch) {
 class ctp_stm_consumer {
 public:
     ss::future<ss::stop_iteration> operator()(model::record_batch batch) {
-        _first_epoch = extract_epoch(std::move(batch));
-        co_return ss::stop_iteration::yes;
+        if (_first_epoch.has_value()) {
+            _first_epoch = std::min(
+              _first_epoch.value(), extract_epoch(std::move(batch)));
+        } else {
+            _first_epoch = extract_epoch(std::move(batch));
+        }
+        // Since we're accepting out of order epoch we have to read all
+        // placeholders. The epochs in the partition are not strictly monotonic
+        // so we need to read up until the end.
+        // This code is only used for testing so it doesn't make sense to
+        // optimize it.
+        co_return ss::stop_iteration::no;
     }
 
     std::optional<cluster_epoch> end_of_stream() { return _first_epoch; }
@@ -191,7 +201,9 @@ ss::future<bool> ctp_stm::sync_in_term(
 }
 
 std::optional<cluster_epoch> ctp_stm::estimate_inactive_epoch() const noexcept {
-    return _state.estimate_min_epoch().transform(prev_cluster_epoch);
+    auto estimate = _state.estimate_min_epoch().transform(prev_cluster_epoch);
+    auto prev = _state.get_previous_epoch().transform(prev_cluster_epoch);
+    return std::min(estimate, prev); // returning nullopt here is safe
 }
 
 ss::future<std::optional<cluster_epoch>> ctp_stm::get_inactive_epoch() {
@@ -321,11 +333,10 @@ void ctp_stm::apply_placeholder(const model::record_batch& batch) {
     // because the assertion is about the physical content of the log rather
     // than the computed state.
     vassert(
-      id.epoch >= _last_seen_epoch,
+      id.epoch >= _state.get_previous_epoch().value_or(cluster_epoch::min()),
       "Observed a non-monotonic epoch sequence {} < {}",
       id.epoch,
-      _last_seen_epoch);
-    _last_seen_epoch = id.epoch;
+      _state.get_previous_epoch());
     _state.advance_epoch(id.epoch, batch.header().base_offset);
 }
 
@@ -372,11 +383,13 @@ ctp_stm::fence_epoch(cluster_epoch e) {
     while (true) {
         auto fence_epoch = _state.get_max_seen_epoch().or_else(
           get_applied_epoch);
-        if (fence_epoch.has_value() && fence_epoch.value() == e) {
-            // Case 1. Same epoch, need to acquire read-lock.
+        if (_state.epoch_in_window(e)) {
+            // Case 1.1. Same epoch, need to acquire read-lock.
+            // Case 1.2. This epoch is out of order. We can accept it if it lies
+            //           in [previous-epoch, max-seen-epoch) range. We also need
+            //           to acquire a read fence as in 1.1.
             auto unit = co_await ss::get_units(_lock, 1, _as);
-            if (_state.get_max_seen_epoch().or_else(get_applied_epoch) == e) {
-                // The max_seen_epoch didn't advance after the scheduling point
+            if (_state.epoch_in_window(e)) {
                 co_return cluster_epoch_fence{
                   .unit = std::move(unit), .term = term};
             }

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -129,10 +129,6 @@ private:
     /// Current in-memory state of the STM
     ctp_stm_state _state;
 
-    // The last observed epoch to be applied to the state machine. This value is
-    // used to check for violations of monotonicity in epoch order.
-    cluster_epoch _last_seen_epoch{};
-
     // An abort source to stop the prefix truncation loop on stop.
     ss::condition_variable _lro_advanced;
     ss::abort_source _as;

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
@@ -38,7 +38,30 @@ ctp_stm_state::estimate_min_epoch() const noexcept {
 
 std::optional<cluster_epoch>
 ctp_stm_state::get_previous_epoch() const noexcept {
-    return std::max(_previous_epoch, _previous_seen_epoch);
+    return _previous_epoch;
+}
+
+bool ctp_stm_state::epoch_in_window(cluster_epoch epoch) const noexcept {
+    // NOTE: the window should move forward with _max_seen_epoch.
+    // If _max_seen_epoch is greater than _max_applied_epoch then
+    // the window should be [_previous_seen_epoch, _max_seen_epoch].
+    // The window reflects in-flight requests. Write fence is required
+    // to move it forward.
+    auto end = _max_seen_epoch.value_or(
+      _max_applied_epoch.value_or(cluster_epoch::min()));
+    auto begin = _previous_seen_epoch.value_or(_previous_epoch.value_or(end));
+    return epoch >= begin && epoch <= end;
+}
+
+std::optional<cluster_epoch>
+ctp_stm_state::estimate_inactive_epoch() const noexcept {
+    // NOTE: the inactive epoch shouldn't be estimated using the transient
+    // state (_previous_seen_epoch, _max_seen_epoch). It should only take
+    // into account committed state and ignore state that reflects in-flight
+    // requests.
+    auto estimate = estimate_min_epoch().transform(prev_cluster_epoch);
+    auto prev = _previous_epoch.transform(prev_cluster_epoch);
+    return std::min(estimate, prev); // returning nullopt here is safe
 }
 
 void ctp_stm_state::advance_epoch(cluster_epoch epoch, model::offset offset) {

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
@@ -16,7 +16,7 @@ namespace cloud_topics {
 
 void ctp_stm_state::advance_max_seen_epoch(cluster_epoch epoch) noexcept {
     if (epoch > _max_seen_epoch) {
-        _previous_seen_epoch = _max_seen_epoch;
+        _previous_seen_epoch = _max_seen_epoch.value_or(epoch);
         _max_seen_epoch = epoch;
     }
 }
@@ -38,7 +38,7 @@ ctp_stm_state::estimate_min_epoch() const noexcept {
 
 std::optional<cluster_epoch>
 ctp_stm_state::get_previous_epoch() const noexcept {
-    return _previous_epoch;
+    return _previous_applied_epoch;
 }
 
 bool ctp_stm_state::epoch_in_window(cluster_epoch epoch) const noexcept {
@@ -49,19 +49,14 @@ bool ctp_stm_state::epoch_in_window(cluster_epoch epoch) const noexcept {
     // to move it forward.
     auto end = _max_seen_epoch.value_or(
       _max_applied_epoch.value_or(cluster_epoch::min()));
-    auto begin = _previous_seen_epoch.value_or(_previous_epoch.value_or(end));
+    auto begin = _previous_seen_epoch.value_or(
+      _previous_applied_epoch.value_or(end));
     return epoch >= begin && epoch <= end;
 }
 
 std::optional<cluster_epoch>
 ctp_stm_state::estimate_inactive_epoch() const noexcept {
-    // NOTE: the inactive epoch shouldn't be estimated using the transient
-    // state (_previous_seen_epoch, _max_seen_epoch). It should only take
-    // into account committed state and ignore state that reflects in-flight
-    // requests.
-    auto estimate = estimate_min_epoch().transform(prev_cluster_epoch);
-    auto prev = _previous_epoch.transform(prev_cluster_epoch);
-    return std::min(estimate, prev); // returning nullopt here is safe
+    return estimate_min_epoch().transform(prev_cluster_epoch);
 }
 
 void ctp_stm_state::advance_epoch(cluster_epoch epoch, model::offset offset) {
@@ -72,16 +67,16 @@ void ctp_stm_state::advance_epoch(cluster_epoch epoch, model::offset offset) {
       _max_seen_epoch.value_or(cluster_epoch::min()), epoch);
     // Register new epoch
     if (_max_applied_epoch.value_or(cluster_epoch::min()) < epoch) {
-        // Record previous max applied epoch and offset.
-        // The condition above guarantees that the invariant of the
-        // _previous_epoch is respected.
-        _previous_epoch = _max_applied_epoch;
-        _max_applied_epoch = epoch;
-        _max_applied_epoch_offset = offset;
+        // A new max epoch requires the sliding window of epoch values in flight
+        // to be moved.
         if (!_min_epoch_lower_bound.has_value()) {
             // First epoch applied to the STM
-            _min_epoch_lower_bound = _max_applied_epoch;
+            _min_epoch_lower_bound = epoch;
         }
+        // Move the sliding window
+        _previous_applied_epoch = _max_applied_epoch.value_or(epoch);
+        _max_applied_epoch = epoch;
+        _current_epoch_window_offset = offset;
     }
 }
 
@@ -89,12 +84,12 @@ void ctp_stm_state::advance_last_reconciled_offset(
   kafka::offset new_last_reconciled_offset,
   model::offset new_last_reconciled_log_offset) noexcept {
     if (
-      _max_applied_epoch_offset.value_or(model::offset{})
+      _current_epoch_window_offset.value_or(model::offset{})
       <= new_last_reconciled_log_offset) {
         // We advanced LRO past the offset at which we saw the current
-        // max_applied_epoch value so we can use max_applied_epoch as
+        // epoch window value so we can use previous epoch as
         // the new min_applied_epoch
-        _min_epoch_lower_bound = _max_applied_epoch;
+        _min_epoch_lower_bound = _previous_applied_epoch;
     }
     _last_reconciled_offset = std::max(
       _last_reconciled_offset.value_or(kafka::offset{}),

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
@@ -15,8 +15,10 @@
 namespace cloud_topics {
 
 void ctp_stm_state::advance_max_seen_epoch(cluster_epoch epoch) noexcept {
-    _max_seen_epoch = std::max(
-      epoch, _max_seen_epoch.value_or(cluster_epoch{}));
+    if (epoch > _max_seen_epoch) {
+        _previous_seen_epoch = _max_seen_epoch;
+        _max_seen_epoch = epoch;
+    }
 }
 
 std::optional<kafka::offset>
@@ -34,16 +36,24 @@ ctp_stm_state::estimate_min_epoch() const noexcept {
     return _min_epoch_lower_bound;
 }
 
+std::optional<cluster_epoch>
+ctp_stm_state::get_previous_epoch() const noexcept {
+    return std::max(_previous_epoch, _previous_seen_epoch);
+}
+
 void ctp_stm_state::advance_epoch(cluster_epoch epoch, model::offset offset) {
     // The STM works on both leader and followers, on a leader the
     // max_seen_epoch epoch is updated by the fencing mechanism.
     // On the follower the max_seen_epoch epoch has to follow the max epoch.
     _max_seen_epoch = std::max(
-      _max_seen_epoch.value_or(cluster_epoch{}), epoch);
+      _max_seen_epoch.value_or(cluster_epoch::min()), epoch);
     // Register new epoch
-    if (_max_applied_epoch.value_or(cluster_epoch{}) != epoch) {
-        _max_applied_epoch = std::max(
-          epoch, _max_applied_epoch.value_or(cluster_epoch{}));
+    if (_max_applied_epoch.value_or(cluster_epoch::min()) < epoch) {
+        // Record previous max applied epoch and offset.
+        // The condition above guarantees that the invariant of the
+        // _previous_epoch is respected.
+        _previous_epoch = _max_applied_epoch;
+        _max_applied_epoch = epoch;
         _max_applied_epoch_offset = offset;
         if (!_min_epoch_lower_bound.has_value()) {
             // First epoch applied to the STM

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
@@ -86,13 +86,11 @@ public:
     /// Note that this value is not necessary equal to estimate_min_epoch.
     std::optional<cluster_epoch> get_previous_epoch() const noexcept;
 
-    bool epoch_in_window(cluster_epoch epoch) const noexcept {
-        auto end = _max_seen_epoch.value_or(
-          _max_applied_epoch.value_or(cluster_epoch::min()));
-        auto begin = _previous_seen_epoch.value_or(
-          _previous_epoch.value_or(end));
-        return epoch >= begin && epoch <= end;
-    }
+    /// Return true if the epoch can be replicated
+    bool epoch_in_window(cluster_epoch epoch) const noexcept;
+
+    /// Estimate inactive epoch
+    std::optional<cluster_epoch> estimate_inactive_epoch() const noexcept;
 
     /// Advance LRO and it's translated log offset counterpart.
     void advance_last_reconciled_offset(

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
@@ -107,9 +107,9 @@ public:
           _max_applied_epoch,
           _last_reconciled_offset,
           _last_reconciled_log_offset,
-          _max_applied_epoch_offset,
+          _current_epoch_window_offset,
           _min_epoch_lower_bound,
-          _previous_epoch,
+          _previous_applied_epoch,
           _start_offset);
     }
 
@@ -134,31 +134,35 @@ private:
     /// that is lower than this value.
     std::optional<cluster_epoch> _max_seen_epoch;
 
+    /// The previous epoch after the current in flight requests are applied.
+    /// Requests with epochs below this value are fenced and not allowed to be
+    /// applied to the STM.
+    ///
+    /// Not persisted with the snapshot because it reflects the state of
+    /// in-flight requests.
+    std::optional<cluster_epoch> _previous_seen_epoch;
+
     /// The maximum epoch of applied batches to the STM.
     ///
     /// We enforce no epochs applied or replicated are less than this value.
     std::optional<cluster_epoch> _max_applied_epoch;
 
-    /// The offset at which the max_applied_epoch was recorded first.
-    std::optional<model::offset> _max_applied_epoch_offset;
+    /// The previous max epoch applied to the STM state.
+    /// Invariant:
+    /// - _previous_epoch < _max_applied_epoch
+    /// - _previous_epoch <= _previous_seen_epoch
+    std::optional<cluster_epoch> _previous_applied_epoch;
 
-    /// The epoch which is less or equal to the epoch referenced
+    /// The offset at which the current applied epoch window was transitioned
+    /// to.
+    std::optional<model::offset> _current_epoch_window_offset;
+
+    /// The epoch which is less or equal to the current epoch window referenced
     /// by the first record batch after the last reconciled offset.
     /// This epoch is not guaranteed to be "active" (from the point of
     /// view of the partition) but it's guaranteed that all epochs before
     /// this epoch are "inactive".
     std::optional<cluster_epoch> _min_epoch_lower_bound;
-
-    /// The previous epoch after the current in flight requests are applied.
-    /// Not persisted with the snapshot because it reflects the state of
-    /// in-flight requests.
-    std::optional<cluster_epoch> _previous_seen_epoch;
-
-    /// The previous epoch applied to the STM state.
-    /// Invariant:
-    /// - _previous_epoch < _max_applied_epoch
-    /// - _previous_epoch <= _previous_seen_epoch
-    std::optional<cluster_epoch> _previous_epoch;
 
     /// The last offset that was uploaded to L1. This value may lag behind
     /// the value stored in the L1 metastore, but should never be ahead of

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
@@ -78,6 +78,22 @@ public:
     /// \note This value might be stale.
     std::optional<cluster_epoch> estimate_min_epoch() const noexcept;
 
+    /// Return the previous epoch value.
+    /// The request can be replicated only if its epoch is greater or
+    /// equal to epoch returned by this method. If the method returns
+    /// nullopt then the epoch wasn't advanced yet so there is no
+    /// previous epoch.
+    /// Note that this value is not necessary equal to estimate_min_epoch.
+    std::optional<cluster_epoch> get_previous_epoch() const noexcept;
+
+    bool epoch_in_window(cluster_epoch epoch) const noexcept {
+        auto end = _max_seen_epoch.value_or(
+          _max_applied_epoch.value_or(cluster_epoch::min()));
+        auto begin = _previous_seen_epoch.value_or(
+          _previous_epoch.value_or(end));
+        return epoch >= begin && epoch <= end;
+    }
+
     /// Advance LRO and it's translated log offset counterpart.
     void advance_last_reconciled_offset(
       kafka::offset new_last_reconciled_offset,
@@ -95,6 +111,7 @@ public:
           _last_reconciled_log_offset,
           _max_applied_epoch_offset,
           _min_epoch_lower_bound,
+          _previous_epoch,
           _start_offset);
     }
 
@@ -133,6 +150,17 @@ private:
     /// view of the partition) but it's guaranteed that all epochs before
     /// this epoch are "inactive".
     std::optional<cluster_epoch> _min_epoch_lower_bound;
+
+    /// The previous epoch after the current in flight requests are applied.
+    /// Not persisted with the snapshot because it reflects the state of
+    /// in-flight requests.
+    std::optional<cluster_epoch> _previous_seen_epoch;
+
+    /// The previous epoch applied to the STM state.
+    /// Invariant:
+    /// - _previous_epoch < _max_applied_epoch
+    /// - _previous_epoch <= _previous_seen_epoch
+    std::optional<cluster_epoch> _previous_epoch;
 
     /// The last offset that was uploaded to L1. This value may lag behind
     /// the value stored in the L1 metastore, but should never be ahead of

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
@@ -167,11 +167,7 @@ TEST(ctp_stm_state_test, sliding_window_issue) {
 
     auto estimate_inactive_epoch =
       [&state] -> std::optional<ct::cluster_epoch> {
-        auto estimate = state.estimate_min_epoch().transform(
-          ct::prev_cluster_epoch);
-        auto prev = state.get_previous_epoch().transform(
-          ct::prev_cluster_epoch);
-        return std::min(estimate, prev);
+        return state.estimate_inactive_epoch();
     };
 
     auto apply_replicated = [&state, &hwm](ct::cluster_epoch epoch) {
@@ -226,7 +222,7 @@ TEST(ctp_stm_state_test, sliding_window_issue) {
     EXPECT_TRUE(state.epoch_in_window(3_epoch));
 
     // Still not safe to GC, we accept stuff at epoch 0
-    EXPECT_EQ(estimate_inactive_epoch(), ct::cluster_epoch::min());
+    EXPECT_EQ(estimate_inactive_epoch(), std::nullopt);
 
     apply_replicated(5_epoch);
 

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
@@ -110,24 +110,31 @@ TEST(ctp_stm_state_test, advance_lro_updates_min_epoch) {
     ct::ctp_stm_state state;
     ct::cluster_epoch epoch1(10);
     ct::cluster_epoch epoch2(20);
+    ct::cluster_epoch epoch3(30);
 
     // Initially min epoch is not set
     EXPECT_FALSE(state.estimate_min_epoch().has_value());
 
     state.advance_epoch(epoch1, model::offset(1));
-    EXPECT_TRUE(state.estimate_min_epoch().has_value());
-    EXPECT_EQ(state.estimate_min_epoch().value(), epoch1);
+    EXPECT_EQ(state.estimate_min_epoch(), epoch1);
 
     state.advance_epoch(epoch2, model::offset(5));
-    EXPECT_EQ(state.estimate_min_epoch().value(), epoch1);
+    EXPECT_EQ(state.estimate_min_epoch(), epoch1);
+
+    state.advance_epoch(epoch3, model::offset(10));
+    EXPECT_EQ(state.estimate_min_epoch(), epoch1);
 
     // Advance LRO past the offset of epoch1
     state.advance_last_reconciled_offset(kafka::offset(100), model::offset(2));
-    EXPECT_EQ(state.estimate_min_epoch().value(), epoch1);
+    EXPECT_EQ(state.estimate_min_epoch(), epoch1);
 
     // Advance LRO past the offset of epoch2
     state.advance_last_reconciled_offset(kafka::offset(200), model::offset(6));
-    EXPECT_EQ(state.estimate_min_epoch().value(), epoch2);
+    EXPECT_EQ(state.estimate_min_epoch(), epoch1);
+
+    // Advance LRO past the offset of epoch3
+    state.advance_last_reconciled_offset(kafka::offset(300), model::offset(11));
+    EXPECT_EQ(state.estimate_min_epoch(), epoch2);
 }
 
 TEST(ctp_stm_state_test, advance_start_offset) {
@@ -183,57 +190,62 @@ TEST(ctp_stm_state_test, sliding_window_issue) {
     // Our start state, we can't GC anything and we have to
     // get the write lock before we can start our window
     EXPECT_EQ(estimate_inactive_epoch(), std::nullopt);
-    EXPECT_FALSE(state.epoch_in_window(0_epoch));
+    // Start our epochs at 2
+    EXPECT_FALSE(state.epoch_in_window(2_epoch));
 
     // Write lock grabbed, max epoch can be advanced!
-    state.advance_max_seen_epoch(0_epoch);
+    state.advance_max_seen_epoch(2_epoch);
 
     // Now epoch 0 is in the window
-    EXPECT_TRUE(state.epoch_in_window(0_epoch));
+    EXPECT_TRUE(state.epoch_in_window(2_epoch));
     // Epoch 1 is not in the window
     EXPECT_FALSE(state.epoch_in_window(1_epoch));
+    // Nor is 3
+    EXPECT_FALSE(state.epoch_in_window(3_epoch));
 
     // Now the batch that was replicated with offset 0
-    apply_replicated(0_epoch);
+    apply_replicated(2_epoch);
 
-    // Still not safe to GC
-    EXPECT_EQ(estimate_inactive_epoch(), std::nullopt);
+    // We can GC anything below our initial epoch, we enforce nothing is before
+    // it
+    EXPECT_EQ(estimate_inactive_epoch(), 1_epoch);
 
-    // Let's now add another batch at epoch 0
-    EXPECT_TRUE(state.epoch_in_window(0_epoch));
-    apply_replicated(0_epoch);
+    // Let's now add another batch at epoch 2
+    EXPECT_TRUE(state.epoch_in_window(2_epoch));
+    apply_replicated(2_epoch);
 
     // Reconciler now runs
     reconcile(hwm);
 
-    // Still not safe to GC
-    EXPECT_EQ(estimate_inactive_epoch(), std::nullopt);
+    // Our epoch window hasn't moved
+    EXPECT_EQ(estimate_inactive_epoch(), 1_epoch);
 
     EXPECT_FALSE(state.epoch_in_window(5_epoch));
 
-    // Epoch is bumped, our window should now be [0, 5]
+    // Epoch is bumped, our window should now be [2, 5]
     state.advance_max_seen_epoch(5_epoch);
 
     // This is our new epoch
     EXPECT_TRUE(state.epoch_in_window(5_epoch));
     // Our previous epoch is good still
-    EXPECT_TRUE(state.epoch_in_window(0_epoch));
+    EXPECT_TRUE(state.epoch_in_window(2_epoch));
     // And so is something in between (unlikely in real life, but just to show)
     EXPECT_TRUE(state.epoch_in_window(3_epoch));
+    // Something below is still bad
+    EXPECT_FALSE(state.epoch_in_window(1_epoch));
 
     // Still not safe to GC, we accept stuff at epoch 0
-    EXPECT_EQ(estimate_inactive_epoch(), std::nullopt);
+    EXPECT_EQ(estimate_inactive_epoch(), 1_epoch);
 
     apply_replicated(5_epoch);
 
-    // Still not safe to GC
-    EXPECT_EQ(estimate_inactive_epoch(), ct::cluster_epoch::min());
+    // GC window still the same
+    EXPECT_EQ(estimate_inactive_epoch(), 1_epoch);
 
-    // We can still replicate an epoch at 0
-    apply_replicated(0_epoch);
+    // We can still replicate an epoch at 2
+    apply_replicated(2_epoch);
 
-    // Still not safe to GC
-    EXPECT_EQ(estimate_inactive_epoch(), ct::cluster_epoch::min());
+    EXPECT_EQ(estimate_inactive_epoch(), 1_epoch);
 
     // Now we start to replicate to the epoch to 10 (write lock grabbed)
     state.advance_max_seen_epoch(10_epoch);
@@ -245,7 +257,7 @@ TEST(ctp_stm_state_test, sliding_window_issue) {
 
     apply_replicated(10_epoch);
 
-    EXPECT_EQ(estimate_inactive_epoch(), ct::cluster_epoch::min());
+    EXPECT_EQ(estimate_inactive_epoch(), 1_epoch);
 
     // Reconcile
     reconcile(hwm);
@@ -260,8 +272,18 @@ TEST(ctp_stm_state_test, sliding_window_issue) {
     EXPECT_TRUE(state.epoch_in_window(12_epoch));
     EXPECT_FALSE(state.epoch_in_window(9_epoch));
 
-    // The min epoch CANNOT CHANGE YET! The reconciler has not run.
     EXPECT_EQ(estimate_inactive_epoch(), 4_epoch);
+
+    apply_replicated(15_epoch);
+
+    // reconciliation has not run, it's not save to bump the epoch yet.
+    // So we should keep the epoch at 4, even if the window advances
+    EXPECT_EQ(estimate_inactive_epoch(), 4_epoch);
+
+    reconcile(hwm);
+
+    // Now the inactive epoch can be advanced because we're reconciled up to it.
+    EXPECT_EQ(estimate_inactive_epoch(), 9_epoch);
 }
 
 } // anonymous namespace

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
@@ -152,4 +152,120 @@ TEST(ctp_stm_state_test, advance_start_offset) {
     EXPECT_EQ(state.start_offset(), kafka::offset{5});
 }
 
+ct::cluster_epoch operator""_epoch(unsigned long long v) {
+    return ct::cluster_epoch(static_cast<int64_t>(v));
+}
+
+kafka::offset operator""_offset(unsigned long long v) {
+    return kafka::offset(static_cast<int64_t>(v));
+}
+
+TEST(ctp_stm_state_test, sliding_window_issue) {
+    ct::ctp_stm_state state;
+
+    kafka::offset hwm = 0_offset;
+
+    auto estimate_inactive_epoch =
+      [&state] -> std::optional<ct::cluster_epoch> {
+        auto estimate = state.estimate_min_epoch().transform(
+          ct::prev_cluster_epoch);
+        auto prev = state.get_previous_epoch().transform(
+          ct::prev_cluster_epoch);
+        return std::min(estimate, prev);
+    };
+
+    auto apply_replicated = [&state, &hwm](ct::cluster_epoch epoch) {
+        state.advance_epoch(epoch, kafka::offset_cast(hwm));
+        hwm++;
+    };
+
+    auto reconcile = [&state](kafka::offset offset) {
+        state.advance_last_reconciled_offset(
+          offset, kafka::offset_cast(offset));
+    };
+
+    // Our start state, we can't GC anything and we have to
+    // get the write lock before we can start our window
+    EXPECT_EQ(estimate_inactive_epoch(), std::nullopt);
+    EXPECT_FALSE(state.epoch_in_window(0_epoch));
+
+    // Write lock grabbed, max epoch can be advanced!
+    state.advance_max_seen_epoch(0_epoch);
+
+    // Now epoch 0 is in the window
+    EXPECT_TRUE(state.epoch_in_window(0_epoch));
+    // Epoch 1 is not in the window
+    EXPECT_FALSE(state.epoch_in_window(1_epoch));
+
+    // Now the batch that was replicated with offset 0
+    apply_replicated(0_epoch);
+
+    // Still not safe to GC
+    EXPECT_EQ(estimate_inactive_epoch(), std::nullopt);
+
+    // Let's now add another batch at epoch 0
+    EXPECT_TRUE(state.epoch_in_window(0_epoch));
+    apply_replicated(0_epoch);
+
+    // Reconciler now runs
+    reconcile(hwm);
+
+    // Still not safe to GC
+    EXPECT_EQ(estimate_inactive_epoch(), std::nullopt);
+
+    EXPECT_FALSE(state.epoch_in_window(5_epoch));
+
+    // Epoch is bumped, our window should now be [0, 5]
+    state.advance_max_seen_epoch(5_epoch);
+
+    // This is our new epoch
+    EXPECT_TRUE(state.epoch_in_window(5_epoch));
+    // Our previous epoch is good still
+    EXPECT_TRUE(state.epoch_in_window(0_epoch));
+    // And so is something in between (unlikely in real life, but just to show)
+    EXPECT_TRUE(state.epoch_in_window(3_epoch));
+
+    // Still not safe to GC, we accept stuff at epoch 0
+    EXPECT_EQ(estimate_inactive_epoch(), ct::cluster_epoch::min());
+
+    apply_replicated(5_epoch);
+
+    // Still not safe to GC
+    EXPECT_EQ(estimate_inactive_epoch(), ct::cluster_epoch::min());
+
+    // We can still replicate an epoch at 0
+    apply_replicated(0_epoch);
+
+    // Still not safe to GC
+    EXPECT_EQ(estimate_inactive_epoch(), ct::cluster_epoch::min());
+
+    // Now we start to replicate to the epoch to 10 (write lock grabbed)
+    state.advance_max_seen_epoch(10_epoch);
+    EXPECT_TRUE(state.epoch_in_window(10_epoch));
+    EXPECT_TRUE(state.epoch_in_window(5_epoch));
+    EXPECT_TRUE(state.epoch_in_window(8_epoch));
+    EXPECT_FALSE(state.epoch_in_window(0_epoch));
+    EXPECT_FALSE(state.epoch_in_window(4_epoch));
+
+    apply_replicated(10_epoch);
+
+    EXPECT_EQ(estimate_inactive_epoch(), ct::cluster_epoch::min());
+
+    // Reconcile
+    reconcile(hwm);
+
+    // NOW we can GC everything below the window
+    EXPECT_EQ(estimate_inactive_epoch(), 4_epoch);
+
+    // Now we bump the window again, but haven't replicated it yet.
+    state.advance_max_seen_epoch(15_epoch);
+    EXPECT_TRUE(state.epoch_in_window(10_epoch));
+    EXPECT_TRUE(state.epoch_in_window(15_epoch));
+    EXPECT_TRUE(state.epoch_in_window(12_epoch));
+    EXPECT_FALSE(state.epoch_in_window(9_epoch));
+
+    // The min epoch CANNOT CHANGE YET! The reconciler has not run.
+    EXPECT_EQ(estimate_inactive_epoch(), 4_epoch);
+}
+
 } // anonymous namespace

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
@@ -11,6 +11,8 @@
 #include "cloud_topics/level_zero/stm/ctp_stm_state.h"
 #include "cloud_topics/types.h"
 #include "gtest/gtest.h"
+#include "model/fundamental.h"
+#include "random/generators.h"
 #include "test_utils/test.h"
 #include "utils/uuid.h"
 
@@ -284,6 +286,180 @@ TEST(ctp_stm_state_test, sliding_window_issue) {
 
     // Now the inactive epoch can be advanced because we're reconciled up to it.
     EXPECT_EQ(estimate_inactive_epoch(), 9_epoch);
+}
+
+TEST(ctp_stm_state_test, l0_simulation) {
+    struct uploaded_l0_file_batch {
+        ct::cluster_epoch epoch;
+    };
+    struct placeholder_batch {
+        ct::cluster_epoch epoch;
+        kafka::offset offset;
+    };
+    struct l0_simulation_state {
+        // The state for the STM
+        ct::ctp_stm_state stm;
+        // Batches that are uploaded, but have not yet been fenced nor
+        // replicated, so this is basically just a queue of epochs that will
+        // be applied to the log. The epochs may not be in order because they
+        // may come from different shards/brokers.
+        ss::chunked_fifo<uploaded_l0_file_batch> uploaded_batches;
+        // Placeholders that are replicated, but not yet applied to the
+        // to the STM.
+        ss::chunked_fifo<placeholder_batch> unapplied_placeholders;
+        // All the placeholders in the log
+        ss::chunked_fifo<placeholder_batch> log_placeholders;
+        // hwm for the partition
+        kafka::offset hwm = 0_offset;
+
+        testing::AssertionResult validate() {
+            // The main thing we want to validate is that there are no batches
+            // in the log that are GC eligable but have not been reconciled.
+            auto lro = stm.get_last_reconciled_offset();
+            // Remove reconciled batches
+            auto non_reconciled_batches = std::views::filter(
+              log_placeholders, [lro](const placeholder_batch& batch) {
+                  return batch.offset > lro.value_or(kafka::offset::min());
+              });
+            // Find the min active epoch in the log
+            auto min_active_epoch = std::ranges::min_element(
+              non_reconciled_batches,
+              std::less<>(),
+              [](const placeholder_batch& batch) { return batch.epoch; });
+            // What do we say we can GC?
+            auto inactive_epoch = stm.estimate_inactive_epoch();
+            if (min_active_epoch == non_reconciled_batches.end()) {
+                // There is nothing in the log unreconcilded, we should not yet
+                // have an inactive epoch above what is yet to be replicated.
+                if (!uploaded_batches.empty()) {
+                    auto it = std::ranges::min_element(
+                      uploaded_batches, std::less<>(), [](const auto& batch) {
+                          return batch.epoch;
+                      });
+                    if (inactive_epoch > it->epoch) {
+                        return testing::AssertionFailure() << fmt::format(
+                                 "expected inactive epoch ({}) to not be above "
+                                 "active epochs {}",
+                                 inactive_epoch.value(),
+                                 it->epoch);
+                    }
+                }
+            } else if (inactive_epoch >= min_active_epoch->epoch) {
+                return testing::AssertionFailure() << fmt::format(
+                         "expected the min log epoch ({}) to be all be "
+                         "above inactive_epoch: {}",
+                         min_active_epoch->epoch,
+                         inactive_epoch.value());
+            }
+            return testing::AssertionSuccess();
+        }
+    };
+    // We simulate the operations for a single partition in l0
+    l0_simulation_state universe;
+
+    {
+        std::vector<uploaded_l0_file_batch> batches{
+          // clang-format off
+          {.epoch = 5_epoch},
+          {.epoch = 5_epoch},
+          {.epoch = 6_epoch},
+          {.epoch = 8_epoch},
+          {.epoch = 6_epoch},
+          {.epoch = 8_epoch},
+          {.epoch = 8_epoch},
+          {.epoch = 10_epoch},
+          {.epoch = 8_epoch},
+          {.epoch = 9_epoch},
+          {.epoch = 10_epoch},
+          {.epoch = 8_epoch},
+          {.epoch = 10_epoch},
+          {.epoch = 10_epoch},
+          {.epoch = 10_epoch},
+          {.epoch = 8_epoch},
+          {.epoch = 8_epoch},
+          {.epoch = 15_epoch},
+          {.epoch = 15_epoch},
+          {.epoch = 10_epoch},
+          {.epoch = 12_epoch},
+          {.epoch = 10_epoch},
+          {.epoch = 15_epoch},
+          // clang-format on
+        };
+        std::ranges::copy(
+          batches, std::back_inserter(universe.uploaded_batches));
+    }
+
+    std::vector<std::string> oplog;
+
+    while (true) {
+        // Always check our invariants
+        ASSERT_TRUE(universe.validate())
+          << fmt::format("operations:\n{}", fmt::join(oplog, "\n"));
+        // Possible operations we can perform in the universe.
+        std::vector<std::function<void()>> possible_operations;
+        // If there are batches to upload, let's do it.
+        if (!universe.uploaded_batches.empty()) {
+            possible_operations.emplace_back([&universe, &oplog] {
+                auto batch = universe.uploaded_batches.front();
+                universe.uploaded_batches.pop_front();
+                if (!universe.stm.epoch_in_window(batch.epoch)) {
+                    universe.stm.advance_max_seen_epoch(batch.epoch);
+                    ASSERT_TRUE(universe.stm.epoch_in_window(batch.epoch));
+                }
+                placeholder_batch placeholder{
+                  .epoch = batch.epoch, .offset = universe.hwm++};
+                universe.unapplied_placeholders.push_back(placeholder);
+                universe.log_placeholders.push_back(placeholder);
+                oplog.push_back(
+                  fmt::format(
+                    "replicated batch {} with epoch {}",
+                    placeholder.offset,
+                    placeholder.epoch));
+            });
+        }
+        // Apply to STM if we haven't yet
+        if (!universe.unapplied_placeholders.empty()) {
+            possible_operations.emplace_back([&universe, &oplog] {
+                auto batch = universe.unapplied_placeholders.front();
+                universe.unapplied_placeholders.pop_front();
+                // Apply to the STM
+                universe.stm.advance_epoch(
+                  batch.epoch, kafka::offset_cast(batch.offset));
+                oplog.push_back(
+                  fmt::format(
+                    "applied batch {} with epoch {}",
+                    batch.offset,
+                    batch.epoch));
+            });
+        }
+        // Run reconciliation
+        auto last_offset = kafka::prev_offset(universe.hwm);
+        auto lro = universe.stm.get_last_reconciled_offset().value_or(
+          kafka::offset::min());
+        if (lro < last_offset) {
+            possible_operations.emplace_back(
+              [&universe, &oplog, lro, last_offset] {
+                  auto new_lro = random_generators::get_int(
+                    kafka::next_offset(lro)(), last_offset());
+                  universe.stm.advance_last_reconciled_offset(
+                    kafka::offset(new_lro), model::offset(new_lro));
+                  oplog.push_back(fmt::format("reconciled to {}", new_lro));
+              });
+        }
+        if (possible_operations.empty()) {
+            // No more possible operations
+            fmt::print(
+              std::cerr,
+              "min_epoch: {}\n",
+              universe.stm.estimate_inactive_epoch().value_or(
+                ct::cluster_epoch::min()));
+            fmt::print(std::cerr, "operations:\n{}\n", fmt::join(oplog, "\n"));
+            return;
+        }
+        // Run a random operation
+        auto op = random_generators::random_choice(possible_operations);
+        op();
+    }
 }
 
 } // anonymous namespace

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -164,6 +164,8 @@ TEST_F_CORO(ctp_stm_fixture, test_fencing) {
         auto fence
           = co_await api(node(*get_leader())).fence_epoch(ct::cluster_epoch{2});
         ASSERT_TRUE_CORO(fence.has_value());
+        // Read fence
+        ASSERT_EQ_CORO(fence.value().unit.count(), 1);
     }
 
     // Acquire the fence for epoch 1 (should fail)
@@ -539,4 +541,174 @@ TEST_F_CORO(ctp_stm_fixture, test_fence_epoch_concurrent_new_epoch) {
     auto max_seen = api(leader).get_max_seen_epoch();
     ASSERT_TRUE_CORO(max_seen.has_value());
     ASSERT_EQ_CORO(max_seen.value(), ct::cluster_epoch{2});
+}
+
+TEST_F_CORO(ctp_stm_fixture, test_previous_epoch_fencing_with_lro) {
+    // This test verifies that:
+    // 1. The previous epoch is correctly tracked through epoch application and
+    // fencing
+    // 2. Out-of-order epochs can only be fenced if they are >= previous epoch
+    // 3. When LRO is propagated, the inactive epoch computation respects the
+    //    previous epoch invariant (inactive_epoch < previous_epoch)
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+
+    auto& leader = node(*get_leader());
+    auto leader_api = api(leader);
+
+    // Establish epoch 1
+    auto b1 = make_record_batch(ct::cluster_epoch{1}, model::offset{0}, 0, 10);
+    auto res1 = co_await replicate_record_batch(leader, std::move(b1));
+    ASSERT_TRUE_CORO(res1.has_value());
+
+    // Establish epoch 2
+    auto b2 = make_record_batch(
+      ct::cluster_epoch{2}, model::offset{10}, 10, 10);
+    auto res2 = co_await replicate_record_batch(leader, std::move(b2));
+    ASSERT_TRUE_CORO(res2.has_value());
+
+    // Establish epoch 3
+    auto b3 = make_record_batch(
+      ct::cluster_epoch{3}, model::offset{20}, 20, 10);
+    auto res3 = co_await replicate_record_batch(leader, std::move(b3));
+    ASSERT_TRUE_CORO(res3.has_value());
+
+    // Verify epochs are established
+    auto max_epoch = leader_api.get_max_epoch();
+    auto max_seen_epoch = leader_api.get_max_seen_epoch();
+    ASSERT_TRUE_CORO(max_epoch.has_value());
+    ASSERT_TRUE_CORO(max_seen_epoch.has_value());
+    ASSERT_EQ_CORO(max_epoch.value(), ct::cluster_epoch{3});
+    ASSERT_EQ_CORO(max_seen_epoch.value(), ct::cluster_epoch{3});
+
+    // Get the previous epoch (should be epoch 2, the previous
+    // max_applied_epoch)
+    auto stm = get_stm<0>(leader);
+    auto previous_epoch = stm->state().get_previous_epoch();
+    ASSERT_TRUE_CORO(previous_epoch.has_value());
+    ASSERT_EQ_CORO(previous_epoch.value(), ct::cluster_epoch{2});
+
+    // Check inactive epoch before any LRO advance
+    // Since we have epochs 1, 2, 3, epoch 0 is already inactive
+    auto inactive_epoch_before = co_await leader_api.get_inactive_epoch();
+    ASSERT_TRUE_CORO(inactive_epoch_before);
+    ASSERT_TRUE_CORO(inactive_epoch_before->has_value());
+    ASSERT_EQ_CORO(inactive_epoch_before->value(), ct::cluster_epoch{0});
+
+    // Check the estimate as well
+    auto estimated_inactive_before = leader_api.estimate_inactive_epoch();
+    ASSERT_TRUE_CORO(estimated_inactive_before.has_value());
+    ASSERT_EQ_CORO(estimated_inactive_before.value(), ct::cluster_epoch{0});
+
+    // Fence epoch 4 to advance max_seen_epoch
+    {
+        auto fence_4 = co_await leader_api.fence_epoch(ct::cluster_epoch{4});
+        ASSERT_TRUE_CORO(fence_4.has_value());
+
+        // Previous epoch should now be epoch 3 (updated by
+        // advance_max_seen_epoch) when we fenced epoch 4
+        previous_epoch = stm->state().get_previous_epoch();
+        ASSERT_TRUE_CORO(previous_epoch.has_value());
+        ASSERT_EQ_CORO(previous_epoch.value(), ct::cluster_epoch{3});
+    }
+
+    // Try to fence an out-of-order epoch (epoch 2) that is < previous epoch (3)
+    // and < max_seen_epoch (4) - should fail because epoch 2 < previous epoch
+    {
+        auto fence_prev = co_await leader_api.fence_epoch(ct::cluster_epoch{2});
+        ASSERT_FALSE_CORO(fence_prev.has_value())
+          << "Should not be able to fence an out-of-order epoch < previous "
+             "epoch";
+    }
+
+    // Advance LRO to the middle of epoch 1 (kafka offset 5)
+    // This should make epochs before epoch 1 inactive, but not epoch 1 itself
+    co_await leader_api.advance_reconciled_offset(
+      kafka::offset{5}, model::no_timeout, as);
+
+    // Check that inactive epoch is computed correctly
+    // Even though LRO is in the middle of epoch 1, epoch 0 is still inactive
+    // because the minimum epoch referenced is 1
+    auto inactive_after_lro1 = co_await leader_api.get_inactive_epoch();
+    ASSERT_TRUE_CORO(inactive_after_lro1);
+    ASSERT_TRUE_CORO(inactive_after_lro1->has_value());
+    ASSERT_EQ_CORO(inactive_after_lro1->value(), ct::cluster_epoch{0});
+
+    // Check the estimate
+    auto estimated_inactive_lro1 = leader_api.estimate_inactive_epoch();
+    ASSERT_TRUE_CORO(estimated_inactive_lro1.has_value());
+    ASSERT_EQ_CORO(estimated_inactive_lro1.value(), ct::cluster_epoch{0});
+
+    // Advance LRO to the end of epoch 1 (kafka offset 9)
+    co_await leader_api.advance_reconciled_offset(
+      kafka::offset{9}, model::no_timeout, as);
+
+    // Now epochs 0 and 1 are inactive (we've reconciled all of epoch 1)
+    // The minimum epoch referenced is now 2
+    auto inactive_after_lro2 = co_await leader_api.get_inactive_epoch();
+    ASSERT_TRUE_CORO(inactive_after_lro2);
+    ASSERT_TRUE_CORO(inactive_after_lro2->has_value());
+    ASSERT_EQ_CORO(inactive_after_lro2->value(), ct::cluster_epoch{1});
+
+    // Check the estimate (should be lower in this case)
+    auto estimated_inactive_lro2 = leader_api.estimate_inactive_epoch();
+    ASSERT_TRUE_CORO(estimated_inactive_lro2.has_value());
+    ASSERT_EQ_CORO(estimated_inactive_lro2.value(), ct::cluster_epoch{0});
+
+    // Get the previous epoch (lower bound of active epochs)
+    // The previous epoch should still be 3 (hasn't changed since the fence)
+    previous_epoch = stm->state().get_previous_epoch();
+    ASSERT_TRUE_CORO(previous_epoch.has_value());
+    ASSERT_EQ_CORO(previous_epoch.value(), ct::cluster_epoch{3});
+
+    // Advance LRO past epoch 2 (kafka offset 19)
+    // This is before _max_applied_epoch_offset (20), so _min_epoch_lower_bound
+    // won't be updated yet (it will remain stale)
+    co_await leader_api.advance_reconciled_offset(
+      kafka::offset{19}, model::no_timeout, as);
+
+    // Check inactive epoch after advancing past epoch 2
+    // The inactive epoch is computed by scanning the log, so it should be 2
+    auto inactive_after_lro3 = co_await leader_api.get_inactive_epoch();
+    ASSERT_TRUE_CORO(inactive_after_lro3);
+    ASSERT_TRUE_CORO(inactive_after_lro3->has_value());
+    ASSERT_EQ_CORO(inactive_after_lro3->value(), ct::cluster_epoch{2});
+
+    // Check the estimate - it may be stale at this point since we're before
+    // _max_applied_epoch_offset, but it should still be <= the precise value
+    auto estimated_inactive_lro3 = leader_api.estimate_inactive_epoch();
+    if (estimated_inactive_lro3.has_value()) {
+        ASSERT_LE_CORO(estimated_inactive_lro3.value(), ct::cluster_epoch{2})
+          << "Estimated inactive epoch should be <= precise value";
+    }
+
+    // The previous epoch is still 3 (set when we fenced epoch 4)
+    // Note that inactive_epoch (2) < previous_epoch (3), so the invariant holds
+    previous_epoch = stm->state().get_previous_epoch();
+    ASSERT_TRUE_CORO(previous_epoch.has_value());
+    ASSERT_EQ_CORO(previous_epoch.value(), ct::cluster_epoch{3});
+
+    // Advance LRO past epoch 3 (kafka offset 29)
+    // This advances past _max_applied_epoch_offset (20), so
+    // _min_epoch_lower_bound should be updated to _max_applied_epoch (3)
+    // The previous epoch remains 3 (no new epochs have been applied)
+    co_await leader_api.advance_reconciled_offset(
+      kafka::offset{29}, model::no_timeout, as);
+
+    // Check inactive epoch after advancing past epoch 3
+    // Since we've advanced LRO past all epochs, get_inactive_epoch() may return
+    // nullopt (no epochs left in the log after LRO)
+    auto inactive_after_lro4 = co_await leader_api.get_inactive_epoch();
+    ASSERT_TRUE_CORO(inactive_after_lro4);
+
+    // Previous epoch should still be 3 (unchanged)
+    previous_epoch = stm->state().get_previous_epoch();
+    ASSERT_TRUE_CORO(previous_epoch.has_value());
+    ASSERT_EQ_CORO(previous_epoch.value(), ct::cluster_epoch{3});
+
+    // Check the estimate after advancing past _max_applied_epoch_offset
+    // Now _min_epoch_lower_bound should be updated to _max_applied_epoch (3)
+    // The estimate should match the precise value or be close to it
+    auto estimated_inactive_lro4 = leader_api.estimate_inactive_epoch();
+    ASSERT_EQ_CORO(estimated_inactive_lro4.value(), ct::cluster_epoch{2});
 }

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -605,20 +605,22 @@ TEST_F_CORO(ctp_stm_fixture, test_previous_epoch_fencing_with_lro) {
         auto fence_4 = co_await leader_api.fence_epoch(ct::cluster_epoch{4});
         ASSERT_TRUE_CORO(fence_4.has_value());
 
-        // Previous epoch should now be epoch 3 (updated by
-        // advance_max_seen_epoch) when we fenced epoch 4
+        // get_previous_epoch() returns the committed _previous_epoch, which
+        // is still 2 because no batch with epoch 4 has been applied yet.
+        // The transient _previous_seen_epoch is 3 (used by epoch_in_window).
         previous_epoch = stm->state().get_previous_epoch();
         ASSERT_TRUE_CORO(previous_epoch.has_value());
-        ASSERT_EQ_CORO(previous_epoch.value(), ct::cluster_epoch{3});
+        ASSERT_EQ_CORO(previous_epoch.value(), ct::cluster_epoch{2});
     }
 
-    // Try to fence an out-of-order epoch (epoch 2) that is < previous epoch (3)
-    // and < max_seen_epoch (4) - should fail because epoch 2 < previous epoch
+    // Try to fence an out-of-order epoch (epoch 2) that is <
+    // _previous_seen_epoch (3) and < max_seen_epoch (4) - should fail because
+    // epoch_in_window checks against the transient _previous_seen_epoch
     {
         auto fence_prev = co_await leader_api.fence_epoch(ct::cluster_epoch{2});
         ASSERT_FALSE_CORO(fence_prev.has_value())
-          << "Should not be able to fence an out-of-order epoch < previous "
-             "epoch";
+          << "Should not be able to fence an out-of-order epoch < "
+             "_previous_seen_epoch";
     }
 
     // Advance LRO to the middle of epoch 1 (kafka offset 5)
@@ -656,10 +658,10 @@ TEST_F_CORO(ctp_stm_fixture, test_previous_epoch_fencing_with_lro) {
     ASSERT_EQ_CORO(estimated_inactive_lro2.value(), ct::cluster_epoch{0});
 
     // Get the previous epoch (lower bound of active epochs)
-    // The previous epoch should still be 3 (hasn't changed since the fence)
+    // The previous epoch is still 2 (no new epochs have been applied)
     previous_epoch = stm->state().get_previous_epoch();
     ASSERT_TRUE_CORO(previous_epoch.has_value());
-    ASSERT_EQ_CORO(previous_epoch.value(), ct::cluster_epoch{3});
+    ASSERT_EQ_CORO(previous_epoch.value(), ct::cluster_epoch{2});
 
     // Advance LRO past epoch 2 (kafka offset 19)
     // This is before _max_applied_epoch_offset (20), so _min_epoch_lower_bound
@@ -682,11 +684,10 @@ TEST_F_CORO(ctp_stm_fixture, test_previous_epoch_fencing_with_lro) {
           << "Estimated inactive epoch should be <= precise value";
     }
 
-    // The previous epoch is still 3 (set when we fenced epoch 4)
-    // Note that inactive_epoch (2) < previous_epoch (3), so the invariant holds
+    // The previous epoch is still 2 (no new epochs have been applied)
     previous_epoch = stm->state().get_previous_epoch();
     ASSERT_TRUE_CORO(previous_epoch.has_value());
-    ASSERT_EQ_CORO(previous_epoch.value(), ct::cluster_epoch{3});
+    ASSERT_EQ_CORO(previous_epoch.value(), ct::cluster_epoch{2});
 
     // Advance LRO past epoch 3 (kafka offset 29)
     // This advances past _max_applied_epoch_offset (20), so
@@ -701,14 +702,15 @@ TEST_F_CORO(ctp_stm_fixture, test_previous_epoch_fencing_with_lro) {
     auto inactive_after_lro4 = co_await leader_api.get_inactive_epoch();
     ASSERT_TRUE_CORO(inactive_after_lro4);
 
-    // Previous epoch should still be 3 (unchanged)
+    // Previous epoch should still be 2 (unchanged, no new epochs applied)
     previous_epoch = stm->state().get_previous_epoch();
     ASSERT_TRUE_CORO(previous_epoch.has_value());
-    ASSERT_EQ_CORO(previous_epoch.value(), ct::cluster_epoch{3});
+    ASSERT_EQ_CORO(previous_epoch.value(), ct::cluster_epoch{2});
 
     // Check the estimate after advancing past _max_applied_epoch_offset
     // Now _min_epoch_lower_bound should be updated to _max_applied_epoch (3)
-    // The estimate should match the precise value or be close to it
+    // estimate_inactive_epoch returns min(_min_epoch_lower_bound - 1,
+    // _previous_epoch - 1) = min(3 - 1, 2 - 1) = min(2, 1) = 1
     auto estimated_inactive_lro4 = leader_api.estimate_inactive_epoch();
-    ASSERT_EQ_CORO(estimated_inactive_lro4.value(), ct::cluster_epoch{2});
+    ASSERT_EQ_CORO(estimated_inactive_lro4.value(), ct::cluster_epoch{1});
 }

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -178,10 +178,10 @@ TEST_F_CORO(ctp_stm_fixture, test_fencing) {
       = co_await api(node(*get_leader())).fence_epoch(ct::cluster_epoch{3});
     ASSERT_TRUE_CORO(write_fence.has_value());
 
-    // Out of order fence for epoch 2 (should be waiting for the fence to be
+    // Out of order fence for epoch 1 (should be waiting for the fence to be
     // released)
     auto leader_api = api(node(*get_leader()));
-    auto fut = leader_api.fence_epoch(ct::cluster_epoch{2});
+    auto fut = leader_api.fence_epoch(ct::cluster_epoch{1});
     co_await ss::sleep(100ms);
 
     write_fence = {};


### PR DESCRIPTION
This PR adds support for out-of-order epoch handling.

It adds additional field (`_previous_epoch`) to the `ctp_stm_state` which is updated every time `_max_seen_epoch` is updated. The epoch can be fenced if it's greater or equal to `_previous_epoch`.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none