### PR TITLE
[CORE-15271] kafka/server: expose user based client quotas

### DIFF
--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -128,6 +128,8 @@ std::string_view to_string_view(feature f) {
         return "schema_registry_authz";
     case feature::group_based_authorization:
         return "group_based_authorization";
+    case feature::user_based_client_quota:
+        return "user_based_client_quota";
 
     /*
      * testing features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -46,6 +46,7 @@ enum class feature : std::uint64_t {
     schema_registry_authz = 1ULL << 3U,
     topic_ids_api = 1ULL << 4U,
     controller_forced_reconfiguration = 1ULL << 5U,
+    user_based_client_quota = 1ULL << 6U,
     consumer_groups_migrations = 1ULL << 7U,
     shadow_linking = 1ULL << 8U,
     coordinated_compaction = 1ULL << 10U,
@@ -525,6 +526,12 @@ inline constexpr std::array feature_schema{
     release_version::v26_1_1,
     "group_based_authorization",
     feature::group_based_authorization,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    release_version::v26_1_1,
+    "user_based_client_quota",
+    feature::user_based_client_quota,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 };

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -637,12 +637,12 @@ connection_context::record_tp_and_calculate_throttle(
     static_assert(std::is_same_v<clock, delay_t::clock>);
     const auto now = clock::now();
 
+    const auto principal = get_principal();
     // Throttle on client based quotas
     connection_context::delay_t client_quota_delay{};
     if (r_data.request_key == fetch_api::key) {
-        // TODO: wire in principal
         auto fetch_delay = co_await _server.quota_mgr().throttle_fetch_tp(
-          std::nullopt, r_data.client_id, now);
+          principal.name_view(), r_data.client_id, now);
         auto fetch_enforced = _throttling_state.update_fetch_delay(
           fetch_delay, now);
         client_quota_delay = delay_t{
@@ -650,10 +650,9 @@ connection_context::record_tp_and_calculate_throttle(
           .enforce = fetch_enforced,
         };
     } else if (r_data.request_key == produce_api::key) {
-        // TODO: wire in principal
         auto produce_delay
           = co_await _server.quota_mgr().record_produce_tp_and_throttle(
-            std::nullopt, r_data.client_id, request_size, now);
+            principal.name_view(), r_data.client_id, request_size, now);
         auto datalake_produce_delay
           = co_await _server.get_datalake_producer_throttle(r_data.client_id);
 
@@ -1184,9 +1183,9 @@ connection_context::client_protocol_state::do_process_responses(
 
     auto msg = response_as_scattered(std::move(resp_and_res.response));
     if (resp_and_res.resources->request_data.request_key == fetch_api::key) {
-        // TODO: wire in principal
+        const auto principal = connection_ctx->get_principal();
         co_await connection_ctx->_server.quota_mgr().record_fetch_tp(
-          std::nullopt,
+          principal.name_view(),
           resp_and_res.resources->request_data.client_id,
           msg.size(),
           quota_manager::clock::now());

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -298,16 +298,6 @@ public:
 
     connection_attributes& attributes() { return _attributes; }
 
-private:
-    template<typename T>
-    security::auth_result authorized_user(
-      security::acl_principal principal,
-      security::acl_operation operation,
-      const T& name,
-      authz_quiet quiet,
-      superuser_required superuser_required,
-      const chunked_vector<security::acl_principal>& groups);
-
     security::acl_principal get_principal() const {
         if (_mtls_state) {
             return _mtls_state->principal();
@@ -317,6 +307,16 @@ private:
         // anonymous user
         return security::acl_principal{security::principal_type::user, {}};
     }
+
+private:
+    template<typename T>
+    security::auth_result authorized_user(
+      security::acl_principal principal,
+      security::acl_operation operation,
+      const T& name,
+      authz_quiet quiet,
+      superuser_required superuser_required,
+      const chunked_vector<security::acl_principal>& groups);
 
     const chunked_vector<security::acl_principal>& get_groups() const;
 

--- a/src/v/kafka/server/handlers/client_quotas.cc
+++ b/src/v/kafka/server/handlers/client_quotas.cc
@@ -111,14 +111,15 @@ exact_match_key(const component_data& component) {
     return string_switch<result<entity_key::part_t, kerror>>(
              component.entity_type)
       .match(
+        "user", entity_key::part_t{entity_key::user_match{*component.match}})
+      .match(
         "client-id",
         entity_key::part_t{entity_key::client_id_match{*component.match}})
       .match(
         "client-id-prefix",
         entity_key::part_t{
           entity_key::client_id_prefix_match{*component.match}})
-      .match_all(
-        "user",
+      .match(
         "ip",
         {
           error_code::unsupported_version,
@@ -136,6 +137,7 @@ result<entity_key::part_t, kerror>
 default_match_key(const component_data& component) {
     return string_switch<result<entity_key::part_t, kerror>>(
              component.entity_type)
+      .match("user", entity_key::part_t{entity_key::user_default_match{}})
       .match(
         "client-id", entity_key::part_t{entity_key::client_id_default_match{}})
       .match(
@@ -143,8 +145,7 @@ default_match_key(const component_data& component) {
         {kafka::error_code::invalid_request,
          "Invalid quota entity type, client-id-prefix entity should not "
          "be used at the default level (use client-id default instead)."})
-      .match_all(
-        "user",
+      .match(
         "ip",
         {
           error_code::unsupported_version,
@@ -172,6 +173,11 @@ any_match_filter(const component_data& component) {
     return string_switch<result<key_part_predicate, kerror>>(
              component.entity_type)
       .match(
+        "user",
+        make_any_filter<
+          entity_key::part::user_default_match,
+          entity_key::part::user_match>())
+      .match(
         "client-id",
         make_any_filter<
           entity_key::part::client_id_default_match,
@@ -179,8 +185,7 @@ any_match_filter(const component_data& component) {
       .match(
         "client-id-prefix",
         make_any_filter<entity_key::part::client_id_prefix_match>())
-      .match_all(
-        "user",
+      .match(
         "ip",
         {
           error_code::unsupported_version,
@@ -251,7 +256,15 @@ result<entity_key::part_t, kerror> make_part(const auto& entity) {
         part.part.emplace<entity_key::part::client_id_prefix_match>(
           entity_key::part::client_id_prefix_match{
             .value = entity.entity_name.value_or("")});
-    } else if (entity.entity_type == "user" || entity.entity_type == "ip") {
+    } else if (entity.entity_type == "user") {
+        if (is_null_or_empty(entity.entity_name)) {
+            part.part.emplace<entity_key::part::user_default_match>();
+        } else {
+            part.part.emplace<entity_key::part::user_match>(
+              entity_key::part::user_match{
+                .value = entity.entity_name.value_or("")});
+        }
+    } else if (entity.entity_type == "ip") {
         return {
           error_code::unsupported_version,
           fmt::format("Entity type '{}' not yet supported", entity.entity_type),
@@ -267,14 +280,28 @@ result<entity_key::part_t, kerror> make_part(const auto& entity) {
 
 using alter_entities = chunked_vector<alter_client_quotas_request_entity_data>;
 result<entity_key, kerror> make_key(const alter_entities& entity) {
-    // TODO: once we support compound user+client keys, we should check that
-    // either there's only a single key part or the key is a user+client
-    // compound key
-    if (entity.size() != 1) {
+    if (entity.empty() || (entity.size() > 2)) {
         return kerror{
           error_code::invalid_request,
           "Invalid client quota entity",
         };
+    }
+
+    if (entity.size() == 2) {
+        const auto has_user = std::ranges::any_of(
+          entity, [](const auto& e) { return e.entity_type == "user"; });
+        const auto has_client = std::ranges::any_of(entity, [](const auto& e) {
+            return e.entity_type == "client-id"
+                   || e.entity_type == "client-id-prefix";
+        });
+        if (!(has_user && has_client)) {
+            return kerror{
+              error_code::invalid_request,
+              ss::format(
+                "Invalid combination of client quota entities: '{}' and '{}'",
+                entity[0].entity_type,
+                entity[1].entity_type)};
+        }
     }
 
     entity_key key;
@@ -328,20 +355,11 @@ ss::future<response_ptr> describe_client_quotas_handler::handle(
     }
 
     std::optional<key_part_predicate> client_predicate;
-    // std::optional<key_part_predicate> user_predicate;
+    std::optional<key_part_predicate> user_predicate;
     // std::optional<key_part_predicate> ip_predicate;
 
     for (const auto& component : request.data.components) {
-        // This is a work around for the fact that we don't support user based
-        // quotas yet.  The `kafka-configs` tool will error out when attempting
-        // to describe a principal when this returns unsupported_version.  This
-        // is a problem with implementing support for KIP-554, as
-        // `kafka-configs` is a common kafka tool used to manage users.
-        // TODO: Fully implement quotas
-        if (component.entity_type == "user") {
-            continue;
-        }
-
+        // Unsupported entity types need to be handled on this call
         auto filter_or_err = make_filter(component);
 
         if (filter_or_err.has_error()) {
@@ -351,18 +369,19 @@ ss::future<response_ptr> describe_client_quotas_handler::handle(
         }
 
         auto& predicate = [&]() mutable -> auto& {
-            return client_predicate;
-            // TODO: later add support for user/ip quotas
-            // if (component.entity_type == "client-id" ||
-            // component.entity_type == "client-id-prefix") {
-            //     return client_predicate;
-            // } else if (component.entity_type == "user") {
-            //     return user_predicate;
-            // } else if (component.entity_type == "ip") {
-            //     return ip_predicate;
-            // } else {
-            //     // ERROR: unknown
-            // }
+            if (
+              component.entity_type == "client-id"
+              || component.entity_type == "client-id-prefix") {
+                return client_predicate;
+            } else if (component.entity_type == "user") {
+                return user_predicate;
+                //} else if (component.entity_type == "ip") {
+                //    return ip_predicate;
+            } else {
+                vassert(
+                  false,
+                  "Unsupported entity type should have been caught earlier");
+            }
         }();
 
         if (predicate.has_value()) {
@@ -376,34 +395,35 @@ ss::future<response_ptr> describe_client_quotas_handler::handle(
         predicate = std::move(filter_or_err).assume_value();
     }
 
-    auto quotas = ctx.quota_store().range(
-      [&client_predicate, strict = request.data.strict](
-        const std::pair<entity_key, entity_value>& kv) {
-          // Each predicate in the request needs to have at least one key part
-          // that matches it (regardless of strict mode)
-          const auto& key = kv.first;
-          auto each_predicate_has_a_match = !client_predicate
-                                            || std::ranges::any_of(
-                                              key.parts, *client_predicate);
-          // && (!user_predicate || std::ranges::any_of(key.parts,
-          // *user_predicate))
-          // && (!ip_predicate || std::ranges::any_of(key.parts,
-          // *ip_predicate));
+    auto quotas = ctx.quota_store().range([&client_predicate,
+                                           &user_predicate,
+                                           strict = request.data.strict](
+                                            const std::pair<
+                                              entity_key,
+                                              entity_value>& kv) {
+        // Each predicate in the request needs to have at least one key part
+        // that matches it (regardless of strict mode)
+        const auto& key = kv.first;
+        auto each_predicate_has_a_match
+          = (!client_predicate
+             || std::ranges::any_of(key.parts, *client_predicate))
+            && (!user_predicate || std::ranges::any_of(key.parts, *user_predicate));
+        // && (!ip_predicate || std::ranges::any_of(key.parts,  *ip_predicate));
 
-          if (!each_predicate_has_a_match) {
-              return false;
-          }
+        if (!each_predicate_has_a_match) {
+            return false;
+        }
 
-          // In strict mode, also require that each key part has a matching
-          // predicate
-          auto reverse_predicate =
-            [&client_predicate](const entity_key::part_t& part) {
-                return client_predicate && (*client_predicate)(part);
-                //  || (user_predicate && (*user_predicate)(part))
-                //  || (ip_predicate && (*ip_predicate)(part));
-            };
-          return !strict || std::ranges::all_of(key.parts, reverse_predicate);
-      });
+        // In strict mode, also require that each key part has a matching
+        // predicate
+        auto reverse_predicate =
+          [&client_predicate, &user_predicate](const entity_key::part_t& part) {
+              return (client_predicate && (*client_predicate)(part))
+                     || (user_predicate && (*user_predicate)(part));
+              //  || (ip_predicate && (*ip_predicate)(part));
+          };
+        return !strict || std::ranges::all_of(key.parts, reverse_predicate);
+    });
 
     res.data.entries->reserve(quotas.size());
     for (const auto& q : quotas) {

--- a/src/v/kafka/server/handlers/client_quotas.cc
+++ b/src/v/kafka/server/handlers/client_quotas.cc
@@ -21,6 +21,7 @@
 #include "kafka/server/errors.h"
 #include "kafka/server/handlers/alter_client_quotas.h"
 #include "kafka/server/handlers/describe_client_quotas.h"
+#include "kafka/server/request_context.h"
 
 #include <seastar/core/sstring.hh>
 #include <seastar/util/variant_utils.hh>
@@ -325,6 +326,13 @@ bool valid_key_combination(const entity_key&, entity_value_diff::key) {
     // For now, all combinations we can parse are valid
     return true;
 }
+
+bool has_feature_user_quota(const request_context& ctx) {
+    constexpr auto feature = features::feature::user_based_client_quota;
+    const auto& ft = ctx.feature_table().local();
+    return ft.is_active(feature);
+}
+
 } // namespace
 
 template<>
@@ -480,6 +488,18 @@ ss::future<response_ptr> alter_client_quotas_handler::handle(
 
     for (const auto& [entry, entry_res] :
          boost::combine(request.data.entries, response.data.entries)) {
+        if (!has_feature_user_quota(ctx)) [[unlikely]] {
+            constexpr auto is_entity_type_user = [](const auto& e) {
+                return e.entity_type == "user";
+            };
+            if (std::ranges::any_of(entry.entity, is_entity_type_user)) {
+                entry_res.error_code = error_code::unsupported_version;
+                entry_res.error_message
+                  = "user-based client quotas are not yet available";
+                continue;
+            }
+        }
+
         auto key_or_err = make_key(entry.entity);
         if (key_or_err.has_error()) {
             std::tie(entry_res.error_code, entry_res.error_message)

--- a/src/v/kafka/server/handlers/create_partitions.cc
+++ b/src/v/kafka/server/handlers/create_partitions.cc
@@ -274,6 +274,7 @@ ss::future<response_ptr> create_partitions_handler::handle(
       });
 
     const auto now = quota_manager::clock::now();
+    const auto principal = ctx.connection()->get_principal();
     valid_range_end = co_await validate_range_async(
       request.data.topics.begin(),
       valid_range_end,
@@ -282,7 +283,7 @@ ss::future<response_ptr> create_partitions_handler::handle(
          ? error_code::throttling_quota_exceeded
          : error_code::unknown_server_error),
       "Too many partition mutations requested",
-      [&ctx, &resp, now](const create_partitions_topic& tp) {
+      [&ctx, &resp, now, &principal](const create_partitions_topic& tp) {
           const auto cfg = ctx.metadata_cache().get_topic_cfg(
             model::topic_namespace_view(model::kafka_namespace, tp.name));
           vassert(cfg, "Topic exist check has already occurred");
@@ -290,10 +291,9 @@ ss::future<response_ptr> create_partitions_handler::handle(
             tp.count > cfg->partition_count,
             "Sanity check for request increase partition count failed");
           const auto mutations = (tp.count - cfg->partition_count);
-          // TODO: wire in principal
           return ctx.quota_mgr()
             .record_partition_mutations(
-              std::nullopt, ctx.header().client_id, mutations, now)
+              principal.name_view(), ctx.header().client_id, mutations, now)
             .then([&resp](std::chrono::milliseconds delay) {
                 resp.data.throttle_time_ms = std::max(
                   resp.data.throttle_time_ms, delay);

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -400,15 +400,19 @@ ss::future<response_ptr> create_topics_handler::handle(
     // Record the number of partition mutations in each requested topic,
     // calulcating throttle delay if necessary
     const auto now = quota_manager::clock::now();
+    const auto principal = ctx.connection()->get_principal();
     auto quota_exceeded_it = co_await ssx::partition(
-      begin, valid_range_end, [&ctx, &response, now](const creatable_topic& t) {
+      begin,
+      valid_range_end,
+      [&ctx, &response, now, &principal](const creatable_topic& t) {
           /// Capture before next scheduling point below
           auto& response_ref = response;
-          return ctx
-            .quota_mgr()
-            // TODO: wire in principal
+          return ctx.quota_mgr()
             .record_partition_mutations(
-              std::nullopt, ctx.header().client_id, t.num_partitions, now)
+              principal.name_view(),
+              ctx.header().client_id,
+              t.num_partitions,
+              now)
             .then([&response_ref](std::chrono::milliseconds delay) {
                 response_ref.data.throttle_time_ms = std::max(
                   response_ref.data.throttle_time_ms, delay);

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -1680,18 +1680,18 @@ delete_topics_handler::handle(request_context ctx, ss::smp_service_group) {
     // Measure the partition mutation rate
     auto resp_delay = 0ms;
     const auto now = quota_manager::clock::now();
+    const auto principal = ctx.connection()->get_principal();
     auto quota_exceeded_it = co_await ssx::partition(
       valid_topic_names.begin(),
       valid_topic_names.end(),
-      [&ctx, &resp_delay, now](const model::topic& t) {
+      [&ctx, &resp_delay, now, &principal](const model::topic& t) {
           const auto cfg = ctx.metadata_cache().get_topic_cfg(as_tp_ns_view(t));
           const auto mutations = cfg ? cfg->partition_count : 0;
           /// Capture before next scheduling point below
           auto& resp_delay_ref = resp_delay;
-          // TODO: wire in principal
           return ctx.quota_mgr()
             .record_partition_mutations(
-              std::nullopt, ctx.header().client_id, mutations, now)
+              principal.name_view(), ctx.header().client_id, mutations, now)
             .then([&resp_delay_ref](std::chrono::milliseconds delay) {
                 resp_delay_ref = std::max(delay, resp_delay_ref);
                 return delay == 0ms;

--- a/tests/rptest/clients/kcl.py
+++ b/tests/rptest/clients/kcl.py
@@ -604,10 +604,13 @@ class RawKCL(KCL):
             input=json.dumps(alter_configs_request),
         )
 
-    def raw_alter_quotas(self, body: dict[str, Any]) -> dict[str, Any]:
+    def raw_alter_quotas(
+        self, body: dict[str, Any], node: Any | None = None
+    ) -> dict[str, Any]:
         res = self._cmd(
             ["misc", "raw-req", "-b", str(self._controller_id()), "-k", "49"],
             input=json.dumps(body),
+            node=node,
         )
         return json.loads(res)
 

--- a/tests/rptest/tests/quota_management_test.py
+++ b/tests/rptest/tests/quota_management_test.py
@@ -20,8 +20,17 @@ from rptest.clients.kcl import RawKCL
 from rptest.clients.rpk import RpkException, RpkTool
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
+from rptest.services.redpanda import LoggingConfig
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import expect_exception
+
+log_config = LoggingConfig(
+    "info",
+    logger_levels={
+        "kafka": "trace",
+        "kafka_quotas": "trace",
+    },
+)
 
 
 def expect_kafka_cli_error_msg(error_msg: str):
@@ -33,8 +42,16 @@ def expect_rpk_error_msg(error_msg: str):
 
 
 class QuotaEntityType(Enum):
+    USER = "user"
     CLIENT_ID = "client-id"
     CLIENT_ID_PREFIX = "client-id-prefix"
+
+    def _get_ordering(self):
+        return {name: idx for idx, name in enumerate(self.__class__)}
+
+    def __lt__(self, other):
+        ordering = self._get_ordering()
+        return ordering[self] < ordering[other]
 
 
 class QuotaEntityPart(NamedTuple):
@@ -45,9 +62,27 @@ class QuotaEntityPart(NamedTuple):
     def from_dict(cls, d: dict):
         return cls(name=d["name"], type=QuotaEntityType(d["type"]))
 
+    def __lt__(self, other):
+        if self.type != other.type:
+            return self.type.__lt__(other.type)
+        return self.name.__lt__(other.name)
+
+    def __gt__(self, other):
+        if self.type != other.type:
+            return self.type.__gt__(other.type)
+        return self.name.__gt__(other.name)
+
 
 class QuotaEntity(NamedTuple):
     parts: list[QuotaEntityPart]
+
+    @staticmethod
+    def user_default():
+        return QuotaEntity([QuotaEntityPart("<default>", QuotaEntityType.USER)])
+
+    @staticmethod
+    def user(name):
+        return QuotaEntity([QuotaEntityPart(name, QuotaEntityType.USER)])
 
     @staticmethod
     def client_id_default():
@@ -60,6 +95,15 @@ class QuotaEntity(NamedTuple):
     @staticmethod
     def client_id_prefix(name):
         return QuotaEntity([QuotaEntityPart(name, QuotaEntityType.CLIENT_ID_PREFIX)])
+
+    @staticmethod
+    def client_id_default_and_user_default():
+        return QuotaEntity(
+            [
+                QuotaEntityPart("<default>", QuotaEntityType.USER),
+                QuotaEntityPart("<default>", QuotaEntityType.CLIENT_ID),
+            ]
+        )
 
     @classmethod
     def from_list(cls, l: list):
@@ -131,7 +175,7 @@ class QuotaOutput(NamedTuple):
 
 class QuotaManagementTest(RedpandaTest):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, log_config=log_config, **kwargs)
 
         self.rpk = RpkTool(self.redpanda)
         self.kafka_cli = KafkaCliTools(self.redpanda)
@@ -195,6 +239,58 @@ Quota configs for client-id 'custom-producer' are producer_byte_rate=20480.0"""
 
         out = self.kafka_cli.describe_quota_config("--entity-type clients")
         expected = ""
+        assert_outputs_equal(out, expected)
+
+        self.redpanda.logger.debug("Create a config for user default")
+        self.kafka_cli.alter_quota_config(
+            "--entity-type users --entity-default",
+            to_add={"consumer_byte_rate": 10241.0},
+        )
+
+        self.redpanda.logger.debug("Create a config for a specific user")
+        self.kafka_cli.alter_quota_config(
+            "--entity-type users --entity-name custom-user",
+            to_add={"producer_byte_rate": 20481.0},
+        )
+
+        self.redpanda.logger.debug(
+            "Check describe filtering works for a default user match"
+        )
+        out = self.kafka_cli.describe_quota_config("--user-defaults")
+        expected = "Quota configs for the default user-principal are consumer_byte_rate=10241.0"
+        assert_outputs_equal(out, expected)
+
+        self.redpanda.logger.debug("Check specific match filtering works")
+        out = self.kafka_cli.describe_quota_config(
+            "--entity-type users --entity-name custom-user"
+        )
+        expected = "Quota configs for user-principal 'custom-user' are producer_byte_rate=20481.0"
+        assert_outputs_equal(out, expected)
+
+        self.redpanda.logger.debug("Create a config for specific client, specific user")
+        self.kafka_cli.alter_quota_config(
+            "--user custom-user-2 --client test-client",
+            to_add={"producer_byte_rate": 20482.0},
+        )
+
+        self.redpanda.logger.debug("Check specific match filtering works")
+        out = self.kafka_cli.describe_quota_config(
+            "--user custom-user-2 --client test-client"
+        )
+        expected = "Quota configs for user-principal 'custom-user-2', client-id 'test-client' are producer_byte_rate=20482.0"
+        assert_outputs_equal(out, expected)
+
+        self.redpanda.logger.debug("Create a config for default client, specific user")
+        self.kafka_cli.alter_quota_config(
+            "--entity-type users --entity-name custom-user-3 --entity-type clients --entity-default",
+            to_add={"producer_byte_rate": 20483.0},
+        )
+
+        self.redpanda.logger.debug("Check specific match filtering works")
+        out = self.kafka_cli.describe_quota_config(
+            "--entity-type users --entity-name custom-user-3 --entity-type clients --entity-default"
+        )
+        expected = "Quota configs for user-principal 'custom-user-3', the default client-id are producer_byte_rate=20483.0"
         assert_outputs_equal(out, expected)
 
     def describe(self, *args, **kwargs) -> QuotaOutput:
@@ -424,40 +520,41 @@ Quota configs for client-id 'custom-producer' are producer_byte_rate=20480.0"""
         self.redpanda.logger.debug(
             "Verify that describe rejects multiple filter components of the same type (client/user/ip)"
         )
+
         with expect_rpk_error_msg("INVALID_REQUEST"):
             self.describe(any=["client-id", "client-id-prefix"], strict=strict)
 
-        # TODO: uncomment this once (user, client) compound keys are supported
-        # For now, this is just included to document the expected behaviour of
-        # compound keys and the strict field
-        # self.alter(default=["client-id", "user"],
-        #            add=["producer_byte_rate=2222"])
-        #
-        # got = self.describe(any=["client-id", "user"], strict=strict)
-        # compound_output = QuotaOutput([
-        #     Quota(entity=QuotaEntity.client_id_default_and_user_default(),
-        #           values=[QuotaValue.producer_byte_rate("2222")])
-        # ])
-        # self._assert_equal(got, compound_output)
-        #
-        # got = self.describe(any=["client-id"], strict=strict)
-        # expected = QuotaOutput() if strict else compound_output
-        # self._assert_equal(got, expected)
-        #
-        # got = self.describe(any=["user"], strict=strict)
-        # expected = QuotaOutput() if strict else compound_output
-        # self._assert_equal(got, expected)
+        with expect_rpk_error_msg("INVALID_REQUEST"):
+            self.describe(any=["user", "user"], strict=strict)
+
+        with expect_rpk_error_msg("INVALID_REQUEST"):
+            self.describe(any=["user", "client-id", "client-id"], strict=strict)
+
+        self.alter(default=["client-id", "user"], add=["producer_byte_rate=2222"])
+
+        got = self.describe(any=["client-id", "user"], strict=strict)
+        compound_output = QuotaOutput(
+            [
+                Quota(
+                    entity=QuotaEntity.client_id_default_and_user_default(),
+                    values=[QuotaValue.producer_byte_rate("2222")],
+                )
+            ]
+        )
+        self._assert_equal(got, compound_output)
+
+        got = self.describe(any=["client-id"], strict=strict)
+        expected = QuotaOutput([]) if strict else compound_output
+        self._assert_equal(got, expected)
+
+        got = self.describe(any=["user"], strict=strict)
+        expected = QuotaOutput([]) if strict else compound_output
+        self._assert_equal(got, expected)
 
     @cluster(num_nodes=1)
     def test_error_handling(self):
         # rpk has client-side validation for the supported types,
         # so use other clients to exercise unsupported types
-        self.redpanda.logger.debug(
-            "Verify that any request for user quotas will return nothing"
-        )
-        got = self.kafka_cli.describe_quota_config("--user-defaults")
-        assert got == "", f"Unexpected output: {got}"
-
         self.redpanda.logger.debug(
             "Verify that the default for client-id-prefix is not supported with alter"
         )
@@ -544,7 +641,7 @@ Quota configs for client-id 'custom-producer' are producer_byte_rate=20480.0"""
                 {
                     "Entity": [
                         {
-                            "Type": "user",  # Not yet supported
+                            "Type": "role",  # Not a valid entity type
                         }
                     ],
                     "Ops": [
@@ -559,7 +656,7 @@ Quota configs for client-id 'custom-producer' are producer_byte_rate=20480.0"""
         res = self.kcl.raw_alter_quotas(alter_body)
         assert len(res["Entries"]) == 2, f"Unexpected entries: {res}"
         assert res["Entries"][0]["ErrorCode"] == 0, f"Unexpected response: {res}"
-        assert res["Entries"][1]["ErrorCode"] == 35, f"Unexpected response: {res}"
+        assert res["Entries"][1]["ErrorCode"] == 42, f"Unexpected response: {res}"
         got = self.describe(default=["client-id"])
         expected = QuotaOutput(
             [
@@ -570,6 +667,38 @@ Quota configs for client-id 'custom-producer' are producer_byte_rate=20480.0"""
             ]
         )
         self._assert_equal(got, expected)
+
+        self.redpanda.logger.debug("Verify that a describe on ip results in an error")
+        describe_body = {
+            "Components": [
+                {
+                    "EntityType": "ip",
+                    "MatchType": "DEFAULT",
+                }
+            ],
+        }
+        res = self.kcl.raw_describe_quotas(describe_body)
+        assert res["ErrorCode"] == 35, f"Unexpected response: {res}"
+        assert res["ErrorMessage"] == "Entity type 'ip' not yet supported", (
+            f"Unexpected response: {res}"
+        )
+
+        self.redpanda.logger.debug(
+            "Verify that a describe on a custom entity type results in an error"
+        )
+        describe_body = {
+            "Components": [
+                {
+                    "EntityType": "bad-entity-type",
+                    "MatchType": "DEFAULT",
+                }
+            ],
+        }
+        res = self.kcl.raw_describe_quotas(describe_body)
+        assert res["ErrorCode"] == 35, f"Unexpected response: {res}"
+        assert (
+            res["ErrorMessage"] == "Custom entity type 'bad-entity-type' not supported"
+        ), f"Unexpected response: {res}"
 
     @cluster(num_nodes=3)
     def test_multi_node(self):

--- a/tests/rptest/tests/quota_management_test.py
+++ b/tests/rptest/tests/quota_management_test.py
@@ -16,11 +16,18 @@ from ducktape.mark import parametrize
 from ducktape.utils.util import wait_until
 
 from rptest.clients.kafka_cli_tools import KafkaCliTools, KafkaCliToolsError
+from rptest.services.redpanda_installer import (
+    wait_for_num_versions,
+    InstallOptions,
+    RedpandaVersionTriple,
+    RedpandaInstaller,
+)
+from rptest.tests.end_to_end import EndToEndTest
 from rptest.clients.kcl import RawKCL
 from rptest.clients.rpk import RpkException, RpkTool
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import LoggingConfig
+from rptest.services.redpanda import LoggingConfig, RESTART_LOG_ALLOW_LIST, SISettings
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import expect_exception
 
@@ -743,3 +750,81 @@ Quota configs for client-id 'custom-producer' are producer_byte_rate=20480.0"""
             retry_on_exc=True,
             err_msg="Describe did not succeed in time",
         )
+
+
+class QuotaManagementUpgradeTest(EndToEndTest):
+    """
+    Verify that user quota clients work as expected during an upgrade
+    """
+
+    def __init__(self, test_context):
+        super().__init__(test_context=test_context)
+
+    @cluster(num_nodes=2, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_upgrade(self):
+        install_opts = InstallOptions(version=RedpandaVersionTriple((25, 3, 1)))
+        self.start_redpanda(
+            num_nodes=2,
+            si_settings=SISettings(test_context=self.test_context),
+            install_opts=install_opts,
+        )
+
+        self.kcl = RawKCL(self.redpanda)
+
+        first_node = self.redpanda.nodes[0]
+        second_node = self.redpanda.nodes[1]
+
+        alter_user_quota_body = {
+            "Entries": [
+                {
+                    "Entity": [
+                        {
+                            "Type": "user",
+                        }
+                    ],
+                    "Ops": [
+                        {
+                            "Key": "producer_byte_rate",
+                            "Value": 10.0,
+                        }
+                    ],
+                }
+            ],
+        }
+
+        # Sanity check: v25.3 doesn't support user quotas
+        self.redpanda.logger.debug(
+            "Verify that user quotas are not supported in older version"
+        )
+        res = self.kcl.raw_alter_quotas(alter_user_quota_body)
+        assert len(res["Entries"]) == 1, f"Unexpected entries: {res}"
+        entry = res["Entries"][0]
+        assert entry["ErrorCode"] == 35, f"Unexpected entry: {entry}"
+        assert entry["ErrorMessage"] == "Entity type 'user' not yet supported", (
+            f"Unexpected entry: {entry}"
+        )
+
+        # Upgrade one node to the head version.
+        self.redpanda._installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
+        self.redpanda.restart_nodes([first_node])
+        wait_for_num_versions(self.redpanda, 2)
+
+        self.redpanda.logger.debug(
+            "Verify that during upgrade user quotas are disabled"
+        )
+        res = self.kcl.raw_alter_quotas(alter_user_quota_body)
+        assert len(res["Entries"]) == 1, f"Unexpected entries: {res}"
+        entry = res["Entries"][0]
+        assert entry["ErrorCode"] == 35, f"Unexpected entry: {entry}"
+        assert (
+            entry["ErrorMessage"] == "user-based client quotas are not yet available"
+        ), f"Unexpected entry: {entry}"
+
+        self.redpanda.restart_nodes([second_node])
+        wait_for_num_versions(self.redpanda, 1)
+
+        self.redpanda.logger.debug("Verify that user quotas are now enabled")
+        res = self.kcl.raw_alter_quotas(alter_user_quota_body, node=second_node)
+        assert len(res["Entries"]) == 1, f"Unexpected entries: {res}"
+        entry = res["Entries"][0]
+        assert entry["ErrorCode"] == 0, f"Unexpected entry: {entry}"


### PR DESCRIPTION
Implements : [CORE-15271](https://redpandadata.atlassian.net/browse/CORE-15271)

Expose entity type `user` through the describe/alter client quota kafka api.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Features

* Implement user-based client quotas.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-15271]: https://redpandadata.atlassian.net/browse/CORE-15271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ