### PR TITLE
[DNM] dt: unstable verification

### DIFF
--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -1874,7 +1874,32 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             msg_size=128,
             msg_cnt=10000,
             use_transactions=True,
-            producer_properties={"transaction_abort_rate": "0.3"},
+            producer_properties={
+                "transaction_abort_rate": "0.3",
+            },
+        ):
+            self.verify()
+
+        topic_2 = TopicSpec(
+            name="source-topic-2", partition_count=1, replication_factor=3
+        )
+        self.source_default_client().create_topic(topic_2)
+        self.target_cluster.service.wait_until(
+            lambda: self.topic_partitions_exists_in_target(topic_2),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"Topic {topic_2.name} not found in target cluster",
+        )
+
+        with self.producer_consumer(
+            topic=topic_2.name,
+            msg_size=128,
+            msg_cnt=5000000,
+            use_transactions=True,
+            producer_properties={
+                "msgs_per_transaction": "1000000",
+                "transaction_abort_rate": "0.3",
+            },
         ):
             self.verify()
 


### PR DESCRIPTION
This is the smallest values that the test is unstable in local testing.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
