### PR TITLE
ct/l0/stm: add more logging for debugging

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -605,10 +605,11 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
     if (!fence.has_value()) {
         vlog(
           cd_log.warn,
-          "Failed to fence epoch {} for ntp {}, ctp latest seen epoch is {}",
+          "Failed to fence epoch {} for ntp {}, ctp window is [{}, {}]",
           upload_res.value().front().id.epoch,
           ntp,
-          fence.error().latest_seen);
+          fence.error().window_min,
+          fence.error().window_max);
         co_return default_errc;
     }
 
@@ -742,10 +743,12 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
     if (!fence.has_value()) {
         vlog(
           cd_log.warn,
-          "Failed to fence epoch {} for ntp {}, ctp latest seen epoch is {}",
+          "Failed to fence epoch {} for ntp {}, ctp latest seen epoch is [{}, "
+          "{}]",
           res.value().front().id.epoch,
           ntp(),
-          fence.error().latest_seen);
+          fence.error().window_min,
+          fence.error().window_max);
         co_return std::unexpected(
           kafka::make_error_code(kafka::error_code::request_timed_out));
     }

--- a/src/v/cloud_topics/level_zero/stm/BUILD
+++ b/src/v/cloud_topics/level_zero/stm/BUILD
@@ -84,7 +84,11 @@ redpanda_cc_library(
     name = "ctp_stm_state",
     srcs = ["ctp_stm_state.cc"],
     hdrs = ["ctp_stm_state.h"],
+    implementation_deps = [
+        "//src/v/utils:to_string",
+    ],
     deps = [
+        "//src/v/base",
         "//src/v/cloud_topics:types",
         "//src/v/model",
         "//src/v/serde",
@@ -108,6 +112,7 @@ redpanda_cc_library(
         "//src/v/ssx:future_util",
         "//src/v/ssx:watchdog",
         "//src/v/storage",
+        "//src/v/utils:to_string",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -258,7 +258,7 @@ ss::future<std::optional<cluster_epoch>> ctp_stm::get_inactive_epoch() {
           _log.debug,
           "No epochs found in partition {}, max epoch {}, returning nullopt",
           _raft->ntp(),
-          _state.get_max_epoch());
+          _state.get_max_applied_epoch());
         co_return std::nullopt;
     }
 }
@@ -327,7 +327,7 @@ void ctp_stm::apply_placeholder(const model::record_batch& batch) {
     });
     auto placeholder = serde::from_iobuf<ctp_placeholder>(std::move(value));
     auto id = placeholder.id;
-    _epoch_checker.check_epoch(id.epoch, batch.header().base_offset);
+    _epoch_checker.check_epoch(ntp(), id.epoch, batch.header().base_offset);
     _state.advance_epoch(id.epoch, batch.header().base_offset);
 }
 
@@ -345,6 +345,11 @@ ctp_stm::apply_local_snapshot(raft::stm_snapshot_header header, iobuf&& buf) {
     auto snap = serde::from_iobuf<ctp_stm_snapshot>(std::move(buf));
     _state = snap.state;
     _epoch_checker = snap.checker;
+    vlog(
+      _log.debug,
+      "applied local snapshot to state={}, checker={}",
+      _state,
+      _epoch_checker);
     co_return raft::local_snapshot_applied::yes;
 }
 
@@ -353,6 +358,12 @@ ctp_stm::take_local_snapshot(ssx::semaphore_units) {
     auto buf = serde::to_iobuf(
       ctp_stm_snapshot{.state = _state, .checker = _epoch_checker});
     auto snapshot_offset = last_applied();
+    vlog(
+      _log.debug,
+      "taking local snapshot@{} with state={}, checker={}",
+      last_applied(),
+      _state,
+      _epoch_checker);
     co_return raft::stm_snapshot::create(0, snapshot_offset, std::move(buf));
 }
 
@@ -360,6 +371,11 @@ ss::future<> ctp_stm::apply_raft_snapshot(const iobuf& buf) {
     auto snap = serde::from_iobuf<ctp_stm_snapshot>(buf.copy());
     _state = snap.state;
     _epoch_checker = snap.checker;
+    vlog(
+      _log.debug,
+      "applied raft snapshot to state={}, checker={}",
+      _state,
+      _epoch_checker);
     co_return;
 }
 
@@ -369,6 +385,12 @@ ss::future<iobuf> ctp_stm::take_raft_snapshot(model::offset snapshot_at) {
       "The snapshot is taken at offset {} but current insync offset is {}",
       snapshot_at,
       last_applied());
+    vlog(
+      _log.debug,
+      "taking raft snapshot @ {} with state={}, checker={}",
+      last_applied(),
+      _state,
+      _epoch_checker);
     co_return serde::to_iobuf(
       ctp_stm_snapshot{.state = _state, .checker = _epoch_checker});
 }
@@ -383,14 +405,7 @@ ctp_stm::fence_epoch(cluster_epoch e) {
         throw std::runtime_error(fmt_with_ctx(fmt::format, "Sync timeout"));
     }
     auto term = _raft->confirmed_term();
-    // The max_seen_epoch is not persisted to disk as part of the snapshot
-    // because it represents in-flight batches. If this epoch is nullopt we
-    // should take max_applied_epoch into account.
-    auto get_applied_epoch = [this] { return _state.get_max_epoch(); };
-
     while (true) {
-        auto fence_epoch = _state.get_max_seen_epoch().or_else(
-          get_applied_epoch);
         if (_state.epoch_in_window(e)) {
             // Case 1.1. Same epoch, need to acquire read-lock.
             // Case 1.2. This epoch is out of order. We can accept it if it lies
@@ -401,7 +416,7 @@ ctp_stm::fence_epoch(cluster_epoch e) {
                 co_return cluster_epoch_fence{
                   .unit = std::move(unit), .term = term};
             }
-        } else if (!fence_epoch.has_value() || fence_epoch.value() < e) {
+        } else if (_state.epoch_above_window(e)) {
             // Case 2. New epoch, need to acquire write-lock.
             auto epoch_update_lock = _epoch_update_lock.try_get_units();
             if (!epoch_update_lock) {
@@ -415,10 +430,8 @@ ctp_stm::fence_epoch(cluster_epoch e) {
             auto unit = co_await ss::get_units(
               _lock, ss::semaphore::max_counter(), _as);
 
-            auto current_epoch = _state.get_max_seen_epoch().or_else(
-              get_applied_epoch);
             std::optional<cluster_epoch_fence> epoch_fence_opt;
-            if (!current_epoch.has_value() || current_epoch.value() <= e) {
+            if (_state.epoch_in_window(e) || _state.epoch_above_window(e)) {
                 vlog(_log.debug, "Bumping max seen epoch to {}", e);
                 _state.advance_max_seen_epoch(e);
                 // Demote to reader lock after max_seen_epoch is updated.
@@ -438,9 +451,17 @@ ctp_stm::fence_epoch(cluster_epoch e) {
 
         // If we reach here, it means that we need to discard the batch.
         co_return std::unexpected(
-          stale_cluster_epoch(_state.get_max_seen_epoch()
-                                .or_else(get_applied_epoch)
-                                .value_or(cluster_epoch{-1})));
+          stale_cluster_epoch{
+            .window_min = _state.get_previous_seen_epoch()
+                            .or_else([this] {
+                                return _state.get_previous_applied_epoch();
+                            })
+                            .value_or(cluster_epoch{-1}),
+            .window_max = _state.get_max_seen_epoch()
+                            .or_else(
+                              [this] { return _state.get_max_applied_epoch(); })
+                            .value_or(cluster_epoch{-1}),
+          });
     }
 }
 
@@ -451,7 +472,7 @@ model::offset ctp_stm::max_removable_local_log_offset() {
 l0::producer_queue& ctp_stm::producer_queue() { return _producer_queue; }
 
 void epoch_window_checker::check_epoch(
-  cluster_epoch epoch, model::offset offset) {
+  const model::ntp& ntp, cluster_epoch epoch, model::offset offset) {
     if (offset < _latest_offset) {
         return;
     }
@@ -464,7 +485,8 @@ void epoch_window_checker::check_epoch(
     }
     vassert(
       _min_epoch <= epoch && epoch <= _max_epoch,
-      "epoch {} at {} is outside of sliding window [{}, {}]",
+      "[{}] epoch {} at {} is outside of sliding window [{}, {}]",
+      ntp,
       epoch,
       offset,
       _min_epoch,
@@ -472,4 +494,8 @@ void epoch_window_checker::check_epoch(
     _latest_offset = offset;
 }
 
+fmt::iterator epoch_window_checker::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it, "window=[{}, {}], offset={}", _min_epoch, _max_epoch, _latest_offset);
+}
 }; // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -37,7 +37,10 @@ struct epoch_window_checker
     }
 
     // Assert if the epoch at this offset in the log is valid or not.
-    void check_epoch(cluster_epoch epoch, model::offset offset);
+    void
+    check_epoch(const model::ntp&, cluster_epoch epoch, model::offset offset);
+
+    fmt::iterator format_to(fmt::iterator it) const;
 
     cluster_epoch _min_epoch;
     cluster_epoch _max_epoch;

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
@@ -187,7 +187,7 @@ ctp_stm_api::fence_epoch(cluster_epoch e) {
 }
 
 std::optional<cluster_epoch> ctp_stm_api::get_max_epoch() const {
-    return _stm->state().get_max_epoch();
+    return _stm->state().get_max_applied_epoch();
 }
 
 std::optional<cluster_epoch> ctp_stm_api::get_max_seen_epoch() const {

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
@@ -11,6 +11,7 @@
 #include "cloud_topics/level_zero/stm/ctp_stm_state.h"
 
 #include "model/fundamental.h"
+#include "utils/to_string.h"
 
 namespace cloud_topics {
 
@@ -37,8 +38,13 @@ ctp_stm_state::estimate_min_epoch() const noexcept {
 }
 
 std::optional<cluster_epoch>
-ctp_stm_state::get_previous_epoch() const noexcept {
+ctp_stm_state::get_previous_applied_epoch() const noexcept {
     return _previous_applied_epoch;
+}
+
+std::optional<cluster_epoch>
+ctp_stm_state::get_previous_seen_epoch() const noexcept {
+    return _previous_seen_epoch;
 }
 
 bool ctp_stm_state::epoch_in_window(cluster_epoch epoch) const noexcept {
@@ -52,6 +58,12 @@ bool ctp_stm_state::epoch_in_window(cluster_epoch epoch) const noexcept {
     auto begin = _previous_seen_epoch.value_or(
       _previous_applied_epoch.value_or(end));
     return epoch >= begin && epoch <= end;
+}
+
+bool ctp_stm_state::epoch_above_window(cluster_epoch epoch) const noexcept {
+    auto end = _max_seen_epoch.value_or(
+      _max_applied_epoch.value_or(cluster_epoch::min()));
+    return epoch > end;
 }
 
 std::optional<cluster_epoch>
@@ -99,7 +111,8 @@ void ctp_stm_state::advance_last_reconciled_offset(
       new_last_reconciled_log_offset);
 }
 
-std::optional<cluster_epoch> ctp_stm_state::get_max_epoch() const noexcept {
+std::optional<cluster_epoch>
+ctp_stm_state::get_max_applied_epoch() const noexcept {
     return _max_applied_epoch;
 }
 
@@ -125,6 +138,23 @@ void ctp_stm_state::set_start_offset(kafka::offset new_offset) noexcept {
 
 kafka::offset ctp_stm_state::start_offset() const noexcept {
     return _start_offset;
+}
+
+fmt::iterator ctp_stm_state::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it,
+      "{{seen_window=[{}, {}], applied_window=[{}, {}], "
+      "epoch_window_offset={}, min_epoch_lower_bound={}, lro={}, lrlo={}, "
+      "start_offset={}}}",
+      _previous_seen_epoch,
+      _max_seen_epoch,
+      _previous_applied_epoch,
+      _max_applied_epoch,
+      _current_epoch_window_offset,
+      _min_epoch_lower_bound,
+      _last_reconciled_offset,
+      _last_reconciled_log_offset,
+      _start_offset);
 }
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "base/format_to.h"
 #include "cloud_topics/types.h"
 #include "model/fundamental.h"
 #include "serde/envelope.h"
@@ -59,7 +60,15 @@ public:
     kafka::offset start_offset() const noexcept;
 
     /// Find the maximum cluster epoch registered in the state.
-    std::optional<cluster_epoch> get_max_epoch() const noexcept;
+    std::optional<cluster_epoch> get_max_applied_epoch() const noexcept;
+
+    /// Return the previous epoch value.
+    /// The request can be replicated only if its epoch is greater or
+    /// equal to epoch returned by this method. If the method returns
+    /// nullopt then the epoch wasn't advanced yet so there is no
+    /// previous epoch.
+    /// Note that this value is not necessary equal to estimate_min_epoch.
+    std::optional<cluster_epoch> get_previous_applied_epoch() const noexcept;
 
     /// Return the max_seen_epoch epoch.
     ///
@@ -74,20 +83,17 @@ public:
     /// \return max_seen_epoch epoch.
     std::optional<cluster_epoch> get_max_seen_epoch() const noexcept;
 
+    /// Return the previous_seen_epoch epoch.
+    std::optional<cluster_epoch> get_previous_seen_epoch() const noexcept;
+
     /// Estimate the minimum epoch referenced by this ctp_stm.
     /// \note This value might be stale.
     std::optional<cluster_epoch> estimate_min_epoch() const noexcept;
 
-    /// Return the previous epoch value.
-    /// The request can be replicated only if its epoch is greater or
-    /// equal to epoch returned by this method. If the method returns
-    /// nullopt then the epoch wasn't advanced yet so there is no
-    /// previous epoch.
-    /// Note that this value is not necessary equal to estimate_min_epoch.
-    std::optional<cluster_epoch> get_previous_epoch() const noexcept;
-
     /// Return true if the epoch can be replicated
     bool epoch_in_window(cluster_epoch epoch) const noexcept;
+    /// Return true if the epoch is above the current window
+    bool epoch_above_window(cluster_epoch epoch) const noexcept;
 
     /// Estimate inactive epoch
     std::optional<cluster_epoch> estimate_inactive_epoch() const noexcept;
@@ -125,6 +131,8 @@ public:
     ///
     /// \return Max collectible offset.
     model::offset get_max_collectible_offset() const noexcept;
+
+    fmt::iterator format_to(fmt::iterator) const;
 
 private:
     /// The max epoch after the current in flight requests are applied.

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
@@ -25,7 +25,7 @@ namespace {
 
 TEST(ctp_stm_state_test, initial_state) {
     ct::ctp_stm_state state;
-    EXPECT_FALSE(state.get_max_epoch().has_value());
+    EXPECT_FALSE(state.get_max_applied_epoch().has_value());
     EXPECT_FALSE(state.get_max_seen_epoch().has_value());
     EXPECT_FALSE(state.get_last_reconciled_offset().has_value());
     EXPECT_FALSE(state.get_last_reconciled_log_offset().has_value());
@@ -56,16 +56,16 @@ TEST(ctp_stm_state_test, advance_epoch) {
     ct::cluster_epoch epoch3(10);
 
     state.advance_epoch(epoch1, model::offset(1));
-    EXPECT_EQ(state.get_max_epoch().value(), epoch1);
+    EXPECT_EQ(state.get_max_applied_epoch().value(), epoch1);
     EXPECT_EQ(state.get_max_seen_epoch().value(), epoch1);
 
     state.advance_epoch(epoch2, model::offset(2));
-    EXPECT_EQ(state.get_max_epoch().value(), epoch2);
+    EXPECT_EQ(state.get_max_applied_epoch().value(), epoch2);
     EXPECT_EQ(state.get_max_seen_epoch().value(), epoch2);
 
     // Should not go backwards
     state.advance_epoch(epoch3, model::offset(3));
-    EXPECT_EQ(state.get_max_epoch().value(), epoch2);
+    EXPECT_EQ(state.get_max_applied_epoch().value(), epoch2);
     EXPECT_EQ(state.get_max_seen_epoch().value(), epoch2);
 }
 
@@ -77,7 +77,7 @@ TEST(ctp_stm_state_test, advance_epoch_on_a_follower) {
     state.advance_epoch(advance_epoch, model::offset(1));
 
     EXPECT_EQ(state.get_max_seen_epoch().value(), advance_epoch);
-    EXPECT_EQ(state.get_max_epoch().value(), advance_epoch);
+    EXPECT_EQ(state.get_max_applied_epoch().value(), advance_epoch);
 }
 
 TEST(ctp_stm_state_test, advance_last_reconciled_offset) {

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -584,7 +584,7 @@ TEST_F_CORO(ctp_stm_fixture, test_previous_epoch_fencing_with_lro) {
     // Get the previous epoch (should be epoch 2, the previous
     // max_applied_epoch)
     auto stm = get_stm<0>(leader);
-    auto previous_epoch = stm->state().get_previous_epoch();
+    auto previous_epoch = stm->state().get_previous_applied_epoch();
     ASSERT_TRUE_CORO(previous_epoch.has_value());
     ASSERT_EQ_CORO(previous_epoch.value(), ct::cluster_epoch{2});
 
@@ -608,7 +608,7 @@ TEST_F_CORO(ctp_stm_fixture, test_previous_epoch_fencing_with_lro) {
         // get_previous_epoch() returns the committed _previous_epoch, which
         // is still 2 because no batch with epoch 4 has been applied yet.
         // The transient _previous_seen_epoch is 3 (used by epoch_in_window).
-        previous_epoch = stm->state().get_previous_epoch();
+        previous_epoch = stm->state().get_previous_applied_epoch();
         ASSERT_TRUE_CORO(previous_epoch.has_value());
         ASSERT_EQ_CORO(previous_epoch.value(), ct::cluster_epoch{2});
     }
@@ -659,7 +659,7 @@ TEST_F_CORO(ctp_stm_fixture, test_previous_epoch_fencing_with_lro) {
 
     // Get the previous epoch (lower bound of active epochs)
     // The previous epoch is still 2 (no new epochs have been applied)
-    previous_epoch = stm->state().get_previous_epoch();
+    previous_epoch = stm->state().get_previous_applied_epoch();
     ASSERT_TRUE_CORO(previous_epoch.has_value());
     ASSERT_EQ_CORO(previous_epoch.value(), ct::cluster_epoch{2});
 
@@ -685,7 +685,7 @@ TEST_F_CORO(ctp_stm_fixture, test_previous_epoch_fencing_with_lro) {
     }
 
     // The previous epoch is still 2 (no new epochs have been applied)
-    previous_epoch = stm->state().get_previous_epoch();
+    previous_epoch = stm->state().get_previous_applied_epoch();
     ASSERT_TRUE_CORO(previous_epoch.has_value());
     ASSERT_EQ_CORO(previous_epoch.value(), ct::cluster_epoch{2});
 
@@ -703,7 +703,7 @@ TEST_F_CORO(ctp_stm_fixture, test_previous_epoch_fencing_with_lro) {
     ASSERT_TRUE_CORO(inactive_after_lro4);
 
     // Previous epoch should still be 2 (unchanged, no new epochs applied)
-    previous_epoch = stm->state().get_previous_epoch();
+    previous_epoch = stm->state().get_previous_applied_epoch();
     ASSERT_TRUE_CORO(previous_epoch.has_value());
     ASSERT_EQ_CORO(previous_epoch.value(), ct::cluster_epoch{2});
 

--- a/src/v/cloud_topics/level_zero/stm/types.h
+++ b/src/v/cloud_topics/level_zero/stm/types.h
@@ -32,8 +32,10 @@ struct [[nodiscard]] cluster_epoch_fence {
 // The error returned when the CTP STM has seen a newer epoch than the one
 // attempting to be used.
 struct [[nodiscard]] stale_cluster_epoch {
-    // The latest cluster epoch
-    cluster_epoch latest_seen;
+    // The lowest epoch we accept
+    cluster_epoch window_min;
+    // The highest epoch we accept
+    cluster_epoch window_max;
 };
 
 } // namespace cloud_topics


### PR DESCRIPTION
To track down: https://ci-artifacts.dev.vectorized.cloud/production-devprod/redpanda/79581/019beccf-748d-4b6d-bfb3-3dfc6c7c45b6/vbuild/ducktape/results/2026-01-23--001/report.html

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
