### PR TITLE
licenses: drop libnuma

### DIFF
--- a/licenses/third_party.md
+++ b/licenses/third_party.md
@@ -24,7 +24,6 @@ please keep this up to date with every new library use.
 | lexy            | Boost Software License Version 1.0 |
 | libcxx          | Apache License 2                   |
 | libcxxabi       | Apache License 2                   |
-| libnumactl      | LGPL v2.1                          |
 | libpciaccess    | MIT                                |
 | libxml2         | MIT                                |
 | liburing        | MIT                                |


### PR DESCRIPTION
We no longer use this library as of https://github.com/redpanda-data/redpanda/pull/25041

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
