### PR TITLE
tools: add --port-offset argument to dev_cluster.py

### DIFF
--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -553,6 +553,12 @@ async def main() -> None:
         default=8092,
     )
     parser.add_argument(
+        "--port-offset",
+        type=int,
+        help="offset to add to all base ports (useful for running multiple clusters)",
+        default=0,
+    )
+    parser.add_argument(
         "--listen-address", type=str, help="listening address", default="127.0.0.1"
     )
     parser.add_argument(
@@ -616,6 +622,14 @@ async def main() -> None:
 
     if args.directory is None:
         args.directory = Path(os.environ.get("BUILD_WORKSPACE_DIRECTORY", ".")) / "data"
+
+    # Apply port offset to all base ports
+    if args.port_offset:
+        args.base_rpc_port += args.port_offset
+        args.base_kafka_port += args.port_offset
+        args.base_admin_port += args.port_offset
+        args.base_schema_registry_port += args.port_offset
+        args.base_pandaproxy_port += args.port_offset
 
     # Use the first 3 nodes as seed servers
     rpc_addresses = [


### PR DESCRIPTION
Add a single CLI argument to offset all base ports at once, making it easier to run multiple dev clusters simultaneously.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
