### PR TITLE
cloud_storage_clients: implement dynamic upstream routing

### DIFF
--- a/src/v/cloud_io/tests/s3_imposter.cc
+++ b/src/v/cloud_io/tests/s3_imposter.cc
@@ -551,7 +551,10 @@ s3_imposter_fixture::get_object(const ss::sstring& url) const {
 }
 
 ss::sstring s3_imposter_fixture::url_base() const {
-    switch (conf.url_style) {
+    if (!conf.url_style.has_value()) {
+        return fmt::format("");
+    }
+    switch (*conf.url_style) {
     case cloud_storage_clients::s3_url_style::virtual_host:
         return fmt::format("");
     case cloud_storage_clients::s3_url_style::path:

--- a/src/v/cloud_storage_clients/BUILD
+++ b/src/v/cloud_storage_clients/BUILD
@@ -72,6 +72,7 @@ redpanda_cc_library(
         "//src/v/utils:named_type",
         "//src/v/utils:retry_chain_node",
         "//src/v/utils:stop_signal",
+        "//src/v/utils:unresolved_address",
         "//src/v/utils:uuid",
         "@ada",
         "@boost//:beast",

--- a/src/v/cloud_storage_clients/BUILD
+++ b/src/v/cloud_storage_clients/BUILD
@@ -31,6 +31,7 @@ redpanda_cc_library(
         "s3_error.h",
         "types.h",
         "upstream.h",
+        "upstream_key.h",
         "upstream_registry.h",
         "util.h",
         "xml_sax_parser.h",

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -1151,6 +1151,10 @@ bool abs_client::is_valid() const noexcept {
     return _upstream_ptr.get() != nullptr;
 }
 
+fmt::iterator abs_client::format_to(fmt::iterator it) const {
+    return fmt::format_to(it, "ABSClient{{{}}}", _client.server_address());
+}
+
 ss::future<result<abs_client::list_bucket_result, error_outcome>>
 abs_client::list_objects(
   const plain_bucket_name& name,

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -275,6 +275,8 @@ public:
       object_key path,
       ss::lowres_clock::duration timeout);
 
+    fmt::iterator format_to(fmt::iterator it) const override;
+
 private:
     template<typename T>
     ss::future<result<T, error_outcome>> send_request(

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -192,6 +192,9 @@ public:
     /// created.
     virtual bool is_valid() const noexcept = 0;
 
+    /// Format human-readable representation of the client.
+    virtual fmt::iterator format_to(fmt::iterator it) const = 0;
+
 protected:
     ss::weak_ptr<upstream> _upstream_ptr;
 };

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -35,7 +35,7 @@ constexpr auto pool_ready_timeout = 15s;
 namespace cloud_storage_clients {
 
 namespace {
-constexpr auto default_upstream_key = upstream_key{};
+const auto default_upstream_key = upstream_key{};
 }
 
 client_pool::client_pool(
@@ -193,8 +193,7 @@ ss::future<client_pool::client_lease> client_pool::acquire(
   std::optional<ss::lowres_clock::time_point> deadline) {
     auto guard = _gate.hold();
 
-    // Support for bucket_name_parts connection parameters is currently a no-op.
-    std::ignore = bucket;
+    auto up_key = make_upstream_key(_config, bucket);
 
     std::optional<unsigned int> source_sid;
     std::optional<client_ptr> client;
@@ -236,14 +235,34 @@ ss::future<client_pool::client_lease> client_pool::acquire(
             }
         }
 
-        // Pool is ready. This is unlikely to block but theoretically possible.
-        auto& up = _default_upstream.value();
+        std::optional<upstream_registry::handle> dynamic_up_holder;
+        upstream_registry::handle* up_ptr = nullptr;
+        if (up_key == default_upstream_key) {
+            up_ptr = &_default_upstream.value();
+        } else {
+            dynamic_up_holder.emplace(co_await _upstreams.get(up_key));
+            up_ptr = &*dynamic_up_holder;
+        }
+        auto& up = *up_ptr;
 
         while (!deadline_reached() && !_gate.is_closed()
                && !_as.abort_requested()) {
             if (up_key != default_upstream_key) {
                 // For now, we don't implement client re-use for non-default
                 // upstreams. Just create a new client every time.
+                // But we still need to respect capacity limits by consuming
+                // a slot from the pool.
+                if (_idle_clients.empty()) {
+                    co_await ssx::with_timeout_abortable(
+                      _cvar.wait(), deadline.value_or(model::no_timeout), as);
+                    continue;
+                }
+                // Consume a slot from the pool.
+                auto slot_client = pop_least_recently_used();
+                slot_client->shutdown();
+                ssx::spawn_with_gate(_bg_gate, [slot_client] {
+                    return slot_client->stop().finally([slot_client] {});
+                });
                 client = up->make_client(_as);
                 break;
             }
@@ -375,8 +394,22 @@ ss::future<client_pool::client_lease> client_pool::acquire(
       ss::make_deleter([pool = weak_from_this(),
                         client = client.value(),
                         g = std::move(guard),
-                        source_sid]() mutable {
+                        source_sid,
+                        up_key]() mutable {
           if (pool) {
+              if (up_key != default_upstream_key) {
+                  // For now, we don't implement client re-use for non-default
+                  // upstreams. Just shutdown the client and return the slot
+                  // to the pool.
+                  pool->emplace_idle(pool->_default_upstream.value());
+                  pool->_cvar.signal();
+                  client->shutdown();
+                  ssx::spawn_with_gate(pool->_bg_gate, [client] {
+                      return client->stop().finally([client] {});
+                  });
+                  return;
+              }
+
               if (source_sid.has_value()) {
                   // If all clients from the local pool are in-use we will
                   // shutdown the borrowed one and return the "accounting unit"

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -241,6 +241,13 @@ ss::future<client_pool::client_lease> client_pool::acquire(
 
         while (!deadline_reached() && !_gate.is_closed()
                && !_as.abort_requested()) {
+            if (up_key != default_upstream_key) {
+                // For now, we don't implement client re-use for non-default
+                // upstreams. Just create a new client every time.
+                client = up->make_client(_as);
+                break;
+            }
+
             if (client.has_value()) {
                 if (!(*client)->is_valid()) {
                     vlog(
@@ -318,7 +325,7 @@ ss::future<client_pool::client_lease> client_pool::acquire(
                         _probe->register_borrow();
                     }
                     source_sid = sid;
-                    client = up->make_client();
+                    client = up->make_client(_as);
                 } else {
                     vlog(pool_log.debug, "can't borrow connection, waiting");
                     // In-between failing to borrow from local pool and failing
@@ -518,7 +525,7 @@ void client_pool::return_one(
 }
 
 void client_pool::emplace_idle(upstream_registry::handle& up) noexcept {
-    auto new_client = up->make_client();
+    auto new_client = up->make_client(_as);
     const client* raw_ptr = new_client.get();
     auto [it, inserted] = _idle_clients.emplace(
       raw_ptr, idle_entry(std::move(new_client)));

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -34,10 +34,6 @@ constexpr auto pool_ready_timeout = 15s;
 
 namespace cloud_storage_clients {
 
-namespace {
-const auto default_upstream_key = upstream_key{};
-}
-
 client_pool::client_pool(
   upstream_registry& registry,
   size_t size,

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -70,8 +70,9 @@ struct s3_configuration : common_configuration {
     std::optional<cloud_roles::public_key_str> access_key;
     /// AWS secret key, optional if configuration uses temporary credentials
     std::optional<cloud_roles::private_key_str> secret_key;
-    /// AWS URL style, either virtual-hosted-style or path-style.
-    s3_url_style url_style = s3_url_style::virtual_host;
+    /// AWS URL style, either virtual-hosted-style or path-style. Nullopt means
+    /// that the style needs to be determined with self-configuration.
+    std::optional<s3_url_style> url_style = std::nullopt;
     /// Whether the s3-compatible backend is GCS. Used in the client pool to
     /// select between s3_client and gcs_client at client creation time.
     bool is_gcs{false};

--- a/src/v/cloud_storage_clients/credential_manager.cc
+++ b/src/v/cloud_storage_clients/credential_manager.cc
@@ -33,6 +33,10 @@ ss::future<> credential_manager::start() {
         _upstream.load_credentials(
           _auth_refresh_bg_op.build_static_credentials());
     } else {
+        const ss::sstring metrics_tag = _upstream.key() == default_upstream_key
+                                          ? ""
+                                          : ssx::sformat("{}", _upstream.key());
+
         // Launch background operation to fetch credentials on
         // auth_refresh_shard_id, and copy them to other shards. We do not wait
         // for this operation here, the wait is done in client_pool::acquire to
@@ -43,7 +47,8 @@ ss::future<> credential_manager::start() {
                 [c = std::move(credentials)](upstream& svc) {
                     svc.load_credentials(std::move(c));
                 });
-          });
+          },
+          metrics_tag);
     }
 
     _azure_shared_key_binding.watch([this] {

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -509,7 +509,7 @@ request_creator::make_gcs_batch_delete_request(
 }
 
 std::string request_creator::make_host(const plain_bucket_name& name) const {
-    switch (_ap_style) {
+    switch (_ap_style.value()) {
     case s3_url_style::virtual_host:
         // Host: bucket-name.s3.region-code.amazonaws.com
         return fmt::format("{}.{}", name(), _ap());
@@ -521,7 +521,7 @@ std::string request_creator::make_host(const plain_bucket_name& name) const {
 
 std::string request_creator::make_target(
   const plain_bucket_name& name, const object_key& key) const {
-    switch (_ap_style) {
+    switch (_ap_style.value()) {
     case s3_url_style::virtual_host:
         // Target: /homepage.html
         return fmt::format("/{}", key().string());
@@ -907,8 +907,6 @@ s3_client::s3_client(
 
 ss::future<result<client_self_configuration_output, error_outcome>>
 s3_client::self_configure() {
-    auto result = s3_self_configuration_result{
-      .url_style = s3_url_style::virtual_host};
     // Oracle cloud storage only supports path-style requests
     // (https://www.oracle.com/ca-en/cloud/storage/object-storage/faq/#category-amazon),
     // but self-configuration will misconfigure to virtual-host style due to a
@@ -926,8 +924,7 @@ s3_client::self_configure() {
     if (
       backend == model::cloud_storage_backend::oracle_s3_compat
       || backend == model::cloud_storage_backend::minio) {
-        result.url_style = s3_url_style::path;
-        co_return result;
+        co_return s3_self_configuration_result{.url_style = s3_url_style::path};
     }
 
     // Also handle possibly inferred backend.
@@ -935,8 +932,7 @@ s3_client::self_configure() {
     if (
       inferred_backend == model::cloud_storage_backend::oracle_s3_compat
       || inferred_backend == model::cloud_storage_backend::minio) {
-        result.url_style = s3_url_style::path;
-        co_return result;
+        co_return s3_self_configuration_result{.url_style = s3_url_style::path};
     }
 
     // Test virtual host style addressing, fall back to path if necessary.
@@ -948,10 +944,11 @@ s3_client::self_configure() {
     if (!bucket_config.value().has_value()) {
         vlog(
           s3_log.warn,
-          "Could not self-configure S3 Client, {} is not set. Defaulting to {}",
-          bucket_config.name(),
-          result.url_style);
-        co_return result;
+          "Could not self-configure S3 Client, {} is not set. Defaulting to "
+          "virtual_host",
+          bucket_config.name());
+        co_return s3_self_configuration_result{
+          .url_style = s3_url_style::virtual_host};
     }
 
     // TODO: Review this code. It is likely buggy when Remote Read Replicas are
@@ -963,12 +960,15 @@ s3_client::self_configure() {
 
     // Test virtual_host style.
     vassert(
-      _requestor._ap_style == s3_url_style::virtual_host,
-      "_ap_style should be virtual host by default before self configuration "
+      !_requestor._ap_style.has_value()
+        || _requestor._ap_style == s3_url_style::virtual_host,
+      "_ap_style should be unset or virtual host before self configuration "
       "begins");
+    _requestor._ap_style = s3_url_style::virtual_host;
     if (co_await self_configure_test(bucket)) {
-        // Virtual-host style request succeeded.
-        co_return result;
+        // Virtual host style request succeeded.
+        co_return s3_self_configuration_result{
+          .url_style = s3_url_style::virtual_host};
     }
 
     // fips mode can only work in virtual_host mode, so if the above test failed
@@ -980,10 +980,9 @@ s3_client::self_configure() {
 
     // Test path style.
     _requestor._ap_style = s3_url_style::path;
-    result.url_style = _requestor._ap_style;
     if (co_await self_configure_test(bucket)) {
         // Path style request succeeded.
-        co_return result;
+        co_return s3_self_configuration_result{.url_style = s3_url_style::path};
     }
 
     // Both addressing styles failed.

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -1505,6 +1505,10 @@ bool s3_client::is_valid() const noexcept {
     return _upstream_ptr.get() != nullptr;
 }
 
+fmt::iterator s3_client::format_to(fmt::iterator it) const {
+    return fmt::format_to(it, "S3Client{{{}}}", _client.server_address());
+}
+
 gcs_client::gcs_client(
   ss::weak_ptr<upstream> upstream_ptr,
   const s3_configuration& conf,
@@ -1597,4 +1601,9 @@ auto gcs_client::do_delete_objects(
     }
     co_return std::move(result).value();
 }
+
+fmt::iterator gcs_client::format_to(fmt::iterator it) const {
+    return fmt::format_to(it, "GCSClient{{{}}}", _client.server_address());
+}
+
 } // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -218,6 +218,8 @@ public:
 
     bool is_valid() const noexcept override;
 
+    fmt::iterator format_to(fmt::iterator it) const override;
+
 private:
     ss::future<head_object_result> do_head_object(
       const plain_bucket_name& name,
@@ -300,6 +302,8 @@ public:
       const plain_bucket_name& bucket,
       const chunked_vector<object_key>& keys,
       ss::lowres_clock::duration timeout) override;
+
+    fmt::iterator format_to(fmt::iterator it) const override;
 
 private:
     ss::future<delete_objects_result> do_delete_objects(

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -122,7 +122,7 @@ private:
 
     access_point_uri _ap;
 
-    s3_url_style _ap_style;
+    std::optional<s3_url_style> _ap_style;
     /// Applies credentials to http requests by adding headers and signing
     /// request payload. Shared pointer so that the credentials can be rotated
     /// through the client pool.

--- a/src/v/cloud_storage_clients/tests/BUILD
+++ b/src/v/cloud_storage_clients/tests/BUILD
@@ -130,6 +130,19 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "upstream_registry_test",
+    timeout = "short",
+    srcs = [
+        "upstream_registry_test.cc",
+    ],
+    deps = [
+        "//src/v/cloud_storage_clients",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
 redpanda_test_cc_library(
     name = "client_pool_builder",
     hdrs = [

--- a/src/v/cloud_storage_clients/tests/client_pool_mt_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_mt_test.cc
@@ -24,6 +24,7 @@
 
 #include <boost/test/tools/old/interface.hpp>
 
+#include <algorithm>
 #include <deque>
 #include <random>
 
@@ -48,7 +49,7 @@ static cloud_storage_clients::s3_configuration client_configuration() {
     conf.secret_key = cloud_roles::private_key_str("secret-key");
     conf.region = cloud_roles::aws_region_name("us-east-1");
     conf.service = cloud_roles::aws_service_name("s3");
-    conf.url_style = cloud_storage_clients::s3_url_style::virtual_host;
+    conf.url_style = cloud_storage_clients::s3_url_style::path;
     conf.server_addr = server_addr;
     return conf;
 }
@@ -426,4 +427,145 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_concurrent_acquire_release) {
           }
       })
       .get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_client_pool_multiple_upstreams) {
+    // Smoke test for multiple upstreams support in the client pool.
+
+    constexpr size_t num_connections_per_shard = 4;
+
+    ss::sharded<cloud_storage_clients::client_pool> pool;
+    auto pool_stop = test_pool_builder.copy()
+                       .connections_per_shard(num_connections_per_shard)
+                       .build(pool)
+                       .get();
+
+    struct shard_stats {
+        size_t current{0};
+        size_t max{0};
+
+        void acquired() {
+            ++current;
+            max = std::max(max, current);
+        }
+        void released() { --current; }
+    };
+    ss::sharded<shard_stats> stats;
+    stats.start().get();
+    auto stats_stop = ss::defer([&stats] { stats.stop().get(); });
+
+    cloud_storage_clients::bucket_name_parts bucket1{
+      .name = cloud_storage_clients::plain_bucket_name("test-bucket-1"),
+      .params = {{"region", "us-east-1"}, {"endpoint", "my-east-1.localhost"}},
+    };
+
+    cloud_storage_clients::bucket_name_parts bucket2{
+      .name = cloud_storage_clients::plain_bucket_name("test-bucket-2"),
+      .params = {{"region", "us-west-2"}, {"endpoint", "my-west-2.localhost"}},
+    };
+
+    // Acquire concurrently
+    // - from multiple shards
+    // - from multiple upstreams
+    pool
+      .invoke_on_all([&](cloud_storage_clients::client_pool& p) {
+          return ss::async([&] {
+              ss::abort_source as;
+              auto fut1 = p.acquire(test_bucket, as);
+              auto fut2 = p.acquire(bucket1, as);
+              auto fut3 = p.acquire(bucket2, as);
+
+              auto r = ss::when_all_succeed(
+                         std::move(fut1), std::move(fut2), std::move(fut3))
+                         .get();
+
+              BOOST_REQUIRE_EQUAL(
+                fmt::format("{}", std::get<0>(r).client),
+                "S3Client{{host: localhost, port: 4434}}");
+              BOOST_REQUIRE_EQUAL(
+                fmt::format("{}", std::get<1>(r).client),
+                "S3Client{{host: my-east-1.localhost, port: 4434}}");
+              BOOST_REQUIRE_EQUAL(
+                fmt::format("{}", std::get<2>(r).client),
+                "S3Client{{host: my-west-2.localhost, port: 4434}}");
+          });
+      })
+      .get();
+
+    std::vector<cloud_storage_clients::bucket_name_parts> concurrent_requests{};
+    concurrent_requests.reserve(1000);
+    for (size_t i = 0; i < 1000; i++) {
+        cloud_storage_clients::bucket_name_parts bucket;
+        switch (i % 3) {
+        case 0:
+            // Default upstream (no params).
+            bucket.name = cloud_storage_clients::plain_bucket_name(
+              fmt::format("test-bucket-{}", i));
+            break;
+        case 1:
+            bucket.name = cloud_storage_clients::plain_bucket_name(
+              fmt::format("test-bucket-{}", i));
+            bucket.params = {
+              {"region", "us-east-1"}, {"endpoint", "my-east-1.localhost"}};
+            break;
+        case 2:
+            bucket.name = cloud_storage_clients::plain_bucket_name(
+              fmt::format("test-bucket-{}", i));
+            bucket.params = {
+              {"region", "us-west-2"}, {"endpoint", "my-west-2.localhost"}};
+            break;
+        }
+        concurrent_requests.push_back(std::move(bucket));
+    }
+
+    auto expected_host =
+      [](const cloud_storage_clients::bucket_name_parts& b) -> std::string {
+        if (b.params.empty()) {
+            return "localhost";
+        }
+        auto it = std::ranges::find_if(
+          b.params, [](const auto& kv) { return kv.first == "endpoint"; });
+        if (it != b.params.end()) {
+            return it->second;
+        }
+        throw std::runtime_error("endpoint param not found");
+    };
+
+    for (int i = 0; i < 3; i++) {
+        pool
+          .invoke_on_all([&](cloud_storage_clients::client_pool& p) {
+              return ss::parallel_for_each(
+                concurrent_requests,
+                [&](cloud_storage_clients::bucket_name_parts& bucket) {
+                    return ss::async([&] {
+                        ss::abort_source as;
+                        auto lease = p.acquire(bucket, as).get();
+                        stats.local().acquired();
+                        auto release_guard = ss::defer(
+                          [&] { stats.local().released(); });
+
+                        BOOST_REQUIRE_EQUAL(
+                          fmt::format("{}", lease.client),
+                          fmt::format(
+                            "S3Client{{{{host: {}, port: 4434}}}}",
+                            expected_host(bucket)));
+
+                        // Hold the lease for a bit to increase
+                        // chance of contention.
+                        ss::sleep(random_generators::get_int(3) * 1ms).get();
+                    });
+                });
+          })
+          .get();
+
+        ss::yield().get();
+    }
+
+    stats
+      .invoke_on_all([=](shard_stats& s) {
+          BOOST_REQUIRE_LE(s.max, num_connections_per_shard);
+      })
+      .get();
+
+    BOOST_REQUIRE_EQUAL(pool.local().idle_count(), pool.local().capacity());
 }

--- a/src/v/cloud_storage_clients/tests/client_pool_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_test.cc
@@ -246,3 +246,37 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_self_configure_abortable) {
 
     BOOST_REQUIRE_THROW(f.get(), ss::abort_requested_exception);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_client_pool_max_upstreams_limit) {
+    // The upstream registry enforces a maximum of 10 upstreams. The default
+    // upstream (empty endpoint/region) counts as one, leaving room for 9
+    // dynamic upstreams.
+
+    ss::sharded<cloud_storage_clients::client_pool> pool;
+    auto stop_guard = test_pool_builder.build(pool).get();
+
+    ss::abort_source as;
+
+    // Create 9 dynamic upstreams (default upstream already exists)
+    for (size_t i = 0; i < 9; ++i) {
+        cloud_storage_clients::bucket_name_parts bucket{
+          .name = cloud_storage_clients::plain_bucket_name("test-bucket"),
+          .params = {{"endpoint", fmt::format("endpoint-{}.localhost", i)}},
+        };
+        auto lease = pool.local().acquire(bucket, as).get();
+    }
+
+    // The 10th dynamic upstream should fail
+    cloud_storage_clients::bucket_name_parts bucket_over_limit{
+      .name = cloud_storage_clients::plain_bucket_name("test-bucket"),
+      .params = {{"endpoint", "endpoint-over-limit.localhost"}},
+    };
+
+    BOOST_REQUIRE_EXCEPTION(
+      pool.local().acquire(bucket_over_limit, as).get(),
+      std::exception,
+      [](const std::exception& e) {
+          return std::string_view(e.what()).find("registry entry limit")
+                 != std::string_view::npos;
+      });
+}

--- a/src/v/cloud_storage_clients/tests/upstream_registry_test.cc
+++ b/src/v/cloud_storage_clients/tests/upstream_registry_test.cc
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage_clients/upstream_registry.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace {
+
+using namespace cloud_storage_clients;
+using namespace testing;
+
+bucket_name_parts
+make_bucket(std::vector<std::pair<ss::sstring, ss::sstring>> params = {}) {
+    return {
+      .name = plain_bucket_name{"test-bucket"}, .params = std::move(params)};
+}
+
+} // namespace
+
+TEST(MakeUpstreamKey, EmptyParams) {
+    auto key = make_upstream_key(s3_configuration{}, make_bucket());
+    EXPECT_TRUE(key.region().empty());
+    EXPECT_TRUE(key.endpoint().empty());
+    EXPECT_FALSE(key.server_addr.has_value());
+}
+
+TEST(MakeUpstreamKey, ParsesParamsPathStyle) {
+    s3_configuration cfg;
+    cfg.url_style = s3_url_style::path;
+    cfg.server_addr = net::unresolved_address("default.example.com", 443);
+
+    auto key = make_upstream_key(
+      cfg,
+      make_bucket({{"region", "us-west-2"}, {"endpoint", "s3.example.com"}}));
+
+    EXPECT_EQ(key.region(), "us-west-2");
+    EXPECT_EQ(key.endpoint(), "s3.example.com");
+    ASSERT_TRUE(key.server_addr.has_value());
+    EXPECT_EQ(key.server_addr->host(), "s3.example.com");
+    EXPECT_EQ(key.server_addr->port(), 443);
+}
+
+TEST(MakeUpstreamKey, ParsesParamsVirtualHostStyle) {
+    s3_configuration cfg;
+    cfg.url_style = s3_url_style::virtual_host;
+    cfg.server_addr = net::unresolved_address("default.example.com", 443);
+
+    auto key = make_upstream_key(
+      cfg,
+      make_bucket({{"region", "us-west-2"}, {"endpoint", "s3.example.com"}}));
+
+    EXPECT_EQ(key.region(), "us-west-2");
+    EXPECT_EQ(key.endpoint(), "s3.example.com");
+    ASSERT_TRUE(key.server_addr.has_value());
+    EXPECT_EQ(key.server_addr->host(), "test-bucket.s3.example.com");
+    EXPECT_EQ(key.server_addr->port(), 443);
+}
+
+TEST(MakeUpstreamKey, RejectsParamsForABS) {
+    EXPECT_THROW(
+      make_upstream_key(
+        abs_configuration{}, make_bucket({{"region", "us-west-2"}})),
+      std::invalid_argument);
+}
+
+TEST(MakeUpstreamKey, RejectsParamsForGCS) {
+    s3_configuration gcs_cfg;
+    gcs_cfg.is_gcs = true;
+    EXPECT_THROW(
+      make_upstream_key(gcs_cfg, make_bucket({{"region", "us-west-2"}})),
+      std::invalid_argument);
+}
+
+TEST(MakeUpstreamKey, RejectsUnknownParam) {
+    s3_configuration cfg;
+    cfg.url_style = s3_url_style::path;
+    EXPECT_THROW(
+      make_upstream_key(cfg, make_bucket({{"foo", "bar"}})),
+      std::invalid_argument);
+}
+
+TEST(MakeUpstreamKey, RejectsParamsWithoutUrlStyle) {
+    EXPECT_THAT(
+      [] {
+          make_upstream_key(
+            s3_configuration{}, make_bucket({{"region", "us-west-2"}}));
+      },
+      ThrowsMessage<std::invalid_argument>(StrEq(
+        "Cannot specify bucket params when cloud storage url style is not set "
+        "explicitly")));
+}

--- a/src/v/cloud_storage_clients/upstream.cc
+++ b/src/v/cloud_storage_clients/upstream.cc
@@ -97,17 +97,18 @@ void upstream::prepare_stop() {
     _credentials_var.broken();
 }
 
-upstream::client_ptr upstream::make_client() noexcept {
+upstream::client_ptr
+upstream::make_client(ss::abort_source& client_as) noexcept {
     return ss::visit(
       _config,
-      [this](const s3_configuration& cfg) -> client_ptr {
+      [this, &client_as](const s3_configuration& cfg) -> client_ptr {
           if (cfg.is_gcs) {
               return ss::make_shared<gcs_client>(
                 weak_from_this(),
                 cfg,
                 _transport_config,
                 _probe,
-                _as,
+                client_as,
                 _apply_credentials);
           }
           return ss::make_shared<s3_client>(
@@ -115,16 +116,16 @@ upstream::client_ptr upstream::make_client() noexcept {
             cfg,
             _transport_config,
             _probe,
-            _as,
+            client_as,
             _apply_credentials);
       },
-      [this](const abs_configuration& cfg) -> client_ptr {
+      [this, &client_as](const abs_configuration& cfg) -> client_ptr {
           return ss::make_shared<abs_client>(
             weak_from_this(),
             cfg,
             _transport_config,
             _probe,
-            _as,
+            client_as,
             _apply_credentials);
       });
 }
@@ -172,7 +173,7 @@ ss::future<> upstream::client_self_configure() {
           pool_log.info,
           "Client requires self configuration step. Proceeding ...");
 
-        auto client = make_client();
+        auto client = make_client(_as);
         auto shutdown_on_abort = _as.subscribe(
           [client]() noexcept { client->shutdown(); });
         auto result = co_await do_client_self_configure(client);

--- a/src/v/cloud_storage_clients/upstream.cc
+++ b/src/v/cloud_storage_clients/upstream.cc
@@ -26,10 +26,12 @@ constexpr auto self_configure_backoff = 1s;
 } // namespace
 
 upstream::upstream(
+  upstream_key key,
   client_configuration config,
   ss::shared_ptr<ss::tls::certificate_credentials> tls_credentials,
   ss::shared_ptr<client_probe> probe)
-  : _config(std::move(config))
+  : _key(std::move(key))
+  , _config(std::move(config))
   , _transport_config(build_transport_configuration(_config, tls_credentials))
   , _probe(std::move(probe))
   , _credential_manager(

--- a/src/v/cloud_storage_clients/upstream.h
+++ b/src/v/cloud_storage_clients/upstream.h
@@ -45,7 +45,20 @@ public:
     void prepare_stop();
     /// @}
 
-    client_ptr make_client() noexcept;
+    /// Create a client using the provided abort source.
+    ///
+    /// Client lifetime is decoupled from the upstream so that clients can
+    /// complete in-flight operations even if the upstream is evicted from the
+    /// registry.
+    ///
+    /// A client that outlives the upstream can finish in-flight operations but
+    /// new ones might fail i.e. because of outdated credentials.
+    /// client::is_valid can be used to check if the client is still valid for
+    /// new operations.
+    ///
+    /// Abort source must outlive the client. Abort status is checked
+    /// asynchronously.
+    client_ptr make_client(ss::abort_source& client_as) noexcept;
 
     void maybe_refresh_credentials();
     uint64_t token_refresh_count() const noexcept;

--- a/src/v/cloud_storage_clients/upstream.h
+++ b/src/v/cloud_storage_clients/upstream.h
@@ -14,6 +14,7 @@
 #include "cloud_storage_clients/client.h"
 #include "cloud_storage_clients/configuration.h"
 #include "cloud_storage_clients/credential_manager.h"
+#include "cloud_storage_clients/upstream_key.h"
 
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/sharded.hh>
@@ -34,6 +35,7 @@ public:
     using client_ptr = ss::shared_ptr<client>;
 
     explicit upstream(
+      upstream_key key,
       client_configuration config,
       ss::shared_ptr<ss::tls::certificate_credentials> tls_credentials,
       ss::shared_ptr<client_probe> probe);
@@ -44,6 +46,8 @@ public:
     ss::future<> stop();
     void prepare_stop();
     /// @}
+
+    const upstream_key& key() const noexcept { return _key; }
 
     /// Create a client using the provided abort source.
     ///
@@ -80,6 +84,8 @@ private:
 
     ss::abort_source _as;
     ss::gate _gate;
+
+    upstream_key _key;
 
     client_configuration _config;
     net::base_transport::configuration _transport_config;

--- a/src/v/cloud_storage_clients/upstream_key.h
+++ b/src/v/cloud_storage_clients/upstream_key.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "base/format_to.h"
+#include "cloud_roles/types.h"
+#include "cloud_storage_clients/types.h"
+#include "utils/unresolved_address.h"
+
+namespace cloud_storage_clients {
+
+/// Key identifying an upstream service instance.
+struct upstream_key {
+    cloud_roles::aws_region_name region;
+    cloud_storage_clients::endpoint_url endpoint;
+
+    /// Takes precedence over endpoint if set. When using virtual host
+    /// addressing, this address includes the bucket name as a prefix.
+    ///
+    /// For Remote Read Replicas with endpoint overrides, this creates a unique
+    /// upstream key per bucket, ensuring clients connect to correct servers.
+    ///
+    /// For Remote Read Replicas without endpoint overrides, this remains
+    /// std::nullopt and for now follow original behavior of using the default
+    /// bucket server address for the TCP connection but custom HOST header.
+    std::optional<net::unresolved_address> server_addr;
+
+    auto operator<=>(const upstream_key&) const = default;
+
+    fmt::iterator format_to(fmt::iterator it) const {
+        return fmt::format_to(
+          it,
+          "upstream_key{{region={}, endpoint={}, server_addr={}}}",
+          region().empty() ? "<default>" : region(),
+          endpoint().empty() ? "<default>" : endpoint(),
+          server_addr.has_value() ? fmt::format("{}", *server_addr)
+                                  : "<default>");
+    }
+};
+
+inline const upstream_key default_upstream_key{};
+
+} // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/upstream_registry.cc
+++ b/src/v/cloud_storage_clients/upstream_registry.cc
@@ -12,17 +12,67 @@
 
 #include "cloud_storage_clients/detail/registry_def.h" // IWYU pragma: keep
 #include "cloud_storage_clients/logger.h"
+#include "utils/unresolved_address.h"
 
 #include <seastar/core/sharded.hh>
 
 namespace cloud_storage_clients {
+
+/// A reasonable upper limit on the number of upstreams.
+constexpr size_t max_upstreams = 10;
+
+constexpr std::string_view s3_region_key = "region";
+constexpr std::string_view s3_endpoint_key = "endpoint";
+
+upstream_key make_upstream_key(
+  const client_configuration& cfg, const bucket_name_parts& bucket) {
+    upstream_key key;
+
+    if (bucket.params.empty()) {
+        return key;
+    }
+
+    if (auto s3_cfg = std::get_if<s3_configuration>(&cfg);
+        !s3_cfg || s3_cfg->is_gcs) {
+        throw std::invalid_argument(
+          "Cannot specify bucket params for non-S3 cloud storage "
+          "configurations");
+    } else {
+        if (!s3_cfg->url_style.has_value()) {
+            throw std::invalid_argument(
+              "Cannot specify bucket params when cloud storage url style is "
+              "not set explicitly");
+        }
+
+        for (const auto& [param_key, param_value] : bucket.params) {
+            if (param_key == s3_region_key) {
+                key.region = cloud_roles::aws_region_name{param_value};
+            } else if (param_key == s3_endpoint_key) {
+                key.endpoint = cloud_storage_clients::endpoint_url{param_value};
+
+                auto host = *s3_cfg->url_style == s3_url_style::virtual_host
+                              ? ssx::sformat("{}.{}", bucket.name, param_value)
+                              : ss::sstring{param_value};
+                key.server_addr = net::unresolved_address(
+                  std::move(host),
+                  s3_cfg->server_addr.port(),
+                  s3_cfg->server_addr.family());
+            } else {
+                throw std::invalid_argument(
+                  fmt::format("Unknown bucket param '{}'", param_key));
+            }
+        }
+    }
+
+    return key;
+}
 
 template class detail::
   basic_registry<upstream, upstream_key, upstream_registry>;
 
 upstream_registry::upstream_registry(client_configuration config)
   : detail::basic_registry<upstream, upstream_key, upstream_registry>(
-      pool_log, no_entry_limit)
+      pool_log, max_upstreams)
   , _config(std::move(config))
   , _probe(std::visit([](auto&& p) { return p.make_probe(); }, _config)) {}
 
@@ -30,10 +80,29 @@ ss::future<> upstream_registry::start() {
     _tls_credentials = co_await build_tls_credentials(_config);
 }
 
-ss::future<>
-upstream_registry::start_svc(sharded_constructor& ctor, const upstream_key&) {
-    auto& svc = co_await ctor.start(
+ss::future<> upstream_registry::start_svc(
+  sharded_constructor& ctor, const upstream_key& key) {
+    client_configuration cfg = ss::visit(
       _config,
+      [&key](s3_configuration s3_conf) -> client_configuration {
+          if (!key.region().empty()) {
+              s3_conf.region = key.region;
+          }
+
+          if (!key.endpoint().empty()) {
+              s3_conf.tls_sni_hostname = key.endpoint();
+              s3_conf.uri = access_point_uri{key.endpoint()};
+              s3_conf.server_addr = *key.server_addr;
+          }
+
+          return s3_conf;
+      },
+      [](abs_configuration abs_conf) -> client_configuration {
+          return abs_conf;
+      });
+
+    auto& svc = co_await ctor.start(
+      cfg,
       ss::sharded_parameter(
         [this] { return container().local()._tls_credentials; }),
       ss::sharded_parameter([this] { return container().local().probe(); }));

--- a/src/v/cloud_storage_clients/upstream_registry.cc
+++ b/src/v/cloud_storage_clients/upstream_registry.cc
@@ -12,7 +12,7 @@
 
 #include "cloud_storage_clients/detail/registry_def.h" // IWYU pragma: keep
 #include "cloud_storage_clients/logger.h"
-#include "utils/unresolved_address.h"
+#include "cloud_storage_clients/upstream_key.h"
 
 #include <seastar/core/sharded.hh>
 
@@ -102,6 +102,7 @@ ss::future<> upstream_registry::start_svc(
       });
 
     auto& svc = co_await ctor.start(
+      key,
       cfg,
       ss::sharded_parameter(
         [this] { return container().local()._tls_credentials; }),

--- a/src/v/cloud_storage_clients/upstream_registry.h
+++ b/src/v/cloud_storage_clients/upstream_registry.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "base/format_to.h"
+#include "cloud_storage_clients/bucket_name_parts.h"
 #include "cloud_storage_clients/configuration.h"
 #include "cloud_storage_clients/detail/registry.h"
 #include "cloud_storage_clients/upstream.h"
@@ -19,17 +20,37 @@
 
 namespace cloud_storage_clients {
 
-/// A reasonable upper limit on the number of upstreams.
-constexpr size_t max_upstreams = 10;
-
 /// Key identifying an upstream service instance.
 struct upstream_key {
+    cloud_roles::aws_region_name region;
+    cloud_storage_clients::endpoint_url endpoint;
+
+    /// Takes precedence over endpoint if set. When using virtual host
+    /// addressing, this address includes the bucket name as a prefix.
+    ///
+    /// For Remote Read Replicas with endpoint overrides, this creates a unique
+    /// upstream key per bucket, ensuring clients connect to correct servers.
+    ///
+    /// For Remote Read Replicas without endpoint overrides, this remains
+    /// std::nullopt and for now follow original behavior of using the default
+    /// bucket server address for the TCP connection but custom HOST header.
+    std::optional<net::unresolved_address> server_addr;
+
     auto operator<=>(const upstream_key&) const = default;
 
     fmt::iterator format_to(fmt::iterator it) const {
-        return fmt::format_to(it, "upstream_key{{}}");
+        return fmt::format_to(
+          it,
+          "upstream_key{{region={}, endpoint={}, server_addr={}}}",
+          region().empty() ? "<default>" : region(),
+          endpoint().empty() ? "<default>" : endpoint(),
+          server_addr.has_value() ? fmt::format("{}", *server_addr)
+                                  : "<default>");
     }
 };
+
+upstream_key make_upstream_key(
+  const client_configuration& config, const bucket_name_parts& bucket);
 
 /// Registry for upstream cloud storage clients.
 class upstream_registry final

--- a/src/v/cloud_storage_clients/upstream_registry.h
+++ b/src/v/cloud_storage_clients/upstream_registry.h
@@ -20,35 +20,6 @@
 
 namespace cloud_storage_clients {
 
-/// Key identifying an upstream service instance.
-struct upstream_key {
-    cloud_roles::aws_region_name region;
-    cloud_storage_clients::endpoint_url endpoint;
-
-    /// Takes precedence over endpoint if set. When using virtual host
-    /// addressing, this address includes the bucket name as a prefix.
-    ///
-    /// For Remote Read Replicas with endpoint overrides, this creates a unique
-    /// upstream key per bucket, ensuring clients connect to correct servers.
-    ///
-    /// For Remote Read Replicas without endpoint overrides, this remains
-    /// std::nullopt and for now follow original behavior of using the default
-    /// bucket server address for the TCP connection but custom HOST header.
-    std::optional<net::unresolved_address> server_addr;
-
-    auto operator<=>(const upstream_key&) const = default;
-
-    fmt::iterator format_to(fmt::iterator it) const {
-        return fmt::format_to(
-          it,
-          "upstream_key{{region={}, endpoint={}, server_addr={}}}",
-          region().empty() ? "<default>" : region(),
-          endpoint().empty() ? "<default>" : endpoint(),
-          server_addr.has_value() ? fmt::format("{}", *server_addr)
-                                  : "<default>");
-    }
-};
-
 upstream_key make_upstream_key(
   const client_configuration& config, const bucket_name_parts& bucket);
 

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -273,6 +273,9 @@ public:
     /// Whether the client has a valid connection.
     using net::base_transport::is_valid;
 
+    /// Server address.
+    using net::base_transport::server_address;
+
     /**
      * Dispatch a request with the provided headers and body.
      *

--- a/src/v/redpanda/tests/fixture.cc
+++ b/src/v/redpanda/tests/fixture.cc
@@ -397,7 +397,10 @@ void redpanda_thread_fixture::configure(
               .set_value(std::make_optional(s3_config->server_addr.host()));
             config.get("cloud_storage_url_style")
               .set_value(std::make_optional([&] {
-                  switch (s3_config->url_style) {
+                  if (!s3_config->url_style.has_value()) {
+                      return config::s3_url_style::virtual_host;
+                  }
+                  switch (*s3_config->url_style) {
                   case cloud_storage_clients::s3_url_style::virtual_host:
                       return config::s3_url_style::virtual_host;
                   case cloud_storage_clients::s3_url_style::path:

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -9,6 +9,7 @@
 from typing import List, NamedTuple, Optional
 
 from ducktape.mark import matrix
+from ducktape.mark._mark import Mark
 from ducktape.tests.test import TestContext
 
 from rptest.clients.default import DefaultClient
@@ -22,6 +23,7 @@ from rptest.services.redpanda import (
     MetricsEndpoint,
     RedpandaService,
     SISettings,
+    get_cloud_provider,
     get_cloud_storage_type,
     get_cloud_storage_type_and_url_style,
     make_redpanda_service,
@@ -128,6 +130,47 @@ def create_read_replica_topic(dst_cluster, topic_name, bucket_name) -> None:
     )
 
 
+class CrossRegionRRRTestMark(Mark):
+    """
+    This mark uses the current cloud provider (via get_cloud_provider)
+    to decide whether a test should be skipped: tests are only executed
+    when running on supported providers (docker and aws), and are marked
+    as ignored on other providers.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def apply(self, seed_context, context_list):
+        assert len(context_list) > 0, (
+            "ignore annotation is not being applied to any test cases"
+        )
+
+        should_ignore_test = False
+        if get_cloud_provider() not in ["docker", "aws"]:
+            seed_context.logger.info(
+                "Skipping cross-region read-replica test outside of docker and aws"
+            )
+            should_ignore_test = True
+
+        for ctx in context_list:
+            ctx.ignore = ctx.ignore or should_ignore_test
+
+        return context_list
+
+
+def cross_region_rrr_test(func, /):
+    """
+    Decorator to mark a test as a cross region remote read replica test.
+    These tests run only in docker and aws. For GCS overrides aren't necessary
+    and we don't allow them. ABS has a different model and needs additional
+    work.
+    """
+
+    Mark.mark(func, CrossRegionRRRTestMark())
+    return func
+
+
 class TestReadReplicaService(EndToEndTest):
     log_segment_size = 1048576  # 5MB
     topic_name = "panda-topic"
@@ -164,6 +207,7 @@ class TestReadReplicaService(EndToEndTest):
             cloud_storage_segment_max_upload_interval_sec=5,
             cloud_storage_housekeeping_interval_ms=10,
         )
+        self.rr_topic_bucket = self.si_settings.cloud_storage_bucket
         self.second_cluster = None
 
     def start_second_cluster(self, num_brokers=3) -> None:
@@ -179,7 +223,7 @@ class TestReadReplicaService(EndToEndTest):
 
     def create_read_replica_topic(self) -> None:
         create_read_replica_topic(
-            self.second_cluster, self.topic_name, self.si_settings.cloud_storage_bucket
+            self.second_cluster, self.topic_name, self.rr_topic_bucket
         )
 
     def start_consumer(self) -> None:
@@ -227,6 +271,7 @@ class TestReadReplicaService(EndToEndTest):
         producer_timeout=None,
         num_source_brokers=3,
         num_rrr_brokers=3,
+        replication_factor=3,
     ) -> None:
         if producer_timeout is None:
             producer_timeout = 30
@@ -239,7 +284,9 @@ class TestReadReplicaService(EndToEndTest):
         # Create original topic
         self.start_redpanda(num_source_brokers, si_settings=self.si_settings)
         spec = TopicSpec(
-            name=self.topic_name, partition_count=partition_count, replication_factor=3
+            name=self.topic_name,
+            partition_count=partition_count,
+            replication_factor=replication_factor,
         )
 
         DefaultClient(self.redpanda).create_topic(spec)
@@ -489,6 +536,37 @@ class TestReadReplicaService(EndToEndTest):
         if delta:
             m = f"S3 Bucket usage changed during read replica test: {delta}"
             assert False, m
+
+    # fips on S3 is not compatible with path-style urls. TODO remove this once get_cloud_storage_type_and_url_style is fips aware
+    @skip_fips_mode
+    @cross_region_rrr_test
+    @cluster(num_nodes=4, log_allow_list=READ_REPLICA_LOG_ALLOW_LIST)
+    @matrix(
+        cloud_storage_type=[CloudStorageType.S3],
+        cloud_storage_url_style=["path", "virtual_host"],
+    )
+    def test_cross_region_end_to_end(
+        self, cloud_storage_type: CloudStorageType, cloud_storage_url_style: str
+    ):
+        bucket_region = self.rr_settings.cloud_storage_region
+        bucket_endpoint = self.rr_settings.cloud_storage_api_endpoint
+        self.rr_topic_bucket = f"{self.si_settings.cloud_storage_bucket}?region={bucket_region}&endpoint={bucket_endpoint}"
+
+        # Bogus region and endpoint to test overrides take effect.
+        self.rr_settings.cloud_storage_region = "unknown-region-1"
+        self.rr_settings.cloud_storage_api_endpoint = "nonexistent.localhost"
+
+        self._setup_read_replica(
+            num_messages=100000,
+            partition_count=3,
+            producer_timeout=300,
+            num_source_brokers=1,
+            num_rrr_brokers=1,
+            replication_factor=1,
+        )
+
+        self.start_consumer()
+        self.run_validation(consumer_timeout_sec=300)
 
     def _get_node_assignments(self, admin, topic, partition):
         def try_get_partitions():


### PR DESCRIPTION
Enable client pool to route requests to different cloud storage endpoints based on bucket parameters (region, endpoint override).

Key changes:

1. Decouple client abort source from upstream - Clients now take an external abort source rather than using the upstream's internal one. This prevents upstream eviction from aborting
in-flight operations. Clients hold a weak_ptr to their upstream to avoid complicating eviction semantics.
2. Dynamic upstream routing - upstream_key now carries region/endpoint overrides parsed from bucket params. The registry creates configured upstream instances on demand.

Non-default upstreams bypass connection pooling (fresh client per request). Client re-use for dynamic upstreams is deferred to a follow-up.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Features

* Remote Read Replicas now support cross-region access by specifying region and endpoint overrides in the read replica topic's bucket property (e.g. `bucket-name?region=us-east-1&endpoint=s3.us-east-1.amazonaws.com`), enabling RRR to read from buckets in different regions on AWS S3, and other S3 compatible backends.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
