### PR TITLE
[v25.3.x] bazel: Update seastar to latest

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -250,7 +250,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "gQeuBJYqdshCs4zY1sdwBrGRIG43zsK+zQGlcdzNggQ=",
+        "bzlTransitiveDigest": "vNcSSlZD2+P+cGLkIeJrTHWuNQPYHsA973J3jZA87JY=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -430,9 +430,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "73fecd1f4d73ed72e8048de07636652dd15a6970acfacf72a95cc3819398362a",
-              "strip_prefix": "seastar-81284fb0f209380b0c537e98ec9cb8ef5a4ebfa2",
-              "url": "https://github.com/redpanda-data/seastar/archive/81284fb0f209380b0c537e98ec9cb8ef5a4ebfa2.tar.gz"
+              "sha256": "1ef450a3fddb9c06c87dfbec7b431a8abd7f545cb94964f12c822568992e750c",
+              "strip_prefix": "seastar-bb19ecd39a1f97bc777cc075be9d9026feedd63e",
+              "url": "https://github.com/redpanda-data/seastar/archive/bb19ecd39a1f97bc777cc075be9d9026feedd63e.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -170,9 +170,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "73fecd1f4d73ed72e8048de07636652dd15a6970acfacf72a95cc3819398362a",
-        strip_prefix = "seastar-81284fb0f209380b0c537e98ec9cb8ef5a4ebfa2",
-        url = "https://github.com/redpanda-data/seastar/archive/81284fb0f209380b0c537e98ec9cb8ef5a4ebfa2.tar.gz",
+        sha256 = "1ef450a3fddb9c06c87dfbec7b431a8abd7f545cb94964f12c822568992e750c",
+        strip_prefix = "seastar-bb19ecd39a1f97bc777cc075be9d9026feedd63e",
+        url = "https://github.com/redpanda-data/seastar/archive/bb19ecd39a1f97bc777cc075be9d9026feedd63e.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Pull in epoll fixes.   

x
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


* none

