### PR TITLE
configuration.cc: Fix autodecommission timeout setting name

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3279,7 +3279,7 @@ configuration::configuration()
       15min)
   , partition_autobalancing_node_autodecommission_timeout_sec(
       *this,
-      "partition_autobalancing_node_autodecommission_time",
+      "partition_autobalancing_node_autodecommission_timeout_sec",
       "When a node is unavailable for at least this timeout duration, it "
       "triggers Redpanda to decommission the node. This property "
       "applies only when `partition_autobalancing_mode` is set to "

--- a/tests/rptest/tests/auto_decommission_test.py
+++ b/tests/rptest/tests/auto_decommission_test.py
@@ -193,7 +193,7 @@ class AutoDecommissionTest(PreallocNodesTest):
             {
                 "partition_autobalancing_mode": "continuous",
                 "partition_autobalancing_node_availability_timeout_sec": partition_balancer_unavailable_timeout_s,
-                "partition_autobalancing_node_autodecommission_time": autodecommission_timeout_s,
+                "partition_autobalancing_node_autodecommission_timeout_sec": autodecommission_timeout_s,
                 "partition_autobalancing_tick_interval_ms": partition_balancer_tick_interval_ms,
             }
         )
@@ -267,7 +267,7 @@ class AutoDecommissionTest(PreallocNodesTest):
             {
                 "partition_autobalancing_mode": "continuous",
                 "partition_autobalancing_node_availability_timeout_sec": partition_balancer_unavailable_timeout_s,
-                "partition_autobalancing_node_autodecommission_time": autodecommission_timeout_s,
+                "partition_autobalancing_node_autodecommission_timeout_sec": autodecommission_timeout_s,
                 "partition_autobalancing_tick_interval_ms": partition_balancer_tick_interval_ms,
             }
         )


### PR DESCRIPTION
partition_autobalancing_node_autodecommission_time -> partition_autobalancing_node_autodecommission_timeout_sec

This was the intended name but the edit was missed in the string name of the variable. timeout_sec provides units and parity with the variable name.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required


<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
