### PR TITLE
config: validate partition_balancer_planner

### DIFF
--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <optional>
 #include <unordered_map>
 
@@ -449,6 +450,78 @@ validate_cloud_topics_reconciliation_intervals(const configuration& config) {
           max_interval.count());
     }
 
+    return std::nullopt;
+}
+
+std::optional<ss::sstring>
+validate_sane_partition_balancer_timeouts(const configuration& config) {
+    // how often node status sends an rpc
+    auto node_status = config.node_status_interval();
+    // in pbp, if 7 consecutive node statuses are missed, the node is considered
+    // down for the purposes of determining alive / dead quorums
+    auto node_unresponsiveness = 7 * node_status;
+    // how often the partition balancer runs
+    auto pbp_tick_interval = config.partition_autobalancing_tick_interval_ms();
+    // timeout after which the partition balancer will start draining partitions
+    // from a node
+    auto node_availability
+      = config.partition_autobalancing_node_availability_timeout_sec();
+    // timeout or nullopt. If timeout, its the timeout after which the partition
+    // balancer may consider a node for automatic decommissioning
+    auto maybe_auto_decom_timeout
+      = config.partition_autobalancing_node_autodecommission_timeout_sec();
+    // how often the health report refreshes of its own accord
+    auto health_report_tick_time = config.health_monitor_tick_interval();
+
+    // pbp is written under the assumption that node_status << pbp_tick_interval
+    if (node_status > pbp_tick_interval) {
+        return fmt::format(
+          "node_status_interval ({}) must be less than or equal to "
+          "partition_autobalancing_tick_interval_ms ({})",
+          node_status,
+          pbp_tick_interval);
+    }
+
+    // node_unresponsiveness is when a node is considered down from the
+    // perspective of quorum liveness, aka pbp will consider partitions
+    // immutable if their source quorum is down.
+    // node_availability is the time at which a node is preemptively drained of
+    // replicas. The sane assumption is that node_unresponsiveness <
+    // node_availability
+    if (node_unresponsiveness > node_availability) {
+        return fmt::format(
+          "node_status_interval * 7 ({}) should be less than "
+          "partition_autobalancing_node_availability_timeout_sec ({})",
+          node_unresponsiveness,
+          node_availability);
+    }
+
+    // pbp relies on health reports for feedback on how its last round of
+    // balancing actions worked out. If the health report interval is greater
+    // than the pbp_tick interval, pbp may exhibit oscillating behavior where it
+    // overshoots balance. It is best to keep the health report interval lower
+    // than the pbp tick
+    if (pbp_tick_interval < health_report_tick_time) {
+        return fmt::format(
+          "health_monitor_tick_interval ({}) must be less than "
+          "partition_autobalancing_tick_interval_ms ({})",
+          health_report_tick_time,
+          pbp_tick_interval);
+    }
+
+    // sanity check, we should drain but not decommission a node before we
+    // attempt to eject it from the cluster
+    if (
+      maybe_auto_decom_timeout
+      && std::chrono::duration_cast<std::chrono::seconds>(node_availability)
+           > maybe_auto_decom_timeout) {
+        return fmt::format(
+          "partition_autobalancing_node_availability_timeout_sec ({}) must be "
+          "less than partition_autobalancing_node_autodecommission_timeout_sec "
+          "({})",
+          node_availability,
+          *maybe_auto_decom_timeout);
+    }
     return std::nullopt;
 }
 

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -84,4 +84,7 @@ validate_cloud_storage_cluster_name(const std::optional<ss::sstring>&);
 std::optional<ss::sstring>
 validate_cloud_topics_reconciliation_intervals(const configuration& config);
 
+std::optional<ss::sstring>
+validate_sane_partition_balancer_timeouts(const configuration& config);
+
 }; // namespace config

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -2046,6 +2046,12 @@ void config_multi_property_validation(
           updated_config.cloud_topics_reconciliation_min_interval.name()}]
           = interval_err.value();
     }
+
+    auto pbp_err = config::validate_sane_partition_balancer_timeouts(
+      updated_config);
+    if (pbp_err.has_value()) {
+        errors[ss::sstring{"partition_balancer_planner"}] = *pbp_err;
+    }
 }
 } // namespace
 

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -665,6 +665,17 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
         exclude_settings.add(CLOUD_TOPICS_CONFIG_STR)
         exclude_settings.add("iceberg_enabled")
 
+        # Partition balancer relies on relative sizes of these values
+        exclude_settings.update(
+            [
+                "node_status_interval",
+                "partition_autobalancing_tick_interval_ms",
+                "partition_autobalancing_node_availability_timeout_sec",
+                "partition_autobalancing_node_autodecommission_timeout_sec",
+                "health_monitor_tick_interval",
+            ]
+        )
+
         # List of settings that must be odd
         odd_settings = ["default_topic_replications", "minimum_topic_replications"]
 

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -409,6 +409,7 @@ class NodesDecommissioningTest(PreallocNodesTest):
         self.start_redpanda()
         self.redpanda.set_cluster_config(
             {
+                "health_monitor_tick_interval": min(int(tick_interval / 3), 3000),
                 "partition_autobalancing_tick_interval_ms": tick_interval,
                 "partition_autobalancing_concurrent_moves": 2,
             }

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -63,6 +63,7 @@ class PartitionBalancerService(EndToEndTest):
             ctx,
             *args,
             extra_rp_conf={
+                "health_monitor_tick_interval": 1500,
                 "partition_autobalancing_mode": "continuous",
                 "partition_autobalancing_node_availability_timeout_sec": 10,
                 "partition_autobalancing_tick_interval_ms": 5000,


### PR DESCRIPTION
Adds sanity validation to the cluster configuration validator.

Partition_balancer_planner has a litany of configuration parameters with assumptions on the relative sizes of timeouts. Although I am not aware of any bugs that are guaranteed to occur should these assumptions be violated, it is best to keep the cluster on the rails.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
### Improvements

* Adds commons sense validation to intervals relevant to partition balancing
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
