### PR TITLE
CORE-15275 SR Context: implement a feature flag for subject parsing

### DIFF
--- a/src/v/config/BUILD
+++ b/src/v/config/BUILD
@@ -1,6 +1,16 @@
 load("//bazel:build.bzl", "redpanda_cc_library")
 
 redpanda_cc_library(
+    name = "startup_config",
+    hdrs = ["startup_config.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "config",
     srcs = [
         "base_property.cc",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3784,6 +3784,15 @@ configuration::configuration()
        .visibility = visibility::user,
        .aliases = {"schema_registry_normalize_on_startup"}},
       false)
+  , schema_registry_enable_qualified_subjects(
+      *this,
+      "schema_registry_enable_qualified_subjects",
+      "Enable parsing of qualified subject syntax (:.context:subject). "
+      "When false, subjects are treated literally, as subjects in the default "
+      "context. When true, qualified syntax is parsed to extract context and "
+      "subject.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      false)
   , schema_registry_protobuf_renderer_v2(
       *this, "schema_registry_protobuf_renderer_v2")
   , pp_sr_smp_max_non_local_requests(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -707,6 +707,7 @@ struct configuration final : public config_store {
 
     enterprise<property<bool>> schema_registry_enable_authorization;
     property<bool> schema_registry_always_normalize;
+    property<bool> schema_registry_enable_qualified_subjects;
     deprecated_property schema_registry_protobuf_renderer_v2;
     property<std::optional<uint32_t>> pp_sr_smp_max_non_local_requests;
     bounded_property<size_t> max_in_flight_schema_registry_requests_per_shard;

--- a/src/v/config/startup_config.h
+++ b/src/v/config/startup_config.h
@@ -1,0 +1,79 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "base/vassert.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/smp.hh>
+
+#include <optional>
+
+namespace config {
+
+/// A config value captured at startup that remains fixed until explicitly
+/// reset. Stored in thread_local storage on each shard for fast local access.
+///
+/// This is useful for config values that:
+/// - Must be consistent throughout a service's lifetime
+/// - Should only change on restart (even if the underlying config can change)
+///
+/// Usage:
+///   using my_feature = startup_config<bool, struct my_feature_tag>;
+///
+///   // In start():
+///   co_await my_feature::initialize(config::shard_local_cfg().my_feature());
+///
+///   // Anywhere:
+///   if (my_feature::get()) { ... }
+///
+///   // In stop(), when stop()/start() cycles are possible:
+///   co_await my_feature::reset();
+///
+template<typename T, typename Tag>
+class startup_config {
+public:
+    /// Initialize the value on all shards. Must be called before get().
+    static ss::future<> initialize(T value) {
+        return ss::smp::invoke_on_all([value] { set_local(value); });
+    }
+
+    /// Set the value on the current shard only. Useful for testing.
+    static void set_local(T value) {
+        vassert(!_value.has_value(), "startup_config already initialized");
+        _value = value;
+    }
+
+    /// Get the value. Asserts if not initialized.
+    static T get() {
+        vassert(_value.has_value(), "startup_config not initialized");
+        return *_value;
+    }
+
+    /// Check if initialized on this shard.
+    static bool is_initialized() { return _value.has_value(); }
+
+    /// Reset on all shards, allowing re-initialization on restart.
+    static ss::future<> reset() {
+        return ss::smp::invoke_on_all([] { reset_local(); });
+    }
+
+    /// Reset on the current shard only. Useful for testing.
+    static void reset_local() {
+        vassert(_value.has_value(), "startup_config not initialized");
+        _value.reset();
+    }
+
+private:
+    static inline thread_local std::optional<T> _value;
+};
+
+} // namespace config

--- a/src/v/config/tests/BUILD
+++ b/src/v/config/tests/BUILD
@@ -250,3 +250,17 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "startup_config_test",
+    timeout = "short",
+    srcs = [
+        "startup_config_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/config:startup_config",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/config/tests/startup_config_test.cc
+++ b/src/v/config/tests/startup_config_test.cc
@@ -1,0 +1,67 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/startup_config.h"
+
+#include <gtest/gtest.h>
+
+namespace config {
+
+using test_bool_config = startup_config<bool, struct test_bool_tag>;
+using another_test_bool_config
+  = startup_config<bool, struct another_test_bool_config_tag>;
+
+class StartupConfigTest : public ::testing::Test {
+protected:
+    void TearDown() override {
+        // Reset configs after each test
+        if (test_bool_config::is_initialized()) {
+            test_bool_config::reset_local();
+        }
+        if (another_test_bool_config::is_initialized()) {
+            another_test_bool_config::reset_local();
+        }
+    }
+};
+
+TEST_F(StartupConfigTest, InitializeAndGet) {
+    test_bool_config::set_local(true);
+    EXPECT_TRUE(test_bool_config::is_initialized());
+    EXPECT_TRUE(test_bool_config::get());
+
+    test_bool_config::reset_local();
+    test_bool_config::set_local(false);
+    EXPECT_FALSE(test_bool_config::get());
+}
+
+TEST_F(StartupConfigTest, ResetAllowsReinitialization) {
+    test_bool_config::set_local(true);
+    EXPECT_TRUE(test_bool_config::get());
+
+    test_bool_config::reset_local();
+    EXPECT_FALSE(test_bool_config::is_initialized());
+
+    test_bool_config::set_local(false);
+    EXPECT_FALSE(test_bool_config::get());
+}
+
+TEST_F(StartupConfigTest, DifferentTagsHaveIndependentStorage) {
+    test_bool_config::set_local(true);
+    another_test_bool_config::set_local(false);
+
+    EXPECT_TRUE(test_bool_config::get());
+    EXPECT_EQ(another_test_bool_config::get(), false);
+
+    test_bool_config::reset_local();
+    EXPECT_FALSE(test_bool_config::is_initialized());
+    EXPECT_TRUE(another_test_bool_config::is_initialized());
+    EXPECT_EQ(another_test_bool_config::get(), false);
+}
+
+} // namespace config

--- a/src/v/pandaproxy/schema_registry/BUILD
+++ b/src/v/pandaproxy/schema_registry/BUILD
@@ -56,6 +56,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",
+        "//src/v/config:startup_config",
         "//src/v/json",
         "//src/v/kafka/protocol",
         "//src/v/utils:named_type",
@@ -246,6 +247,7 @@ redpanda_cc_library(
         ":rjson",
         ":subject_name_strategy",
         ":types",
+        "//src/v/config:startup_config",
         "//src/v/kafka/client",
     ],
 )

--- a/src/v/pandaproxy/schema_registry/BUILD
+++ b/src/v/pandaproxy/schema_registry/BUILD
@@ -156,6 +156,7 @@ redpanda_cc_library(
         ":types",
         "//src/v/base",
         "//src/v/config",
+        "//src/v/config:startup_config",
         "//src/v/kafka/client",
         "//src/v/kafka/client:config_utils",
         "//src/v/kafka/client:configuration",
@@ -276,6 +277,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":server",
+        "//src/v/config:startup_config",
         "//src/v/pandaproxy:core",
     ],
 )

--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -68,6 +68,13 @@ api::api(
 api::~api() noexcept = default;
 
 ss::future<> api::start() {
+    co_await enable_qualified_subjects::initialize(
+      config::shard_local_cfg().schema_registry_enable_qualified_subjects());
+    vlog(
+      srlog.info,
+      "Qualified subject parsing enabled: {}",
+      enable_qualified_subjects::get());
+
     _store = std::make_unique<sharded_store>();
     co_await _store->start(is_mutable(_cfg.mode_mutability), _sg);
     co_await _schema_id_validation_probe.start();
@@ -123,6 +130,7 @@ ss::future<> api::stop() {
     if (_store) {
         co_await _store->stop();
     }
+    co_await enable_qualified_subjects::reset();
     vlog(srlog.debug, "Stopped schema registry API...");
 }
 

--- a/src/v/pandaproxy/schema_registry/requests/test/post_subject_versions.cc
+++ b/src/v/pandaproxy/schema_registry/requests/test/post_subject_versions.cc
@@ -13,6 +13,7 @@
 #include "pandaproxy/schema_registry/types.h"
 
 #include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
 
 #include <fmt/ostream.h>
 
@@ -25,6 +26,9 @@ using parse_result
   = pps::post_subject_versions_request_handler<>::rjson_parse_result;
 
 SEASTAR_THREAD_TEST_CASE(test_post_subject_versions_parser) {
+    pps::enable_qualified_subjects::set_local(true);
+    auto reset_flag = ss::defer(
+      [] { pps::enable_qualified_subjects::reset_local(); });
     const ss::sstring escaped_schema_def{
       R"({\"type\":\"record\",\"name\":\"test\",\"fields\":[{\"type\":\"string\",\"name\":\"field1\"},{\"type\":\"com.acme.Referenced\",\"name\":\"int\"}]})"};
     const pps::schema_definition expected_schema_def{
@@ -81,6 +85,10 @@ SEASTAR_THREAD_TEST_CASE(test_post_subject_versions_parser) {
 }
 
 BOOST_AUTO_TEST_CASE(test_post_subject_versions_serde_metadata) {
+    pps::enable_qualified_subjects::set_local(true);
+    auto reset_flag = ss::defer(
+      [] { pps::enable_qualified_subjects::reset_local(); });
+
     const pps::subject sub{"test_subject"};
     {
         constexpr std::string_view no_metadata{

--- a/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
@@ -87,6 +87,10 @@ inline model::record_batch make_delete_subject_permanently_batch(
 }
 
 SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
+    pps::enable_qualified_subjects::set_local(true);
+    auto reset_flag = ss::defer(
+      [] { pps::enable_qualified_subjects::reset_local(); });
+
     pps::sharded_store s;
     s.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
     auto stop_store = ss::defer([&s]() { s.stop().get(); });
@@ -209,6 +213,10 @@ model::record_batch as_record_batch(Key key) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_consume_to_store_after_compaction) {
+    pps::enable_qualified_subjects::set_local(true);
+    auto reset_flag = ss::defer(
+      [] { pps::enable_qualified_subjects::reset_local(); });
+
     pps::sharded_store s;
     s.start(pps::is_mutable::no, ss::default_smp_service_group()).get();
     auto stop_store = ss::defer([&s]() { s.stop().get(); });
@@ -265,6 +273,10 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store_after_compaction) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_writes_disabled) {
+    pps::enable_qualified_subjects::set_local(true);
+    auto reset_flag = ss::defer(
+      [] { pps::enable_qualified_subjects::reset_local(); });
+
     pps::sharded_store s;
     s.start(pps::is_mutable::no, ss::default_smp_service_group()).get();
     auto stop_store = ss::defer([&s]() { s.stop().get(); });

--- a/src/v/pandaproxy/schema_registry/test/context_subject.cc
+++ b/src/v/pandaproxy/schema_registry/test/context_subject.cc
@@ -13,7 +13,13 @@
 
 namespace pandaproxy::schema_registry {
 
-TEST(ContextSubjectTest, FromString) {
+class ContextSubjectTest : public ::testing::Test {
+protected:
+    void SetUp() override { enable_qualified_subjects::set_local(true); }
+    void TearDown() override { enable_qualified_subjects::reset_local(); }
+};
+
+TEST_F(ContextSubjectTest, FromString) {
     // Unqualified subjects use default context
     EXPECT_EQ(
       context_subject::from_string("my-topic"),
@@ -48,7 +54,7 @@ TEST(ContextSubjectTest, FromString) {
       (context_subject{default_context, subject{":.no-second-colon"}}));
 }
 
-TEST(ContextSubjectTest, ToStringAndRoundTrip) {
+TEST_F(ContextSubjectTest, ToStringAndRoundTrip) {
     // Default context: just the subject
     auto unqualified = context_subject{default_context, subject{"my-topic"}};
     EXPECT_EQ(unqualified.to_string(), "my-topic");
@@ -64,6 +70,42 @@ TEST(ContextSubjectTest, ToStringAndRoundTrip) {
     auto ctx_only = context_subject{context{".my-ctx"}, subject{""}};
     EXPECT_EQ(ctx_only.to_string(), ":.my-ctx:");
     EXPECT_EQ(context_subject::from_string(ctx_only.to_string()), ctx_only);
+}
+
+TEST_F(ContextSubjectTest, FlagOffTreatsQualifiedAsLiteral) {
+    enable_qualified_subjects::reset_local();
+    enable_qualified_subjects::set_local(false);
+
+    auto ctx_sub = context_subject::from_string(":.myctx:my-topic");
+
+    // With flag off, the entire string is the subject in default context
+    EXPECT_EQ(ctx_sub.ctx, default_context);
+    EXPECT_EQ(ctx_sub.sub(), ":.myctx:my-topic");
+}
+
+TEST_F(ContextSubjectTest, FlagOnParsesQualifiedSyntax) {
+    auto ctx_sub = context_subject::from_string(":.myctx:my-topic");
+
+    // With flag on, qualified syntax is parsed
+    EXPECT_EQ(ctx_sub.ctx(), ".myctx");
+    EXPECT_EQ(ctx_sub.sub(), "my-topic");
+}
+
+TEST_F(ContextSubjectTest, FlagOnUnqualifiedUsesDefaultContext) {
+    auto ctx_sub = context_subject::from_string("plain-topic");
+
+    EXPECT_EQ(ctx_sub.ctx, default_context);
+    EXPECT_EQ(ctx_sub.sub(), "plain-topic");
+}
+
+TEST_F(ContextSubjectTest, FlagOffUnqualifiedUsesDefaultContext) {
+    enable_qualified_subjects::reset_local();
+    enable_qualified_subjects::set_local(false);
+
+    auto ctx_sub = context_subject::from_string("plain-topic");
+
+    EXPECT_EQ(ctx_sub.ctx, default_context);
+    EXPECT_EQ(ctx_sub.sub(), "plain-topic");
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -128,7 +128,13 @@ const auto expected_delete_subject_value = delete_subject_value{
 
 } // namespace
 
-TEST(StorageTest, Serde) {
+class StorageTest : public ::testing::Test {
+protected:
+    void SetUp() override { enable_qualified_subjects::set_local(true); }
+    void TearDown() override { enable_qualified_subjects::reset_local(); }
+};
+
+TEST_F(StorageTest, Serde) {
     {
         auto key = ppj::impl::rjson_parse(
           schema_key_sv.data(), schema_key_handler<>{});
@@ -202,7 +208,7 @@ TEST(StorageTest, Serde) {
     }
 }
 
-TEST(StorageTest, SerdeMetadata) {
+TEST_F(StorageTest, SerdeMetadata) {
     const auto make_schema = [](std::optional<std::string_view> metadata) {
         constexpr std::string_view fmt_schema{
           R"({{
@@ -279,7 +285,7 @@ TEST(StorageTest, SerdeMetadata) {
     }
 }
 
-TEST(StorageTest, SerdeContextSubject) {
+TEST_F(StorageTest, SerdeContextSubject) {
     // Test schema_key with context_subject (qualified format)
     {
         constexpr std::string_view schema_key_ctx_sv{

--- a/src/v/pandaproxy/schema_registry/test/store_fixture.cc
+++ b/src/v/pandaproxy/schema_registry/test/store_fixture.cc
@@ -9,11 +9,14 @@
 
 #include "pandaproxy/schema_registry/test/store_fixture.h"
 
+#include "pandaproxy/schema_registry/types.h"
+
 #include <seastar/core/smp.hh>
 
 namespace pandaproxy::schema_registry::test_utils {
 
 store_fixture::store_fixture() {
+    enable_qualified_subjects::set_local(true);
     _smp_svc_group = std::make_unique<ss::smp_service_group>(
       ss::create_smp_service_group(ss::smp_service_group_config{}).get());
     _store.start(is_mutable::yes, *_smp_svc_group).get();
@@ -23,6 +26,7 @@ store_fixture::~store_fixture() {
     _store.stop().get();
     ss::destroy_smp_service_group(*_smp_svc_group).get();
     _smp_svc_group.reset();
+    enable_qualified_subjects::reset_local();
 }
 
 schema_id store_fixture::insert(

--- a/src/v/pandaproxy/schema_registry/types.cc
+++ b/src/v/pandaproxy/schema_registry/types.cc
@@ -83,4 +83,22 @@ fmt::iterator schema_metadata::format_to(fmt::iterator it) const {
     return fmt::format_to(it, "{{ properties: {{ {} }} }}", properties);
 }
 
+context_subject context_subject::from_string(std::string_view input) {
+    // Check for qualified syntax: starts with ":."
+    if (input.starts_with(":.")) {
+        // Find the second colon that separates context from subject
+        auto second_colon = input.find(':', 2);
+
+        if (second_colon != std::string_view::npos) {
+            auto ctx_str = input.substr(1, second_colon - 1);
+            auto sub_str = input.substr(second_colon + 1);
+
+            return context_subject{context{ctx_str}, subject{sub_str}};
+        }
+    }
+
+    // Default case: unqualified subject or invalid qualified syntax
+    return context_subject{default_context, subject{input}};
+}
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/types.cc
+++ b/src/v/pandaproxy/schema_registry/types.cc
@@ -84,6 +84,11 @@ fmt::iterator schema_metadata::format_to(fmt::iterator it) const {
 }
 
 context_subject context_subject::from_string(std::string_view input) {
+    // If qualified subject parsing is disabled, treat everything as literal
+    if (!enable_qualified_subjects::get()) {
+        return context_subject{default_context, subject{input}};
+    }
+
     // Check for qualified syntax: starts with ":."
     if (input.starts_with(":.")) {
         // Find the second colon that separates context from subject

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -14,6 +14,7 @@
 #include "absl/container/btree_map.h"
 #include "base/outcome.h"
 #include "base/seastarx.h"
+#include "config/startup_config.h"
 #include "container/chunked_vector.h"
 #include "kafka/protocol/errors.h"
 #include "model/fundamental.h"
@@ -135,6 +136,10 @@ using subject = named_type<ss::sstring, struct subject_tag>;
 /// separation, and so on. By default, schemas are stored under the "." context.
 using context = named_type<ss::sstring, struct context_tag>;
 inline const context default_context{"."};
+
+/// Whether qualified subject parsing is enabled. Captured at SR startup.
+using enable_qualified_subjects
+  = config::startup_config<bool, struct enable_qualified_subjects_tag>;
 
 // A subject bound to a context
 struct context_subject {

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -167,23 +167,7 @@ struct context_subject {
 
     /// Parse from qualified subject ":.context:subject" or unqualified
     /// "subject" (which uses the default context)
-    static context_subject from_string(std::string_view input) {
-        // Check for qualified syntax: starts with ":."
-        if (input.starts_with(":.")) {
-            // Find the second colon that separates context from subject
-            auto second_colon = input.find(':', 2);
-
-            if (second_colon != std::string_view::npos) {
-                auto ctx_str = input.substr(1, second_colon - 1);
-                auto sub_str = input.substr(second_colon + 1);
-
-                return context_subject{context{ctx_str}, subject{sub_str}};
-            }
-        }
-
-        // Default case: unqualified subject or invalid qualified syntax
-        return context_subject{default_context, subject{input}};
-    }
+    static context_subject from_string(std::string_view input);
 
     /// Format as qualified subject ":.context:subject" or "subject" if in the
     /// default context

--- a/src/v/security/tests/authorizer_test.cc
+++ b/src/v/security/tests/authorizer_test.cc
@@ -16,6 +16,8 @@
 #include "security/role_store.h"
 #include "utils/base64.h"
 
+#include <seastar/util/defer.hh>
+
 #include <boost/algorithm/string.hpp>
 #include <fmt/ostream.h>
 #include <gtest/gtest.h>
@@ -1915,6 +1917,10 @@ TEST(AUTHORIZER_TEST, role_authz_remove_binding_multiple_match) {
 
 TEST(AUTHORIZER_TEST, authz_filter_out_non_kafka_resources) {
     namespace ppsr = pandaproxy::schema_registry;
+    ppsr::enable_qualified_subjects::set_local(true);
+    auto reset_flag = ss::defer(
+      [] { ppsr::enable_qualified_subjects::reset_local(); });
+
     acl_principal user(principal_type::user, "alice");
     acl_host host("192.168.2.1");
 
@@ -3130,6 +3136,10 @@ TEST(AUTHORIZER_TEST, group_role_authz_implied_operations) {
 // Test ACL pattern types (prefix, literal, wildcard) for context subjects.
 TEST(AUTHORIZER_TEST, authz_sr_context_subject_patterns) {
     namespace ppsr = pandaproxy::schema_registry;
+    ppsr::enable_qualified_subjects::set_local(true);
+    auto reset_flag = ss::defer(
+      [] { ppsr::enable_qualified_subjects::reset_local(); });
+
     auto user = acl_principal{principal_type::user, "user"};
     auto host = acl_host{"192.168.2.1"};
 

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -3092,6 +3092,9 @@ class AuditLogTestSchemaRegistryACLs(AuditLogTestSchemaRegistryBase):
         - Context-level (e.g., /config/:.ctx:) uses sr_registry
         - Subject-level (e.g., /config/:.ctx:subject) uses sr_subject
         """
+        self.redpanda.set_cluster_config(
+            {"schema_registry_enable_qualified_subjects": True}, expect_restart=True
+        )
         self.setup_cluster()
 
         context_only = ":.staging:"

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -5002,7 +5002,10 @@ class SchemaRegistryContextTest(SchemaRegistryEndpoints):
         schema_registry_config = SchemaRegistryConfig()
         schema_registry_config.mode_mutability = True
         super().__init__(
-            context, schema_registry_config=schema_registry_config, **kwargs
+            context,
+            schema_registry_config=schema_registry_config,
+            extra_rp_conf={"schema_registry_enable_qualified_subjects": True},
+            **kwargs,
         )
 
     @cluster(num_nodes=1)

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -3770,6 +3770,37 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
 
         test_runner(test_subjects_subject_versions_version_schema)
 
+    @cluster(num_nodes=1)
+    def test_qualified_subjects_flag_off(self):
+        """
+        With enable_qualified_subjects off (default), the qualified syntax is not parsed, and all
+        subjects are treated as if they are in the default context.
+        """
+
+        # Register a schema in the default context first
+        result = self.sr_client.post_subjects_subject_versions(
+            subject="normal-subject", data=json.dumps({"schema": schema1_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["id"], 1)
+
+        # Register a DIFFERENT schema with qualified-looking subject name
+        # Flag OFF: Same context as above, so gets id=2 (shared counter)
+        # Flag ON: Would be in .ctx context with independent counter, gets id=1
+        # TODO: once implemented, we could make this test simpler by just using the `GET /contexts`
+        # API instead of using schema ID allocation behaviour to verify that these subjects land in
+        # different contexts.
+        qualified_subject = ":.ctx:my-subject"
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=qualified_subject, data=json.dumps({"schema": schema2_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(
+            result.json()["id"],
+            2,
+            "Expected id=2 proving shared counter with default context",
+        )
+
 
 class SchemaRegistryModeNotMutableTest(SchemaRegistryEndpoints):
     """

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1256,11 +1256,15 @@ class SchemaRegistryEndpoints(RedpandaTest):
         context: TestContext,
         schema_registry_config: SchemaRegistryConfig = SchemaRegistryConfig(),
         num_brokers: int = 3,
+        extra_rp_conf: Optional[dict[str, Any]] = None,
         **kwargs: Any,
     ):
+        merged_rp_conf = {"auto_create_topics_enabled": False}
+        if extra_rp_conf:
+            merged_rp_conf.update(extra_rp_conf)
         super(SchemaRegistryEndpoints, self).__init__(
             context,
-            extra_rp_conf={"auto_create_topics_enabled": False},
+            extra_rp_conf=merged_rp_conf,
             resource_settings=ResourceSettings(num_cpus=1),
             log_config=log_config,
             pandaproxy_config=PandaproxyConfig(),
@@ -1718,231 +1722,6 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             self.logger.debug(result_raw)
             assert result_raw.status_code == requests.codes.ok
             assert result_raw.json()["id"] == 1
-
-    @cluster(num_nodes=1)
-    def test_contexts(self):
-        """Verify context-aware endpoints work with qualified subjects."""
-
-        schema_data = json.dumps({"schema": schema1_def})
-        compat_schema_data = json.dumps({"schema": schema2_def})
-        ctx_subject = ":.ctx1:sub1"
-
-        # Register in context
-        result = self.sr_client.post_subjects_subject_versions(
-            subject=ctx_subject, data=schema_data
-        )
-        self.assert_equal(result.status_code, requests.codes.ok)
-
-        # Lookup in context
-        result = self.sr_client.post_subjects_subject(
-            subject=ctx_subject, data=schema_data
-        )
-        self.assert_equal(result.status_code, requests.codes.ok)
-
-        # Compatibility check in context
-        result = self.sr_client.post_compatibility_subject_version(
-            subject=ctx_subject, version="latest", data=compat_schema_data
-        )
-        self.assert_equal(result.status_code, requests.codes.ok)
-        self.assert_equal(result.json()["is_compatible"], True)
-
-        # List versions in context
-        result = self.sr_client.get_subjects_subject_versions(subject=ctx_subject)
-        self.assert_equal(result.status_code, requests.codes.ok)
-        self.assert_equal(result.json(), [1])
-
-        # Get specific version in context
-        result = self.sr_client.get_subjects_subject_versions_version(
-            subject=ctx_subject, version=1
-        )
-        self.assert_equal(result.status_code, requests.codes.ok)
-        self.assert_equal(result.json()["version"], 1)
-
-        # Get schema only for specific version in context
-        result = self.sr_client.get_subjects_subject_versions_version_schema(
-            subject=ctx_subject, version=1
-        )
-        self.assert_equal(result.status_code, requests.codes.ok)
-
-        # Get referenced-by in context (empty list, no references)
-        result = self.sr_client.get_subjects_subject_versions_version_referenced_by(
-            subject=ctx_subject, version=1
-        )
-        self.assert_equal(result.status_code, requests.codes.ok)
-        self.assert_equal(result.json(), [])
-
-        # Delete specific version in context
-        result = self.sr_client.delete_subject_version(subject=ctx_subject, version=1)
-        self.assert_equal(result.status_code, requests.codes.ok)
-        self.assert_equal(result.json(), 1)
-
-        # Delete subject in context (cleanup)
-        result = self.sr_client.delete_subject(subject=ctx_subject, permanent=True)
-        self.assert_equal(result.status_code, requests.codes.ok)
-
-    @cluster(num_nodes=1)
-    def test_context_isolation(self):
-        """Verify contexts are isolated: independent IDs, no cross-context lookups."""
-
-        # Register in default context
-        result = self.sr_client.post_subjects_subject_versions(
-            subject="sub1", data=json.dumps({"schema": schema1_def})
-        )
-        self.assert_equal(result.status_code, requests.codes.ok)
-        self.assert_equal(result.json()["id"], 1)
-
-        # Register same schema in .ctx1 - should get id=1 (independent counter)
-        result = self.sr_client.post_subjects_subject_versions(
-            subject=":.ctx1:sub1", data=json.dumps({"schema": schema2_def})
-        )
-        self.assert_equal(result.status_code, requests.codes.ok)
-        self.assert_equal(result.json()["id"], 1)
-
-        # Lookup schema in different context - should fail
-        result = self.sr_client.post_subjects_subject(
-            subject=":.ctx2:sub1", data=json.dumps({"schema": schema1_def})
-        )
-        self.assert_equal(result.status_code, requests.codes.not_found)
-
-    @cluster(num_nodes=1)
-    def test_context_references(self):
-        """Test schema references work with context-qualified subjects."""
-        # Test all schema types using existing test data
-        for schema_type in ["proto", "avro", "json"]:
-            base = base_schemas[schema_type]
-            dependent = dependent_schemas[schema_type]
-            ref_name = dependent["references"][0]["name"]
-
-            ctx = f"ctx-{schema_type}"
-            ctx_ref_subject = f":.{ctx}:base"
-            ctx_main_subject = f":.{ctx}:dependent"
-
-            # Register base schema in context
-            ref_data = json.dumps(
-                {"schema": base["schema"], "schemaType": base["type"]}
-            )
-            result = self.sr_client.post_subjects_subject_versions(
-                subject=ctx_ref_subject, data=ref_data
-            )
-            self.assert_equal(result.status_code, requests.codes.ok)
-
-            # Register dependent schema with in-context reference
-            main_data = json.dumps(
-                {
-                    "schema": dependent["schema"],
-                    "schemaType": dependent["type"],
-                    "references": [
-                        {"name": ref_name, "subject": ctx_ref_subject, "version": 1}
-                    ],
-                }
-            )
-            result = self.sr_client.post_subjects_subject_versions(
-                subject=ctx_main_subject, data=main_data
-            )
-            self.assert_equal(result.status_code, requests.codes.ok)
-
-            # Verify referenced-by works with context subjects
-            result = self.sr_client.get_subjects_subject_versions_version_referenced_by(
-                subject=ctx_ref_subject, version=1
-            )
-            self.assert_equal(result.status_code, requests.codes.ok)
-            self.assert_equal(len(result.json()), 1)
-
-        # Test cross-context references
-        base = base_schemas["proto"]
-        dependent = dependent_schemas["proto"]
-        cross_ref_subject = ":.ctx-cross-ref:base"
-        cross_main_subject = ":.ctx-cross-main:dependent"
-
-        result = self.sr_client.post_subjects_subject_versions(
-            subject=cross_ref_subject,
-            data=json.dumps({"schema": base["schema"], "schemaType": base["type"]}),
-        )
-        self.assert_equal(result.status_code, requests.codes.ok)
-
-        result = self.sr_client.post_subjects_subject_versions(
-            subject=cross_main_subject,
-            data=json.dumps(
-                {
-                    "schema": dependent["schema"],
-                    "schemaType": dependent["type"],
-                    "references": [
-                        {
-                            "name": dependent["references"][0]["name"],
-                            "subject": cross_ref_subject,
-                            "version": 1,
-                        }
-                    ],
-                }
-            ),
-        )
-        self.assert_equal(result.status_code, requests.codes.ok)
-
-    @cluster(num_nodes=1)
-    def test_context_config(self):
-        """Test context-level config operations."""
-
-        ctx = "test-ctx"
-        ctx_prefix = f":.{ctx}:"
-        ctx_subject = f"{ctx_prefix}test-sub"
-
-        # Register a schema in the context first
-        result = self.sr_client.post_subjects_subject_versions(
-            subject=ctx_subject, data=json.dumps({"schema": schema1_def})
-        )
-        self.assert_equal(result.status_code, requests.codes.ok)
-
-        # Set context-level config (empty subject = context-level)
-        result = self.sr_client.set_config_subject(
-            subject=ctx_prefix,
-            data=json.dumps({"compatibility": "NONE"}),
-        )
-        self.assert_equal(result.status_code, requests.codes.ok)
-
-        # Get context-level config
-        result = self.sr_client.get_config_subject(subject=ctx_prefix)
-        self.assert_equal(result.status_code, requests.codes.ok)
-        self.assert_equal(result.json()["compatibilityLevel"], "NONE")
-
-        # Subject-level config should fall back to context-level
-        result = self.sr_client.get_config_subject(subject=ctx_subject, fallback=True)
-        self.assert_equal(result.status_code, requests.codes.ok)
-        self.assert_equal(result.json()["compatibilityLevel"], "NONE")
-
-        # Default context should not be affected by context-level config
-        result = self.sr_client.get_config()
-        self.assert_equal(result.status_code, requests.codes.ok)
-        self.assert_equal(result.json()["compatibilityLevel"], "BACKWARD")
-
-        # Set subject-level config (different from context-level)
-        result = self.sr_client.set_config_subject(
-            subject=ctx_subject,
-            data=json.dumps({"compatibility": "FULL"}),
-        )
-        self.assert_equal(result.status_code, requests.codes.ok)
-
-        # Subject should now have FULL (not context's NONE)
-        result = self.sr_client.get_config_subject(subject=ctx_subject, fallback=False)
-        self.assert_equal(result.status_code, requests.codes.ok)
-        self.assert_equal(result.json()["compatibilityLevel"], "FULL")
-
-        # Delete subject-level config
-        result = self.sr_client.delete_config_subject(subject=ctx_subject)
-        self.assert_equal(result.status_code, requests.codes.ok)
-
-        # Subject should fall back to context-level NONE
-        result = self.sr_client.get_config_subject(subject=ctx_subject, fallback=True)
-        self.assert_equal(result.status_code, requests.codes.ok)
-        self.assert_equal(result.json()["compatibilityLevel"], "NONE")
-
-        # Delete the context-level config
-        result = self.sr_client.delete_config_subject(subject=ctx_prefix)
-        self.assert_equal(result.status_code, requests.codes.ok)
-
-        # Subject should fall back to default BACKWARD
-        result = self.sr_client.get_config_subject(subject=ctx_subject, fallback=True)
-        self.assert_equal(result.status_code, requests.codes.ok)
-        self.assert_equal(result.json()["compatibilityLevel"], "BACKWARD")
 
     @cluster(num_nodes=3)
     def test_post_subjects_subject_versions_null_metadata_ruleset(self):
@@ -5210,8 +4989,250 @@ class SchemaRegistryModeMutableTest(SchemaRegistryEndpoints):
         self.assert_equal(result_raw.status_code, 200)
         self.assert_equal(result_raw.json()["id"], 2)
 
+
+class SchemaRegistryContextTest(SchemaRegistryEndpoints):
+    """
+    Tests for context-qualified subject functionality.
+
+    These tests verify that Schema Registry correctly handles context-qualified
+    subjects (e.g., ":.ctx:subject") for isolation, references, config, and mode.
+    """
+
+    def __init__(self, context: TestContext, **kwargs: Any):
+        schema_registry_config = SchemaRegistryConfig()
+        schema_registry_config.mode_mutability = True
+        super().__init__(
+            context, schema_registry_config=schema_registry_config, **kwargs
+        )
+
+    @cluster(num_nodes=1)
+    def test_contexts(self):
+        """Verify context-aware endpoints work with qualified subjects."""
+
+        schema_data = json.dumps({"schema": schema1_def})
+        compat_schema_data = json.dumps({"schema": schema2_def})
+        ctx_subject = ":.ctx1:sub1"
+
+        # Register in context
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=ctx_subject, data=schema_data
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Lookup in context
+        result = self.sr_client.post_subjects_subject(
+            subject=ctx_subject, data=schema_data
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Compatibility check in context
+        result = self.sr_client.post_compatibility_subject_version(
+            subject=ctx_subject, version="latest", data=compat_schema_data
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["is_compatible"], True)
+
+        # List versions in context
+        result = self.sr_client.get_subjects_subject_versions(subject=ctx_subject)
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json(), [1])
+
+        # Get specific version in context
+        result = self.sr_client.get_subjects_subject_versions_version(
+            subject=ctx_subject, version=1
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["version"], 1)
+
+        # Get schema only for specific version in context
+        result = self.sr_client.get_subjects_subject_versions_version_schema(
+            subject=ctx_subject, version=1
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Get referenced-by in context (empty list, no references)
+        result = self.sr_client.get_subjects_subject_versions_version_referenced_by(
+            subject=ctx_subject, version=1
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json(), [])
+
+        # Delete specific version in context
+        result = self.sr_client.delete_subject_version(subject=ctx_subject, version=1)
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json(), 1)
+
+        # Delete subject in context (cleanup)
+        result = self.sr_client.delete_subject(subject=ctx_subject, permanent=True)
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+    @cluster(num_nodes=1)
+    def test_context_isolation(self):
+        """Verify contexts are isolated: independent IDs, no cross-context lookups."""
+
+        # Register in default context
+        result = self.sr_client.post_subjects_subject_versions(
+            subject="sub1", data=json.dumps({"schema": schema1_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["id"], 1)
+
+        # Register same schema in .ctx1 - should get id=1 (independent counter)
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=":.ctx1:sub1", data=json.dumps({"schema": schema2_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["id"], 1)
+
+        # Lookup schema in different context - should fail
+        result = self.sr_client.post_subjects_subject(
+            subject=":.ctx2:sub1", data=json.dumps({"schema": schema1_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.not_found)
+
+    @cluster(num_nodes=1)
+    def test_context_references(self):
+        """Test schema references work with context-qualified subjects."""
+        # Test all schema types using existing test data
+        for schema_type in ["proto", "avro", "json"]:
+            base = base_schemas[schema_type]
+            dependent = dependent_schemas[schema_type]
+            ref_name = dependent["references"][0]["name"]
+
+            ctx = f"ctx-{schema_type}"
+            ctx_ref_subject = f":.{ctx}:base"
+            ctx_main_subject = f":.{ctx}:dependent"
+
+            # Register base schema in context
+            ref_data = json.dumps(
+                {"schema": base["schema"], "schemaType": base["type"]}
+            )
+            result = self.sr_client.post_subjects_subject_versions(
+                subject=ctx_ref_subject, data=ref_data
+            )
+            self.assert_equal(result.status_code, requests.codes.ok)
+
+            # Register dependent schema with in-context reference
+            main_data = json.dumps(
+                {
+                    "schema": dependent["schema"],
+                    "schemaType": dependent["type"],
+                    "references": [
+                        {"name": ref_name, "subject": ctx_ref_subject, "version": 1}
+                    ],
+                }
+            )
+            result = self.sr_client.post_subjects_subject_versions(
+                subject=ctx_main_subject, data=main_data
+            )
+            self.assert_equal(result.status_code, requests.codes.ok)
+
+            # Verify referenced-by works with context subjects
+            result = self.sr_client.get_subjects_subject_versions_version_referenced_by(
+                subject=ctx_ref_subject, version=1
+            )
+            self.assert_equal(result.status_code, requests.codes.ok)
+            self.assert_equal(len(result.json()), 1)
+
+        # Test cross-context references
+        base = base_schemas["proto"]
+        dependent = dependent_schemas["proto"]
+        cross_ref_subject = ":.ctx-cross-ref:base"
+        cross_main_subject = ":.ctx-cross-main:dependent"
+
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=cross_ref_subject,
+            data=json.dumps({"schema": base["schema"], "schemaType": base["type"]}),
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=cross_main_subject,
+            data=json.dumps(
+                {
+                    "schema": dependent["schema"],
+                    "schemaType": dependent["type"],
+                    "references": [
+                        {
+                            "name": dependent["references"][0]["name"],
+                            "subject": cross_ref_subject,
+                            "version": 1,
+                        }
+                    ],
+                }
+            ),
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+    @cluster(num_nodes=1)
+    def test_context_config(self):
+        """Test context-level config operations."""
+
+        ctx = "test-ctx"
+        ctx_prefix = f":.{ctx}:"
+        ctx_subject = f"{ctx_prefix}test-sub"
+
+        # Register a schema in the context first
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=ctx_subject, data=json.dumps({"schema": schema1_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Set context-level config (empty subject = context-level)
+        result = self.sr_client.set_config_subject(
+            subject=ctx_prefix,
+            data=json.dumps({"compatibility": "NONE"}),
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Get context-level config
+        result = self.sr_client.get_config_subject(subject=ctx_prefix)
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["compatibilityLevel"], "NONE")
+
+        # Subject-level config should fall back to context-level
+        result = self.sr_client.get_config_subject(subject=ctx_subject, fallback=True)
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["compatibilityLevel"], "NONE")
+
+        # Default context should not be affected by context-level config
+        result = self.sr_client.get_config()
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["compatibilityLevel"], "BACKWARD")
+
+        # Set subject-level config (different from context-level)
+        result = self.sr_client.set_config_subject(
+            subject=ctx_subject,
+            data=json.dumps({"compatibility": "FULL"}),
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Subject should now have FULL (not context's NONE)
+        result = self.sr_client.get_config_subject(subject=ctx_subject, fallback=False)
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["compatibilityLevel"], "FULL")
+
+        # Delete subject-level config
+        result = self.sr_client.delete_config_subject(subject=ctx_subject)
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Subject should fall back to context-level NONE
+        result = self.sr_client.get_config_subject(subject=ctx_subject, fallback=True)
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["compatibilityLevel"], "NONE")
+
+        # Delete the context-level config
+        result = self.sr_client.delete_config_subject(subject=ctx_prefix)
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Subject should fall back to default BACKWARD
+        result = self.sr_client.get_config_subject(subject=ctx_subject, fallback=True)
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["compatibilityLevel"], "BACKWARD")
+
     @cluster(num_nodes=1)
     def test_default_context(self):
+        """Test that qualified subject syntax works for the default context."""
         schema_data = json.dumps({"schema": schema1_def})
 
         # Register in default context with unqualified subject


### PR DESCRIPTION
Implements a cluster config called `schema_registry_enable_qualified_subjects` to release the contexts implementation in beta behind this feature flag for 26.1, with future plans of enabling this by default in 26.2.

The flag guards the subject parsing behaviour. It enables the parsing of subjects with the qualified subject syntax (:.context:subject). When false, subjects are treated literally, as subjects in the default context. When true, qualified syntax is parsed to extract context and subject.

Fixes https://redpandadata.atlassian.net/browse/CORE-15275

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
