### PR TITLE
[UX-93] rpk: show documentation for fields in `rpk profile edit`

### DIFF
--- a/src/go/rpk/pkg/cli/profile/edit.go
+++ b/src/go/rpk/pkg/cli/profile/edit.go
@@ -10,6 +10,7 @@
 package profile
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -17,6 +18,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func newEditCommand(fs afero.Fs, p *config.Params) *cobra.Command {
@@ -50,6 +52,7 @@ exist, this command creates it and switches to it.
 				p = y.Profile(name)
 			}
 
+			original := *p
 			preFromCloud := p.FromCloud
 			preCloudDetails := p.CloudCluster
 			update, err := rpkos.EditTmpYAMLFile(fs, *p)
@@ -64,6 +67,11 @@ exist, this command creates it and switches to it.
 			// If a user clears the name by accident, we keep the old name.
 			if update.Name == "" {
 				update.Name = name
+			}
+
+			if profilesEqual(original, update) {
+				fmt.Printf("No changes made to profile %q.\n", name)
+				return
 			}
 
 			var renamed, updatedCurrent bool
@@ -89,4 +97,20 @@ exist, this command creates it and switches to it.
 			}
 		},
 	}
+}
+
+// profilesEqual compares two profiles by their YAML representations. We use
+// YAML marshaling instead of reflect.DeepEqual because internal fields
+// (like 'c') differ between original and parsed profiles. If Marshalling fails,
+// we return false.
+func profilesEqual(a, b config.RpkProfile) bool {
+	aYAML, err := yaml.Marshal(a)
+	if err != nil {
+		return false
+	}
+	bYAML, err := yaml.Marshal(b)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(aYAML, bYAML)
 }

--- a/src/go/rpk/pkg/cli/profile/edit.go
+++ b/src/go/rpk/pkg/cli/profile/edit.go
@@ -30,6 +30,10 @@ func newEditCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 This command opens your default editor to edit the specified profile, or
 the current profile if no profile is specified. If the profile does not
 exist, this command creates it and switches to it.
+
+The editor will display all available configuration fields. Fields that are
+not currently set are shown as comments with documentation. To set a field,
+uncomment it and provide a value.
 `,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: ValidProfiles(fs, p),
@@ -55,7 +59,7 @@ exist, this command creates it and switches to it.
 			original := *p
 			preFromCloud := p.FromCloud
 			preCloudDetails := p.CloudCluster
-			update, err := rpkos.EditTmpYAMLFile(fs, *p)
+			update, err := rpkos.EditTmpYAMLFileWithEncoder(fs, *p, config.ProfileToDocumentedYAML)
 			out.MaybeDieErr(err)
 
 			if preFromCloud {

--- a/src/go/rpk/pkg/config/BUILD
+++ b/src/go/rpk/pkg/config/BUILD
@@ -6,6 +6,7 @@ go_library(
         "config.go",
         "format.go",
         "params.go",
+        "profile_doc.go",
         "redpanda_yaml.go",
         "rpk_yaml.go",
         "weak.go",
@@ -36,6 +37,7 @@ go_test(
     srcs = [
         "config_test.go",
         "params_test.go",
+        "profile_doc_test.go",
         "rpk_yaml_test.go",
         "weak_test.go",
     ],

--- a/src/go/rpk/pkg/config/profile_doc.go
+++ b/src/go/rpk/pkg/config/profile_doc.go
@@ -1,0 +1,498 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// profileFieldDocs contains documentation for profile fields, keyed by their
+// YAML path. These are displayed as comments when editing a profile.
+var profileFieldDocs = map[string]string{
+	"name":        "Unique identifier for this profile",
+	"description": "Human-readable description of this profile",
+	"prompt":      "Custom shell prompt format; overrides globals.prompt if set",
+
+	"kafka_api":                          "Kafka API connection configuration",
+	"kafka_api.brokers":                  "Comma-separated list of broker addresses (host:port)",
+	"kafka_api.tls":                      "TLS configuration for Kafka API connections",
+	"kafka_api.tls.key_file":             "Path to client private key file for mTLS",
+	"kafka_api.tls.cert_file":            "Path to client certificate file for mTLS",
+	"kafka_api.tls.ca_file":              "Path to CA certificate file for TLS verification",
+	"kafka_api.tls.insecure_skip_verify": "Skip TLS certificate verification (not recommended for production)",
+	"kafka_api.sasl":                     "SASL authentication configuration",
+	"kafka_api.sasl.user":                "username for authentication",
+	"kafka_api.sasl.password":            "password for authentication",
+	"kafka_api.sasl.mechanism":           "SCRAM-SHA-256 or SCRAM-SHA-512",
+
+	"admin_api":                          "Admin API connection configuration",
+	"admin_api.addresses":                "Comma-separated list of Admin API addresses (host:port)",
+	"admin_api.tls":                      "TLS configuration for Admin API connections",
+	"admin_api.tls.key_file":             "Path to client private key file for mTLS",
+	"admin_api.tls.cert_file":            "Path to client certificate file for mTLS",
+	"admin_api.tls.ca_file":              "Path to CA certificate file for TLS verification",
+	"admin_api.tls.insecure_skip_verify": "Skip TLS certificate verification (not recommended for production)",
+
+	"schema_registry":                          "Schema Registry connection configuration",
+	"schema_registry.addresses":                "Comma-separated list of Schema Registry addresses (host:port)",
+	"schema_registry.tls":                      "TLS configuration for Schema Registry connections",
+	"schema_registry.tls.key_file":             "Path to client private key file for mTLS",
+	"schema_registry.tls.cert_file":            "Path to client certificate file for mTLS",
+	"schema_registry.tls.ca_file":              "Path to CA certificate file for TLS verification",
+	"schema_registry.tls.insecure_skip_verify": "Skip TLS certificate verification (not recommended for production)",
+}
+
+// excludedFields contains fields that should not be shown in the documented
+// output because they are internal or managed by rpk.
+var excludedFields = map[string]struct{}{
+	"cloud_environment": {},
+	"license_check":     {},
+}
+
+// noCommentFields contains fields that should be shown but without any
+// documentation comments (e.g., rpk-cloud-managed fields). If a parent field
+// is listed, all nested children are also treated as no-comment fields.
+var noCommentFields = map[string]struct{}{
+	"from_cloud":    {},
+	"cloud_cluster": {},
+}
+
+// isNoCommentField returns true if the given path or any of its parent paths
+// are in noCommentFields.
+func isNoCommentField(path string) bool {
+	for path != "" {
+		if _, ok := noCommentFields[path]; ok {
+			return true
+		}
+		idx := strings.LastIndex(path, ".")
+		if idx == -1 {
+			return false
+		}
+		path = path[:idx]
+	}
+	return false
+}
+
+// ProfileToDocumentedYAML generates a YAML representation of the profile with
+// all available fields shown. Fields that have values are displayed normally,
+// while unset fields are shown as comments with documentation.
+func ProfileToDocumentedYAML(p RpkProfile) ([]byte, error) {
+	var buf bytes.Buffer
+
+	buf.WriteString("# Available fields are shown below. Uncomment and edit as needed.\n")
+	buf.WriteString("# For more information, run: rpk profile set --help\n\n")
+
+	if err := writeDocumentedStruct(&buf, reflect.ValueOf(p), reflect.TypeOf(p), "", 0); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// writeDocumentedStruct writes a struct to the buffer with documentation.
+func writeDocumentedStruct(buf *bytes.Buffer, v reflect.Value, t reflect.Type, pathPrefix string, indent int) error {
+	indentStr := strings.Repeat("  ", indent)
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		fieldValue := v.Field(i)
+
+		// Unexported/Internal fields should be skipped.
+		if !field.IsExported() {
+			continue
+		}
+
+		// Parse yaml tag: 'yaml:"name,omitempty"' -> 'name'
+		yamlTag := field.Tag.Get("yaml")
+		if yamlTag == "" || yamlTag == "-" {
+			continue
+		}
+		tagParts := strings.Split(yamlTag, ",")
+		fieldName := tagParts[0]
+
+		// Build full path for doc lookup.
+		fullPath := fieldName
+		if pathPrefix != "" {
+			fullPath = pathPrefix + "." + fieldName
+		}
+
+		if _, ok := excludedFields[fullPath]; ok {
+			continue
+		}
+
+		noComment := isNoCommentField(fullPath)
+		isEmpty := isEmptyValue(fieldValue)
+
+		// noComment fields that are empty are skipped entirely.
+		if noComment && isEmpty {
+			continue
+		}
+
+		var doc string
+		if !noComment {
+			doc = profileFieldDocs[fullPath]
+		}
+
+		if isEmpty {
+			writeCommentedField(buf, fieldName, field.Type, doc, fullPath, indentStr)
+		} else {
+			// Hack: Add warning before cloud-managed fields.
+			if fullPath == "from_cloud" {
+				buf.WriteString(fmt.Sprintf("%s# The following fields are managed by rpk. Altering them manually may\n", indentStr))
+				buf.WriteString(fmt.Sprintf("%s# result in unexpected behavior.\n", indentStr))
+			}
+			if err := writeValueField(buf, fieldName, fieldValue, doc, fullPath, indentStr); err != nil {
+				return err
+			}
+		}
+
+		// Add blank line after top-level fields for readability (except before cloud_cluster)
+		if indent == 0 && fullPath != "from_cloud" {
+			buf.WriteString("\n")
+		}
+	}
+	return nil
+}
+
+// isStructAllEmpty checks if a struct has all empty/zero fields.
+func isStructAllEmpty(v reflect.Value) bool {
+	// I checked for struct before calling this function. However, since
+	// it's reflection-based, let's be safe.
+	if v.Kind() != reflect.Struct {
+		return false
+	}
+	for i := 0; i < v.NumField(); i++ {
+		if v.Type().Field(i).IsExported() && !isEmptyValue(v.Field(i)) {
+			return false
+		}
+	}
+	return true
+}
+
+// isEmptyValue checks if a reflect.Value is considered "empty".
+// Note: A non-nil pointer to an empty struct is NOT considered empty,
+// as it may be semantically meaningful (e.g., tls: {} enables TLS).
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Ptr:
+		// A non-nil pointer is not empty, even if it points to a zero struct.
+		// This preserves semantics like `tls: {}` which signals TLS is enabled.
+		return v.IsNil()
+	case reflect.Interface:
+		return v.IsNil()
+	case reflect.Slice, reflect.Map:
+		return v.IsNil() || v.Len() == 0
+	case reflect.String:
+		return v.String() == ""
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if v.Type().Field(i).IsExported() && !isEmptyValue(v.Field(i)) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+// writeCommentedField writes a field as a YAML comment.
+func writeCommentedField(buf *bytes.Buffer, name string, t reflect.Type, doc, fullPath, indent string) {
+	// Write documentation comment
+	if doc != "" {
+		buf.WriteString(fmt.Sprintf("%s# %s\n", indent, doc))
+	}
+
+	// Handle pointer types
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	// Write commented field based on type
+	switch t.Kind() {
+	case reflect.Struct:
+		// Write struct template as comment
+		buf.WriteString(fmt.Sprintf("%s# %s:\n", indent, name))
+		writeCommentedStructTemplate(buf, t, fullPath, indent+"  ")
+	case reflect.Slice:
+		buf.WriteString(fmt.Sprintf("%s# %s: []\n", indent, name))
+	case reflect.Bool:
+		buf.WriteString(fmt.Sprintf("%s# %s: false\n", indent, name))
+	case reflect.String:
+		buf.WriteString(fmt.Sprintf("%s# %s: \"\"\n", indent, name))
+	default:
+		buf.WriteString(fmt.Sprintf("%s# %s:\n", indent, name))
+	}
+}
+
+// writeCommentedStructTemplate writes a struct template as comments.
+func writeCommentedStructTemplate(buf *bytes.Buffer, t reflect.Type, pathPrefix, indent string) {
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+
+		yamlTag := field.Tag.Get("yaml")
+		if yamlTag == "" || yamlTag == "-" {
+			continue
+		}
+
+		tagParts := strings.Split(yamlTag, ",")
+		fieldName := tagParts[0]
+		if fieldName == "" {
+			fieldName = strings.ToLower(field.Name)
+		}
+
+		fullPath := pathPrefix + "." + fieldName
+
+		// Skip excluded
+		if _, ok := excludedFields[fieldName]; ok {
+			continue
+		}
+
+		// Skip noCommentFields entirely in commented templates
+		if isNoCommentField(fullPath) {
+			continue
+		}
+
+		doc := profileFieldDocs[fullPath]
+		if doc != "" {
+			buf.WriteString(fmt.Sprintf("%s# %s\n", indent, doc))
+		}
+
+		fieldType := field.Type
+		if fieldType.Kind() == reflect.Ptr {
+			fieldType = fieldType.Elem()
+		}
+
+		switch fieldType.Kind() {
+		case reflect.Struct:
+			buf.WriteString(fmt.Sprintf("%s# %s:\n", indent, fieldName))
+			writeCommentedStructTemplate(buf, fieldType, fullPath, indent+"  ")
+		case reflect.Slice:
+			buf.WriteString(fmt.Sprintf("%s# %s: []\n", indent, fieldName))
+		case reflect.Bool:
+			buf.WriteString(fmt.Sprintf("%s# %s: false\n", indent, fieldName))
+		case reflect.String:
+			buf.WriteString(fmt.Sprintf("%s# %s: \"\"\n", indent, fieldName))
+		default:
+			buf.WriteString(fmt.Sprintf("%s# %s:\n", indent, fieldName))
+		}
+	}
+}
+
+// writeValueField writes a field with its actual value.
+func writeValueField(buf *bytes.Buffer, name string, v reflect.Value, doc, fullPath, indent string) error {
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			writeCommentedField(buf, name, v.Type(), doc, fullPath, indent)
+			return nil
+		}
+		v = v.Elem()
+	}
+
+	// Write documentation comment on top (if present)
+	if doc != "" {
+		buf.WriteString(fmt.Sprintf("%s# %s\n", indent, doc))
+	}
+
+	switch v.Kind() {
+	case reflect.Struct:
+		// If struct is empty, write as {} to preserve semantics. (e.g., tls: {})
+		if isStructAllEmpty(v) {
+			buf.WriteString(fmt.Sprintf("%s%s: {}\n", indent, name))
+		} else {
+			buf.WriteString(fmt.Sprintf("%s%s:\n", indent, name))
+			if err := writeDocumentedStruct(buf, v, v.Type(), fullPath, len(indent)/2+1); err != nil {
+				return err
+			}
+		}
+
+	case reflect.Slice:
+		buf.WriteString(fmt.Sprintf("%s%s:\n", indent, name))
+		for i := 0; i < v.Len(); i++ {
+			elem := v.Index(i)
+			if err := writeSliceElement(buf, elem, indent+"  "); err != nil {
+				return err
+			}
+		}
+
+	case reflect.String:
+		val := v.String()
+		if needsQuoting(val) {
+			val = fmt.Sprintf("%q", val)
+		}
+		buf.WriteString(fmt.Sprintf("%s%s: %s\n", indent, name, val))
+
+	case reflect.Bool:
+		val := "false"
+		if v.Bool() {
+			val = "true"
+		}
+		buf.WriteString(fmt.Sprintf("%s%s: %s\n", indent, name, val))
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		buf.WriteString(fmt.Sprintf("%s%s: %d\n", indent, name, v.Int()))
+
+	default:
+		// Use yaml.Marshal for other types.
+		valBytes, err := yaml.Marshal(v.Interface())
+		if err != nil {
+			return fmt.Errorf("marshal field %q: %w", name, err)
+		}
+		val := strings.TrimSpace(string(valBytes))
+		buf.WriteString(fmt.Sprintf("%s%s: %s\n", indent, name, val))
+	}
+	return nil
+}
+
+func writeSliceElement(buf *bytes.Buffer, v reflect.Value, indent string) error {
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil
+		}
+		v = v.Elem()
+	}
+
+	switch v.Kind() {
+	case reflect.String:
+		val := v.String()
+		if needsQuoting(val) {
+			val = fmt.Sprintf("%q", val)
+		}
+		buf.WriteString(fmt.Sprintf("%s- %s\n", indent, val))
+
+	case reflect.Struct:
+		// First field on same line as dash, rest indented
+		t := v.Type()
+		first := true
+		for i := 0; i < t.NumField(); i++ {
+			field := t.Field(i)
+			if !field.IsExported() {
+				continue
+			}
+			yamlTag := field.Tag.Get("yaml")
+			if yamlTag == "" || yamlTag == "-" {
+				continue
+			}
+			tagParts := strings.Split(yamlTag, ",")
+			fieldName := tagParts[0]
+
+			fieldValue := v.Field(i)
+			if isEmptyValue(fieldValue) {
+				continue
+			}
+
+			if first {
+				buf.WriteString(fmt.Sprintf("%s- %s: ", indent, fieldName))
+				if err := writeInlineValue(buf, fieldValue); err != nil {
+					return err
+				}
+				buf.WriteString("\n")
+				first = false
+			} else {
+				buf.WriteString(fmt.Sprintf("%s  %s: ", indent, fieldName))
+				if err := writeInlineValue(buf, fieldValue); err != nil {
+					return err
+				}
+				buf.WriteString("\n")
+			}
+		}
+		if first {
+			// Empty struct
+			buf.WriteString(fmt.Sprintf("%s- {}\n", indent))
+		}
+
+	default:
+		valBytes, err := yaml.Marshal(v.Interface())
+		if err != nil {
+			return fmt.Errorf("marshal slice element: %w", err)
+		}
+		buf.WriteString(fmt.Sprintf("%s- %s", indent, strings.TrimSpace(string(valBytes))))
+		if !strings.HasSuffix(string(valBytes), "\n") {
+			buf.WriteString("\n")
+		}
+	}
+	return nil
+}
+
+func writeInlineValue(buf *bytes.Buffer, v reflect.Value) error {
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			buf.WriteString("null")
+			return nil
+		}
+		v = v.Elem()
+	}
+
+	switch v.Kind() {
+	case reflect.String:
+		val := v.String()
+		if needsQuoting(val) {
+			buf.WriteString(fmt.Sprintf("%q", val))
+		} else {
+			buf.WriteString(val)
+		}
+	case reflect.Bool:
+		if v.Bool() {
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		buf.WriteString(fmt.Sprintf("%d", v.Int()))
+	default:
+		valBytes, err := yaml.Marshal(v.Interface())
+		if err != nil {
+			return fmt.Errorf("marshal value: %w", err)
+		}
+		buf.WriteString(strings.TrimSpace(string(valBytes)))
+	}
+	return nil
+}
+
+// needsQuoting returns true if a string needs to be quoted in YAML. It checks
+// for special characters, leading/trailing whitespace, and values that may be
+// interpreted as bool/null (YAML 1.1/1.2 compatibility).
+func needsQuoting(s string) bool {
+	if s == "" {
+		return true
+	}
+	// Characters with special meaning in YAML (indicators, anchors, etc.)
+	if strings.ContainsAny(s, ":{}[]!@#$%^&*|'\"`\\") {
+		return true
+	}
+	// leading/trailing whitespace
+	if strings.TrimSpace(s) != s {
+		return true
+	}
+	// Values that yaml.v3 may interpret as bool/null when decoding into typed
+	// fields. See https://pkg.go.dev/gopkg.in/yaml.v3 for YAML 1.1/1.2
+	// compatibility details.
+	lower := strings.ToLower(s)
+	switch lower {
+	case "true", "false", "null", "yes", "no", "on", "off":
+		return true
+	}
+	return false
+}

--- a/src/go/rpk/pkg/config/profile_doc_test.go
+++ b/src/go/rpk/pkg/config/profile_doc_test.go
@@ -1,0 +1,408 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package config
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestProfileToDocumentedYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		profile  RpkProfile
+		contains []string
+	}{
+		{
+			name: "empty profile shows documented fields as comments",
+			profile: RpkProfile{
+				Name: "test-profile",
+			},
+			contains: []string{
+				"# Available fields are shown below",
+				"name: test-profile",
+				"# kafka_api:",
+				"# admin_api:",
+				"# schema_registry:",
+				"# description:",
+				"# prompt:",
+				// Documentation strings from profileFieldDocs
+				"# Unique identifier for this profile",
+				"# Human-readable description of this profile",
+				"# Kafka API connection configuration",
+				"# Comma-separated list of broker addresses",
+				"# TLS configuration for Kafka API",
+				"# SASL authentication configuration",
+				"# Admin API connection configuration",
+				"# Schema Registry connection configuration",
+			},
+		},
+		{
+			name: "profile with kafka brokers shows them and comments for tls/sasl",
+			profile: RpkProfile{
+				Name:        "kafka-profile",
+				Description: "Profile with Kafka config",
+				KafkaAPI: RpkKafkaAPI{
+					Brokers: []string{"localhost:9092", "localhost:9093"},
+				},
+			},
+			contains: []string{
+				"name: kafka-profile",
+				"description: Profile with Kafka config",
+				"kafka_api:",
+				"brokers:",
+				`"localhost:9092"`,
+				`"localhost:9093"`,
+				"# tls:",
+				"# sasl:",
+			},
+		},
+		{
+			name: "profile with TLS shows TLS fields",
+			profile: RpkProfile{
+				Name: "tls-profile",
+				KafkaAPI: RpkKafkaAPI{
+					Brokers: []string{"localhost:9092"},
+					TLS: &TLS{
+						TruststoreFile: "/path/to/ca.pem",
+						CertFile:       "/path/to/cert.pem",
+						KeyFile:        "/path/to/key.pem",
+					},
+				},
+			},
+			contains: []string{
+				"name: tls-profile",
+				"tls:",
+				"ca_file: /path/to/ca.pem",
+				"cert_file: /path/to/cert.pem",
+				"key_file: /path/to/key.pem",
+			},
+		},
+		{
+			name: "profile with empty TLS struct preserves it",
+			profile: RpkProfile{
+				Name: "tls-empty",
+				KafkaAPI: RpkKafkaAPI{
+					Brokers: []string{"localhost:9092"},
+					TLS:     &TLS{}, // Empty but non-nil signals TLS enabled
+				},
+			},
+			contains: []string{
+				"name: tls-empty",
+				"tls: {}",
+			},
+		},
+		{
+			name: "profile with SASL shows credentials",
+			profile: RpkProfile{
+				Name: "sasl-profile",
+				KafkaAPI: RpkKafkaAPI{
+					Brokers: []string{"localhost:9092"},
+					SASL: &SASL{
+						User:      "admin",
+						Password:  "secret",
+						Mechanism: "SCRAM-SHA-256",
+					},
+				},
+			},
+			contains: []string{
+				"sasl:",
+				"user: admin",
+				"password: secret",
+				"mechanism: SCRAM-SHA-256",
+			},
+		},
+		{
+			name: "profile with admin API",
+			profile: RpkProfile{
+				Name: "admin-profile",
+				AdminAPI: RpkAdminAPI{
+					Addresses: []string{"localhost:9644"},
+				},
+			},
+			contains: []string{
+				"admin_api:",
+				"addresses:",
+				`"localhost:9644"`,
+			},
+		},
+		{
+			name: "profile with schema registry",
+			profile: RpkProfile{
+				Name: "sr-profile",
+				SR: RpkSchemaRegistryAPI{
+					Addresses: []string{"localhost:8081"},
+				},
+			},
+			contains: []string{
+				"schema_registry:",
+				"addresses:",
+				`"localhost:8081"`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ProfileToDocumentedYAML(tt.profile)
+			require.NoError(t, err)
+
+			resultStr := string(result)
+			for _, expected := range tt.contains {
+				require.Contains(t, resultStr, expected, "expected output to contain %q", expected)
+			}
+		})
+	}
+}
+
+func TestProfileToDocumentedYAML_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile RpkProfile
+	}{
+		{
+			name: "minimal profile",
+			profile: RpkProfile{
+				Name: "test-profile",
+			},
+		},
+		{
+			name: "full profile",
+			profile: RpkProfile{
+				Name:        "full-profile",
+				Description: "A fully configured profile",
+				Prompt:      "custom-prompt",
+				KafkaAPI: RpkKafkaAPI{
+					Brokers: []string{"localhost:9092", "broker2:9092"},
+					TLS: &TLS{
+						TruststoreFile:     "/path/to/ca.pem",
+						CertFile:           "/path/to/cert.pem",
+						KeyFile:            "/path/to/key.pem",
+						InsecureSkipVerify: false,
+					},
+					SASL: &SASL{
+						User:      "user",
+						Password:  "pass",
+						Mechanism: "SCRAM-SHA-512",
+					},
+				},
+				AdminAPI: RpkAdminAPI{
+					Addresses: []string{"localhost:9644"},
+					TLS: &TLS{
+						TruststoreFile: "/path/to/admin-ca.pem",
+					},
+				},
+				SR: RpkSchemaRegistryAPI{
+					Addresses: []string{"localhost:8081"},
+				},
+			},
+		},
+		{
+			name: "special characters in values",
+			profile: RpkProfile{
+				Name:        "special-chars",
+				Description: "Description with: colon and 'quotes'",
+				KafkaAPI: RpkKafkaAPI{
+					Brokers: []string{"host:9092"},
+					SASL: &SASL{
+						User:     "user@domain",
+						Password: "pass:word!@#",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			yamlBytes, err := ProfileToDocumentedYAML(tt.profile)
+			require.NoError(t, err)
+
+			var parsed RpkProfile
+			err = yaml.Unmarshal(yamlBytes, &parsed)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.profile, parsed)
+		})
+	}
+}
+
+func TestProfileToDocumentedYAML_ExcludesInternalFields(t *testing.T) {
+	profile := RpkProfile{
+		Name:      "internal-test",
+		FromCloud: true,
+		CloudCluster: RpkCloudCluster{
+			ClusterID:   "test-cluster",
+			ClusterName: "test",
+		},
+		CloudEnvironment: "production",
+	}
+
+	result, err := ProfileToDocumentedYAML(profile)
+	require.NoError(t, err)
+
+	resultStr := string(result)
+
+	// Cloud fields appear so they're preserved on edit
+	require.Contains(t, resultStr, "from_cloud: true")
+	require.Contains(t, resultStr, "cloud_cluster:")
+	require.Contains(t, resultStr, "cluster_id: test-cluster")
+	require.Contains(t, resultStr, "cluster_name: test")
+
+	// Excluded fields should not appear
+	for field := range excludedFields {
+		require.NotContains(t, resultStr, field, "internal field %q should be excluded", field)
+	}
+
+	// Empty Cloud fields should have NO documentation comments
+	require.NotContains(t, resultStr, "# auth_org_id")
+	require.NotContains(t, resultStr, "# cluster_type")
+}
+
+func TestNeedsQuoting(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"empty string", "", true},
+		{"simple string", "simple", false},
+		{"string with space", "with space", false},
+		{"string with colon", "with:colon", true},
+		{"yaml bool true", "true", true},
+		{"yaml bool false", "false", true},
+		{"yaml null", "null", true},
+		{"yaml bool yes", "yes", true},
+		{"yaml bool no", "no", true},
+		{"host:port", "localhost:9092", true},
+		{"file path", "/path/to/file.pem", false},
+		{"mechanism", "SCRAM-SHA-256", false},
+		{"leading space", " leading-space", true},
+		{"trailing space", "trailing-space ", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := needsQuoting(tt.input)
+			require.Equal(t, tt.expected, result, "needsQuoting(%q)", tt.input)
+		})
+	}
+}
+
+func TestIsEmptyValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    interface{}
+		expected bool
+	}{
+		{"empty string", "", true},
+		{"non-empty string", "hello", false},
+		{"zero int", 0, true},
+		{"non-zero int", 42, false},
+		{"false bool", false, true},
+		{"true bool", true, false},
+		{"nil slice", []string(nil), true},
+		{"empty slice", []string{}, true},
+		{"non-empty slice", []string{"a"}, false},
+		{"nil map", map[string]string(nil), true},
+		{"empty map", map[string]string{}, true},
+		{"non-empty map", map[string]string{"a": "b"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isEmptyValue(reflect.ValueOf(tt.value))
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestProfileFieldDocsCompleteness(t *testing.T) {
+	// This test ensures all fields in RpkProfile are documented in
+	// profileFieldDocs, excludedFields, or noCommentFields. When adding new
+	// fields to RpkProfile, you must add documentation for them.
+	var missing []string
+	collectUndocumentedFields(reflect.TypeOf(RpkProfile{}), "", &missing)
+
+	if len(missing) > 0 {
+		t.Errorf("The following fields are missing documentation in profileFieldDocs, excludedFields, or noCommentFields:\n  %s",
+			strings.Join(missing, "\n  "))
+	}
+}
+
+// collectUndocumentedFields recursively collects all YAML field paths that are
+// not documented.
+func collectUndocumentedFields(t reflect.Type, pathPrefix string, missing *[]string) {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+
+		// Skip unexported fields
+		if !field.IsExported() {
+			continue
+		}
+
+		// Get yaml tag
+		yamlTag := field.Tag.Get("yaml")
+		if yamlTag == "" || yamlTag == "-" {
+			continue
+		}
+
+		// Parse yaml tag to get field name
+		tagParts := strings.Split(yamlTag, ",")
+		fieldName := tagParts[0]
+		if fieldName == "" {
+			fieldName = strings.ToLower(field.Name)
+		}
+
+		// Build full path
+		fullPath := fieldName
+		if pathPrefix != "" {
+			fullPath = pathPrefix + "." + fieldName
+		}
+
+		// Check if documented, excluded, or in noCommentFields
+		_, inDocs := profileFieldDocs[fullPath]
+		_, isExcluded := excludedFields[fullPath]
+		isNoComment := isNoCommentField(fullPath)
+
+		if !inDocs && !isExcluded && !isNoComment {
+			*missing = append(*missing, fullPath)
+		}
+
+		// Skip recursing into excluded or noComment fields - their nested fields are also excluded/no-comment
+		if isExcluded || isNoComment {
+			continue
+		}
+
+		// Recurse into nested structs
+		fieldType := field.Type
+		if fieldType.Kind() == reflect.Ptr {
+			fieldType = fieldType.Elem()
+		}
+		if fieldType.Kind() == reflect.Struct {
+			// Skip time.Duration wrapper and other non-config structs
+			if fieldType.PkgPath() != "" && !strings.Contains(fieldType.PkgPath(), "config") {
+				continue
+			}
+			collectUndocumentedFields(fieldType, fullPath, missing)
+		}
+	}
+}

--- a/src/go/rpk/pkg/os/file.go
+++ b/src/go/rpk/pkg/os/file.go
@@ -160,3 +160,25 @@ func decodeStrictYAML(b []byte, v any) error {
 	dec.KnownFields(true)
 	return dec.Decode(v)
 }
+
+// EditTmpYAMLFileWithEncoder is like EditTmpYAMLFile but accepts a custom
+// encoder function to generate the initial YAML content. This allows for
+// customization such as adding documentation comments.
+func EditTmpYAMLFileWithEncoder[T any](fs afero.Fs, v T, encode func(T) ([]byte, error)) (T, error) {
+	var update T
+	f, err := encode(v)
+	if err != nil {
+		return update, fmt.Errorf("unable to encode: %w", err)
+	}
+	read, err := EditTmpFile(fs, f)
+	if err != nil {
+		return update, fmt.Errorf("unable to edit: %w", err)
+	}
+	if len(read) == 0 || string(read) == "\n" {
+		return update, fmt.Errorf("no changes made")
+	}
+	if err := decodeStrictYAML(read, &update); err != nil {
+		return update, fmt.Errorf("unable to parse edited file: %w", err)
+	}
+	return update, nil
+}


### PR DESCRIPTION
When editing a profile, all available configuration fields are now displayed. Fields that are not set are shown as comments with documentation describing their purpose. This helps users discover available options without consulting external documentation.

### Samples

**Before**
```yaml
name: rpk-container
description: Automatically generated profile from 'rpk container start'
prompt: ""
from_cloud: false
kafka_api:
    brokers:
        - 127.0.0.1:9092
    sasl:
        user: foo
admin_api:
    addresses:
        - 127.0.0.1:9644
schema_registry:
    addresses:
        - 127.0.0.1:8081
```

**After**
```yaml
# Available fields are shown below. Uncomment and edit as needed.
# For more information, run: rpk profile set --help

# Unique identifier for this profile
name: rpk-container

# Human-readable description of this profile
description: "Automatically generated profile from 'rpk container start'"

# Custom shell prompt format; overrides globals.prompt if set
# prompt: ""

# Kafka API connection configuration
kafka_api:
  # Comma-separated list of broker addresses (host:port)
  brokers:
    - "127.0.0.1:9092"
  # TLS configuration for Kafka API connections
  # tls:
    # Path to client private key file for mTLS
    # key_file: ""
    # Path to client certificate file for mTLS
    # cert_file: ""
    # Path to CA certificate file for TLS verification
    # ca_file: ""
    # Skip TLS certificate verification (not recommended for production)
    # insecure_skip_verify: false
  # SASL authentication configuration
  sasl:
    # username for authentication
    user: foo
    # password for authentication
    # password: ""
    # SCRAM-SHA-256 or SCRAM-SHA-512
    # mechanism: ""

# Admin API connection configuration
admin_api:
  # Comma-separated list of Admin API addresses (host:port)
  addresses:
    - "127.0.0.1:9644"
  # TLS configuration for Admin API connections
  # tls:
    # Path to client private key file for mTLS
    # key_file: ""
    # Path to client certificate file for mTLS
    # cert_file: ""
    # Path to CA certificate file for TLS verification
    # ca_file: ""
    # Skip TLS certificate verification (not recommended for production)
    # insecure_skip_verify: false

# Schema Registry connection configuration
schema_registry:
  # Comma-separated list of Schema Registry addresses (host:port)
  addresses:
    - "127.0.0.1:8081"
  # TLS configuration for Schema Registry connections
  # tls:
    # Path to client private key file for mTLS
    # key_file: ""
    # Path to client certificate file for mTLS
    # cert_file: ""
    # Path to CA certificate file for TLS verification
    # ca_file: ""
    # Skip TLS certificate verification (not recommended for production)
    # insecure_skip_verify: false
```

In addition, we now detect whether a profile was modified while being edited, and the message shown after closing the editor indicates whether any changes were made.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Features

* rpk profile edit now documents each available field for an rpk profile
