### PR TITLE
cluster: remove probe singleton usage

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/tests/log_collector_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/log_collector_test.cc
@@ -30,18 +30,13 @@ using namespace std::chrono_literals;
 namespace cloud_topics::l1 {
 
 struct log_collector_test_fixture : public seastar_test {
-    static void SetUpTestSuite() {
-        ss::smp::invoke_on_all([] {
-            config::node().node_id.set_value(model::node_id{1});
-        }).get();
-    }
-
     ss::future<> SetUpAsync() override {
         co_await _as.start();
         co_await _migrated_resources.start();
-        co_await _topics.start(ss::sharded_parameter([this] {
-            return std::ref(_migrated_resources.local());
-        }));
+        co_await _topics.start(
+          ss::sharded_parameter(
+            [this] { return std::ref(_migrated_resources.local()); }),
+          model::node_id{1});
         co_await _leaders.start_single(std::ref(_topics), std::ref(_as));
     }
 

--- a/src/v/cloud_topics/level_one/metastore/tests/topic_purger_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/topic_purger_test.cc
@@ -53,10 +53,8 @@ private:
 class TopicPurgerTest : public testing::Test {
 public:
     void SetUp() override {
-        ss::smp::invoke_on_all([] {
-            config::node().node_id.set_value(model::node_id{1});
-        }).get();
-        topic_table = std::make_unique<cluster::topic_table>(mr);
+        topic_table = std::make_unique<cluster::topic_table>(
+          mr, model::node_id{1});
     }
     model::offset next_topic_table_offset() const {
         return model::offset(topic_table->last_applied_revision()() + 1);

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -224,9 +224,10 @@ ss::future<> controller::wire_up() {
             }));
       })
       .then([this] {
-          return _tp_state.start(ss::sharded_parameter([this] {
-              return std::ref(_data_migrated_resources.local());
-          }));
+          return _tp_state.start(
+            ss::sharded_parameter(
+              [this] { return std::ref(_data_migrated_resources.local()); }),
+            config::node().node_id().value());
       })
       .then([this] {
           return _partition_balancer_state.start_single(

--- a/src/v/cluster/tests/data_migration_table_test.cc
+++ b/src/v/cluster/tests/data_migration_table_test.cc
@@ -85,16 +85,13 @@ create_groups(std::vector<std::string_view> strings) {
 struct data_migration_table_fixture : public seastar_test {
     ss::future<> SetUpAsync() override {
         // for all new topics to be created with it
-        ss::smp::invoke_on_all([] {
-            config::node().node_id.set_value(model::node_id{1});
-        }).get();
         config::shard_local_cfg().cloud_storage_enable_remote_write.set_value(
           true);
 
         co_await resources.start();
-        co_await topics.start(ss::sharded_parameter([this] {
-            return std::ref(resources.local());
-        }));
+        co_await topics.start(
+          ss::sharded_parameter([this] { return std::ref(resources.local()); }),
+          model::node_id{1});
         table = std::make_unique<cluster::data_migrations::migrations_table>(
           resources, topics, true);
         table->register_notification([this](cluster::data_migrations::id id) {

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -71,14 +71,12 @@ struct controller_workers {
 public:
     controller_workers()
       : dispatcher(allocator, table, state) {
-        ss::smp::invoke_on_all([] {
-            config::node().node_id.set_value(model::node_id{1});
-        }).get();
         migrated_resources.start().get();
         table
-          .start(ss::sharded_parameter([this] {
-              return std::ref(migrated_resources.local());
-          }))
+          .start(
+            ss::sharded_parameter(
+              [this] { return std::ref(migrated_resources.local()); }),
+            model::node_id{1})
           .get();
         members.start_single().get();
         features.start().get();

--- a/src/v/cluster/tests/partition_balancer_planner_test.cc
+++ b/src/v/cluster/tests/partition_balancer_planner_test.cc
@@ -1002,7 +1002,7 @@ FIXTURE_TEST(
         }
     });
     cluster::data_migrations::migrated_resources migrated_resources;
-    cluster::topic_table other_tt(migrated_resources);
+    cluster::topic_table other_tt(migrated_resources, model::node_id{0});
     model::offset controller_offset{0};
     std::set<ss::sstring> cur_topics;
     bool node_isolated = false;

--- a/src/v/cluster/tests/partition_leaders_table_test.cc
+++ b/src/v/cluster/tests/partition_leaders_table_test.cc
@@ -39,18 +39,13 @@ namespace cluster {
 struct test_fixture : public seastar_test {
     test_fixture() = default;
 
-    static void SetUpTestSuite() {
-        ss::smp::invoke_on_all([] {
-            config::node().node_id.set_value(model::node_id{1});
-        }).get();
-    }
-
     ss::future<> SetUpAsync() {
         co_await as.start();
         co_await migrated_resources.start();
-        co_await topics.start(ss::sharded_parameter([this] {
-            return std::ref(migrated_resources.local());
-        }));
+        co_await topics.start(
+          ss::sharded_parameter(
+            [this] { return std::ref(migrated_resources.local()); }),
+          model::node_id{1});
         leaders = std::make_unique<partition_leaders_table>(topics, as);
     }
     ss::future<> TearDownAsync() {

--- a/src/v/cluster/tests/plugin_frontend_validation_test.cc
+++ b/src/v/cluster/tests/plugin_frontend_validation_test.cc
@@ -75,15 +75,11 @@ public:
     model::offset _latest_offset{0};
     model::transform_id _latest_id{0};
 
-    static void SetUpTestSuite() {
-        config::node().node_id.set_value(model::node_id{1});
-    }
-
     absl::flat_hash_set<model::topic> active_shadow_topics{};
 
     plugin_table _plugin_table;
     data_migrations::migrated_resources _migrated_resources;
-    topic_table _topic_table{_migrated_resources};
+    topic_table _topic_table{_migrated_resources, model::node_id{1}};
     plugin_frontend::validator _validator{
       &_topic_table,
       &_plugin_table,

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -45,9 +45,10 @@ struct topic_table_fixture {
     topic_table_fixture() {
         migrated_resources.start().get();
         table
-          .start(ss::sharded_parameter([this] {
-              return std::ref(migrated_resources.local());
-          }))
+          .start(
+            ss::sharded_parameter(
+              [this] { return std::ref(migrated_resources.local()); }),
+            model::node_id{1})
           .get();
         members.start_single().get();
         features.start().get();
@@ -179,15 +180,6 @@ struct topic_table_fixture {
         return total;
     }
 
-    struct set_config_node_id {
-        set_config_node_id() {
-            ss::smp::invoke_on_all([] {
-                config::node().node_id.set_value(model::node_id{1});
-            }).get();
-        }
-    };
-
-    set_config_node_id setter;
     ss::sharded<cluster::members_table> members;
     ss::sharded<features::feature_table> features;
     ss::sharded<cluster::partition_allocator> allocator;

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -36,8 +36,9 @@
 namespace cluster {
 
 topic_table::topic_table(
-  data_migrations::migrated_resources& migrated_resources)
-  : _probe(*this)
+  data_migrations::migrated_resources& migrated_resources,
+  model::node_id node_id)
+  : _probe(*this, node_id)
   , _migrated_resources(migrated_resources) {}
 
 ss::future<std::error_code>

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -498,7 +498,7 @@ public:
         const in_progress_update* update = nullptr;
     };
 
-    explicit topic_table(data_migrations::migrated_resources&);
+    explicit topic_table(data_migrations::migrated_resources&, model::node_id);
 
     cluster::notification_id_type
     register_topic_delta_notification(topic_delta_cb_t cb) {

--- a/src/v/cluster/topic_table_probe.cc
+++ b/src/v/cluster/topic_table_probe.cc
@@ -19,9 +19,10 @@
 
 namespace cluster {
 
-topic_table_probe::topic_table_probe(const topic_table& topic_table)
+topic_table_probe::topic_table_probe(
+  const topic_table& topic_table, model::node_id node_id)
   : _topic_table(topic_table)
-  , _node_id(config::node().node_id().value()) {
+  , _node_id(node_id) {
     setup_metrics();
 }
 

--- a/src/v/cluster/topic_table_probe.h
+++ b/src/v/cluster/topic_table_probe.h
@@ -19,7 +19,7 @@ namespace cluster {
 
 class topic_table_probe {
 public:
-    explicit topic_table_probe(const topic_table&);
+    explicit topic_table_probe(const topic_table&, model::node_id);
 
     topic_table_probe(const topic_table_probe&) = delete;
     topic_table_probe(topic_table_probe&&) = delete;

--- a/src/v/datalake/coordinator/tests/coordinator_test.cc
+++ b/src/v/datalake/coordinator/tests/coordinator_test.cc
@@ -65,7 +65,7 @@ struct coordinator_node {
       std::chrono::milliseconds commit_interval)
       : stm(*stm)
       , commit_interval_ms(commit_interval)
-      , topic_table(mr)
+      , topic_table(mr, model::node_id{0})
       , file_committer(std::move(committer))
       , snapshot_remover(std::move(remover))
       , crd(
@@ -206,9 +206,6 @@ public:
     }
 
     void SetUp() override {
-        ss::smp::invoke_on_all([] {
-            config::node().node_id.set_value(model::node_id{1});
-        }).get();
         cfg.get("raft_heartbeat_interval_ms").set_value(50ms);
         cfg.get("raft_heartbeat_timeout_ms").set_value(500ms);
         auto args = param();

--- a/src/v/datalake/coordinator/tests/state_machine_test.cc
+++ b/src/v/datalake/coordinator/tests/state_machine_test.cc
@@ -25,11 +25,6 @@ using stm = datalake::coordinator::coordinator_stm;
 using stm_ptr = ss::shared_ptr<stm>;
 
 struct coordinator_stm_fixture : stm_raft_fixture<stm> {
-    static void SetUpTestSuite() {
-        ss::smp::invoke_on_all([] {
-            config::node().node_id.set_value(model::node_id{0});
-        }).get();
-    }
     ss::future<> TearDownAsync() override {
         for (auto& [_, coordinator] : coordinators) {
             co_await coordinator->stop_and_wait();
@@ -191,7 +186,7 @@ struct coordinator_stm_fixture : stm_raft_fixture<stm> {
     model::topic_partition tp{tp_ns.tp, model::partition_id{0}};
     model::revision_id rev{123};
     cluster::data_migrations::migrated_resources mr;
-    cluster::topic_table topic_table{mr};
+    cluster::topic_table topic_table{mr, model::node_id{0}};
     datalake::binary_type_resolver type_resolver;
     datalake::simple_schema_manager schema_mgr;
     datalake::coordinator::simple_file_committer file_committer;


### PR DESCRIPTION

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
