### PR TITLE
storage: add split_writes and writes_completed appender metrics

### DIFF
--- a/src/v/storage/log_manager_probe.cc
+++ b/src/v/storage/log_manager_probe.cc
@@ -23,10 +23,8 @@ void log_manager_probe::setup_metrics() {
 
     namespace sm = ss::metrics;
 
-    auto group_name = prometheus_sanitize::metrics_name("storage:manager");
-
     _metrics.add_group(
-      group_name,
+      "storage_manger",
       {
         sm::make_gauge(
           "logs",
@@ -40,53 +38,73 @@ void log_manager_probe::setup_metrics() {
           "housekeeping_log_processed",
           [this] { return _housekeeping_log_processed; },
           sm::description("Number of logs processed by housekeeping")),
+      },
+      {},
+      {});
+
+    // segment appender metrics (which are per-shard, unlike log_probe stuff)
+    _metrics.add_group(
+      "segment_appender",
+      {
         sm::make_counter(
-          "appender_merged_writes",
+          "merged_writes",
           [this] { return _appender_stats->merged_writes; },
           sm::description(
             "Number of writes merged into queued writes prior to dispatch.")),
         sm::make_counter(
-          "appender_bytes_requested",
+          "bytes_requested",
           [this] { return _appender_stats->bytes_requested; },
           sm::description(
             "Logical bytes appended (the number of bytes appended by the upper "
             "layers, before alignment.")),
         sm::make_counter(
-          "appender_bytes_written",
+          "bytes_written",
           [this] { return _appender_stats->bytes_written; },
           sm::description(
             "Physical bytes appended (the number of bytes actually written via "
             "dma_write calls, which is in general higher than logical bytes "
             "due to alignment).")),
         sm::make_counter(
-          "appender_appends_requested",
+          "appends_requested",
           [this] { return _appender_stats->appends; },
           sm::description(
             "Logical number of append requests to segment appenders.")),
         sm::make_counter(
-          "appender_flushes",
+          "flushes",
           [this] { return _appender_stats->flushes; },
           sm::description("Number of flush calls to segment appenders.")),
         sm::make_counter(
-          "appender_fsyncs",
+          "fsyncs",
           [this] { return _appender_stats->fsyncs; },
           sm::description(
             "Number of disk fsync calls from segment appenders.")),
         sm::make_counter(
-          "appender_truncates",
+          "truncates",
           [this] { return _appender_stats->truncates; },
           sm::description(
             "Number of truncate operations on segment appenders.")),
         sm::make_counter(
-          "appender_fallocations",
+          "fallocations",
           [this] { return _appender_stats->fallocations; },
           sm::description(
             "Number of fallocate operations on segment appenders.")),
         sm::make_counter(
-          "appender_last_page_hydrations",
+          "last_page_hydrations",
           [this] { return _appender_stats->last_page_hydrations; },
           sm::description(
             "Number of last page hydrations in segment appenders.")),
+        sm::make_counter(
+          "split_writes",
+          [this] { return _appender_stats->split_writes; },
+          sm::description(
+            "Number of writes that needed to be split across multiple chunks "
+            "(i.e., the write didn't fit in the current chunk).")),
+        sm::make_counter(
+          "writes_completed",
+          [this] { return _appender_stats->writes_completed; },
+          sm::description(
+            "Number of physical writes (dma_write calls) that completed "
+            "successfully.")),
       },
       {},
       {});

--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -231,6 +231,9 @@ ss::future<> segment_appender::do_append(const char* buf, size_t n) {
             co_return;
         }
 
+        // increment split writes
+        ++_opts.shared_stats->split_writes;
+
         // barrier. do not hold the units!
         auto units = co_await ss::get_units(_concurrent_flushes, 1);
         units.return_all();
@@ -653,6 +656,7 @@ void segment_appender::dispatch_background_head_write() {
 #pragma clang diagnostic pop
                   .then([this, w, dma_size](size_t got) {
                       _opts.shared_stats->bytes_written += dma_size;
+                      ++_opts.shared_stats->writes_completed;
                       /*
                        * the continuation that captured full=true is the
                        * end of the dependency chain for this chunk. it
@@ -811,7 +815,7 @@ fmt::iterator segment_appender::stats::format_to(fmt::iterator it) const {
       "{{ merged_writes: {}, bytes_requested : {}, bytes_written : {}, "
       "appends "
       ": {}, flushes: {}, fsyncs: {}, truncates: {}, fallocations: {}, "
-      "last_page_hydrations: {}}}",
+      "last_page_hydrations: {}, split_writes: {}, writes_completed: {}}}",
       merged_writes,
       bytes_requested,
       bytes_written,
@@ -820,7 +824,9 @@ fmt::iterator segment_appender::stats::format_to(fmt::iterator it) const {
       fsyncs,
       truncates,
       fallocations,
-      last_page_hydrations);
+      last_page_hydrations,
+      split_writes,
+      writes_completed);
 }
 
 std::ostream&

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -72,6 +72,12 @@ public:
         // A counter of number of bytes copied into new chunk to avoid writing
         // to a chunk which write was already dispatched
         size_t bytes_copied_in_chunk_remainder{0};
+        // A counter of the number of writes that needed to be split across
+        // multiple chunks (i.e., the write didn't fit in the current chunk)
+        size_t split_writes{0};
+        // A counter of the number of physical writes (dma_write calls) that
+        // completed successfully
+        size_t writes_completed{0};
 
         fmt::iterator format_to(fmt::iterator it) const;
     };


### PR DESCRIPTION
## Summary
- Add two new metrics to track segment appender behavior:
  - `split_writes`: counts appends that didn't fit in the current chunk and required allocating a new one
  - `writes_completed`: counts physical dma_write calls that completed successfully
- Reorganizes segment appender metrics into their own metric group ("segment_appender") separate from the storage manager metrics

## Test plan
- [ ] CI passes