### PR TITLE
`config`: rename `unstable_beta_feature_cloud_topics_enabled`

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4519,7 +4519,7 @@ configuration::configuration()
   , cloud_topics_enabled(
       *this,
       true,
-      "unstable_beta_feature_cloud_topics_enabled",
+      "cloud_topics_enabled",
       "Enable cloud topics.",
       meta{.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -328,7 +328,7 @@ OIDC_ALLOW_LIST = [
     re.compile("security - .* - Error updating"),
 ]
 
-CLOUD_TOPICS_CONFIG_STR = "unstable_beta_feature_cloud_topics_enabled"
+CLOUD_TOPICS_CONFIG_STR = "cloud_topics_enabled"
 
 
 class RemoteClusterNode(Protocol):

--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -77,7 +77,7 @@ class RedpandaConfig:
     rack: Optional[str] = None
     cloud_storage_enabled: bool = False
     iceberg_enabled: bool = False
-    unstable_beta_feature_cloud_topics_enabled: bool = False
+    cloud_topics_enabled: bool = False
     enable_developmental_unrecoverable_data_corrupting_features: int = int(time.time())
     enable_metrics_reporter: bool = False
 
@@ -94,7 +94,7 @@ class DefaultMinioRedpandaConfig:
     cloud_storage_disable_tls: bool = True
     cloud_storage_backend: str = "aws"
     iceberg_enabled: bool = True
-    unstable_beta_feature_cloud_topics_enabled: bool = True
+    cloud_topics_enabled: bool = True
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
We should have a more typical cluster property name for GA.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
