### PR TITLE
[UX-793] rpk prompt: add raw as an option to prompt params

### DIFF
--- a/src/go/rpk/pkg/cli/profile/prompt.go
+++ b/src/go/rpk/pkg/cli/profile/prompt.go
@@ -67,6 +67,15 @@ The "bg-" prefix modifies the background color: "bg-black", "bg-hi-red", etc.
 MODIFIERS
 
 Four modifiers are supported, "bold", "faint", "underline", and "invert".
+
+RAW MODE
+
+The "raw" modifier disables ANSI color escapes entirely, outputting plain text.
+This is useful when your shell has issues with ANSI escape sequences affecting
+terminal width calculations.
+
+    prompt: raw, "%n"
+    prompt: raw, "[%p]"
 `,
 		Args: cobra.ExactArgs(0),
 		Run: func(_ *cobra.Command, _ []string) {
@@ -106,14 +115,18 @@ Four modifiers are supported, "bold", "faint", "underline", and "invert".
 
 			var sb strings.Builder
 			for _, g := range parens {
-				text, attrs, err := parsePrompt(g, p.Name)
+				text, attrs, raw, err := parsePrompt(g, p.Name)
 				if err != nil {
 					errmsg = err.Error()
 					return
 				}
-				c := color.New(attrs...)
-				c.EnableColor()
-				sb.WriteString(c.Sprint(text))
+				if raw {
+					sb.WriteString(text)
+				} else {
+					c := color.New(attrs...)
+					c.EnableColor()
+					sb.WriteString(c.Sprint(text))
+				}
 			}
 			if validate {
 				fmt.Print("Prompt ok! Output:\nvvv\n")
@@ -126,11 +139,12 @@ Four modifiers are supported, "bold", "faint", "underline", and "invert".
 	return cmd
 }
 
-func parsePrompt(s string, name string) (string, []color.Attribute, error) {
+func parsePrompt(s string, name string) (string, []color.Attribute, bool, error) {
 	var (
 		b       = make([]byte, 0, 16) // current text or attribute buffer
 		text    []byte                // if non nil, this has been initialized; we cannot have multiple quoted strings
 		attrs   []color.Attribute
+		raw     bool
 		inQuote bool
 	)
 	for i := 0; i < len(s); i++ {
@@ -138,7 +152,7 @@ func parsePrompt(s string, name string) (string, []color.Attribute, error) {
 		switch c {
 		case '\\':
 			if !inQuote {
-				return "", nil, errors.New("backslash is only allowed inside a quoted string")
+				return "", nil, false, errors.New("backslash is only allowed inside a quoted string")
 			}
 			if len(s) > i+1 {
 				b = append(b, s[i+1])
@@ -150,11 +164,11 @@ func parsePrompt(s string, name string) (string, []color.Attribute, error) {
 				b = b[:0]
 				inQuote = false
 			} else if text != nil {
-				return "", nil, errors.New("only one quoted string can appear in a prompt, we saw a second")
+				return "", nil, false, errors.New("only one quoted string can appear in a prompt, we saw a second")
 			} else {
 				b = bytes.TrimSpace(b)
 				if len(b) > 0 {
-					return "", nil, fmt.Errorf("unexpected text %q before quoted string", string(b))
+					return "", nil, false, fmt.Errorf("unexpected text %q before quoted string", string(b))
 				}
 				inQuote = true
 			}
@@ -167,9 +181,14 @@ func parsePrompt(s string, name string) (string, []color.Attribute, error) {
 			if len(b) == 0 {
 				continue
 			}
+			if strings.EqualFold(string(b), "raw") {
+				raw = true
+				b = b[:0]
+				continue
+			}
 			attr, ok := out.ParseColor(string(b))
 			if !ok {
-				return "", nil, fmt.Errorf("invalid color or attribute %q", string(b))
+				return "", nil, false, fmt.Errorf("invalid color or attribute %q", string(b))
 			}
 			attrs = append(attrs, attr)
 			b = b[:0]
@@ -181,11 +200,15 @@ func parsePrompt(s string, name string) (string, []color.Attribute, error) {
 	// If b is non-empty, the prompt either ended in unneeded spaces or it
 	// ended in an attr -- any ending quote is handled in the above block.
 	if b = bytes.TrimSpace(b); len(b) > 0 {
-		attr, ok := out.ParseColor(string(b))
-		if !ok {
-			return "", nil, fmt.Errorf("invalid color or attribute %q", string(b))
+		if strings.EqualFold(string(b), "raw") {
+			raw = true
+		} else {
+			attr, ok := out.ParseColor(string(b))
+			if !ok {
+				return "", nil, false, fmt.Errorf("invalid color or attribute %q", string(b))
+			}
+			attrs = append(attrs, attr)
 		}
-		attrs = append(attrs, attr)
 	}
 
 	output := make([]byte, 0, len(s)+len(text))
@@ -202,7 +225,7 @@ func parsePrompt(s string, name string) (string, []color.Attribute, error) {
 					output = append(output, '%')
 					i++
 				default:
-					return "", nil, fmt.Errorf("unknown escape %%%c", text[i+1])
+					return "", nil, false, fmt.Errorf("unknown escape %%%c", text[i+1])
 				}
 			}
 		default:
@@ -212,7 +235,7 @@ func parsePrompt(s string, name string) (string, []color.Attribute, error) {
 	if len(s) != 0 && len(text) == 0 {
 		output = append(output, name...)
 	}
-	return string(output), attrs, nil
+	return string(output), attrs, raw, nil
 }
 
 func splitPromptParens(s string) ([]string, error) {

--- a/src/go/rpk/pkg/cli/profile/prompt_test.go
+++ b/src/go/rpk/pkg/cli/profile/prompt_test.go
@@ -53,23 +53,31 @@ func TestParsePrompt(t *testing.T) {
 		in      string
 		expText string
 		expAttr []color.Attribute
+		expRaw  bool
 		expErr  bool
 	}{
-		{"", "", nil, false}, // empty is ok
-		{`blue , green , bg-hi-blue, "%n"`, "foo", []color.Attribute{color.FgBlue, color.FgGreen, color.BgHiBlue}, false}, // somewhat complete
-		{`\"blue\"`, "", nil, true},          // backslash only allowed in quoted str
-		{` "prompt" `, "prompt", nil, false}, // simple
-		{`unknown-thing `, "", nil, true},    // unknown keyword stripped
-		{`blue	green red, bg-hi-blue`, "foo", []color.Attribute{color.FgBlue, color.FgGreen, color.FgRed, color.BgHiBlue}, false}, // attr at end is kept, name is added by default
-		{` " %n " `, " foo ", nil, false},   // name swapped in
-		{`"\\\%%%%n"`, "\\%%n", nil, false}, // escaping works, and %% works
-		{`"text1" "text2"`, "", nil, true},  // one quoted string
-		{`b"text"`, "", nil, true},          // unexpected text before quote
-		{`blue unknown`, "", nil, true},     // unknown attr at end
-		{`"%u"`, "", nil, true},             // unknown % escape
+		{"", "", nil, false, false}, // empty is ok
+		{`blue , green , bg-hi-blue, "%n"`, "foo", []color.Attribute{color.FgBlue, color.FgGreen, color.BgHiBlue}, false, false}, // somewhat complete
+		{`\"blue\"`, "", nil, false, true},          // backslash only allowed in quoted str
+		{` "prompt" `, "prompt", nil, false, false}, // simple
+		{`unknown-thing `, "", nil, false, true},    // unknown keyword stripped
+		{`blue	green red, bg-hi-blue`, "foo", []color.Attribute{color.FgBlue, color.FgGreen, color.FgRed, color.BgHiBlue}, false, false}, // attr at end is kept, name is added by default
+		{` " %n " `, " foo ", nil, false, false},   // name swapped in
+		{`"\\\%%%%n"`, "\\%%n", nil, false, false}, // escaping works, and %% works
+		{`"text1" "text2"`, "", nil, false, true},  // one quoted string
+		{`b"text"`, "", nil, false, true},          // unexpected text before quote
+		{`blue unknown`, "", nil, false, true},     // unknown attr at end
+		{`"%u"`, "", nil, false, true},             // unknown % escape
+
+		// raw modifier tests
+		{`raw, "%n"`, "foo", nil, true, false},                                   // raw with format string
+		{`raw`, "foo", nil, true, false},                                         // raw alone defaults to name
+		{`raw, blue, "%n"`, "foo", []color.Attribute{color.FgBlue}, true, false}, // raw with colors (raw wins, colors parsed but not applied)
+		{`RAW, "%n"`, "foo", nil, true, false},                                   // case-insensitive
+		{`blue, raw, "%n"`, "foo", []color.Attribute{color.FgBlue}, true, false}, // raw can appear anywhere
 	} {
 		t.Run(test.in, func(t *testing.T) {
-			gotText, gotAttr, err := parsePrompt(test.in, name)
+			gotText, gotAttr, gotRaw, err := parsePrompt(test.in, name)
 			gotErr := err != nil
 			if gotErr != test.expErr {
 				t.Errorf("got err? %v (%v), exp %v", gotErr, err, test.expErr)
@@ -80,6 +88,9 @@ func TestParsePrompt(t *testing.T) {
 			}
 			if !reflect.DeepEqual(gotAttr, test.expAttr) {
 				t.Errorf("got attr %v != exp %v", gotAttr, test.expAttr)
+			}
+			if gotRaw != test.expRaw {
+				t.Errorf("got raw %v != exp %v", gotRaw, test.expRaw)
 			}
 		})
 	}


### PR DESCRIPTION
This allows us to just pass through the text w/o
the ANSI escapes for users who don't want to
rely on our color parsing but still want to use
the rest of the prompt mechanism.

Effectively, one could use 'rpk profile current'
and achieve the same effect but this is nice to
have in case in the future we add more options
other than %p/%n

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


### Improvements

* rpk profile prompt: add 'raw' as a modifier option to our prompt parsing.