### PR TITLE
partition_balancer_planner: dampen oscillations

### DIFF
--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -242,6 +242,16 @@ void partition_balancer_backend::on_topic_table_update() {
           current_in_progress_updates,
           last_in_progress_updates);
 
+        // without this, numerous balancing ticks can run without feedback on
+        // the new cluster balance. This lead to underdamped / oscillating
+        // behavior where the balancer would repeatedly use an old health report
+        // to move partitions, overfilling or underfilling a single node. This
+        // feedback should dampen the balancing process enough to prevent most
+        // oscillating behavior. Given that this pathway is an opportunistic
+        // optimization to sneak in additional balancer rounds in the case of
+        // large imbalances, we can afford the additional time to gather new
+        // health reports.
+        _cur_term->_force_health_report_refresh = true;
         maybe_rearm_timer(/*now=*/true);
     }
 }


### PR DESCRIPTION
_concurrent_moves_drop_threshold is an optimization which allows for a new round of partition balancing to occur if a sufficient percentage of the prior round's partition movemenet actions have completed.

An issue with the prior implementation, though, is opportunistic re-ticks did not update their health report. Given that the parititon_balancer_planner is stateless between ticks, this meant that the planner did not consider the effects of inflight actions on cluster balance.

As a result, use of the old health reports allowed for the planner to overshoot balance, either overfilling or overemptying a node. On next health report, a new cluster state would be recognized, with the imbalance cause by overshoot being realized. Then the partition balancer planner would do the opposite of its prior movements to undo the overshoot.

Typically, this behavior was a dampened oscillation that would eventually result in balance.

This change requires that shortcut ticks must update their health reports such that every tick has feedback from the prior ticks. This feedback should dampen the oscillating behavior, preventing most unnessesary partition movements.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
### Improvements

* Reduces oscillating behavior in partition balancing

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
