### PR TITLE
cloud_io: handle key_not_found when listing bucket objects

### DIFF
--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -1132,11 +1132,8 @@ ss::future<list_result> remote::list_objects(
             result = cloud_storage_clients::error_outcome::fail;
             break;
         case cloud_storage_clients::error_outcome::key_not_found:
-            vassert(
-              false,
-              "Unexpected key_not_found outcome received when listing bucket "
-              "{}",
-              bucket);
+            result = cloud_storage_clients::error_outcome::fail;
+            break;
         case cloud_storage_clients::error_outcome::authentication_failed:
             result = cloud_storage_clients::error_outcome::fail;
             break;


### PR DESCRIPTION
A 404 response (mapped to key_not_found) can occur when cloud storage is misconfigured. Rather than crashing with an assertion failure, propagate the failure as a result to allow graceful error handling.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
