### PR TITLE
`ssx`: add `if constexpr` check around use of `yield_called()`

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -68,7 +68,7 @@ static constexpr auto L0_replicate_default_timeout = 1s;
 // The default `async_algo_traits::interval` value of `100` seems a bit too high
 // to reliably prevent reactor stalls in the `convert_to_placeholders()` loop.
 // Use this lower value instead.
-struct convert_to_placeholders_loop_traits : ssx::async_algo_traits {
+struct convert_to_placeholders_loop_traits {
     static constexpr ssize_t interval = 10;
 };
 

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -40,7 +40,7 @@ using consensus_set = heartbeat_manager::consensus_set;
 // async_for_each_counter trait for gathering heartbeats
 // cost is 1 per raft group, and each raft group will have on average 3ish
 // followers. This should yield around every 100 followers
-struct loop_traits : ssx::async_algo_traits {
+struct loop_traits {
     static constexpr ssize_t interval = 30;
 };
 

--- a/src/v/ssx/async_algorithm.h
+++ b/src/v/ssx/async_algorithm.h
@@ -40,6 +40,15 @@
 
 namespace ssx {
 
+namespace detail {
+
+template<typename T>
+concept HasYieldCalled = requires {
+    { T::yield_called() } -> std::same_as<void>;
+};
+
+} // namespace detail
+
 struct async_counter {
     // internal details, don't rely on the values
     ssize_t count = 0;
@@ -143,7 +152,9 @@ async_for_each_coro(Counter counter, Iterator begin, EndIterator end, Fn f) {
         if (counter.count >= Traits::interval) {
             co_await ss::coroutine::maybe_yield();
             counter.count = 0;
-            Traits::yield_called();
+            if constexpr (detail::HasYieldCalled<Traits>) {
+                Traits::yield_called();
+            }
         }
     } while (begin != end);
 }
@@ -397,7 +408,9 @@ ss::future<> async_while_counter(async_counter& counter, Cond cond, Fn f) {
         if (!stop && counter.count >= Traits::interval) {
             co_await ss::coroutine::maybe_yield();
             counter.count = 0;
-            Traits::yield_called();
+            if constexpr (detail::HasYieldCalled<Traits>) {
+                Traits::yield_called();
+            }
         }
     }
 }


### PR DESCRIPTION
This isn't used much outside of testing, so why not hide the cost for explicitly specialized use cases.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
