### PR TITLE
bazel: allow user env vars to override the defaults

### DIFF
--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -160,7 +160,7 @@ def _redpanda_cc_test(
             "layering_check",
         ],
         tags = resource_tags + tags,
-        env = {"RP_FIXTURE_ENV": "1"} | env | test_env,
+        env = {"RP_FIXTURE_ENV": "1"} | test_env | env,
         target_compatible_with = target_compatible_with,
         data = data + test_data,
         local_defines = local_defines,
@@ -204,7 +204,7 @@ def _redpanda_cc_fuzz_test(
         tags = [
             "fuzz",
         ],
-        env = env | test_env,
+        env = test_env | env,
         data = data + test_data,
         linkopts = [
             "-fsanitize=fuzzer",
@@ -500,7 +500,7 @@ def redpanda_cc_bench(
         main = "bench_wrapper.py",
         tags = resource_tags + tags,
         srcs = ["//bazel:bench_wrapper"],
-        env = env | test_env,
+        env = test_env | env,
         args = args + ["--iterations=1 --runs=1 --duration=0 --no-stdout --overprovisioned"],
         data = [":" + binary_name] + data + test_data,
     )


### PR DESCRIPTION
Change the env merge order from `env | test_env` to `test_env | env` so that user-provided environment variables in test definitions take precedence over the default test environment.

No existing tests are affected by this change since no currently specify env vars overlap with the test_env ones.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
