### PR TITLE
`ct`: respect `max_pinned_data_offset()` in deletion

### DIFF
--- a/src/v/cloud_topics/housekeeper/housekeeper.cc
+++ b/src/v/cloud_topics/housekeeper/housekeeper.cc
@@ -55,6 +55,18 @@ ss::future<> housekeeper::do_housekeeping() {
         auto offset = co_await do_time_retention(*retention_duration);
         new_start_offset = std::max(new_start_offset, offset);
     }
+    auto max_allowed_start_offset = _l0_metastore->get_max_allowed_start_offset(
+      _tidp);
+    if (max_allowed_start_offset < new_start_offset) {
+        vlog(
+          cd_log.trace,
+          "{} - Pinning requested new start offset {} by max allowed start "
+          "offset {}",
+          _tidp,
+          new_start_offset,
+          max_allowed_start_offset);
+        new_start_offset = max_allowed_start_offset;
+    }
     if (new_start_offset != kafka::offset::min()) {
         co_await _l0_metastore->set_start_offset(_tidp, new_start_offset, &_as);
     }

--- a/src/v/cloud_topics/housekeeper/housekeeper.h
+++ b/src/v/cloud_topics/housekeeper/housekeeper.h
@@ -54,6 +54,11 @@ public:
         virtual ss::future<> set_start_offset(
           const model::topic_id_partition&, kafka::offset, ss::abort_source*)
           = 0;
+
+        // Get the highest start offset we're allowed to prefix truncate to.
+        virtual kafka::offset
+        get_max_allowed_start_offset(const model::topic_id_partition&)
+          = 0;
     };
 
     // A wrapper around a source of configuration for a give topic id +

--- a/src/v/cloud_topics/housekeeper/manager.cc
+++ b/src/v/cloud_topics/housekeeper/manager.cc
@@ -49,6 +49,21 @@ public:
           offset, model::timeout_clock::now() + stm_timeout, *as);
     }
 
+    kafka::offset get_max_allowed_start_offset(
+      const model::topic_id_partition& tidp) override {
+        // If the partition has a pinned offset (e.g. it has not translated data
+        // to Iceberg), that bounds our potential start offset.
+        auto& state = _state->at(tidp);
+        auto lowest_pinned = state.partition->raft()
+                               ->log()
+                               ->stm_manager()
+                               ->lowest_pinned_data_offset();
+        if (!lowest_pinned.has_value()) {
+            return kafka::offset::max();
+        }
+        return lowest_pinned.value();
+    }
+
 private:
     ctp_stm_api get_api(const model::topic_id_partition& tidp) {
         auto& state = _state->at(tidp);

--- a/src/v/cloud_topics/housekeeper/tests/housekeeper_test.cc
+++ b/src/v/cloud_topics/housekeeper/tests/housekeeper_test.cc
@@ -28,9 +28,12 @@ class fake_l0_metastore
   : public cloud_topics::housekeeper::l0_metadata_storage {
 public:
     fake_l0_metastore(
-      model::topic_id_partition tidp, kafka::offset start_offset)
+      model::topic_id_partition tidp,
+      kafka::offset start_offset,
+      kafka::offset max_allowed_start_offset = kafka::offset::max())
       : _tidp(tidp)
-      , _start_offset(start_offset) {}
+      , _start_offset(start_offset)
+      , _max_allowed_start_offset(max_allowed_start_offset) {}
 
     kafka::offset
     get_start_offset(const model::topic_id_partition& tidp) override {
@@ -54,12 +57,17 @@ public:
 
     kafka::offset
     get_max_allowed_start_offset(const model::topic_id_partition&) override {
-        return kafka::offset::max();
+        return _max_allowed_start_offset;
+    }
+
+    void set_max_allowed_start_offset(kafka::offset offset) {
+        _max_allowed_start_offset = offset;
     }
 
 private:
     model::topic_id_partition _tidp;
     kafka::offset _start_offset;
+    kafka::offset _max_allowed_start_offset;
 };
 
 struct simple_retention_config {
@@ -139,6 +147,10 @@ public:
     void set_start_offset(kafka::offset offset) {
         ss::abort_source as;
         _l0_metastore.set_start_offset(_tidp, offset, &as).get();
+    }
+
+    void set_max_allowed_start_offset(kafka::offset offset) {
+        _l0_metastore.set_max_allowed_start_offset(offset);
     }
 
     kafka::offset l1_start_offset() {
@@ -503,4 +515,122 @@ TEST_F(HousekeeperTest, SyncsToL1) {
 
     EXPECT_EQ(start_offset(), kafka::offset{50});
     EXPECT_EQ(l1_start_offset(), kafka::offset{50});
+}
+
+TEST_F(HousekeeperTest, TimeRetentionLimitedByMaxAllowedStartOffset) {
+    // Time retention would advance to offset 50, but max_allowed_start_offset
+    // limits it to 25.
+    simple_retention_config cfg;
+    cfg.duration = 30min;
+    auto housekeeper = make_housekeeper(cfg);
+    EXPECT_EQ(start_offset(), kafka::offset{0});
+
+    // Set max allowed before housekeeping runs
+    set_max_allowed_start_offset(kafka::offset{25});
+
+    // Add old object (would normally be deleted entirely)
+    add_object({
+      .records = 50,
+      .size = 500_KiB,
+      .max_timestamp = model::timestamp_clock::now() - 2h,
+    });
+
+    // Add recent object (should be kept)
+    add_object({
+      .records = 75,
+      .size = 750_KiB,
+      .max_timestamp = model::timestamp_clock::now() - 10min,
+    });
+
+    housekeeper.do_housekeeping().get();
+    // Should be clamped to max_allowed_start_offset (25), not 50
+    EXPECT_EQ(start_offset(), kafka::offset{25});
+}
+
+TEST_F(HousekeeperTest, BytesRetentionLimitedByMaxAllowedStartOffset) {
+    // Bytes retention would advance to offset 100, but max_allowed_start_offset
+    // limits it to 50.
+    simple_retention_config cfg;
+    cfg.bytes = 2_MiB;
+    auto housekeeper = make_housekeeper(cfg);
+    EXPECT_EQ(start_offset(), kafka::offset{0});
+
+    // Set max allowed before housekeeping runs
+    set_max_allowed_start_offset(kafka::offset{50});
+
+    // Add objects totaling more than 2MiB to trigger retention
+    add_object({
+      .records = 100,
+      .size = 3_MiB,
+      .max_timestamp = model::timestamp_clock::now() - 1h,
+    });
+    add_object({
+      .records = 150,
+      .size = 2_MiB,
+      .max_timestamp = model::timestamp_clock::now() - 30min,
+    });
+
+    housekeeper.do_housekeeping().get();
+    // Should be clamped to max_allowed_start_offset (50), not 100
+    EXPECT_EQ(start_offset(), kafka::offset{50});
+}
+
+TEST_F(HousekeeperTest, MixedRetentionLimitedByMaxAllowedStartOffset) {
+    // Both retention policies agree on deleting to offset 100, but
+    // max_allowed_start_offset limits to 75.
+    simple_retention_config cfg;
+    cfg.bytes = 1_MiB;
+    cfg.duration = 30min;
+    auto housekeeper = make_housekeeper(cfg);
+    EXPECT_EQ(start_offset(), kafka::offset{0});
+
+    // Set max allowed before housekeeping runs
+    set_max_allowed_start_offset(kafka::offset{75});
+
+    // Add old large object (violates both policies)
+    add_object({
+      .records = 100,
+      .size = 3_MiB,
+      .max_timestamp = model::timestamp_clock::now() - 2h,
+    });
+    // Add recent small object
+    add_object({
+      .records = 150,
+      .size = 500_KiB,
+      .max_timestamp = model::timestamp_clock::now() - 10min,
+    });
+
+    housekeeper.do_housekeeping().get();
+    // Should be clamped to max_allowed_start_offset (75), not 100
+    EXPECT_EQ(start_offset(), kafka::offset{75});
+}
+
+TEST_F(HousekeeperTest, MaxAllowedStartOffsetDoesNotLimitWhenHigher) {
+    // max_allowed_start_offset is higher than what retention computes,
+    // so it should not affect the result.
+    simple_retention_config cfg;
+    cfg.duration = 30min;
+    auto housekeeper = make_housekeeper(cfg);
+    EXPECT_EQ(start_offset(), kafka::offset{0});
+
+    // Set max allowed to a high value
+    set_max_allowed_start_offset(kafka::offset{1000});
+
+    // Add old object (should be deleted)
+    add_object({
+      .records = 50,
+      .size = 500_KiB,
+      .max_timestamp = model::timestamp_clock::now() - 2h,
+    });
+
+    // Add recent object (should be kept)
+    add_object({
+      .records = 75,
+      .size = 750_KiB,
+      .max_timestamp = model::timestamp_clock::now() - 10min,
+    });
+
+    housekeeper.do_housekeeping().get();
+    // Should advance to 50 as normal, not limited by max_allowed
+    EXPECT_EQ(start_offset(), kafka::offset{50});
 }

--- a/src/v/cloud_topics/housekeeper/tests/housekeeper_test.cc
+++ b/src/v/cloud_topics/housekeeper/tests/housekeeper_test.cc
@@ -52,6 +52,11 @@ public:
 
     kafka::offset start_offset() const { return _start_offset; }
 
+    kafka::offset
+    get_max_allowed_start_offset(const model::topic_id_partition&) override {
+        return kafka::offset::max();
+    }
+
 private:
     model::topic_id_partition _tidp;
     kafka::offset _start_offset;

--- a/tests/rptest/tests/cloud_topics/e2e_test.py
+++ b/tests/rptest/tests/cloud_topics/e2e_test.py
@@ -9,7 +9,9 @@
 
 from ducktape.utils.util import wait_until
 from ducktape.mark import matrix
+from ducktape.tests.test import TestContext
 from collections.abc import Iterable
+from typing import Any
 
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.rpk import RpkTool
@@ -45,7 +47,12 @@ class EndToEndCloudTopicsBase(EndToEndTest):
 
     rpk: RpkTool
 
-    def __init__(self, test_context, extra_rp_conf=None, environment=None):
+    def __init__(
+        self,
+        test_context: TestContext,
+        extra_rp_conf: dict[str, Any] | None = None,
+        environment: dict[str, str] | None = None,
+    ) -> None:
         super(EndToEndCloudTopicsBase, self).__init__(test_context=test_context)
 
         self.test_context = test_context

--- a/tests/rptest/tests/cloud_topics/iceberg_test.py
+++ b/tests/rptest/tests/cloud_topics/iceberg_test.py
@@ -1,0 +1,278 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.utils.util import wait_until
+from ducktape.mark import matrix
+from typing import Any
+from ducktape.tests.test import TestContext
+from rptest.clients.admin.v2 import metastore_pb, ntp_pb
+from rptest.clients.types import TopicSpec
+from rptest.services.catalog_service import CatalogType
+from rptest.services.cluster import cluster
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+from rptest.services.redpanda import MetricsEndpoint
+from rptest.context.cloud_storage import CloudStorageType
+from rptest.tests.datalake.datalake_services import DatalakeServices
+from rptest.tests.datalake.query_engine_base import QueryEngineBase, QueryEngineType
+from rptest.tests.datalake.utils import supported_storage_types
+from rptest.tests.cloud_topics.e2e_test import EndToEndCloudTopicsBase
+
+
+class EndToEndCloudTopicsIcebergTestBase(EndToEndCloudTopicsBase):
+    """
+    Base class for cloud topics + Iceberg integration tests.
+    Provides common setup, configuration, and helper methods.
+    """
+
+    num_brokers = 1
+    topics = ()  # Topics created via DatalakeServices
+
+    # Subclasses should override these
+    topic_name: str = "iceberg_test"
+    msg_size: int = 1024
+    msg_count: int = 1000
+
+    def __init__(
+        self, test_ctx: TestContext, extra_rp_conf: dict[str, Any] | None = None
+    ) -> None:
+        iceberg_conf = {"iceberg_enabled": True}
+        if extra_rp_conf:
+            iceberg_conf.update(extra_rp_conf)
+
+        super().__init__(test_ctx, extra_rp_conf=iceberg_conf)
+        self.test_ctx = test_ctx
+
+    def setUp(self):
+        # DatalakeServices will start redpanda, not us
+        pass
+
+    def get_hwm(self) -> int:
+        """Get the high watermark for the topic."""
+        for part in self.rpk.describe_topic(self.topic_name):
+            return part.high_watermark
+        raise RuntimeError(f"Failed to get_hwm() for topic {self.topic_name}")
+
+    def get_cloud_start_offset(self) -> int:
+        """Get the start offset from the cloud topic's L1 metastore."""
+        metastore = self.admin.metastore()
+        req = metastore_pb.GetOffsetsRequest(
+            partition=ntp_pb.TopicPartition(topic=self.topic_name, partition=0)
+        )
+        result = metastore.get_offsets(req=req)
+        return result.offsets.start_offset
+
+    def check_all_offsets_in_iceberg(
+        self, spark: QueryEngineBase, expected_hwm: int
+    ) -> None:
+        """
+        Verify that every offset from 0 to expected_hwm-1 exists in the
+        Iceberg table.
+        """
+        assert self.redpanda
+        result = spark.run_query_fetch_one(
+            f"SELECT COUNT(DISTINCT redpanda.offset) FROM redpanda.{self.topic_name}"
+        )
+        distinct_count = result[0]
+        self.redpanda.logger.info(
+            f"Iceberg table has {distinct_count} distinct offsets, expected {expected_hwm}"
+        )
+        assert distinct_count == expected_hwm, (
+            f"Expected {expected_hwm} distinct offsets in Iceberg, got {distinct_count}"
+        )
+
+        result = spark.run_query_fetch_one(
+            f"SELECT MIN(redpanda.offset), MAX(redpanda.offset) FROM redpanda.{self.topic_name}"
+        )
+        min_offset, max_offset = result[0], result[1]
+        assert min_offset == 0, f"Expected min offset 0, got {min_offset}"
+        assert max_offset == expected_hwm - 1, (
+            f"Expected max offset {expected_hwm - 1}, got {max_offset}"
+        )
+
+
+class EndToEndCloudTopicsIcebergCompactionTest(EndToEndCloudTopicsIcebergTestBase):
+    """
+    Tests that with cloud topics and Iceberg both enabled on a compacted topic,
+    every offset produced ends up in the Iceberg table even though the Kafka
+    log may be compacted.
+    """
+
+    topic_name = "compaction_iceberg_test"
+    msg_size = 1024
+    msg_count = 5000
+    key_set_cardinality = 50
+
+    def __init__(self, test_ctx: TestContext):
+        super().__init__(
+            test_ctx,
+            extra_rp_conf={
+                "iceberg_catalog_commit_interval_ms": 5000,
+                "iceberg_target_lag_ms": 5000,
+                "log_compaction_interval_ms": 5000,
+                "min_cleanable_dirty_ratio": 0.0,
+            },
+        )
+
+    @cluster(num_nodes=4)
+    @matrix(cloud_storage_type=supported_storage_types())
+    def test_compaction_preserves_all_offsets_in_iceberg(
+        self, cloud_storage_type: CloudStorageType
+    ):
+        """
+        Produce messages with a small key set (causing many duplicates),
+        trigger compaction, and verify that all offsets still exist in
+        the Iceberg table.
+        """
+        assert self.redpanda
+        with DatalakeServices(
+            self.test_ctx,
+            redpanda=self.redpanda,
+            include_query_engines=[QueryEngineType.SPARK],
+            catalog_type=CatalogType.REST_JDBC,
+        ) as dl:
+            dl.create_iceberg_enabled_topic(
+                self.topic_name,
+                iceberg_mode="key_value",
+                config={
+                    "redpanda.cloud_topic.enabled": "true",
+                    "cleanup.policy": TopicSpec.CLEANUP_COMPACT,
+                },
+            )
+
+            spark = dl.spark()
+
+            producer = KgoVerifierProducer(
+                self.test_ctx,
+                self.redpanda,
+                self.topic_name,
+                msg_size=self.msg_size,
+                msg_count=self.msg_count,
+                key_set_cardinality=self.key_set_cardinality,
+            )
+            try:
+                producer.start()
+                producer.wait()
+            finally:
+                producer.stop()
+                producer.free()
+
+            hwm = self.get_hwm()
+            assert hwm > 0, f"Expected HWM > 0, got {hwm}"
+            self.redpanda.logger.info(f"High watermark after produce: {hwm}")
+
+            dl.wait_for_translation_until_offset(
+                self.topic_name, hwm - 1, timeout=120, backoff_sec=5
+            )
+
+            def compaction_occurred():
+                assert self.redpanda
+                return (
+                    self.redpanda.metric_sum(
+                        metric_name="vectorized_cloud_topics_compaction_scheduler_log_compactions",
+                        metrics_endpoint=MetricsEndpoint.METRICS,
+                        expect_metric=True,
+                    )
+                    > 0
+                )
+
+            wait_until(
+                compaction_occurred,
+                timeout_sec=120,
+                backoff_sec=5,
+                err_msg="Compaction did not occur",
+            )
+
+            self.check_all_offsets_in_iceberg(spark, hwm)
+
+
+class EndToEndCloudTopicsIcebergDeletionTest(EndToEndCloudTopicsIcebergTestBase):
+    """
+    Tests that with cloud topics and Iceberg both enabled, we cannot
+    prefix truncate (delete records) beyond data that has been translated
+    to Iceberg. The lowest_pinned_data_offset should prevent premature
+    deletion.
+    """
+
+    topic_name = "deletion_pinning_test"
+    msg_size = 1024
+    msg_count = 1000
+
+    def __init__(self, test_ctx: TestContext) -> None:
+        super().__init__(
+            test_ctx,
+            extra_rp_conf={
+                # Frequent housekeeping
+                "cloud_storage_housekeeping_interval_ms": 500,
+                # Moderate translation speed
+                "iceberg_catalog_commit_interval_ms": 5000,
+                "iceberg_target_lag_ms": 5000,
+            },
+        )
+
+    @cluster(num_nodes=4)
+    @matrix(cloud_storage_type=supported_storage_types())
+    def test_deletion_blocked_until_translated(
+        self, cloud_storage_type: CloudStorageType
+    ):
+        """
+        Test that even when running with very low retention policies, we
+        cannot advance the start offset beyond the last translated Iceberg
+        offset.
+        """
+        assert self.redpanda
+        with DatalakeServices(
+            self.test_ctx,
+            redpanda=self.redpanda,
+            include_query_engines=[QueryEngineType.SPARK],
+            catalog_type=CatalogType.REST_JDBC,
+        ) as dl:
+            dl.create_iceberg_enabled_topic(
+                self.topic_name,
+                iceberg_mode="key_value",
+                config={
+                    "redpanda.cloud_topic.enabled": "true",
+                    "retention.ms": 500,
+                    "retention.bytes": 1024,
+                },
+            )
+
+            spark = dl.spark()
+            producer = KgoVerifierProducer(
+                self.test_ctx,
+                self.redpanda,
+                self.topic_name,
+                msg_size=self.msg_size,
+                msg_count=self.msg_count,
+            )
+            try:
+                producer.start()
+                producer.wait()
+            finally:
+                producer.stop()
+                producer.free()
+
+            hwm = self.get_hwm()
+            self.redpanda.logger.info(f"High watermark after produce: {hwm}")
+            assert hwm > 0, f"Expected HWM > 0, got {hwm}"
+
+            # Wait for full translation
+            dl.wait_for_translation_until_offset(
+                self.topic_name, hwm - 1, timeout=120, backoff_sec=5
+            )
+
+            # Verify all offsets made it to Iceberg
+            self.check_all_offsets_in_iceberg(spark, hwm)
+
+            # After translation completes, cloud topic should eventually be truncated to the HWM
+            wait_until(
+                lambda: self.get_cloud_start_offset() >= hwm,
+                timeout_sec=60,
+                backoff_sec=1,
+                err_msg="Cloud topic data was not truncated after translation completed",
+            )

--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -232,7 +232,7 @@ class DatalakeServices:
 
     def create_iceberg_enabled_topic(
         self,
-        name,
+        name: str,
         partitions=1,
         replicas=1,
         iceberg_mode: Literal["key_value"]
@@ -241,7 +241,7 @@ class DatalakeServices:
         | str = "key_value",
         target_lag_ms: Optional[int] = None,
         config: dict[str, Any] = dict(),
-    ):
+    ) -> None:
         config[TopicSpec.PROPERTY_ICEBERG_MODE] = iceberg_mode
         if target_lag_ms:
             config[TopicSpec.PROPERTY_ICEBERG_TARGET_LAG_MS] = target_lag_ms
@@ -307,8 +307,8 @@ class DatalakeServices:
         )
 
     def wait_for_translation_until_offset(
-        self, topic, offset, partition=0, timeout=30, backoff_sec=5
-    ):
+        self, topic: str, offset: int, partition=0, timeout=30, backoff_sec=5
+    ) -> None:
         self.wait_for_iceberg_table("redpanda", topic, timeout, backoff_sec)
 
         def translation_done():

--- a/tests/rptest/tests/datalake/query_engine_base.py
+++ b/tests/rptest/tests/datalake/query_engine_base.py
@@ -10,7 +10,7 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from enum import Enum
-
+from typing import Any
 from rptest.tests.datalake.iceberg import Identifier
 
 from ducktape.services.service import Service
@@ -68,7 +68,7 @@ class QueryEngineBase(Service, ABC):
             self.logger.debug(f"query result: {result}")
             return result
 
-    def run_query_fetch_one(self, query):
+    def run_query_fetch_one(self, query: Any) -> Any:
         with self.run_query(query) as cursor:
             return cursor.fetchone()
 


### PR DESCRIPTION
Also adds some end to end ducktape testing of iceberg enabled cloud topics, ensuring that retention enforcement
for both `compact` and `delete` topics respect translation and the minimum pinned data offset (i.e. the last non-translated offset in the log).

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
