### PR TITLE
bazel: add fuzz config for libFuzzer coverage instrumentation

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -168,6 +168,20 @@ build:debug --config=debugger
 build:debug --copt=-O1
 
 # =================================
+# Fuzz
+# =================================
+# Fuzz configuration for running fuzz tests. It includes the coverage information
+# that libFuzzer needs to guide fuzzing. Fuzz tests still run without this, but
+# the state space will be poorly explored, you will see a message like:
+#
+# WARNING: no interesting inputs were found so far. Is the code instrumented for coverage?
+# This may also happen if the target rejected all inputs we tried so far
+#
+# https://llvm.org/docs/LibFuzzer.html
+build:fuzz --config=debug
+build:fuzz --copt=-fsanitize=fuzzer-no-link
+
+# =================================
 # ODR Finder
 # =================================
 build:odr-finder --cxxopt -stdlib=libc++


### PR DESCRIPTION
## Summary
- Add `--config=fuzz` to enable coverage instrumentation for fuzz tests
- Without this config, libFuzzer cannot effectively guide fuzzing and reports "no interesting inputs found"
- Uses `-fsanitize=fuzzer-no-link` to instrument compiled objects without requiring the fuzzer runtime for all targets

What I did to test this:

- Run fuzz test without config: `bazel test --config=san-asan-only //src/v/bytes/tests:iobuf_fuzz` - observe "no interesting inputs" warning
- Run with config: `bazel test --config=fuzz //src/v/bytes/tests:iobuf_fuzz` - observe corpus growing

I also made some random mutations to the iobuf impl and checked if `--config=debug` and `--config=fuzz` could find them. debug can still find a lot of bugs since most random changes aren't going to create a "deep" bug: it will be found pretty quickly without a long path to get there. However some changes were never found by debug, or it took a lot longer. 

One example, change [this line](https://github.com/redpanda-data/redpanda/blob/dev/src/v/bytes/iobuf.cc#L85) to `pos = 1`, debug doens't find it at all in 30 seconds*, but fuzz finds it in a couple of seconds. The more complex the system being tested, the more important coverage is. Stats for config=fuzz over 10 runs

```
Stats over 10 runs: max = 4.8s, min = 1.4s, avg = 2.1s, dev = 0.9s
```

* _one_ time it does find it in ~30s but other times it runs for > 200 seconds w/o finding it
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
