### PR TITLE
cluster_link/replication: fix warn log message

### DIFF
--- a/src/v/cluster_link/replication/partition_replicator.cc
+++ b/src/v/cluster_link/replication/partition_replicator.cc
@@ -380,10 +380,14 @@ ss::future<> partition_replicator::prefix_truncate(kafka::offset o) {
     // less than or equal to this offset
 
     if (ec != kafka::error_code::none) {
-        vlog(_log.warn, "Failed to truncate source partition to {}: {}", o, ec);
+        vlog(
+          _log.warn,
+          "Failed to prefix truncate shadow partition to {}: {}",
+          o,
+          ec);
         co_return;
     }
-    vlog(_log.debug, "Successfully truncated shadow partition to {}", o);
+    vlog(_log.debug, "Successfully prefix truncated shadow partition to {}", o);
 }
 
 } // namespace cluster_link::replication


### PR DESCRIPTION
As per the title, fixes the source <-> shadow mixup in the warning log line, which made it misleading.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
### Improvements

* Improve cluster linking shadow topic prefix truncation error message.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
