### PR TITLE
[v25.3.x] bytes: ensure `iobuf::operator<=>(...)` is an unsigned byte-wise comparison

### DIFF
--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -130,7 +130,8 @@ std::strong_ordering iobuf::operator<=>(const iobuf& o) const {
     constexpr static size_t max_byte_for_byte_cmp = 4;
     const auto n = std::min({lhs.size(), rhs.size(), max_byte_for_byte_cmp});
     for (size_t i = 0; i < n; ++i) {
-        const auto cmp = lhs[i] <=> rhs[i];
+        const auto cmp = static_cast<unsigned char>(lhs[i])
+                         <=> static_cast<unsigned char>(rhs[i]);
         if (cmp != std::strong_ordering::equal) {
             return cmp;
         }

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -252,6 +252,7 @@ public:
     bool operator==(const iobuf&) const;
     bool operator<(const iobuf&) const;
     bool operator!=(const iobuf&) const;
+    /// Does an unsigned byte-wise comparison between this iobuf and the other.
     std::strong_ordering operator<=>(const iobuf&) const;
 
     bool operator==(std::string_view) const;

--- a/src/v/bytes/tests/iobuf_tests.cc
+++ b/src/v/bytes/tests/iobuf_tests.cc
@@ -51,6 +51,7 @@ SEASTAR_THREAD_TEST_CASE(test_lt) {
     BOOST_CHECK_LT(iobuf::from(""), iobuf::from("cat"));
     BOOST_CHECK_LT(iobuf::from("cat"), iobuf::from("dog"));
     BOOST_CHECK_LT(iobuf::from("cat"), iobuf::from("catastrophe"));
+    BOOST_CHECK_LT(iobuf::from("\x01"), iobuf::from("\xFF"));
     BOOST_CHECK_EQUAL(false, iobuf::from("cat") < iobuf::from("cat"));
     BOOST_CHECK_EQUAL(false, iobuf{} < iobuf{});
     BOOST_CHECK(std::strong_ordering::equal == (iobuf{} <=> iobuf{}));


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/29267
