### PR TITLE
ct: fix timeout handling in level zero reader

### DIFF
--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -108,8 +108,22 @@ level_zero_log_reader_impl::read_some(
      * Combine metadata with payloads (from cache or object storage) to
      * construct the full batches expected by the caller (e.g. Kafka Fetch).
      */
-    auto batches = co_await materialize_batches(
+    auto maybe_batches = co_await materialize_batches(
       std::move(log_read_metadata), deadline);
+    if (!maybe_batches.has_value()) {
+        if (maybe_batches.error() == errc::timeout) {
+            if (_bytes_consumed >= _config.min_bytes) {
+                co_return model::record_batch_reader::storage_t{};
+            }
+            throw ss::timed_out_error();
+        }
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format,
+          "Reader experienced unhandled error: {}",
+          maybe_batches.error()));
+    }
+
+    auto batches = std::move(maybe_batches).value();
     if (batches.empty()) {
         set_end_of_stream();
         co_return model::record_batch_reader::storage_t{};
@@ -247,7 +261,7 @@ level_zero_log_reader_impl::fetch_metadata(
     co_return ret;
 }
 
-ss::future<chunked_circular_buffer<model::record_batch>>
+ss::future<std::expected<chunked_circular_buffer<model::record_batch>, errc>>
 level_zero_log_reader_impl::materialize_batches(
   chunked_circular_buffer<local_log_batch> unhydrated,
   model::timeout_clock::time_point deadline) {
@@ -313,7 +327,7 @@ level_zero_log_reader_impl::materialize_batches(
         }
         if (mat_res.error() == errc::timeout) {
             vlog(_log.debug, "Materialize aborted due to timeout");
-            throw ss::timed_out_error();
+            co_return std::unexpected(errc::timeout);
         }
         throw std::runtime_error(
           fmt::format(

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
@@ -9,10 +9,13 @@
  */
 #pragma once
 
+#include "cloud_topics/errc.h"
 #include "cloud_topics/level_zero/common/extent_meta.h"
 #include "cloud_topics/log_reader_config.h"
 #include "model/record_batch_reader.h"
 #include "utils/prefix_logger.h"
+
+#include <expected>
 
 namespace cluster {
 class partition;
@@ -108,7 +111,8 @@ private:
     fetch_metadata(
       storage::local_log_reader_config cfg,
       model::timeout_clock::time_point deadline) const;
-    ss::future<chunked_circular_buffer<model::record_batch>>
+    ss::future<
+      std::expected<chunked_circular_buffer<model::record_batch>, errc>>
     materialize_batches(
       chunked_circular_buffer<local_log_batch> unhydrated,
       model::timeout_clock::time_point deadline);


### PR DESCRIPTION
If a timeout occurred but we had returned min bytes to the reader then don't surface an error.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
