### PR TITLE
[CORE-15271] k/server: Extend quota manager to accept user argument

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -640,8 +640,9 @@ connection_context::record_tp_and_calculate_throttle(
     // Throttle on client based quotas
     connection_context::delay_t client_quota_delay{};
     if (r_data.request_key == fetch_api::key) {
+        // TODO: wire in principal
         auto fetch_delay = co_await _server.quota_mgr().throttle_fetch_tp(
-          r_data.client_id, now);
+          std::nullopt, r_data.client_id, now);
         auto fetch_enforced = _throttling_state.update_fetch_delay(
           fetch_delay, now);
         client_quota_delay = delay_t{
@@ -649,9 +650,10 @@ connection_context::record_tp_and_calculate_throttle(
           .enforce = fetch_enforced,
         };
     } else if (r_data.request_key == produce_api::key) {
+        // TODO: wire in principal
         auto produce_delay
           = co_await _server.quota_mgr().record_produce_tp_and_throttle(
-            r_data.client_id, request_size, now);
+            std::nullopt, r_data.client_id, request_size, now);
         auto datalake_produce_delay
           = co_await _server.get_datalake_producer_throttle(r_data.client_id);
 
@@ -1182,7 +1184,9 @@ connection_context::client_protocol_state::do_process_responses(
 
     auto msg = response_as_scattered(std::move(resp_and_res.response));
     if (resp_and_res.resources->request_data.request_key == fetch_api::key) {
+        // TODO: wire in principal
         co_await connection_ctx->_server.quota_mgr().record_fetch_tp(
+          std::nullopt,
           resp_and_res.resources->request_data.client_id,
           msg.size(),
           quota_manager::clock::now());

--- a/src/v/kafka/server/handlers/create_partitions.cc
+++ b/src/v/kafka/server/handlers/create_partitions.cc
@@ -290,8 +290,10 @@ ss::future<response_ptr> create_partitions_handler::handle(
             tp.count > cfg->partition_count,
             "Sanity check for request increase partition count failed");
           const auto mutations = (tp.count - cfg->partition_count);
+          // TODO: wire in principal
           return ctx.quota_mgr()
-            .record_partition_mutations(ctx.header().client_id, mutations, now)
+            .record_partition_mutations(
+              std::nullopt, ctx.header().client_id, mutations, now)
             .then([&resp](std::chrono::milliseconds delay) {
                 resp.data.throttle_time_ms = std::max(
                   resp.data.throttle_time_ms, delay);

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -404,9 +404,11 @@ ss::future<response_ptr> create_topics_handler::handle(
       begin, valid_range_end, [&ctx, &response, now](const creatable_topic& t) {
           /// Capture before next scheduling point below
           auto& response_ref = response;
-          return ctx.quota_mgr()
+          return ctx
+            .quota_mgr()
+            // TODO: wire in principal
             .record_partition_mutations(
-              ctx.header().client_id, t.num_partitions, now)
+              std::nullopt, ctx.header().client_id, t.num_partitions, now)
             .then([&response_ref](std::chrono::milliseconds delay) {
                 response_ref.data.throttle_time_ms = std::max(
                   response_ref.data.throttle_time_ms, delay);

--- a/src/v/kafka/server/quota_manager.cc
+++ b/src/v/kafka/server/quota_manager.cc
@@ -314,6 +314,7 @@ ss::future<> quota_manager::do_update_client_quotas() {
 }
 
 ss::future<std::chrono::milliseconds> quota_manager::record_partition_mutations(
+  std::optional<std::string_view> user,
   std::optional<std::string_view> client_id,
   uint32_t mutations,
   clock::time_point now) {
@@ -325,6 +326,7 @@ ss::future<std::chrono::milliseconds> quota_manager::record_partition_mutations(
     }
     auto ctx = client_quota_request_ctx{
       .q_type = client_quota_type::partition_mutation_quota,
+      .user = user,
       .client_id = client_id,
     };
     auto [key, value] = _translator.find_quota(ctx);
@@ -391,6 +393,7 @@ clock::duration quota_manager::cap_to_max_delay(
 
 // record a new observation and return <previous delay, new delay>
 ss::future<clock::duration> quota_manager::record_produce_tp_and_throttle(
+  std::optional<std::string_view> user,
   std::optional<std::string_view> client_id,
   uint64_t bytes,
   clock::time_point now) {
@@ -399,6 +402,7 @@ ss::future<clock::duration> quota_manager::record_produce_tp_and_throttle(
     }
     auto ctx = client_quota_request_ctx{
       .q_type = client_quota_type::produce_quota,
+      .user = user,
       .client_id = client_id,
     };
     auto [key, value] = _translator.find_quota(ctx);
@@ -443,6 +447,7 @@ ss::future<clock::duration> quota_manager::record_produce_tp_and_throttle(
 }
 
 ss::future<> quota_manager::record_fetch_tp(
+  std::optional<std::string_view> user,
   std::optional<std::string_view> client_id,
   uint64_t bytes,
   clock::time_point now) {
@@ -451,6 +456,7 @@ ss::future<> quota_manager::record_fetch_tp(
     }
     auto ctx = client_quota_request_ctx{
       .q_type = client_quota_type::fetch_quota,
+      .user = user,
       .client_id = client_id,
     };
     auto [key, value] = _translator.find_quota(ctx);
@@ -477,12 +483,15 @@ ss::future<> quota_manager::record_fetch_tp(
 }
 
 ss::future<clock::duration> quota_manager::throttle_fetch_tp(
-  std::optional<std::string_view> client_id, clock::time_point now) {
+  std::optional<std::string_view> user,
+  std::optional<std::string_view> client_id,
+  clock::time_point now) {
     if (_translator.is_empty()) {
         co_return 0ms;
     }
     auto ctx = client_quota_request_ctx{
       .q_type = client_quota_type::fetch_quota,
+      .user = user,
       .client_id = client_id,
     };
     auto [key, value] = _translator.find_quota(ctx);

--- a/src/v/kafka/server/quota_manager.h
+++ b/src/v/kafka/server/quota_manager.h
@@ -98,24 +98,29 @@ public:
 
     // record a new observation
     ss::future<clock::duration> record_produce_tp_and_throttle(
+      std::optional<std::string_view> user,
       std::optional<std::string_view> client_id,
       uint64_t bytes,
       clock::time_point now);
 
     // record a new observation
     ss::future<> record_fetch_tp(
+      std::optional<std::string_view> user,
       std::optional<std::string_view> client_id,
       uint64_t bytes,
       clock::time_point now);
 
     ss::future<clock::duration> throttle_fetch_tp(
-      std::optional<std::string_view> client_id, clock::time_point now);
+      std::optional<std::string_view> user,
+      std::optional<std::string_view> client_id,
+      clock::time_point now);
 
     // Used to record new number of partitions mutations
     // Only for use with the quotas introduced by KIP-599, namely to track
     // partition creation and deletion events (create topics, delete topics &
     // create partitions)
     ss::future<std::chrono::milliseconds> record_partition_mutations(
+      std::optional<std::string_view> user,
       std::optional<std::string_view> client_id,
       uint32_t mutations,
       clock::time_point now);

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -1688,8 +1688,10 @@ delete_topics_handler::handle(request_context ctx, ss::smp_service_group) {
           const auto mutations = cfg ? cfg->partition_count : 0;
           /// Capture before next scheduling point below
           auto& resp_delay_ref = resp_delay;
+          // TODO: wire in principal
           return ctx.quota_mgr()
-            .record_partition_mutations(ctx.header().client_id, mutations, now)
+            .record_partition_mutations(
+              std::nullopt, ctx.header().client_id, mutations, now)
             .then([&resp_delay_ref](std::chrono::milliseconds delay) {
                 resp_delay_ref = std::max(delay, resp_delay_ref);
                 return delay == 0ms;

--- a/src/v/kafka/server/tests/quota_manager_bench.cc
+++ b/src/v/kafka/server/tests/quota_manager_bench.cc
@@ -25,6 +25,7 @@
 
 namespace kafka {
 
+static const auto fixed_user = "shared-user";
 static const auto fixed_client_id = "shared-client-id";
 static const size_t total_requests = 100000;
 static const size_t unique_client_id_count = 1000;
@@ -51,13 +52,13 @@ ss::future<> send_requests(quota_manager& qm, size_t count, bool use_unique) {
         // contention on produce/fetch token buckets for the same client id
         if (ss::this_shard_id() % 2 == 0) {
             co_await qm.record_fetch_tp(
-              client_id, 1, quota_manager::clock::now());
+              fixed_user, client_id, 1, quota_manager::clock::now());
             auto delay = co_await qm.throttle_fetch_tp(
-              client_id, quota_manager::clock::now());
+              fixed_user, client_id, quota_manager::clock::now());
             perf_tests::do_not_optimize(delay);
         } else {
             auto delay = co_await qm.record_produce_tp_and_throttle(
-              client_id, 1, quota_manager::clock::now());
+              fixed_user, client_id, 1, quota_manager::clock::now());
             perf_tests::do_not_optimize(delay);
         }
         co_await maybe_yield();
@@ -188,7 +189,7 @@ future<size_t> run_latency_test(latency_test_case tc) {
           // Have a non-trivial number of existing clients in the map
           for (int i = 0; i < tc.n_other_clients; i++) {
               co_await qm.record_produce_tp_and_throttle(
-                fmt::format("client-{}", i), 1, now);
+                fixed_user, fmt::format("client-{}", i), 1, now);
           }
 
           // Pre-generate the client-id's used during the benchmark
@@ -204,7 +205,7 @@ future<size_t> run_latency_test(latency_test_case tc) {
               }
               // Ensure that the client id used is already "known"
               co_await qm.record_produce_tp_and_throttle(
-                fixed_client_id, 1, now);
+                fixed_user, fixed_client_id, 1, now);
           }
 
           perf_tests::start_measuring_time();
@@ -214,13 +215,15 @@ future<size_t> run_latency_test(latency_test_case tc) {
               if (tc.is_produce_not_fetch) {
                   // Produce
                   auto res = co_await qm.record_produce_tp_and_throttle(
-                    client_ids[i], 1, now);
+                    fixed_user, client_ids[i], 1, now);
                   perf_tests::do_not_optimize(res);
               } else {
                   // Fetch
-                  auto res = co_await qm.throttle_fetch_tp(client_ids[i], now);
+                  auto res = co_await qm.throttle_fetch_tp(
+                    fixed_user, client_ids[i], now);
                   perf_tests::do_not_optimize(res);
-                  co_await qm.record_fetch_tp(client_ids[i], 1, now);
+                  co_await qm.record_fetch_tp(
+                    fixed_user, client_ids[i], 1, now);
               }
           }
 

--- a/src/v/kafka/server/tests/quota_manager_bench.cc
+++ b/src/v/kafka/server/tests/quota_manager_bench.cc
@@ -146,12 +146,14 @@ PERF_TEST_CN(throughput_group, test_quota_manager_off_unique) {
       });
 }
 
+enum class req_t { produce, fetch };
+enum class quota_t { none, client_id };
 struct latency_test_case {
-    bool is_new_client;
-    bool is_produce_not_fetch;
-    int n_other_clients;
+    bool is_new_key;
+    req_t req;
+    int n_other_keys;
     bool on_shard_0;
-    bool no_quotas;
+    quota_t quotas = quota_t::client_id;
 };
 
 static const size_t n_repeats = 100;
@@ -171,10 +173,14 @@ future<size_t> run_latency_test(latency_test_case tc) {
       shard, [&sqm, &quota_store, tc](this auto) -> ss::future<> {
           auto& qm = sqm.local();
 
+          using cluster::client_quota::entity_key;
+          using cluster::client_quota::entity_value;
+
           // Try to create a realistic setup
-          if (!tc.no_quotas) {
-              using cluster::client_quota::entity_key;
-              using cluster::client_quota::entity_value;
+          switch (tc.quotas) {
+          case quota_t::none:
+              break;
+          case quota_t::client_id: {
               auto key = entity_key{entity_key::client_id_default_match{}};
               auto value = entity_value{
                 .producer_byte_rate = 1 << 30, .consumer_byte_rate = 1 << 30};
@@ -182,12 +188,14 @@ future<size_t> run_latency_test(latency_test_case tc) {
                 [&key, &value](cluster::client_quota::store& qs) {
                     qs.set_quota(key, value);
                 });
+              break;
+          }
           }
 
           auto now = quota_manager::clock::now();
 
           // Have a non-trivial number of existing clients in the map
-          for (int i = 0; i < tc.n_other_clients; i++) {
+          for (int i = 0; i < tc.n_other_keys; i++) {
               co_await qm.record_produce_tp_and_throttle(
                 fixed_user, fmt::format("client-{}", i), 1, now);
           }
@@ -195,7 +203,7 @@ future<size_t> run_latency_test(latency_test_case tc) {
           // Pre-generate the client-id's used during the benchmark
           auto client_ids = std::vector<ss::sstring>{};
           client_ids.reserve(n_repeats);
-          if (tc.is_new_client) {
+          if (tc.is_new_key) {
               for (size_t i = 0; i < n_repeats; i++) {
                   client_ids.emplace_back(fmt::format("new-client-{}", i));
               }
@@ -212,18 +220,21 @@ future<size_t> run_latency_test(latency_test_case tc) {
 
           // Run repeatedly to reduce the overhead of start/stop_measuring_time
           for (size_t i = 0; i < n_repeats; i++) {
-              if (tc.is_produce_not_fetch) {
-                  // Produce
+              switch (tc.req) {
+              case req_t::produce: {
                   auto res = co_await qm.record_produce_tp_and_throttle(
                     fixed_user, client_ids[i], 1, now);
                   perf_tests::do_not_optimize(res);
-              } else {
-                  // Fetch
+                  break;
+              }
+              case req_t::fetch: {
                   auto res = co_await qm.throttle_fetch_tp(
                     fixed_user, client_ids[i], now);
                   perf_tests::do_not_optimize(res);
                   co_await qm.record_fetch_tp(
                     fixed_user, client_ids[i], 1, now);
+                  break;
+              }
               }
           }
 
@@ -241,9 +252,9 @@ struct latency_group {};
 PERF_TEST_CN(latency_group, existing_client_produce_100_others) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = false,
-        .is_produce_not_fetch = true,
-        .n_other_clients = 100,
+        .is_new_key = false,
+        .req = req_t::produce,
+        .n_other_keys = 100,
         .on_shard_0 = true,
       });
 }
@@ -251,9 +262,9 @@ PERF_TEST_CN(latency_group, existing_client_produce_100_others) {
 PERF_TEST_CN(latency_group, existing_client_fetch_100_others) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = false,
-        .is_produce_not_fetch = false,
-        .n_other_clients = 100,
+        .is_new_key = false,
+        .req = req_t::fetch,
+        .n_other_keys = 100,
         .on_shard_0 = true,
       });
 }
@@ -261,9 +272,9 @@ PERF_TEST_CN(latency_group, existing_client_fetch_100_others) {
 PERF_TEST_CN(latency_group, new_client_produce_100_others) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = true,
-        .is_produce_not_fetch = true,
-        .n_other_clients = 100,
+        .is_new_key = true,
+        .req = req_t::produce,
+        .n_other_keys = 100,
         .on_shard_0 = true,
       });
 }
@@ -271,9 +282,9 @@ PERF_TEST_CN(latency_group, new_client_produce_100_others) {
 PERF_TEST_CN(latency_group, new_client_fetch_100_others) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = true,
-        .is_produce_not_fetch = false,
-        .n_other_clients = 100,
+        .is_new_key = true,
+        .req = req_t::fetch,
+        .n_other_keys = 100,
         .on_shard_0 = true,
       });
 }
@@ -281,9 +292,9 @@ PERF_TEST_CN(latency_group, new_client_fetch_100_others) {
 PERF_TEST_CN(latency_group, existing_client_produce_1000_others) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = false,
-        .is_produce_not_fetch = true,
-        .n_other_clients = 1000,
+        .is_new_key = false,
+        .req = req_t::produce,
+        .n_other_keys = 1000,
         .on_shard_0 = true,
       });
 }
@@ -291,9 +302,9 @@ PERF_TEST_CN(latency_group, existing_client_produce_1000_others) {
 PERF_TEST_CN(latency_group, existing_client_fetch_1000_others) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = false,
-        .is_produce_not_fetch = false,
-        .n_other_clients = 1000,
+        .is_new_key = false,
+        .req = req_t::fetch,
+        .n_other_keys = 1000,
         .on_shard_0 = true,
       });
 }
@@ -301,9 +312,9 @@ PERF_TEST_CN(latency_group, existing_client_fetch_1000_others) {
 PERF_TEST_CN(latency_group, new_client_produce_1000_others) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = true,
-        .is_produce_not_fetch = true,
-        .n_other_clients = 1000,
+        .is_new_key = true,
+        .req = req_t::produce,
+        .n_other_keys = 1000,
         .on_shard_0 = true,
       });
 }
@@ -311,9 +322,9 @@ PERF_TEST_CN(latency_group, new_client_produce_1000_others) {
 PERF_TEST_CN(latency_group, new_client_fetch_1000_others) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = true,
-        .is_produce_not_fetch = false,
-        .n_other_clients = 1000,
+        .is_new_key = true,
+        .req = req_t::fetch,
+        .n_other_keys = 1000,
         .on_shard_0 = true,
       });
 }
@@ -321,9 +332,9 @@ PERF_TEST_CN(latency_group, new_client_fetch_1000_others) {
 PERF_TEST_CN(latency_group, existing_client_produce_10000_others) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = false,
-        .is_produce_not_fetch = true,
-        .n_other_clients = 10000,
+        .is_new_key = false,
+        .req = req_t::produce,
+        .n_other_keys = 10000,
         .on_shard_0 = true,
       });
 }
@@ -331,9 +342,9 @@ PERF_TEST_CN(latency_group, existing_client_produce_10000_others) {
 PERF_TEST_CN(latency_group, existing_client_fetch_10000_others) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = false,
-        .is_produce_not_fetch = false,
-        .n_other_clients = 10000,
+        .is_new_key = false,
+        .req = req_t::fetch,
+        .n_other_keys = 10000,
         .on_shard_0 = true,
       });
 }
@@ -341,9 +352,9 @@ PERF_TEST_CN(latency_group, existing_client_fetch_10000_others) {
 PERF_TEST_CN(latency_group, new_client_produce_10000_others) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = true,
-        .is_produce_not_fetch = true,
-        .n_other_clients = 10000,
+        .is_new_key = true,
+        .req = req_t::produce,
+        .n_other_keys = 10000,
         .on_shard_0 = true,
       });
 }
@@ -351,9 +362,9 @@ PERF_TEST_CN(latency_group, new_client_produce_10000_others) {
 PERF_TEST_CN(latency_group, new_client_fetch_10000_others) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = true,
-        .is_produce_not_fetch = false,
-        .n_other_clients = 10000,
+        .is_new_key = true,
+        .req = req_t::fetch,
+        .n_other_keys = 10000,
         .on_shard_0 = true,
       });
 }
@@ -361,9 +372,9 @@ PERF_TEST_CN(latency_group, new_client_fetch_10000_others) {
 PERF_TEST_CN(latency_group, existing_client_produce_100_others_not_shard_0) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = false,
-        .is_produce_not_fetch = true,
-        .n_other_clients = 100,
+        .is_new_key = false,
+        .req = req_t::produce,
+        .n_other_keys = 100,
         .on_shard_0 = false,
       });
 }
@@ -371,9 +382,9 @@ PERF_TEST_CN(latency_group, existing_client_produce_100_others_not_shard_0) {
 PERF_TEST_CN(latency_group, existing_client_fetch_100_others_not_shard_0) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = false,
-        .is_produce_not_fetch = false,
-        .n_other_clients = 100,
+        .is_new_key = false,
+        .req = req_t::fetch,
+        .n_other_keys = 100,
         .on_shard_0 = false,
       });
 }
@@ -381,9 +392,9 @@ PERF_TEST_CN(latency_group, existing_client_fetch_100_others_not_shard_0) {
 PERF_TEST_CN(latency_group, new_client_produce_100_others_not_shard_0) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = true,
-        .is_produce_not_fetch = true,
-        .n_other_clients = 100,
+        .is_new_key = true,
+        .req = req_t::produce,
+        .n_other_keys = 100,
         .on_shard_0 = false,
       });
 }
@@ -391,9 +402,9 @@ PERF_TEST_CN(latency_group, new_client_produce_100_others_not_shard_0) {
 PERF_TEST_CN(latency_group, new_client_fetch_100_others_not_shard_0) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = true,
-        .is_produce_not_fetch = false,
-        .n_other_clients = 100,
+        .is_new_key = true,
+        .req = req_t::fetch,
+        .n_other_keys = 100,
         .on_shard_0 = false,
       });
 }
@@ -401,9 +412,9 @@ PERF_TEST_CN(latency_group, new_client_fetch_100_others_not_shard_0) {
 PERF_TEST_CN(latency_group, existing_client_produce_1000_others_not_shard_0) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = false,
-        .is_produce_not_fetch = true,
-        .n_other_clients = 1000,
+        .is_new_key = false,
+        .req = req_t::produce,
+        .n_other_keys = 1000,
         .on_shard_0 = false,
       });
 }
@@ -411,9 +422,9 @@ PERF_TEST_CN(latency_group, existing_client_produce_1000_others_not_shard_0) {
 PERF_TEST_CN(latency_group, existing_client_fetch_1000_others_not_shard_0) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = false,
-        .is_produce_not_fetch = false,
-        .n_other_clients = 1000,
+        .is_new_key = false,
+        .req = req_t::fetch,
+        .n_other_keys = 1000,
         .on_shard_0 = false,
       });
 }
@@ -421,9 +432,9 @@ PERF_TEST_CN(latency_group, existing_client_fetch_1000_others_not_shard_0) {
 PERF_TEST_CN(latency_group, new_client_produce_1000_others_not_shard_0) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = true,
-        .is_produce_not_fetch = true,
-        .n_other_clients = 1000,
+        .is_new_key = true,
+        .req = req_t::produce,
+        .n_other_keys = 1000,
         .on_shard_0 = false,
       });
 }
@@ -431,9 +442,9 @@ PERF_TEST_CN(latency_group, new_client_produce_1000_others_not_shard_0) {
 PERF_TEST_CN(latency_group, new_client_fetch_1000_others_not_shard_0) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = true,
-        .is_produce_not_fetch = false,
-        .n_other_clients = 1000,
+        .is_new_key = true,
+        .req = req_t::fetch,
+        .n_other_keys = 1000,
         .on_shard_0 = false,
       });
 }
@@ -441,9 +452,9 @@ PERF_TEST_CN(latency_group, new_client_fetch_1000_others_not_shard_0) {
 PERF_TEST_CN(latency_group, existing_client_produce_10000_others_not_shard_0) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = false,
-        .is_produce_not_fetch = true,
-        .n_other_clients = 10000,
+        .is_new_key = false,
+        .req = req_t::produce,
+        .n_other_keys = 10000,
         .on_shard_0 = false,
       });
 }
@@ -451,9 +462,9 @@ PERF_TEST_CN(latency_group, existing_client_produce_10000_others_not_shard_0) {
 PERF_TEST_CN(latency_group, existing_client_fetch_10000_others_not_shard_0) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = false,
-        .is_produce_not_fetch = false,
-        .n_other_clients = 10000,
+        .is_new_key = false,
+        .req = req_t::fetch,
+        .n_other_keys = 10000,
         .on_shard_0 = false,
       });
 }
@@ -461,9 +472,9 @@ PERF_TEST_CN(latency_group, existing_client_fetch_10000_others_not_shard_0) {
 PERF_TEST_CN(latency_group, new_client_produce_10000_others_not_shard_0) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = true,
-        .is_produce_not_fetch = true,
-        .n_other_clients = 10000,
+        .is_new_key = true,
+        .req = req_t::produce,
+        .n_other_keys = 10000,
         .on_shard_0 = false,
       });
 }
@@ -471,9 +482,9 @@ PERF_TEST_CN(latency_group, new_client_produce_10000_others_not_shard_0) {
 PERF_TEST_CN(latency_group, new_client_fetch_10000_others_not_shard_0) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = true,
-        .is_produce_not_fetch = false,
-        .n_other_clients = 10000,
+        .is_new_key = true,
+        .req = req_t::fetch,
+        .n_other_keys = 10000,
         .on_shard_0 = false,
       });
 }
@@ -481,22 +492,22 @@ PERF_TEST_CN(latency_group, new_client_fetch_10000_others_not_shard_0) {
 PERF_TEST_CN(latency_group, default_configs_produce_worst) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = true,
-        .is_produce_not_fetch = true,
-        .n_other_clients = 0,
+        .is_new_key = true,
+        .req = req_t::produce,
+        .n_other_keys = 0,
         .on_shard_0 = false,
-        .no_quotas = true,
+        .quotas = quota_t::none,
       });
 }
 
 PERF_TEST_CN(latency_group, default_configs_fetch_worst) {
     return run_latency_test(
       latency_test_case{
-        .is_new_client = true,
-        .is_produce_not_fetch = false,
-        .n_other_clients = 0,
+        .is_new_key = true,
+        .req = req_t::fetch,
+        .n_other_keys = 0,
         .on_shard_0 = false,
-        .no_quotas = true,
+        .quotas = quota_t::none,
       });
 }
 } // namespace kafka

--- a/src/v/kafka/server/tests/quota_manager_bench.cc
+++ b/src/v/kafka/server/tests/quota_manager_bench.cc
@@ -28,37 +28,38 @@ namespace kafka {
 static const auto fixed_user = "shared-user";
 static const auto fixed_client_id = "shared-client-id";
 static const size_t total_requests = 100000;
-static const size_t unique_client_id_count = 1000;
+static const size_t unique_count = 1000;
 
-std::vector<ss::sstring> initialize_client_ids() {
-    std::vector<ss::sstring> client_ids;
-    client_ids.reserve(unique_client_id_count);
-    for (size_t i = 0; i < unique_client_id_count; ++i) {
-        client_ids.push_back("client-id-" + std::to_string(i));
+std::vector<ss::sstring> initialize_unique(std::string_view prefix) {
+    std::vector<ss::sstring> unique_names;
+    unique_names.reserve(unique_count);
+    for (size_t i = 0; i < unique_count; ++i) {
+        unique_names.push_back(ss::format("{}-{}", prefix, i));
     }
-    return client_ids;
+    return unique_names;
 }
 
-std::vector<ss::sstring> unique_client_ids = initialize_client_ids();
+std::vector<ss::sstring> unique_users = initialize_unique("user");
+std::vector<ss::sstring> unique_client_ids = initialize_unique("client-id");
 
 ss::future<> send_requests(quota_manager& qm, size_t count, bool use_unique) {
     auto offset = ss::this_shard_id() * count;
     for (size_t i = 0; i < count; ++i) {
-        auto cid_idx = (offset + i) % unique_client_id_count;
-        auto client_id = use_unique ? unique_client_ids[cid_idx]
-                                    : fixed_client_id;
+        auto idx = (offset + i) % unique_count;
+        auto user = use_unique ? unique_users[idx] : fixed_user;
+        auto client_id = use_unique ? unique_client_ids[idx] : fixed_client_id;
 
         // Have a mixed workload of produce and fetch to highlight any cache
         // contention on produce/fetch token buckets for the same client id
         if (ss::this_shard_id() % 2 == 0) {
             co_await qm.record_fetch_tp(
-              fixed_user, client_id, 1, quota_manager::clock::now());
+              user, client_id, 1, quota_manager::clock::now());
             auto delay = co_await qm.throttle_fetch_tp(
-              fixed_user, client_id, quota_manager::clock::now());
+              user, client_id, quota_manager::clock::now());
             perf_tests::do_not_optimize(delay);
         } else {
             auto delay = co_await qm.record_produce_tp_and_throttle(
-              fixed_user, client_id, 1, quota_manager::clock::now());
+              user, client_id, 1, quota_manager::clock::now());
             perf_tests::do_not_optimize(delay);
         }
         co_await maybe_yield();
@@ -147,7 +148,7 @@ PERF_TEST_CN(throughput_group, test_quota_manager_off_unique) {
 }
 
 enum class req_t { produce, fetch };
-enum class quota_t { none, client_id };
+enum class quota_t { none, client_id, user, user_client_id };
 struct latency_test_case {
     bool is_new_key;
     req_t req;
@@ -175,6 +176,8 @@ future<size_t> run_latency_test(latency_test_case tc) {
 
           using cluster::client_quota::entity_key;
           using cluster::client_quota::entity_value;
+          const entity_value value{
+            .producer_byte_rate = 1 << 30, .consumer_byte_rate = 1 << 30};
 
           // Try to create a realistic setup
           switch (tc.quotas) {
@@ -182,8 +185,24 @@ future<size_t> run_latency_test(latency_test_case tc) {
               break;
           case quota_t::client_id: {
               auto key = entity_key{entity_key::client_id_default_match{}};
-              auto value = entity_value{
-                .producer_byte_rate = 1 << 30, .consumer_byte_rate = 1 << 30};
+              co_await quota_store.invoke_on_all(
+                [&key, &value](cluster::client_quota::store& qs) {
+                    qs.set_quota(key, value);
+                });
+              break;
+          }
+          case quota_t::user: {
+              auto key = entity_key{entity_key::user_default_match{}};
+              co_await quota_store.invoke_on_all(
+                [&key, &value](cluster::client_quota::store& qs) {
+                    qs.set_quota(key, value);
+                });
+              break;
+          }
+          case quota_t::user_client_id: {
+              auto key = entity_key{
+                entity_key::user_default_match{},
+                entity_key::client_id_default_match{}};
               co_await quota_store.invoke_on_all(
                 [&key, &value](cluster::client_quota::store& qs) {
                     qs.set_quota(key, value);
@@ -197,18 +216,22 @@ future<size_t> run_latency_test(latency_test_case tc) {
           // Have a non-trivial number of existing clients in the map
           for (int i = 0; i < tc.n_other_keys; i++) {
               co_await qm.record_produce_tp_and_throttle(
-                fixed_user, fmt::format("client-{}", i), 1, now);
+                fmt::format("user-{}", i), fmt::format("client-{}", i), 1, now);
           }
 
-          // Pre-generate the client-id's used during the benchmark
+          // Pre-generate user and client-id's used during the benchmark
+          auto users = std::vector<ss::sstring>{};
+          users.reserve(n_repeats);
           auto client_ids = std::vector<ss::sstring>{};
           client_ids.reserve(n_repeats);
           if (tc.is_new_key) {
               for (size_t i = 0; i < n_repeats; i++) {
+                  users.emplace_back(fmt::format("new-user-{}", i));
                   client_ids.emplace_back(fmt::format("new-client-{}", i));
               }
           } else {
               for (size_t i = 0; i < n_repeats; i++) {
+                  users.emplace_back(fixed_user);
                   client_ids.emplace_back(fixed_client_id);
               }
               // Ensure that the client id used is already "known"
@@ -223,16 +246,15 @@ future<size_t> run_latency_test(latency_test_case tc) {
               switch (tc.req) {
               case req_t::produce: {
                   auto res = co_await qm.record_produce_tp_and_throttle(
-                    fixed_user, client_ids[i], 1, now);
+                    users[i], client_ids[i], 1, now);
                   perf_tests::do_not_optimize(res);
                   break;
               }
               case req_t::fetch: {
                   auto res = co_await qm.throttle_fetch_tp(
-                    fixed_user, client_ids[i], now);
+                    users[i], client_ids[i], now);
                   perf_tests::do_not_optimize(res);
-                  co_await qm.record_fetch_tp(
-                    fixed_user, client_ids[i], 1, now);
+                  co_await qm.record_fetch_tp(users[i], client_ids[i], 1, now);
                   break;
               }
               }
@@ -259,6 +281,26 @@ PERF_TEST_CN(latency_group, existing_client_produce_100_others) {
       });
 }
 
+PERF_TEST_CN(latency_group, existing_user_produce_100_others) {
+    return run_latency_test(
+      latency_test_case{
+        .is_new_key = false,
+        .req = req_t::produce,
+        .n_other_keys = 100,
+        .on_shard_0 = true,
+        .quotas = quota_t::user});
+}
+
+PERF_TEST_CN(latency_group, existing_user_client_produce_100_others) {
+    return run_latency_test(
+      latency_test_case{
+        .is_new_key = false,
+        .req = req_t::produce,
+        .n_other_keys = 100,
+        .on_shard_0 = true,
+        .quotas = quota_t::user_client_id});
+}
+
 PERF_TEST_CN(latency_group, existing_client_fetch_100_others) {
     return run_latency_test(
       latency_test_case{
@@ -267,6 +309,26 @@ PERF_TEST_CN(latency_group, existing_client_fetch_100_others) {
         .n_other_keys = 100,
         .on_shard_0 = true,
       });
+}
+
+PERF_TEST_CN(latency_group, existing_user_fetch_100_others) {
+    return run_latency_test(
+      latency_test_case{
+        .is_new_key = false,
+        .req = req_t::fetch,
+        .n_other_keys = 100,
+        .on_shard_0 = true,
+        .quotas = quota_t::user});
+}
+
+PERF_TEST_CN(latency_group, existing_user_client_fetch_100_others) {
+    return run_latency_test(
+      latency_test_case{
+        .is_new_key = false,
+        .req = req_t::fetch,
+        .n_other_keys = 100,
+        .on_shard_0 = true,
+        .quotas = quota_t::user_client_id});
 }
 
 PERF_TEST_CN(latency_group, new_client_produce_100_others) {
@@ -279,6 +341,26 @@ PERF_TEST_CN(latency_group, new_client_produce_100_others) {
       });
 }
 
+PERF_TEST_CN(latency_group, new_user_produce_100_others) {
+    return run_latency_test(
+      latency_test_case{
+        .is_new_key = true,
+        .req = req_t::produce,
+        .n_other_keys = 100,
+        .on_shard_0 = true,
+        .quotas = quota_t::user});
+}
+
+PERF_TEST_CN(latency_group, new_user_client_produce_100_others) {
+    return run_latency_test(
+      latency_test_case{
+        .is_new_key = true,
+        .req = req_t::produce,
+        .n_other_keys = 100,
+        .on_shard_0 = true,
+        .quotas = quota_t::user_client_id});
+}
+
 PERF_TEST_CN(latency_group, new_client_fetch_100_others) {
     return run_latency_test(
       latency_test_case{
@@ -287,6 +369,26 @@ PERF_TEST_CN(latency_group, new_client_fetch_100_others) {
         .n_other_keys = 100,
         .on_shard_0 = true,
       });
+}
+
+PERF_TEST_CN(latency_group, new_user_fetch_100_others) {
+    return run_latency_test(
+      latency_test_case{
+        .is_new_key = true,
+        .req = req_t::fetch,
+        .n_other_keys = 100,
+        .on_shard_0 = true,
+        .quotas = quota_t::user});
+}
+
+PERF_TEST_CN(latency_group, new_user_client_fetch_100_others) {
+    return run_latency_test(
+      latency_test_case{
+        .is_new_key = true,
+        .req = req_t::fetch,
+        .n_other_keys = 100,
+        .on_shard_0 = true,
+        .quotas = quota_t::user_client_id});
 }
 
 PERF_TEST_CN(latency_group, existing_client_produce_1000_others) {

--- a/src/v/kafka/server/tests/quota_manager_test.cc
+++ b/src/v/kafka/server/tests/quota_manager_test.cc
@@ -23,12 +23,16 @@
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include <array>
+#include <chrono>
+
 using namespace std::chrono_literals;
 using cluster::client_quota::entity_key;
 using cluster::client_quota::entity_value;
 
 static const auto default_key = entity_key(
   entity_key::client_id_default_match{});
+static const auto user = "alice";
 static const auto cid = "franz-go";
 static const auto franz_go_key = entity_key{
   entity_key::client_id_prefix_match{"franz-go"}};
@@ -89,8 +93,8 @@ SEASTAR_THREAD_TEST_CASE(quota_manager_fetch_no_throttling) {
     const auto now = quota_manager::clock::now();
 
     // Test that if fetch throttling is disabled, we don't throttle
-    qm.record_fetch_tp(cid, 10000000000000, now).get();
-    auto delay = qm.throttle_fetch_tp(cid, now).get();
+    qm.record_fetch_tp(user, cid, 10000000000000, now).get();
+    auto delay = qm.throttle_fetch_tp(user, cid, now).get();
 
     BOOST_CHECK_EQUAL(0ms, delay);
 }
@@ -108,22 +112,22 @@ SEASTAR_THREAD_TEST_CASE(quota_manager_fetch_throttling) {
     auto now = quota_manager::clock::now();
 
     // Test that below the fetch quota we don't throttle
-    qm.record_fetch_tp(cid, 99, now).get();
-    auto delay = qm.throttle_fetch_tp(cid, now).get();
+    qm.record_fetch_tp(user, cid, 99, now).get();
+    auto delay = qm.throttle_fetch_tp(user, cid, now).get();
 
     BOOST_CHECK_EQUAL(delay, 0ms);
 
     // Test that above the fetch quota we throttle
-    qm.record_fetch_tp(cid, 10, now).get();
-    delay = qm.throttle_fetch_tp(cid, now).get();
+    qm.record_fetch_tp(user, cid, 10, now).get();
+    delay = qm.throttle_fetch_tp(user, cid, now).get();
 
     BOOST_CHECK_GT(delay, 0ms);
 
     // Test that once we wait out the throttling delay, we don't
     // throttle again (as long as we stay under the limit)
     now += 1s;
-    qm.record_fetch_tp(cid, 10, now).get();
-    delay = qm.throttle_fetch_tp(cid, now).get();
+    qm.record_fetch_tp(user, cid, 10, now).get();
+    delay = qm.throttle_fetch_tp(user, cid, now).get();
 
     BOOST_CHECK_EQUAL(delay, 0ms);
 }
@@ -152,9 +156,9 @@ SEASTAR_THREAD_TEST_CASE(quota_manager_fetch_stress_test) {
         ss::coroutine::lambda([](quota_manager& qm) -> ss::future<> {
             for (size_t i = 0; i < 1000; ++i) {
                 co_await qm.record_fetch_tp(
-                  cid, 1, quota_manager::clock::now());
+                  user, cid, 1, quota_manager::clock::now());
                 auto delay [[maybe_unused]] = co_await qm.throttle_fetch_tp(
-                  cid, quota_manager::clock::now());
+                  user, cid, quota_manager::clock::now());
                 co_await ss::maybe_yield();
             }
         }))
@@ -173,9 +177,11 @@ SEASTAR_THREAD_TEST_CASE(static_config_test) {
 
     {
         ss::sstring client_id = "franz-go";
-        f.sqm.local().record_fetch_tp(client_id, 1, now).get();
-        f.sqm.local().record_produce_tp_and_throttle(client_id, 1, now).get();
-        f.sqm.local().record_partition_mutations(client_id, 1, now).get();
+        f.sqm.local().record_fetch_tp(user, client_id, 1, now).get();
+        f.sqm.local()
+          .record_produce_tp_and_throttle(user, client_id, 1, now)
+          .get();
+        f.sqm.local().record_partition_mutations(user, client_id, 1, now).get();
         auto it = buckets_map->find(k_group_name{client_id});
         BOOST_REQUIRE(it != buckets_map->end());
         BOOST_REQUIRE(it->second->tp_produce_rate.has_value());
@@ -186,9 +192,11 @@ SEASTAR_THREAD_TEST_CASE(static_config_test) {
     }
     {
         ss::sstring client_id = "not-franz-go";
-        f.sqm.local().record_fetch_tp(client_id, 1, now).get();
-        f.sqm.local().record_produce_tp_and_throttle(client_id, 1, now).get();
-        f.sqm.local().record_partition_mutations(client_id, 1, now).get();
+        f.sqm.local().record_fetch_tp(user, client_id, 1, now).get();
+        f.sqm.local()
+          .record_produce_tp_and_throttle(user, client_id, 1, now)
+          .get();
+        f.sqm.local().record_partition_mutations(user, client_id, 1, now).get();
         auto it = buckets_map->find(k_group_name{client_id});
         BOOST_REQUIRE(it != buckets_map->end());
         BOOST_REQUIRE(it->second->tp_produce_rate.has_value());
@@ -199,9 +207,11 @@ SEASTAR_THREAD_TEST_CASE(static_config_test) {
     }
     {
         ss::sstring client_id = "unconfigured";
-        f.sqm.local().record_fetch_tp(client_id, 1, now).get();
-        f.sqm.local().record_produce_tp_and_throttle(client_id, 1, now).get();
-        f.sqm.local().record_partition_mutations(client_id, 1, now).get();
+        f.sqm.local().record_fetch_tp(user, client_id, 1, now).get();
+        f.sqm.local()
+          .record_produce_tp_and_throttle(user, client_id, 1, now)
+          .get();
+        f.sqm.local().record_partition_mutations(user, client_id, 1, now).get();
         auto it = buckets_map->find(k_client_id{client_id});
         BOOST_REQUIRE(it != buckets_map->end());
         BOOST_REQUIRE(it->second->tp_produce_rate.has_value());
@@ -225,9 +235,9 @@ SEASTAR_THREAD_TEST_CASE(update_test) {
     {
         // Update fetch config
         ss::sstring client_id = "franz-go";
-        f.sqm.local().record_fetch_tp(client_id, 8194, now).get();
+        f.sqm.local().record_fetch_tp(user, client_id, 8194, now).get();
         f.sqm.local()
-          .record_produce_tp_and_throttle(client_id, 8192, now)
+          .record_produce_tp_and_throttle(user, client_id, 8192, now)
           .get();
 
         // Increment the franz-go and not-franz-go group fetch quotas
@@ -260,7 +270,7 @@ SEASTAR_THREAD_TEST_CASE(update_test) {
         // Check produce is the same bucket
         BOOST_REQUIRE(it->second->tp_produce_rate.has_value());
         auto delay = f.sqm.local()
-                       .record_produce_tp_and_throttle(client_id, 1, now)
+                       .record_produce_tp_and_throttle(user, client_id, 1, now)
                        .get();
         BOOST_CHECK_EQUAL(delay / 1ms, 1000);
     }
@@ -268,9 +278,9 @@ SEASTAR_THREAD_TEST_CASE(update_test) {
     {
         // Remove produce config
         ss::sstring client_id = "franz-go";
-        f.sqm.local().record_fetch_tp(client_id, 8196, now).get();
+        f.sqm.local().record_fetch_tp(user, client_id, 8196, now).get();
         f.sqm.local()
-          .record_produce_tp_and_throttle(client_id, 8192, now)
+          .record_produce_tp_and_throttle(user, client_id, 8192, now)
           .get();
 
         auto franz_go_values = f.quota_store.local().get_quota(franz_go_key);
@@ -290,12 +300,13 @@ SEASTAR_THREAD_TEST_CASE(update_test) {
 
         // Check fetch is the same bucket
         BOOST_REQUIRE(it->second->tp_fetch_rate.has_value());
-        auto delay = f.sqm.local().throttle_fetch_tp(client_id, now).get();
+        auto delay
+          = f.sqm.local().throttle_fetch_tp(user, client_id, now).get();
         BOOST_CHECK_EQUAL(delay / 1ms, 1000);
 
         // Check the new produce rate now applies
         f.sqm.local()
-          .record_produce_tp_and_throttle(client_id, 8192, now)
+          .record_produce_tp_and_throttle(user, client_id, 8192, now)
           .get();
         auto client_it = buckets_map->find(k_client_id{client_id});
         BOOST_REQUIRE(client_it != buckets_map->end());
@@ -318,6 +329,178 @@ SEASTAR_THREAD_TEST_CASE(update_test) {
         BOOST_REQUIRE(it != buckets_map->end());
         BOOST_REQUIRE(it->second->tp_fetch_rate.has_value());
         BOOST_CHECK_EQUAL(it->second->tp_fetch_rate->rate(), 16384);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_increasing_specificity) {
+    fixture f;
+
+    using clock = quota_manager::clock;
+
+    auto& buckets_map = f.sqm.local().get_global_map_for_testing();
+    auto now = clock::now();
+
+    struct request_size {
+        uint64_t produce_bytes = 1;
+        uint64_t consume_bytes = 1;
+        uint32_t n_mutations = 1;
+    };
+
+    struct delays {
+        clock::duration produce_delay;
+        clock::duration consume_delay;
+        std::chrono::milliseconds pm_delay;
+    };
+
+    const auto make_size = [](uint32_t i) {
+        return request_size{
+          .produce_bytes = i + 1,
+          .consume_bytes = i + 2,
+          .n_mutations = i + 3,
+        };
+    };
+
+    const auto make_records = [&f] [[nodiscard]] (
+                                const quota_manager::clock::time_point& now,
+                                request_size r = {}) {
+        auto produce_delay = f.sqm.local()
+                               .record_produce_tp_and_throttle(
+                                 user, cid, r.produce_bytes, now)
+                               .get();
+
+        f.sqm.local().record_fetch_tp(user, cid, r.consume_bytes, now).get();
+        auto consume_delay
+          = f.sqm.local().throttle_fetch_tp(user, cid, now).get();
+
+        // partition mutations throttles after we have exceeded the capacity.
+        // Add a dummy second call to simplify testing code below
+        f.sqm.local()
+          .record_partition_mutations(user, cid, r.n_mutations, now)
+          .get();
+        auto pm_delay
+          = f.sqm.local().record_partition_mutations(user, cid, 0, now).get();
+        return delays{produce_delay, consume_delay, pm_delay};
+    };
+
+    // Sanity: no quotas
+    const delays d = make_records(now);
+    BOOST_REQUIRE(buckets_map->empty());
+    BOOST_REQUIRE_EQUAL(d.produce_delay, 0ms);
+    BOOST_REQUIRE_EQUAL(d.consume_delay, 0ms);
+    BOOST_REQUIRE_EQUAL(d.pm_delay, 0ms);
+
+    auto kcid = k_client_id{cid};
+    auto kgroup = k_group_name{cid};
+    auto kuser = k_user{user};
+
+    auto default_cid_match = entity_key::client_id_default_match{};
+    auto prefix_cid_match = entity_key::client_id_prefix_match{cid};
+    auto exact_cid_match = entity_key::client_id_match{cid};
+
+    auto default_user_match = entity_key::user_default_match{};
+    auto exact_user_match = entity_key::user_match{user};
+
+    struct test_case {
+        entity_key ekey;
+        tracker_key tkey;
+    };
+
+    const auto test_cases = std::to_array<test_case>({
+      {
+        .ekey{default_cid_match},
+        .tkey{kcid},
+      },
+      {
+        .ekey{prefix_cid_match},
+        .tkey{kgroup},
+      },
+      {
+        .ekey{exact_cid_match},
+        .tkey{kcid},
+      },
+      {
+        .ekey{default_user_match},
+        .tkey{kuser},
+      },
+      {
+        .ekey{default_user_match, default_cid_match},
+        .tkey{std::make_pair(kuser, kcid)},
+      },
+      {
+        .ekey{default_user_match, prefix_cid_match},
+        .tkey{std::make_pair(kuser, kgroup)},
+      },
+      {
+        .ekey{default_user_match, exact_cid_match},
+        .tkey{std::make_pair(kuser, kcid)},
+      },
+      {
+        .ekey{exact_user_match},
+        .tkey{kuser},
+      },
+      {
+        .ekey{exact_user_match, default_cid_match},
+        .tkey{std::make_pair(kuser, kcid)},
+      },
+      {
+        .ekey{exact_user_match, prefix_cid_match},
+        .tkey{std::make_pair(kuser, kgroup)},
+      },
+      {
+        .ekey{exact_user_match, exact_cid_match},
+        .tkey{std::make_pair(kuser, kcid)},
+      },
+    });
+
+    for (size_t i = 0; i < test_cases.size(); ++i) {
+        const auto& tc = test_cases[i];
+        request_size max_rate = make_size(10 * i);
+
+        // Refresh buckets: The operations bellow use 2x the quota for each key.
+        // By going 5 seconds in the future, buckets are bound to be full again
+        now += 5s;
+        BOOST_TEST_CONTEXT(i, tc.ekey, tc.tkey) {
+            auto quota = entity_value{
+              .producer_byte_rate = max_rate.produce_bytes,
+              .consumer_byte_rate = max_rate.consume_bytes,
+              .controller_mutation_rate = max_rate.n_mutations,
+            };
+            f.quota_store.local().set_quota(tc.ekey, quota);
+
+            // Record zero bytes to update the global map to new rates
+            const delays d = make_records(now, {0, 0, 0});
+            // Sanity check: Zero byte-requests should not be throttled
+            BOOST_REQUIRE_EQUAL(d.produce_delay, 0ms);
+            BOOST_REQUIRE_EQUAL(d.consume_delay, 0ms);
+            BOOST_REQUIRE_EQUAL(d.pm_delay, 0ms);
+
+            // Verify that all rates have been updated
+            auto it = buckets_map->find(tc.tkey);
+            BOOST_REQUIRE(it != buckets_map->end());
+
+            auto& produce_rate = it->second->tp_produce_rate;
+            BOOST_REQUIRE(produce_rate.has_value());
+            BOOST_REQUIRE_EQUAL(produce_rate->rate(), max_rate.produce_bytes);
+
+            auto& fetch_rate = it->second->tp_fetch_rate;
+            BOOST_REQUIRE(fetch_rate.has_value());
+            BOOST_REQUIRE_EQUAL(fetch_rate->rate(), max_rate.consume_bytes);
+
+            auto& pm_rate = it->second->pm_rate;
+            BOOST_REQUIRE(pm_rate.has_value());
+            BOOST_REQUIRE_EQUAL(pm_rate->rate(), max_rate.n_mutations);
+
+            // Requesting double the quota should end up with 1s throttling time
+            delays throttle = make_records(
+              now,
+              {2 * max_rate.produce_bytes,
+               2 * max_rate.consume_bytes,
+               2 * max_rate.n_mutations});
+
+            BOOST_REQUIRE_EQUAL(throttle.produce_delay, 1s);
+            BOOST_REQUIRE_EQUAL(throttle.consume_delay, 1s);
+            BOOST_REQUIRE_EQUAL(throttle.pm_delay, 1s);
+        }
     }
 }
 } // namespace kafka


### PR DESCRIPTION
Implement (partially): [CORE-15271](https://redpandadata.atlassian.net/browse/CORE-15271)

Extends the quota_manager api to accept a `user` argument and forward it to `client_quota_translator`.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-15271]: https://redpandadata.atlassian.net/browse/CORE-15271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ