### PR TITLE
[CORE-15166] security/tests: add group support to role_store_bench

### DIFF
--- a/src/v/security/tests/role_store_bench.cc
+++ b/src/v/security/tests/role_store_bench.cc
@@ -200,8 +200,6 @@ void run_authz(
     }
 
     auto role1_principal = role::to_principal(role1_name.value()());
-    acl_principal mem1_principal{
-      principal_type::user, ss::sstring(mem1.name())};
 
     const model::topic topic1("topic1");
     acl_host host1("192.168.1.1");

--- a/src/v/security/tests/role_store_bench.cc
+++ b/src/v/security/tests/role_store_bench.cc
@@ -68,6 +68,11 @@ const std::vector<role_member> members_data = generate_members(N_MEMBERS);
 const std::vector<role_member> members_512_data = generate_members(512ul);
 const std::vector<role_name> role_names_data = generate_role_names(N_ROLES);
 
+const std::vector<role_member> mixed_members_data = generate_members(
+  N_MEMBERS, {role_member_type::user, role_member_type::group});
+const std::vector<role_member> mixed_members_512_data = generate_members(
+  512ul, {role_member_type::user, role_member_type::group});
+
 role_store make_store(
   const decltype(role_names_data)& roles = role_names_data,
   const decltype(members_data)& mems = members_data) {
@@ -95,6 +100,19 @@ const role_store store_64_r_512_m_data = make_store(
   generate_role_names(64ul), members_512_data);
 const role_store store_8_r_1Ki_m_data = make_store(
   generate_role_names(8ul), members_data);
+
+const role_store mixed_store_512_r_1Ki_m_data = make_store(
+  role_names_data, mixed_members_data);
+const role_store mixed_store_256_r_1Ki_m_data = make_store(
+  generate_role_names(256ul), mixed_members_data);
+const role_store mixed_store_128_r_1Ki_m_data = make_store(
+  generate_role_names(128ul), mixed_members_data);
+const role_store mixed_store_64_r_1Ki_m_data = make_store(
+  generate_role_names(64ul), mixed_members_data);
+const role_store mixed_store_64_r_512_m_data = make_store(
+  generate_role_names(64ul), mixed_members_512_data);
+const role_store mixed_store_8_r_1Ki_m_data = make_store(
+  generate_role_names(8ul), mixed_members_data);
 
 template<bool materialize>
 void run_get_member_roles(
@@ -178,6 +196,65 @@ PERF_TEST(role_store_bench, put_role) {
     std::vector<role_member> all_members;
     all_members.reserve(N_MEMBERS);
     std::ranges::copy(members_data, std::back_inserter(all_members));
+    perf_tests::start_measuring_time();
+    store.put(std::move(name), all_members);
+    perf_tests::stop_measuring_time();
+}
+
+PERF_TEST(role_store_bench, get_member_roles_mixed) {
+    run_get_member_roles<true>(
+      mixed_members_data, mixed_store_512_r_1Ki_m_data);
+}
+
+PERF_TEST(role_store_bench, get_member_roles_bare_query_mixed) {
+    run_get_member_roles<false>(
+      mixed_members_data, mixed_store_512_r_1Ki_m_data);
+}
+
+PERF_TEST(role_store_bench, range_query_mixed) {
+    run_range_queries<true>(mixed_members_data, mixed_store_512_r_1Ki_m_data);
+}
+
+PERF_TEST(role_store_bench, range_query_bare_query_mixed) {
+    run_range_queries<false>(mixed_members_data, mixed_store_512_r_1Ki_m_data);
+}
+
+PERF_TEST(role_store_bench, remove_role_mixed) {
+    auto store = make_store(role_names_data, mixed_members_data);
+    size_t i = random_generators::get_int(role_names_data.size() - 1);
+    perf_tests::start_measuring_time();
+    store.remove(role_names_data[i]);
+    perf_tests::stop_measuring_time();
+}
+
+PERF_TEST(role_store_bench, update_role_mixed) {
+    auto store = make_store(role_names_data, mixed_members_data);
+    std::vector<std::string_view> member_roles;
+    role_member m;
+    while (member_roles.empty()) {
+        m = mixed_members_data[random_generators::get_int(
+          mixed_members_data.size() - 1)];
+        auto rng = store.roles_for_member(m);
+        std::copy(rng.begin(), rng.end(), std::back_inserter(member_roles));
+    }
+
+    role_name n{
+      member_roles[random_generators::get_int(member_roles.size() - 1)]};
+    perf_tests::start_measuring_time();
+    auto r = store.get(n).value();
+    auto mems = std::move(r).members();
+    store.remove(n);
+    mems.erase(m);
+    store.put(n, mems);
+    perf_tests::stop_measuring_time();
+}
+
+PERF_TEST(role_store_bench, put_role_mixed) {
+    role_store store = make_store(role_names_data, mixed_members_data);
+    role_name name{random_generators::gen_alphanum_string(NAME_LEN)};
+    std::vector<role_member> all_members;
+    all_members.reserve(N_MEMBERS);
+    std::ranges::copy(mixed_members_data, std::back_inserter(all_members));
     perf_tests::start_measuring_time();
     store.put(std::move(name), all_members);
     perf_tests::stop_measuring_time();
@@ -306,6 +383,64 @@ PERF_TEST(role_store_bench, role_authz_64_roles_512_members_deny) {
 
 PERF_TEST(role_store_bench, role_authz_8_roles_1Ki_members) {
     run_authz(store_8_r_1Ki_m_data, members_data);
+}
+
+PERF_TEST(role_store_bench, role_authz_512_roles_1Ki_members_mixed) {
+    run_authz(mixed_store_512_r_1Ki_m_data, mixed_members_data);
+}
+
+PERF_TEST(role_store_bench, role_authz_256_roles_1Ki_members_mixed) {
+    run_authz(mixed_store_256_r_1Ki_m_data, mixed_members_data);
+}
+
+PERF_TEST(role_store_bench, role_authz_128_roles_1Ki_members_mixed) {
+    run_authz(mixed_store_128_r_1Ki_m_data, mixed_members_data);
+}
+
+PERF_TEST(role_store_bench, role_authz_64_roles_1Ki_members_mixed) {
+    run_authz(mixed_store_64_r_1Ki_m_data, mixed_members_data);
+}
+
+PERF_TEST(
+  role_store_bench, role_authz_64_roles_1Ki_members_4_extra_bindings_mixed) {
+    run_authz(
+      mixed_store_64_r_1Ki_m_data,
+      mixed_members_data,
+      acl_permission::allow,
+      4);
+}
+
+PERF_TEST(
+  role_store_bench, role_authz_64_roles_1Ki_members_8_extra_bindings_mixed) {
+    run_authz(
+      mixed_store_64_r_1Ki_m_data,
+      mixed_members_data,
+      acl_permission::allow,
+      8);
+}
+
+PERF_TEST(
+  role_store_bench, role_authz_64_roles_1Ki_members_16_extra_bindings_mixed) {
+    run_authz(
+      mixed_store_64_r_1Ki_m_data,
+      mixed_members_data,
+      acl_permission::allow,
+      16);
+}
+
+PERF_TEST(role_store_bench, role_authz_64_roles_512_members_mixed) {
+    run_authz(mixed_store_64_r_512_m_data, mixed_members_512_data);
+}
+
+PERF_TEST(role_store_bench, role_authz_64_roles_512_members_deny_mixed) {
+    run_authz(
+      mixed_store_64_r_512_m_data,
+      mixed_members_512_data,
+      acl_permission::deny);
+}
+
+PERF_TEST(role_store_bench, role_authz_8_roles_1Ki_members_mixed) {
+    run_authz(mixed_store_8_r_1Ki_m_data, mixed_members_data);
 }
 
 PERF_TEST(role_store_bench, role_authz_empty_store) {

--- a/src/v/security/tests/role_store_bench.cc
+++ b/src/v/security/tests/role_store_bench.cc
@@ -29,12 +29,15 @@ using namespace security;
 // choose something that will generally circumvent small string optimization
 constexpr size_t NAME_LEN = 32;
 
-std::vector<role_member> generate_members(size_t N) {
+std::vector<role_member> generate_members(
+  size_t N,
+  const std::vector<role_member_type>& types = {role_member_type::user}) {
+    vassert(!types.empty(), "Must specify at least one role_member_type");
     std::vector<role_member> mems;
     mems.reserve(N);
-    std::ranges::for_each(boost::irange(0ul, N), [&mems](auto) {
+    std::ranges::for_each(boost::irange(0ul, N), [&mems, &types](auto) {
         mems.emplace_back(
-          role_member_type::user,
+          random_generators::random_choice(types),
           random_generators::gen_alphanum_string(NAME_LEN));
     });
     return mems;

--- a/src/v/security/tests/role_store_bench.cc
+++ b/src/v/security/tests/role_store_bench.cc
@@ -29,6 +29,16 @@ using namespace security;
 // choose something that will generally circumvent small string optimization
 constexpr size_t NAME_LEN = 32;
 
+principal_type principal_type_for_member_type(role_member_type t) {
+    switch (t) {
+    case role_member_type::user:
+        return principal_type::user;
+    case role_member_type::group:
+        return principal_type::group;
+    }
+    __builtin_unreachable();
+}
+
 std::vector<role_member> generate_members(
   size_t N,
   const std::vector<role_member_type>& types = {role_member_type::user}) {
@@ -237,7 +247,8 @@ void run_authz(
     auth.add_bindings(bindings);
 
     const auto& m = members[random_generators::get_int(members.size() - 1)];
-    acl_principal p{principal_type::user, ss::sstring{m.name()}};
+    acl_principal p{
+      principal_type_for_member_type(m.type()), ss::sstring{m.name()}};
 
     perf_tests::start_measuring_time();
     auto result = auth.authorized(

--- a/src/v/security/tests/role_store_bench.cc
+++ b/src/v/security/tests/role_store_bench.cc
@@ -85,9 +85,9 @@ const role_store store_8_r_1Ki_m_data = make_store(
 
 template<bool materialize>
 void run_get_member_roles() {
-    perf_tests::start_measuring_time();
     const auto& m
       = members_data[random_generators::get_int(members_data.size() - 1)];
+    perf_tests::start_measuring_time();
     auto rng = store_512_r_1Ki_m_data.roles_for_member(m);
     perf_tests::do_not_optimize(rng);
     if constexpr (materialize) {
@@ -99,9 +99,9 @@ void run_get_member_roles() {
 
 template<bool materialize>
 void run_range_queries() {
-    perf_tests::start_measuring_time();
     const auto& m
       = members_data[random_generators::get_int(members_data.size() - 1)];
+    perf_tests::start_measuring_time();
     auto rng = store_512_r_1Ki_m_data.range(
       [&m](const auto& e) { return role_store::has_member(e, m); });
     perf_tests::do_not_optimize(rng);

--- a/src/v/security/tests/role_store_bench.cc
+++ b/src/v/security/tests/role_store_bench.cc
@@ -97,11 +97,11 @@ const role_store store_8_r_1Ki_m_data = make_store(
   generate_role_names(8ul), members_data);
 
 template<bool materialize>
-void run_get_member_roles() {
-    const auto& m
-      = members_data[random_generators::get_int(members_data.size() - 1)];
+void run_get_member_roles(
+  const std::vector<role_member>& members, const role_store& store) {
+    const auto& m = members[random_generators::get_int(members.size() - 1)];
     perf_tests::start_measuring_time();
-    auto rng = store_512_r_1Ki_m_data.roles_for_member(m);
+    auto rng = store.roles_for_member(m);
     perf_tests::do_not_optimize(rng);
     if constexpr (materialize) {
         bool is_empty = rng.empty();
@@ -111,11 +111,11 @@ void run_get_member_roles() {
 }
 
 template<bool materialize>
-void run_range_queries() {
-    const auto& m
-      = members_data[random_generators::get_int(members_data.size() - 1)];
+void run_range_queries(
+  const std::vector<role_member>& members, const role_store& store) {
+    const auto& m = members[random_generators::get_int(members.size() - 1)];
     perf_tests::start_measuring_time();
-    auto rng = store_512_r_1Ki_m_data.range(
+    auto rng = store.range(
       [&m](const auto& e) { return role_store::has_member(e, m); });
     perf_tests::do_not_optimize(rng);
     if constexpr (materialize) {
@@ -127,16 +127,20 @@ void run_range_queries() {
 
 } // namespace
 
-PERF_TEST(role_store_bench, get_member_roles) { run_get_member_roles<true>(); }
-
-PERF_TEST(role_store_bench, get_member_roles_bare_query) {
-    run_get_member_roles<false>();
+PERF_TEST(role_store_bench, get_member_roles) {
+    run_get_member_roles<true>(members_data, store_512_r_1Ki_m_data);
 }
 
-PERF_TEST(role_store_bench, user_range_query) { run_range_queries<true>(); }
+PERF_TEST(role_store_bench, get_member_roles_bare_query) {
+    run_get_member_roles<false>(members_data, store_512_r_1Ki_m_data);
+}
+
+PERF_TEST(role_store_bench, user_range_query) {
+    run_range_queries<true>(members_data, store_512_r_1Ki_m_data);
+}
 
 PERF_TEST(role_store_bench, user_range_query_bare_query) {
-    run_range_queries<false>();
+    run_range_queries<false>(members_data, store_512_r_1Ki_m_data);
 }
 
 PERF_TEST(role_store_bench, remove_role) {


### PR DESCRIPTION
Previously, the role_store benchmarks only tested authorization scenarios with user members. This PR extends the benchmarks to support both user and group member types.

The changes include:
- Parameterize `generate_members()` to accept a vector of role member types instead of always generating users
- Add `principal_type_for_member_type()` helper to convert between `role_member_type` and `principal_type`
- Update `run_authz()` to use the actual member type instead of hardcoding `principal_type::user`
- Refactor benchmark helpers to accept parameterized member data and store references
- Add 18 new benchmark tests using mixed user/group members alongside existing users-only tests
- Remove unused dead code

Resolves [CORE-15166](https://redpandadata.atlassian.net/browse/CORE-15166)

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

[CORE-15166]: https://redpandadata.atlassian.net/browse/CORE-15166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ