### PR TITLE
`ct/reconciler`: reconcile topics together based on time-based retention properties

### DIFF
--- a/src/v/cloud_topics/reconciler/BUILD
+++ b/src/v/cloud_topics/reconciler/BUILD
@@ -67,6 +67,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_zero/stm:ctp_stm_api",
         "//src/v/config",
         "//src/v/kafka/utils:txn_reader",
+        "//src/v/storage",
         "//src/v/utils:retry_chain_node",
     ],
     visibility = ["//visibility:public"],

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -33,6 +33,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <exception>
 #include <expected>
 #include <iterator>
@@ -239,25 +240,56 @@ ss::future<> reconciler::reconcile() {
 }
 
 chunked_vector<chunked_vector<ss::shared_ptr<source>>>
-reconciler::partition_sources_into_sets(
-  chunked_vector<ss::shared_ptr<source>> sources) {
+partition_sources_into_sets(chunked_vector<ss::shared_ptr<source>> sources) {
+    // Bucket width for logarithmic bucketing based on retention lifetimes. Each
+    // bucket spans ~1.65x. With natural log scaling and a bucket_width = 0.5,
+    // we will have at most (when considering the int64_t::max() cap on
+    // retention properties) 87 buckets.
+    static constexpr double bucket_width = 0.5;
+
+    // Sources with retention are bucketed by log(retention)/bucket_width.
+    // Sources without retention are grouped by topic_id.
+    chunked_hash_map<uint8_t, chunked_vector<ss::shared_ptr<source>>>
+      retention_bucket_idx_to_source;
     chunked_hash_map<model::topic_id, chunked_vector<ss::shared_ptr<source>>>
-      topic_id_to_sources;
+      topic_id_to_source;
+
     for (auto& src : sources) {
-        auto& src_vec = topic_id_to_sources[src->topic_id_partition().topic_id];
-        src_vec.push_back(std::move(src));
+        auto retention = src->effective_retention_ms();
+        if (retention.has_value()) {
+            uint8_t bucket_idx = 0;
+            if (retention.value().count() >= 1) {
+                // std::log(0) = -inf, and std::log(x) where x < 1 is -ve.
+                bucket_idx = static_cast<uint8_t>(
+                  std::log(static_cast<double>(retention.value().count()))
+                  / bucket_width);
+            }
+            retention_bucket_idx_to_source[bucket_idx].push_back(
+              std::move(src));
+        } else {
+            topic_id_to_source[src->topic_id_partition().topic_id].push_back(
+              std::move(src));
+        }
+    }
+
+    chunked_vector<chunked_vector<ss::shared_ptr<source>>> result;
+    result.reserve(
+      retention_bucket_idx_to_source.size() + topic_id_to_source.size());
+
+    for (auto& [_, src_vec] : retention_bucket_idx_to_source) {
+        result.push_back(std::move(src_vec));
+    }
+    for (auto& [_, src_vec] : topic_id_to_source) {
+        result.push_back(std::move(src_vec));
     }
 
     vlog(
       lg.debug,
-      "Partitioned sources into {} sets by topic_id",
-      topic_id_to_sources.size());
+      "Partitioned sources into {} sets ({} by retention, {} by topic)",
+      result.size(),
+      retention_bucket_idx_to_source.size(),
+      topic_id_to_source.size());
 
-    chunked_vector<chunked_vector<ss::shared_ptr<source>>> result;
-    result.reserve(topic_id_to_sources.size());
-    for (auto& [_, src_vec] : topic_id_to_sources) {
-        result.push_back(std::move(src_vec));
-    }
     return result;
 }
 

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -250,12 +250,6 @@ private:
       std::unique_ptr<l1::metastore::object_metadata_builder> meta_builder);
 
     /*
-     * Partition sources into sets for reconciliation.
-     */
-    chunked_vector<chunked_vector<ss::shared_ptr<source>>>
-    partition_sources_into_sets(chunked_vector<ss::shared_ptr<source>> sources);
-
-    /*
      * Reconcile a set of sources. Creates a metadata builder, maps sources to
      * objects, builds and uploads objects, and commits them to the metastore.
      * Returns the max object size produced, or 0 if no objects were
@@ -271,5 +265,9 @@ private:
     reconciler_probe _probe;
     adaptive_interval _scheduler;
 };
+
+// Partition sources into sets for reconciliation.
+chunked_vector<chunked_vector<ss::shared_ptr<source>>>
+partition_sources_into_sets(chunked_vector<ss::shared_ptr<source>> sources);
 
 } // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/reconciliation_source.cc
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.cc
@@ -19,6 +19,7 @@
 #include "kafka/utils/txn_reader.h"
 #include "model/fundamental.h"
 #include "model/timeout_clock.h"
+#include "storage/ntp_config.h"
 #include "utils/retry_chain_node.h"
 
 #include <expected>
@@ -132,6 +133,26 @@ public:
 
         co_return model::make_record_batch_reader<kafka::read_committed_reader>(
           std::move(tracker), std::move(reader.reader));
+    }
+
+    std::optional<std::chrono::milliseconds>
+    effective_retention_ms() const override {
+        const auto& cfg = _partition->get_ntp_config();
+        auto policy = cfg.cleanup_policy();
+
+        std::optional<std::chrono::milliseconds> res;
+
+        if (model::is_compaction_enabled(policy)) {
+            res = cfg.max_compaction_lag_ms();
+        }
+
+        if (model::is_deletion_enabled(policy)) {
+            if (auto retention = cfg.retention_duration()) {
+                res = res ? std::min(*res, *retention) : retention;
+            }
+        }
+
+        return res;
     }
 
 private:

--- a/src/v/cloud_topics/reconciler/reconciliation_source.h
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.h
@@ -16,6 +16,7 @@
 
 #include <seastar/core/shared_ptr.hh>
 
+#include <chrono>
 #include <expected>
 
 namespace cluster {
@@ -79,6 +80,14 @@ public:
     // It *is* valid for this reader to outlive `source`.
     virtual ss::future<model::record_batch_reader>
       make_reader(reader_config) = 0;
+
+    // Get the effective retention value for this source used for bucketing
+    // during reconciliation.
+    // - For compact topics: returns max_compaction_lag_ms
+    // - For delete topics: returns retention_duration
+    // - Returns std::nullopt if no time-based retention is configured
+    virtual std::optional<std::chrono::milliseconds>
+    effective_retention_ms() const = 0;
 
 private:
     model::ntp _ntp;

--- a/src/v/cloud_topics/reconciler/tests/BUILD
+++ b/src/v/cloud_topics/reconciler/tests/BUILD
@@ -93,3 +93,21 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "partition_sources_into_sets_test",
+    timeout = "short",
+    srcs = [
+        "partition_sources_into_sets_test.cc",
+    ],
+    deps = [
+        ":test_utils",
+        "//src/v/cloud_topics/reconciler",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:tristate",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/reconciler/tests/BUILD
+++ b/src/v/cloud_topics/reconciler/tests/BUILD
@@ -25,6 +25,7 @@ redpanda_test_cc_library(
         "//src/v/cloud_topics/reconciler",
         "//src/v/model",
         "//src/v/model/tests:random",
+        "//src/v/storage",
         "@seastar",
     ],
 )

--- a/src/v/cloud_topics/reconciler/tests/partition_sources_into_sets_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/partition_sources_into_sets_test.cc
@@ -1,0 +1,383 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/reconciler/reconciler.h"
+#include "cloud_topics/reconciler/tests/test_utils.h"
+#include "model/fundamental.h"
+#include "model/tests/randoms.h"
+#include "utils/tristate.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+using namespace cloud_topics;
+using namespace std::chrono_literals;
+using cloud_topics::reconciler::test::fake_l0_source;
+
+class PartitionSourcesIntoSetsTest : public testing::Test {
+public:
+    /// Create a source with cleanup_policy=compaction and max_compaction_lag_ms
+    ss::shared_ptr<fake_l0_source> make_compact_source(
+      std::chrono::milliseconds max_compaction_lag,
+      std::optional<model::topic_id> tid = std::nullopt) {
+        if (!tid.has_value()) {
+            tid = model::create_topic_id();
+        }
+        auto ntp = model::random_ntp();
+        auto tidp = model::topic_id_partition(tid.value(), ntp.tp.partition);
+
+        auto overrides
+          = std::make_unique<storage::ntp_config::default_overrides>();
+        overrides->cleanup_policy_bitflags
+          = model::cleanup_policy_bitflags::compaction;
+        overrides->max_compaction_lag_ms = max_compaction_lag;
+
+        storage::ntp_config cfg(ntp, "/fake", std::move(overrides));
+        return ss::make_shared<fake_l0_source>(ntp, tidp, std::move(cfg));
+    }
+
+    /// Create a source with cleanup_policy=deletion and retention_time
+    ss::shared_ptr<fake_l0_source> make_delete_source(
+      std::chrono::milliseconds retention,
+      std::optional<model::topic_id> tid = std::nullopt) {
+        if (!tid.has_value()) {
+            tid = model::create_topic_id();
+        }
+        auto ntp = model::random_ntp();
+        auto tidp = model::topic_id_partition(tid.value(), ntp.tp.partition);
+
+        auto overrides
+          = std::make_unique<storage::ntp_config::default_overrides>();
+        overrides->cleanup_policy_bitflags
+          = model::cleanup_policy_bitflags::deletion;
+        overrides->retention_time = tristate<std::chrono::milliseconds>(
+          retention);
+
+        storage::ntp_config cfg(ntp, "/fake", std::move(overrides));
+        return ss::make_shared<fake_l0_source>(ntp, tidp, std::move(cfg));
+    }
+
+    /// Create a source with cleanup_policy=compact,delete
+    ss::shared_ptr<fake_l0_source> make_compact_delete_source(
+      std::chrono::milliseconds max_compaction_lag,
+      std::chrono::milliseconds retention,
+      std::optional<model::topic_id> tid = std::nullopt) {
+        if (!tid.has_value()) {
+            tid = model::create_topic_id();
+        }
+        auto ntp = model::random_ntp();
+        auto tidp = model::topic_id_partition(tid.value(), ntp.tp.partition);
+
+        auto overrides
+          = std::make_unique<storage::ntp_config::default_overrides>();
+        overrides->cleanup_policy_bitflags
+          = model::cleanup_policy_bitflags::compaction
+            | model::cleanup_policy_bitflags::deletion;
+        overrides->max_compaction_lag_ms = max_compaction_lag;
+        overrides->retention_time = tristate<std::chrono::milliseconds>(
+          retention);
+
+        storage::ntp_config cfg(ntp, "/fake", std::move(overrides));
+        return ss::make_shared<fake_l0_source>(ntp, tidp, std::move(cfg));
+    }
+};
+
+TEST_F(PartitionSourcesIntoSetsTest, EmptySources) {
+    chunked_vector<ss::shared_ptr<reconciler::source>> sources;
+    auto result = reconciler::partition_sources_into_sets(std::move(sources));
+    EXPECT_TRUE(result.empty());
+}
+
+TEST_F(PartitionSourcesIntoSetsTest, SingleCompactSource) {
+    chunked_vector<ss::shared_ptr<reconciler::source>> sources;
+    sources.push_back(make_compact_source(1h));
+
+    auto result = reconciler::partition_sources_into_sets(std::move(sources));
+
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 1);
+}
+
+TEST_F(PartitionSourcesIntoSetsTest, SingleDeleteSource) {
+    chunked_vector<ss::shared_ptr<reconciler::source>> sources;
+    sources.push_back(make_delete_source(1h));
+
+    auto result = reconciler::partition_sources_into_sets(std::move(sources));
+
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 1);
+}
+
+TEST_F(PartitionSourcesIntoSetsTest, SimilarRetentionGroupedTogether) {
+    // Sources with the same retention value should be grouped together
+    chunked_vector<ss::shared_ptr<reconciler::source>> sources;
+    sources.push_back(make_delete_source(1h));
+    sources.push_back(make_compact_source(1h));
+    sources.push_back(make_delete_source(1h));
+
+    auto result = reconciler::partition_sources_into_sets(std::move(sources));
+
+    // All three should be in the same bucket
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 3);
+}
+
+TEST_F(PartitionSourcesIntoSetsTest, DifferentRetentionSeparated) {
+    // Sources with very different retention values should be in different
+    // buckets
+    chunked_vector<ss::shared_ptr<reconciler::source>> sources;
+    sources.push_back(make_compact_source(1h));
+    sources.push_back(make_delete_source(24h)); // 24x different
+
+    auto result = reconciler::partition_sources_into_sets(std::move(sources));
+
+    // Should be in different buckets
+    ASSERT_EQ(result.size(), 2);
+    EXPECT_EQ(result[0].size(), 1);
+    EXPECT_EQ(result[1].size(), 1);
+}
+
+TEST_F(PartitionSourcesIntoSetsTest, DifferentTopicsWithSameRetentionGrouped) {
+    auto tid1 = model::create_topic_id();
+    auto tid2 = model::create_topic_id();
+
+    chunked_vector<ss::shared_ptr<reconciler::source>> sources;
+    // Sources from different topics but same retention
+    sources.push_back(make_compact_source(1h, tid1));
+    sources.push_back(make_delete_source(1h, tid2));
+
+    auto result = reconciler::partition_sources_into_sets(std::move(sources));
+
+    // Should be in the same bucket (retention-based, not topic-based)
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 2);
+}
+
+TEST_F(PartitionSourcesIntoSetsTest, LogarithmicBucketBoundaries) {
+    // Test bucket boundaries with bucket_width=0.5 (~1.65x per bucket)
+    // e^0.5 ~ 1.649
+    chunked_vector<ss::shared_ptr<reconciler::source>> sources;
+
+    // These should all be in different buckets due to log scaling
+    // 1h, ~2.7h (1h * e), ~7.4h (1h * e^2), ~20h (1h * e^3)
+    sources.push_back(make_delete_source(1h));
+    sources.push_back(make_compact_source(
+      std::chrono::milliseconds(
+        static_cast<int64_t>(std::chrono::milliseconds(1h).count() * 2.72))));
+    sources.push_back(make_delete_source(
+      std::chrono::milliseconds(
+        static_cast<int64_t>(std::chrono::milliseconds(1h).count() * 7.39))));
+    sources.push_back(make_compact_source(
+      std::chrono::milliseconds(
+        static_cast<int64_t>(std::chrono::milliseconds(1h).count() * 20.09))));
+
+    auto result = reconciler::partition_sources_into_sets(std::move(sources));
+
+    // With bucket_width=0.5, these span multiple buckets
+    // Each e^1 jump is 2 buckets (since bucket_width=0.5)
+    EXPECT_GE(result.size(), 3);
+}
+
+TEST_F(PartitionSourcesIntoSetsTest, CompactAndDeleteTopicsWithSameLifetime) {
+    // A compact topic with max_compaction_lag_ms=1day and
+    // a delete topic with retention_ms=1day. Both should be grouped together.
+    auto compact_topic_id = model::create_topic_id();
+    auto delete_topic_id = model::create_topic_id();
+
+    chunked_vector<ss::shared_ptr<reconciler::source>> sources;
+    sources.push_back(make_compact_source(24h, compact_topic_id));
+    sources.push_back(make_delete_source(24h, delete_topic_id));
+
+    auto result = reconciler::partition_sources_into_sets(std::move(sources));
+
+    // Both should be in the same bucket since they have the same lifetime
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 2);
+}
+
+TEST_F(
+  PartitionSourcesIntoSetsTest, CompactAndDeleteTopicsWithDifferentLifetimes) {
+    // A compact topic with max_compaction_lag_ms=1day and
+    // a delete topic with retention_ms=7days. They should be in different
+    // buckets.
+    auto compact_topic_id = model::create_topic_id();
+    auto delete_topic_id = model::create_topic_id();
+
+    chunked_vector<ss::shared_ptr<reconciler::source>> sources;
+    sources.push_back(make_compact_source(24h, compact_topic_id));
+    sources.push_back(make_delete_source(24h * 7, delete_topic_id));
+
+    auto result = reconciler::partition_sources_into_sets(std::move(sources));
+
+    // Should be in different buckets (7x difference = ~4 buckets apart)
+    ASSERT_EQ(result.size(), 2);
+}
+
+TEST_F(PartitionSourcesIntoSetsTest, MultipleCompactAndDeleteTopicsMixed) {
+    // Multiple compact and delete topics with similar lifetimes.
+    // All should be grouped together.
+    auto compact_topic1 = model::create_topic_id();
+    auto compact_topic2 = model::create_topic_id();
+    auto delete_topic1 = model::create_topic_id();
+    auto delete_topic2 = model::create_topic_id();
+
+    chunked_vector<ss::shared_ptr<reconciler::source>> sources;
+    // Compact topics with ~1 day max_compaction_lag_ms
+    sources.push_back(make_compact_source(24h, compact_topic1));
+    sources.push_back(make_compact_source(24h, compact_topic1));
+    sources.push_back(make_compact_source(24h, compact_topic2));
+    // Delete topics with ~1 day retention_ms
+    sources.push_back(make_delete_source(24h, delete_topic1));
+    sources.push_back(make_delete_source(24h, delete_topic2));
+    sources.push_back(make_delete_source(24h, delete_topic2));
+
+    auto result = reconciler::partition_sources_into_sets(std::move(sources));
+
+    // All 6 partitions should be in the same bucket
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 6);
+}
+
+TEST_F(PartitionSourcesIntoSetsTest, ZeroRetentionFromDifferentTopics) {
+    // Sources with 0ms effective_retention (immediate compaction/deletion)
+    // from different topics should be grouped together
+    auto tid1 = model::create_topic_id();
+    auto tid2 = model::create_topic_id();
+    auto tid3 = model::create_topic_id();
+
+    chunked_vector<ss::shared_ptr<reconciler::source>> sources;
+    sources.push_back(make_compact_source(0ms, tid1));
+    sources.push_back(make_delete_source(0ms, tid2));
+    sources.push_back(make_compact_source(0ms, tid3));
+
+    auto result = reconciler::partition_sources_into_sets(std::move(sources));
+
+    // All should be in the same bucket (bucket 0)
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 3);
+}
+
+TEST_F(PartitionSourcesIntoSetsTest, ZeroRetentionSeparateFromLargeRetention) {
+    // 0ms retention should be separate from topics with large retention
+    auto zero_tid = model::create_topic_id();
+    auto large_tid = model::create_topic_id();
+
+    chunked_vector<ss::shared_ptr<reconciler::source>> sources;
+    // 0ms retention (immediate)
+    sources.push_back(make_compact_source(0ms, zero_tid));
+    sources.push_back(make_delete_source(0ms, zero_tid));
+    // 1 day retention
+    sources.push_back(make_delete_source(24h, large_tid));
+
+    auto result = reconciler::partition_sources_into_sets(std::move(sources));
+
+    // Should be in different buckets
+    ASSERT_EQ(result.size(), 2);
+}
+
+TEST_F(PartitionSourcesIntoSetsTest, MixOfZeroAndSmallRetention) {
+    // 0ms and 1ms should both end up in bucket 0 (log(1) = 0)
+    auto tid1 = model::create_topic_id();
+    auto tid2 = model::create_topic_id();
+
+    chunked_vector<ss::shared_ptr<reconciler::source>> sources;
+    sources.push_back(make_compact_source(0ms, tid1));
+    sources.push_back(make_delete_source(1ms, tid2));
+
+    auto result = reconciler::partition_sources_into_sets(std::move(sources));
+
+    // Both should be in bucket 0
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 2);
+}
+
+TEST_F(PartitionSourcesIntoSetsTest, RealisticMixOfTopicTypes) {
+    // A realistic scenario with multiple topic types:
+    // - Short-lived compact topics (1 hour max_compaction_lag)
+    // - Medium-lived delete topics (1 day retention)
+    // - Long-lived compact topics (7 day max_compaction_lag)
+    auto short_compact_tid = model::create_topic_id();
+    auto medium_delete_tid = model::create_topic_id();
+    auto long_compact_tid = model::create_topic_id();
+
+    chunked_vector<ss::shared_ptr<reconciler::source>> sources;
+
+    // Short-lived compact (1 hour max_compaction_lag_ms)
+    sources.push_back(make_compact_source(1h, short_compact_tid));
+    sources.push_back(make_compact_source(1h, short_compact_tid));
+
+    // Medium-lived delete (1 day retention_ms)
+    sources.push_back(make_delete_source(24h, medium_delete_tid));
+    sources.push_back(make_delete_source(24h, medium_delete_tid));
+
+    // Long-lived compact (7 days max_compaction_lag_ms)
+    sources.push_back(make_compact_source(24h * 7, long_compact_tid));
+
+    auto result = reconciler::partition_sources_into_sets(std::move(sources));
+
+    // Should have 3 groups:
+    // 1. Short-lived (1h) - 2 partitions
+    // 2. Medium-lived (1d) - 2 partitions
+    // 3. Long-lived (7d) - 1 partition
+    ASSERT_EQ(result.size(), 3);
+
+    // Verify total partitions
+    size_t total = 0;
+    for (const auto& group : result) {
+        total += group.size();
+    }
+    EXPECT_EQ(total, 5);
+}
+
+TEST_F(PartitionSourcesIntoSetsTest, CompactDeleteTopicUsesMinimum) {
+    // A compact,delete topic should use min(max_compaction_lag, retention)
+    // Here compaction_lag=1h, retention=1d, so effective=1h
+    chunked_vector<ss::shared_ptr<reconciler::source>> sources;
+    sources.push_back(make_compact_delete_source(1h, 24h));
+    // This compact-only source with 1h should be in the same bucket
+    sources.push_back(make_compact_source(1h));
+
+    auto result = reconciler::partition_sources_into_sets(std::move(sources));
+
+    // Both should be in the same bucket (effective retention = 1h)
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 2);
+}
+
+TEST_F(PartitionSourcesIntoSetsTest, CompactDeleteTopicUsesMinimumRetention) {
+    // A compact,delete topic where retention is shorter than compaction_lag
+    // Here compaction_lag=7d, retention=1d, so effective=1d
+    chunked_vector<ss::shared_ptr<reconciler::source>> sources;
+    sources.push_back(make_compact_delete_source(24h * 7, 24h));
+    // This delete-only source with 1d should be in the same bucket
+    sources.push_back(make_delete_source(24h));
+
+    auto result = reconciler::partition_sources_into_sets(std::move(sources));
+
+    // Both should be in the same bucket (effective retention = 1d)
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 2);
+}
+
+TEST_F(
+  PartitionSourcesIntoSetsTest, CompactDeleteSeparatedByEffectiveLifetime) {
+    // Two compact,delete topics with different effective lifetimes
+    chunked_vector<ss::shared_ptr<reconciler::source>> sources;
+    // effective = min(1h, 7d) = 1h
+    sources.push_back(make_compact_delete_source(1h, 24h * 7));
+    // effective = min(7d, 1d) = 1d
+    sources.push_back(make_compact_delete_source(24h * 7, 24h));
+
+    auto result = reconciler::partition_sources_into_sets(std::move(sources));
+
+    // Should be in different buckets (1h vs 1d)
+    ASSERT_EQ(result.size(), 2);
+}

--- a/src/v/cloud_topics/reconciler/tests/test_utils.h
+++ b/src/v/cloud_topics/reconciler/tests/test_utils.h
@@ -17,9 +17,11 @@
 #include "model/record.h"
 #include "model/record_batch_reader.h"
 #include "model/tests/random_batch.h"
+#include "storage/ntp_config.h"
 
 #include <seastar/core/future.hh>
 
+#include <chrono>
 #include <expected>
 #include <optional>
 #include <stdexcept>
@@ -98,6 +100,55 @@ private:
     bool _fail_set_lro = false;
     bool _fail_make_reader = false;
     std::optional<std::chrono::milliseconds> _effective_retention_ms;
+};
+
+/// A fake source that uses an ntp_config to determine effective_retention_ms,
+/// matching the real l0_source implementation.
+class fake_l0_source : public source {
+public:
+    fake_l0_source(
+      model::ntp ntp, model::topic_id_partition tidp, storage::ntp_config cfg)
+      : source(std::move(ntp), tidp)
+      , _cfg(std::move(cfg)) {}
+
+    kafka::offset last_reconciled_offset() override { return _lro; }
+
+    ss::future<std::expected<void, errc>>
+    set_last_reconciled_offset(kafka::offset o, ss::abort_source&) override {
+        _lro = o;
+        co_return std::expected<void, errc>{};
+    }
+
+    ss::future<model::record_batch_reader>
+    make_reader(source::reader_config) override {
+        co_return model::make_empty_record_batch_reader();
+    }
+
+    /// Same implementation as l0_source::effective_retention_ms()
+    std::optional<std::chrono::milliseconds>
+    effective_retention_ms() const override {
+        auto policy = _cfg.cleanup_policy();
+
+        std::optional<std::chrono::milliseconds> res;
+
+        if (model::is_compaction_enabled(policy)) {
+            res = _cfg.max_compaction_lag_ms();
+        }
+
+        if (model::is_deletion_enabled(policy)) {
+            if (auto retention = _cfg.retention_duration()) {
+                res = res ? std::min(*res, *retention) : retention;
+            }
+        }
+
+        return res;
+    }
+
+    const storage::ntp_config& get_ntp_config() const { return _cfg; }
+
+private:
+    kafka::offset _lro;
+    storage::ntp_config _cfg;
 };
 
 class unreliable_metastore : public l1::simple_metastore {

--- a/src/v/cloud_topics/reconciler/tests/test_utils.h
+++ b/src/v/cloud_topics/reconciler/tests/test_utils.h
@@ -79,6 +79,16 @@ public:
           std::move(log));
     }
 
+    std::optional<std::chrono::milliseconds>
+    effective_retention_ms() const override {
+        return _effective_retention_ms;
+    }
+
+    void set_effective_retention_ms(
+      std::optional<std::chrono::milliseconds> retention) {
+        _effective_retention_ms = retention;
+    }
+
     void fail_set_lro(bool fail) { _fail_set_lro = fail; }
     void fail_make_reader(bool fail) { _fail_make_reader = fail; }
 
@@ -87,6 +97,7 @@ private:
     chunked_vector<model::record_batch> _source_log;
     bool _fail_set_lro = false;
     bool _fail_make_reader = false;
+    std::optional<std::chrono::milliseconds> _effective_retention_ms;
 };
 
 class unreliable_metastore : public l1::simple_metastore {


### PR DESCRIPTION
We recently changed the `reconciler` to only multiplex together partitions from the same topic.

This is overly pessimistic- to make garbage collection of L1 objects efficient, we should be able to reconcile together partitions that have similar expected data lifetimes. The easiest way, at present, to do this is to use time based retention properties like `retention.ms` (for `delete` topics) or `max.compaction.lag.ms` (for `compact` topics).

In the worst case (or for topics that don't have time based retention enabled), this approach falls back to grouping together sources by `topic_id`.

We are not yet grouping together topics based on their size-based retention properties (`retention.bytes`, `min.cleanable.dirty.ratio`), as this requires assumptions about ingress rates & behaviors that are not explicitly defined by these properties alone.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
