### PR TITLE
`ct/l1`: `compaction_committer` tweaks [take 2]

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/committer.cc
+++ b/src/v/cloud_topics/level_one/compaction/committer.cc
@@ -81,10 +81,8 @@ ss::future<> compaction_committer::compaction_job::finalize(
 
     if (!_inflight_uploads.empty()) {
         // Await and discard unresolved inflight futures, if any.
-        auto inflight_uploads = std::exchange(_inflight_uploads, {});
-        using res_t = chunked_vector<expected_t>;
         auto res = co_await ss::coroutine::as_future(
-          ssx::when_all_succeed<res_t>(std::move(inflight_uploads)));
+          do_await_inflight_uploads());
         res.ignore_ready_future();
     }
 
@@ -233,15 +231,18 @@ void compaction_committer::compaction_job::upload_some() {
     }
 }
 
+ss::future<chunked_vector<compaction_committer::compaction_job::expected_t>>
+compaction_committer::compaction_job::do_await_inflight_uploads() {
+    auto inflight_uploads = std::exchange(_inflight_uploads, {});
+    return ssx::when_all_succeed<chunked_vector<expected_t>>(
+      std::move(inflight_uploads));
+}
+
 ss::future<std::optional<ss::sstring>>
 compaction_committer::compaction_job::await_inflight_uploads() {
     co_await _last_upload_scheduled.wait();
 
-    auto inflight_uploads = std::exchange(_inflight_uploads, {});
-
-    using res_t = chunked_vector<expected_t>;
-    auto res = co_await ssx::when_all_succeed<res_t>(
-      std::move(inflight_uploads));
+    auto res = co_await do_await_inflight_uploads();
 
     auto failed = res | std::views::filter([](const expected_t& res) {
                       return !res.has_value();

--- a/src/v/cloud_topics/level_one/compaction/committer.cc
+++ b/src/v/cloud_topics/level_one/compaction/committer.cc
@@ -90,10 +90,11 @@ ss::future<> compaction_committer::compaction_job::finalize(
     }
 }
 
-void compaction_committer::compaction_job::cancel_job() {
+ss::future<> compaction_committer::compaction_job::stop() {
     _as.request_abort();
     _upload_sem.broken();
     _last_upload_scheduled.broken();
+    co_await _gate.close();
 }
 
 ss::future<> compaction_committer::compaction_job::remove_staging_files() {
@@ -132,17 +133,20 @@ ss::future<> compaction_committer::compaction_job::upload_loop() {
 }
 
 void compaction_committer::compaction_job::start_upload_loop() {
-    ssx::background = upload_loop().handle_exception(
-      [this](const std::exception_ptr& e) {
-          auto log_level = ssx::is_shutdown_exception(e) ? ss::log_level::debug
-                                                         : ss::log_level::warn;
-          vlogl(
-            compaction_log,
-            log_level,
-            "Encountered exception in upload loop for job {}: {}",
-            _id,
-            e);
-      });
+    ssx::spawn_with_gate(_gate, [this] {
+        return upload_loop().handle_exception(
+          [this](const std::exception_ptr& e) {
+              auto log_level = ssx::is_shutdown_exception(e)
+                                 ? ss::log_level::debug
+                                 : ss::log_level::warn;
+              vlogl(
+                compaction_log,
+                log_level,
+                "Encountered exception in upload loop for job {}: {}",
+                _id,
+                e);
+          });
+    });
 }
 
 ss::future<compaction_committer::compaction_job::expected_t>
@@ -482,6 +486,8 @@ ss::future<> compaction_committer::finalize_compaction_job(
       std::move(new_cleaned_ranges),
       std::move(removed_tombstone_ranges),
       expected_compaction_epoch);
+
+    co_await job_ptr->stop();
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/committer.cc
+++ b/src/v/cloud_topics/level_one/compaction/committer.cc
@@ -426,9 +426,7 @@ ss::future<> compaction_committer::stop() {
       "Stopping compaction committer with {} active jobs.",
       _compaction_jobs.size());
     _as.request_abort();
-    auto close_fut = _gate.close();
-    cancel_active_jobs();
-    co_await std::move(close_fut);
+    co_await _gate.close();
 }
 
 ss::future<compaction_committer::compaction_job*>
@@ -484,12 +482,6 @@ ss::future<> compaction_committer::finalize_compaction_job(
       std::move(new_cleaned_ranges),
       std::move(removed_tombstone_ranges),
       expected_compaction_epoch);
-}
-
-void compaction_committer::cancel_active_jobs() {
-    for (auto& [_, job] : _compaction_jobs) {
-        job->cancel_job();
-    }
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/committer.cc
+++ b/src/v/cloud_topics/level_one/compaction/committer.cc
@@ -27,7 +27,6 @@ compaction_committer::compaction_job::compaction_job(
   compaction_job_id id,
   model::topic_id_partition tidp,
   std::unique_ptr<metastore::object_metadata_builder> metadata_builder,
-  compaction_committer* committer,
   io* io,
   metastore* metastore,
   committing_policy* policy,
@@ -36,7 +35,6 @@ compaction_committer::compaction_job::compaction_job(
   , _tp(tidp)
   , _metadata_builder(std::move(metadata_builder))
   , _upload_sem(0, fmt::format("upload_sem_{}", id))
-  , _committer(committer)
   , _io(io)
   , _metastore(metastore)
   , _policy(policy)
@@ -90,8 +88,6 @@ ss::future<> compaction_committer::compaction_job::finalize(
         // Remove leftover staging files, if any.
         co_await remove_staging_files();
     }
-
-    _committer->finalize_job(_id);
 }
 
 void compaction_committer::compaction_job::cancel_job() {
@@ -459,7 +455,6 @@ compaction_committer::begin_compaction_job(model::topic_id_partition tidp) {
         id,
         tidp,
         std::move(metadata_builder),
-        this,
         _io,
         _metastore,
         _policy.get(),
@@ -475,12 +470,20 @@ compaction_committer::begin_compaction_job(model::topic_id_partition tidp) {
     co_return it->second.get();
 }
 
-void compaction_committer::finalize_job(compaction_job_id id) {
-    // Now safe to extract/remove the underlying job state from
-    // `_compaction_jobs`.
+ss::future<> compaction_committer::finalize_compaction_job(
+  compaction_job_id id,
+  chunked_vector<metastore::compaction_update::cleaned_range>
+    new_cleaned_ranges,
+  offset_interval_set removed_tombstone_ranges,
+  metastore::compaction_epoch expected_compaction_epoch) {
     auto job_ptr_opt = _compaction_jobs.extract(id);
     vassert(job_ptr_opt.has_value(), "concurrency issue?");
     auto job_ptr = std::move(job_ptr_opt.value().second);
+
+    co_await job_ptr->finalize(
+      std::move(new_cleaned_ranges),
+      std::move(removed_tombstone_ranges),
+      expected_compaction_epoch);
 }
 
 void compaction_committer::cancel_active_jobs() {

--- a/src/v/cloud_topics/level_one/compaction/committer.h
+++ b/src/v/cloud_topics/level_one/compaction/committer.h
@@ -116,6 +116,10 @@ public:
         // `_staging_file_and_md_infos` to cloud storage via `start_upload()`.
         void upload_some();
 
+        // Exchanges and awaits all futures in `_inflight_uploads`, leaving it
+        // empty.
+        ss::future<chunked_vector<expected_t>> do_await_inflight_uploads();
+
         // Awaits all inflight uploads. Returns `std::nullopt` if successful and
         // a string describing the error(s) otherwise.
         ss::future<std::optional<ss::sstring>> await_inflight_uploads();

--- a/src/v/cloud_topics/level_one/compaction/committer.h
+++ b/src/v/cloud_topics/level_one/compaction/committer.h
@@ -61,8 +61,9 @@ public:
           offset_interval_set,
           metastore::compaction_epoch);
 
-        // Breaks all necessary concurrency objects, indicating a cancelled job.
-        void cancel_job();
+        // Breaks all necessary concurrency objects. Must be called to safely
+        // shut down a `compaction_job` after `finalize()` is called.
+        ss::future<> stop();
 
         // Removes all staging files left on disk for the provided job.
         ss::future<> remove_staging_files();
@@ -166,6 +167,7 @@ public:
         // or when the job is marked as `finalized`.
         ssx::semaphore _upload_sem;
         ss::abort_source _as;
+        ss::gate _gate;
         // Condition variable that is signalled when the last L1 object has been
         // uploaded, and awaited upon within `await_inflight_uploads()`.
         ss::condition_variable _last_upload_scheduled;

--- a/src/v/cloud_topics/level_one/compaction/committer.h
+++ b/src/v/cloud_topics/level_one/compaction/committer.h
@@ -39,7 +39,6 @@ public:
           compaction_job_id,
           model::topic_id_partition,
           std::unique_ptr<metastore::object_metadata_builder>,
-          compaction_committer*,
           io*,
           metastore*,
           committing_policy*,
@@ -56,9 +55,7 @@ public:
         // the built update is either successfully or unsuccessfully committed
         // to the `metastore`. The newly cleaned ranges, removed tombstone
         // ranges, and expected compaction epoch are provided in order to help
-        // build up the final compaction update to the `metastore`. After the
-        // update is committed, the job is unlinked from the `_committer`, and
-        // the job becomes a dangling pointer.
+        // build up the final compaction update to the `metastore`.
         ss::future<> finalize(
           chunked_vector<metastore::compaction_update::cleaned_range>,
           offset_interval_set,
@@ -173,7 +170,6 @@ public:
         // uploaded, and awaited upon within `await_inflight_uploads()`.
         ss::condition_variable _last_upload_scheduled;
 
-        compaction_committer* _committer;
         io* _io;
         metastore* _metastore;
         committing_policy* _policy;
@@ -201,11 +197,11 @@ public:
     // Extracts the compaction job for the provided `id` and destructs it.
     // Use of any raw `job_state*` objects for this `id` after function is
     // called will result in use of a dangling pointer.
-    void finalize_job(compaction_job_id);
-
-    // Cancels a inflight job for the requested tidp, if one exists in this
-    // `committer`.
-    void cancel_job_for_tidp(model::topic_id_partition);
+    ss::future<> finalize_compaction_job(
+      compaction_job_id,
+      chunked_vector<metastore::compaction_update::cleaned_range>,
+      offset_interval_set,
+      metastore::compaction_epoch);
 
 private:
     friend class ::ReducerTestFixture;

--- a/src/v/cloud_topics/level_one/compaction/committer.h
+++ b/src/v/cloud_topics/level_one/compaction/committer.h
@@ -216,10 +216,6 @@ private:
         return job_it->second.get();
     }
 
-    // Indicates that any active jobs should be cancelled due to requested
-    // abort, likely during shutdown.
-    void cancel_active_jobs();
-
 private:
     chunked_hash_map<compaction_job_id, job_ptr_t> _compaction_jobs;
 

--- a/src/v/cloud_topics/level_one/compaction/sink.cc
+++ b/src/v/cloud_topics/level_one/compaction/sink.cc
@@ -256,22 +256,27 @@ ss::future<> compaction_sink::finalize() {
         co_return;
     }
 
-    if (_inflight_object) {
-        if (!_processed_extents.empty()) {
-            auto last_offset
-              = _processed_extents.make_reverse_stream().next().last_offset;
-            co_await flush(last_offset);
-        } else {
-            // We started an object but didn't process any extents, which means
-            // no meaningful work has been performed. Discard the inflight
-            // object.
-            auto inflight_object = std::exchange(_inflight_object, nullptr);
-            auto active_staging_file = std::exchange(
-              inflight_object->active_staging_file, nullptr);
-            auto builder = std::exchange(inflight_object->builder, nullptr);
-            co_await active_staging_file->remove();
-            co_await builder->close();
+    std::exception_ptr eptr;
+    try {
+        if (_inflight_object) {
+            if (!_processed_extents.empty()) {
+                auto last_offset
+                  = _processed_extents.make_reverse_stream().next().last_offset;
+                co_await flush(last_offset);
+            } else {
+                // We started an object but didn't process any extents, which
+                // means no meaningful work has been performed. Discard the
+                // inflight object.
+                auto inflight_object = std::exchange(_inflight_object, nullptr);
+                auto active_staging_file = std::exchange(
+                  inflight_object->active_staging_file, nullptr);
+                auto builder = std::exchange(inflight_object->builder, nullptr);
+                co_await active_staging_file->remove();
+                co_await builder->close();
+            }
         }
+    } catch (...) {
+        eptr = std::current_exception();
     }
 
     auto removed_tombstone_ranges = get_removed_tombstone_ranges(
@@ -286,6 +291,10 @@ ss::future<> compaction_sink::finalize() {
       std::move(new_cleaned_ranges),
       std::move(removed_tombstone_ranges),
       _expected_compaction_epoch);
+
+    if (eptr) {
+        std::rethrow_exception(eptr);
+    }
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/sink.cc
+++ b/src/v/cloud_topics/level_one/compaction/sink.cc
@@ -279,7 +279,10 @@ ss::future<> compaction_sink::finalize() {
     auto new_cleaned_ranges = get_new_cleaned_ranges(
       _new_cleaned_ranges, _processed_extents, _start_offset);
 
-    co_await _job->finalize(
+    auto id = _job->id();
+    _job = nullptr;
+    co_await _committer->finalize_compaction_job(
+      id,
       std::move(new_cleaned_ranges),
       std::move(removed_tombstone_ranges),
       _expected_compaction_epoch);


### PR DESCRIPTION
Leaving https://github.com/redpanda-data/redpanda/pull/29327 open as something funky is going on with it.

Follow-up to https://github.com/redpanda-data/redpanda/pull/29325 on some things that weren't quite passing the concurrency/lifetime sniff test.

These changes should all hopefully be described well by the commit messages and make the lifetimes/logic of a `compaction_job` and the `committer` a bit more clear.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
