### PR TITLE
Priority leadership Pinning

### DIFF
--- a/src/v/cluster/scheduling/leader_balancer_constraints.cc
+++ b/src/v/cluster/scheduling/leader_balancer_constraints.cc
@@ -11,6 +11,8 @@
 #include "cluster/scheduling/leader_balancer_constraints.h"
 
 #include "base/vassert.h"
+#include "cluster/scheduling/leader_balancer_types.h"
+#include "config/leaders_preference.h"
 #include "model/metadata.h"
 
 namespace cluster::leader_balancer_types {
@@ -228,33 +230,65 @@ std::vector<shard_load> even_shard_load_constraint::stats() const {
 double pinning_constraint::evaluate_internal(const reassignment& r) {
     int diff = 0;
 
-    const leaders_preference* preference = &_preference_idx.default_preference;
-
     topic_id_t topic_id = _group2topic.get().at(r.group);
     auto pref_it = _preference_idx.topic2preference.find(topic_id);
-    if (pref_it != _preference_idx.topic2preference.end()) {
-        preference = &pref_it->second;
-    }
+    const auto& preference = pref_it == _preference_idx.topic2preference.end()
+                               ? _preference_idx.default_preference
+                               : pref_it->second;
 
-    if (preference->racks.empty()) {
+    switch (preference.type) {
+    case config::leaders_preference::type_t::none:
+        vassert(
+          preference.racks.empty(),
+          "no racks should be present if the preference type is none");
         return diff;
+    case config::leaders_preference::type_t::racks:
+        return do_evaluate_unordered(r, _preference_idx.node2rack, preference);
+    case config::leaders_preference::type_t::ordered_racks:
+        return do_evaluate_ordered(r, _preference_idx.node2rack, preference);
     }
+}
 
-    auto from_it = _preference_idx.node2rack.find(r.from.node_id);
+double pinning_constraint::do_evaluate_unordered(
+  const reassignment& r,
+  const absl::flat_hash_map<model::node_id, model::rack_id>& node_to_rack,
+  const leaders_preference& preference) {
+    double diff{0};
+    auto from_it = node_to_rack.find(r.from.node_id);
     if (
-      from_it != _preference_idx.node2rack.end()
-      && std::ranges::contains(preference->racks, from_it->second)) {
+      from_it != node_to_rack.end()
+      && std::ranges::contains(preference.racks, from_it->second)) {
         diff -= 1;
     }
 
-    auto to_it = _preference_idx.node2rack.find(r.to.node_id);
+    auto to_it = node_to_rack.find(r.to.node_id);
     if (
-      to_it != _preference_idx.node2rack.end()
-      && std::ranges::contains(preference->racks, to_it->second)) {
+      to_it != node_to_rack.end()
+      && std::ranges::contains(preference.racks, to_it->second)) {
         diff += 1;
     }
-
     return diff;
+}
+
+double pinning_constraint::do_evaluate_ordered(
+  const reassignment& reassignment,
+  const absl::flat_hash_map<model::node_id, model::rack_id>& node_to_rack,
+  const leaders_preference& preference) {
+    const auto do_find_priority = [&preference,
+                                   &node_to_rack](model::node_id to_evaluate) {
+        auto it = node_to_rack.find(to_evaluate);
+        if (it == node_to_rack.end()) {
+            return preference.racks.end();
+        }
+        const auto& rack = it->second;
+        return std::ranges::find(preference.racks, rack);
+    };
+
+    auto from_priority = do_find_priority(reassignment.from.node_id);
+    auto to_priority = do_find_priority(reassignment.to.node_id);
+
+    // snap to -1, 0, 1, were 'higher is preferable'
+    return (to_priority < from_priority) - (from_priority < to_priority);
 }
 
 even_node_load_constraint::even_node_load_constraint(const shard_index& si) {

--- a/src/v/cluster/scheduling/leader_balancer_constraints.cc
+++ b/src/v/cluster/scheduling/leader_balancer_constraints.cc
@@ -243,14 +243,14 @@ double pinning_constraint::evaluate_internal(const reassignment& r) {
     auto from_it = _preference_idx.node2rack.find(r.from.node_id);
     if (
       from_it != _preference_idx.node2rack.end()
-      && preference->racks.contains(from_it->second)) {
+      && std::ranges::contains(preference->racks, from_it->second)) {
         diff -= 1;
     }
 
     auto to_it = _preference_idx.node2rack.find(r.to.node_id);
     if (
       to_it != _preference_idx.node2rack.end()
-      && preference->racks.contains(to_it->second)) {
+      && std::ranges::contains(preference->racks, to_it->second)) {
         diff += 1;
     }
 

--- a/src/v/cluster/scheduling/leader_balancer_constraints.h
+++ b/src/v/cluster/scheduling/leader_balancer_constraints.h
@@ -284,6 +284,16 @@ private:
     double evaluate_internal(const reassignment& r) override;
 
 private:
+    static double do_evaluate_unordered(
+      const reassignment& r,
+      const absl::flat_hash_map<model::node_id, model::rack_id>& node_to_rack,
+      const leaders_preference& preference);
+
+    static double do_evaluate_ordered(
+      const reassignment& r,
+      const absl::flat_hash_map<model::node_id, model::rack_id>& node_to_rack,
+      const leaders_preference& preference);
+
     std::reference_wrapper<const group_id_to_topic_id> _group2topic;
     preference_index _preference_idx;
 };

--- a/src/v/cluster/scheduling/leader_balancer_constraints.h
+++ b/src/v/cluster/scheduling/leader_balancer_constraints.h
@@ -15,16 +15,9 @@
 #include "cluster/scheduling/leader_balancer_types.h"
 #include "container/chunked_hash_map.h"
 #include "model/metadata.h"
-#include "raft/fundamental.h"
-
-#include <seastar/core/metrics.hh>
-#include <seastar/core/sstring.hh>
-
-#include <boost/range/adaptor/reversed.hpp>
 
 #include <functional>
 #include <numeric>
-#include <optional>
 
 namespace cluster::leader_balancer_types {
 

--- a/src/v/cluster/scheduling/leader_balancer_types.h
+++ b/src/v/cluster/scheduling/leader_balancer_types.h
@@ -11,13 +11,14 @@
 #pragma once
 
 #include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
 #include "config/leaders_preference.h"
 #include "container/chunked_hash_map.h"
 #include "model/metadata.h"
 #include "raft/fundamental.h"
 
 #include <roaring/roaring64map.hh>
+
+#include <ranges>
 
 namespace cluster::leader_balancer_types {
 
@@ -51,16 +52,21 @@ template<typename ValueType>
 using topic_map = chunked_hash_map<topic_id_t, ValueType>;
 
 struct leaders_preference {
-    absl::flat_hash_set<model::rack_id> racks;
+    config::leaders_preference::type_t type{
+      config::leaders_preference::type_t::none};
+    // O(N) find operations, fine so long as the rack preference number is small
+    std::vector<model::rack_id> racks;
 
     leaders_preference() = default;
-    explicit leaders_preference(const config::leaders_preference& cfg) {
+    explicit leaders_preference(const config::leaders_preference& cfg)
+      : type{cfg.type} {
         switch (cfg.type) {
         case config::leaders_preference::type_t::none:
             break;
         case config::leaders_preference::type_t::racks:
-            racks.reserve(cfg.racks.size());
-            racks.insert(cfg.racks.begin(), cfg.racks.end());
+            [[fallthrough]];
+        case config::leaders_preference::type_t::ordered_racks:
+            racks = std::vector<model::rack_id>(std::from_range, cfg.racks);
             break;
         }
     }

--- a/src/v/cluster/scheduling/tests/BUILD
+++ b/src/v/cluster/scheduling/tests/BUILD
@@ -1,0 +1,20 @@
+load("//bazel:test.bzl", "redpanda_cc_gtest")
+
+redpanda_cc_gtest(
+    name = "leader_pinning_test",
+    timeout = "short",
+    srcs = [
+        "leader_pinning_test.cc",
+    ],
+    deps = [
+        "//src/v/cluster",
+        "//src/v/config",
+        "//src/v/model",
+        "//src/v/raft",
+        "//src/v/test_utils:gtest",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@abseil-cpp//absl/container:flat_hash_set",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cluster/scheduling/tests/leader_pinning_test.cc
+++ b/src/v/cluster/scheduling/tests/leader_pinning_test.cc
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "absl/container/flat_hash_map.h"
+#include "cluster/scheduling/leader_balancer_constraints.h"
+#include "cluster/scheduling/leader_balancer_types.h"
+#include "config/leaders_preference.h"
+#include "model/metadata.h"
+#include "raft/fundamental.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <gtest/gtest.h>
+
+namespace lbt = cluster::leader_balancer_types;
+
+class PinningConstraintTest : public ::testing::Test {
+protected:
+    // Helper to create a reassignment
+    static lbt::reassignment create_reassignment(
+      raft::group_id group_id,
+      model::node_id from_node,
+      model::node_id to_node) {
+        return lbt::reassignment{
+          group_id,
+          model::broker_shard{.node_id = from_node, .shard = 0},
+          model::broker_shard{.node_id = to_node, .shard = 0}};
+    }
+
+    // Helper to setup basic test data
+    void SetUp() override {
+        // Setup group to topic mapping
+        _group_to_topic[raft::group_id{0}] = lbt::topic_id_t{0};
+        _group_to_topic[raft::group_id{1}] = lbt::topic_id_t{1};
+        _group_to_topic[raft::group_id{2}] = lbt::topic_id_t{2};
+
+        for (auto node_number : std::ranges::views::iota(0, 5)) {
+            const auto node_id = model::node_id{node_number};
+            const auto rack_id = rack_from_node(node_id);
+            _node_to_rack[node_id] = rack_id;
+            auto& node_pair = _rack_to_nodes[rack_id];
+            if (node_number % 2 == 0) {
+                node_pair.first = node_id;
+            } else {
+                node_pair.second = node_id;
+            }
+            _last_configured_node = node_id;
+        }
+    }
+
+protected:
+    model::rack_id rack_from_node(model::node_id node_id) {
+        return rack_from_number(int(node_id) / 2);
+    }
+
+    model::rack_id rack_from_number(int number) {
+        return model::rack_id{ss::sstring{fmt::format("rack{}", number)}};
+    }
+
+    model::node_id pick_a_node(model::rack_id rack_id) {
+        return _rack_to_nodes[rack_id].first;
+    }
+
+    lbt::group_id_to_topic_id _group_to_topic;
+    absl::flat_hash_map<model::node_id, model::rack_id> _node_to_rack;
+    absl::
+      flat_hash_map<model::rack_id, std::pair<model::node_id, model::node_id>>
+        _rack_to_nodes;
+    model::node_id _last_configured_node{-1};
+};
+
+namespace {
+// easier to differentiate bad good neutral than LT GT EQ
+constexpr inline void expect_bad_reconfiguration(double value) {
+    EXPECT_LT(value, 0.0) << "expected a reconfiguration value less than 0";
+}
+constexpr inline void expect_good_reconfiguration(double value) {
+    EXPECT_GT(value, 0.0) << "expected a reconfiguration value greater than 0";
+}
+constexpr inline void expect_neutral_reconfiguration(double value) {
+    EXPECT_EQ(value, 0.0) << "expected a reconfiguration value of 0";
+}
+} // namespace
+
+TEST_F(PinningConstraintTest, OrderedRacksPriorityBasedMovement) {
+    // Test that the ordered_racks preference type correctly evaluates
+    // movements based on rack priority order
+
+    const auto default_group = raft::group_id{1};
+
+    // Create preference with ordered racks: rack0 > rack1 > rack2
+    lbt::preference_index pref_idx;
+    pref_idx.node2rack = _node_to_rack;
+    pref_idx.default_preference.type
+      = config::leaders_preference::type_t::ordered_racks;
+    pref_idx.default_preference.racks = {
+      rack_from_number(0), rack_from_number(1), rack_from_number(2)};
+
+    lbt::pinning_constraint constraint(_group_to_topic, std::move(pref_idx));
+
+    {
+        // low pri to higher pri, (rack2 -> rack0)
+        auto reassignment = create_reassignment(
+          default_group,
+          pick_a_node(rack_from_number(2)),
+          pick_a_node(rack_from_number(0)));
+        expect_good_reconfiguration(constraint.evaluate(reassignment));
+    }
+
+    {
+        // high pri to lower pri, (rack0 -> rack2)
+        auto reassignment = create_reassignment(
+          default_group,
+          pick_a_node(rack_from_number(0)),
+          pick_a_node(rack_from_number(2)));
+        expect_bad_reconfiguration(constraint.evaluate(reassignment));
+    }
+
+    {
+        // no change (rack0 -> rack0), different nodes, though
+        auto reassignment = create_reassignment(
+          default_group,
+          _rack_to_nodes[rack_from_number(0)].first,
+          _rack_to_nodes[rack_from_number(0)].second);
+        expect_neutral_reconfiguration(constraint.evaluate(reassignment));
+    }
+
+    {
+        // litmus test, lower to higher (rack1 -> rack0)
+        auto reassignment = create_reassignment(
+          default_group,
+          pick_a_node(rack_from_number(1)),
+          pick_a_node(rack_from_number(0)));
+        expect_good_reconfiguration(constraint.evaluate(reassignment));
+    }
+}
+
+TEST_F(PinningConstraintTest, OrderedRacksWithUnknownRacks) {
+    // Test behavior for nodes that either have racks not in the preference or
+    // nodes with no rack whatsoever
+
+    const auto default_group = raft::group_id{1};
+
+    auto last_configured_node = _last_configured_node;
+    const auto unknown_rack_node = model::node_id{++last_configured_node};
+    const auto missing_rack_node = model::node_id{++last_configured_node};
+
+    // Add a node in an unknown rack
+    _node_to_rack[unknown_rack_node] = model::rack_id{"rack_unknown"};
+
+    // Create preference with ordered racks: rack0 > rack1
+    lbt::preference_index pref_idx;
+    pref_idx.node2rack = _node_to_rack;
+    pref_idx.default_preference.type
+      = config::leaders_preference::type_t::ordered_racks;
+    pref_idx.default_preference.racks = {
+      rack_from_number(0), rack_from_number(1)};
+
+    lbt::pinning_constraint constraint(_group_to_topic, std::move(pref_idx));
+
+    for (const auto invalid_node_id : {unknown_rack_node, missing_rack_node}) {
+        // invalid here is going to refer to either an unknown rack_id or node
+        // with missing rack_id
+        {
+            // invalid rack to preferred rack (rack_invalid -> rack0)
+            auto reassignment = create_reassignment(
+              default_group, invalid_node_id, pick_a_node(rack_from_number(0)));
+            expect_good_reconfiguration(constraint.evaluate(reassignment));
+        }
+
+        {
+            // preferred rack to invalid rack (rack0 -> rack_invalid)
+            auto reassignment = create_reassignment(
+              default_group, pick_a_node(rack_from_number(0)), invalid_node_id);
+            expect_bad_reconfiguration(constraint.evaluate(reassignment));
+        }
+
+        {
+            // between invalid/non-preferred racks (rack_invalid -> rack2)
+            // no preference
+            auto reassignment = create_reassignment(
+              default_group, invalid_node_id, pick_a_node(rack_from_number(2)));
+            expect_neutral_reconfiguration(constraint.evaluate(reassignment));
+        }
+    }
+
+    // check that theres no preference between unspecified and missing rack
+    {
+        // unknown to missing
+        auto reassignment = create_reassignment(
+          default_group, unknown_rack_node, missing_rack_node);
+        expect_neutral_reconfiguration(constraint.evaluate(reassignment));
+    }
+    {
+        // missing to unknown
+        auto reassignment = create_reassignment(
+          default_group, missing_rack_node, unknown_rack_node);
+        expect_neutral_reconfiguration(constraint.evaluate(reassignment));
+    }
+}
+
+TEST_F(PinningConstraintTest, OrderedRacksPerTopicPreference) {
+    // Test that topic-specific preferences override default preferences
+
+    lbt::preference_index pref_idx;
+    pref_idx.node2rack = _node_to_rack;
+
+    // Default preference: rack1 > rack2
+    pref_idx.default_preference.type
+      = config::leaders_preference::type_t::ordered_racks;
+    pref_idx.default_preference.racks = {
+      rack_from_number(1), rack_from_number(2)};
+
+    // Topic 2 specific preference: rack2 > rack1 (reversed)
+    lbt::leaders_preference topic2_pref;
+    topic2_pref.type = config::leaders_preference::type_t::ordered_racks;
+    topic2_pref.racks = {rack_from_number(2), rack_from_number(1)};
+    pref_idx.topic2preference[lbt::topic_id_t{2}] = topic2_pref;
+
+    lbt::pinning_constraint constraint(_group_to_topic, std::move(pref_idx));
+
+    {
+        // topic 0 uses default preference (rack1 > rack2)
+        // movement from rack2 to rack1 should improve
+        auto reassignment = create_reassignment(
+          raft::group_id{0},
+          pick_a_node(rack_from_number(2)),
+          pick_a_node(rack_from_number(1)));
+        expect_good_reconfiguration(constraint.evaluate(reassignment));
+    }
+
+    {
+        // topic 2 uses reversed preference (rack2 > rack1)
+        // same movement (rack2 to rack1) should degrade
+        auto reassignment = create_reassignment(
+          raft::group_id{2},
+          pick_a_node(rack_from_number(2)),
+          pick_a_node(rack_from_number(1)));
+        expect_bad_reconfiguration(constraint.evaluate(reassignment));
+    }
+}
+
+TEST_F(PinningConstraintTest, OrderedRacksEmptyPreference) {
+    // Test behavior with empty rack list
+
+    const auto default_group = raft::group_id{1};
+
+    // Create preference with no racks specified
+    lbt::preference_index pref_idx;
+    pref_idx.node2rack = _node_to_rack;
+    pref_idx.default_preference.type
+      = config::leaders_preference::type_t::ordered_racks;
+    pref_idx.default_preference.racks = {}; // Empty rack list
+
+    lbt::pinning_constraint constraint(_group_to_topic, std::move(pref_idx));
+
+    {
+        // all movements should be neutral when no racks are preferred
+        auto reassignment = create_reassignment(
+          default_group,
+          pick_a_node(rack_from_number(0)),
+          pick_a_node(rack_from_number(1)));
+        expect_neutral_reconfiguration(constraint.evaluate(reassignment));
+    }
+
+    {
+        // test movement from higher numbered rack to lower numbered rack
+        auto reassignment = create_reassignment(
+          default_group,
+          pick_a_node(rack_from_number(2)),
+          pick_a_node(rack_from_number(0)));
+        expect_neutral_reconfiguration(constraint.evaluate(reassignment));
+    }
+}
+
+TEST_F(PinningConstraintTest, CompareOrderedVsUnorderedBehavior) {
+    // Test to ensure ordered_racks behaves differently from unordered racks
+
+    const auto default_group = raft::group_id{1};
+
+    // Setup ordered preference: rack1 > rack2
+    lbt::preference_index ordered_pref_idx;
+    ordered_pref_idx.node2rack = _node_to_rack;
+    ordered_pref_idx.default_preference.type
+      = config::leaders_preference::type_t::ordered_racks;
+    ordered_pref_idx.default_preference.racks = {
+      rack_from_number(1), rack_from_number(2)};
+
+    // Setup unordered preference (regular racks type) with same racks
+    lbt::preference_index unordered_pref_idx;
+    unordered_pref_idx.node2rack = _node_to_rack;
+    unordered_pref_idx.default_preference.type
+      = config::leaders_preference::type_t::racks;
+    unordered_pref_idx.default_preference.racks = {
+      rack_from_number(1), rack_from_number(2)};
+
+    lbt::pinning_constraint ordered_constraint(
+      _group_to_topic, std::move(ordered_pref_idx));
+    lbt::pinning_constraint unordered_constraint(
+      _group_to_topic, std::move(unordered_pref_idx));
+
+    {
+        // movement between preferred racks (rack2 -> rack1)
+        auto reassignment = create_reassignment(
+          default_group,
+          pick_a_node(rack_from_number(2)),
+          pick_a_node(rack_from_number(1)));
+
+        // ordered should show improvement (lower priority to higher priority)
+        expect_good_reconfiguration(ordered_constraint.evaluate(reassignment));
+
+        // unordered should be neutral (both are equally preferred)
+        expect_neutral_reconfiguration(
+          unordered_constraint.evaluate(reassignment));
+    }
+
+    {
+        // reverse movement (rack1 -> rack2)
+        auto reassignment = create_reassignment(
+          default_group,
+          pick_a_node(rack_from_number(1)),
+          pick_a_node(rack_from_number(2)));
+
+        // ordered should show degradation (higher priority to lower priority)
+        expect_bad_reconfiguration(ordered_constraint.evaluate(reassignment));
+
+        // unordered should still be neutral (both are equally preferred)
+        expect_neutral_reconfiguration(
+          unordered_constraint.evaluate(reassignment));
+    }
+}

--- a/src/v/config/leaders_preference.cc
+++ b/src/v/config/leaders_preference.cc
@@ -10,63 +10,68 @@
 #include "config/leaders_preference.h"
 
 #include <boost/algorithm/string.hpp>
+#include <fmt/format.h>
+
+#include <ranges>
+#include <unordered_set>
 
 namespace config {
 
-std::ostream& operator<<(std::ostream& os, const leaders_preference& lp) {
-    switch (lp.type) {
-    case leaders_preference::type_t::none:
-        os << "none";
-        break;
-    case leaders_preference::type_t::racks: {
-        os << "racks:";
-        bool first = true;
-        for (const auto& r : lp.racks) {
-            if (first) {
-                first = false;
-            } else {
-                os << ",";
-            }
-            os << r;
-        }
-        break;
-    }
-    default:
-        throw std::invalid_argument("unknown leaders_preference type");
-    }
+std::ostream& operator<<(std::ostream& os, leaders_preference::type_t type) {
+    os << leaders_preference::type_to_string(type);
     return os;
 }
 
+std::ostream& operator<<(std::ostream& os, const leaders_preference& lp) {
+    auto prefix = leaders_preference::type_to_prefix(lp.type);
+    return os << prefix << fmt::format("{}", fmt::join(lp.racks, ","));
+}
+
 leaders_preference leaders_preference::parse(std::string_view s) {
-    static constexpr std::string_view racks_prefix = "racks:";
-    if (s == "none") {
+    leaders_preference::type_t found_type{leaders_preference::type_t::none};
+    size_t prefix_length{0};
+    if (s == leaders_preference::none_prefix) {
         return leaders_preference{};
     } else if (s.starts_with(racks_prefix)) {
-        std::vector<ss::sstring> tokens;
-        boost::algorithm::split(
-          tokens, s.substr(racks_prefix.length()), [](char c) {
-              return c == ',';
-          });
-
-        leaders_preference ret;
-        ret.type = leaders_preference::type_t::racks;
-        ret.racks.reserve(tokens.size());
-        for (auto& tok : tokens) {
-            boost::algorithm::trim(tok);
-            if (tok.empty()) {
-                throw std::runtime_error(
-                  "couldn't parse leaders_preference: "
-                  "empty rack token");
-            }
-            ret.racks.emplace_back(std::move(tok));
-        }
-        ret.type = leaders_preference::type_t::racks;
-        return ret;
+        found_type = leaders_preference::type_t::racks;
+        prefix_length = racks_prefix.length();
+    } else if (s.starts_with(ordered_racks_prefix)) {
+        found_type = leaders_preference::type_t::ordered_racks;
+        prefix_length = ordered_racks_prefix.length();
     } else {
         throw std::runtime_error(
           "couldn't parse leaders_preference: should be "
-          "\"none\" or start with \"racks:\"");
+          "\"none\" or start with \"racks:\" or \"ordered_racks:\"");
     }
+
+    std::vector<ss::sstring> tokens;
+    boost::algorithm::split(
+      tokens, s.substr(prefix_length), [](char c) { return c == ','; });
+
+    leaders_preference ret;
+    ret.type = found_type;
+    ret.racks.reserve(tokens.size());
+    for (auto& tok : tokens) {
+        boost::algorithm::trim(tok);
+        if (tok.empty()) {
+            throw std::runtime_error(
+              "couldn't parse leaders_preference: "
+              "empty rack token");
+        }
+        ret.racks.emplace_back(std::move(tok));
+    }
+
+    // back compat for unordered, but enforce no duplicates for ordered
+    if (ret.type == type_t::ordered_racks) {
+        auto no_duplicates_set = std::unordered_set<model::rack_id>{
+          std::from_range, ret.racks};
+        if (no_duplicates_set.size() != ret.racks.size()) {
+            throw std::runtime_error(
+              "couldn't parse leaders_preference: preference list should not "
+              "contain duplicates");
+        }
+    }
+    return ret;
 }
 
 std::istream& operator>>(std::istream& is, leaders_preference& res) {

--- a/src/v/config/leaders_preference.h
+++ b/src/v/config/leaders_preference.h
@@ -14,6 +14,10 @@
 #include "model/metadata.h"
 #include "serde/envelope.h"
 
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+
 namespace config {
 
 struct leaders_preference
@@ -22,15 +26,59 @@ struct leaders_preference
       serde::version<0>,
       serde::compat_version<0>> {
     enum class type_t {
+        // no preferece
         none,
+        // user specifies a set of desired racks with no preference between them
         racks,
+        // user specifies an ordered list of racks where closer to the beginning
+        // of the list is better
+        ordered_racks,
     };
+
+    // names for logging
+    static constexpr std::string_view none_str = "none";
+    static constexpr std::string_view racks_str = "racks";
+    static constexpr std::string_view ordered_racks_str = "ordered_racks";
+
+    // prefixes for parsing from config string
+    static constexpr std::string_view none_prefix = "none";
+    static constexpr std::string_view racks_prefix = "racks:";
+    static constexpr std::string_view ordered_racks_prefix = "ordered_racks:";
+
+    static constexpr std::string_view type_to_prefix(type_t t) {
+        switch (t) {
+        case type_t::none:
+            return none_str;
+        case type_t::racks:
+            return racks_prefix;
+        case type_t::ordered_racks:
+            return ordered_racks_prefix;
+        default:
+            throw std::invalid_argument("unknown leaders_preference type");
+        }
+        std::unreachable();
+    }
+
+    static constexpr std::string_view type_to_string(type_t t) {
+        switch (t) {
+        case type_t::none:
+            return none_str;
+        case type_t::racks:
+            return racks_str;
+        case type_t::ordered_racks:
+            return ordered_racks_str;
+        default:
+            throw std::invalid_argument("unknown leaders_preference type");
+        }
+        std::unreachable();
+    }
 
     type_t type = type_t::none;
     std::vector<model::rack_id> racks;
 
     static leaders_preference parse(std::string_view);
 
+    friend std::ostream& operator<<(std::ostream&, type_t);
     friend std::ostream& operator<<(std::ostream&, const leaders_preference&);
     friend std::istream& operator>>(std::istream&, leaders_preference&);
 

--- a/src/v/config/tests/leaders_preference_test.cc
+++ b/src/v/config/tests/leaders_preference_test.cc
@@ -13,50 +13,92 @@
 
 #include <seastar/testing/thread_test_case.hh>
 
+#include <stdexcept>
+
 SEASTAR_THREAD_TEST_CASE(parse_leaders_preference) {
-    {
-        auto lp = config::leaders_preference::parse("none");
-        BOOST_CHECK(lp.type == config::leaders_preference::type_t::none);
+    using lp = config::leaders_preference;
+    using lp_t = config::leaders_preference::type_t;
+
+    { // config none -> lp none
+        auto lp = lp::parse(lp::none_prefix);
+        BOOST_CHECK_EQUAL(lp.type, lp_t::none);
         BOOST_CHECK_EQUAL(lp.racks.size(), 0);
     }
 
-    {
-        auto lp = config::leaders_preference::parse("racks: A");
-        BOOST_CHECK(lp.type == config::leaders_preference::type_t::racks);
-        BOOST_CHECK_EQUAL(lp.racks.size(), 1);
-        BOOST_CHECK_EQUAL(lp.racks[0], model::rack_id{"A"});
+    { // default round trip lp -> str -> lp
+        lp orig{};
+        auto parsed = lp::parse(fmt::to_string(orig));
+        BOOST_CHECK_EQUAL(orig, parsed);
     }
 
-    {
-        auto lp = config::leaders_preference::parse("racks:rack1, rack2 ");
-        BOOST_CHECK(lp.type == config::leaders_preference::type_t::racks);
-        BOOST_CHECK_EQUAL(lp.racks.size(), 2);
-        BOOST_CHECK_EQUAL(lp.racks[0], model::rack_id{"rack1"});
-        BOOST_CHECK_EQUAL(lp.racks[1], model::rack_id{"rack2"});
+    static constexpr auto parse_combos = {
+      std::pair{lp_t::racks, lp::racks_prefix},
+      std::pair{lp_t::ordered_racks, lp::ordered_racks_prefix}};
+
+    static const auto rack_a = model::rack_id{"A"};
+    static const auto rack_b = model::rack_id{"B"};
+
+    for (const auto& [pref_type, pref_prefix] : parse_combos) {
+        { // single rack str -> lp
+            auto lp = lp::parse(fmt::format("{}{}", pref_prefix, rack_a));
+            BOOST_CHECK_EQUAL(lp.type, pref_type);
+            BOOST_CHECK_EQUAL(lp.racks.size(), 1);
+            BOOST_CHECK_EQUAL(lp.racks[0], rack_a);
+        }
+
+        { // multi rack str -> lp
+            // backwards just to check that its not incidentally sorting
+            auto lp = lp::parse(
+              fmt::format("{}{}, {} ", pref_prefix, rack_b, rack_a));
+            BOOST_CHECK_EQUAL(lp.type, pref_type);
+            BOOST_CHECK_EQUAL(lp.racks.size(), 2);
+            BOOST_CHECK_EQUAL(lp.racks[0], rack_b);
+            BOOST_CHECK_EQUAL(lp.racks[1], rack_a);
+        }
+
+        { // multi rack rountrip lp -> str -> lp
+            lp orig{};
+            orig.type = pref_type;
+            orig.racks = {rack_a, rack_b};
+            auto parsed = lp::parse(fmt::to_string(orig));
+            BOOST_CHECK_EQUAL(orig, parsed);
+        }
+
+        // no racks specified
+        BOOST_CHECK_THROW(
+          lp::parse(fmt::format("{} ", pref_prefix)), std::runtime_error);
+
+        // empty string rack
+        BOOST_CHECK_THROW(
+          lp::parse(fmt::format("{} {},,{}", pref_prefix, rack_a, rack_b)),
+          std::runtime_error);
+
+        // trailing comma / empty string rack
+        BOOST_CHECK_THROW(
+          lp::parse(fmt::format("{}{},", pref_prefix, rack_a)),
+          std::runtime_error);
     }
 
-    {
-        auto orig = config::leaders_preference{};
-        auto parsed = config::leaders_preference::parse(fmt::to_string(orig));
-        BOOST_CHECK(orig == parsed);
-    }
+    // normal invalid racks config
+    BOOST_CHECK_THROW(lp::parse("quux"), std::runtime_error);
 
-    {
-        auto orig = config::leaders_preference{};
-        orig.type = config::leaders_preference::type_t::racks;
-        orig.racks = {model::rack_id{"A"}, model::rack_id{"rack"}};
-        auto parsed = config::leaders_preference::parse(fmt::to_string(orig));
-        BOOST_CHECK(orig == parsed);
-        BOOST_CHECK(parsed.type == config::leaders_preference::type_t::racks);
-        BOOST_CHECK_EQUAL(parsed.racks.size(), 2);
-    }
+    // ordered: duplicate racks should throw
+    // if there's two instances of a rack in the config order, which should be
+    // used for priority?
+    BOOST_CHECK_THROW(
+      lp::parse(
+        fmt::format(
+          "{} {},{},{}", lp::ordered_racks_prefix, rack_a, rack_a, rack_b)),
+      std::runtime_error);
 
-    BOOST_CHECK_THROW(
-      config::leaders_preference::parse("quux"), std::runtime_error);
-    BOOST_CHECK_THROW(
-      config::leaders_preference::parse("racks: "), std::runtime_error);
-    BOOST_CHECK_THROW(
-      config::leaders_preference::parse("racks: a,,b"), std::runtime_error);
-    BOOST_CHECK_THROW(
-      config::leaders_preference::parse("racks:a,"), std::runtime_error);
+    // prior to ordered, racks were stored as a set, so duplicates were allowed
+    // and deduplicated. behavior change: if theres duplicates return them as
+    // provided
+    { // unordered: duplicate racks are fine, check no error and roundtrip
+        lp orig{};
+        orig.type = lp_t::racks;
+        orig.racks = {rack_a, rack_b};
+        auto parsed = lp::parse(fmt::to_string(orig));
+        BOOST_CHECK_EQUAL(orig, parsed);
+    }
 }

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -120,6 +120,8 @@ std::string_view to_string_view(feature f) {
         return "topic_ids_api";
     case feature::controller_forced_reconfiguration:
         return "controller_forced_reconfiguration";
+    case feature::ordered_leaders_pinning:
+        return "ordered_leaders_pinning";
     case feature::kafka_data_rpc:
         return "kafka_data_rpc";
     case feature::topic_locations_in_outbound_migrations:

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -49,6 +49,7 @@ enum class feature : std::uint64_t {
     user_based_client_quota = 1ULL << 6U,
     consumer_groups_migrations = 1ULL << 7U,
     shadow_linking = 1ULL << 8U,
+    ordered_leaders_pinning = 1ULL << 9U,
     coordinated_compaction = 1ULL << 10U,
     cloud_retention = 1ULL << 11U,
     group_based_authorization = 1ULL << 12U,
@@ -532,6 +533,12 @@ inline constexpr std::array feature_schema{
     release_version::v26_1_1,
     "user_based_client_quota",
     feature::user_based_client_quota,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    release_version::v26_1_1,
+    "ordered_leaders_pinning",
+    feature::ordered_leaders_pinning,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 };

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -13,6 +13,7 @@
 #include "cluster/metadata_cache.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
+#include "config/leaders_preference.h"
 #include "features/feature_table.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/alter_configs_request.h"
@@ -352,11 +353,28 @@ create_topic_properties_update(
                 continue;
             }
             if (cfg.name == topic_property_leaders_preference) {
+                // if we evaluate to ordered_racks, check that its fully enabled
+                // before setting it
+                // TODO remove in 26.2
+                auto feature_enabled_validator =
+                  [&feature_table = ctx.feature_table().local()](
+                    const ss::sstring&, const config::leaders_preference& lp)
+                  -> std::optional<ss::sstring> {
+                    if (
+                      lp.type
+                        == config::leaders_preference::type_t::ordered_racks
+                      && !feature_table.is_active(
+                        features::feature::ordered_leaders_pinning)) {
+                        return "ordered leaders pinning is not available until "
+                               "the cluster upgrade is finalized";
+                    }
+                    return std::nullopt;
+                };
                 parse_and_set_optional(
                   update.properties.leaders_preference,
                   cfg.value,
                   kafka::config_resource_operation::set,
-                  noop_validator<config::leaders_preference>{},
+                  feature_enabled_validator,
                   config::leaders_preference::parse);
                 continue;
             }


### PR DESCRIPTION
Implements [ENG-699](https://redpandadata.atlassian.net/browse/ENG-699)

Adds a new prefix / setting type to leadership pinning which is "ordered_racks"

When a user specifies ordered_racks, the balancer will preferentially move leadership to nodes which are part of a rack_id which occurs earlier in the list.

If the rack is given as A, B, C, then reassignments from nodes in B to nodes in A will be considered desirable.

Reassignments to nodes with racks either NOT in the preference list or with no rack will be considered undesirable.

As usual, reassignments within a rack will be considered neutral and yield to lower priority decision criteria.

Other changes:
- a rack setting with duplicates will now be returned in the order specified and with the provided duplicates

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
### Features

* Allow leadership pinning to racks in priority order

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[ENG-699]: https://redpandadata.atlassian.net/browse/ENG-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ