### PR TITLE
[UX-72] rpk: strict yaml unmarshal on edits

### DIFF
--- a/src/go/rpk/pkg/os/BUILD
+++ b/src/go/rpk/pkg/os/BUILD
@@ -24,9 +24,12 @@ go_library(
 go_test(
     name = "os_test",
     size = "small",
-    srcs = ["proc_test.go"],
+    srcs = [
+        "file_test.go",
+        "proc_test.go",
+    ],
+    embed = [":os"],
     deps = [
-        ":os",
         "//src/go/rpk/pkg/utils",
         "@com_github_spf13_afero//:afero",
         "@com_github_stretchr_testify//require",

--- a/src/go/rpk/pkg/os/file.go
+++ b/src/go/rpk/pkg/os/file.go
@@ -10,6 +10,7 @@
 package os
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -146,8 +147,16 @@ func EditTmpYAMLFile[T any](fs afero.Fs, v T) (T, error) {
 	if len(read) == 0 || string(read) == "\n" {
 		return update, fmt.Errorf("no changes made")
 	}
-	if err := yaml.Unmarshal(read, &update); err != nil {
+	if err := decodeStrictYAML(read, &update); err != nil {
 		return update, fmt.Errorf("unable to parse edited file: %w", err)
 	}
 	return update, nil
+}
+
+// decodeStrict decodes YAML from b into v, returning an error if there are
+// unknown fields.
+func decodeStrictYAML(b []byte, v any) error {
+	dec := yaml.NewDecoder(bytes.NewReader(b))
+	dec.KnownFields(true)
+	return dec.Decode(v)
 }

--- a/src/go/rpk/pkg/os/file_test.go
+++ b/src/go/rpk/pkg/os/file_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package os
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeStrictYAML(t *testing.T) {
+	type testType struct {
+		Enabled bool `yaml:"enabled"`
+	}
+	tests := []struct {
+		name     string
+		input    string
+		expError bool
+	}{
+		{
+			name:     "valid YAML",
+			input:    `enabled: true`,
+			expError: false,
+		},
+		{
+			name:     "invalid YAML",
+			input:    `:`,
+			expError: true,
+		},
+		{
+			name:     "unknown field",
+			input:    `unknown: value`,
+			expError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result testType
+			err := decodeStrictYAML([]byte(tt.input), &result)
+			if tt.expError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
We are now strictly enforcing known fields to
avoid misleading (update successful) for users
that update their files with an unknown field.

This can let them catch typos faster, as we were
not reporting these.

This affects: profile edit, profile edit-globals,
and shadow update


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Improvements

* rpk profile edit, rpk profile edit-globals, rpk shadow update now report when an updated file contains unknown fields.
