### PR TITLE
container/chunked_vector: force usage of same iterator for comparison

### DIFF
--- a/src/v/container/chunked_vector.h
+++ b/src/v/container/chunked_vector.h
@@ -435,10 +435,16 @@ public:
 
         bool operator==(const iter& o) const {
             check_generation();
+            dassert(
+              _vec == o._vec,
+              "iterator compared with different chunked_vector");
             return std::tie(_index, _vec) == std::tie(o._index, o._vec);
         };
         auto operator<=>(const iter& o) const {
             check_generation();
+            dassert(
+              _vec == o._vec,
+              "iterator compared with different chunked_vector");
             return std::tie(_index, _vec) <=> std::tie(o._index, o._vec);
         };
 
@@ -463,13 +469,11 @@ public:
         }
 
         inline void check_generation() const {
-#ifndef NDEBUG
-            vassert(
+            dassert(
               _vec->_generation == _my_generation,
               "Attempting to use an invalidated iterator. The corresponding "
               "chunked_vector container has been mutated since this "
               "iterator was constructed.");
-#endif
         }
 
         size_t _index{};


### PR DESCRIPTION
It's a mistake to compare an iterator from another container. We should
disallow it.

Followup to: https://github.com/redpanda-data/redpanda/pull/29177

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
