### PR TITLE
Add option to internally flush row groups in parquet writer

### DIFF
--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -124,6 +124,17 @@ ss::future<reservation_error> translator_mem_tracker::reserve_bytes(
 ss::future<>
 translator_mem_tracker::free_bytes(size_t bytes, ss::abort_source&) {
     _current_usage -= std::min(_current_usage, bytes);
+    auto excess_reservation = total_reserved() - _current_usage;
+    // In cases where the underlying translator decided to flush its buffered
+    // memory to disk we want to avoid holding excess memory units.
+    //
+    // We do hold on one reservation block so that some meaningful progess can
+    // still be made by the translator in cases where memory units are highly
+    // contended.
+    if (excess_reservation > _reservations_tracker.reservation_block_size()) {
+        _reservations.return_units(
+          excess_reservation - _reservations_tracker.reservation_block_size());
+    }
     return ss::now();
 }
 

--- a/src/v/datalake/translation/scheduling.cc
+++ b/src/v/datalake/translation/scheduling.cc
@@ -78,6 +78,10 @@ public:
         return _total_memory - _available_memory.available_units();
     }
 
+    size_t reservation_block_size() const override {
+        return _reservation_block_size;
+    }
+
     /*
      * disk reservation overages are handled by requesting units from the global
      * disk manager, and then waiting for sufficient disk resources to become

--- a/src/v/datalake/translation/scheduling.h
+++ b/src/v/datalake/translation/scheduling.h
@@ -102,6 +102,7 @@ public:
     virtual bool memory_exhausted() const = 0;
 
     virtual size_t allocated_memory() const = 0;
+    virtual size_t reservation_block_size() const = 0;
 
     /**
      * Returns a reservation of disk space. The reservation may be any size,

--- a/src/v/serde/parquet/tests/BUILD
+++ b/src/v/serde/parquet/tests/BUILD
@@ -192,6 +192,25 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "writer_test",
+    timeout = "short",
+    srcs = [
+        "writer_test.cc",
+    ],
+    cpu = 1,
+    memory = "64MiB",
+    deps = [
+        "//src/v/bytes:iostream",
+        "//src/v/serde/parquet:schema",
+        "//src/v/serde/parquet:value",
+        "//src/v/serde/parquet:writer",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
 redpanda_cc_bench(
     name = "column_writer_rpbench",
     srcs = [

--- a/src/v/serde/parquet/tests/writer_test.cc
+++ b/src/v/serde/parquet/tests/writer_test.cc
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/iostream.h"
+#include "serde/parquet/schema.h"
+#include "serde/parquet/value.h"
+#include "serde/parquet/writer.h"
+
+#include <gtest/gtest.h>
+
+namespace serde::parquet {
+namespace {
+
+schema_element leaf_node(
+  ss::sstring name,
+  field_repetition_type rep_type,
+  physical_type ptype,
+  logical_type ltype = logical_type{}) {
+    return {
+      .type = ptype,
+      .repetition_type = rep_type,
+      .path = {std::move(name)},
+      .logical_type = ltype,
+    };
+}
+
+schema_element simple_schema() {
+    chunked_vector<schema_element> children;
+    children.push_back(
+      leaf_node("data", field_repetition_type::required, byte_array_type{}));
+    return {
+      .repetition_type = field_repetition_type::required,
+      .path = {"root"},
+      .children = std::move(children),
+    };
+}
+
+group_value make_row(size_t data_size) {
+    chunked_vector<group_member> fields;
+    fields.push_back(
+      group_member{byte_array_value{iobuf::from(std::string(data_size, 'x'))}});
+    return fields;
+}
+
+} // namespace
+
+// NOLINTBEGIN(*magic-number*)
+
+TEST(ParquetWriter, FlushesRowGroupWhenSizeExceeded) {
+    constexpr size_t row_group_size = 1_KiB;
+    constexpr size_t row_size = 256;
+    constexpr size_t rows_to_write = 5;
+
+    iobuf file;
+    writer w(
+      {
+        .schema = simple_schema(),
+        .row_group_size = row_group_size,
+      },
+      make_iobuf_ref_output_stream(file));
+    w.init().get();
+
+    file_stats stats;
+    for (size_t i = 0; i < rows_to_write; ++i) {
+        stats = w.write_row(make_row(row_size)).get();
+    }
+    EXPECT_GE(stats.flushed_size, row_group_size);
+    EXPECT_LT(stats.buffered_size, row_group_size);
+
+    w.close().get();
+}
+
+TEST(ParquetWriter, NoEarlyFlushWhenUnderLimit) {
+    constexpr size_t row_group_size = 64_MiB;
+    constexpr size_t row_size = 256;
+    constexpr size_t rows_to_write = 5;
+
+    iobuf file;
+    writer w(
+      {
+        .schema = simple_schema(),
+        .row_group_size = row_group_size,
+      },
+      make_iobuf_ref_output_stream(file));
+    w.init().get();
+
+    file_stats stats;
+    for (size_t i = 0; i < rows_to_write; ++i) {
+        stats = w.write_row(make_row(row_size)).get();
+    }
+
+    // flushed_size should only be the magic bytes (PAR1 = 4 bytes)
+    EXPECT_EQ(stats.flushed_size, 4);
+    EXPECT_GE(stats.buffered_size, row_size * rows_to_write);
+
+    w.close().get();
+}
+
+// NOLINTEND(*magic-number*)
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/writer.cc
+++ b/src/v/serde/parquet/writer.cc
@@ -70,17 +70,22 @@ public:
           _opts.schema, std::move(row), [this](shredded_value sv) {
               return write_value(std::move(sv));
           });
-        file_stats stats;
-        stats.buffered_size = 0;
+        int64_t buffered_size = 0;
         for (auto& [_, col] : _columns) {
             int64_t usage = col.writer.current_page_memory_usage();
             if (usage > _opts.page_buffer_size) {
                 co_await col.writer.next_page();
             }
-            stats.buffered_size += col.writer.memory_usage();
+            buffered_size += col.writer.memory_usage();
         }
-        stats.flushed_size = _flushed_bytes;
-        co_return stats;
+        if (buffered_size >= _opts.row_group_size) {
+            co_await flush_row_group();
+            co_return stats();
+        }
+        co_return file_stats{
+          .flushed_size = _flushed_bytes,
+          .buffered_size = buffered_size,
+        };
     }
 
     file_stats stats() const {

--- a/src/v/serde/parquet/writer.h
+++ b/src/v/serde/parquet/writer.h
@@ -52,6 +52,10 @@ public:
         // group). Ecosystem libraries tend to default between 256Kib-1MiB
         static constexpr int64_t default_page_size = 512_KiB;
         int64_t page_buffer_size = default_page_size;
+
+        // Row groups are flushed to disk internally if they exceed this size.
+        static constexpr int64_t default_row_group_size = 128_MiB;
+        int64_t row_group_size = default_row_group_size;
     };
 
     // Create a new parquet file writer using the given options that


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Prior to this PR a user would have to explicitly call
`flush_row_group` to flush a row group out of memory and to the output
stream. Now if the size of the row group exceeds `options::row_group_size`
the flushing is done internally within `write_row`.

This implicit flushing becomes important in the Iceberg impl where
`flush_row_group` is only called at the end of every translation
interval(30s by default). For large messages or messages with simple
schemas it's entirely possible for row groups to be 100-300MiB within
this 30s interval. This often results in memory units being exhausted
and translation on a given shard coming to a halt until the scheduler
terminates an on-going translation.

With more periodic flushing though we can avoid having to pause on-going
translations due to high memory usage. The reason for this
periodic flushing to be in the writer layer instead of say the scheduler
is because the only the writer is aware of the most optimal way to
layout/write a given file format and how much it needs to buffer in
memory to achieve that.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
