### PR TITLE
Refactor record_mutliplexer benchmark 

### DIFF
--- a/src/v/datalake/tests/record_multiplexer_bench.cc
+++ b/src/v/datalake/tests/record_multiplexer_bench.cc
@@ -350,11 +350,11 @@ share_batches(chunked_vector<model::record_batch>& batches) {
 }
 
 struct counting_consumer {
-    size_t total_bytes = 0;
+    size_t total_records = 0;
     datalake::record_multiplexer mux;
     ss::abort_source& as;
     ss::future<ss::stop_iteration> operator()(model::record_batch&& batch) {
-        total_bytes += batch.size_bytes();
+        total_records += batch.record_count();
         return mux.do_multiplex(std::move(batch), kafka::offset{}, as);
     }
     ss::future<counting_consumer> end_of_stream() {
@@ -439,7 +439,7 @@ public:
           std::move(consumer), model::no_timeout);
         perf_tests::stop_measuring_time();
 
-        co_return res.total_bytes;
+        co_return res.total_records;
     }
 
 private:

--- a/src/v/datalake/tests/record_multiplexer_bench.cc
+++ b/src/v/datalake/tests/record_multiplexer_bench.cc
@@ -374,6 +374,19 @@ struct counting_consumer {
     }
 };
 
+// Specifies how many batches should be in the test dataset.
+#ifdef NDEBUG
+static constexpr size_t batches = 1000;
+#else
+static constexpr size_t batches = 1;
+#endif
+// Specifies how many records should be in each batch of the test dataset.
+static constexpr size_t records_per_batch = 10;
+
+static constexpr size_t small_field_size_bytes = 8;
+static constexpr size_t large_field_size_bytes = 256;
+static constexpr size_t max_nesting_level = 40;
+
 } // namespace
 
 class record_multiplexer_bench_fixture
@@ -440,6 +453,93 @@ public:
         perf_tests::stop_measuring_time();
 
         co_return res.total_records;
+    }
+
+    ss::future<size_t> run_protobuf_linear_bench(
+      size_t num_fields,
+      size_t field_size,
+      model::compression compression = model::compression::none) {
+        co_await configure_bench(
+          ::testing::protobuf_generator_config{
+            .string_length_range{field_size, field_size}},
+          generate_linear_proto(num_fields),
+          batches,
+          records_per_batch,
+          compression);
+        co_return co_await run_bench();
+    }
+
+    ss::future<size_t> run_protobuf_nested_bench(
+      size_t num_levels,
+      size_t field_size,
+      model::compression compression = model::compression::none) {
+        co_await configure_bench(
+          ::testing::protobuf_generator_config{
+            .string_length_range{field_size, field_size},
+            .max_nesting_level = max_nesting_level},
+          generate_nested_proto(num_levels),
+          batches,
+          records_per_batch,
+          compression);
+        co_return co_await run_bench();
+    }
+
+    ss::future<size_t> run_avro_linear_bench(
+      size_t num_fields,
+      size_t field_size,
+      model::compression compression = model::compression::none) {
+        co_await configure_bench(
+          ::testing::avro_generator_config{
+            .string_length_range{field_size, field_size}},
+          generate_linear_avro(num_fields),
+          batches,
+          records_per_batch,
+          compression);
+        co_return co_await run_bench();
+    }
+
+    ss::future<size_t> run_avro_nested_bench(
+      size_t num_levels,
+      size_t field_size,
+      model::compression compression = model::compression::none) {
+        co_await configure_bench(
+          ::testing::avro_generator_config{
+            .string_length_range{field_size, field_size},
+            .max_nesting_level = max_nesting_level},
+          generate_nested_avro(num_levels),
+          batches,
+          records_per_batch,
+          compression);
+        co_return co_await run_bench();
+    }
+
+    ss::future<size_t> run_json_linear_bench(
+      size_t num_fields,
+      size_t field_size,
+      model::compression compression = model::compression::none) {
+        co_await configure_bench(
+          iceberg::conversion::json_schema::testing::generator_config{
+            .string_length_range{field_size, field_size}},
+          generate_linear_json(num_fields),
+          batches,
+          records_per_batch,
+          compression);
+        co_return co_await run_bench();
+    }
+
+    ss::future<size_t> run_json_nested_bench(
+      size_t num_levels,
+      size_t field_size,
+      model::compression compression = model::compression::none) {
+        co_await configure_bench(
+          iceberg::conversion::json_schema::testing::generator_config{
+            .string_length_range{field_size, field_size},
+            .max_nesting_level = max_nesting_level},
+          generate_nested_json(num_levels),
+          batches,
+          records_per_batch,
+          compression);
+        co_return co_await run_bench();
     }
 
 private:
@@ -605,365 +705,306 @@ private:
     }
 };
 
-namespace {
+PERF_TEST_CN(record_multiplexer_bench_fixture, protobuf_linear_1_field_small) {
+    co_return co_await run_protobuf_linear_bench(1, small_field_size_bytes);
+}
 
-// Specifies how many batches should be in the test dataset.
-#ifdef NDEBUG
-static constexpr size_t batches = 1000;
-#else
-static constexpr size_t batches = 1;
-#endif
-// Specifies how many records should be in each batch of the test dataset.
-static constexpr size_t records_per_batch = 10;
-
-} // namespace
-
-PERF_TEST_CN(
-  record_multiplexer_bench_fixture, protobuf_381_byte_message_linear_1_field) {
-    co_await configure_bench(
-      ::testing::protobuf_generator_config{.string_length_range{302, 302}},
-      generate_linear_proto(1),
-      batches,
-      records_per_batch);
-    co_return co_await run_bench();
+PERF_TEST_CN(record_multiplexer_bench_fixture, protobuf_linear_1_field_large) {
+    co_return co_await run_protobuf_linear_bench(1, large_field_size_bytes);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture,
-  protobuf_381_byte_message_linear_1_field_zstd) {
-    co_await configure_bench(
-      ::testing::protobuf_generator_config{.string_length_range{302, 302}},
-      generate_linear_proto(1),
-      batches,
-      records_per_batch,
-      model::compression::zstd);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, protobuf_linear_1_field_small_zstd) {
+    co_return co_await run_protobuf_linear_bench(
+      1, small_field_size_bytes, model::compression::zstd);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture,
-  protobuf_381_byte_message_linear_40_fields) {
-    co_await configure_bench(
-      ::testing::protobuf_generator_config{.string_length_range{5, 5}},
-      generate_linear_proto(40),
-      batches,
-      records_per_batch);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, protobuf_linear_1_field_large_zstd) {
+    co_return co_await run_protobuf_linear_bench(
+      1, large_field_size_bytes, model::compression::zstd);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture,
-  protobuf_381_byte_message_linear_40_fields_zstd) {
-    co_await configure_bench(
-      ::testing::protobuf_generator_config{.string_length_range{5, 5}},
-      generate_linear_proto(40),
-      batches,
-      records_per_batch,
-      model::compression::zstd);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, protobuf_linear_40_fields_small) {
+    co_return co_await run_protobuf_linear_bench(40, small_field_size_bytes);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture,
-  protobuf_381_byte_message_linear_80_fields) {
-    co_await configure_bench(
-      ::testing::protobuf_generator_config{.string_length_range{1, 1}},
-      generate_linear_proto(80),
-      batches,
-      records_per_batch);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, protobuf_linear_40_fields_large) {
+    co_return co_await run_protobuf_linear_bench(40, large_field_size_bytes);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture,
-  protobuf_381_byte_message_linear_80_fields_zstd) {
-    co_await configure_bench(
-      ::testing::protobuf_generator_config{.string_length_range{1, 1}},
-      generate_linear_proto(80),
-      batches,
-      records_per_batch,
-      model::compression::zstd);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, protobuf_linear_40_fields_small_zstd) {
+    co_return co_await run_protobuf_linear_bench(
+      40, small_field_size_bytes, model::compression::zstd);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture,
-  protobuf_384_byte_message_nested_24_levels) {
-    co_await configure_bench(
-      ::testing::protobuf_generator_config{
-        .string_length_range{7, 7}, .max_nesting_level = 40},
-      generate_nested_proto(24),
-      batches,
-      records_per_batch);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, protobuf_linear_40_fields_large_zstd) {
+    co_return co_await run_protobuf_linear_bench(
+      40, large_field_size_bytes, model::compression::zstd);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture,
-  protobuf_384_byte_message_nested_24_levels_zstd) {
-    co_await configure_bench(
-      ::testing::protobuf_generator_config{
-        .string_length_range{7, 7}, .max_nesting_level = 40},
-      generate_nested_proto(24),
-      batches,
-      records_per_batch,
-      model::compression::zstd);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, protobuf_linear_80_fields_small) {
+    co_return co_await run_protobuf_linear_bench(80, small_field_size_bytes);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture,
-  protobuf_386_byte_message_nested_31_levels) {
-    co_await configure_bench(
-      ::testing::protobuf_generator_config{
-        .string_length_range{4, 4}, .max_nesting_level = 40},
-      generate_nested_proto(31),
-      batches,
-      records_per_batch);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, protobuf_linear_80_fields_large) {
+    co_return co_await run_protobuf_linear_bench(80, large_field_size_bytes);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture,
-  protobuf_386_byte_message_nested_31_levels_zstd) {
-    co_await configure_bench(
-      ::testing::protobuf_generator_config{
-        .string_length_range{4, 4}, .max_nesting_level = 40},
-      generate_nested_proto(31),
-      batches,
-      records_per_batch,
-      model::compression::zstd);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, protobuf_linear_80_fields_small_zstd) {
+    co_return co_await run_protobuf_linear_bench(
+      80, small_field_size_bytes, model::compression::zstd);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture, avro_385_byte_message_linear_1_field) {
-    co_await configure_bench(
-      ::testing::avro_generator_config{.string_length_range{308, 308}},
-      generate_linear_avro(1),
-      batches,
-      records_per_batch);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, protobuf_linear_80_fields_large_zstd) {
+    co_return co_await run_protobuf_linear_bench(
+      80, large_field_size_bytes, model::compression::zstd);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture, avro_385_byte_message_linear_1_field_zstd) {
-    co_await configure_bench(
-      ::testing::avro_generator_config{.string_length_range{308, 308}},
-      generate_linear_avro(1),
-      batches,
-      records_per_batch,
-      model::compression::zstd);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, protobuf_nested_10_levels_small) {
+    co_return co_await run_protobuf_nested_bench(10, small_field_size_bytes);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture, avro_385_byte_message_linear_31_fields) {
-    co_await configure_bench(
-      ::testing::avro_generator_config{.string_length_range{9, 9}},
-      generate_linear_avro(31),
-      batches,
-      records_per_batch);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, protobuf_nested_10_levels_large) {
+    co_return co_await run_protobuf_nested_bench(10, large_field_size_bytes);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture,
-  avro_385_byte_message_linear_31_fields_zstd) {
-    co_await configure_bench(
-      ::testing::avro_generator_config{.string_length_range{9, 9}},
-      generate_linear_avro(31),
-      batches,
-      records_per_batch,
-      model::compression::zstd);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, protobuf_nested_10_levels_small_zstd) {
+    co_return co_await run_protobuf_nested_bench(
+      10, small_field_size_bytes, model::compression::zstd);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture, avro_385_byte_message_linear_62_fields) {
-    co_await configure_bench(
-      ::testing::avro_generator_config{.string_length_range{4, 4}},
-      generate_linear_avro(62),
-      batches,
-      records_per_batch);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, protobuf_nested_10_levels_large_zstd) {
+    co_return co_await run_protobuf_nested_bench(
+      10, large_field_size_bytes, model::compression::zstd);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture,
-  avro_385_byte_message_linear_62_fields_zstd) {
-    co_await configure_bench(
-      ::testing::avro_generator_config{.string_length_range{4, 4}},
-      generate_linear_avro(62),
-      batches,
-      records_per_batch,
-      model::compression::zstd);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, protobuf_nested_30_levels_small) {
+    co_return co_await run_protobuf_nested_bench(30, small_field_size_bytes);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture, avro_385_byte_message_nested_31_levels) {
-    co_await configure_bench(
-      ::testing::avro_generator_config{
-        .string_length_range{9, 9}, .max_nesting_level = 40},
-      generate_nested_avro(31),
-      batches,
-      records_per_batch);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, protobuf_nested_30_levels_large) {
+    co_return co_await run_protobuf_nested_bench(30, large_field_size_bytes);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture,
-  avro_385_byte_message_nested_31_levels_zstd) {
-    co_await configure_bench(
-      ::testing::avro_generator_config{
-        .string_length_range{9, 9}, .max_nesting_level = 40},
-      generate_nested_avro(31),
-      batches,
-      records_per_batch,
-      model::compression::zstd);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, protobuf_nested_30_levels_small_zstd) {
+    co_return co_await run_protobuf_nested_bench(
+      30, small_field_size_bytes, model::compression::zstd);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture, avro_385_byte_message_nested_62_levels) {
-    co_await configure_bench(
-      ::testing::avro_generator_config{
-        .string_length_range{4, 4}, .max_nesting_level = 40},
-      generate_nested_avro(62),
-      batches,
-      records_per_batch);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, protobuf_nested_30_levels_large_zstd) {
+    co_return co_await run_protobuf_nested_bench(
+      30, large_field_size_bytes, model::compression::zstd);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, avro_linear_1_field_small) {
+    co_return co_await run_avro_linear_bench(1, small_field_size_bytes);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, avro_linear_1_field_large) {
+    co_return co_await run_avro_linear_bench(1, large_field_size_bytes);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, avro_linear_1_field_small_zstd) {
+    co_return co_await run_avro_linear_bench(
+      1, small_field_size_bytes, model::compression::zstd);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, avro_linear_1_field_large_zstd) {
+    co_return co_await run_avro_linear_bench(
+      1, large_field_size_bytes, model::compression::zstd);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, avro_linear_40_fields_small) {
+    co_return co_await run_avro_linear_bench(40, small_field_size_bytes);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, avro_linear_40_fields_large) {
+    co_return co_await run_avro_linear_bench(40, large_field_size_bytes);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture,
-  avro_385_byte_message_nested_62_levels_zstd) {
-    co_await configure_bench(
-      ::testing::avro_generator_config{
-        .string_length_range{4, 4}, .max_nesting_level = 40},
-      generate_nested_avro(62),
-      batches,
-      records_per_batch,
-      model::compression::zstd);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, avro_linear_40_fields_small_zstd) {
+    co_return co_await run_avro_linear_bench(
+      40, small_field_size_bytes, model::compression::zstd);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture, json_320_byte_message_linear_1_field) {
-    co_await configure_bench(
-      iceberg::conversion::json_schema::testing::generator_config{
-        .string_length_range{302, 302}},
-      generate_linear_json(1),
-      batches,
-      records_per_batch);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, avro_linear_40_fields_large_zstd) {
+    co_return co_await run_avro_linear_bench(
+      40, large_field_size_bytes, model::compression::zstd);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, avro_linear_80_fields_small) {
+    co_return co_await run_avro_linear_bench(80, small_field_size_bytes);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, avro_linear_80_fields_large) {
+    co_return co_await run_avro_linear_bench(80, large_field_size_bytes);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture, json_320_byte_message_linear_1_field_zstd) {
-    co_await configure_bench(
-      iceberg::conversion::json_schema::testing::generator_config{
-        .string_length_range{302, 302}},
-      generate_linear_json(1),
-      batches,
-      records_per_batch,
-      model::compression::zstd);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, avro_linear_80_fields_small_zstd) {
+    co_return co_await run_avro_linear_bench(
+      80, small_field_size_bytes, model::compression::zstd);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture, json_716_byte_message_linear_40_fields) {
-    co_await configure_bench(
-      iceberg::conversion::json_schema::testing::generator_config{
-        .string_length_range{5, 5}},
-      generate_linear_json(40),
-      batches,
-      records_per_batch);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, avro_linear_80_fields_large_zstd) {
+    co_return co_await run_avro_linear_bench(
+      80, large_field_size_bytes, model::compression::zstd);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, avro_nested_10_levels_small) {
+    co_return co_await run_avro_nested_bench(10, small_field_size_bytes);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, avro_nested_10_levels_large) {
+    co_return co_await run_avro_nested_bench(10, large_field_size_bytes);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture,
-  json_716_byte_message_linear_40_fields_zstd) {
-    co_await configure_bench(
-      iceberg::conversion::json_schema::testing::generator_config{
-        .string_length_range{5, 5}},
-      generate_linear_json(40),
-      batches,
-      records_per_batch,
-      model::compression::zstd);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, avro_nested_10_levels_small_zstd) {
+    co_return co_await run_avro_nested_bench(
+      10, small_field_size_bytes, model::compression::zstd);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture, json_1116_byte_message_linear_80_fields) {
-    co_await configure_bench(
-      iceberg::conversion::json_schema::testing::generator_config{
-        .string_length_range{1, 1}},
-      generate_linear_json(80),
-      batches,
-      records_per_batch);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, avro_nested_10_levels_large_zstd) {
+    co_return co_await run_avro_nested_bench(
+      10, large_field_size_bytes, model::compression::zstd);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, avro_nested_30_levels_small) {
+    co_return co_await run_avro_nested_bench(30, small_field_size_bytes);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, avro_nested_30_levels_large) {
+    co_return co_await run_avro_nested_bench(30, large_field_size_bytes);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture,
-  json_1116_byte_message_linear_80_fields_zstd) {
-    co_await configure_bench(
-      iceberg::conversion::json_schema::testing::generator_config{
-        .string_length_range{1, 1}},
-      generate_linear_json(80),
-      batches,
-      records_per_batch,
-      model::compression::zstd);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, avro_nested_30_levels_small_zstd) {
+    co_return co_await run_avro_nested_bench(
+      30, small_field_size_bytes, model::compression::zstd);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture, json_719_byte_message_nested_24_levels) {
-    co_await configure_bench(
-      iceberg::conversion::json_schema::testing::generator_config{
-        .string_length_range{7, 7}, .max_nesting_level = 40},
-      generate_nested_json(24),
-      batches,
-      records_per_batch);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, avro_nested_30_levels_large_zstd) {
+    co_return co_await run_avro_nested_bench(
+      30, large_field_size_bytes, model::compression::zstd);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, json_linear_1_field_small) {
+    co_return co_await run_json_linear_bench(1, small_field_size_bytes);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, json_linear_1_field_large) {
+    co_return co_await run_json_linear_bench(1, large_field_size_bytes);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, json_linear_1_field_small_zstd) {
+    co_return co_await run_json_linear_bench(
+      1, small_field_size_bytes, model::compression::zstd);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, json_linear_1_field_large_zstd) {
+    co_return co_await run_json_linear_bench(
+      1, large_field_size_bytes, model::compression::zstd);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, json_linear_40_fields_small) {
+    co_return co_await run_json_linear_bench(40, small_field_size_bytes);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, json_linear_40_fields_large) {
+    co_return co_await run_json_linear_bench(40, large_field_size_bytes);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture,
-  json_719_byte_message_nested_24_levels_zstd) {
-    co_await configure_bench(
-      iceberg::conversion::json_schema::testing::generator_config{
-        .string_length_range{7, 7}, .max_nesting_level = 40},
-      generate_nested_json(24),
-      batches,
-      records_per_batch,
-      model::compression::zstd);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, json_linear_40_fields_small_zstd) {
+    co_return co_await run_json_linear_bench(
+      40, small_field_size_bytes, model::compression::zstd);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture, json_843_byte_message_nested_31_levels) {
-    co_await configure_bench(
-      iceberg::conversion::json_schema::testing::generator_config{
-        .string_length_range{4, 4}, .max_nesting_level = 40},
-      generate_nested_json(31),
-      batches,
-      records_per_batch);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, json_linear_40_fields_large_zstd) {
+    co_return co_await run_json_linear_bench(
+      40, large_field_size_bytes, model::compression::zstd);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, json_linear_80_fields_small) {
+    co_return co_await run_json_linear_bench(80, small_field_size_bytes);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, json_linear_80_fields_large) {
+    co_return co_await run_json_linear_bench(80, large_field_size_bytes);
 }
 
 PERF_TEST_CN(
-  record_multiplexer_bench_fixture,
-  json_843_byte_message_nested_31_levels_zstd) {
-    co_await configure_bench(
-      iceberg::conversion::json_schema::testing::generator_config{
-        .string_length_range{4, 4}, .max_nesting_level = 40},
-      generate_nested_json(31),
-      batches,
-      records_per_batch,
-      model::compression::zstd);
-    co_return co_await run_bench();
+  record_multiplexer_bench_fixture, json_linear_80_fields_small_zstd) {
+    co_return co_await run_json_linear_bench(
+      80, small_field_size_bytes, model::compression::zstd);
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture, json_linear_80_fields_large_zstd) {
+    co_return co_await run_json_linear_bench(
+      80, large_field_size_bytes, model::compression::zstd);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, json_nested_10_levels_small) {
+    co_return co_await run_json_nested_bench(10, small_field_size_bytes);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, json_nested_10_levels_large) {
+    co_return co_await run_json_nested_bench(10, large_field_size_bytes);
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture, json_nested_10_levels_small_zstd) {
+    co_return co_await run_json_nested_bench(
+      10, small_field_size_bytes, model::compression::zstd);
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture, json_nested_10_levels_large_zstd) {
+    co_return co_await run_json_nested_bench(
+      10, large_field_size_bytes, model::compression::zstd);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, json_nested_30_levels_small) {
+    co_return co_await run_json_nested_bench(30, small_field_size_bytes);
+}
+
+PERF_TEST_CN(record_multiplexer_bench_fixture, json_nested_30_levels_large) {
+    co_return co_await run_json_nested_bench(30, large_field_size_bytes);
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture, json_nested_30_levels_small_zstd) {
+    co_return co_await run_json_nested_bench(
+      30, small_field_size_bytes, model::compression::zstd);
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture, json_nested_30_levels_large_zstd) {
+    co_return co_await run_json_nested_bench(
+      30, large_field_size_bytes, model::compression::zstd);
 }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR changes the record multiplexer benchmark to output translation time per record instead of per byte. It also ensures that field count and size test cases are the same across all formats. The overall goal is to increase readability of the results and make performance comparisons between serialization types easier.

The refactored microbenchmark cases have the following results:
| test                                                                  |     iters |           runtime |    allocs |     tasks |      inst |    cycles |
  | -                                                                     |        -: |                -: |        -: |        -: |        -: |        -: |
  | record_multiplexer_bench_fixture.protobuf_linear_1_field_small        |    160000 |    2.59µs ± 0.19% |    91.471 |     0.082 |  39497.24 |   13506.2 |
  | record_multiplexer_bench_fixture.protobuf_linear_1_field_large        |    130000 |    3.41µs ± 0.17% |    91.518 |     0.087 |  57136.42 |   17801.6 |
  | record_multiplexer_bench_fixture.protobuf_linear_1_field_small_zstd   |    150000 |    2.65µs ± 0.18% |    91.671 |     0.083 |  40130.29 |   13784.3 |
  | record_multiplexer_bench_fixture.protobuf_linear_1_field_large_zstd   |    110000 |    3.69µs ± 0.15% |    91.718 |     0.089 |  61333.10 |   19280.9 |
  | record_multiplexer_bench_fixture.protobuf_linear_40_fields_small      |     20000 |   16.01µs ± 0.18% |   235.044 |     0.254 | 268365.28 |   84589.1 |
  | record_multiplexer_bench_fixture.protobuf_linear_40_fields_large      |     10000 |   49.34µs ± 0.27% |   236.885 |     0.372 | 970307.71 |  260756.8 |
  | record_multiplexer_bench_fixture.protobuf_linear_40_fields_small_zstd |     20000 |   16.30µs ± 0.26% |   235.244 |     0.256 | 274544.54 |   86151.9 |
  | record_multiplexer_bench_fixture.protobuf_linear_40_fields_large_zstd |     10000 |   54.83µs ± 0.14% |   237.086 |     0.395 | 1074997.3 |  290187.9 |
  | record_multiplexer_bench_fixture.protobuf_linear_80_fields_small      |     10000 |   29.43µs ± 0.13% |   361.628 |     0.426 | 500106.09 |  155779.4 |
  | record_multiplexer_bench_fixture.protobuf_linear_80_fields_large      |     10000 |   95.09µs ± 0.14% |   372.768 |     0.686 | 1886247.2 |  502945.5 |
  | record_multiplexer_bench_fixture.protobuf_linear_80_fields_small_zstd |     10000 |   29.99µs ± 0.28% |   361.827 |     0.429 | 511029.45 |  158727.2 |
  | record_multiplexer_bench_fixture.protobuf_linear_80_fields_large_zstd |     10000 |  106.26µs ± 0.32% |   373.168 |     0.731 | 2097615.5 |  562458.1 |
  | record_multiplexer_bench_fixture.protobuf_nested_10_levels_small      |     30000 |    9.75µs ± 0.06% |   329.642 |     0.224 | 160974.52 |   51461.9 |
  | record_multiplexer_bench_fixture.protobuf_nested_10_levels_large      |     20000 |   18.19µs ± 0.08% |   330.101 |     0.253 | 334221.95 |   96128.3 |
  | record_multiplexer_bench_fixture.protobuf_nested_10_levels_small_zstd |     30000 |   10.01µs ± 0.24% |   329.842 |     0.226 | 165028.36 |   52832.4 |
  | record_multiplexer_bench_fixture.protobuf_nested_10_levels_large_zstd |     20000 |   19.55µs ± 0.13% |   330.300 |     0.263 | 363801.62 |  103359.3 |
  | record_multiplexer_bench_fixture.protobuf_nested_30_levels_small      |     10000 |   26.25µs ± 0.65% |   851.061 |     0.900 | 434437.60 |  138908.3 |
  | record_multiplexer_bench_fixture.protobuf_nested_30_levels_large      |     10000 |   50.84µs ± 0.10% |   852.441 |     0.933 | 956258.78 |  269168.5 |
  | record_multiplexer_bench_fixture.protobuf_nested_30_levels_small_zstd |     10000 |   26.62µs ± 0.10% |   851.260 |     0.894 | 442502.81 |  140999.1 |
  | record_multiplexer_bench_fixture.protobuf_nested_30_levels_large_zstd |     10000 |   55.53µs ± 0.15% |   852.640 |     0.954 | 1041359.0 |  294114.2 |
  | record_multiplexer_bench_fixture.avro_linear_1_field_small            |    230000 |    2.66µs ± 0.08% |    87.470 |     0.084 |  39675.92 |   13911.6 |
  | record_multiplexer_bench_fixture.avro_linear_1_field_large            |    180000 |    3.50µs ± 0.01% |    87.517 |     0.090 |  57351.43 |   18306.8 |
  | record_multiplexer_bench_fixture.avro_linear_1_field_small_zstd       |    220000 |    2.71µs ± 0.15% |    87.671 |     0.084 |  40306.97 |   14147.8 |
  | record_multiplexer_bench_fixture.avro_linear_1_field_large_zstd       |    150000 |    3.73µs ± 0.14% |    87.717 |     0.090 |  61429.63 |   19549.4 |
  | record_multiplexer_bench_fixture.avro_linear_40_fields_small          |     30000 |   17.50µs ± 0.09% |   342.045 |     0.284 | 305225.67 |   92515.2 |
  | record_multiplexer_bench_fixture.avro_linear_40_fields_large          |     20000 |   51.40µs ± 0.20% |   343.888 |     0.404 | 1005803.8 |  271688.5 |
  | record_multiplexer_bench_fixture.avro_linear_40_fields_small_zstd     |     30000 |   17.87µs ± 0.10% |   342.245 |     0.285 | 310459.36 |   94501.2 |
  | record_multiplexer_bench_fixture.avro_linear_40_fields_large_zstd     |     10000 |   56.74µs ± 0.17% |   344.086 |     0.420 | 1112421.0 |  300370.9 |
  | record_multiplexer_bench_fixture.avro_linear_80_fields_small          |     20000 |   33.07µs ± 0.14% |   587.627 |     0.489 | 575628.56 |  175128.7 |
  | record_multiplexer_bench_fixture.avro_linear_80_fields_large          |     10000 |   98.94µs ± 0.19% |   597.769 |     0.749 | 1961707.7 |  522586.9 |
  | record_multiplexer_bench_fixture.avro_linear_80_fields_small_zstd     |     20000 |   33.62µs ± 0.16% |   587.827 |     0.492 | 585296.15 |  177959.4 |
  | record_multiplexer_bench_fixture.avro_linear_80_fields_large_zstd     |     10000 |  110.02µs ± 0.50% |   598.169 |     0.805 | 2169754.5 |  582433.2 |
  | record_multiplexer_bench_fixture.avro_nested_10_levels_small          |     30000 |    9.55µs ± 0.25% |   324.644 |     0.244 | 156371.46 |   50415.3 |
  | record_multiplexer_bench_fixture.avro_nested_10_levels_large          |     20000 |   17.88µs ± 0.02% |   325.103 |     0.276 | 329522.78 |   94410.5 |
  | record_multiplexer_bench_fixture.avro_nested_10_levels_small_zstd     |     30000 |    9.73µs ± 0.16% |   324.844 |     0.241 | 159128.58 |   51346.4 |
  | record_multiplexer_bench_fixture.avro_nested_10_levels_large_zstd     |     20000 |   19.19µs ± 0.08% |   325.303 |     0.275 | 357787.73 |  101427.2 |
  | record_multiplexer_bench_fixture.avro_nested_30_levels_small          |     10000 |   24.37µs ± 0.36% |   806.061 |     0.929 | 408772.54 |  128936.8 |
  | record_multiplexer_bench_fixture.avro_nested_30_levels_large          |     10000 |   49.37µs ± 0.22% |   807.446 |     1.014 | 930526.92 |  261221.7 |
  | record_multiplexer_bench_fixture.avro_nested_30_levels_small_zstd     |     10000 |   24.82µs ± 0.04% |   806.261 |     0.964 | 413021.71 |  131317.5 |
  | record_multiplexer_bench_fixture.avro_nested_30_levels_large_zstd     |     10000 |   53.49µs ± 0.17% |   807.646 |     1.063 | 1010275.5 |  283115.6 |
  | record_multiplexer_bench_fixture.json_linear_1_field_small            |     50000 |    4.05µs ± 0.33% |   156.478 |     0.096 |  59550.42 |   21320.1 |
  | record_multiplexer_bench_fixture.json_linear_1_field_large            |     50000 |    5.15µs ± 0.35% |   156.532 |     0.108 |  83936.19 |   27099.6 |
  | record_multiplexer_bench_fixture.json_linear_1_field_small_zstd       |     50000 |    4.13µs ± 0.24% |   156.679 |     0.097 |  60187.69 |   21760.3 |
  | record_multiplexer_bench_fixture.json_linear_1_field_large_zstd       |     50000 |    5.41µs ± 0.00% |   156.732 |     0.109 |  88078.15 |   28484.1 |
  | record_multiplexer_bench_fixture.json_linear_40_fields_small          |     10000 |   37.94µs ± 0.11% |  1339.193 |     0.533 | 640438.89 |  201748.1 |
  | record_multiplexer_bench_fixture.json_linear_40_fields_large          |     10000 |   81.04µs ± 0.19% |  1341.318 |     0.928 | 1599906.7 |  429561.6 |
  | record_multiplexer_bench_fixture.json_linear_40_fields_small_zstd     |     10000 |   38.47µs ± 0.03% |  1339.396 |     0.553 | 650834.62 |  204556.4 |
  | record_multiplexer_bench_fixture.json_linear_40_fields_large_zstd     |     10000 |   86.91µs ± 0.21% |  1341.519 |     0.957 | 1711556.7 |  461066.8 |
  | record_multiplexer_bench_fixture.json_linear_80_fields_small          |     10000 |   74.23µs ± 0.14% |  2511.920 |     1.014 | 1249030.7 |  395153.5 |
  | record_multiplexer_bench_fixture.json_linear_80_fields_large          |     10000 |  159.27µs ± 0.12% |  2521.660 |     1.724 | 3146290.1 |  844870.8 |
  | record_multiplexer_bench_fixture.json_linear_80_fields_small_zstd     |     10000 |   75.41µs ± 0.22% |  2512.118 |     0.992 | 1265430.2 |  401310.8 |
  | record_multiplexer_bench_fixture.json_linear_80_fields_large_zstd     |     10000 |  172.45µs ± 0.07% |  2522.063 |     1.769 | 3384898.8 |  915028.7 |
  | record_multiplexer_bench_fixture.json_nested_10_levels_small          |     10000 |   19.47µs ± 0.16% |   843.698 |     0.480 | 320331.31 |  103489.2 |
  | record_multiplexer_bench_fixture.json_nested_10_levels_large          |     10000 |   30.31µs ± 0.13% |   844.224 |     0.660 | 559821.53 |  160748.6 |
  | record_multiplexer_bench_fixture.json_nested_10_levels_small_zstd     |     10000 |   19.63µs ± 0.12% |   843.897 |     0.470 | 325264.73 |  104295.4 |
  | record_multiplexer_bench_fixture.json_nested_10_levels_large_zstd     |     10000 |   31.64µs ± 0.06% |   844.424 |     0.666 | 590039.50 |  167797.8 |
  | record_multiplexer_bench_fixture.json_nested_30_levels_small          |     10000 |   55.39µs ± 0.32% |  2350.226 |     2.644 | 904447.14 |  294783.9 |
  | record_multiplexer_bench_fixture.json_nested_30_levels_large          |     10000 |   87.23µs ± 0.21% |  2351.825 |     3.630 | 1620075.3 |  463191.1 |
  | record_multiplexer_bench_fixture.json_nested_30_levels_small_zstd     |     10000 |   55.43µs ± 0.15% |  2350.426 |     2.587 | 914269.60 |  294995.3 |
  | record_multiplexer_bench_fixture.json_nested_30_levels_large_zstd     |     10000 |   92.41µs ± 0.19% |  2352.025 |     3.655 | 1705089.3 |  490775.5 |

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none 
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
