### PR TITLE
Container improvements

### DIFF
--- a/src/v/container/chunked_hash_map.h
+++ b/src/v/container/chunked_hash_map.h
@@ -73,6 +73,27 @@ using chunked_hash_map = ankerl::unordered_dense::segmented_map<
   ankerl::unordered_dense::bucket_type::standard,
   chunked_vector<ankerl::unordered_dense::bucket_type::standard>>;
 
+namespace detail {
+template<typename Range>
+struct chunked_hash_map_from_range_impl {
+    using value_t = std::ranges::range_value_t<std::decay_t<Range>>;
+    using first_t = typename value_t::first_type;
+    using second_t = typename value_t::second_type;
+    using ret_t = chunked_hash_map<first_t, second_t>;
+};
+} // namespace detail
+
+// reserves if range size is known
+template<typename Range>
+typename detail::chunked_hash_map_from_range_impl<Range>::ret_t
+chunked_hash_map_from_range(Range&& range) {
+    size_t size = 0;
+    if constexpr (std::ranges::sized_range<Range>) {
+        size = std::ranges::size(range);
+    }
+    return {std::ranges::begin(range), std::ranges::end(range), size};
+};
+
 /**
  * @brief A set counterpart of chunked_hash_map (uses a chunked vector as the
  * underlying storage).

--- a/src/v/container/chunked_hash_map.h
+++ b/src/v/container/chunked_hash_map.h
@@ -146,3 +146,16 @@ memory_usage_lower_bound(const chunked_hash_map<K, V, Hash, EqualTo>& m) {
              * sizeof(typename chunked_hash_map<K, V>::bucket_type)
            + m.values().capacity() * sizeof(m.values()[0]);
 }
+
+template<typename K>
+struct fmt::formatter<chunked_hash_set<K>> {
+    using type = chunked_hash_set<K>;
+
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    typename FormatContext::iterator
+    format(const type& set, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "[{}]", fmt::join(set, ","));
+    }
+};

--- a/src/v/container/chunked_vector.h
+++ b/src/v/container/chunked_vector.h
@@ -126,11 +126,13 @@ public:
      * https://en.cppreference.com/w/cpp/ranges/as_rvalue_view.html
      */
     template<typename Range>
-    requires(std::ranges::sized_range<Range>)
+    requires(std::ranges::range<Range>)
     // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
     chunked_vector(std::from_range_t, Range&& range)
       : chunked_vector() {
-        reserve(std::ranges::size(range));
+        if constexpr (std::ranges::sized_range<Range>) {
+            reserve(std::ranges::size(range));
+        }
         std::copy(
           std::ranges::begin(range),
           std::ranges::end(range),

--- a/src/v/container/tests/chunked_hash_map_test.cc
+++ b/src/v/container/tests/chunked_hash_map_test.cc
@@ -13,6 +13,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include <list>
+
 struct foo_with_std_hash {
     int a;
     int b;
@@ -59,4 +61,27 @@ TEST(chunked_hash_map, test_move_assignment) {
     chunked_hash_map<foo_with_absl_hash, int> map;
     chunked_hash_map<foo_with_absl_hash, int> other_map;
     other_map = std::move(map);
+}
+
+TEST(chunked_hash_map, from_range_vector) {
+    std::vector<std::pair<int, int>> input{{1, 10}, {2, 20}, {3, 30}};
+    auto map = chunked_hash_map_from_range(input);
+    chunked_hash_map<int, int> expected{{1, 10}, {2, 20}, {3, 30}};
+    EXPECT_EQ(map, expected);
+}
+
+TEST(chunked_hash_map, from_range_list) {
+    std::list<std::pair<std::string, int>> input{
+      {"one", 1}, {"two", 2}, {"three", 3}};
+    auto map = chunked_hash_map_from_range(input);
+    chunked_hash_map<std::string, int> expected{
+      {"one", 1}, {"two", 2}, {"three", 3}};
+    EXPECT_EQ(map, expected);
+}
+
+TEST(chunked_hash_map, from_range_array) {
+    std::array<std::pair<int, std::string>, 2> input{{{1, "one"}, {2, "two"}}};
+    auto map = chunked_hash_map_from_range(input);
+    chunked_hash_map<int, std::string> expected{{1, "one"}, {2, "two"}};
+    EXPECT_EQ(map, expected);
 }

--- a/src/v/container/tests/chunked_vector_test.cc
+++ b/src/v/container/tests/chunked_vector_test.cc
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <initializer_list>
 #include <limits>
+#include <list>
 #include <numeric>
 #include <ranges>
 #include <stdexcept>
@@ -605,9 +606,14 @@ TEST(ChunkedVector, FromRange) {
     for (int i = 0; i < 10; ++i) {
         buffer.push_back(i);
     }
-
     auto vec = chunked_vector<int32_t>(std::from_range, buffer);
     EXPECT_THAT(vec, ElementsAreArray(buffer));
+}
+
+TEST(ChunkedVector, FromRangeUnsized) {
+    std::list<int32_t> input{1, 2, 3, 4, 5};
+    auto vec = chunked_vector<int32_t>(std::from_range, input);
+    EXPECT_THAT(vec, ElementsAreArray(input));
 }
 
 struct move_only_t {


### PR DESCRIPTION
Container improvements:
* implement formatter for chunked_hash_set
* from_range container/chunked_vector constructor to support non-sized ranges (but still reserve if source size is known)
* add a function to create container/chunked_hash_map from a range and reserves if possible in a similar fashion

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
