### PR TITLE
CORE-15185 SR Context: Implement CONTEXT record writing on first register into a new context

### DIFF
--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -258,8 +258,23 @@ seq_writer::do_write_subject_version(
           projected.id,
           projected.version);
 
+        batch_builder rb(write_at);
+        auto record_offset = write_at;
+
+        // If context isn't materialized yet, prepend CONTEXT record
+        if (auto is_materialized = co_await _store.is_context_materialized(
+              sub.ctx);
+            !is_materialized) {
+            vlog(srlog.debug, "Writing CONTEXT record for ctx={}", sub.ctx);
+            auto ctx_key = context_key{
+              .seq{record_offset}, .node{_node_id}, .ctx{sub.ctx}};
+            auto ctx_value = context_value{.ctx{sub.ctx}};
+            rb(std::move(ctx_key), std::move(ctx_value));
+            ++record_offset;
+        }
+
         auto key = schema_key{
-          .seq{write_at},
+          .seq{record_offset},
           .node{_node_id},
           .sub{sub},
           .version{projected.version}};
@@ -268,8 +283,6 @@ seq_writer::do_write_subject_version(
           .version{projected.version},
           .id{projected.id},
           .deleted = is_deleted::no};
-
-        batch_builder rb(write_at);
         rb(std::move(key), std::move(value));
 
         if (co_await produce_and_apply(write_at, std::move(rb).build())) {

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -928,9 +928,10 @@ sharded_store::get_schema_id(context ctx, schema_definition def) const {
       map, std::optional<schema_id>{}, reduce);
 }
 
-ss::future<chunked_vector<context>> sharded_store::get_contexts() const {
+ss::future<chunked_vector<context>>
+sharded_store::get_materialized_contexts() const {
     using contexts = chunked_vector<context>;
-    auto map = [](const store& s) { return s.get_contexts(); };
+    auto map = [](const store& s) { return s.get_materialized_contexts(); };
     auto reduce = [](contexts acc, contexts ctxs) {
         acc.reserve(acc.size() + ctxs.size());
         std::ranges::move(ctxs, std::back_inserter(acc));
@@ -941,6 +942,18 @@ ss::future<chunked_vector<context>> sharded_store::get_contexts() const {
     auto uniq = std::ranges::unique(ctxs);
     ctxs.erase_to_end(uniq.begin());
     co_return ctxs;
+}
+
+ss::future<bool> sharded_store::is_context_materialized(context ctx) const {
+    co_return _store.local().is_context_materialized(ctx);
+}
+
+ss::future<>
+sharded_store::set_context_materialized(context ctx, bool materialized) {
+    co_await _store.invoke_on_all(
+      _smp_opts, [ctx{std::move(ctx)}, materialized](store& s) {
+          s.set_context_materialized(ctx, materialized);
+      });
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -232,8 +232,14 @@ public:
     ss::future<std::optional<schema_id>>
     get_schema_id(context ctx, schema_definition def) const;
 
-    /// \brief List all contexts in the store
-    ss::future<chunked_vector<context>> get_contexts() const;
+    /// \brief List all materialized contexts (always includes default_context)
+    ss::future<chunked_vector<context>> get_materialized_contexts() const;
+
+    /// \brief Check if a context is materialized (has a CONTEXT record)
+    ss::future<bool> is_context_materialized(context ctx) const;
+
+    /// \brief Set the materialized state of a context
+    ss::future<> set_context_materialized(context ctx, bool materialized);
 
 private:
     ss::future<compatibility_result> do_is_compatible(

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -38,7 +38,14 @@
 namespace pandaproxy::schema_registry {
 
 using topic_key_magic = named_type<int32_t, struct topic_key_magic_tag>;
-enum class topic_key_type { noop = 0, schema, config, mode, delete_subject };
+enum class topic_key_type {
+    noop = 0,
+    schema,
+    config,
+    mode,
+    delete_subject,
+    context
+};
 
 constexpr std::string_view to_string_view(topic_key_type kt) {
     switch (kt) {
@@ -52,6 +59,8 @@ constexpr std::string_view to_string_view(topic_key_type kt) {
         return "MODE";
     case topic_key_type::delete_subject:
         return "DELETE_SUBJECT";
+    case topic_key_type::context:
+        return "CONTEXT";
     }
     return "{invalid}";
 };
@@ -66,6 +75,7 @@ from_string_view<topic_key_type>(std::string_view sv) {
       .match(
         to_string_view(topic_key_type::delete_subject),
         topic_key_type::delete_subject)
+      .match(to_string_view(topic_key_type::context), topic_key_type::context)
       .default_match(std::nullopt);
 }
 
@@ -1411,6 +1421,272 @@ public:
     }
 };
 
+struct context_key {
+    static constexpr topic_key_type keytype{topic_key_type::context};
+    std::optional<model::offset> seq;
+    std::optional<model::node_id> node;
+    ss::sstring tenant{"default"};
+    context ctx;
+    topic_key_magic magic{0};
+
+    friend bool operator==(const context_key&, const context_key&) = default;
+
+    friend std::ostream& operator<<(std::ostream& os, const context_key& v) {
+        if (v.seq.has_value() && v.node.has_value()) {
+            fmt::print(
+              os,
+              "seq: {}, node: {}, keytype: {}, tenant: {}, context: {}, magic: "
+              "{}",
+              *v.seq,
+              *v.node,
+              to_string_view(v.keytype),
+              v.tenant,
+              v.ctx,
+              v.magic);
+        } else {
+            fmt::print(
+              os,
+              "unsequenced keytype: {}, tenant: {}, context: {}, magic: {}",
+              to_string_view(v.keytype),
+              v.tenant,
+              v.ctx,
+              v.magic);
+        }
+        return os;
+    }
+};
+
+struct context_value {
+    ss::sstring tenant{"default"};
+    context ctx;
+
+    friend bool operator==(const context_value&, const context_value&)
+      = default;
+
+    friend std::ostream& operator<<(std::ostream& os, const context_value& v) {
+        fmt::print(os, "tenant: {}, context: {}", v.tenant, v.ctx);
+        return os;
+    }
+};
+
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const schema_registry::context_key& key) {
+    w.StartObject();
+    w.Key("keytype");
+    ::json::rjson_serialize(w, to_string_view(key.keytype));
+    w.Key("tenant");
+    w.String(key.tenant);
+    w.Key("context");
+    w.String(key.ctx());
+    w.Key("magic");
+    ::json::rjson_serialize(w, key.magic);
+    if (key.seq.has_value()) {
+        w.Key("seq");
+        ::json::rjson_serialize(w, *key.seq);
+    }
+    if (key.node.has_value()) {
+        w.Key("node");
+        ::json::rjson_serialize(w, *key.node);
+    }
+    w.EndObject();
+}
+
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const schema_registry::context_value& val) {
+    w.StartObject();
+    w.Key("tenant");
+    w.String(val.tenant);
+    w.Key("context");
+    w.String(val.ctx());
+    w.EndObject();
+}
+
+template<typename Encoding = ::json::UTF8<>>
+class context_key_handler : public json::base_handler<Encoding> {
+    enum class state {
+        empty = 0,
+        object,
+        keytype,
+        seq,
+        node,
+        tenant,
+        context,
+        magic,
+    };
+    state _state = state::empty;
+
+public:
+    using Ch = typename json::base_handler<Encoding>::Ch;
+    using rjson_parse_result = context_key;
+    rjson_parse_result result;
+
+    context_key_handler()
+      : json::base_handler<Encoding>{json::serialization_format::none} {}
+
+    bool Key(const Ch* str, ::json::SizeType len, bool) {
+        auto sv = std::string_view{str, len};
+        std::optional<state> s{string_switch<std::optional<state>>(sv)
+                                 .match("keytype", state::keytype)
+                                 .match("seq", state::seq)
+                                 .match("node", state::node)
+                                 .match("tenant", state::tenant)
+                                 .match("context", state::context)
+                                 .match("magic", state::magic)
+                                 .default_match(std::nullopt)};
+        return s.has_value() && std::exchange(_state, *s) == state::object;
+    }
+
+    bool Uint(int i) {
+        switch (_state) {
+        case state::magic: {
+            result.magic = topic_key_magic{i};
+            _state = state::object;
+            return true;
+        }
+        case state::seq: {
+            result.seq = model::offset{i};
+            _state = state::object;
+            return true;
+        }
+        case state::node: {
+            result.node = model::node_id{i};
+            _state = state::object;
+            return true;
+        }
+        case state::empty:
+        case state::tenant:
+        case state::context:
+        case state::keytype:
+        case state::object:
+            return false;
+        }
+        return false;
+    }
+
+    bool String(const Ch* str, ::json::SizeType len, bool) {
+        auto sv = std::string_view{str, len};
+        switch (_state) {
+        case state::keytype: {
+            auto kt = from_string_view<topic_key_type>(sv);
+            _state = state::object;
+            return kt == result.keytype;
+        }
+        case state::tenant: {
+            // Accept only "default" as valid tenant
+            if (sv != "default") {
+                return false;
+            }
+            result.tenant = ss::sstring{sv};
+            _state = state::object;
+            return true;
+        }
+        case state::context: {
+            result.ctx = context{ss::sstring{sv}};
+            _state = state::object;
+            return true;
+        }
+        case state::empty:
+        case state::seq:
+        case state::node:
+        case state::object:
+        case state::magic:
+            return false;
+        }
+        return false;
+    }
+
+    bool Null() {
+        // The tenant is nullable (treat as "default")
+        if (_state == state::tenant) {
+            result.tenant = "default";
+            _state = state::object;
+            return true;
+        }
+        return false;
+    }
+
+    bool StartObject() {
+        return std::exchange(_state, state::object) == state::empty;
+    }
+
+    bool EndObject(::json::SizeType) {
+        return result.seq.has_value() == result.node.has_value()
+               && std::exchange(_state, state::empty) == state::object;
+    }
+};
+
+template<typename Encoding = ::json::UTF8<>>
+class context_value_handler : public json::base_handler<Encoding> {
+    enum class state {
+        empty = 0,
+        object,
+        tenant,
+        context,
+    };
+    state _state = state::empty;
+
+public:
+    using Ch = typename json::base_handler<Encoding>::Ch;
+    using rjson_parse_result = context_value;
+    rjson_parse_result result;
+
+    context_value_handler()
+      : json::base_handler<Encoding>{json::serialization_format::none} {}
+
+    bool Key(const Ch* str, ::json::SizeType len, bool) {
+        auto sv = std::string_view{str, len};
+        std::optional<state> s{string_switch<std::optional<state>>(sv)
+                                 .match("tenant", state::tenant)
+                                 .match("context", state::context)
+                                 .default_match(std::nullopt)};
+        return s.has_value() && std::exchange(_state, *s) == state::object;
+    }
+
+    bool String(const Ch* str, ::json::SizeType len, bool) {
+        auto sv = std::string_view{str, len};
+        switch (_state) {
+        case state::tenant: {
+            // Accept only "default" as valid tenant
+            if (sv != "default") {
+                return false;
+            }
+            result.tenant = ss::sstring{sv};
+            _state = state::object;
+            return true;
+        }
+        case state::context: {
+            result.ctx = context{ss::sstring{sv}};
+            _state = state::object;
+            return true;
+        }
+        case state::empty:
+        case state::object:
+            return false;
+        }
+        return false;
+    }
+
+    bool Null() {
+        // The tenant is nullable (treat as "default")
+        if (_state == state::tenant) {
+            result.tenant = "default";
+            _state = state::object;
+            return true;
+        }
+        return false;
+    }
+
+    bool StartObject() {
+        return std::exchange(_state, state::object) == state::empty;
+    }
+
+    bool EndObject(::json::SizeType) {
+        return std::exchange(_state, state::empty) == state::object;
+    }
+};
+
 template<typename Handler, typename... Args>
 auto from_json_iobuf(iobuf&& iobuf, Args&&... args) {
     return json::rjson_parse(
@@ -1464,6 +1740,9 @@ struct consume_to_store {
 
         switch (*key_type) {
         case topic_key_type::noop:
+            break;
+        case topic_key_type::context:
+            // TODO: implement in the next commit
             break;
         case topic_key_type::schema: {
             std::optional<schema_value> val;

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -1741,9 +1741,19 @@ struct consume_to_store {
         switch (*key_type) {
         case topic_key_type::noop:
             break;
-        case topic_key_type::context:
-            // TODO: implement in the next commit
+        case topic_key_type::context: {
+            std::optional<context_value> val;
+            if (!record.value().empty()) {
+                val.emplace(
+                  from_json_iobuf<context_value_handler<>>(
+                    record.release_value()));
+            }
+            co_await apply(
+              offset,
+              from_json_iobuf<context_key_handler<>>(std::move(key)),
+              std::move(val));
             break;
+        }
         case topic_key_type::schema: {
             std::optional<schema_value> val;
             if (!record.value().empty()) {
@@ -2023,6 +2033,43 @@ struct consume_to_store {
                 .key_type = seq_marker_key_type::delete_subject},
               key.sub,
               permanent_delete::no);
+        } catch (const exception& e) {
+            vlog(srlog.debug, "Error replaying: {}: {}", key, e);
+        }
+    }
+
+    ss::future<> apply(
+      model::offset offset, context_key key, std::optional<context_value> val) {
+        // Check seq if it was provided, otherwise assume 3rdparty
+        // compatibility, which can't collide.
+        if (val && key.seq.has_value() && offset != key.seq) {
+            vlog(
+              srlog.debug,
+              "Ignoring out of order {} (at offset {})",
+              key,
+              offset);
+            co_return;
+        }
+
+        if (key.magic != 0) {
+            throw exception(
+              error_code::topic_parse_error,
+              fmt::format("Unexpected magic: {}", key));
+        }
+
+        try {
+            vlog(
+              srlog.debug,
+              "Applying: {} tombstone={} (at offset {})",
+              key,
+              !val.has_value(),
+              offset);
+
+            if (val.has_value()) {
+                co_await _store.set_context_materialized(key.ctx, true);
+            } else {
+                co_await _store.set_context_materialized(key.ctx, false);
+            }
         } catch (const exception& e) {
             vlog(srlog.debug, "Error replaying: {}: {}", key, e);
         }

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -875,9 +875,27 @@ public:
         return _context_stores[ctx]._next_schema_id;
     }
 
-    chunked_vector<context> get_contexts() const {
-        return _context_stores | std::views::keys
-               | std::ranges::to<chunked_vector<context>>();
+    chunked_vector<context> get_materialized_contexts() const {
+        chunked_vector<context> result;
+        result.push_back(default_context);
+        for (const auto& [ctx, store] : _context_stores) {
+            if (store._materialized && ctx != default_context) {
+                result.push_back(ctx);
+            }
+        }
+        return result;
+    }
+
+    bool is_context_materialized(const context& ctx) const {
+        if (ctx == default_context) {
+            return true;
+        }
+        auto it = _context_stores.find(ctx);
+        return it != _context_stores.end() && it->second._materialized;
+    }
+
+    void set_context_materialized(const context& ctx, bool materialized) {
+        _context_stores[ctx]._materialized = materialized;
     }
 
 private:
@@ -1009,6 +1027,7 @@ private:
         std::optional<compatibility_level> _compatibility{std::nullopt};
         std::optional<mode> _mode{std::nullopt};
         schema_id _next_schema_id{1};
+        bool _materialized{false};
 
         chunked_vector<seq_marker> _config_written_at;
         chunked_vector<seq_marker> _mode_written_at;
@@ -1024,6 +1043,9 @@ private:
     //  - next_schema_id: sharded by context
     //  - compatibility: replicated across all shards
     //  - mode: replicated across all shards
+    //  - materialized: replicated across all shards
+    //  - _config_written_at: replicated across all shards
+    //  - _mode_written_at: replicated across all shards
     // _mutable: replicated across all shards
 
     // Alternative: Keep the store as is, but key the existing state under a

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -126,6 +126,30 @@ constexpr std::string_view delete_subject_value_sv{
 const auto expected_delete_subject_value = delete_subject_value{
   .sub{subject{"my-kafka-value"}}};
 
+constexpr std::string_view context_key_sv{
+  R"({
+  "keytype": "CONTEXT",
+  "tenant": "default",
+  "context": ".staging",
+  "magic": 0,
+  "seq": 42,
+  "node": 2
+})"};
+const auto expected_context_key = context_key{
+  .seq{model::offset{42}},
+  .node{model::node_id{2}},
+  .tenant{"default"},
+  .ctx{context{".staging"}},
+  .magic{topic_key_magic{0}}};
+
+constexpr std::string_view context_value_sv{
+  R"({
+  "tenant": "default",
+  "context": ".staging"
+})"};
+const auto expected_context_value = context_value{
+  .tenant{"default"}, .ctx{context{".staging"}}};
+
 } // namespace
 
 class StorageTest : public ::testing::Test {
@@ -205,6 +229,24 @@ TEST_F(StorageTest, Serde) {
 
         auto str = ppj::rjson_serialize_str(expected_delete_subject_value);
         EXPECT_EQ(str, ::json::minify(delete_subject_value_sv));
+    }
+
+    {
+        auto key = ppj::impl::rjson_parse(
+          context_key_sv.data(), context_key_handler<>{});
+        EXPECT_EQ(expected_context_key, key);
+
+        auto str = ppj::rjson_serialize_str(expected_context_key);
+        EXPECT_EQ(str, ::json::minify(context_key_sv));
+    }
+
+    {
+        auto val = ppj::impl::rjson_parse(
+          context_value_sv.data(), context_value_handler<>{});
+        EXPECT_EQ(expected_context_value, val);
+
+        auto str = ppj::rjson_serialize_str(expected_context_value);
+        EXPECT_EQ(str, ::json::minify(context_value_sv));
     }
 }
 
@@ -549,6 +591,56 @@ TEST_F(StorageTest, SerdeContextSubject) {
         auto str = ppj::rjson_serialize_str(expected_mode_key_legacy);
         EXPECT_EQ(str, ::json::minify(mode_key_legacy_sv));
     }
+}
+
+TEST_F(StorageTest, ContextKeyTenantValidation) {
+    // null tenant should be accepted
+    constexpr std::string_view null_tenant_sv{
+      R"({"keytype": "CONTEXT", "tenant": null, "context": ".test", "magic": 0})"};
+    auto null_key = ppj::impl::rjson_parse(
+      null_tenant_sv.data(), context_key_handler<>{});
+    EXPECT_EQ(null_key.tenant, "default");
+    EXPECT_EQ(null_key.ctx, context{".test"});
+
+    // missing tenant should be accepted
+    constexpr std::string_view missing_tenant_sv{
+      R"({"keytype": "CONTEXT", "context": ".test", "magic": 0})"};
+    auto missing_key = ppj::impl::rjson_parse(
+      missing_tenant_sv.data(), context_key_handler<>{});
+    EXPECT_EQ(missing_key.tenant, "default");
+    EXPECT_EQ(missing_key.ctx, context{".test"});
+
+    // invalid tenant should be rejected
+    constexpr std::string_view invalid_tenant_sv{
+      R"({"keytype": "CONTEXT", "tenant": "other", "context": ".test", "magic": 0})"};
+    EXPECT_THROW(
+      ppj::impl::rjson_parse(invalid_tenant_sv.data(), context_key_handler<>{}),
+      ppj::parse_error);
+}
+
+TEST_F(StorageTest, ContextValueTenantValidation) {
+    // null tenant should be accepted
+    constexpr std::string_view null_tenant_sv{
+      R"({"tenant": null, "context": ".test"})"};
+    auto null_val = ppj::impl::rjson_parse(
+      null_tenant_sv.data(), context_value_handler<>{});
+    EXPECT_EQ(null_val.tenant, "default");
+    EXPECT_EQ(null_val.ctx, context{".test"});
+
+    // missing tenant should be accepted
+    constexpr std::string_view missing_tenant_sv{R"({"context": ".test"})"};
+    auto missing_val = ppj::impl::rjson_parse(
+      missing_tenant_sv.data(), context_value_handler<>{});
+    EXPECT_EQ(missing_val.tenant, "default");
+    EXPECT_EQ(missing_val.ctx, context{".test"});
+
+    // invalid tenant should be rejected
+    constexpr std::string_view invalid_tenant_sv{
+      R"({"tenant": "other", "context": ".test"})"};
+    EXPECT_THROW(
+      ppj::impl::rjson_parse(
+        invalid_tenant_sv.data(), context_value_handler<>{}),
+      ppj::parse_error);
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -1013,3 +1013,31 @@ BOOST_AUTO_TEST_CASE(test_store_context_config_written_at) {
     markers = s.get_context_config_written_at(test_ctx).value();
     BOOST_REQUIRE(markers.empty());
 }
+
+BOOST_AUTO_TEST_CASE(test_store_context_materialized) {
+    pps::store s;
+    auto test_ctx = pps::context{".test"};
+
+    // Empty state
+    BOOST_REQUIRE(s.is_context_materialized(pps::default_context));
+    BOOST_REQUIRE(!s.is_context_materialized(test_ctx));
+    auto contexts = s.get_materialized_contexts();
+    BOOST_REQUIRE_EQUAL(contexts.size(), 1);
+    BOOST_REQUIRE_EQUAL(contexts[0], pps::default_context);
+
+    // Set .test context as materialized
+    s.set_context_materialized(test_ctx, true);
+    BOOST_REQUIRE(s.is_context_materialized(test_ctx));
+    contexts = s.get_materialized_contexts();
+    BOOST_REQUIRE_EQUAL(contexts.size(), 2);
+    BOOST_REQUIRE(
+      std::ranges::find(contexts, pps::default_context) != contexts.end());
+    BOOST_REQUIRE(std::ranges::find(contexts, test_ctx) != contexts.end());
+
+    // Set .test context as not materialized (tombstone)
+    s.set_context_materialized(test_ctx, false);
+    BOOST_REQUIRE(!s.is_context_materialized(test_ctx));
+    contexts = s.get_materialized_contexts();
+    BOOST_REQUIRE_EQUAL(contexts.size(), 1);
+    BOOST_REQUIRE_EQUAL(contexts[0], pps::default_context);
+}

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -5393,6 +5393,47 @@ class SchemaRegistryContextTest(SchemaRegistryEndpoints):
         self.assert_equal(result.status_code, requests.codes.ok)
         self.assert_equal(result.json()["mode"], "READWRITE")
 
+    @cluster(num_nodes=1)
+    def test_context_record_persistence(self):
+        # First, register a schema in the default context (no CONTEXT record)
+        result = self.sr_client.post_subjects_subject_versions(
+            subject="default-ctx-sub", data=json.dumps({"schema": schema1_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Verify no CONTEXT record was written for default context
+        time.sleep(1)  # Give some time for logs to be flushed
+        assert not self.redpanda.search_log_any("Writing CONTEXT record for ctx=\\."), (
+            "CONTEXT record should not be written for default context"
+        )
+
+        # Now register a schema in a non-default context
+        ctx = ".test-context"
+        ctx_subject = f":{ctx}:test-sub"
+
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=ctx_subject, data=json.dumps({"schema": schema2_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Verify CONTEXT record was written
+        # TODO: This test can be simplified with GET /contexts support later
+        # instead of relying on log lines.
+        write_pattern = f"Writing CONTEXT record for ctx={ctx}"
+        wait_until(
+            lambda: self.redpanda.search_log_any(write_pattern),
+            timeout_sec=10,
+            err_msg=f"Failed to find write log: {write_pattern}",
+        )
+
+        # Verify CONTEXT record was replayed (key contains "keytype: CONTEXT")
+        replay_pattern = f"keytype: CONTEXT.*context: {ctx}"
+        wait_until(
+            lambda: self.redpanda.search_log_any(replay_pattern),
+            timeout_sec=10,
+            err_msg=f"Failed to find replay log: {replay_pattern}",
+        )
+
 
 class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
     """


### PR DESCRIPTION
Implements the serde of CONTEXT records, which are used to materialize/delete contexts. When a schema is first registered in a non-default context, the registration path writes a CONTEXT record before the first SCHEMA record to materialize the context. After this, the context will show up in the `GET /context` endpoint's result (to be implemented in a follow up PR). These CONTEXT records can then be used to also delete the context through the to-be-implemented `DELETE /contexts/{context}` API as well.

Fixes https://redpandadata.atlassian.net/browse/CORE-15185

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
