### PR TITLE
ct: remove explicit states from the L0 reader

### DIFF
--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -85,6 +85,22 @@ level_zero_log_reader_impl::read_some(
         }
         [[fallthrough]];
     case state::ready_state:
+        if (_current == state::end_of_stream_state) {
+            vlog(_log.trace, "Materialize batches called while EOS");
+            break;
+        }
+        if (_hydrated.size() > 0) {
+            _current = state::materialized_state;
+            vlog(
+              _log.trace,
+              "Materialize batches call redundant, already materialized");
+            break;
+        }
+        if (_unhydrated.empty()) {
+            _current = state::end_of_stream_state;
+            vlog(_log.trace, "Materialize batches without unhydrated batches");
+            break;
+        }
         co_await materialize_batches(deadline);
         [[fallthrough]];
     case state::materialized_state:
@@ -265,31 +281,10 @@ level_zero_log_reader_impl::fetch_metadata(
 
 ss::future<> level_zero_log_reader_impl::materialize_batches(
   model::timeout_clock::time_point deadline) {
-    if (_current == state::end_of_stream_state) {
-        _current = state::end_of_stream_state;
-        vlog(_log.trace, "Materialize batches called while EOS");
-        co_return;
-    }
     vassert(
       _current == state::ready_state || _current == state::materialized_state,
       "Invalid state transition, unexpected current state: {}",
       std::to_underlying(_current));
-
-    if (_hydrated.size() > 0) {
-        // We're already materialized.
-        _current = state::materialized_state;
-        vlog(
-          _log.trace,
-          "Materialize batches call redundant, already materialized");
-        co_return;
-    }
-
-    if (_unhydrated.empty()) {
-        // Nothing to materialize.
-        _current = state::end_of_stream_state;
-        vlog(_log.trace, "Materialize batches without unhydrated batches");
-        co_return;
-    }
 
     // Cherry-pick enough L0 meta batches to materialize.
     try {

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -287,7 +287,6 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
       std::to_underlying(_current));
 
     // Cherry-pick enough L0 meta batches to materialize.
-    try {
         chunked_vector<cloud_topics::extent_meta> to_materialize;
         auto unhydrated_it = _unhydrated.begin();
         size_t materialize_bytes = 0;
@@ -417,16 +416,6 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
           _log.debug,
           "Materialized {} batches from the L0 meta batches",
           _hydrated.size());
-    } catch (...) {
-        vlog(
-          _log.info,
-          "Failed to materialize batches {}",
-          std::current_exception());
-        _hydrated.clear();
-        _unhydrated.clear();
-        _current = state::end_of_stream_state;
-        throw;
-    }
 
     _current = _hydrated.empty() ? state::end_of_stream_state
                                  : state::materialized_state;

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -50,7 +50,6 @@ level_zero_log_reader_impl::do_load_slice(
     } catch (...) {
         vlog(
           _log.error, "Reader caught exception: {}", std::current_exception());
-        _hydrated.clear();
         _unhydrated.clear();
         _current = state::end_of_stream_state;
         throw;
@@ -89,19 +88,17 @@ level_zero_log_reader_impl::read_some(
             vlog(_log.trace, "Materialize batches called while EOS");
             break;
         }
-        if (_hydrated.size() > 0) {
-            _current = state::materialized_state;
-            vlog(
-              _log.trace,
-              "Materialize batches call redundant, already materialized");
-            break;
-        }
         if (_unhydrated.empty()) {
             _current = state::end_of_stream_state;
             vlog(_log.trace, "Materialize batches without unhydrated batches");
             break;
         }
-        co_await materialize_batches(deadline);
+        res = co_await materialize_batches(deadline);
+        if (res.empty()) {
+            _current = state::end_of_stream_state;
+        } else {
+            _current = state::materialized_state;
+        }
         [[fallthrough]];
     case state::materialized_state:
     case state::end_of_stream_state:
@@ -117,7 +114,16 @@ level_zero_log_reader_impl::read_some(
         _current = state::end_of_stream_state;
         throw std::runtime_error("Invalid reader state (ready/empty)");
     case state::materialized_state:
-        consume_materialized_batches(&res);
+        vlog(
+          _log.debug,
+          "consuming {} materialized batches, cached {} extents",
+          res.size(),
+          _unhydrated.size());
+        vassert(!res.empty(), "expected non-empty hydrated set");
+        _next_offset = model::offset_cast(
+          model::next_offset(res.back().last_offset()));
+        _current = _unhydrated.empty() ? state::empty_state
+                                       : state::ready_state;
         [[fallthrough]];
     case state::end_of_stream_state:
         break;
@@ -279,7 +285,8 @@ level_zero_log_reader_impl::fetch_metadata(
     co_return ret;
 }
 
-ss::future<> level_zero_log_reader_impl::materialize_batches(
+ss::future<chunked_circular_buffer<model::record_batch>>
+level_zero_log_reader_impl::materialize_batches(
   model::timeout_clock::time_point deadline) {
     vassert(
       _current == state::ready_state || _current == state::materialized_state,
@@ -349,7 +356,7 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
         if (mat_res.error() == errc::timeout) {
             vlog(_log.debug, "Materialize aborted due to timeout");
             _current = state::end_of_stream_state;
-            co_return;
+            throw ss::timed_out_error();
         }
         throw std::runtime_error(
           fmt::format(
@@ -406,15 +413,11 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
     vassert(
       batches_it == batches.end(), "All materialized batches should be used");
     _unhydrated.erase(range_to_materialize.begin(), range_to_materialize.end());
-    _hydrated = std::move(hydrated);
-    // Materialize batches from the L0 meta batches.
     vlog(
       _log.debug,
       "Materialized {} batches from the L0 meta batches",
-      _hydrated.size());
-
-    _current = _hydrated.empty() ? state::end_of_stream_state
-                                 : state::materialized_state;
+      hydrated.size());
+    co_return hydrated;
 }
 
 bool level_zero_log_reader_impl::cache_enabled() const {
@@ -428,19 +431,6 @@ bool level_zero_log_reader_impl::cache_enabled() const {
         return false;
     }
     return true;
-}
-
-void level_zero_log_reader_impl::consume_materialized_batches(
-  chunked_circular_buffer<model::record_batch>* dest) {
-    vlog(
-      _log.debug,
-      "consuming {} materialized batches, cached {} extents",
-      _hydrated.size(),
-      _unhydrated.size());
-    *dest = std::exchange(_hydrated, {});
-    _next_offset = model::offset_cast(
-      model::next_offset(dest->back().last_offset()));
-    _current = _unhydrated.empty() ? state::empty_state : state::ready_state;
 }
 
 void level_zero_log_reader_impl::print(std::ostream& o) {

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -60,7 +60,14 @@ level_zero_log_reader_impl::do_load_slice(
     chunked_circular_buffer<model::record_batch> res;
     switch (_current) {
     case state::empty_state:
-        co_await fetch_metadata(deadline);
+        if (_unhydrated.empty()) {
+            _unhydrated = co_await fetch_metadata(deadline);
+        }
+        if (_unhydrated.empty()) {
+            _current = state::end_of_stream_state;
+        } else {
+            _current = state::ready_state;
+        }
         [[fallthrough]];
     case state::ready_state:
         co_await materialize_batches(deadline);
@@ -186,17 +193,14 @@ storage::local_log_reader_config level_zero_log_reader_impl::ctp_read_config() {
     return cfg;
 }
 
-ss::future<> level_zero_log_reader_impl::fetch_metadata(
+ss::future<chunked_circular_buffer<level_zero_log_reader_impl::local_log_batch>>
+level_zero_log_reader_impl::fetch_metadata(
   model::timeout_clock::time_point deadline) {
     vassert(
       _current == state::empty_state || _current == state::materialized_state,
       "Invalid state transition, unexpected current state: {}",
       std::to_underlying(_current));
-    if (_unhydrated.size() > 0) {
-        // If we already have metadata, we can skip fetching it again.
-        _current = state::ready_state;
-        co_return;
-    }
+    chunked_circular_buffer<local_log_batch> ret;
     try {
         auto cfg = ctp_read_config();
         auto reader = co_await _ctp->make_local_reader(cfg);
@@ -209,7 +213,7 @@ ss::future<> level_zero_log_reader_impl::fetch_metadata(
             if (header.type == model::record_batch_type::raft_data) {
                 local_log_batch local_batch{.header = header};
                 local_batch.data = std::move(batch).release_data();
-                _unhydrated.push_back(std::move(local_batch));
+                ret.push_back(std::move(local_batch));
                 continue;
             }
             if (header.type != model::record_batch_type::ctp_placeholder) {
@@ -223,16 +227,16 @@ ss::future<> level_zero_log_reader_impl::fetch_metadata(
             e.id = placeholder.id;
             e.first_byte_offset = placeholder.offset;
             e.byte_range_size = placeholder.size_bytes;
-            _unhydrated.push_back(local_log_batch{.header = header, .data = e});
+            ret.push_back(local_log_batch{.header = header, .data = e});
         }
-        if (!_unhydrated.empty()) {
+        if (!ret.empty()) {
             vlog(
               _log.debug,
               "Fetched {} L0 meta batches from the underlying "
               "partition, first offset: {}, last offset: {}",
-              _unhydrated.size(),
-              _unhydrated.front().header.base_offset,
-              _unhydrated.back().header.last_offset());
+              ret.size(),
+              ret.front().header.base_offset,
+              ret.back().header.last_offset());
         } else {
             vlog(
               _log.debug,
@@ -251,8 +255,7 @@ ss::future<> level_zero_log_reader_impl::fetch_metadata(
         _current = state::end_of_stream_state;
         throw;
     }
-    _current = _unhydrated.empty() ? state::end_of_stream_state
-                                   : state::ready_state;
+    co_return ret;
 }
 
 ss::future<> level_zero_log_reader_impl::materialize_batches(

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -287,135 +287,131 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
       std::to_underlying(_current));
 
     // Cherry-pick enough L0 meta batches to materialize.
-        chunked_vector<cloud_topics::extent_meta> to_materialize;
-        auto unhydrated_it = _unhydrated.begin();
-        size_t materialize_bytes = 0;
-        for (; unhydrated_it != _unhydrated.end(); ++unhydrated_it) {
-            size_t hydrated_batch_size = ss::visit(
-              unhydrated_it->data,
-              [](const local_log_batch::payload& payload) {
-                  return payload.size_bytes();
-              },
-              [](const cloud_topics::extent_meta& meta) {
-                  return meta.byte_range_size();
-              });
-            if (is_over_limit(hydrated_batch_size)) {
-                // If the next meta batch exceeds the max bytes limit, we stop
-                // materializing. The only exception is if we didn't collect any
-                // batches yet, in which case we still materialize the next
-                // batch. This could happen if the first meta batch is larger
-                // than the max bytes limit (oversized batch or too small
-                // limit). In this case we don't want to stall the reader
-                // completely.
-                vlog(
-                  _log.trace,
-                  "Materialize batches overshot at {} bytes, config: {}, last "
-                  "hydrated batch size: {}",
-                  materialize_bytes,
-                  _config,
-                  hydrated_batch_size);
-                break;
-            }
-            _bytes_consumed += hydrated_batch_size;
-            if (
-              auto* meta = std::get_if<cloud_topics::extent_meta>(
-                &unhydrated_it->data)) {
-                materialize_bytes += meta->byte_range_size;
-                to_materialize.push_back(*meta);
-                vlog(
-                  _log.trace,
-                  "Materialize {} bytes total...",
-                  materialize_bytes);
-            }
+    chunked_vector<cloud_topics::extent_meta> to_materialize;
+    auto unhydrated_it = _unhydrated.begin();
+    size_t materialize_bytes = 0;
+    for (; unhydrated_it != _unhydrated.end(); ++unhydrated_it) {
+        size_t hydrated_batch_size = ss::visit(
+          unhydrated_it->data,
+          [](const local_log_batch::payload& payload) {
+              return payload.size_bytes();
+          },
+          [](const cloud_topics::extent_meta& meta) {
+              return meta.byte_range_size();
+          });
+        if (is_over_limit(hydrated_batch_size)) {
+            // If the next meta batch exceeds the max bytes limit, we stop
+            // materializing. The only exception is if we didn't collect any
+            // batches yet, in which case we still materialize the next
+            // batch. This could happen if the first meta batch is larger
+            // than the max bytes limit (oversized batch or too small
+            // limit). In this case we don't want to stall the reader
+            // completely.
+            vlog(
+              _log.trace,
+              "Materialize batches overshot at {} bytes, config: {}, last "
+              "hydrated batch size: {}",
+              materialize_bytes,
+              _config,
+              hydrated_batch_size);
+            break;
         }
-        size_t materialize_count = to_materialize.size();
-        vlog(
-          _log.trace,
-          "Invoking 'materialize' for {}: {} bytes, {} batches to materialize",
-          _ctp->ntp(),
-          materialize_bytes,
-          materialize_count);
-        // Ask data layer to bring data from the cloud storage.
-        auto mat_res = co_await _ct_api->materialize(
-          _ctp->ntp(),
-          materialize_bytes,
-          std::move(to_materialize),
-          deadline,
-          _config.abort_source);
-        if (!mat_res.has_value()) {
-            if (mat_res.error() == errc::shutting_down) {
-                vlog(_log.debug, "Materialize aborted due to shutdown");
-                _current = state::end_of_stream_state;
-                throw ss::abort_requested_exception();
-            }
-            if (mat_res.error() == errc::timeout) {
-                vlog(_log.debug, "Materialize aborted due to timeout");
-                _current = state::end_of_stream_state;
-                co_return;
-            }
-            throw std::runtime_error(
-              fmt::format(
-                "Failed to materialize batches from the cloud storage: {}",
-                mat_res.error().message()));
+        _bytes_consumed += hydrated_batch_size;
+        if (
+          auto* meta = std::get_if<cloud_topics::extent_meta>(
+            &unhydrated_it->data)) {
+            materialize_bytes += meta->byte_range_size;
+            to_materialize.push_back(*meta);
+            vlog(
+              _log.trace, "Materialize {} bytes total...", materialize_bytes);
         }
-        auto batches = std::move(mat_res.value());
-        if (batches.size() != materialize_count) {
-            throw std::runtime_error(
-              fmt::format(
-                "Materialized unexpected number of batches: {}, expected: {}",
-                batches.size(),
-                materialize_count));
+    }
+    size_t materialize_count = to_materialize.size();
+    vlog(
+      _log.trace,
+      "Invoking 'materialize' for {}: {} bytes, {} batches to materialize",
+      _ctp->ntp(),
+      materialize_bytes,
+      materialize_count);
+    // Ask data layer to bring data from the cloud storage.
+    auto mat_res = co_await _ct_api->materialize(
+      _ctp->ntp(),
+      materialize_bytes,
+      std::move(to_materialize),
+      deadline,
+      _config.abort_source);
+    if (!mat_res.has_value()) {
+        if (mat_res.error() == errc::shutting_down) {
+            vlog(_log.debug, "Materialize aborted due to shutdown");
+            _current = state::end_of_stream_state;
+            throw ss::abort_requested_exception();
         }
-        // Merge our selected subset of unhydrated batches with the materialized
-        // batches, preserving control batches from the local log.
-        auto batches_it = batches.begin();
-        chunked_circular_buffer<model::record_batch> hydrated;
-        auto range_to_materialize = std::ranges::subrange(
-          _unhydrated.begin(), unhydrated_it);
-        for (local_log_batch& local_batch : range_to_materialize) {
-            if (_config.abort_source.has_value()) {
-                _config.abort_source.value().get().check();
-            }
-            auto& local_batch_header = local_batch.header;
-            model::record_batch batch = ss::visit(
-              local_batch.data,
-              [this, &local_batch_header, &batches_it](
-                const cloud_topics::extent_meta&) {
-                  model::record_batch batch = apply_placeholder_to_batch(
-                    local_batch_header, std::move(*batches_it));
-                  ++batches_it;
-                  // Propagate materialized batches to the record batch cache
-                  if (cache_enabled()) {
-                      vlog(
-                        _log.trace,
-                        "Putting batch for {} to cache: {}, term: {}",
-                        _ctp->ntp(),
-                        batch.base_offset(),
-                        batch.term());
-                      _ct_api->cache_put(_ctp->ntp(), batch);
-                  }
-                  return batch;
-              },
-              [&local_batch_header](local_log_batch::payload& payload) {
-                  return model::record_batch(
-                    local_batch_header,
-                    std::move(payload),
-                    model::record_batch::tag_ctor_ng{});
-              });
-            hydrated.push_back(std::move(batch));
-            co_await ss::coroutine::maybe_yield();
+        if (mat_res.error() == errc::timeout) {
+            vlog(_log.debug, "Materialize aborted due to timeout");
+            _current = state::end_of_stream_state;
+            co_return;
         }
-        vassert(
-          batches_it == batches.end(),
-          "All materialized batches should be used");
-        _unhydrated.erase(
-          range_to_materialize.begin(), range_to_materialize.end());
-        _hydrated = std::move(hydrated);
-        // Materialize batches from the L0 meta batches.
-        vlog(
-          _log.debug,
-          "Materialized {} batches from the L0 meta batches",
-          _hydrated.size());
+        throw std::runtime_error(
+          fmt::format(
+            "Failed to materialize batches from the cloud storage: {}",
+            mat_res.error().message()));
+    }
+    auto batches = std::move(mat_res.value());
+    if (batches.size() != materialize_count) {
+        throw std::runtime_error(
+          fmt::format(
+            "Materialized unexpected number of batches: {}, expected: {}",
+            batches.size(),
+            materialize_count));
+    }
+    // Merge our selected subset of unhydrated batches with the materialized
+    // batches, preserving control batches from the local log.
+    auto batches_it = batches.begin();
+    chunked_circular_buffer<model::record_batch> hydrated;
+    auto range_to_materialize = std::ranges::subrange(
+      _unhydrated.begin(), unhydrated_it);
+    for (local_log_batch& local_batch : range_to_materialize) {
+        if (_config.abort_source.has_value()) {
+            _config.abort_source.value().get().check();
+        }
+        auto& local_batch_header = local_batch.header;
+        model::record_batch batch = ss::visit(
+          local_batch.data,
+          [this, &local_batch_header, &batches_it](
+            const cloud_topics::extent_meta&) {
+              model::record_batch batch = apply_placeholder_to_batch(
+                local_batch_header, std::move(*batches_it));
+              ++batches_it;
+              // Propagate materialized batches to the record batch cache
+              if (cache_enabled()) {
+                  vlog(
+                    _log.trace,
+                    "Putting batch for {} to cache: {}, term: {}",
+                    _ctp->ntp(),
+                    batch.base_offset(),
+                    batch.term());
+                  _ct_api->cache_put(_ctp->ntp(), batch);
+              }
+              return batch;
+          },
+          [&local_batch_header](local_log_batch::payload& payload) {
+              return model::record_batch(
+                local_batch_header,
+                std::move(payload),
+                model::record_batch::tag_ctor_ng{});
+          });
+        hydrated.push_back(std::move(batch));
+        co_await ss::coroutine::maybe_yield();
+    }
+    vassert(
+      batches_it == batches.end(), "All materialized batches should be used");
+    _unhydrated.erase(range_to_materialize.begin(), range_to_materialize.end());
+    _hydrated = std::move(hydrated);
+    // Materialize batches from the L0 meta batches.
+    vlog(
+      _log.debug,
+      "Materialized {} batches from the L0 meta batches",
+      _hydrated.size());
 
     _current = _hydrated.empty() ? state::end_of_stream_state
                                  : state::materialized_state;

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -58,6 +58,18 @@ level_zero_log_reader_impl::do_load_slice(
 ss::future<model::record_batch_reader::storage_t>
 level_zero_log_reader_impl::read_some(
   model::timeout_clock::time_point deadline) {
+    if (_next_offset > _config.max_offset) {
+        vlog(
+          _log.debug,
+          "reached end of stream, start offset: {}, max offset: {}, "
+          "next offset: {}",
+          _config.start_offset,
+          _config.max_offset,
+          _next_offset);
+        set_end_of_stream();
+        co_return chunked_circular_buffer<model::record_batch>{};
+    }
+
     if (is_over_limit(0)) {
         set_end_of_stream();
         co_return chunked_circular_buffer<model::record_batch>{};
@@ -133,19 +145,6 @@ level_zero_log_reader_impl::maybe_read_batches_from_cache() {
         _bytes_consumed += batch_size;
         _next_offset = model::offset_cast(
           model::next_offset(ret.back().last_offset()));
-    }
-
-    // TODO: should this be moved into read_some? should we have a
-    // is_end_of_stream check in read_some? see L1 reader...
-    if (_next_offset > _config.max_offset) {
-        vlog(
-          _log.debug,
-          "reached end of stream, start offset: {}, max offset: {}, "
-          "next offset: {}",
-          _config.start_offset,
-          _config.max_offset,
-          _next_offset);
-        set_end_of_stream();
     }
 
     return ret;

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -45,6 +45,21 @@ level_zero_log_reader_impl::level_zero_log_reader_impl(
 ss::future<model::record_batch_reader::storage_t>
 level_zero_log_reader_impl::do_load_slice(
   model::timeout_clock::time_point deadline) {
+    try {
+        return read_some(deadline);
+    } catch (...) {
+        vlog(
+          _log.error, "Reader caught exception: {}", std::current_exception());
+        _hydrated.clear();
+        _unhydrated.clear();
+        _current = state::end_of_stream_state;
+        throw;
+    }
+}
+
+ss::future<model::record_batch_reader::storage_t>
+level_zero_log_reader_impl::read_some(
+  model::timeout_clock::time_point deadline) {
     if (is_over_limit(0)) {
         _current = state::end_of_stream_state;
         co_return chunked_circular_buffer<model::record_batch>{};
@@ -144,7 +159,7 @@ level_zero_log_reader_impl::maybe_read_batches_from_cache() {
     return ret;
 }
 
-storage::local_log_reader_config level_zero_log_reader_impl::ctp_read_config() {
+storage::local_log_reader_config level_zero_log_reader_impl::ctp_read_config() const {
     /*
      * The requested offset range in the cloud topic reader configuration are
      * specified as offsets in the kafka address space and need to first be
@@ -195,13 +210,12 @@ storage::local_log_reader_config level_zero_log_reader_impl::ctp_read_config() {
 
 ss::future<chunked_circular_buffer<level_zero_log_reader_impl::local_log_batch>>
 level_zero_log_reader_impl::fetch_metadata(
-  model::timeout_clock::time_point deadline) {
+  model::timeout_clock::time_point deadline) const {
     vassert(
       _current == state::empty_state || _current == state::materialized_state,
       "Invalid state transition, unexpected current state: {}",
       std::to_underlying(_current));
     chunked_circular_buffer<local_log_batch> ret;
-    try {
         auto cfg = ctp_read_config();
         auto reader = co_await _ctp->make_local_reader(cfg);
         auto batches = std::move(reader).generator(deadline);
@@ -245,16 +259,6 @@ level_zero_log_reader_impl::fetch_metadata(
               cfg.start_offset,
               cfg.max_offset);
         }
-    } catch (...) {
-        vlog(
-          _log.info,
-          "Failed to fetch metadata from the underlying partition: {}",
-          std::current_exception());
-        _hydrated.clear();
-        _unhydrated.clear();
-        _current = state::end_of_stream_state;
-        throw;
-    }
     co_return ret;
 }
 

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -93,7 +93,7 @@ level_zero_log_reader_impl::read_some(
             vlog(_log.trace, "Materialize batches without unhydrated batches");
             break;
         }
-        res = co_await materialize_batches(deadline);
+        res = co_await materialize_batches(std::move(_unhydrated), deadline);
         if (res.empty()) {
             _current = state::end_of_stream_state;
         } else {
@@ -114,16 +114,11 @@ level_zero_log_reader_impl::read_some(
         _current = state::end_of_stream_state;
         throw std::runtime_error("Invalid reader state (ready/empty)");
     case state::materialized_state:
-        vlog(
-          _log.debug,
-          "consuming {} materialized batches, cached {} extents",
-          res.size(),
-          _unhydrated.size());
+        vlog(_log.debug, "consuming {} materialized batches", res.size());
         vassert(!res.empty(), "expected non-empty hydrated set");
         _next_offset = model::offset_cast(
           model::next_offset(res.back().last_offset()));
-        _current = _unhydrated.empty() ? state::empty_state
-                                       : state::ready_state;
+        _current = state::empty_state;
         [[fallthrough]];
     case state::end_of_stream_state:
         break;
@@ -287,6 +282,7 @@ level_zero_log_reader_impl::fetch_metadata(
 
 ss::future<chunked_circular_buffer<model::record_batch>>
 level_zero_log_reader_impl::materialize_batches(
+  chunked_circular_buffer<local_log_batch> unhydrated,
   model::timeout_clock::time_point deadline) {
     vassert(
       _current == state::ready_state || _current == state::materialized_state,
@@ -295,9 +291,9 @@ level_zero_log_reader_impl::materialize_batches(
 
     // Cherry-pick enough L0 meta batches to materialize.
     chunked_vector<cloud_topics::extent_meta> to_materialize;
-    auto unhydrated_it = _unhydrated.begin();
+    auto unhydrated_it = unhydrated.begin();
     size_t materialize_bytes = 0;
-    for (; unhydrated_it != _unhydrated.end(); ++unhydrated_it) {
+    for (; unhydrated_it != unhydrated.end(); ++unhydrated_it) {
         size_t hydrated_batch_size = ss::visit(
           unhydrated_it->data,
           [](const local_log_batch::payload& payload) {
@@ -376,7 +372,7 @@ level_zero_log_reader_impl::materialize_batches(
     auto batches_it = batches.begin();
     chunked_circular_buffer<model::record_batch> hydrated;
     auto range_to_materialize = std::ranges::subrange(
-      _unhydrated.begin(), unhydrated_it);
+      unhydrated.begin(), unhydrated_it);
     for (local_log_batch& local_batch : range_to_materialize) {
         if (_config.abort_source.has_value()) {
             _config.abort_source.value().get().check();
@@ -412,7 +408,6 @@ level_zero_log_reader_impl::materialize_batches(
     }
     vassert(
       batches_it == batches.end(), "All materialized batches should be used");
-    _unhydrated.erase(range_to_materialize.begin(), range_to_materialize.end());
     vlog(
       _log.debug,
       "Materialized {} batches from the L0 meta batches",

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -50,8 +50,7 @@ level_zero_log_reader_impl::do_load_slice(
     } catch (...) {
         vlog(
           _log.error, "Reader caught exception: {}", std::current_exception());
-        _unhydrated.clear();
-        _current = state::end_of_stream_state;
+        set_end_of_stream();
         throw;
     }
 }
@@ -60,7 +59,7 @@ ss::future<model::record_batch_reader::storage_t>
 level_zero_log_reader_impl::read_some(
   model::timeout_clock::time_point deadline) {
     if (is_over_limit(0)) {
-        _current = state::end_of_stream_state;
+        set_end_of_stream();
         co_return chunked_circular_buffer<model::record_batch>{};
     }
     // We're only fetching from the record batch cache if the reader is in
@@ -71,59 +70,33 @@ level_zero_log_reader_impl::read_some(
         co_return cached;
     }
 
-    chunked_circular_buffer<model::record_batch> res;
-    switch (_current) {
-    case state::empty_state:
-        if (_unhydrated.empty()) {
-            _unhydrated = co_await fetch_metadata(deadline);
-        }
-        if (_unhydrated.empty()) {
-            _current = state::end_of_stream_state;
-        } else {
-            _current = state::ready_state;
-        }
-        [[fallthrough]];
-    case state::ready_state:
-        if (_current == state::end_of_stream_state) {
-            vlog(_log.trace, "Materialize batches called while EOS");
-            break;
-        }
-        if (_unhydrated.empty()) {
-            _current = state::end_of_stream_state;
-            vlog(_log.trace, "Materialize batches without unhydrated batches");
-            break;
-        }
-        res = co_await materialize_batches(std::move(_unhydrated), deadline);
-        if (res.empty()) {
-            _current = state::end_of_stream_state;
-        } else {
-            _current = state::materialized_state;
-        }
-        [[fallthrough]];
-    case state::materialized_state:
-    case state::end_of_stream_state:
-        // Handled in the next switch statement
-        break;
+    /*
+     * Read metadata (raft batches, placeholders, etc...) from the underlying
+     * cloud topics partition. In the case of placeholders, the payloads are
+     * missing, and will be handled below.
+     */
+    auto log_read_metadata = co_await fetch_metadata(deadline);
+    if (log_read_metadata.empty()) {
+        set_end_of_stream();
+        co_return model::record_batch_reader::storage_t{};
     }
 
-    // Invariant: in case of success the state will be either materialized
-    // or end_of_stream. In case of error the state will be end_of_stream.
-    switch (_current) {
-    case state::empty_state:
-    case state::ready_state:
-        _current = state::end_of_stream_state;
-        throw std::runtime_error("Invalid reader state (ready/empty)");
-    case state::materialized_state:
-        vlog(_log.debug, "consuming {} materialized batches", res.size());
-        vassert(!res.empty(), "expected non-empty hydrated set");
-        _next_offset = model::offset_cast(
-          model::next_offset(res.back().last_offset()));
-        _current = state::empty_state;
-        [[fallthrough]];
-    case state::end_of_stream_state:
-        break;
+    /*
+     * Combine metadata with payloads (from cache or object storage) to
+     * construct the full batches expected by the caller (e.g. Kafka Fetch).
+     */
+    auto batches = co_await materialize_batches(
+      std::move(log_read_metadata), deadline);
+    if (batches.empty()) {
+        set_end_of_stream();
+        co_return model::record_batch_reader::storage_t{};
     }
-    co_return res;
+
+    vlog(_log.debug, "consuming {} materialized batches", batches.size());
+    _next_offset = model::offset_cast(
+      model::next_offset(batches.back().last_offset()));
+
+    co_return batches;
 }
 
 chunked_circular_buffer<model::record_batch>
@@ -162,6 +135,8 @@ level_zero_log_reader_impl::maybe_read_batches_from_cache() {
           model::next_offset(ret.back().last_offset()));
     }
 
+    // TODO: should this be moved into read_some? should we have a
+    // is_end_of_stream check in read_some? see L1 reader...
     if (_next_offset > _config.max_offset) {
         vlog(
           _log.debug,
@@ -170,7 +145,7 @@ level_zero_log_reader_impl::maybe_read_batches_from_cache() {
           _config.start_offset,
           _config.max_offset,
           _next_offset);
-        _current = state::end_of_stream_state;
+        set_end_of_stream();
     }
 
     return ret;
@@ -229,10 +204,6 @@ level_zero_log_reader_impl::ctp_read_config() const {
 ss::future<chunked_circular_buffer<level_zero_log_reader_impl::local_log_batch>>
 level_zero_log_reader_impl::fetch_metadata(
   model::timeout_clock::time_point deadline) const {
-    vassert(
-      _current == state::empty_state || _current == state::materialized_state,
-      "Invalid state transition, unexpected current state: {}",
-      std::to_underlying(_current));
     chunked_circular_buffer<local_log_batch> ret;
     auto cfg = ctp_read_config();
     auto reader = co_await _ctp->make_local_reader(cfg);
@@ -284,11 +255,6 @@ ss::future<chunked_circular_buffer<model::record_batch>>
 level_zero_log_reader_impl::materialize_batches(
   chunked_circular_buffer<local_log_batch> unhydrated,
   model::timeout_clock::time_point deadline) {
-    vassert(
-      _current == state::ready_state || _current == state::materialized_state,
-      "Invalid state transition, unexpected current state: {}",
-      std::to_underlying(_current));
-
     // Cherry-pick enough L0 meta batches to materialize.
     chunked_vector<cloud_topics::extent_meta> to_materialize;
     auto unhydrated_it = unhydrated.begin();
@@ -346,12 +312,10 @@ level_zero_log_reader_impl::materialize_batches(
     if (!mat_res.has_value()) {
         if (mat_res.error() == errc::shutting_down) {
             vlog(_log.debug, "Materialize aborted due to shutdown");
-            _current = state::end_of_stream_state;
             throw ss::abort_requested_exception();
         }
         if (mat_res.error() == errc::timeout) {
             vlog(_log.debug, "Materialize aborted due to timeout");
-            _current = state::end_of_stream_state;
             throw ss::timed_out_error();
         }
         throw std::runtime_error(
@@ -432,8 +396,10 @@ void level_zero_log_reader_impl::print(std::ostream& o) {
     o << "cloud_topics_reader";
 }
 
+void level_zero_log_reader_impl::set_end_of_stream() { _end_of_stream = true; }
+
 bool level_zero_log_reader_impl::is_end_of_stream() const {
-    return _current == state::end_of_stream_state;
+    return _end_of_stream;
 }
 
 bool level_zero_log_reader_impl::is_over_limit(size_t size) const {

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -83,11 +83,26 @@ level_zero_log_reader_impl::read_some(
      * cloud topics partition. In the case of placeholders, the payloads are
      * missing, and will be handled below.
      */
-    auto log_read_metadata = co_await fetch_metadata(deadline);
+    auto log_read_cfg = ctp_read_config();
+    auto log_read_metadata = co_await fetch_metadata(log_read_cfg, deadline);
     if (log_read_metadata.empty()) {
+        vlog(
+          _log.debug,
+          "No L0 meta batches fetched from the underlying partition, "
+          "start offset: {}, max offset: {}",
+          log_read_cfg.start_offset,
+          log_read_cfg.max_offset);
         set_end_of_stream();
         co_return model::record_batch_reader::storage_t{};
     }
+
+    vlog(
+      _log.debug,
+      "Fetched {} L0 meta batches from the underlying "
+      "partition, first offset: {}, last offset: {}",
+      log_read_metadata.size(),
+      log_read_metadata.front().header.base_offset,
+      log_read_metadata.back().header.last_offset());
 
     /*
      * Combine metadata with payloads (from cache or object storage) to
@@ -199,9 +214,9 @@ level_zero_log_reader_impl::ctp_read_config() const {
 
 ss::future<chunked_circular_buffer<level_zero_log_reader_impl::local_log_batch>>
 level_zero_log_reader_impl::fetch_metadata(
+  storage::local_log_reader_config cfg,
   model::timeout_clock::time_point deadline) const {
     chunked_circular_buffer<local_log_batch> ret;
-    auto cfg = ctp_read_config();
     auto reader = co_await _ctp->make_local_reader(cfg);
     auto batches = std::move(reader).generator(deadline);
 
@@ -228,22 +243,7 @@ level_zero_log_reader_impl::fetch_metadata(
         e.byte_range_size = placeholder.size_bytes;
         ret.push_back(local_log_batch{.header = header, .data = e});
     }
-    if (!ret.empty()) {
-        vlog(
-          _log.debug,
-          "Fetched {} L0 meta batches from the underlying "
-          "partition, first offset: {}, last offset: {}",
-          ret.size(),
-          ret.front().header.base_offset,
-          ret.back().header.last_offset());
-    } else {
-        vlog(
-          _log.debug,
-          "No L0 meta batches fetched from the underlying partition, "
-          "start offset: {}, max offset: {}",
-          cfg.start_offset,
-          cfg.max_offset);
-    }
+
     co_return ret;
 }
 

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -159,7 +159,8 @@ level_zero_log_reader_impl::maybe_read_batches_from_cache() {
     return ret;
 }
 
-storage::local_log_reader_config level_zero_log_reader_impl::ctp_read_config() const {
+storage::local_log_reader_config
+level_zero_log_reader_impl::ctp_read_config() const {
     /*
      * The requested offset range in the cloud topic reader configuration are
      * specified as offsets in the kafka address space and need to first be
@@ -216,49 +217,49 @@ level_zero_log_reader_impl::fetch_metadata(
       "Invalid state transition, unexpected current state: {}",
       std::to_underlying(_current));
     chunked_circular_buffer<local_log_batch> ret;
-        auto cfg = ctp_read_config();
-        auto reader = co_await _ctp->make_local_reader(cfg);
-        auto batches = std::move(reader).generator(deadline);
+    auto cfg = ctp_read_config();
+    auto reader = co_await _ctp->make_local_reader(cfg);
+    auto batches = std::move(reader).generator(deadline);
 
-        // Convert L0 meta batches to extent_meta structures.
-        while (auto maybe_batch = co_await batches()) {
-            auto batch = std::move(maybe_batch->get());
-            auto& header = batch.header();
-            if (header.type == model::record_batch_type::raft_data) {
-                local_log_batch local_batch{.header = header};
-                local_batch.data = std::move(batch).release_data();
-                ret.push_back(std::move(local_batch));
-                continue;
-            }
-            if (header.type != model::record_batch_type::ctp_placeholder) {
-                continue;
-            }
-            cloud_topics::extent_meta e{
-              .base_offset = model::offset_cast(batch.base_offset()),
-              .last_offset = model::offset_cast(batch.last_offset()),
-            };
-            auto placeholder = parse_placeholder_batch(std::move(batch));
-            e.id = placeholder.id;
-            e.first_byte_offset = placeholder.offset;
-            e.byte_range_size = placeholder.size_bytes;
-            ret.push_back(local_log_batch{.header = header, .data = e});
+    // Convert L0 meta batches to extent_meta structures.
+    while (auto maybe_batch = co_await batches()) {
+        auto batch = std::move(maybe_batch->get());
+        auto& header = batch.header();
+        if (header.type == model::record_batch_type::raft_data) {
+            local_log_batch local_batch{.header = header};
+            local_batch.data = std::move(batch).release_data();
+            ret.push_back(std::move(local_batch));
+            continue;
         }
-        if (!ret.empty()) {
-            vlog(
-              _log.debug,
-              "Fetched {} L0 meta batches from the underlying "
-              "partition, first offset: {}, last offset: {}",
-              ret.size(),
-              ret.front().header.base_offset,
-              ret.back().header.last_offset());
-        } else {
-            vlog(
-              _log.debug,
-              "No L0 meta batches fetched from the underlying partition, "
-              "start offset: {}, max offset: {}",
-              cfg.start_offset,
-              cfg.max_offset);
+        if (header.type != model::record_batch_type::ctp_placeholder) {
+            continue;
         }
+        cloud_topics::extent_meta e{
+          .base_offset = model::offset_cast(batch.base_offset()),
+          .last_offset = model::offset_cast(batch.last_offset()),
+        };
+        auto placeholder = parse_placeholder_batch(std::move(batch));
+        e.id = placeholder.id;
+        e.first_byte_offset = placeholder.offset;
+        e.byte_range_size = placeholder.size_bytes;
+        ret.push_back(local_log_batch{.header = header, .data = e});
+    }
+    if (!ret.empty()) {
+        vlog(
+          _log.debug,
+          "Fetched {} L0 meta batches from the underlying "
+          "partition, first offset: {}, last offset: {}",
+          ret.size(),
+          ret.front().header.base_offset,
+          ret.back().header.last_offset());
+    } else {
+        vlog(
+          _log.debug,
+          "No L0 meta batches fetched from the underlying partition, "
+          "start offset: {}, max offset: {}",
+          cfg.start_offset,
+          cfg.max_offset);
+    }
     co_return ret;
 }
 

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -70,10 +70,6 @@ level_zero_log_reader_impl::read_some(
         co_return chunked_circular_buffer<model::record_batch>{};
     }
 
-    if (is_over_limit(0)) {
-        set_end_of_stream();
-        co_return chunked_circular_buffer<model::record_batch>{};
-    }
     // We're only fetching from the record batch cache if the reader is in
     // the 'empty' state. It doesn't make any difference if the reader is in
     // the 'materialized' state. If we're in 'ready' state we risk to go out
@@ -137,12 +133,13 @@ level_zero_log_reader_impl::maybe_read_batches_from_cache() {
           batch.value().term());
 
         auto batch_size = batch.value().size_bytes();
-        if (is_over_limit(batch_size)) {
+        if (is_over_limit_with_bytes(batch_size)) {
+            set_end_of_stream();
             break;
         }
+        _bytes_consumed += batch_size;
 
         ret.push_back(std::move(batch.value()));
-        _bytes_consumed += batch_size;
         _next_offset = model::offset_cast(
           model::next_offset(ret.back().last_offset()));
     }
@@ -267,7 +264,7 @@ level_zero_log_reader_impl::materialize_batches(
           [](const cloud_topics::extent_meta& meta) {
               return meta.byte_range_size();
           });
-        if (is_over_limit(hydrated_batch_size)) {
+        if (is_over_limit_with_bytes(hydrated_batch_size)) {
             // If the next meta batch exceeds the max bytes limit, we stop
             // materializing. The only exception is if we didn't collect any
             // batches yet, in which case we still materialize the next
@@ -282,6 +279,7 @@ level_zero_log_reader_impl::materialize_batches(
               materialize_bytes,
               _config,
               hydrated_batch_size);
+            set_end_of_stream();
             break;
         }
         _bytes_consumed += hydrated_batch_size;
@@ -401,7 +399,7 @@ bool level_zero_log_reader_impl::is_end_of_stream() const {
     return _end_of_stream;
 }
 
-bool level_zero_log_reader_impl::is_over_limit(size_t size) const {
+bool level_zero_log_reader_impl::is_over_limit_with_bytes(size_t size) const {
     return (_config.strict_max_bytes || _bytes_consumed > 0)
            && (_bytes_consumed + size) > _config.max_bytes;
 }

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
@@ -114,9 +114,8 @@ private:
     ss::future<
       chunked_circular_buffer<level_zero_log_reader_impl::local_log_batch>>
     fetch_metadata(model::timeout_clock::time_point deadline) const;
-    ss::future<> materialize_batches(model::timeout_clock::time_point deadline);
-    void consume_materialized_batches(
-      chunked_circular_buffer<model::record_batch>* dest);
+    ss::future<chunked_circular_buffer<model::record_batch>>
+    materialize_batches(model::timeout_clock::time_point deadline);
     // Return data from the record batch cache.
     // This method could change state of the reader to end_of_stream_state
     // when it reaches committed offset.
@@ -135,10 +134,6 @@ private:
     // All batches in _unhydrated come after the _hydrated batches (in offset
     // ordering).
     chunked_circular_buffer<local_log_batch> _unhydrated;
-    // Data that has been hydrated from L0 and is ready to be returned.
-    //
-    // The data stored in this buffer is ascending order by offset.
-    chunked_circular_buffer<model::record_batch> _hydrated;
 
     cloud_topic_log_reader_config _config;
     kafka::offset _next_offset;

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
@@ -80,6 +80,20 @@ public:
     void print(std::ostream& o) final;
 
 private:
+    // A batch read from the local log, these can be either placeholder batches
+    // with pointers to the actual data in cloud storage, or it can be control
+    // batches from the local log (i.e. transaction markers). We need to
+    // preserve transactional markers because clients expect to be able to read
+    // them.
+    struct local_log_batch {
+        model::record_batch_header header;
+        // For control batches, we preserve the batch record data, but for
+        // placeholder batches we extract out the extent_meta to be hydrated
+        // later.
+        using payload = iobuf;
+        std::variant<cloud_topics::extent_meta, payload> data;
+    };
+
     // States
     enum class state {
         empty_state,
@@ -94,7 +108,9 @@ private:
     // other metadata batches from the CTP.
     storage::local_log_reader_config ctp_read_config();
 
-    ss::future<> fetch_metadata(model::timeout_clock::time_point deadline);
+    ss::future<
+      chunked_circular_buffer<level_zero_log_reader_impl::local_log_batch>>
+    fetch_metadata(model::timeout_clock::time_point deadline);
     ss::future<> materialize_batches(model::timeout_clock::time_point deadline);
     void consume_materialized_batches(
       chunked_circular_buffer<model::record_batch>* dest);
@@ -108,20 +124,6 @@ private:
     bool is_over_limit(size_t size) const;
 
     state _current{state::empty_state};
-
-    // A batch read from the local log, these can be either placeholder batches
-    // with pointers to the actual data in cloud storage, or it can be control
-    // batches from the local log (i.e. transaction markers). We need to
-    // preserve transactional markers because clients expect to be able to read
-    // them.
-    struct local_log_batch {
-        model::record_batch_header header;
-        // For control batches, we preserve the batch record data, but for
-        // placeholder batches we extract out the extent_meta to be hydrated
-        // later.
-        using payload = iobuf;
-        std::variant<cloud_topics::extent_meta, payload> data;
-    };
 
     // Data from the local log that is not yet hydrated from data in L0
     //

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
@@ -106,11 +106,14 @@ private:
 
     // Prepare a local log reader configuration for reading placeholder and
     // other metadata batches from the CTP.
-    storage::local_log_reader_config ctp_read_config();
+    storage::local_log_reader_config ctp_read_config() const;
+
+    ss::future<model::record_batch_reader::storage_t>
+      read_some(model::timeout_clock::time_point);
 
     ss::future<
       chunked_circular_buffer<level_zero_log_reader_impl::local_log_batch>>
-    fetch_metadata(model::timeout_clock::time_point deadline);
+    fetch_metadata(model::timeout_clock::time_point deadline) const;
     ss::future<> materialize_batches(model::timeout_clock::time_point deadline);
     void consume_materialized_batches(
       chunked_circular_buffer<model::record_batch>* dest);

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
@@ -115,7 +115,9 @@ private:
       chunked_circular_buffer<level_zero_log_reader_impl::local_log_batch>>
     fetch_metadata(model::timeout_clock::time_point deadline) const;
     ss::future<chunked_circular_buffer<model::record_batch>>
-    materialize_batches(model::timeout_clock::time_point deadline);
+    materialize_batches(
+      chunked_circular_buffer<local_log_batch> unhydrated,
+      model::timeout_clock::time_point deadline);
     // Return data from the record batch cache.
     // This method could change state of the reader to end_of_stream_state
     // when it reaches committed offset.

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
@@ -94,14 +94,6 @@ private:
         std::variant<cloud_topics::extent_meta, payload> data;
     };
 
-    // States
-    enum class state {
-        empty_state,
-        ready_state,
-        materialized_state,
-        end_of_stream_state,
-    };
-
     bool cache_enabled() const;
 
     // Prepare a local log reader configuration for reading placeholder and
@@ -127,8 +119,6 @@ private:
     // If adding a batch of `size` would cause this to go over the bytes limit.
     bool is_over_limit(size_t size) const;
 
-    state _current{state::empty_state};
-
     // Data from the local log that is not yet hydrated from data in L0
     //
     // The data stored in this buffer is ascending order by offset.
@@ -136,6 +126,9 @@ private:
     // All batches in _unhydrated come after the _hydrated batches (in offset
     // ordering).
     chunked_circular_buffer<local_log_batch> _unhydrated;
+
+    void set_end_of_stream();
+    bool _end_of_stream{false};
 
     cloud_topic_log_reader_config _config;
     kafka::offset _next_offset;

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
@@ -117,7 +117,7 @@ private:
     maybe_read_batches_from_cache();
 
     // If adding a batch of `size` would cause this to go over the bytes limit.
-    bool is_over_limit(size_t size) const;
+    bool is_over_limit_with_bytes(size_t size) const;
 
     // Data from the local log that is not yet hydrated from data in L0
     //

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
@@ -105,7 +105,9 @@ private:
 
     ss::future<
       chunked_circular_buffer<level_zero_log_reader_impl::local_log_batch>>
-    fetch_metadata(model::timeout_clock::time_point deadline) const;
+    fetch_metadata(
+      storage::local_log_reader_config cfg,
+      model::timeout_clock::time_point deadline) const;
     ss::future<chunked_circular_buffer<model::record_batch>>
     materialize_batches(
       chunked_circular_buffer<local_log_batch> unhydrated,


### PR DESCRIPTION
This PR removes the explicit states from the L0 reader and instead relies on the structure and flow of the information to implicitly define the states.

This is the same approach we took in the L1 reader, and this change aligns their structure for easier testing and easier development when jumping between the two reader implementations.

Structure of this PR is that first ~8 commits are intended to be structural changes with little to no behavior change. The final commits remove the explicit states and make a few other minor code refactors.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
