### PR TITLE
CORE-15436 delete topic enable

### DIFF
--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -278,6 +278,9 @@ feature_manager::report_enterprise_features() const {
     report.set(
       features::license_required_feature::cloud_topics,
       cfg.cloud_topics_enabled());
+    report.set(
+      features::license_required_feature::topic_deletion_disabled,
+      !cfg.delete_topic_enable());
     return report;
 }
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1755,6 +1755,17 @@ configuration::configuration()
       "compressed, the limit applies to the compressed batch size.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1_MiB)
+  , delete_topic_enable(
+      *this,
+      false,
+      "delete_topic_enable",
+      "Enable or disable topic deletion via the Kafka DeleteTopics API. When "
+      "set to false, all topic deletion requests are rejected with error code "
+      "73 (TOPIC_DELETION_DISABLED). This is a cluster-wide safety setting "
+      "that cannot be overridden by superusers. Topics in "
+      "kafka_nodelete_topics are always protected regardless of this setting.",
+      meta{.needs_restart = needs_restart::no, .visibility = visibility::user},
+      true)
   , kafka_nodelete_topics(
       *this,
       "kafka_nodelete_topics",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -368,6 +368,7 @@ struct configuration final : public config_store {
     deprecated_property node_management_operation_timeout_ms;
     property<uint32_t> kafka_request_max_bytes;
     property<uint32_t> kafka_batch_max_bytes;
+    enterprise<property<bool>> delete_topic_enable;
     property<std::vector<ss::sstring>> kafka_nodelete_topics;
     property<std::vector<ss::sstring>> kafka_noproduce_topics;
     property<std::optional<uint32_t>> kafka_topics_max;

--- a/src/v/features/enterprise_features.cc
+++ b/src/v/features/enterprise_features.cc
@@ -45,6 +45,8 @@ std::ostream& operator<<(std::ostream& os, license_required_feature f) {
         return os << "shadow_linking";
     case license_required_feature::cloud_topics:
         return os << "cloud_topics";
+    case license_required_feature::topic_deletion_disabled:
+        return os << "topic_deletion_disabled";
     }
     __builtin_unreachable();
 }

--- a/src/v/features/enterprise_features.h
+++ b/src/v/features/enterprise_features.h
@@ -35,6 +35,7 @@ enum class license_required_feature {
     leadership_pinning,
     shadow_linking,
     cloud_topics,
+    topic_deletion_disabled,
 };
 
 std::ostream& operator<<(std::ostream&, license_required_feature);
@@ -70,6 +71,7 @@ public:
     // | Cluster     | `iceberg_enabled`               | `true`        |
     // | Cluster     | `enable_shadow_linking`         | `true`        |
     // | Cluster     | `cloud_topics_enabled`          | `true`        |
+    // | Cluster     | `delete_topic_enable`           | `false`       |
     // | Node        | `fips_mode`                     | `enabled`     |
     // | Node        | `fips_mode`                     | `permissive`  |
     // +-------------+---------------------------------+---------------+

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -1462,6 +1462,41 @@ delete_topics_handler::handle(request_context ctx, ss::smp_service_group) {
     request.decode(ctx.reader(), ctx.header().version);
     log_request(ctx.header(), request);
 
+    // Check if topic deletion is globally disabled
+    if (!config::shard_local_cfg().delete_topic_enable()) {
+        delete_topics_response resp;
+        resp.data.responses.reserve(
+          request.data.topic_names.size() + request.data.topics.size());
+
+        // Use appropriate error code based on API version
+        // API version 3+ supports topic_deletion_disabled (error 73)
+        const auto ec = (ctx.header().version >= api_version(3))
+                          ? error_code::topic_deletion_disabled
+                          : error_code::invalid_request;
+        const auto err_msg = "Topic deletion is disabled.";
+
+        std::ranges::transform(
+          request.data.topic_names,
+          std::back_inserter(resp.data.responses),
+          [ec, err_msg](const model::topic& t) {
+              return deletable_topic_result{
+                .name = t, .error_code = ec, .error_message = err_msg};
+          });
+
+        std::ranges::transform(
+          request.data.topics,
+          std::back_inserter(resp.data.responses),
+          [ec, err_msg](const delete_topic_state& t) {
+              return deletable_topic_result{
+                .name = t.name,
+                .topic_id = t.topic_id,
+                .error_code = ec,
+                .error_message = err_msg};
+          });
+
+        co_return co_await ctx.respond(std::move(resp));
+    }
+
     // Determine the names and IDs that have been provided, and detect
     // duplicates.
     chunked_hash_set<model::topic> provided_names;

--- a/src/v/kafka/server/tests/delete_topics_test.cc
+++ b/src/v/kafka/server/tests/delete_topics_test.cc
@@ -469,6 +469,113 @@ FIXTURE_TEST(
       "The provided topic name maps to an ID that was already supplied.");
 }
 
+FIXTURE_TEST(delete_topic_enable_disabled_v6, delete_topics_request_fixture) {
+    wait_for_controller_leadership().get();
+
+    create_topic("test-topic", 1, 1);
+
+    // Disable topic deletion globally (must set on all shards)
+    ss::smp::invoke_on_all([] {
+        config::shard_local_cfg().delete_topic_enable.set_value(false);
+    }).get();
+    auto reset_config = ss::defer([] {
+        ss::smp::invoke_on_all([] {
+            config::shard_local_cfg().delete_topic_enable.set_value(true);
+        }).get();
+    });
+
+    // Attempt to delete - should fail with topic_deletion_disabled (API v6)
+    auto resp = send_delete_topics_request(
+      kafka::delete_topics_request{
+        .data = {.topics = {{.name{"test-topic"}}}, .timeout_ms = 10s}},
+      kafka::api_version{6});
+
+    BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+    BOOST_REQUIRE_EQUAL(
+      resp.data.responses[0].name, model::topic("test-topic"));
+    BOOST_REQUIRE_EQUAL(
+      resp.data.responses[0].error_code,
+      kafka::error_code::topic_deletion_disabled);
+    BOOST_REQUIRE_EQUAL(
+      resp.data.responses[0].error_message, "Topic deletion is disabled.");
+
+    // Verify topic still exists
+    auto md = get_topic_metadata(model::topic("test-topic"));
+    auto it = std::find_if(
+      md.data.topics.begin(),
+      md.data.topics.end(),
+      [](const kafka::metadata_response::topic& t) {
+          return t.name == model::topic("test-topic");
+      });
+    BOOST_REQUIRE(it != md.data.topics.end());
+    BOOST_REQUIRE_EQUAL(it->error_code, kafka::error_code::none);
+}
+
+FIXTURE_TEST(delete_topic_enable_disabled_v2, delete_topics_request_fixture) {
+    wait_for_controller_leadership().get();
+
+    create_topic("test-topic-v2", 1, 1);
+
+    // Disable topic deletion globally (must set on all shards)
+    ss::smp::invoke_on_all([] {
+        config::shard_local_cfg().delete_topic_enable.set_value(false);
+    }).get();
+    auto reset_config = ss::defer([] {
+        ss::smp::invoke_on_all([] {
+            config::shard_local_cfg().delete_topic_enable.set_value(true);
+        }).get();
+    });
+
+    // Attempt to delete with old API version - should get invalid_request
+    auto resp = send_delete_topics_request(
+      make_delete_topics_request(
+        chunked_vector<model::topic>{{model::topic("test-topic-v2")}}, 10s),
+      kafka::api_version{2});
+
+    BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+    BOOST_REQUIRE_EQUAL(
+      resp.data.responses[0].name, model::topic("test-topic-v2"));
+    BOOST_REQUIRE_EQUAL(
+      resp.data.responses[0].error_code, kafka::error_code::invalid_request);
+    // Note: error_message field was only added in API version 5+, so we don't
+    // check it for v2
+}
+
+FIXTURE_TEST(delete_topic_enable_reenabled, delete_topics_request_fixture) {
+    wait_for_controller_leadership().get();
+
+    create_topic("test-topic-reenable", 1, 1);
+
+    // Disable topic deletion globally (must set on all shards)
+    ss::smp::invoke_on_all([] {
+        config::shard_local_cfg().delete_topic_enable.set_value(false);
+    }).get();
+
+    // Attempt to delete - should fail
+    auto resp1 = send_delete_topics_request(
+      kafka::delete_topics_request{
+        .data
+        = {.topics = {{.name{"test-topic-reenable"}}}, .timeout_ms = 10s}},
+      kafka::api_version{6});
+
+    BOOST_REQUIRE_EQUAL(resp1.data.responses.size(), 1);
+    BOOST_REQUIRE_EQUAL(
+      resp1.data.responses[0].error_code,
+      kafka::error_code::topic_deletion_disabled);
+
+    // Re-enable topic deletion (must set on all shards)
+    ss::smp::invoke_on_all([] {
+        config::shard_local_cfg().delete_topic_enable.set_value(true);
+    }).get();
+
+    // Now deletion should succeed
+    validate_valid_delete_topics_request(
+      kafka::delete_topics_request{
+        .data
+        = {.topics = {{.name{"test-topic-reenable"}}}, .timeout_ms = 10s}},
+      kafka::api_version{6});
+}
+
 #if 0
 // TODO(michal) - fix test fixture.
 //

--- a/tests/rptest/tests/delete_topic_enable_test.py
+++ b/tests/rptest/tests/delete_topic_enable_test.py
@@ -1,0 +1,165 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+
+from ducktape.utils.util import wait_until
+
+from rptest.clients.rpk import RpkException, RpkTool
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.util import expect_exception
+
+from typing import Any
+
+
+class DeleteTopicEnableTest(RedpandaTest):
+    """
+    Verify that the `delete_topic_enable` configuration property
+    functions as intended to globally disable topic deletion.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.rpk = RpkTool(self.redpanda)
+
+    @cluster(num_nodes=3)
+    def test_delete_topic_enable_disabled(self):
+        """Test that topics cannot be deleted when delete_topic_enable=false"""
+        test_topic = "test-topic"
+        self.rpk.create_topic(test_topic)
+
+        wait_until(
+            lambda: test_topic in self.rpk.list_topics(),
+            timeout_sec=30,
+            backoff_sec=3,
+        )
+
+        # Disable topic deletion globally
+        self.redpanda.set_cluster_config({"delete_topic_enable": False})
+
+        # Attempt to delete - should fail with TOPIC_DELETION_DISABLED
+        with expect_exception(
+            RpkException, lambda e: "TOPIC_DELETION_DISABLED" in str(e)
+        ):
+            self.rpk.delete_topic(test_topic)
+
+        # Allow time for any erroneous deletion to be propagated
+        time.sleep(5)
+
+        # Verify topic still exists
+        topics = list(self.rpk.list_topics())
+        assert test_topic in topics, f"Topic {test_topic} should still exist"
+
+        # Re-enable and verify deletion works
+        self.redpanda.set_cluster_config({"delete_topic_enable": True})
+        self.rpk.delete_topic(test_topic)
+
+        wait_until(
+            lambda: test_topic not in self.rpk.list_topics(),
+            timeout_sec=30,
+            backoff_sec=3,
+        )
+
+    @cluster(num_nodes=3)
+    def test_delete_topic_enable_default(self):
+        """Test that the default value allows deletion (backward compat)"""
+        test_topic = "test-topic-default"
+        self.rpk.create_topic(test_topic)
+
+        wait_until(
+            lambda: test_topic in self.rpk.list_topics(),
+            timeout_sec=30,
+            backoff_sec=3,
+        )
+
+        # Without changing config, deletion should work
+        self.rpk.delete_topic(test_topic)
+
+        wait_until(
+            lambda: test_topic not in self.rpk.list_topics(),
+            timeout_sec=30,
+            backoff_sec=3,
+        )
+
+    @cluster(num_nodes=3)
+    def test_nodelete_topics_still_protected(self):
+        """Test that kafka_nodelete_topics is still honored when delete_topic_enable=true"""
+        test_topic = "protected-topic"
+        self.rpk.create_topic(test_topic)
+
+        wait_until(
+            lambda: test_topic in self.rpk.list_topics(),
+            timeout_sec=30,
+            backoff_sec=3,
+        )
+
+        # Protect topic via kafka_nodelete_topics
+        self.redpanda.set_cluster_config({"kafka_nodelete_topics": [test_topic]})
+
+        # Even with delete_topic_enable=true (default), protected topics can't be deleted
+        with expect_exception(
+            RpkException, lambda e: "TOPIC_AUTHORIZATION_FAILED" in str(e)
+        ):
+            self.rpk.delete_topic(test_topic)
+
+        # Allow time for any erroneous deletion to be propagated
+        time.sleep(5)
+
+        # Verify topic still exists
+        topics = list(self.rpk.list_topics())
+        assert test_topic in topics, f"Topic {test_topic} should still exist"
+
+        # Remove from protection list and delete
+        self.redpanda.set_cluster_config({"kafka_nodelete_topics": []})
+        self.rpk.delete_topic(test_topic)
+
+        wait_until(
+            lambda: test_topic not in self.rpk.list_topics(),
+            timeout_sec=30,
+            backoff_sec=3,
+        )
+
+    @cluster(num_nodes=3)
+    def test_delete_topic_enable_multiple_topics(self):
+        """Test that all topics are rejected when delete_topic_enable=false"""
+        topics = ["topic-a", "topic-b", "topic-c"]
+
+        for topic in topics:
+            self.rpk.create_topic(topic)
+
+        for topic in topics:
+            wait_until(
+                lambda t=topic: t in self.rpk.list_topics(),
+                timeout_sec=30,
+                backoff_sec=3,
+            )
+
+        # Disable topic deletion globally
+        self.redpanda.set_cluster_config({"delete_topic_enable": False})
+
+        # Attempt to delete each topic - all should fail
+        for topic in topics:
+            with expect_exception(
+                RpkException, lambda e: "TOPIC_DELETION_DISABLED" in str(e)
+            ):
+                self.rpk.delete_topic(topic)
+
+        # Allow time for any erroneous deletion to be propagated
+        time.sleep(5)
+
+        # Verify all topics still exist
+        existing_topics = list(self.rpk.list_topics())
+        for topic in topics:
+            assert topic in existing_topics, f"Topic {topic} should still exist"
+
+        # Re-enable and clean up
+        self.redpanda.set_cluster_config({"delete_topic_enable": True})
+        for topic in topics:
+            self.rpk.delete_topic(topic)

--- a/tests/rptest/tests/enterprise_features_license_test.py
+++ b/tests/rptest/tests/enterprise_features_license_test.py
@@ -48,6 +48,7 @@ class Feature(IntEnum):
     oidc_override = 12
     shadow_linking = 13
     cloud_topics = 14
+    topic_deletion_disabled = 15
 
 
 def to_enterprise_feature(feature):
@@ -80,6 +81,7 @@ FEATURE_DEPENDENT_CONFIG = {
     Feature.oidc_override: "sasl_mechanisms_overrides",
     Feature.shadow_linking: "enable_shadow_linking",
     Feature.cloud_topics: CLOUD_TOPICS_CONFIG_STR,
+    Feature.topic_deletion_disabled: "delete_topic_enable",
 }
 
 SKIP_FEATURES = [
@@ -257,6 +259,8 @@ class EnterpriseFeaturesTest(EnterpriseFeaturesTestBase):
             self.redpanda.set_cluster_config({"enable_shadow_linking": "true"})
         elif feature == Feature.cloud_topics:
             self.redpanda.set_cluster_config({CLOUD_TOPICS_CONFIG_STR: "true"})
+        elif feature == Feature.topic_deletion_disabled:
+            self.redpanda.set_cluster_config({"delete_topic_enable": "false"})
         else:
             assert False, f"Unexpected feature={feature}"
 


### PR DESCRIPTION
## Add `delete_topic_enable` cluster configuration

This PR implements a new cluster configuration property `delete_topic_enable` that allows administrators to globally disable topic deletion via the Kafka DeleteTopics API, similar to Apache Kafka's `delete.topic.enable` broker configuration.

**Motivation:** Customers have requested the ability to prevent accidental topic deletion in production environments. While `kafka_nodelete_topics` protects specific topics, there was no way to globally disable topic deletion as a safety measure.

**Implementation:**
- Added `delete_topic_enable` as a dynamic boolean cluster config (default: `true` for backward compatibility)
- When set to `false`, all DeleteTopics requests are rejected with error code 73 (`TOPIC_DELETION_DISABLED`) for API v3+, or `INVALID_REQUEST` for older clients
- The check happens before authorization, ensuring consistent behavior regardless of topic existence or permissions
- This is a safety setting that cannot be overridden by superusers

Fixes #29347

## Backports Required

- [x] none - not a bug fix

## Release Notes

### Features

* Added `delete_topic_enable` cluster configuration property to globally enable or disable topic deletion via the Kafka API. When set to `false`, all topic deletion requests are rejected with error code `TOPIC_DELETION_DISABLED` (73). Default is `true` for backward compatibility. This setting works independently of `kafka_nodelete_topics`, which continues to protect specific topics regardless of this setting.
