### PR TITLE
`ct/l1`: fix `earliest_dirty_ts` logic in `simple_metastore` and `db_domain_manager`

### DIFF
--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -569,8 +569,12 @@ db_domain_manager::do_get_compaction_info(
             total_size += extent.val.len;
             if (!cleaned_ranges.covers(base, last)) {
                 dirty_size += extent.val.len;
-                // Track earliest dirty timestamp.
-                if (!earliest_dirty_ts.has_value()) {
+                // Track earliest dirty timestamp. We cannot assume timestamps
+                // are monotonic with offsets, so we must find the minimum
+                // across all dirty extents.
+                if (
+                  !earliest_dirty_ts.has_value()
+                  || extent.val.max_timestamp < *earliest_dirty_ts) {
                     earliest_dirty_ts = extent.val.max_timestamp;
                 }
             }

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -639,31 +639,34 @@ simple_metastore::get_earliest_dirty_ts(
 
     const auto& compaction_state = prt.compaction_state;
 
-    // Start search for first dirty offset from the start offset of the log
-    // (which may not be 0 for a `compact,delete` topic). If compaction hasn't
-    // yet been run for this partition, this value is already the first dirty
-    // offset.
-    kafka::offset first_dirty_offset{prt.start_offset};
+    // Get cleaned ranges if compaction has been run.
+    offset_interval_set cleaned_ranges;
     if (compaction_state.has_value()) {
-        const auto& clean_ranges = compaction_state->cleaned_ranges;
-        auto clean_ranges_strm = clean_ranges.make_stream();
-        while (clean_ranges_strm.has_next()) {
-            auto clean_interval = clean_ranges_strm.next();
-            if (first_dirty_offset < clean_interval.base_offset) {
-                break;
-            }
+        cleaned_ranges = compaction_state->cleaned_ranges;
+    }
 
-            first_dirty_offset = kafka::next_offset(clean_interval.last_offset);
+    // Iterate through all extents to find the minimum timestamp among dirty
+    // extents.
+    std::optional<model::timestamp> earliest_dirty_ts;
+    for (const auto& extent : prt.extents) {
+        auto base = extent.base_offset;
+        if (base < prt.start_offset) {
+            // The extent is partially truncated.
+            base = prt.start_offset;
+        }
+        auto last = extent.last_offset;
+
+        if (!cleaned_ranges.covers(base, last)) {
+            // This extent is dirty. Track the minimum timestamp.
+            if (
+              !earliest_dirty_ts.has_value()
+              || extent.max_timestamp < *earliest_dirty_ts) {
+                earliest_dirty_ts = extent.max_timestamp;
+            }
         }
     }
 
-    auto it = std::ranges::lower_bound(
-      prt.extents, first_dirty_offset, std::less<>{}, &extent::last_offset);
-    if (it != prt.extents.end()) {
-        return it->max_timestamp;
-    }
-
-    return std::nullopt;
+    return earliest_dirty_ts;
 }
 
 std::expected<metastore::compaction_epoch, metastore::errc>

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -1615,6 +1615,144 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsSingleDirtyAtEnd) {
       testing::ElementsAre(MatchesRange(100_o, 100_o)));
 }
 
+TEST(
+  SimpleMetastoreTest,
+  TestEarliestDirtyTsNonMonotonicTimestampsCleanedInOrder) {
+    simple_metastore m;
+    om_list_t os;
+    auto tp = model::topic_id_partition::from(tid_a);
+
+    // Create three extents with non-monotonic timestamps:
+    // - Extent 1: offsets [0-9], max_timestamp = 1000
+    // - Extent 2: offsets [10-19], max_timestamp = 300
+    // - Extent 3: offsets [20-29], max_timestamp = 500
+    os.emplace_back(
+      om_builder(oid1, 100, 1100).add(tid_a, 0_o, 9_o, 1000_t, 0, 99).build());
+    os.emplace_back(
+      om_builder(oid2, 100, 1100).add(tid_a, 10_o, 19_o, 300_t, 0, 99).build());
+    os.emplace_back(
+      om_builder(oid3, 100, 1100).add(tid_a, 20_o, 29_o, 500_t, 0, 99).build());
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    // Initially all extents are dirty. The earliest_dirty_ts should be the
+    // minimum timestamp across all extents, which is 300.
+    auto to_collect = metastore::compaction_info_spec{
+      .tidp = tp, .tombstone_removal_upper_bound_ts = 3000_t};
+    auto compaction_info = m.get_compaction_info(to_collect).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    ASSERT_TRUE(compaction_info->earliest_dirty_ts.has_value());
+    EXPECT_EQ(compaction_info->earliest_dirty_ts.value(), 300_t);
+
+    // Clean the first extent [0-9]. Now only extents 2 and 3 are dirty.
+    {
+        om_list_t new_os;
+        new_os.emplace_back(om_builder(oid4, 100, 1100)
+                              .add(tid_a, 0_o, 9_o, 1000_t, 0, 99)
+                              .build());
+
+        auto cmb = cm_builder();
+        cmb.clean(tid_a, 0_o, 9_o, 3000_t);
+        cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{0});
+        auto compact_res = m.compact_objects(new_os, cmb.build()).get();
+        ASSERT_TRUE(compact_res.has_value());
+    }
+
+    compaction_info = m.get_compaction_info(to_collect).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    ASSERT_TRUE(compaction_info->earliest_dirty_ts.has_value());
+    EXPECT_EQ(compaction_info->earliest_dirty_ts.value(), 300_t);
+
+    // Clean extent 2 [0-19].
+    {
+        om_list_t new_os;
+        new_os.emplace_back(om_builder(oid5, 100, 1100)
+                              .add(tid_a, 0_o, 19_o, 300_t, 0, 99)
+                              .build());
+
+        auto cmb = cm_builder();
+        cmb.clean(tid_a, 10_o, 19_o, 3000_t);
+        cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{1});
+        auto compact_res = m.compact_objects(new_os, cmb.build()).get();
+        ASSERT_TRUE(compact_res.has_value());
+    }
+
+    compaction_info = m.get_compaction_info(to_collect).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    ASSERT_TRUE(compaction_info->earliest_dirty_ts.has_value());
+    EXPECT_EQ(compaction_info->earliest_dirty_ts.value(), 500_t);
+}
+
+TEST(
+  SimpleMetastoreTest,
+  TestEarliestDirtyTsNonMonotonicTimestampsCleanedOutOfOrder) {
+    simple_metastore m;
+    om_list_t os;
+    auto tp = model::topic_id_partition::from(tid_a);
+
+    // Create three extents with non-monotonic timestamps:
+    // - Extent 1: offsets [0-9], max_timestamp = 1000
+    // - Extent 2: offsets [10-19], max_timestamp = 500
+    // - Extent 3: offsets [20-29], max_timestamp = 300
+    os.emplace_back(
+      om_builder(oid1, 100, 1100).add(tid_a, 0_o, 9_o, 1000_t, 0, 99).build());
+    os.emplace_back(
+      om_builder(oid2, 100, 1100).add(tid_a, 10_o, 19_o, 500_t, 0, 99).build());
+    os.emplace_back(
+      om_builder(oid3, 100, 1100).add(tid_a, 20_o, 29_o, 300_t, 0, 99).build());
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    // Initially all extents are dirty. The earliest_dirty_ts should be the
+    // minimum timestamp across all extents, which is 300.
+    auto to_collect = metastore::compaction_info_spec{
+      .tidp = tp, .tombstone_removal_upper_bound_ts = 3000_t};
+    auto compaction_info = m.get_compaction_info(to_collect).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    ASSERT_TRUE(compaction_info->earliest_dirty_ts.has_value());
+    EXPECT_EQ(compaction_info->earliest_dirty_ts.value(), 300_t);
+
+    // Clean the first extent [0-9]. Now only extents 2 and 3 are dirty.
+    {
+        om_list_t new_os;
+        new_os.emplace_back(om_builder(oid4, 100, 1100)
+                              .add(tid_a, 0_o, 9_o, 1000_t, 0, 99)
+                              .build());
+
+        auto cmb = cm_builder();
+        cmb.clean(tid_a, 0_o, 9_o, 3000_t);
+        cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{0});
+        auto compact_res = m.compact_objects(new_os, cmb.build()).get();
+        ASSERT_TRUE(compact_res.has_value());
+    }
+
+    compaction_info = m.get_compaction_info(to_collect).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    ASSERT_TRUE(compaction_info->earliest_dirty_ts.has_value());
+    EXPECT_EQ(compaction_info->earliest_dirty_ts.value(), 300_t);
+
+    // Clean extent 3 [20-29].
+    {
+        om_list_t new_os;
+        new_os.emplace_back(om_builder(oid5, 100, 1100)
+                              .add(tid_a, 0_o, 29_o, 500_t, 0, 99)
+                              .build());
+
+        auto cmb = cm_builder();
+        cmb.clean(tid_a, 20_o, 29_o, 3000_t);
+        cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{1});
+        auto compact_res = m.compact_objects(new_os, cmb.build()).get();
+        ASSERT_TRUE(compact_res.has_value());
+    }
+
+    compaction_info = m.get_compaction_info(to_collect).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    ASSERT_TRUE(compaction_info->earliest_dirty_ts.has_value());
+    EXPECT_EQ(compaction_info->earliest_dirty_ts.value(), 500_t);
+}
+
 TEST(SimpleMetastoreTest, TestAddGetOffsetAfterBytes) {
     simple_metastore m;
     om_list_t os;


### PR DESCRIPTION
Timestamps cannot be assumed to be monotonic in the log/in `metastore` `extent`s.
## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
