### PR TITLE
storage: expose segment appender stats as shard-level metrics

### DIFF
--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -460,6 +460,7 @@ redpanda_cc_library(
         "@seastar",
     ],
     deps = [
+        ":segment_appender",
         "//src/v/metrics",
     ],
 )

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1655,7 +1655,11 @@ ss::future<> disk_log_impl::rewrite_segment_with_offset_map(
 
     const auto size_before = seg->size_bytes();
     auto appender = co_await internal::make_segment_appender(
-      tmpname, size_before, resources(), cfg.sanitizer_config);
+      tmpname,
+      size_before,
+      resources(),
+      cfg.sanitizer_config,
+      seg->get_appender_stats());
 
     auto cmp_idx_name = seg->path().to_compacted_index();
     auto compacted_idx_writer = make_file_backed_compacted_index(

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -305,7 +305,9 @@ ss::future<> kvstore::roll() {
                  _resources,
                  _feature_table,
                  _ntp_sanitizer_config,
-                 _conf.max_segment_size)
+                 _conf.max_segment_size,
+                 // we don't track kvstore segment appender stats
+                 nullptr)
           .then([this](ss::lw_shared_ptr<segment> seg) {
               _segment = std::move(seg);
           });
@@ -348,7 +350,8 @@ ss::future<> kvstore::roll() {
                        _resources,
                        _feature_table,
                        _ntp_sanitizer_config,
-                       _conf.max_segment_size)
+                       _conf.max_segment_size,
+                       nullptr)
                 .then([this](ss::lw_shared_ptr<segment> seg) {
                     _segment = std::move(seg);
                 });

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -712,7 +712,8 @@ ss::future<ss::lw_shared_ptr<segment>> log_manager::make_log_segment(
       _resources,
       _feature_table,
       std::move(ntp_sanitizer_cfg),
-      segment_size_hint);
+      segment_size_hint,
+      _probe->get_appender_stats());
 }
 
 std::optional<batch_cache_index>

--- a/src/v/storage/log_manager_probe.cc
+++ b/src/v/storage/log_manager_probe.cc
@@ -40,6 +40,53 @@ void log_manager_probe::setup_metrics() {
           "housekeeping_log_processed",
           [this] { return _housekeeping_log_processed; },
           sm::description("Number of logs processed by housekeeping")),
+        sm::make_counter(
+          "appender_merged_writes",
+          [this] { return _appender_stats->merged_writes; },
+          sm::description(
+            "Number of writes merged into queued writes prior to dispatch.")),
+        sm::make_counter(
+          "appender_bytes_requested",
+          [this] { return _appender_stats->bytes_requested; },
+          sm::description(
+            "Logical bytes appended (the number of bytes appended by the upper "
+            "layers, before alignment.")),
+        sm::make_counter(
+          "appender_bytes_written",
+          [this] { return _appender_stats->bytes_written; },
+          sm::description(
+            "Physical bytes appended (the number of bytes actually written via "
+            "dma_write calls, which is in general higher than logical bytes "
+            "due to alignment).")),
+        sm::make_counter(
+          "appender_appends_requested",
+          [this] { return _appender_stats->appends; },
+          sm::description(
+            "Logical number of append requests to segment appenders.")),
+        sm::make_counter(
+          "appender_flushes",
+          [this] { return _appender_stats->flushes; },
+          sm::description("Number of flush calls to segment appenders.")),
+        sm::make_counter(
+          "appender_fsyncs",
+          [this] { return _appender_stats->fsyncs; },
+          sm::description(
+            "Number of disk fsync calls from segment appenders.")),
+        sm::make_counter(
+          "appender_truncates",
+          [this] { return _appender_stats->truncates; },
+          sm::description(
+            "Number of truncate operations on segment appenders.")),
+        sm::make_counter(
+          "appender_fallocations",
+          [this] { return _appender_stats->fallocations; },
+          sm::description(
+            "Number of fallocate operations on segment appenders.")),
+        sm::make_counter(
+          "appender_last_page_hydrations",
+          [this] { return _appender_stats->last_page_hydrations; },
+          sm::description(
+            "Number of last page hydrations in segment appenders.")),
       },
       {},
       {});

--- a/src/v/storage/log_manager_probe.h
+++ b/src/v/storage/log_manager_probe.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "metrics/metrics.h"
+#include "storage/segment_appender.h"
 
 #include <cstdint>
 
@@ -34,10 +35,19 @@ public:
     void housekeeping_log_processed() { ++_housekeeping_log_processed; }
     void urgent_gc_run() { ++_urgent_gc_runs; }
 
+    // Returns shared pointer to segment appender stats for this shard.
+    // Segment appenders increment these stats directly.
+    segment_appender::stats_ptr get_appender_stats() { return _appender_stats; }
+
 private:
     uint32_t _log_count = 0;
     uint64_t _urgent_gc_runs = 0;
     uint64_t _housekeeping_log_processed = 0;
+
+    // Segment appender stats (accumulated across all segment appenders on this
+    // shard)
+    segment_appender::stats_ptr _appender_stats
+      = ss::make_lw_shared<segment_appender::stats>();
 
     metrics::internal_metric_groups _metrics;
 };

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -60,6 +60,7 @@ segment::segment(
   , _reader(std::move(r))
   , _idx(std::move(i))
   , _appender(std::move(a))
+  , _appender_stats(_appender ? _appender->get_stats() : nullptr)
   , _compaction_index(std::move(ci))
   , _cache(std::move(c))
   , _first_write(std::nullopt) {
@@ -842,7 +843,8 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
   storage_resources& resources,
   ss::sharded<features::feature_table>& feature_table,
   std::optional<ntp_sanitizer_config> ntp_sanitizer_config,
-  size_t segment_size_hint) {
+  size_t segment_size_hint,
+  segment_appender::stats_ptr shared_stats) {
     auto path = segment_full_path(ntpc, base_offset, term, version);
     vlog(stlog.info, "Creating new segment {}", path);
     return open_segment(
@@ -853,17 +855,24 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
              resources,
              feature_table,
              ntp_sanitizer_config)
-      .then([path, segment_size_hint, &resources, ntp_sanitizer_config](
-              ss::lw_shared_ptr<segment> seg) mutable {
+      .then([path,
+             segment_size_hint,
+             &resources,
+             ntp_sanitizer_config,
+             shared_stats](ss::lw_shared_ptr<segment> seg) mutable {
           return with_segment(
             std::move(seg),
-            [path, segment_size_hint, &resources, ntp_sanitizer_config](
-              const ss::lw_shared_ptr<segment>& seg) mutable {
+            [path,
+             segment_size_hint,
+             &resources,
+             ntp_sanitizer_config,
+             shared_stats](const ss::lw_shared_ptr<segment>& seg) mutable {
                 return internal::make_segment_appender(
                          path,
                          segment_size_hint,
                          resources,
-                         std::move(ntp_sanitizer_config))
+                         std::move(ntp_sanitizer_config),
+                         shared_stats)
                   .then([seg, &resources](segment_appender_ptr a) {
                       return ss::make_ready_future<ss::lw_shared_ptr<segment>>(
                         ss::make_lw_shared<segment>(

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -218,6 +218,7 @@ public:
     segment_appender& appender();
     const segment_appender& appender() const;
     bool has_appender() const;
+    segment_appender::stats_ptr get_appender_stats() const;
     compacted_index_writer& compaction_index();
     const compacted_index_writer& compaction_index() const;
     // We currently use `max_removable_local_log_offset` to control both
@@ -341,6 +342,7 @@ private:
     segment_index _idx;
     bitflags _flags{bitflags::none};
     segment_appender_ptr _appender;
+    segment_appender::stats_ptr _appender_stats;
     std::optional<size_t> _data_disk_usage_size;
 
     // compaction index size should be cleared whenever the size might change
@@ -399,7 +401,8 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
   storage_resources&,
   ss::sharded<features::feature_table>& feature_table,
   std::optional<ntp_sanitizer_config> ntp_sanitizer_config,
-  size_t segment_size_hint);
+  size_t segment_size_hint,
+  segment_appender::stats_ptr shared_stats);
 
 // bitflags operators
 [[gnu::always_inline]] inline segment::bitflags
@@ -565,6 +568,9 @@ inline segment_appender_ptr segment::release_appender() {
 inline segment_appender& segment::appender() { return *_appender; }
 inline const segment_appender& segment::appender() const { return *_appender; }
 inline bool segment::has_appender() const { return !!_appender; }
+inline segment_appender::stats_ptr segment::get_appender_stats() const {
+    return _appender_stats;
+}
 inline compacted_index_writer& segment::compaction_index() {
     return *_compaction_index.value();
 }

--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -62,6 +62,9 @@ segment_appender::segment_appender(ss::file f, options opts)
   , _prev_head_write(ss::make_lw_shared<ssx::semaphore>(1, head_sem_name))
   , _inactive_timer([this] { handle_inactive_timer(); })
   , _chunk_size(internal::chunks().chunk_size()) {
+    if (!_opts.shared_stats) {
+        _opts.shared_stats = ss::make_lw_shared<stats>();
+    }
     const auto alignment = _out.disk_write_dma_alignment();
     vassert(
       internal::chunk_cache::alignment % alignment == 0,
@@ -104,8 +107,7 @@ segment_appender::segment_appender(segment_appender&& o) noexcept
   , _dispatched_writes(std::exchange(o._dispatched_writes, 0))
   , _committed_offset_clb(std::exchange(o._committed_offset_clb, {}))
   , _inactive_timer([this] { handle_inactive_timer(); })
-  , _chunk_size(o._chunk_size)
-  , _stats(std::exchange(o._stats, {})) {
+  , _chunk_size(o._chunk_size) {
     o._closed = true;
 }
 
@@ -145,8 +147,8 @@ ss::future<> segment_appender::append(const char* buf, const size_t n) {
 }
 
 ss::future<> segment_appender::do_append(const char* buf, size_t n) {
-    ++_stats.appends;
-    _stats.bytes_requested += n;
+    ++_opts.shared_stats->appends;
+    _opts.shared_stats->bytes_requested += n;
     while (true) {
         vassert(!_closed, "append() on closed segment: {}", *this);
 
@@ -197,7 +199,7 @@ ss::future<> segment_appender::do_append(const char* buf, size_t n) {
             // swap in the new head with the remainder from the old one.
 
             _head = new_head;
-            _stats.bytes_copied_in_chunk_remainder += remainder_sz;
+            _opts.shared_stats->bytes_copied_in_chunk_remainder += remainder_sz;
             /**
              * This is the place where we need to release the old head or
              * mark it for release after the write completes. The
@@ -311,7 +313,7 @@ ss::future<> segment_appender::hydrate_last_half_page() {
       .dma_read(sz, buff, read_align /*must be full _write_ alignment*/)
 #pragma clang diagnostic pop
       .then([this, bytes_to_read](size_t actual) {
-          ++_stats.last_page_hydrations;
+          ++_opts.shared_stats->last_page_hydrations;
           vassert(
             bytes_to_read <= actual && bytes_to_read == _head->flushed_pos(),
             "Could not hydrate partial page bytes: expected:{}, "
@@ -335,8 +337,8 @@ ss::future<> segment_appender::hydrate_last_half_page() {
 ss::future<> segment_appender::do_truncation(size_t n) {
     return _out.truncate(n)
       .then([this] {
-          ++_stats.truncates;
-          return _out.flush().then([this] { ++_stats.fsyncs; });
+          ++_opts.shared_stats->truncates;
+          return _out.flush().then([this] { ++_opts.shared_stats->fsyncs; });
       })
       .handle_exception([n, this](std::exception_ptr e) {
           vassert(
@@ -425,7 +427,7 @@ ss::future<> segment_appender::do_next_adaptive_fallocation() {
                    _committed_offset);
                  return _out.allocate(_fallocation_offset, step)
                    .then([this, step] {
-                       ++_stats.fallocations;
+                       ++_opts.shared_stats->fallocations;
                        // ss::file::allocate does not adjust logical
                        // file size hence we need to do that explicitly
                        // with an extra truncate. This allows for more
@@ -537,7 +539,7 @@ ss::future<> segment_appender::process_flush_ops(size_t committed) {
         // in multiple places.
         --_inflight_dispatched;
         _flushed_offset = committed;
-        ++_stats.fsyncs;
+        ++_opts.shared_stats->fsyncs;
         /*
          * TODO: as an optimization, add a little house keeping to
          * determine if eligible flush operations showed up while
@@ -602,7 +604,7 @@ void segment_appender::dispatch_background_head_write() {
         // Yay! The latest in-flight write is still queued (i.e., has
         // not been dispatched to the disk) so we just append this write
         // to that entry.
-        ++_stats.merged_writes;
+        ++_opts.shared_stats->merged_writes;
         return;
     }
 
@@ -650,7 +652,7 @@ void segment_appender::dispatch_background_head_write() {
                     dma_size)
 #pragma clang diagnostic pop
                   .then([this, w, dma_size](size_t got) {
-                      _stats.bytes_written += dma_size;
+                      _opts.shared_stats->bytes_written += dma_size;
                       /*
                        * the continuation that captured full=true is the
                        * end of the dependency chain for this chunk. it
@@ -684,7 +686,7 @@ void segment_appender::dispatch_background_head_write() {
 }
 
 ss::future<> segment_appender::flush() {
-    ++_stats.flushes;
+    ++_opts.shared_stats->flushes;
     _inactive_timer.cancel();
 
     // dispatched write will drive flush completion
@@ -719,7 +721,7 @@ ss::future<> segment_appender::flush() {
       *this);
 
     return _out.flush()
-      .then([this] { ++_stats.fsyncs; })
+      .then([this] { ++_opts.shared_stats->fsyncs; })
       .handle_exception([this](std::exception_ptr e) {
           vunreachable("Could not flush: {} - {}", e, *this);
       });
@@ -739,7 +741,8 @@ ss::future<> segment_appender::hard_flush() {
                    _flush_ops.empty(),
                    "Pending flushes after hard flush {}",
                    *this);
-                 return _out.flush().then([this] { ++_stats.fsyncs; });
+                 return _out.flush().then(
+                   [this] { ++_opts.shared_stats->fsyncs; });
              })
       .handle_exception([this](std::exception_ptr e) {
           vunreachable("Could not flush: {} - {}", e, *this);
@@ -792,15 +795,14 @@ fmt::iterator segment_appender::format_to(fmt::iterator iterator) const {
       iterator,
       "{{closed:{}, fallocation_offset:{}, stable_offset:{}, "
       "flushed_offset:{}, committed_offset:{}, inflight: {}, "
-      "bytes_flush_pending:{}, stats: {}}}",
+      "bytes_flush_pending:{}}}",
       _closed,
       _fallocation_offset,
       _stable_offset,
       _flushed_offset,
       _committed_offset,
       _inflight.size(),
-      _bytes_flush_pending,
-      _stats);
+      _bytes_flush_pending);
 }
 
 fmt::iterator segment_appender::stats::format_to(fmt::iterator it) const {

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -21,9 +21,7 @@
 #include "storage/storage_resources.h"
 
 #include <seastar/core/file.hh>
-#include <seastar/core/fstream.hh>
-#include <seastar/core/iostream.hh>
-#include <seastar/core/sstring.hh>
+#include <seastar/core/shared_ptr.hh>
 
 #include <iosfwd>
 
@@ -78,6 +76,7 @@ public:
         fmt::iterator format_to(fmt::iterator it) const;
     };
 
+    using stats_ptr = ss::lw_shared_ptr<stats>;
     using chunk = segment_appender_chunk;
     using committed_offset_clb = ss::noncopyable_function<void(size_t)>;
 
@@ -85,9 +84,11 @@ public:
       = segment_appender_fallocation_alignment;
 
     struct options {
-        options(std::optional<uint64_t> s, storage_resources& r)
+        options(
+          std::optional<uint64_t> s, storage_resources& r, stats_ptr shared)
           : segment_size(s)
-          , resources(r) {}
+          , resources(r)
+          , shared_stats(std::move(shared)) {}
 
         // Generally a segment appender doesn't need to know the target size
         // of the segment it's appending to, but this is used as an input
@@ -95,6 +96,9 @@ public:
         // more space than a segment would ever need.
         std::optional<uint64_t> segment_size;
         storage_resources& resources;
+        // Optional shared stats for shard-level metrics aggregation.
+        // May be null in which case stats will not be collected.
+        stats_ptr shared_stats;
     };
 
     segment_appender(ss::file f, options opts);
@@ -156,9 +160,10 @@ public:
         _committed_offset_clb = std::move(callback);
     }
 
-    fmt::iterator format_to(fmt::iterator) const;
+    // Returns the shared stats pointer.
+    stats_ptr get_stats() const { return _opts.shared_stats; }
 
-    const stats& get_stats() const { return _stats; }
+    fmt::iterator format_to(fmt::iterator) const;
 
 private:
     using chunk_ptr = ss::lw_shared_ptr<chunk>;
@@ -331,7 +336,6 @@ private:
     void handle_inactive_timer();
 
     size_t _chunk_size{0};
-    stats _stats;
     // Bit-map tracking the types of batches in the `_head` chunk that have
     // not been written to disk yet.
     static_assert(static_cast<uint8_t>(model::record_batch_type::MAX) <= 63);

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -158,11 +158,13 @@ ss::future<segment_appender_ptr> make_segment_appender(
   const segment_full_path& path,
   std::optional<uint64_t> segment_size,
   storage_resources& resources,
-  std::optional<ntp_sanitizer_config> ntp_sanitizer_config) {
+  std::optional<ntp_sanitizer_config> ntp_sanitizer_config,
+  segment_appender::stats_ptr shared_stats) {
     return internal::make_writer_handle(path, std::nullopt)
       .then([path,
              segment_size,
              &resources,
+             shared_stats,
              ntp_sanitizer_config = std::move(ntp_sanitizer_config)](
               ss::file writer) mutable {
           // file_io_sanitizer requires a pointer to the appender,
@@ -183,7 +185,9 @@ ss::future<segment_appender_ptr> make_segment_appender(
               // exception during an OOM condition, since the appender allocates
               // 1MB of memory aligned buffers
               auto appender_ptr = std::make_unique<segment_appender>(
-                writer, segment_appender::options(segment_size, resources));
+                writer,
+                segment_appender::options(
+                  segment_size, resources, shared_stats));
 
               if (sanitized_writer) {
                   sanitized_writer->set_pointer_to_appender(appender_ptr.get());
@@ -381,7 +385,11 @@ ss::future<storage::index_state> do_copy_segment_data(
 
     auto size_before = seg->size_bytes();
     auto appender = co_await make_segment_appender(
-      tmpname, size_before, resources, cfg.sanitizer_config);
+      tmpname,
+      size_before,
+      resources,
+      cfg.sanitizer_config,
+      seg->get_appender_stats());
 
     vlog(
       gclog.trace,

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -164,7 +164,8 @@ ss::future<segment_appender_ptr> make_segment_appender(
   const segment_full_path& path,
   std::optional<uint64_t> segment_size,
   storage_resources& resources,
-  std::optional<ntp_sanitizer_config> ntp_sanitizer_config);
+  std::optional<ntp_sanitizer_config> ntp_sanitizer_config,
+  segment_appender::stats_ptr shared_stats);
 
 uint64_t segment_size_from_config(const storage::ntp_config&);
 

--- a/src/v/storage/spill_key_index.cc
+++ b/src/v/storage/spill_key_index.cc
@@ -61,7 +61,7 @@ spill_key_index::spill_key_index(
   , _appender(
       storage::segment_appender(
         std::move(dummy_file),
-        segment_appender::options(std::nullopt, _resources)))
+        segment_appender::options(std::nullopt, _resources, nullptr)))
   , _max_mem(max_mem) {}
 
 spill_key_index::~spill_key_index() {
@@ -342,7 +342,7 @@ ss::future<> spill_key_index::open() {
     _appender.emplace(
       storage::segment_appender(
         std::move(index_file),
-        segment_appender::options(std::nullopt, _resources)));
+        segment_appender::options(std::nullopt, _resources, nullptr)));
 }
 
 ss::future<> spill_key_index::close() {

--- a/src/v/storage/tests/log_replayer_test.cc
+++ b/src/v/storage/tests/log_replayer_test.cc
@@ -69,7 +69,7 @@ public:
             ntp_sanitizer_config{.sanitize_only = true})));
 
         auto appender = std::make_unique<segment_appender>(
-          fd, segment_appender::options(std::nullopt, resources));
+          fd, segment_appender::options(std::nullopt, resources, nullptr));
         auto indexer = segment_index(
           segment_full_path::mock(base_name + ".index"),
           std::move(fidx),

--- a/src/v/storage/tests/log_segment_appender_test.cc
+++ b/src/v/storage/tests/log_segment_appender_test.cc
@@ -10,21 +10,17 @@
 #include "base/seastarx.h"
 #include "bytes/iobuf.h"
 #include "bytes/iostream.h"
-#include "config/configuration.h"
 #include "random/generators.h"
 #include "storage/chunk_cache.h"
 #include "storage/segment_appender.h"
 #include "storage/storage_resources.h"
 #include "test_utils/random_bytes.h"
 
+#include <seastar/core/file.hh>
+#include <seastar/core/fstream.hh>
 #include <seastar/core/future.hh>
-#include <seastar/core/reactor.hh>
+#include <seastar/core/seastar.hh>
 #include <seastar/core/sleep.hh>
-#include <seastar/core/thread.hh>
-#include <seastar/testing/thread_test_case.hh>
-
-// test gate
-#include <seastar/core/gate.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/later.hh>
 
@@ -77,7 +73,6 @@ struct storage::segment_appender_test_accessor {
     }
     auto inflight_dispatched() { return sa._inflight_dispatched; }
     auto total_dispatched() { return sa._dispatched_writes; }
-    auto total_merged() { return sa.get_stats().merged_writes; }
     auto info() {
         return segment_appender_info{
           .committed_offset = sa._committed_offset,
@@ -100,10 +95,13 @@ ss::file open_file(std::string_view filename) {
       .get();
 }
 
-segment_appender
-make_segment_appender(ss::file file, storage::storage_resources& resources) {
+segment_appender make_segment_appender(
+  ss::file file,
+  storage::storage_resources& resources,
+  segment_appender::stats_ptr stats = nullptr) {
     return segment_appender(
-      std::move(file), segment_appender::options(std::nullopt, resources));
+      std::move(file),
+      segment_appender::options(std::nullopt, resources, std::move(stats)));
 }
 
 iobuf make_random_data(size_t len) {
@@ -165,7 +163,8 @@ static void run_test_can_append_mixed(size_t fallocate_size) {
     auto f = open_file("test_log_segment_mixed.log");
     storage::storage_resources resources(
       config::mock_binding<size_t>(std::move(fallocate_size)));
-    auto appender = make_segment_appender(f, resources);
+    auto stats = ss::make_lw_shared<segment_appender::stats>();
+    auto appender = make_segment_appender(f, resources, stats);
     auto close = ss::defer([&appender] { appender.close().get(); });
     auto alignment = f.disk_write_dma_alignment();
     constexpr size_t iterations = 100;
@@ -233,7 +232,7 @@ static void run_test_can_append_mixed(size_t fallocate_size) {
     EXPECT_LT(write_count, 2 * iterations);
 
     // we expect 0 merges with the A+F pattern
-    EXPECT_EQ(access(appender).total_merged(), 0);
+    EXPECT_EQ(stats->merged_writes, 0);
 }
 
 TEST(log_segment_appender_test, test_can_append_mixed) {
@@ -245,7 +244,8 @@ static void run_test_can_append_10MB(size_t fallocate_size) {
     auto f = open_file("test_segment_appender.log");
     storage::storage_resources resources(
       config::mock_binding<size_t>(std::move(fallocate_size)));
-    auto appender = make_segment_appender(f, resources);
+    auto stats = ss::make_lw_shared<segment_appender::stats>();
+    auto appender = make_segment_appender(f, resources, stats);
     auto close = ss::defer([&appender] { appender.close().get(); });
 
     constexpr size_t iterations = 10;
@@ -276,7 +276,7 @@ static void run_test_can_append_10MB(size_t fallocate_size) {
     EXPECT_EQ(write_count, expected_writes);
 
     // we expect 0 merges with the A+F pattern
-    EXPECT_EQ(access(appender).total_merged(), 0);
+    EXPECT_EQ(stats->merged_writes, 0);
 }
 
 TEST(log_segment_appender_test, test_can_append_10MB) {
@@ -334,7 +334,8 @@ static void run_concurrent_append_flush(
       "run_concurrent_append_flush_{}_{}.log", fallocate_size, max_buf_size);
     auto seg_file = open_file(filename);
     storage::storage_resources resources(config::mock_binding(+fallocate_size));
-    auto appender = make_segment_appender(seg_file, resources);
+    auto stats = ss::make_lw_shared<segment_appender::stats>();
+    auto appender = make_segment_appender(seg_file, resources, stats);
     auto close = ss::defer([&appender] { appender.close().get(); });
 
     auto seed = random_generators::get_int<size_t>();
@@ -479,7 +480,7 @@ static void run_concurrent_append_flush(
 
     // check that we got some writes and merges (we don't know how many)
     EXPECT_GT(access(appender).total_dispatched(), 0);
-    EXPECT_GT(access(appender).total_merged(), 0);
+    EXPECT_GT(stats->merged_writes, 0);
 
     // now we expect all the prior flush futures to be available
     // we don't guarantee this is in the API currently but it is how it

--- a/src/v/storage/tests/segment_appender_bench.cc
+++ b/src/v/storage/tests/segment_appender_bench.cc
@@ -22,7 +22,8 @@ struct appender_fixture {
     make_appender(tmpbuf_file::store_t& store) {
         auto file = ss::file(ss::make_shared<tmpbuf_file>(store));
 
-        storage::segment_appender::options opts(std::nullopt, _resources);
+        storage::segment_appender::options opts(
+          std::nullopt, _resources, nullptr);
 
         co_return std::make_unique<storage::segment_appender>(
           std::move(file), opts);

--- a/src/v/storage/tests/segment_appender_test.cc
+++ b/src/v/storage/tests/segment_appender_test.cc
@@ -46,7 +46,7 @@ public:
             | ss::open_flags::truncate,
           ss::file_open_options{});
 
-        storage::segment_appender::options opts(std::nullopt, resources);
+        storage::segment_appender::options opts(std::nullopt, resources, stats);
         appender = std::make_unique<storage::segment_appender>(
           std::move(file), opts);
     }
@@ -188,6 +188,8 @@ public:
 
     std::string_view file_name = "test_segment.log";
     storage::storage_resources resources;
+    ss::lw_shared_ptr<storage::segment_appender::stats> stats
+      = ss::make_lw_shared<storage::segment_appender::stats>();
     std::unique_ptr<storage::segment_appender> appender;
     ss::gate gate;
     iobuf reference;
@@ -262,7 +264,7 @@ TEST_F(SegmentAppenderFixture, TestFlushesAreMerged) {
     }
     ops.emplace_back(flush_op(true));
     execute_operations(std::move(ops)).get();
-    EXPECT_GE(appender->get_stats().fsyncs, 1);
+    EXPECT_GE(stats->fsyncs, 1);
     // TODO: fix possible redundant flushes in segment appender
     // EXPECT_LE(appender->get_stats().fsyncs, 2);
     appender->close().get();
@@ -271,7 +273,7 @@ TEST_F(SegmentAppenderFixture, TestFlushesAreMerged) {
 
 TEST_F(SegmentAppenderFixture, TestConcurrentFlushes) {
     execute_concurrent_flush_and_writes(1, 16_KiB).get();
-    ASSERT_GT(appender->get_stats().bytes_copied_in_chunk_remainder, 0);
+    ASSERT_GT(stats->bytes_copied_in_chunk_remainder, 0);
     appender->close().get();
     ASSERT_TRUE(file_content_equal_to_reference().get());
     ASSERT_EQ(reference.size_bytes(), 16_KiB);
@@ -279,7 +281,7 @@ TEST_F(SegmentAppenderFixture, TestConcurrentFlushes) {
 
 TEST_F(SegmentAppenderFixture, TestConcurrentFlushesPageBoundaryWrites) {
     execute_concurrent_flush_and_writes(4_KiB, 1_MiB).get();
-    ASSERT_EQ(appender->get_stats().bytes_copied_in_chunk_remainder, 0);
+    ASSERT_EQ(stats->bytes_copied_in_chunk_remainder, 0);
     appender->close().get();
     ASSERT_TRUE(file_content_equal_to_reference().get());
     ASSERT_GE(reference.size_bytes(), 1_MiB);
@@ -290,7 +292,7 @@ TEST_F(SegmentAppenderFixture, TestConcurrentFlushesSmallWritesShifted) {
     execute_operation(write_op(8_KiB)).get();
     // now execute concurrent flushes with 1 byte writes
     execute_concurrent_flush_and_writes(1, 16_KiB).get();
-    ASSERT_GT(appender->get_stats().bytes_copied_in_chunk_remainder, 0);
+    ASSERT_GT(stats->bytes_copied_in_chunk_remainder, 0);
     appender->close().get();
     ASSERT_TRUE(file_content_equal_to_reference().get());
     ASSERT_GE(reference.size_bytes(), 24_KiB);

--- a/src/v/storage/tests/segment_deduplication_test.cc
+++ b/src/v/storage/tests/segment_deduplication_test.cc
@@ -526,10 +526,13 @@ TEST(DeduplicateSegmentsTest, TestBadReader) {
     // Set up an appender and index writer.
     auto first_seg = segs[0];
     const auto tmpname = first_seg->reader().path().to_compaction_staging();
-    auto appender
-      = storage::internal::make_segment_appender(
-          tmpname, std::nullopt, disk_log.resources(), cfg.sanitizer_config)
-          .get();
+    auto appender = storage::internal::make_segment_appender(
+                      tmpname,
+                      std::nullopt,
+                      disk_log.resources(),
+                      cfg.sanitizer_config,
+                      nullptr)
+                      .get();
     const auto cmp_idx_tmpname = tmpname.to_compacted_index();
     auto compacted_idx_writer = make_file_backed_compacted_index(
       cmp_idx_tmpname, true, disk_log.resources(), cfg.sanitizer_config);


### PR DESCRIPTION
Segment appender operations were not being tracked for metrics. This change adds shard-level counters for segment appender statistics including merged writes, bytes requested/written, appends, flushes, fsyncs, truncates, fallocations, and last page hydrations.

The stats are stored in log_manager_probe and shared across all segment appenders on a shard via a shared pointer (stats_ptr). Each appender increments the shared counters directly during operations. A shared_stats() getter on segment_appender allows propagating stats to new appenders created during compaction.

kvstore segments do not participate in metrics collection and pass nullptr for the stats pointer.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Improvements

* Low-level metrics for the segment appender are not available, such as bytes requested/written, IOs issued, etc. This lets us calculate various types of write amplification at the appender level and otherwise monitor the appender behavior.

