### PR TITLE
[CORE-14860] `redpanda.storage.mode`

### DIFF
--- a/proto/redpanda/core/admin/v2/shadow_link.proto
+++ b/proto/redpanda/core/admin/v2/shadow_link.proto
@@ -351,7 +351,7 @@ message TopicMetadataSyncOptions {
     // - `redpanda.remote.allowgaps`
     // - `redpanda.virtual.cluster.id`
     // - `redpanda.leaders.preference`
-    // - `redpanda.cloud_topic.enabled`
+    // - `redpanda.storage.mode`
     //
     // This list is a list of properties in addition to the default properties
     // that will be synced.  See `exclude_default`.

--- a/src/v/cloud_storage/tests/delete_records_e2e_test.cc
+++ b/src/v/cloud_storage/tests/delete_records_e2e_test.cc
@@ -103,6 +103,7 @@ public:
         // Create a tiered storage topic with very little local retention.
         cluster::topic_properties props;
         props.shadow_indexing = model::shadow_indexing_mode::full;
+        props.storage_mode = model::redpanda_storage_mode::tiered;
         props.retention_local_target_bytes = tristate<size_t>(1);
         props.cleanup_policy_bitflags
           = model::cleanup_policy_bitflags::deletion;

--- a/src/v/cloud_storage/tests/read_replica_test.cc
+++ b/src/v/cloud_storage/tests/read_replica_test.cc
@@ -33,6 +33,7 @@ FIXTURE_TEST(test_read_replica_basic_sync, read_replica_e2e_fixture) {
     model::ntp ntp(model::kafka_namespace, topic_name, 0);
     cluster::topic_properties props;
     props.shadow_indexing = model::shadow_indexing_mode::full;
+    props.storage_mode = model::redpanda_storage_mode::tiered;
     props.retention_local_target_bytes = tristate<size_t>(1);
     add_topic({model::kafka_namespace, topic_name}, 1, props).get();
     wait_for_leader(ntp).get();
@@ -55,6 +56,7 @@ FIXTURE_TEST(test_read_replica_basic_sync, read_replica_e2e_fixture) {
 
     cluster::topic_properties read_replica_props;
     read_replica_props.shadow_indexing = model::shadow_indexing_mode::fetch;
+    read_replica_props.storage_mode = model::redpanda_storage_mode::tiered;
     read_replica_props.read_replica = true;
     read_replica_props.read_replica_bucket = "test-bucket";
     rr_rp
@@ -93,6 +95,7 @@ FIXTURE_TEST(
     model::ntp ntp(model::kafka_namespace, topic_name, 0);
     cluster::topic_properties props;
     props.shadow_indexing = model::shadow_indexing_mode::full;
+    props.storage_mode = model::redpanda_storage_mode::tiered;
     props.retention_local_target_bytes = tristate<size_t>(1);
     add_topic({model::kafka_namespace, topic_name}, 1, props).get();
     wait_for_leader(ntp).get();
@@ -106,6 +109,7 @@ FIXTURE_TEST(
     auto rr_rp = start_read_replica_fixture();
     cluster::topic_properties read_replica_props;
     read_replica_props.shadow_indexing = model::shadow_indexing_mode::fetch;
+    read_replica_props.storage_mode = model::redpanda_storage_mode::tiered;
     read_replica_props.read_replica = true;
     read_replica_props.read_replica_bucket = "test-bucket";
     rr_rp
@@ -135,6 +139,7 @@ FIXTURE_TEST(test_read_replica_delete_records, read_replica_e2e_fixture) {
     model::ntp ntp(model::kafka_namespace, topic_name, 0);
     cluster::topic_properties props;
     props.shadow_indexing = model::shadow_indexing_mode::full;
+    props.storage_mode = model::redpanda_storage_mode::tiered;
     props.retention_local_target_bytes = tristate<size_t>(1);
     add_topic({model::kafka_namespace, topic_name}, 1, props).get();
     wait_for_leader(ntp).get();
@@ -160,6 +165,7 @@ FIXTURE_TEST(test_read_replica_delete_records, read_replica_e2e_fixture) {
     auto rr_rp = start_read_replica_fixture();
     cluster::topic_properties read_replica_props;
     read_replica_props.shadow_indexing = model::shadow_indexing_mode::fetch;
+    read_replica_props.storage_mode = model::redpanda_storage_mode::tiered;
     read_replica_props.read_replica = true;
     read_replica_props.read_replica_bucket = "test-bucket";
     rr_rp
@@ -235,6 +241,7 @@ FIXTURE_TEST(
     model::ntp ntp(model::kafka_namespace, topic_name, 0);
     cluster::topic_properties props;
     props.shadow_indexing = model::shadow_indexing_mode::full;
+    props.storage_mode = model::redpanda_storage_mode::tiered;
     props.retention_local_target_bytes = tristate<size_t>(1);
     add_topic({model::kafka_namespace, topic_name}, 1, props).get();
     wait_for_leader(ntp).get();
@@ -288,6 +295,7 @@ FIXTURE_TEST(
     auto rr_rp = start_read_replica_fixture();
     cluster::topic_properties read_replica_props;
     read_replica_props.shadow_indexing = model::shadow_indexing_mode::fetch;
+    read_replica_props.storage_mode = model::redpanda_storage_mode::tiered;
     read_replica_props.read_replica = true;
     read_replica_props.read_replica_bucket = "test-bucket";
     rr_rp

--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -505,7 +505,6 @@ SEASTAR_THREAD_TEST_CASE(test_topic_manifest_serde_feature_table) {
       std::nullopt,
       model::iceberg_mode::disabled,
       std::nullopt,
-      false,
       tristate<std::chrono::milliseconds>{},
       std::nullopt,
       std::nullopt,

--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -517,6 +517,7 @@ SEASTAR_THREAD_TEST_CASE(test_topic_manifest_serde_feature_table) {
       std::nullopt,
       std::nullopt,
       std::nullopt,
+      model::redpanda_storage_mode::tiered,
     };
 
     auto random_initial_revision_id

--- a/src/v/cloud_storage/tests/topic_namespace_override_recovery_test.cc
+++ b/src/v/cloud_storage/tests/topic_namespace_override_recovery_test.cc
@@ -79,6 +79,7 @@ TEST_F(TopicRecoveryFixture, TestTopicNamespaceOverrideRecovery) {
 
     cluster::topic_properties src_props;
     src_props.shadow_indexing = model::shadow_indexing_mode::full;
+    src_props.storage_mode = model::redpanda_storage_mode::tiered;
     src_props.retention_local_target_bytes = tristate<size_t>(1);
 
     add_topic(src_tp_ns, 1, src_props).get();
@@ -158,6 +159,7 @@ TEST_F(TopicRecoveryFixture, TestTopicNamespaceOverrideRecovery) {
 
     cluster::topic_properties dest_props;
     dest_props.shadow_indexing = model::shadow_indexing_mode::full;
+    dest_props.storage_mode = model::redpanda_storage_mode::tiered;
     dest_props.retention_local_target_bytes = tristate<size_t>(1);
     dest_props.remote_topic_namespace_override = src_tp_ns;
     dest_props.recovery = true;

--- a/src/v/cloud_topics/frontend/tests/frontend_test.cc
+++ b/src/v/cloud_topics/frontend/tests/frontend_test.cc
@@ -121,7 +121,7 @@ TEST_F(frontend_fixture, test_replicate_epoch) {
     model::ntp ntp(model::kafka_namespace, topic_name, 0);
 
     cluster::topic_properties props;
-    props.cloud_topic_enabled = true;
+    props.storage_mode = model::redpanda_storage_mode::cloud;
     props.shadow_indexing = model::shadow_indexing_mode::disabled;
 
     add_topic({model::kafka_namespace, topic_name}, 1, props).get();

--- a/src/v/cloud_topics/level_one/compaction/tests/compaction_e2e_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/compaction_e2e_test.cc
@@ -43,7 +43,7 @@ public:
 
     ss::future<>
     create_cloud_topic(model::ntp ntp, cluster::topic_properties props) {
-        props.cloud_topic_enabled = true;
+        props.storage_mode = model::redpanda_storage_mode::cloud;
         props.shadow_indexing = model::shadow_indexing_mode::disabled;
 
         co_await add_topic(model::topic_namespace_view{ntp}, 1, props);

--- a/src/v/cloud_topics/level_one/compaction/tests/log_collector_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/log_collector_test.cc
@@ -54,7 +54,7 @@ struct log_collector_test_fixture : public seastar_test {
         cluster::topic_configuration_assignment tca;
         tca.cfg = cluster::topic_configuration(
           model::kafka_namespace, tp, partition_count, 1, tp_id);
-        tca.cfg.properties.cloud_topic_enabled = true;
+        tca.cfg.properties.storage_mode = model::redpanda_storage_mode::cloud;
         // Explicitly NOT setting compaction - topic is not compacted.
 
         for (auto p = 0; p < partition_count; ++p) {
@@ -193,7 +193,7 @@ TEST_F_CORO(
     cluster::topic_configuration_assignment tca;
     tca.cfg = cluster::topic_configuration(
       model::kafka_namespace, tp, 1, 1, tp_id);
-    tca.cfg.properties.cloud_topic_enabled = true;
+    tca.cfg.properties.storage_mode = model::redpanda_storage_mode::cloud;
     tca.cfg.properties.cleanup_policy_bitflags
       = model::cleanup_policy_bitflags::compaction;
     tca.assignments.push_back(
@@ -247,7 +247,7 @@ TEST_F_CORO(
     cluster::topic_configuration_assignment tca;
     tca.cfg = cluster::topic_configuration(
       model::kafka_namespace, tp, 1, 1, tp_id);
-    tca.cfg.properties.cloud_topic_enabled = true;
+    tca.cfg.properties.storage_mode = model::redpanda_storage_mode::cloud;
     tca.cfg.properties.cleanup_policy_bitflags
       = model::cleanup_policy_bitflags::compaction;
     tca.assignments.push_back(

--- a/src/v/cloud_topics/level_one/metastore/tests/topic_purger_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/topic_purger_test.cc
@@ -65,7 +65,7 @@ public:
       model::topic_id tp_id) {
         auto topic_cfg = cluster::topic_configuration(
           model::kafka_namespace, topic, 1, 1, tp_id);
-        topic_cfg.properties.cloud_topic_enabled = true;
+        topic_cfg.properties.storage_mode = model::redpanda_storage_mode::cloud;
         topic_cfg.properties.remote_delete = true;
         co_return co_await topic_table->apply(
           cluster::create_topic_cmd{

--- a/src/v/cloud_topics/manager/manager.cc
+++ b/src/v/cloud_topics/manager/manager.cc
@@ -87,7 +87,8 @@ ss::future<> cloud_topics_manager::start() {
               return;
           }
           if (
-            !config->properties.cloud_topic_enabled
+            config->properties.storage_mode
+              != model::redpanda_storage_mode::cloud
             && model::topic_namespace_view(ntp) != model::l1_metastore_nt) {
               return;
           }

--- a/src/v/cloud_topics/tests/cluster_recovery_test.cc
+++ b/src/v/cloud_topics/tests/cluster_recovery_test.cc
@@ -116,7 +116,7 @@ public:
 
     ss::future<> create_cloud_topic(model::topic t = topic) {
         cluster::topic_properties props;
-        props.cloud_topic_enabled = true;
+        props.storage_mode = model::redpanda_storage_mode::cloud;
         props.shadow_indexing = model::shadow_indexing_mode::disabled;
         co_await create_topic(
           {model::kafka_namespace, t}, num_partitions, 3, props);

--- a/src/v/cloud_topics/tests/end_to_end_test.cc
+++ b/src/v/cloud_topics/tests/end_to_end_test.cc
@@ -45,7 +45,7 @@ public:
 
     void SetUp() override {
         cluster::topic_properties props;
-        props.cloud_topic_enabled = true;
+        props.storage_mode = model::redpanda_storage_mode::cloud;
         props.shadow_indexing = model::shadow_indexing_mode::disabled;
         add_topic({model::kafka_namespace, topic_name}, 1, props).get();
         wait_for_leader(ntp).get();

--- a/src/v/cloud_topics/tests/leader_epoch_test.cc
+++ b/src/v/cloud_topics/tests/leader_epoch_test.cc
@@ -43,7 +43,7 @@ public:
         wait_for_all_members(5s).get();
 
         cluster::topic_properties props;
-        props.cloud_topic_enabled = true;
+        props.storage_mode = model::redpanda_storage_mode::cloud;
         props.shadow_indexing = model::shadow_indexing_mode::disabled;
 
         create_topic({model::kafka_namespace, topic_name}, 1, 3, props).get();

--- a/src/v/cloud_topics/tests/topic_manifest_uploader_test.cc
+++ b/src/v/cloud_topics/tests/topic_manifest_uploader_test.cc
@@ -46,7 +46,7 @@ public:
     ss::future<>
     create_cloud_topic(model::topic topic_name, int partitions = 1) {
         cluster::topic_properties props;
-        props.cloud_topic_enabled = true;
+        props.storage_mode = model::redpanda_storage_mode::cloud;
         props.shadow_indexing = model::shadow_indexing_mode::disabled;
         co_await create_topic(
           {model::kafka_namespace, topic_name}, partitions, 3, props);

--- a/src/v/cluster/archival/purger.cc
+++ b/src/v/cluster/archival/purger.cc
@@ -370,7 +370,7 @@ ss::future<housekeeping_job::run_result> purger::run(run_quota_t quota) {
     }
     for (auto& [nt_revision, marker] : markers) {
         // Double check the topic config is elegible for remote deletion
-        if (!marker.config.properties.requires_remote_erase()) {
+        if (!marker.config.properties.requires_tiered_remote_erase()) {
             vlog(
               archival_log.warn,
               "Dropping lifecycle marker {}, is not suitable for remote purge",

--- a/src/v/cluster/archival/tests/archival_service_fixture.h
+++ b/src/v/cluster/archival/tests/archival_service_fixture.h
@@ -101,6 +101,9 @@ public:
         cluster::topic_configuration cfg(
           model::kafka_namespace, id, num_partitions, (int16_t)replicas.size());
 
+        // Enable tiered storage for the topic
+        cfg.properties.storage_mode = model::redpanda_storage_mode::tiered;
+
         cluster::custom_assignable_topic_configuration cat_cfg{cfg};
         for (int i = 0; i < num_partitions; i++) {
             cat_cfg.custom_assignments.emplace_back(

--- a/src/v/cluster/archival/tests/async_data_uploader_fixture.h
+++ b/src/v/cluster/archival/tests/async_data_uploader_fixture.h
@@ -93,15 +93,14 @@ public:
     }
 
     void create_topic(bool compacted = false) {
-        std::optional<cluster::topic_properties> props;
+        cluster::topic_properties p;
+        p.storage_mode = model::redpanda_storage_mode::tiered;
         if (compacted) {
-            cluster::topic_properties p;
             p.cleanup_policy_bitflags
               = model::cleanup_policy_bitflags::compaction;
             p.compaction_strategy = model::compaction_strategy::header;
-            props = p;
         }
-        add_topic(model::topic_namespace(test_namespace, test_topic), 1, props)
+        add_topic(model::topic_namespace(test_namespace, test_topic), 1, p)
           .get();
         wait_for_leader(test_ntp).get();
     }

--- a/src/v/cluster/archival/tests/ntp_archiver_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_test.cc
@@ -1586,6 +1586,7 @@ FIXTURE_TEST(test_flush_not_leader, cloud_storage_manual_multinode_test_base) {
     model::ntp ntp(model::kafka_namespace, topic_name, 0);
     cluster::topic_properties props;
     props.shadow_indexing = model::shadow_indexing_mode::full;
+    props.storage_mode = model::redpanda_storage_mode::tiered;
     props.cleanup_policy_bitflags = model::cleanup_policy_bitflags::deletion;
     props.segment_size = 64_KiB;
     props.retention_local_target_bytes = tristate<size_t>(1);
@@ -1643,6 +1644,7 @@ FIXTURE_TEST(test_flush_leader, cloud_storage_manual_multinode_test_base) {
     model::ntp ntp(model::kafka_namespace, topic_name, 0);
     cluster::topic_properties props;
     props.shadow_indexing = model::shadow_indexing_mode::full;
+    props.storage_mode = model::redpanda_storage_mode::tiered;
     props.cleanup_policy_bitflags = model::cleanup_policy_bitflags::deletion;
     props.segment_size = 64_KiB;
     props.retention_local_target_bytes = tristate<size_t>(1);

--- a/src/v/cluster/cloud_metadata/tests/cluster_metadata_utils.h
+++ b/src/v/cluster/cloud_metadata/tests/cluster_metadata_utils.h
@@ -14,6 +14,7 @@
 #include "cluster/tests/topic_properties_generator.h"
 #include "cluster/types.h"
 #include "model/fundamental.h"
+#include "model/metadata.h"
 #include "raft/consensus.h"
 #include "security/acl.h"
 #include "storage/types.h"
@@ -79,7 +80,7 @@ inline topic_properties non_remote_topic_properties() {
 
 inline topic_properties cloud_topic_properties() {
     topic_properties props;
-    props.cloud_topic_enabled = true;
+    props.storage_mode = model::redpanda_storage_mode::cloud;
     props.shadow_indexing = model::shadow_indexing_mode::disabled;
     props.recovery = std::nullopt;
     props.read_replica = std::nullopt;

--- a/src/v/cluster/cloud_metadata/tests/cluster_metadata_utils.h
+++ b/src/v/cluster/cloud_metadata/tests/cluster_metadata_utils.h
@@ -66,6 +66,8 @@ inline topic_properties uploadable_topic_properties() {
     props.recovery = false;
     props.read_replica = false;
     props.cleanup_policy_bitflags = model::cleanup_policy_bitflags::deletion;
+    // Set storage_mode to tiered, to match the shadow_indexing setting.
+    props.storage_mode = model::redpanda_storage_mode::tiered;
     return props;
 }
 

--- a/src/v/cluster/cloud_metadata/tests/offsets_lookup_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/offsets_lookup_test.cc
@@ -51,6 +51,7 @@ public:
 
         cluster::topic_properties props;
         props.shadow_indexing = model::shadow_indexing_mode::full;
+        props.storage_mode = model::redpanda_storage_mode::tiered;
         props.retention_local_target_bytes = tristate<size_t>(1);
         props.cleanup_policy_bitflags
           = model::cleanup_policy_bitflags::deletion;

--- a/src/v/cluster/cloud_metadata/tests/offsets_recovery_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/offsets_recovery_test.cc
@@ -83,6 +83,7 @@ public:
     ss::future<std::vector<cluster::partition*>> make_partitions(int n) {
         cluster::topic_properties props;
         props.shadow_indexing = model::shadow_indexing_mode::full;
+        props.storage_mode = model::redpanda_storage_mode::tiered;
         props.retention_local_target_bytes = tristate<size_t>(1);
         props.cleanup_policy_bitflags
           = model::cleanup_policy_bitflags::deletion;

--- a/src/v/cluster/cluster_link/tests/frontend_validation_test.cc
+++ b/src/v/cluster/cluster_link/tests/frontend_validation_test.cc
@@ -985,7 +985,7 @@ TEST_F_CORO(
         m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
           = ::cluster_link::model::topic_metadata_mirroring_config::
             properties_set{
-              ss::sstring{kafka::topic_property_cloud_topic_enabled}};
+              ss::sstring{kafka::topic_property_redpanda_storage_mode}};
 
         EXPECT_EQ(
           co_await upsert_cluster_link(std::move(m1)),

--- a/src/v/cluster/cluster_recovery_reconciler.cc
+++ b/src/v/cluster/cluster_recovery_reconciler.cc
@@ -191,7 +191,6 @@ controller_snapshot_reconciler::get_actions(
         const auto& snap_tables = snap.topics.topics;
         for (const auto& [tp_ns, meta] : snap_tables) {
             const auto& tp_config = meta.metadata.configuration;
-            auto& si_props = tp_config.properties.shadow_indexing;
             if (_topic_table.contains(tp_ns)) {
                 continue;
             }
@@ -210,9 +209,8 @@ controller_snapshot_reconciler::get_actions(
                 actions.cloud_topics.emplace_back(std::move(new_config));
                 continue;
             }
-            if (
-              si_props.has_value()
-              && model::is_archival_enabled(si_props.value())) {
+
+            if (tp_config.properties.is_archival_enabled()) {
                 // We expect to create the topic with tiered storage data.
                 auto new_config = tp_config;
                 if (!new_config.properties.remote_topic_properties

--- a/src/v/cluster/data_migration_table.cc
+++ b/src/v/cluster/data_migration_table.cc
@@ -302,9 +302,7 @@ migrations_table::validate_migrated_resources(
                  t)}};
         }
 
-        if (!model::is_archival_enabled(
-              maybe_topic_cfg->properties.shadow_indexing.value_or(
-                model::shadow_indexing_mode::disabled))) {
+        if (!maybe_topic_cfg->properties.is_archival_enabled()) {
             return {
               {errc::data_migration_invalid_resources,
                ssx::sformat(

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -360,6 +360,10 @@ metadata_cache::get_default_message_timestamp_after_max_ms() const {
     return config::shard_local_cfg().log_message_timestamp_after_max_ms();
 }
 
+model::redpanda_storage_mode metadata_cache::get_default_storage_mode() const {
+    return config::shard_local_cfg().default_redpanda_storage_mode();
+}
+
 topic_properties metadata_cache::get_default_properties() const {
     topic_properties tp;
     tp.compression = {get_default_compression()};
@@ -387,6 +391,7 @@ topic_properties metadata_cache::get_default_properties() const {
       = get_default_message_timestamp_before_max_ms();
     tp.message_timestamp_after_max_ms
       = get_default_message_timestamp_after_max_ms();
+    tp.storage_mode = get_default_storage_mode();
 
     return tp;
 }

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -217,6 +217,7 @@ public:
     get_default_message_timestamp_before_max_ms() const;
     std::chrono::milliseconds
     get_default_message_timestamp_after_max_ms() const;
+    model::redpanda_storage_mode get_default_storage_mode() const;
 
     topic_properties get_default_properties() const;
     std::optional<partition_assignment>

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -849,9 +849,7 @@ ss::future<> partition::update_configuration(topic_properties properties) {
     bool cloud_storage_changed = false;
 
     bool old_archival = old_ntp_config.is_archival_enabled();
-    bool new_archival = new_ntp_config.shadow_indexing_mode
-                        && model::is_archival_enabled(
-                          new_ntp_config.shadow_indexing_mode.value());
+    bool new_archival = properties.is_archival_enabled();
 
     auto old_retention_ms = old_ntp_config.has_overrides()
                               ? old_ntp_config.get_overrides().retention_time

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -840,28 +840,28 @@ uint64_t partition::non_log_disk_size_bytes() const {
     return raft_size + stm_local_size;
 }
 
-ss::future<> partition::update_configuration(topic_properties properties) {
+ss::future<> partition::update_configuration(topic_properties new_properties) {
     auto& old_ntp_config = _raft->log()->config();
-    auto new_ntp_config = properties.get_ntp_cfg_overrides();
+    auto new_overrides = new_properties.get_ntp_cfg_overrides();
 
     // Before applying change, consider whether it changes cloud storage
     // mode
     bool cloud_storage_changed = false;
 
     bool old_archival = old_ntp_config.is_archival_enabled();
-    bool new_archival = properties.is_archival_enabled();
+    bool new_archival = new_properties.is_archival_enabled();
 
     auto old_retention_ms = old_ntp_config.has_overrides()
                               ? old_ntp_config.get_overrides().retention_time
                               : tristate<std::chrono::milliseconds>(
                                   std::nullopt);
-    auto new_retention_ms = new_ntp_config.retention_time;
+    auto new_retention_ms = new_overrides.retention_time;
 
     auto old_retention_bytes
       = old_ntp_config.has_overrides()
           ? old_ntp_config.get_overrides().retention_bytes
           : tristate<size_t>(std::nullopt);
-    auto new_retention_bytes = new_ntp_config.retention_bytes;
+    auto new_retention_bytes = new_overrides.retention_bytes;
 
     if (old_archival != new_archival) {
         vlog(
@@ -889,7 +889,7 @@ ss::future<> partition::update_configuration(topic_properties properties) {
     }
 
     // Pass the configuration update into the storage layer
-    _raft->log()->set_overrides(new_ntp_config);
+    _raft->log()->set_overrides(new_overrides);
     bool compaction_changed = _raft->log()->notify_compaction_update();
     if (compaction_changed) {
         vlog(
@@ -901,7 +901,7 @@ ss::future<> partition::update_configuration(topic_properties properties) {
 
     // Update cached instance of topic properties
     if (_topic_cfg) {
-        _topic_cfg->properties = std::move(properties);
+        _topic_cfg->properties = std::move(new_properties);
     }
 
     // Pass the configuration update to the raft layer

--- a/src/v/cluster/tests/data_migration_table_test.cc
+++ b/src/v/cluster/tests/data_migration_table_test.cc
@@ -119,10 +119,17 @@ struct data_migration_table_fixture : public seastar_test {
             topic_configuration cfg(tp_ns.ns, tp_ns.tp, p_cnt, 3);
             // Cloud topics don't use tiered storage, but regular topics need it
             // enabled for unmount to work.
-            cfg.properties.shadow_indexing
-              = cloud_topic_enabled ? model::shadow_indexing_mode::disabled
-                                    : model::shadow_indexing_mode::full;
-            cfg.properties.cloud_topic_enabled = cloud_topic_enabled;
+            if (cloud_topic_enabled) {
+                cfg.properties.shadow_indexing
+                  = model::shadow_indexing_mode::disabled;
+                cfg.properties.storage_mode
+                  = model::redpanda_storage_mode::cloud;
+            } else {
+                cfg.properties.shadow_indexing
+                  = model::shadow_indexing_mode::full;
+                cfg.properties.storage_mode
+                  = model::redpanda_storage_mode::tiered;
+            }
             ss::chunked_fifo<partition_assignment> assignments;
             for (auto i = 0; i < p_cnt; ++i) {
                 assignments.push_back(

--- a/src/v/cluster/tests/topic_properties_generator.h
+++ b/src/v/cluster/tests/topic_properties_generator.h
@@ -74,6 +74,10 @@ inline cluster::topic_properties random_topic_properties() {
     properties.flush_bytes = tests::random_optional(
       [] { return random_generators::get_int<size_t>(); });
     properties.iceberg_mode = model::iceberg_mode::disabled;
+    properties.storage_mode = random_generators::random_choice(
+      {model::redpanda_storage_mode::local,
+       model::redpanda_storage_mode::tiered,
+       model::redpanda_storage_mode::cloud});
 
     return properties;
 }

--- a/src/v/cluster/topic_configuration.cc
+++ b/src/v/cluster/topic_configuration.cc
@@ -58,7 +58,6 @@ storage::ntp_config topic_configuration::make_ntp_config(
             .flush_ms = properties.flush_ms,
             .flush_bytes = properties.flush_bytes,
             .iceberg_mode = properties.iceberg_mode,
-            .cloud_topic_enabled = properties.cloud_topic_enabled,
             .delete_retention_ms = properties.delete_retention_ms,
             .min_cleanable_dirty_ratio = properties.min_cleanable_dirty_ratio,
             .min_compaction_lag_ms = properties.min_compaction_lag_ms,

--- a/src/v/cluster/topic_configuration.cc
+++ b/src/v/cluster/topic_configuration.cc
@@ -64,6 +64,7 @@ storage::ntp_config topic_configuration::make_ntp_config(
             .min_compaction_lag_ms = properties.min_compaction_lag_ms,
             .max_compaction_lag_ms = properties.max_compaction_lag_ms,
             .remote_allow_gaps = properties.remote_topic_allow_gaps,
+            .storage_mode = properties.storage_mode,
           });
     }
     return {

--- a/src/v/cluster/topic_configuration.h
+++ b/src/v/cluster/topic_configuration.h
@@ -69,7 +69,9 @@ struct topic_configuration
                || properties.record_value_schema_id_validation_compat.value_or(
                  false);
     }
-    bool is_cloud_topic() const { return properties.cloud_topic_enabled; }
+    bool is_cloud_topic() const {
+        return properties.storage_mode == model::redpanda_storage_mode::cloud;
+    }
     bool is_compacted() const { return properties.is_compacted(); }
 
     const model::topic_namespace& remote_tp_ns() const {

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -10,6 +10,7 @@
 #include "cluster/topic_properties.h"
 
 #include "model/adl_serde.h"
+#include "model/metadata.h"
 #include "reflection/adl.h"
 
 namespace cluster {
@@ -49,9 +50,10 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       "iceberg_target_lag_ms: {}, "
       "min_cleanable_dirty_ratio: {}, "
       "min_compaction_lag_ms: {}, "
-      "max_compaction_lag_ms: {},"
-      "message_timestamp_before_max_ms: {},"
-      "message_timestamp_after_max_ms: {}",
+      "max_compaction_lag_ms: {}, "
+      "message_timestamp_before_max_ms: {}, "
+      "message_timestamp_after_max_ms: {}, "
+      "redpanda_storage_mode: {}",
       properties.compression,
       properties.cleanup_policy_bitflags,
       properties.compaction_strategy,
@@ -97,7 +99,8 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.min_compaction_lag_ms,
       properties.max_compaction_lag_ms,
       properties.message_timestamp_before_max_ms,
-      properties.message_timestamp_after_max_ms);
+      properties.message_timestamp_after_max_ms,
+      properties.storage_mode);
 
     if (config::shard_local_cfg().cloud_topics_enabled()) {
         fmt::print(
@@ -151,7 +154,8 @@ bool topic_properties::has_overrides() const {
         || max_compaction_lag_ms.has_value()
         || remote_topic_allow_gaps.has_value()
         || message_timestamp_before_max_ms.has_value()
-        || message_timestamp_after_max_ms.has_value();
+        || message_timestamp_after_max_ms.has_value()
+        || storage_mode != storage::ntp_config::default_storage_mode;
 
     if (config::shard_local_cfg().cloud_topics_enabled()) {
         return overrides
@@ -198,6 +202,7 @@ topic_properties::get_ntp_cfg_overrides() const {
     ret.min_compaction_lag_ms = min_compaction_lag_ms;
     ret.max_compaction_lag_ms = max_compaction_lag_ms;
     ret.remote_allow_gaps = remote_topic_allow_gaps;
+    ret.storage_mode = storage_mode;
     return ret;
 }
 
@@ -300,6 +305,7 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       std::nullopt,
       std::nullopt,
       std::nullopt,
+      model::redpanda_storage_mode::local,
     };
 }
 

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -102,11 +102,6 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.message_timestamp_after_max_ms,
       properties.storage_mode);
 
-    if (config::shard_local_cfg().cloud_topics_enabled()) {
-        fmt::print(
-          o, ", cloud_topic_enabled: {}", properties.cloud_topic_enabled);
-    }
-
     o << "}";
 
     return o;
@@ -156,11 +151,6 @@ bool topic_properties::has_overrides() const {
         || message_timestamp_before_max_ms.has_value()
         || message_timestamp_after_max_ms.has_value()
         || storage_mode != storage::ntp_config::default_storage_mode;
-
-    if (config::shard_local_cfg().cloud_topics_enabled()) {
-        return overrides
-               || (cloud_topic_enabled != storage::ntp_config::default_cloud_topic_enabled);
-    }
 
     return overrides;
 }
@@ -224,7 +214,6 @@ topic_properties::get_ntp_cfg_overrides() const {
     ret.flush_ms = flush_ms;
     ret.flush_bytes = flush_bytes;
     ret.iceberg_mode = iceberg_mode;
-    ret.cloud_topic_enabled = cloud_topic_enabled;
     ret.delete_retention_ms = delete_retention_ms;
     ret.min_cleanable_dirty_ratio = min_cleanable_dirty_ratio;
     ret.min_compaction_lag_ms = min_compaction_lag_ms;
@@ -321,7 +310,6 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       std::nullopt,
       model::iceberg_mode::disabled,
       std::nullopt,
-      false,
       tristate<std::chrono::milliseconds>{disable_tristate},
       std::nullopt,
       std::nullopt,

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -175,6 +175,34 @@ bool topic_properties::requires_remote_erase() const {
            && !read_replica.value_or(false) && remote_delete;
 }
 
+bool topic_properties::is_archival_enabled() const {
+    // Explicit tiered
+    if (storage_mode == model::redpanda_storage_mode::tiered) {
+        return true;
+    }
+    // Explicit local or cloud
+    if (storage_mode != model::redpanda_storage_mode::unset) {
+        return false;
+    }
+    // Unset = fall back to legacy shadow_indexing
+    return shadow_indexing.has_value()
+           && model::is_archival_enabled(shadow_indexing.value());
+}
+
+bool topic_properties::is_remote_fetch_enabled() const {
+    // Explicit tiered
+    if (storage_mode == model::redpanda_storage_mode::tiered) {
+        return true;
+    }
+    // Explicit local or cloud
+    if (storage_mode != model::redpanda_storage_mode::unset) {
+        return false;
+    }
+    // Unset = fall back to legacy shadow_indexing
+    return shadow_indexing.has_value()
+           && model::is_fetch_enabled(shadow_indexing.value());
+}
+
 storage::ntp_config::default_overrides
 topic_properties::get_ntp_cfg_overrides() const {
     storage::ntp_config::default_overrides ret;

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -155,14 +155,43 @@ bool topic_properties::has_overrides() const {
     return overrides;
 }
 
-bool topic_properties::requires_remote_erase() const {
-    // A topic requires remote erase if it matches all of:
-    // * Using tiered storage
+bool topic_properties::requires_tiered_remote_erase() const {
+    // A tiered topic requires remote erase if it matches all of:
+    // * Using tiered storage (explicit or inferred via shadow_indexing)
     // * Not a read replica
     // * Has redpanda.remote.delete=true
+    if (read_replica.value_or(false) || !remote_delete) {
+        return false;
+    }
+    // Explicit tiered = requires remote erase
+    if (storage_mode == model::redpanda_storage_mode::tiered) {
+        return true;
+    }
+    // Explicit local or cloud = no remote erase for tiered
+    if (storage_mode != model::redpanda_storage_mode::unset) {
+        return false;
+    }
+    // Unset = check if shadow_indexing indicates tiered storage
     auto mode = shadow_indexing.value_or(model::shadow_indexing_mode::disabled);
-    return mode != model::shadow_indexing_mode::disabled
+    return mode != model::shadow_indexing_mode::disabled;
+}
+
+bool topic_properties::requires_cloud_topic_remote_erase() const {
+    // A cloud topic requires remote erase if it matches all of:
+    // * Using cloud topics
+    // * Not a read replica
+    // * Has redpanda.remote.delete=true
+    return storage_mode == model::redpanda_storage_mode::cloud
            && !read_replica.value_or(false) && remote_delete;
+}
+
+bool topic_properties::requires_iceberg_remote_erase() const {
+    // An iceberg-enabled topic requires remote erase if it matches all of:
+    // * Using iceberg
+    // * Has redpanda.iceberg.delete=true
+    return iceberg_mode != model::iceberg_mode::disabled
+           && iceberg_delete.value_or(
+             config::shard_local_cfg().iceberg_delete());
 }
 
 bool topic_properties::is_archival_enabled() const {

--- a/src/v/cluster/topic_properties.h
+++ b/src/v/cluster/topic_properties.h
@@ -237,7 +237,15 @@ struct topic_properties
 
     bool is_compacted() const;
     bool has_overrides() const;
-    bool requires_remote_erase() const;
+    // Returns true if this topic is a tiered topic that requires
+    // deletion of Redpanda data in cloud storage.
+    bool requires_tiered_remote_erase() const;
+    // Returns true if this topic is a cloud topic that requires
+    // deletion of Redpanda data in cloud storage.
+    bool requires_cloud_topic_remote_erase() const;
+    // Returns true if this topic is an iceberg-enabled topic that requires
+    // deletion of Iceberg data in cloud storage.
+    bool requires_iceberg_remote_erase() const;
 
     // Returns true if the topic has archival (remote write on a tiered topic)
     // enabled. This checks both storage_mode and shadow_indexing to ensure the

--- a/src/v/cluster/topic_properties.h
+++ b/src/v/cluster/topic_properties.h
@@ -74,7 +74,6 @@ struct topic_properties
       std::optional<size_t> flush_bytes,
       model::iceberg_mode iceberg_mode,
       std::optional<config::leaders_preference> leaders_preference,
-      bool cloud_topic_enabled,
       tristate<std::chrono::milliseconds> delete_retention_ms,
       std::optional<bool> iceberg_delete,
       std::optional<ss::sstring> iceberg_partition_spec,
@@ -128,7 +127,6 @@ struct topic_properties
       , flush_bytes(flush_bytes)
       , iceberg_mode(iceberg_mode)
       , leaders_preference(std::move(leaders_preference))
-      , cloud_topic_enabled(cloud_topic_enabled)
       , delete_retention_ms(delete_retention_ms)
       , iceberg_delete(iceberg_delete)
       , iceberg_partition_spec(std::move(iceberg_partition_spec))
@@ -214,8 +212,6 @@ struct topic_properties
 
     std::optional<config::leaders_preference> leaders_preference;
 
-    bool cloud_topic_enabled{storage::ntp_config::default_cloud_topic_enabled};
-
     tristate<std::chrono::milliseconds> delete_retention_ms{disable_tristate};
     // Should we delete the corresponding iceberg table when deleting the topic.
     std::optional<bool> iceberg_delete;
@@ -293,7 +289,7 @@ struct topic_properties
           remote_topic_namespace_override,
           iceberg_mode,
           leaders_preference,
-          cloud_topic_enabled,
+          deprecated_cloud_topic_enabled,
           delete_retention_ms,
           iceberg_delete,
           iceberg_partition_spec,
@@ -310,6 +306,11 @@ struct topic_properties
 
     friend bool operator==(const topic_properties&, const topic_properties&)
       = default;
+
+private:
+    // This was deprecated in favour of redpanda.storage.mode, but is kept here
+    // for backwards compatible serde purposes.
+    bool deprecated_cloud_topic_enabled{false};
 };
 
 } // namespace cluster

--- a/src/v/cluster/topic_properties.h
+++ b/src/v/cluster/topic_properties.h
@@ -33,7 +33,7 @@ namespace cluster {
  */
 struct topic_properties
   : serde::
-      envelope<topic_properties, serde::version<12>, serde::compat_version<0>> {
+      envelope<topic_properties, serde::version<13>, serde::compat_version<0>> {
     topic_properties() noexcept = default;
     topic_properties(
       std::optional<model::compression> compression,
@@ -86,7 +86,8 @@ struct topic_properties
       std::optional<std::chrono::milliseconds> max_compaction_lag_ms,
       std::optional<bool> remote_topic_allow_gaps,
       std::optional<std::chrono::milliseconds> message_timestamp_before_max_ms,
-      std::optional<std::chrono::milliseconds> message_timestamp_after_max_ms)
+      std::optional<std::chrono::milliseconds> message_timestamp_after_max_ms,
+      model::redpanda_storage_mode storage_mode)
       : compression(compression)
       , cleanup_policy_bitflags(cleanup_policy_bitflags)
       , compaction_strategy(compaction_strategy)
@@ -137,7 +138,8 @@ struct topic_properties
       , min_compaction_lag_ms(min_compaction_lag_ms)
       , max_compaction_lag_ms(max_compaction_lag_ms)
       , message_timestamp_before_max_ms(message_timestamp_before_max_ms)
-      , message_timestamp_after_max_ms(message_timestamp_after_max_ms) {}
+      , message_timestamp_after_max_ms(message_timestamp_after_max_ms)
+      , storage_mode(storage_mode) {}
 
     std::optional<model::compression> compression;
     std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
@@ -233,6 +235,10 @@ struct topic_properties
     std::optional<std::chrono::milliseconds> message_timestamp_before_max_ms{};
     std::optional<std::chrono::milliseconds> message_timestamp_after_max_ms{};
 
+    // Storage mode for the topic: local, tiered, or cloud
+    model::redpanda_storage_mode storage_mode{
+      storage::ntp_config::default_storage_mode};
+
     bool is_compacted() const;
     bool has_overrides() const;
     bool requires_remote_erase() const;
@@ -288,7 +294,8 @@ struct topic_properties
           min_compaction_lag_ms,
           max_compaction_lag_ms,
           message_timestamp_before_max_ms,
-          message_timestamp_after_max_ms);
+          message_timestamp_after_max_ms,
+          storage_mode);
     }
 
     friend bool operator==(const topic_properties&, const topic_properties&)

--- a/src/v/cluster/topic_properties.h
+++ b/src/v/cluster/topic_properties.h
@@ -243,6 +243,16 @@ struct topic_properties
     bool has_overrides() const;
     bool requires_remote_erase() const;
 
+    // Returns true if the topic has archival (remote write on a tiered topic)
+    // enabled. This checks both storage_mode and shadow_indexing to ensure the
+    // topic is configured for tiered storage with archival.
+    bool is_archival_enabled() const;
+
+    // Returns true if the topic has remote fetch (remote read on a tiered
+    // topic) enabled. This checks both storage_mode and shadow_indexing to
+    // ensure the topic is configured for tiered storage with remote fetch.
+    bool is_remote_fetch_enabled() const;
+
     storage::ntp_config::default_overrides get_ntp_cfg_overrides() const;
 
     friend std::ostream& operator<<(std::ostream&, const topic_properties&);

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -227,7 +227,7 @@ topic_table::apply(topic_lifecycle_transition soft_del, model::offset offset) {
         }
 
         if (
-          topic_properties.cloud_topic_enabled
+          topic_properties.storage_mode == model::redpanda_storage_mode::cloud
           && !topic_properties.read_replica.value_or(false)
           && topic_properties.remote_delete) {
             auto tp_id = topic_cfg.tp_id;

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -190,7 +190,7 @@ topic_table::apply(topic_lifecycle_transition soft_del, model::offset offset) {
         const auto& topic_cfg = tp->second.get_configuration();
         const auto& topic_properties = topic_cfg.properties;
 
-        if (topic_properties.requires_remote_erase()) {
+        if (topic_properties.requires_tiered_remote_erase()) {
             auto tombstone = nt_lifecycle_marker{
               .config = tp->second.get_configuration(),
               .initial_revision_id = tp->second.get_remote_revision().value_or(
@@ -205,10 +205,7 @@ topic_table::apply(topic_lifecycle_transition soft_del, model::offset offset) {
               soft_del.topic.initial_revision_id);
         }
 
-        if (
-          topic_properties.iceberg_mode != model::iceberg_mode::disabled
-          && topic_properties.iceberg_delete.value_or(
-            config::shard_local_cfg().iceberg_delete())) {
+        if (topic_properties.requires_iceberg_remote_erase()) {
             // Note that for iceberg tombstones we use topic.get_revision()
             // (i.e. revision that got assigned to the topic at creation time)
             // and not topic.get_remote_revision() (which may be an earlier
@@ -226,10 +223,7 @@ topic_table::apply(topic_lifecycle_transition soft_del, model::offset offset) {
               it->second.last_deleted_revision);
         }
 
-        if (
-          topic_properties.storage_mode == model::redpanda_storage_mode::cloud
-          && !topic_properties.read_replica.value_or(false)
-          && topic_properties.remote_delete) {
+        if (topic_properties.requires_cloud_topic_remote_erase()) {
             auto tp_id = topic_cfg.tp_id;
             if (tp_id.has_value()) {
                 auto tombstone = nt_cloud_topic_tombstone{

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -1050,6 +1050,31 @@ void incremental_update(
     }
 }
 
+void incremental_update(
+  model::redpanda_storage_mode& property,
+  property_update<std::optional<model::redpanda_storage_mode>> override,
+  model::redpanda_storage_mode /*default_value*/) {
+    // Validation of storage mode transitions is done at the kafka layer.
+    // This function only applies the update.
+    switch (override.op) {
+    case incremental_update_operation::remove:
+        // Cannot remove redpanda.storage.mode - it can only be set explicitly
+        vlog(
+          clusterlog.warn,
+          "Cannot remove property redpanda.storage.mode - it can only be set "
+          "explicitly. Current value: {}",
+          property);
+        return;
+    case incremental_update_operation::set:
+        if (override.value) {
+            property = *override.value;
+        }
+        return;
+    case incremental_update_operation::none:
+        return;
+    }
+}
+
 template<typename T>
 void incremental_update(
   tristate<T>& property, property_update<tristate<T>> override) {
@@ -1208,6 +1233,10 @@ topic_properties topic_table::update_topic_properties(
       updated_properties.message_timestamp_after_max_ms,
       overrides.message_timestamp_after_max_ms);
     incremental_update(updated_properties.remote_label, overrides.remote_label);
+    incremental_update(
+      updated_properties.storage_mode,
+      overrides.storage_mode,
+      storage::ntp_config::default_storage_mode);
     return updated_properties;
 }
 

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -74,12 +74,13 @@ namespace {
 std::vector<std::string_view>
 get_enterprise_features(const cluster::topic_configuration& cfg) {
     std::vector<std::string_view> features;
-    const auto si_disabled = model::shadow_indexing_mode::disabled;
+    static const auto si_disabled = model::shadow_indexing_mode::disabled;
     // Only enforce tiered storage topic config sanctions when cloud storage is
     // enabled for the cluster
     if (config::shard_local_cfg().cloud_storage_enabled.is_restricted()) {
         if (
-          cfg.properties.shadow_indexing.value_or(si_disabled) != si_disabled) {
+          (cfg.properties.shadow_indexing.value_or(si_disabled) != si_disabled)
+          || (cfg.properties.storage_mode == model::redpanda_storage_mode::tiered)) {
             features.emplace_back("tiered storage");
         }
         if (cfg.is_recovery_enabled()) {
@@ -134,13 +135,20 @@ std::vector<std::string_view> get_enterprise_features(
       properties, {update.tp_ns, update.properties});
 
     std::vector<std::string_view> features;
-    const auto si_disabled = model::shadow_indexing_mode::disabled;
+    static const auto si_disabled = model::shadow_indexing_mode::disabled;
+    static const auto tiered = model::redpanda_storage_mode::tiered;
     // Only enforce tiered storage topic config sanctions when cloud storage is
     // enabled for the cluster
     if (config::shard_local_cfg().cloud_storage_enabled.is_restricted()) {
+        // Check if tiered storage is being enabled (wasn't before, is now)
+        auto old_si_mode = properties.shadow_indexing.value_or(si_disabled);
+        auto new_si_mode = updated_properties.shadow_indexing.value_or(
+          si_disabled);
+        auto old_storage_mode = properties.storage_mode;
+        auto new_storage_mode = updated_properties.storage_mode;
         if (
-          (properties.shadow_indexing.value_or(si_disabled)
-           < updated_properties.shadow_indexing.value_or(si_disabled))
+          old_si_mode < new_si_mode
+          || (old_storage_mode != tiered && new_storage_mode == tiered)
           || (properties.remote_delete < updated_properties.remote_delete)) {
             features.emplace_back("tiered storage");
         }

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -114,7 +114,8 @@ get_enterprise_features(const cluster::topic_configuration& cfg) {
         }
     }
     if (config::shard_local_cfg().cloud_topics_enabled.is_restricted()) {
-        if (cfg.properties.cloud_topic_enabled) {
+        if (
+          cfg.properties.storage_mode == model::redpanda_storage_mode::cloud) {
             features.emplace_back("cloud topics");
         }
     }
@@ -225,7 +226,7 @@ std::vector<std::string_view> get_enterprise_features(
         }
     }
     if (config::shard_local_cfg().cloud_topics_enabled.is_restricted()) {
-        if (properties.cloud_topic_enabled) {
+        if (properties.storage_mode == model::redpanda_storage_mode::cloud) {
             features.emplace_back("cloud topics");
         }
     }
@@ -655,9 +656,11 @@ topic_result topics_frontend::validate_topic_configuration(
     // the only way that cloud topics can be enabled on a topic is if the cloud
     // topics development feature is also enabled.
     if (!config::shard_local_cfg().cloud_topics_enabled()) {
-        if (assignable_config.cfg.properties.cloud_topic_enabled) {
+        if (
+          assignable_config.cfg.properties.storage_mode
+          == model::redpanda_storage_mode::cloud) {
             auto msg = ssx::sformat(
-              "Cloud topic flag on {} is set but development feature is "
+              "Cloud storage mode on {} is set but development feature is "
               "disabled",
               assignable_config.cfg.tp_ns);
             vlog(clusterlog.error, "{}", msg);
@@ -746,7 +749,8 @@ ss::future<topic_result> topics_frontend::do_create_topic(
         co_return result;
     }
 
-    auto is_cloud_topic = assignable_config.cfg.properties.cloud_topic_enabled;
+    auto is_cloud_topic = assignable_config.cfg.properties.storage_mode
+                          == model::redpanda_storage_mode::cloud;
     if (assignable_config.is_read_replica()) {
         if (!assignable_config.cfg.properties.read_replica_bucket) {
             co_return make_error_result(

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -653,6 +653,7 @@ struct incremental_topic_updates
       message_timestamp_before_max_ms;
     property_update<std::optional<std::chrono::milliseconds>>
       message_timestamp_after_max_ms;
+    property_update<std::optional<model::redpanda_storage_mode>> storage_mode;
 
     // Not a regular topic property. Used to assign topic UUIDs to pre-25-2
     // topics that were created without one.
@@ -715,7 +716,8 @@ struct incremental_topic_updates
           max_compaction_lag_ms,
           message_timestamp_before_max_ms,
           message_timestamp_after_max_ms,
-          remote_label);
+          remote_label,
+          storage_mode);
     }
 
     friend std::ostream&

--- a/src/v/cluster_link/model/types.h
+++ b/src/v/cluster_link/model/types.h
@@ -76,7 +76,7 @@ inline auto disallowed_topic_properties = std::to_array<std::string_view>({
   kafka::topic_property_remote_allow_gaps,
   kafka::topic_property_mpx_virtual_cluster_id,
   kafka::topic_property_leaders_preference,
-  kafka::topic_property_cloud_topic_enabled,
+  kafka::topic_property_redpanda_storage_mode,
 });
 
 /**

--- a/src/v/cluster_link/utils/topic_properties_utils.cc
+++ b/src/v/cluster_link/utils/topic_properties_utils.cc
@@ -148,20 +148,14 @@ bool maybe_append_update(
           topic_config.tp_ns,
           update.properties.remote_read,
           config_value,
-          topic_config.properties.shadow_indexing.has_value()
-            ? ::model::is_fetch_enabled(
-                topic_config.properties.shadow_indexing.value())
-            : false);
+          topic_config.properties.is_remote_fetch_enabled());
     }
     if (config_name == kafka::topic_property_remote_write) {
         return parse_and_set(
           topic_config.tp_ns,
           update.properties.remote_write,
           config_value,
-          topic_config.properties.shadow_indexing.has_value()
-            ? ::model::is_fetch_enabled(
-                topic_config.properties.shadow_indexing.value())
-            : false);
+          topic_config.properties.is_archival_enabled());
     }
     if (config_name == kafka::topic_property_remote_delete) {
         return parse_and_set(

--- a/src/v/cluster_link/utils/topic_properties_utils.cc
+++ b/src/v/cluster_link/utils/topic_properties_utils.cc
@@ -242,13 +242,6 @@ bool maybe_append_update(
           topic_config.properties.leaders_preference,
           kafka::noop_validator<config::leaders_preference>{});
     }
-    if (config_name == kafka::topic_property_cloud_topic_enabled) {
-        if (config::shard_local_cfg().cloud_topics_enabled()) {
-            throw kafka::validation_error(
-              "Cloud topics property cannot be changed");
-        }
-        throw kafka::validation_error("Cloud topics is not enabled");
-    }
     if (config_name == kafka::topic_property_delete_retention_ms) {
         return parse_and_set(
           topic_config.tp_ns,

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2021,6 +2021,22 @@ configuration::configuration()
       "Default remote write value for new topics",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
+  , default_redpanda_storage_mode(
+      *this,
+      "default_redpanda_storage_mode",
+      "Default storage mode for newly-created topics. Determines how topic "
+      "data is stored: `local` for broker-local storage only, `tiered` for "
+      "both local and object storage, `cloud` for object-only storage using "
+      "the Cloud Topics architecture, or `unset` to use legacy "
+      "remote.read/write configs for backwards compatibility.",
+      {.needs_restart = needs_restart::no,
+       .example = "tiered",
+       .visibility = visibility::user},
+      model::redpanda_storage_mode::unset,
+      {model::redpanda_storage_mode::local,
+       model::redpanda_storage_mode::tiered,
+       model::redpanda_storage_mode::cloud,
+       model::redpanda_storage_mode::unset})
   , cloud_storage_disable_archiver_manager(
       *this,
       "cloud_storage_disable_archiver_manager",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -374,6 +374,7 @@ struct configuration final : public config_store {
     enterprise<property<bool>> cloud_storage_enabled;
     property<bool> cloud_storage_enable_remote_read;
     property<bool> cloud_storage_enable_remote_write;
+    enum_property<model::redpanda_storage_mode> default_redpanda_storage_mode;
     property<bool> cloud_storage_disable_archiver_manager;
     property<std::optional<ss::sstring>> cloud_storage_access_key;
     property<std::optional<ss::sstring>> cloud_storage_secret_key;

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -543,6 +543,23 @@ struct convert<model::write_caching_mode> {
 };
 
 template<>
+struct convert<model::redpanda_storage_mode> {
+    using type = model::redpanda_storage_mode;
+
+    static Node encode(const type& rhs) { return Node(fmt::format("{}", rhs)); }
+
+    static bool decode(const Node& node, type& rhs) {
+        auto value = node.as<std::string>();
+        auto mode = model::redpanda_storage_mode_from_string(value);
+        if (!mode) {
+            return false;
+        }
+        rhs = mode.value();
+        return true;
+    }
+};
+
+template<>
 struct convert<model::recovery_validation_mode> {
     using type = model::recovery_validation_mode;
     constexpr static auto acceptable_values = std::to_array(

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -718,6 +718,8 @@ consteval std::string_view property_type_name() {
                            type,
                            security::oidc::nested_group_behavior>) {
         return "string";
+    } else if constexpr (std::is_same_v<type, model::redpanda_storage_mode>) {
+        return "string";
     } else {
         static_assert(
           base::unsupported_type<T>::value, "Type name not defined");

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -321,4 +321,9 @@ void rjson_serialize(
     stringize(w, ngb);
 }
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const model::redpanda_storage_mode& m) {
+    stringize(w, m);
+}
+
 } // namespace json

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -157,4 +157,7 @@ void rjson_serialize(
 void rjson_serialize(
   json::Writer<json::StringBuffer>&, security::oidc::nested_group_behavior);
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>&, const model::redpanda_storage_mode&);
+
 } // namespace json

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -454,6 +454,29 @@ validate_cloud_topics_reconciliation_intervals(const configuration& config) {
 }
 
 std::optional<ss::sstring>
+validate_default_redpanda_storage_mode(const configuration& config) {
+    auto mode = config.default_redpanda_storage_mode();
+
+    if (
+      mode == model::redpanda_storage_mode::tiered
+      && !config.cloud_storage_enabled()) {
+        return fmt::format(
+          "default_redpanda_storage_mode cannot be set to tiered when "
+          "cloud_storage_enabled is false");
+    }
+
+    if (
+      mode == model::redpanda_storage_mode::cloud
+      && !config.cloud_topics_enabled()) {
+        return fmt::format(
+          "default_redpanda_storage_mode cannot be set to cloud when "
+          "cloud_topics_enabled is false");
+    }
+
+    return std::nullopt;
+}
+
+std::optional<ss::sstring>
 validate_sane_partition_balancer_timeouts(const configuration& config) {
     // how often node status sends an rpc
     auto node_status = config.node_status_interval();

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -87,4 +87,7 @@ validate_cloud_topics_reconciliation_intervals(const configuration& config);
 std::optional<ss::sstring>
 validate_sane_partition_balancer_timeouts(const configuration& config);
 
+std::optional<ss::sstring>
+validate_default_redpanda_storage_mode(const configuration& config);
+
 }; // namespace config

--- a/src/v/datalake/tests/fixture.h
+++ b/src/v/datalake/tests/fixture.h
@@ -13,6 +13,7 @@
 #include "cluster/archival/tests/archival_service_fixture.h"
 #include "datalake/coordinator/frontend.h"
 #include "datalake/coordinator/state_machine.h"
+#include "model/metadata.h"
 
 static ss::logger logger{"datalake-test-logger"};
 namespace datalake::tests {
@@ -55,6 +56,7 @@ public:
       model::topic topic, int num_partitions = 1, int16_t num_replicas = 3) {
         cluster::topic_properties props;
         props.iceberg_mode = model::iceberg_mode::key_value;
+        props.storage_mode = model::redpanda_storage_mode::tiered;
         return cluster_test_fixture::create_topic(
           {model::kafka_namespace, topic},
           num_partitions,

--- a/src/v/kafka/protocol/topic_properties.h
+++ b/src/v/kafka/protocol/topic_properties.h
@@ -77,6 +77,9 @@ inline constexpr std::string_view topic_property_leaders_preference
   = "redpanda.leaders.preference";
 
 inline constexpr std::string_view topic_property_cloud_topic_enabled
-  = "redpanda.cloud_topic.enabled";
+  = "cloud.topic.enabled";
+
+inline constexpr std::string_view topic_property_redpanda_storage_mode
+  = "redpanda.storage.mode";
 
 } // namespace kafka

--- a/src/v/kafka/protocol/topic_properties.h
+++ b/src/v/kafka/protocol/topic_properties.h
@@ -76,9 +76,6 @@ inline constexpr std::string_view topic_property_mpx_virtual_cluster_id
 inline constexpr std::string_view topic_property_leaders_preference
   = "redpanda.leaders.preference";
 
-inline constexpr std::string_view topic_property_cloud_topic_enabled
-  = "cloud.topic.enabled";
-
 inline constexpr std::string_view topic_property_redpanda_storage_mode
   = "redpanda.storage.mode";
 

--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -65,6 +65,7 @@ redpanda_cc_library(
         "@boost//:algorithm",
         "@boost//:container",
         "@boost//:lexical_cast",
+        "@fmt",
         "@seastar",
     ],
 )

--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -35,6 +35,7 @@ redpanda_cc_library(
     hdrs = [
         "handlers/configs/config_response_utils.h",
         "handlers/configs/config_utils.h",
+        "handlers/configs/storage_mode_properties.h",
         "handlers/topics/topic_utils.h",
         "handlers/topics/types.h",
         "handlers/topics/validators.h",

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -96,7 +96,7 @@ create_topic_properties_update(
     std::apply(apply_op(op_t::none), update.custom_properties.serde_fields());
 
     static_assert(
-      std::tuple_size_v<decltype(update.properties.serde_fields())> == 43,
+      std::tuple_size_v<decltype(update.properties.serde_fields())> == 44,
       "If you add a property, decide on its default alter config "
       "policy, and handle the update in the loop below");
     static_assert(
@@ -138,6 +138,8 @@ create_topic_properties_update(
       properties.
      */
     update.properties.delete_retention_ms.op = op_t::none;
+
+    update.properties.storage_mode.op = op_t::none;
 
     // Now that the defaults are set, continue to set properties from the
     // request
@@ -491,6 +493,14 @@ create_topic_properties_update(
                   kafka::config_resource_operation::set,
                   message_timestamp_after_max_ms_validator,
                   /*clamp_to_duration_max=*/true);
+                continue;
+            }
+            if (cfg.name == topic_property_redpanda_storage_mode) {
+                parse_and_set_optional(
+                  update.properties.storage_mode,
+                  cfg.value,
+                  kafka::config_resource_operation::set,
+                  storage_mode_validator{current_storage_mode});
                 continue;
             }
 

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -408,13 +408,6 @@ create_topic_properties_update(
                   config::leaders_preference::parse);
                 continue;
             }
-            if (cfg.name == topic_property_cloud_topic_enabled) {
-                if (config::shard_local_cfg().cloud_topics_enabled()) {
-                    throw validation_error(
-                      "Cloud topics property cannot be changed");
-                }
-                throw validation_error("Cloud topics is not enabled");
-            }
             if (cfg.name == topic_property_delete_retention_ms) {
                 parse_and_set_tristate(
                   update.properties.delete_retention_ms,

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -20,6 +20,7 @@
 #include "kafka/protocol/schemata/alter_configs_response.h"
 #include "kafka/protocol/types.h"
 #include "kafka/server/handlers/configs/config_utils.h"
+#include "kafka/server/handlers/configs/storage_mode_properties.h"
 #include "kafka/server/handlers/details/alter_config_utils.h"
 #include "kafka/server/handlers/topics/types.h"
 #include "kafka/server/request_context.h"
@@ -71,6 +72,13 @@ create_topic_properties_update(
     model::topic_namespace tp_ns(
       model::kafka_namespace, model::topic(resource.resource_name));
     cluster::topic_properties_update update(tp_ns);
+
+    // Get the topic's current storage mode for validation warnings
+    auto topic_cfg = ctx.metadata_cache().get_topic_cfg(tp_ns);
+    std::optional<model::redpanda_storage_mode> current_storage_mode;
+    if (topic_cfg) {
+        current_storage_mode = topic_cfg->properties.storage_mode;
+    }
 
     if (!ctx.is_topic_mutable(tp_ns.tp)) {
         return make_error_alter_config_resource_response<
@@ -148,6 +156,22 @@ create_topic_properties_update(
       update.properties};
 
     for (auto& cfg : resource.configs) {
+        // Log warning if property is not relevant for the topic's storage mode
+        if (
+          current_storage_mode
+          && !is_property_valid_for_storage_mode(
+            cfg.name, *current_storage_mode)) {
+            vlog(
+              klog.warn,
+              "{} is not a relevant property for topic {} with "
+              "redpanda.storage.mode={} - it is only supported for "
+              "topics of redpanda.storage.mode={{{}}}",
+              cfg.name,
+              tp_ns.tp,
+              *current_storage_mode,
+              get_valid_storage_modes_string(cfg.name));
+        }
+
         try {
             if (cfg.name == topic_property_cleanup_policy) {
                 parse_and_set_optional(

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -869,25 +869,6 @@ config_response_container_t make_topic_configs(
           });
     }
 
-    if (config::shard_local_cfg().cloud_topics_enabled()) {
-        if (config_property_requested(
-              config_keys, topic_property_cloud_topic_enabled)) {
-            add_topic_config<bool>(
-              result,
-              topic_property_cloud_topic_enabled,
-              false,
-              topic_property_cloud_topic_enabled,
-              override_if_not_default(
-                std::make_optional<bool>(topic_properties.cloud_topic_enabled),
-                false),
-              include_synonyms,
-              maybe_make_documentation(
-                include_documentation,
-                "Cloud topic enabled on this topic if ture."),
-              [](const bool& b) { return b ? "true" : "false"; });
-        }
-    }
-
     add_topic_config_if_requested(
       config_keys,
       result,

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -185,7 +185,8 @@ consteval describe_configs_type property_config_type() {
         std::is_same_v<T, model::vcluster_id> ||
         std::is_same_v<T, model::write_caching_mode> ||
         std::is_same_v<T, config::leaders_preference> || std::is_same_v<T, model::iceberg_mode> ||
-        std::is_same_v<T, model::iceberg_invalid_record_action>;
+        std::is_same_v<T, model::iceberg_invalid_record_action> ||
+        std::is_same_v<T, model::redpanda_storage_mode>;
 
     constexpr auto is_long_type = is_long<T> ||
         // Long type since seconds is atleast a 35-bit signed integral
@@ -1204,6 +1205,22 @@ config_response_container_t make_topic_configs(
         include_documentation,
         config::shard_local_cfg().log_message_timestamp_after_max_ms.desc()),
       describe_as_string<std::chrono::milliseconds>);
+
+    add_topic_config_if_requested(
+      config_keys,
+      result,
+      config::shard_local_cfg().default_redpanda_storage_mode.name(),
+      config::shard_local_cfg().default_redpanda_storage_mode(),
+      topic_property_redpanda_storage_mode,
+      override_if_not_default(
+        std::make_optional<model::redpanda_storage_mode>(
+          topic_properties.storage_mode),
+        config::shard_local_cfg().default_redpanda_storage_mode()),
+      include_synonyms,
+      maybe_make_documentation(
+        include_documentation,
+        config::shard_local_cfg().default_redpanda_storage_mode.desc()),
+      &describe_as_string<model::redpanda_storage_mode>);
 
     return result;
 }

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -349,6 +349,77 @@ struct batch_max_bytes_limits_validator {
     }
 };
 
+// Check if a storage mode transition is permitted.
+// Returns true if the transition is allowed, false otherwise.
+//
+// Permitted transitions:
+//   local -> tiered: Permitted
+//   tiered -> local: Permitted (with caution)
+//   unset -> local: Permitted (with caution)
+//   unset -> tiered: Permitted
+// Not permitted:
+//   local -> unset: Not permitted
+//   local -> cloud: Not permitted
+//   tiered -> unset: Not permitted
+//   tiered -> cloud: Not permitted
+//   cloud -> local: Not permitted
+//   cloud -> tiered: Not permitted
+//   unset <-> cloud: Not permitted (cloud requires explicit choice)
+inline bool is_storage_mode_transition_permitted(
+  model::redpanda_storage_mode from, model::redpanda_storage_mode to) {
+    using sm = model::redpanda_storage_mode;
+
+    // No-op transitions are fine.
+    if (from == to) {
+        return true;
+    }
+
+    // Permitted transitions:
+    //   local -> tiered: Permitted
+    //   tiered -> local: Permitted (with caution)
+    //   unset -> local: Permitted (with caution)
+    //   unset -> tiered: Permitted
+    if (from == sm::local && to == sm::tiered) {
+        return true;
+    }
+    if (from == sm::tiered && to == sm::local) {
+        return true;
+    }
+    if (from == sm::unset && to == sm::local) {
+        return true;
+    }
+    if (from == sm::unset && to == sm::tiered) {
+        return true;
+    }
+
+    // All other transitions are not permitted
+    return false;
+}
+
+/// Validator for redpanda.storage.mode property.
+/// Validates that the transition from current storage mode to the new value is
+/// permitted.
+struct storage_mode_validator {
+    std::optional<model::redpanda_storage_mode> current_mode;
+
+    std::optional<ss::sstring>
+    operator()(const ss::sstring&, const model::redpanda_storage_mode& value) {
+        // If we don't have a current mode (new topic), allow any value
+        if (!current_mode) {
+            return std::nullopt;
+        }
+
+        if (!is_storage_mode_transition_permitted(*current_mode, value)) {
+            return fmt::format(
+              "Cannot alter redpanda.storage.mode from {} to {} - this "
+              "transition is not permitted",
+              *current_mode,
+              value);
+        }
+        return std::nullopt;
+    }
+};
+
 template<typename T, typename... ValidatorTypes>
 requires requires(
   model::topic_namespace_view tns,

--- a/src/v/kafka/server/handlers/configs/storage_mode_properties.h
+++ b/src/v/kafka/server/handlers/configs/storage_mode_properties.h
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "kafka/protocol/topic_properties.h"
+#include "kafka/server/handlers/topics/types.h"
+#include "model/metadata.h"
+
+#include <array>
+#include <string_view>
+
+namespace kafka {
+
+// Bitmask for storage modes a property is valid for
+enum class storage_mode_mask : uint8_t {
+    none = 0,
+    local = 1 << 0,
+    tiered = 1 << 1,
+    cloud = 1 << 2,
+    unset = 1 << 3,
+    // Common combinations
+    local_tiered = local | tiered,
+    tiered_cloud = tiered | cloud,
+    all = local | tiered | cloud | unset,
+};
+
+constexpr storage_mode_mask
+operator|(storage_mode_mask a, storage_mode_mask b) {
+    return static_cast<storage_mode_mask>(
+      static_cast<uint8_t>(a) | static_cast<uint8_t>(b));
+}
+
+constexpr storage_mode_mask
+operator&(storage_mode_mask a, storage_mode_mask b) {
+    return static_cast<storage_mode_mask>(
+      static_cast<uint8_t>(a) & static_cast<uint8_t>(b));
+}
+
+// Entry mapping a property name to its valid storage modes
+struct property_storage_mode_entry {
+    std::string_view property_name;
+    storage_mode_mask valid_modes;
+};
+
+// Complete mapping of all topic properties to their valid storage modes.
+// Every topic property must be listed here.
+inline constexpr auto storage_mode_properties
+  = std::to_array<property_storage_mode_entry>({
+    // Properties valid for all storage modes
+    {topic_property_compression, storage_mode_mask::all},
+    {topic_property_cleanup_policy, storage_mode_mask::all},
+    {topic_property_retention_duration, storage_mode_mask::all},
+    {topic_property_retention_bytes, storage_mode_mask::all},
+    {topic_property_timestamp_type, storage_mode_mask::all},
+    {topic_property_max_message_bytes, storage_mode_mask::all},
+    {topic_property_delete_retention_ms, storage_mode_mask::all},
+    {topic_property_min_cleanable_dirty_ratio, storage_mode_mask::all},
+    {topic_property_min_compaction_lag_ms, storage_mode_mask::all},
+    {topic_property_max_compaction_lag_ms, storage_mode_mask::all},
+    {topic_property_message_timestamp_before_max_ms, storage_mode_mask::all},
+    {topic_property_message_timestamp_after_max_ms, storage_mode_mask::all},
+    {topic_property_leaders_preference, storage_mode_mask::all},
+    {topic_property_mpx_virtual_cluster_id, storage_mode_mask::all},
+    {topic_property_recovery, storage_mode_mask::all},
+    {topic_property_compaction_strategy, storage_mode_mask::all},
+    {topic_property_redpanda_storage_mode, storage_mode_mask::all},
+    // Schema validation properties - valid for all modes
+    {topic_property_record_key_schema_id_validation, storage_mode_mask::all},
+    {topic_property_record_key_subject_name_strategy, storage_mode_mask::all},
+    {topic_property_record_value_schema_id_validation, storage_mode_mask::all},
+    {topic_property_record_value_subject_name_strategy, storage_mode_mask::all},
+    {topic_property_record_key_schema_id_validation_compat,
+     storage_mode_mask::all},
+    {topic_property_record_key_subject_name_strategy_compat,
+     storage_mode_mask::all},
+    {topic_property_record_value_schema_id_validation_compat,
+     storage_mode_mask::all},
+    {topic_property_record_value_subject_name_strategy_compat,
+     storage_mode_mask::all},
+
+    // Properties valid for local and tiered only (NOT cloud)
+    {topic_property_flush_bytes, storage_mode_mask::local_tiered},
+    {topic_property_flush_ms, storage_mode_mask::local_tiered},
+    {topic_property_segment_size, storage_mode_mask::local_tiered},
+    {topic_property_segment_ms, storage_mode_mask::local_tiered},
+    {topic_property_write_caching, storage_mode_mask::local_tiered},
+
+    // Properties valid for tiered only
+    {topic_property_initial_retention_local_target_bytes,
+     storage_mode_mask::tiered},
+    {topic_property_initial_retention_local_target_ms,
+     storage_mode_mask::tiered},
+    {topic_property_remote_read, storage_mode_mask::tiered},
+    {topic_property_remote_write, storage_mode_mask::tiered},
+    {topic_property_retention_local_target_bytes, storage_mode_mask::tiered},
+    {topic_property_retention_local_target_ms, storage_mode_mask::tiered},
+    {topic_property_remote_allow_gaps, storage_mode_mask::tiered},
+
+    // Properties valid for tiered and cloud only (NOT local)
+    {topic_property_iceberg_mode, storage_mode_mask::tiered_cloud},
+    {topic_property_iceberg_delete, storage_mode_mask::tiered_cloud},
+    {topic_property_iceberg_partition_spec, storage_mode_mask::tiered_cloud},
+    {topic_property_iceberg_invalid_record_action,
+     storage_mode_mask::tiered_cloud},
+    {topic_property_iceberg_target_lag_ms, storage_mode_mask::tiered_cloud},
+    {topic_property_remote_delete, storage_mode_mask::tiered_cloud},
+    {topic_property_read_replica, storage_mode_mask::tiered_cloud},
+
+    // Properties only valid for cloud mode
+    {topic_property_cloud_topic_enabled, storage_mode_mask::cloud},
+  });
+
+// Convert a storage mode enum to its corresponding mask bit
+constexpr storage_mode_mask
+storage_mode_to_mask(model::redpanda_storage_mode mode) {
+    switch (mode) {
+    case model::redpanda_storage_mode::local:
+        return storage_mode_mask::local;
+    case model::redpanda_storage_mode::tiered:
+        return storage_mode_mask::tiered;
+    case model::redpanda_storage_mode::cloud:
+        return storage_mode_mask::cloud;
+    case model::redpanda_storage_mode::unset:
+        return storage_mode_mask::unset;
+    }
+    return storage_mode_mask::none;
+}
+
+// Check if a property is valid for a given storage mode.
+// All properties must be in the storage_mode_properties list.
+// When storage_mode is unset, all properties are considered valid since
+// the actual mode depends on legacy shadow_indexing configuration.
+inline bool is_property_valid_for_storage_mode(
+  std::string_view property_name, model::redpanda_storage_mode mode) {
+    // When unset, allow all properties since the actual mode depends on
+    // legacy shadow_indexing configuration
+    if (mode == model::redpanda_storage_mode::unset) {
+        return true;
+    }
+
+    const auto mode_mask = storage_mode_to_mask(mode);
+
+    for (const auto& entry : storage_mode_properties) {
+        if (entry.property_name == property_name) {
+            return (entry.valid_modes & mode_mask) != storage_mode_mask::none;
+        }
+    }
+
+    return true;
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/handlers/configs/storage_mode_properties.h
+++ b/src/v/kafka/server/handlers/configs/storage_mode_properties.h
@@ -116,9 +116,6 @@ inline constexpr auto storage_mode_properties
     {topic_property_iceberg_target_lag_ms, storage_mode_mask::tiered_cloud},
     {topic_property_remote_delete, storage_mode_mask::tiered_cloud},
     {topic_property_read_replica, storage_mode_mask::tiered_cloud},
-
-    // Properties only valid for cloud mode
-    {topic_property_cloud_topic_enabled, storage_mode_mask::cloud},
   });
 
 // Convert a storage mode enum to its corresponding mask bit

--- a/src/v/kafka/server/handlers/configs/storage_mode_properties.h
+++ b/src/v/kafka/server/handlers/configs/storage_mode_properties.h
@@ -15,6 +15,8 @@
 #include "kafka/server/handlers/topics/types.h"
 #include "model/metadata.h"
 
+#include <seastar/core/sstring.hh>
+
 #include <array>
 #include <string_view>
 
@@ -156,6 +158,43 @@ inline bool is_property_valid_for_storage_mode(
     }
 
     return true;
+}
+
+// Get the valid storage modes for a property as a human-readable string.
+// Returns a string like "local, tiered" or "cloud".
+inline ss::sstring
+get_valid_storage_modes_string(std::string_view property_name) {
+    for (const auto& entry : storage_mode_properties) {
+        if (entry.property_name == property_name) {
+            ss::sstring result;
+            bool first = true;
+            if (
+              (entry.valid_modes & storage_mode_mask::local)
+              != storage_mode_mask::none) {
+                result += "local";
+                first = false;
+            }
+            if (
+              (entry.valid_modes & storage_mode_mask::tiered)
+              != storage_mode_mask::none) {
+                if (!first) {
+                    result += ", ";
+                }
+                result += "tiered";
+                first = false;
+            }
+            if (
+              (entry.valid_modes & storage_mode_mask::cloud)
+              != storage_mode_mask::none) {
+                if (!first) {
+                    result += ", ";
+                }
+                result += "cloud";
+            }
+            return result;
+        }
+    }
+    return "unknown";
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -88,7 +88,8 @@ bool is_supported(std::string_view name) {
        topic_property_max_compaction_lag_ms,
        topic_property_remote_allow_gaps,
        topic_property_message_timestamp_before_max_ms,
-       topic_property_message_timestamp_after_max_ms});
+       topic_property_message_timestamp_after_max_ms,
+       topic_property_redpanda_storage_mode});
 
     if (std::any_of(
           supported_configs.begin(),
@@ -133,7 +134,8 @@ using validators = make_validator_types<
   iceberg_invalid_record_action_validator,
   cloud_topic_config_validator,
   iceberg_target_lag_ms_validator,
-  min_max_compaction_lag_ms_validator>;
+  min_max_compaction_lag_ms_validator,
+  storage_mode_config_validator>;
 
 static void
 append_topic_configs(request_context& ctx, create_topics_response& response) {

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -98,17 +98,6 @@ bool is_supported(std::string_view name) {
         return true;
     }
 
-    /*
-     * check development features below. if a development feature is not
-     * enabled, the system should behave as if the feature does not exist.
-     */
-
-    if (config::shard_local_cfg().cloud_topics_enabled()) {
-        if (name == topic_property_cloud_topic_enabled) {
-            return true;
-        }
-    }
-
     return false;
 }
 } // namespace
@@ -132,7 +121,6 @@ using validators = make_validator_types<
   write_caching_configs_validator,
   iceberg_config_validator,
   iceberg_invalid_record_action_validator,
-  cloud_topic_config_validator,
   iceberg_target_lag_ms_validator,
   min_max_compaction_lag_ms_validator,
   storage_mode_config_validator>;

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -391,13 +391,6 @@ create_topic_properties_update(
                   config::leaders_preference::parse);
                 continue;
             }
-            if (cfg.name == topic_property_cloud_topic_enabled) {
-                if (config::shard_local_cfg().cloud_topics_enabled()) {
-                    throw validation_error(
-                      "Cloud topics property cannot be changed");
-                }
-                throw validation_error("Cloud topics is not enabled");
-            }
             if (cfg.name == topic_property_delete_retention_ms) {
                 parse_and_set_tristate(
                   update.properties.delete_retention_ms, cfg.value, op);

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -462,6 +462,15 @@ create_topic_properties_update(
                   /*clamp_to_duration_max=*/true);
                 continue;
             }
+
+            if (cfg.name == topic_property_redpanda_storage_mode) {
+                parse_and_set_optional(
+                  update.properties.storage_mode,
+                  cfg.value,
+                  op,
+                  storage_mode_validator{current_storage_mode});
+                continue;
+            }
         } catch (const validation_error& e) {
             vlog(
               klog.debug,

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -17,6 +17,7 @@
 #include "kafka/protocol/schemata/incremental_alter_configs_request.h"
 #include "kafka/protocol/schemata/incremental_alter_configs_response.h"
 #include "kafka/server//handlers/configs/config_utils.h"
+#include "kafka/server/handlers/configs/storage_mode_properties.h"
 #include "kafka/server/handlers/details/alter_config_utils.h"
 #include "kafka/server/handlers/topics/types.h"
 #include "kafka/server/request_context.h"
@@ -131,6 +132,13 @@ create_topic_properties_update(
       model::kafka_namespace, model::topic(resource.resource_name));
     cluster::topic_properties_update update(tp_ns);
 
+    // Get the topic's current storage mode for validation warnings
+    auto topic_cfg = ctx.metadata_cache().get_topic_cfg(tp_ns);
+    std::optional<model::redpanda_storage_mode> current_storage_mode;
+    if (topic_cfg) {
+        current_storage_mode = topic_cfg->properties.storage_mode;
+    }
+
     if (!ctx.is_topic_mutable(tp_ns.tp)) {
         return make_error_alter_config_resource_response<resp_resource_t>(
           resource,
@@ -170,6 +178,23 @@ create_topic_properties_update(
             // error case
             return *err;
         }
+
+        // Log warning if property is not relevant for the topic's storage mode
+        if (
+          current_storage_mode
+          && !is_property_valid_for_storage_mode(
+            cfg.name, *current_storage_mode)) {
+            vlog(
+              klog.warn,
+              "{} is not a relevant property for topic {} with "
+              "redpanda.storage.mode={} - it is only supported for "
+              "topics of redpanda.storage.mode={{{}}}",
+              cfg.name,
+              tp_ns.tp,
+              *current_storage_mode,
+              get_valid_storage_modes_string(cfg.name));
+        }
+
         try {
             if (cfg.name == topic_property_cleanup_policy) {
                 parse_and_set_optional(

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -203,6 +203,10 @@ ss::future<metadata_response::topic> create_topic(
       topic,
       config::shard_local_cfg().default_topic_partitions(),
       config::shard_local_cfg().default_topic_replication()};
+    // Need to respect the default_redpanda_storage_mode when autocreating a
+    // topic.
+    cfg.properties.storage_mode
+      = config::shard_local_cfg().default_redpanda_storage_mode();
     auto tout = config::shard_local_cfg().internal_rpc_request_timeout_ms();
     try {
         auto res = co_await ctx.topics_frontend().autocreate_topics(

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -350,6 +350,11 @@ cluster::topic_configuration to_topic_config(
         topic_property_message_timestamp_after_max_ms,
         /*clamp_to_duration_max=*/true);
 
+    cfg.properties.storage_mode
+      = get_enum_value<model::redpanda_storage_mode>(
+          config_entries, topic_property_redpanda_storage_mode)
+          .value_or(config::shard_local_cfg().default_redpanda_storage_mode());
+
     schema_id_validation_config_parser schema_id_validation_config_parser{
       cfg.properties};
 

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -363,12 +363,6 @@ cluster::topic_configuration to_topic_config(
           name, value, kafka::config_resource_operation::set);
     }
 
-    if (config::shard_local_cfg().cloud_topics_enabled()) {
-        cfg.properties.cloud_topic_enabled
-          = get_bool_value(config_entries, topic_property_cloud_topic_enabled)
-              .value_or(storage::ntp_config::default_cloud_topic_enabled);
-    }
-
     return cfg;
 }
 

--- a/src/v/kafka/server/handlers/topics/validators.h
+++ b/src/v/kafka/server/handlers/topics/validators.h
@@ -366,40 +366,6 @@ struct iceberg_invalid_record_action_validator {
     }
 };
 
-/*
- * it's an error to set the cloud topic property if cloud topics development
- * feature hasn't been enabled.
- */
-struct cloud_topic_config_validator {
-    static constexpr const char* error_message
-      = "Cloud topics property is invalid, or support for this development "
-        "feature is not enabled.";
-    static constexpr error_code ec = error_code::invalid_config;
-
-    static bool is_valid(const creatable_topic& c) {
-        auto it = std::find_if(
-          c.configs.begin(),
-          c.configs.end(),
-          [](const createable_topic_config& cfg) {
-              return cfg.name == topic_property_cloud_topic_enabled;
-          });
-        if (it == c.configs.end()) {
-            return true;
-        }
-        if (!config::shard_local_cfg().cloud_topics_enabled()) {
-            return false;
-        }
-        try {
-            std::ignore = string_switch<bool>(it->value.value())
-                            .match("true", true)
-                            .match("false", false);
-            return true;
-        } catch (...) {
-            return false;
-        }
-    }
-};
-
 struct write_caching_configs_validator {
     static constexpr const char* error_message
       = "Unsupported write caching configuration.";

--- a/src/v/kafka/server/handlers/topics/validators.h
+++ b/src/v/kafka/server/handlers/topics/validators.h
@@ -566,6 +566,48 @@ struct min_max_compaction_lag_ms_validator {
     }
 };
 
+/*
+ * Validates that storage_mode is compatible with the cluster configuration:
+ * - 'cloud' mode requires cloud_topics_enabled()
+ * - 'tiered' mode requires cloud_storage_enabled()
+ * - 'local' mode is always allowed
+ */
+struct storage_mode_config_validator {
+    static constexpr const char* error_message
+      = "Invalid storage mode: 'cloud' requires cloud topics to be enabled, "
+        "'tiered' requires cloud storage to be enabled.";
+    static constexpr error_code ec = error_code::invalid_config;
+
+    static bool is_valid(const creatable_topic& c) {
+        auto it = std::find_if(
+          c.configs.begin(),
+          c.configs.end(),
+          [](const createable_topic_config& cfg) {
+              return cfg.name == topic_property_redpanda_storage_mode;
+          });
+        if (it == c.configs.end() || !it->value.has_value()) {
+            return true;
+        }
+        auto mode = model::redpanda_storage_mode_from_string(it->value.value());
+        if (!mode) {
+            return false;
+        }
+        switch (*mode) {
+        case model::redpanda_storage_mode::local:
+            return true;
+        case model::redpanda_storage_mode::tiered:
+            return config::shard_local_cfg().cloud_storage_enabled();
+        case model::redpanda_storage_mode::cloud:
+            return config::shard_local_cfg().cloud_topics_enabled();
+        case model::redpanda_storage_mode::unset:
+            // unset is always valid - actual behavior depends on
+            // shadow_indexing
+            return true;
+        }
+        return false;
+    }
+};
+
 using compression_type_validator
   = configuration_value_validator<compression_type_validator_details>;
 using compaction_strategy_validator

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -758,7 +758,8 @@ FIXTURE_TEST(
       "min.compaction.lag.ms",
       "max.compaction.lag.ms",
       "message.timestamp.before.max.ms",
-      "message.timestamp.after.max.ms"};
+      "message.timestamp.after.max.ms",
+      "redpanda.storage.mode"};
 
     // All properties_request
     auto all_describe_resp = describe_configs(test_tp);

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -582,6 +582,37 @@ std::optional<write_caching_mode>
 std::ostream& operator<<(std::ostream&, write_caching_mode);
 std::istream& operator>>(std::istream&, write_caching_mode&);
 
+// Storage mode for a Redpanda topic
+// unset (255) enables fallback to legacy shadow_indexing behavior during
+// deprecation. When storage_mode is explicit (local/tiered/cloud), it is
+// authoritative. When unset, legacy shadow_indexing configs are used.
+enum class redpanda_storage_mode : uint8_t {
+    local = 0,
+    tiered = 1,
+    cloud = 2,
+    unset = 255
+};
+
+constexpr const char* redpanda_storage_mode_to_string(redpanda_storage_mode m) {
+    switch (m) {
+    case redpanda_storage_mode::local:
+        return "local";
+    case redpanda_storage_mode::tiered:
+        return "tiered";
+    case redpanda_storage_mode::cloud:
+        return "cloud";
+    case redpanda_storage_mode::unset:
+        return "unset";
+    }
+    throw std::invalid_argument("unknown redpanda_storage_mode");
+}
+
+std::optional<redpanda_storage_mode>
+  redpanda_storage_mode_from_string(std::string_view);
+
+std::ostream& operator<<(std::ostream&, redpanda_storage_mode);
+std::istream& operator>>(std::istream&, redpanda_storage_mode&);
+
 enum class recovery_validation_mode : std::uint16_t {
     // ensure that either the manifest is in TS or that no manifest is present.
     // download issues will fail the validation

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -578,6 +578,45 @@ write_caching_mode_from_string(std::string_view s) {
       .default_match(std::nullopt);
 }
 
+std::ostream& operator<<(std::ostream& o, redpanda_storage_mode mode) {
+    o << redpanda_storage_mode_to_string(mode);
+    return o;
+}
+
+std::istream& operator>>(std::istream& i, redpanda_storage_mode& mode) {
+    ss::sstring s;
+    i >> s;
+    auto value = redpanda_storage_mode_from_string(s);
+    if (!value) {
+        i.setstate(std::ios::failbit);
+        return i;
+    }
+    mode = *value;
+    return i;
+}
+
+std::optional<redpanda_storage_mode>
+redpanda_storage_mode_from_string(std::string_view s) {
+    return string_switch<std::optional<redpanda_storage_mode>>(s)
+      .match(
+        model::redpanda_storage_mode_to_string(
+          model::redpanda_storage_mode::local),
+        model::redpanda_storage_mode::local)
+      .match(
+        model::redpanda_storage_mode_to_string(
+          model::redpanda_storage_mode::tiered),
+        model::redpanda_storage_mode::tiered)
+      .match(
+        model::redpanda_storage_mode_to_string(
+          model::redpanda_storage_mode::cloud),
+        model::redpanda_storage_mode::cloud)
+      .match(
+        model::redpanda_storage_mode_to_string(
+          model::redpanda_storage_mode::unset),
+        model::redpanda_storage_mode::unset)
+      .default_match(std::nullopt);
+}
+
 std::ostream& operator<<(std::ostream& os, recovery_validation_mode vm) {
     using enum recovery_validation_mode;
     switch (vm) {

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -2054,6 +2054,14 @@ void config_multi_property_validation(
     if (pbp_err.has_value()) {
         errors[ss::sstring{"partition_balancer_planner"}] = *pbp_err;
     }
+
+    // Validate default_redpanda_storage_mode dependencies
+    auto storage_mode_err = config::validate_default_redpanda_storage_mode(
+      updated_config);
+    if (storage_mode_err.has_value()) {
+        errors[ss::sstring{updated_config.default_redpanda_storage_mode.name()}]
+          = storage_mode_err.value();
+    }
 }
 } // namespace
 

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -36,6 +36,8 @@ public:
     static inline model::iceberg_mode default_iceberg_mode
       = model::iceberg_mode{};
     static constexpr bool default_cloud_topic_enabled{false};
+    static constexpr model::redpanda_storage_mode default_storage_mode{
+      model::redpanda_storage_mode::unset};
 
     static constexpr std::chrono::milliseconds read_replica_retention{3600000};
 
@@ -91,6 +93,9 @@ public:
 
         // Controls behavior during pause
         std::optional<bool> remote_allow_gaps;
+
+        // Storage mode for the topic (local, tiered, or cloud)
+        model::redpanda_storage_mode storage_mode{default_storage_mode};
 
         friend std::ostream&
         operator<<(std::ostream&, const default_overrides&);

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -35,7 +35,6 @@ public:
     static constexpr bool legacy_remote_delete{false};
     static inline model::iceberg_mode default_iceberg_mode
       = model::iceberg_mode{};
-    static constexpr bool default_cloud_topic_enabled{false};
     static constexpr model::redpanda_storage_mode default_storage_mode{
       model::redpanda_storage_mode::unset};
 
@@ -82,7 +81,6 @@ public:
         std::optional<std::chrono::milliseconds> flush_ms;
         std::optional<size_t> flush_bytes;
         model::iceberg_mode iceberg_mode{default_iceberg_mode};
-        bool cloud_topic_enabled{default_cloud_topic_enabled};
 
         tristate<std::chrono::milliseconds> delete_retention_ms;
 
@@ -450,8 +448,9 @@ public:
         if (!config::shard_local_cfg().cloud_topics_enabled()) {
             return false;
         }
-        return _overrides ? _overrides->cloud_topic_enabled
-                          : default_cloud_topic_enabled;
+        return _overrides
+               && _overrides->storage_mode
+                    == model::redpanda_storage_mode::cloud;
     }
 
     std::optional<double> min_cleanable_dirty_ratio() const {

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -250,19 +250,37 @@ public:
     }
 
     bool is_archival_enabled() const {
-        if (cloud_topic_enabled()) {
+        if (_overrides == nullptr) {
             return false;
         }
-        return _overrides != nullptr && _overrides->shadow_indexing_mode
+        // Explicit tiered
+        if (_overrides->storage_mode == model::redpanda_storage_mode::tiered) {
+            return true;
+        }
+        // Explicit local or cloud
+        if (_overrides->storage_mode != model::redpanda_storage_mode::unset) {
+            return false;
+        }
+        // Unset, fall back to legacy shadow_indexing
+        return _overrides->shadow_indexing_mode
                && model::is_archival_enabled(
                  _overrides->shadow_indexing_mode.value());
     }
 
     bool is_remote_fetch_enabled() const {
-        if (cloud_topic_enabled()) {
+        if (_overrides == nullptr) {
             return false;
         }
-        return _overrides != nullptr && _overrides->shadow_indexing_mode
+        // Explicit tiered
+        if (_overrides->storage_mode == model::redpanda_storage_mode::tiered) {
+            return true;
+        }
+        // Explicit local or cloud
+        if (_overrides->storage_mode != model::redpanda_storage_mode::unset) {
+            return false;
+        }
+        // Unset, fall back to legacy shadow_indexing
+        return _overrides->shadow_indexing_mode
                && model::is_fetch_enabled(
                  _overrides->shadow_indexing_mode.value());
     }
@@ -289,13 +307,23 @@ public:
      * both reads and writes to S3, and is not a read replica.
      */
     bool is_tiered_storage() const {
-        if (cloud_topic_enabled()) {
+        if (_overrides == nullptr) {
             return false;
         }
-        return _overrides != nullptr
-               && !_overrides->read_replica.value_or(false)
-               && _overrides->shadow_indexing_mode
-                    == model::shadow_indexing_mode::full;
+        if (_overrides->read_replica.value_or(false)) {
+            return false;
+        }
+        // Explicit tiered
+        if (_overrides->storage_mode == model::redpanda_storage_mode::tiered) {
+            return true;
+        }
+        // Explicit local or cloud
+        if (_overrides->storage_mode != model::redpanda_storage_mode::unset) {
+            return false;
+        }
+        // Unset, fall back to legacy shadow_indexing
+        return _overrides->shadow_indexing_mode
+               == model::shadow_indexing_mode::full;
     }
 
     bool remote_delete() const {
@@ -367,10 +395,7 @@ public:
             // 2) this prefix is truncated away locally
             // 3) correspondent tombstone (or tx end marker) is compacted away
             // locally.
-            if (
-              _overrides->shadow_indexing_mode.has_value()
-              && _overrides->shadow_indexing_mode.value()
-                   != model::shadow_indexing_mode::disabled) {
+            if (is_archival_enabled() || is_remote_fetch_enabled()) {
                 return std::nullopt;
             }
         }

--- a/src/v/storage/tests/log_retention_test.cc
+++ b/src/v/storage/tests/log_retention_test.cc
@@ -293,6 +293,7 @@ TEST_F(gc_fixture, retention_by_size_with_remote_write) {
 
     storage::ntp_config::default_overrides overrides;
     overrides.shadow_indexing_mode = model::shadow_indexing_mode::full;
+    overrides.storage_mode = model::redpanda_storage_mode::tiered;
     overrides.retention_local_target_bytes = tristate<size_t>{size_limit};
     config.set_overrides(overrides);
 
@@ -364,6 +365,7 @@ TEST_F(gc_fixture, retention_by_time_with_remote_write) {
 
     storage::ntp_config::default_overrides overrides;
     overrides.shadow_indexing_mode = model::shadow_indexing_mode::full;
+    overrides.storage_mode = model::redpanda_storage_mode::tiered;
     config.set_overrides(overrides);
 
     auto log_creation_time = model::timestamp{
@@ -397,6 +399,7 @@ TEST_F(gc_fixture, retention_by_time_with_remote_write) {
     // Override the local target retention.
     storage::ntp_config::default_overrides time_override;
     time_override.shadow_indexing_mode = model::shadow_indexing_mode::full;
+    time_override.storage_mode = model::redpanda_storage_mode::tiered;
     time_override.retention_local_target_ms
       = tristate<std::chrono::milliseconds>{0ms};
     builder.update_configuration(time_override).get();

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -3923,6 +3923,7 @@ TEST_F(storage_test_fixture, test_bytes_eviction_overrides) {
         if (tc.cloud_storage) {
             have_overrides = true;
             overrides.shadow_indexing_mode = model::shadow_indexing_mode::full;
+            overrides.storage_mode = model::redpanda_storage_mode::tiered;
         }
 
         if (
@@ -6559,6 +6560,7 @@ TEST_F(storage_test_fixture, delete_retention_ms_with_ts) {
     ov.delete_retention_ms = tristate<std::chrono::milliseconds>(
       delete_retention_ms);
     ov.shadow_indexing_mode = model::shadow_indexing_mode::full;
+    ov.storage_mode = model::redpanda_storage_mode::tiered;
     auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
 

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -142,7 +142,8 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       "initial_retention_local_target_ms: {}, write_caching: {}, flush_ms: {}, "
       "flush_bytes: {}, iceberg_mode: {}, remote_allow_gaps: {}, "
       "delete_retention_ms: {}, min_cleanable_dirty_ratio: {}, "
-      "min_compaction_lag_ms: {}, max_compaction_lag_ms: {} }}",
+      "min_compaction_lag_ms: {}, max_compaction_lag_ms: {}, storage_mode: {} "
+      "}}",
       v.compaction_strategy,
       v.cleanup_policy_bitflags,
       v.segment_size,
@@ -163,11 +164,8 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       v.delete_retention_ms,
       v.min_cleanable_dirty_ratio,
       v.min_compaction_lag_ms,
-      v.max_compaction_lag_ms);
-
-    if (config::shard_local_cfg().cloud_topics_enabled()) {
-        fmt::print(o, ", cloud_topic_enabled: {}", v.cloud_topic_enabled);
-    }
+      v.max_compaction_lag_ms,
+      v.storage_mode);
 
     o << "}";
 

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1450,7 +1450,7 @@ class RpkTool:
         ]
         return self._execute(cmd).strip()
 
-    def cluster_config_set(self, key: str, value):
+    def cluster_config_set(self, key: str, value: Any) -> Any:
         """
         Note: This method returns without waiting for the configuration to be
         applied to all shards/nodes. If you get the configuration immediately

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -24,6 +24,11 @@ class TopicSpec:
     CLEANUP_DELETE = "delete"
     CLEANUP_COMPACT_DELETE = "compact,delete"
 
+    STORAGE_MODE_LOCAL = "local"
+    STORAGE_MODE_TIERED = "tiered"
+    STORAGE_MODE_CLOUD = "cloud"
+    STORAGE_MODE_UNSET = "unset"
+
     PROPERTY_COMPRESSSION = "compression.type"
     PROPERTY_CLEANUP_POLICY = "cleanup.policy"
     PROPERTY_COMPACTION_STRATEGY = "compaction.strategy"
@@ -46,9 +51,9 @@ class TopicSpec:
     PROPERTY_MIN_COMPACTION_LAG_MS = "min.compaction.lag.ms"
     PROPERTY_MAX_COMPACTION_LAG_MS = "max.compaction.lag.ms"
     PROPERTY_MAX_MESSAGE_BYTES = "max.message.bytes"
-
-    # requires dev features enabled. only valid at topic create time
-    PROPERTY_CLOUD_TOPIC_ENABLE = "redpanda.cloud_topic.enabled"
+    PROPERTY_REMOTE_READ = "redpanda.remote.read"
+    PROPERTY_REMOTE_WRITE = "redpanda.remote.write"
+    PROPERTY_STORAGE_MODE = "redpanda.storage.mode"
 
     class CompressionTypes(str, Enum):
         """
@@ -144,7 +149,7 @@ class TopicSpec:
         min_cleanable_dirty_ratio: float | None = None,
         min_compaction_lag_ms: int | None = None,
         max_compaction_lag_ms: int | None = None,
-        cloud_topics_enabled: bool | None = None,
+        redpanda_storage_mode: str | None = None,
     ):
         self.name = name or f"topic-{self._random_topic_suffix()}"
         self.partition_count = partition_count
@@ -183,7 +188,7 @@ class TopicSpec:
         self.min_cleanable_dirty_ratio = min_cleanable_dirty_ratio
         self.min_compaction_lag_ms = min_compaction_lag_ms
         self.max_compaction_lag_ms = max_compaction_lag_ms
-        self.cloud_topics_enabled = cloud_topics_enabled
+        self.redpanda_storage_mode = redpanda_storage_mode
 
     def __str__(self):
         return self.name

--- a/tests/rptest/tests/cloud_topics/e2e_test.py
+++ b/tests/rptest/tests/cloud_topics/e2e_test.py
@@ -97,7 +97,7 @@ class EndToEndCloudTopicsBase(EndToEndTest):
         self.redpanda.start()
         for topic in self.topics:
             config = {
-                "redpanda.cloud_topic.enabled": "true",
+                TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD,
                 "cleanup.policy": topic.cleanup_policy,
             }
             if topic.min_cleanable_dirty_ratio is not None:

--- a/tests/rptest/tests/cloud_topics/iceberg_test.py
+++ b/tests/rptest/tests/cloud_topics/iceberg_test.py
@@ -140,7 +140,7 @@ class EndToEndCloudTopicsIcebergCompactionTest(EndToEndCloudTopicsIcebergTestBas
                 self.topic_name,
                 iceberg_mode="key_value",
                 config={
-                    "redpanda.cloud_topic.enabled": "true",
+                    TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD,
                     "cleanup.policy": TopicSpec.CLEANUP_COMPACT,
                 },
             )
@@ -236,7 +236,7 @@ class EndToEndCloudTopicsIcebergDeletionTest(EndToEndCloudTopicsIcebergTestBase)
                 self.topic_name,
                 iceberg_mode="key_value",
                 config={
-                    "redpanda.cloud_topic.enabled": "true",
+                    TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD,
                     "retention.ms": 500,
                     "retention.bytes": 1024,
                 },

--- a/tests/rptest/tests/cloud_topics/l0_gc_test.py
+++ b/tests/rptest/tests/cloud_topics/l0_gc_test.py
@@ -64,7 +64,7 @@ class CloudTopicsL0GCTestBase(RedpandaTest):
                 spec.name,
                 spec.partition_count,
                 spec.replication_factor,
-                config={"redpanda.cloud_topic.enabled": "true"},
+                config={TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD},
             )
 
     def get_num_objects_deleted(self, nodes: list[ClusterNode] | None = None):

--- a/tests/rptest/tests/cloud_topics/retention_test.py
+++ b/tests/rptest/tests/cloud_topics/retention_test.py
@@ -144,7 +144,7 @@ class CloudTopicsRetentionTest(EndToEndCloudTopicsBase):
             partitions=1,
             replicas=3,
             config={
-                "redpanda.cloud_topic.enabled": "true",
+                TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD,
                 "cleanup.policy": TopicSpec.CLEANUP_DELETE,
                 "retention.bytes": str(initial_retention),
             },
@@ -228,7 +228,7 @@ class CloudTopicsRetentionTest(EndToEndCloudTopicsBase):
             partitions=1,
             replicas=3,
             config={
-                "redpanda.cloud_topic.enabled": "true",
+                TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD,
                 "cleanup.policy": TopicSpec.CLEANUP_DELETE,
                 "retention.ms": str(3600000),  # 1 hour - data won't be deleted yet
             },

--- a/tests/rptest/tests/cloud_topics_test.py
+++ b/tests/rptest/tests/cloud_topics_test.py
@@ -47,7 +47,7 @@ class CloudTopicsTest(RedpandaTest):
                 spec.name,
                 spec.partition_count,
                 spec.replication_factor,
-                config={"redpanda.cloud_topic.enabled": "true"},
+                config={TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD},
             )
 
     # Ignored because it's flaky but the test is still useful locally.

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -664,6 +664,7 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
         exclude_settings.add("cloud_storage_enabled")
         exclude_settings.add(CLOUD_TOPICS_CONFIG_STR)
         exclude_settings.add("iceberg_enabled")
+        exclude_settings.add("default_redpanda_storage_mode")
 
         # Partition balancer relies on relative sizes of these values
         exclude_settings.update(

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -86,7 +86,7 @@ DISALLOWED_SYNCED_TOPIC_PROPERTIES = [
     "redpanda.remote.allowgaps",
     "redpanda.virtual.cluster.id",
     "redpanda.leaders.preference",
-    "redpanda.cloud_topic.enabled",
+    "redpanda.storage.mode",
 ]
 
 CONTROLLER_LOCKED_TASKS = [

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -1502,7 +1502,7 @@ class DataMigrationsApiTest(DataMigrationTestMixin):
             topic_name,
             partitions=3,
             replicas=3,
-            config={"redpanda.cloud_topic.enabled": "true"},
+            config={TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD},
         )
 
         # Verify the topic was created

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -327,6 +327,15 @@ class DescribeTopicsTest(RedpandaTest):
                 "`message.timestamp.after.max.ms` overrides the value of "
                 "`log_message_timestamp_after_max_ms` at the topic level.",
             ),
+            "redpanda.storage.mode": ConfigProperty(
+                config_type="STRING",
+                value="unset",
+                doc_string="Default storage mode for newly-created topics. Determines how topic "
+                "data is stored: `local` for broker-local storage only, `tiered` for "
+                "both local and object storage, `cloud` for object-only storage using "
+                "the Cloud Topics architecture, or `unset` to use legacy "
+                "remote.read/write configs for backwards compatibility.",
+            ),
         }
 
         tp_spec = TopicSpec()

--- a/tests/rptest/tests/follower_fetching_test.py
+++ b/tests/rptest/tests/follower_fetching_test.py
@@ -36,12 +36,13 @@ class FetchFrom(str, Enum):
 def make_topic_config(fetch_from):
     if fetch_from == FetchFrom.CLOUD_TOPIC:
         config = {
-            "redpanda.cloud_topic.enabled": "true",
+            TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD,
         }
     elif fetch_from == FetchFrom.TIERED_STORAGE:
         config = {
-            "redpanda.remote.read": "true",
-            "redpanda.remote.write": "true",
+            TopicSpec.PROPERTY_REMOTE_READ: "true",
+            TopicSpec.PROPERTY_REMOTE_WRITE: "true",
+            TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_TIERED,
         }
     else:
         config = {}

--- a/tests/rptest/tests/license_enforcement_test.py
+++ b/tests/rptest/tests/license_enforcement_test.py
@@ -12,6 +12,7 @@ import re
 from ducktape.mark import matrix
 
 from rptest.clients.rpk import RpkException, RpkTool
+from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import LoggingConfig, SISettings, CLOUD_TOPICS_CONFIG_STR
@@ -389,10 +390,11 @@ class LicenseEnforcementPermittedTopicParams(RedpandaTest):
         # even with the cluster property set.
         try:
             self.rpk.create_topic(
-                "test", config={"redpanda.cloud_topic.enabled": "true"}
+                "test",
+                config={TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD},
             )
             assert False, (
-                "Should have failed to create topic with redpanda.cloud_topic.enabled set"
+                "Should have failed to create topic with redpanda.storage.mode=cloud set"
             )
         except RpkException:
             pass

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -92,7 +92,9 @@ class NodesDecommissioningTest(PreallocNodesTest):
             spec = TopicSpec(
                 partition_count=partitions,
                 replication_factor=random.choice(replication_factors),
-                cloud_topics_enabled=cloud_topic,
+                redpanda_storage_mode=TopicSpec.STORAGE_MODE_CLOUD
+                if cloud_topic
+                else None,
             )
             topics.append(spec)
             total_partitions += partitions
@@ -103,10 +105,10 @@ class NodesDecommissioningTest(PreallocNodesTest):
                 "redpanda.remote.read": "false",
                 "redpanda.remote.write": "false",
             }
-            if spec.cloud_topics_enabled:
+            if spec.redpanda_storage_mode == "cloud":
                 config.update(
                     {
-                        "redpanda.cloud_topic.enabled": "true",
+                        TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD,
                     }
                 )
             rpk = RpkTool(self.redpanda)

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -1031,7 +1031,7 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         self.topic = "topic"
         config = dict[str, Any]()
         if with_cloud_topics:
-            config[TopicSpec.PROPERTY_CLOUD_TOPIC_ENABLE] = "true"
+            config[TopicSpec.PROPERTY_STORAGE_MODE] = TopicSpec.STORAGE_MODE_CLOUD
         self.rpk_client().create_topic(
             self.topic,
             partitions=partitions,
@@ -1100,7 +1100,7 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         self.topic = "topic"
         config = dict[str, Any]()
         if with_cloud_topics:
-            config[TopicSpec.PROPERTY_CLOUD_TOPIC_ENABLE] = "true"
+            config[TopicSpec.PROPERTY_STORAGE_MODE] = TopicSpec.STORAGE_MODE_CLOUD
         self.rpk_client().create_topic(
             self.topic,
             partitions=partitions,

--- a/tests/rptest/tests/random_node_operations_smoke_test.py
+++ b/tests/rptest/tests/random_node_operations_smoke_test.py
@@ -698,7 +698,7 @@ class RandomNodeOperationsBase(PreallocNodesTest):
                     "cleanup.policy": "delete",
                     "redpanda.remote.read": "false",
                     "redpanda.remote.write": "false",
-                    "redpanda.cloud_topic.enabled": "true",
+                    TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD,
                 },
             )
             self.maybe_enable_iceberg_for_topic(
@@ -715,7 +715,7 @@ class RandomNodeOperationsBase(PreallocNodesTest):
                     "cleanup.policy": "compact",
                     "redpanda.remote.read": "false",
                     "redpanda.remote.write": "false",
-                    "redpanda.cloud_topic.enabled": "true",
+                    TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD,
                 },
             )
             self.maybe_enable_iceberg_for_topic(

--- a/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
+++ b/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
@@ -335,8 +335,15 @@ class TSWithAlreadyCompactedTopic(EndToEndTest):
         )
 
         # enable TS for the topic
-        self._rpk_client.alter_topic_config(topic_name, "redpanda.remote.read", "true")
-        self._rpk_client.alter_topic_config(topic_name, "redpanda.remote.write", "true")
+        self._rpk_client.alter_topic_config(
+            topic_name, TopicSpec.PROPERTY_REMOTE_READ, "true"
+        )
+        self._rpk_client.alter_topic_config(
+            topic_name, TopicSpec.PROPERTY_REMOTE_WRITE, "true"
+        )
+        self._rpk_client.alter_topic_config(
+            topic_name, TopicSpec.PROPERTY_STORAGE_MODE, TopicSpec.STORAGE_MODE_TIERED
+        )
 
         # Transfer leadership while the data is uploaded.
         for _ in range(0, 10):

--- a/tests/rptest/tests/storage_mode_test.py
+++ b/tests/rptest/tests/storage_mode_test.py
@@ -1,0 +1,614 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.tests.test import TestContext
+
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import (
+    RESTART_LOG_ALLOW_LIST,
+    SISettings,
+)
+from rptest.services.redpanda_installer import (
+    RedpandaInstaller,
+    wait_for_num_versions,
+)
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.util import expect_http_error
+
+
+class StorageModeTestBase(RedpandaTest):
+    """
+    Base class for storage mode tests with common helper methods.
+    """
+
+    CLUSTER_CONFIG_DEFAULT_STORAGE_MODE = "default_redpanda_storage_mode"
+
+    def _get_topic_config(
+        self, rpk: RpkTool, topic_name: str, property_name: str
+    ) -> str | None:
+        """Get a topic config property value, or None if not present."""
+        configs = rpk.describe_topic_configs(topic_name)
+        if property_name in configs:
+            return configs[property_name][0]
+        return None
+
+    def _get_topic_storage_mode(self, rpk: RpkTool, topic_name: str) -> str | None:
+        """Get the storage mode property value for a topic."""
+        return self._get_topic_config(rpk, topic_name, TopicSpec.PROPERTY_STORAGE_MODE)
+
+    def _get_topic_remote_read(self, rpk: RpkTool, topic_name: str) -> str | None:
+        """Get the remote read property value for a topic."""
+        return self._get_topic_config(rpk, topic_name, TopicSpec.PROPERTY_REMOTE_READ)
+
+    def _get_topic_remote_write(self, rpk: RpkTool, topic_name: str) -> str | None:
+        """Get the remote write property value for a topic."""
+        return self._get_topic_config(rpk, topic_name, TopicSpec.PROPERTY_REMOTE_WRITE)
+
+    def _create_topic(
+        self,
+        rpk: RpkTool,
+        topic_name: str,
+        config: dict[str, str] | None = None,
+    ):
+        """Create a topic with optional config overrides."""
+        rpk.create_topic(
+            topic=topic_name, partitions=1, replicas=3, config=config or {}
+        )
+
+    def _set_cluster_default_storage_mode(self, rpk: RpkTool, mode: str):
+        """Set the cluster default storage mode."""
+        rpk.cluster_config_set(self.CLUSTER_CONFIG_DEFAULT_STORAGE_MODE, mode)
+
+
+class StorageModeDefaultTest(StorageModeTestBase):
+    """
+    Test that cluster default storage mode is respected for new topics,
+    and that explicit storage mode at topic creation overrides the default.
+    """
+
+    def __init__(self, test_context: TestContext):
+        si_settings = SISettings(
+            test_context,
+            cloud_storage_enable_remote_read=False,
+            cloud_storage_enable_remote_write=False,
+        )
+
+        super(StorageModeDefaultTest, self).__init__(
+            test_context=test_context,
+            num_brokers=3,
+            si_settings=si_settings,
+        )
+
+    @cluster(num_nodes=3)
+    def test_cluster_default_storage_mode(self):
+        """
+        Test that topics inherit the cluster default storage mode.
+        """
+        rpk = RpkTool(self.redpanda)
+
+        # Test with default_redpanda_storage_mode = local
+        self._set_cluster_default_storage_mode(rpk, TopicSpec.STORAGE_MODE_LOCAL)
+        self._create_topic(rpk, "topic-default-local")
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-default-local")
+            == TopicSpec.STORAGE_MODE_LOCAL
+        ), "Topic should have storage_mode=local from cluster default"
+
+        # Test with default_redpanda_storage_mode = tiered
+        self._set_cluster_default_storage_mode(rpk, TopicSpec.STORAGE_MODE_TIERED)
+        self._create_topic(rpk, "topic-default-tiered")
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-default-tiered")
+            == TopicSpec.STORAGE_MODE_TIERED
+        ), "Topic should have storage_mode=tiered from cluster default"
+
+    @cluster(num_nodes=3)
+    def test_explicit_storage_mode_overrides_default(self):
+        """
+        Test that explicitly setting storage_mode at topic creation
+        overrides the cluster default.
+        """
+        rpk = RpkTool(self.redpanda)
+
+        # Set cluster default to local
+        self._set_cluster_default_storage_mode(rpk, TopicSpec.STORAGE_MODE_LOCAL)
+
+        # Create topic with explicit storage_mode=tiered (overriding local default)
+        self._create_topic(
+            rpk,
+            "topic-explicit-tiered",
+            config={TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_TIERED},
+        )
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-explicit-tiered")
+            == TopicSpec.STORAGE_MODE_TIERED
+        ), "Explicit storage_mode=tiered should override cluster default"
+
+        # Set cluster default to tiered
+        self._set_cluster_default_storage_mode(rpk, TopicSpec.STORAGE_MODE_TIERED)
+
+        # Create topic with explicit storage_mode=local (overriding tiered default)
+        self._create_topic(
+            rpk,
+            "topic-explicit-local",
+            config={TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_LOCAL},
+        )
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-explicit-local")
+            == TopicSpec.STORAGE_MODE_LOCAL
+        ), "Explicit storage_mode=local should override cluster default"
+
+
+class StorageModeUpgradeTest(StorageModeTestBase):
+    """
+    Test that topics created before the storage_mode property existed
+    default to 'unset' after upgrade while preserving their tiered storage
+    settings (remote_read/remote_write).
+    """
+
+    def __init__(self, test_context: TestContext):
+        si_settings = SISettings(
+            test_context,
+            cloud_storage_enable_remote_read=False,
+            cloud_storage_enable_remote_write=False,
+        )
+
+        super(StorageModeUpgradeTest, self).__init__(
+            test_context=test_context,
+            num_brokers=3,
+            si_settings=si_settings,
+        )
+        self.installer = self.redpanda._installer
+
+    def setUp(self):
+        # Use v25.3 as the previous version (before storage_mode existed)
+        self.prev_version = (25, 3)
+        # Install old version before starting cluster
+        self.installer.install(self.redpanda.nodes, self.prev_version)
+        super(StorageModeUpgradeTest, self).setUp()
+
+    def _create_topic_with_tiered_storage_config(
+        self, rpk: RpkTool, topic_name: str, remote_read: bool, remote_write: bool
+    ):
+        """Create a topic with specific remote read/write settings."""
+        config = {
+            TopicSpec.PROPERTY_REMOTE_READ: str(remote_read).lower(),
+            TopicSpec.PROPERTY_REMOTE_WRITE: str(remote_write).lower(),
+        }
+        self._create_topic(rpk, topic_name, config)
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_storage_mode_unset_on_upgrade(self):
+        """
+        Test that topics created before the storage_mode property existed
+        default to 'unset' after upgrade, while preserving their tiered
+        storage settings (remote_read/remote_write).
+
+        Creates topics with various remote read/write configurations in an
+        old version, then upgrades and verifies:
+        - storage_mode defaults to 'unset' for all pre-existing topics
+        - remote_read/remote_write settings are preserved
+        """
+        rpk = RpkTool(self.redpanda)
+
+        _ = wait_for_num_versions(self.redpanda, 1)
+
+        # Create topics with different tiered storage configurations
+        # These represent topics that existed before storage_mode was introduced
+        test_cases = [
+            # (topic_name, remote_read, remote_write)
+            ("topic-tiered-both", True, True),
+            ("topic-tiered-read-only", True, False),
+            ("topic-tiered-write-only", False, True),
+            ("topic-local", False, False),
+        ]
+
+        for topic_name, remote_read, remote_write in test_cases:
+            self._create_topic_with_tiered_storage_config(
+                rpk, topic_name, remote_read, remote_write
+            )
+            # On old version, properties are always present with "true"/"false"
+            actual_read = self._get_topic_remote_read(rpk, topic_name)
+            actual_write = self._get_topic_remote_write(rpk, topic_name)
+            assert actual_read == str(remote_read).lower(), (
+                f"Topic {topic_name} remote_read mismatch: expected {str(remote_read).lower()}, got {actual_read}"
+            )
+            assert actual_write == str(remote_write).lower(), (
+                f"Topic {topic_name} remote_write mismatch: expected {str(remote_write).lower()}, got {actual_write}"
+            )
+
+        # Upgrade all nodes to HEAD
+        self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        # Wait for cluster to stabilize on new version
+        _ = wait_for_num_versions(self.redpanda, 1)
+
+        # Verify all topics have storage_mode=unset and preserved tiered settings
+        for topic_name, remote_read, remote_write in test_cases:
+            # Verify remote_read/remote_write are preserved
+            actual_read = self._get_topic_remote_read(rpk, topic_name)
+            actual_write = self._get_topic_remote_write(rpk, topic_name)
+            expected_read = str(remote_read).lower()
+            expected_write = str(remote_write).lower()
+            assert actual_read == expected_read, (
+                f"Topic {topic_name}: remote_read is {actual_read}, expected {expected_read}"
+            )
+            assert actual_write == expected_write, (
+                f"Topic {topic_name}: remote_write is {actual_write}, expected {expected_write}"
+            )
+
+            # Verify storage_mode defaults to 'unset' for all pre-existing topics
+            actual_mode = self._get_topic_storage_mode(rpk, topic_name)
+            assert actual_mode == TopicSpec.STORAGE_MODE_UNSET, (
+                f"Topic {topic_name}: expected storage_mode=unset, got {actual_mode}"
+            )
+
+
+class StorageModeUnsetTest(StorageModeTestBase):
+    """
+    Test that storage_mode=unset correctly falls back to legacy shadow_indexing
+    behavior, and that explicit storage_mode values (local/tiered) override
+    shadow_indexing settings.
+    """
+
+    def __init__(self, test_context: TestContext):
+        si_settings = SISettings(
+            test_context,
+            cloud_storage_enable_remote_read=False,
+            cloud_storage_enable_remote_write=False,
+        )
+
+        super(StorageModeUnsetTest, self).__init__(
+            test_context=test_context,
+            num_brokers=3,
+            si_settings=si_settings,
+        )
+
+    @cluster(num_nodes=3)
+    def test_unset_storage_mode_default(self):
+        """
+        Test that the default storage mode is 'unset' and topics created
+        without explicit storage_mode get 'unset'.
+        """
+        rpk = RpkTool(self.redpanda)
+
+        # Verify the cluster default is 'unset'
+        self._set_cluster_default_storage_mode(rpk, TopicSpec.STORAGE_MODE_UNSET)
+
+        # Create topic without explicit storage_mode
+        self._create_topic(rpk, "topic-default-unset")
+        actual_mode = self._get_topic_storage_mode(rpk, "topic-default-unset")
+        assert actual_mode == TopicSpec.STORAGE_MODE_UNSET, (
+            f"Topic should have storage_mode=unset, got {actual_mode}"
+        )
+
+    @cluster(num_nodes=3)
+    def test_unset_falls_back_to_shadow_indexing(self):
+        """
+        Test that when storage_mode=unset, the legacy shadow_indexing configs
+        (remote.read/remote.write) determine tiered storage behavior.
+        """
+        rpk = RpkTool(self.redpanda)
+
+        # Set cluster default to unset
+        self._set_cluster_default_storage_mode(rpk, TopicSpec.STORAGE_MODE_UNSET)
+
+        # Create topic with unset storage mode and enable remote write
+        self._create_topic(
+            rpk,
+            "topic-unset-with-remote-write",
+            config={
+                TopicSpec.PROPERTY_REMOTE_WRITE: "true",
+            },
+        )
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-unset-with-remote-write")
+            == TopicSpec.STORAGE_MODE_UNSET
+        ), "Topic should have storage_mode=unset"
+        assert (
+            self._get_topic_remote_write(rpk, "topic-unset-with-remote-write") == "true"
+        ), "Topic should have remote_write=true"
+
+        # Create topic with unset storage mode and no shadow_indexing
+        self._create_topic(rpk, "topic-unset-no-shadow")
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-unset-no-shadow")
+            == TopicSpec.STORAGE_MODE_UNSET
+        ), "Topic should have storage_mode=unset"
+        # remote.read and remote.write should be false (disabled)
+        assert self._get_topic_remote_read(rpk, "topic-unset-no-shadow") == "false", (
+            "Topic should have remote_read=false"
+        )
+        assert self._get_topic_remote_write(rpk, "topic-unset-no-shadow") == "false", (
+            "Topic should have remote_write=false"
+        )
+
+    @cluster(num_nodes=3)
+    def test_explicit_tiered_overrides_shadow_indexing(self):
+        """
+        Test that storage_mode=tiered enables both archival (write) and fetch
+        (read), regardless of shadow_indexing settings.
+        """
+        rpk = RpkTool(self.redpanda)
+
+        # Create topic with explicit tiered mode, without setting shadow_indexing
+        self._create_topic(
+            rpk,
+            "topic-tiered-no-shadow",
+            config={TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_TIERED},
+        )
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-tiered-no-shadow")
+            == TopicSpec.STORAGE_MODE_TIERED
+        ), "Topic should have storage_mode=tiered"
+
+        # Create topic with explicit tiered and shadow_indexing=archival (write-only)
+        # Both read and write should still be enabled because tiered is authoritative
+        self._create_topic(
+            rpk,
+            "topic-tiered-archival-only",
+            config={
+                TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_TIERED,
+                TopicSpec.PROPERTY_REMOTE_WRITE: "true",
+                TopicSpec.PROPERTY_REMOTE_READ: "false",
+            },
+        )
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-tiered-archival-only")
+            == TopicSpec.STORAGE_MODE_TIERED
+        ), "Topic should have storage_mode=tiered"
+
+    @cluster(num_nodes=3)
+    def test_explicit_local_overrides_shadow_indexing(self):
+        """
+        Test that storage_mode=local disables tiered storage features,
+        regardless of shadow_indexing settings.
+        """
+        rpk = RpkTool(self.redpanda)
+
+        # Create topic with explicit local mode, but trying to enable shadow_indexing
+        # This should result in local mode where tiered features are disabled
+        self._create_topic(
+            rpk,
+            "topic-local-with-shadow",
+            config={TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_LOCAL},
+        )
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-local-with-shadow")
+            == TopicSpec.STORAGE_MODE_LOCAL
+        ), "Topic should have storage_mode=local"
+
+
+class StorageModeTransitionTest(StorageModeTestBase):
+    """
+    Test storage mode transitions, including transitions to/from 'unset'.
+    """
+
+    def __init__(self, test_context: TestContext):
+        si_settings = SISettings(
+            test_context,
+            cloud_storage_enable_remote_read=False,
+            cloud_storage_enable_remote_write=False,
+        )
+
+        super(StorageModeTransitionTest, self).__init__(
+            test_context=test_context,
+            num_brokers=3,
+            si_settings=si_settings,
+        )
+
+    @cluster(num_nodes=3)
+    def test_storage_mode_transitions(self):
+        """
+        Test all permitted and blocked storage mode transitions.
+
+        Permitted transitions:
+        - unset -> local
+        - unset -> tiered
+        - local -> tiered
+        - tiered -> local
+
+        Blocked transitions:
+        - local -> unset
+        - tiered -> unset
+        - unset -> cloud
+        """
+        rpk = RpkTool(self.redpanda)
+
+        # Set cluster default to unset for initial topic creation
+        self._set_cluster_default_storage_mode(rpk, TopicSpec.STORAGE_MODE_UNSET)
+
+        # Test unset -> local transition (permitted)
+        self._create_topic(rpk, "topic-unset-to-local")
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-unset-to-local")
+            == TopicSpec.STORAGE_MODE_UNSET
+        )
+        rpk.alter_topic_config(
+            "topic-unset-to-local",
+            TopicSpec.PROPERTY_STORAGE_MODE,
+            TopicSpec.STORAGE_MODE_LOCAL,
+        )
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-unset-to-local")
+            == TopicSpec.STORAGE_MODE_LOCAL
+        ), "Transition from unset to local should succeed"
+
+        # Test unset -> tiered transition (permitted)
+        self._create_topic(rpk, "topic-unset-to-tiered")
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-unset-to-tiered")
+            == TopicSpec.STORAGE_MODE_UNSET
+        )
+        rpk.alter_topic_config(
+            "topic-unset-to-tiered",
+            TopicSpec.PROPERTY_STORAGE_MODE,
+            TopicSpec.STORAGE_MODE_TIERED,
+        )
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-unset-to-tiered")
+            == TopicSpec.STORAGE_MODE_TIERED
+        ), "Transition from unset to tiered should succeed"
+
+        # Test local -> tiered transition (permitted)
+        self._create_topic(
+            rpk,
+            "topic-local-to-tiered",
+            config={TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_LOCAL},
+        )
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-local-to-tiered")
+            == TopicSpec.STORAGE_MODE_LOCAL
+        )
+        rpk.alter_topic_config(
+            "topic-local-to-tiered",
+            TopicSpec.PROPERTY_STORAGE_MODE,
+            TopicSpec.STORAGE_MODE_TIERED,
+        )
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-local-to-tiered")
+            == TopicSpec.STORAGE_MODE_TIERED
+        ), "Transition from local to tiered should succeed"
+
+        # Test tiered -> local transition (permitted)
+        self._create_topic(
+            rpk,
+            "topic-tiered-to-local",
+            config={TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_TIERED},
+        )
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-tiered-to-local")
+            == TopicSpec.STORAGE_MODE_TIERED
+        )
+        rpk.alter_topic_config(
+            "topic-tiered-to-local",
+            TopicSpec.PROPERTY_STORAGE_MODE,
+            TopicSpec.STORAGE_MODE_LOCAL,
+        )
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-tiered-to-local")
+            == TopicSpec.STORAGE_MODE_LOCAL
+        ), "Transition from tiered to local should succeed"
+
+        # Test blocked transition: local -> unset
+        self._create_topic(
+            rpk,
+            "topic-local-to-unset",
+            config={TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_LOCAL},
+        )
+        try:
+            rpk.alter_topic_config(
+                "topic-local-to-unset",
+                TopicSpec.PROPERTY_STORAGE_MODE,
+                TopicSpec.STORAGE_MODE_UNSET,
+            )
+            assert False, "Transition from local to unset should have been rejected"
+        except Exception:
+            pass  # Expected - transition should be rejected
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-local-to-unset")
+            == TopicSpec.STORAGE_MODE_LOCAL
+        ), "Storage mode should still be local after rejected transition"
+
+        # Test blocked transition: tiered -> unset
+        self._create_topic(
+            rpk,
+            "topic-tiered-to-unset",
+            config={TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_TIERED},
+        )
+        try:
+            rpk.alter_topic_config(
+                "topic-tiered-to-unset",
+                TopicSpec.PROPERTY_STORAGE_MODE,
+                TopicSpec.STORAGE_MODE_UNSET,
+            )
+            assert False, "Transition from tiered to unset should have been rejected"
+        except Exception:
+            pass  # Expected - transition should be rejected
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-tiered-to-unset")
+            == TopicSpec.STORAGE_MODE_TIERED
+        ), "Storage mode should still be tiered after rejected transition"
+
+        # Test blocked transition: unset -> cloud
+        self._create_topic(rpk, "topic-unset-to-cloud")
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-unset-to-cloud")
+            == TopicSpec.STORAGE_MODE_UNSET
+        )
+        try:
+            rpk.alter_topic_config(
+                "topic-unset-to-cloud",
+                TopicSpec.PROPERTY_STORAGE_MODE,
+                TopicSpec.STORAGE_MODE_CLOUD,
+            )
+            assert False, "Transition from unset to cloud should have been rejected"
+        except Exception:
+            pass  # Expected - transition should be rejected
+        assert (
+            self._get_topic_storage_mode(rpk, "topic-unset-to-cloud")
+            == TopicSpec.STORAGE_MODE_UNSET
+        ), "Storage mode should still be unset after rejected transition"
+
+
+class StorageModeValidationTest(RedpandaTest):
+    """
+    Test that the default_redpanda_storage_mode cluster config validation
+    correctly enforces dependencies on cloud_storage_enabled and
+    cloud_topics_enabled.
+    """
+
+    def __init__(self, test_context: TestContext):
+        # Start without cloud storage to test validation
+        super(StorageModeValidationTest, self).__init__(
+            test_context=test_context,
+            num_brokers=3,
+        )
+
+    @cluster(num_nodes=3)
+    def test_default_storage_mode_validation(self):
+        """
+        Test that default_redpanda_storage_mode validation enforces:
+        - 'tiered' requires cloud_storage_enabled=true
+        - 'cloud' requires cloud_topics_enabled=true
+        """
+        admin = Admin(self.redpanda)
+
+        # Verify preconditions
+        config = admin.get_cluster_config()
+        assert config["cloud_storage_enabled"] is False, (
+            "cloud_storage_enabled should be false for this test"
+        )
+        assert config["cloud_topics_enabled"] is False, (
+            "cloud_topics_enabled should be false for this test"
+        )
+
+        # Test: setting 'tiered' should fail without cloud_storage_enabled
+        with expect_http_error(400):
+            admin.patch_cluster_config(
+                upsert={"default_redpanda_storage_mode": "tiered"}
+            )
+        config = admin.get_cluster_config()
+        assert config["default_redpanda_storage_mode"] != "tiered", (
+            "default_redpanda_storage_mode should not be tiered"
+        )
+
+        # Test: setting 'cloud' should fail without cloud_topics_enabled
+        with expect_http_error(400):
+            admin.patch_cluster_config(
+                upsert={"default_redpanda_storage_mode": "cloud"}
+            )
+        config = admin.get_cluster_config()
+        assert config["default_redpanda_storage_mode"] != "cloud", (
+            "default_redpanda_storage_mode should not be cloud"
+        )

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -78,7 +78,7 @@ class RapidTopicRecreateTest(RedpandaTest):
             topic=self.cloud_topic_name,
             partitions=self._current_partitions,
             replicas=replication_factor,
-            config={TopicSpec.PROPERTY_CLOUD_TOPIC_ENABLE: "true"},
+            config={TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD},
         )
 
     def delete(self):
@@ -215,7 +215,7 @@ class TopicRecreateTest(RedpandaTest):
         rpk.create_topic(
             topic=topic,
             partitions=partition_count,
-            config={TopicSpec.PROPERTY_CLOUD_TOPIC_ENABLE: "true"},
+            config={TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD},
         )
 
         producer_properties = {
@@ -251,7 +251,7 @@ class TopicRecreateTest(RedpandaTest):
                 topic=topic,
                 partitions=partition_count,
                 replicas=rf,
-                config={TopicSpec.PROPERTY_CLOUD_TOPIC_ENABLE: "true"},
+                config={TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD},
             )
             wait_until(topic_is_healthy, 30, 2, err_msg=f"Topic {topic} health")
             sleep(5)

--- a/tests/rptest/transactions/tx_verifier_test.py
+++ b/tests/rptest/transactions/tx_verifier_test.py
@@ -15,6 +15,7 @@ from ducktape.tests.test import TestContext
 
 from rptest.context.cloud_storage import CloudStorageType
 from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import (
     SISettings,
@@ -99,7 +100,7 @@ class TxVerifierTest(RedpandaTest):
 
         # 2 cloud topics
         cloud_topic_config = {
-            "redpanda.cloud_topic.enabled": "true",
+            TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD,
         }
         specs.append(("topic1-ct", "topic2-ct", "groupId-ct"))
         rpk.create_topic(specs[-1][0], config=cloud_topic_config)

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -141,7 +141,7 @@ def read_topic_properties_serde(rdr: Reader, version):
         topic_properties |= {
             "iceberg_mode": read_iceberg_mode(rdr),
             "leaders_preference": rdr.read_optional(read_leaders_preference),
-            "cloud_topic_enabled": rdr.read_bool(),
+            "deprecated_cloud_topic_enabled": rdr.read_bool(),
             "delete_retention_ms": rdr.read_tristate(Reader.read_int64),
             "iceberg_delete": rdr.read_optional(Reader.read_bool),
         }
@@ -156,6 +156,19 @@ def read_topic_properties_serde(rdr: Reader, version):
     if version >= 11:
         topic_properties |= {
             "remote_topic_allow_gaps": rdr.read_optional(Reader.read_bool),
+        }
+
+    if version >= 12:
+        topic_properties |= {
+            "min_compaction_lag_ms": rdr.read_optional(Reader.read_int64),
+            "max_compaction_lag_ms": rdr.read_optional(Reader.read_int64),
+        }
+
+    if version >= 13:
+        topic_properties |= {
+            "message_timestamp_before_max_ms": rdr.read_optional(Reader.read_int64),
+            "message_timestamp_after_max_ms": rdr.read_optional(Reader.read_int64),
+            "storage_mode": rdr.read_serde_enum(),
         }
 
     return topic_properties


### PR DESCRIPTION
`redpanda.storage.mode`: `unset`, `local`, `tiered`, or `cloud` (topic config). Default create your topics by setting `default_redpanda_storage_mode` at the cluster level, this defaults to `unset`.

Hopefully one day this can replace any interaction with `redpanda.remote.{read/write}` for tiered topics.

Remote read replicas are still supported and configured with their old properties, but will have either `tiered` or `cloud` assigned.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
