### PR TITLE
bazel: Remove custom inline threshold

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -217,7 +217,6 @@ build:secure --config=relro
 # least --stamp=full and PGO-specific compile steps (outside of bazel).
 build:release --compilation_mode opt
 build:release --config=secure
-build:release --copt -mllvm --copt -inline-threshold=2500
 build:release --@seastar//:stack_guards=False --@seastar//:debug=False
 build:release --//src/v/redpanda:lto=True
 build:release --copt -flto=thin --copt -ffat-lto-objects


### PR DESCRIPTION
We had inherited the custom inline threshold from scylla a long time.
The idea was obviously that it improves performance but its impact has
never been clear.

What is very clear is the negative impact it has on compile times and
binary sizes. On some random //:redpanda compile bench on Travis'
machine we go from ~800s to 1050s and 1.5GB to 2.2GB redpanda binary
size when bumping the inline threshold to 2500 (from the 225 default).

With PGO the flag becomes effectively unused as PGO data overrides the
static inline thresholds.

We also see no measurable impact on baseline benches in either the PGO
or non-PGO build:

 - No PGO: https://perf-team-public.s3.us-west-2.amazonaws.com/reports/inline_threshold.html
 - PGO: https://perf-team-public.s3.us-west-2.amazonaws.com/reports/inline_threshold_pgo.html

Hence, this patch removes the flag. This will speed up all forms of
release builds (as even in the PGO build we still build all the unit
tests without PGO and the instrumented build is still affected by the
flag) and release pressure on the bazel cache.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
