### PR TITLE
train_pgo: Bump iceberg upload interval

### DIFF
--- a/tools/pgo_bolt/train_pgo.py
+++ b/tools/pgo_bolt/train_pgo.py
@@ -70,6 +70,7 @@ async def setup_iceberg_schema_registry_and_topic(
         "-r",
         "3",
         "--topic-config=redpanda.iceberg.mode=value_schema_latest",
+        "--topic-config=redpanda.iceberg.target.lag.ms=20000",
     ]
     proc = await asyncio.create_subprocess_exec(
         *topic_create_args,


### PR DESCRIPTION
Seeing some of the iceberg checks fail on CI. For now can only explain this with upload lag. Lower the target lag to avoid this.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes



* none
