### PR TITLE
kafka: cleanup debounce timeout parameter for making a reader

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1219,10 +1219,8 @@ size_t remote_partition::reader_mem_use_estimate() noexcept {
            + sizeof(partition_record_batch_reader_impl);
 }
 
-ss::future<storage::translating_reader> remote_partition::make_reader(
-  cloud_storage::cloud_log_reader_config config,
-  std::optional<model::timeout_clock::time_point> deadline) {
-    std::ignore = deadline;
+ss::future<storage::translating_reader>
+remote_partition::make_reader(cloud_storage::cloud_log_reader_config config) {
     vlog(
       _ctxlog.debug,
       "remote partition make_reader invoked (waiting for units), config: {}, "

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -78,13 +78,8 @@ public:
     /// batch reader will produce batches with kafka offsets and the config will
     /// be updated using kafka offsets.
     /// \param config is a reader config
-    /// \param deadline is an optional time point which is used to debounce
-    ///        readers which are waiting for an offset. This is not a
-    ///        cancellation deadline.  Not used for tiered-storage.
-    ss::future<storage::translating_reader> make_reader(
-      cloud_storage::cloud_log_reader_config config,
-      std::optional<model::timeout_clock::time_point> debounce_deadline
-      = std::nullopt);
+    ss::future<storage::translating_reader>
+    make_reader(cloud_storage::cloud_log_reader_config config);
 
     static size_t reader_mem_use_estimate() noexcept;
 

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -241,9 +241,8 @@ model::term_id frontend::leader_epoch() const {
     return _partition->raft()->confirmed_term();
 }
 
-ss::future<storage::translating_reader> frontend::make_reader(
-  cloud_topic_log_reader_config cfg,
-  std::optional<model::timeout_clock::time_point>) {
+ss::future<storage::translating_reader>
+frontend::make_reader(cloud_topic_log_reader_config cfg) {
     vassert(_data_plane != nullptr, "cloud topics api not initialized");
 
     const auto lro = _ctp_stm_api->get_last_reconciled_offset();
@@ -470,7 +469,7 @@ frontend::refine_timequery_result(
     // giving the reader a timestamp so it uses the L1 object indexes to seek
     // to the correct spot within the index, this would allow us to optimize IO
     // against the cloud.
-    auto reader = co_await make_reader(reader_cfg, std::nullopt);
+    auto reader = co_await make_reader(reader_cfg);
     auto generator = std::move(reader.reader).generator(model::no_timeout);
     auto query_interval = model::bounded_offset_interval::checked(
       kafka::offset_cast(input.start_offset),

--- a/src/v/cloud_topics/frontend/frontend.h
+++ b/src/v/cloud_topics/frontend/frontend.h
@@ -127,9 +127,8 @@ public:
     raft::replicate_stages replicate(
       model::batch_identity, model::record_batch, raft::replicate_options);
 
-    ss::future<storage::translating_reader> make_reader(
-      cloud_topic_log_reader_config cfg,
-      std::optional<model::timeout_clock::time_point>);
+    ss::future<storage::translating_reader>
+    make_reader(cloud_topic_log_reader_config cfg);
 
     ss::future<std::vector<model::tx_range>> aborted_transactions(
       kafka::offset base,

--- a/src/v/cloud_topics/reconciler/reconciliation_source.cc
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.cc
@@ -119,10 +119,7 @@ public:
         if (cfg.max_offset < cfg.start_offset) {
             co_return model::make_empty_record_batch_reader();
         }
-        auto reader = co_await _fe->make_reader(
-          cfg,
-          /*debounce_deadline=*/
-          std::nullopt);
+        auto reader = co_await _fe->make_reader(cfg);
 
         // It's important the `aborted_transaction_tracker_impl` takes a shared
         // so we don't have to worry about the lifetimes of the reader and

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -328,14 +328,13 @@ model::offset partition::next_cloud_offset() const {
     return kafka::offset_cast(_cloud_storage_partition->next_kafka_offset());
 }
 
-ss::future<storage::translating_reader> partition::make_cloud_reader(
-  cloud_storage::cloud_log_reader_config config,
-  std::optional<model::timeout_clock::time_point> deadline) {
+ss::future<storage::translating_reader>
+partition::make_cloud_reader(cloud_storage::cloud_log_reader_config config) {
     vassert(
       cloud_data_available(),
       "Method can only be called if cloud data is available, ntp: {}",
       _raft->ntp());
-    return _cloud_storage_partition->make_reader(config, deadline);
+    return _cloud_storage_partition->make_reader(config);
 }
 
 ss::future<result<kafka_result>> partition::replicate(
@@ -1614,10 +1613,9 @@ partition::remote_partition() const {
     return _cloud_storage_partition;
 }
 
-ss::future<model::record_batch_reader> partition::make_local_reader(
-  storage::local_log_reader_config config,
-  std::optional<model::timeout_clock::time_point> debounce_deadline) {
-    return _raft->make_reader(std::move(config), debounce_deadline);
+ss::future<model::record_batch_reader>
+partition::make_local_reader(storage::local_log_reader_config config) {
+    return _raft->make_reader(config);
 }
 
 model::term_id partition::term() const { return _raft->term(); }

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -100,10 +100,9 @@ public:
      * the minimum of the max offset requested and the committed index of the
      * underlying raft group.
      */
-    ss::future<model::record_batch_reader> make_local_reader(
-      storage::local_log_reader_config config,
-      std::optional<model::timeout_clock::time_point> debounce_deadline
-      = std::nullopt);
+    ss::future<model::record_batch_reader>
+    make_local_reader(storage::local_log_reader_config config);
+
     ss::future<result<model::offset, std::error_code>>
     sync_kafka_start_offset_override(model::timeout_clock::duration timeout);
 
@@ -268,9 +267,8 @@ public:
     model::offset next_cloud_offset() const;
 
     /// Create a reader that will fetch data from remote storage
-    ss::future<storage::translating_reader> make_cloud_reader(
-      cloud_storage::cloud_log_reader_config config,
-      std::optional<model::timeout_clock::time_point> deadline = std::nullopt);
+    ss::future<storage::translating_reader>
+    make_cloud_reader(cloud_storage::cloud_log_reader_config config);
 
     std::optional<model::offset> kafka_start_offset_override() const;
 

--- a/src/v/kafka/data/cloud_topic_partition.cc
+++ b/src/v/kafka/data/cloud_topic_partition.cc
@@ -136,11 +136,10 @@ kafka::leader_epoch cloud_topic_partition::leader_epoch() const {
     return kafka::leader_epoch(static_cast<int32_t>(term()));
 }
 
-ss::future<storage::translating_reader> cloud_topic_partition::make_reader(
-  kafka::log_reader_config cfg,
-  std::optional<model::timeout_clock::time_point> deadline) {
+ss::future<storage::translating_reader>
+cloud_topic_partition::make_reader(kafka::log_reader_config cfg) {
     auto config = kafka_to_cloud_topic_log_reader_config(cfg);
-    return _fe->make_reader(config, deadline);
+    return _fe->make_reader(config);
 }
 
 ss::future<std::vector<cluster::tx::tx_range>>

--- a/src/v/kafka/data/cloud_topic_partition.h
+++ b/src/v/kafka/data/cloud_topic_partition.h
@@ -72,9 +72,8 @@ public:
       model::record_batch,
       raft::replicate_options) final;
 
-    ss::future<storage::translating_reader> make_reader(
-      kafka::log_reader_config cfg,
-      std::optional<model::timeout_clock::time_point>) final;
+    ss::future<storage::translating_reader>
+    make_reader(kafka::log_reader_config cfg) final;
 
     ss::future<std::vector<model::tx_range>> aborted_transactions(
       model::offset base,

--- a/src/v/kafka/data/partition_proxy.h
+++ b/src/v/kafka/data/partition_proxy.h
@@ -71,10 +71,8 @@ public:
         virtual ss::future<std::error_code> linearizable_barrier() = 0;
         virtual ss::future<error_code>
           prefix_truncate(model::offset, ss::lowres_clock::time_point) = 0;
-        virtual ss::future<storage::translating_reader> make_reader(
-          kafka::log_reader_config,
-          std::optional<model::timeout_clock::time_point>)
-          = 0;
+        virtual ss::future<storage::translating_reader>
+          make_reader(kafka::log_reader_config) = 0;
         virtual ss::future<std::optional<storage::timequery_result>>
           timequery(storage::timequery_config) = 0;
         virtual ss::future<std::vector<model::tx_range>> aborted_transactions(
@@ -139,11 +137,9 @@ public:
         return _impl->aborted_transactions(base, last, std::move(ot_state));
     }
 
-    ss::future<storage::translating_reader> make_reader(
-      kafka::log_reader_config cfg,
-      std::optional<model::timeout_clock::time_point> debounce_deadline
-      = std::nullopt) {
-        return _impl->make_reader(cfg, debounce_deadline);
+    ss::future<storage::translating_reader>
+    make_reader(kafka::log_reader_config cfg) {
+        return _impl->make_reader(cfg);
     }
 
     ss::future<std::optional<storage::timequery_result>>

--- a/src/v/kafka/data/replicated_partition.cc
+++ b/src/v/kafka/data/replicated_partition.cc
@@ -202,9 +202,8 @@ kafka::leader_epoch replicated_partition::leader_epoch() const {
 }
 
 // TODO: use previous translation speed up lookup
-ss::future<storage::translating_reader> replicated_partition::make_reader(
-  kafka::log_reader_config cfg,
-  std::optional<model::timeout_clock::time_point> debounce_deadline) {
+ss::future<storage::translating_reader>
+replicated_partition::make_reader(kafka::log_reader_config cfg) {
     if (
       _partition->is_read_replica_mode_enabled()
       && _partition->cloud_data_available()) {
@@ -221,16 +220,14 @@ ss::future<storage::translating_reader> replicated_partition::make_reader(
            >= model::offset_cast(_partition->start_cloud_offset())) {
         auto config = kafka_to_cloud_log_reader_config(cfg);
         config.type_filter = {model::record_batch_type::raft_data};
-        co_return co_await _partition->make_cloud_reader(
-          config, debounce_deadline);
+        co_return co_await _partition->make_cloud_reader(config);
     }
 
     auto config = kafka_to_local_log_reader_config(cfg, _translator);
     config.type_filter = {model::record_batch_type::raft_data};
     config.translate_offsets = model::translate_offsets::yes;
 
-    auto rdr = co_await _partition->make_local_reader(
-      std::move(config), debounce_deadline);
+    auto rdr = co_await _partition->make_local_reader(config);
     co_return storage::translating_reader(std::move(rdr), _translator);
 }
 

--- a/src/v/kafka/data/replicated_partition.h
+++ b/src/v/kafka/data/replicated_partition.h
@@ -69,9 +69,8 @@ public:
       model::record_batch,
       raft::replicate_options) final;
 
-    ss::future<storage::translating_reader> make_reader(
-      kafka::log_reader_config cfg,
-      std::optional<model::timeout_clock::time_point>) final;
+    ss::future<storage::translating_reader>
+    make_reader(kafka::log_reader_config cfg) final;
 
     ss::future<std::vector<model::tx_range>> aborted_transactions(
       model::offset base,

--- a/src/v/kafka/data/rpc/service.cc
+++ b/src/v/kafka/data/rpc/service.cc
@@ -225,8 +225,7 @@ local_service::consume(
           auto deadline = model::timeout_clock::now() + timeout;
 
           // Create reader
-          auto translating_reader = co_await partition->make_reader(
-            reader_cfg, deadline);
+          auto translating_reader = co_await partition->make_reader(reader_cfg);
 
           // Consume batches from reader
           try {

--- a/src/v/kafka/data/rpc/test/deps.h
+++ b/src/v/kafka/data/rpc/test/deps.h
@@ -110,9 +110,8 @@ public:
     prefix_truncate(model::offset, ss::lowres_clock::time_point) final {
         throw std::runtime_error("unimplemented");
     }
-    ss::future<storage::translating_reader> make_reader(
-      kafka::log_reader_config config,
-      std::optional<model::timeout_clock::time_point>) final {
+    ss::future<storage::translating_reader>
+    make_reader(kafka::log_reader_config config) final {
         if (config.first_timestamp.has_value()) {
             throw std::runtime_error("unimplemented");
         }

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -904,22 +904,10 @@ consensus::do_make_reader(storage::local_log_reader_config config) {
     return _log->make_reader(config);
 }
 
-ss::future<model::record_batch_reader> consensus::make_reader(
-  storage::local_log_reader_config config,
-  std::optional<clock_type::time_point> debounce_timeout) {
-    return ss::try_with_gate(_bg, [this, config, debounce_timeout] {
-        if (!debounce_timeout) {
-            // fast path, do not wait
-            return do_make_reader(config);
-        }
-
-        return _consumable_offset_monitor
-          .wait(
-            model::next_offset(_majority_replicated_index),
-            *debounce_timeout,
-            _as)
-          .then([this, config]() mutable { return do_make_reader(config); });
-    });
+ss::future<model::record_batch_reader>
+consensus::make_reader(storage::local_log_reader_config config) {
+    return ss::try_with_gate(
+      _bg, [this, config] { return do_make_reader(config); });
 }
 
 bool consensus::should_skip_vote(bool ignore_heartbeat) {

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -296,9 +296,8 @@ public:
 
     std::optional<state_machine_manager>& stm_manager() { return _stm_manager; }
 
-    ss::future<model::record_batch_reader> make_reader(
-      storage::local_log_reader_config,
-      std::optional<clock_type::time_point> = std::nullopt);
+    ss::future<model::record_batch_reader>
+      make_reader(storage::local_log_reader_config);
 
     model::offset get_latest_configuration_offset() const;
     model::offset committed_offset() const { return _commit_index; }


### PR DESCRIPTION
This is no longer used and is dead code

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
