### PR TITLE
ct/l1/lsm: more state_reader methods for metastore read path

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/lsm/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/lsm/BUILD
@@ -129,6 +129,7 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         ":keys",
+        "//src/v/cloud_topics:logger",
         "//src/v/lsm/core:exceptions",
         "//src/v/ssx:future_util",
     ],

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_reader.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_reader.cc
@@ -544,6 +544,52 @@ state_reader::get_term_le(
     }
 }
 
+ss::future<std::expected<std::optional<kafka::offset>, state_reader::errc>>
+state_reader::get_term_end(
+  const model::topic_id_partition& tidp, model::term_id term) {
+    try {
+        auto iter = co_await snap_.create_iterator();
+
+        // Seek to the term key.
+        co_await iter.seek(term_row_key::encode(tidp, term));
+        if (!is_at_term(iter, tidp)) {
+            // All terms are below the requested term.
+            co_return std::nullopt;
+        }
+
+        auto key = term_row_key::decode(iter.key());
+        if (key->term > term) {
+            // Found a higher term; return its start offset as the exclusive
+            // end of the requested term.
+            auto val = serde::from_iobuf<term_row_value>(iter.value());
+            co_return val.term_start_offset;
+        }
+
+        // Otherwise, we found the exact term. Look for the next term so we can
+        // use it to get this term's end.
+        co_await iter.next();
+        if (is_at_term(iter, tidp)) {
+            auto val = serde::from_iobuf<term_row_value>(iter.value());
+            co_return val.term_start_offset;
+        }
+
+        // If there was no term above the requested term, return the
+        // partition's next offset.
+        auto metadata_res
+          = co_await get_val<metadata_row_key, metadata_row_value>(tidp);
+        if (!metadata_res.has_value()) {
+            co_return std::unexpected(metadata_res.error());
+        }
+        if (!metadata_res.value().has_value()) {
+            vlog(cd_log.error, "Missing partition metadata for {}", tidp);
+            co_return std::unexpected(errc::corruption);
+        }
+        co_return metadata_res.value()->next_offset;
+    } catch (...) {
+        co_return std::unexpected(to_errc(std::current_exception()));
+    }
+}
+
 template<typename KeyT, typename ValT, typename... KeyEncodeArgs>
 ss::future<std::expected<std::optional<ValT>, state_reader::errc>>
 state_reader::get_val(KeyEncodeArgs... args) {

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_reader.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_reader.cc
@@ -345,6 +345,148 @@ state_reader::get_extent_range(
       direction::forward);
 }
 
+ss::future<std::expected<
+  std::optional<std::pair<ss::sstring, ss::sstring>>,
+  state_reader::errc>>
+state_reader::find_inclusive_extent_keys(
+  const model::topic_id_partition& tidp,
+  std::optional<kafka::offset> min_offset,
+  std::optional<kafka::offset> max_offset) {
+    ss::sstring base_key;
+    ss::sstring last_key;
+    try {
+        auto iter = co_await snap_.create_iterator();
+        if (min_offset.has_value()) {
+            // Find the first extent where last_offset >= min_offset.
+            // Seek to min_offset+1, then prev to find extent that may contain
+            // min_offset.
+            auto seek_key = extent_row_key::encode(
+              tidp, kafka::next_offset(min_offset.value()));
+            co_await iter.seek(seek_key);
+            if (iter.valid()) {
+                co_await iter.prev();
+                if (!is_at_extent(iter, tidp)) {
+                    // If there were no extents below the seek_key result, seek
+                    // back to that key in case it's an extent -- if it is, its
+                    // last_offset will be >= min_offset.
+                    co_await iter.seek(seek_key);
+                }
+            } else {
+                co_await iter.seek_to_last();
+            }
+
+            if (!is_at_extent(iter, tidp)) {
+                co_return std::nullopt;
+            }
+
+            // Validate extent's last_offset >= min_offset.
+            auto val = serde::from_iobuf<extent_row_value>(iter.value());
+            if (val.last_offset < min_offset.value()) {
+                co_await iter.next();
+                if (!is_at_extent(iter, tidp)) {
+                    co_return std::nullopt;
+                }
+            }
+        } else {
+            // No lower bound, start from first extent.
+            co_await iter.seek(extent_row_key::encode(tidp, kafka::offset(0)));
+            if (!is_at_extent(iter, tidp)) {
+                co_return std::nullopt;
+            }
+        }
+        base_key = ss::sstring(iter.key());
+
+        if (max_offset.has_value()) {
+            // Find the last extent whose base_offset <= max_offset.
+            // Seek to max_offset+1, then prev to find extent with base <= max.
+            auto seek_key = extent_row_key::encode(
+              tidp, kafka::next_offset(max_offset.value()));
+            co_await iter.seek(seek_key);
+            if (iter.valid()) {
+                co_await iter.prev();
+            } else {
+                co_await iter.seek_to_last();
+            }
+
+            if (!is_at_extent(iter, tidp)) {
+                co_return std::nullopt;
+            }
+        } else {
+            // No upper bound, end at last extent in this partition. Seek to
+            // next partition, then prev.
+            co_await iter.seek(
+              extent_row_key::encode(next_partition(tidp), kafka::offset(0)));
+            if (iter.valid()) {
+                co_await iter.prev();
+            } else {
+                co_await iter.seek_to_last();
+            }
+            if (!is_at_extent(iter, tidp)) {
+                co_return std::nullopt;
+            }
+        }
+        last_key = ss::sstring(iter.key());
+
+        // Sanity check: base_key <= last_key.
+        if (base_key > last_key) {
+            co_return std::nullopt;
+        }
+    } catch (...) {
+        co_return std::unexpected(to_errc(std::current_exception()));
+    }
+
+    co_return std::make_optional(
+      std::make_pair(std::move(base_key), std::move(last_key)));
+}
+
+ss::future<std::expected<
+  std::optional<state_reader::extent_key_range>,
+  state_reader::errc>>
+state_reader::get_inclusive_extents(
+  const model::topic_id_partition& tidp,
+  std::optional<kafka::offset> min_offset,
+  std::optional<kafka::offset> max_offset) {
+    auto keys_res = co_await find_inclusive_extent_keys(
+      tidp, min_offset, max_offset);
+    if (!keys_res.has_value()) {
+        co_return std::unexpected(keys_res.error());
+    }
+    if (!keys_res.value().has_value()) {
+        co_return std::nullopt;
+    }
+
+    auto iter = co_await snap_.create_iterator();
+    co_return extent_key_range(
+      std::move(keys_res.value()->first),
+      std::move(keys_res.value()->second),
+      std::move(iter),
+      direction::forward);
+}
+
+ss::future<std::expected<
+  std::optional<state_reader::extent_key_range>,
+  state_reader::errc>>
+state_reader::get_inclusive_extents_backward(
+  const model::topic_id_partition& tidp,
+  std::optional<kafka::offset> min_offset,
+  std::optional<kafka::offset> max_offset) {
+    auto keys_res = co_await find_inclusive_extent_keys(
+      tidp, min_offset, max_offset);
+    if (!keys_res.has_value()) {
+        co_return std::unexpected(keys_res.error());
+    }
+    if (!keys_res.value().has_value()) {
+        co_return std::nullopt;
+    }
+
+    auto iter = co_await snap_.create_iterator();
+    co_return extent_key_range(
+      std::move(keys_res.value()->first),
+      std::move(keys_res.value()->second),
+      std::move(iter),
+      direction::backward);
+}
+
 template<typename KeyT, typename ValT, typename... KeyEncodeArgs>
 ss::future<std::expected<std::optional<ValT>, state_reader::errc>>
 state_reader::get_val(KeyEncodeArgs... args) {

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_reader.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_reader.cc
@@ -10,6 +10,7 @@
 #include "cloud_topics/level_one/metastore/lsm/state_reader.h"
 
 #include "cloud_topics/level_one/metastore/lsm/keys.h"
+#include "cloud_topics/logger.h"
 #include "lsm/core/exceptions.h"
 #include "ssx/future-util.h"
 
@@ -58,6 +59,14 @@ bool is_at_extent(
 
 } // namespace
 
+ss::sstring state_reader::extent_key_range::to_string() {
+    return fmt::format(
+      "extent_key_range: [{}, {}], iter: {}",
+      _base_key,
+      _last_key,
+      _iter.valid() ? _iter.key() : "{invalid iterator}");
+}
+
 ss::coroutine::experimental::generator<
   std::expected<state_reader::extent_row, state_reader::errc>>
 state_reader::extent_key_range::get_rows() {
@@ -68,6 +77,7 @@ state_reader::extent_key_range::get_rows() {
         co_return;
     }
     if (!_iter.valid() || _iter.key() != _base_key) {
+        vlog(cd_log.error, "Expected base key: {}", to_string());
         co_yield std::unexpected(errc::corruption);
         co_return;
     }
@@ -83,6 +93,7 @@ state_reader::extent_key_range::get_rows() {
                 co_return;
             }
             if (_iter.key() > _last_key) {
+                vlog(cd_log.error, "Unexpected key past last: {}", to_string());
                 co_yield std::unexpected(errc::corruption);
                 co_return;
             }
@@ -91,6 +102,8 @@ state_reader::extent_key_range::get_rows() {
             ex = std::current_exception();
         }
         if (ex) {
+            vlog(
+              cd_log.warn, "Exception when iterating {}: {}", to_string(), ex);
             co_yield std::unexpected(to_errc(ex));
             co_return;
         }
@@ -145,6 +158,7 @@ ss::future<std::expected<std::optional<term_start>, state_reader::errc>>
 state_reader::get_max_term(const model::topic_id_partition& tidp) {
     iobuf val_buf;
     model::term_id term;
+    ss::sstring base_key_str;
     try {
         // Seek to the first term of the next partition and then iterate
         // backwards to find the highest term of this partition.
@@ -159,7 +173,8 @@ state_reader::get_max_term(const model::topic_id_partition& tidp) {
         if (!iter.valid()) {
             co_return std::nullopt;
         }
-        auto key = term_row_key::decode(iter.key());
+        base_key_str = ss::sstring(iter.key());
+        auto key = term_row_key::decode(base_key_str);
         if (!key.has_value() || key->tidp != tidp) {
             co_return std::nullopt;
         }
@@ -173,6 +188,14 @@ state_reader::get_max_term(const model::topic_id_partition& tidp) {
         co_return term_start{
           .term_id = term, .start_offset = val.term_start_offset};
     } catch (...) {
+        vlog(
+          cd_log.error,
+          "Unexpected exception decoding term row value for {} term {} "
+          "key {}: {}",
+          tidp,
+          term,
+          base_key_str,
+          std::current_exception());
         co_return std::unexpected(errc::corruption);
     }
 }
@@ -182,6 +205,7 @@ state_reader::get_extent_ge(
   const model::topic_id_partition& tidp, kafka::offset o) {
     iobuf val_buf;
     kafka::offset base_offset;
+    ss::sstring base_key_str;
     try {
         auto iter = co_await snap_.create_iterator();
         // Seek to o+1 and iterate backwards to find the extent that may
@@ -207,7 +231,8 @@ state_reader::get_extent_ge(
             co_return std::nullopt;
         }
 
-        auto key = extent_row_key::decode(iter.key());
+        base_key_str = ss::sstring(iter.key());
+        auto key = extent_row_key::decode(base_key_str);
         if (!key.has_value() || key->tidp != tidp) {
             co_return std::nullopt;
         }
@@ -232,6 +257,14 @@ state_reader::get_extent_ge(
           .oid = val.oid,
         };
     } catch (...) {
+        vlog(
+          cd_log.error,
+          "Unexpected exception decoding extent row value for {} offset {} "
+          "key {}: {}",
+          tidp,
+          base_offset,
+          base_key_str,
+          std::current_exception());
         co_return std::unexpected(errc::corruption);
     }
 }
@@ -279,6 +312,14 @@ state_reader::get_extent_range(
             co_return std::nullopt;
         }
     } catch (...) {
+        vlog(
+          cd_log.error,
+          "Unexpected exception decoding extent row value for {} offset {} "
+          "key {}: {}",
+          tidp,
+          base,
+          base_key,
+          std::current_exception());
         co_return std::unexpected(errc::corruption);
     }
     // Position iterator back at base_key to return to the caller.
@@ -295,8 +336,8 @@ state_reader::get_extent_range(
 template<typename KeyT, typename ValT, typename... KeyEncodeArgs>
 ss::future<std::expected<std::optional<ValT>, state_reader::errc>>
 state_reader::get_val(KeyEncodeArgs... args) {
-    auto fut = co_await ss::coroutine::as_future(
-      snap_.get(KeyT::encode(args...)));
+    auto key_str = KeyT::encode(args...);
+    auto fut = co_await ss::coroutine::as_future(snap_.get(key_str));
     if (fut.failed()) {
         co_return std::unexpected(to_errc(fut.get_exception()));
     }
@@ -308,6 +349,11 @@ state_reader::get_val(KeyEncodeArgs... args) {
         auto val = serde::from_iobuf<ValT>(std::move(*opt_buf));
         co_return val;
     } catch (...) {
+        vlog(
+          cd_log.error,
+          "Unexpected exception decoding value at key {}: {}",
+          key_str,
+          std::current_exception());
         co_return std::unexpected(errc::corruption);
     }
 }

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_reader.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_reader.cc
@@ -61,22 +61,27 @@ bool is_at_extent(
 
 ss::sstring state_reader::extent_key_range::to_string() {
     return fmt::format(
-      "extent_key_range: [{}, {}], iter: {}",
+      "extent_key_range: [{}, {}], {} iter: {}",
       _base_key,
       _last_key,
+      _direction == direction::forward ? "forward" : "backward",
       _iter.valid() ? _iter.key() : "{invalid iterator}");
 }
 
 ss::coroutine::experimental::generator<
   std::expected<state_reader::extent_row, state_reader::errc>>
 state_reader::extent_key_range::get_rows() {
-    auto fut = co_await ss::coroutine::as_future(_iter.seek(_base_key));
+    const bool forward = _direction == direction::forward;
+    const auto& start_key = forward ? _base_key : _last_key;
+    const auto& end_key = forward ? _last_key : _base_key;
+
+    auto fut = co_await ss::coroutine::as_future(_iter.seek(start_key));
     if (fut.failed()) {
         auto ex = fut.get_exception();
         co_yield std::unexpected(to_errc(ex));
         co_return;
     }
-    if (!_iter.valid() || _iter.key() != _base_key) {
+    if (!_iter.valid() || _iter.key() != start_key) {
         vlog(cd_log.error, "Expected base key: {}", to_string());
         co_yield std::unexpected(errc::corruption);
         co_return;
@@ -89,15 +94,19 @@ state_reader::extent_key_range::get_rows() {
               .key = ss::sstring(_iter.key()),
               .val = val,
             };
-            if (_iter.key() == _last_key) {
+            if (_iter.key() == end_key) {
                 co_return;
             }
-            if (_iter.key() > _last_key) {
+            if (forward ? (_iter.key() > end_key) : (_iter.key() < end_key)) {
                 vlog(cd_log.error, "Unexpected key past last: {}", to_string());
                 co_yield std::unexpected(errc::corruption);
                 co_return;
             }
-            co_await _iter.next();
+            if (forward) {
+                co_await _iter.next();
+            } else {
+                co_await _iter.prev();
+            }
         } catch (...) {
             ex = std::current_exception();
         }
@@ -330,7 +339,10 @@ state_reader::get_extent_range(
         co_return std::unexpected(to_errc(std::current_exception()));
     }
     co_return extent_key_range(
-      std::move(base_key), std::move(last_key), std::move(iter));
+      std::move(base_key),
+      std::move(last_key),
+      std::move(iter),
+      direction::forward);
 }
 
 template<typename KeyT, typename ValT, typename... KeyEncodeArgs>

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_reader.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_reader.cc
@@ -487,6 +487,63 @@ state_reader::get_inclusive_extents_backward(
       direction::backward);
 }
 
+namespace {
+
+bool is_at_term(
+  lsm::iterator& iter,
+  const model::topic_id_partition& tidp,
+  term_row_key* out = nullptr) {
+    if (!iter.valid()) {
+        return false;
+    }
+    auto key = term_row_key::decode(iter.key());
+    if (!key.has_value() || key->tidp != tidp) {
+        return false;
+    }
+    if (out) {
+        *out = key.value();
+    }
+    return true;
+}
+
+} // namespace
+
+ss::future<std::expected<std::optional<term_start>, state_reader::errc>>
+state_reader::get_term_le(
+  const model::topic_id_partition& tidp, kafka::offset offset) {
+    try {
+        auto iter = co_await snap_.create_iterator();
+
+        // Seek to the first term of the next partition and iterate backwards.
+        co_await iter.seek(
+          term_row_key::encode(next_partition(tidp), model::term_id(0)));
+        if (!iter.valid()) {
+            co_await iter.seek_to_last();
+        } else {
+            co_await iter.prev();
+        }
+
+        // Iterate backwards through terms, find first with start_offset <=
+        // offset.
+        while (is_at_term(iter, tidp)) {
+            auto val = serde::from_iobuf<term_row_value>(iter.value());
+            if (val.term_start_offset <= offset) {
+                auto key = term_row_key::decode(iter.key());
+                co_return term_start{
+                  .term_id = key->term,
+                  .start_offset = val.term_start_offset,
+                };
+            }
+            co_await iter.prev();
+        }
+
+        // No term found with start_offset <= offset.
+        co_return std::nullopt;
+    } catch (...) {
+        co_return std::unexpected(to_errc(std::current_exception()));
+    }
+}
+
 template<typename KeyT, typename ValT, typename... KeyEncodeArgs>
 ss::future<std::expected<std::optional<ValT>, state_reader::errc>>
 state_reader::get_val(KeyEncodeArgs... args) {

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_reader.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_reader.cc
@@ -89,17 +89,17 @@ state_reader::extent_key_range::get_rows() {
     while (_iter.valid()) {
         std::exception_ptr ex;
         try {
+            if (forward ? (_iter.key() > end_key) : (_iter.key() < end_key)) {
+                vlog(cd_log.error, "Unexpected key past last: {}", to_string());
+                co_yield std::unexpected(errc::corruption);
+                co_return;
+            }
             auto val = serde::from_iobuf<extent_row_value>(_iter.value());
             co_yield extent_row{
               .key = ss::sstring(_iter.key()),
               .val = val,
             };
             if (_iter.key() == end_key) {
-                co_return;
-            }
-            if (forward ? (_iter.key() > end_key) : (_iter.key() < end_key)) {
-                vlog(cd_log.error, "Unexpected key past last: {}", to_string());
-                co_yield std::unexpected(errc::corruption);
                 co_return;
             }
             if (forward) {

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_reader.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_reader.h
@@ -106,6 +106,11 @@ public:
       std::optional<kafka::offset> min_offset,
       std::optional<kafka::offset> max_offset);
 
+    // Returns the term containing the given offset, i.e. the term with the
+    // start_offset <= the given offset, or  nullopt if no such term exists.
+    ss::future<std::expected<std::optional<term_start>, errc>>
+    get_term_le(const model::topic_id_partition&, kafka::offset);
+
 private:
     ss::future<
       std::expected<std::optional<std::pair<ss::sstring, ss::sstring>>, errc>>

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_reader.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_reader.h
@@ -111,6 +111,14 @@ public:
     ss::future<std::expected<std::optional<term_start>, errc>>
     get_term_le(const model::topic_id_partition&, kafka::offset);
 
+    // Returns the end offset (exclusive) for the given term:
+    // - If a higher term exists, returns the start_offset of the next term
+    // - If this is the highest term, the partition's next_offset
+    // Returns nullopt if all terms are below the given term or the term
+    // doesn't exist.
+    ss::future<std::expected<std::optional<kafka::offset>, errc>>
+    get_term_end(const model::topic_id_partition&, model::term_id);
+
 private:
     ss::future<
       std::expected<std::optional<std::pair<ss::sstring, ss::sstring>>, errc>>

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_reader.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_reader.h
@@ -47,6 +47,8 @@ public:
         materialize_rows();
 
     private:
+        ss::sstring to_string();
+
         ss::sstring _base_key;
         ss::sstring _last_key;
 

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_reader.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_reader.h
@@ -92,7 +92,28 @@ public:
     get_extent_range(
       const model::topic_id_partition&, kafka::offset base, kafka::offset last);
 
+    // Returns an iterator for all extents that overlap with the inclusive
+    // range [min_offset, max_offset]. Returns nullopt if there are no extents
+    // in the given bounds.
+    ss::future<std::expected<std::optional<extent_key_range>, errc>>
+    get_inclusive_extents(
+      const model::topic_id_partition&,
+      std::optional<kafka::offset> min_offset,
+      std::optional<kafka::offset> max_offset);
+    ss::future<std::expected<std::optional<extent_key_range>, errc>>
+    get_inclusive_extents_backward(
+      const model::topic_id_partition&,
+      std::optional<kafka::offset> min_offset,
+      std::optional<kafka::offset> max_offset);
+
 private:
+    ss::future<
+      std::expected<std::optional<std::pair<ss::sstring, ss::sstring>>, errc>>
+    find_inclusive_extent_keys(
+      const model::topic_id_partition&,
+      std::optional<kafka::offset> min_offset,
+      std::optional<kafka::offset> max_offset);
+
     template<typename KeyT, typename ValT, typename... KeyEncodeArgs>
     ss::future<std::expected<std::optional<ValT>, errc>>
     get_val(KeyEncodeArgs...);

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_reader.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_reader.h
@@ -29,12 +29,17 @@ public:
         ss::sstring key;
         extent_row_value val;
     };
+
+    enum class direction { forward, backward };
+
     class extent_key_range {
     public:
-        extent_key_range(ss::sstring base, ss::sstring last, lsm::iterator it)
+        extent_key_range(
+          ss::sstring base, ss::sstring last, lsm::iterator it, direction dir)
           : _base_key(std::move(base))
           , _last_key(std::move(last))
-          , _iter(std::move(it)) {}
+          , _iter(std::move(it))
+          , _direction(dir) {}
 
         // Returns extent_rows matching exactly between _base_key and
         // _last_key, or generates an error if it can't.
@@ -54,6 +59,7 @@ public:
 
         // Snapshot of the database.
         lsm::iterator _iter;
+        direction _direction;
     };
 
     explicit state_reader(lsm::snapshot snap)

--- a/src/v/cloud_topics/level_one/metastore/lsm/tests/state_reader_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/tests/state_reader_test.cc
@@ -754,3 +754,52 @@ TEST_F(StateReaderTestFixture, TestGetExtentsBackward) {
         EXPECT_FALSE(res.value().has_value());
     }
 }
+
+namespace {
+
+void verify_term_of(
+  state_reader& reader,
+  const model::topic_id_partition& tidp,
+  kafka::offset o,
+  std::optional<model::term_id> expected_term) {
+    SCOPED_TRACE(fmt::format("tidp={}, o={}", tidp, o));
+    auto res = reader.get_term_le(tidp, o).get();
+    ASSERT_TRUE(res.has_value());
+    if (expected_term.has_value()) {
+        ASSERT_TRUE(res.value().has_value());
+        EXPECT_EQ(res.value()->term_id, expected_term.value());
+    } else {
+        EXPECT_FALSE(res.value().has_value());
+    }
+}
+
+} // namespace
+
+TEST_F(StateReaderTestFixture, TestGetTermLe) {
+    auto tidp = make_tidp(0);
+    write_term_start(tidp, model::term_id(1), kafka::offset(10));
+    write_term_start(tidp, model::term_id(3), kafka::offset(100));
+    write_term_start(tidp, model::term_id(7), kafka::offset(250));
+
+    auto reader = make_reader();
+
+    // Offsets below which we have term start return nullopt.
+    verify_term_of(reader, tidp, kafka::offset(0), std::nullopt);
+    verify_term_of(reader, tidp, kafka::offset(9), std::nullopt);
+
+    // Offsets before term 3 should be in term 1.
+    verify_term_of(reader, tidp, kafka::offset(10), model::term_id(1));
+    verify_term_of(reader, tidp, kafka::offset(99), model::term_id(1));
+
+    // Offsets before term 7 should be in term 3.
+    verify_term_of(reader, tidp, kafka::offset(100), model::term_id(3));
+    verify_term_of(reader, tidp, kafka::offset(249), model::term_id(3));
+
+    // Offsets at or after term 7 should be in term 7.
+    verify_term_of(reader, tidp, kafka::offset(250), model::term_id(7));
+    verify_term_of(reader, tidp, kafka::offset(1000), model::term_id(7));
+
+    // Missing partition should return nullopt.
+    auto missing_tidp = make_tidp(1);
+    verify_term_of(reader, missing_tidp, kafka::offset(100), std::nullopt);
+}

--- a/src/v/cloud_topics/level_one/metastore/lsm/tests/state_reader_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/tests/state_reader_test.cc
@@ -773,6 +773,22 @@ void verify_term_of(
     }
 }
 
+void verify_term_end(
+  state_reader& reader,
+  const model::topic_id_partition& tidp,
+  model::term_id t,
+  std::optional<kafka::offset> expected_end) {
+    SCOPED_TRACE(fmt::format("tidp={}, term={}", tidp, t));
+    auto res = reader.get_term_end(tidp, t).get();
+    ASSERT_TRUE(res.has_value());
+    if (expected_end.has_value()) {
+        ASSERT_TRUE(res.value().has_value());
+        EXPECT_EQ(res.value().value(), expected_end.value());
+    } else {
+        EXPECT_FALSE(res.value().has_value());
+    }
+}
+
 } // namespace
 
 TEST_F(StateReaderTestFixture, TestGetTermLe) {
@@ -802,4 +818,28 @@ TEST_F(StateReaderTestFixture, TestGetTermLe) {
     // Missing partition should return nullopt.
     auto missing_tidp = make_tidp(1);
     verify_term_of(reader, missing_tidp, kafka::offset(100), std::nullopt);
+}
+
+TEST_F(StateReaderTestFixture, TestGetTermEnd) {
+    auto tidp = make_tidp(0);
+
+    write_term_start(tidp, model::term_id(1), kafka::offset(0));
+    write_term_start(tidp, model::term_id(3), kafka::offset(100));
+    write_term_start(tidp, model::term_id(7), kafka::offset(250));
+    write_metadata(tidp, kafka::offset(0), kafka::offset(400));
+
+    auto reader = make_reader();
+    verify_term_end(reader, tidp, model::term_id(0), kafka::offset(0));
+    verify_term_end(reader, tidp, model::term_id(1), kafka::offset(100));
+    verify_term_end(reader, tidp, model::term_id(2), kafka::offset(100));
+    verify_term_end(reader, tidp, model::term_id(3), kafka::offset(250));
+    verify_term_end(reader, tidp, model::term_id(4), kafka::offset(250));
+    verify_term_end(reader, tidp, model::term_id(5), kafka::offset(250));
+    verify_term_end(reader, tidp, model::term_id(6), kafka::offset(250));
+    verify_term_end(reader, tidp, model::term_id(7), kafka::offset(400));
+    verify_term_end(reader, tidp, model::term_id(8), std::nullopt);
+
+    // Missing partition should return nullopt.
+    auto missing_tidp = make_tidp(1);
+    verify_term_end(reader, missing_tidp, model::term_id(1), std::nullopt);
 }

--- a/src/v/cloud_topics/level_one/metastore/lsm/tests/state_reader_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/tests/state_reader_test.cc
@@ -402,6 +402,43 @@ void validate_extent_range(
     EXPECT_EQ(rows.back()->val.last_offset(), last);
 }
 
+void verify_inclusive_extents(
+  state_reader& reader,
+  const model::topic_id_partition& tidp,
+  std::optional<int64_t> min_offset,
+  std::optional<int64_t> max_offset,
+  std::vector<int64_t> expected_base_offsets) {
+    SCOPED_TRACE(
+      fmt::format(
+        "min={}, max={}", min_offset.value_or(-1), max_offset.value_or(-1)));
+
+    std::optional<kafka::offset> min_opt = min_offset
+                                             ? std::make_optional(
+                                                 kafka::offset(*min_offset))
+                                             : std::nullopt;
+    std::optional<kafka::offset> max_opt = max_offset
+                                             ? std::make_optional(
+                                                 kafka::offset(*max_offset))
+                                             : std::nullopt;
+
+    auto res = reader.get_inclusive_extents(tidp, min_opt, max_opt).get();
+    ASSERT_TRUE(res.has_value());
+
+    if (expected_base_offsets.empty()) {
+        EXPECT_FALSE(res.value().has_value());
+        return;
+    }
+
+    ASSERT_TRUE(res.value().has_value());
+    auto rows = res.value()->materialize_rows().get();
+    ASSERT_EQ(rows.size(), expected_base_offsets.size());
+    for (size_t i = 0; i < expected_base_offsets.size(); ++i) {
+        auto key = extent_row_key::decode(rows[i]->key);
+        ASSERT_TRUE(key.has_value());
+        EXPECT_EQ(key->base_offset, kafka::offset(expected_base_offsets[i]));
+    }
+}
+
 } // namespace
 
 TEST_F(StateReaderTestFixture, TestGetExtentRangeSurroundedPartitions) {
@@ -503,4 +540,217 @@ TEST_F(StateReaderTestFixture, TestGetExtentRange) {
     validate_extent_range(reader, tidp1, 200, 200, 0);
     validate_extent_range(reader, tidp1, 200, 300, 0);
     validate_extent_range(reader, tidp1, 300, 300, 0);
+}
+
+TEST_F(StateReaderTestFixture, TestGetExtentsForward) {
+    auto tidp = make_tidp(0);
+    auto oid = make_oid();
+
+    // Create 3 extents: [100-199], [200-299], [300-399]
+    write_extent(
+      tidp,
+      kafka::offset(100),
+      kafka::offset(199),
+      model::timestamp(1000),
+      0,
+      1024,
+      oid);
+    write_extent(
+      tidp,
+      kafka::offset(200),
+      kafka::offset(299),
+      model::timestamp(2000),
+      1024,
+      1024,
+      oid);
+    write_extent(
+      tidp,
+      kafka::offset(300),
+      kafka::offset(399),
+      model::timestamp(3000),
+      2048,
+      1024,
+      oid);
+
+    auto reader = make_reader();
+
+    // Exact matches.
+    verify_inclusive_extents(reader, tidp, 100, 399, {100, 200, 300});
+    verify_inclusive_extents(reader, tidp, 200, 399, {200, 300});
+    verify_inclusive_extents(reader, tidp, 100, 299, {100, 200});
+    verify_inclusive_extents(reader, tidp, 100, 199, {100});
+    verify_inclusive_extents(reader, tidp, 200, 299, {200});
+    verify_inclusive_extents(reader, tidp, 300, 399, {300});
+
+    // Imprecise boundaries.
+    verify_inclusive_extents(reader, tidp, 150, 350, {100, 200, 300});
+    verify_inclusive_extents(reader, tidp, 99, 399, {100, 200, 300});
+    verify_inclusive_extents(reader, tidp, 100, 400, {100, 200, 300});
+    verify_inclusive_extents(reader, tidp, 99, 400, {100, 200, 300});
+    verify_inclusive_extents(reader, tidp, 0, 1000, {100, 200, 300});
+    verify_inclusive_extents(reader, tidp, 99, 199, {100});
+    verify_inclusive_extents(reader, tidp, 300, 400, {300});
+    verify_inclusive_extents(reader, tidp, 0, 99, {});
+    verify_inclusive_extents(reader, tidp, 400, 500, {});
+
+    // Null boundaries.
+    verify_inclusive_extents(reader, tidp, std::nullopt, 99, {});
+    verify_inclusive_extents(reader, tidp, std::nullopt, 100, {100});
+    verify_inclusive_extents(reader, tidp, std::nullopt, 199, {100});
+    verify_inclusive_extents(reader, tidp, std::nullopt, 200, {100, 200});
+    verify_inclusive_extents(reader, tidp, std::nullopt, 299, {100, 200});
+    verify_inclusive_extents(reader, tidp, std::nullopt, 300, {100, 200, 300});
+    verify_inclusive_extents(reader, tidp, std::nullopt, 399, {100, 200, 300});
+    verify_inclusive_extents(reader, tidp, std::nullopt, 400, {100, 200, 300});
+    verify_inclusive_extents(reader, tidp, 99, std::nullopt, {100, 200, 300});
+    verify_inclusive_extents(reader, tidp, 100, std::nullopt, {100, 200, 300});
+    verify_inclusive_extents(reader, tidp, 199, std::nullopt, {100, 200, 300});
+    verify_inclusive_extents(reader, tidp, 200, std::nullopt, {200, 300});
+    verify_inclusive_extents(reader, tidp, 299, std::nullopt, {200, 300});
+    verify_inclusive_extents(reader, tidp, 300, std::nullopt, {300});
+    verify_inclusive_extents(reader, tidp, 399, std::nullopt, {300});
+    verify_inclusive_extents(reader, tidp, 400, std::nullopt, {});
+
+    // Both bounds special cases
+    verify_inclusive_extents(
+      reader, tidp, std::nullopt, std::nullopt, {100, 200, 300});
+    verify_inclusive_extents(reader, tidp, 199, 200, {100, 200});
+    verify_inclusive_extents(reader, tidp, 200, 200, {200});
+    verify_inclusive_extents(reader, tidp, 300, 100, {});
+}
+
+TEST_F(StateReaderTestFixture, TestGetExtentsSizeOne) {
+    auto tidp = make_tidp(0);
+    auto oid = make_oid();
+
+    // Create 3 extents with size 1: [100-100], [101-101], [102-102]
+    write_extent(
+      tidp,
+      kafka::offset(100),
+      kafka::offset(100),
+      model::timestamp(1000),
+      0,
+      1024,
+      oid);
+    write_extent(
+      tidp,
+      kafka::offset(101),
+      kafka::offset(101),
+      model::timestamp(2000),
+      1024,
+      1024,
+      oid);
+    write_extent(
+      tidp,
+      kafka::offset(102),
+      kafka::offset(102),
+      model::timestamp(3000),
+      2048,
+      1024,
+      oid);
+
+    auto reader = make_reader();
+
+    // Exact matches.
+    verify_inclusive_extents(reader, tidp, 100, 102, {100, 101, 102});
+    verify_inclusive_extents(reader, tidp, 101, 102, {101, 102});
+    verify_inclusive_extents(reader, tidp, 100, 101, {100, 101});
+    verify_inclusive_extents(reader, tidp, 100, 100, {100});
+    verify_inclusive_extents(reader, tidp, 101, 101, {101});
+    verify_inclusive_extents(reader, tidp, 102, 102, {102});
+
+    // Imprecise boundaries.
+    verify_inclusive_extents(reader, tidp, 99, 102, {100, 101, 102});
+    verify_inclusive_extents(reader, tidp, 100, 103, {100, 101, 102});
+    verify_inclusive_extents(reader, tidp, 99, 103, {100, 101, 102});
+    verify_inclusive_extents(reader, tidp, 0, 1000, {100, 101, 102});
+    verify_inclusive_extents(reader, tidp, 99, 100, {100});
+    verify_inclusive_extents(reader, tidp, 102, 103, {102});
+    verify_inclusive_extents(reader, tidp, 99, 99, {});
+    verify_inclusive_extents(reader, tidp, 103, 103, {});
+
+    // Null boundaries.
+    verify_inclusive_extents(reader, tidp, std::nullopt, 99, {});
+    verify_inclusive_extents(reader, tidp, std::nullopt, 100, {100});
+    verify_inclusive_extents(reader, tidp, std::nullopt, 101, {100, 101});
+    verify_inclusive_extents(reader, tidp, std::nullopt, 102, {100, 101, 102});
+    verify_inclusive_extents(reader, tidp, std::nullopt, 103, {100, 101, 102});
+    verify_inclusive_extents(
+      reader, tidp, std::nullopt, std::nullopt, {100, 101, 102});
+    verify_inclusive_extents(reader, tidp, 101, std::nullopt, {101, 102});
+    verify_inclusive_extents(reader, tidp, 102, std::nullopt, {102});
+    verify_inclusive_extents(reader, tidp, 103, std::nullopt, {});
+    verify_inclusive_extents(reader, tidp, 103, std::nullopt, {});
+}
+
+TEST_F(StateReaderTestFixture, TestGetExtentsBackward) {
+    auto tidp = make_tidp(0);
+    auto oid = make_oid();
+
+    // Create 3 extents: [100-199], [200-299], [300-399]
+    write_extent(
+      tidp,
+      kafka::offset(100),
+      kafka::offset(199),
+      model::timestamp(1000),
+      0,
+      1024,
+      oid);
+    write_extent(
+      tidp,
+      kafka::offset(200),
+      kafka::offset(299),
+      model::timestamp(2000),
+      1024,
+      1024,
+      oid);
+    write_extent(
+      tidp,
+      kafka::offset(300),
+      kafka::offset(399),
+      model::timestamp(3000),
+      2048,
+      1024,
+      oid);
+
+    auto reader = make_reader();
+
+    // Query range [150, 350] should return all 3 extents in reverse order
+    {
+        auto res = reader
+                     .get_inclusive_extents_backward(
+                       tidp, kafka::offset(150), kafka::offset(350))
+                     .get();
+        ASSERT_TRUE(res.has_value());
+        ASSERT_TRUE(res.value().has_value());
+        auto rows = res.value()->materialize_rows().get();
+        ASSERT_EQ(rows.size(), 3);
+        // Backward order: highest base_offset first
+        EXPECT_EQ(rows[0]->val.last_offset, kafka::offset(399));
+        EXPECT_EQ(rows[1]->val.last_offset, kafka::offset(299));
+        EXPECT_EQ(rows[2]->val.last_offset, kafka::offset(199));
+    }
+
+    // Query range [200, 299] should return only middle extent
+    {
+        auto res = reader
+                     .get_inclusive_extents_backward(
+                       tidp, kafka::offset(200), kafka::offset(299))
+                     .get();
+        ASSERT_TRUE(res.has_value());
+        ASSERT_TRUE(res.value().has_value());
+        auto rows = res.value()->materialize_rows().get();
+        ASSERT_EQ(rows.size(), 1);
+        EXPECT_EQ(rows[0]->val.last_offset, kafka::offset(299));
+    }
+
+    // Query range [0, 99] should return no extents (before all data)
+    {
+        auto res = reader
+                     .get_inclusive_extents_backward(
+                       tidp, kafka::offset(0), kafka::offset(99))
+                     .get();
+        ASSERT_TRUE(res.has_value());
+        EXPECT_FALSE(res.value().has_value());
+    }
 }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This adds more methods that will be used by the metastore to serve its read queries:
- getting extents that overlap with an offset range
- get_term_le
- get_term_end

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
