### PR TITLE
ct/l1: put objects in a directory

### DIFF
--- a/src/v/cloud_topics/level_one/common/object_utils.cc
+++ b/src/v/cloud_topics/level_one/common/object_utils.cc
@@ -14,9 +14,12 @@
 
 namespace cloud_topics::l1 {
 
+constexpr auto level_one_data_dir_str = "level_one/data/";
+
 cloud_storage_clients::object_key
 object_path_factory::level_one_path(object_id id) {
-    return cloud_storage_clients::object_key(ssx::sformat("l1_v0_{}", id));
+    return cloud_storage_clients::object_key(
+      ssx::sformat("{}v0_{}", level_one_data_dir_str, id));
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/tests/object_utils_test.cc
+++ b/src/v/cloud_topics/level_one/common/tests/object_utils_test.cc
@@ -19,5 +19,6 @@ TEST(ObjectPathFactory, LevelOnePathFormat) {
     auto path = cloud_topics::l1::object_path_factory::level_one_path(
       cloud_topics::l1::create_object_id());
     EXPECT_THAT(
-      path().string(), ::testing::MatchesRegex("^l1_v0_" UUID_REGEX "$"));
+      path().string(),
+      ::testing::MatchesRegex("^level_one/data/v0_" UUID_REGEX "$"));
 }


### PR DESCRIPTION
Fixes: CORE-15313

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
