### PR TITLE
ct/l1/lsm: fix replace_objects when below start offset

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
@@ -71,23 +71,64 @@ ss::future<std::expected<void, db_update_error>> validate_new_objects_missing(
 // Returns the extents of the given partition that align exactly with the input
 // intervals. If there any of the intervals don't align with exact intervals,
 // returns an error.
+//
+// Intervals that start below start_offset are adjusted: we find the first
+// extent at or above start_offset and use that as the range start. This allows
+// replacement extents referencing offsets that have been truncated.
 ss::future<std::expected<void, db_update_error>> collect_exact_intervals(
   const model::topic_id_partition& tidp,
   const chunked_vector<offset_interval_set::interval>& intervals,
+  kafka::offset start_offset,
   state_reader& state,
   chunked_vector<ss::sstring>& out_extent_keys,
   chunked_hash_map<object_id, size_t>& out_sizes) {
     for (const auto& interval : intervals) {
-        auto range_res = co_await state.get_extent_range(
-          tidp, interval.base_offset, interval.last_offset);
+        auto base = interval.base_offset;
+        auto last = interval.last_offset;
+        if (last < start_offset) {
+            // This whole interval is below the start offset. We don't need to
+            // find extents for it, as it will be dropped.
+            continue;
+        }
+
+        // If base < start_offset, we are considering replacing an extent that
+        // starts below the log start offset. Adjust the base offset to point
+        // at the first extent; we'll collect all extents below the start
+        // offset for removal.
+        if (base < start_offset) {
+            auto first_extent_res = co_await state.get_extent_ge(
+              tidp, kafka::offset(0));
+            if (!first_extent_res.has_value()) {
+                co_return std::unexpected(wrap_read_err(
+                  std::move(first_extent_res.error()),
+                  "Error getting first extent >= {} for {}",
+                  start_offset,
+                  tidp));
+            }
+            if (!first_extent_res->has_value()) {
+                // There are no extents at all, and therefore we cannot collect
+                // extents to replace.
+                co_return std::unexpected(db_update_error(
+                  invalid_update,
+                  fmt::format(
+                    "Partition {} doesn't contain extents that span exactly "
+                    "[{}, {}]",
+                    tidp,
+                    base,
+                    last)));
+            }
+            base = first_extent_res->value().base_offset;
+        }
+
+        auto range_res = co_await state.get_extent_range(tidp, base, last);
 
         if (!range_res.has_value()) {
             co_return std::unexpected(wrap_read_err(
               std::move(range_res.error()),
               "Error getting extent range for {} [{}, {}]",
               tidp,
-              interval.base_offset,
-              interval.last_offset));
+              base,
+              last));
         }
         if (!range_res.value().has_value()) {
             co_return std::unexpected(db_update_error(
@@ -96,8 +137,8 @@ ss::future<std::expected<void, db_update_error>> collect_exact_intervals(
                 "Partition {} doesn't contain extents that span exactly "
                 "[{}, {}]",
                 tidp,
-                interval.base_offset,
-                interval.last_offset)));
+                base,
+                last)));
         }
 
         auto extent_gen = range_res.value()->get_rows();
@@ -107,8 +148,8 @@ ss::future<std::expected<void, db_update_error>> collect_exact_intervals(
                   std::move(extent_res->get().error()),
                   "Error iterating through {} extents in range [{}, {}]",
                   tidp,
-                  interval.base_offset,
-                  interval.last_offset));
+                  base,
+                  last));
             }
             auto& row = extent_res->get().value();
             out_sizes[row.val.oid] += row.val.len;
@@ -553,6 +594,8 @@ replace_objects_db_update::build_rows(
     chunked_hash_map<object_id, size_t> old_extent_sizes_by_oid;
     chunked_hash_map<model::topic_id_partition, chunked_vector<ss::sstring>>
       extent_keys_to_delete;
+    chunked_hash_map<model::topic_id_partition, kafka::offset>
+      start_offsets_by_tp;
     for (const auto& [tidp, intervals] : contiguous_intervals_by_tp) {
         auto meta_res = co_await state.get_metadata(tidp);
         if (!meta_res.has_value()) {
@@ -566,9 +609,11 @@ replace_objects_db_update::build_rows(
               invalid_update,
               fmt::format("Partition {} not tracked by state", tidp)));
         }
+        start_offsets_by_tp[tidp] = meta_res.value()->start_offset;
         auto exact_intervals_res = co_await collect_exact_intervals(
           tidp,
           intervals,
+          meta_res.value()->start_offset,
           state,
           extent_keys_to_delete[tidp],
           old_extent_sizes_by_oid);
@@ -630,7 +675,17 @@ replace_objects_db_update::build_rows(
     // Generate the rows.
     chunked_hash_set<ss::sstring> added_extent_keys;
     for (const auto& [tidp, extents] : new_extents_by_tp) {
+        auto start_it = start_offsets_by_tp.find(tidp);
+        auto start_offset = start_it != start_offsets_by_tp.end()
+                              ? start_it->second
+                              : kafka::offset{0};
         for (const auto& extent : extents) {
+            // Skip extents fully below start_offset. These are stale
+            // replacements for extents that have been truncated.
+            if (extent.last_offset < start_offset) {
+                new_objects_map[extent.oid].removed_data_size += extent.len;
+                continue;
+            }
             auto key = extent_row_key::encode(tidp, extent.base_offset);
             added_extent_keys.emplace(key);
             out.emplace_back(
@@ -646,6 +701,12 @@ replace_objects_db_update::build_rows(
                   }),
               });
         }
+    }
+    if (added_extent_keys.empty()) {
+        // No extents, e.g. because all replacements are below the current
+        // start offsets.
+        co_return std::unexpected(db_update_error(
+          invalid_update, "Replacement extents all filtered out"));
     }
     for (const auto& [tidp, keys] : extent_keys_to_delete) {
         for (const auto& key : keys) {

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -934,7 +934,7 @@ TEST_P(StateUpdateParamTest, TestReplaceInvalidNonContiguousDoesNotSpan) {
     ASSERT_EQ(p.extents.size(), 3);
 }
 
-TEST(StateUpdateTest, TestReplaceSingleExtentBeforeNewStartOffset) {
+TEST_P(StateUpdateParamTest, TestReplaceSingleExtentBeforeNewStartOffset) {
     auto add = add_objects_builder()
                  .add(new_obj_builder(oid1, 100, 1100)
                         .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
@@ -947,16 +947,12 @@ TEST(StateUpdateTest, TestReplaceSingleExtentBeforeNewStartOffset) {
                         .build())
                  .add_term_start(tidp_a, 0_tm, 0_o)
                  .build();
-    state s;
-    auto add_res = add.apply(s);
+    auto add_res = apply_add_objects(std::move(add));
     ASSERT_TRUE(add_res.has_value());
 
     auto tp = model::topic_id_partition::from(tidp_a);
-    auto set_start_update = set_start_offset_update::build(s, tp, 150_o);
-    ASSERT_TRUE(set_start_update.has_value());
-
-    auto apply_res = set_start_update->apply(s);
-    ASSERT_TRUE(apply_res.has_value());
+    auto set_start_res = apply_set_start_offset(tp, 150_o);
+    ASSERT_TRUE(set_start_res.has_value());
 
     // Attempt to replace with a list of valid objects, with one extent
     // containing offsets before the truncation point (the new start offset).
@@ -974,11 +970,12 @@ TEST(StateUpdateTest, TestReplaceSingleExtentBeforeNewStartOffset) {
                             .build())
                      .build();
 
-    auto replace_res = replace.apply(s);
+    auto replace_res = apply_replace_objects(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 }
 
-TEST(StateUpdateTest, TestReplaceWithAlignedExtentsBeforeNewStartOffset) {
+TEST_P(
+  StateUpdateParamTest, TestReplaceWithAlignedExtentsBeforeNewStartOffset) {
     auto add = add_objects_builder()
                  .add(new_obj_builder(oid1, 100, 1100)
                         .add(tidp_a, 0_o, 30_o, 1999_t, 0, 99)
@@ -991,16 +988,12 @@ TEST(StateUpdateTest, TestReplaceWithAlignedExtentsBeforeNewStartOffset) {
                         .build())
                  .add_term_start(tidp_a, 0_tm, 0_o)
                  .build();
-    state s;
-    auto add_res = add.apply(s);
+    auto add_res = apply_add_objects(std::move(add));
     ASSERT_TRUE(add_res.has_value());
 
     auto tp = model::topic_id_partition::from(tidp_a);
-    auto set_start_update = set_start_offset_update::build(s, tp, 61_o);
-    ASSERT_TRUE(set_start_update.has_value());
-
-    auto apply_res = set_start_update->apply(s);
-    ASSERT_TRUE(apply_res.has_value());
+    auto set_start_res = apply_set_start_offset(tp, 61_o);
+    ASSERT_TRUE(set_start_res.has_value());
 
     // Attempt to replace with a list of valid objects built before the
     // truncation occurred. The metastore should be able to accept and prune the
@@ -1017,15 +1010,16 @@ TEST(StateUpdateTest, TestReplaceWithAlignedExtentsBeforeNewStartOffset) {
                             .build())
                      .build();
 
-    auto replace_res = replace.apply(s);
+    auto replace_res = apply_replace_objects(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 
+    auto& s = get_state();
     auto p_state = s.partition_state(tp);
     ASSERT_TRUE(p_state.has_value());
     EXPECT_EQ(p_state->get().extents.size(), 1);
 }
 
-TEST(StateUpdateTest, TestReplaceAllExtentsBeforeNewStartOffset) {
+TEST_P(StateUpdateParamTest, TestReplaceAllExtentsBeforeNewStartOffset) {
     auto add = add_objects_builder()
                  .add(new_obj_builder(oid1, 100, 1100)
                         .add(tidp_a, 0_o, 99_o, 1999_t, 0, 99)
@@ -1038,16 +1032,12 @@ TEST(StateUpdateTest, TestReplaceAllExtentsBeforeNewStartOffset) {
                         .build())
                  .add_term_start(tidp_a, 0_tm, 0_o)
                  .build();
-    state s;
-    auto add_res = add.apply(s);
+    auto add_res = apply_add_objects(std::move(add));
     ASSERT_TRUE(add_res.has_value());
 
     auto tp = model::topic_id_partition::from(tidp_a);
-    auto set_start_update = set_start_offset_update::build(s, tp, 300_o);
-    ASSERT_TRUE(set_start_update.has_value());
-
-    auto apply_res = set_start_update->apply(s);
-    ASSERT_TRUE(apply_res.has_value());
+    auto set_start_res = apply_set_start_offset(tp, 300_o);
+    ASSERT_TRUE(set_start_res.has_value());
 
     // Attempt to replace with a list of valid objects, with all extents
     // containing offsets before the truncation point (the new start offset).
@@ -1064,31 +1054,23 @@ TEST(StateUpdateTest, TestReplaceAllExtentsBeforeNewStartOffset) {
                             .build())
                      .build();
 
-    auto replace_res = replace.apply(s);
+    auto replace_res = apply_replace_objects(std::move(replace));
     ASSERT_FALSE(replace_res.has_value());
-    EXPECT_THAT(
-      std::string(replace_res.error()()),
-      testing::ContainsRegex(
-        "Partition .+ doesn't contain extents that span exactly"));
 }
 
-TEST(StateUpdateTest, TestReplaceMultipleExtentsBeforeNewStartOffset) {
+TEST_P(StateUpdateParamTest, TestReplaceMultipleExtentsBeforeNewStartOffset) {
     auto add = add_objects_builder()
                  .add(new_obj_builder(oid1, 100, 1100)
                         .add(tidp_a, 0_o, 100_o, 1999_t, 0, 99)
                         .build())
                  .add_term_start(tidp_a, 0_tm, 0_o)
                  .build();
-    state s;
-    auto add_res = add.apply(s);
+    auto add_res = apply_add_objects(std::move(add));
     ASSERT_TRUE(add_res.has_value());
 
     auto tp = model::topic_id_partition::from(tidp_a);
-    auto set_start_update = set_start_offset_update::build(s, tp, 75_o);
-    ASSERT_TRUE(set_start_update.has_value());
-
-    auto apply_res = set_start_update->apply(s);
-    ASSERT_TRUE(apply_res.has_value());
+    auto set_start_res = apply_set_start_offset(tp, 75_o);
+    ASSERT_TRUE(set_start_res.has_value());
 
     // Attempt to replace with a list of valid objects, with some extents
     // containing offsets before the truncation point (the new start offset).
@@ -1107,15 +1089,17 @@ TEST(StateUpdateTest, TestReplaceMultipleExtentsBeforeNewStartOffset) {
                             .build())
                      .build();
 
-    auto replace_res = replace.apply(s);
+    auto replace_res = apply_replace_objects(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 
+    auto& s = get_state();
     auto p_state = s.partition_state(tp);
     ASSERT_TRUE(p_state.has_value());
     EXPECT_EQ(p_state->get().extents.size(), 1);
 }
 
-TEST(StateUpdateTest, TestReplaceMisalignedButContiguousWithNewStartOffset) {
+TEST_P(
+  StateUpdateParamTest, TestReplaceMisalignedButContiguousWithNewStartOffset) {
     auto add = add_objects_builder()
                  .add(new_obj_builder(oid1, 100, 1100)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
@@ -1129,16 +1113,12 @@ TEST(StateUpdateTest, TestReplaceMisalignedButContiguousWithNewStartOffset) {
                  .add_term_start(tidp_a, 0_tm, 0_o)
                  .build();
 
-    state s;
-    auto add_res = add.apply(s);
+    auto add_res = apply_add_objects(std::move(add));
     ASSERT_TRUE(add_res.has_value());
 
     auto tp = model::topic_id_partition::from(tidp_a);
-    auto set_start_update = set_start_offset_update::build(s, tp, 15_o);
-    ASSERT_TRUE(set_start_update.has_value());
-
-    auto apply_res = set_start_update->apply(s);
-    ASSERT_TRUE(apply_res.has_value());
+    auto set_start_res = apply_set_start_offset(tp, 15_o);
+    ASSERT_TRUE(set_start_res.has_value());
 
     // Attempt to replace with a list of extents that are misaligned to the
     // existing extents ([11,20],[21,30]), but form a valid, contiguous update
@@ -1152,9 +1132,10 @@ TEST(StateUpdateTest, TestReplaceMisalignedButContiguousWithNewStartOffset) {
                             .build())
                      .build();
 
-    auto replace_res = replace.apply(s);
+    auto replace_res = apply_replace_objects(std::move(replace));
     ASSERT_TRUE(replace_res.has_value());
 
+    auto& s = get_state();
     auto p_state = s.partition_state(tp);
     ASSERT_TRUE(p_state.has_value());
     EXPECT_EQ(p_state->get().extents.size(), 2);


### PR DESCRIPTION
The LSM implementation didn't match the simple implementation, which is more lax about replacing extents that start below the log start.

This updates the LSM implementation to match: when there are extents below the start offset being replaced:
- if they're entirely below the start offset, drop them -- if they are all dropped, consider the replacement op a failure
- if one is partially above and partially below the start offset, remove it and all extents down to the first extent

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
