### PR TITLE
.github: update python version in render worflow

### DIFF
--- a/.github/workflows/render-pr-body-release-notes.yml
+++ b/.github/workflows/render-pr-body-release-notes.yml
@@ -24,7 +24,7 @@ jobs:
           chmod +x rpchangelog/rpchangelog.py
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
           cache: 'pip'
       - run: pip3 install -r ./rpchangelog/requirements.txt
       - name: Render PR body release notes to job summary


### PR DESCRIPTION
The script has an explicit dependency on ghapi package that implicitly depends on fastcore and fetches the latest. Any python version older than 3.12 leads to a failure while importing the package in the script with the below error:

```
Traceback (most recent call last):
  File "/home/runner/work/redpanda/redpanda/./rpchangelog/rpchangelog.py", line 10, in <module>
    from ghapi.all import GhApi
  File "/opt/hostedtoolcache/Python/3.10.19/x64/lib/python3.10/site-packages/ghapi/all.py", line 1, in <module>
    from .core import *
  File "/opt/hostedtoolcache/Python/3.10.19/x64/lib/python3.10/site-packages/ghapi/core.py", line 9, in <module>
    from fastcore.all import *
  File "/opt/hostedtoolcache/Python/3.10.19/x64/lib/python3.10/site-packages/fastcore/all.py", line 9, in <module>
    from .script import *
  File "/opt/hostedtoolcache/Python/3.10.19/x64/lib/python3.10/site-packages/fastcore/script.py", line 15, in <module>
    from .docments import docments
  File "/opt/hostedtoolcache/Python/3.10.19/x64/lib/python3.10/site-packages/fastcore/docments.py", line 359
    sig_str = f"def {get_name(self.obj)}(\n    {'\n    '.join(lines)}\n{self._ret_str}"
```

ref: https://github.com/AnswerDotAI/fastcore/issues/751

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x

## Release Notes

* none
