### PR TITLE
[CORE-15307] better prefix truncation checks

### DIFF
--- a/src/v/cluster_link/replication/deps.h
+++ b/src/v/cluster_link/replication/deps.h
@@ -50,6 +50,9 @@ public:
     // Returns the HWM of the partition
     virtual kafka::offset high_watermark() const = 0;
 
+    // Returns whether or not the sink support prefix truncation
+    virtual bool can_prefix_truncate() const = 0;
+
     // Performs a prefix truncation on the sink partition
     virtual ss::future<kafka::error_code> prefix_truncate(
       kafka::offset truncation_offset, ss::lowres_clock::time_point deadline)

--- a/src/v/cluster_link/replication/partition_replicator.cc
+++ b/src/v/cluster_link/replication/partition_replicator.cc
@@ -315,6 +315,11 @@ void partition_replicator::maybe_synchronize_start_offset() {
     auto shadow_partition_start_offset = _sink->start_offset();
     auto source_offsets = _source->get_offsets();
 
+    if (!_sink->can_prefix_truncate()) {
+        vlog(_log.trace, "Partition does not support prefix truncation");
+        return;
+    }
+
     if (_in_progress_truncate_offset.has_value()) {
         vlog(
           _log.trace,

--- a/src/v/cluster_link/replication/tests/deps_test_impl.cc
+++ b/src/v/cluster_link/replication/tests/deps_test_impl.cc
@@ -58,6 +58,8 @@ void accounting_sink::notify_replicator_failure(model::term_id) {}
 
 kafka::offset accounting_sink::high_watermark() const { return _last_offset; }
 
+bool accounting_sink::can_prefix_truncate() const { return true; }
+
 ss::future<kafka::error_code> accounting_sink::prefix_truncate(
   kafka::offset truncation_offset, ss::lowres_clock::time_point) {
     if (truncation_offset <= start_offset()) {

--- a/src/v/cluster_link/replication/tests/deps_test_impl.h
+++ b/src/v/cluster_link/replication/tests/deps_test_impl.h
@@ -34,6 +34,7 @@ public:
       ss::abort_source& as) override;
     void notify_replicator_failure(::model::term_id) override;
     kafka::offset high_watermark() const final;
+    bool can_prefix_truncate() const final;
     ss::future<kafka::error_code> prefix_truncate(
       kafka::offset truncation_offset,
       ss::lowres_clock::time_point deadline) final;

--- a/src/v/cluster_link/replication/tests/link_replication_mgr_tests.cc
+++ b/src/v/cluster_link/replication/tests/link_replication_mgr_tests.cc
@@ -98,6 +98,8 @@ public:
 
     kafka::offset high_watermark() const final { return {}; }
 
+    bool can_prefix_truncate() const final { return true; }
+
     ss::future<kafka::error_code>
     prefix_truncate(kafka::offset, ss::lowres_clock::time_point) final {
         co_return kafka::error_code::none;

--- a/src/v/cluster_link/replication/tests/partition_replicator_tests.cc
+++ b/src/v/cluster_link/replication/tests/partition_replicator_tests.cc
@@ -153,6 +153,8 @@ public:
         return kafka::next_offset(_last_replicated_offset);
     }
 
+    bool can_prefix_truncate() const final { return true; }
+
     ss::future<kafka::error_code> prefix_truncate(
       kafka::offset truncation_offset, ss::lowres_clock::time_point) final {
         if (truncation_offset <= start_offset()) {

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -542,6 +542,11 @@ public:
           _partition->log()->from_log_offset(_partition->high_watermark()));
     }
 
+    bool can_prefix_truncate() const final {
+        _gate.check();
+        return _partition->get_ntp_config().is_locally_collectable();
+    }
+
     ss::future<kafka::error_code> prefix_truncate(
       kafka::offset truncation_offset,
       ss::lowres_clock::time_point deadline) final {


### PR DESCRIPTION
Add a capability check to the sink partition interface to determine whether prefix truncation is supported before attempting the operation. This prevents unnecessary work for partitions that don't support prefix truncation, such as cloud topics.

Fixes: CORE-15307

## Summary

When cluster link replication attempts to synchronize start offsets between source and sink partitions, it currently proceeds with prefix truncation logic regardless of whether the sink partition actually supports this operation. Cloud topics, for example, do not support local prefix truncation as they manage retention differently.

This PR:
- Adds a new `can_prefix_truncate()` method to the sink partition interface that checks if the partition is locally collectable
- Updates `maybe_synchronize_start_offset()` to early-return when prefix truncation is not supported, avoiding unnecessary computation

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Bug Fixes

* Fixed cluster link replication attempting prefix truncation on partitions that do not support it (e.g., cloud topics)