### PR TITLE
`cluster`: add `vassert` to `archiver_manager`

### DIFF
--- a/src/v/cluster/archival/archiver_manager.cc
+++ b/src/v/cluster/archival/archiver_manager.cc
@@ -600,7 +600,9 @@ private:
           expected_term);
 
         auto archiver = maybe_construct_archiver();
-
+        vassert(
+          archiver != nullptr,
+          "Expected create_and_start_archiver() to return a built archiver.");
         co_await archiver->start();
         co_return archiver;
     }


### PR DESCRIPTION
We immediately dereference this assuming its not `nullptr`. Better to `vassert` this case rather than try to track down a backtrace via segmentation fault.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
