### PR TITLE
CORE-14656: dt: unflake sl metrics test

### DIFF
--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -3408,12 +3408,11 @@ class ShadowLinkingMetricsTests(ShadowLinkPreAllocTestBase):
             msg_cnt=5000000,
             use_transactions=True,
             producer_properties={
-                "msgs_per_transaction": "10000",
-                "transaction_abort_rate": "0.3",
+                "msgs_per_transaction": "100000",
             },
         ):
             validate_metrics(
-                timeout_sec=30,
+                timeout_sec=120,
                 metric_validators=[
                     (self.SHADOW_LAG, check_shadow_lag_positive),
                 ],


### PR DESCRIPTION
Fixes: [CORE-14656](https://redpandadata.atlassian.net/browse/CORE-14656)

When testing for positive shadowlag, on local testing, the full 5M messages takes about 2 minutes (in debug mode). Increase timeout to roughly match that.

Also, between metric-check ticks, there seems to be ~50k processed messages. In the current 10k messages-per-transaction, it is pretty easy to not encouter any possitive value for shadow lag. Messages-per-transaction is increased to a much bigger number (x2) to ensure a positive lag metric value.

Also the `transaction_abort_rate` has been removed because it was causing flakiness in the `verify`. This will be explored separately to understand if there is an underlying issue there.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-14656]: https://redpandadata.atlassian.net/browse/CORE-14656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ