### PR TITLE
tests: Increase OMB timeout in datalake test

### DIFF
--- a/tests/rptest/perf/datalake_test.py
+++ b/tests/rptest/perf/datalake_test.py
@@ -154,6 +154,6 @@ class DatalakeTest(RedpandaTest):
                 local_payload_dir=payloads,
             )
             benchmark.start()
-            benchmark_time_min = benchmark.benchmark_time_mins() + 1
+            benchmark_time_min = benchmark.benchmark_time_mins() + 5
             benchmark.wait(timeout_sec=benchmark_time_min * 60)
             benchmark.check_succeed()


### PR DESCRIPTION
We are still seeing OMB stuck (slow?) in terminating.

Also seeing this locally sometimes where it's super slow to stop after printing the aggregated metrics (which is what seems to be happening here).

Bump the OMB timeout to what we use in all our other OMB tests.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


* none

