### PR TITLE
`ct/l0`: re-work `ctp_stm::fence_epoch()`

### DIFF
--- a/src/v/cloud_topics/level_zero/stm/BUILD
+++ b/src/v/cloud_topics/level_zero/stm/BUILD
@@ -115,6 +115,7 @@ redpanda_cc_library(
         ":types",
         "//src/v/cloud_topics/level_zero/common:producer_queue",
         "//src/v/raft",
+        "//src/v/ssx:mutex",
         "@seastar",
     ],
 )

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -380,7 +380,7 @@ ctp_stm::fence_epoch(cluster_epoch e) {
                 co_return cluster_epoch_fence{
                   .unit = std::move(unit), .term = term};
             }
-        } else {
+        } else if (!fence_epoch.has_value() || fence_epoch.value() < e) {
             // Case 2. New epoch, need to acquire write-lock.
             auto epoch_update_lock = _epoch_update_lock.try_get_units();
             if (!epoch_update_lock) {

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -73,6 +73,8 @@ ss::future<> ctp_stm::start() {
 ss::future<> ctp_stm::stop() {
     _lro_advanced.broken();
     _as.request_abort();
+    _epoch_update_lock.broken();
+    _epoch_updated_cv.broken();
     // We can't break the lock because that could cause UAF
     // as the units are held outside of this class.
     // however lock acquisition uses the above abort_source so
@@ -366,34 +368,58 @@ ctp_stm::fence_epoch(cluster_epoch e) {
     // because it represents in-flight batches. If this epoch is nullopt we
     // should take max_applied_epoch into account.
     auto get_applied_epoch = [this] { return _state.get_max_epoch(); };
-    auto fence_epoch = _state.get_max_seen_epoch().or_else(get_applied_epoch);
-    if (fence_epoch.has_value() && fence_epoch.value() == e) {
-        // Case 1. Same epoch, need to acquire read-lock.
-        auto unit = co_await ss::get_units(_lock, 1, _as);
-        if (_state.get_max_seen_epoch().or_else(get_applied_epoch) == e) {
-            // The max_seen_epoch didn't advance after the scheduling point
-            co_return cluster_epoch_fence{
-              .unit = std::move(unit), .term = term};
-        }
-    } else {
-        // Case 2. New epoch, need to acquire write-lock.
-        auto unit = co_await ss::get_units(
-          _lock, ss::semaphore::max_counter(), _as);
-        auto current_epoch = _state.get_max_seen_epoch().or_else(
+
+    while (true) {
+        auto fence_epoch = _state.get_max_seen_epoch().or_else(
           get_applied_epoch);
-        if (!current_epoch.has_value() || current_epoch.value() <= e) {
-            _state.advance_max_seen_epoch(e);
-            // Demote to reader lock after max_seen_epoch is updated.
-            unit.return_units(unit.count() - 1);
-            co_return cluster_epoch_fence{
-              .unit = std::move(unit), .term = term};
+        if (fence_epoch.has_value() && fence_epoch.value() == e) {
+            // Case 1. Same epoch, need to acquire read-lock.
+            auto unit = co_await ss::get_units(_lock, 1, _as);
+            if (_state.get_max_seen_epoch().or_else(get_applied_epoch) == e) {
+                // The max_seen_epoch didn't advance after the scheduling point
+                co_return cluster_epoch_fence{
+                  .unit = std::move(unit), .term = term};
+            }
+        } else {
+            // Case 2. New epoch, need to acquire write-lock.
+            auto epoch_update_lock = _epoch_update_lock.try_get_units();
+            if (!epoch_update_lock) {
+                // Someone else is updating the epoch - wait for the update and
+                // then re-check.
+                co_await _epoch_updated_cv.wait();
+                continue;
+            }
+
+            // We're the epoch updater, get a write-lock
+            auto unit = co_await ss::get_units(
+              _lock, ss::semaphore::max_counter(), _as);
+
+            auto current_epoch = _state.get_max_seen_epoch().or_else(
+              get_applied_epoch);
+            std::optional<cluster_epoch_fence> epoch_fence_opt;
+            if (!current_epoch.has_value() || current_epoch.value() <= e) {
+                _state.advance_max_seen_epoch(e);
+                // Demote to reader lock after max_seen_epoch is updated.
+                unit.return_units(unit.count() - 1);
+                epoch_fence_opt.emplace(std::move(unit), term);
+            }
+
+            // Clear units and broadcast to any waiters on success or failure to
+            // update the epoch.
+            epoch_update_lock.reset();
+            _epoch_updated_cv.broadcast();
+
+            if (epoch_fence_opt.has_value()) {
+                co_return std::move(epoch_fence_opt).value();
+            }
         }
+
+        // If we reach here, it means that we need to discard the batch.
+        co_return std::unexpected(
+          stale_cluster_epoch(_state.get_max_seen_epoch()
+                                .or_else(get_applied_epoch)
+                                .value_or(cluster_epoch{-1})));
     }
-    // If we reach here, it means that we need to discard the batch.
-    co_return std::unexpected(
-      stale_cluster_epoch(_state.get_max_seen_epoch()
-                            .or_else(get_applied_epoch)
-                            .value_or(cluster_epoch{-1})));
 }
 
 model::offset ctp_stm::max_removable_local_log_offset() {

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -14,6 +14,7 @@
 #include "cloud_topics/level_zero/stm/ctp_stm_state.h"
 #include "cloud_topics/level_zero/stm/types.h"
 #include "raft/persisted_stm.h"
+#include "ssx/mutex.h"
 
 #include <seastar/core/semaphore.hh>
 
@@ -115,6 +116,16 @@ private:
     /// When the new epoch is applied we need to acquire a write lock.
     /// Otherwise, we need to acquire a read lock.
     ss::semaphore _lock;
+    // We only need one updater for the state's epoch at a time - the updater
+    // still needs to obtain write lock units from `_lock`, but we can prevent
+    // pessimizing with multiple waiters on write lock units by having a
+    // separate lock for this purpose.
+    ssx::mutex _epoch_update_lock{"ctp_stm::epoch_update_lock"};
+    // Used to signal to waiters that the state's epoch has potentially been
+    // updated by the holder of `_epoch_update_lock` (it is possible that the
+    // lock holder may fail to update the epoch).
+    ss::condition_variable _epoch_updated_cv;
+
     /// Current in-memory state of the STM
     ctp_stm_state _state;
 

--- a/src/v/cloud_topics/level_zero/stm/tests/BUILD
+++ b/src/v/cloud_topics/level_zero/stm/tests/BUILD
@@ -36,6 +36,7 @@ redpanda_cc_gtest(
         "//src/v/cluster:state_machine_registry",
         "//src/v/model",
         "//src/v/raft/tests:raft_fixture",
+        "//src/v/ssx:when_all",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
     ],

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -17,6 +17,7 @@
 #include "model/timeout_clock.h"
 #include "model/timestamp.h"
 #include "raft/tests/raft_fixture.h"
+#include "ssx/when_all.h"
 #include "test_utils/async.h"
 
 #include <optional>
@@ -40,6 +41,10 @@ struct ctp_stm_accessor {
     auto install_snapshot(ctp_stm& stm, raft::stm_snapshot snapshot) {
         return stm.apply_local_snapshot(
           snapshot.header, std::move(snapshot.data));
+    }
+
+    bool epoch_cv_has_waiters(ctp_stm& stm) {
+        return stm._epoch_updated_cv.has_waiters();
     }
 };
 } // namespace cloud_topics
@@ -459,4 +464,79 @@ TEST_F_CORO(ctp_stm_fixture, test_snapshot) {
         auto fence = co_await api(leader).fence_epoch(ct::cluster_epoch{1});
         ASSERT_FALSE_CORO(fence.has_value());
     }
+}
+
+TEST_F_CORO(ctp_stm_fixture, test_fence_epoch_concurrent_new_epoch) {
+    // This test verifies the optimization in fence_epoch() where multiple
+    // concurrent requests for a new epoch only require one write lock.
+    // The first request acquires the epoch_update_lock and write lock, updates
+    // the epoch, then signals waiters. The remaining requests wake up and take
+    // the read-lock path since the epoch has been updated.
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+
+    auto& leader = node(*get_leader());
+    auto stm = get_stm<0>(leader);
+    ct::ctp_stm_accessor accessor;
+
+    // First, establish epoch 1 by replicating a batch
+    auto b1 = make_record_batch(ct::cluster_epoch{1}, model::offset{0}, 0);
+    auto res = co_await replicate_record_batch(leader, std::move(b1));
+    ASSERT_TRUE_CORO(res.has_value());
+
+    // Verify epoch 1 is established
+    auto max_epoch = api(leader).get_max_epoch();
+    ASSERT_TRUE_CORO(max_epoch.has_value());
+    ASSERT_EQ_CORO(max_epoch.value(), ct::cluster_epoch{1});
+
+    // Launch multiple concurrent fence_epoch calls for epoch 2 (a new epoch).
+    // All of these will initially see max_seen_epoch=1 and need to bump to 2.
+    // With the optimization:
+    // - One request acquires _epoch_update_lock, gets write lock, updates epoch
+    // - Others wait on condition variable, then take read-lock path
+    constexpr size_t num_concurrent_requests = 10;
+    using expected_t
+      = std::expected<ct::cluster_epoch_fence, ct::stale_cluster_epoch>;
+    std::vector<ss::future<expected_t>> futures;
+    futures.reserve(num_concurrent_requests);
+
+    {
+        auto leader_api = api(leader);
+        // Make a single request which fences the current epoch (thus holding a
+        // read lock)
+        auto initial_fence = co_await leader_api.fence_epoch(
+          ct::cluster_epoch{1});
+        ASSERT_TRUE_CORO(initial_fence.has_value());
+        // Push back a number of futures which will not yet be able to be
+        // resolved since a read lock is outstanding, forcing a number of
+        // requests to become waiters while a single request waits for a
+        // write lock- previously, this would have resulted in all requests
+        // waiting on a write lock sequentially.
+        for (size_t i = 0; i < num_concurrent_requests; ++i) {
+            futures.push_back(leader_api.fence_epoch(ct::cluster_epoch{2}));
+        }
+        // All requests but one should be waiting on cv.
+        RPTEST_REQUIRE_EVENTUALLY_CORO(
+          10s, [&] { return accessor.epoch_cv_has_waiters(*stm); });
+        // Let `initial_fence` go out of scope.
+    }
+
+    // Wait for all fences to be acquired - they should all be able to succeed
+    // without hanging because only one request (the first request) had to
+    // obtain a write lock, which then downgraded to a read lock, and the rest
+    // of the requests could obtain read locks for the current epoch.
+    auto fences = co_await ssx::when_all_succeed<std::vector<expected_t>>(
+      std::move(futures));
+    for (auto& fence : fences) {
+        ASSERT_TRUE_CORO(fence.has_value())
+          << "All fence requests should succeed";
+        ASSERT_EQ_CORO(fence->unit.count(), 1);
+    }
+
+    ASSERT_FALSE_CORO(accessor.epoch_cv_has_waiters(*stm));
+
+    // Verify epoch 2 is now established
+    auto max_seen = api(leader).get_max_seen_epoch();
+    ASSERT_TRUE_CORO(max_seen.has_value());
+    ASSERT_EQ_CORO(max_seen.value(), ct::cluster_epoch{2});
 }


### PR DESCRIPTION
It seems that multiple concurrent requests to `fence_epoch()` could end up pessimizing if the epoch has changed.

For context, I have a test timeout with this in the broker logs:

```
DEBUG 2026-01-09 23:58:27,819 [shard 0:prod] cloud_topics - [{kafka/tp-workload-ct-delete/1} (ctp_stm)] - ctp_stm_api.cc:179 - Fencing epoch 539 in term 4
DEBUG 2026-01-09 23:58:27,819 [shard 0:prod] cloud_topics - [{kafka/tp-workload-ct-delete/1} (ctp_stm)] - ctp_stm_api.cc:179 - Fencing epoch 539 in term 4
DEBUG 2026-01-09 23:58:27,819 [shard 0:prod] cloud_topics - [{kafka/tp-workload-ct-delete/1} (ctp_stm)] - ctp_stm_api.cc:179 - Fencing epoch 539 in term 4
DEBUG 2026-01-09 23:58:27,819 [shard 0:prod] cloud_topics - [{kafka/tp-workload-ct-delete/1} (ctp_stm)] - ctp_stm_api.cc:179 - Fencing epoch 539 in term 4
DEBUG 2026-01-09 23:58:27,819 [shard 0:prod] cloud_topics - [{kafka/tp-workload-ct-delete/1} (ctp_stm)] - ctp_stm_api.cc:185 - Fence acquired = true in term 4
```

Only one fence is acquired, there are no sync timeouts from the `ctp_stm`, and the test finally times out 10 minutes later.

```
INFO  2026-01-10 00:08:57,666 [shard 0:main] main - application.cc:327 - Shutdown complete.
```

I hypothesize that each of these requests took case 2, waiting on a write lock, and a slow moving request results in the rest being blocked.

To fix this, rework the function with a new `mutex` and `condition_variable`. We will now:
1. If we are the first request to observe a new epoch, obtain a `mutex`. If we are not the first to observe, we await a `condition_variable`.
2. After the `mutex` holder attempts to advance the epoch, we alert all waiters and proceed as normal (waiters will then repeat the relevant epoch checks).

This approach prevents the pessimization shown before, in which all concurrent requests which arrive while an epoch has changed & previous read locks are held results in near sequential behavior due to an overwhelmed system. This likely has a profound effect on the throughput of the produce path.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
