### PR TITLE
`ct`: yield more frequently in `convert_to_placeholders()`

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -65,6 +65,13 @@ struct placeholder_batches_with_size {
 static constexpr auto L0_upload_default_timeout = 1s;
 static constexpr auto L0_replicate_default_timeout = 1s;
 
+// The default `async_algo_traits::interval` value of `100` seems a bit too high
+// to reliably prevent reactor stalls in the `convert_to_placeholders()` loop.
+// Use this lower value instead.
+struct convert_to_placeholders_loop_traits : ssx::async_algo_traits {
+    static constexpr ssize_t interval = 10;
+};
+
 // Utility function to convert array of extent_meta structs to
 // array of placeholder batches.
 static ss::future<placeholder_batches_with_size> convert_to_placeholders(
@@ -72,7 +79,7 @@ static ss::future<placeholder_batches_with_size> convert_to_placeholders(
   const chunked_vector<model::record_batch_header>& headers) {
     placeholder_batches_with_size result;
     result.batches.reserve(extents.size());
-    co_await ssx::async_for_each(
+    co_await ssx::async_for_each<convert_to_placeholders_loop_traits>(
       std::views::zip(extents, headers), [&result](const auto& pair) {
           const auto& [extent, header] = pair;
           vassert(


### PR DESCRIPTION
The default `async_algo_traits::interval` value of `100` seems a bit too high to reliably prevent reactor stalls in the `convert_to_placeholders()` loop. Use a lower value instead.

For example, in this run, nearly all reactor stalls are in `convert_to_placeholders()`:

[Backtraces](https://ci-artifacts.dev.vectorized.cloud/production-devprod/redpanda/78843/019ba4dd-1c07-435a-9221-91a4fb23b57a/vbuild/ducktape/results/2026-01-09--001/RedpandaNodeOperationsSmokeTest/test_node_ops_smoke_test/cloud_storage_type=CloudStorageType.S3.mixed_versions=False/8/RedpandaService-0-281471346282544/docker-rp-1/redpanda_backtrace.log), [Ducktape Run](https://ci-artifacts.dev.vectorized.cloud/production-devprod/redpanda/78843/019ba4dd-1c07-435a-9221-91a4fb23b57a/vbuild/ducktape/results/2026-01-09--001/RedpandaNodeOperationsSmokeTest/test_node_ops_smoke_test/cloud_storage_type=CloudStorageType.S3.mixed_versions=False/8/), [Build](https://buildkite.com/redpanda/redpanda/builds/78843#019ba4dd-1c07-435a-9221-91a4fb23b57a)

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
