### PR TITLE
Two dev_cluster fixes

### DIFF
--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -441,10 +441,12 @@ class Redpanda:
         else:
             cores_args = ""
 
-        # If user did not specify memory, share 75% of memory equally between nodes
+        # If user did not specify memory, share 75% of memory equally between nodes, capped at 4GB
         if not has_arg("-m", "--memory"):
+            max_memory_per_node = 4 * 2**30  # 4GB
             memory_total = psutil.virtual_memory().total
             memory_per_node = (3 * (memory_total // 4)) // self.node_meta.cluster_size
+            memory_per_node = min(memory_per_node, max_memory_per_node)
             memory_args = f"-m {memory_per_node // (1024 * 1024)}M"
         else:
             memory_args = ""

--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -427,8 +427,12 @@ class Redpanda:
     async def run(self) -> int:
         log_path = Path(os.path.dirname(self.node_meta.config_path)) / "redpanda.log"
 
+        def has_arg(*prefixes: str) -> bool:
+            """Check if any extra_arg starts with any of the given prefixes."""
+            return any(arg.startswith(prefixes) for arg in self.extra_args)
+
         # If user did not override cores with extra args, apply it from our internal cores setting
-        if not {"-c", "--smp"} & set(self.extra_args):
+        if not has_arg("-c", "--smp"):
             # Caller is required to pass a finite core count
             assert self.cores > 0
             base_core = self.cores * self.node_meta.index
@@ -438,7 +442,7 @@ class Redpanda:
             cores_args = ""
 
         # If user did not specify memory, share 75% of memory equally between nodes
-        if not {"-m", "--memory"} & set(self.extra_args):
+        if not has_arg("-m", "--memory"):
             memory_total = psutil.virtual_memory().total
             memory_per_node = (3 * (memory_total // 4)) // self.node_meta.cluster_size
             memory_args = f"-m {memory_per_node // (1024 * 1024)}M"


### PR DESCRIPTION
[tools/dev_cluster: fix arg detection for --arg=value style](https://github.com/redpanda-data/redpanda/commit/9d7c36f6cede49e9c947f9697762cade0e57126e)

[tools/dev_cluster: cap automatic memory allocation at 4GB per node](https://github.com/redpanda-data/redpanda/commit/a3e1ba3568fa1768f54333d4e60065b948f991ae)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
