### PR TITLE
`ct/l1`: some minor `domain_manager::gc_loop()` tweaks

### DIFF
--- a/src/v/cloud_topics/level_one/domain/domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.cc
@@ -642,8 +642,9 @@ ss::future<> domain_manager::gc_loop() {
 
     // TODO: make configurable.
     garbage_collector gc(stm_.get(), object_io_);
+    auto ntp = stm_->raft()->log()->config().ntp();
     while (!as_.abort_requested()) {
-        vlog(cd_log.debug, "Running garbage collection now...");
+        vlog(cd_log.debug, "{} - Running garbage collection now...", ntp);
         auto gc_res = co_await gc.remove_unreferenced_objects(&as_);
         if (!gc_res.has_value()) {
             vlog(cd_log.warn, "Garbage collection failed: {}", gc_res.error());
@@ -651,7 +652,8 @@ ss::future<> domain_manager::gc_loop() {
         auto sleep_interval = gc_interval_();
         vlog(
           cd_log.debug,
-          "Re-running garbage collection in {}...",
+          "{} - Re-running garbage collection in {}...",
+          ntp,
           sleep_interval);
         try {
             co_await sem_.wait(
@@ -670,7 +672,8 @@ ss::future<> domain_manager::gc_loop() {
               eptr);
         }
     }
-    vlog(cd_log.debug, "Garbage collection loop stopped...");
+
+    vlog(cd_log.debug, "{} - Garbage collection loop stopped...", ntp);
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/domain/domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.cc
@@ -21,6 +21,8 @@
 
 #include <seastar/core/sleep.hh>
 
+#include <exception>
+
 namespace cloud_topics::l1 {
 namespace {
 rpc::errc convert_stm_errc(simple_stm::errc e) {
@@ -64,8 +66,13 @@ meta_to_rpc_extent_metadata(metastore::extent_metadata_vec v) {
 } // namespace
 
 domain_manager::domain_manager(ss::shared_ptr<simple_stm> stm, io* io)
-  : stm_(std::move(stm))
-  , object_io_(io) {}
+  : gc_interval_(
+      config::shard_local_cfg()
+        .cloud_topics_long_term_garbage_collection_interval)
+  , stm_(std::move(stm))
+  , object_io_(io) {
+    gc_interval_.watch([this]() { sem_.signal(); });
+}
 
 void domain_manager::start() {
     ssx::spawn_with_gate(gate_, [this] { return gc_loop(); });
@@ -74,6 +81,7 @@ void domain_manager::start() {
 ss::future<> domain_manager::stop_and_wait() {
     vlog(cd_log.debug, "Domain manager stopping...");
     as_.request_abort();
+    sem_.broken();
     co_await gate_.close();
     vlog(cd_log.debug, "Domain manager stopped...");
 }
@@ -626,16 +634,12 @@ domain_manager::get_extent_metadata(rpc::get_extent_metadata_request req) {
       .extents = meta_to_rpc_extent_metadata(std::move(get_res->extents))};
 }
 
-ss::lowres_clock::duration domain_manager::gc_interval() const {
-    return config::shard_local_cfg()
-      .cloud_topics_long_term_garbage_collection_interval();
-}
-
 ss::future<> domain_manager::gc_loop() {
     auto gate = maybe_gate();
     if (!gate.has_value()) {
         co_return;
     }
+
     // TODO: make configurable.
     garbage_collector gc(stm_.get(), object_io_);
     while (!as_.abort_requested()) {
@@ -644,15 +648,18 @@ ss::future<> domain_manager::gc_loop() {
         if (!gc_res.has_value()) {
             vlog(cd_log.warn, "Garbage collection failed: {}", gc_res.error());
         }
-        auto sleep_interval = gc_interval();
+        auto sleep_interval = gc_interval_();
         vlog(
           cd_log.debug,
           "Re-running garbage collection in {}...",
           sleep_interval);
-        auto sleep_res = co_await ss::coroutine::as_future(
-          ssx::sleep_abortable(sleep_interval, as_));
-        if (sleep_res.failed()) {
-            auto eptr = sleep_res.get_exception();
+        try {
+            co_await sem_.wait(
+              sleep_interval, std::max(sem_.current(), size_t(1)));
+        } catch (const ss::semaphore_timed_out&) {
+            // Fall through
+        } catch (...) {
+            auto eptr = std::current_exception();
             auto log_lvl = ssx::is_shutdown_exception(eptr)
                              ? ss::log_level::debug
                              : ss::log_level::warn;

--- a/src/v/cloud_topics/level_one/domain/domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.h
@@ -70,10 +70,15 @@ public:
 private:
     std::optional<ss::gate::holder> maybe_gate();
     ss::future<> gc_loop();
-    ss::lowres_clock::duration gc_interval() const;
 
     rpc::get_compaction_info_reply
     do_get_compaction_info(const state&, rpc::get_compaction_info_request);
+
+    config::binding<std::chrono::milliseconds> gc_interval_;
+    // This semaphore is used as a way to signal a change to
+    // `cloud_topics_long_term_garbage_collection_interval` during the `wait()`
+    // operation in the main garbage collection loop.
+    ssx::semaphore sem_{0, "domain_manager::gc_loop"};
 
     ss::gate gate_;
     ss::abort_source as_;


### PR DESCRIPTION
* Better respecting changes to cluster config `cloud_topics_long_term_garbage_collection_interval`
* Add `ntp` to some logging statements in `gc_loop()`

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
