### PR TITLE
 [CORE-15425] security/oidc: Handle Azure AD group overage scenario    

### DIFF
--- a/src/v/security/oidc_authenticator.cc
+++ b/src/v/security/oidc_authenticator.cc
@@ -68,16 +68,16 @@ result<authentication_data> authenticate(
     }
 
     auto groups = group_policy_apply(group_policy, jwt);
-    if (groups.has_error()) {
-        return groups.assume_error();
+    if (!groups.has_value()) {
+        return groups.error();
     }
-    vlog(seclog.trace, "Groups found in claim: {}", groups.assume_value());
+    vlog(seclog.trace, "Groups found in claim: {}", groups.value());
 
     return {
       std::move(principal).assume_value(),
       ss::sstring{jwt.sub().value_or("")},
       exp,
-      std::move(groups).assume_value()};
+      std::move(groups).value()};
 }
 
 result<authentication_data> authenticate(

--- a/src/v/security/oidc_error.h
+++ b/src/v/security/oidc_error.h
@@ -35,6 +35,7 @@ enum class errc {
     kid_not_found,
     invalid_principal_mapping,
     invalid_group_claim_pointer,
+    group_claim_not_found
 };
 
 struct errc_category final : public std::error_category {
@@ -84,6 +85,8 @@ struct errc_category final : public std::error_category {
             return "invalid principal mapping rule";
         case errc::invalid_group_claim_pointer:
             return "invalid group claim pointer";
+        case errc::group_claim_not_found:
+            return "group claim not found";
         }
     }
 };

--- a/src/v/security/oidc_principal_mapping_applicator.cc
+++ b/src/v/security/oidc_principal_mapping_applicator.cc
@@ -10,7 +10,10 @@
 
 #include "security/oidc_principal_mapping_applicator.h"
 
+#include "container/chunked_vector.h"
+#include "security/acl.h"
 #include "security/logger.h"
+#include "security/oidc_error.h"
 #include "security/oidc_principal_mapping.h"
 
 #include <boost/algorithm/string.hpp>
@@ -19,7 +22,7 @@
 namespace security::oidc {
 
 namespace {
-std::optional<chunked_vector<std::string_view>>
+std::expected<chunked_vector<std::string_view>, errc>
 get_group_claim(const json::Pointer& p, const jwt& jwt) {
     if (auto list_claim = jwt.claim<chunked_vector<std::string_view>>(p);
         list_claim) {
@@ -42,7 +45,7 @@ get_group_claim(const json::Pointer& p, const jwt& jwt) {
         return string_claim_parsed;
     }
 
-    return std::nullopt;
+    return std::unexpected(errc::group_claim_not_found);
 }
 
 acl_principal
@@ -77,19 +80,21 @@ result<acl_principal> principal_mapping_rule_apply(
     return {principal_type::user, std::move(principal).value()};
 }
 
-result<chunked_vector<acl_principal>>
+std::expected<chunked_vector<acl_principal>, errc>
 group_policy_apply(const group_claim_policy& policy, const jwt& jwt) {
     auto group_claim = get_group_claim(policy.group_pointer(), jwt);
-    if (!group_claim) {
-        return chunked_vector<acl_principal>{};
+    if (group_claim) {
+        return chunked_vector<acl_principal>(
+          std::from_range,
+          std::views::transform(
+            *group_claim,
+            [behavior = policy.nested_behavior()](std::string_view g) {
+                return apply_nested_group_policy(g, behavior);
+            }));
     }
-    return chunked_vector<acl_principal>(
-      std::from_range,
-      std::views::transform(
-        *group_claim,
-        [behavior = policy.nested_behavior()](std::string_view g) {
-            return apply_nested_group_policy(g, behavior);
-        }));
+
+    // Will do error checking here
+    return chunked_vector<acl_principal>{};
 }
 
 } // namespace security::oidc

--- a/src/v/security/oidc_principal_mapping_applicator.cc
+++ b/src/v/security/oidc_principal_mapping_applicator.cc
@@ -93,8 +93,24 @@ group_policy_apply(const group_claim_policy& policy, const jwt& jwt) {
             }));
     }
 
-    // Will do error checking here
-    return chunked_vector<acl_principal>{};
+    if (group_claim.error() == errc::group_claim_not_found) {
+        if (auto claim_names_groups = jwt.claim<std::string_view>(
+              json::Pointer("/_claim_names/groups"));
+            claim_names_groups) {
+            vlog(
+              seclog.warn,
+              "Azure AD group overage detected: JWT contains "
+              "_claim_names.groups instead of actual groups (occurs when "
+              "user has >200 groups). Redpanda does not support fetching "
+              "groups from external endpoints. Configure Azure AD to limit "
+              "groups in the token or use security group filtering");
+        }
+
+        vlog(seclog.debug, "Treating missing group claim as empty groups");
+        return chunked_vector<acl_principal>{};
+    } else {
+        return std::unexpected(group_claim.error());
+    }
 }
 
 } // namespace security::oidc

--- a/src/v/security/oidc_principal_mapping_applicator.cc
+++ b/src/v/security/oidc_principal_mapping_applicator.cc
@@ -21,8 +21,8 @@ namespace security::oidc {
 namespace {
 std::optional<chunked_vector<std::string_view>>
 get_group_claim(const json::Pointer& p, const jwt& jwt) {
-    auto list_claim = jwt.claim<chunked_vector<std::string_view>>(p);
-    if (list_claim) {
+    if (auto list_claim = jwt.claim<chunked_vector<std::string_view>>(p);
+        list_claim) {
         vlog(
           seclog.trace,
           "Group claim found as string list: {}",
@@ -30,17 +30,19 @@ get_group_claim(const json::Pointer& p, const jwt& jwt) {
         return std::move(list_claim).value();
     }
 
-    auto string_claim = jwt.claim<std::string_view>(p);
-    if (!string_claim) {
-        return std::nullopt;
+    if (auto string_claim = jwt.claim<std::string_view>(p); string_claim) {
+        vlog(
+          seclog.trace,
+          "Group claim found as string: {}",
+          string_claim.value());
+
+        chunked_vector<std::string_view> string_claim_parsed;
+        boost::split(
+          string_claim_parsed, string_claim.value(), boost::is_any_of(","));
+        return string_claim_parsed;
     }
 
-    vlog(seclog.trace, "Group claim found as string: {}", string_claim.value());
-
-    chunked_vector<std::string_view> string_claim_parsed;
-    boost::split(
-      string_claim_parsed, string_claim.value(), boost::is_any_of(","));
-    return string_claim_parsed;
+    return std::nullopt;
 }
 
 acl_principal

--- a/src/v/security/oidc_principal_mapping_applicator.cc
+++ b/src/v/security/oidc_principal_mapping_applicator.cc
@@ -21,7 +21,7 @@
 
 namespace security::oidc {
 
-namespace {
+namespace detail {
 std::expected<chunked_vector<std::string_view>, errc>
 get_group_claim(const json::Pointer& p, const jwt& jwt) {
     if (auto list_claim = jwt.claim<chunked_vector<std::string_view>>(p);
@@ -63,7 +63,7 @@ apply_nested_group_policy(std::string_view user, nested_group_behavior b) {
     }
     }
 }
-} // namespace
+} // namespace detail
 
 result<acl_principal> principal_mapping_rule_apply(
   const principal_mapping_rule& mapping, const jwt& jwt) {
@@ -82,14 +82,14 @@ result<acl_principal> principal_mapping_rule_apply(
 
 std::expected<chunked_vector<acl_principal>, errc>
 group_policy_apply(const group_claim_policy& policy, const jwt& jwt) {
-    auto group_claim = get_group_claim(policy.group_pointer(), jwt);
+    auto group_claim = detail::get_group_claim(policy.group_pointer(), jwt);
     if (group_claim) {
         return chunked_vector<acl_principal>(
           std::from_range,
           std::views::transform(
             *group_claim,
             [behavior = policy.nested_behavior()](std::string_view g) {
-                return apply_nested_group_policy(g, behavior);
+                return detail::apply_nested_group_policy(g, behavior);
             }));
     }
 

--- a/src/v/security/oidc_principal_mapping_applicator.h
+++ b/src/v/security/oidc_principal_mapping_applicator.h
@@ -12,14 +12,17 @@
 #include "base/outcome.h"
 #include "security/acl.h"
 #include "security/jwt.h"
+#include "security/oidc_error.h"
 #include "security/oidc_principal_mapping.h"
+
+#include <expected>
 
 namespace security::oidc {
 
 result<acl_principal>
 principal_mapping_rule_apply(const principal_mapping_rule&, const jwt& jwt);
 
-result<chunked_vector<acl_principal>>
+std::expected<chunked_vector<acl_principal>, errc>
 group_policy_apply(const group_claim_policy&, const jwt& jwt);
 
 } // namespace security::oidc

--- a/src/v/security/oidc_principal_mapping_applicator.h
+++ b/src/v/security/oidc_principal_mapping_applicator.h
@@ -25,4 +25,14 @@ principal_mapping_rule_apply(const principal_mapping_rule&, const jwt& jwt);
 std::expected<chunked_vector<acl_principal>, errc>
 group_policy_apply(const group_claim_policy&, const jwt& jwt);
 
+namespace detail {
+
+std::expected<chunked_vector<std::string_view>, errc>
+get_group_claim(const json::Pointer& p, const jwt& jwt);
+
+acl_principal
+apply_nested_group_policy(std::string_view user, nested_group_behavior b);
+
+} // namespace detail
+
 } // namespace security::oidc

--- a/src/v/security/tests/oidc_principal_mapping_test.cc
+++ b/src/v/security/tests/oidc_principal_mapping_test.cc
@@ -316,3 +316,111 @@ BOOST_AUTO_TEST_CASE(test_get_group_claim_comma_with_spaces) {
     BOOST_CHECK_EQUAL(groups[1], " developers");
     BOOST_CHECK_EQUAL(groups[2], " users");
 }
+
+BOOST_AUTO_TEST_CASE(test_apply_nested_group_policy_none_simple) {
+    // Test: nested_group_behavior::none with simple group name
+    auto principal = security::oidc::detail::apply_nested_group_policy(
+      "admin", security::oidc::nested_group_behavior::none);
+
+    BOOST_CHECK_EQUAL(principal.type(), security::principal_type::group);
+    BOOST_CHECK_EQUAL(principal.name(), "admin");
+}
+
+BOOST_AUTO_TEST_CASE(test_apply_nested_group_policy_none_nested) {
+    // Test: nested_group_behavior::none with nested group name
+    auto principal = security::oidc::detail::apply_nested_group_policy(
+      "parent/child/admin", security::oidc::nested_group_behavior::none);
+
+    BOOST_CHECK_EQUAL(principal.type(), security::principal_type::group);
+    BOOST_CHECK_EQUAL(principal.name(), "parent/child/admin");
+}
+
+BOOST_AUTO_TEST_CASE(test_apply_nested_group_policy_none_empty) {
+    // Test: nested_group_behavior::none with empty string
+    auto principal = security::oidc::detail::apply_nested_group_policy(
+      "", security::oidc::nested_group_behavior::none);
+
+    BOOST_CHECK_EQUAL(principal.type(), security::principal_type::group);
+    BOOST_CHECK_EQUAL(principal.name(), "");
+}
+
+BOOST_AUTO_TEST_CASE(test_apply_nested_group_policy_none_trailing_slash) {
+    // Test: nested_group_behavior::none with trailing slash
+    auto principal = security::oidc::detail::apply_nested_group_policy(
+      "parent/child/", security::oidc::nested_group_behavior::none);
+
+    BOOST_CHECK_EQUAL(principal.type(), security::principal_type::group);
+    BOOST_CHECK_EQUAL(principal.name(), "parent/child/");
+}
+
+BOOST_AUTO_TEST_CASE(test_apply_nested_group_policy_none_leading_slash) {
+    // Test: nested_group_behavior::none with leading slash
+    auto principal = security::oidc::detail::apply_nested_group_policy(
+      "/admin", security::oidc::nested_group_behavior::none);
+
+    BOOST_CHECK_EQUAL(principal.type(), security::principal_type::group);
+    BOOST_CHECK_EQUAL(principal.name(), "/admin");
+}
+
+BOOST_AUTO_TEST_CASE(test_apply_nested_group_policy_suffix_simple) {
+    // Test: nested_group_behavior::suffix with simple group name (no slashes)
+    auto principal = security::oidc::detail::apply_nested_group_policy(
+      "admin", security::oidc::nested_group_behavior::suffix);
+
+    BOOST_CHECK_EQUAL(principal.type(), security::principal_type::group);
+    BOOST_CHECK_EQUAL(principal.name(), "admin");
+}
+
+BOOST_AUTO_TEST_CASE(test_apply_nested_group_policy_suffix_single_level) {
+    // Test: nested_group_behavior::suffix with single-level nested group
+    auto principal = security::oidc::detail::apply_nested_group_policy(
+      "parent/child", security::oidc::nested_group_behavior::suffix);
+
+    BOOST_CHECK_EQUAL(principal.type(), security::principal_type::group);
+    BOOST_CHECK_EQUAL(principal.name(), "child");
+}
+
+BOOST_AUTO_TEST_CASE(test_apply_nested_group_policy_suffix_multi_level) {
+    // Test: nested_group_behavior::suffix with multi-level nested group
+    auto principal = security::oidc::detail::apply_nested_group_policy(
+      "a/b/c/d", security::oidc::nested_group_behavior::suffix);
+
+    BOOST_CHECK_EQUAL(principal.type(), security::principal_type::group);
+    BOOST_CHECK_EQUAL(principal.name(), "d");
+}
+
+BOOST_AUTO_TEST_CASE(test_apply_nested_group_policy_suffix_trailing_slash) {
+    // Test: nested_group_behavior::suffix with trailing slash
+    auto principal = security::oidc::detail::apply_nested_group_policy(
+      "parent/child/", security::oidc::nested_group_behavior::suffix);
+
+    BOOST_CHECK_EQUAL(principal.type(), security::principal_type::group);
+    BOOST_CHECK_EQUAL(principal.name(), "");
+}
+
+BOOST_AUTO_TEST_CASE(test_apply_nested_group_policy_suffix_leading_slash) {
+    // Test: nested_group_behavior::suffix with leading slash
+    auto principal = security::oidc::detail::apply_nested_group_policy(
+      "/admin", security::oidc::nested_group_behavior::suffix);
+
+    BOOST_CHECK_EQUAL(principal.type(), security::principal_type::group);
+    BOOST_CHECK_EQUAL(principal.name(), "admin");
+}
+
+BOOST_AUTO_TEST_CASE(test_apply_nested_group_policy_suffix_only_slash) {
+    // Test: nested_group_behavior::suffix with only slash
+    auto principal = security::oidc::detail::apply_nested_group_policy(
+      "/", security::oidc::nested_group_behavior::suffix);
+
+    BOOST_CHECK_EQUAL(principal.type(), security::principal_type::group);
+    BOOST_CHECK_EQUAL(principal.name(), "");
+}
+
+BOOST_AUTO_TEST_CASE(test_apply_nested_group_policy_suffix_empty) {
+    // Test: nested_group_behavior::suffix with empty string
+    auto principal = security::oidc::detail::apply_nested_group_policy(
+      "", security::oidc::nested_group_behavior::suffix);
+
+    BOOST_CHECK_EQUAL(principal.type(), security::principal_type::group);
+    BOOST_CHECK_EQUAL(principal.name(), "");
+}

--- a/src/v/security/tests/oidc_principal_mapping_test.cc
+++ b/src/v/security/tests/oidc_principal_mapping_test.cc
@@ -123,3 +123,196 @@ BOOST_DATA_TEST_CASE(
     BOOST_REQUIRE(principal.has_value());
     BOOST_REQUIRE_EQUAL(principal.assume_value(), d.principal.assume_value());
 }
+
+namespace {
+result<security::oidc::jwt> make_test_jwt(std::string_view payload_json) {
+    json::Document header;
+    header.Parse(R"({"alg": "RS256", "typ": "JWT", "kid": "42"})");
+
+    json::Document payload;
+    payload.Parse(payload_json.data(), payload_json.length());
+
+    return security::oidc::jwt::make(std::move(header), std::move(payload));
+}
+} // namespace
+
+BOOST_AUTO_TEST_CASE(test_get_group_claim_string_array) {
+    // Test: Group claim as a string array
+    auto jwt = make_test_jwt(R"({
+        "iss": "http://example.com",
+        "sub": "user123",
+        "groups": ["admin", "developers", "users"]
+    })");
+    BOOST_REQUIRE(jwt.has_value());
+
+    json::Pointer group_pointer("/groups");
+    auto result = security::oidc::detail::get_group_claim(
+      group_pointer, jwt.assume_value());
+
+    BOOST_REQUIRE(result.has_value());
+    auto groups = std::move(result).value();
+    BOOST_REQUIRE_EQUAL(groups.size(), 3);
+    BOOST_CHECK_EQUAL(groups[0], "admin");
+    BOOST_CHECK_EQUAL(groups[1], "developers");
+    BOOST_CHECK_EQUAL(groups[2], "users");
+}
+
+BOOST_AUTO_TEST_CASE(test_get_group_claim_single_string) {
+    // Test: Group claim as a single string (no comma)
+    auto jwt = make_test_jwt(R"({
+        "iss": "http://example.com",
+        "sub": "user123",
+        "groups": "admin"
+    })");
+    BOOST_REQUIRE(jwt.has_value());
+
+    json::Pointer group_pointer("/groups");
+    auto result = security::oidc::detail::get_group_claim(
+      group_pointer, jwt.assume_value());
+
+    BOOST_REQUIRE(result.has_value());
+    auto groups = std::move(result).value();
+    BOOST_REQUIRE_EQUAL(groups.size(), 1);
+    BOOST_CHECK_EQUAL(groups[0], "admin");
+}
+
+BOOST_AUTO_TEST_CASE(test_get_group_claim_comma_separated_string) {
+    // Test: Group claim as comma-separated string
+    auto jwt = make_test_jwt(R"({
+        "iss": "http://example.com",
+        "sub": "user123",
+        "groups": "admin,developers,users"
+    })");
+    BOOST_REQUIRE(jwt.has_value());
+
+    json::Pointer group_pointer("/groups");
+    auto result = security::oidc::detail::get_group_claim(
+      group_pointer, jwt.assume_value());
+
+    BOOST_REQUIRE(result.has_value());
+    auto groups = std::move(result).value();
+    BOOST_REQUIRE_EQUAL(groups.size(), 3);
+    BOOST_CHECK_EQUAL(groups[0], "admin");
+    BOOST_CHECK_EQUAL(groups[1], "developers");
+    BOOST_CHECK_EQUAL(groups[2], "users");
+}
+
+BOOST_AUTO_TEST_CASE(test_get_group_claim_missing) {
+    // Test: Missing group claim
+    auto jwt = make_test_jwt(R"({
+        "iss": "http://example.com",
+        "sub": "user123"
+    })");
+    BOOST_REQUIRE(jwt.has_value());
+
+    json::Pointer group_pointer("/groups");
+    auto result = security::oidc::detail::get_group_claim(
+      group_pointer, jwt.assume_value());
+
+    BOOST_REQUIRE(!result.has_value());
+    BOOST_CHECK_EQUAL(
+      result.error(), security::oidc::errc::group_claim_not_found);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_group_claim_empty_array) {
+    // Test: Empty group array
+    auto jwt = make_test_jwt(R"({
+        "iss": "http://example.com",
+        "sub": "user123",
+        "groups": []
+    })");
+    BOOST_REQUIRE(jwt.has_value());
+
+    json::Pointer group_pointer("/groups");
+    auto result = security::oidc::detail::get_group_claim(
+      group_pointer, jwt.assume_value());
+
+    BOOST_REQUIRE(result.has_value());
+    auto groups = std::move(result).value();
+    BOOST_CHECK_EQUAL(groups.size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_group_claim_empty_string) {
+    // Test: Empty string (results in one empty element after split)
+    auto jwt = make_test_jwt(R"({
+        "iss": "http://example.com",
+        "sub": "user123",
+        "groups": ""
+    })");
+    BOOST_REQUIRE(jwt.has_value());
+
+    json::Pointer group_pointer("/groups");
+    auto result = security::oidc::detail::get_group_claim(
+      group_pointer, jwt.assume_value());
+
+    BOOST_REQUIRE(result.has_value());
+    auto groups = std::move(result).value();
+    // boost::split on empty string produces one empty element
+    BOOST_REQUIRE_EQUAL(groups.size(), 1);
+    BOOST_CHECK_EQUAL(groups[0], "");
+}
+
+BOOST_AUTO_TEST_CASE(test_get_group_claim_nested_path) {
+    // Test: Nested group claim path
+    auto jwt = make_test_jwt(R"({
+        "iss": "http://example.com",
+        "sub": "user123",
+        "resource_access": {
+            "redpanda": {
+                "roles": ["admin", "user"]
+            }
+        }
+    })");
+    BOOST_REQUIRE(jwt.has_value());
+
+    json::Pointer group_pointer("/resource_access/redpanda/roles");
+    auto result = security::oidc::detail::get_group_claim(
+      group_pointer, jwt.assume_value());
+
+    BOOST_REQUIRE(result.has_value());
+    auto groups = std::move(result).value();
+    BOOST_REQUIRE_EQUAL(groups.size(), 2);
+    BOOST_CHECK_EQUAL(groups[0], "admin");
+    BOOST_CHECK_EQUAL(groups[1], "user");
+}
+
+BOOST_AUTO_TEST_CASE(test_get_group_claim_invalid_type) {
+    // Test: Group claim with invalid type (number)
+    auto jwt = make_test_jwt(R"({
+        "iss": "http://example.com",
+        "sub": "user123",
+        "groups": 123
+    })");
+    BOOST_REQUIRE(jwt.has_value());
+
+    json::Pointer group_pointer("/groups");
+    auto result = security::oidc::detail::get_group_claim(
+      group_pointer, jwt.assume_value());
+
+    BOOST_REQUIRE(!result.has_value());
+    BOOST_CHECK_EQUAL(
+      result.error(), security::oidc::errc::group_claim_not_found);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_group_claim_comma_with_spaces) {
+    // Test: Comma-separated string with spaces around commas
+    auto jwt = make_test_jwt(R"({
+        "iss": "http://example.com",
+        "sub": "user123",
+        "groups": "admin, developers, users"
+    })");
+    BOOST_REQUIRE(jwt.has_value());
+
+    json::Pointer group_pointer("/groups");
+    auto result = security::oidc::detail::get_group_claim(
+      group_pointer, jwt.assume_value());
+
+    BOOST_REQUIRE(result.has_value());
+    auto groups = std::move(result).value();
+    BOOST_REQUIRE_EQUAL(groups.size(), 3);
+    // Note: boost::split includes the spaces
+    // TODO: Update this so that leading/trailing spaces are trimmed.
+    BOOST_CHECK_EQUAL(groups[0], "admin");
+    BOOST_CHECK_EQUAL(groups[1], " developers");
+    BOOST_CHECK_EQUAL(groups[2], " users");
+}


### PR DESCRIPTION
Azure AD has a limitation where users with more than 200 group memberships do not receive the groups claim directly in the JWT token. Instead, Azure AD provides `_claim_names.groups` and `_claim_sources` fields that reference an external Microsoft Graph API endpoint to fetch the full group list.

Redpanda does not support fetching groups from external endpoints during authentication. This PR detects the Azure AD group overage scenario and provides clear diagnostic guidance to administrators, suggesting they either:
- Configure Azure AD to limit groups included in the token
- Use security group filtering in Azure AD application settings

Additionally, this PR refactors the group claim handling to use `std::expected` for better error handling, adds a new `group_claim_not_found` error code, and includes comprehensive test coverage for the group claim parsing logic and nested group policy behavior.

[CORE-15425](https://redpandadata.atlassian.net/browse/CORE-15425)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

[CORE-15425]: https://redpandadata.atlassian.net/browse/CORE-15425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ