### PR TITLE
`ct/l1`: remove use of `ssx::with_timeout_abortable` in `committer`

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/committer.cc
+++ b/src/v/cloud_topics/level_one/compaction/committer.cc
@@ -359,9 +359,7 @@ ss::future<> compaction_committer::compaction_job::do_finalize(
       _id,
       _tp);
 
-    auto f = await_inflight_uploads();
-    auto fut = co_await ss::coroutine::as_future(
-      ssx::with_timeout_abortable(std::move(f), model::no_timeout, _as));
+    auto fut = co_await ss::coroutine::as_future(await_inflight_uploads());
 
     if (_metadata_builder->is_empty()) {
         // There is no update to push.


### PR DESCRIPTION
This function is more dangerous than you would expect- it backgrounds futures which can lead to UAFs.

Remove its use and rely on the fact that `do_upload()` should resolve promptly at shutdown.


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
