### PR TITLE
CORE-15165 Expand testing

### DIFF
--- a/src/v/cluster/cloud_metadata/tests/cluster_metadata_utils.h
+++ b/src/v/cluster/cloud_metadata/tests/cluster_metadata_utils.h
@@ -47,6 +47,11 @@ inline security::acl_binding binding_for_role(const ss::sstring& role_name) {
       security::acl_principal{security::principal_type::role, role_name});
 }
 
+inline security::acl_binding binding_for_group(const ss::sstring& group_name) {
+    return binding_for_principal(
+      security::acl_principal{security::principal_type::group, group_name});
+}
+
 inline topic_properties uploadable_topic_properties() {
     auto props = random_topic_properties();
     if (

--- a/src/v/cluster/cloud_metadata/tests/controller_snapshot_reconciliation_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/controller_snapshot_reconciliation_test.cc
@@ -296,3 +296,79 @@ TEST_F(
     actions = reconciler.get_actions(snap);
     ASSERT_TRUE(actions.empty());
 }
+
+TEST_F(controller_snapshot_reconciliation_fixture, test_reconciler_group_acls) {
+    cluster::controller_snapshot snap;
+    auto binding = binding_for_group("test_group");
+    snap.security.acls.emplace_back(binding);
+
+    // When the snapshot contains Group ACLs, we should see actions.
+    auto actions = reconciler.get_actions(snap);
+    ASSERT_TRUE(
+      actions_contain(actions, cluster::recovery_stage::recovered_acls));
+    validate_actions(actions);
+
+    // Verify the Group ACL is included in the actions.
+    ASSERT_EQ(actions.acls.size(), 1);
+    ASSERT_EQ(
+      actions.acls[0].entry().principal().type(),
+      security::principal_type::group);
+    ASSERT_EQ(actions.acls[0].entry().principal().name_view(), "test_group");
+
+    // The current implementation doesn't dedupe.
+    app.controller->get_security_frontend()
+      .local()
+      .create_acls({binding}, 5s)
+      .get();
+    actions = reconciler.get_actions(snap);
+    ASSERT_TRUE(
+      actions_contain(actions, cluster::recovery_stage::recovered_acls));
+    validate_actions(actions);
+}
+
+TEST_F(
+  controller_snapshot_reconciliation_fixture,
+  test_reconciler_mixed_principal_acls) {
+    // Test that recovery handles a mix of user, role, and group ACLs.
+    cluster::controller_snapshot snap;
+
+    auto user_binding = binding_for_user("test_user");
+    auto role_binding = binding_for_role("test_role");
+    auto group_binding = binding_for_group("test_group");
+
+    snap.security.acls.emplace_back(user_binding);
+    snap.security.acls.emplace_back(role_binding);
+    snap.security.acls.emplace_back(group_binding);
+
+    auto actions = reconciler.get_actions(snap);
+    ASSERT_TRUE(
+      actions_contain(actions, cluster::recovery_stage::recovered_acls));
+    validate_actions(actions);
+
+    // Verify all three ACL types are included in the actions.
+    ASSERT_EQ(actions.acls.size(), 3);
+
+    bool found_user = false, found_role = false, found_group = false;
+    for (const auto& acl : actions.acls) {
+        switch (acl.entry().principal().type()) {
+        case security::principal_type::ephemeral_user:
+            found_user = true;
+            ASSERT_EQ(acl.entry().principal().name_view(), "test_user");
+            break;
+        case security::principal_type::role:
+            found_role = true;
+            ASSERT_EQ(acl.entry().principal().name_view(), "test_role");
+            break;
+        case security::principal_type::group:
+            found_group = true;
+            ASSERT_EQ(acl.entry().principal().name_view(), "test_group");
+            break;
+        default:
+            break;
+        }
+    }
+
+    ASSERT_TRUE(found_user) << "User ACL not found in actions";
+    ASSERT_TRUE(found_role) << "Role ACL not found in actions";
+    ASSERT_TRUE(found_group) << "Group ACL not found in actions";
+}

--- a/src/v/cluster/cloud_metadata/tests/controller_snapshot_reconciliation_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/controller_snapshot_reconciliation_test.cc
@@ -257,6 +257,71 @@ TEST_F(controller_snapshot_reconciliation_fixture, test_reconciler_roles) {
 }
 
 TEST_F(
+  controller_snapshot_reconciliation_fixture,
+  test_reconciler_roles_with_group_members) {
+    // Test that roles with Group members are properly recovered.
+    cluster::controller_snapshot snap;
+    auto& security_snap = snap.security;
+    security_snap.roles.emplace_back(
+      security::role_name("role_with_groups"),
+      security::role({{security::role_member_type::group, "admin_group"}}));
+
+    auto actions = reconciler.get_actions(snap);
+    ASSERT_TRUE(
+      actions_contain(actions, cluster::recovery_stage::recovered_acls));
+    validate_actions(actions);
+
+    // Verify the role with group member is in the actions.
+    ASSERT_EQ(actions.roles.size(), 1);
+    ASSERT_EQ(actions.roles[0].name, security::role_name("role_with_groups"));
+    ASSERT_EQ(actions.roles[0].role.members().size(), 1);
+    ASSERT_TRUE(actions.roles[0].role.members().contains(
+      security::role_member{security::role_member_type::group, "admin_group"}));
+}
+
+TEST_F(
+  controller_snapshot_reconciliation_fixture,
+  test_reconciler_roles_with_mixed_members) {
+    // Test that roles with both user and group members are recovered.
+    cluster::controller_snapshot snap;
+    auto& security_snap = snap.security;
+
+    // Create a role with both user and group members
+    security::role mixed_role{{
+      {security::role_member_type::user, "test_user"},
+      {security::role_member_type::group, "test_group"},
+      {security::role_member_type::group, "admin_group"},
+    }};
+    security_snap.roles.emplace_back(
+      security::role_name("mixed_member_role"), std::move(mixed_role));
+
+    auto actions = reconciler.get_actions(snap);
+    ASSERT_TRUE(
+      actions_contain(actions, cluster::recovery_stage::recovered_acls));
+    validate_actions(actions);
+
+    // Verify the role with mixed members is in the actions.
+    ASSERT_EQ(actions.roles.size(), 1);
+    ASSERT_EQ(actions.roles[0].name, security::role_name("mixed_member_role"));
+
+    const auto& members = actions.roles[0].role.members();
+    ASSERT_EQ(members.size(), 3);
+
+    // Verify user member
+    ASSERT_TRUE(members.contains(
+      security::role_member{security::role_member_type::user, "test_user"}))
+      << "User member not found in role";
+
+    // Verify group members
+    ASSERT_TRUE(members.contains(
+      security::role_member{security::role_member_type::group, "test_group"}))
+      << "test_group member not found in role";
+    ASSERT_TRUE(members.contains(
+      security::role_member{security::role_member_type::group, "admin_group"}))
+      << "admin_group member not found in role";
+}
+
+TEST_F(
   controller_snapshot_reconciliation_fixture, test_reconcile_remote_topics) {
     cluster::controller_snapshot snap;
     model::topic_namespace tp_ns{model::kafka_namespace, model::topic{"foo"}};

--- a/src/v/cluster_link/tests/security_migrator_test.cc
+++ b/src/v/cluster_link/tests/security_migrator_test.cc
@@ -155,4 +155,138 @@ TEST_F_CORO(security_migrator_test, migrate_all_acls) {
       security::acl_host::wildcard_host(),
       security::acl_permission::allow));
 }
+
+TEST_F_CORO(security_migrator_test, migrate_group_acls) {
+    // This test verifies that Group: principal ACLs are properly migrated
+    security::resource_pattern topic_resource{
+      security::resource_type::topic,
+      "test-topic",
+      security::pattern_type::literal};
+    security::resource_pattern cluster_resource{
+      security::resource_type::cluster,
+      security::resource_pattern::wildcard,
+      security::pattern_type::literal};
+
+    fixture().get_cluster_mock().acl_store().add_bindings(
+      {// Group ACL on topic resource
+       security::acl_binding(
+         topic_resource,
+         security::acl_entry{
+           security::acl_principal::from_string("Group:test-group"),
+           security::acl_host::wildcard_host(),
+           security::acl_operation::read,
+           security::acl_permission::allow}),
+       // Group ACL on cluster resource
+       security::acl_binding(
+         cluster_resource,
+         security::acl_entry{
+           security::acl_principal::from_string("Group:test-group"),
+           security::acl_host::wildcard_host(),
+           security::acl_operation::describe,
+           security::acl_permission::allow})});
+
+    co_await fixture().upsert_link(get_default_metadata());
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      5s, [this] { return fixture().security_service().acls().size() >= 2; })
+
+    const auto& local_acls = fixture().security_service().acls();
+
+    EXPECT_EQ(local_acls.size(), 2);
+
+    const auto topic_it = local_acls.find(topic_resource);
+    ASSERT_NE_CORO(topic_it, local_acls.end())
+      << "Failed to find topic resource " << topic_resource;
+    ASSERT_FALSE_CORO(topic_it->second.empty())
+      << "Topic resource contains no acls";
+
+    EXPECT_TRUE(topic_it->second.contains(
+      security::acl_operation::read,
+      security::acl_principal::from_string("Group:test-group"),
+      security::acl_host::wildcard_host(),
+      security::acl_permission::allow));
+
+    const auto cluster_it = local_acls.find(cluster_resource);
+    ASSERT_NE_CORO(cluster_it, local_acls.end())
+      << "Failed to find cluster resource " << cluster_resource;
+    ASSERT_FALSE_CORO(cluster_it->second.empty())
+      << "Cluster resource contains no acls";
+
+    EXPECT_TRUE(cluster_it->second.contains(
+      security::acl_operation::describe,
+      security::acl_principal::from_string("Group:test-group"),
+      security::acl_host::wildcard_host(),
+      security::acl_permission::allow));
+}
+
+TEST_F_CORO(security_migrator_test, migrate_mixed_principal_acls) {
+    // This test verifies that a mix of User, Role, and Group ACLs are migrated
+    security::resource_pattern topic_resource{
+      security::resource_type::topic,
+      "test-topic",
+      security::pattern_type::literal};
+
+    fixture().get_cluster_mock().acl_store().add_bindings(
+      {// User ACL
+       security::acl_binding(
+         topic_resource,
+         security::acl_entry{
+           security::acl_principal::from_string("User:test-user"),
+           security::acl_host::wildcard_host(),
+           security::acl_operation::read,
+           security::acl_permission::allow}),
+       // Role ACL
+       security::acl_binding(
+         topic_resource,
+         security::acl_entry{
+           security::acl_principal::from_string("RedpandaRole:test-role"),
+           security::acl_host::wildcard_host(),
+           security::acl_operation::write,
+           security::acl_permission::allow}),
+       // Group ACL
+       security::acl_binding(
+         topic_resource,
+         security::acl_entry{
+           security::acl_principal::from_string("Group:test-group"),
+           security::acl_host::wildcard_host(),
+           security::acl_operation::describe,
+           security::acl_permission::allow})});
+
+    co_await fixture().upsert_link(get_default_metadata());
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      5s, [this] { return fixture().security_service().acls().size() >= 1; })
+
+    const auto& local_acls = fixture().security_service().acls();
+
+    EXPECT_EQ(local_acls.size(), 1);
+
+    const auto topic_it = local_acls.find(topic_resource);
+    ASSERT_NE_CORO(topic_it, local_acls.end())
+      << "Failed to find topic resource " << topic_resource;
+
+    // Verify User ACL
+    EXPECT_TRUE(topic_it->second.contains(
+      security::acl_operation::read,
+      security::acl_principal::from_string("User:test-user"),
+      security::acl_host::wildcard_host(),
+      security::acl_permission::allow))
+      << "User ACL not found";
+
+    // Verify Role ACL
+    EXPECT_TRUE(topic_it->second.contains(
+      security::acl_operation::write,
+      security::acl_principal::from_string("RedpandaRole:test-role"),
+      security::acl_host::wildcard_host(),
+      security::acl_permission::allow))
+      << "Role ACL not found";
+
+    // Verify Group ACL
+    EXPECT_TRUE(topic_it->second.contains(
+      security::acl_operation::describe,
+      security::acl_principal::from_string("Group:test-group"),
+      security::acl_host::wildcard_host(),
+      security::acl_permission::allow))
+      << "Group ACL not found";
+}
 } // namespace cluster_link::tests

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -2775,6 +2775,190 @@ class ShadowLinkSecurityTests(ShadowLinkTestBase):
             err_msg="Failed to sync acls",
         )
 
+    @cluster(num_nodes=6)
+    def test_group_acl_sync(self):
+        """
+        This test verifies that Group: principal ACLs are synced from source
+        to target cluster when a shadow link is created and configured
+        """
+        req = self.create_default_link_request("test-link")
+
+        resource_filter = shadow_link_pb2.ACLResourceFilter(
+            resource_type=acl_pb2.ACL_RESOURCE_ANY,
+            pattern_type=acl_pb2.ACL_PATTERN_ANY,
+        )
+        access_filter = shadow_link_pb2.ACLAccessFilter(
+            permission_type=acl_pb2.ACL_PERMISSION_TYPE_ANY,
+            operation=acl_pb2.ACL_OPERATION_ANY,
+        )
+        acl_filter = shadow_link_pb2.ACLFilter(
+            resource_filter=resource_filter, access_filter=access_filter
+        )
+        acl_filters: list[shadow_link_pb2.ACLFilter] = [acl_filter]
+
+        security_sync_options = shadow_link_pb2.SecuritySettingsSyncOptions(
+            interval=google.protobuf.duration_pb2.Duration(seconds=1),
+            acl_filters=acl_filters,
+        )
+        req.shadow_link.configurations.security_sync_options.CopyFrom(
+            security_sync_options
+        )
+
+        _ = self.create_link_with_request(req=req)
+        self.logger.info("Successfully created link")
+
+        target_acls: Any = self.target_cluster_rpk.acl_list(format="json")
+        assert len(target_acls["matches"]) == 0, (
+            f"Expected no ACLs on target cluster, got {target_acls}"
+        )
+
+        # Create a Group ACL on the source cluster
+        group_acl = RPKACLInput(
+            allow_principal=["Group:test-group"],
+            allow_host=["*"],
+            topic=["test-topic"],
+            operation=["read", "describe"],
+            resource_pattern_type="literal",
+        )
+        self.source_cluster_rpk.acl_create(group_acl)
+
+        def check_if_group_acls_synced():
+            target_acls: Any = self.target_cluster_rpk.acl_list(format="json")
+            # We expect 2 ACLs (one for read, one for describe)
+            group_acls_found = [
+                acl
+                for acl in target_acls.get("matches", [])
+                if acl.get("principal") == "Group:test-group"
+            ]
+            if len(group_acls_found) != 2:
+                self.logger.debug(f"Found {len(group_acls_found)} ACLs")
+                return False
+
+            self.logger.info(f"Found Group ACLs on target cluster: {group_acls_found}")
+            for acl in group_acls_found:
+                if not (
+                    acl["host"] == "*"
+                    and acl["resource_type"] == "TOPIC"
+                    and acl["resource_name"] == "test-topic"
+                    and acl["resource_pattern_type"] == "LITERAL"
+                    and acl["permission"] == "ALLOW"
+                ):
+                    return False
+            return True
+
+        wait_until(
+            check_if_group_acls_synced,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Failed to sync Group ACLs",
+        )
+
+        self.logger.info("Group ACLs successfully synced")
+
+    @cluster(num_nodes=6)
+    def test_mixed_principal_acl_sync(self):
+        """
+        This test verifies that a mix of User, Role, and Group ACLs are all
+        synced from source to target cluster
+        """
+        req = self.create_default_link_request("test-link")
+
+        resource_filter = shadow_link_pb2.ACLResourceFilter(
+            resource_type=acl_pb2.ACL_RESOURCE_ANY,
+            pattern_type=acl_pb2.ACL_PATTERN_ANY,
+        )
+        access_filter = shadow_link_pb2.ACLAccessFilter(
+            permission_type=acl_pb2.ACL_PERMISSION_TYPE_ANY,
+            operation=acl_pb2.ACL_OPERATION_ANY,
+        )
+        acl_filter = shadow_link_pb2.ACLFilter(
+            resource_filter=resource_filter, access_filter=access_filter
+        )
+        acl_filters: list[shadow_link_pb2.ACLFilter] = [acl_filter]
+
+        security_sync_options = shadow_link_pb2.SecuritySettingsSyncOptions(
+            interval=google.protobuf.duration_pb2.Duration(seconds=1),
+            acl_filters=acl_filters,
+        )
+        req.shadow_link.configurations.security_sync_options.CopyFrom(
+            security_sync_options
+        )
+
+        _ = self.create_link_with_request(req=req)
+        self.logger.info("Successfully created link")
+
+        target_acls: Any = self.target_cluster_rpk.acl_list(format="json")
+        assert len(target_acls["matches"]) == 0, (
+            f"Expected no ACLs on target cluster, got {target_acls}"
+        )
+
+        # Create User ACL
+        user_acl = RPKACLInput(
+            allow_principal=["test-user"],
+            topic=["mixed-topic"],
+            operation=["read"],
+            resource_pattern_type="literal",
+        )
+        self.source_cluster_rpk.acl_create(user_acl)
+
+        # Create Role ACL
+        role_acl = RPKACLInput(
+            allow_role=["test-role"],
+            topic=["mixed-topic"],
+            operation=["write"],
+            resource_pattern_type="literal",
+        )
+        self.source_cluster_rpk.acl_create(role_acl)
+
+        # Create Group ACL
+        group_acl = RPKACLInput(
+            allow_principal=["Group:test-group"],
+            allow_host=["*"],
+            topic=["mixed-topic"],
+            operation=["describe"],
+            resource_pattern_type="literal",
+        )
+        self.source_cluster_rpk.acl_create(group_acl)
+
+        def check_if_all_acls_synced():
+            target_acls: Any = self.target_cluster_rpk.acl_list(format="json")
+            matches = target_acls.get("matches", [])
+
+            user_acl_found = any(
+                acl.get("principal") == "User:test-user"
+                and acl.get("operation") == "READ"
+                for acl in matches
+            )
+            role_acl_found = any(
+                acl.get("principal") == "RedpandaRole:test-role"
+                and acl.get("operation") == "WRITE"
+                for acl in matches
+            )
+            group_acl_found = any(
+                acl.get("principal") == "Group:test-group"
+                and acl.get("operation") == "DESCRIBE"
+                for acl in matches
+            )
+
+            if user_acl_found and role_acl_found and group_acl_found:
+                self.logger.info(f"All ACL types found on target cluster: {matches}")
+                return True
+
+            self.logger.debug(
+                f"Waiting for ACLs - User: {user_acl_found}, Role: {role_acl_found}, "
+                f"Group: {group_acl_found}, matches: {matches}"
+            )
+            return False
+
+        wait_until(
+            check_if_all_acls_synced,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Failed to sync mixed principal ACLs",
+        )
+
+        self.logger.info("All mixed principal ACLs successfully synced")
+
 
 class ShadowLinkTopicFailoverTests(ShadowLinkPreAllocTestBase):
     def _maybe_failure_injector(self, with_failures: bool):

--- a/tests/rptest/tests/cluster_recovery_test.py
+++ b/tests/rptest/tests/cluster_recovery_test.py
@@ -202,6 +202,227 @@ class ClusterRecoveryTest(RedpandaTest):
             assert found_role_acl, f"Couldn't find {role_name} in {acls_lines}"
 
     @cluster(num_nodes=4)
+    def test_group_acl_restore(self):
+        """
+        Tests that Group ACLs (ACLs with Group: principal prefix) are properly
+        backed up and restored by cluster recovery.
+        """
+        rpk = RpkTool(self.redpanda)
+
+        for t in self.topics:
+            KgoVerifierProducer.oneshot(
+                self.test_context,
+                self.redpanda,
+                t.name,
+                self.message_size,
+                100,
+                batch_max_bytes=self.message_size * 8,
+                timeout_sec=60,
+            )
+        quiesce_uploads(self.redpanda, [t.name for t in self.topics], timeout_sec=60)
+
+        # Create Group ACLs with different operations and resource types
+        group_acls = []
+        for i in range(3):
+            group_name = f"test_group_{random_string(6)}"
+
+            # Create a Group ACL on the cluster resource
+            cluster_acl = RPKACLInput()
+            cluster_acl.allow_principal = [f"Group:{group_name}"]
+            cluster_acl.allow_host = ["*"]
+            cluster_acl.operation = ["describe"]
+            cluster_acl.cluster = True
+            rpk.acl_create(cluster_acl)
+
+            # Create a Group ACL on a topic resource
+            topic_acl = RPKACLInput()
+            topic_acl.allow_principal = [f"Group:{group_name}"]
+            topic_acl.allow_host = ["*"]
+            topic_acl.operation = ["read", "describe"]
+            topic_acl.topic = [self.topics[i].name]
+            rpk.acl_create(topic_acl)
+
+            group_acls.append(group_name)
+
+        self.logger.info(f"Created Group ACLs for groups: {group_acls}")
+
+        # Verify ACLs were created
+        acls_before = rpk.acl_list(format="json")
+        for group_name in group_acls:
+            group_acl_found = any(
+                acl.get("principal") == f"Group:{group_name}"
+                for acl in acls_before.get("matches", [])
+            )
+            assert group_acl_found, f"Group:{group_name} ACL not found before recovery"
+
+        time.sleep(5)
+
+        # Stop and wipe the cluster
+        self.redpanda.stop()
+        for n in self.redpanda.nodes:
+            self.redpanda.remove_local_data(n)
+        self.redpanda.restart_nodes(
+            self.redpanda.nodes, auto_assign_node_id=True, omit_seeds_on_idx_one=False
+        )
+        self.redpanda._admin.await_stable_leader(
+            "controller", partition=0, namespace="redpanda", timeout_s=60, backoff_s=2
+        )
+
+        self.logger.info("Verifying that no ACLs are present before recovery")
+        assert len(rpk.acl_list().splitlines()) == 1, "Expected no ACLs before recovery"
+
+        self.logger.info("Initializing cluster recovery")
+        self.redpanda._admin.initialize_cluster_recovery()
+
+        def cluster_recovery_complete():
+            return (
+                "inactive"
+                in self.redpanda._admin.get_cluster_recovery_status().json()["state"]
+            )
+
+        wait_until(cluster_recovery_complete, timeout_sec=30, backoff_sec=1)
+
+        self.logger.info("Verifying Group ACLs are restored")
+
+        acls_after = rpk.acl_list(format="json")
+        for group_name in group_acls:
+            # Check for cluster ACL
+            cluster_acl_found = any(
+                acl.get("principal") == f"Group:{group_name}"
+                and acl.get("resource_type") == "CLUSTER"
+                for acl in acls_after.get("matches", [])
+            )
+            assert cluster_acl_found, f"Group:{group_name} cluster ACL not restored"
+
+            # Check for topic ACL
+            topic_acl_found = any(
+                acl.get("principal") == f"Group:{group_name}"
+                and acl.get("resource_type") == "TOPIC"
+                for acl in acls_after.get("matches", [])
+            )
+            assert topic_acl_found, f"Group:{group_name} topic ACL not restored"
+
+        self.logger.info("All Group ACLs successfully restored")
+
+    @cluster(num_nodes=4)
+    def test_mixed_principal_acl_restore(self):
+        """
+        Tests that a mix of User, Role, and Group ACLs are all properly
+        backed up and restored by cluster recovery.
+        """
+        rpk = RpkTool(self.redpanda)
+
+        for t in self.topics:
+            KgoVerifierProducer.oneshot(
+                self.test_context,
+                self.redpanda,
+                t.name,
+                self.message_size,
+                100,
+                batch_max_bytes=self.message_size * 8,
+                timeout_sec=60,
+            )
+        quiesce_uploads(self.redpanda, [t.name for t in self.topics], timeout_sec=60)
+
+        algorithm = "SCRAM-SHA-256"
+
+        # Create a user with ACL
+        user_name = f"user-{random_string(6)}"
+        user_password = f"pass-{random_string(9)}"
+        self.redpanda._admin.create_user(user_name, user_password, algorithm)
+        rpk.acl_create_allow_cluster(user_name, op="describe")
+
+        # Create a role with ACL
+        role_name = f"role-{random_string(6)}"
+        self.redpanda._admin.create_role(role_name)
+        self.redpanda._admin.update_role_members(
+            role_name, add=[RoleMember.User(user_name)]
+        )
+        role_acl = RPKACLInput()
+        role_acl.allow_role = [role_name]
+        role_acl.cluster = True
+        role_acl.operation = ["ALL"]
+        rpk.acl_create(role_acl)
+
+        # Create a group ACL
+        group_name = f"group-{random_string(6)}"
+        group_acl = RPKACLInput()
+        group_acl.allow_principal = [f"Group:{group_name}"]
+        group_acl.allow_host = ["*"]
+        group_acl.operation = ["describe", "read"]
+        group_acl.cluster = True
+        rpk.acl_create(group_acl)
+
+        self.logger.info(
+            f"Created mixed ACLs - User: {user_name}, Role: {role_name}, Group: {group_name}"
+        )
+
+        time.sleep(5)
+
+        # Stop and wipe the cluster
+        self.redpanda.stop()
+        for n in self.redpanda.nodes:
+            self.redpanda.remove_local_data(n)
+        self.redpanda.restart_nodes(
+            self.redpanda.nodes, auto_assign_node_id=True, omit_seeds_on_idx_one=False
+        )
+        self.redpanda._admin.await_stable_leader(
+            "controller", partition=0, namespace="redpanda", timeout_s=60, backoff_s=2
+        )
+
+        self.logger.info("Initializing cluster recovery")
+        self.redpanda._admin.initialize_cluster_recovery()
+
+        def cluster_recovery_complete():
+            return (
+                "inactive"
+                in self.redpanda._admin.get_cluster_recovery_status().json()["state"]
+            )
+
+        wait_until(cluster_recovery_complete, timeout_sec=30, backoff_sec=1)
+
+        self.logger.info("Verifying all ACL types are restored")
+
+        acls = rpk.acl_list()
+        acls_lines = acls.splitlines()
+
+        # Check user ACL
+        user_acl_found = any(
+            user_name in line and "ALLOW" in line and "DESCRIBE" in line
+            for line in acls_lines
+        )
+        assert user_acl_found, f"User ACL for {user_name} not restored"
+
+        # Check role ACL
+        role_acl_found = any(
+            role_name in line and "ALLOW" in line and "ALL" in line
+            for line in acls_lines
+        )
+        assert role_acl_found, f"Role ACL for {role_name} not restored"
+
+        # Check group ACL
+        group_acl_found = any(
+            f"Group:{group_name}" in line and "ALLOW" in line for line in acls_lines
+        )
+        assert group_acl_found, f"Group ACL for {group_name} not restored"
+
+        # Verify role membership is also restored
+        restored_roles = rpk.list_roles().get("roles", [])
+        assert role_name in restored_roles, f"Role {role_name} not restored"
+
+        role_details = rpk.describe_role(role_name)
+        restored_members = [
+            m["name"]
+            for m in role_details.get("members", [])
+            if m["principal_type"] == RoleMember.PrincipalType.USER.value
+        ]
+        assert user_name in restored_members, (
+            f"User {user_name} not in role {role_name} members after restore"
+        )
+
+        self.logger.info("All mixed principal ACLs successfully restored")
+
+    @cluster(num_nodes=4)
     def test_bootstrap_with_recovery(self):
         """
         Smoke test that configuring automated recovery at bootstrap will kick

--- a/tests/rptest/tests/cluster_recovery_test.py
+++ b/tests/rptest/tests/cluster_recovery_test.py
@@ -20,12 +20,15 @@ from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 
 from rptest.services.admin import RoleMember
+from rptest.clients.admin.proto.redpanda.core.admin.v2 import security_pb2
+from rptest.clients.admin.v2 import Admin as AdminV2
 from rptest.clients.rpk import RPKACLInput, RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
 from rptest.services.redpanda import SISettings
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.util import wait_until_result
 from rptest.utils.si_utils import quiesce_uploads
 
 KiB = 1024
@@ -421,6 +424,190 @@ class ClusterRecoveryTest(RedpandaTest):
         )
 
         self.logger.info("All mixed principal ACLs successfully restored")
+
+    @cluster(num_nodes=4)
+    def test_role_with_group_members_restore(self):
+        """
+        Tests that roles with Group members (not just User members) are properly
+        backed up and restored by cluster recovery.
+        """
+        for t in self.topics:
+            KgoVerifierProducer.oneshot(
+                self.test_context,
+                self.redpanda,
+                t.name,
+                self.message_size,
+                100,
+                batch_max_bytes=self.message_size * 8,
+                timeout_sec=60,
+            )
+        quiesce_uploads(self.redpanda, [t.name for t in self.topics], timeout_sec=60)
+
+        # Use Admin v2 API to create roles with Group members
+        superuser = self.redpanda.SUPERUSER_CREDENTIALS
+        admin_v2 = AdminV2(self.redpanda, auth=(superuser.username, superuser.password))
+
+        # Create a role with only Group members
+        group_only_role = f"group-only-role-{random_string(6)}"
+        group_name_1 = f"admin-group-{random_string(4)}"
+        group_name_2 = f"dev-group-{random_string(4)}"
+        group_members = [
+            security_pb2.RoleMember(group=security_pb2.RoleGroup(name=group_name_1)),
+            security_pb2.RoleMember(group=security_pb2.RoleGroup(name=group_name_2)),
+        ]
+        admin_v2.security().create_role(
+            security_pb2.CreateRoleRequest(
+                role=security_pb2.Role(name=group_only_role, members=group_members)
+            )
+        )
+
+        # Create a role with mixed User and Group members
+        mixed_role = f"mixed-role-{random_string(6)}"
+        user_name = f"user-{random_string(6)}"
+        user_password = f"pass-{random_string(9)}"
+        self.redpanda._admin.create_user(user_name, user_password, "SCRAM-SHA-256")
+
+        ops_group_name = f"ops-group-{random_string(4)}"
+        mixed_members = [
+            security_pb2.RoleMember(user=security_pb2.RoleUser(name=user_name)),
+            security_pb2.RoleMember(group=security_pb2.RoleGroup(name=ops_group_name)),
+        ]
+        admin_v2.security().create_role(
+            security_pb2.CreateRoleRequest(
+                role=security_pb2.Role(name=mixed_role, members=mixed_members)
+            )
+        )
+
+        self.logger.info(
+            f"Created roles - group_only_role: {group_only_role} with groups [{group_name_1}, {group_name_2}], "
+            f"mixed_role: {mixed_role} with user [{user_name}] and group [{ops_group_name}]"
+        )
+
+        # Helper to extract members from protobuf Role
+        def get_group_members(role: security_pb2.Role) -> list[str]:
+            return [
+                m.group.name for m in role.members if m.WhichOneof("member") == "group"
+            ]
+
+        def get_user_members(role: security_pb2.Role) -> list[str]:
+            return [
+                m.user.name for m in role.members if m.WhichOneof("member") == "user"
+            ]
+
+        # Verify roles were created correctly before recovery using AdminV2
+        group_only_role_obj = (
+            admin_v2.security()
+            .get_role(security_pb2.GetRoleRequest(name=group_only_role))
+            .role
+        )
+        assert len(group_only_role_obj.members) == 2, (
+            f"Expected 2 members in {group_only_role}, got {group_only_role_obj.members}"
+        )
+
+        def get_role_if_it_exists(
+            role_name: str,
+        ) -> tuple[bool, security_pb2.Role | None]:
+            try:
+                role = (
+                    admin_v2.security()
+                    .get_role(security_pb2.GetRoleRequest(name=role_name))
+                    .role
+                )
+                return True, role
+            except Exception:
+                return False, None
+
+        mixed_role_obj = wait_until_result(
+            lambda: get_role_if_it_exists(mixed_role),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"Unable to find role {mixed_role}",
+        )
+
+        assert len(mixed_role_obj.members) == 2, (
+            f"Expected 2 members in {mixed_role}, got {mixed_role_obj.members}"
+        )
+
+        time.sleep(5)
+
+        # Stop and wipe the cluster
+        self.redpanda.stop()
+        for n in self.redpanda.nodes:
+            self.redpanda.remove_local_data(n)
+        self.redpanda.restart_nodes(
+            self.redpanda.nodes, auto_assign_node_id=True, omit_seeds_on_idx_one=False
+        )
+        self.redpanda._admin.await_stable_leader(
+            "controller", partition=0, namespace="redpanda", timeout_s=60, backoff_s=2
+        )
+
+        # Recreate AdminV2 client after cluster restart
+        admin_v2 = AdminV2(self.redpanda, auth=(superuser.username, superuser.password))
+
+        self.logger.info("Verifying that no roles are present before recovery")
+        roles_before_recovery = (
+            admin_v2.security().list_roles(security_pb2.ListRolesRequest()).roles
+        )
+        assert len(roles_before_recovery) == 0, "Expected no roles before recovery"
+
+        self.logger.info("Initializing cluster recovery")
+        self.redpanda._admin.initialize_cluster_recovery()
+
+        def cluster_recovery_complete():
+            return (
+                "inactive"
+                in self.redpanda._admin.get_cluster_recovery_status().json()["state"]
+            )
+
+        wait_until(cluster_recovery_complete, timeout_sec=30, backoff_sec=1)
+
+        self.logger.info("Verifying roles with Group members are restored")
+
+        # Verify group-only role using AdminV2
+        restored_roles = (
+            admin_v2.security().list_roles(security_pb2.ListRolesRequest()).roles
+        )
+        restored_role_names = [r.name for r in restored_roles]
+        assert group_only_role in restored_role_names, (
+            f"Role {group_only_role} not restored"
+        )
+
+        group_only_restored = (
+            admin_v2.security()
+            .get_role(security_pb2.GetRoleRequest(name=group_only_role))
+            .role
+        )
+        restored_group_members = get_group_members(group_only_restored)
+        assert len(restored_group_members) == 2, (
+            f"Expected 2 Group members in {group_only_role}, got {restored_group_members}"
+        )
+        for group_name in [group_name_1, group_name_2]:
+            assert group_name in restored_group_members, (
+                f"Group member {group_name} not restored in {group_only_role}"
+            )
+
+        # Verify mixed role using AdminV2
+        assert mixed_role in restored_role_names, f"Role {mixed_role} not restored"
+
+        mixed_restored = (
+            admin_v2.security()
+            .get_role(security_pb2.GetRoleRequest(name=mixed_role))
+            .role
+        )
+        restored_user_members = get_user_members(mixed_restored)
+        restored_mixed_group_members = get_group_members(mixed_restored)
+
+        assert user_name in restored_user_members, (
+            f"User {user_name} not restored as member of {mixed_role}"
+        )
+        assert len(restored_mixed_group_members) == 1, (
+            f"Expected 1 Group member in {mixed_role}, got {restored_mixed_group_members}"
+        )
+        assert ops_group_name in restored_mixed_group_members, (
+            f"Group member {ops_group_name} not restored in {mixed_role}"
+        )
+
+        self.logger.info("All roles with Group members successfully restored")
 
     @cluster(num_nodes=4)
     def test_bootstrap_with_recovery(self):


### PR DESCRIPTION
Add comprehensive test coverage for Group ACLs and Group role members across cluster recovery and cluster linking features.

**Cluster Recovery:**
- Add C++ unit tests verifying Group ACLs in controller snapshots are recognized and included in recovery actions
- Add C++ unit tests verifying roles with Group members (not just User members) are properly recovered
- Add Python integration tests for end-to-end Group ACL backup/restore on cluster and topic resources
- Add Python integration test for roles with Group members backup/restore

**Shadow Linking:**
- Add C++ unit tests verifying Group ACLs on topic and cluster resources are migrated correctly during Shadow Linking
- Add Python integration tests for end-to-end Group ACL sync from source to target cluster

All tests include mixed principal scenarios (User, Role, and Group) to ensure all principal types work together correctly.

Fixes: CORE-15165

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none