### PR TITLE
[CORE-15277] `ct/reconciler`: partition sources before reconciliation

### DIFF
--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -224,6 +224,49 @@ ss::future<> reconciler::reconcile() {
         co_return;
     }
 
+    auto source_sets = partition_sources_into_sets(std::move(sources));
+
+    // Adapt scheduling interval based on max object size produced.
+    // Note that we slow down if there's nothing to reconcile or if all
+    // objects failed. This is a sort of retry with backoff mechanism.
+    size_t max_bytes_produced = 0;
+    for (auto& source_set : source_sets) {
+        auto bytes = co_await reconcile_source_set(std::move(source_set));
+        max_bytes_produced = std::max(max_bytes_produced, bytes);
+    }
+
+    _scheduler.adapt(max_bytes_produced);
+}
+
+chunked_vector<chunked_vector<ss::shared_ptr<source>>>
+reconciler::partition_sources_into_sets(
+  chunked_vector<ss::shared_ptr<source>> sources) {
+    chunked_hash_map<model::topic_id, chunked_vector<ss::shared_ptr<source>>>
+      topic_id_to_sources;
+    for (auto& src : sources) {
+        auto& src_vec = topic_id_to_sources[src->topic_id_partition().topic_id];
+        src_vec.push_back(std::move(src));
+    }
+
+    vlog(
+      lg.debug,
+      "Partitioned sources into {} sets by topic_id",
+      topic_id_to_sources.size());
+
+    chunked_vector<chunked_vector<ss::shared_ptr<source>>> result;
+    result.reserve(topic_id_to_sources.size());
+    for (auto& [_, src_vec] : topic_id_to_sources) {
+        result.push_back(std::move(src_vec));
+    }
+    return result;
+}
+
+ss::future<size_t> reconciler::reconcile_source_set(
+  chunked_vector<ss::shared_ptr<source>> sources) {
+    if (sources.empty()) {
+        co_return 0;
+    }
+
     // Begin by creating the set of objects to be built.
     retry_chain_node rtc = l1::make_default_metastore_rtc(_as);
     auto metadata_builder_res = co_await l1::retry_metastore_op(
@@ -248,7 +291,7 @@ ss::future<> reconciler::reconcile() {
           "Could not create object metadata builder: {}",
           metadata_builder_res.error());
         _probe.increment_rounds_failed();
-        co_return;
+        co_return 0;
     }
     auto& metadata_builder = metadata_builder_res.value();
     chunked_hash_map<l1::object_id, chunked_vector<ss::shared_ptr<source>>>
@@ -259,7 +302,7 @@ ss::future<> reconciler::reconcile() {
         if (!oid.has_value()) {
             vlog(lg.warn, "Could not get object: {}", oid.error());
             _probe.increment_rounds_failed();
-            co_return;
+            co_return 0;
         }
         oid_to_sources[oid.value()].push_back(src);
     }
@@ -271,9 +314,9 @@ ss::future<> reconciler::reconcile() {
       futures;
     oids.reserve(oid_to_sources.size());
     futures.reserve(oid_to_sources.size());
-    for (const auto& [oid, sources] : oid_to_sources) {
+    for (const auto& [oid, srcs] : oid_to_sources) {
         oids.push_back(oid);
-        futures.push_back(reconcile_sources(oid, sources));
+        futures.push_back(reconcile_sources(oid, srcs));
     }
     // Unbounded concurrency because #futures = #domains, which is small (3).
     auto results = co_await ss::when_all(futures.begin(), futures.end());
@@ -295,7 +338,7 @@ ss::future<> reconciler::reconcile() {
               oid,
               ex);
             if (is_shutdown) {
-                co_return;
+                co_return 0;
             }
             failed_objects.push_back(oid);
             continue;
@@ -328,22 +371,19 @@ ss::future<> reconciler::reconcile() {
           rm_ret.has_value(), "Removing object {} in non-pending state", oid);
     }
 
-    // Adapt scheduling interval based on max object size produced.
-    // Note that we slow down if there's nothing to reconcile or if all
-    // objects failed. This is a sort of retry with backoff mechanism.
+    // Calculate the max object size produced for scheduling adaptation.
     size_t max_bytes_produced = 0;
     for (const auto& obj : successful_objects) {
         max_bytes_produced = std::max(
           max_bytes_produced, obj.object_info.size_bytes);
     }
-    _scheduler.adapt(max_bytes_produced);
 
     // Check if we have any successful objects to commit.
     if (successful_objects.empty()) {
         // NB: This doesn't count as failing the round because it may be that
         // all sources are fully reconciled.
         vlog(lg.debug, "No successful objects to commit to metastore");
-        co_return;
+        co_return 0;
     }
 
     // Commit all successful objects to the metastore.
@@ -354,8 +394,10 @@ ss::future<> reconciler::reconcile() {
           "Abandoning reconciliation run because the L1 metastore operation "
           "failed"));
         _probe.increment_rounds_failed();
-        co_return;
+        co_return 0;
     }
+
+    co_return max_bytes_produced;
 }
 
 ss::future<std::expected<reconciler::built_object_metadata, reconcile_error>>

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -249,6 +249,21 @@ private:
       const chunked_vector<built_object_metadata>& objects,
       std::unique_ptr<l1::metastore::object_metadata_builder> meta_builder);
 
+    /*
+     * Partition sources into sets for reconciliation.
+     */
+    chunked_vector<chunked_vector<ss::shared_ptr<source>>>
+    partition_sources_into_sets(chunked_vector<ss::shared_ptr<source>> sources);
+
+    /*
+     * Reconcile a set of sources. Creates a metadata builder, maps sources to
+     * objects, builds and uploads objects, and commits them to the metastore.
+     * Returns the max object size produced, or 0 if no objects were
+     * successfully committed.
+     */
+    ss::future<size_t>
+    reconcile_source_set(chunked_vector<ss::shared_ptr<source>> sources);
+
     l1::io* _l1_io;
     l1::metastore* _metastore;
     ss::gate _gate;

--- a/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
@@ -36,10 +36,18 @@ class ReconcilerMetricsTest : public testing::Test {
 public:
     ReconcilerMetricsTest() { _reconciler.setup_metrics_for_tests(); }
 
-    ss::shared_ptr<fake_source> add_source() {
+    ss::shared_ptr<fake_source> add_source(
+      std::optional<model::topic> tp = std::nullopt,
+      std::optional<model::topic_id> tid = std::nullopt) {
+        if (!tid.has_value()) {
+            tid = model::create_topic_id();
+        }
         auto ntp = model::random_ntp();
-        auto tid = model::create_topic_id();
-        auto tidp = model::topic_id_partition(tid, ntp.tp.partition);
+        if (tp.has_value()) {
+            ntp.tp.topic = tp.value();
+        }
+
+        auto tidp = model::topic_id_partition(tid.value(), ntp.tp.partition);
         auto src = ss::make_shared<fake_source>(ntp, tidp);
         _reconciler.attach_source(src);
         return src;
@@ -127,8 +135,11 @@ TEST_F(ReconcilerMetricsTest, ThroughputCounters) {
     EXPECT_THAT(get_object_upload_failed(), Optional(0));
     EXPECT_THAT(get_empty_objects_skipped(), Optional(0));
 
-    auto src1 = add_source();
-    auto src2 = add_source();
+    const model::topic tp{"tapioca"};
+    const model::topic_id tid = model::topic_id::create();
+
+    auto src1 = add_source(tp, tid);
+    auto src2 = add_source(tp, tid);
 
     src1->add_batch({.count = 10});
     src1->add_batch({.count = 10});
@@ -211,11 +222,14 @@ TEST_F(ReconcilerMetricsTest, HistogramMetrics) {
     EXPECT_GT(metastore_add_objects_duration.sample_count, 0);
 }
 
-// This test depends on the simple metastore packing all sources into one
-// object.
+// This test depends on the simple metastore packing all sources of the same
+// topic into one object.
 TEST_F(ReconcilerMetricsTest, ObjectMetrics) {
-    auto src1 = add_source();
-    auto src2 = add_source();
+    const model::topic tp{"tapioca"};
+    const model::topic_id tid = model::topic_id::create();
+
+    auto src1 = add_source(tp, tid);
+    auto src2 = add_source(tp, tid);
 
     src1->add_batch({.count = 10});
     src2->add_batch({.count = 5});

--- a/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
@@ -40,11 +40,19 @@ public:
     ReconcilerTest()
       : _reconciler(&_io, &_metastore) {}
 
-    ss::shared_ptr<fake_source> add_source() {
+    ss::shared_ptr<fake_source> add_source(
+      std::optional<model::topic> tp = std::nullopt,
+      std::optional<model::topic_id> tid = std::nullopt) {
+        if (!tid.has_value()) {
+            tid = model::create_topic_id();
+        }
         auto ntp = model::random_ntp();
-        auto tid = model::create_topic_id();
-        auto src = ss::make_shared<fake_source>(
-          ntp, model::topic_id_partition{tid, ntp.tp.partition});
+        if (tp.has_value()) {
+            ntp.tp.topic = tp.value();
+        }
+
+        auto tidp = model::topic_id_partition(tid.value(), ntp.tp.partition);
+        auto src = ss::make_shared<fake_source>(ntp, tidp);
         _reconciler.attach_source(src);
         return src;
     }
@@ -107,9 +115,12 @@ TEST_F(ReconcilerTest, SingleSourceWithControlBatches) {
 }
 
 TEST_F(ReconcilerTest, MultipleSources) {
-    auto src1 = add_source();
-    auto src2 = add_source();
-    auto src3 = add_source();
+    const model::topic tp{"tapioca"};
+    const model::topic_id tid = model::topic_id::create();
+
+    auto src1 = add_source(tp, tid);
+    auto src2 = add_source(tp, tid);
+    auto src3 = add_source(tp, tid);
 
     src1->add_batch({.count = 10});
     src1->add_batch({.count = 5});
@@ -202,8 +213,11 @@ TEST_F(ReconcilerTest, ObjectSizeLimitMultipleSources) {
     cfg.get("cloud_topics_reconciliation_max_object_size")
       .set_value(size_t{1_MiB});
 
-    auto src1 = add_source();
-    auto src2 = add_source();
+    const model::topic tp{"tapioca"};
+    const model::topic_id tid = model::topic_id::create();
+
+    auto src1 = add_source(tp, tid);
+    auto src2 = add_source(tp, tid);
 
     // 960KiB in source 1 (15 * 64KiB).
     // Disable compression to ensure predictable sizes.
@@ -259,8 +273,11 @@ TEST_F(ReconcilerTest, ObjectSizeLimitOneSourcePerRound) {
     cfg.get("cloud_topics_reconciliation_max_object_size")
       .set_value(size_t{1_MiB});
 
-    auto src1 = add_source();
-    auto src2 = add_source();
+    const model::topic tp{"tapioca"};
+    const model::topic_id tid = model::topic_id::create();
+
+    auto src1 = add_source(tp, tid);
+    auto src2 = add_source(tp, tid);
 
     // Each source: 25 batches of 64KiB = 1.6MiB > 1MiB limit.
     constexpr auto batch_count = 25;


### PR DESCRIPTION
The motivating factor behind this change, at present, is the possibility that topics may be multiplexed with other topics with varying retention lifetimes, leading to a number of pessimistic cases in terms of garbage collection enforcement in L1 since data will not be removed from object storage until the reference count for all data in all partitions is 0 for L1 objects.

To avoid this issue, partition sources by `topic_id` when reconciling L0 data to L1. In the future, we will be able to extend `partition_sources_into_sets()` further (e.g. implement herustics that will do a better job of grouping together sources from different topics but with similar retention lifetimes together to provide better reconciler throughput).

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
