### PR TITLE
ct: reduce shutdown error logging

### DIFF
--- a/src/v/cloud_topics/frontend/BUILD
+++ b/src/v/cloud_topics/frontend/BUILD
@@ -30,6 +30,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_zero/stm:ctp_stm",
         "//src/v/cloud_topics/level_zero/stm:placeholder",
         "//src/v/cluster",
+        "//src/v/ssx:future_util",
         "//src/v/storage:record_batch_builder",
     ],
     visibility = ["//visibility:public"],

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -33,6 +33,7 @@
 #include "model/timeout_clock.h"
 #include "raft/errc.h"
 #include "raft/replicate.h"
+#include "ssx/future-util.h"
 #include "storage/log_reader.h"
 #include "storage/offset_translator_state.h"
 #include "storage/record_batch_builder.h"
@@ -591,8 +592,10 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
       ctp_stm_api->fence_epoch(upload_res.value().front().id.epoch));
     if (fence_fut.failed()) {
         auto e = fence_fut.get_exception();
-        vlog(
-          cd_log.warn,
+        vlogl(
+          cd_log,
+          ssx::is_shutdown_exception(e) ? ss::log_level::debug
+                                        : ss::log_level::warn,
           "Failed to fence epoch {} for ntp {}, error: {}",
           upload_res.value().front().id.epoch,
           ntp,
@@ -725,10 +728,11 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
     auto fence_fut = co_await ss::coroutine::as_future(
       _ctp_stm_api->fence_epoch(res.value().front().id.epoch));
     if (fence_fut.failed()) {
-        // TODO: handle shutdown failures gracefully
         auto e = fence_fut.get_exception();
-        vlog(
-          cd_log.warn,
+        vlogl(
+          cd_log,
+          ssx::is_shutdown_exception(e) ? ss::log_level::debug
+                                        : ss::log_level::warn,
           "Failed to fence epoch {} for ntp {}, error: {}",
           res.value().front().id.epoch,
           ntp(),

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -380,6 +380,8 @@ ss::future<std::expected<cluster_epoch_fence, stale_cluster_epoch>>
 ctp_stm::fence_epoch(cluster_epoch e) {
     auto holder = _gate.hold();
     if (!co_await sync(sync_timeout, _as)) {
+        // Prevent the below log spam if we are shutting down.
+        _as.check();
         vlog(_log.warn, "ctp_stm::fence_epoch sync timeout");
         throw std::runtime_error(fmt_with_ctx(fmt::format, "Sync timeout"));
     }


### PR DESCRIPTION
this can happen if the replica is moving, and a lot of these can build
up as the upload is a slow operation.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
