### PR TITLE
ct: correct epoch assertion

### DIFF
--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -332,7 +332,8 @@ void ctp_stm::apply_placeholder(const model::record_batch& batch) {
     // than the computed state.
     vassert(
       id.epoch >= _state.get_previous_epoch().value_or(cluster_epoch::min()),
-      "Observed a non-monotonic epoch sequence {} < {}",
+      "[{}] Observed a non-monotonic epoch sequence {} < {}",
+      ntp(),
       id.epoch,
       _state.get_previous_epoch());
     _state.advance_epoch(id.epoch, batch.header().base_offset);

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -330,12 +330,16 @@ void ctp_stm::apply_placeholder(const model::record_batch& batch) {
     // this assertion is made here rather than inside the state object itself
     // because the assertion is about the physical content of the log rather
     // than the computed state.
+    if (id.epoch > _epoch_window_max) {
+        _epoch_window_min = _epoch_window_max;
+        _epoch_window_max = id.epoch;
+    }
     vassert(
-      id.epoch >= _state.get_previous_epoch().value_or(cluster_epoch::min()),
+      id.epoch >= _epoch_window_min,
       "[{}] Observed a non-monotonic epoch sequence {} < {}",
       ntp(),
       id.epoch,
-      _state.get_previous_epoch());
+      _epoch_window_min);
     _state.advance_epoch(id.epoch, batch.header().base_offset);
 }
 

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -129,6 +129,16 @@ private:
     /// Current in-memory state of the STM
     ctp_stm_state _state;
 
+    // Log sliding window state, we use this to assert that the log contents
+    // never break the invariants that the epoch fencing should enforce.
+    //
+    // Note that in the state object we assign the first epoch ever observed
+    // to be the min *and* max. Here we only can assign it to the max because
+    // we don't know if we are truly at the beginning of the log or not due to
+    // this state being ephemeral.
+    cluster_epoch _epoch_window_min;
+    cluster_epoch _epoch_window_max;
+
     // An abort source to stop the prefix truncation loop on stop.
     ss::condition_variable _lro_advanced;
     ss::abort_source _as;


### PR DESCRIPTION
- **ct/stm: vassert with name of ntp**
- **ct/l0/stm: correct assertion**

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
