### PR TITLE
Controller Force Reconfiguration Longest Log Test

### DIFF
--- a/tests/rptest/tests/controller_forced_reconfiguration_test.py
+++ b/tests/rptest/tests/controller_forced_reconfiguration_test.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from enum import Enum
 from random import shuffle
 from rptest.clients.kcl import KCL
+import threading
 from typing import Any, Optional
 
 from ducktape.cluster.cluster import ClusterNode
@@ -868,3 +869,151 @@ class ControllerForcedReconfiguration_Size5(
         producer.wait(timeout_sec=medium_timeout.timeout_s)
         status = producer.produce_status
         assert status.sent == 3000
+
+
+class ControllerForcedReconfiguration_Size6(
+    ControllerForceReconfigurationTestBase, PartitionMovementMixin
+):
+    cluster_size: int = 6
+
+    def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any):
+        super(ControllerForcedReconfiguration_Size6, self).__init__(
+            test_context,
+            cluster_size=ControllerForcedReconfiguration_Size6.cluster_size,
+            *args,
+            **kwargs,
+        )
+
+    @cluster(num_nodes=6)
+    def test_longest_log(self):
+        """
+        This test will ensure that the longest log is always chosen.
+        The scheme is as follows:
+          Node ids:
+           1  2  3  4  5  6
+        A [1  2  3  4  5  6] -> will receive the creation of topic "all"
+        B             [5  6] -> will be shut down
+        C [1  2  3  4]       -> will receive the creation of topic "some"
+        D    [2  3  4]       -> will be shut down
+        E             [5  6] -> will be started up
+        F [1           5  6] -> will receive a cfr command
+        G then we check that the resultant post CFR cluster contains all and some
+          after new leader election
+        """
+
+        """constants"""
+        cluster_size: int = ControllerForcedReconfiguration_Size6.cluster_size
+        all_topic_spec = TopicSpec(name="all", replication_factor=3, partition_count=3)
+        some_topic_spec = TopicSpec(
+            name="some", replication_factor=3, partition_count=3
+        )
+        designated_survivor_id = 1
+        step_b_shut_down_ids = [5, 6]
+        step_d_shut_down_ids = [2, 3, 4]
+        step_e_start_up_ids = step_b_shut_down_ids
+        step_f_survivor_ids = step_e_start_up_ids.copy()
+        step_f_survivor_ids.append(designated_survivor_id)
+        step_f_dead_ids = step_d_shut_down_ids
+
+        admin = AdminV2(self.redpanda)
+        _ = self._start_redpanda(cluster_size=cluster_size)
+
+        step_b_shut_down_nodes = [
+            self.redpanda.node_by_id(node_id) for node_id in step_b_shut_down_ids
+        ]
+        step_d_shut_down_nodes = [
+            self.redpanda.node_by_id(node_id) for node_id in step_d_shut_down_ids
+        ]
+        step_e_start_up_nodes = [
+            self.redpanda.node_by_id(node_id) for node_id in step_e_start_up_ids
+        ]
+        step_f_survivor_nodes = [
+            self.redpanda.node_by_id(node_id) for node_id in step_f_survivor_ids
+        ]
+
+        """ step A: all receive the creation of topic"""
+        self.client().create_topic(all_topic_spec)
+
+        """ step B: stop step_b_shut_down_nodes """
+        for stop_node in step_b_shut_down_nodes:
+            self.redpanda.stop_node(stop_node, timeout=really_short_timeout.timeout_s)
+
+        """ step C: create topic some"""
+        self.client().create_topic(some_topic_spec)
+
+        """ step D: stop step_d_shut_down_nodes """
+        for stop_node in step_d_shut_down_nodes:
+            self.redpanda.stop_node(stop_node, timeout=really_short_timeout.timeout_s)
+
+        """ step E: start step_e_start_up_nodes """
+        for start_node in step_e_start_up_nodes:
+            self.redpanda.start_node(start_node, timeout=short_timeout.timeout_s)
+
+        """ step F: CFR the surviving nodes"""
+
+        """ bulk reboot into recovery mode """
+        self._bulk_toggle_recovery_mode(
+            nodes=step_f_survivor_nodes,
+            timeout=medium_timeout,
+            recovery_mode_enabled=True,
+        )
+
+        """ do CFR requests """
+        self.redpanda.logger.debug("beginning CFR requests")
+        cfr_threads: list[threading.Thread] = []
+        for survivor in step_f_survivor_nodes:
+
+            def execute_cfr_against_node():
+                # concurrency: survivor will change definition
+                local_survivor_id = self.redpanda.node_id(survivor)
+                local_survivor = self.redpanda.get_node_by_id(local_survivor_id)
+                self.redpanda.logger.debug(
+                    f"cfr on node {local_survivor.name} with id {local_survivor_id}"
+                )
+                breaklgass_client = admin.breakglass(node=local_survivor)
+                request = breakglass_pb2.ControllerForcedReconfigurationRequest(
+                    dead_node_ids=step_f_dead_ids,
+                    surviving_node_count=len(step_f_survivor_ids),
+                )
+                result = self._do_request(breaklgass_client, request)
+                self.redpanda.logger.debug(
+                    f"CFR request on {local_survivor.name} finished"
+                )
+
+                error = result.error()
+                if error is not None:
+                    # this happens when there are multiple candidate leaders
+                    # and one wins the election before all cfr requests have been finished
+                    if "use the existing controller leader" in error.message:
+                        return
+                    error_message = f"CFR request on node {local_survivor.name} failed with error {result.error()}"
+                    self.redpanda.logger.info(error_message)
+                    assert False, error_message
+
+            cfr_thread = threading.Thread(target=execute_cfr_against_node)
+            cfr_thread.start()
+            cfr_threads.append(cfr_thread)
+
+        for cfr_thread in cfr_threads:
+            cfr_thread.join()
+
+        def controller_available():
+            controller = self.redpanda.controller()
+            return (
+                controller is not None
+                and self.redpanda.node_id(controller) not in step_f_dead_ids
+            )
+
+        self.redpanda.logger.debug("waiting for controller to recover")
+        wait_until(
+            lambda: controller_available(),
+            timeout_sec=long_timeout.timeout_s,
+            backoff_sec=long_timeout.backoff_s,
+            err_msg="Controller never came back",
+        )
+        self.redpanda.logger.debug("controller recovered")
+
+        """ step G: ensure 'some' is in the topic list """
+        rpk = RpkTool(self.redpanda)
+        assert "some" in rpk.list_topics()
+        assert int(self.redpanda.node_id(self.redpanda.controller())) == 1

--- a/tests/rptest/tests/controller_forced_reconfiguration_test.py
+++ b/tests/rptest/tests/controller_forced_reconfiguration_test.py
@@ -442,6 +442,55 @@ class ControllerForceReconfigurationTestBase(RedpandaTest):
             topic=ntp.topic, partition=ntp.partition, replicas=new_replicas
         )
 
+    def _execute_cfr_against_node(
+        self,
+        survivor: ClusterNode,
+        admin: AdminV2,
+        dead_node_ids: list[int],
+        surviving_node_count: int,
+    ):
+        """Execute a CFR request against a specific node"""
+        survivor_id = self.redpanda.node_id(survivor)
+        self.redpanda.logger.debug(f"cfr on node {survivor.name} with id {survivor_id}")
+        breakglass_client = admin.breakglass(node=survivor)
+        request = breakglass_pb2.ControllerForcedReconfigurationRequest(
+            dead_node_ids=dead_node_ids,
+            surviving_node_count=surviving_node_count,
+        )
+        result = self._do_request(breakglass_client, request)
+        self.redpanda.logger.debug(f"CFR request on {survivor.name} finished")
+
+        error = result.error()
+        if error is not None:
+            # this happens when there are multiple candidate leaders
+            # and one wins the election before all cfr requests have been finished
+            if "use the existing controller leader" in error.message:
+                return
+            error_message = f"CFR request on node {survivor.name} failed with error {result.error()}"
+            self.redpanda.logger.info(error_message)
+            assert False, error_message
+
+    def _execute_cfr_requests_parallel(
+        self,
+        nodes: list[ClusterNode],
+        admin: AdminV2,
+        dead_node_ids: list[int],
+        surviving_node_count: int,
+    ):
+        """Execute CFR requests in parallel against multiple nodes using threads"""
+        self.redpanda.logger.debug("beginning CFR requests")
+        cfr_threads: list[threading.Thread] = []
+        for survivor in nodes:
+            cfr_thread = threading.Thread(
+                target=self._execute_cfr_against_node,
+                args=(survivor, admin, dead_node_ids, surviving_node_count),
+            )
+            cfr_thread.start()
+            cfr_threads.append(cfr_thread)
+
+        for cfr_thread in cfr_threads:
+            cfr_thread.join()
+
 
 class ControllerForcedReconfiguration_SmokeTest(
     ControllerForceReconfigurationTestBase, PartitionMovementMixin
@@ -516,16 +565,12 @@ class ControllerForcedReconfiguration_SmokeTest(
             recovery_mode_enabled=True,
         )
 
-        self.redpanda.logger.debug("beginning CFR request")
-        breakgass_client = admin.breakglass(node=designated_survivor)
-        request = breakglass_pb2.ControllerForcedReconfigurationRequest(
-            dead_node_ids=killed_node_ids, surviving_node_count=1
+        self._execute_cfr_requests_parallel(
+            nodes=[designated_survivor],
+            admin=admin,
+            dead_node_ids=killed_node_ids,
+            surviving_node_count=1,
         )
-        result = self._do_request(breakgass_client, request)
-        self.redpanda.logger.debug("CFR request finished")
-
-        error = result.error()
-        assert error is None, f"CFR request failed with error {result.error()}"
 
         def controller_available():
             controller = self.redpanda.controller()
@@ -735,24 +780,12 @@ class ControllerForcedReconfiguration_Size5(
         )
 
         """ meat 3: CFR requests"""
-        self.redpanda.logger.debug("beginning CFR requests")
-        for survivor in designated_survivors:
-            self.redpanda.logger.debug(f"cfr on node {survivor.name}")
-            breakgass_client = admin.breakglass(node=survivor)
-            request = breakglass_pb2.ControllerForcedReconfigurationRequest(
-                dead_node_ids=killed_node_ids,
-                surviving_node_count=len(designated_survivors),
-            )
-            result = self._do_request(breakgass_client, request)
-            self.redpanda.logger.debug("CFR request finished")
-
-            error = result.error()
-            if error is not None:
-                # this happens when there are multiple candidate leaders
-                # and one wins the election before all cfr requests have been finished
-                if "use the existing controller leader" in error.message:
-                    continue
-                assert False, f"CFR request failed with error {result.error()}"
+        self._execute_cfr_requests_parallel(
+            nodes=designated_survivors,
+            admin=admin,
+            dead_node_ids=killed_node_ids,
+            surviving_node_count=len(designated_survivors),
+        )
 
         def controller_available():
             controller = self.redpanda.controller()
@@ -959,43 +992,12 @@ class ControllerForcedReconfiguration_Size6(
         )
 
         """ do CFR requests """
-        self.redpanda.logger.debug("beginning CFR requests")
-        cfr_threads: list[threading.Thread] = []
-        for survivor in step_f_survivor_nodes:
-
-            def execute_cfr_against_node():
-                # concurrency: survivor will change definition
-                local_survivor_id = self.redpanda.node_id(survivor)
-                local_survivor = self.redpanda.get_node_by_id(local_survivor_id)
-                self.redpanda.logger.debug(
-                    f"cfr on node {local_survivor.name} with id {local_survivor_id}"
-                )
-                breaklgass_client = admin.breakglass(node=local_survivor)
-                request = breakglass_pb2.ControllerForcedReconfigurationRequest(
-                    dead_node_ids=step_f_dead_ids,
-                    surviving_node_count=len(step_f_survivor_ids),
-                )
-                result = self._do_request(breaklgass_client, request)
-                self.redpanda.logger.debug(
-                    f"CFR request on {local_survivor.name} finished"
-                )
-
-                error = result.error()
-                if error is not None:
-                    # this happens when there are multiple candidate leaders
-                    # and one wins the election before all cfr requests have been finished
-                    if "use the existing controller leader" in error.message:
-                        return
-                    error_message = f"CFR request on node {local_survivor.name} failed with error {result.error()}"
-                    self.redpanda.logger.info(error_message)
-                    assert False, error_message
-
-            cfr_thread = threading.Thread(target=execute_cfr_against_node)
-            cfr_thread.start()
-            cfr_threads.append(cfr_thread)
-
-        for cfr_thread in cfr_threads:
-            cfr_thread.join()
+        self._execute_cfr_requests_parallel(
+            nodes=step_f_survivor_nodes,
+            admin=admin,
+            dead_node_ids=step_f_dead_ids,
+            surviving_node_count=len(step_f_survivor_ids),
+        )
 
         def controller_available():
             controller = self.redpanda.controller()

--- a/tests/rptest/tests/controller_forced_reconfiguration_test.py
+++ b/tests/rptest/tests/controller_forced_reconfiguration_test.py
@@ -1018,4 +1018,8 @@ class ControllerForcedReconfiguration_Size6(
         """ step G: ensure 'some' is in the topic list """
         rpk = RpkTool(self.redpanda)
         assert "some" in rpk.list_topics()
-        assert int(self.redpanda.node_id(self.redpanda.controller())) == 1
+        leader_node = self.redpanda.controller()
+        assert leader_node is not None, "there should be a controller leader"
+        leader_id = self.redpanda.node_id(leader_node)
+        assert leader_id is not None, "there should be a controller leader"
+        assert int(leader_id) == 1


### PR DESCRIPTION
Adds a test which checks that CFR uniformly picks the longest log as the new leader / source of truth.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
