### PR TITLE
[UX-828] rpk/registry: support metadata properties

### DIFF
--- a/src/go/rpk/pkg/cli/registry/schema/BUILD
+++ b/src/go/rpk/pkg/cli/registry/schema/BUILD
@@ -27,7 +27,10 @@ go_library(
 go_test(
     name = "schema_test",
     size = "small",
-    srcs = ["schema_test.go"],
+    srcs = [
+        "create_test.go",
+        "schema_test.go",
+    ],
     embed = [":schema"],
     deps = [
         "@com_github_spf13_afero//:afero",

--- a/src/go/rpk/pkg/cli/registry/schema/create.go
+++ b/src/go/rpk/pkg/cli/registry/schema/create.go
@@ -10,6 +10,7 @@
 package schema
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -24,11 +25,12 @@ import (
 
 func newCreateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var (
-		refs          string
-		schemaFile    string
-		schemaType    string
-		id            int
-		schemaVersion int
+		refs               string
+		schemaFile         string
+		schemaType         string
+		id                 int
+		schemaVersion      int
+		metadataProperties []string
 	)
 	cmd := &cobra.Command{
 		Use:   "create SUBJECT --schema {filename}",
@@ -62,11 +64,17 @@ version 1:
 
 Create a schema with a specific ID and version in import mode:
   rpk registry schema create foo --schema /path/to/file.proto --id 42 --schema-version 3
+
+Create a schema with metadata properties:
+  rpk registry schema create foo --schema /path/to/file.proto --metadata-properties owner=team-a --metadata-properties env=prod
+
+Create a schema with metadata properties using JSON format (useful for special characters):
+  rpk registry schema create foo --schema /path/to/file.proto --metadata-properties '{"owner":"team-a","env":"prod"}'
 `,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			f := p.Formatter
-			if h, ok := f.Help(subjectSchema{}); ok {
+			if h, ok := f.Help(subjectSchemaMetadata{}); ok {
 				out.Exit(h)
 			}
 
@@ -89,17 +97,25 @@ Create a schema with a specific ID and version in import mode:
 			references, err := parseReferenceFlag(fs, refs)
 			out.MaybeDie(err, "unable to parse reference flag %q: %v", refs, err)
 
+			mProperties, err := parseMetadataProperties(metadataProperties)
+			out.MaybeDie(err, "unable to parse metadata properties flag %q: %v", metadataProperties, err)
+
+			var schemaMetadata *sr.SchemaMetadata
+			if mProperties != nil {
+				schemaMetadata = &sr.SchemaMetadata{Properties: mProperties}
+			}
 			subject := args[0]
 			schema := sr.Schema{
-				Schema:     string(file),
-				Type:       t,
-				References: references,
+				Schema:         string(file),
+				Type:           t,
+				References:     references,
+				SchemaMetadata: schemaMetadata,
 			}
 
 			s, err := cl.CreateSchemaWithIDAndVersion(cmd.Context(), subject, schema, id, schemaVersion)
 			out.MaybeDie(err, "unable to create schema: %v", err)
 
-			err = printSubjectSchemaTable(f, true, s)
+			err = printSubjectSchemaWithMetadata(f, true, len(mProperties) > 0, s)
 			out.MaybeDieErr(err)
 		},
 	}
@@ -109,8 +125,64 @@ Create a schema with a specific ID and version in import mode:
 	cmd.Flags().StringVar(&refs, "references", "", "Comma-separated list of references (name:subject:version) or path to reference file")
 	cmd.Flags().IntVar(&id, "id", -1, "Optional schema ID to use when creating the schema in import mode")
 	cmd.Flags().IntVar(&schemaVersion, "schema-version", -1, "Optional schema version to use when creating the schema in import mode (requires --id)")
-	cmd.MarkFlagRequired("schema")
+	// This has to be a ArrayVar to allow both key=values AND JSON, as JSON
+	// contains "," and a StringSliceVar flag will use "," to separate values.
+	cmd.Flags().StringArrayVarP(&metadataProperties, "metadata-properties", "p", nil, "Schema metadata properties as key=value pairs or JSON (e.g., '{\"key\":\"value\"}')")
 
+	cmd.MarkFlagRequired("schema")
 	cmd.RegisterFlagCompletionFunc("type", validTypes())
 	return cmd
+}
+
+func parseMetadataProperties(metadataProperties []string) (map[string]string, error) {
+	if len(metadataProperties) == 0 {
+		return nil, nil
+	}
+	result := make(map[string]string)
+	for _, prop := range metadataProperties {
+		m, err := parseMetadataProperty(prop)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range m {
+			result[k] = v
+		}
+	}
+	return result, nil
+}
+
+func parseMetadataProperty(prop string) (map[string]string, error) {
+	trimmed := strings.TrimSpace(prop)
+	// If it looks like JSON, try JSON first
+	if strings.HasPrefix(trimmed, "{") && strings.HasSuffix(trimmed, "}") {
+		m := make(map[string]string)
+		jsonErr := json.Unmarshal([]byte(trimmed), &m)
+		if jsonErr == nil {
+			return m, nil
+		}
+		// JSON failed, try key=value
+		kv, kvErr := parseMetadataPropertyKV(trimmed)
+		if kvErr != nil {
+			return nil, fmt.Errorf("unable to parse %q as JSON (%v) or as key=value (%v)", prop, jsonErr, kvErr)
+		}
+		return kv, nil
+	}
+
+	return parseMetadataPropertyKV(trimmed)
+}
+
+func parseMetadataPropertyKV(prop string) (map[string]string, error) {
+	parts := strings.SplitN(prop, "=", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("expected key=value format, got %q", prop)
+	}
+	k := strings.TrimSpace(parts[0])
+	v := strings.TrimSpace(parts[1])
+	if k == "" {
+		return nil, fmt.Errorf("empty key in %q", prop)
+	}
+	if v == "" {
+		return nil, fmt.Errorf("empty value in %q", prop)
+	}
+	return map[string]string{k: v}, nil
 }

--- a/src/go/rpk/pkg/cli/registry/schema/create_test.go
+++ b/src/go/rpk/pkg/cli/registry/schema/create_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_parseMetadataProperties(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		input  []string
+		exp    map[string]string
+		expErr bool
+	}{
+		{name: "empty input", input: nil, exp: nil},
+		{name: "single key=value", input: []string{"key=value"}, exp: map[string]string{"key": "value"}},
+		{name: "multiple key=value", input: []string{"k1=v1", "k2=v2"}, exp: map[string]string{"k1": "v1", "k2": "v2"}},
+		{name: "key=value with spaces", input: []string{" key = value "}, exp: map[string]string{"key": "value"}},
+		{name: "value with equals", input: []string{"key=val=ue"}, exp: map[string]string{"key": "val=ue"}},
+		{name: "json object", input: []string{`{"k1":"v1","k2":"v2"}`}, exp: map[string]string{"k1": "v1", "k2": "v2"}},
+		{name: "json with spaces", input: []string{` {"k1":"v1"} `}, exp: map[string]string{"k1": "v1"}},
+		{name: "json with special chars in value", input: []string{`{"key":"a=b,c:d"}`}, exp: map[string]string{"key": "a=b,c:d"}},
+		{name: "mixed json and kv", input: []string{`{"k1":"v1"}`, "k2=v2"}, exp: map[string]string{"k1": "v1", "k2": "v2"}},
+		{name: "key starting with brace", input: []string{"{mykey=value"}, exp: map[string]string{"{mykey": "value"}},
+		{name: "braces with kv fallback", input: []string{"{a=b}"}, exp: map[string]string{"{a": "b}"}},
+		{name: "no delimiter fails", input: []string{"nodeli"}, expErr: true},
+		{name: "empty key fails", input: []string{"=value"}, expErr: true},
+		{name: "empty value fails", input: []string{"key="}, expErr: true},
+		{name: "invalid json falls back to kv and fails", input: []string{`{invalid}`}, expErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseMetadataProperties(tt.input)
+			if tt.expErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.exp, got)
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/registry/schema/get.go
+++ b/src/go/rpk/pkg/cli/registry/schema/get.go
@@ -26,12 +26,13 @@ import (
 
 func newGetCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var (
-		deleted     bool
-		printSchema bool
-		id          int
-		schemaFile  string
-		schemaType  string
-		sversion    string
+		deleted       bool
+		printSchema   bool
+		printMetadata bool
+		id            int
+		schemaFile    string
+		schemaType    string
+		sversion      string
 	)
 	cmd := &cobra.Command{
 		Use:   "get [SUBJECT]",
@@ -46,6 +47,8 @@ potential (mutually exclusive) ways:
 * By schema, checking if the schema has been created in the subject
 
 To print the schema, use the '--print-schema' flag.
+
+To print schema metadata properties, use the '--print-metadata' flag.
 `,
 		Args: cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -53,7 +56,7 @@ To print the schema, use the '--print-schema' flag.
 			if printSchema && f.Kind != "text" {
 				out.Die("--print-schema cannot be used along with --format %v", f.Kind)
 			}
-			if h, ok := f.Help([]subjectSchema{}); ok {
+			if h, ok := f.Help([]subjectSchemaMetadata{}); ok {
 				out.Exit(h)
 			}
 			p, err := p.LoadVirtualProfile(fs)
@@ -125,7 +128,7 @@ To print the schema, use the '--print-schema' flag.
 				printSchemaString(ss)
 				return
 			}
-			err = printSubjectSchemaTable(f, false, ss...)
+			err = printSubjectSchemaWithMetadata(f, false, printMetadata, ss...)
 			out.MaybeDieErr(err)
 		},
 	}
@@ -136,7 +139,9 @@ To print the schema, use the '--print-schema' flag.
 	cmd.Flags().StringVar(&schemaType, "type", "", fmt.Sprintf("Schema type of the file used to lookup (%v); overrides schema file extension", strings.Join(supportedTypes, ",")))
 	cmd.Flags().BoolVar(&deleted, "deleted", false, "If true, also return deleted schemas")
 	cmd.Flags().BoolVar(&printSchema, "print-schema", false, "Prints the schema in JSON format")
+	cmd.Flags().BoolVar(&printMetadata, "print-metadata", false, "Print the schema metadata properties")
 
+	cmd.MarkFlagsMutuallyExclusive("print-schema", "print-metadata")
 	cmd.RegisterFlagCompletionFunc("type", validTypes())
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/registry/schema/references.go
+++ b/src/go/rpk/pkg/cli/registry/schema/references.go
@@ -27,7 +27,7 @@ func newReferencesCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			f := p.Formatter
-			if h, ok := f.Help([]subjectSchema{}); ok {
+			if h, ok := f.Help([]subjectSchemaMetadata{}); ok {
 				out.Exit(h)
 			}
 			p, err := p.LoadVirtualProfile(fs)
@@ -48,7 +48,7 @@ func newReferencesCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			references, err := cl.SchemaReferences(ctx, subject, version)
 			out.MaybeDie(err, "unable to check for references of subject %q and version %q: %v", subject, sversion, err)
 
-			err = printSubjectSchemaTable(f, false, references...)
+			err = printSubjectSchemaWithMetadata(f, false, false, references...)
 			out.MaybeDieErr(err)
 		},
 	}

--- a/src/go/rpk/pkg/cli/registry/schema/schema.go
+++ b/src/go/rpk/pkg/cli/registry/schema/schema.go
@@ -42,21 +42,27 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	return cmd
 }
 
-type subjectSchema struct {
-	Subject string `json:"subject" yaml:"subject"`
-	Version int    `json:"version" yaml:"version"`
-	ID      int    `json:"id" yaml:"id"`
-	Type    string `json:"type" yaml:"type"`
+type subjectSchemaMetadata struct {
+	Subject            string            `json:"subject" yaml:"subject"`
+	Version            int               `json:"version" yaml:"version"`
+	ID                 int               `json:"id" yaml:"id"`
+	Type               string            `json:"type" yaml:"type"`
+	MetadataProperties map[string]string `json:"metadata_properties,omitempty" yaml:"metadata_properties,omitempty"`
 }
 
-func printSubjectSchemaTable(f config.OutFormatter, single bool, ss ...sr.SubjectSchema) error {
-	var rows []subjectSchema
+func printSubjectSchemaWithMetadata(f config.OutFormatter, single, printMetadata bool, ss ...sr.SubjectSchema) error {
+	var rows []subjectSchemaMetadata
 	for _, s := range ss {
-		rows = append(rows, subjectSchema{
-			Subject: s.Subject,
-			Version: s.Version,
-			ID:      s.ID,
-			Type:    s.Type.String(),
+		var props map[string]string
+		if s.SchemaMetadata != nil && len(s.SchemaMetadata.Properties) > 0 {
+			props = s.SchemaMetadata.Properties
+		}
+		rows = append(rows, subjectSchemaMetadata{
+			Subject:            s.Subject,
+			Version:            s.Version,
+			ID:                 s.ID,
+			Type:               s.Type.String(),
+			MetadataProperties: props,
 		})
 	}
 	// There are commands where a table for text format is fine, but a json
@@ -72,11 +78,40 @@ func printSubjectSchemaTable(f config.OutFormatter, single bool, ss ...sr.Subjec
 		fmt.Println(s)
 		return nil
 	}
-	tw := out.NewTable("subject", "version", "id", "type")
-	defer tw.Flush()
-	for _, r := range rows {
-		tw.PrintStructFields(r)
+
+	// Multiple rows only occur when querying by ID (without subject filter).
+	// Since changing metadata properties creates a new ID on the same schema,
+	// all rows here share the same metadata. We pick the first.
+	var props map[string]string
+	if len(rows) > 0 {
+		props = rows[0].MetadataProperties
 	}
+
+	secSchema := "schema"
+	secMetadata := "metadata properties"
+	sections := out.NewMaybeHeaderSections(
+		out.ConditionalSectionHeaders(map[string]bool{
+			secSchema:   true,
+			secMetadata: printMetadata,
+		})...,
+	)
+
+	sections.Add(secSchema, func() {
+		tw := out.NewTable("subject", "version", "id", "type")
+		defer tw.Flush()
+		for _, r := range rows {
+			tw.Print(r.Subject, r.Version, r.ID, r.Type)
+		}
+	})
+
+	sections.Add(secMetadata, func() {
+		tw := out.NewTable("key", "value")
+		defer tw.Flush()
+		for k, v := range props {
+			tw.Print(k, v)
+		}
+	})
+
 	return nil
 }
 


### PR DESCRIPTION
This change includes an update on creation, where
we added --metadata-properties, which allows users
to specify schema metadata properties when
creating a schema. It accepts either key=value
pairs or JSON format, and both can be mixed in the same command.

And it updates the other registry functions that
prints schemas (get and references) to display
the schema metadata properties as a new section
in text form (or a new field in json/yaml output).

### Examples

**Create**

_Using key=value_
```
$ rpk registry schema create test1 --schema /tmp/schema.avsc --metadata-properties foo=bar
SCHEMA
======
SUBJECT  VERSION  ID    TYPE
test1    1        7     AVRO

METADATA PROPERTIES
===================
KEY   VALUE
foo   bar
```

_Using JSON_
```
$ rpk registry schema create test1 --schema /tmp/schema.avro -p '{"owner":"redpanda","url":"https://redpanda.com"}'
SCHEMA
======
SUBJECT  VERSION  ID    TYPE
test1    2        14    AVRO

METADATA PROPERTIES
===================
KEY    VALUE
owner  redpanda
url    https://redpanda.com
```

**Get**
```
$ rpk registry schema get test --id 2
SUBJECT  VERSION  ID    TYPE
test     2        2     AVRO

$ rpk registry schema get test --id 2 --print-metadata
SCHEMA
======
SUBJECT  VERSION  ID    TYPE
test     2        2     AVRO

METADATA PROPERTIES
===================
KEY       VALUE
version  test=test

$ rpk registry schema get test --id 2 --print-metadata --format json
[{"subject":"test","version":2,"id":2,"type":"AVRO","metadata_properties":{"version":"test=test"}}]
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Features

* rpk now supports Schema Registry metadata properties.
