### PR TITLE
`ct/l1`: respect `lowest_pinned_data_offset()` in `compaction`

### DIFF
--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -120,7 +120,9 @@ ss::future<> app::construct(
         .self = self,
         .leaders_table = leaders_table,
         .topic_table = &controller->get_topics_state(),
-        .metadata_cache = metadata_cache},
+        .metadata_cache = metadata_cache,
+        .shard_table = &controller->get_shard_table(),
+        .partition_manager = &controller->get_partition_manager()},
       &l1_io,
       &replicated_metastore);
 

--- a/src/v/cloud_topics/level_one/compaction/log_collector.h
+++ b/src/v/cloud_topics/level_one/compaction/log_collector.h
@@ -27,6 +27,8 @@ struct compaction_cluster_state {
     ss::sharded<cluster::partition_leaders_table>* leaders_table;
     ss::sharded<cluster::topic_table>* topic_table;
     ss::sharded<cluster::metadata_cache>* metadata_cache;
+    ss::sharded<cluster::shard_table>* shard_table;
+    ss::sharded<cluster::partition_manager>* partition_manager;
 };
 
 // Responsible for pushing CTPs/logs that require compaction to the

--- a/src/v/cloud_topics/level_one/compaction/log_info_collector.cc
+++ b/src/v/cloud_topics/level_one/compaction/log_info_collector.cc
@@ -12,6 +12,8 @@
 
 #include "cloud_topics/level_one/compaction/logger.h"
 #include "cloud_topics/level_one/compaction/meta.h"
+#include "cluster/partition_manager.h"
+#include "cluster/shard_table.h"
 #include "compaction/utils.h"
 #include "config/configuration.h"
 #include "container/chunked_vector.h"
@@ -63,6 +65,55 @@ topic_cfg_provider_impl::get_topic_cfg(model::topic_namespace_view tp) const {
     }
 
     return topic_md_ref.value().get().get_configuration();
+}
+
+max_compactible_offset_provider_impl::max_compactible_offset_provider_impl(
+  ss::sharded<cluster::shard_table>* shard_table,
+  ss::sharded<cluster::partition_manager>* partition_manager)
+  : _shard_table(shard_table)
+  , _partition_manager(partition_manager) {}
+
+ss::future<> max_compactible_offset_provider_impl::fill_max_compactible_offsets(
+  chunked_hash_map<model::ntp, kafka::offset>& ntp_to_max_compactible_offset)
+  const {
+    // Group NTPs by their owning shard to batch cross-shard calls.
+    chunked_hash_map<ss::shard_id, chunked_vector<model::ntp>> ntps_by_shard;
+    for (const auto& [ntp, _] : ntp_to_max_compactible_offset) {
+        auto shard_opt = _shard_table->local().shard_for(ntp);
+        if (shard_opt) {
+            ntps_by_shard[*shard_opt].push_back(ntp);
+        }
+    }
+
+    for (auto& [shard, shard_ntps] : ntps_by_shard) {
+        auto shard_results = co_await _partition_manager->invoke_on(
+          shard,
+          [ntps = std::move(shard_ntps)](
+            const cluster::partition_manager& pm) mutable {
+              chunked_hash_map<model::ntp, kafka::offset> results;
+              for (auto& ntp : ntps) {
+                  auto p = pm.get(ntp);
+                  if (!p) {
+                      continue;
+                  }
+                  auto lowest_pinned = p->raft()
+                                         ->log()
+                                         ->stm_manager()
+                                         ->lowest_pinned_data_offset();
+                  auto max_compactible = lowest_pinned.has_value()
+                                           ? kafka::prev_offset(
+                                               lowest_pinned.value())
+                                           : kafka::offset::max();
+                  results.insert_or_assign(std::move(ntp), max_compactible);
+              }
+              return results;
+          });
+
+        for (auto& [ntp, offset] : shard_results) {
+            ntp_to_max_compactible_offset.insert_or_assign(
+              std::move(ntp), offset);
+        }
+    }
 }
 
 log_info_collector::log_info_collector(

--- a/src/v/cloud_topics/level_one/compaction/log_info_collector.cc
+++ b/src/v/cloud_topics/level_one/compaction/log_info_collector.cc
@@ -118,9 +118,13 @@ ss::future<> max_compactible_offset_provider_impl::fill_max_compactible_offsets(
 
 log_info_collector::log_info_collector(
   metastore* metastore,
-  std::unique_ptr<topic_cfg_provider> tp_metadata_provider)
+  std::unique_ptr<topic_cfg_provider> tp_metadata_provider,
+  std::unique_ptr<max_compactible_offset_provider>
+    max_compactible_offset_provider)
   : _metastore(metastore)
-  , _topic_metadata_provider(std::move(tp_metadata_provider)) {}
+  , _topic_metadata_provider(std::move(tp_metadata_provider))
+  , _max_compactible_offset_provider(
+      std::move(max_compactible_offset_provider)) {}
 
 ss::future<> log_info_collector::collect_info_for_logs(
   log_set_t& logs_set,
@@ -142,8 +146,31 @@ ss::future<> log_info_collector::collect_info_for_logs(
 
     auto compaction_infos = std::move(compaction_infos_res).value();
 
+    // Collect NTPs that need max compactible offset lookups.
+    chunked_hash_map<model::ntp, kafka::offset> ntp_to_max_compactible_offset;
+    for (const auto& log : logs_list) {
+        // We have to iterate over logs_list and perform a look-up in
+        // compaction_infos unfortunately due to grouping by tidp, but needing
+        // to look up compactible_offsets by ntp. If shard_table offered a way
+        // to look up by tidp, this wouldn't be pessimized.
+        if (log.link.is_linked() && compaction_infos.contains(log.tidp)) {
+            // Use kafka::offset::min() as a placeholder; real values are filled
+            // in by fill_max_compactible_offsets below.
+            ntp_to_max_compactible_offset.insert_or_assign(
+              log.ntp, kafka::offset::min());
+        }
+    }
+
+    co_await _max_compactible_offset_provider->fill_max_compactible_offsets(
+      ntp_to_max_compactible_offset);
+
     populate_log_infos(
-      compaction_infos, logs_set, logs_list, compaction_queue, now);
+      compaction_infos,
+      logs_set,
+      logs_list,
+      compaction_queue,
+      ntp_to_max_compactible_offset,
+      now);
 }
 
 chunked_vector<metastore::compaction_info_spec>
@@ -233,6 +260,8 @@ void log_info_collector::populate_log_infos(
   log_set_t& logs_set,
   log_list_t& logs_list,
   log_compaction_queue& compaction_queue,
+  const chunked_hash_map<model::ntp, kafka::offset>&
+    ntp_to_max_compactible_offset,
   model::timestamp collection_timestamp) const {
     for (auto& log : logs_list) {
         if (!log.link.is_linked()) {
@@ -263,15 +292,27 @@ void log_info_collector::populate_log_infos(
             continue;
         }
 
+        auto offset_it = ntp_to_max_compactible_offset.find(log.ntp);
+        if (offset_it == ntp_to_max_compactible_offset.end()) {
+            // Likely this log was concurrently removed during some scheduling
+            // point.
+            continue;
+        }
+
+        auto max_compactible_offset = offset_it->second;
+
         log.info_and_ts = compaction_info_and_timestamp{
           .info = std::move(compaction_info).value(),
-          .collected_at = collection_timestamp};
+          .collected_at = collection_timestamp,
+          .max_compactible_offset = max_compactible_offset};
 
         vlog(
           compaction_log.debug,
-          "Compaction info for CTP {} returned {}",
+          "Compaction info for CTP {} returned {} with max_compactible_offset: "
+          "{}",
           log.ntp,
-          log.info_and_ts->info);
+          log.info_and_ts->info,
+          max_compactible_offset);
 
         if (log.state != log_compaction_meta::log_state::idle) {
             // We don't need to queue an already queued log.
@@ -298,9 +339,15 @@ void log_info_collector::populate_log_infos(
 }
 
 log_info_collector make_default_log_info_collector(
-  metastore* metastore, cluster::metadata_cache* metadata_cache) {
+  metastore* metastore,
+  cluster::metadata_cache* metadata_cache,
+  ss::sharded<cluster::shard_table>* shard_table,
+  ss::sharded<cluster::partition_manager>* partition_manager) {
     return log_info_collector(
-      metastore, std::make_unique<topic_cfg_provider_impl>(metadata_cache));
+      metastore,
+      std::make_unique<topic_cfg_provider_impl>(metadata_cache),
+      std::make_unique<max_compactible_offset_provider_impl>(
+        shard_table, partition_manager));
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/log_info_collector.h
+++ b/src/v/cloud_topics/level_one/compaction/log_info_collector.h
@@ -13,7 +13,10 @@
 #include "cloud_topics/level_one/compaction/meta.h"
 #include "cloud_topics/level_one/metastore/metastore.h"
 #include "cluster/metadata_cache.h"
+#include "cluster/partition_manager.h"
+#include "cluster/shard_table.h"
 #include "cluster/types.h"
+#include "model/fundamental.h"
 
 namespace cloud_topics::l1 {
 
@@ -38,6 +41,38 @@ public:
 
 private:
     cluster::metadata_cache* _metadata_cache;
+};
+
+// Provides the maximum offset which is compactible for a given ntp.
+class max_compactible_offset_provider {
+public:
+    virtual ~max_compactible_offset_provider() noexcept = default;
+
+    // Fills the provided map with max compactible offsets for the given NTPs.
+    // NTPs that cannot be looked up (e.g. partition not found) will not have
+    // an entry added to the map.
+    virtual ss::future<> fill_max_compactible_offsets(
+      chunked_hash_map<model::ntp, kafka::offset>&) const
+      = 0;
+};
+
+// Default max_compactible_offset_provider, which uses the `shard_table` and
+// `partition_manager` to access a partition's `lowest_pinned_data_offset()`
+// through its `stm_manager()`. Batches cross-shard calls by grouping NTPs
+// by their owning shard.
+class max_compactible_offset_provider_impl
+  : public max_compactible_offset_provider {
+public:
+    max_compactible_offset_provider_impl(
+      ss::sharded<cluster::shard_table>*,
+      ss::sharded<cluster::partition_manager>*);
+
+    ss::future<> fill_max_compactible_offsets(
+      chunked_hash_map<model::ntp, kafka::offset>&) const final;
+
+private:
+    ss::sharded<cluster::shard_table>* _shard_table;
+    ss::sharded<cluster::partition_manager>* _partition_manager;
 };
 
 // Responsible for issuing `get_compaction_info()` requests to the `metastore`

--- a/src/v/cloud_topics/level_one/compaction/log_info_collector.h
+++ b/src/v/cloud_topics/level_one/compaction/log_info_collector.h
@@ -79,7 +79,10 @@ private:
 // when attempting to schedule a round of compactions.
 class log_info_collector {
 public:
-    log_info_collector(metastore*, std::unique_ptr<topic_cfg_provider>);
+    log_info_collector(
+      metastore*,
+      std::unique_ptr<topic_cfg_provider>,
+      std::unique_ptr<max_compactible_offset_provider>);
 
     // Populates `info_and_ts` within `log_compaction_meta`s from the provided
     // `log_list_t` by collecting each log's compaction info from the metastore.
@@ -108,15 +111,21 @@ private:
       log_set_t&,
       log_list_t&,
       log_compaction_queue&,
+      const chunked_hash_map<model::ntp, kafka::offset>&,
       model::timestamp) const;
 
     // Owned by `app`.
     metastore* _metastore;
 
     std::unique_ptr<topic_cfg_provider> _topic_metadata_provider;
+    std::unique_ptr<max_compactible_offset_provider>
+      _max_compactible_offset_provider;
 };
 
-log_info_collector
-make_default_log_info_collector(metastore*, cluster::metadata_cache*);
+log_info_collector make_default_log_info_collector(
+  metastore*,
+  cluster::metadata_cache*,
+  ss::sharded<cluster::shard_table>*,
+  ss::sharded<cluster::partition_manager>*);
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/meta.h
+++ b/src/v/cloud_topics/level_one/compaction/meta.h
@@ -31,6 +31,7 @@ namespace cloud_topics::l1 {
 struct compaction_info_and_timestamp {
     metastore::compaction_info_response info;
     model::timestamp collected_at;
+    kafka::offset max_compactible_offset;
 };
 
 struct log_compaction_meta {

--- a/src/v/cloud_topics/level_one/compaction/scheduler.cc
+++ b/src/v/cloud_topics/level_one/compaction/scheduler.cc
@@ -40,7 +40,10 @@ compaction_scheduler::compaction_scheduler(
       [this](const model::ntp& ntp) { return is_managed(ntp); },
       state))
   , _log_info_collector(make_default_log_info_collector(
-      &_metastore->local(), &state.metadata_cache->local()))
+      &_metastore->local(),
+      &state.metadata_cache->local(),
+      state.shard_table,
+      state.partition_manager))
   , _scheduling_policy(make_default_scheduling_policy())
   , _worker_manager(
       _compaction_queue,

--- a/src/v/cloud_topics/level_one/compaction/source.cc
+++ b/src/v/cloud_topics/level_one/compaction/source.cc
@@ -133,6 +133,7 @@ compaction_source::compaction_source(
   const chunked_vector<offset_interval_set::interval>& dirty_range_intervals,
   const offset_interval_set& removable_tombstone_ranges,
   kafka::offset start_offset,
+  kafka::offset max_compactible_offset,
   compaction::key_offset_map* map,
   std::chrono::milliseconds min_compaction_lag_ms,
   metastore* metastore,
@@ -145,6 +146,7 @@ compaction_source::compaction_source(
   , _dirty_range_intervals(dirty_range_intervals)
   , _removable_tombstone_ranges(removable_tombstone_ranges)
   , _start_offset(start_offset)
+  , _max_compactible_offset(max_compactible_offset)
   , _dirty_range_it(_dirty_range_intervals.crbegin())
   , _extent_reader(
       metastore,
@@ -264,6 +266,12 @@ ss::future<ss::stop_iteration> compaction_source::deduplication_iteration(
     }
 
     auto extent = std::move(extent_res).value();
+
+    if (extent.last_offset > _max_compactible_offset) {
+        // We have iterated to an extent we cannot compact, stop compaction
+        // here.
+        co_return ss::stop_iteration::yes;
+    }
 
     if (should_compact_extent(extent, _min_compaction_lag_ms)) {
         kafka::offset start_offset{extent.base_offset};

--- a/src/v/cloud_topics/level_one/compaction/source.h
+++ b/src/v/cloud_topics/level_one/compaction/source.h
@@ -32,6 +32,7 @@ public:
       const chunked_vector<offset_interval_set::interval>&,
       const offset_interval_set&,
       kafka::offset,
+      kafka::offset,
       compaction::key_offset_map*,
       std::chrono::milliseconds,
       metastore*,
@@ -62,6 +63,9 @@ private:
 
     // The start offset of the CTP.
     kafka::offset _start_offset;
+
+    // The maximum compactible offset, as pinned by e.g. iceberg translation.
+    kafka::offset _max_compactible_offset;
 
     // Iterator used during `map_building_iteration()` which points into the
     // above vector `_dirty_range_intervals`. Iterating backwards over extents

--- a/src/v/cloud_topics/level_one/compaction/tests/log_info_collector_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/log_info_collector_test.cc
@@ -39,10 +39,20 @@ private:
     cluster::topic_configuration _cfg{};
 };
 
+// A fake offset provider which always returns kafka::offset::max().
+class fake_offset_provider : public l1::max_compactible_offset_provider {
+public:
+    ss::future<> fill_max_compactible_offsets(
+      chunked_hash_map<model::ntp, kafka::offset>&) const final {
+        co_return;
+    }
+};
+
 TEST_F(LogInfoCollectorTestFixture, TestInfoCollector) {
     auto cfg_provider = std::make_unique<fake_cfg_provider>();
+    auto offset_provider = std::make_unique<fake_offset_provider>();
     l1::log_info_collector log_info_collector(
-      &_metastore, std::move(cfg_provider));
+      &_metastore, std::move(cfg_provider), std::move(offset_provider));
     std::vector<std::pair<model::ntp, model::topic_id_partition>> ntidps;
     const auto topic_names = {"topic_a", "topic_b", "topic_c"};
     const auto num_topics = topic_names.size();

--- a/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
@@ -105,6 +105,7 @@ ss::future<> do_compact(
     auto state = l1::compaction_job_state::running;
     auto map = compaction::simple_key_offset_map();
     auto dirty_range_intervals = offsets_response.dirty_ranges.to_vec();
+    auto max_compactible_offset = kafka::offset::max();
     l1::compaction_worker_probe probe;
     auto src = std::make_unique<l1::compaction_source>(
       ntp,
@@ -112,6 +113,7 @@ ss::future<> do_compact(
       dirty_range_intervals,
       offsets_response.removable_tombstone_ranges,
       start_offset,
+      max_compactible_offset,
       &map,
       min_compaction_lag_ms,
       metastore,

--- a/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
@@ -99,13 +99,12 @@ ss::future<> do_compact(
   l1::compaction_committer& committer,
   l1::metastore* metastore,
   l1::io* io,
-  std::chrono::milliseconds min_compaction_lag_ms = std::chrono::milliseconds{
-    0}) {
+  std::chrono::milliseconds min_compaction_lag_ms = 0ms,
+  kafka::offset max_compactible_offset = kafka::offset::max()) {
     ss::abort_source as;
     auto state = l1::compaction_job_state::running;
     auto map = compaction::simple_key_offset_map();
     auto dirty_range_intervals = offsets_response.dirty_ranges.to_vec();
-    auto max_compactible_offset = kafka::offset::max();
     l1::compaction_worker_probe probe;
     auto src = std::make_unique<l1::compaction_source>(
       ntp,
@@ -810,4 +809,87 @@ TEST_F(ReducerTestFixture, MinCompactionLagMsReducerInterleavedTimestamps) {
     auto output_batches = read_all(std::move(reader));
     linear_int_kv_batch_generator::validate_post_compaction(
       std::move(output_batches));
+}
+
+TEST_F(ReducerTestFixture, MaxCompactibleOffsetReducer) {
+    // This test verifies that compaction respects the max_compactible_offset
+    // boundary. We create multiple extents and set max_compactible_offset to
+    // fall within the middle of the log, expecting only extents below that
+    // offset to be compacted.
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    int num_produce_rounds = 4;
+    int num_batches = 10;
+    int num_records = 10;
+    int records_per_extent = num_batches * num_records;
+    kafka::offset start_offset{0};
+    kafka::offset last_offset{(num_produce_rounds * records_per_extent) - 1};
+    auto gen = linear_int_kv_batch_generator();
+    auto ts = model::timestamp::now();
+
+    // Create 4 extents.
+    for (int i = 0; i < num_produce_rounds; ++i) {
+        model::test::record_batch_spec spec{
+          .allow_compression = true,
+          .count = num_records,
+          .timestamp = ts,
+          .all_records_have_same_timestamp = true};
+        auto batches = gen(spec, num_batches);
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, std::move(batches));
+        make_l1_objects(std::move(tidp_batches)).get();
+    }
+
+    auto info_spec = l1::metastore::compaction_info_spec{
+      .tidp = tidp,
+      .tombstone_removal_upper_bound_ts = model::timestamp::max()};
+    auto compaction_info = _metastore.get_compaction_info(info_spec).get();
+
+    ASSERT_TRUE(compaction_info.has_value());
+    ASSERT_FLOAT_EQ(compaction_info->dirty_ratio, 1.0);
+    ASSERT_TRUE(compaction_info->offsets_response.dirty_ranges.covers(
+      start_offset, last_offset));
+
+    auto committer = l1::compaction_committer(
+      l1::make_default_committing_policy(), &_io, &_metastore);
+    auto committer_stop = ss::defer([&committer] { committer.stop().get(); });
+
+    // Set max_compactible_offset to the start of the 3rd extent.
+    // This should allow compaction of extents [0] and [1], but not [2] or [3].
+    auto max_compactible_offset = kafka::offset{2 * records_per_extent};
+
+    do_compact(
+      tidp,
+      ntp,
+      std::move(compaction_info->offsets_response),
+      compaction_info->compaction_epoch,
+      compaction_info->start_offset,
+      committer,
+      &_metastore,
+      &_io,
+      0ms,
+      max_compactible_offset)
+      .get();
+
+    auto reader = make_reader(ntp, tidp);
+    auto output_batches = read_all(std::move(reader));
+
+    // Extents [0] and [1] should be compacted (num_batches records each after
+    // dedup), extents [2] and [3] should remain untouched (num_batches *
+    // num_records each).
+    int output_num_records = std::accumulate(
+      output_batches.begin(),
+      output_batches.end(),
+      int{0},
+      [](int acc, model::record_batch& b) { return acc + b.record_count(); });
+
+    auto compacted_records = 2 * num_batches;          // 2 compacted extents
+    auto uncompacted_records = 2 * records_per_extent; // 2 untouched extents
+    ASSERT_EQ(output_num_records, compacted_records + uncompacted_records);
+
+    // Verify dirty ranges still include the uncompacted extents.
+    compaction_info = _metastore.get_compaction_info(info_spec).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    ASSERT_GT(compaction_info->dirty_ratio, 0.0);
+    ASSERT_TRUE(compaction_info->offsets_response.dirty_ranges.covers(
+      max_compactible_offset, last_offset));
 }

--- a/src/v/cloud_topics/level_one/compaction/tests/scheduler_fixture.h
+++ b/src/v/cloud_topics/level_one/compaction/tests/scheduler_fixture.h
@@ -42,13 +42,23 @@ private:
     mutable underlying_t _topic_metadata;
 };
 
+class fake_offset_provider : public l1::max_compactible_offset_provider {
+public:
+    ss::future<> fill_max_compactible_offsets(
+      chunked_hash_map<model::ntp, kafka::offset>&) const final {
+        co_return;
+    }
+};
+
 class SchedulerTestFixture : public l1::l1_reader_fixture {
 public:
     ss::future<> SetUpAsync() override { co_await start_scheduler(); }
 
     ss::future<> start_scheduler() {
         auto info_collector = l1::log_info_collector(
-          &_metastore, std::make_unique<fake_topic_metadata_provider>());
+          &_metastore,
+          std::make_unique<fake_topic_metadata_provider>(),
+          std::make_unique<fake_offset_provider>());
         // not `std::make_unique` because private `compaction_scheduler` c-tor.
         scheduler = std::unique_ptr<l1::compaction_scheduler>(
           new l1::compaction_scheduler(std::move(info_collector)));

--- a/src/v/cloud_topics/level_one/compaction/worker.cc
+++ b/src/v/cloud_topics/level_one/compaction/worker.cc
@@ -171,6 +171,7 @@ ss::future<> compaction_worker::compact_log(log_compaction_meta* log) {
       = log->info_and_ts->info.offsets_response.removable_tombstone_ranges};
     auto expected_compaction_epoch = log->info_and_ts->info.compaction_epoch;
     auto start_offset = log->info_and_ts->info.start_offset;
+    auto max_compactible_offset = log->info_and_ts->max_compactible_offset;
 
     // Lazy initialization of offset map.
     if (!_map) {
@@ -203,6 +204,7 @@ ss::future<> compaction_worker::compact_log(log_compaction_meta* log) {
       dirty_range_intervals,
       compaction_offsets.removable_tombstone_ranges,
       start_offset,
+      max_compactible_offset,
       _map.get(),
       min_lag_ms,
       _metastore,

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -406,10 +406,6 @@ public:
     }
 
     model::iceberg_mode iceberg_mode() const {
-        // TODO(cloud_topics): support iceberg
-        if (cloud_topic_enabled()) {
-            return model::iceberg_mode::disabled;
-        }
         if (!config::shard_local_cfg().iceberg_enabled) {
             return model::iceberg_mode::disabled;
         }


### PR DESCRIPTION
Up till now, we did not respect `lowest_pinned_data_offset()` while compacting a cloud topic partition. We should be doing that.

Unfortunately we have to make some awkward cross-shard calls to access the underlying `partition` from the `partition_manager`, but we make an attempt to batch these in `log_info_collector`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
