### PR TITLE
`cloud_io`: don't call `_tick_dl_throttled_metric` if not set

### DIFF
--- a/src/v/cloud_io/io_resources.cc
+++ b/src/v/cloud_io/io_resources.cc
@@ -71,7 +71,9 @@ private:
             auto duration
               = std::chrono::duration_cast<std::chrono::milliseconds>(
                 throttled.value());
-            _tick_dl_throttled_metric(duration.count());
+            if (_tick_dl_throttled_metric) {
+                _tick_dl_throttled_metric(duration.count());
+            }
             vlog(
               log.trace,
               "Download throttled: sleep time is {} ms",


### PR DESCRIPTION
In `cloud_topics/level_one/common/file_io.cc`, we weren't setting this lambda [1], leading to a `std::bad_function_call` exception being thrown when throttled.

Check it for "null" state before calling it.

[1]:

https://github.com/redpanda-data/redpanda/blob/bdb142585b280a6d116f624b3ffb5df1732ef89c/src/v/cloud_topics/level_one/common/file_io.cc#L221-L239

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
