### PR TITLE
Support scaled cloud clusters in OMB validation tests

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -179,8 +179,8 @@ class OMBValidationTest(RedpandaCloudTest):
             )
         config_profile = install_pack["config_profiles"][self.config_profile_name]
 
-        self.num_brokers: int = config_profile["nodes_count"]
-        self.tier_limits: ThroughputTierInfo = not_none(self.redpanda.get_tier())
+        self.num_brokers: int = len(self.redpanda.pods)
+        self.tier_limits: ThroughputTierInfo = not_none(self.redpanda.get_scaled_tier())
         self.tier_machine_info = get_machine_info(config_profile["machine_type"])
         self.rpk = RpkTool(self.redpanda)
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -80,7 +80,11 @@ from rptest.context.gcp import GCPContext
 from rptest.services import redpanda_types, tls
 from rptest.services.admin import Admin
 from rptest.services.cloud_broker import CloudBroker
-from rptest.services.redpanda_cloud import CloudCluster, get_config_profile_name
+from rptest.services.redpanda_cloud import (
+    CloudCluster,
+    get_config_profile_name,
+    ThroughputTierInfo,
+)
 from rptest.services.redpanda_installer import (
     VERSION_RE as RI_VERSION_RE,
 )
@@ -2227,6 +2231,37 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
         Returns none if product info for the tier is not found.
         """
         return self._cloud_cluster.get_tier()
+
+    def get_scaled_tier(self) -> ThroughputTierInfo | None:
+        """Get tier limits scaled for the actual number of nodes.
+
+        Returns tier info with limits adjusted proportionally based on
+        the ratio of actual nodes to the default tier node count.
+        Returns None if base tier info is not found.
+        """
+        tier = self.get_tier()
+        if tier is None:
+            return None
+
+        # Global limits
+        global_partition_limit = 112500
+
+        default_nodes = int(self.config_profile["nodes_count"])
+        actual_nodes = len(self.pods)
+
+        if actual_nodes == default_nodes:
+            return tier
+
+        scale_factor = actual_nodes / default_nodes
+
+        return ThroughputTierInfo(
+            max_ingress=int(tier.max_ingress * scale_factor),
+            max_egress=int(tier.max_egress * scale_factor),
+            max_connections_count=int(tier.max_connections_count * scale_factor),
+            max_partition_count=min(
+                int(tier.max_partition_count * scale_factor), global_partition_limit
+            ),
+        )
 
     def get_install_pack(self):
         install_pack_client = InstallPackClient(

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1839,10 +1839,10 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
         )
 
         self.rebuild_pods_classes()
+        self._initial_node_count = len(self.pods)
 
-        node_count = self.config_profile["nodes_count"]
-        assert self._min_brokers <= node_count, (
-            f"Not enough brokers: test needs {self._min_brokers} but cluster has {node_count}"
+        assert self._min_brokers <= self._initial_node_count, (
+            f"Not enough brokers: test needs {self._min_brokers} but cluster has {self._initial_node_count}"
         )
 
     @property
@@ -2327,20 +2327,20 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
 
         self._cloud_cluster._ensure_cluster_health()
 
-        expected_nodes = int(self.config_profile["nodes_count"])
+        expected_nodes = self._initial_node_count
         active, _, _ = self.get_redpanda_pods_presorted()
         failed = self.get_redpanda_pods_filtered("failed")
         active_count = len(active)
         failed_count = len(failed)
         assert expected_nodes == active_count, (
-            f"Expected {expected_nodes} per tier definition but found {active_count} active pods"
+            f"Expected {expected_nodes} nodes (initial count) but found {active_count} active pods"
         )
         assert failed_count == 0, f"Expected no failed pods, found {failed_count}"
 
         brokers = self._cloud_cluster.get_brokers()
         broker_count = len(brokers)
         assert expected_nodes == broker_count, (
-            f"Expected {expected_nodes} per tier definition but there "
+            f"Expected {expected_nodes} nodes (initial count) but there "
             f"were only {broker_count} brokers: {brokers}"
         )
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This PR:
  - Adds the `RedpandaServiceCloud::get_scaled_tier()` method which returns tier limits scaled proportionally based on actual vs default node count.
  - Tracks the initial node count at test startup for cluster state validation in `RedpandaServiceCloud::assert_cluster_is_reusable()` in order to handle cases where tests are running on scaled up clusters.
  - Updates the OMB validation tests to use actual pod count and scaled tier limits instead of static tier configuration.

These changes should not effect non-scaled clusters and have so far been validated on a scaled tier 1 cluster. To follow is testing to ensure various tiers scale as expected along with other misc changes needed in ducktape to facilitate that.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
