### PR TITLE
CORE-15179 SR Context: seq_writer (mostly) context-aware

### DIFF
--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -538,7 +538,7 @@ ss::sstring avro_schema_definition::name() const {
 class collected_schema {
     struct schema_entry {
         avro::ValidSchema schema;
-        subject source_subject;
+        context_subject source_subject;
         schema_version source_version;
     };
 
@@ -547,7 +547,7 @@ public:
         return _schemas.contains(name);
     }
 
-    std::optional<std::pair<subject, schema_version>>
+    std::optional<std::pair<context_subject, schema_version>>
     get_source(const avro::Name& name) const {
         auto it = _schemas.find(name);
         if (it == _schemas.end()) {
@@ -560,7 +560,7 @@ public:
     bool insert(
       avro::Name name,
       avro::ValidSchema schema,
-      subject source_subject,
+      context_subject source_subject,
       schema_version source_version) {
         auto [it, inserted] = _schemas.try_emplace(
           std::move(name),

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -269,7 +269,7 @@ delete_config_subject(server::request_t rq, server::reply_t rp) {
 
     // ensure we see latest writes
     co_await rq.service().writer().read_sync();
-    co_await rq.service().writer().check_mutable(sub);
+    co_await rq.service().writer().check_mutable(default_context, sub);
 
     compatibility_level lvl{};
     try {

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -178,16 +178,13 @@ struct json_schema_definition::impl {
 
     impl(
       document_context ctx,
-      std::string_view name,
       schema_definition::references refs,
       std::optional<schema_metadata> meta)
       : ctx{std::move(ctx)}
-      , name{name}
       , refs(std::move(refs))
       , meta(std::move(meta)) {}
 
     document_context ctx;
-    ss::sstring name;
     schema_definition::references refs;
     std::optional<schema_metadata> meta;
 };
@@ -223,8 +220,6 @@ const schema_definition::references& json_schema_definition::refs() const {
 const std::optional<schema_metadata>& json_schema_definition::meta() const {
     return _impl->meta;
 }
-
-ss::sstring json_schema_definition::name() const { return {_impl->name}; };
 
 std::optional<ss::sstring> json_schema_definition::title() const {
     if (!_impl->ctx.doc.IsObject()) {
@@ -2391,10 +2386,9 @@ make_json_schema_definition(schema_getter&, subject_schema schema) {
     auto [sub, unparsed] = std::move(schema).destructure();
     auto [def, type, refs, meta] = std::move(unparsed).destructure();
     auto doc = parse_json(std::move(def)).value(); // throws on error
-    std::string_view name = sub();
     co_return json_schema_definition{
       ss::make_shared<json_schema_definition::impl>(
-        std::move(doc), name, std::move(refs), std::move(meta))};
+        std::move(doc), std::move(refs), std::move(meta))};
 }
 
 ss::future<subject_schema> make_canonical_json_schema(

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -476,7 +476,7 @@ ss::future<pb::FileDescriptorProto> import_schema(
   normalize norm) {
     try {
         co_return co_await build_file_with_refs(
-          dp, store, schema.sub()(), schema.share(), norm);
+          dp, store, schema.sub().to_string(), schema.share(), norm);
     } catch (const exception& e) {
         // Rethrow if the schema is missing references
         if (e.code() == error_code::schema_missing_reference) {
@@ -667,7 +667,7 @@ ss::future<subject_schema> make_canonical_protobuf_schema(
   subject_schema schema,
   normalize norm,
   output_format format) {
-    subject sub = schema.sub();
+    auto sub = schema.sub();
     co_return subject_schema{
       std::move(sub),
       co_await validate_protobuf_schema(
@@ -681,7 +681,10 @@ ss::future<schema_definition> format_protobuf_schema_definition(
         throw as_exception(format_not_supported(format));
     case output_format::serialized: {
         auto serialized = co_await make_canonical_protobuf_schema(
-          store, {{}, std::move(schema)}, normalize::no, format);
+          store,
+          {context_subject{default_context, subject{""}}, std::move(schema)},
+          normalize::no,
+          format);
         auto [_, def] = std::move(serialized).destructure();
         co_return std::move(def);
     }

--- a/src/v/pandaproxy/schema_registry/requests/get_subject_versions_version.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_subject_versions_version.h
@@ -26,7 +26,7 @@ void rjson_serialize(
   const get_subject_versions_version_response& res) {
     w.StartObject();
     w.Key("subject");
-    ::json::rjson_serialize(w, res.stored_schema.schema.sub());
+    w.String(res.stored_schema.schema.sub().to_string());
     w.Key("version");
     ::json::rjson_serialize(w, res.stored_schema.version);
     w.Key("id");

--- a/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
+++ b/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
@@ -403,7 +403,7 @@ void rjson_serialize(
   const schema_registry::post_subject_response& res) {
     w.StartObject();
     w.Key("subject");
-    ::json::rjson_serialize(w, res.schema.sub());
+    w.String(res.schema.sub().to_string());
     w.Key("version");
     ::json::rjson_serialize(w, res.version);
     w.Key("id");

--- a/src/v/pandaproxy/schema_registry/rjson.h
+++ b/src/v/pandaproxy/schema_registry/rjson.h
@@ -31,7 +31,7 @@ void rjson_serialize(
     w.Key("name");
     ::json::rjson_serialize(w, ref.name);
     w.Key("subject");
-    ::json::rjson_serialize(w, ref.sub);
+    w.String(ref.sub.to_string());
     w.Key("version");
     ::json::rjson_serialize(w, ref.version);
     w.EndObject();

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -123,11 +123,13 @@ ss::future<> seq_writer::read_sync() {
     co_await _store.process_marked_schemas();
 }
 
-ss::future<> seq_writer::check_mutable(const std::optional<subject>& sub) {
-    auto mode = sub ? co_await _store.get_mode(*sub, default_to_global::yes)
-                    : co_await _store.get_mode(default_context);
+ss::future<> seq_writer::check_mutable(
+  const context& ctx, const std::optional<subject>& sub) {
+    auto mode = sub ? co_await _store.get_mode(
+                        {ctx, *sub}, default_to_global::yes)
+                    : co_await _store.get_mode(ctx);
     if (mode == mode::read_only) {
-        throw as_exception(mode_is_readonly(default_context, sub));
+        throw as_exception(mode_is_readonly(ctx, sub));
     }
     co_return;
 }
@@ -225,7 +227,7 @@ ss::future<std::optional<sharded_store::insert_result>>
 seq_writer::do_write_subject_version(
   stored_schema schema, model::offset write_at) {
     const auto& sub = schema.schema.sub();
-    co_await check_mutable(sub);
+    co_await check_mutable(default_context, sub);
 
     // Check if store already contains this data: if
     // so, we do no I/O and return the schema ID.
@@ -298,7 +300,7 @@ ss::future<std::optional<bool>> seq_writer::do_write_config(
       to_string_view(compat),
       write_at);
 
-    co_await check_mutable(sub);
+    co_await check_mutable(default_context, sub);
 
     try {
         // Check for no-op case
@@ -340,7 +342,7 @@ ss::future<bool> seq_writer::write_config(
 ss::future<std::optional<bool>> seq_writer::do_delete_config(subject sub) {
     vlog(srlog.debug, "delete config sub={}", sub);
 
-    co_await check_mutable(sub);
+    co_await check_mutable(default_context, sub);
 
     try {
         co_await _store.get_compatibility(sub, default_to_global::no);
@@ -475,7 +477,7 @@ ss::future<bool> seq_writer::delete_mode(subject sub) {
 /// Impermanent delete: update a version with is_deleted=true
 ss::future<std::optional<bool>> seq_writer::do_delete_subject_version(
   subject sub, schema_version version, model::offset write_at) {
-    co_await check_mutable(sub);
+    co_await check_mutable(default_context, sub);
 
     if (co_await _store.is_referenced(sub, version)) {
         throw as_exception(has_references(sub, version));
@@ -523,7 +525,7 @@ seq_writer::delete_subject_version(subject sub, schema_version version) {
 
 ss::future<std::optional<chunked_vector<schema_version>>>
 seq_writer::do_delete_subject_impermanent(subject sub, model::offset write_at) {
-    co_await check_mutable(sub);
+    co_await check_mutable(default_context, sub);
 
     // Grab the versions before they're gone.
     auto versions = co_await _store.get_versions(sub, include_deleted::no);
@@ -601,7 +603,7 @@ seq_writer::delete_subject_permanent_inner(
     /// within these store functions (will throw a 404-equivalent if so)
     vlog(srlog.debug, "delete_subject_permanent sub={}", sub);
 
-    co_await check_mutable(sub);
+    co_await check_mutable(default_context, sub);
 
     if (version.has_value()) {
         // Check version first to see if the version exists

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -229,7 +229,7 @@ ss::future<std::optional<sharded_store::insert_result>>
 seq_writer::do_write_subject_version(
   stored_schema schema, model::offset write_at) {
     const auto& sub = schema.schema.sub();
-    co_await check_mutable(default_context, sub);
+    co_await check_mutable(sub.ctx, sub.sub);
 
     // Check if store already contains this data: if
     // so, we do no I/O and return the schema ID.

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -59,7 +59,7 @@ struct batch_builder : public storage::record_batch_builder {
           to_json_iobuf(std::forward<V>(value)));
     }
 
-    void add_tombstone(const subject& sub, const seq_marker& s) {
+    void add_tombstone(const context_subject& sub, const seq_marker& s) {
         vlog(
           srlog.debug,
           "Delete {} tombstoning sub={} at {}",
@@ -81,11 +81,13 @@ struct batch_builder : public storage::record_batch_builder {
             add_raw_kv(to_json_iobuf(std::move(key)), std::nullopt);
         } break;
         case seq_marker_key_type::config: {
-            auto key = config_key{.seq{s.seq}, .node{s.node}, .sub{sub}};
+            // TODO: use the full context_subject once it is stored
+            auto key = config_key{.seq{s.seq}, .node{s.node}, .sub{sub.sub}};
             add_raw_kv(to_json_iobuf(std::move(key)), std::nullopt);
         } break;
         case seq_marker_key_type::mode: {
-            auto key = mode_key{.seq{s.seq}, .node{s.node}, .sub{sub}};
+            // TODO: use the full context_subject once it is stored
+            auto key = mode_key{.seq{s.seq}, .node{s.node}, .sub{sub.sub}};
             add_raw_kv(to_json_iobuf(std::move(key)), std::nullopt);
         } break;
         case seq_marker_key_type::invalid:
@@ -95,7 +97,7 @@ struct batch_builder : public storage::record_batch_builder {
     }
 
     void add_tombstones(
-      const subject& sub, const chunked_vector<seq_marker>& sequences) {
+      const context_subject& sub, const chunked_vector<seq_marker>& sequences) {
         for (const seq_marker& s : sequences) {
             add_tombstone(sub, s);
         }
@@ -476,8 +478,8 @@ ss::future<bool> seq_writer::delete_mode(subject sub) {
 
 /// Impermanent delete: update a version with is_deleted=true
 ss::future<std::optional<bool>> seq_writer::do_delete_subject_version(
-  subject sub, schema_version version, model::offset write_at) {
-    co_await check_mutable(default_context, sub);
+  context_subject sub, schema_version version, model::offset write_at) {
+    co_await check_mutable(sub.ctx, sub.sub);
 
     if (co_await _store.is_referenced(sub, version)) {
         throw as_exception(has_references(sub, version));
@@ -492,7 +494,6 @@ ss::future<std::optional<bool>> seq_writer::do_delete_subject_version(
     schema_value value{
       .schema{subject_schema{sub, std::move(schema)}},
       .version{version},
-      // TODO: use the full s_id here
       .id{s_id.id},
       .deleted{is_deleted::yes}};
 
@@ -515,8 +516,8 @@ ss::future<std::optional<bool>> seq_writer::do_delete_subject_version(
     }
 }
 
-ss::future<bool>
-seq_writer::delete_subject_version(subject sub, schema_version version) {
+ss::future<bool> seq_writer::delete_subject_version(
+  context_subject sub, schema_version version) {
     return sequenced_write(
       [sub{std::move(sub)}, version](model::offset write_at, seq_writer& seq) {
           return seq.do_delete_subject_version(sub, version, write_at);
@@ -524,8 +525,9 @@ seq_writer::delete_subject_version(subject sub, schema_version version) {
 }
 
 ss::future<std::optional<chunked_vector<schema_version>>>
-seq_writer::do_delete_subject_impermanent(subject sub, model::offset write_at) {
-    co_await check_mutable(default_context, sub);
+seq_writer::do_delete_subject_impermanent(
+  context_subject sub, model::offset write_at) {
+    co_await check_mutable(sub.ctx, sub.sub);
 
     // Grab the versions before they're gone.
     auto versions = co_await _store.get_versions(sub, include_deleted::no);
@@ -573,7 +575,7 @@ seq_writer::do_delete_subject_impermanent(subject sub, model::offset write_at) {
 }
 
 ss::future<chunked_vector<schema_version>>
-seq_writer::delete_subject_impermanent(subject sub) {
+seq_writer::delete_subject_impermanent(context_subject sub) {
     vlog(srlog.debug, "delete_subject_impermanent sub={}", sub);
     return sequenced_write(
       [sub{std::move(sub)}](model::offset write_at, seq_writer& seq) {
@@ -586,7 +588,7 @@ seq_writer::delete_subject_impermanent(subject sub) {
 /// Include a version if we are only to hard delete that version, otherwise
 /// will hard-delete the whole subject.
 ss::future<chunked_vector<schema_version>> seq_writer::delete_subject_permanent(
-  subject sub, std::optional<schema_version> version) {
+  context_subject sub, std::optional<schema_version> version) {
     return sequenced_write(
       [sub{std::move(sub)}, version](model::offset, seq_writer& seq) {
           return seq.delete_subject_permanent_inner(sub, version);
@@ -595,7 +597,7 @@ ss::future<chunked_vector<schema_version>> seq_writer::delete_subject_permanent(
 
 ss::future<std::optional<chunked_vector<schema_version>>>
 seq_writer::delete_subject_permanent_inner(
-  subject sub, std::optional<schema_version> version) {
+  context_subject sub, std::optional<schema_version> version) {
     chunked_vector<seq_marker> sequences;
     batch_builder rb{model::offset{0}};
 
@@ -603,7 +605,7 @@ seq_writer::delete_subject_permanent_inner(
     /// within these store functions (will throw a 404-equivalent if so)
     vlog(srlog.debug, "delete_subject_permanent sub={}", sub);
 
-    co_await check_mutable(default_context, sub);
+    co_await check_mutable(sub.ctx, sub.sub);
 
     if (version.has_value()) {
         // Check version first to see if the version exists

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -60,7 +60,8 @@ public:
     ss::future<> read_sync();
 
     // Throws 42205 if the subject cannot be modified
-    ss::future<> check_mutable(const std::optional<subject>& sub);
+    ss::future<>
+    check_mutable(const context& ctx, const std::optional<subject>& sub);
 
     // API for readers: notify us when they have read and applied an offset
     ss::future<> advance_offset(model::offset offset);

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -79,13 +79,13 @@ public:
     ss::future<bool> delete_mode(subject sub);
 
     ss::future<bool>
-    delete_subject_version(subject sub, schema_version version);
+    delete_subject_version(context_subject sub, schema_version version);
 
     ss::future<chunked_vector<schema_version>>
-    delete_subject_impermanent(subject sub);
+    delete_subject_impermanent(context_subject sub);
 
     ss::future<chunked_vector<schema_version>> delete_subject_permanent(
-      subject sub, std::optional<schema_version> version);
+      context_subject sub, std::optional<schema_version> version);
 
 private:
     ss::smp_submit_to_options _smp_opts;
@@ -114,14 +114,14 @@ private:
     do_delete_mode(subject sub, model::offset write_at);
 
     ss::future<std::optional<bool>> do_delete_subject_version(
-      subject sub, schema_version version, model::offset write_at);
+      context_subject sub, schema_version version, model::offset write_at);
 
     ss::future<std::optional<chunked_vector<schema_version>>>
-    do_delete_subject_impermanent(subject sub, model::offset write_at);
+    do_delete_subject_impermanent(context_subject sub, model::offset write_at);
 
     ss::future<std::optional<chunked_vector<schema_version>>>
     delete_subject_permanent_inner(
-      subject sub, std::optional<schema_version> version);
+      context_subject sub, std::optional<schema_version> version);
 
     simple_time_jitter<ss::lowres_clock> _jitter{std::chrono::milliseconds{50}};
 

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -283,12 +283,13 @@ sharded_store::has_schema(subject_schema schema, include_deleted inc_del) {
     });
     for (auto entry : versions) {
         try {
-            auto def = co_await get_schema_definition(entry.id);
+            auto def = co_await get_schema_definition(
+              {schema.sub().ctx, entry.id});
             if (schema.def() == def) {
                 co_return stored_schema{
                   .schema = {schema.sub(), std::move(def)},
                   .version = entry.version,
-                  .id = entry.id.id,
+                  .id = entry.id,
                   .deleted = entry.deleted};
             }
         } catch (const exception& e) {
@@ -394,7 +395,7 @@ ss::future<context_schema_id> sharded_store::get_id(
             .value();
       });
 
-    co_return v_id.id;
+    co_return context_schema_id{sub.ctx, v_id.id};
 }
 
 ss::future<stored_schema> sharded_store::get_subject_schema(
@@ -406,16 +407,17 @@ ss::future<stored_schema> sharded_store::get_subject_schema(
       sub_shard, _smp_opts, [sub, version, inc_del](store& s) {
           return s.get_subject_version_id(sub, version, inc_del).value();
       });
-
+    auto ctx_id = context_schema_id{sub.ctx, v_id.id};
+    auto ctx_id_shard = shard_for(ctx_id);
     auto def = co_await _store.invoke_on(
-      shard_for(v_id.id), _smp_opts, [id = v_id.id](store& s) {
-          return s.get_schema_definition(id).value();
+      ctx_id_shard, _smp_opts, [ctx_id{std::move(ctx_id)}](store& s) {
+          return s.get_schema_definition(ctx_id).value();
       });
 
     co_return stored_schema{
       .schema = {std::move(sub), std::move(def)},
       .version = v_id.version,
-      .id = v_id.id.id,
+      .id = v_id.id,
       .deleted = v_id.deleted};
 }
 
@@ -582,7 +584,7 @@ ss::future<bool> sharded_store::delete_subject_version(
                              .value()
                              .id;
           auto result = s.delete_subject_version(sub, ver, force).value();
-          return std::make_pair(schema_id, result);
+          return std::make_pair(context_schema_id{sub.ctx, schema_id}, result);
       });
 
     auto remaining_subjects_exist = co_await _store.map_reduce0(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -169,11 +169,15 @@ sharded_store::project_ids(stored_schema schema) {
     auto s_id = schema.id;
     if (s_id == invalid_schema_id) {
         // New schema, project an ID for it.
-        s_id = co_await project_schema_id(default_context);
-        vlog(srlog.debug, "project_ids: projected new ID {}", s_id);
+        s_id = co_await project_schema_id(sub.ctx);
+        vlog(
+          srlog.debug,
+          "project_ids (context: {}): projected new ID {}",
+          sub.ctx,
+          s_id);
     }
 
-    auto ctx_sub = context_subject{default_context, sub};
+    auto ctx_sub = sub;
     auto sub_shard{shard_for(ctx_sub)};
     auto v_id = co_await _store.invoke_on(
       sub_shard, _smp_opts, [ctx_sub, s_id](store& s) {
@@ -216,15 +220,9 @@ ss::future<bool> sharded_store::upsert(
     // mark schemas that failed to be processed here. They will be given
     // one more chance once we have loaded all the topic to the store.
     co_await upsert_schema(
-      context_schema_id{default_context, id},
-      std::move(def),
-      processing_failed);
+      context_schema_id{sub.ctx, id}, std::move(def), processing_failed);
     co_return co_await upsert_subject(
-      marker,
-      context_subject{default_context, std::move(sub)},
-      version,
-      id,
-      deleted);
+      marker, std::move(sub), version, id, deleted);
 }
 
 ss::future<> sharded_store::process_marked_schemas() {
@@ -285,7 +283,6 @@ sharded_store::has_schema(subject_schema schema, include_deleted inc_del) {
     });
     for (auto entry : versions) {
         try {
-            // TODO: deduce the context from the subject/entry.id
             auto def = co_await get_schema_definition(entry.id);
             if (schema.def() == def) {
                 co_return stored_schema{
@@ -416,8 +413,7 @@ ss::future<stored_schema> sharded_store::get_subject_schema(
       });
 
     co_return stored_schema{
-      // TODO: pass sub directly instead of sub.sub
-      .schema = {sub.sub, std::move(def)},
+      .schema = {std::move(sub), std::move(def)},
       .version = v_id.version,
       .id = v_id.id.id,
       .deleted = v_id.deleted};

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -132,7 +132,7 @@ struct schema_key {
     // preceding valid writes.
     std::optional<model::node_id> node;
 
-    subject sub;
+    context_subject sub;
     schema_version version;
     topic_key_magic magic{1};
 
@@ -170,7 +170,7 @@ void rjson_serialize(
     w.Key("keytype");
     ::json::rjson_serialize(w, to_string_view(key.keytype));
     w.Key("subject");
-    ::json::rjson_serialize(w, key.sub());
+    w.String(key.sub.to_string());
     w.Key("version");
     ::json::rjson_serialize(w, key.version);
     w.Key("magic");
@@ -277,7 +277,7 @@ public:
             return kt == result.keytype;
         }
         case state::subject: {
-            result.sub = subject{ss::sstring{sv}};
+            result.sub = context_subject::from_string(sv);
             _state = state::object;
             return true;
         }
@@ -371,7 +371,7 @@ class schema_value_handler final : public json::base_handler<Encoding> {
     state _state = state::empty;
 
     struct mutable_schema {
-        subject sub{invalid_subject};
+        context_subject sub{invalid_subject};
         typename schema_definition::raw_string def;
         schema_type type{schema_type::avro};
         typename schema_definition::references refs;
@@ -515,7 +515,7 @@ public:
         auto sv = std::string_view{str, len};
         switch (_state) {
         case state::subject: {
-            _schema.sub = subject{ss::sstring{sv}};
+            _schema.sub = context_subject::from_string(sv);
             _state = state::object;
             return true;
         }
@@ -538,7 +538,7 @@ public:
             return true;
         }
         case state::reference_subject: {
-            _schema.refs.back().sub = subject{ss::sstring{sv}};
+            _schema.refs.back().sub = context_subject::from_string(sv);
             _state = state::reference;
             return true;
         }
@@ -1153,7 +1153,7 @@ struct delete_subject_key {
     static constexpr topic_key_type keytype{topic_key_type::delete_subject};
     std::optional<model::offset> seq;
     std::optional<model::node_id> node;
-    subject sub;
+    context_subject sub;
     topic_key_magic magic{0};
 
     friend bool operator==(const delete_subject_key&, const delete_subject_key&)
@@ -1188,7 +1188,7 @@ void rjson_serialize(::json::Writer<Buffer>& w, const delete_subject_key& key) {
     w.Key("keytype");
     ::json::rjson_serialize(w, to_string_view(key.keytype));
     w.Key("subject");
-    ::json::rjson_serialize(w, key.sub());
+    w.String(key.sub.to_string());
     w.Key("magic");
     ::json::rjson_serialize(w, key.magic);
     if (key.seq.has_value()) {
@@ -1285,7 +1285,7 @@ public:
             return kt == result.keytype;
         }
         case state::subject: {
-            result.sub = subject{ss::sstring{sv}};
+            result.sub = context_subject::from_string(sv);
             _state = state::object;
             return true;
         }
@@ -1310,7 +1310,7 @@ public:
 };
 
 struct delete_subject_value {
-    subject sub;
+    context_subject sub;
 
     friend bool
     operator==(const delete_subject_value&, const delete_subject_value&)
@@ -1328,7 +1328,7 @@ void rjson_serialize(
   ::json::Writer<Buffer>& w, const delete_subject_value& val) {
     w.StartObject();
     w.Key("subject");
-    ::json::rjson_serialize(w, val.sub);
+    w.String(val.sub.to_string());
     w.EndObject();
 }
 
@@ -1375,7 +1375,7 @@ public:
         auto sv = std::string_view{str, len};
         switch (_state) {
         case state::subject: {
-            result.sub = subject{ss::sstring{sv}};
+            result.sub = context_subject::from_string(sv);
             _state = state::object;
             return true;
         }

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -326,7 +326,7 @@ template<typename Buffer>
 void rjson_serialize(::json::iobuf_writer<Buffer>& w, const schema_value& val) {
     w.StartObject();
     w.Key("subject");
-    ::json::rjson_serialize(w, val.schema.sub());
+    w.String(val.schema.sub().to_string());
     w.Key("version");
     ::json::rjson_serialize(w, val.version);
     w.Key("id");

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -169,12 +169,13 @@ public:
         auto v_id = BOOST_OUTCOME_TRYX(
           get_subject_version_id(sub, version, inc_del));
 
-        auto def = BOOST_OUTCOME_TRYX(get_schema_definition(v_id.id));
+        auto def = BOOST_OUTCOME_TRYX(
+          get_schema_definition({sub.ctx, v_id.id}));
 
         return stored_schema{
           .schema = {sub, std::move(def)},
           .version = v_id.version,
-          .id = v_id.id.id,
+          .id = v_id.id,
           .deleted = v_id.deleted};
     }
 
@@ -437,8 +438,9 @@ public:
         schema_id_set has_ids;
         for (const auto& s : _subjects) {
             for (const auto& r : s.second.versions) {
-                if (!r.deleted && ids.contains(r.id)) {
-                    has_ids.insert(r.id);
+                auto ctx_id = context_schema_id{s.first.ctx, r.id};
+                if (!r.deleted && ids.contains(ctx_id)) {
+                    has_ids.insert(ctx_id);
                 }
             }
         }

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -75,10 +75,8 @@ public:
     /// return the schema_version and schema_id, and whether it's new.
     insert_result insert(subject_schema schema) {
         auto [sub, def] = std::move(schema).destructure();
-        // TODO: deduce the context from the subject
-        auto ctx_sub = context_subject{default_context, std::move(sub)};
-        auto id = insert_schema(ctx_sub.ctx, std::move(def)).id;
-        auto [version, inserted] = insert_subject(std::move(ctx_sub), id);
+        auto id = insert_schema(sub.ctx, std::move(def)).id;
+        auto [version, inserted] = insert_subject(std::move(sub), id);
         return {version, id, inserted};
     }
 
@@ -174,8 +172,7 @@ public:
         auto def = BOOST_OUTCOME_TRYX(get_schema_definition(v_id.id));
 
         return stored_schema{
-          // TODO: pass sub directly instead of sub.sub
-          .schema = {sub.sub, std::move(def)},
+          .schema = {sub, std::move(def)},
           .version = v_id.version,
           .id = v_id.id.id,
           .deleted = v_id.deleted};

--- a/src/v/pandaproxy/schema_registry/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/test/BUILD
@@ -113,8 +113,8 @@ redpanda_cc_btest(
     ],
 )
 
-redpanda_cc_btest(
-    name = "storage",
+redpanda_cc_gtest(
+    name = "storage_test",
     timeout = "short",
     srcs = [
         "storage.cc",
@@ -122,10 +122,9 @@ redpanda_cc_btest(
     deps = [
         "//src/v/pandaproxy:json",
         "//src/v/pandaproxy/schema_registry:core",
-        "//src/v/test_utils:seastar_boost",
-        "@boost//:test",
+        "//src/v/test_utils:gtest",
         "@fmt",
-        "@seastar//:testing",
+        "@googletest//:gtest",
     ],
 )
 

--- a/src/v/pandaproxy/schema_registry/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/test/BUILD
@@ -283,6 +283,21 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "protobuf_schema_references_test",
+    timeout = "short",
+    srcs = [
+        "protobuf_schema_references.cc",
+    ],
+    deps = [
+        ":store_fixture",
+        "//src/v/pandaproxy/schema_registry:core",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
 redpanda_cc_btest(
     name = "compatibility_avro_test",
     timeout = "short",

--- a/src/v/pandaproxy/schema_registry/test/api_bench.cc
+++ b/src/v/pandaproxy/schema_registry/test/api_bench.cc
@@ -34,7 +34,7 @@ struct perf_settings {
 
 struct endpoint {
     using signature = consumed_response (*)(
-      ::http::client&, const pps::subject&, const ss::sstring&);
+      ::http::client&, const pps::context_subject&, const ss::sstring&);
     signature fn;
     ss::sstring name;
 };
@@ -48,8 +48,8 @@ ss::sstring make_payload(
       absl::CEscape(schema));
 }
 
-pps::subject make_subject(int i_sub) {
-    return pps::subject{ss::format("TestSubject{}", i_sub)};
+pps::context_subject make_subject(int i_sub) {
+    return pps::context_subject{ss::format("TestSubject{}", i_sub)};
 }
 
 pps::schema_version middle_version(int n_versions) {
@@ -65,7 +65,7 @@ pps::schema_version last_version(int n_versions) {
 
 void setup_client(::http::client& client, perf_settings ps) {
     for (int i_sub = 0; i_sub < ps.n_subjects; ++i_sub) {
-        pps::subject sub = make_subject(i_sub);
+        auto sub = make_subject(i_sub);
         for (int i_ver = 1; i_ver <= ps.n_versions; ++i_ver) {
             auto schema = pps::test_utils::make_proto_schema(sub, i_ver);
             auto payload = make_payload(schema);

--- a/src/v/pandaproxy/schema_registry/test/client_utils.h
+++ b/src/v/pandaproxy/schema_registry/test/client_utils.h
@@ -34,10 +34,12 @@ inline iobuf make_body(const ss::sstring& body) {
 }
 
 inline auto put_config(
-  http::client& client, const pps::subject& sub, pps::compatibility_level lvl) {
+  http::client& client,
+  const pps::context_subject& sub,
+  pps::compatibility_level lvl) {
     return http_request(
       client,
-      fmt::format("/config/{}", sub()),
+      fmt::format("/config/{}", sub.to_string()),
       make_body(
         fmt::format(R"({{"compatibility": "{}"}})", to_string_view(lvl))),
       boost::beast::http::verb::put,
@@ -46,10 +48,12 @@ inline auto put_config(
 }
 
 inline auto lookup_schema(
-  http::client& client, const pps::subject& sub, const ss::sstring& payload) {
+  http::client& client,
+  const pps::context_subject& sub,
+  const ss::sstring& payload) {
     return http_request(
       client,
-      fmt::format("/subjects/{}", sub()),
+      fmt::format("/subjects/{}", sub.to_string()),
       make_body(payload),
       boost::beast::http::verb::post,
       ppj::serialization_format::schema_registry_v1_json,
@@ -57,10 +61,12 @@ inline auto lookup_schema(
 }
 
 inline auto post_schema(
-  http::client& client, const pps::subject& sub, const ss::sstring& payload) {
+  http::client& client,
+  const pps::context_subject& sub,
+  const ss::sstring& payload) {
     return http_request(
       client,
-      fmt::format("/subjects/{}/versions", sub()),
+      fmt::format("/subjects/{}/versions", sub.to_string()),
       make_body(payload),
       boost::beast::http::verb::post,
       ppj::serialization_format::schema_registry_v1_json,
@@ -69,11 +75,11 @@ inline auto post_schema(
 
 inline auto delete_subject(
   http::client& client,
-  const pps::subject& sub,
+  const pps::context_subject& sub,
   pps::permanent_delete del = {}) {
     return http_request(
       client,
-      fmt::format("/subjects/{}?permanent={}", sub(), del),
+      fmt::format("/subjects/{}?permanent={}", sub.to_string(), del),
       boost::beast::http::verb::delete_,
       ppj::serialization_format::schema_registry_v1_json,
       ppj::serialization_format::schema_registry_v1_json);
@@ -81,12 +87,13 @@ inline auto delete_subject(
 
 inline auto delete_subject_version(
   http::client& client,
-  const pps::subject& sub,
+  const pps::context_subject& sub,
   pps::schema_version ver,
   pps::permanent_delete del = {}) {
     return http_request(
       client,
-      fmt::format("/subjects/{}/versions/{}?permanent={}", sub(), ver(), del),
+      fmt::format(
+        "/subjects/{}/versions/{}?permanent={}", sub.to_string(), ver(), del),
       boost::beast::http::verb::delete_,
       ppj::serialization_format::schema_registry_v1_json,
       ppj::serialization_format::schema_registry_v1_json);
@@ -94,11 +101,11 @@ inline auto delete_subject_version(
 
 inline auto get_subject_versions(
   http::client& client,
-  const pps::subject& sub,
+  const pps::context_subject& sub,
   pps::include_deleted del = {}) {
     return http_request(
       client,
-      fmt::format("/subjects/{}/versions?deleted={}", sub(), del),
+      fmt::format("/subjects/{}/versions?deleted={}", sub.to_string(), del),
       boost::beast::http::verb::get,
       ppj::serialization_format::schema_registry_v1_json,
       ppj::serialization_format::schema_registry_v1_json);

--- a/src/v/pandaproxy/schema_registry/test/protobuf_large_alloc.cc
+++ b/src/v/pandaproxy/schema_registry/test/protobuf_large_alloc.cc
@@ -80,7 +80,7 @@ TEST(ProtoLargeAlloc, test_protobuf_memory_stuff) {
     // Size of these schemas is set to around half-megabyte. The exact value is
     // not important, as long as it is significantly larger than the
     // fragmentation interval introduced in fragment_memory
-    const pps::subject sub{"test_subject_01"};
+    const pps::context_subject sub{"test_subject_01"};
     const auto large_schema = pps::test_utils::make_proto_schema(sub, 25'000);
     EXPECT_EQ(large_schema.size(), 552841);
 

--- a/src/v/pandaproxy/schema_registry/test/protobuf_schema_references.cc
+++ b/src/v/pandaproxy/schema_registry/test/protobuf_schema_references.cc
@@ -1,0 +1,99 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/schema_registry/protobuf.h"
+#include "pandaproxy/schema_registry/test/store_fixture.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace pandaproxy::schema_registry {
+
+using ::testing::HasSubstr;
+
+class ProtobufSchemaReferencesTest
+  : public ::testing::Test
+  , public test_utils::store_fixture {};
+
+// subject_schema.sub().to_string() is used as the protobuf file name.
+// Verify protobuf accepts file names with dots from qualified subjects.
+TEST_F(ProtobufSchemaReferencesTest, DottedFileName) {
+    auto sub = context_subject{context{".my.ctx"}, subject{"test"}};
+    ASSERT_THAT(sub.to_string(), HasSubstr("."));
+
+    auto schema
+      = make_protobuf_schema_definition(
+          _store,
+          subject_schema{
+            sub,
+            schema_definition{
+              R"(syntax = "proto3"; message Test { string value = 1; })",
+              schema_type::protobuf}})
+          .get();
+
+    auto name_result = schema.name({0});
+    ASSERT_TRUE(name_result.has_value());
+    EXPECT_EQ(name_result.value(), "Test");
+}
+
+// Same subject name in different contexts should not collide.
+TEST_F(ProtobufSchemaReferencesTest, SameSubjectDifferentContexts) {
+    auto dep_ctx_a = context_subject{context{".ctx_a"}, subject{"dep"}};
+    auto dep_ctx_b = context_subject{context{".ctx_b"}, subject{"dep"}};
+
+    insert(
+      dep_ctx_a,
+      schema_definition{
+        R"(syntax = "proto3"; message Dep { string a = 1; })",
+        schema_type::protobuf},
+      schema_version{1});
+
+    insert(
+      dep_ctx_b,
+      schema_definition{
+        R"(syntax = "proto3"; message Dep { int32 b = 1; })",
+        schema_type::protobuf},
+      schema_version{1});
+
+    // Reference dep from ctx_a
+    auto test_schema = R"(syntax = "proto3";
+import "dep.proto";
+message Test { Dep d = 1; })";
+    auto schema_a = make_protobuf_schema_definition(
+                      _store,
+                      subject_schema{
+                        context_subject{context{".ctx_a"}, subject{"test"}},
+                        schema_definition{
+                          test_schema,
+                          schema_type::protobuf,
+                          {{"dep.proto", dep_ctx_a, schema_version{1}}},
+                          {}}})
+                      .get();
+
+    // Reference dep from ctx_b
+    auto schema_b = make_protobuf_schema_definition(
+                      _store,
+                      subject_schema{
+                        context_subject{context{".ctx_b"}, subject{"test"}},
+                        schema_definition{
+                          test_schema,
+                          schema_type::protobuf,
+                          {{"dep.proto", dep_ctx_b, schema_version{1}}},
+                          {}}})
+                      .get();
+
+    auto name_a = schema_a.name({0});
+    auto name_b = schema_b.name({0});
+    ASSERT_TRUE(name_a.has_value());
+    ASSERT_TRUE(name_b.has_value());
+    EXPECT_EQ(name_a.value(), "Test");
+    EXPECT_EQ(name_b.value(), "Test");
+}
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/test/protobuf_utils.cc
+++ b/src/v/pandaproxy/schema_registry/test/protobuf_utils.cc
@@ -17,9 +17,9 @@ namespace pps = pp::schema_registry;
 
 namespace pandaproxy::schema_registry::test_utils {
 
-ss::sstring make_proto_schema(const pps::subject& sub, int n_fields) {
+ss::sstring make_proto_schema(const pps::context_subject& sub, int n_fields) {
     ss::sstring body = ss::format(
-      "syntax = \"proto3\";\nmessage MyType{} {{\n", sub);
+      "syntax = \"proto3\";\nmessage MyType{} {{\n", sub.to_string());
     for (int32_t i = 1; i <= n_fields; ++i) {
         body += ss::format("\tint32 i{} = {};\n", i, i);
     }

--- a/src/v/pandaproxy/schema_registry/test/protobuf_utils.h
+++ b/src/v/pandaproxy/schema_registry/test/protobuf_utils.h
@@ -16,7 +16,7 @@ namespace pps = pp::schema_registry;
 
 namespace pandaproxy::schema_registry::test_utils {
 
-ss::sstring make_proto_schema(const pps::subject& sub, int n_fields);
+ss::sstring make_proto_schema(const pps::context_subject& sub, int n_fields);
 
 std::string sanitize(
   std::string_view raw_proto,

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -12,15 +12,18 @@
 #include "pandaproxy/json/rjson_util.h"
 #include "pandaproxy/schema_registry/types.h"
 
-#include <boost/test/unit_test.hpp>
-#include <fmt/format.h>
+#include <fmt/core.h>
+#include <gtest/gtest.h>
 
 #include <optional>
 
-namespace ppj = pandaproxy::json;
-namespace pps = pandaproxy::schema_registry;
+namespace pandaproxy::schema_registry {
 
-constexpr std::string_view avro_schema_key_sv{
+namespace {
+
+namespace ppj = pandaproxy::json;
+
+constexpr std::string_view schema_key_sv{
   R"({
   "keytype": "SCHEMA",
   "subject": "my-kafka-value",
@@ -29,14 +32,14 @@ constexpr std::string_view avro_schema_key_sv{
   "seq": 42,
   "node": 2
 })"};
-const pps::schema_key avro_schema_key{
+const auto expected_schema_key = schema_key{
   .seq{model::offset{42}},
   .node{model::node_id{2}},
-  .sub{pps::subject{"my-kafka-value"}},
-  .version{pps::schema_version{1}},
-  .magic{pps::topic_key_magic{1}}};
+  .sub{subject{"my-kafka-value"}},
+  .version{schema_version{1}},
+  .magic{topic_key_magic{1}}};
 
-constexpr std::string_view avro_schema_value_sv{
+constexpr std::string_view schema_value_sv{
   R"({
   "subject": "my-kafka-value",
   "version": 1,
@@ -47,17 +50,17 @@ constexpr std::string_view avro_schema_value_sv{
   "schema": "{\"type\":\"string\"}",
   "deleted": true
 })"};
-const pps::schema_value avro_schema_value{
+const auto expected_schema_value = schema_value{
   .schema{
-    pps::subject{"my-kafka-value"},
-    pps::schema_definition{
+    subject{"my-kafka-value"},
+    schema_definition{
       R"({"type":"string"})",
-      pps::schema_type::avro,
-      {{{"name"}, pps::subject{"subject"}, pps::schema_version{1}}},
+      schema_type::avro,
+      {{{"name"}, subject{"subject"}, schema_version{1}}},
       {}}},
-  .version{pps::schema_version{1}},
-  .id{pps::schema_id{1}},
-  .deleted = pps::is_deleted::yes};
+  .version{schema_version{1}},
+  .id{schema_id{1}},
+  .deleted = is_deleted::yes};
 
 constexpr std::string_view config_key_sv{
   R"({
@@ -67,11 +70,11 @@ constexpr std::string_view config_key_sv{
   "seq": 0,
   "node": 0
 })"};
-const pps::config_key config_key{
+const auto expected_config_key = config_key{
   .seq{model::offset{0}},
   .node{model::node_id{0}},
   .sub{},
-  .magic{pps::topic_key_magic{0}}};
+  .magic{topic_key_magic{0}}};
 
 constexpr std::string_view config_key_sub_sv{
   R"({
@@ -81,28 +84,27 @@ constexpr std::string_view config_key_sub_sv{
   "seq": 0,
   "node": 0
 })"};
-const pps::config_key config_key_sub{
+const auto expected_config_key_sub = config_key{
   .seq{model::offset{0}},
   .node{model::node_id{0}},
-  .sub{pps::subject{"my-kafka-value"}},
-  .magic{pps::topic_key_magic{0}}};
+  .sub{subject{"my-kafka-value"}},
+  .magic{topic_key_magic{0}}};
 
 constexpr std::string_view config_value_sv{
   R"({
   "compatibilityLevel": "FORWARD_TRANSITIVE"
 })"};
-const pps::config_value config_value{
-  .compat = pps::compatibility_level::forward_transitive};
+const auto expected_config_value = config_value{
+  .compat = compatibility_level::forward_transitive};
 
 constexpr std::string_view config_value_sub_sv{
   R"({
   "subject": "my-kafka-value",
   "compatibilityLevel": "FORWARD_TRANSITIVE"
 })"};
-const pps::config_value config_value_sub{
-
-  .compat = pps::compatibility_level::forward_transitive,
-  .sub{pps::subject{"my-kafka-value"}}};
+const auto expected_config_value_sub = config_value{
+  .compat = compatibility_level::forward_transitive,
+  .sub{subject{"my-kafka-value"}}};
 
 constexpr std::string_view delete_subject_key_sv{
   R"({
@@ -112,94 +114,95 @@ constexpr std::string_view delete_subject_key_sv{
   "seq": 42,
   "node": 2
 })"};
-const pps::delete_subject_key delete_subject_key{
+const auto expected_delete_subject_key = delete_subject_key{
   .seq{model::offset{42}},
   .node{model::node_id{2}},
-  .sub{pps::subject{"my-kafka-value"}}};
+  .sub{subject{"my-kafka-value"}}};
 
 constexpr std::string_view delete_subject_value_sv{
   R"({
   "subject": "my-kafka-value"
 })"};
-const pps::delete_subject_value delete_subject_value{
-  .sub{pps::subject{"my-kafka-value"}}};
+const auto expected_delete_subject_value = delete_subject_value{
+  .sub{subject{"my-kafka-value"}}};
 
-BOOST_AUTO_TEST_CASE(test_storage_serde) {
+} // namespace
+
+TEST(StorageTest, Serde) {
     {
         auto key = ppj::impl::rjson_parse(
-          avro_schema_key_sv.data(), pps::schema_key_handler<>{});
-        BOOST_CHECK_EQUAL(avro_schema_key, key);
+          schema_key_sv.data(), schema_key_handler<>{});
+        EXPECT_EQ(expected_schema_key, key);
 
-        auto str = ppj::rjson_serialize_str(avro_schema_key);
-        BOOST_CHECK_EQUAL(str, ::json::minify(avro_schema_key_sv));
+        auto str = ppj::rjson_serialize_str(expected_schema_key);
+        EXPECT_EQ(str, ::json::minify(schema_key_sv));
     }
 
     {
         auto val = ppj::impl::rjson_parse(
-          avro_schema_value_sv.data(), pps::schema_value_handler{});
-        BOOST_CHECK_EQUAL(avro_schema_value, val);
+          schema_value_sv.data(), schema_value_handler{});
+        EXPECT_EQ(expected_schema_value, val);
 
-        auto str = ppj::rjson_serialize_str(avro_schema_value);
-        BOOST_CHECK_EQUAL(str, ::json::minify(avro_schema_value_sv));
+        auto str = ppj::rjson_serialize_str(expected_schema_value);
+        EXPECT_EQ(str, ::json::minify(schema_value_sv));
     }
 
     {
         auto val = ppj::impl::rjson_parse(
-          config_key_sv.data(), pps::config_key_handler<>{});
-        BOOST_CHECK_EQUAL(config_key, val);
+          config_key_sv.data(), config_key_handler<>{});
+        EXPECT_EQ(expected_config_key, val);
 
-        auto str = ppj::rjson_serialize_str(config_key);
-        BOOST_CHECK_EQUAL(str, ::json::minify(config_key_sv));
+        auto str = ppj::rjson_serialize_str(expected_config_key);
+        EXPECT_EQ(str, ::json::minify(config_key_sv));
     }
 
     {
         auto val = ppj::impl::rjson_parse(
-          config_key_sub_sv.data(), pps::config_key_handler<>{});
-        BOOST_CHECK_EQUAL(config_key_sub, val);
+          config_key_sub_sv.data(), config_key_handler<>{});
+        EXPECT_EQ(expected_config_key_sub, val);
 
-        auto str = ppj::rjson_serialize_str(config_key_sub);
-        BOOST_CHECK_EQUAL(str, ::json::minify(config_key_sub_sv));
+        auto str = ppj::rjson_serialize_str(expected_config_key_sub);
+        EXPECT_EQ(str, ::json::minify(config_key_sub_sv));
     }
 
     {
         auto val = ppj::impl::rjson_parse(
-          config_value_sv.data(), pps::config_value_handler<>{});
-        BOOST_CHECK_EQUAL(config_value, val);
+          config_value_sv.data(), config_value_handler<>{});
+        EXPECT_EQ(expected_config_value, val);
 
-        auto str = ppj::rjson_serialize_str(config_value);
-        BOOST_CHECK_EQUAL(str, ::json::minify(config_value_sv));
+        auto str = ppj::rjson_serialize_str(expected_config_value);
+        EXPECT_EQ(str, ::json::minify(config_value_sv));
     }
 
     {
         auto val = ppj::impl::rjson_parse(
-          config_value_sub_sv.data(), pps::config_value_handler<>{});
-        BOOST_CHECK_EQUAL(config_value_sub, val);
+          config_value_sub_sv.data(), config_value_handler<>{});
+        EXPECT_EQ(expected_config_value_sub, val);
 
-        auto str = ppj::rjson_serialize_str(config_value_sub);
-        BOOST_CHECK_EQUAL(str, ::json::minify(config_value_sub_sv));
+        auto str = ppj::rjson_serialize_str(expected_config_value_sub);
+        EXPECT_EQ(str, ::json::minify(config_value_sub_sv));
     }
 
     {
         auto val = ppj::impl::rjson_parse(
-          delete_subject_key_sv.data(), pps::delete_subject_key_handler<>{});
-        BOOST_CHECK_EQUAL(delete_subject_key, val);
+          delete_subject_key_sv.data(), delete_subject_key_handler<>{});
+        EXPECT_EQ(expected_delete_subject_key, val);
 
-        auto str = ppj::rjson_serialize_str(delete_subject_key);
-        BOOST_CHECK_EQUAL(str, ::json::minify(delete_subject_key_sv));
+        auto str = ppj::rjson_serialize_str(expected_delete_subject_key);
+        EXPECT_EQ(str, ::json::minify(delete_subject_key_sv));
     }
 
     {
         auto val = ppj::impl::rjson_parse(
-          delete_subject_value_sv.data(),
-          pps::delete_subject_value_handler<>{});
-        BOOST_CHECK_EQUAL(delete_subject_value, val);
+          delete_subject_value_sv.data(), delete_subject_value_handler<>{});
+        EXPECT_EQ(expected_delete_subject_value, val);
 
-        auto str = ppj::rjson_serialize_str(delete_subject_value);
-        BOOST_CHECK_EQUAL(str, ::json::minify(delete_subject_value_sv));
+        auto str = ppj::rjson_serialize_str(expected_delete_subject_value);
+        EXPECT_EQ(str, ::json::minify(delete_subject_value_sv));
     }
 }
 
-BOOST_AUTO_TEST_CASE(test_storage_serde_metadata) {
+TEST(StorageTest, SerdeMetadata) {
     const auto make_schema = [](std::optional<std::string_view> metadata) {
         constexpr std::string_view fmt_schema{
           R"({{
@@ -218,47 +221,46 @@ BOOST_AUTO_TEST_CASE(test_storage_serde_metadata) {
     {
         auto no_metadata = make_schema(std::nullopt);
         auto val = ppj::impl::rjson_parse(
-          no_metadata.data(), pps::schema_value_handler<>{});
-        BOOST_CHECK_EQUAL(
-          ppj::rjson_serialize_str(val), ::json::minify(no_metadata));
-        BOOST_CHECK(!val.schema.def().meta().has_value());
+          no_metadata.data(), schema_value_handler<>{});
+        EXPECT_EQ(ppj::rjson_serialize_str(val), ::json::minify(no_metadata));
+        EXPECT_FALSE(val.schema.def().meta().has_value());
     }
     {
         auto null_metadata = make_schema("null");
         auto val = ppj::impl::rjson_parse(
-          null_metadata.data(), pps::schema_value_handler<>{});
-        BOOST_CHECK(!val.schema.def().meta().has_value());
+          null_metadata.data(), schema_value_handler<>{});
+        EXPECT_FALSE(val.schema.def().meta().has_value());
     }
     {
         auto empty_metadata = make_schema("{}");
         auto val = ppj::impl::rjson_parse(
-          empty_metadata.data(), pps::schema_value_handler<>{});
-        BOOST_CHECK_EQUAL(
+          empty_metadata.data(), schema_value_handler<>{});
+        EXPECT_EQ(
           ppj::rjson_serialize_str(val), ::json::minify(empty_metadata));
-        BOOST_CHECK(val.schema.def().meta().has_value());
-        BOOST_CHECK(!val.schema.def().meta()->properties.has_value());
+        EXPECT_TRUE(val.schema.def().meta().has_value());
+        EXPECT_FALSE(val.schema.def().meta()->properties.has_value());
     }
     {
         auto null_metadata_properties = make_schema(R"({
     "properties": null
   })");
         auto val = ppj::impl::rjson_parse(
-          null_metadata_properties.data(), pps::schema_value_handler<>{});
-        BOOST_CHECK(val.schema.def().meta().has_value());
-        BOOST_CHECK(!val.schema.def().meta()->properties.has_value());
+          null_metadata_properties.data(), schema_value_handler<>{});
+        EXPECT_TRUE(val.schema.def().meta().has_value());
+        EXPECT_FALSE(val.schema.def().meta()->properties.has_value());
     }
     {
         auto empty_metadata_properties = make_schema(R"({
     "properties": {}
   })");
         auto val = ppj::impl::rjson_parse(
-          empty_metadata_properties.data(), pps::schema_value_handler<>{});
-        BOOST_CHECK_EQUAL(
+          empty_metadata_properties.data(), schema_value_handler<>{});
+        EXPECT_EQ(
           ppj::rjson_serialize_str(val),
           ::json::minify(empty_metadata_properties));
-        BOOST_CHECK(val.schema.def().meta().has_value());
-        BOOST_CHECK(val.schema.def().meta()->properties.has_value());
-        BOOST_CHECK(val.schema.def().meta()->properties->empty());
+        EXPECT_TRUE(val.schema.def().meta().has_value());
+        EXPECT_TRUE(val.schema.def().meta()->properties.has_value());
+        EXPECT_TRUE(val.schema.def().meta()->properties->empty());
     }
     {
         auto metadata_properties = make_schema(R"({
@@ -268,11 +270,13 @@ BOOST_AUTO_TEST_CASE(test_storage_serde_metadata) {
     }
   })");
         auto val = ppj::impl::rjson_parse(
-          metadata_properties.data(), pps::schema_value_handler<>{});
-        BOOST_CHECK_EQUAL(
+          metadata_properties.data(), schema_value_handler<>{});
+        EXPECT_EQ(
           ppj::rjson_serialize_str(val), ::json::minify(metadata_properties));
-        BOOST_CHECK(val.schema.def().meta().has_value());
-        BOOST_CHECK(val.schema.def().meta()->properties.has_value());
-        BOOST_CHECK_EQUAL(val.schema.def().meta()->properties->size(), 2);
+        EXPECT_TRUE(val.schema.def().meta().has_value());
+        EXPECT_TRUE(val.schema.def().meta()->properties.has_value());
+        EXPECT_EQ(val.schema.def().meta()->properties->size(), 2);
     }
 }
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -35,7 +35,7 @@ constexpr std::string_view schema_key_sv{
 const auto expected_schema_key = schema_key{
   .seq{model::offset{42}},
   .node{model::node_id{2}},
-  .sub{subject{"my-kafka-value"}},
+  .sub{context_subject{"my-kafka-value"}},
   .version{schema_version{1}},
   .magic{topic_key_magic{1}}};
 
@@ -276,6 +276,110 @@ TEST(StorageTest, SerdeMetadata) {
         EXPECT_TRUE(val.schema.def().meta().has_value());
         EXPECT_TRUE(val.schema.def().meta()->properties.has_value());
         EXPECT_EQ(val.schema.def().meta()->properties->size(), 2);
+    }
+}
+
+TEST(StorageTest, SerdeContextSubject) {
+    // Test schema_key with context_subject (qualified format)
+    {
+        constexpr std::string_view schema_key_ctx_sv{
+          R"({
+  "keytype": "SCHEMA",
+  "subject": ":.my-context:my-kafka-value",
+  "version": 1,
+  "magic": 1,
+  "seq": 42,
+  "node": 2
+})"};
+        const auto expected_schema_key_ctx = schema_key{
+          .seq{model::offset{42}},
+          .node{model::node_id{2}},
+          .sub{context{".my-context"}, subject{"my-kafka-value"}},
+          .version{schema_version{1}},
+          .magic{topic_key_magic{1}}};
+
+        auto key = ppj::impl::rjson_parse(
+          schema_key_ctx_sv.data(), schema_key_handler<>{});
+        EXPECT_EQ(expected_schema_key_ctx, key);
+
+        auto str = ppj::rjson_serialize_str(expected_schema_key_ctx);
+        EXPECT_EQ(str, ::json::minify(schema_key_ctx_sv));
+    }
+
+    // Test schema_value with context_subject and reference with context_subject
+    {
+        constexpr std::string_view schema_value_ctx_sv{
+          R"({
+  "subject": ":.my-context:my-kafka-value",
+  "version": 1,
+  "id": 1,
+  "references": [
+    {"name": "ref-name", "subject": ":.ref-context:ref-subject", "version": 2}
+  ],
+  "schema": "{\"type\":\"string\"}",
+  "deleted": false
+})"};
+        const auto expected_schema_value_ctx = schema_value{
+          .schema{
+            context_subject{context{".my-context"}, subject{"my-kafka-value"}},
+            schema_definition{
+              R"({"type":"string"})",
+              schema_type::avro,
+              {{{"ref-name"},
+                context_subject{
+                  context{".ref-context"}, subject{"ref-subject"}},
+                schema_version{2}}},
+              {}}},
+          .version{schema_version{1}},
+          .id{schema_id{1}},
+          .deleted = is_deleted::no};
+
+        auto val = ppj::impl::rjson_parse(
+          schema_value_ctx_sv.data(), schema_value_handler{});
+        EXPECT_EQ(expected_schema_value_ctx, val);
+
+        auto str = ppj::rjson_serialize_str(expected_schema_value_ctx);
+        EXPECT_EQ(str, ::json::minify(schema_value_ctx_sv));
+    }
+
+    // Test delete_subject_key with context_subject
+    {
+        constexpr std::string_view delete_key_ctx_sv{
+          R"({
+  "keytype": "DELETE_SUBJECT",
+  "subject": ":.del-context:my-kafka-value",
+  "magic": 0,
+  "seq": 42,
+  "node": 2
+})"};
+        const auto expected_delete_key_ctx = delete_subject_key{
+          .seq{model::offset{42}},
+          .node{model::node_id{2}},
+          .sub{context{".del-context"}, subject{"my-kafka-value"}}};
+
+        auto key = ppj::impl::rjson_parse(
+          delete_key_ctx_sv.data(), delete_subject_key_handler<>{});
+        EXPECT_EQ(expected_delete_key_ctx, key);
+
+        auto str = ppj::rjson_serialize_str(expected_delete_key_ctx);
+        EXPECT_EQ(str, ::json::minify(delete_key_ctx_sv));
+    }
+
+    // Test delete_subject_value with context_subject
+    {
+        constexpr std::string_view delete_value_ctx_sv{
+          R"({
+  "subject": ":.del-context:my-kafka-value"
+})"};
+        const auto expected_delete_value_ctx = delete_subject_value{
+          .sub{context{".del-context"}, subject{"my-kafka-value"}}};
+
+        auto val = ppj::impl::rjson_parse(
+          delete_value_ctx_sv.data(), delete_subject_value_handler<>{});
+        EXPECT_EQ(expected_delete_value_ctx, val);
+
+        auto str = ppj::rjson_serialize_str(expected_delete_value_ctx);
+        EXPECT_EQ(str, ::json::minify(delete_value_ctx_sv));
     }
 }
 

--- a/src/v/pandaproxy/schema_registry/test/store_fixture.cc
+++ b/src/v/pandaproxy/schema_registry/test/store_fixture.cc
@@ -26,7 +26,7 @@ store_fixture::~store_fixture() {
 }
 
 schema_id store_fixture::insert(
-  const subject& sub,
+  const context_subject& sub,
   const schema_definition& schema_def,
   schema_version version) {
     const auto id = _next_id++;

--- a/src/v/pandaproxy/schema_registry/test/store_fixture.h
+++ b/src/v/pandaproxy/schema_registry/test/store_fixture.h
@@ -26,7 +26,7 @@ public:
     store_fixture& operator=(store_fixture&&) = delete;
 
     schema_id insert(
-      const subject& sub,
+      const context_subject& sub,
       const schema_definition& schema_def,
       schema_version version);
 

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -418,8 +418,6 @@ public:
         return {raw(), type(), refs().copy(), meta()};
     }
 
-    ss::sstring name() const;
-
     // retrieve "title" property from the schema, used to form the record name
     std::optional<ss::sstring> title() const;
 

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -611,13 +611,13 @@ struct stored_schema {
 ///\brief A mapping of version and schema id for a subject.
 struct subject_version_entry {
     subject_version_entry(
-      schema_version version, context_schema_id id, is_deleted deleted)
+      schema_version version, schema_id id, is_deleted deleted)
       : version{version}
-      , id{std::move(id)}
+      , id{id}
       , deleted(deleted) {}
 
     schema_version version;
-    context_schema_id id;
+    schema_id id;
     is_deleted deleted{is_deleted::no};
 };
 

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -570,7 +570,7 @@ class subject_schema {
 public:
     subject_schema() = default;
 
-    subject_schema(subject sub, schema_definition def)
+    subject_schema(context_subject sub, schema_definition def)
       : _sub{std::move(sub)}
       , _def{std::move(def)} {}
 
@@ -580,7 +580,7 @@ public:
     friend std::ostream&
     operator<<(std::ostream& os, const subject_schema& schema);
 
-    const subject& sub() const { return _sub; }
+    const context_subject& sub() const { return _sub; }
     schema_type type() const { return _def.type(); }
     const schema_definition& def() const { return _def; }
 
@@ -588,11 +588,11 @@ public:
     subject_schema copy() const { return {sub(), def().copy()}; }
 
     auto destructure() && {
-        return make_tuple(std::move(_sub), std::move(_def));
+        return std::make_tuple(std::move(_sub), std::move(_def));
     }
 
 private:
-    subject _sub{invalid_subject};
+    context_subject _sub{invalid_subject};
     schema_definition _def{"", schema_type::avro, {}, {}};
 };
 

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -224,7 +224,7 @@ struct schema_reference {
     operator<(const schema_reference& lhs, const schema_reference& rhs);
 
     ss::sstring name;
-    subject sub{invalid_subject};
+    context_subject sub{invalid_subject};
     schema_version version{invalid_schema_version};
 };
 

--- a/src/v/wasm/schema_registry_module.cc
+++ b/src/v/wasm/schema_registry_module.cc
@@ -60,7 +60,7 @@ void write_encoded_schema_def(
     w->append(def.refs().size());
     for (const auto& ref : def.refs()) {
         w->append_with_length(ref.name);
-        w->append_with_length(ref.sub());
+        w->append_with_length(ref.sub.to_string());
         w->append(ref.version());
     }
 }


### PR DESCRIPTION
This PR continues making the Schema Registry context-aware by migrating the seq_writer layer and storage serialization in preparation for schema registry context support.

There are no user-visible changes in this PR, since all handlers still operate in the default context.

### The key changes are:
- move more types in `types.h` to be context-aware, which requires changes in various places in the schema registry codebase
- moving `schema` type records to store a qualified subject

### Still future work:
- the handling of mode and config changes is a bit more involved, so they are left context-unaware for now (both in store.h and seq_writer), and there is a follow up ticket to implement making them context-aware end-to-end (CORE-15187)

With these sets of changes, apart from the config/mode-related future work, `bazel build //src/v/pandaproxy/schema_registry:core` (store, sharded_store, storage, seq_writer) compiles even without the implicit constructors of `context_subject` and `context_schema_id`.

Fixes https://redpandadata.atlassian.net/browse/CORE-15179

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
