### PR TITLE
CORE-14896 audit log updates

### DIFF
--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -561,7 +561,7 @@ ss::future<response_ptr> sasl_authenticate_handler::handle(
                   ctx.sasl()->session_lifetime_ms());
                 if (!ctx.audit_authn_success(
                       ctx.sasl()->mechanism().mechanism_name(),
-                      ctx.sasl()->mechanism().audit_user())) {
+                      ctx.sasl()->mechanism().audit_user().copy())) {
                     ctx.sasl()->set_state(
                       security::sasl_server::sasl_state::failed);
                     sasl_authenticate_response_data data{
@@ -602,7 +602,7 @@ ss::future<response_ptr> sasl_authenticate_handler::handle(
     if (!ctx.audit_authn_failure(
           fmt::format("SASL authentication failed: {}", ec.message()),
           ctx.sasl()->mechanism().mechanism_name(),
-          ctx.sasl()->mechanism().audit_user())) {
+          ctx.sasl()->mechanism().audit_user().copy())) {
         data.error_code = error_code::broker_not_available;
         data.error_message = "Broker not available - audit system failure";
     } else {

--- a/src/v/pandaproxy/schema_registry/auth.cc
+++ b/src/v/pandaproxy/schema_registry/auth.cc
@@ -46,6 +46,26 @@ make_authn_event_options(const server::request_t& rq) {
         .type_id = rq.user.name.empty() ? security::audit::user::type::unknown
                                         : security::audit::user::type::user}};
 }
+
+security::audit::authentication_event_options make_authn_event_options(
+  const server::request_t& rq, const request_auth_result& auth_result) {
+    return {
+      .auth_protocol = auth_result.get_sasl_mechanism(),
+      .server_addr = net::unresolved_address{rq.req->get_server_address()},
+      .svc_name = audit_svc_name,
+      .client_addr = net::unresolved_address{rq.req->get_client_address()},
+      .is_cleartext = is_cleartext(rq.req->get_protocol_name()),
+      .user = {
+        .name = auth_result.get_username().empty() ? "{{anonymous}}"
+                                                   : auth_result.get_username(),
+        .type_id = auth_result.is_authenticated()
+                     ? (auth_result.is_superuser()
+                          ? security::audit::user::type::admin
+                          : security::audit::user::type::user)
+                     : security::audit::user::type::unknown,
+        .groups = security::acl_principals_to_audit_groups(
+          auth_result.get_groups())}};
+}
 security::audit::authentication_event_options make_authn_event_error(
   const server::request_t& rq,
   std::string_view username,
@@ -105,6 +125,11 @@ void audit_authn_failure(
 
 void audit_authn_success(const server::request_t& rq) {
     do_audit_authn(rq, make_authn_event_options(rq));
+}
+
+void audit_authn_success(
+  const server::request_t& rq, const request_auth_result& auth_result) {
+    do_audit_authn(rq, make_authn_event_options(rq, auth_result));
 }
 
 void audit_authz_success(const server::request_t& rq) { do_audit_authz(rq); }
@@ -182,7 +207,7 @@ std::optional<request_auth_result> auth::handle_auth(
           auth_result.get_username(),
           auth_result.get_password(),
           auth_result.get_sasl_mechanism()};
-        audit_authn_success(rq);
+        audit_authn_success(rq, auth_result);
 
         // Will throw 403 if user enabled HTTP Basic Auth but
         // did not give the authorization header.

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -188,7 +188,9 @@ security::audit::authentication_event_options make_authn_event_options(
                      ? (auth_result.is_superuser()
                           ? security::audit::user::type::admin
                           : security::audit::user::type::user)
-                     : security::audit::user::type::unknown}};
+                     : security::audit::user::type::unknown,
+        .groups = security::acl_principals_to_audit_groups(
+          auth_result.get_groups())}};
 }
 
 security::audit::authentication_event_options make_authn_event_options(

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -906,4 +906,19 @@ get_allowed_operations<pandaproxy::schema_registry::subject>();
 template const std::vector<acl_operation>&
 get_allowed_operations<pandaproxy::schema_registry::registry_resource>();
 
+chunked_vector<audit::group> acl_principals_to_audit_groups(
+  const chunked_vector<acl_principal>& principals) {
+    chunked_vector<audit::group> audit_groups;
+    audit_groups.reserve(principals.size());
+    std::ranges::copy(
+      principals | std::views::filter([](const auto& p) {
+          return p.type() == principal_type::group;
+      }) | std::views::transform([](const auto& p) {
+          return audit::group{
+            .type = audit::group::type_id::idp_group, .name = p.name()};
+      }),
+      std::back_inserter(audit_groups));
+    return audit_groups;
+}
+
 } // namespace security

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -16,6 +16,7 @@
 #include "kafka/protocol/types.h"
 #include "model/fundamental.h"
 #include "pandaproxy/schema_registry/types.h"
+#include "security/audit/schemas/types.h"
 #include "serde/envelope.h"
 #include "serde/rw/enum.h"
 #include "serde/rw/envelope.h"
@@ -345,6 +346,12 @@ private:
     principal_type _type;
     ss::sstring _name;
 };
+
+/// Convert ACL group principals to audit group objects for inclusion in audit
+/// logs. Filters to only principals with type::group and converts them to
+/// audit::group with type idp_group.
+chunked_vector<::security::audit::group>
+acl_principals_to_audit_groups(const chunked_vector<acl_principal>& principals);
 
 } // namespace security
 

--- a/src/v/security/audit/BUILD
+++ b/src/v/security/audit/BUILD
@@ -8,6 +8,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",
+        "//src/v/container:json",
         "//src/v/json",
         "//src/v/version",
     ],

--- a/src/v/security/audit/schemas/schemas.h
+++ b/src/v/security/audit/schemas/schemas.h
@@ -184,7 +184,8 @@ private:
     template<typename T>
     size_t estimated_ocsf_size(const T& t) const noexcept {
         size_t sz = 0;
-        if constexpr (reflection::is_std_vector<T>) {
+        if constexpr (
+          reflection::is_std_vector<T> || reflection::is_chunked_vector<T>) {
             sz += sizeof(t);
             for (const auto& element : t) {
                 sz += estimated_ocsf_size(element);

--- a/src/v/security/audit/schemas/tests/ocsf_schemas_test.cc
+++ b/src/v/security/audit/schemas/tests/ocsf_schemas_test.cc
@@ -55,7 +55,7 @@ static const sa::user default_user_with_role{
   .name = "redpanda-user",
   .type_id = sa::user::type::user,
   .uid = "none",
-  .groups = std::vector<sa::group>{
+  .groups = chunked_vector<sa::group>{
     {sa::group{.type = sa::group::type_id::role, .name = "redpanda-group"}}}};
 
 static const ss::sstring default_user_with_role_ser{
@@ -304,7 +304,8 @@ BOOST_AUTO_TEST_CASE(validate_api_activity) {
     auto api_act = sa::api_activity{
       sa::api_activity::activity_id::create,
       sa::actor{
-        .authorizations = {authz_success}, .user = default_user_with_role},
+        .authorizations = {authz_success},
+        .user = default_user_with_role.copy()},
       sa::api{api_create_topic},
       std::move(dst_endpoint),
       test_http_request(),
@@ -373,7 +374,7 @@ BOOST_AUTO_TEST_CASE(validate_authentication_sasl_scram) {
       sa::authentication::status_id::success,
       std::nullopt,
       now,
-      sa::user{default_user});
+      sa::user{default_user.copy()});
 
     auto ser = sa::rjson_serialize(authn);
 
@@ -427,7 +428,7 @@ BOOST_AUTO_TEST_CASE(validate_authentication_kerberos) {
       sa::authentication::status_id::failure,
       "Failure",
       now,
-      sa::user{default_user});
+      sa::user{default_user.copy()});
 
     auto ser = sa::rjson_serialize(authn);
 
@@ -985,6 +986,5 @@ BOOST_AUTO_TEST_CASE(test_ocsf_size) {
                           + sizeof(ss::sstring) + user.groups[0].name.size();
     }
 
-    BOOST_CHECK_EQUAL(estimated_size, 416);
-    BOOST_CHECK_EQUAL(authn.estimated_size(), 416);
+    BOOST_CHECK_EQUAL(estimated_size, authn.estimated_size());
 }

--- a/src/v/security/audit/schemas/types.h
+++ b/src/v/security/audit/schemas/types.h
@@ -211,7 +211,7 @@ struct authorization_result {
 // A collection or association of entities, such as users, policies, or devices.
 // https://schema.ocsf.io/1.0.0/objects/group?extensions=
 struct group {
-    enum class type_id : int { unknown = 0, role = 1 };
+    enum class type_id : int { unknown = 0, role = 1, idp_group = 2 };
 
     type_id type{type_id::unknown};
     ss::sstring name;
@@ -482,6 +482,8 @@ inline void rjson_serialize(Writer<StringBuffer>& w, sa::group::type_id type) {
         return rjson_serialize(w, std::string_view{"unknown"});
     case sa::group::type_id::role:
         return rjson_serialize(w, std::string_view{"role"});
+    case sa::group::type_id::idp_group:
+        return rjson_serialize(w, std::string_view{"idp_group"});
     }
 }
 

--- a/src/v/security/audit/schemas/types.h
+++ b/src/v/security/audit/schemas/types.h
@@ -11,6 +11,8 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "container/chunked_vector.h"
+#include "container/json.h"
 #include "json/json.h"
 #include "json/stringbuffer.h"
 #include "utils/named_type.h"
@@ -232,7 +234,17 @@ struct user {
     ss::sstring name;
     type type_id{type::unknown};
     ss::sstring uid;
-    std::vector<group> groups;
+    chunked_vector<group> groups;
+
+    user copy() const {
+        user u;
+        u.domain = domain;
+        u.name = name;
+        u.type_id = type_id;
+        u.uid = uid;
+        u.groups = groups.copy();
+        return u;
+    }
 
     auto equality_fields() const {
         return std::tie(domain, name, type_id, uid, groups);

--- a/src/v/security/audit/schemas/utils.cc
+++ b/src/v/security/audit/schemas/utils.cc
@@ -180,6 +180,7 @@ user user_from_request_auth_result(const request_auth_result& r) {
       .type_id = r.is_authenticated()
                    ? (r.is_superuser() ? user::type::admin : user::type::user)
                    : user::type::unknown,
+      .groups = acl_principals_to_audit_groups(r.get_groups()),
     };
 }
 

--- a/src/v/security/audit/schemas/utils.cc
+++ b/src/v/security/audit/schemas/utils.cc
@@ -247,10 +247,10 @@ actor result_to_actor(const security::auth_result& result) {
     user user{
       .name = result.principal.name(),
       .type_id = result.is_superuser ? user::type::admin : user::type::user,
-      .groups = result.role ? std::vector<group>{group{
+      .groups = result.role ? chunked_vector<group>{group{
                                 .type = group::type_id::role,
                                 .name = result.role.value()}}
-                            : std::vector<group>{}};
+                            : chunked_vector<group>{}};
 
     policy policy;
     policy.name = "aclAuthorization";

--- a/src/v/security/gssapi_authenticator.cc
+++ b/src/v/security/gssapi_authenticator.cc
@@ -215,7 +215,7 @@ ss::future<result<bytes>> gssapi_authenticator::authenticate(bytes auth_bytes) {
 
     _state = res.state;
     _audit_user = co_await _worker.submit(
-      [this]() { return _impl->audit_user(); });
+      [this]() { return _impl->audit_user().copy(); });
     if (_state == state::complete) {
         std::optional<std::chrono::seconds> lifetime;
         std::tie(_principal, lifetime) = co_await _worker.submit([this]() {

--- a/src/v/security/oidc_authenticator.cc
+++ b/src/v/security/oidc_authenticator.cc
@@ -12,6 +12,7 @@
 #include "base/vlog.h"
 #include "config/property.h"
 #include "security/acl.h"
+#include "security/audit/schemas/types.h"
 #include "security/errc.h"
 #include "security/jwt.h"
 #include "security/logger.h"
@@ -207,6 +208,7 @@ ss::future<result<bytes>> sasl_authenticator::authenticate(bytes auth_bytes) {
     _audit_user.type_id = audit::user::type::user;
     _audit_user.name = _auth_data.principal.name();
     _audit_user.uid = _auth_data.sub;
+    _audit_user.groups = acl_principals_to_audit_groups(_auth_data.groups);
     _state = state::complete;
 
     co_return bytes{};

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -24,6 +24,8 @@ from ducktape.errors import TimeoutError
 from ducktape.mark import matrix
 from keycloak import KeycloakOpenID
 
+from rptest.clients.admin.proto.redpanda.core.admin.v2 import security_pb2
+from rptest.clients.admin.v2 import Admin as AdminV2
 from rptest.clients.default import DefaultClient
 from rptest.clients.kcl import KCL
 from rptest.clients.python_librdkafka import PythonLibrdkafka
@@ -2285,6 +2287,46 @@ class AuditLogTestOauth(AuditLogTestBase):
         )
 
     @staticmethod
+    def normalize_group_name(name: str) -> str:
+        """Normalize group name by stripping leading / prefix (Keycloak convention)"""
+        return name.lstrip("/") if name else name
+
+    @staticmethod
+    def oidc_authn_with_groups_filter_function(
+        service_name: str,
+        username: Optional[str],
+        sub: Optional[str],
+        expected_groups: list[str],
+        record,
+    ):
+        """Filter for OIDC authentication events that include IDP groups"""
+        if not (
+            record["class_uid"] == 3002
+            and record["service"]["name"] == service_name
+            and record["auth_protocol_id"] == 6
+            and (record["user"]["name"] == username if username is not None else True)
+            and (record["user"]["uid"] == sub if sub is not None else True)
+        ):
+            return False
+
+        # Check that groups are present and match expected
+        user_groups = record.get("user", {}).get("groups", [])
+        if not expected_groups:
+            return True
+
+        # Verify all expected groups are present with type "idp_group"
+        # Normalize group names to handle Keycloak's leading / prefix
+        for expected_group in expected_groups:
+            if not any(
+                g.get("type") == "idp_group"
+                and AuditLogTestOauth.normalize_group_name(g.get("name", ""))
+                == expected_group
+                for g in user_groups
+            ):
+                return False
+        return True
+
+    @staticmethod
     def oidc_metadata_filter_function(
         service_name: str, topic: str, username: str, role: Optional[str], record
     ):
@@ -2447,6 +2489,336 @@ class AuditLogTestOauth(AuditLogTestBase):
 
         assert len(records) == len(ip_set), (
             f"Expected one record but received {len(records)}"
+        )
+
+    @skip_fips_mode
+    @cluster(num_nodes=6)
+    @matrix(audit_transport_mode=get_audit_modes())
+    def test_kafka_oauth_with_idp_groups(self, audit_transport_mode):
+        """
+        Validate that IDP groups from OIDC tokens are included in audit log
+        authentication messages for Kafka clients
+        """
+        kc_node = self.keycloak.nodes[0]
+        self.super_rpk.create_topic(self.example_topic)
+
+        # Create groups and group mapper in Keycloak
+        test_groups = ["developers", "admins"]
+        for group_name in test_groups:
+            self.keycloak.admin.create_group(group_name)
+
+        # Create group mapper to include groups in the token
+        self.keycloak.admin.create_group_mapper(self.client_id)
+
+        # Add service account to groups
+        for group_name in test_groups:
+            self.keycloak.admin.add_service_user_to_group(self.client_id, group_name)
+
+        service_user_id = self.keycloak.admin_ll.get_user_id(
+            f"service-account-{self.client_id}"
+        )
+
+        # Grant permissions to the service account
+        _ = self.super_rpk.sasl_allow_principal(
+            f"User:{service_user_id}",
+            ["all"],
+            "topic",
+            self.example_topic,
+            self.redpanda.SUPERUSER_CREDENTIALS[0],
+            self.redpanda.SUPERUSER_CREDENTIALS[1],
+            self.redpanda.SUPERUSER_CREDENTIALS[2],
+        )
+
+        cfg = self.keycloak.generate_oauth_config(kc_node, self.client_id)
+        assert cfg.client_secret is not None, "client_secret is None"
+        assert cfg.token_endpoint is not None, "token_endpoint is None"
+
+        k_client = PythonLibrdkafka(
+            self.redpanda, algorithm="OAUTHBEARER", oauth_config=cfg
+        )
+        producer = k_client.get_producer()
+        producer.poll(0.0)
+
+        expected_topics = set([self.example_topic])
+        wait_until(
+            lambda: set(producer.list_topics(timeout=5).topics.keys())
+            == expected_topics,
+            timeout_sec=5,
+        )
+
+        # Read audit log and verify groups are present
+        records = self.read_all_from_audit_log(
+            partial(
+                self.oidc_authn_with_groups_filter_function,
+                self.kafka_rpc_service_name,
+                service_user_id,
+                service_user_id,
+                test_groups,
+            ),
+            lambda records: self.aggregate_count(records) >= 1,
+        )
+
+        assert len(records) >= 1, (
+            f"Expected at least 1 record with IDP groups but received {len(records)}"
+        )
+
+        # Verify the groups in the record
+        for record in records:
+            user_groups = record.get("user", {}).get("groups", [])
+            self.logger.debug(f"Found groups in audit record: {user_groups}")
+            for expected_group in test_groups:
+                assert any(
+                    g.get("type") == "idp_group"
+                    and self.normalize_group_name(g.get("name", "")) == expected_group
+                    for g in user_groups
+                ), (
+                    f"Expected group '{expected_group}' with type 'idp_group' not found in {user_groups}"
+                )
+
+    @skip_fips_mode
+    @cluster(num_nodes=6)
+    @matrix(audit_transport_mode=get_audit_modes())
+    def test_admin_oauth_with_idp_groups(self, audit_transport_mode):
+        """
+        Validate that IDP groups from OIDC tokens are included in audit log
+        authentication messages for Admin API requests
+        """
+        kc_node = self.keycloak.nodes[0]
+
+        # Create groups and group mapper in Keycloak
+        test_groups = ["ops-team", "platform-admins"]
+        for group_name in test_groups:
+            self.keycloak.admin.create_group(group_name)
+
+        # Create group mapper to include groups in the token
+        self.keycloak.admin.create_group_mapper(self.client_id)
+
+        # Add service account to groups
+        for group_name in test_groups:
+            self.keycloak.admin.add_service_user_to_group(self.client_id, group_name)
+
+        cfg = self.keycloak.generate_oauth_config(kc_node, self.client_id)
+        token_endpoint_url = urlparse(cfg.token_endpoint)
+        openid = KeycloakOpenID(
+            server_url=f"{token_endpoint_url.scheme}://{token_endpoint_url.netloc}",
+            client_id=cfg.client_id,
+            client_secret_key=cfg.client_secret,
+            realm_name=DEFAULT_REALM,
+            verify=True,
+        )
+        token = openid.token(grant_type="client_credentials")
+        userinfo = openid.userinfo(token["access_token"])
+
+        def check_cluster_status():
+            response = requests.get(
+                url=f"http://{self.redpanda.nodes[0].account.hostname}:9644/v1/status/ready",
+                headers={
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {token['access_token']}",
+                },
+                timeout=5,
+            )
+            return response.status_code == requests.codes.ok
+
+        wait_until(check_cluster_status, timeout_sec=5)
+
+        # Read audit log and verify groups are present
+        records = self.read_all_from_audit_log(
+            partial(
+                self.oidc_authn_with_groups_filter_function,
+                self.admin_audit_svc_name,
+                userinfo["sub"],
+                None,
+                test_groups,
+            ),
+            lambda records: self.aggregate_count(records) >= 1,
+        )
+
+        assert len(records) >= 1, (
+            f"Expected at least 1 record with IDP groups but received {len(records)}"
+        )
+
+        # Verify the groups in the record
+        for record in records:
+            user_groups = record.get("user", {}).get("groups", [])
+            self.logger.debug(f"Found groups in audit record: {user_groups}")
+            for expected_group in test_groups:
+                assert any(
+                    g.get("type") == "idp_group"
+                    and self.normalize_group_name(g.get("name", "")) == expected_group
+                    for g in user_groups
+                ), (
+                    f"Expected group '{expected_group}' with type 'idp_group' not found in {user_groups}"
+                )
+
+    @staticmethod
+    def oidc_authz_with_role_filter_function(
+        service_name: str,
+        username: Optional[str],
+        expected_role: str,
+        record,
+    ):
+        """Filter for authorization events that include a role"""
+        if not (
+            record["class_uid"] == 6003
+            and record["api"]["service"]["name"] == service_name
+            and (record["actor"]["user"]["name"] == username if username else True)
+        ):
+            return False
+
+        # Check that role is present in groups
+        user_groups = record.get("actor", {}).get("user", {}).get("groups", [])
+        if not user_groups:
+            return False
+
+        # Check for expected role
+        return any(
+            g.get("type") == "role" and g.get("name") == expected_role
+            for g in user_groups
+        )
+
+    @skip_fips_mode
+    @cluster(num_nodes=6)
+    @matrix(audit_transport_mode=get_audit_modes())
+    def test_kafka_oauth_with_groups_and_role(self, audit_transport_mode):
+        """
+        Validate that the complete audit trail contains:
+        1. IDP groups from OIDC tokens (in authentication events)
+        2. Role assigned via group membership (in authorization events)
+
+        This test creates a Keycloak group, assigns it to a Redpanda role,
+        grants permissions to the role, and verifies that:
+        - Authentication events contain the IDP group
+        - Authorization events contain the role used for permission
+        """
+        self.modify_audit_event_types(["describe", "authenticate"])
+        kc_node = self.keycloak.nodes[0]
+        self.super_rpk.create_topic(self.example_topic)
+
+        # Create Keycloak group and group mapper
+        # use_full_path=False gives simple group names (e.g., "mygroup" instead of "/mygroup")
+        test_group = "audit-test-group"
+        self.keycloak.admin.create_group(test_group)
+        self.keycloak.admin.create_group_mapper(self.client_id, use_full_path=False)
+        self.keycloak.admin.add_service_user_to_group(self.client_id, test_group)
+
+        service_user_id = self.keycloak.admin_ll.get_user_id(
+            f"service-account-{self.client_id}"
+        )
+
+        # Create a role in Redpanda with the Keycloak group as a member
+        role_name = "audit-test-role"
+        admin_v2 = AdminV2(
+            self.redpanda,
+            auth=(
+                self.redpanda.SUPERUSER_CREDENTIALS[0],
+                self.redpanda.SUPERUSER_CREDENTIALS[1],
+            ),
+        )
+        role = security_pb2.Role(
+            name=role_name,
+            members=[
+                security_pb2.RoleMember(group=security_pb2.RoleGroup(name=test_group))
+            ],
+        )
+        admin_v2.security().create_role(security_pb2.CreateRoleRequest(role=role))
+        self.logger.info(
+            f"Created role '{role_name}' with group '{test_group}' as member"
+        )
+
+        # Grant permissions to the role
+        self.super_rpk.sasl_allow_principal(
+            f"RedpandaRole:{role_name}",
+            ["all"],
+            "topic",
+            self.example_topic,
+            self.redpanda.SUPERUSER_CREDENTIALS[0],
+            self.redpanda.SUPERUSER_CREDENTIALS[1],
+            self.redpanda.SUPERUSER_CREDENTIALS[2],
+        )
+        self.logger.info(f"Granted 'all' permission to role '{role_name}'")
+
+        # Authenticate and perform an action
+        cfg = self.keycloak.generate_oauth_config(kc_node, self.client_id)
+        assert cfg.client_secret is not None, "client_secret is None"
+        assert cfg.token_endpoint is not None, "token_endpoint is None"
+
+        k_client = PythonLibrdkafka(
+            self.redpanda, algorithm="OAUTHBEARER", oauth_config=cfg
+        )
+        producer = k_client.get_producer()
+        producer.poll(0.0)
+
+        expected_topics = set([self.example_topic])
+        wait_until(
+            lambda: set(producer.list_topics(timeout=5).topics.keys())
+            == expected_topics,
+            timeout_sec=5,
+        )
+
+        # Verify authentication event contains IDP groups
+        records = self.read_all_from_audit_log(
+            partial(
+                self.oidc_authn_with_groups_filter_function,
+                self.kafka_rpc_service_name,
+                service_user_id,
+                service_user_id,
+                [test_group],
+            ),
+            lambda records: self.aggregate_count(records) >= 1,
+        )
+
+        assert len(records) >= 1, (
+            f"Expected at least 1 authentication record with IDP group but received {len(records)}"
+        )
+        self.logger.info(
+            f"Found {len(records)} authentication record(s) with IDP group '{test_group}'"
+        )
+
+        # Verify authentication record contains the IDP group
+        for record in records:
+            user_groups = record.get("user", {}).get("groups", [])
+            self.logger.debug(
+                f"Found groups in authentication audit record: {user_groups}"
+            )
+            idp_groups = [g for g in user_groups if g.get("type") == "idp_group"]
+            assert len(idp_groups) >= 1, (
+                f"Expected at least 1 IDP group in authentication record, found {idp_groups}"
+            )
+
+        # Verify authorization event contains the role
+        records = self.read_all_from_audit_log(
+            partial(
+                self.oidc_authz_with_role_filter_function,
+                self.kafka_rpc_service_name,
+                service_user_id,
+                role_name,
+            ),
+            lambda records: self.aggregate_count(records) >= 1,
+        )
+
+        assert len(records) >= 1, (
+            f"Expected at least 1 authorization record with role but received {len(records)}"
+        )
+
+        # Verify authorization record contains the role
+        for record in records:
+            user_groups = record.get("actor", {}).get("user", {}).get("groups", [])
+            self.logger.debug(
+                f"Found groups in authorization audit record: {user_groups}"
+            )
+            roles = [g for g in user_groups if g.get("type") == "role"]
+            assert len(roles) >= 1, (
+                f"Expected at least 1 role in authorization record, found {roles}"
+            )
+            assert any(g.get("name") == role_name for g in roles), (
+                f"Expected role '{role_name}' not found in {roles}"
+            )
+
+        self.logger.info(
+            f"Verified complete audit trail: authentication contains IDP group '{test_group}', "
+            f"authorization contains role '{role_name}'"
         )
 
 


### PR DESCRIPTION
This PR enhances audit logging to include Identity Provider (IDP) group memberships from OIDC tokens in audit events across all authentication paths (Kafka, Admin API, Schema Registry, and HTTP Proxy). This provides better visibility into the group-based authorization context used for permission decisions.

The changes add a new `idp_group` type to the audit log schema and populate user group information from OIDC authentication results. The PR also improves memory efficiency by switching from `std::vector` to `chunked_vector` for user groups, and adds proper copy semantics to ensure safe lifetime management across async boundaries.

Fixes #14896

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
