### PR TITLE
detailed_error: add constructor with fmt args

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/lsm/state_reader.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_reader.cc
@@ -25,7 +25,7 @@ namespace {
 
 error to_error(std::exception_ptr e, std::string_view prefix = "") {
     if (ssx::is_shutdown_exception(e)) {
-        return {errc::shutting_down, fmt::format("{}{}", prefix, e)};
+        return {errc::shutting_down, "{}{}", prefix, e};
     }
     errc ec{};
     ss::sstring msg;
@@ -96,8 +96,8 @@ state_reader::extent_key_range::get_rows() {
         co_return;
     }
     if (!_iter.valid() || _iter.key() != start_key) {
-        co_yield std::unexpected(error(
-          errc::corruption, fmt::format("Expected base key: {}", to_string())));
+        co_yield std::unexpected(
+          error(errc::corruption, "Expected base key: {}", to_string()));
         co_return;
     }
     while (_iter.valid()) {
@@ -106,7 +106,8 @@ state_reader::extent_key_range::get_rows() {
             if (forward ? (_iter.key() > end_key) : (_iter.key() < end_key)) {
                 co_yield std::unexpected(error(
                   errc::corruption,
-                  fmt::format("Unexpected key past last: {}", to_string())));
+                  "Unexpected key past last: {}",
+                  to_string()));
                 co_return;
             }
             auto val = serde::from_iobuf<extent_row_value>(_iter.value());
@@ -214,11 +215,10 @@ state_reader::get_max_term(const model::topic_id_partition& tidp) {
     } catch (...) {
         co_return std::unexpected(error(
           errc::corruption,
-          fmt::format(
-            "Failed to decode term row value for {} term {} key {}",
-            tidp,
-            term,
-            base_key_str)));
+          "Failed to decode term row value for {} term {} key {}",
+          tidp,
+          term,
+          base_key_str));
     }
 }
 
@@ -281,11 +281,10 @@ state_reader::get_extent_ge(
     } catch (...) {
         co_return std::unexpected(error(
           errc::corruption,
-          fmt::format(
-            "Failed to decode extent row value for {} offset {} key {}",
-            tidp,
-            base_offset,
-            base_key_str)));
+          "Failed to decode extent row value for {} offset {} key {}",
+          tidp,
+          base_offset,
+          base_key_str));
     }
 }
 
@@ -334,11 +333,10 @@ state_reader::get_extent_range(
     } catch (...) {
         co_return std::unexpected(error(
           errc::corruption,
-          fmt::format(
-            "Failed to decode extent row value for {} offset {} key {}",
-            tidp,
-            base,
-            base_key)));
+          "Failed to decode extent row value for {} offset {} key {}",
+          tidp,
+          base,
+          base_key));
     }
     // Position iterator back at base_key to return to the caller.
     try {
@@ -591,8 +589,7 @@ state_reader::get_term_end(
         }
         if (!metadata_res.value().has_value()) {
             co_return std::unexpected(error(
-              errc::corruption,
-              fmt::format("Missing partition metadata for {}", tidp)));
+              errc::corruption, "Missing partition metadata for {}", tidp));
         }
         co_return metadata_res.value()->next_offset;
     } catch (...) {
@@ -616,9 +613,8 @@ state_reader::get_val(KeyEncodeArgs... args) {
         auto val = serde::from_iobuf<ValT>(std::move(*opt_buf));
         co_return val;
     } catch (...) {
-        co_return std::unexpected(error(
-          errc::corruption,
-          fmt::format("Failed to decode value at key {}", key_str)));
+        co_return std::unexpected(
+          error(errc::corruption, "Failed to decode value at key {}", key_str));
     }
 }
 

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
@@ -22,14 +22,19 @@ namespace {
 
 using enum db_update_errc;
 
-db_update_error wrap_read_err(state_reader::error e, ss::sstring msg) {
+template<typename... T>
+db_update_error wrap_read_err(
+  state_reader::error e, fmt::format_string<T...> msg, T&&... args) {
     switch (e.e) {
     case state_reader::errc::io_error:
-        return std::move(e).wrap(io_error, std::move(msg));
+        return std::move(e).wrap(
+          io_error, std::move(msg), std::forward<T>(args)...);
     case state_reader::errc::corruption:
-        return std::move(e).wrap(corruption, std::move(msg));
+        return std::move(e).wrap(
+          corruption, std::move(msg), std::forward<T>(args)...);
     case state_reader::errc::shutting_down:
-        return std::move(e).wrap(shutting_down, std::move(msg));
+        return std::move(e).wrap(
+          shutting_down, std::move(msg), std::forward<T>(args)...);
     }
 }
 
@@ -79,11 +84,10 @@ ss::future<std::expected<void, db_update_error>> collect_exact_intervals(
         if (!range_res.has_value()) {
             co_return std::unexpected(wrap_read_err(
               std::move(range_res.error()),
-              fmt::format(
-                "Error getting extent range for {} [{}, {}]",
-                tidp,
-                interval.base_offset,
-                interval.last_offset)));
+              "Error getting extent range for {} [{}, {}]",
+              tidp,
+              interval.base_offset,
+              interval.last_offset));
         }
         if (!range_res.value().has_value()) {
             co_return std::unexpected(db_update_error(
@@ -101,11 +105,10 @@ ss::future<std::expected<void, db_update_error>> collect_exact_intervals(
             if (!extent_res->get().has_value()) {
                 co_return std::unexpected(wrap_read_err(
                   std::move(extent_res->get().error()),
-                  fmt::format(
-                    "Error iterating through {} extents in range [{}, {}]",
-                    tidp,
-                    interval.base_offset,
-                    interval.last_offset)));
+                  "Error iterating through {} extents in range [{}, {}]",
+                  tidp,
+                  interval.base_offset,
+                  interval.last_offset));
             }
             auto& row = extent_res->get().value();
             out_sizes[row.val.oid] += row.val.len;
@@ -126,8 +129,8 @@ ss::future<std::expected<void, db_update_error>> merge_compaction_state(
     if (!meta_res.has_value()) {
         co_return std::unexpected(wrap_read_err(
           std::move(meta_res.error()),
-          fmt::format(
-            "Error getting metadata for {} during compaction", tidp)));
+          "Error getting metadata for {} during compaction",
+          tidp));
     }
     if (!meta_res.value().has_value()) {
         co_return std::unexpected(db_update_error(
@@ -152,7 +155,8 @@ ss::future<std::expected<void, db_update_error>> merge_compaction_state(
     if (!comp_res.has_value()) {
         co_return std::unexpected(wrap_read_err(
           std::move(comp_res.error()),
-          fmt::format("Error getting compaction metadata for {}", tidp)));
+          "Error getting compaction metadata for {}",
+          tidp));
     }
 
     // Validate and apply new cleaned ranges.
@@ -270,7 +274,8 @@ add_objects_db_update::build_rows(
         if (!meta_res.has_value()) {
             co_return std::unexpected(wrap_read_err(
               std::move(meta_res.error()),
-              fmt::format("Error getting metadata for {}", tidp)));
+              "Error getting metadata for {}",
+              tidp));
         }
         auto opt = meta_res.value();
         auto expected_next = opt ? opt->next_offset : kafka::offset{0};
@@ -310,7 +315,8 @@ add_objects_db_update::build_rows(
         if (!term_res.has_value()) {
             co_return std::unexpected(wrap_read_err(
               std::move(term_res.error()),
-              fmt::format("Error getting max term for {}", tp)));
+              "Error getting max term for {}",
+              tp));
         }
         auto term_opt = term_res.value();
         if (term_opt.has_value()) {
@@ -528,7 +534,8 @@ replace_objects_db_update::build_rows(
         if (!meta_res.has_value()) {
             co_return std::unexpected(wrap_read_err(
               std::move(meta_res.error()),
-              fmt::format("Error getting metadata for {}", tidp)));
+              "Error getting metadata for {}",
+              tidp));
         }
         if (!meta_res.value().has_value()) {
             co_return std::unexpected(db_update_error(
@@ -554,7 +561,8 @@ replace_objects_db_update::build_rows(
         if (!obj_res.has_value()) {
             co_return std::unexpected(wrap_read_err(
               std::move(obj_res.error()),
-              fmt::format("Error getting object {} for update", oid)));
+              "Error getting object {} for update",
+              oid));
         }
         if (obj_res.value().has_value()) {
             auto obj_entry = obj_res.value().value();

--- a/src/v/utils/detailed_error.h
+++ b/src/v/utils/detailed_error.h
@@ -35,9 +35,15 @@ struct detailed_error {
 public:
     explicit detailed_error(ErrorT e)
       : e(std::move(e)) {}
+
     detailed_error(ErrorT e, ss::sstring detail)
       : e(std::move(e))
       , details({std::move(detail)}) {}
+
+    template<typename... T>
+    detailed_error(ErrorT e, fmt::format_string<T...> msg, T&&... args)
+      : e(std::move(e))
+      , details({fmt::format(std::move(msg), std::forward<T>(args)...)}) {}
 
     ~detailed_error() = default;
     detailed_error& operator=(const detailed_error&) = delete;
@@ -56,12 +62,13 @@ public:
         return ret;
     }
 
-    template<typename OtherErrorT>
+    template<typename OtherErrorT, typename... T>
     detailed_error<OtherErrorT>
-    wrap(OtherErrorT&& other, ss::sstring detail) && {
+    wrap(OtherErrorT&& other, fmt::format_string<T...> msg, T&&... args) && {
         detailed_error<OtherErrorT> ret(std::forward<OtherErrorT>(other));
         ret.details = std::move(details);
-        ret.details.push_front(std::move(detail));
+        ret.details.push_front(
+          fmt::format(std::move(msg), std::forward<T>(args)...));
         return std::move(ret);
     }
 
@@ -69,11 +76,15 @@ public:
     static detailed_error wrap(detailed_error<OtherErrorT> other, ErrorT&& e) {
         return std::move(other).wrap(std::forward<ErrorT>(e));
     }
-    template<typename OtherErrorT>
-    static detailed_error
-    wrap(detailed_error<OtherErrorT> other, ErrorT&& e, ss::sstring detail) {
+
+    template<typename OtherErrorT, typename... T>
+    static detailed_error wrap(
+      detailed_error<OtherErrorT> other,
+      ErrorT&& e,
+      fmt::format_string<T...> msg,
+      T&&... args) {
         return std::move(other).wrap(
-          std::forward<ErrorT>(e), std::move(detail));
+          std::forward<ErrorT>(e), std::move(msg), std::forward<T>(args)...);
     }
 
     fmt::iterator format_to(fmt::iterator it) const {

--- a/src/v/utils/tests/detailed_error_test.cc
+++ b/src/v/utils/tests/detailed_error_test.cc
@@ -45,6 +45,16 @@ TEST(DetailedErrorTest, TestErrorAndDetails) {
     EXPECT_EQ(fmt::format("{}", error(errc::foo, "msg")), "[foo]: msg");
 }
 
+TEST(DetailedErrorTest, TestErrorAndFmtDetails) {
+    EXPECT_EQ(fmt::format("{}", error(errc::foo, "{} msg", 1)), "[foo]: 1 msg");
+}
+
+TEST(DetailedErrorTest, TestWrapFmt) {
+    auto inner = error(errc::bar, "inner");
+    auto outer = error::wrap(std::move(inner), errc::foo, "{} outer", 1);
+    EXPECT_EQ(fmt::format("{}", outer), "[foo]: 1 outer: inner");
+}
+
 TEST(DetailedErrorTest, TestWrap) {
     auto inner = error(errc::bar, "inner");
     auto outer = error::wrap(std::move(inner), errc::foo, "outer");
@@ -55,6 +65,12 @@ TEST(DetailedErrorTest, TestWrapCall) {
     auto inner = error(errc::bar, "inner");
     auto outer = std::move(inner).wrap(errc::foo, "outer");
     EXPECT_EQ(fmt::format("{}", outer), "[foo]: outer: inner");
+}
+
+TEST(DetailedErrorTest, TestWrapCallFmt) {
+    auto inner = error(errc::bar, "inner");
+    auto outer = std::move(inner).wrap(errc::foo, "{} outer", 1);
+    EXPECT_EQ(fmt::format("{}", outer), "[foo]: 1 outer: inner");
 }
 
 TEST(DetailedErrorTest, TestWrapChain) {


### PR DESCRIPTION
This allows for shorthand construction of using format strings without adding a fmt::format() call.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
