### PR TITLE
utils: add detailed error type

### DIFF
--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -675,3 +675,15 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "detailed_error",
+    hdrs = [
+        "detailed_error.h",
+    ],
+    deps = [
+        "//src/v/base",
+        "@fmt",
+        "@seastar",
+    ],
+)

--- a/src/v/utils/detailed_error.h
+++ b/src/v/utils/detailed_error.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "base/format_to.h"
+#include "base/seastarx.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <fmt/format.h>
+
+#include <forward_list>
+#include <utility>
+
+// An error type that includes an error code and a list of detail messages.
+// As errors propagate through layers, each layer can wrap the error with
+// additional context using wrap().
+//
+// Example:
+//   ```
+//   auto inner = error(errc::foo, "inner");
+//   auto outer = error::wrap(std::move(inner), errc::bar, "outer");
+//   ```
+//   Formats as: "[bar]: outer: inner"
+template<typename ErrorT>
+struct detailed_error {
+public:
+    explicit detailed_error(ErrorT e)
+      : e(std::move(e)) {}
+    detailed_error(ErrorT e, ss::sstring detail)
+      : e(std::move(e))
+      , details({std::move(detail)}) {}
+
+    ~detailed_error() = default;
+    detailed_error(const detailed_error&) = delete;
+    detailed_error& operator=(const detailed_error&) = delete;
+    detailed_error(detailed_error&&) noexcept = default;
+    detailed_error& operator=(detailed_error&&) noexcept = default;
+
+    template<typename OtherErrorT>
+    detailed_error<OtherErrorT> wrap(OtherErrorT&& other) && {
+        detailed_error<OtherErrorT> ret(std::forward<OtherErrorT>(other));
+        ret.details = std::move(details);
+        return ret;
+    }
+
+    template<typename OtherErrorT>
+    detailed_error<OtherErrorT>
+    wrap(OtherErrorT&& other, ss::sstring detail) && {
+        detailed_error<OtherErrorT> ret(std::forward<OtherErrorT>(other));
+        ret.details = std::move(details);
+        ret.details.push_front(std::move(detail));
+        return std::move(ret);
+    }
+
+    template<typename OtherErrorT>
+    static detailed_error wrap(detailed_error<OtherErrorT> other, ErrorT&& e) {
+        return std::move(other).wrap(std::forward<ErrorT>(e));
+    }
+    template<typename OtherErrorT>
+    static detailed_error
+    wrap(detailed_error<OtherErrorT> other, ErrorT&& e, ss::sstring detail) {
+        return std::move(other).wrap(
+          std::forward<ErrorT>(e), std::move(detail));
+    }
+
+    fmt::iterator format_to(fmt::iterator it) const {
+        it = fmt::format_to(it, "[{}]", e);
+        for (const auto& msg : details) {
+            it = fmt::format_to(it, ": {}", msg);
+        }
+        return it;
+    }
+
+    ErrorT e;
+    std::forward_list<ss::sstring> details;
+};

--- a/src/v/utils/tests/BUILD
+++ b/src/v/utils/tests/BUILD
@@ -41,6 +41,21 @@ redpanda_cc_btest_no_seastar(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "detailed_error_test",
+    timeout = "short",
+    srcs = [
+        "detailed_error_test.cc",
+    ],
+    deps = [
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:detailed_error",
+        "@fmt",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
 redpanda_cc_btest(
     name = "object_pool_test",
     timeout = "short",

--- a/src/v/utils/tests/detailed_error_test.cc
+++ b/src/v/utils/tests/detailed_error_test.cc
@@ -1,0 +1,88 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "utils/detailed_error.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/sstring.hh>
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+
+#include <expected>
+
+enum class errc { foo, bar };
+enum class other_errc { baz };
+
+template<>
+struct fmt::formatter<errc> : fmt::formatter<std::string_view> {
+    auto format(errc e, format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", e == errc::foo ? "foo" : "bar");
+    }
+};
+
+template<>
+struct fmt::formatter<other_errc> : fmt::formatter<std::string_view> {
+    auto format(other_errc, format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "baz");
+    }
+};
+
+using error = detailed_error<errc>;
+
+TEST(DetailedErrorTest, TestErrorOnly) {
+    EXPECT_EQ(fmt::format("{}", error(errc::foo)), "[foo]");
+}
+
+TEST(DetailedErrorTest, TestErrorAndDetails) {
+    EXPECT_EQ(fmt::format("{}", error(errc::foo, "msg")), "[foo]: msg");
+}
+
+TEST(DetailedErrorTest, TestWrap) {
+    auto inner = error(errc::bar, "inner");
+    auto outer = error::wrap(std::move(inner), errc::foo, "outer");
+    EXPECT_EQ(fmt::format("{}", outer), "[foo]: outer: inner");
+}
+
+TEST(DetailedErrorTest, TestWrapCall) {
+    auto inner = error(errc::bar, "inner");
+    auto outer = std::move(inner).wrap(errc::foo, "outer");
+    EXPECT_EQ(fmt::format("{}", outer), "[foo]: outer: inner");
+}
+
+TEST(DetailedErrorTest, TestWrapChain) {
+    auto a = error(errc::foo, "a");
+    auto b = error::wrap(std::move(a), errc::bar, "b");
+    auto c = error::wrap(std::move(b), errc::foo, "c");
+    EXPECT_EQ(fmt::format("{}", c), "[foo]: c: b: a");
+}
+
+TEST(DetailedErrorTest, TestWrapDifferentTypes) {
+    auto inner = detailed_error<other_errc>(other_errc::baz, "inner");
+    auto outer = error::wrap(std::move(inner), errc::foo, "outer");
+    EXPECT_EQ(fmt::format("{}", outer), "[foo]: outer: inner");
+}
+
+ss::future<std::expected<int, error>> make_error() {
+    co_return std::unexpected(error(errc::foo, "async"));
+}
+
+ss::future<std::expected<int, error>> make_wrapped_error() {
+    auto res = co_await make_error();
+    co_return std::unexpected(
+      error::wrap(std::move(res.error()), errc::bar, "wrapped"));
+}
+
+TEST(DetailedErrorTest, TestFunctionError) {
+    auto r1 = make_error().get();
+    EXPECT_EQ(fmt::format("{}", r1.error()), "[foo]: async");
+    auto r2 = make_wrapped_error().get();
+    EXPECT_EQ(fmt::format("{}", r2.error()), "[bar]: wrapped: async");
+}


### PR DESCRIPTION
Introduces an error type that includes an error code and a list of detail messages. As errors propagate through layers, each layer can wrap the error with additional context.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
