### PR TITLE
bytes: ensure `iobuf::operator<=>(...)` is an unsigned byte-wise comparison

### DIFF
--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -130,7 +130,8 @@ std::strong_ordering iobuf::operator<=>(const iobuf& o) const {
     constexpr static size_t max_byte_for_byte_cmp = 4;
     const auto n = std::min({lhs.size(), rhs.size(), max_byte_for_byte_cmp});
     for (size_t i = 0; i < n; ++i) {
-        const auto cmp = lhs[i] <=> rhs[i];
+        const auto cmp = static_cast<unsigned char>(lhs[i])
+                         <=> static_cast<unsigned char>(rhs[i]);
         if (cmp != std::strong_ordering::equal) {
             return cmp;
         }

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -254,6 +254,7 @@ public:
     bool operator==(const iobuf&) const;
     bool operator<(const iobuf&) const;
     bool operator!=(const iobuf&) const;
+    /// Does an unsigned byte-wise comparison between this iobuf and the other.
     std::strong_ordering operator<=>(const iobuf&) const;
 
     bool operator==(std::string_view) const;

--- a/src/v/bytes/tests/iobuf_tests.cc
+++ b/src/v/bytes/tests/iobuf_tests.cc
@@ -51,6 +51,7 @@ SEASTAR_THREAD_TEST_CASE(test_lt) {
     BOOST_CHECK_LT(iobuf::from(""), iobuf::from("cat"));
     BOOST_CHECK_LT(iobuf::from("cat"), iobuf::from("dog"));
     BOOST_CHECK_LT(iobuf::from("cat"), iobuf::from("catastrophe"));
+    BOOST_CHECK_LT(iobuf::from("\x01"), iobuf::from("\xFF"));
     BOOST_CHECK_EQUAL(false, iobuf::from("cat") < iobuf::from("cat"));
     BOOST_CHECK_EQUAL(false, iobuf{} < iobuf{});
     BOOST_CHECK(std::strong_ordering::equal == (iobuf{} <=> iobuf{}));


### PR DESCRIPTION
Caught by the fuzzer. `a[i] <=> b[i]` is a signed comparison which is not what we want for ordering in parquet files or otherwise. This PR changes `iobuf::operator<=>` to consistently be an unsigned byte-wise comparison between two iobufs which yields the expected lexicographical ordering on both UTF-8 encoded byte arrays and general byte arrays.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
