### PR TITLE
ct/l1/lsm: add the remaining LSM-backed state_updates

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/lsm/state_reader.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_reader.cc
@@ -647,4 +647,48 @@ state_reader::get_term_keys(
     co_return keys;
 }
 
+namespace {
+
+bool is_at_metadata(
+  lsm::iterator& iter,
+  const model::topic_id& tid,
+  metadata_row_key* out = nullptr) {
+    if (!iter.valid()) {
+        return false;
+    }
+    auto key = metadata_row_key::decode(iter.key());
+    if (!key.has_value() || key->tidp.topic_id != tid) {
+        return false;
+    }
+    if (out) {
+        *out = key.value();
+    }
+    return true;
+}
+
+} // namespace
+
+ss::future<
+  std::expected<chunked_vector<model::partition_id>, state_reader::error>>
+state_reader::get_partitions_for_topic(const model::topic_id& tid) {
+    chunked_vector<model::partition_id> partitions;
+    try {
+        auto iter = co_await snap_.create_iterator();
+
+        // Seek to the first metadata row for this topic.
+        auto tidp = model::topic_id_partition(tid, model::partition_id(0));
+        co_await iter.seek(metadata_row_key::encode(tidp));
+
+        // Iterate through all metadata rows for this topic.
+        while (is_at_metadata(iter, tid)) {
+            auto key = metadata_row_key::decode(iter.key());
+            partitions.push_back(key->tidp.partition);
+            co_await iter.next();
+        }
+    } catch (...) {
+        co_return std::unexpected(to_error(std::current_exception()));
+    }
+    co_return partitions;
+}
+
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_reader.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_reader.cc
@@ -618,4 +618,33 @@ state_reader::get_val(KeyEncodeArgs... args) {
     }
 }
 
+ss::future<std::expected<chunked_vector<ss::sstring>, state_reader::error>>
+state_reader::get_term_keys(
+  const model::topic_id_partition& tidp,
+  std::optional<kafka::offset> upper_bound) {
+    chunked_vector<ss::sstring> keys;
+    try {
+        auto iter = co_await snap_.create_iterator();
+
+        // Seek to the first term row for this partition.
+        co_await iter.seek(term_row_key::encode(tidp, model::term_id(0)));
+
+        // Iterate through term rows, collecting keys.
+        while (is_at_term(iter, tidp)) {
+            if (upper_bound.has_value()) {
+                auto val = serde::from_iobuf<term_row_value>(iter.value());
+                if (val.term_start_offset > *upper_bound) {
+                    // Stop once we find a term with start_offset > upper_bound.
+                    break;
+                }
+            }
+            keys.push_back(ss::sstring(iter.key()));
+            co_await iter.next();
+        }
+    } catch (...) {
+        co_return std::unexpected(to_error(std::current_exception()));
+    }
+    co_return keys;
+}
+
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_reader.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_reader.h
@@ -134,6 +134,10 @@ public:
       const model::topic_id_partition&,
       std::optional<kafka::offset> upper_bound);
 
+    // Returns all partition IDs that have metadata for the given topic.
+    ss::future<std::expected<chunked_vector<model::partition_id>, error>>
+    get_partitions_for_topic(const model::topic_id&);
+
 private:
     ss::future<
       std::expected<std::optional<std::pair<ss::sstring, ss::sstring>>, error>>

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_reader.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_reader.h
@@ -127,6 +127,13 @@ public:
     ss::future<std::expected<std::optional<kafka::offset>, error>>
     get_term_end(const model::topic_id_partition&, model::term_id);
 
+    // Returns term row keys for the given partition. If `upper_bound` is
+    // provided, returns keys for all terms up to and including the highest
+    // term with start_offset <= upper_bound.
+    ss::future<std::expected<chunked_vector<ss::sstring>, error>> get_term_keys(
+      const model::topic_id_partition&,
+      std::optional<kafka::offset> upper_bound);
+
 private:
     ss::future<
       std::expected<std::optional<std::pair<ss::sstring, ss::sstring>>, error>>

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
@@ -911,4 +911,87 @@ set_start_offset_db_update::build_rows(
     co_return std::expected<void, db_update_error>{};
 }
 
+ss::future<std::expected<void, db_update_error>>
+remove_topics_db_update::build_rows(
+  state_reader& reader, chunked_vector<write_batch_row>& out) const {
+    if (topics.empty()) {
+        co_return std::expected<void, db_update_error>{};
+    }
+
+    // Track removed data sizes by object across all topics/partitions.
+    chunked_hash_map<object_id, size_t> removed_size_by_oid;
+
+    // TODO: this is embarassingly parallel.
+    for (const auto& tid : topics) {
+        // Get all partitions for this topic.
+        auto partitions_res = co_await reader.get_partitions_for_topic(tid);
+        if (!partitions_res.has_value()) {
+            co_return std::unexpected(wrap_read_err(
+              std::move(partitions_res.error()),
+              "Error getting partitions for topic {}",
+              tid));
+        }
+
+        for (const auto& pid : partitions_res.value()) {
+            model::topic_id_partition tidp(tid, pid);
+
+            // Collect all extents to be removed and track the removed sizes by
+            // object.
+            auto extents_res = co_await reader.get_inclusive_extents(
+              tidp, std::nullopt, std::nullopt);
+            if (extents_res.has_value() && extents_res->has_value()) {
+                auto extent_gen = (*extents_res)->get_rows();
+                while (auto row_res = co_await extent_gen()) {
+                    const auto& row = row_res->get();
+                    if (!row.has_value()) {
+                        break;
+                    }
+                    const auto& extent = *row;
+                    removed_size_by_oid[extent.val.oid] += extent.val.len;
+
+                    // Write tombstone for each extent row.
+                    out.emplace_back(
+                      write_batch_row{.key = extent.key, .value = iobuf{}});
+                }
+            }
+
+            // Get all term keys and write tombstones.
+            auto terms_res = co_await reader.get_term_keys(tidp, std::nullopt);
+            if (terms_res.has_value()) {
+                for (const auto& term_key : *terms_res) {
+                    out.emplace_back(
+                      write_batch_row{.key = term_key, .value = iobuf{}});
+                }
+            }
+
+            // Write tombstone for the partition's compaction row.
+            out.emplace_back(
+              write_batch_row{
+                .key = compaction_row_key::encode(tidp), .value = iobuf{}});
+
+            // Write tombstone for the partition's metadata row.
+            out.emplace_back(
+              write_batch_row{
+                .key = metadata_row_key::encode(tidp), .value = iobuf{}});
+        }
+    }
+
+    // Update object entries with removed_data_size.
+    auto updated_old_objects_res = co_await build_object_removal_entries(
+      reader, removed_size_by_oid);
+    if (!updated_old_objects_res.has_value()) {
+        co_return std::unexpected(updated_old_objects_res.error());
+    }
+    auto& updated_old_objects = updated_old_objects_res.value();
+    for (const auto& [oid, obj_entry] : updated_old_objects) {
+        out.emplace_back(
+          write_batch_row{
+            .key = object_row_key::encode(oid),
+            .value = serde::to_iobuf(object_row_value{.object = obj_entry}),
+          });
+    }
+
+    co_return std::expected<void, db_update_error>{};
+}
+
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
@@ -241,6 +241,30 @@ ss::future<std::expected<void, db_update_error>> merge_compaction_state(
     co_return std::expected<void, db_update_error>{};
 }
 
+// Goes through the given removed objects and builds a map of object_entries of
+// corresponding objects with the provided sizes removed.
+ss::future<
+  std::expected<chunked_hash_map<object_id, object_entry>, db_update_error>>
+build_object_removal_entries(
+  state_reader& state,
+  const chunked_hash_map<object_id, size_t>& removed_sizes_by_oid) {
+    chunked_hash_map<object_id, object_entry> updated_old_objects;
+    for (const auto& [oid, removed_size] : removed_sizes_by_oid) {
+        auto obj_res = co_await state.get_object(oid);
+        if (!obj_res.has_value()) {
+            co_return std::unexpected(wrap_read_err(
+              std::move(obj_res.error()), "Error getting object {}", oid));
+        }
+        if (obj_res.value().has_value()) {
+            auto obj_entry = obj_res.value().value();
+            obj_entry.removed_data_size += removed_size;
+            updated_old_objects[oid] = obj_entry;
+        }
+        // If object doesn't exist, skip it (benign).
+    }
+    co_return updated_old_objects;
+}
+
 } // namespace
 
 ss::future<std::expected<void, db_update_error>>
@@ -555,22 +579,12 @@ replace_objects_db_update::build_rows(
 
     // Update existing object entries to indicate the removal of data from
     // replaced extents.
-    chunked_hash_map<object_id, object_entry> updated_old_objects;
-    for (const auto& [oid, removed_size] : old_extent_sizes_by_oid) {
-        auto obj_res = co_await state.get_object(oid);
-        if (!obj_res.has_value()) {
-            co_return std::unexpected(wrap_read_err(
-              std::move(obj_res.error()),
-              "Error getting object {} for update",
-              oid));
-        }
-        if (obj_res.value().has_value()) {
-            auto obj_entry = obj_res.value().value();
-            obj_entry.removed_data_size += removed_size;
-            updated_old_objects[oid] = obj_entry;
-        }
-        // If object doesn't exist, skip it (benign).
+    auto updated_old_objects_res = co_await build_object_removal_entries(
+      state, old_extent_sizes_by_oid);
+    if (!updated_old_objects_res.has_value()) {
+        co_return std::unexpected(updated_old_objects_res.error());
     }
+    auto& updated_old_objects = updated_old_objects_res.value();
 
     chunked_hash_map<model::topic_id_partition, compaction_state>
       merged_compaction_states;
@@ -751,6 +765,150 @@ replace_objects_db_update::validate_inputs() const {
     }
 
     return std::expected<void, db_update_error>{};
+}
+
+ss::future<std::expected<void, db_update_error>>
+set_start_offset_db_update::build_rows(
+  state_reader& reader, chunked_vector<write_batch_row>& out) const {
+    auto meta_res = co_await reader.get_metadata(tp);
+    if (!meta_res.has_value()) {
+        co_return std::unexpected(wrap_read_err(
+          std::move(meta_res.error()), "Error reading metadata for {}", tp));
+    }
+    if (!meta_res->has_value()) {
+        co_return std::unexpected(db_update_error(
+          invalid_update, fmt::format("Partition {} not found", tp)));
+    }
+    const auto& metadata = meta_res.value().value();
+
+    // Validate the current offset range.
+    if (
+      new_start_offset < metadata.start_offset
+      || new_start_offset > metadata.next_offset) {
+        co_return std::unexpected(db_update_error(
+          invalid_update,
+          fmt::format(
+            "Invalid start offset {} for partition {} (current range: [{}, "
+            "{}])",
+            new_start_offset,
+            tp,
+            metadata.start_offset,
+            metadata.next_offset)));
+    }
+    if (metadata.start_offset >= new_start_offset) {
+        co_return std::expected<void, db_update_error>{};
+    }
+
+    // Find extents below new_start_offset and collect for deletion.
+    chunked_hash_map<object_id, size_t> removed_size_by_oid;
+    chunked_vector<ss::sstring> extent_keys_to_delete;
+
+    auto max_to_remove = kafka::prev_offset(new_start_offset);
+    auto extents_res = co_await reader.get_inclusive_extents(
+      tp, metadata.start_offset, max_to_remove);
+    if (!extents_res.has_value()) {
+        co_return std::unexpected(wrap_read_err(
+          std::move(extents_res.error()),
+          "Error getting {} extents for removal in range [{}, {}]",
+          tp,
+          metadata.start_offset,
+          max_to_remove));
+    }
+    if (extents_res.value().has_value()) {
+        auto extent_gen = (*extents_res)->get_rows();
+        while (auto row_res = co_await extent_gen()) {
+            const auto& row = row_res->get();
+            if (!row.has_value()) {
+                co_return std::unexpected(wrap_read_err(
+                  row.error(),
+                  "Error iterating through {} extents in range [{}, {}]",
+                  tp,
+                  metadata.start_offset,
+                  max_to_remove));
+            }
+            // Only delete if extent is fully below new_start_offset.
+            const auto& extent = *row;
+            if (extent.val.last_offset < new_start_offset) {
+                removed_size_by_oid[extent.val.oid] += extent.val.len;
+                extent_keys_to_delete.push_back(extent.key);
+            }
+        }
+    }
+
+    // Write tombstones for deleted extents.
+    for (const auto& key : extent_keys_to_delete) {
+        out.emplace_back(write_batch_row{.key = key, .value = iobuf{}});
+    }
+
+    // Update object entries with removed_data_size.
+    auto updated_old_objects_res = co_await build_object_removal_entries(
+      reader, removed_size_by_oid);
+    if (!updated_old_objects_res.has_value()) {
+        co_return std::unexpected(updated_old_objects_res.error());
+    }
+    auto& updated_old_objects = updated_old_objects_res.value();
+    for (const auto& [oid, obj_entry] : updated_old_objects) {
+        out.emplace_back(
+          write_batch_row{
+            .key = object_row_key::encode(oid),
+            .value = serde::to_iobuf(object_row_value{.object = obj_entry}),
+          });
+    }
+
+    // Collect term starts at or below new_start_offset.
+    auto term_keys_res = co_await reader.get_term_keys(tp, new_start_offset);
+    if (!term_keys_res.has_value()) {
+        co_return std::unexpected(wrap_read_err(
+          std::move(term_keys_res.error()),
+          "Error getting term keys for {}",
+          tp));
+    }
+    auto& term_keys = *term_keys_res;
+    if (!term_keys.empty()) {
+        // Keep the last one to ensure we still have the term for the start
+        // offset.
+        term_keys.pop_back();
+    }
+    for (const auto& term_key : term_keys) {
+        out.emplace_back(write_batch_row{.key = term_key, .value = iobuf{}});
+    }
+
+    // Truncate compaction state if it exists.
+    if (metadata.compaction_epoch > partition_state::compaction_epoch_t(0)) {
+        auto comp_res = co_await reader.get_compaction_metadata(tp);
+        if (!comp_res.has_value()) {
+            co_return std::unexpected(wrap_read_err(
+              std::move(comp_res.error()),
+              "Error getting compaction metadata for {}",
+              tp));
+        }
+        if (comp_res->has_value()) {
+            auto comp_state = std::move(comp_res.value().value());
+            comp_state.truncate_with_new_start_offset(new_start_offset);
+            out.emplace_back(
+              write_batch_row{
+                .key = compaction_row_key::encode(tp),
+                .value = serde::to_iobuf(
+                  compaction_row_value{.state = comp_state}),
+              });
+        }
+    }
+
+    // Finally, write updated partition metadata.
+    out.emplace_back(
+      write_batch_row{
+        .key = metadata_row_key::encode(tp),
+        .value = serde::to_iobuf(
+          metadata_row_value{
+            .start_offset = new_start_offset,
+            .next_offset = metadata.next_offset,
+            .compaction_epoch = metadata.compaction_epoch,
+          }),
+      });
+
+    // TODO: if the resulting set of rows is too large, we should consider
+    // doing some incremental prefix truncation.
+    co_return std::expected<void, db_update_error>{};
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
@@ -994,4 +994,44 @@ remove_topics_db_update::build_rows(
     co_return std::expected<void, db_update_error>{};
 }
 
+ss::future<std::expected<void, db_update_error>>
+remove_objects_db_update::build_rows(
+  state_reader& reader, chunked_vector<write_batch_row>& out) const {
+    if (objects.empty()) {
+        co_return std::expected<void, db_update_error>{};
+    }
+
+    for (const auto& oid : objects) {
+        auto obj_res = co_await reader.get_object(oid);
+        if (!obj_res.has_value()) {
+            co_return std::unexpected(wrap_read_err(
+              std::move(obj_res.error()), "Error getting object {}", oid));
+        }
+        if (!obj_res.value().has_value()) {
+            // Object doesn't exist, skip.
+            continue;
+        }
+
+        const auto& obj_entry = obj_res.value().value();
+
+        // Reject if object still has referenced data.
+        if (obj_entry.removed_data_size < obj_entry.total_data_size) {
+            co_return std::unexpected(db_update_error(
+              invalid_update,
+              fmt::format(
+                "Object {} is still referenced (removed_data_size={}, "
+                "total_data_size={})",
+                oid,
+                obj_entry.removed_data_size,
+                obj_entry.total_data_size)));
+        }
+
+        out.emplace_back(
+          write_batch_row{
+            .key = object_row_key::encode(oid), .value = iobuf{}});
+    }
+
+    co_return std::expected<void, db_update_error>{};
+}
+
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.h
@@ -75,6 +75,14 @@ struct replace_objects_db_update {
       compaction_updates;
 };
 
+struct set_start_offset_db_update {
+    ss::future<std::expected<void, db_update_error>>
+    build_rows(state_reader&, chunked_vector<write_batch_row>&) const;
+
+    model::topic_id_partition tp;
+    kafka::offset new_start_offset;
+};
+
 } // namespace cloud_topics::l1
 
 template<>

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.h
@@ -83,6 +83,13 @@ struct set_start_offset_db_update {
     kafka::offset new_start_offset;
 };
 
+struct remove_topics_db_update {
+    ss::future<std::expected<void, db_update_error>>
+    build_rows(state_reader&, chunked_vector<write_batch_row>&) const;
+
+    chunked_vector<model::topic_id> topics;
+};
+
 } // namespace cloud_topics::l1
 
 template<>

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.h
@@ -90,6 +90,16 @@ struct remove_topics_db_update {
     chunked_vector<model::topic_id> topics;
 };
 
+struct remove_objects_db_update {
+    // Removes objects that are no longer referenced by any extents.
+    // An object is considered unreferenced when removed_data_size >=
+    // total_data_size.
+    ss::future<std::expected<void, db_update_error>>
+    build_rows(state_reader&, chunked_vector<write_batch_row>&) const;
+
+    chunked_vector<object_id> objects;
+};
+
 } // namespace cloud_topics::l1
 
 template<>

--- a/src/v/cloud_topics/level_one/metastore/lsm/tests/state_reader_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/tests/state_reader_test.cc
@@ -789,6 +789,21 @@ void verify_term_end(
     }
 }
 
+void verify_term_keys(
+  state_reader& reader,
+  const model::topic_id_partition& tidp,
+  std::optional<kafka::offset> upper_bound,
+  size_t expected_count) {
+    SCOPED_TRACE(
+      fmt::format(
+        "tidp={}, upper_bound={}",
+        tidp,
+        upper_bound.has_value() ? fmt::format("{}", *upper_bound) : "nullopt"));
+    auto res = reader.get_term_keys(tidp, upper_bound).get();
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->size(), expected_count);
+}
+
 } // namespace
 
 TEST_F(StateReaderTestFixture, TestGetTermLe) {
@@ -842,4 +857,38 @@ TEST_F(StateReaderTestFixture, TestGetTermEnd) {
     // Missing partition should return nullopt.
     auto missing_tidp = make_tidp(1);
     verify_term_end(reader, missing_tidp, model::term_id(1), std::nullopt);
+}
+
+TEST_F(StateReaderTestFixture, TestGetTermKeys) {
+    auto tidp = make_tidp(0);
+    write_term_start(tidp, model::term_id(1), kafka::offset(0));
+    write_term_start(tidp, model::term_id(3), kafka::offset(50));
+    write_term_start(tidp, model::term_id(7), kafka::offset(100));
+    auto reader = make_reader();
+
+    // No upper bound, grab all the terms.
+    verify_term_keys(reader, tidp, std::nullopt, 3);
+
+    // With upper_bound below first term, returns empty.
+    verify_term_keys(reader, tidp, kafka::offset(-1), 0);
+
+    // With upper_bound between first and second term, returns first term only.
+    verify_term_keys(reader, tidp, kafka::offset(0), 1);
+    verify_term_keys(reader, tidp, kafka::offset(1), 1);
+    verify_term_keys(reader, tidp, kafka::offset(49), 1);
+
+    // With upper_bound at second term's start_offset, returns first two.
+    verify_term_keys(reader, tidp, kafka::offset(50), 2);
+    verify_term_keys(reader, tidp, kafka::offset(51), 2);
+    verify_term_keys(reader, tidp, kafka::offset(99), 2);
+
+    // With upper_bound at or beyond third term, returns all three.
+    verify_term_keys(reader, tidp, kafka::offset(100), 3);
+    verify_term_keys(reader, tidp, kafka::offset(1000), 3);
+
+    // Missing partition returns empty.
+    auto missing_tidp = make_tidp(1);
+    verify_term_keys(reader, missing_tidp, kafka::offset(0), 0);
+    verify_term_keys(reader, missing_tidp, kafka::offset(100), 0);
+    verify_term_keys(reader, missing_tidp, std::nullopt, 0);
 }

--- a/src/v/cloud_topics/level_one/metastore/lsm/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/tests/state_update_test.cc
@@ -374,6 +374,33 @@ protected:
         apply_replace_update(db_update);
     }
 
+    void apply_set_start_offset_update(set_start_offset_db_update& update) {
+        auto reader = make_reader();
+        chunked_vector<write_batch_row> rows;
+        auto result = update.build_rows(reader, rows).get();
+        ASSERT_TRUE(result.has_value());
+
+        auto seqno = next_seqno();
+        auto wb = db_->create_write_batch();
+        for (const auto& row : rows) {
+            if (row.value.empty()) {
+                wb.remove(row.key, seqno);
+            } else {
+                wb.put(row.key, row.value.copy(), seqno);
+            }
+        }
+        db_->apply(std::move(wb)).get();
+    }
+
+    void
+    set_start_offset(model::topic_id_partition tidp, kafka::offset offset) {
+        auto update = set_start_offset_db_update{
+          .tp = tidp,
+          .new_start_offset = offset,
+        };
+        apply_set_start_offset_update(update);
+    }
+
     std::optional<lsm::database> db_;
 };
 
@@ -853,4 +880,188 @@ TEST_F(StateUpdateTest, TestReplaceObjectsRejectsCleanedRangeNotAtLogStart) {
       tidp0,
       /*expected_cleaned_ranges=*/{{100, 199}},
       /*expected_tombstone_ranges=*/{});
+}
+
+TEST_F(StateUpdateTest, TestSetStartOffsetBasic) {
+    // Set up partition with three extents.
+    auto oid1 = make_oid();
+    auto oid2 = make_oid();
+    auto oid3 = make_oid();
+    add_objects(
+      {terms(tidp0, {{0, 1}})},
+      make_object(oid1, tp(tidp0, 0, 99).pos(0, 1023)),
+      make_object(oid2, tp(tidp0, 100, 199).pos(0, 1023)),
+      make_object(oid3, tp(tidp0, 200, 299).pos(0, 1023)));
+
+    verify_metadata(tidp0, kafka::offset(0), kafka::offset(300));
+
+    // Set start offset to 200, which should remove the first two extents.
+    set_start_offset(tidp0, kafka::offset(200));
+
+    // Verify metadata is updated.
+    verify_metadata(tidp0, kafka::offset(200), kafka::offset(300));
+
+    // Verify first two extents are removed.
+    verify_extent_missing(tidp0, kafka::offset(0));
+    verify_extent_missing(tidp0, kafka::offset(100));
+
+    // Verify third extent still exists.
+    verify_extent_exists(tidp0, kafka::offset(200), kafka::offset(299));
+
+    // Verify object entries have updated removed_data_size.
+    verify_object_exists(oid1, 1024, /*removed_data_size=*/1024);
+    verify_object_exists(oid2, 1024, /*removed_data_size=*/1024);
+    verify_object_exists(oid3, 1024, /*removed_data_size=*/0);
+}
+
+TEST_F(StateUpdateTest, TestSetStartOffsetNoOp) {
+    // Set up partition.
+    auto oid = make_oid();
+    add_objects(
+      {terms(tidp0, {{0, 1}})},
+      make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
+
+    verify_metadata(tidp0, kafka::offset(0), kafka::offset(100));
+
+    // Set start offset to 0 (same as current), should be no-op.
+    set_start_offset(tidp0, kafka::offset(0));
+
+    // Verify nothing changed.
+    verify_metadata(tidp0, kafka::offset(0), kafka::offset(100));
+    verify_extent_exists(tidp0, kafka::offset(0), kafka::offset(99));
+    verify_object_exists(oid, 1024, /*removed_data_size=*/0);
+}
+
+TEST_F(StateUpdateTest, TestSetStartOffsetPartialRemoval) {
+    // Set up partition with three extents.
+    auto oid1 = make_oid();
+    auto oid2 = make_oid();
+    auto oid3 = make_oid();
+    add_objects(
+      {terms(tidp0, {{0, 1}})},
+      make_object(oid1, tp(tidp0, 0, 99).pos(0, 1023)),
+      make_object(oid2, tp(tidp0, 100, 199).pos(0, 1023)),
+      make_object(oid3, tp(tidp0, 200, 299).pos(0, 1023)));
+
+    // Set start offset to 100, which should only remove the first extent.
+    set_start_offset(tidp0, kafka::offset(100));
+
+    verify_metadata(tidp0, kafka::offset(100), kafka::offset(300));
+    verify_extent_missing(tidp0, kafka::offset(0));
+    verify_extent_exists(tidp0, kafka::offset(100), kafka::offset(199));
+    verify_extent_exists(tidp0, kafka::offset(200), kafka::offset(299));
+    verify_object_exists(oid1, 1024, /*removed_data_size=*/1024);
+    verify_object_exists(oid2, 1024, /*removed_data_size=*/0);
+    verify_object_exists(oid3, 1024, /*removed_data_size=*/0);
+}
+
+TEST_F(StateUpdateTest, TestSetStartOffsetWithinExtent) {
+    // Set up partition with extent [0-99].
+    auto oid = make_oid();
+    add_objects(
+      {terms(tidp0, {{0, 1}})},
+      make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
+
+    // Set start offset to 50 (within the extent).
+    // The extent [0-99] should NOT be deleted since its last_offset >= 50.
+    set_start_offset(tidp0, kafka::offset(50));
+
+    verify_metadata(tidp0, kafka::offset(50), kafka::offset(100));
+    // The extent should still exist since last_offset (99) >= new_start (50).
+    verify_extent_exists(tidp0, kafka::offset(0), kafka::offset(99));
+    // No data removed since extent wasn't fully deleted.
+    verify_object_exists(oid, 1024, /*removed_data_size=*/0);
+}
+
+TEST_F(StateUpdateTest, TestSetStartOffsetRejectsBelowStart) {
+    // Set up partition with start_offset=100.
+    add_objects(
+      {terms(tidp0, {{0, 1}})},
+      make_object(make_oid(), tp(tidp0, 0, 99).pos(0, 1023)));
+    set_start_offset(tidp0, kafka::offset(50));
+
+    verify_metadata(tidp0, kafka::offset(50), kafka::offset(100));
+
+    // Try to set start offset below current start.
+    auto update = set_start_offset_db_update{
+      .tp = tidp0,
+      .new_start_offset = kafka::offset(25),
+    };
+    auto reader = make_reader();
+    chunked_vector<write_batch_row> rows;
+    auto result = update.build_rows(reader, rows).get();
+    ASSERT_FALSE(result.has_value());
+}
+
+TEST_F(StateUpdateTest, TestSetStartOffsetRejectsAboveNext) {
+    // Set up partition with next_offset=100.
+    add_objects(
+      {terms(tidp0, {{0, 1}})},
+      make_object(make_oid(), tp(tidp0, 0, 99).pos(0, 1023)));
+
+    verify_metadata(tidp0, kafka::offset(0), kafka::offset(100));
+
+    // Try to set start offset above next_offset.
+    auto update = set_start_offset_db_update{
+      .tp = tidp0,
+      .new_start_offset = kafka::offset(150),
+    };
+    auto reader = make_reader();
+    chunked_vector<write_batch_row> rows;
+    auto result = update.build_rows(reader, rows).get();
+    ASSERT_FALSE(result.has_value());
+}
+
+TEST_F(StateUpdateTest, TestSetStartOffsetRejectsMissingPartition) {
+    // Try to set start offset on a partition that doesn't exist.
+    auto update = set_start_offset_db_update{
+      .tp = tidp0,
+      .new_start_offset = kafka::offset(50),
+    };
+    auto reader = make_reader();
+    chunked_vector<write_batch_row> rows;
+    auto result = update.build_rows(reader, rows).get();
+    ASSERT_FALSE(result.has_value());
+}
+
+TEST_F(StateUpdateTest, TestSetStartOffsetRemovesAllExtents) {
+    // Set up partition with extents [0-99].
+    auto oid = make_oid();
+    add_objects(
+      {terms(tidp0, {{0, 1}})},
+      make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
+
+    // Set start offset to next_offset, which removes all extents.
+    set_start_offset(tidp0, kafka::offset(100));
+
+    verify_metadata(tidp0, kafka::offset(100), kafka::offset(100));
+    verify_extent_missing(tidp0, kafka::offset(0));
+    verify_object_exists(oid, 1024, /*removed_data_size=*/1024);
+}
+
+TEST_F(StateUpdateTest, TestSetStartOffsetTruncatesCompactionState) {
+    auto oid1 = make_oid();
+    add_objects(
+      {terms(tidp0, {{0, 1}})},
+      make_object(oid1, tp(tidp0, 0, 99).pos(0, 1023)));
+
+    replace_objects(
+      {{compact_spec{
+        .tidp = tidp0,
+        .cleaned = {{20, 80, true}},
+      }}},
+      make_object(make_oid(), tp(tidp0, 0, 99).pos(0, 511)));
+
+    verify_compaction_state(
+      tidp0,
+      /*expected_cleaned_ranges=*/{{20, 80}},
+      /*expected_tombstone_ranges=*/{{20, 80, 1000}});
+
+    // Set start offset to 50, which should truncate compaction ranges.
+    set_start_offset(tidp0, kafka::offset(50));
+    verify_metadata(tidp0, kafka::offset(50), kafka::offset(100));
+    verify_compaction_state(
+      tidp0,
+      /*expected_cleaned_ranges=*/{{50, 80}},
+      /*expected_tombstone_ranges=*/{{50, 80, 1000}});
 }

--- a/src/v/cloud_topics/level_one/metastore/lsm/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/tests/state_update_test.cc
@@ -401,6 +401,45 @@ protected:
         apply_set_start_offset_update(update);
     }
 
+    void apply_remove_topics_update(remove_topics_db_update& update) {
+        auto reader = make_reader();
+        chunked_vector<write_batch_row> rows;
+        auto result = update.build_rows(reader, rows).get();
+        ASSERT_TRUE(result.has_value());
+
+        auto seqno = next_seqno();
+        auto wb = db_->create_write_batch();
+        for (const auto& row : rows) {
+            if (row.value.empty()) {
+                wb.remove(row.key, seqno);
+            } else {
+                wb.put(row.key, row.value.copy(), seqno);
+            }
+        }
+        db_->apply(std::move(wb)).get();
+    }
+
+    void remove_topics(chunked_vector<model::topic_id> topics) {
+        auto update = remove_topics_db_update{
+          .topics = std::move(topics),
+        };
+        apply_remove_topics_update(update);
+    }
+
+    void verify_metadata_missing(model::topic_id_partition tidp) {
+        auto reader = make_reader();
+        auto res = reader.get_metadata(tidp).get();
+        ASSERT_TRUE(res.has_value());
+        EXPECT_FALSE(res->has_value());
+    }
+
+    void verify_compaction_missing(model::topic_id_partition tidp) {
+        auto reader = make_reader();
+        auto res = reader.get_compaction_metadata(tidp).get();
+        ASSERT_TRUE(res.has_value());
+        EXPECT_FALSE(res->has_value());
+    }
+
     std::optional<lsm::database> db_;
 };
 
@@ -1064,4 +1103,153 @@ TEST_F(StateUpdateTest, TestSetStartOffsetTruncatesCompactionState) {
       tidp0,
       /*expected_cleaned_ranges=*/{{50, 80}},
       /*expected_tombstone_ranges=*/{{50, 80, 1000}});
+}
+
+TEST_F(StateUpdateTest, TestRemoveTopicsBasic) {
+    // Set up partition with extents.
+    auto oid1 = make_oid();
+    auto oid2 = make_oid();
+    add_objects(
+      {terms(tidp0, {{0, 1}})},
+      make_object(oid1, tp(tidp0, 0, 99).pos(0, 1023)),
+      make_object(oid2, tp(tidp0, 100, 199).pos(0, 1023)));
+
+    verify_metadata(tidp0, kafka::offset(0), kafka::offset(200));
+    verify_extent_exists(tidp0, kafka::offset(0), kafka::offset(99));
+    verify_extent_exists(tidp0, kafka::offset(100), kafka::offset(199));
+
+    // Remove the topic.
+    chunked_vector<model::topic_id> topics_to_remove;
+    topics_to_remove.push_back(tidp0.topic_id);
+    remove_topics(std::move(topics_to_remove));
+
+    // Verify metadata, extents, and terms are removed.
+    verify_metadata_missing(tidp0);
+    verify_extent_missing(tidp0, kafka::offset(0));
+    verify_extent_missing(tidp0, kafka::offset(100));
+    verify_compaction_missing(tidp0);
+
+    // Verify objects have updated removed_data_size.
+    verify_object_exists(oid1, 1024, /*removed_data_size=*/1024);
+    verify_object_exists(oid2, 1024, /*removed_data_size=*/1024);
+}
+
+TEST_F(StateUpdateTest, TestRemoveTopicsMultiplePartitions) {
+    // Set up two partitions for the same topic.
+    auto tidp1 = make_tidp(1);
+    auto oid1 = make_oid();
+    auto oid2 = make_oid();
+    add_objects(
+      {terms(tidp0, {{0, 1}})},
+      make_object(oid1, tp(tidp0, 0, 99).pos(0, 1023)));
+    add_objects(
+      {terms(tidp1, {{0, 1}})},
+      make_object(oid2, tp(tidp1, 0, 99).pos(0, 1023)));
+
+    verify_metadata(tidp0, kafka::offset(0), kafka::offset(100));
+    verify_metadata(tidp1, kafka::offset(0), kafka::offset(100));
+
+    // Remove the topic (should remove both partitions).
+    chunked_vector<model::topic_id> topics_to_remove;
+    topics_to_remove.push_back(tidp0.topic_id);
+    remove_topics(std::move(topics_to_remove));
+
+    // Both partitions should be removed.
+    verify_metadata_missing(tidp0);
+    verify_metadata_missing(tidp1);
+    verify_extent_missing(tidp0, kafka::offset(0));
+    verify_extent_missing(tidp1, kafka::offset(0));
+
+    // Both objects should have updated removed_data_size.
+    verify_object_exists(oid1, 1024, /*removed_data_size=*/1024);
+    verify_object_exists(oid2, 1024, /*removed_data_size=*/1024);
+}
+
+TEST_F(StateUpdateTest, TestRemoveTopicsWithCompaction) {
+    // Set up partition with compaction state.
+    auto oid = make_oid();
+    add_objects(
+      {terms(tidp0, {{0, 1}})},
+      make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
+
+    // Add a cleaned range.
+    replace_objects(
+      {{compact_spec{
+        .tidp = tidp0,
+        .cleaned = {{0, 49, true}},
+      }}},
+      make_object(make_oid(), tp(tidp0, 0, 99).pos(0, 511)));
+
+    verify_compaction_state(
+      tidp0,
+      /*expected_cleaned_ranges=*/{{0, 49}},
+      /*expected_tombstone_ranges=*/{{0, 49, 1000}});
+
+    // Remove the topic.
+    chunked_vector<model::topic_id> topics_to_remove;
+    topics_to_remove.push_back(tidp0.topic_id);
+    remove_topics(std::move(topics_to_remove));
+
+    // Verify all state is removed.
+    verify_metadata_missing(tidp0);
+    verify_extent_missing(tidp0, kafka::offset(0));
+    verify_compaction_missing(tidp0);
+}
+
+TEST_F(StateUpdateTest, TestRemoveTopicsEmpty) {
+    // Removing empty topics list should be no-op.
+    chunked_vector<model::topic_id> topics_to_remove;
+    remove_topics(std::move(topics_to_remove));
+    // No crash, no side effects.
+}
+
+TEST_F(StateUpdateTest, TestRemoveTopicsNonExistent) {
+    // Set up a partition.
+    auto oid = make_oid();
+    add_objects(
+      {terms(tidp0, {{0, 1}})},
+      make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
+
+    // Try to remove a different topic.
+    auto other_topic = model::topic_id(
+      uuid_t::from_string("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
+    chunked_vector<model::topic_id> topics_to_remove;
+    topics_to_remove.push_back(other_topic);
+    remove_topics(std::move(topics_to_remove));
+
+    // Original topic should still exist.
+    verify_metadata(tidp0, kafka::offset(0), kafka::offset(100));
+    verify_extent_exists(tidp0, kafka::offset(0), kafka::offset(99));
+    verify_object_exists(oid, 1024, /*removed_data_size=*/0);
+}
+
+TEST_F(StateUpdateTest, TestRemoveTopicsMultipleTopics) {
+    // Set up two different topics.
+    auto topic2 = model::topic_id(
+      uuid_t::from_string("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
+    auto tidp_t2 = model::topic_id_partition(topic2, model::partition_id(0));
+    auto oid1 = make_oid();
+    auto oid2 = make_oid();
+
+    add_objects(
+      {terms(tidp0, {{0, 1}})},
+      make_object(oid1, tp(tidp0, 0, 99).pos(0, 1023)));
+    add_objects(
+      {terms(tidp_t2, {{0, 1}})},
+      make_object(oid2, tp(tidp_t2, 0, 99).pos(0, 1023)));
+
+    verify_metadata(tidp0, kafka::offset(0), kafka::offset(100));
+    verify_metadata(tidp_t2, kafka::offset(0), kafka::offset(100));
+
+    // Remove both topics.
+    chunked_vector<model::topic_id> topics_to_remove;
+    topics_to_remove.push_back(tidp0.topic_id);
+    topics_to_remove.push_back(topic2);
+    remove_topics(std::move(topics_to_remove));
+
+    // Both should be removed.
+    verify_metadata_missing(tidp0);
+    verify_metadata_missing(tidp_t2);
+    verify_object_exists(oid1, 1024, /*removed_data_size=*/1024);
+    verify_object_exists(oid2, 1024, /*removed_data_size=*/1024);
 }

--- a/src/v/cloud_topics/level_one/metastore/lsm/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/tests/state_update_test.cc
@@ -440,6 +440,38 @@ protected:
         EXPECT_FALSE(res->has_value());
     }
 
+    void apply_remove_objects_update(remove_objects_db_update& update) {
+        auto reader = make_reader();
+        chunked_vector<write_batch_row> rows;
+        auto result = update.build_rows(reader, rows).get();
+        ASSERT_TRUE(result.has_value());
+
+        auto seqno = next_seqno();
+        auto wb = db_->create_write_batch();
+        for (const auto& row : rows) {
+            if (row.value.empty()) {
+                wb.remove(row.key, seqno);
+            } else {
+                wb.put(row.key, row.value.copy(), seqno);
+            }
+        }
+        db_->apply(std::move(wb)).get();
+    }
+
+    void remove_objects(chunked_vector<object_id> objects) {
+        auto update = remove_objects_db_update{
+          .objects = std::move(objects),
+        };
+        apply_remove_objects_update(update);
+    }
+
+    void verify_object_missing(object_id oid) {
+        auto reader = make_reader();
+        auto res = reader.get_object(oid).get();
+        ASSERT_TRUE(res.has_value());
+        EXPECT_FALSE(res->has_value());
+    }
+
     std::optional<lsm::database> db_;
 };
 
@@ -1252,4 +1284,128 @@ TEST_F(StateUpdateTest, TestRemoveTopicsMultipleTopics) {
     verify_metadata_missing(tidp_t2);
     verify_object_exists(oid1, 1024, /*removed_data_size=*/1024);
     verify_object_exists(oid2, 1024, /*removed_data_size=*/1024);
+}
+
+TEST_F(StateUpdateTest, TestRemoveObjectsFullyRemoved) {
+    // Set up partition and then remove all extents via set_start_offset.
+    auto oid = make_oid();
+    add_objects(
+      {terms(tidp0, {{0, 1}})},
+      make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
+
+    verify_object_exists(oid, 1024, /*removed_data_size=*/0);
+
+    // Remove all extents by setting start_offset to next_offset.
+    set_start_offset(tidp0, kafka::offset(100));
+    verify_object_exists(oid, 1024, /*removed_data_size=*/1024);
+
+    // Now remove the object.
+    chunked_vector<object_id> objects_to_remove;
+    objects_to_remove.push_back(oid);
+    remove_objects(std::move(objects_to_remove));
+
+    // Object should be removed.
+    verify_object_missing(oid);
+}
+
+TEST_F(StateUpdateTest, TestRemoveObjectsPartiallyRemoved) {
+    // Set up partition with two extents from different objects.
+    auto oid1 = make_oid();
+    auto oid2 = make_oid();
+    add_objects(
+      {terms(tidp0, {{0, 1}})},
+      make_object(oid1, tp(tidp0, 0, 99).pos(0, 1023)),
+      make_object(oid2, tp(tidp0, 100, 199).pos(0, 1023)));
+
+    // Remove first extent only.
+    set_start_offset(tidp0, kafka::offset(100));
+    verify_object_exists(oid1, 1024, /*removed_data_size=*/1024);
+    verify_object_exists(oid2, 1024, /*removed_data_size=*/0);
+
+    // Try to remove both objects - should fail because oid2 is still
+    // referenced.
+    auto update = remove_objects_db_update{
+      .objects = {},
+    };
+    update.objects.push_back(oid1);
+    update.objects.push_back(oid2);
+    auto reader = make_reader();
+    chunked_vector<write_batch_row> rows;
+    auto result = update.build_rows(reader, rows).get();
+    ASSERT_FALSE(result.has_value());
+
+    // Both objects should still exist (update rejected).
+    verify_object_exists(oid1, 1024, /*removed_data_size=*/1024);
+    verify_object_exists(oid2, 1024, /*removed_data_size=*/0);
+}
+
+TEST_F(StateUpdateTest, TestRemoveObjectsNoneRemoved) {
+    // Set up partition with extents still referencing objects.
+    auto oid = make_oid();
+    add_objects(
+      {terms(tidp0, {{0, 1}})},
+      make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
+
+    verify_object_exists(oid, 1024, /*removed_data_size=*/0);
+
+    // Try to remove the object without removing extents first - should fail.
+    auto update = remove_objects_db_update{
+      .objects = {},
+    };
+    update.objects.push_back(oid);
+    auto reader = make_reader();
+    chunked_vector<write_batch_row> rows;
+    auto result = update.build_rows(reader, rows).get();
+    ASSERT_FALSE(result.has_value());
+
+    // Object should still exist (still referenced by extents).
+    verify_object_exists(oid, 1024, /*removed_data_size=*/0);
+}
+
+TEST_F(StateUpdateTest, TestRemoveObjectsEmpty) {
+    // Removing empty objects list should be no-op.
+    chunked_vector<object_id> objects_to_remove;
+    remove_objects(std::move(objects_to_remove));
+    // No crash, no side effects.
+}
+
+TEST_F(StateUpdateTest, TestRemoveObjectsNonExistent) {
+    // Set up a partition with an object.
+    auto oid = make_oid();
+    add_objects(
+      {terms(tidp0, {{0, 1}})},
+      make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
+
+    // Try to remove a non-existent object.
+    auto other_oid = make_oid();
+    chunked_vector<object_id> objects_to_remove;
+    objects_to_remove.push_back(other_oid);
+    remove_objects(std::move(objects_to_remove));
+
+    // Original object should still exist.
+    verify_object_exists(oid, 1024, /*removed_data_size=*/0);
+}
+
+TEST_F(StateUpdateTest, TestRemoveObjectsAfterTopicRemoval) {
+    // Set up partition and remove the topic.
+    auto oid = make_oid();
+    add_objects(
+      {terms(tidp0, {{0, 1}})},
+      make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
+
+    // Remove the topic.
+    chunked_vector<model::topic_id> topics_to_remove;
+    topics_to_remove.push_back(tidp0.topic_id);
+    remove_topics(std::move(topics_to_remove));
+
+    // Object should have removed_data_size == total_data_size.
+    verify_object_exists(oid, 1024, /*removed_data_size=*/1024);
+
+    // Now remove the object.
+    chunked_vector<object_id> objects_to_remove;
+    objects_to_remove.push_back(oid);
+    remove_objects(std::move(objects_to_remove));
+
+    // Object should be removed.
+    verify_object_missing(oid);
 }

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -227,6 +227,32 @@ protected:
         return std::monostate{};
     }
 
+    std::expected<std::monostate, stm_update_error> apply_set_start_offset(
+      const model::topic_id_partition& tp, kafka::offset new_start_offset) {
+        if (GetParam() == state_backend::simple) {
+            auto update = set_start_offset_update::build(
+              state_, tp, new_start_offset);
+            if (!update.has_value()) {
+                return std::unexpected(
+                  stm_update_error{fmt::format("{}", update.error())});
+            }
+            return update->apply(state_);
+        }
+        set_start_offset_db_update db_update{
+          .tp = tp,
+          .new_start_offset = new_start_offset,
+        };
+        auto reader = state_reader(db_->create_snapshot());
+        chunked_vector<write_batch_row> rows;
+        auto result = db_update.build_rows(reader, rows).get();
+        if (!result.has_value()) {
+            return std::unexpected(
+              stm_update_error{fmt::format("{}", result.error())});
+        }
+        apply_rows_to_db(rows);
+        return std::monostate{};
+    }
+
     state& get_state() {
         if (GetParam() == state_backend::lsm) {
             state_ = snapshot_to_state();
@@ -1597,8 +1623,7 @@ TEST_P(StateUpdateParamTest, TestAddExtentEndsBelowLastTermStart) {
     EXPECT_FALSE(res.has_value());
 }
 
-TEST(StateUpdateTest, TestSetStartOffsetAlignedWithExtent) {
-    state s;
+TEST_P(StateUpdateParamTest, TestSetStartOffsetAlignedWithExtent) {
     // Add some extents
     auto add_update = add_objects_builder()
                         .add(new_obj_builder(oid1, 100, 1100)
@@ -1612,23 +1637,20 @@ TEST(StateUpdateTest, TestSetStartOffsetAlignedWithExtent) {
                                .build())
                         .add_term_start(tidp_a, 0_tm, 0_o)
                         .build();
-    auto res = add_update.apply(s);
+    auto res = apply_add_objects(std::move(add_update));
     ASSERT_TRUE(res.has_value());
 
     auto tp = model::topic_id_partition::from(tidp_a);
-    auto p_state = s.partition_state(tp);
+    auto p_state = get_state().partition_state(tp);
     ASSERT_TRUE(p_state.has_value());
     EXPECT_EQ(3, p_state->get().extents.size());
 
     // Set start offset to be aligned with the second extent (starts at 11)
-    auto set_start_update = set_start_offset_update::build(s, tp, 11_o);
-    ASSERT_TRUE(set_start_update.has_value());
-
-    auto apply_res = set_start_update->apply(s);
+    auto apply_res = apply_set_start_offset(tp, 11_o);
     ASSERT_TRUE(apply_res.has_value());
 
     // Verify that the state has been updated correctly
-    p_state = s.partition_state(tp);
+    p_state = get_state().partition_state(tp);
     ASSERT_TRUE(p_state.has_value());
     EXPECT_EQ(11_o, p_state->get().start_offset);
     EXPECT_EQ(31_o, p_state->get().next_offset);
@@ -1638,8 +1660,7 @@ TEST(StateUpdateTest, TestSetStartOffsetAlignedWithExtent) {
     EXPECT_EQ(2, p_state->get().extents.size());
 }
 
-TEST(StateUpdateTest, TestSetStartOffsetNotAlignedWithExtent) {
-    state s;
+TEST_P(StateUpdateParamTest, TestSetStartOffsetNotAlignedWithExtent) {
     // Add some extents
     auto add_update = add_objects_builder()
                         .add(new_obj_builder(oid1, 100, 1100)
@@ -1653,24 +1674,21 @@ TEST(StateUpdateTest, TestSetStartOffsetNotAlignedWithExtent) {
                                .build())
                         .add_term_start(tidp_a, 0_tm, 0_o)
                         .build();
-    auto res = add_update.apply(s);
+    auto res = apply_add_objects(std::move(add_update));
     ASSERT_TRUE(res.has_value());
 
     auto tp = model::topic_id_partition::from(tidp_a);
-    auto p_state = s.partition_state(tp);
+    auto p_state = get_state().partition_state(tp);
     ASSERT_TRUE(p_state.has_value());
     EXPECT_EQ(3, p_state->get().extents.size());
 
     // Set start offset to be not aligned with any extent (offset 15 is in the
     // middle of second extent)
-    auto set_start_update = set_start_offset_update::build(s, tp, 15_o);
-    ASSERT_TRUE(set_start_update.has_value());
-
-    auto apply_res = set_start_update->apply(s);
+    auto apply_res = apply_set_start_offset(tp, 15_o);
     ASSERT_TRUE(apply_res.has_value());
 
     // Verify that the state has been updated correctly
-    p_state = s.partition_state(tp);
+    p_state = get_state().partition_state(tp);
     ASSERT_TRUE(p_state.has_value());
     EXPECT_EQ(15_o, p_state->get().start_offset);
     EXPECT_EQ(31_o, p_state->get().next_offset);
@@ -1680,8 +1698,7 @@ TEST(StateUpdateTest, TestSetStartOffsetNotAlignedWithExtent) {
     EXPECT_EQ(2, p_state->get().extents.size());
 }
 
-TEST(StateUpdateTest, TestSetStartOffsetEmptyWithTerms) {
-    state s;
+TEST_P(StateUpdateParamTest, TestSetStartOffsetEmptyWithTerms) {
     // Add extents with various terms
     auto add_update = add_objects_builder()
                         .add(new_obj_builder(oid1, 100, 1100)
@@ -1691,23 +1708,20 @@ TEST(StateUpdateTest, TestSetStartOffsetEmptyWithTerms) {
                         .add_term_start(tidp_a, 2_tm, 3_o)
                         .add_term_start(tidp_a, 5_tm, 7_o)
                         .build();
-    auto res = add_update.apply(s);
+    auto res = apply_add_objects(std::move(add_update));
     ASSERT_TRUE(res.has_value());
 
     auto tp = model::topic_id_partition::from(tidp_a);
-    auto p_state = s.partition_state(tp);
+    auto p_state = get_state().partition_state(tp);
     ASSERT_TRUE(p_state.has_value());
     EXPECT_EQ(1, p_state->get().extents.size());
     EXPECT_EQ(3, p_state->get().term_starts.size());
 
     // Set start offset beyond the end of all extents to make log empty.
-    auto set_start_update = set_start_offset_update::build(s, tp, 10_o);
-    ASSERT_TRUE(set_start_update.has_value());
-
-    auto apply_res = set_start_update->apply(s);
+    auto apply_res = apply_set_start_offset(tp, 10_o);
     ASSERT_TRUE(apply_res.has_value());
 
-    p_state = s.partition_state(tp);
+    p_state = get_state().partition_state(tp);
     ASSERT_TRUE(p_state.has_value());
     EXPECT_EQ(10_o, p_state->get().start_offset);
     EXPECT_EQ(10_o, p_state->get().next_offset);
@@ -1720,11 +1734,10 @@ TEST(StateUpdateTest, TestSetStartOffsetEmptyWithTerms) {
     EXPECT_EQ(1, p_state->get().term_starts.size());
 }
 
-TEST(StateUpdateTest, TestSetStartOffsetWithCompactionState) {
+TEST_P(StateUpdateParamTest, TestSetStartOffsetWithCompactionState) {
     using testing::ElementsAre;
     using range = struct compaction_state_update::cleaned_range;
 
-    state s;
     // Add an extent and then compact it
     auto add_update = add_objects_builder()
                         .add(new_obj_builder(oid1, 100, 1100)
@@ -1732,7 +1745,7 @@ TEST(StateUpdateTest, TestSetStartOffsetWithCompactionState) {
                                .build())
                         .add_term_start(tidp_a, 0_tm, 0_o)
                         .build();
-    auto res = add_update.apply(s);
+    auto res = apply_add_objects(std::move(add_update));
     ASSERT_TRUE(res.has_value());
 
     // Compact part of the extent (clean offsets [5, 15])
@@ -1748,11 +1761,11 @@ TEST(StateUpdateTest, TestSetStartOffsetWithCompactionState) {
             3000_t)
           .set_expected_epoch(tidp_a, partition_state::compaction_epoch_t{0})
           .build();
-    auto replace_res = replace_update.apply(s);
+    auto replace_res = apply_replace_objects(std::move(replace_update));
     ASSERT_TRUE(replace_res.has_value());
 
     auto tp = model::topic_id_partition::from(tidp_a);
-    auto p_state = s.partition_state(tp);
+    auto p_state = get_state().partition_state(tp);
     ASSERT_TRUE(p_state.has_value());
     ASSERT_TRUE(p_state->get().compaction_state.has_value());
 
@@ -1767,14 +1780,11 @@ TEST(StateUpdateTest, TestSetStartOffsetWithCompactionState) {
       p_state->get().compaction_epoch, partition_state::compaction_epoch_t{1});
 
     // Set start offset to fall within the cleaned range (offset 10)
-    auto set_start_update = set_start_offset_update::build(s, tp, 10_o);
-    ASSERT_TRUE(set_start_update.has_value());
-
-    auto apply_res = set_start_update->apply(s);
+    auto apply_res = apply_set_start_offset(tp, 10_o);
     ASSERT_TRUE(apply_res.has_value());
 
     // Verify that the state has been updated correctly
-    p_state = s.partition_state(tp);
+    p_state = get_state().partition_state(tp);
     ASSERT_TRUE(p_state.has_value());
     EXPECT_EQ(10_o, p_state->get().start_offset);
     EXPECT_EQ(21_o, p_state->get().next_offset);

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -253,6 +253,35 @@ protected:
         return std::monostate{};
     }
 
+    std::expected<std::monostate, stm_update_error>
+    apply_remove_topics(std::initializer_list<model::topic_id> topics_list) {
+        chunked_vector<model::topic_id> topics;
+        for (const auto& t : topics_list) {
+            topics.push_back(t);
+        }
+        if (GetParam() == state_backend::simple) {
+            auto update = remove_topics_update::build(
+              state_, std::move(topics));
+            if (!update.has_value()) {
+                return std::unexpected(
+                  stm_update_error{fmt::format("{}", update.error())});
+            }
+            return update->apply(state_);
+        }
+        remove_topics_db_update db_update{
+          .topics = std::move(topics),
+        };
+        auto reader = state_reader(db_->create_snapshot());
+        chunked_vector<write_batch_row> rows;
+        auto result = db_update.build_rows(reader, rows).get();
+        if (!result.has_value()) {
+            return std::unexpected(
+              stm_update_error{fmt::format("{}", result.error())});
+        }
+        apply_rows_to_db(rows);
+        return std::monostate{};
+    }
+
     state& get_state() {
         if (GetParam() == state_backend::lsm) {
             state_ = snapshot_to_state();
@@ -1916,8 +1945,7 @@ TEST(StateUpdateTest, TestRemoveMissingObjects) {
     EXPECT_EQ(0, s.objects.size());
 }
 
-TEST(StateUpdateTest, TestRemoveTopicsBasic) {
-    state s;
+TEST_P(StateUpdateParamTest, TestRemoveTopicsBasic) {
     auto add = add_objects_builder()
                  .add(new_obj_builder(oid1, 200, 1100)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
@@ -1926,21 +1954,22 @@ TEST(StateUpdateTest, TestRemoveTopicsBasic) {
                  .add_term_start(tidp_a, 0_tm, 0_o)
                  .add_term_start(tidp_b, 0_tm, 0_o)
                  .build();
-    ASSERT_TRUE(add.apply(s).has_value());
-    EXPECT_EQ(2, s.topic_to_state.size());
-    EXPECT_EQ(1, s.objects.size());
-
-    auto& obj = s.objects.at(oid1);
-    EXPECT_EQ(198, obj.total_data_size);
-    EXPECT_EQ(0, obj.removed_data_size);
+    ASSERT_TRUE(apply_add_objects(std::move(add)).has_value());
+    {
+        auto& s = get_state();
+        EXPECT_EQ(2, s.topic_to_state.size());
+        EXPECT_EQ(1, s.objects.size());
+        auto& obj = s.objects.at(oid1);
+        EXPECT_EQ(198, obj.total_data_size);
+        EXPECT_EQ(0, obj.removed_data_size);
+    }
 
     // Remove just one topic.
     auto tp_a = model::topic_id_partition::from(tidp_a);
-    auto remove_topics_res = remove_topics_update::build(s, {tp_a.topic_id});
-    ASSERT_TRUE(remove_topics_res.has_value());
-    ASSERT_TRUE(remove_topics_res->apply(s).has_value());
+    ASSERT_TRUE(apply_remove_topics({tp_a.topic_id}).has_value());
 
     // Just the other topic should remain in the state.
+    auto& s = get_state();
     EXPECT_EQ(1, s.topic_to_state.size());
     EXPECT_FALSE(s.topic_to_state.contains(tp_a.topic_id));
     auto tp_b = model::topic_id_partition::from(tidp_b);
@@ -1948,29 +1977,11 @@ TEST(StateUpdateTest, TestRemoveTopicsBasic) {
 
     // Validate object accounting.
     EXPECT_EQ(1, s.objects.size());
-    EXPECT_EQ(198, obj.total_data_size);
-    EXPECT_EQ(99, obj.removed_data_size);
-
-    // We should be unable to remove object until the other topic is removed.
-    auto remove_obj_res = remove_objects_update::build(s, {oid1});
-    EXPECT_FALSE(remove_obj_res.has_value());
-    EXPECT_THAT(
-      remove_obj_res.error()(), testing::ContainsRegex("is still referenced"));
-    EXPECT_EQ(1, s.objects.size());
-
-    // Now remove the other topic and try again.
-    remove_topics_res = remove_topics_update::build(s, {tp_b.topic_id});
-    ASSERT_TRUE(remove_topics_res.has_value());
-    ASSERT_TRUE(remove_topics_res->apply(s).has_value());
-
-    remove_obj_res = remove_objects_update::build(s, {oid1});
-    EXPECT_TRUE(remove_obj_res.has_value());
-    ASSERT_TRUE(remove_obj_res->apply(s).has_value());
-    EXPECT_EQ(0, s.objects.size());
+    EXPECT_EQ(198, s.objects.at(oid1).total_data_size);
+    EXPECT_EQ(99, s.objects.at(oid1).removed_data_size);
 }
 
-TEST(StateUpdateTest, TestRemoveMultipleTopics) {
-    state s;
+TEST_P(StateUpdateParamTest, TestRemoveMultipleTopics) {
     auto add = add_objects_builder()
                  .add(new_obj_builder(oid1, 200, 1100)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
@@ -1990,34 +2001,29 @@ TEST(StateUpdateTest, TestRemoveMultipleTopics) {
                  .add_term_start(tidp_b, 0_tm, 0_o)
                  .add_term_start(tidp_c, 0_tm, 0_o)
                  .build();
-    ASSERT_TRUE(add.apply(s).has_value());
-    EXPECT_EQ(3, s.topic_to_state.size());
-    EXPECT_EQ(4, s.objects.size());
+    ASSERT_TRUE(apply_add_objects(std::move(add)).has_value());
+    {
+        auto& s = get_state();
+        EXPECT_EQ(3, s.topic_to_state.size());
+        EXPECT_EQ(4, s.objects.size());
+    }
 
     // Remove all the topics in a single update.
     auto tp_a = model::topic_id_partition::from(tidp_a);
     auto tp_b = model::topic_id_partition::from(tidp_b);
     auto tp_c = model::topic_id_partition::from(tidp_c);
-    auto remove_topics_res = remove_topics_update::build(
-      s, {tp_a.topic_id, tp_b.topic_id, tp_c.topic_id});
-    ASSERT_TRUE(remove_topics_res.has_value());
-    ASSERT_TRUE(remove_topics_res->apply(s).has_value());
-    EXPECT_EQ(0, s.topic_to_state.size());
+    ASSERT_TRUE(
+      apply_remove_topics({tp_a.topic_id, tp_b.topic_id, tp_c.topic_id})
+        .has_value());
 
     // Sanity check, the objects should still be there -- only the topics are
     // removed.
+    auto& s = get_state();
+    EXPECT_EQ(0, s.topic_to_state.size());
     EXPECT_EQ(4, s.objects.size());
-
-    // All the objects should be removable now.
-    auto remove_obj_res = remove_objects_update::build(
-      s, {oid1, oid2, oid3, oid4});
-    ASSERT_TRUE(remove_obj_res.has_value());
-    ASSERT_TRUE(remove_obj_res->apply(s).has_value());
-    EXPECT_EQ(0, s.objects.size());
 }
 
-TEST(StateUpdateTest, TestRemoveMissingTopic) {
-    state s;
+TEST_P(StateUpdateParamTest, TestRemoveMissingTopic) {
     // Add just one topic.
     auto add = add_objects_builder()
                  .add(new_obj_builder(oid1, 100, 1100)
@@ -2025,33 +2031,36 @@ TEST(StateUpdateTest, TestRemoveMissingTopic) {
                         .build())
                  .add_term_start(tidp_a, 0_tm, 0_o)
                  .build();
-    ASSERT_TRUE(add.apply(s).has_value());
-    EXPECT_EQ(1, s.topic_to_state.size());
-    EXPECT_EQ(1, s.objects.size());
+    ASSERT_TRUE(apply_add_objects(std::move(add)).has_value());
+    {
+        auto& s = get_state();
+        EXPECT_EQ(1, s.topic_to_state.size());
+        EXPECT_EQ(1, s.objects.size());
+    }
 
     // Remove topics that don't exist (and one that does).
     auto tp_a = model::topic_id_partition::from(tidp_a);
     auto tp_b = model::topic_id_partition::from(tidp_b);
     auto tp_c = model::topic_id_partition::from(tidp_c);
-    auto remove_topics_res = remove_topics_update::build(
-      s, {tp_a.topic_id, tp_b.topic_id, tp_c.topic_id});
-    ASSERT_TRUE(remove_topics_res.has_value());
-    ASSERT_TRUE(remove_topics_res->apply(s).has_value());
+    ASSERT_TRUE(
+      apply_remove_topics({tp_a.topic_id, tp_b.topic_id, tp_c.topic_id})
+        .has_value());
 
     // Should succeed gracefully despite having other topics.
-    EXPECT_EQ(0, s.topic_to_state.size());
-    EXPECT_EQ(1, s.objects.size());
+    {
+        auto& s = get_state();
+        EXPECT_EQ(0, s.topic_to_state.size());
+        EXPECT_EQ(1, s.objects.size());
 
-    // Object accounting should only reflect the removed topic A.
-    auto& obj = s.objects.at(oid1);
-    EXPECT_EQ(99, obj.total_data_size);
-    EXPECT_EQ(99, obj.removed_data_size);
+        // Object accounting should only reflect the removed topic A.
+        EXPECT_EQ(99, s.objects.at(oid1).total_data_size);
+        EXPECT_EQ(99, s.objects.at(oid1).removed_data_size);
+    }
 
     // Do the same with only non-existent topics. This is a no-op.
-    remove_topics_res = remove_topics_update::build(
-      s, {tp_b.topic_id, tp_c.topic_id});
-    ASSERT_TRUE(remove_topics_res.has_value());
-    ASSERT_TRUE(remove_topics_res->apply(s).has_value());
+    ASSERT_TRUE(
+      apply_remove_topics({tp_b.topic_id, tp_c.topic_id}).has_value());
+    auto& s = get_state();
     EXPECT_EQ(0, s.topic_to_state.size());
     EXPECT_EQ(1, s.objects.size());
 }

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -282,6 +282,35 @@ protected:
         return std::monostate{};
     }
 
+    std::expected<std::monostate, stm_update_error>
+    apply_remove_objects(std::initializer_list<object_id> objects_list) {
+        chunked_vector<object_id> objects;
+        for (const auto& o : objects_list) {
+            objects.push_back(o);
+        }
+        if (GetParam() == state_backend::simple) {
+            auto update = remove_objects_update::build(
+              state_, std::move(objects));
+            if (!update.has_value()) {
+                return std::unexpected(
+                  stm_update_error{fmt::format("{}", update.error())});
+            }
+            return update->apply(state_);
+        }
+        remove_objects_db_update db_update{
+          .objects = std::move(objects),
+        };
+        auto reader = state_reader(db_->create_snapshot());
+        chunked_vector<write_batch_row> rows;
+        auto result = db_update.build_rows(reader, rows).get();
+        if (!result.has_value()) {
+            return std::unexpected(
+              stm_update_error{fmt::format("{}", result.error())});
+        }
+        apply_rows_to_db(rows);
+        return std::monostate{};
+    }
+
     state& get_state() {
         if (GetParam() == state_backend::lsm) {
             state_ = snapshot_to_state();
@@ -1831,8 +1860,7 @@ TEST_P(StateUpdateParamTest, TestSetStartOffsetWithCompactionState) {
       p_state->get().compaction_epoch, partition_state::compaction_epoch_t{1});
 }
 
-TEST(StateUpdateTest, TestRemoveObjectsBasic) {
-    state s;
+TEST_P(StateUpdateParamTest, TestRemoveObjectsBasic) {
     auto add = add_objects_builder()
                  .add(new_obj_builder(oid1, 100, 1100)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
@@ -1843,8 +1871,8 @@ TEST(StateUpdateTest, TestRemoveObjectsBasic) {
                  .add_term_start(tidp_a, 0_tm, 0_o)
                  .add_term_start(tidp_b, 0_tm, 0_o)
                  .build();
-    ASSERT_TRUE(add.apply(s).has_value());
-    EXPECT_EQ(2, s.objects.size());
+    ASSERT_TRUE(apply_add_objects(std::move(add)).has_value());
+    EXPECT_EQ(2, get_state().objects.size());
 
     // Replace objects to mark originals as unreferenced.
     auto replace = replace_objects_builder()
@@ -1855,40 +1883,32 @@ TEST(StateUpdateTest, TestRemoveObjectsBasic) {
                             .add(tidp_b, 0_o, 10_o, 1999_t, 0, 99)
                             .build())
                      .build();
-    ASSERT_TRUE(replace.apply(s).has_value());
-    EXPECT_EQ(4, s.objects.size());
+    ASSERT_TRUE(apply_replace_objects(std::move(replace)).has_value());
+    EXPECT_EQ(4, get_state().objects.size());
 
     // Remove the unreferenced objects.
-    auto remove_res = remove_objects_update::build(s, {oid1, oid2});
-    ASSERT_TRUE(remove_res.has_value());
-    ASSERT_TRUE(remove_res->apply(s).has_value());
+    ASSERT_TRUE(apply_remove_objects({oid1, oid2}).has_value());
 
-    EXPECT_FALSE(s.objects.contains(oid1));
-    EXPECT_FALSE(s.objects.contains(oid2));
-    EXPECT_TRUE(s.objects.contains(oid3));
-    EXPECT_TRUE(s.objects.contains(oid4));
-    EXPECT_EQ(2, s.objects.size());
+    EXPECT_FALSE(get_state().objects.contains(oid1));
+    EXPECT_FALSE(get_state().objects.contains(oid2));
+    EXPECT_TRUE(get_state().objects.contains(oid3));
+    EXPECT_TRUE(get_state().objects.contains(oid4));
+    EXPECT_EQ(2, get_state().objects.size());
 
     // Move the start offset such that one of the partition's objects are fully
     // unreferenced.
     auto tp = model::topic_id_partition::from(tidp_a);
-    auto set_start_update = set_start_offset_update::build(s, tp, 11_o);
-    ASSERT_TRUE(set_start_update.has_value());
-    auto apply_res = set_start_update->apply(s);
-    ASSERT_TRUE(apply_res.has_value());
+    ASSERT_TRUE(apply_set_start_offset(tp, 11_o).has_value());
 
     // Remove the unreferenced objects.
-    remove_res = remove_objects_update::build(s, {oid3});
-    ASSERT_TRUE(remove_res.has_value());
-    ASSERT_TRUE(remove_res->apply(s).has_value());
+    ASSERT_TRUE(apply_remove_objects({oid3}).has_value());
 
-    EXPECT_FALSE(s.objects.contains(oid3));
-    EXPECT_TRUE(s.objects.contains(oid4));
-    EXPECT_EQ(1, s.objects.size());
+    EXPECT_FALSE(get_state().objects.contains(oid3));
+    EXPECT_TRUE(get_state().objects.contains(oid4));
+    EXPECT_EQ(1, get_state().objects.size());
 }
 
-TEST(StateUpdateTest, TestRemoveObjectsWithReferences) {
-    state s;
+TEST_P(StateUpdateParamTest, TestRemoveObjectsWithReferences) {
     auto add = add_objects_builder()
                  .add(new_obj_builder(oid1, 200, 1100)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
@@ -1897,52 +1917,42 @@ TEST(StateUpdateTest, TestRemoveObjectsWithReferences) {
                  .add_term_start(tidp_a, 0_tm, 0_o)
                  .add_term_start(tidp_b, 0_tm, 0_o)
                  .build();
-    ASSERT_TRUE(add.apply(s).has_value());
-    EXPECT_EQ(1, s.objects.size());
+    ASSERT_TRUE(apply_add_objects(std::move(add)).has_value());
+    EXPECT_EQ(1, get_state().objects.size());
 
     // Move the start offset such that one of the partitions is gone, but the
     // object is still referenced by the other.
     auto tp = model::topic_id_partition::from(tidp_a);
-    auto set_start_update = set_start_offset_update::build(s, tp, 11_o);
-    ASSERT_TRUE(set_start_update.has_value());
-    auto apply_res = set_start_update->apply(s);
-    ASSERT_TRUE(apply_res.has_value());
+    ASSERT_TRUE(apply_set_start_offset(tp, 11_o).has_value());
 
-    auto remove_res = remove_objects_update::build(s, {oid1});
+    auto remove_res = apply_remove_objects({oid1});
     ASSERT_FALSE(remove_res.has_value());
     EXPECT_THAT(
       remove_res.error()(), testing::ContainsRegex("is still referenced"));
 
-    EXPECT_EQ(1, s.objects.size());
-    EXPECT_TRUE(s.objects.contains(oid1));
+    EXPECT_EQ(1, get_state().objects.size());
+    EXPECT_TRUE(get_state().objects.contains(oid1));
 }
 
-TEST(StateUpdateTest, TestRemoveMissingObjects) {
-    state s;
+TEST_P(StateUpdateParamTest, TestRemoveMissingObjects) {
     auto add = add_objects_builder()
                  .add(new_obj_builder(oid1, 100, 1100)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .build())
                  .add_term_start(tidp_a, 0_tm, 0_o)
                  .build();
-    ASSERT_TRUE(add.apply(s).has_value());
-    EXPECT_EQ(1, s.objects.size());
+    ASSERT_TRUE(apply_add_objects(std::move(add)).has_value());
+    EXPECT_EQ(1, get_state().objects.size());
 
     // Remove references to oid1.
     auto tp = model::topic_id_partition::from(tidp_a);
-    auto set_start_update = set_start_offset_update::build(s, tp, 11_o);
-    ASSERT_TRUE(set_start_update.has_value());
-    auto apply_res = set_start_update->apply(s);
-    ASSERT_TRUE(apply_res.has_value());
+    ASSERT_TRUE(apply_set_start_offset(tp, 11_o).has_value());
 
     // Remove it, and objects that don't exist.
-    auto remove_res = remove_objects_update::build(s, {oid1, oid2, oid3, oid4});
-    ASSERT_TRUE(remove_res.has_value());
-    apply_res = remove_res->apply(s);
-    EXPECT_TRUE(apply_res.has_value());
+    ASSERT_TRUE(apply_remove_objects({oid1, oid2, oid3, oid4}).has_value());
 
     // The operation should have succeeded.
-    EXPECT_EQ(0, s.objects.size());
+    EXPECT_EQ(0, get_state().objects.size());
 }
 
 TEST_P(StateUpdateParamTest, TestRemoveTopicsBasic) {
@@ -1979,6 +1989,19 @@ TEST_P(StateUpdateParamTest, TestRemoveTopicsBasic) {
     EXPECT_EQ(1, s.objects.size());
     EXPECT_EQ(198, s.objects.at(oid1).total_data_size);
     EXPECT_EQ(99, s.objects.at(oid1).removed_data_size);
+
+    // We should be unable to remove object until the other topic is removed.
+    auto remove_obj_res = apply_remove_objects({oid1});
+    EXPECT_FALSE(remove_obj_res.has_value());
+    EXPECT_THAT(
+      remove_obj_res.error()(), testing::ContainsRegex("is still referenced"));
+    EXPECT_EQ(1, get_state().objects.size());
+
+    // Now remove the other topic and try again.
+    ASSERT_TRUE(apply_remove_topics({tp_b.topic_id}).has_value());
+
+    ASSERT_TRUE(apply_remove_objects({oid1}).has_value());
+    EXPECT_EQ(0, get_state().objects.size());
 }
 
 TEST_P(StateUpdateParamTest, TestRemoveMultipleTopics) {
@@ -2021,6 +2044,10 @@ TEST_P(StateUpdateParamTest, TestRemoveMultipleTopics) {
     auto& s = get_state();
     EXPECT_EQ(0, s.topic_to_state.size());
     EXPECT_EQ(4, s.objects.size());
+
+    // All the objects should be removable now.
+    ASSERT_TRUE(apply_remove_objects({oid1, oid2, oid3, oid4}).has_value());
+    EXPECT_EQ(0, get_state().objects.size());
 }
 
 TEST_P(StateUpdateParamTest, TestRemoveMissingTopic) {


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This PR adds LSM-backed state updates for:
- set_start_offset
- remove_topics
- remove_objects

This is a fairly direct translation of simple state update to LSM state update, which means we can reuse the state_update_tests by parameterizing on state backend, as we did for the other state updates.

There's definitely remove to improve scale here, but these are left as future work:
- for remove_topics, we read a lot of state serially; we should be able to parallelize the reads easily, given the partitions are independent of one another
- for set_start_offset and remove_topics, if the resulting set of keys to remove is too large, we should consider incrementally prefix truncating until the resulting keys to remove is manageable

NOTE: while almost all tests in state_update_test are now parameterized, some tests for compaction with a non-zero start offset are not, because the behavior of replacement when replacing below the start offset is not quite correct. That will be addressed in a separate change.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
