### PR TITLE
tuner: Two tiny fixups

### DIFF
--- a/src/go/rpk/pkg/tuners/network/nic.go
+++ b/src/go/rpk/pkg/tuners/network/nic.go
@@ -274,14 +274,14 @@ func gvnicIrqToQueueIdx(irq IrqInfo, numIRQs int) int {
 	// New pattern: gve-ntfy-blk30@pci:0000:00:08.0
 	newPattern := regexp.MustCompile(`gve-ntfy-blk(\d+)`)
 
-	virtioMatch := newPattern.FindStringSubmatch(irq.ProcLine)
-	if len(virtioMatch) == 0 {
+	gvnicMatch := newPattern.FindStringSubmatch(irq.ProcLine)
+	if len(gvnicMatch) == 0 {
 		// try the legacy pattern
 		legacyPattern := regexp.MustCompile(`ntfy-block\.(\d+)$`)
-		virtioMatch = legacyPattern.FindStringSubmatch(irq.ProcLine)
+		gvnicMatch = legacyPattern.FindStringSubmatch(irq.ProcLine)
 	}
-	if len(virtioMatch) == 2 {
-		idx, _ := strconv.Atoi(virtioMatch[1])
+	if len(gvnicMatch) == 2 {
+		idx, _ := strconv.Atoi(gvnicMatch[1])
 		// https://github.com/torvalds/linux/blob/v6.17/drivers/net/ethernet/google/gve/gve.h#L1082-L1094
 		// TX is the lower half, RX the upper half of the IRQs
 		return idx % (numIRQs / 2)

--- a/src/go/rpk/pkg/tuners/network/nic_test.go
+++ b/src/go/rpk/pkg/tuners/network/nic_test.go
@@ -732,7 +732,7 @@ func Test_azureHyperVIrqToQueueIdx(t *testing.T) {
 	}
 }
 
-func test_azureManaIrqToQueueIdx(t *testing.T) {
+func Test_azureManaIrqToQueueIdx(t *testing.T) {
 	{
 		irq := IrqInfo{
 			Num:       34,


### PR DESCRIPTION
 - Fix mana test being ignore
 - Fix some copy pasta in the gvnic queue idx function

No functional changes.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


* none

