### PR TITLE
rpk: rename decommission --force flag

### DIFF
--- a/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission.go
@@ -15,7 +15,7 @@ import (
 )
 
 func newDecommissionBroker(fs afero.Fs, p *config.Params) *cobra.Command {
-	var force bool
+	var skipLivenessCheck bool
 	cmd := &cobra.Command{
 		Use:   "decommission [BROKER ID]",
 		Short: "Decommission the given broker",
@@ -30,7 +30,7 @@ For safety on v22.x clusters, this command will not run if the requested
 broker is in maintenance mode. As of v23.x, Redpanda supports 
 decommissioning a node that is currently in maintenance mode. If you are on 
 a v22.x cluster and need to bypass the maintenance mode check (perhaps your 
-cluster is unreachable), use the hidden --force flag.
+cluster is unreachable), use the --skip-liveness-check flag.
 `,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -47,9 +47,9 @@ cluster is unreachable), use the hidden --force flag.
 			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			if !force {
+			if !skipLivenessCheck {
 				brokers, err := cl.Brokers(cmd.Context())
-				out.MaybeDie(err, "unable to get broker list: %v; to bypass the node version check re-run this with --force; see this command's help text for more details", err)
+				out.MaybeDie(err, "unable to get broker list: %v; to bypass the node version check re-run this with --skip-liveness-check; see this command's help text for more details", err)
 
 				var (
 					b             rpadmin.Broker
@@ -58,10 +58,10 @@ cluster is unreachable), use the hidden --force flag.
 				for _, br := range brokers {
 					if br.NodeID == broker {
 						if br.Version == "" {
-							out.Exit("version for broker %d is unknown, is the node offline?\nto bypass the node version check re-run this with --force; see this command's help text for more details", br.NodeID)
+							out.Exit("version for broker %d is unknown, is the node offline?\nto bypass the node version check re-run this with --skip-liveness-check; see this command's help text for more details", br.NodeID)
 						}
 						version, err := redpanda.VersionFromString(br.Version)
-						out.MaybeDie(err, "unable to get broker %d version: %v; to bypass the node version check re-run this with --force; see this command's help text for more details", br.NodeID, err)
+						out.MaybeDie(err, "unable to get broker %d version: %v; to bypass the node version check re-run this with --skip-liveness-check; see this command's help text for more details", br.NodeID, err)
 						isOld := version.Less(redpanda.Version{Major: 23, Feature: 1, Patch: 1})
 
 						anyOld = anyOld || isOld
@@ -70,7 +70,7 @@ cluster is unreachable), use the hidden --force flag.
 					}
 				}
 				if !found {
-					out.Die("unable to find broker %v in the cluster; to bypass the node version check re-run this with --force; see this command's help text for more details", broker)
+					out.Die("unable to find broker %v in the cluster; to bypass the node version check re-run this with --skip-liveness-check; see this command's help text for more details", broker)
 				}
 
 				// If any of the brokers is older than v23.1.1 we need to check
@@ -83,7 +83,7 @@ cluster is unreachable), use the hidden --force flag.
 						out.Die(`Node cannot be decommissioned while it is in maintenance mode.
 Take the node out of maintenance mode first by running: 
     rpk cluster maintenance disable %v
-To bypass the node version check re-run this with --force; see this command's
+To bypass the node version check re-run this with --skip-liveness-check; see this command's
 help text for more details on why.`, broker)
 					}
 				}
@@ -92,15 +92,19 @@ help text for more details on why.`, broker)
 			err = cl.DecommissionBroker(cmd.Context(), broker)
 			out.MaybeDie(err, "unable to decommission broker: %v", err)
 
-			fmt.Printf("Success, broker %d decommission started.  Use `rpk redpanda admin brokers decommission-status %d` to monitor data movement.\n`", broker, broker)
+			fmt.Printf("Success, broker %d decommission started.  Use 'rpk redpanda admin brokers decommission-status %d' to monitor data movement.\n", broker, broker)
 		},
 	}
 
 	// Before using the flag, make sure that the controller leader version is at
 	// least 23.1.0, using it is the equivalent of manually issuing the request
 	// using /v1/brokers/<broker-id>/decommission.
-	cmd.Flags().BoolVar(&force, "force", false, "If enabled, rpk will issue the decommission request without checking if the broker is in maintenance mode")
+	cmd.Flags().BoolVar(&skipLivenessCheck, "skip-liveness-check", false, "If enabled, rpk will issue the decommission request without checking if the broker is in maintenance mode")
+
+	// Old flag, renamed to skip-liveness-check.
+	cmd.Flags().BoolVar(&skipLivenessCheck, "force", false, "If enabled, rpk will issue the decommission request without checking if the broker is in maintenance mode")
 	cmd.Flags().MarkHidden("force")
+	cmd.Flags().MarkDeprecated("force", "use --skip-liveness-check")
 
 	return cmd
 }


### PR DESCRIPTION
To skip-liveness-check. The --force flag is not clear because it implies that it modifies the behavior of the decommissioning, but it just skips checks.

Please note that I'm not hiding the flag anymore; it is advertised in our help text and in every error message, so it's better to have it present, showing what it does in the help text.

Fixes INC-1056

**Example**:

Using `--force` will throw a warning, but still work
```
$ rpk redpanda admin brokers decommission 0 --force
Flag --force has been deprecated, use --skip-liveness-check
Success, broker 0 decommission started.  Use 'rpk redpanda admin brokers decommission-status 0' to monitor data movement.
```

With the new flag
```
$ rpk redpanda admin brokers decommission 0 --skip-liveness-check
Success, broker 0 decommission started.  Use 'rpk redpanda admin brokers decommission-status 0' to monitor data movement.
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Improvements

* rpk redpanda admin brokers decommission: `--force` flag has been deprecated and renamed to `--skip-liveness-check`.
