### PR TITLE
CORE-15181 SR Context: integrate all `/subject/...` endpoints

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -638,6 +638,7 @@
         "parameters": [
           {
             "name": "subject",
+            "description": "The subject name. Supports context-qualified subjects with the format `[:.<context>:]<subject>`.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -719,6 +720,7 @@
         "parameters": [
           {
             "name": "subject",
+            "description": "The subject name. Supports context-qualified subjects with the format `[:.<context>:]<subject>`.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -767,6 +769,7 @@
         "parameters": [
           {
             "name": "subject",
+            "description": "The subject name. Supports context-qualified subjects with the format `[:.<context>:]<subject>`.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -815,6 +818,7 @@
         "parameters": [
           {
             "name": "subject",
+            "description": "The subject name. Supports context-qualified subjects with the format `[:.<context>:]<subject>`.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -873,6 +877,7 @@
         "parameters": [
           {
             "name": "subject",
+            "description": "The subject name. Supports context-qualified subjects with the format `[:.<context>:]<subject>`.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -942,6 +947,7 @@
         "parameters": [
           {
             "name": "subject",
+            "description": "The subject name. Supports context-qualified subjects with the format `[:.<context>:]<subject>`.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -1001,6 +1007,7 @@
         "parameters": [
           {
             "name": "subject",
+            "description": "The subject name. Supports context-qualified subjects with the format `[:.<context>:]<subject>`.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -1072,6 +1079,7 @@
         "parameters": [
           {
             "name": "subject",
+            "description": "The subject name. Supports context-qualified subjects with the format `[:.<context>:]<subject>`.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -1128,6 +1136,7 @@
         "parameters": [
           {
             "name": "subject",
+            "description": "The subject name. Supports context-qualified subjects with the format `[:.<context>:]<subject>`.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -1188,6 +1197,7 @@
         "parameters": [
           {
             "name": "subject",
+            "description": "The subject name. Supports context-qualified subjects with the format `[:.<context>:]<subject>`.",
             "in": "path",
             "required": true,
             "type": "string"

--- a/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
@@ -14,13 +14,16 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The name used to reference this schema in the dependent schema definition."
         },
         "subject": {
-          "type": "string"
+          "type": "string",
+          "description": "The subject name of the referenced schema. Supports context-qualified subjects with the format `[:.<context>:]<subject>`."
         },
         "version": {
-          "type": "integer"
+          "type": "integer",
+          "description": "The version of the referenced schema."
         }
       }
     },

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -794,7 +794,8 @@ ss::future<ctx_server<service>::reply_t>
 get_subject_versions_version_referenced_by(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp) {
     parse_accept_header(rq, rp);
-    auto sub = parse::request_param<subject>(*rq.req, "subject");
+    auto ctx_sub = context_subject::from_string(
+      parse::request_param<ss::sstring>(*rq.req, "subject"));
     auto ver = parse::request_param<ss::sstring>(*rq.req, "version");
 
     co_await rq.service().writer().read_sync();
@@ -802,7 +803,7 @@ get_subject_versions_version_referenced_by(
     auto version = parse_schema_version(ver).value();
 
     auto references = ppj::rjson_serialize_iobuf(to_non_context_schema_ids(
-      co_await rq.service().schema_store().referenced_by(sub, version)));
+      co_await rq.service().schema_store().referenced_by(ctx_sub, version)));
 
     log_response(*rq.req, references);
     rp.rep->write_body("json", ppj::as_body_writer(std::move(references)));

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -729,7 +729,8 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
 ss::future<ctx_server<service>::reply_t> get_subject_versions_version(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp) {
     parse_accept_header(rq, rp);
-    auto sub = parse::request_param<subject>(*rq.req, "subject");
+    auto ctx_sub = context_subject::from_string(
+      parse::request_param<ss::sstring>(*rq.req, "subject"));
     auto ver = parse::request_param<ss::sstring>(*rq.req, "version");
     auto inc_del{
       parse::query_param<std::optional<include_deleted>>(*rq.req, "deleted")
@@ -740,9 +741,9 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version(
 
     auto version = parse_schema_version(ver).value();
 
-    auto get_res = co_await get_or_load(rq, [&rq, sub, version, inc_del]() {
+    auto get_res = co_await get_or_load(rq, [&rq, ctx_sub, version, inc_del]() {
         return rq.service().schema_store().get_subject_schema(
-          sub, version, inc_del);
+          ctx_sub, version, inc_del);
     });
 
     auto [subject, def] = std::move(get_res.schema).destructure();

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -810,7 +810,8 @@ get_subject_versions_version_referenced_by(
 ss::future<server::reply_t>
 delete_subject(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
-    auto sub{parse::request_param<subject>(*rq.req, "subject")};
+    auto ctx_sub = context_subject::from_string(
+      parse::request_param<ss::sstring>(*rq.req, "subject"));
     auto permanent{
       parse::query_param<std::optional<permanent_delete>>(*rq.req, "permanent")
         .value_or(permanent_delete::no)};
@@ -822,8 +823,8 @@ delete_subject(server::request_t rq, server::reply_t rp) {
     auto versions
       = permanent
           ? co_await rq.service().writer().delete_subject_permanent(
-              sub, std::nullopt)
-          : co_await rq.service().writer().delete_subject_impermanent(sub);
+              ctx_sub, std::nullopt)
+          : co_await rq.service().writer().delete_subject_impermanent(ctx_sub);
 
     auto resp = ppj::rjson_serialize_iobuf(std::move(versions));
     log_response(*rq.req, resp);

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -765,7 +765,8 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version(
 ss::future<ctx_server<service>::reply_t> get_subject_versions_version_schema(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp) {
     parse_accept_header(rq, rp);
-    auto sub = parse::request_param<subject>(*rq.req, "subject");
+    auto ctx_sub = context_subject::from_string(
+      parse::request_param<ss::sstring>(*rq.req, "subject"));
     auto ver = parse::request_param<ss::sstring>(*rq.req, "version");
     auto inc_del{
       parse::query_param<std::optional<include_deleted>>(*rq.req, "deleted")
@@ -777,7 +778,7 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version_schema(
     auto version = parse_schema_version(ver).value();
 
     auto get_res = co_await rq.service().schema_store().get_subject_schema(
-      sub, version, inc_del);
+      ctx_sub, version, inc_del);
 
     auto [_, def] = std::move(get_res.schema).destructure();
     auto formatted_schema = co_await rq.service().schema_store().format_schema(

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -584,14 +584,15 @@ ss::future<server::reply_t>
 post_subject_versions(server::request_t rq, server::reply_t rp) {
     parse_content_type_header(rq);
     parse_accept_header(rq, rp);
-    const auto sub = parse::request_param<subject>(*rq.req, "subject");
+    const auto ctx_sub = context_subject::from_string(
+      parse::request_param<ss::sstring>(*rq.req, "subject"));
     const auto norm{
       parse::query_param<std::optional<normalize>>(*rq.req, "normalize")
         .value_or(normalize::no)};
     vlog(
       srlog.debug,
       "post_subject_versions subject='{}', normalize='{}'",
-      sub,
+      ctx_sub,
       norm);
 
     auto& wr = rq.service().writer();
@@ -600,7 +601,7 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
     co_await wr.read_sync();
 
     auto unparsed = co_await rjson_parse(
-      *rq.req, post_subject_versions_request_handler<>{sub});
+      *rq.req, post_subject_versions_request_handler<>{ctx_sub});
 
     // If presented with a non-positive integer for version, set it to
     // invalid_schema_version so that the version number can be projected
@@ -613,7 +614,7 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
         unparsed.id = invalid_schema_id;
     }
 
-    const auto mode = co_await st.get_mode(sub, default_to_global::yes);
+    const auto mode = co_await st.get_mode(ctx_sub, default_to_global::yes);
 
     stored_schema schema{
       .schema = co_await make_canonical_schema_with_metadata(
@@ -627,7 +628,7 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
 
     // Determine if the definition already exists
     auto s_id = co_await st.get_schema_id(
-      default_context, schema.schema.def().share());
+      ctx_sub.ctx, schema.schema.def().share());
 
     vlog(
       srlog.debug, "post_subject_versions: ID for schema definition: {}", s_id);
@@ -635,7 +636,7 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
     // Determine if the subject already has a version that references this
     // schema, deleted versions are not seen.
     const auto undeleted_versions = co_await st.get_subject_versions(
-      sub, include_deleted::no);
+      ctx_sub, include_deleted::no);
 
     std::optional<schema_version> v_id;
     if (s_id.has_value()) {
@@ -666,19 +667,20 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
     if (!matched) {
         // Check if the request is appropriate for the mode
         if (mode == mode::read_only) {
-            throw as_exception(mode_is_readonly(sub));
+            throw as_exception(mode_is_readonly(ctx_sub));
         }
         if (schema.id >= 0 && mode != mode::import) {
-            throw as_exception(mode_not_import(schema.schema.sub()));
+            throw as_exception(mode_not_import(ctx_sub));
         }
         if (schema.id < 0 && mode != mode::read_write) {
-            throw as_exception(mode_not_readwrite(sub));
+            throw as_exception(mode_not_readwrite(ctx_sub));
         }
 
         // Determine if a provided schema id is appropriate
         if (
           schema.id != invalid_schema_id && s_id != schema.id
-          && co_await st.has_schema(schema.id)) {
+          && co_await st.has_schema(
+            context_schema_id{ctx_sub.ctx, schema.id})) {
             // The supplied id already exists, but the schema is different
             co_return ss::coroutine::return_exception(
               as_exception(overwrite_schema_with_id_not_permitted(schema.id)));
@@ -696,7 +698,7 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
                   fmt::format(
                     "Schema being registered is incompatible with an earlier "
                     "schema for subject \"{}\", details: [{}]",
-                    sub,
+                    ctx_sub,
                     fmt::join(compat.messages, ", ")));
             }
         }

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -883,12 +883,13 @@ compatibility_subject_version(server::request_t rq, server::reply_t rp) {
     parse_content_type_header(rq);
     parse_accept_header(rq, rp);
     auto ver = parse::request_param<ss::sstring>(*rq.req, "version");
-    auto sub = parse::request_param<subject>(*rq.req, "subject");
+    auto ctx_sub = context_subject::from_string(
+      parse::request_param<ss::sstring>(*rq.req, "subject"));
     auto is_verbose{
       parse::query_param<std::optional<verbose>>(*rq.req, "verbose")
         .value_or(verbose::no)};
     auto unparsed = co_await rjson_parse(
-      *rq.req, post_subject_versions_request_handler<>{sub});
+      *rq.req, post_subject_versions_request_handler<>{ctx_sub});
 
     // Must read, in case we have the subject in cache with an outdated config
     co_await rq.service().writer().read_sync();

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -836,7 +836,8 @@ delete_subject(server::request_t rq, server::reply_t rp) {
 ss::future<server::reply_t>
 delete_subject_version(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
-    auto sub{parse::request_param<subject>(*rq.req, "subject")};
+    auto ctx_sub = context_subject::from_string(
+      parse::request_param<ss::sstring>(*rq.req, "subject"));
     auto ver = parse::request_param<ss::sstring>(*rq.req, "version");
     auto permanent{
       parse::query_param<std::optional<permanent_delete>>(*rq.req, "permanent")
@@ -852,9 +853,9 @@ delete_subject_version(server::request_t rq, server::reply_t rp) {
         // (Clearly this will never succeed for permanent=true -- calling
         //  with latest+permanent is a bad request per API docs)
         auto versions = co_await rq.service().schema_store().get_versions(
-          sub, include_deleted::no);
+          ctx_sub, include_deleted::no);
         if (versions.empty()) {
-            throw as_exception(not_found(sub, version));
+            throw as_exception(not_found(ctx_sub, version));
         }
         version = versions.back();
     } else {
@@ -863,16 +864,17 @@ delete_subject_version(server::request_t rq, server::reply_t rp) {
 
     // A permanent deletion emits tombstones for prior schema_key messages
     if (permanent) {
-        co_await rq.service().writer().delete_subject_permanent(sub, version);
+        co_await rq.service().writer().delete_subject_permanent(
+          ctx_sub, version);
     } else {
         // Refuse to soft-delete the same thing twice
         if (co_await rq.service().schema_store().is_subject_version_deleted(
-              sub, version)) {
-            throw as_exception(soft_deleted(sub, version));
+              ctx_sub, version)) {
+            throw as_exception(soft_deleted(ctx_sub, version));
         }
 
         // Upsert the version with is_deleted=1
-        co_await rq.service().writer().delete_subject_version(sub, version);
+        co_await rq.service().writer().delete_subject_version(ctx_sub, version);
     }
 
     auto resp = ppj::rjson_serialize_iobuf(version);

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -504,7 +504,8 @@ ss::future<server::reply_t> get_subjects(
 ss::future<server::reply_t>
 get_subject_versions(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
-    auto sub = parse::request_param<subject>(*rq.req, "subject");
+    auto ctx_sub = context_subject::from_string(
+      parse::request_param<ss::sstring>(*rq.req, "subject"));
     auto inc_del{
       parse::query_param<std::optional<include_deleted>>(*rq.req, "deleted")
         .value_or(include_deleted::no)};
@@ -513,7 +514,7 @@ get_subject_versions(server::request_t rq, server::reply_t rp) {
     co_await rq.service().writer().read_sync();
 
     auto versions = ppj::rjson_serialize_iobuf(
-      co_await rq.service().schema_store().get_versions(sub, inc_del));
+      co_await rq.service().schema_store().get_versions(ctx_sub, inc_del));
 
     log_response(*rq.req, versions);
     rp.rep->write_body("json", ppj::as_body_writer(std::move(versions)));

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -524,7 +524,8 @@ ss::future<server::reply_t>
 post_subject(server::request_t rq, server::reply_t rp) {
     parse_content_type_header(rq);
     parse_accept_header(rq, rp);
-    auto sub = parse::request_param<subject>(*rq.req, "subject");
+    auto ctx_sub = context_subject::from_string(
+      parse::request_param<ss::sstring>(*rq.req, "subject"));
     auto inc_del{
       parse::query_param<std::optional<include_deleted>>(*rq.req, "deleted")
         .value_or(include_deleted::no)};
@@ -534,7 +535,7 @@ post_subject(server::request_t rq, server::reply_t rp) {
     vlog(
       srlog.debug,
       "post_subject subject='{}', normalize='{}', deleted='{}', format='{}'",
-      sub,
+      ctx_sub,
       norm,
       inc_del,
       format);
@@ -545,22 +546,22 @@ post_subject(server::request_t rq, server::reply_t rp) {
     co_await rq.service().writer().read_sync();
 
     // Force 40401 if no subject
-    co_await st.get_versions(sub, inc_del);
+    co_await st.get_versions(ctx_sub, inc_del);
 
     subject_schema schema;
     try {
         auto unparsed = co_await rjson_parse(
-          *rq.req, post_subject_versions_request_handler<>{sub});
-        const auto mode = co_await st.get_mode(sub, default_to_global::yes);
+          *rq.req, post_subject_versions_request_handler<>{ctx_sub});
+        const auto mode = co_await st.get_mode(ctx_sub, default_to_global::yes);
         schema = co_await make_canonical_schema_with_metadata(
           st, std::move(unparsed.def), norm, mode);
     } catch (const exception& e) {
         if (e.code() == error_code::schema_empty) {
-            throw as_exception(invalid_subject_schema(sub));
+            throw as_exception(invalid_subject_schema(ctx_sub));
         }
         throw;
     } catch (const ppj::parse_error&) {
-        throw as_exception(invalid_subject_schema(sub));
+        throw as_exception(invalid_subject_schema(ctx_sub));
     }
 
     auto sub_schema = co_await rq.service().schema_store().has_schema(

--- a/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
+++ b/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
@@ -51,7 +51,7 @@ class post_subject_versions_request_handler
     state _state = state::empty;
 
     struct mutable_schema {
-        subject sub{invalid_subject};
+        context_subject sub{invalid_subject};
         schema_definition::raw_string def;
         schema_type type{schema_type::avro};
         schema_definition::references refs;
@@ -69,7 +69,7 @@ public:
     };
     rjson_parse_result result;
 
-    explicit post_subject_versions_request_handler(subject sub)
+    explicit post_subject_versions_request_handler(context_subject sub)
       : json::base_handler<Encoding>{json::serialization_format::none}
       , _schema{std::move(sub)} {}
 
@@ -243,7 +243,7 @@ public:
             return true;
         }
         case state::reference_subject: {
-            _schema.refs.back().sub = subject{ss::sstring{sv}};
+            _schema.refs.back().sub = context_subject::from_string(sv);
             _state = state::reference;
             return true;
         }

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -579,7 +579,7 @@ schema_avro_dependee_def = """
     ]
 }"""
 
-soft_deleted_schemas = {
+base_schemas = {
     "proto": {
         "subject": "schema_proto",
         "schema": schema_proto_def,
@@ -1762,6 +1762,13 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         )
         self.assert_equal(result.status_code, requests.codes.ok)
 
+        # Get referenced-by in context (empty list, no references)
+        result = self.sr_client.get_subjects_subject_versions_version_referenced_by(
+            subject=ctx_subject, version=1
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json(), [])
+
         # Delete specific version in context
         result = self.sr_client.delete_subject_version(subject=ctx_subject, version=1)
         self.assert_equal(result.status_code, requests.codes.ok)
@@ -1794,6 +1801,80 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             subject=":.ctx2:sub1", data=json.dumps({"schema": schema1_def})
         )
         self.assert_equal(result.status_code, requests.codes.not_found)
+
+    @cluster(num_nodes=1)
+    def test_context_references(self):
+        """Test schema references work with context-qualified subjects."""
+        # Test all schema types using existing test data
+        for schema_type in ["proto", "avro", "json"]:
+            base = base_schemas[schema_type]
+            dependent = dependent_schemas[schema_type]
+            ref_name = dependent["references"][0]["name"]
+
+            ctx = f"ctx-{schema_type}"
+            ctx_ref_subject = f":.{ctx}:base"
+            ctx_main_subject = f":.{ctx}:dependent"
+
+            # Register base schema in context
+            ref_data = json.dumps(
+                {"schema": base["schema"], "schemaType": base["type"]}
+            )
+            result = self.sr_client.post_subjects_subject_versions(
+                subject=ctx_ref_subject, data=ref_data
+            )
+            self.assert_equal(result.status_code, requests.codes.ok)
+
+            # Register dependent schema with in-context reference
+            main_data = json.dumps(
+                {
+                    "schema": dependent["schema"],
+                    "schemaType": dependent["type"],
+                    "references": [
+                        {"name": ref_name, "subject": ctx_ref_subject, "version": 1}
+                    ],
+                }
+            )
+            result = self.sr_client.post_subjects_subject_versions(
+                subject=ctx_main_subject, data=main_data
+            )
+            self.assert_equal(result.status_code, requests.codes.ok)
+
+            # Verify referenced-by works with context subjects
+            result = self.sr_client.get_subjects_subject_versions_version_referenced_by(
+                subject=ctx_ref_subject, version=1
+            )
+            self.assert_equal(result.status_code, requests.codes.ok)
+            self.assert_equal(len(result.json()), 1)
+
+        # Test cross-context references
+        base = base_schemas["proto"]
+        dependent = dependent_schemas["proto"]
+        cross_ref_subject = ":.ctx-cross-ref:base"
+        cross_main_subject = ":.ctx-cross-main:dependent"
+
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=cross_ref_subject,
+            data=json.dumps({"schema": base["schema"], "schemaType": base["type"]}),
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=cross_main_subject,
+            data=json.dumps(
+                {
+                    "schema": dependent["schema"],
+                    "schemaType": dependent["type"],
+                    "references": [
+                        {
+                            "name": dependent["references"][0]["name"],
+                            "subject": cross_ref_subject,
+                            "version": 1,
+                        }
+                    ],
+                }
+            ),
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
 
     @cluster(num_nodes=3)
     def test_post_subjects_subject_versions_null_metadata_ruleset(self):
@@ -3606,7 +3687,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         # Test setup. Insert and soft-delete schemas to be referencedby
 
         for name in ["proto", "json", "avro"]:
-            schema = soft_deleted_schemas[name]
+            schema = base_schemas[name]
             result_raw = self.sr_client.post_subjects_subject_versions(
                 subject=schema["subject"],
                 data=json.dumps(

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1749,6 +1749,13 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         self.assert_equal(result.status_code, requests.codes.ok)
         self.assert_equal(result.json(), [1])
 
+        # Get specific version in context
+        result = self.sr_client.get_subjects_subject_versions_version(
+            subject=ctx_subject, version=1
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["version"], 1)
+
         # Delete subject in context
         result = self.sr_client.delete_subject(subject=ctx_subject)
         self.assert_equal(result.status_code, requests.codes.ok)

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1749,6 +1749,11 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         self.assert_equal(result.status_code, requests.codes.ok)
         self.assert_equal(result.json(), [1])
 
+        # Delete subject in context
+        result = self.sr_client.delete_subject(subject=ctx_subject)
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json(), [1])
+
     @cluster(num_nodes=1)
     def test_context_isolation(self):
         """Verify contexts are isolated: independent IDs, no cross-context lookups."""

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1756,6 +1756,12 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         self.assert_equal(result.status_code, requests.codes.ok)
         self.assert_equal(result.json()["version"], 1)
 
+        # Get schema only for specific version in context
+        result = self.sr_client.get_subjects_subject_versions_version_schema(
+            subject=ctx_subject, version=1
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
         # Delete specific version in context
         result = self.sr_client.delete_subject_version(subject=ctx_subject, version=1)
         self.assert_equal(result.status_code, requests.codes.ok)

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1701,6 +1701,34 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             assert result_raw.status_code == requests.codes.ok
             assert result_raw.json()["id"] == 1
 
+    @cluster(num_nodes=1)
+    def test_default_context(self):
+        schema_data = json.dumps({"schema": schema1_def})
+
+        result = self.sr_client.post_subjects_subject_versions(
+            subject="default-ctx-subject", data=schema_data
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["id"], 1)
+
+    @cluster(num_nodes=1)
+    def test_context_isolation(self):
+        """Verify contexts are isolated: independent IDs."""
+
+        # Register in default context
+        result = self.sr_client.post_subjects_subject_versions(
+            subject="sub1", data=json.dumps({"schema": schema1_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["id"], 1)
+
+        # Register same schema in .ctx1 - should get id=1 (independent counter)
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=":.ctx1:sub1", data=json.dumps({"schema": schema2_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["id"], 1)
+
     @cluster(num_nodes=3)
     def test_post_subjects_subject_versions_null_metadata_ruleset(self):
         """

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1722,6 +1722,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         """Verify context-aware endpoints work with qualified subjects."""
 
         schema_data = json.dumps({"schema": schema1_def})
+        compat_schema_data = json.dumps({"schema": schema2_def})
         ctx_subject = ":.ctx1:sub1"
 
         # Register in context
@@ -1735,6 +1736,13 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             subject=ctx_subject, data=schema_data
         )
         self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Compatibility check in context
+        result = self.sr_client.post_compatibility_subject_version(
+            subject=ctx_subject, version="latest", data=compat_schema_data
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["is_compatible"], True)
 
     @cluster(num_nodes=1)
     def test_context_isolation(self):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1711,9 +1711,34 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         self.assert_equal(result.status_code, requests.codes.ok)
         self.assert_equal(result.json()["id"], 1)
 
+        result = self.sr_client.post_subjects_subject(
+            subject=":.:default-ctx-subject", data=schema_data
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["id"], 1)
+
+    @cluster(num_nodes=1)
+    def test_contexts(self):
+        """Verify context-aware endpoints work with qualified subjects."""
+
+        schema_data = json.dumps({"schema": schema1_def})
+        ctx_subject = ":.ctx1:sub1"
+
+        # Register in context
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=ctx_subject, data=schema_data
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Lookup in context
+        result = self.sr_client.post_subjects_subject(
+            subject=ctx_subject, data=schema_data
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
     @cluster(num_nodes=1)
     def test_context_isolation(self):
-        """Verify contexts are isolated: independent IDs."""
+        """Verify contexts are isolated: independent IDs, no cross-context lookups."""
 
         # Register in default context
         result = self.sr_client.post_subjects_subject_versions(
@@ -1728,6 +1753,12 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         )
         self.assert_equal(result.status_code, requests.codes.ok)
         self.assert_equal(result.json()["id"], 1)
+
+        # Lookup schema in different context - should fail
+        result = self.sr_client.post_subjects_subject(
+            subject=":.ctx2:sub1", data=json.dumps({"schema": schema1_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.not_found)
 
     @cluster(num_nodes=3)
     def test_post_subjects_subject_versions_null_metadata_ruleset(self):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1756,10 +1756,14 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         self.assert_equal(result.status_code, requests.codes.ok)
         self.assert_equal(result.json()["version"], 1)
 
-        # Delete subject in context
-        result = self.sr_client.delete_subject(subject=ctx_subject)
+        # Delete specific version in context
+        result = self.sr_client.delete_subject_version(subject=ctx_subject, version=1)
         self.assert_equal(result.status_code, requests.codes.ok)
-        self.assert_equal(result.json(), [1])
+        self.assert_equal(result.json(), 1)
+
+        # Delete subject in context (cleanup)
+        result = self.sr_client.delete_subject(subject=ctx_subject, permanent=True)
+        self.assert_equal(result.status_code, requests.codes.ok)
 
     @cluster(num_nodes=1)
     def test_context_isolation(self):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1744,6 +1744,11 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         self.assert_equal(result.status_code, requests.codes.ok)
         self.assert_equal(result.json()["is_compatible"], True)
 
+        # List versions in context
+        result = self.sr_client.get_subjects_subject_versions(subject=ctx_subject)
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json(), [1])
+
     @cluster(num_nodes=1)
     def test_context_isolation(self):
         """Verify contexts are isolated: independent IDs, no cross-context lookups."""


### PR DESCRIPTION
This PR continues making the Schema Registry context-aware by migrating all `/subjects/...` handlers and the compatibility endpoint to parse subjects as context-qualified subjects, enabling the `:.context:subject` syntax.

This is the first PR where user-visible changes are introduced: users can now register and query schemas using qualified subjects (e.g., `:.staging:my-topic-value`), with each context maintaining its own independent schema ID counter.

### The key changes are:
  - All subject path parameters in handlers are now parsed using `context_subject::from_string()`, enabling qualified subject syntax
  - Schema references in request bodies are also parsed as context-qualified, enabling cross-context references
  - Schema ID lookups and existence checks are now context-scoped (`get_schema_id(ctx, ...)`, `has_schema(context_schema_id{ctx, id})`)
  - Swagger documentation updated to describe the qualified subject format for all subject parameters

### Not yet implemented:
 - Parent-context-based context-determination for references with unqualified subjects

Fixes https://redpandadata.atlassian.net/browse/CORE-15180
Fixes https://redpandadata.atlassian.net/browse/CORE-15181

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
