### PR TITLE
cluster: Remove old health report bench

### DIFF
--- a/src/v/cluster/tests/health_bench.cc
+++ b/src/v/cluster/tests/health_bench.cc
@@ -24,39 +24,6 @@ namespace cluster {
 
 struct health_bench : health_report_accessor {
     using health_report_accessor::aggregated_report;
-    /**
-     * @brief The original aggregate function prior to optimization.
-     */
-    template<size_t max_partitions_report>
-    static aggregated_report original_aggregate(report_cache_t& reports) {
-        aggregated_report ret;
-
-        absl::node_hash_map<
-          model::topic_namespace,
-          std::vector<model::partition_id>>
-          leaderless, urp;
-
-        for (const auto& [_, report] : reports) {
-            for (const auto& [tp_ns, partitions] : report->topics) {
-                for (const auto& [_, partition] : partitions) {
-                    if (
-                      !partition.leader_id.has_value()
-                      && ret.leaderless.size() < max_partitions_report) {
-                        ret.leaderless.emplace(
-                          tp_ns.ns, tp_ns.tp, partition.id);
-                    }
-                    if (
-                      partition.under_replicated_replicas.value_or(0) > 0
-                      && ret.under_replicated.size() < max_partitions_report) {
-                        ret.under_replicated.emplace(
-                          tp_ns.ns, tp_ns.tp, partition.id);
-                    }
-                }
-            }
-        }
-
-        return ret;
-    }
 
     void bench(auto aggr_fn) {
         using namespace cluster;
@@ -114,14 +81,6 @@ struct health_bench : health_report_accessor {
         perf_tests::stop_measuring_time();
     }
 };
-
-PERF_TEST_F(health_bench, original) {
-    bench(original_aggregate<original_limit>);
-}
-
-PERF_TEST_F(health_bench, original_unlimited) {
-    bench(original_aggregate<std::numeric_limits<size_t>::max()>);
-}
 
 PERF_TEST_F(health_bench, current) { bench(aggregate); }
 


### PR DESCRIPTION
No need to keep benching old code.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
