### PR TITLE
[CORE-15335] `ct/l1`: don't log on benign `missing_ntp` errors in `log_info_collector`

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/log_info_collector.cc
+++ b/src/v/cloud_topics/level_one/compaction/log_info_collector.cc
@@ -301,6 +301,7 @@ void log_info_collector::populate_log_infos(
 
         auto max_compactible_offset = offset_it->second;
 
+        log.has_seen_reconciled_data = true;
         log.info_and_ts = compaction_info_and_timestamp{
           .info = std::move(compaction_info).value(),
           .collected_at = collection_timestamp,

--- a/src/v/cloud_topics/level_one/compaction/log_info_collector.cc
+++ b/src/v/cloud_topics/level_one/compaction/log_info_collector.cc
@@ -283,12 +283,22 @@ void log_info_collector::populate_log_infos(
         auto& compaction_info = it->second;
 
         if (!compaction_info.has_value()) {
-            vlog(
-              compaction_log.warn,
+            // Minimize logging on benign `missing_ntp` errors in case
+            // the `metastore` does not yet have any reconciled data for the log
+            // in question.
+            auto err = compaction_info.error();
+            auto lvl = err == metastore::errc::missing_ntp
+                           && !log.has_seen_reconciled_data
+                         ? ss::log_level::debug
+                         : ss::log_level::warn;
+
+            vlogl(
+              compaction_log,
+              lvl,
               "Failed to collect compaction info for CTP {} during compaction: "
               "{}",
               log.ntp,
-              compaction_info.error());
+              err);
             continue;
         }
 

--- a/src/v/cloud_topics/level_one/compaction/meta.h
+++ b/src/v/cloud_topics/level_one/compaction/meta.h
@@ -54,6 +54,9 @@ struct log_compaction_meta {
     // inflight compaction. Guaranteed to have a value if `state == inflight`.
     std::optional<ss::shard_id> inflight_shard{std::nullopt};
     intrusive_list_hook link;
+    // If `true`, we have been able to sample compaction info from the
+    // `metastore` previously.
+    bool has_seen_reconciled_data{false};
 };
 
 using log_compaction_meta_ptr = ss::lw_shared_ptr<log_compaction_meta>;


### PR DESCRIPTION
There may be a period of time in which a log which is eligible for compaction does not yet have any reconciled data in L1. In this cause, the `metastore` will return a `missing_ntp` error when trying to collect log information.

In this case, `missing_ntp` is benign, and shouldn't be logged at `WARN`.

Alternatively, instead of (or in addition to) adding this extra `bool`, we could reach into the `partition`'s `ctp_stm` to check the reconciled offset is non-zero. Because this would (likely) require a cross-shard call and is a check that is `true` in 99% of cases, I decided to go the route of this PR instead.

Of course, this could end up masking cases where e.g. an `ntp` is truly missing but is managed by the `compaction_scheduler`, and therefore is never able to collect log info, but this is a mostly unforeseeable case.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
