### PR TITLE
ct: use topic id key in batch cache

### DIFF
--- a/src/v/cloud_topics/batch_cache/batch_cache.cc
+++ b/src/v/cloud_topics/batch_cache/batch_cache.cc
@@ -46,7 +46,8 @@ ss::future<> batch_cache::stop() {
     co_await _gate.close();
 }
 
-void batch_cache::put(const model::ntp& ntp, const model::record_batch& b) {
+void batch_cache::put(
+  const model::topic_id_partition& tidp, const model::record_batch& b) {
     vassert(
       b.term() > model::term_id{-1},
       "Batch without term in the cache: {}",
@@ -55,7 +56,7 @@ void batch_cache::put(const model::ntp& ntp, const model::record_batch& b) {
         return;
     }
     _gate.check();
-    auto it = _index.find(ntp);
+    auto it = _index.find(tidp);
     if (it == _index.end()) {
         auto cache_ix = _lm->create_cache(storage::with_cache::yes);
         if (!cache_ix.has_value()) {
@@ -63,7 +64,7 @@ void batch_cache::put(const model::ntp& ntp, const model::record_batch& b) {
         }
         auto [new_it, ok] = _index.insert(
           std::make_pair(
-            ntp,
+            tidp,
             std::make_unique<storage::batch_cache_index>(
               std::move(*cache_ix))));
         if (ok) {
@@ -77,12 +78,12 @@ void batch_cache::put(const model::ntp& ntp, const model::record_batch& b) {
 }
 
 std::optional<model::record_batch>
-batch_cache::get(const model::ntp& ntp, model::offset o) {
+batch_cache::get(const model::topic_id_partition& tidp, model::offset o) {
     if (_lm == nullptr) {
         return std::nullopt;
     }
     _gate.check();
-    if (auto it = _index.find(ntp); it != _index.end()) {
+    if (auto it = _index.find(tidp); it != _index.end()) {
         auto rb = it->second->get(o);
         if (rb.has_value()) {
             vassert(
@@ -92,7 +93,7 @@ batch_cache::get(const model::ntp& ntp, model::offset o) {
             vassert(
               rb->base_offset() <= o && o <= rb->last_offset(),
               "Unexpected batch for {}, got range: [{},{}] for offset {}",
-              ntp,
+              tidp,
               rb->base_offset(),
               rb->last_offset(),
               o);
@@ -119,7 +120,7 @@ ss::future<> batch_cache::cleanup_index_entries() {
             ++it;
         }
         if (ss::need_preempt() && it != _index.end()) {
-            model::ntp next = it->first;
+            model::topic_id_partition next = it->first;
             co_await ss::yield();
             it = _index.lower_bound(next);
         }

--- a/src/v/cloud_topics/batch_cache/batch_cache.h
+++ b/src/v/cloud_topics/batch_cache/batch_cache.h
@@ -57,10 +57,12 @@ public:
     // Put element into the batch cache. The element shouldn't be dirty.
     // The code that uses this class should only use this to cache committed
     // entries.
-    void put(const model::ntp&, const model::record_batch& b);
+    void
+    put(const model::topic_id_partition& tidp, const model::record_batch& b);
 
     // Fetch element from cache.
-    std::optional<model::record_batch> get(const model::ntp&, model::offset o);
+    std::optional<model::record_batch>
+    get(const model::topic_id_partition& tidp, model::offset o);
 
 private:
     // Remove dead index entries
@@ -71,7 +73,10 @@ private:
     // per segment). Here we only have one index per cloud storage partition.
     // From what I see it should be OK to use index this way. Likely even more
     // efficient compared to index per segment.
-    absl::btree_map<model::ntp, storage::batch_cache_index_ptr> _index;
+    // The index is keyed by topic_id_partition to prevent batch resurrection
+    // when topics are deleted and re-created with the same name.
+    absl::btree_map<model::topic_id_partition, storage::batch_cache_index_ptr>
+      _index;
     storage::log_manager* _lm;
     // Periodic cleanup of the index
     ss::timer<> _cleanup_timer;

--- a/src/v/cloud_topics/batch_cache/tests/batch_cache_test.cc
+++ b/src/v/cloud_topics/batch_cache/tests/batch_cache_test.cc
@@ -20,17 +20,19 @@
 
 namespace cloud_topics {
 struct batch_cache_accessor {
-    static void
-    evict_offset(batch_cache& c, const model::ntp& ntp, model::offset o) {
-        c._index[ntp]->testing_evict_from_cache(o);
+    static void evict_offset(
+      batch_cache& c, const model::topic_id_partition& tidp, model::offset o) {
+        c._index[tidp]->testing_evict_from_cache(o);
     }
-    static void reclaim(batch_cache& c, const model::ntp& ntp, size_t size) {
-        // it doesn't really matter what ntp is used, all the indices point to
+    static void reclaim(
+      batch_cache& c, const model::topic_id_partition& tidp, size_t size) {
+        // it doesn't really matter what tidp is used, all the indices point to
         // the same cache.
-        c._index[ntp]->testing_reclaim_from_cache(size);
+        c._index[tidp]->testing_reclaim_from_cache(size);
     }
-    static bool contains_ntp(const batch_cache& c, const model::ntp& ntp) {
-        return c._index.contains(ntp);
+    static bool
+    contains_tidp(const batch_cache& c, const model::topic_id_partition& tidp) {
+        return c._index.contains(tidp);
     }
 };
 
@@ -48,55 +50,59 @@ public:
 
     cloud_topics::batch_cache _cache;
 
-    bool contains_ntp(const model::ntp& ntp) {
-        return cloud_topics::batch_cache_accessor::contains_ntp(_cache, ntp);
+    bool contains_tidp(const model::topic_id_partition& tidp) {
+        return cloud_topics::batch_cache_accessor::contains_tidp(_cache, tidp);
     }
 
-    void evict_offset(const model::ntp& ntp, model::offset o) {
-        cloud_topics::batch_cache_accessor::evict_offset(_cache, ntp, o);
+    void evict_offset(const model::topic_id_partition& tidp, model::offset o) {
+        cloud_topics::batch_cache_accessor::evict_offset(_cache, tidp, o);
     }
 
-    void reclaim(const model::ntp& ntp, size_t size) {
-        cloud_topics::batch_cache_accessor::reclaim(_cache, ntp, size);
+    void reclaim(const model::topic_id_partition& tidp, size_t size) {
+        cloud_topics::batch_cache_accessor::reclaim(_cache, tidp, size);
     }
 };
 
 TEST_F(batch_cache_test_fixture, test_batch_cache_put_get) {
-    model::ntp test_ntp("ns", "topic", 0);
+    auto tidp = model::topic_id_partition{
+      model::topic_id::create(), model::partition_id(0)};
     auto batch = model::test::make_random_batch(model::offset(0), 10, false);
 
     // Put batch in cache
-    _cache.put(test_ntp, batch);
+    _cache.put(tidp, batch);
 
     // Get batch
-    auto retrieved = _cache.get(test_ntp, model::offset(0));
+    auto retrieved = _cache.get(tidp, model::offset(0));
     ASSERT_TRUE(retrieved.has_value());
     ASSERT_EQ(retrieved->base_offset(), batch.base_offset());
     ASSERT_EQ(retrieved->header().record_count, batch.header().record_count);
 }
 
 TEST_F(batch_cache_test_fixture, test_batch_cache_get_nonexistent) {
-    model::ntp test_ntp("ns", "topic", 0);
+    auto tidp = model::topic_id_partition{
+      model::topic_id::create(), model::partition_id(0)};
 
     // Try to get batch that doesn't exist
-    auto retrieved = _cache.get(test_ntp, model::offset(0));
+    auto retrieved = _cache.get(tidp, model::offset(0));
     ASSERT_TRUE(!retrieved.has_value());
 }
 
-TEST_F(batch_cache_test_fixture, test_batch_cache_multiple_ntps) {
-    model::ntp ntp1("ns1", "topic1", 0);
-    model::ntp ntp2("ns2", "topic2", 1);
+TEST_F(batch_cache_test_fixture, test_batch_cache_multiple_tidps) {
+    auto tidp1 = model::topic_id_partition{
+      model::topic_id::create(), model::partition_id(0)};
+    auto tidp2 = model::topic_id_partition{
+      model::topic_id::create(), model::partition_id(1)};
 
     auto batch1 = model::test::make_random_batch(model::offset(0), 5, false);
     auto batch2 = model::test::make_random_batch(model::offset(10), 8, false);
 
     // Put batches in cache
-    _cache.put(ntp1, batch1);
-    _cache.put(ntp2, batch2);
+    _cache.put(tidp1, batch1);
+    _cache.put(tidp2, batch2);
 
     // Get batches
-    auto retrieved1 = _cache.get(ntp1, model::offset(0));
-    auto retrieved2 = _cache.get(ntp2, model::offset(10));
+    auto retrieved1 = _cache.get(tidp1, model::offset(0));
+    auto retrieved2 = _cache.get(tidp2, model::offset(10));
 
     ASSERT_TRUE(retrieved1.has_value());
     ASSERT_TRUE(retrieved2.has_value());
@@ -105,32 +111,69 @@ TEST_F(batch_cache_test_fixture, test_batch_cache_multiple_ntps) {
     ASSERT_EQ(retrieved2->base_offset(), batch2.base_offset());
 
     // Try to get batch with wrong offset
-    auto retrieved = _cache.get(ntp2, model::offset(0));
+    auto retrieved = _cache.get(tidp2, model::offset(0));
     ASSERT_TRUE(!retrieved.has_value());
 }
 
 TEST_F(batch_cache_test_fixture, test_batch_cache_eviction) {
-    model::ntp test_ntp("ns", "topic", 0);
+    auto tidp = model::topic_id_partition{
+      model::topic_id::create(), model::partition_id(0)};
     auto batch = model::test::make_random_batch(model::offset(42), 10, false);
 
     // The cleanup will start in 100ms
     _cache.start().get();
 
     // Put batch in cache
-    _cache.put(test_ntp, batch);
-    auto retrieved = _cache.get(test_ntp, model::offset(42));
+    _cache.put(tidp, batch);
+    auto retrieved = _cache.get(tidp, model::offset(42));
     ASSERT_TRUE(retrieved.has_value());
 
-    ASSERT_TRUE(contains_ntp(test_ntp));
+    ASSERT_TRUE(contains_tidp(tidp));
 
-    reclaim(test_ntp, 1);
+    reclaim(tidp, 1);
 
-    ASSERT_TRUE(contains_ntp(test_ntp));
+    ASSERT_TRUE(contains_tidp(tidp));
 
-    // This should evict the NTP
+    // This should evict the topic_id_partition
     ss::sleep(cache_check_interval * 2).get();
 
-    ASSERT_FALSE(contains_ntp(test_ntp));
+    ASSERT_FALSE(contains_tidp(tidp));
 
     _cache.stop().get();
+}
+
+TEST_F(batch_cache_test_fixture, test_batch_cache_topic_recreation) {
+    // Test that recreating a topic with the same name doesn't resurrect batches
+    auto topic_id_1 = model::topic_id::create();
+    auto topic_id_2 = model::topic_id::create();
+    auto tidp1 = model::topic_id_partition{topic_id_1, model::partition_id(0)};
+    auto tidp2 = model::topic_id_partition{topic_id_2, model::partition_id(0)};
+
+    auto batch1 = model::test::make_random_batch(model::offset(0), 5, false);
+    auto batch2 = model::test::make_random_batch(model::offset(0), 8, false);
+
+    // Put batch for first topic
+    _cache.put(tidp1, batch1);
+
+    // Verify we can get it back
+    auto retrieved1 = _cache.get(tidp1, model::offset(0));
+    ASSERT_TRUE(retrieved1.has_value());
+    ASSERT_EQ(retrieved1->base_offset(), batch1.base_offset());
+
+    // Put batch for second topic (simulating topic recreation)
+    _cache.put(tidp2, batch2);
+
+    // Verify we get the correct batch for each topic
+    auto retrieved1_again = _cache.get(tidp1, model::offset(0));
+    auto retrieved2 = _cache.get(tidp2, model::offset(0));
+
+    ASSERT_TRUE(retrieved1_again.has_value());
+    ASSERT_TRUE(retrieved2.has_value());
+
+    // The batches should be different
+    ASSERT_EQ(retrieved1_again->base_offset(), batch1.base_offset());
+    ASSERT_EQ(retrieved2->base_offset(), batch2.base_offset());
+    ASSERT_NE(
+      retrieved1_again->header().record_count,
+      retrieved2->header().record_count);
 }

--- a/src/v/cloud_topics/data_plane_api.h
+++ b/src/v/cloud_topics/data_plane_api.h
@@ -87,11 +87,13 @@ public:
     virtual size_t materialize_max_bytes() const = 0;
 
     /// Cache materialized record batch
-    virtual void cache_put(const model::ntp&, const model::record_batch& b) = 0;
+    virtual void
+    cache_put(const model::topic_id_partition&, const model::record_batch& b)
+      = 0;
 
     /// Retrieve materialized record batch from cache
     virtual std::optional<model::record_batch>
-    cache_get(const model::ntp&, model::offset o) = 0;
+    cache_get(const model::topic_id_partition&, model::offset o) = 0;
 };
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/data_plane_impl.cc
+++ b/src/v/cloud_topics/data_plane_impl.cc
@@ -192,13 +192,15 @@ public:
         co_return std::move(res.value().results);
     }
 
-    void cache_put(const model::ntp& ntp, const model::record_batch& b) final {
-        _batch_cache.local().put(ntp, b);
+    void cache_put(
+      const model::topic_id_partition& tidp,
+      const model::record_batch& b) final {
+        _batch_cache.local().put(tidp, b);
     }
 
     std::optional<model::record_batch>
-    cache_get(const model::ntp& ntp, model::offset o) final {
-        return _batch_cache.local().get(ntp, o);
+    cache_get(const model::topic_id_partition& tidp, model::offset o) final {
+        return _batch_cache.local().get(tidp, o);
     }
 
     size_t materialize_max_bytes() const final {

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -169,6 +169,20 @@ get_aborted_transactions_local(
     co_return target;
 }
 
+model::topic_id_partition
+get_topic_id_partition(const ss::lw_shared_ptr<cluster::partition>& partition) {
+    const auto& ntp = partition->ntp();
+    auto ct_state = partition->get_cloud_topics_state();
+    auto metadata_cache = ct_state->local().get_metadata_cache();
+    auto topic_cfg = metadata_cache->get_topic_cfg(
+      model::topic_namespace_view(ntp));
+    if (!topic_cfg || !topic_cfg->tp_id) {
+        throw std::runtime_error(
+          fmt::format("no topic ID found for cloud topic {}", ntp));
+    }
+    return model::topic_id_partition{*topic_cfg->tp_id, ntp.tp.partition};
+}
+
 } // namespace
 
 frontend::frontend(
@@ -317,16 +331,8 @@ bool frontend::cache_enabled() const {
     return true;
 }
 
-std::optional<model::topic_id_partition>
-frontend::ntp_to_topic_id_partition(const model::ntp& ntp) const {
-    auto ct_state = _partition->get_cloud_topics_state();
-    auto metadata_cache = ct_state->local().get_metadata_cache();
-    auto topic_cfg = metadata_cache->get_topic_cfg(
-      model::topic_namespace_view(ntp));
-    if (!topic_cfg || !topic_cfg->tp_id) {
-        return std::nullopt;
-    }
-    return model::topic_id_partition{*topic_cfg->tp_id, ntp.tp.partition};
+model::topic_id_partition frontend::topic_id_partition() const {
+    return get_topic_id_partition(_partition);
 }
 
 std::unique_ptr<model::record_batch_reader::impl>
@@ -341,12 +347,10 @@ frontend::make_l1_reader(const cloud_topic_log_reader_config& cfg) const {
     auto l1_metastore = ct_state->local().get_l1_metastore();
     auto l1_io = ct_state->local().get_l1_io();
 
-    auto tidp = ntp_to_topic_id_partition(_partition->ntp());
-    vassert(
-      tidp.has_value(), "No topic id for cloud topic {}", _partition->ntp());
+    auto tidp = topic_id_partition();
 
     return std::make_unique<level_one_log_reader_impl>(
-      cfg, _partition->ntp(), *tidp, l1_metastore, l1_io);
+      cfg, _partition->ntp(), tidp, l1_metastore, l1_io);
 }
 
 ss::future<std::optional<storage::timequery_result>>
@@ -383,12 +387,7 @@ ss::future<std::optional<frontend::coarse_grained_timequery_result>>
 frontend::l1_timequery(storage::timequery_config cfg) {
     auto ct_state = _partition->get_cloud_topics_state();
     auto l1_metastore = ct_state->local().get_l1_metastore();
-    auto maybe_tidp = ntp_to_topic_id_partition(_partition->ntp());
-    vassert(
-      maybe_tidp.has_value(),
-      "No topic id for cloud topic {}",
-      _partition->ntp());
-    const auto& tidp = *maybe_tidp;
+    auto tidp = topic_id_partition();
     // I don't love this, but we clamp min/max offsets by the kafka start offset
     // and the LSO/HWM, but we can ignore the max offset for L1 because we never
     // upload anything less than LSO to L1.
@@ -527,6 +526,7 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
   chunked_vector<model::record_batch> cache_batches,
   raft::replicate_options opts) {
     const auto& ntp = partition->ntp();
+    auto tidp = get_topic_id_partition(partition);
     // The default errc that will cause the client to retry the operation
     constexpr auto default_errc = raft::errc::timeout;
     /*
@@ -664,7 +664,7 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
                   "Putting batch to cache: {}, term: {}",
                   b.base_offset(),
                   b.term());
-                api->cache_put(ntp, b);
+                api->cache_put(tidp, b);
             }
         } else {
             vlog(
@@ -767,6 +767,7 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
     auto ret_offset = model::offset(result.value().last_offset());
     if (!rb_copy.empty()) {
         update_batches(rb_copy, ret_offset, result.value().last_term);
+        auto tidp = topic_id_partition();
         for (const auto& b : rb_copy) {
             vlog(
               cd_log.trace,
@@ -774,7 +775,7 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
               ntp(),
               b.base_offset(),
               b.term());
-            _data_plane->cache_put(ntp(), b);
+            _data_plane->cache_put(tidp, b);
         }
     }
     co_return ret_offset;
@@ -850,10 +851,8 @@ frontend::get_leader_epoch_last_offset(model::term_id term) const {
     // The term falls below the start of the local log -- lookup in L1.
     auto ct_state = _partition->get_cloud_topics_state();
     auto l1_metastore = ct_state->local().get_l1_metastore();
-    auto tidp = ntp_to_topic_id_partition(_partition->ntp());
-    vassert(
-      tidp.has_value(), "No topic id for cloud topic {}", _partition->ntp());
-    auto l1_res = co_await l1_metastore->get_end_offset_for_term(*tidp, term);
+    auto tidp = topic_id_partition();
+    auto l1_res = co_await l1_metastore->get_end_offset_for_term(tidp, term);
     if (!l1_res.has_value()) {
         switch (l1_res.error()) {
         case l1::metastore::errc::out_of_range:

--- a/src/v/cloud_topics/frontend/frontend.h
+++ b/src/v/cloud_topics/frontend/frontend.h
@@ -185,8 +185,7 @@ private:
 
     bool cache_enabled() const;
 
-    std::optional<model::topic_id_partition>
-    ntp_to_topic_id_partition(const model::ntp& ntp) const;
+    model::topic_id_partition topic_id_partition() const;
 
     std::unique_ptr<model::record_batch_reader::impl>
     make_l0_reader(const cloud_topic_log_reader_config& cfg) const;

--- a/src/v/cloud_topics/frontend/tests/frontend_test.cc
+++ b/src/v/cloud_topics/frontend/tests/frontend_test.cc
@@ -69,13 +69,13 @@ public:
     MOCK_METHOD(
       void,
       cache_put,
-      (const model::ntp&, const model::record_batch&),
+      (const model::topic_id_partition&, const model::record_batch&),
       (override));
 
     MOCK_METHOD(
       std::optional<model::record_batch>,
       cache_get,
-      (const model::ntp&, model::offset o),
+      (const model::topic_id_partition&, model::offset o),
       (override));
 
     MOCK_METHOD(size_t, materialize_max_bytes, (), (const, override));

--- a/src/v/cloud_topics/level_zero/frontend_reader/BUILD
+++ b/src/v/cloud_topics/level_zero/frontend_reader/BUILD
@@ -17,6 +17,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics:data_plane_api",
         "//src/v/cloud_topics:log_reader_config",
         "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics:state_accessors",
         "//src/v/cloud_topics:types",
         "//src/v/cloud_topics/level_zero/stm:placeholder",
         "//src/v/cluster",

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -13,6 +13,8 @@
 #include "cloud_topics/errc.h"
 #include "cloud_topics/level_zero/stm/placeholder.h"
 #include "cloud_topics/logger.h"
+#include "cloud_topics/state_accessors.h"
+#include "cluster/metadata_cache.h"
 #include "cluster/partition.h"
 #include "config/configuration.h"
 #include "model/timeout_clock.h"
@@ -26,6 +28,24 @@
 #include <variant>
 
 namespace cloud_topics {
+namespace {
+
+model::topic_id_partition
+get_topic_id_partition(const ss::lw_shared_ptr<cluster::partition>& partition) {
+    const auto& ntp = partition->ntp();
+    auto ct_state = partition->get_cloud_topics_state();
+    auto metadata_cache = ct_state->local().get_metadata_cache();
+    auto topic_cfg = metadata_cache->get_topic_cfg(
+      model::topic_namespace_view(ntp));
+    if (!topic_cfg) {
+        throw std::runtime_error(
+          fmt::format("no config found for cloud topic {}", ntp));
+    }
+    return model::topic_id_partition{
+      topic_cfg->tp_id.value(), ntp.tp.partition};
+}
+
+} // namespace
 
 level_zero_log_reader_impl::level_zero_log_reader_impl(
   const cloud_topic_log_reader_config& cfg,
@@ -129,13 +149,14 @@ level_zero_log_reader_impl::maybe_read_batches_from_cache() {
         return ret;
     }
 
+    auto tidp = get_topic_id_partition(_ctp);
+
     /*
      * Fetch batches from the cache starting at `_next_offset` until we hit a
      * gap or a control batch and must then fetch the data from object storage.
      */
     while (_next_offset <= _config.max_offset) {
-        auto batch = _ct_api->cache_get(
-          _ctp->ntp(), kafka::offset_cast(_next_offset));
+        auto batch = _ct_api->cache_get(tidp, kafka::offset_cast(_next_offset));
         if (!batch.has_value()) {
             break;
         }
@@ -251,6 +272,7 @@ ss::future<chunked_circular_buffer<model::record_batch>>
 level_zero_log_reader_impl::materialize_batches(
   chunked_circular_buffer<local_log_batch> unhydrated,
   model::timeout_clock::time_point deadline) {
+    auto tidp = get_topic_id_partition(_ctp);
     // Cherry-pick enough L0 meta batches to materialize.
     chunked_vector<cloud_topics::extent_meta> to_materialize;
     auto unhydrated_it = unhydrated.begin();
@@ -341,7 +363,7 @@ level_zero_log_reader_impl::materialize_batches(
         auto& local_batch_header = local_batch.header;
         model::record_batch batch = ss::visit(
           local_batch.data,
-          [this, &local_batch_header, &batches_it](
+          [this, &local_batch_header, &batches_it, &tidp](
             const cloud_topics::extent_meta&) {
               model::record_batch batch = apply_placeholder_to_batch(
                 local_batch_header, std::move(*batches_it));
@@ -354,7 +376,7 @@ level_zero_log_reader_impl::materialize_batches(
                     _ctp->ntp(),
                     batch.base_offset(),
                     batch.term());
-                  _ct_api->cache_put(_ctp->ntp(), batch);
+                  _ct_api->cache_put(tidp, batch);
               }
               return batch;
           },


### PR DESCRIPTION
This prevents resurrection of old batches for re-created topic

FIXES: CORE-15339

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
