### PR TITLE
ct: prevent deadlock

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -612,7 +612,6 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
       placeholders.batches.size() == 1,
       "Expected single batch, got {}",
       placeholders.batches.size());
-    
     opts = update_replicate_options(opts, fence->term);
     auto replicate_stages = partition->replicate_in_stages(
       batch_id, std::move(placeholders.batches.front()), opts);

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -568,6 +568,18 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
         co_return default_errc;
     }
 
+    // Wait for all previous requests from this producer to be processed
+    if (opts.as) {
+        co_await ticket.redeem(opts.as->get());
+    } else {
+        co_await ticket.redeem();
+    }
+    // Now that our producer order is resolved, we can fence epochs
+    // we must resolve producer order first to prevent races where a
+    // request waits on a previous request in the producer queue, but
+    // that previous request is waiting on the other request to finish
+    // (because it needs to drain current requests as the epoch is being
+    // bumped).
     auto fence_fut = co_await ss::coroutine::as_future(
       ctp_stm_api->fence_epoch(upload_res.value().front().id.epoch));
     if (fence_fut.failed()) {
@@ -600,13 +612,7 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
       placeholders.batches.size() == 1,
       "Expected single batch, got {}",
       placeholders.batches.size());
-    // Wait for all previous requests from this producer to be processed
-    if (opts.as) {
-        co_await ticket.redeem(opts.as->get());
-    } else {
-        co_await ticket.redeem();
-    }
-    // Replicate now that our ticket is redeemed
+    
     opts = update_replicate_options(opts, fence->term);
     auto replicate_stages = partition->replicate_in_stages(
       batch_id, std::move(placeholders.batches.front()), opts);


### PR DESCRIPTION
See the comments, the producer queue and epoch fencing can interact in a way in which they deadlock.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
