### PR TITLE
CORE-15187 SR Context: make mode and config handlers context-aware

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -6,6 +6,7 @@
         "parameters": [
           {
             "name": "subject",
+            "description": "The subject to get the config for. Use [:.<context>:]<subject> for context-qualified subjects, or just <subject> for the default context. Use :.<context>: for context-level config.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -48,6 +49,7 @@
         "parameters": [
           {
             "name": "subject",
+            "description": "The subject to set the config for. Use [:.<context>:]<subject> for context-qualified subjects, or just <subject> for the default context. Use :.<context>: for context-level config.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -86,6 +88,7 @@
         "parameters": [
           {
             "name": "subject",
+            "description": "The subject to delete the config for. Use [:.<context>:]<subject> for context-qualified subjects, or just <subject> for the default context. Use :.<context>: for context-level config.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -264,7 +267,7 @@
         "parameters": [
           {
             "name": "subject",
-            "description": "The subject to get the mode for.",
+            "description": "The subject to get the mode for. Use [:.<context>:]<subject> for context-qualified subjects, or just <subject> for the default context. Use :.<context>: for context-level mode.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -314,7 +317,7 @@
         "parameters": [
           {
             "name": "subject",
-            "description": "The subject to set the mode for.",
+            "description": "The subject to set the mode for. Use [:.<context>:]<subject> for context-qualified subjects, or just <subject> for the default context. Use :.<context>: for context-level mode.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -372,7 +375,7 @@
         "parameters": [
           {
             "name": "subject",
-            "description": "The subject to delete the mode for.",
+            "description": "The subject to delete the mode for. Use [:.<context>:]<subject> for context-qualified subjects, or just <subject> for the default context. Use :.<context>: for context-level mode.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -638,7 +641,7 @@
         "parameters": [
           {
             "name": "subject",
-            "description": "The subject name. Supports context-qualified subjects with the format `[:.<context>:]<subject>`.",
+            "description": "The subject name. Use [:.<context>:]<subject> for context-qualified subjects, or just <subject> for the default context.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -720,7 +723,7 @@
         "parameters": [
           {
             "name": "subject",
-            "description": "The subject name. Supports context-qualified subjects with the format `[:.<context>:]<subject>`.",
+            "description": "The subject name. Use [:.<context>:]<subject> for context-qualified subjects, or just <subject> for the default context.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -769,7 +772,7 @@
         "parameters": [
           {
             "name": "subject",
-            "description": "The subject name. Supports context-qualified subjects with the format `[:.<context>:]<subject>`.",
+            "description": "The subject name. Use [:.<context>:]<subject> for context-qualified subjects, or just <subject> for the default context.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -818,7 +821,7 @@
         "parameters": [
           {
             "name": "subject",
-            "description": "The subject name. Supports context-qualified subjects with the format `[:.<context>:]<subject>`.",
+            "description": "The subject name. Use [:.<context>:]<subject> for context-qualified subjects, or just <subject> for the default context.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -877,7 +880,7 @@
         "parameters": [
           {
             "name": "subject",
-            "description": "The subject name. Supports context-qualified subjects with the format `[:.<context>:]<subject>`.",
+            "description": "The subject name. Use [:.<context>:]<subject> for context-qualified subjects, or just <subject> for the default context.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -947,7 +950,7 @@
         "parameters": [
           {
             "name": "subject",
-            "description": "The subject name. Supports context-qualified subjects with the format `[:.<context>:]<subject>`.",
+            "description": "The subject name. Use [:.<context>:]<subject> for context-qualified subjects, or just <subject> for the default context.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -1007,7 +1010,7 @@
         "parameters": [
           {
             "name": "subject",
-            "description": "The subject name. Supports context-qualified subjects with the format `[:.<context>:]<subject>`.",
+            "description": "The subject name. Use [:.<context>:]<subject> for context-qualified subjects, or just <subject> for the default context.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -1079,7 +1082,7 @@
         "parameters": [
           {
             "name": "subject",
-            "description": "The subject name. Supports context-qualified subjects with the format `[:.<context>:]<subject>`.",
+            "description": "The subject name. Use [:.<context>:]<subject> for context-qualified subjects, or just <subject> for the default context.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -1136,7 +1139,7 @@
         "parameters": [
           {
             "name": "subject",
-            "description": "The subject name. Supports context-qualified subjects with the format `[:.<context>:]<subject>`.",
+            "description": "The subject name. Use [:.<context>:]<subject> for context-qualified subjects, or just <subject> for the default context.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -1197,7 +1200,7 @@
         "parameters": [
           {
             "name": "subject",
-            "description": "The subject name. Supports context-qualified subjects with the format `[:.<context>:]<subject>`.",
+            "description": "The subject name. Use [:.<context>:]<subject> for context-qualified subjects, or just <subject> for the default context.",
             "in": "path",
             "required": true,
             "type": "string"

--- a/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
@@ -19,7 +19,7 @@
         },
         "subject": {
           "type": "string",
-          "description": "The subject name of the referenced schema. Supports context-qualified subjects with the format `[:.<context>:]<subject>`."
+          "description": "The subject name of the referenced schema. Use [:.<context>:]<subject> for context-qualified subjects, or just <subject> for the default context."
         },
         "version": {
           "type": "integer",

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -186,7 +186,8 @@ put_config(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
     auto config = co_await rjson_parse(*rq.req, put_config_handler<>{});
 
-    co_await rq.service().writer().write_config(std::nullopt, config.compat);
+    auto ctx_sub = context_subject{default_context, subject{""}};
+    co_await rq.service().writer().write_config(ctx_sub, config.compat);
 
     auto resp = ppj::rjson_serialize_iobuf(config);
     log_response(*rq.req, resp);
@@ -197,7 +198,8 @@ put_config(server::request_t rq, server::reply_t rp) {
 ss::future<server::reply_t>
 get_config_subject(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
-    auto sub = parse::request_param<subject>(*rq.req, "subject");
+    auto ctx_sub = context_subject::from_string(
+      parse::request_param<ss::sstring>(*rq.req, "subject"));
     auto fallback = parse::query_param<std::optional<default_to_global>>(
                       *rq.req, "defaultToGlobal")
                       .value_or(default_to_global::no);
@@ -205,8 +207,14 @@ get_config_subject(server::request_t rq, server::reply_t rp) {
     // Ensure we see latest writes
     co_await rq.service().writer().read_sync();
 
-    auto res = co_await rq.service().schema_store().get_compatibility(
-      sub, fallback);
+    compatibility_level res;
+    if (ctx_sub.is_context_only()) {
+        res = co_await rq.service().schema_store().get_compatibility(
+          ctx_sub.ctx);
+    } else {
+        res = co_await rq.service().schema_store().get_compatibility(
+          ctx_sub, fallback);
+    }
 
     auto resp = ppj::rjson_serialize_iobuf(get_config_req_rep{.compat = res});
     log_response(*rq.req, resp);
@@ -249,12 +257,13 @@ ss::future<server::reply_t>
 put_config_subject(server::request_t rq, server::reply_t rp) {
     parse_content_type_header(rq);
     parse_accept_header(rq, rp);
-    auto sub = parse::request_param<subject>(*rq.req, "subject");
+    auto ctx_sub = context_subject::from_string(
+      parse::request_param<ss::sstring>(*rq.req, "subject"));
     auto config = co_await rjson_parse(*rq.req, put_config_handler<>{});
 
     // Ensure we see latest writes
     co_await rq.service().writer().read_sync();
-    co_await rq.service().writer().write_config(sub, config.compat);
+    co_await rq.service().writer().write_config(ctx_sub, config.compat);
 
     auto resp = ppj::rjson_serialize_iobuf(std::move(config));
     log_response(*rq.req, resp);
@@ -265,25 +274,33 @@ put_config_subject(server::request_t rq, server::reply_t rp) {
 ss::future<server::reply_t>
 delete_config_subject(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
-    auto sub = parse::request_param<subject>(*rq.req, "subject");
+    auto ctx_sub = context_subject::from_string(
+      parse::request_param<ss::sstring>(*rq.req, "subject"));
 
     // ensure we see latest writes
     co_await rq.service().writer().read_sync();
-    co_await rq.service().writer().check_mutable(default_context, sub);
+    auto sub_opt = ctx_sub.is_context_only() ? std::nullopt
+                                             : std::make_optional(ctx_sub.sub);
+    co_await rq.service().writer().check_mutable(ctx_sub.ctx, sub_opt);
 
     compatibility_level lvl{};
     try {
-        lvl = co_await rq.service().schema_store().get_compatibility(
-          sub, default_to_global::no);
+        if (ctx_sub.is_context_only()) {
+            lvl = co_await rq.service().schema_store().get_compatibility(
+              ctx_sub.ctx);
+        } else {
+            lvl = co_await rq.service().schema_store().get_compatibility(
+              ctx_sub, default_to_global::no);
+        }
     } catch (const exception& e) {
         if (e.code() == error_code::compatibility_not_found) {
-            throw as_exception(not_found(sub));
+            throw as_exception(not_found(ctx_sub));
         } else {
             throw;
         }
     }
 
-    co_await rq.service().writer().delete_config(sub);
+    co_await rq.service().writer().delete_config(ctx_sub);
 
     auto resp = ppj::rjson_serialize_iobuf(get_config_req_rep{.compat = lvl});
     log_response(*rq.req, resp);
@@ -314,7 +331,8 @@ ss::future<server::reply_t> put_mode(server::request_t rq, server::reply_t rp) {
 
     // Ensure we are up to date (eg. see all existing subjects for import mode)
     co_await rq.service().writer().read_sync();
-    co_await rq.service().writer().write_mode(std::nullopt, res.mode, frc);
+    auto ctx_sub = context_subject{default_context, subject{""}};
+    co_await rq.service().writer().write_mode(ctx_sub, res.mode, frc);
 
     auto resp = ppj::rjson_serialize_iobuf(res);
     log_response(*rq.req, resp);
@@ -325,7 +343,8 @@ ss::future<server::reply_t> put_mode(server::request_t rq, server::reply_t rp) {
 ss::future<server::reply_t>
 get_mode_subject(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
-    auto sub = parse::request_param<subject>(*rq.req, "subject");
+    auto ctx_sub = context_subject::from_string(
+      parse::request_param<ss::sstring>(*rq.req, "subject"));
     auto fallback = parse::query_param<std::optional<default_to_global>>(
                       *rq.req, "defaultToGlobal")
                       .value_or(default_to_global::no);
@@ -333,7 +352,12 @@ get_mode_subject(server::request_t rq, server::reply_t rp) {
     // Ensure we see latest writes
     co_await rq.service().writer().read_sync();
 
-    auto res = co_await rq.service().schema_store().get_mode(sub, fallback);
+    mode res;
+    if (ctx_sub.is_context_only()) {
+        res = co_await rq.service().schema_store().get_mode(ctx_sub.ctx);
+    } else {
+        res = co_await rq.service().schema_store().get_mode(ctx_sub, fallback);
+    }
 
     auto resp = ppj::rjson_serialize_iobuf(mode_req_rep{.mode = res});
     log_response(*rq.req, resp);
@@ -347,12 +371,13 @@ put_mode_subject(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
     auto frc = parse::query_param<std::optional<force>>(*rq.req, "force")
                  .value_or(force::no);
-    auto sub = parse::request_param<subject>(*rq.req, "subject");
+    auto ctx_sub = context_subject::from_string(
+      parse::request_param<ss::sstring>(*rq.req, "subject"));
     auto res = co_await rjson_parse(*rq.req, mode_handler<>{});
 
     // Ensure we see latest writes
     co_await rq.service().writer().read_sync();
-    co_await rq.service().writer().write_mode(sub, res.mode, frc);
+    co_await rq.service().writer().write_mode(ctx_sub, res.mode, frc);
 
     auto resp = ppj::rjson_serialize_iobuf(res);
     log_response(*rq.req, resp);
@@ -363,24 +388,29 @@ put_mode_subject(server::request_t rq, server::reply_t rp) {
 ss::future<server::reply_t>
 delete_mode_subject(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
-    auto sub = parse::request_param<subject>(*rq.req, "subject");
+    auto ctx_sub = context_subject::from_string(
+      parse::request_param<ss::sstring>(*rq.req, "subject"));
 
     // ensure we see latest writes
     co_await rq.service().writer().read_sync();
 
     mode m{};
     try {
-        m = co_await rq.service().schema_store().get_mode(
-          sub, default_to_global::no);
+        if (ctx_sub.is_context_only()) {
+            m = co_await rq.service().schema_store().get_mode(ctx_sub.ctx);
+        } else {
+            m = co_await rq.service().schema_store().get_mode(
+              ctx_sub, default_to_global::no);
+        }
     } catch (const exception& e) {
         if (e.code() == error_code::mode_not_found) {
             // Upstream compatibility: return 40401 instead of 40409
-            throw as_exception(not_found(sub));
+            throw as_exception(not_found(ctx_sub));
         }
         throw;
     }
 
-    co_await rq.service().writer().delete_mode(sub);
+    co_await rq.service().writer().delete_mode(ctx_sub);
 
     auto resp = ppj::rjson_serialize_iobuf(mode_req_rep{.mode = m});
     log_response(*rq.req, resp);

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -81,13 +81,11 @@ struct batch_builder : public storage::record_batch_builder {
             add_raw_kv(to_json_iobuf(std::move(key)), std::nullopt);
         } break;
         case seq_marker_key_type::config: {
-            // TODO: use the full context_subject once it is stored
-            auto key = config_key{.seq{s.seq}, .node{s.node}, .sub{sub.sub}};
+            auto key = config_key{.seq{s.seq}, .node{s.node}, .sub{sub}};
             add_raw_kv(to_json_iobuf(std::move(key)), std::nullopt);
         } break;
         case seq_marker_key_type::mode: {
-            // TODO: use the full context_subject once it is stored
-            auto key = mode_key{.seq{s.seq}, .node{s.node}, .sub{sub.sub}};
+            auto key = mode_key{.seq{s.seq}, .node{s.node}, .sub{sub}};
             add_raw_kv(to_json_iobuf(std::move(key)), std::nullopt);
         } break;
         case seq_marker_key_type::invalid:
@@ -292,9 +290,7 @@ seq_writer::write_subject_version(stored_schema schema) {
 }
 
 ss::future<std::optional<bool>> seq_writer::do_write_config(
-  std::optional<subject> sub,
-  compatibility_level compat,
-  model::offset write_at) {
+  context_subject sub, compatibility_level compat, model::offset write_at) {
     vlog(
       srlog.debug,
       "write_config sub={} compat={} offset={}",
@@ -302,16 +298,18 @@ ss::future<std::optional<bool>> seq_writer::do_write_config(
       to_string_view(compat),
       write_at);
 
-    co_await check_mutable(default_context, sub);
+    auto sub_opt = sub.is_context_only() ? std::nullopt
+                                         : std::make_optional(sub.sub);
+    co_await check_mutable(sub.ctx, sub_opt);
 
     try {
         // Check for no-op case
         compatibility_level existing;
-        if (sub.has_value()) {
+        if (!sub.is_context_only()) {
             existing = co_await _store.get_compatibility(
-              sub.value(), default_to_global::no);
+              sub, default_to_global::no);
         } else {
-            existing = co_await _store.get_compatibility(default_context);
+            existing = co_await _store.get_compatibility(sub.ctx);
         }
         if (existing == compat) {
             co_return false;
@@ -321,10 +319,11 @@ ss::future<std::optional<bool>> seq_writer::do_write_config(
     }
 
     batch_builder rb(write_at);
+    auto sub_key = sub.is_default_context() ? std::optional<context_subject>{}
+                                            : std::make_optional(sub);
     rb(
-      config_key{.seq{write_at}, .node{_node_id}, .sub{sub}},
-      config_value{.compat = compat});
-
+      config_key{.seq{write_at}, .node{_node_id}, .sub{sub_key}},
+      config_value{.compat = compat, .sub{sub_key}});
     if (co_await produce_and_apply(write_at, std::move(rb).build())) {
         co_return true;
     } else {
@@ -333,28 +332,42 @@ ss::future<std::optional<bool>> seq_writer::do_write_config(
     }
 }
 
-ss::future<bool> seq_writer::write_config(
-  std::optional<subject> sub, compatibility_level compat) {
-    return sequenced_write(
-      [sub{std::move(sub)}, compat](model::offset write_at, seq_writer& seq) {
-          return seq.do_write_config(sub, compat, write_at);
-      });
+ss::future<bool>
+seq_writer::write_config(context_subject ctx_sub, compatibility_level compat) {
+    return sequenced_write([ctx_sub{std::move(ctx_sub)},
+                            compat](model::offset write_at, seq_writer& seq) {
+        return seq.do_write_config(ctx_sub, compat, write_at);
+    });
 }
 
-ss::future<std::optional<bool>> seq_writer::do_delete_config(subject sub) {
-    vlog(srlog.debug, "delete config sub={}", sub);
+ss::future<std::optional<bool>>
+seq_writer::do_delete_config(context_subject ctx_sub) {
+    vlog(srlog.debug, "delete config sub={}", ctx_sub);
 
-    co_await check_mutable(default_context, sub);
+    auto sub_opt = ctx_sub.is_context_only() ? std::nullopt
+                                             : std::make_optional(ctx_sub.sub);
+    co_await check_mutable(ctx_sub.ctx, sub_opt);
 
     try {
-        co_await _store.get_compatibility(sub, default_to_global::no);
+        if (ctx_sub.is_context_only()) {
+            co_await _store.get_compatibility(ctx_sub.ctx);
+        } else {
+            co_await _store.get_compatibility(ctx_sub, default_to_global::no);
+        }
+
     } catch (const exception&) {
         // subject config already blank
         co_return false;
     }
 
     batch_builder rb{model::offset{0}};
-    rb.add_tombstones(sub, co_await _store.get_subject_config_written_at(sub));
+    if (ctx_sub.is_context_only()) {
+        rb.add_tombstones(
+          ctx_sub, co_await _store.get_context_config_written_at(ctx_sub.ctx));
+    } else {
+        rb.add_tombstones(
+          ctx_sub, co_await _store.get_subject_config_written_at(ctx_sub));
+    }
 
     if (co_await produce_and_apply(std::nullopt, std::move(rb).build())) {
         co_return true;
@@ -364,19 +377,19 @@ ss::future<std::optional<bool>> seq_writer::do_delete_config(subject sub) {
     }
 }
 
-ss::future<bool> seq_writer::delete_config(subject sub) {
+ss::future<bool> seq_writer::delete_config(context_subject ctx_sub) {
     return sequenced_write(
-      [sub{std::move(sub)}](model::offset, seq_writer& seq) {
-          return seq.do_delete_config(sub);
+      [ctx_sub{std::move(ctx_sub)}](model::offset, seq_writer& seq) {
+          return seq.do_delete_config(ctx_sub);
       });
 }
 
 ss::future<std::optional<bool>> seq_writer::do_write_mode(
-  std::optional<subject> sub, mode m, force f, model::offset write_at) {
+  context_subject ctx_sub, mode m, force f, model::offset write_at) {
     vlog(
       srlog.debug,
       "write_mode sub={} mode={} force={} offset={}",
-      sub,
+      ctx_sub,
       to_string_view(m),
       f,
       write_at);
@@ -385,9 +398,10 @@ ss::future<std::optional<bool>> seq_writer::do_write_mode(
 
     try {
         // Check for no-op case
-        mode existing = sub ? co_await _store.get_mode(
-                                sub.value(), default_to_global::no)
-                            : co_await _store.get_mode(default_context);
+        mode existing = !ctx_sub.is_context_only()
+                          ? co_await _store.get_mode(
+                              ctx_sub, default_to_global::no)
+                          : co_await _store.get_mode(ctx_sub.ctx);
         if (existing == m) {
             co_return false;
         }
@@ -405,15 +419,14 @@ ss::future<std::optional<bool>> seq_writer::do_write_mode(
                 "Schema Registry can only move to import mode if empty"});
         };
         if (
-          !sub
-          && co_await _store.has_subjects(
-            default_context, include_deleted::yes)) {
+          ctx_sub.is_context_only()
+          && co_await _store.has_subjects(ctx_sub.ctx, include_deleted::yes)) {
             throw make_exception();
         }
-        if (sub) {
+        if (!ctx_sub.is_context_only()) {
             try {
                 auto versions = co_await _store.get_versions(
-                  *sub, include_deleted::yes);
+                  ctx_sub, include_deleted::yes);
                 if (!versions.empty()) {
                     throw make_exception();
                 }
@@ -431,9 +444,13 @@ ss::future<std::optional<bool>> seq_writer::do_write_mode(
     }
 
     batch_builder rb(write_at);
+    auto sub_key = ctx_sub.is_default_context()
+                     ? std::optional<context_subject>{}
+                     : std::make_optional(ctx_sub);
+
     rb(
-      mode_key{.seq{write_at}, .node{_node_id}, .sub{sub}},
-      mode_value{.mode = m});
+      mode_key{.seq{write_at}, .node{_node_id}, .sub{sub_key}},
+      mode_value{.mode = m, .sub{sub_key}});
 
     if (co_await produce_and_apply(write_at, std::move(rb).build())) {
         co_return true;
@@ -444,23 +461,33 @@ ss::future<std::optional<bool>> seq_writer::do_write_mode(
 }
 
 ss::future<bool>
-seq_writer::write_mode(std::optional<subject> sub, mode mode, force f) {
-    return sequenced_write(
-      [sub{std::move(sub)}, mode, f](model::offset write_at, seq_writer& seq) {
-          return seq.do_write_mode(sub, mode, f, write_at);
-      });
+seq_writer::write_mode(context_subject ctx_sub, mode mode, force f) {
+    return sequenced_write([ctx_sub{std::move(ctx_sub)}, mode, f](
+                             model::offset write_at, seq_writer& seq) {
+        return seq.do_write_mode(ctx_sub, mode, f, write_at);
+    });
 }
 
 ss::future<std::optional<bool>>
-seq_writer::do_delete_mode(subject sub, model::offset write_at) {
-    vlog(srlog.debug, "delete mode sub={} offset={}", sub, write_at);
-
+seq_writer::do_delete_mode(context_subject ctx_sub, model::offset write_at) {
+    vlog(srlog.debug, "delete mode sub={} offset={}", ctx_sub, write_at);
     // Report an error if the mode isn't registered
-    co_await _store.get_mode(sub, default_to_global::no);
+    if (ctx_sub.is_context_only()) {
+        co_await _store.get_mode(ctx_sub.ctx);
+    } else {
+        co_await _store.get_mode(ctx_sub, default_to_global::no);
+    }
     _store.check_mode_mutability(force::no);
 
     batch_builder rb{write_at};
-    rb.add_tombstones(sub, co_await _store.get_subject_mode_written_at(sub));
+    if (ctx_sub.is_context_only()) {
+        rb.add_tombstones(
+          ctx_sub, co_await _store.get_context_mode_written_at(ctx_sub.ctx));
+    } else {
+        rb.add_tombstones(
+          ctx_sub, co_await _store.get_subject_mode_written_at(ctx_sub));
+    }
+
     if (co_await produce_and_apply(std::nullopt, std::move(rb).build())) {
         co_return true;
     } else {
@@ -469,10 +496,10 @@ seq_writer::do_delete_mode(subject sub, model::offset write_at) {
     }
 }
 
-ss::future<bool> seq_writer::delete_mode(subject sub) {
+ss::future<bool> seq_writer::delete_mode(context_subject ctx_sub) {
     return sequenced_write(
-      [sub{std::move(sub)}](model::offset write_at, seq_writer& seq) {
-          return seq.do_delete_mode(sub, write_at);
+      [ctx_sub{std::move(ctx_sub)}](model::offset write_at, seq_writer& seq) {
+          return seq.do_delete_mode(ctx_sub, write_at);
       });
 }
 

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -70,13 +70,13 @@ public:
     write_subject_version(stored_schema schema);
 
     ss::future<bool>
-    write_config(std::optional<subject> sub, compatibility_level compat);
+    write_config(context_subject ctx_sub, compatibility_level compat);
 
-    ss::future<bool> delete_config(subject sub);
+    ss::future<bool> delete_config(context_subject ctx_sub);
 
-    ss::future<bool> write_mode(std::optional<subject> sub, mode m, force f);
+    ss::future<bool> write_mode(context_subject ctx_sub, mode m, force f);
 
-    ss::future<bool> delete_mode(subject sub);
+    ss::future<bool> delete_mode(context_subject ctx_sub);
 
     ss::future<bool>
     delete_subject_version(context_subject sub, schema_version version);
@@ -101,17 +101,17 @@ private:
     do_write_subject_version(stored_schema schema, model::offset write_at);
 
     ss::future<std::optional<bool>> do_write_config(
-      std::optional<subject> sub,
+      context_subject ctx_sub,
       compatibility_level compat,
       model::offset write_at);
 
-    ss::future<std::optional<bool>> do_delete_config(subject sub);
+    ss::future<std::optional<bool>> do_delete_config(context_subject ctx_sub);
 
     ss::future<std::optional<bool>> do_write_mode(
-      std::optional<subject> sub, mode m, force f, model::offset write_at);
+      context_subject ctx_sub, mode m, force f, model::offset write_at);
 
     ss::future<std::optional<bool>>
-    do_delete_mode(subject sub, model::offset write_at);
+    do_delete_mode(context_subject ctx_sub, model::offset write_at);
 
     ss::future<std::optional<bool>> do_delete_subject_version(
       context_subject sub, schema_version version, model::offset write_at);

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -615,9 +615,10 @@ sharded_store::get_mode(context_subject sub, default_to_global fallback) {
       });
 }
 
-ss::future<bool> sharded_store::set_mode(context ctx, mode m, force f) {
-    auto map = [m, f, ctx{std::move(ctx)}](store& s) {
-        return s.set_mode(ctx, m, f).value();
+ss::future<bool>
+sharded_store::set_mode(seq_marker marker, context ctx, mode m, force f) {
+    auto map = [marker, m, f, ctx{std::move(ctx)}](store& s) {
+        return s.set_mode(marker, ctx, m, f).value();
     };
     auto reduce = std::logical_and<>{};
     co_return co_await _store.map_reduce0(map, true, reduce);
@@ -632,6 +633,14 @@ ss::future<bool> sharded_store::set_mode(
       });
 }
 
+ss::future<bool> sharded_store::clear_mode(context ctx, force f) {
+    auto map = [f, ctx{std::move(ctx)}](store& s) {
+        return s.clear_mode(ctx, f).value();
+    };
+    auto reduce = std::logical_and<>{};
+    co_return co_await _store.map_reduce0(map, true, reduce);
+}
+
 ss::future<bool>
 sharded_store::clear_mode(seq_marker marker, context_subject sub, force f) {
     auto sub_shard{shard_for(sub)};
@@ -639,6 +648,11 @@ sharded_store::clear_mode(seq_marker marker, context_subject sub, force f) {
       sub_shard, _smp_opts, [marker, sub{std::move(sub)}, f](store& s) {
           return s.clear_mode(marker, sub, f).value();
       });
+}
+
+ss::future<chunked_vector<seq_marker>>
+sharded_store::get_context_mode_written_at(context ctx) {
+    co_return _store.local().get_context_mode_written_at(ctx).value();
 }
 
 ss::future<compatibility_level> sharded_store::get_compatibility(context ctx) {
@@ -655,9 +669,9 @@ ss::future<compatibility_level> sharded_store::get_compatibility(
 }
 
 ss::future<bool> sharded_store::set_compatibility(
-  context ctx, compatibility_level compatibility) {
-    auto map = [compatibility, ctx{std::move(ctx)}](store& s) {
-        return s.set_compatibility(ctx, compatibility).value();
+  seq_marker marker, context ctx, compatibility_level compatibility) {
+    auto map = [marker, compatibility, ctx{std::move(ctx)}](store& s) {
+        return s.set_compatibility(marker, ctx, compatibility).value();
     };
     auto reduce = std::logical_and<>{};
     co_return co_await _store.map_reduce0(map, true, reduce);
@@ -674,6 +688,14 @@ ss::future<bool> sharded_store::set_compatibility(
       });
 }
 
+ss::future<bool> sharded_store::clear_compatibility(context ctx) {
+    auto map = [ctx{std::move(ctx)}](store& s) {
+        return s.clear_compatibility(ctx).value();
+    };
+    auto reduce = std::logical_and<>{};
+    co_return co_await _store.map_reduce0(map, true, reduce);
+}
+
 ss::future<bool>
 sharded_store::clear_compatibility(seq_marker marker, context_subject sub) {
     auto sub_shard{shard_for(sub)};
@@ -681,6 +703,11 @@ sharded_store::clear_compatibility(seq_marker marker, context_subject sub) {
       sub_shard, _smp_opts, [marker, sub{std::move(sub)}](store& s) {
           return s.clear_compatibility(marker, sub).value();
       });
+}
+
+ss::future<chunked_vector<seq_marker>>
+sharded_store::get_context_config_written_at(context ctx) {
+    co_return _store.local().get_context_config_written_at(ctx).value();
 }
 
 ss::future<bool> sharded_store::upsert_schema(

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -151,43 +151,60 @@ public:
     /// \param force Override checks for soft-delete first.
     ss::future<bool> delete_subject_version(
       context_subject sub, schema_version version, force f = force::no);
-    ///\brief Get the global mode.
+    ///\brief Get the mode of a context.
     ss::future<mode> get_mode(context ctx);
 
     ///\brief Get the mode for a subject, or fallback to global.
     ss::future<mode> get_mode(context_subject sub, default_to_global fallback);
 
-    ///\brief Set the global mode.
+    ///\brief Set the mode of a context.
     /// \param force Override checks, always apply action
-    ss::future<bool> set_mode(context ctx, mode m, force f);
+    ss::future<bool> set_mode(seq_marker marker, context ctx, mode m, force f);
 
     ///\brief Set the mode for a subject.
     /// \param force Override checks, always apply action
     ss::future<bool>
     set_mode(seq_marker marker, context_subject sub, mode m, force f);
+
+    ///\brief Clear the mode of a context.
+    /// \param force Override checks, always apply action
+    ss::future<bool> clear_mode(context ctx, force f);
     ///\brief Clear the mode for a subject.
     /// \param force Override checks, always apply action
     ss::future<bool>
     clear_mode(seq_marker marker, context_subject sub, force f);
 
-    ///\brief Get the global compatibility level.
+    /// \brief Return the seq_marker write history of a context, but only
+    /// mode keys
+    ss::future<chunked_vector<seq_marker>>
+    get_context_mode_written_at(context ctx);
+
+    ///\brief Get the compatibility level of a context.
     ss::future<compatibility_level> get_compatibility(context ctx);
 
     ///\brief Get the compatibility level for a subject, or fallback to global.
     ss::future<compatibility_level>
     get_compatibility(context_subject sub, default_to_global fallback);
-    ///\brief Set the global compatibility level.
-    ss::future<bool>
-    set_compatibility(context ctx, compatibility_level compatibility);
+    ///\brief Set the compatibility level of a context.
+    ss::future<bool> set_compatibility(
+      seq_marker marker, context ctx, compatibility_level compatibility);
 
     ///\brief Set the compatibility level for a subject.
     ss::future<bool> set_compatibility(
       seq_marker marker,
       context_subject sub,
       compatibility_level compatibility);
+
+    ///\brief Clear the compatibility level of a context.
+    ss::future<bool> clear_compatibility(context ctx);
     ///\brief Clear the compatibility level for a subject.
     ss::future<bool>
     clear_compatibility(seq_marker marker, context_subject sub);
+
+    /// \brief Return the seq_marker write history of a context, but only
+    /// config keys
+    ss::future<chunked_vector<seq_marker>>
+    get_context_config_written_at(context ctx);
 
     ///\brief Check if the provided schema is compatible with the subject and
     /// version, according the the current compatibility.

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -682,7 +682,7 @@ struct config_key {
     static constexpr topic_key_type keytype{topic_key_type::config};
     std::optional<model::offset> seq;
     std::optional<model::node_id> node;
-    std::optional<subject> sub;
+    std::optional<context_subject> sub;
     topic_key_magic magic{0};
 
     friend bool operator==(const config_key&, const config_key&) = default;
@@ -717,7 +717,7 @@ void rjson_serialize(
     ::json::rjson_serialize(w, to_string_view(key.keytype));
     w.Key("subject");
     if (key.sub) {
-        ::json::rjson_serialize(w, key.sub.value());
+        w.String(key.sub->to_string());
     } else {
         w.Null();
     }
@@ -802,7 +802,7 @@ public:
             return kt == result.keytype;
         }
         case state::subject: {
-            result.sub = subject{ss::sstring{sv}};
+            result.sub = context_subject::from_string(sv);
             _state = state::object;
             return true;
         }
@@ -833,7 +833,7 @@ public:
 
 struct config_value {
     compatibility_level compat{compatibility_level::none};
-    std::optional<subject> sub;
+    std::optional<context_subject> sub;
 
     friend bool operator==(const config_value&, const config_value&) = default;
 
@@ -853,7 +853,7 @@ void rjson_serialize(
     w.StartObject();
     if (val.sub.has_value()) {
         w.Key("subject");
-        ::json::rjson_serialize(w, val.sub.value());
+        w.String(val.sub->to_string());
     }
     w.Key("compatibilityLevel");
     ::json::rjson_serialize(w, to_string_view(val.compat));
@@ -898,7 +898,7 @@ public:
             }
             return s.has_value();
         } else if (_state == state::subject) {
-            result.sub.emplace(sv);
+            result.sub = context_subject::from_string(sv);
             _state = state::object;
             return true;
         }
@@ -918,7 +918,7 @@ struct mode_key {
     static constexpr topic_key_type keytype{topic_key_type::mode};
     std::optional<model::offset> seq;
     std::optional<model::node_id> node;
-    std::optional<subject> sub;
+    std::optional<context_subject> sub;
     topic_key_magic magic{0};
 
     friend bool operator==(const mode_key&, const mode_key&) = default;
@@ -953,7 +953,7 @@ void rjson_serialize(
     ::json::rjson_serialize(w, to_string_view(key.keytype));
     w.Key("subject");
     if (key.sub) {
-        ::json::rjson_serialize(w, key.sub.value());
+        w.String(key.sub->to_string());
     } else {
         w.Null();
     }
@@ -1038,7 +1038,7 @@ public:
             return kt == result.keytype;
         }
         case state::subject: {
-            result.sub = subject{ss::sstring{sv}};
+            result.sub = context_subject::from_string(sv);
             _state = state::object;
             return true;
         }
@@ -1069,7 +1069,7 @@ public:
 
 struct mode_value {
     mode mode{mode::read_write};
-    std::optional<subject> sub;
+    std::optional<context_subject> sub;
 
     friend bool operator==(const mode_value&, const mode_value&) = default;
 
@@ -1089,7 +1089,7 @@ void rjson_serialize(
     w.StartObject();
     if (val.sub.has_value()) {
         w.Key("subject");
-        ::json::rjson_serialize(w, val.sub.value());
+        w.String(val.sub->to_string());
     }
     w.Key("mode");
     ::json::rjson_serialize(w, to_string_view(val.mode));
@@ -1133,7 +1133,7 @@ public:
             }
             return s.has_value();
         } else if (_state == state::subject) {
-            result.sub.emplace(sv);
+            result.sub = context_subject::from_string(sv);
             _state = state::object;
             return true;
         }
@@ -1611,7 +1611,8 @@ struct consume_to_store {
         }
         try {
             vlog(srlog.debug, "Applying: {}", key);
-            if (key.sub.has_value()) {
+            if (key.sub.has_value() && !key.sub->is_context_only()) {
+                // Subject-level: non-empty subject name
                 if (!val.has_value()) {
                     co_await _store.clear_compatibility(
                       seq_marker{
@@ -1630,12 +1631,16 @@ struct consume_to_store {
                       *key.sub,
                       val->compat);
                 }
-            } else if (val.has_value()) {
-                co_await _store.set_compatibility(default_context, val->compat);
             } else {
-                vlog(
-                  srlog.warn,
-                  "Tried to apply config with neither subject nor value");
+                // Context-level: context-only qualified subject or nullopt
+                // (default context)
+                auto ctx = key.sub.has_value() ? key.sub->ctx : default_context;
+
+                if (val.has_value()) {
+                    co_await _store.set_compatibility(ctx, val->compat);
+                } else {
+                    co_await _store.clear_compatibility(ctx);
+                }
             }
         } catch (const exception& e) {
             vlog(srlog.debug, "Error replaying: {}: {}", key, e);
@@ -1664,7 +1669,8 @@ struct consume_to_store {
         }
         try {
             vlog(srlog.debug, "Applying: {}", key);
-            if (key.sub.has_value()) {
+            if (key.sub.has_value() && !key.sub->is_context_only()) {
+                // Subject-level: non-empty subject name
                 if (!val.has_value()) {
                     co_await _store.clear_mode(
                       seq_marker{
@@ -1685,13 +1691,16 @@ struct consume_to_store {
                       val->mode,
                       force::yes);
                 }
-            } else if (val.has_value()) {
-                co_await _store.set_mode(
-                  default_context, val->mode, force::yes);
             } else {
-                vlog(
-                  srlog.warn,
-                  "Tried to apply mode with neither subject nor value");
+                // Context-level: context-only qualified subject or nullopt
+                // (default context)
+                auto ctx = key.sub.has_value() ? key.sub->ctx : default_context;
+
+                if (val.has_value()) {
+                    co_await _store.set_mode(ctx, val->mode, force::yes);
+                } else {
+                    co_await _store.clear_mode(ctx, force::yes);
+                }
             }
         } catch (const exception& e) {
             vlog(srlog.debug, "Error replaying: {}: {}", key, e);

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -1609,27 +1609,23 @@ struct consume_to_store {
               error_code::topic_parse_error,
               fmt::format("Unexpected magic: {}", key));
         }
+        auto make_marker = [&key]() {
+            return seq_marker{
+              .seq = key.seq,
+              .node = key.node,
+              .version{invalid_schema_version}, // Not applicable
+              .key_type = seq_marker_key_type::config};
+        };
         try {
             vlog(srlog.debug, "Applying: {}", key);
             if (key.sub.has_value() && !key.sub->is_context_only()) {
                 // Subject-level: non-empty subject name
                 if (!val.has_value()) {
                     co_await _store.clear_compatibility(
-                      seq_marker{
-                        .seq = key.seq,
-                        .node = key.node,
-                        .version{invalid_schema_version}, // Not applicable
-                        .key_type = seq_marker_key_type::config},
-                      *key.sub);
+                      make_marker(), *key.sub);
                 } else {
                     co_await _store.set_compatibility(
-                      seq_marker{
-                        .seq = key.seq,
-                        .node = key.node,
-                        .version{invalid_schema_version}, // Not applicable
-                        .key_type = seq_marker_key_type::config},
-                      *key.sub,
-                      val->compat);
+                      make_marker(), *key.sub, val->compat);
                 }
             } else {
                 // Context-level: context-only qualified subject or nullopt
@@ -1637,7 +1633,8 @@ struct consume_to_store {
                 auto ctx = key.sub.has_value() ? key.sub->ctx : default_context;
 
                 if (val.has_value()) {
-                    co_await _store.set_compatibility(ctx, val->compat);
+                    co_await _store.set_compatibility(
+                      make_marker(), ctx, val->compat);
                 } else {
                     co_await _store.clear_compatibility(ctx);
                 }
@@ -1667,29 +1664,23 @@ struct consume_to_store {
               error_code::topic_parse_error,
               fmt::format("Unexpected magic: {}", key));
         }
+        auto make_marker = [&key]() {
+            return seq_marker{
+              .seq = key.seq,
+              .node = key.node,
+              .version{invalid_schema_version}, // Not applicable
+              .key_type = seq_marker_key_type::mode};
+        };
         try {
             vlog(srlog.debug, "Applying: {}", key);
             if (key.sub.has_value() && !key.sub->is_context_only()) {
                 // Subject-level: non-empty subject name
                 if (!val.has_value()) {
                     co_await _store.clear_mode(
-                      seq_marker{
-                        .seq = key.seq,
-                        .node = key.node,
-                        .version{invalid_schema_version}, // Not applicable
-                        .key_type = seq_marker_key_type::mode},
-                      *key.sub,
-                      force::yes);
+                      make_marker(), *key.sub, force::yes);
                 } else {
                     co_await _store.set_mode(
-                      seq_marker{
-                        .seq = key.seq,
-                        .node = key.node,
-                        .version{invalid_schema_version}, // Not applicable
-                        .key_type = seq_marker_key_type::mode},
-                      *key.sub,
-                      val->mode,
-                      force::yes);
+                      make_marker(), *key.sub, val->mode, force::yes);
                 }
             } else {
                 // Context-level: context-only qualified subject or nullopt
@@ -1697,7 +1688,8 @@ struct consume_to_store {
                 auto ctx = key.sub.has_value() ? key.sub->ctx : default_context;
 
                 if (val.has_value()) {
-                    co_await _store.set_mode(ctx, val->mode, force::yes);
+                    co_await _store.set_mode(
+                      make_marker(), ctx, val->mode, force::yes);
                 } else {
                     co_await _store.clear_mode(ctx, force::yes);
                 }

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -537,11 +537,13 @@ public:
         return true;
     }
 
-    ///\brief Get the global mode of a context.
+    ///\brief Get the mode of a context.
     result<mode> get_mode(const context& ctx) const {
         auto it = _context_stores.find(ctx);
-        return it != _context_stores.end() ? it->second._mode
-                                           : mode::read_write;
+        if (it == _context_stores.end() || !it->second._mode.has_value()) {
+            return mode::read_write;
+        }
+        return *it->second._mode;
     }
 
     ///\brief Get the mode for a subject, or fallback to global.
@@ -556,9 +558,11 @@ public:
         return mode_not_found(sub);
     }
 
-    ///\brief Set the global mode.
-    result<bool> set_mode(const context& ctx, mode m, force f) {
+    ///\brief Set the mode of a context.
+    result<bool>
+    set_mode(seq_marker marker, const context& ctx, mode m, force f) {
         BOOST_OUTCOME_TRYX(check_mode_mutability(f));
+        _context_stores[ctx]._mode_written_at.emplace_back(marker);
         return std::exchange(_context_stores[ctx]._mode, m) != m;
     }
 
@@ -582,11 +586,34 @@ public:
         return std::exchange(sub_it->second.mode, std::nullopt) != std::nullopt;
     }
 
-    ///\brief Get the global compatibility level in a context.
+    ///\brief Clear the mode for a context.
+    result<bool> clear_mode(const context& ctx, force f) {
+        BOOST_OUTCOME_TRYX(check_mode_mutability(f));
+        _context_stores[ctx]._mode_written_at.clear();
+        return std::exchange(_context_stores[ctx]._mode, std::nullopt)
+               != std::nullopt;
+    }
+
+    /// \brief Return the seq_marker write history of a context, but only
+    /// mode keys
+    result<chunked_vector<seq_marker>>
+    get_context_mode_written_at(const context& ctx) const {
+        auto it = _context_stores.find(ctx);
+        if (it == _context_stores.end()) {
+            return chunked_vector<seq_marker>{};
+        }
+        return it->second._mode_written_at.copy();
+    }
+
+    ///\brief Get the compatibility level of a context.
     result<compatibility_level> get_compatibility(const context& ctx) const {
         auto it = _context_stores.find(ctx);
-        return it != _context_stores.end() ? it->second._compatibility
-                                           : compatibility_level::backward;
+        if (
+          it == _context_stores.end()
+          || !it->second._compatibility.has_value()) {
+            return compatibility_level::backward;
+        }
+        return *it->second._compatibility;
     }
 
     ///\brief Get the compatibility level for a subject, or fallback to global.
@@ -606,9 +633,12 @@ public:
         return compatibility_not_found(sub);
     }
 
-    ///\brief Set the global compatibility level.
-    result<bool>
-    set_compatibility(const context& ctx, compatibility_level compatibility) {
+    ///\brief Set the compatibility level of a context.
+    result<bool> set_compatibility(
+      seq_marker marker,
+      const context& ctx,
+      compatibility_level compatibility) {
+        _context_stores[ctx]._config_written_at.push_back(marker);
         return std::exchange(_context_stores[ctx]._compatibility, compatibility)
                != compatibility;
     }
@@ -624,6 +654,13 @@ public:
                != compatibility;
     }
 
+    ///\brief Clear the compatibility level of a context.
+    result<bool> clear_compatibility(const context& ctx) {
+        _context_stores[ctx]._config_written_at.clear();
+        return std::exchange(_context_stores[ctx]._compatibility, std::nullopt)
+               != std::nullopt;
+    }
+
     ///\brief Clear the compatibility level for a subject.
     result<bool>
     clear_compatibility(const seq_marker& marker, const context_subject& sub) {
@@ -633,6 +670,17 @@ public:
         vec.erase_to_end(std::ranges::remove(vec, marker).begin());
         return std::exchange(sub_it->second.compatibility, std::nullopt)
                != std::nullopt;
+    }
+
+    /// \brief Return the seq_marker write history of a context, but only
+    /// config keys
+    result<chunked_vector<seq_marker>>
+    get_context_config_written_at(const context& ctx) const {
+        auto it = _context_stores.find(ctx);
+        if (it == _context_stores.end()) {
+            return chunked_vector<seq_marker>{};
+        }
+        return it->second._config_written_at.copy();
     }
 
     struct insert_schema_result {
@@ -958,9 +1006,12 @@ private:
     }
 
     struct context_store {
-        compatibility_level _compatibility{compatibility_level::backward};
-        mode _mode{mode::read_write};
+        std::optional<compatibility_level> _compatibility{std::nullopt};
+        std::optional<mode> _mode{std::nullopt};
         schema_id _next_schema_id{1};
+
+        chunked_vector<seq_marker> _config_written_at;
+        chunked_vector<seq_marker> _mode_written_at;
     };
     using context_store_map = absl::node_hash_map<context, context_store>;
 
@@ -968,7 +1019,7 @@ private:
     // fields are only present on certain shards.
     // _schemas: sharded by (context, schema_id)
     // _subjects: sharded by (context, subject)
-    // _marked_schemas: shard 0 ??
+    // _marked_schemas: sharded by (context, schema_id)
     // context_store:
     //  - next_schema_id: sharded by context
     //  - compatibility: replicated across all shards

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -39,7 +39,10 @@ bool check_compatible(
   std::string_view reader,
   std::string_view writer) {
     ppstu::store_fixture store;
-    store.store().set_compatibility(pps::default_context, lvl).get();
+    auto dummy_marker = pps::seq_marker{};
+    store.store()
+      .set_compatibility(dummy_marker, pps::default_context, lvl)
+      .get();
     store.insert(
       pandaproxy::schema_registry::subject_schema{
         pps::subject{"sub"},

--- a/src/v/pandaproxy/schema_registry/test/compatibility_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_store.cc
@@ -30,7 +30,7 @@ SEASTAR_THREAD_TEST_CASE(test_avro_basic_backwards_store_compat) {
     pps::seq_marker dummy_marker;
 
     s.set_compatibility(
-       pps::default_context, pps::compatibility_level::backward)
+       dummy_marker, pps::default_context, pps::compatibility_level::backward)
       .get();
     auto sub = pps::subject{"sub"};
     s.upsert(
@@ -73,7 +73,9 @@ SEASTAR_THREAD_TEST_CASE(test_avro_basic_backwards_store_compat) {
       !s.is_compatible(pps::schema_version{1}, {sub, schema3.share()}).get());
 
     s.set_compatibility(
-       pps::default_context, pps::compatibility_level::backward_transitive)
+       dummy_marker,
+       pps::default_context,
+       pps::compatibility_level::backward_transitive)
       .get();
 
     // Test transitive defaulted field to previous - should fail

--- a/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
@@ -296,7 +296,10 @@ SEASTAR_THREAD_TEST_CASE(test_writes_disabled) {
 
     BOOST_REQUIRE_EXCEPTION(
       seq.local()
-        .write_mode(std::nullopt, pps::mode::read_only, pps::force::no)
+        .write_mode(
+          pps::context_subject{pps::default_context, pps::subject{""}},
+          pps::mode::read_only,
+          pps::force::no)
         .get(),
       pps::exception,
       [](pps::exception e) {

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -87,7 +87,7 @@ constexpr std::string_view config_key_sub_sv{
 const auto expected_config_key_sub = config_key{
   .seq{model::offset{0}},
   .node{model::node_id{0}},
-  .sub{subject{"my-kafka-value"}},
+  .sub{context_subject{"my-kafka-value"}},
   .magic{topic_key_magic{0}}};
 
 constexpr std::string_view config_value_sv{
@@ -104,7 +104,7 @@ constexpr std::string_view config_value_sub_sv{
 })"};
 const auto expected_config_value_sub = config_value{
   .compat = compatibility_level::forward_transitive,
-  .sub{subject{"my-kafka-value"}}};
+  .sub{context_subject{"my-kafka-value"}}};
 
 constexpr std::string_view delete_subject_key_sv{
   R"({
@@ -380,6 +380,168 @@ TEST(StorageTest, SerdeContextSubject) {
 
         auto str = ppj::rjson_serialize_str(expected_delete_value_ctx);
         EXPECT_EQ(str, ::json::minify(delete_value_ctx_sv));
+    }
+
+    // Test config_key with context_subject (subject-level config in context)
+    {
+        constexpr std::string_view config_key_ctx_sv{
+          R"({
+  "keytype": "CONFIG",
+  "subject": ":.my-context:my-kafka-value",
+  "magic": 0,
+  "seq": 10,
+  "node": 1
+})"};
+        const auto expected_config_key_ctx = config_key{
+          .seq{model::offset{10}},
+          .node{model::node_id{1}},
+          .sub{
+            context_subject{context{".my-context"}, subject{"my-kafka-value"}}},
+          .magic{topic_key_magic{0}}};
+
+        auto key = ppj::impl::rjson_parse(
+          config_key_ctx_sv.data(), config_key_handler<>{});
+        EXPECT_EQ(expected_config_key_ctx, key);
+
+        auto str = ppj::rjson_serialize_str(expected_config_key_ctx);
+        EXPECT_EQ(str, ::json::minify(config_key_ctx_sv));
+    }
+
+    // Test config_key with context-only (context-level config, empty subject)
+    {
+        constexpr std::string_view config_key_ctx_only_sv{
+          R"({
+  "keytype": "CONFIG",
+  "subject": ":.my-context:",
+  "magic": 0,
+  "seq": 11,
+  "node": 1
+})"};
+        const auto expected_config_key_ctx_only = config_key{
+          .seq{model::offset{11}},
+          .node{model::node_id{1}},
+          .sub{context_subject{context{".my-context"}, subject{""}}},
+          .magic{topic_key_magic{0}}};
+
+        auto key = ppj::impl::rjson_parse(
+          config_key_ctx_only_sv.data(), config_key_handler<>{});
+        EXPECT_EQ(expected_config_key_ctx_only, key);
+
+        auto str = ppj::rjson_serialize_str(expected_config_key_ctx_only);
+        EXPECT_EQ(str, ::json::minify(config_key_ctx_only_sv));
+    }
+
+    // Test config_value with context_subject
+    {
+        constexpr std::string_view config_value_ctx_sv{
+          R"({
+  "subject": ":.my-context:my-kafka-value",
+  "compatibilityLevel": "BACKWARD"
+})"};
+        const auto expected_config_value_ctx = config_value{
+          .compat = compatibility_level::backward,
+          .sub{context_subject{
+            context{".my-context"}, subject{"my-kafka-value"}}}};
+
+        auto val = ppj::impl::rjson_parse(
+          config_value_ctx_sv.data(), config_value_handler<>{});
+        EXPECT_EQ(expected_config_value_ctx, val);
+
+        auto str = ppj::rjson_serialize_str(expected_config_value_ctx);
+        EXPECT_EQ(str, ::json::minify(config_value_ctx_sv));
+    }
+
+    // Test mode_key with context_subject (subject-level mode in context)
+    {
+        constexpr std::string_view mode_key_ctx_sv{
+          R"({
+  "keytype": "MODE",
+  "subject": ":.my-context:my-kafka-value",
+  "magic": 0,
+  "seq": 20,
+  "node": 1
+})"};
+        const auto expected_mode_key_ctx = mode_key{
+          .seq{model::offset{20}},
+          .node{model::node_id{1}},
+          .sub{
+            context_subject{context{".my-context"}, subject{"my-kafka-value"}}},
+          .magic{topic_key_magic{0}}};
+
+        auto key = ppj::impl::rjson_parse(
+          mode_key_ctx_sv.data(), mode_key_handler<>{});
+        EXPECT_EQ(expected_mode_key_ctx, key);
+
+        auto str = ppj::rjson_serialize_str(expected_mode_key_ctx);
+        EXPECT_EQ(str, ::json::minify(mode_key_ctx_sv));
+    }
+
+    // Test mode_key with context-only (context-level mode, empty subject)
+    {
+        constexpr std::string_view mode_key_ctx_only_sv{
+          R"({
+  "keytype": "MODE",
+  "subject": ":.my-context:",
+  "magic": 0,
+  "seq": 21,
+  "node": 1
+})"};
+        const auto expected_mode_key_ctx_only = mode_key{
+          .seq{model::offset{21}},
+          .node{model::node_id{1}},
+          .sub{context_subject{context{".my-context"}, subject{""}}},
+          .magic{topic_key_magic{0}}};
+
+        auto key = ppj::impl::rjson_parse(
+          mode_key_ctx_only_sv.data(), mode_key_handler<>{});
+        EXPECT_EQ(expected_mode_key_ctx_only, key);
+
+        auto str = ppj::rjson_serialize_str(expected_mode_key_ctx_only);
+        EXPECT_EQ(str, ::json::minify(mode_key_ctx_only_sv));
+    }
+
+    // Test mode_value with context_subject
+    {
+        constexpr std::string_view mode_value_ctx_sv{
+          R"({
+  "subject": ":.my-context:my-kafka-value",
+  "mode": "READONLY"
+})"};
+        const auto expected_mode_value_ctx = mode_value{
+          .mode = mode::read_only,
+          .sub{context_subject{
+            context{".my-context"}, subject{"my-kafka-value"}}}};
+
+        auto val = ppj::impl::rjson_parse(
+          mode_value_ctx_sv.data(), mode_value_handler<>{});
+        EXPECT_EQ(expected_mode_value_ctx, val);
+
+        auto str = ppj::rjson_serialize_str(expected_mode_value_ctx);
+        EXPECT_EQ(str, ::json::minify(mode_value_ctx_sv));
+    }
+
+    // Test mode_key/value without context (legacy format in default context)
+    {
+        constexpr std::string_view mode_key_legacy_sv{
+          R"({
+  "keytype": "MODE",
+  "subject": "my-kafka-value",
+  "magic": 0,
+  "seq": 22,
+  "node": 1
+})"};
+        const auto expected_mode_key_legacy = mode_key{
+          .seq{model::offset{22}},
+          .node{model::node_id{1}},
+          .sub{context_subject{"my-kafka-value"}},
+          .magic{topic_key_magic{0}}};
+
+        auto key = ppj::impl::rjson_parse(
+          mode_key_legacy_sv.data(), mode_key_handler<>{});
+        EXPECT_EQ(expected_mode_key_legacy, key);
+
+        auto str = ppj::rjson_serialize_str(expected_mode_key_legacy);
+        EXPECT_EQ(str, ::json::minify(mode_key_legacy_sv));
     }
 }
 

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -452,20 +452,21 @@ BOOST_AUTO_TEST_CASE(test_store_global_compat) {
     // Setting the retrieving global compatibility should be allowed multiple
     // times
 
+    pps::seq_marker dummy_marker;
     pps::compatibility_level expected{pps::compatibility_level::backward};
     pps::store s;
     BOOST_REQUIRE(
       s.get_compatibility(pps::default_context).value() == expected);
 
     // duplicate should return false
-    BOOST_REQUIRE(
-      s.set_compatibility(pps::default_context, expected).value() == false);
+    BOOST_REQUIRE(s.clear_compatibility(pps::default_context).value() == false);
     BOOST_REQUIRE(
       s.get_compatibility(pps::default_context).value() == expected);
 
     expected = pps::compatibility_level::full_transitive;
     BOOST_REQUIRE(
-      s.set_compatibility(pps::default_context, expected).value() == true);
+      s.set_compatibility(dummy_marker, pps::default_context, expected).value()
+      == true);
     BOOST_REQUIRE(
       s.get_compatibility(pps::default_context).value() == expected);
 }
@@ -517,6 +518,7 @@ BOOST_AUTO_TEST_CASE(test_store_subject_compat) {
 
 BOOST_AUTO_TEST_CASE(test_store_subject_compat_fallback) {
     // A Subject should fallback to the current global setting
+    pps::seq_marker dummy_marker;
     auto fallback = pps::default_to_global::yes;
 
     pps::compatibility_level expected{pps::compatibility_level::backward};
@@ -526,7 +528,8 @@ BOOST_AUTO_TEST_CASE(test_store_subject_compat_fallback) {
 
     expected = pps::compatibility_level::forward;
     BOOST_REQUIRE(
-      s.set_compatibility(pps::default_context, expected).value() == true);
+      s.set_compatibility(dummy_marker, pps::default_context, expected).value()
+      == true);
     BOOST_REQUIRE(s.get_compatibility(subject0, fallback).value() == expected);
 }
 
@@ -552,11 +555,11 @@ BOOST_AUTO_TEST_CASE(test_store_delete_subject) {
     const std::vector<pps::schema_version> expected_vers{
       {pps::schema_version{1}, pps::schema_version{2}}};
 
-    pps::store s;
-    s.set_compatibility(pps::default_context, pps::compatibility_level::none)
-      .value();
-
     pps::seq_marker dummy_marker;
+    pps::store s;
+    s.set_compatibility(
+       dummy_marker, pps::default_context, pps::compatibility_level::none)
+      .value();
 
     BOOST_REQUIRE_EQUAL(
       s.delete_subject(dummy_marker, subject0, pps::permanent_delete::no)
@@ -673,7 +676,8 @@ BOOST_AUTO_TEST_CASE(test_store_delete_subject_version) {
 
     pps::seq_marker dummy_marker;
     pps::store s;
-    s.set_compatibility(pps::default_context, pps::compatibility_level::none)
+    s.set_compatibility(
+       dummy_marker, pps::default_context, pps::compatibility_level::none)
       .value();
 
     // Test unknown subject
@@ -750,7 +754,8 @@ BOOST_AUTO_TEST_CASE(test_store_delete_subject_version) {
 BOOST_AUTO_TEST_CASE(test_store_subject_version_latest) {
     pps::seq_marker dummy_marker;
     pps::store s;
-    s.set_compatibility(pps::default_context, pps::compatibility_level::none)
+    s.set_compatibility(
+       dummy_marker, pps::default_context, pps::compatibility_level::none)
       .value();
 
     // First insert, expect id{1}, version{1}
@@ -796,11 +801,11 @@ BOOST_AUTO_TEST_CASE(test_store_subject_version_latest) {
 BOOST_AUTO_TEST_CASE(test_store_delete_subject_after_delete_version) {
     std::vector<pps::schema_version> expected_vers{{pps::schema_version{2}}};
 
-    pps::store s;
-    s.set_compatibility(pps::default_context, pps::compatibility_level::none)
-      .value();
-
     pps::seq_marker dummy_marker;
+    pps::store s;
+    s.set_compatibility(
+       dummy_marker, pps::default_context, pps::compatibility_level::none)
+      .value();
 
     // First insert, expect id{1}, version{1}
     s.insert({subject0, string_def0.share()});

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -129,7 +129,6 @@ using registry_resource = named_type<ss::sstring, struct registry_resource_tag>;
 ///
 /// Typically it will be "<topic>-key" or "<topic>-value".
 using subject = named_type<ss::sstring, struct subject_tag>;
-inline const subject invalid_subject{};
 
 /// \brief A schema context, used for namespacing schemas and schema ids. Can be
 /// used to implement multi-tenancy, environment (e.g., dev, staging, prod)
@@ -201,9 +200,16 @@ struct context_subject {
         return to_string().starts_with(prefix);
     }
 
+    /// Returns true if this represents a context-only identifier (empty
+    /// subject). Used to distinguish context-level operations (like setting
+    /// context-wide mode/config) from subject-level operations.
+    bool is_context_only() const { return sub().empty(); }
+
     context ctx;
     subject sub;
 };
+
+inline const context_subject invalid_subject{default_context, subject{""}};
 
 ///\brief The version of the schema registered with a subject.
 ///

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -205,6 +205,12 @@ struct context_subject {
     /// context-wide mode/config) from subject-level operations.
     bool is_context_only() const { return sub().empty(); }
 
+    /// Retrurns true if this represents the default context with an empty
+    /// subject.
+    bool is_default_context() const {
+        return is_context_only() && ctx == default_context;
+    }
+
     context ctx;
     subject sub;
 };

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1702,22 +1702,6 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             assert result_raw.json()["id"] == 1
 
     @cluster(num_nodes=1)
-    def test_default_context(self):
-        schema_data = json.dumps({"schema": schema1_def})
-
-        result = self.sr_client.post_subjects_subject_versions(
-            subject="default-ctx-subject", data=schema_data
-        )
-        self.assert_equal(result.status_code, requests.codes.ok)
-        self.assert_equal(result.json()["id"], 1)
-
-        result = self.sr_client.post_subjects_subject(
-            subject=":.:default-ctx-subject", data=schema_data
-        )
-        self.assert_equal(result.status_code, requests.codes.ok)
-        self.assert_equal(result.json()["id"], 1)
-
-    @cluster(num_nodes=1)
     def test_contexts(self):
         """Verify context-aware endpoints work with qualified subjects."""
 
@@ -1875,6 +1859,72 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             ),
         )
         self.assert_equal(result.status_code, requests.codes.ok)
+
+    @cluster(num_nodes=1)
+    def test_context_config(self):
+        """Test context-level config operations."""
+
+        ctx = "test-ctx"
+        ctx_prefix = f":.{ctx}:"
+        ctx_subject = f"{ctx_prefix}test-sub"
+
+        # Register a schema in the context first
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=ctx_subject, data=json.dumps({"schema": schema1_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Set context-level config (empty subject = context-level)
+        result = self.sr_client.set_config_subject(
+            subject=ctx_prefix,
+            data=json.dumps({"compatibility": "NONE"}),
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Get context-level config
+        result = self.sr_client.get_config_subject(subject=ctx_prefix)
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["compatibilityLevel"], "NONE")
+
+        # Subject-level config should fall back to context-level
+        result = self.sr_client.get_config_subject(subject=ctx_subject, fallback=True)
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["compatibilityLevel"], "NONE")
+
+        # Default context should not be affected by context-level config
+        result = self.sr_client.get_config()
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["compatibilityLevel"], "BACKWARD")
+
+        # Set subject-level config (different from context-level)
+        result = self.sr_client.set_config_subject(
+            subject=ctx_subject,
+            data=json.dumps({"compatibility": "FULL"}),
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Subject should now have FULL (not context's NONE)
+        result = self.sr_client.get_config_subject(subject=ctx_subject, fallback=False)
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["compatibilityLevel"], "FULL")
+
+        # Delete subject-level config
+        result = self.sr_client.delete_config_subject(subject=ctx_subject)
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Subject should fall back to context-level NONE
+        result = self.sr_client.get_config_subject(subject=ctx_subject, fallback=True)
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["compatibilityLevel"], "NONE")
+
+        # Delete the context-level config
+        result = self.sr_client.delete_config_subject(subject=ctx_prefix)
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Subject should fall back to default BACKWARD
+        result = self.sr_client.get_config_subject(subject=ctx_subject, fallback=True)
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["compatibilityLevel"], "BACKWARD")
 
     @cluster(num_nodes=3)
     def test_post_subjects_subject_versions_null_metadata_ruleset(self):
@@ -5141,6 +5191,134 @@ class SchemaRegistryModeMutableTest(SchemaRegistryEndpoints):
         )
         self.assert_equal(result_raw.status_code, 200)
         self.assert_equal(result_raw.json()["id"], 2)
+
+    @cluster(num_nodes=1)
+    def test_default_context(self):
+        schema_data = json.dumps({"schema": schema1_def})
+
+        # Register in default context with unqualified subject
+        result = self.sr_client.post_subjects_subject_versions(
+            subject="default-ctx-subject", data=schema_data
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["id"], 1)
+
+        # Look up in default context with qualified subject
+        result = self.sr_client.post_subjects_subject(
+            subject=":.:default-ctx-subject", data=schema_data
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["id"], 1)
+
+        # Set the compatibility level with qualified subject
+        result = self.sr_client.set_config_subject(
+            subject=":.:", data=json.dumps({"compatibility": "FULL"})
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["compatibility"], "FULL")
+
+        # Look up the compatibility level of default context
+        result = self.sr_client.get_config()
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["compatibilityLevel"], "FULL")
+
+        # Delete the compatibility level with qualified subject
+        result = self.sr_client.delete_config_subject(subject=":.:")
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["compatibilityLevel"], "FULL")
+
+        # Look up the compatibility level of default context
+        result = self.sr_client.get_config()
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["compatibilityLevel"], "BACKWARD")
+
+        # Set the mode with qualified subject
+        result = self.sr_client.set_mode_subject(
+            subject=":.:", data=json.dumps({"mode": "READONLY"}), force=True
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["mode"], "READONLY")
+
+        # Look up the mode of default context
+        result = self.sr_client.get_mode()
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["mode"], "READONLY")
+
+        # Delete the mode with qualified subject
+        result = self.sr_client.delete_mode_subject(subject=":.:")
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["mode"], "READONLY")
+
+        # Look up the mode of default context
+        result = self.sr_client.get_mode()
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["mode"], "READWRITE")
+
+    @cluster(num_nodes=1)
+    def test_context_mode(self):
+        """Test context-level mode operations."""
+
+        ctx = "test-ctx"
+        ctx_prefix = f":.{ctx}:"
+        ctx_subject = f"{ctx_prefix}test-sub"
+
+        # Register a schema in the context first
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=ctx_subject, data=json.dumps({"schema": schema1_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Set context-level mode (empty subject = context-level)
+        result = self.sr_client.set_mode_subject(
+            subject=ctx_prefix,
+            data=json.dumps({"mode": "READONLY"}),
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Get context-level mode
+        result = self.sr_client.get_mode_subject(subject=ctx_prefix)
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["mode"], "READONLY")
+
+        # Subject-level mode should fall back to context-level
+        result = self.sr_client.get_mode_subject(subject=ctx_subject, fallback=True)
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["mode"], "READONLY")
+
+        # Default context should not be affected by context-level mode
+        result = self.sr_client.get_mode()
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["mode"], "READWRITE")
+
+        # Set subject-level mode (different from context-level)
+        result = self.sr_client.set_mode_subject(
+            subject=ctx_subject,
+            data=json.dumps({"mode": "READWRITE"}),
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Subject should now have READWRITE (not context's READONLY)
+        result = self.sr_client.get_mode_subject(subject=ctx_subject, fallback=False)
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["mode"], "READWRITE")
+
+        # Delete subject-level mode
+        result = self.sr_client.delete_mode_subject(subject=ctx_subject)
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Subject should fall back to context-level READONLY
+        result = self.sr_client.get_mode_subject(subject=ctx_subject, fallback=True)
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["mode"], "READONLY")
+
+        # Delete the context-level mode
+        result = self.sr_client.delete_mode_subject(subject=ctx_prefix)
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Subject should fall back to default READWRITE
+        result = self.sr_client.get_mode_subject(subject=ctx_subject, fallback=True)
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["mode"], "READWRITE")
 
 
 class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):


### PR DESCRIPTION
Makes all /config and /mode endpoints context-aware. This includes ensuring that context-scoped config and mode changes can be correctly written to and replayed from the topic.

It does not yet implement any special handling of the `GLOBAL` context which is going to be lowest-priority layer that spans across contexts.

Fixes https://redpandadata.atlassian.net/browse/CORE-15187

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
