### PR TITLE
[CORE-15249] sr/json: Optimise is_superset to increase recursion depth

### DIFF
--- a/src/v/pandaproxy/schema_registry/BUILD
+++ b/src/v/pandaproxy/schema_registry/BUILD
@@ -99,6 +99,7 @@ redpanda_cc_library(
     implementation_deps = [
         "//src/v/bytes:iobuf_parser",
         "//src/v/bytes:streambuf",
+        "//src/v/container:chunked_hash_map",
         "//src/v/container:chunked_vector",
         "//src/v/container:json",
         "//src/v/hashing:jump_consistent",

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -361,6 +361,13 @@ private:
 struct compatibility_context {
     schema_context older;
     schema_context newer;
+    // Track visited (older, newer) schema pairs for cycle detection.
+    // If we encounter the same pair twice during traversal, we've found a cycle
+    // and can return early (compatible by assumption - cycles that differ would
+    // have been caught on first visit).
+    using visited_locations
+      = chunked_hash_set<std::pair<const json::Value*, const json::Value*>>;
+    visited_locations& visited;
 };
 
 template<json_schema_dialect Dialect>
@@ -1928,7 +1935,7 @@ json_compatibility_result is_not_combinator_superset(
         // less strict than the older subschema, because this means that newer
         // validated less data than older
         auto is_not_superset = is_superset(
-          {ctx.newer, ctx.older},
+          {ctx.newer, ctx.older, ctx.visited},
           newer_it->value,
           older_it->value,
           ignored_path);
@@ -2156,6 +2163,17 @@ json_compatibility_result is_superset(
     if (is_true_schema(older_schema) || is_false_schema(newer_schema)) {
         // either older is the superset of every possible schema, or newer is
         // the subset of every possible schema
+        return res;
+    }
+
+    // Cycle detection: if we've already visited this (older_schema,
+    // newer_schema) pair, we're in a cycle. Return early as compatible - any
+    // incompatibility would have been detected on the first visit to this pair.
+    // We use the input schema pointers (before ref resolution) because they are
+    // stable pointers into the original documents, whereas resolved schemas may
+    // be synthesized with different addresses on each call.
+    auto [_, inserted] = ctx.visited.emplace(&older_schema, &newer_schema);
+    if (!inserted) {
         return res;
     }
 
@@ -2472,7 +2490,9 @@ compatibility_result check_compatible(
     auto raw_compat_result = [&]() {
         // reader is a superset of writer iff every schema that is valid for
         // writer is also valid for reader
-        compatibility_context ctx{.older{reader()}, .newer{writer()}};
+        compatibility_context::visited_locations visited;
+        compatibility_context ctx{
+          .older{reader()}, .newer{writer()}, .visited = visited};
         return is_superset(ctx, reader().ctx.doc, writer().ctx.doc, "#/");
     }();
 

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -414,10 +414,9 @@ result<json_schema_dialect> validate_json_schema(
     }();
 
     // validation of schema: validate it against metaschema
-    // TODO: Temporarily disabled for stack usage testing
     try {
         // Throws when the schema is invalid with details about the failure
-        (void)metaschema_doc; //.validate(schema);
+        metaschema_doc.validate(schema);
     } catch (const std::exception& e) {
         return make_invalid_schema(
           "Invalid json schema: '{}'. Error: '{}'",

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -354,7 +354,7 @@ public:
 
 private:
     const json_schema_definition::impl& _schema;
-    static constexpr int max_recursion_depth{8};
+    static constexpr int max_recursion_depth{63};
     int _ref_units{max_recursion_depth};
 };
 

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -994,8 +994,9 @@ json_compatibility_result is_numeric_property_value_superset(
   const json::Value& newer,
   std::string_view prop_name,
   VPred&& value_predicate,
-  json_incompatibility changed_err,
-  json_incompatibility added_err,
+  json_incompatibility_type changed_err,
+  json_incompatibility_type added_err,
+  const std::filesystem::path& p,
   std::optional<double> default_value = std::nullopt) {
     // get value or default_value
     auto get_value = [&](const json::Value& v) -> std::optional<double> {
@@ -1034,13 +1035,13 @@ json_compatibility_result is_numeric_property_value_superset(
               *older_value,
               *newer_value)) {
             return json_compatibility_result::of<json_incompatibility>(
-              changed_err);
+              p / prop_name, changed_err);
         }
     } else if (older_value.has_value()) {
         if (!default_value.has_value() || *older_value != *default_value) {
             // Non-default value was removed
             return json_compatibility_result::of<json_incompatibility>(
-              added_err);
+              p / prop_name, added_err);
         }
     }
 
@@ -1176,8 +1177,9 @@ json_compatibility_result is_string_superset(
       newer,
       "minLength",
       std::less_equal<>{},
-      {p / "minLength", json_incompatibility_type::min_length_increased},
-      {p / "minLength", json_incompatibility_type::min_length_added},
+      json_incompatibility_type::min_length_increased,
+      json_incompatibility_type::min_length_added,
+      p,
       0));
 
     res.merge(is_numeric_property_value_superset(
@@ -1185,8 +1187,9 @@ json_compatibility_result is_string_superset(
       newer,
       "maxLength",
       std::greater_equal<>{},
-      {p / "maxLength", json_incompatibility_type::max_length_decreased},
-      {p / "maxLength", json_incompatibility_type::max_length_added}));
+      json_incompatibility_type::max_length_decreased,
+      json_incompatibility_type::max_length_added,
+      p));
 
     auto [maybe_gate_value, older_val_p, newer_val_p]
       = extract_property_and_gate_check(older, newer, "pattern");
@@ -1233,8 +1236,9 @@ json_compatibility_result is_numeric_superset(
       newer,
       "minimum",
       std::less_equal<>{},
-      {p / "minimum", json_incompatibility_type::minimum_increased},
-      {p / "minimum", json_incompatibility_type::minimum_added}));
+      json_incompatibility_type::minimum_increased,
+      json_incompatibility_type::minimum_added,
+      p));
 
     // older["maximum"] is not superset of newer["maximum"] because newer is
     // less strict
@@ -1243,8 +1247,9 @@ json_compatibility_result is_numeric_superset(
       newer,
       "maximum",
       std::greater_equal<>{},
-      {p / "maximum", json_incompatibility_type::maximum_decreased},
-      {p / "maximum", json_incompatibility_type::maximum_added}));
+      json_incompatibility_type::maximum_decreased,
+      json_incompatibility_type::maximum_added,
+      p));
 
     // TODO: return multiple_of_expanded instead of multiple_of_changed if older
     // is a multiple of newer
@@ -1252,7 +1257,7 @@ json_compatibility_result is_numeric_superset(
       older,
       newer,
       "multipleOf",
-      [](double older, double newer) {
+      [](double older_val, double newer_val) {
           // check that the reminder of newer/older is close enough to 0.
           // close enough is defined as being close to the Unit in the Last
           // Place of the bigger between the two.
@@ -1260,11 +1265,12 @@ json_compatibility_result is_numeric_superset(
           // representation it would be possible to perform an exact
           // reminder(newer, older)==0 check
           constexpr auto max_ulp_error = 3;
-          return std::abs(std::remainder(newer, older))
-                 <= (max_ulp_error * boost::math::ulp(newer));
+          return std::abs(std::remainder(newer_val, older_val))
+                 <= (max_ulp_error * boost::math::ulp(newer_val));
       },
-      {p / "multipleOf", json_incompatibility_type::multiple_of_changed},
-      {p / "multipleOf", json_incompatibility_type::multiple_of_added}));
+      json_incompatibility_type::multiple_of_changed,
+      json_incompatibility_type::multiple_of_added,
+      p));
 
     // exclusiveMinimum/exclusiveMaximum checks are mostly the same logic,
     // implemented in this helper
@@ -1393,8 +1399,9 @@ json_compatibility_result is_array_superset(
       newer,
       "minItems",
       std::less_equal<>{},
-      {p / "minItems", json_incompatibility_type::min_items_increased},
-      {p / "minItems", json_incompatibility_type::min_items_added},
+      json_incompatibility_type::min_items_increased,
+      json_incompatibility_type::min_items_added,
+      p,
       0));
 
     res.merge(is_numeric_property_value_superset(
@@ -1402,8 +1409,9 @@ json_compatibility_result is_array_superset(
       newer,
       "maxItems",
       std::greater_equal<>{},
-      {p / "maxItems", json_incompatibility_type::max_items_decreased},
-      {p / "maxItems", json_incompatibility_type::max_items_added}));
+      json_incompatibility_type::max_items_decreased,
+      json_incompatibility_type::max_items_added,
+      p));
 
     // uniqueItems makes sense mostly for arrays, but it's also allowed for
     // tuples, so the validation is done here
@@ -1807,9 +1815,9 @@ json_compatibility_result is_object_superset(
       newer,
       "minProperties",
       std::less_equal<>{},
-      {p / "minProperties",
-       json_incompatibility_type::min_properties_increased},
-      {p / "minProperties", json_incompatibility_type::min_properties_added},
+      json_incompatibility_type::min_properties_increased,
+      json_incompatibility_type::min_properties_added,
+      p,
       0));
 
     // newer requires more properties to be set
@@ -1818,9 +1826,9 @@ json_compatibility_result is_object_superset(
       newer,
       "maxProperties",
       std::greater_equal<>{},
-      {p / "maxProperties",
-       json_incompatibility_type::max_properties_decreased},
-      {p / "maxProperties", json_incompatibility_type::max_properties_added}));
+      json_incompatibility_type::max_properties_decreased,
+      json_incompatibility_type::max_properties_added,
+      p));
 
     // Check if additional properties are compatible
     res.merge(is_additional_superset(

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -2252,12 +2252,18 @@ constexpr const char* id_keyword(json_schema_dialect jsd) {
     return "$id";
 }
 
-void collect_bundled_schemas_and_fix_refs(
+// Work item for iterative schema collection.
+struct collect_work_item {
+    jsoncons::uri base_uri;
+    jsoncons::jsonpointer::json_pointer obj_ptr;
+    jsoncons::ojson* obj;
+    json_schema_dialect dialect;
+};
+
+void process_work_item(
   id_to_schema_pointer& bundled_schemas,
-  jsoncons::uri base_uri,
-  jsoncons::jsonpointer::json_pointer this_obj_ptr,
-  jsoncons::ojson& this_obj,
-  json_schema_dialect dialect) {
+  chunked_vector<collect_work_item>& work_stack,
+  collect_work_item item) {
     // scan the json schema object for bundled schema.
     // A bundled schema is defined as a schema with `"$id" : a_base_uri`.
     // all relative refs under this bundled schema will be relative
@@ -2277,12 +2283,12 @@ void collect_bundled_schemas_and_fix_refs(
     //   "id"  |  draft4  |       yes
 
     auto maybe_new_dialect = [&]() -> std::optional<json_schema_dialect> {
-        const auto dialect_it = this_obj.find("$schema");
-        if (dialect_it == this_obj.object_range().end()) {
+        const auto dialect_it = item.obj->find("$schema");
+        if (dialect_it == item.obj->object_range().end()) {
             // If no $schema is declared in an embedded schema, it defaults
             // to using the dialect of the parent schema. from
             // https://json-schema.org/understanding-json-schema/structuring#bundling
-            return dialect;
+            return item.dialect;
         }
 
         // we have a $schema keyword, use this dialect if we find out that
@@ -2296,17 +2302,17 @@ void collect_bundled_schemas_and_fix_refs(
         throw as_exception(invalid_schema(
           fmt::format(
             "bundled schema without a known dialect: '{}'",
-            this_obj["$schema"].as_string_view())));
+            (*item.obj)["$schema"].as_string_view())));
     }
 
-    const auto id_it = this_obj.find(id_keyword(maybe_new_dialect.value()));
+    const auto id_it = item.obj->find(id_keyword(maybe_new_dialect.value()));
 
-    if (id_it != this_obj.object_range().end()) {
+    if (id_it != item.obj->object_range().end()) {
         // we are visiting a bundled schema.
 
         // run validation since we are not a guaranteed to be in proper schema
         if (auto validation = validate_json_schema(
-              maybe_new_dialect.value(), this_obj);
+              maybe_new_dialect.value(), *item.obj);
             validation.has_error()) {
             // stop exploring this branch, the schema is invalid
             throw as_exception(invalid_schema(
@@ -2318,29 +2324,30 @@ void collect_bundled_schemas_and_fix_refs(
         // it's a validated schema. we can register this as a bundled schema and
         // continue scanning. (run resolve because it could be relative to the
         // parent schema).
-        base_uri = jsoncons::uri{id_it->value().as_string()}.resolve(base_uri);
-        dialect = maybe_new_dialect.value();
+        item.base_uri = jsoncons::uri{id_it->value().as_string()}.resolve(
+          item.base_uri);
+        item.dialect = maybe_new_dialect.value();
         bundled_schemas.insert_or_assign(
-          to_json_id_uri(base_uri),
-          std::pair{json::Pointer{this_obj_ptr.to_string()}, dialect});
+          to_json_id_uri(item.base_uri),
+          std::pair{json::Pointer{item.obj_ptr.to_string()}, item.dialect});
     }
 
-    if (auto ref_it = this_obj.find("$ref");
-        ref_it != this_obj.object_range().end()) {
+    if (auto ref_it = item.obj->find("$ref");
+        ref_it != item.obj->object_range().end()) {
         // ensure refs are absolute uris
         ref_it->value() = jsoncons::uri{ref_it->value().as_string()}
-                            .resolve(base_uri)
+                            .resolve(item.base_uri)
                             .string();
     }
 
-    // lambda to recursively scan the object for more bundled schemas and $refs
+    // lambda to scan the object for more bundled schemas and $refs
     auto collect_and_fix = [&](const auto& key, auto& value) {
-        collect_bundled_schemas_and_fix_refs(
-          bundled_schemas, base_uri, this_obj_ptr / key, value, dialect);
+        work_stack.push_back(
+          {item.base_uri, item.obj_ptr / key, &value, item.dialect});
     };
 
-    // recursively scan the object for more bundled schemas and $refs
-    for (auto& e : this_obj.object_range()) {
+    // Iteratively scan the object for more bundled schemas and $refs
+    for (auto& e : item.obj->object_range()) {
         const auto& key = e.key();
         auto& value = e.value();
         if (value.is_object()) {
@@ -2352,6 +2359,25 @@ void collect_bundled_schemas_and_fix_refs(
                 }
             }
         }
+    }
+}
+
+// Iterative version of collect_bundled_schemas_and_fix_refs.
+// Uses an explicit stack to avoid stack overflow on deeply nested schemas.
+void collect_bundled_schemas_and_fix_refs(
+  id_to_schema_pointer& bundled_schemas,
+  jsoncons::uri base_uri,
+  jsoncons::jsonpointer::json_pointer obj_ptr,
+  jsoncons::ojson& obj,
+  json_schema_dialect dialect) {
+    chunked_vector<collect_work_item> work_stack;
+    work_stack.push_back(
+      {std::move(base_uri), std::move(obj_ptr), &obj, dialect});
+
+    while (!work_stack.empty()) {
+        auto item = std::move(work_stack.back());
+        work_stack.pop_back();
+        process_work_item(bundled_schemas, work_stack, std::move(item));
     }
 }
 
@@ -2380,10 +2406,10 @@ result<id_to_schema_pointer> collect_bundled_schema_and_fix_refs(
       {root_id, std::pair{json::Pointer{}, dialect}}};
 
     if (doc.is_object()) {
-        // note: current implementation is overly strict and reject any bundled
-        // schema that is deemed invalid. this could be relaxed if the invalid
-        // schema is not actually accessed by a $ref, but it requires to scan
-        // the document in two passes.
+        // note: current implementation is overly strict and reject any
+        // bundled schema that is deemed invalid. this could be relaxed if
+        // the invalid schema is not actually accessed by a $ref, but it
+        // requires to scan the document in two passes.
         try {
             collect_bundled_schemas_and_fix_refs(
               bundled_schemas, jsoncons::uri{}, {}, doc, dialect);

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -359,9 +359,10 @@ result<json_schema_dialect> validate_json_schema(
     }();
 
     // validation of schema: validate it against metaschema
+    // TODO: Temporarily disabled for stack usage testing
     try {
         // Throws when the schema is invalid with details about the failure
-        metaschema_doc.validate(schema);
+        (void)metaschema_doc; //.validate(schema);
     } catch (const std::exception& e) {
         return error_info{
           error_code::schema_invalid,

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -13,10 +13,10 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
+#include "base/format_to.h"
 #include "json/chunked_buffer.h"
 #include "json/chunked_input_stream.h"
 #include "json/document.h"
-#include "json/ostreamwrapper.h"
 #include "json/pointer.h"
 #include "json/writer.h"
 #include "pandaproxy/schema_registry/compatibility.h"
@@ -58,6 +58,22 @@
 namespace pandaproxy::schema_registry {
 
 namespace {
+
+// Helper to create schema errors without inlining fmt::format machinery
+// into the caller's stack frame.
+template<typename... Args>
+[[gnu::noinline]] error_info
+make_invalid_schema(fmt::format_string<Args...> fmt, Args&&... args) {
+    return error_info{
+      error_code::schema_invalid,
+      fmt::format(fmt, std::forward<Args>(args)...)};
+}
+
+template<typename... Args>
+[[noreturn]] void
+throw_invalid_schema(fmt::format_string<Args...> fmt, Args&&... args) {
+    throw as_exception(make_invalid_schema(fmt, std::forward<Args>(args)...));
+}
 
 template<typename E, std::size_t Size>
 requires std::is_enum_v<E>
@@ -284,23 +300,35 @@ ss::future<> check_references(sharded_store& store, subject_schema schema) {
     }
 }
 
+// OutputStream adapter for rapidjson Writer to write directly to fmt::iterator
+struct fmt_iterator_output_stream {
+    using Ch = char;
+    fmt::iterator& it;
+
+    void Put(Ch c) { *it++ = c; }
+    void Flush() {}
+};
+
 // helper struct to format json::Value
 struct pj {
     const json::Value& v;
-    friend std::ostream& operator<<(std::ostream& os, const pj& p) {
-        auto osw = json::OStreamWrapper{os};
-        auto writer = json::Writer<json::OStreamWrapper>{osw};
-        p.v.Accept(writer);
-        return os;
+
+    fmt::iterator format_to(fmt::iterator it) const {
+        fmt_iterator_output_stream os{it};
+        json::Writer<fmt_iterator_output_stream> writer{os};
+        v.Accept(writer);
+        return os.it;
     }
 };
 
+// helper struct to format json::Pointer
 struct pjp {
     const json::Pointer& p;
-    friend std::ostream& operator<<(std::ostream& os, const pjp& p) {
-        auto osw = json::OStreamWrapper{os};
-        p.p.Stringify(osw);
-        return os;
+
+    fmt::iterator format_to(fmt::iterator it) const {
+        fmt_iterator_output_stream os{it};
+        p.Stringify(os);
+        return os.it;
     }
 };
 
@@ -391,12 +419,10 @@ result<json_schema_dialect> validate_json_schema(
         // Throws when the schema is invalid with details about the failure
         (void)metaschema_doc; //.validate(schema);
     } catch (const std::exception& e) {
-        return error_info{
-          error_code::schema_invalid,
-          fmt::format(
-            "Invalid json schema: '{}'. Error: '{}'",
-            schema.to_string(),
-            e.what())};
+        return make_invalid_schema(
+          "Invalid json schema: '{}'. Error: '{}'",
+          schema.to_string(),
+          e.what());
     }
 
     // schema is a syntactically valid json schema, where $schema == Dialect.
@@ -443,13 +469,11 @@ result<document_context> parse_json(iobuf buf) {
     reader.read(ec);
     if (ec || !decoder.is_valid()) {
         // not a valid json document, return error
-        return error_info{
-          error_code::schema_invalid,
-          fmt::format(
-            "Malformed json schema: {} at line {} column {}",
-            ec ? ec.message() : "Invalid document",
-            reader.line(),
-            reader.column())};
+        return make_invalid_schema(
+          "Malformed json schema: {} at line {} column {}",
+          ec ? ec.message() : "Invalid document",
+          reader.line(),
+          reader.column());
     }
     auto schema = decoder.get_result();
 
@@ -470,11 +494,9 @@ result<document_context> parse_json(iobuf buf) {
               it->value().is_string() == false || !maybe_dialect.has_value()) {
                 // if present, "$schema" have to be a string, and it has to be
                 // one the implemented dialects. If not, return an error
-                return error_info{
-                  error_code::schema_invalid,
-                  fmt::format(
-                    "Unsupported json schema dialect: '{}'",
-                    jsoncons::print(it->value()))};
+                return make_invalid_schema(
+                  "Unsupported json schema dialect: '{}'",
+                  jsoncons::print(it->value()));
             }
         }
     }
@@ -510,12 +532,10 @@ result<document_context> parse_json(iobuf buf) {
         // not a valid json document, return error
         // this is unlikely to happen, since we already parsed this stream with
         // jsoncons, but the possibility of a bug exists
-        return error_info{
-          error_code::schema_invalid,
-          fmt::format(
-            "Malformed json schema: {} at offset {}",
-            rapidjson::GetParseError_En(rapidjson_schema.GetParseError()),
-            rapidjson_schema.GetErrorOffset())};
+        return make_invalid_schema(
+          "Malformed json schema: {} at offset {}",
+          rapidjson::GetParseError_En(rapidjson_schema.GetParseError()),
+          rapidjson_schema.GetErrorOffset());
     }
 
     return {
@@ -584,10 +604,7 @@ constexpr auto parse_json_type(const json::Value& v) {
     auto sv = as_string_view(v);
     auto type = from_string_view(sv);
     if (!type) {
-        throw as_exception(
-          error_info{
-            error_code::schema_invalid,
-            fmt::format("Invalid JSON Schema type: '{}'", sv)});
+        throw_invalid_schema("Invalid JSON Schema type: '{}'", sv);
     }
     return *type;
 }
@@ -781,14 +798,11 @@ json::Pointer to_json_pointer(std::string_view sv) {
     auto candidate = json::Pointer{sv.data(), sv.size()};
     if (auto ec = candidate.GetParseErrorCode();
         ec != rapidjson::kPointerParseErrorNone) {
-        throw as_exception(
-          error_info{
-            error_code::schema_invalid,
-            fmt::format(
-              "invalid fragment '{}' error {} at {}",
-              sv,
-              ec,
-              candidate.GetParseErrorOffset())});
+        throw_invalid_schema(
+          "invalid fragment '{}' error {} at {}",
+          sv,
+          ec,
+          candidate.GetParseErrorOffset());
     }
 
     return candidate;
@@ -801,14 +815,10 @@ resolve_pointer(const json::Pointer& p, const json::Value& root) {
     auto unresolved_token = size_t{0};
     auto* value = p.Get(root, &unresolved_token);
     if (value == nullptr) {
-        throw as_exception(
-          error_info{
-            error_code::schema_invalid,
-            fmt::format(
-              "object not found for pointer '{}' unresolved token at index "
-              "{}",
-              pjp{p},
-              unresolved_token)});
+        throw_invalid_schema(
+          "object not found for pointer '{}' unresolved token at index {}",
+          pjp{p},
+          unresolved_token);
     }
 
     return *value;
@@ -842,10 +852,8 @@ resolve_reference(schema_context& ctx, const json::Value& candidate) {
         auto* lookup_p = ctx.find_bundled(id_uri);
         if (lookup_p == nullptr) {
             // TODO use a better error code
-            throw as_exception(
-              error_info{
-                error_code::schema_invalid,
-                fmt::format("schema pointer not found for uri '{}'", id_uri)});
+            throw_invalid_schema(
+              "schema pointer not found for uri '{}'", id_uri);
         }
         const auto& [schema_pointer, dialect] = *lookup_p;
 
@@ -869,19 +877,15 @@ resolve_reference(schema_context& ctx, const json::Value& candidate) {
             // this requirement could be relaxed but it requires to keep track
             // of the dialect for each json::Value
             if (dialect != ctx.dialect()) {
-                throw as_exception(
-                  error_info{
-                    error_code::schema_invalid,
-                    fmt::format(
-                      "schema dialect mismatch for uri '{}'", id_uri)});
+                throw_invalid_schema(
+                  "schema dialect mismatch for uri '{}'", id_uri);
             }
 
             return merge_references(references_objects);
         }
     }
-    throw std::runtime_error(
-      fmt::format(
-        "max traversals reached for uri {} '{}'", id_uri, pjp{fragment_p}));
+    throw_invalid_schema(
+      "max traversals reached for uri {} '{}'", id_uri, pjp{fragment_p});
 }
 
 // helper to convert a boolean to a schema, and to traverse $refs
@@ -895,11 +899,8 @@ json_const_object get_schema(schema_context& ctx, const json::Value& v) {
         // {}/{"not":{}}
         return v.GetBool() ? get_true_schema() : get_false_schema();
     }
-    throw as_exception(
-      error_info{
-        error_code::schema_invalid,
-        fmt::format(
-          "Invalid JSON Schema, should be object or boolean: '{}'", pj{v})});
+    throw_invalid_schema(
+      "Invalid JSON Schema, should be object or boolean: '{}'", pj{v});
 }
 
 // helper to retrieve the object value for a key, or an empty object if the key
@@ -921,11 +922,8 @@ get_object_or_empty(const json::Value& v, std::string_view key) {
         // {}/{"not":{}}
         return it->value.GetBool() ? get_true_schema() : get_false_schema();
     }
-    throw as_exception(
-      error_info{
-        error_code::schema_invalid,
-        fmt::format(
-          "Invalid JSON Schema, should be object or boolean: '{}'", pj{v})});
+    throw_invalid_schema(
+      "Invalid JSON Schema, should be object or boolean: '{}'", pj{v});
 }
 
 // helper to retrieve the array value for a key, or an empty array if the key
@@ -1014,13 +1012,12 @@ json_compatibility_result is_numeric_property_value_superset(
         // representation. this cannot be caught with this, and it would require
         // some sort of decimal type
         if (!it->value.IsLosslessDouble()) {
-            throw as_exception(invalid_schema(
-              fmt::format(
-                R"(is_numeric_property_value_superset-{} not implemented for type {}. input: older: '{}', newer: '{}')",
-                prop_name,
-                it->value.GetType(),
-                pj{older},
-                pj{newer})));
+            throw_invalid_schema(
+              R"(is_numeric_property_value_superset-{} not implemented for type {}. input: older: '{}', newer: '{}')",
+              prop_name,
+              it->value.GetType(),
+              pj{older},
+              pj{newer});
         }
 
         return it->value.GetDouble();
@@ -1296,12 +1293,11 @@ json_compatibility_result is_numeric_superset(
             if (it->value.IsLosslessDouble()) {
                 return it->value.GetDouble();
             }
-            // v could not be decodes as a double, likely a malformed json
-            throw as_exception(invalid_schema(
-              fmt::format(
-                R"(is_numeric_superset-{} not implemented for types other than "boolean" and "number". input: '{}')",
-                prop_name,
-                pj{v})));
+            // v could not be decoded as a double, likely a malformed json
+            throw_invalid_schema(
+              R"(is_numeric_superset-{} not implemented for types other than "boolean" and "number". input: '{}')",
+              prop_name,
+              pj{v});
         };
 
         return std::visit(
@@ -1336,12 +1332,11 @@ json_compatibility_result is_numeric_superset(
                 return json_compatibility_result{};
             },
             [&](auto, auto) -> json_compatibility_result {
-                throw as_exception(invalid_schema(
-                  fmt::format(
-                    R"(is_numeric_superset-{} not implemented for mixed types: older: '{}', newer: '{}')",
-                    prop_name,
-                    pj{older},
-                    pj{newer})));
+                throw_invalid_schema(
+                  R"(is_numeric_superset-{} not implemented for mixed types: older: '{}', newer: '{}')",
+                  prop_name,
+                  pj{older},
+                  pj{newer});
             }),
           get_value(older),
           get_value(newer));
@@ -1791,11 +1786,10 @@ json_compatibility_result is_object_dependencies_superset(
             }
             return;
         } else {
-            throw as_exception(invalid_schema(
-              fmt::format(
-                "dependencies can only be an array or an object for valid "
-                "schemas but it was: {}",
-                pj{o})));
+            throw_invalid_schema(
+              "dependencies can only be an array or an object for valid "
+              "schemas but it was: {}",
+              pj{o});
         }
     });
 
@@ -1979,8 +1973,8 @@ json_compatibility_result is_positive_combinator_superset(
                     // json schema allows more than one of {"oneOf", "anyOf",
                     // "allOf"} to appear, but it's not currently supported for
                     // is_superset
-                    throw as_exception(invalid_schema(
-                      fmt::format("{} has more than one combinator", pj{v})));
+                    throw_invalid_schema(
+                      "{} has more than one combinator", pj{v});
                 }
                 res = c;
             }

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -13,7 +13,6 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
-#include "absl/container/inlined_vector.h"
 #include "json/chunked_buffer.h"
 #include "json/chunked_input_stream.h"
 #include "json/document.h"
@@ -54,10 +53,38 @@
 #include <filesystem>
 #include <ranges>
 #include <string_view>
+#include <type_traits>
 
 namespace pandaproxy::schema_registry {
 
 namespace {
+
+template<typename E, std::size_t Size>
+requires std::is_enum_v<E>
+struct enum_bitset : std::bitset<Size> {
+    using std::bitset<Size>::bitset;
+    using std::bitset<Size>::set;
+
+    template<typename... Es>
+    requires(std::same_as<Es, E> && ...)
+    explicit enum_bitset(Es... es) {
+        (set(es), ...);
+    }
+
+    enum_bitset& set(E e, bool v = true) {
+        std::bitset<Size>::set(static_cast<size_t>(e), v);
+        return *this;
+    }
+
+    bool test(E e) const {
+        return std::bitset<Size>::test(static_cast<size_t>(e));
+    }
+
+    constexpr friend enum_bitset
+    set_difference(enum_bitset lhs, enum_bitset rhs) {
+        return {(lhs & ~rhs).to_ulong()};
+    }
+};
 
 using json_compatibility_result = raw_compatibility_result;
 
@@ -520,8 +547,7 @@ enum class json_type : uint8_t {
     boolean = 5,
     null = 6
 };
-// enough inlined space to hold all the values of json_type
-using json_type_list = absl::InlinedVector<json_type, 7>;
+using json_type_list = enum_bitset<json_type, 7>;
 
 constexpr std::string_view to_string_view(json_type t) {
     switch (t) {
@@ -641,25 +667,16 @@ json_type_list normalized_type(const json::Value& v) {
     auto ret = json_type_list{};
     if (type_it == v.MemberEnd()) {
         // omit keyword is like accepting all the types
-        ret = {
-          json_type::string,
-          json_type::integer,
-          json_type::number,
-          json_type::object,
-          json_type::array,
-          json_type::boolean,
-          json_type::null};
+        ret.set();
     } else if (type_it->value.IsArray()) {
         // schema ensures that all the values are unique
         for (auto& v : type_it->value.GetArray()) {
-            ret.push_back(parse_json_type(v));
+            ret.set(parse_json_type(v));
         }
     } else {
-        ret.push_back(parse_json_type(type_it->value));
+        ret.set(parse_json_type(type_it->value));
     }
 
-    // to support set difference operations, sort the elements
-    std::ranges::sort(ret);
     return ret;
 }
 
@@ -2143,24 +2160,20 @@ json_compatibility_result is_superset(
 
     // looking for types that are new in `newer`. done as newer_types
     // \ older_types
-    auto newer_minus_older = json_type_list{};
-    std::ranges::set_difference(
-      newer_types, older_types, std::back_inserter(newer_minus_older));
+    auto newer_minus_older = set_difference(newer_types, older_types);
     if (
-      !newer_minus_older.empty()
+      newer_minus_older.any()
       && !(
         newer_minus_older == json_type_list{json_type::integer}
-        && std::ranges::count(older_types, json_type::number) != 0)) {
+        && older_types.test(json_type::number))) {
         // newer_types_not_in_older accepts integer, and we can accept an
         // evolution from number -> integer. everything else is makes `newer`
         // less strict than older
 
-        auto older_minus_newer = json_type_list{};
-        std::ranges::set_difference(
-          older_types, newer_types, std::back_inserter(older_minus_newer));
+        auto older_minus_newer = set_difference(older_types, newer_types);
 
         if (
-          older_minus_newer.empty()
+          older_minus_newer.none()
           || (older_minus_newer == json_type_list{json_type::integer} && newer_minus_older == json_type_list{json_type::number})) {
             // type_narrowed is reported when older has fewer elements or the
             // same but with integer in older instead of number in newer
@@ -2176,32 +2189,23 @@ json_compatibility_result is_superset(
 
     // newer accepts less (or equal) types. for each type, try to find a less
     // strict check
-    for (auto t : newer_types) {
-        // TODO this will perform a depth first search, but it might be better
-        // to do a breadth first search to find a counterexample
-        switch (t) {
-        case json_type::string:
-            res.merge(is_string_superset(older, newer, p));
-            break;
-        case json_type::integer:
-            [[fallthrough]];
-        case json_type::number:
-            res.merge(is_numeric_superset(older, newer, p));
-            break;
-        case json_type::object:
-            res.merge(is_object_superset(ctx, older, newer, p));
-            break;
-        case json_type::array:
-            res.merge(is_array_superset(ctx, older, newer, p));
-            break;
-        case json_type::boolean:
-            // no check needed for boolean;
-            break;
-        case json_type::null:
-            // no check needed for null;
-            break;
-        }
+    // TODO this will perform a depth first search, but it might be better
+    // to do a breadth first search to find a counterexample
+    if (newer_types.test(json_type::string)) {
+        res.merge(is_string_superset(older, newer, p));
     }
+    if (
+      newer_types.test(json_type::integer)
+      || newer_types.test(json_type::number)) {
+        res.merge(is_numeric_superset(older, newer, p));
+    }
+    if (newer_types.test(json_type::object)) {
+        res.merge(is_object_superset(ctx, older, newer, p));
+    }
+    if (newer_types.test(json_type::array)) {
+        res.merge(is_array_superset(ctx, older, newer, p));
+    }
+    // no check needed for boolean and null types
 
     res.merge(is_enum_superset(older, newer, p));
     res.merge(is_not_combinator_superset(ctx, older, newer, p));

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -11,9 +11,8 @@
 
 #include "pandaproxy/schema_registry/json.h"
 
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
 #include "base/format_to.h"
+#include "container/chunked_hash_map.h"
 #include "json/chunked_buffer.h"
 #include "json/chunked_input_stream.h"
 #include "json/document.h"
@@ -158,8 +157,9 @@ using json_id_uri = named_type<ss::sstring, struct json_id_uri_tag>;
 // mapping of $id to jsonpointer to the parent object
 // it contains at least the root $id for doc. If the root $id is not
 // present, then the default value "" is used
-using id_to_schema_pointer = absl::
-  flat_hash_map<json_id_uri, std::pair<json::Pointer, json_schema_dialect>>;
+using id_to_schema_pointer = chunked_hash_map<
+  json_id_uri,
+  std::pair<json::Pointer, json_schema_dialect>>;
 
 json_id_uri to_json_id_uri(const jsoncons::uri& uri) {
     // ensure that only scheme, host and path are used

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -533,7 +533,7 @@ json_compatibility_result is_superset(
   compatibility_context ctx,
   const json::Value& older,
   const json::Value& newer,
-  std::filesystem::path p);
+  const std::filesystem::path& p);
 
 // close the implementation in a namespace to keep it contained
 namespace is_superset_impl {
@@ -1055,7 +1055,7 @@ json_compatibility_result is_additional_superset(
   const json::Value& older,
   const json::Value& newer,
   additional_field_for field_type,
-  std::filesystem::path p) {
+  const std::filesystem::path& p) {
     // "additional___" can be either true (if omitted it's true), false
     // or a schema. The check is performed with this table.
     // older ap | newer ap | compatible
@@ -1157,14 +1157,16 @@ json_compatibility_result is_additional_superset(
         [&ctx,
          &additional_path](const json::Value* older, const json::Value* newer) {
             // check subschemas for compatibility
-            return is_superset(ctx, *older, *newer, std::move(additional_path));
+            return is_superset(ctx, *older, *newer, additional_path);
         }),
       get_additional_props(ctx.older.dialect(), older),
       get_additional_props(ctx.newer.dialect(), newer));
 }
 
 json_compatibility_result is_string_superset(
-  const json::Value& older, const json::Value& newer, std::filesystem::path p) {
+  const json::Value& older,
+  const json::Value& newer,
+  const std::filesystem::path& p) {
     json_compatibility_result res;
 
     // note: "format" is not part of the checks
@@ -1206,7 +1208,9 @@ json_compatibility_result is_string_superset(
 }
 
 json_compatibility_result is_numeric_superset(
-  const json::Value& older, const json::Value& newer, std::filesystem::path p) {
+  const json::Value& older,
+  const json::Value& newer,
+  const std::filesystem::path& p) {
     json_compatibility_result res;
 
     // preconditions:
@@ -1370,7 +1374,7 @@ json_compatibility_result is_array_superset(
   const compatibility_context& ctx,
   const json::Value& older,
   const json::Value& newer,
-  std::filesystem::path p) {
+  const std::filesystem::path& p) {
     json_compatibility_result res;
 
     // "type": "array" is used to model an array or a tuple.
@@ -1557,7 +1561,7 @@ json_compatibility_result is_object_properties_superset(
   const compatibility_context& ctx,
   const json::Value& older,
   const json::Value& newer,
-  std::filesystem::path p) {
+  const std::filesystem::path& p) {
     json_compatibility_result res;
     // check that every property in newer["properties"]
     // if it appears in older["properties"],
@@ -1655,7 +1659,9 @@ json_compatibility_result is_object_properties_superset(
 }
 
 json_compatibility_result is_object_required_superset(
-  const json::Value& older, const json::Value& newer, std::filesystem::path p) {
+  const json::Value& older,
+  const json::Value& newer,
+  const std::filesystem::path& p) {
     json_compatibility_result res;
     // to pass the check, a required property from newer has to be present in
     // older, or if new it needs to have a default value.
@@ -1699,7 +1705,7 @@ json_compatibility_result is_object_dependencies_superset(
   const compatibility_context& ctx,
   const json::Value& older,
   const json::Value& newer,
-  std::filesystem::path p) {
+  const std::filesystem::path& p) {
     json_compatibility_result res;
     // "dependencies", if present, is a dict of <property, string_array |
     // schema>. To be compatible, each key in older has to be in newer and the
@@ -1737,7 +1743,7 @@ json_compatibility_result is_object_dependencies_superset(
             }
 
             // schemas: o and n needs to be compatible
-            res.merge(is_superset(ctx, o, n, std::move(path_dep)));
+            res.merge(is_superset(ctx, o, n, path_dep));
         } else if (o.IsArray()) {
             if (n_it == newer_p.MemberEnd()) {
                 res.emplace<json_incompatibility>(
@@ -1792,7 +1798,7 @@ json_compatibility_result is_object_superset(
   const compatibility_context& ctx,
   const json::Value& older,
   const json::Value& newer,
-  std::filesystem::path p) {
+  const std::filesystem::path& p) {
     json_compatibility_result res;
 
     // newer requires less properties to be set
@@ -1839,13 +1845,15 @@ json_compatibility_result is_object_superset(
     res.merge(is_object_required_superset(older, newer, p));
 
     // Check if dependencies are compatible
-    res.merge(is_object_dependencies_superset(ctx, older, newer, std::move(p)));
+    res.merge(is_object_dependencies_superset(ctx, older, newer, p));
 
     return res;
 }
 
 json_compatibility_result is_enum_superset(
-  const json::Value& older, const json::Value& newer, std::filesystem::path p) {
+  const json::Value& older,
+  const json::Value& newer,
+  const std::filesystem::path& p) {
     json_compatibility_result res;
     auto enum_p = p / "enum";
 
@@ -1899,7 +1907,7 @@ json_compatibility_result is_not_combinator_superset(
   const compatibility_context& ctx,
   const json::Value& older,
   const json::Value& newer,
-  std::filesystem::path p) {
+  const std::filesystem::path& p) {
     json_compatibility_result res;
 
     auto older_it = older.FindMember("not");
@@ -1950,7 +1958,7 @@ json_compatibility_result is_positive_combinator_superset(
   const compatibility_context& ctx,
   const json::Value& older,
   const json::Value& newer,
-  std::filesystem::path p) {
+  const std::filesystem::path& p) {
     json_compatibility_result res;
 
     auto get_combinator = [](const json::Value& v) {
@@ -1983,7 +1991,7 @@ json_compatibility_result is_positive_combinator_superset(
     if (!maybe_newer_comb.has_value()) {
         // older has a combinator but newer does not. not compatible
         res.emplace<json_incompatibility>(
-          std::move(p), json_incompatibility_type::combined_type_changed);
+          p, json_incompatibility_type::combined_type_changed);
         return res;
     }
     // newer has a combinator
@@ -2009,7 +2017,7 @@ json_compatibility_result is_positive_combinator_superset(
               ignored_path);
             if (is_combinator_superset.has_error()) {
                 res.emplace<json_incompatibility>(
-                  std::move(p),
+                  p,
                   json_incompatibility_type::combined_type_subschemas_changed);
             }
             return res;
@@ -2028,7 +2036,7 @@ json_compatibility_result is_positive_combinator_superset(
               });
             if (!any_superset) {
                 res.emplace<json_incompatibility>(
-                  std::move(p),
+                  p,
                   json_incompatibility_type::combined_type_subschemas_changed);
             }
             return res;
@@ -2046,7 +2054,7 @@ json_compatibility_result is_positive_combinator_superset(
               });
             if (!any_superset) {
                 res.emplace<json_incompatibility>(
-                  std::move(p),
+                  p,
                   json_incompatibility_type::combined_type_subschemas_changed);
             }
             return res;
@@ -2054,7 +2062,7 @@ json_compatibility_result is_positive_combinator_superset(
 
         // different combinators, not a special case. not compatible
         res.emplace<json_incompatibility>(
-          std::move(p), json_incompatibility_type::combined_type_changed);
+          p, json_incompatibility_type::combined_type_changed);
         return res;
     }
 
@@ -2067,7 +2075,7 @@ json_compatibility_result is_positive_combinator_superset(
         if (older_comb == p_combinator::allOf) {
             // older has more restrictions than newer, not compatible
             res.emplace<json_incompatibility>(
-              std::move(p), json_incompatibility_type::product_type_extended);
+              p, json_incompatibility_type::product_type_extended);
             return res;
         }
     } else if (older_schemas.Size() < newer_schemas.Size()) {
@@ -2076,7 +2084,7 @@ json_compatibility_result is_positive_combinator_superset(
           || newer_comb == p_combinator::oneOf) {
             // newer has more degrees of freedom than older, not compatible
             res.emplace<json_incompatibility>(
-              std::move(p), json_incompatibility_type::sum_type_narrowed);
+              p, json_incompatibility_type::sum_type_narrowed);
             return res;
         }
     }
@@ -2122,8 +2130,7 @@ json_compatibility_result is_positive_combinator_superset(
         // is_superset() relation with the other schema array, or that the
         // algorithm couldn't find a unique compatible pattern.
         res.emplace<json_incompatibility>(
-          std::move(p),
-          json_incompatibility_type::combined_type_subschemas_changed);
+          p, json_incompatibility_type::combined_type_subschemas_changed);
         return res;
     }
 
@@ -2141,7 +2148,7 @@ json_compatibility_result is_superset(
   compatibility_context ctx,
   const json::Value& older_schema,
   const json::Value& newer_schema,
-  std::filesystem::path p) {
+  const std::filesystem::path& p) {
     json_compatibility_result res;
 
     // break recursion if parameters are atoms:
@@ -2178,11 +2185,11 @@ json_compatibility_result is_superset(
             // type_narrowed is reported when older has fewer elements or the
             // same but with integer in older instead of number in newer
             res.emplace<json_incompatibility>(
-              std::move(p), json_incompatibility_type::type_narrowed);
+              p, json_incompatibility_type::type_narrowed);
         } else {
             // Otherwise report the more general type_changed
             res.emplace<json_incompatibility>(
-              std::move(p), json_incompatibility_type::type_changed);
+              p, json_incompatibility_type::type_changed);
         }
         return res;
     }

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -2373,9 +2373,9 @@ SEASTAR_THREAD_TEST_CASE(test_object_recursion_depths) {
 
     // Test increasing depths to find stack limits.
     // Note: jsoncons validation must be disabled in json.cc for this test,
-    // Setting the limit to 76 causes corruption of the heap stack due to stack
+    // Setting the limit to 88 causes corruption of the heap stack due to stack
     // overflow.
-    constexpr int max_test_depth = 75;
+    constexpr int max_test_depth = 87;
 
     for (int depth = 1; depth <= max_test_depth; ++depth) {
         BOOST_TEST_MESSAGE(fmt::format("Testing depth {}", depth));

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -2372,10 +2372,11 @@ SEASTAR_THREAD_TEST_CASE(test_object_recursion_depths) {
     };
 
     // Test increasing depths to find stack limits.
-    // Note: jsoncons validation must be disabled in json.cc for this test.
-    // Setting the limit above ~130 causes corruption of the heap due to stack
-    // overflow, which manifests as a crash during Seastar shutdown.
-    constexpr int max_test_depth = 129;
+    // Note: jsoncons validation overflows the stack at about 31.
+    // With validation disabled, setting the limit above ~130 causes corruption
+    // of the heap due to stack overflow, which typically manifests as a crash
+    // during Seastar shutdown, or during is_superset.
+    constexpr int max_test_depth = 30;
 
     for (int depth = 1; depth <= max_test_depth; ++depth) {
         BOOST_TEST_MESSAGE(fmt::format("Testing depth {}", depth));

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -1660,7 +1660,7 @@ static const auto compatibility_test_cases = std::to_array<compatibility_test_ca
     .compat_result = {{"#/properties/a/exclusiveMinimum", incompat_t::exclusive_minimum_added}},
   },
   {
-// simple infinite recursive ref
+// simple infinite recursive ref - cycle detection handles this case
     .reader_schema = R"(
 {
   "type": "object",
@@ -1685,7 +1685,7 @@ static const auto compatibility_test_cases = std::to_array<compatibility_test_ca
   }
 })",
     .compat_result = {},
-    .expected_exception = true,
+    .expected_exception = false,
   },
   {
 // simple multiple recursive ref

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -2373,9 +2373,9 @@ SEASTAR_THREAD_TEST_CASE(test_object_recursion_depths) {
 
     // Test increasing depths to find stack limits.
     // Note: jsoncons validation must be disabled in json.cc for this test,
-    // Setting the limit to 71 causes corruption of the heap stack due to stack
+    // Setting the limit to 76 causes corruption of the heap stack due to stack
     // overflow.
-    constexpr int max_test_depth = 70;
+    constexpr int max_test_depth = 75;
 
     for (int depth = 1; depth <= max_test_depth; ++depth) {
         BOOST_TEST_MESSAGE(fmt::format("Testing depth {}", depth));

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -2373,9 +2373,9 @@ SEASTAR_THREAD_TEST_CASE(test_object_recursion_depths) {
 
     // Test increasing depths to find stack limits.
     // Note: jsoncons validation must be disabled in json.cc for this test,
-    // Setting the limit to 62 causes corruption of the heap stack due to stack
+    // Setting the limit to 65 causes corruption of the heap stack due to stack
     // overflow.
-    constexpr int max_test_depth = 61;
+    constexpr int max_test_depth = 64;
 
     for (int depth = 1; depth <= max_test_depth; ++depth) {
         BOOST_TEST_MESSAGE(fmt::format("Testing depth {}", depth));

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -2372,10 +2372,10 @@ SEASTAR_THREAD_TEST_CASE(test_object_recursion_depths) {
     };
 
     // Test increasing depths to find stack limits.
-    // Note: jsoncons validation must be disabled in json.cc for this test,
-    // Setting the limit to 88 causes corruption of the heap stack due to stack
-    // overflow.
-    constexpr int max_test_depth = 87;
+    // Note: jsoncons validation must be disabled in json.cc for this test.
+    // Setting the limit above ~130 causes corruption of the heap due to stack
+    // overflow, which manifests as a crash during Seastar shutdown.
+    constexpr int max_test_depth = 129;
 
     for (int depth = 1; depth <= max_test_depth; ++depth) {
         BOOST_TEST_MESSAGE(fmt::format("Testing depth {}", depth));

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -2372,9 +2372,10 @@ SEASTAR_THREAD_TEST_CASE(test_object_recursion_depths) {
     };
 
     // Test increasing depths to find stack limits.
-    // Setting the limit to 32 causes corruption of the heap stack due to stack
+    // Note: jsoncons validation must be disabled in json.cc for this test,
+    // Setting the limit to 62 causes corruption of the heap stack due to stack
     // overflow.
-    constexpr int max_test_depth = 31;
+    constexpr int max_test_depth = 61;
 
     for (int depth = 1; depth <= max_test_depth; ++depth) {
         BOOST_TEST_MESSAGE(fmt::format("Testing depth {}", depth));

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -2337,6 +2337,66 @@ SEASTAR_THREAD_TEST_CASE(test_json_compat_messages) {
     }
 }
 
+namespace {
+
+// Generate a deeply nested JSON schema with the specified depth.
+// Each level wraps the previous in an object property, creating a schema
+// like:
+// {"type":"object","properties":{"p":{"type":"object","properties":{...}}}}
+ss::sstring generate_deeply_nested_schema(int depth) {
+    if (depth <= 0) {
+        return R"({"type": "string"})";
+    }
+    ss::sstring result = R"({"type": "string"})";
+    for (int i = 0; i < depth; ++i) {
+        result = fmt::format(
+          R"({{"type":"object","properties":{{"p":{}}}}})", result);
+    }
+    return result;
+}
+
+} // namespace
+
+// Test that compatibility checking can handle deeply nested schemas without
+// stack overflow.
+SEASTAR_THREAD_TEST_CASE(test_object_recursion_depths) {
+    store_fixture f;
+    auto make_json_schema = [&](std::string_view schema) {
+        return pps::make_json_schema_definition(
+                 f.store(),
+                 pps::make_canonical_json_schema(
+                   f.store(),
+                   {pps::subject{"test"}, {schema, pps::schema_type::json}})
+                   .get())
+          .get();
+    };
+
+    // Test increasing depths to find stack limits.
+    // Setting the limit to 32 causes corruption of the heap stack due to stack
+    // overflow.
+    constexpr int max_test_depth = 31;
+
+    for (int depth = 1; depth <= max_test_depth; ++depth) {
+        BOOST_TEST_MESSAGE(fmt::format("Testing depth {}", depth));
+        try {
+            auto schema = generate_deeply_nested_schema(depth);
+            auto json_schema = make_json_schema(schema);
+
+            auto result = pps::check_compatible(
+              json_schema, json_schema, pps::verbose::yes);
+
+            BOOST_CHECK_MESSAGE(
+              result.is_compat,
+              fmt::format(
+                "Schema at depth {} should be compatible with itself", depth));
+        } catch (const std::exception& e) {
+            BOOST_TEST_MESSAGE(
+              fmt::format("Depth {} failed: {}", depth, e.what()));
+            break;
+        }
+    }
+}
+
 SEASTAR_THREAD_TEST_CASE(test_refs_fixing) {
     // test that look check that in the in-memory representation of a schema,
     // the refs are absolute

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -2373,9 +2373,9 @@ SEASTAR_THREAD_TEST_CASE(test_object_recursion_depths) {
 
     // Test increasing depths to find stack limits.
     // Note: jsoncons validation must be disabled in json.cc for this test,
-    // Setting the limit to 65 causes corruption of the heap stack due to stack
+    // Setting the limit to 71 causes corruption of the heap stack due to stack
     // overflow.
-    constexpr int max_test_depth = 64;
+    constexpr int max_test_depth = 70;
 
     for (int depth = 1; depth <= max_test_depth; ++depth) {
         BOOST_TEST_MESSAGE(fmt::format("Testing depth {}", depth));


### PR DESCRIPTION
Optimise compatibility checking for json to allow more nested schemas.

The depth was tuned by adding these options to the compiler to determine the stack frame sizes:
```
--copt=-fstack-usage --copt=-Wframe-larger-than=512 --copt=-Wno-error=frame-larger-than
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Improvements

* Schema Registry: Optimise compatibility checking for json to allow more nested schemas.
