### PR TITLE
ct: reconcile from L0 with readahead

### DIFF
--- a/src/v/cloud_topics/reconciler/reconciliation_source.cc
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.cc
@@ -18,6 +18,7 @@
 #include "cluster/partition.h"
 #include "kafka/utils/txn_reader.h"
 #include "model/fundamental.h"
+#include "model/record_batch_reader.h"
 #include "model/timeout_clock.h"
 #include "utils/retry_chain_node.h"
 
@@ -127,8 +128,11 @@ public:
         auto tracker = std::make_unique<aborted_transaction_tracker_impl>(
           _fe, std::move(reader.ot_state));
 
-        co_return model::make_record_batch_reader<kafka::read_committed_reader>(
-          std::move(tracker), std::move(reader.reader));
+        // Wrap the reader with some readahead to hide the latency of
+        // downloading a bit.
+        co_return model::make_readahead_record_batch_reader(
+          model::make_record_batch_reader<kafka::read_committed_reader>(
+            std::move(tracker), std::move(reader.reader)));
     }
 
 private:

--- a/src/v/model/record_batch_reader.cc
+++ b/src/v/model/record_batch_reader.cc
@@ -11,13 +11,12 @@
 
 #include "container/chunked_vector.h"
 #include "model/record.h"
-#include "model/record_batch_types.h"
 
 #include <seastar/core/chunked_fifo.hh>
-#include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/smp.hh>
+#include <seastar/coroutine/as_future.hh>
 #include <seastar/util/variant_utils.hh>
 
 #include <exception>
@@ -171,6 +170,75 @@ record_batch_reader make_generating_record_batch_reader(
     };
 
     return make_record_batch_reader<reader>(std::move(gen));
+}
+
+/// Creates a readahead wrapper around a record_batch_reader that issues one
+/// read ahead of the consumer. When do_load_slice() is called, it returns
+/// any buffered future from the previous readahead and immediately issues a
+/// new read for the next call. This amortizes the latency of the underlying
+/// reader across calls, improving throughput for sequential reads.
+///
+/// Note: Due to the record_batch_reader::impl interface not supporting
+/// concurrent do_load_slice() calls, the readahead depth is fixed at 1.
+record_batch_reader
+make_readahead_record_batch_reader(record_batch_reader&& reader) {
+    class readahead_reader final : public record_batch_reader::impl {
+    public:
+        explicit readahead_reader(std::unique_ptr<impl> underlying)
+          : _underlying(std::move(underlying)) {}
+
+        bool is_end_of_stream() const final {
+            return _underlying->is_end_of_stream()
+                   && !_readahead_future.has_value();
+        }
+
+        void print(std::ostream& os) final {
+            fmt::print(
+              os,
+              "readahead_reader(buffered={}) wrapping: ",
+              _readahead_future.has_value() ? 1 : 0);
+            _underlying->print(os);
+        }
+
+        ss::future<storage_t>
+        do_load_slice(timeout_clock::time_point timeout) final {
+            ss::future<storage_t> fut
+              = _readahead_future
+                  ? std::exchange(_readahead_future, std::nullopt).value()
+                  : _underlying->do_load_slice(timeout);
+            fut = co_await ss::coroutine::as_future(std::move(fut));
+            if (fut.failed()) {
+                // Don't issue readahead if the future fails, this allows the
+                // caller to decide what should happen.
+                std::rethrow_exception(fut.get_exception());
+            }
+            auto slice = std::move(fut.get());
+            if (!_underlying->is_end_of_stream()) {
+                _readahead_future = _underlying->do_load_slice(timeout);
+            }
+            co_return slice;
+        }
+
+        ss::future<> finally() noexcept final {
+            if (!_readahead_future.has_value()) {
+                return _underlying->finally();
+            }
+            // Drain the buffered future before calling underlying finally
+            return std::exchange(_readahead_future, std::nullopt)
+              .value()
+              .then_wrapped([this](ss::future<storage_t> f) {
+                  f.ignore_ready_future();
+                  return _underlying->finally();
+              });
+        }
+
+    private:
+        std::unique_ptr<impl> _underlying;
+        std::optional<ss::future<storage_t>> _readahead_future;
+    };
+
+    auto rdr = std::make_unique<readahead_reader>(std::move(reader).release());
+    return record_batch_reader(std::move(rdr));
 }
 
 namespace {

--- a/src/v/model/record_batch_reader.h
+++ b/src/v/model/record_batch_reader.h
@@ -421,6 +421,10 @@ record_batch_reader make_record_batch_reader(Args&&... args) {
 record_batch_reader
   make_memory_record_batch_reader(record_batch_reader::storage_t);
 
+/// Wraps a record_batch_reader with readahead buffering (depth=1).
+/// Issues reads one step ahead of consumer to hide latency.
+record_batch_reader make_readahead_record_batch_reader(record_batch_reader&&);
+
 record_batch_reader
   make_chunked_memory_record_batch_reader(chunked_vector<model::record_batch>);
 

--- a/src/v/model/tests/record_batch_reader_gtest.cc
+++ b/src/v/model/tests/record_batch_reader_gtest.cc
@@ -76,3 +76,66 @@ TEST_CORO(RecordBatchReaderGenerator, SmallSetMemory) {
         ASSERT_EQ_CORO(r2_materialized[i], r0_materialized[i]);
     }
 }
+
+TEST_CORO(RecordBatchReaderReadahead, BasicReadahead) {
+    // Test that readahead reader produces same results as underlying reader
+    auto batches = make_batches(10, 20, 30, 40, 50);
+    auto r0 = make_memory_record_batch_reader(copy_batches(batches));
+    auto r1 = model::make_readahead_record_batch_reader(
+      make_memory_record_batch_reader(copy_batches(batches)));
+
+    auto r0_materialized = co_await model::consume_reader_to_chunked_vector(
+      std::move(r0), model::no_timeout);
+    auto r1_materialized = co_await model::consume_reader_to_chunked_vector(
+      std::move(r1), model::no_timeout);
+
+    ASSERT_EQ_CORO(r0_materialized.size(), 5);
+    ASSERT_EQ_CORO(r1_materialized.size(), r0_materialized.size());
+    for (int i = 0; i < 5; ++i) {
+        ASSERT_EQ_CORO(r1_materialized[i], r0_materialized[i]);
+    }
+}
+
+TEST_CORO(RecordBatchReaderReadahead, EmptyReader) {
+    // Test that readahead reader handles empty underlying reader
+    auto reader = model::make_readahead_record_batch_reader(
+      model::make_empty_record_batch_reader());
+
+    auto gen = std::move(reader).generator(model::no_timeout);
+    int count = 0;
+    while (auto batch = co_await gen()) {
+        ++count;
+    }
+    ASSERT_EQ_CORO(count, 0);
+}
+
+TEST_CORO(RecordBatchReaderReadahead, SingleBatch) {
+    // Test readahead with single batch
+    auto batches = make_batches(100);
+    auto reader = model::make_readahead_record_batch_reader(
+      make_memory_record_batch_reader(copy_batches(batches)));
+
+    auto materialized = co_await model::consume_reader_to_chunked_vector(
+      std::move(reader), model::no_timeout);
+
+    ASSERT_EQ_CORO(materialized.size(), 1);
+    ASSERT_EQ_CORO(materialized[0].base_offset(), model::offset(100));
+}
+
+TEST_CORO(RecordBatchReaderReadahead, GeneratorAPI) {
+    // Test readahead reader with generator API
+    auto batches = make_batches(1, 2, 3);
+    auto reader = model::make_readahead_record_batch_reader(
+      make_memory_record_batch_reader(copy_batches(batches)));
+
+    chunked_vector<model::record_batch> materialized;
+    auto gen = std::move(reader).generator(model::no_timeout);
+    while (auto batch = co_await gen()) {
+        materialized.push_back(std::move(batch->get()));
+    }
+
+    ASSERT_EQ_CORO(materialized.size(), 3);
+    ASSERT_EQ_CORO(materialized[0].base_offset(), model::offset(1));
+    ASSERT_EQ_CORO(materialized[1].base_offset(), model::offset(2));
+    ASSERT_EQ_CORO(materialized[2].base_offset(), model::offset(3));
+}


### PR DESCRIPTION
This PR introduces some readahead for L0. I'm not sure how much this is going to help, because
the latency between reads for L0 **should** be basically instant (just writing to local disk)
compared to reading from S3. It seems we might want to do this a layer down and have a deeper
queue depth?

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
