### PR TITLE
Deflake Controller Forced Reconfiguration Test with Force Reconfiguration Deadlock Fix

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -746,11 +746,10 @@ controller_backend::force_replica_set_update(
         partition->block_new_leadership();
         co_await partition->raft()->step_down("not_in_force_replica_set");
         co_return ss::stop_iteration::yes;
-    } else {
-        // force of a force may return a replica to the config, make sure
-        // if it was prior blocked from leadership, it isn't anymore
-        partition->unblock_new_leadership();
     }
+    // force of a force may return a replica to the config, make sure
+    // if it was prior blocked from leadership, it isn't anymore
+    partition->unblock_new_leadership();
     auto [voters, learners] = split_voters_learners_for_force_reconfiguration(
       previous_replicas, new_replicas, initial_replicas_revisions, cmd_rev);
     if (partition->cloud_data_available()) {

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -741,7 +741,15 @@ controller_backend::force_replica_set_update(
     if (!contains_node(new_replicas, _self)) {
         // This node will no longer be a part of the raft group,
         // will be cleaned up as a part of update_finished command.
+        // Make sure it can't be leader, though, s.t. update_finished can
+        // actually be sent out.
+        partition->block_new_leadership();
+        co_await partition->raft()->step_down("not_in_force_replica_set");
         co_return ss::stop_iteration::yes;
+    } else {
+        // force of a force may return a replica to the config, make sure
+        // if it was prior blocked from leadership, it isn't anymore
+        partition->unblock_new_leadership();
     }
     auto [voters, learners] = split_voters_learners_for_force_reconfiguration(
       previous_replicas, new_replicas, initial_replicas_revisions, cmd_rev);

--- a/tests/rptest/tests/partition_force_reconfiguration_test.py
+++ b/tests/rptest/tests/partition_force_reconfiguration_test.py
@@ -18,7 +18,7 @@ from ducktape.utils.util import wait_until
 from rptest.clients.kcl import KCL
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
-from rptest.services.admin import Admin, Replica
+from rptest.services.admin import Admin, PartitionDetails, Replica
 from rptest.services.cluster import cluster
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
 from rptest.services.redpanda import RedpandaService, SISettings
@@ -504,6 +504,131 @@ class PartitionForceReconfigurationTest(EndToEndTest, PartitionMovementMixin):
         self.await_num_produced(min_records=10000)
         self.start_consumer()
         self.run_validation()
+
+    @cluster(num_nodes=5)
+    def test_reconfigure_away_from_leader(self):
+        """
+        Regression test for a force reconfiguration deadlock
+
+        Previously, a force reconfiguration away from the partition leader may deadlock
+
+        This would happen because:
+        The previous leader would not step down. This allowed it to continue sending
+        heartbeats which would squash the leadership ambition of any voter in the new config.
+
+        Additionally: shutdown of a partitions which are leaving a replica set only occurs
+        on update_finish, which only occurs when a new leader has been elected.
+
+        The confluence of these two factors allowed the force_reconfiguration to stall forever.
+
+        This test recreates this scenario by doing the following:
+        given a cluster
+        [A B C D E]
+        and a replica placement for a partition
+        [A B C D E]
+        [F L F    ] where F is a follower and L is a leader
+
+        kill one of the followers
+        [A B C D E]
+        [    x    ]
+
+        and then launch a force reconfiguration from [A B C] to [A D E]
+        the new configuration now looks like
+        [A B C D E]
+        [V     L L] where V is voter and L is learner
+
+        A should be able to vote itself leader and finish the reconfiguration even though it
+        was not the leader at the time of force reconfiguration.
+        """
+        self.start_redpanda(
+            num_nodes=5,
+            extra_rp_conf={
+                "partition_autobalancing_mode": "continuous",
+                "enable_leader_balancer": False,
+            },
+        )
+        self.topic = "my_topic"
+        self.client().create_topic(
+            TopicSpec(name=self.topic, replication_factor=3, partition_count=1)
+        )
+
+        admin = self.redpanda._admin
+        rpk = RpkTool(self.redpanda)
+        replicas = []
+        for p in rpk.describe_topic(self.topic, tolerant=True):
+            replicas = [int(r) for r in p.replicas]
+
+        self.logger.info(f"Test topic {self.topic} replicas: {replicas}")
+
+        leader_id = admin.await_stable_leader(topic=self.topic, partition=0)
+        assert leader_id > 0, "should have found leader id"
+
+        non_leader_replicas = list(set(replicas) - {leader_id})
+        random.shuffle(non_leader_replicas)
+        assert len(non_leader_replicas) == 2, "invariant"
+        non_leader_replica, to_kill_replica = non_leader_replicas
+
+        # find two other replicas that are NOT part of the current configuration
+        all_node_ids = {
+            self.redpanda.node_id(node) for node in self.redpanda.all_nodes_abc()
+        }
+        non_replica_node_ids = list(all_node_ids - set(replicas))
+
+        # we want to reconfigure to one voter and two learners, but the voter should NOT be the current
+        # leader
+        assert len(non_replica_node_ids) == 2, "invariant"
+        reconfiguration_target = non_replica_node_ids + [non_leader_replica]
+
+        self.logger.info(
+            f"Force reconfiguration of {self.topic}/0 from {replicas} to {reconfiguration_target} with leader {leader_id}"
+        )
+
+        # stop to kill replica
+        node_to_stop = self.redpanda.get_node_by_id(to_kill_replica)
+        self.logger.debug(f"Stopping node: {to_kill_replica}")
+        self.redpanda.stop_node(node_to_stop)
+
+        target_replicas = [
+            Replica(dict(node_id=node_id, core=0)) for node_id in reconfiguration_target
+        ]
+        self._force_reconfiguration(target_replicas)
+
+        def force_reconfigure_complete():
+            partition_details: PartitionDetails | None = (
+                admin._get_stable_configuration(
+                    hosts=[node.name for node in self.redpanda.started_nodes()],
+                    topic=self.topic,
+                    partition=0,
+                )
+            )
+            if not partition_details:
+                return False
+
+            # movement in flight
+            if partition_details.status == "in_progress":
+                return False
+
+            current_nodes = {replica.node_id for replica in partition_details.replicas}
+            # not on the right nodes
+            if current_nodes != set(reconfiguration_target):
+                return False
+
+            # misplaced leader
+            current_leader = partition_details.leader
+            if not current_leader or current_leader not in reconfiguration_target:
+                return False
+
+            return True
+
+        # force reconfiguration should complete in far less that 30s, any more
+        # and it is likely deadlocked
+        wait_until(
+            condition=force_reconfigure_complete,
+            timeout_sec=30,
+            backoff_sec=3,
+            err_msg="force reconfiguration failed to complete in 30 seconds",
+            retry_on_exc=True,
+        )
 
 
 class NodeWiseRecoveryTest(RedpandaTest):

--- a/tests/rptest/tests/partition_force_reconfiguration_test.py
+++ b/tests/rptest/tests/partition_force_reconfiguration_test.py
@@ -615,7 +615,7 @@ class PartitionForceReconfigurationTest(EndToEndTest, PartitionMovementMixin):
 
             # misplaced leader
             current_leader = partition_details.leader
-            if not current_leader or current_leader not in reconfiguration_target:
+            if current_leader not in reconfiguration_target:
                 return False
 
             return True


### PR DESCRIPTION
Force reconfiguration can stall indefinitely if the current leader of a
partition is removed from the replica set.

This is because the leader will NOT get any notification of removal,
and so long as the leader replica is stable and healthy it will
heartbeat.

Followers accept append entires and heartbeats from all nodes, including
those not in the current configuration (this is required for
correctness).

So long as the voters in the target configuration of a force
reconfiguration accept append_entries from a leader that is NOT in the
new replica set, their leadership aspirations will be suppressed. Until
a new leader is elected, we will never send update_finished, thus the
old leader will never be shut down.

As a result, the force reconfiguration will never complete.

Resolution is:
1. have replicas which are being removed from the configuration step
   down
2. block the leadership of replicas which are no longer in the
   configuration
3. unblock leadership on any replica which is in the target
   configuration of a force command
   - this way if a force overwrites another force, we cleanup any old
     changes

This PR adds the aforementioned fix, a regression test to validate the fix, and some minor const correctness changes to cluster/partition


Fixes [CORE-15251](https://redpandadata.atlassian.net/browse/CORE-15251)
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x

## Release Notes
### Improvements

* Resolve deadlock in force_reconfigure edge case

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-15251]: https://redpandadata.atlassian.net/browse/CORE-15251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ