### PR TITLE
cluster/data_migration: Forbid mount/unmount for cloud topics

### DIFF
--- a/src/v/cluster/data_migration_backend.cc
+++ b/src/v/cluster/data_migration_backend.cc
@@ -1122,6 +1122,13 @@ ss::future<errc> backend::prepare_mount_topic(
           nt);
         co_return errc::topic_operation_error;
     }
+    // Cloud topics can't be unmounted now, but maybe someone will try to
+    // use this code to mount a cloud topic later code unmounts.
+    if (cfg->is_cloud_topic()) {
+        vlog(
+          dm_log.warn, "topic {} is a cloud topic and cannot be mounted", nt);
+        co_return errc::topic_invalid_config;
+    }
     vlog(
       dm_log.info,
       "trying to prepare mount topic, cfg={}, rev_id={}",

--- a/src/v/cluster/data_migration_table.cc
+++ b/src/v/cluster/data_migration_table.cc
@@ -294,6 +294,14 @@ migrations_table::validate_migrated_resources(
                  "topic with name {} does not exists in current cluster", t)}};
         }
 
+        if (maybe_topic_cfg->is_cloud_topic()) {
+            return {
+              {errc::data_migration_invalid_resources,
+               ssx::sformat(
+                 "topic with name {} is a cloud topic and cannot be unmounted",
+                 t)}};
+        }
+
         if (!model::is_archival_enabled(
               maybe_topic_cfg->properties.shadow_indexing.value_or(
                 model::shadow_indexing_mode::disabled))) {

--- a/src/v/cluster/tests/data_migration_table_test.cc
+++ b/src/v/cluster/tests/data_migration_table_test.cc
@@ -111,12 +111,18 @@ struct data_migration_table_fixture : public seastar_test {
     }
 
     ss::future<> populate_topic_table_with_topics(
-      const chunked_vector<model::topic_namespace>& to_create) {
+      const chunked_vector<model::topic_namespace>& to_create,
+      bool cloud_topic_enabled = false) {
         for (const auto& tp_ns : to_create) {
             auto p_cnt = random_generators::get_int(1, 64);
 
             topic_configuration cfg(tp_ns.ns, tp_ns.tp, p_cnt, 3);
-            cfg.properties.shadow_indexing = model::shadow_indexing_mode::full;
+            // Cloud topics don't use tiered storage, but regular topics need it
+            // enabled for unmount to work.
+            cfg.properties.shadow_indexing
+              = cloud_topic_enabled ? model::shadow_indexing_mode::disabled
+                                    : model::shadow_indexing_mode::full;
+            cfg.properties.cloud_topic_enabled = cloud_topic_enabled;
             ss::chunked_fifo<partition_assignment> assignments;
             for (auto i = 0; i < p_cnt; ++i) {
                 assignments.push_back(
@@ -539,5 +545,23 @@ TEST_F_CORO(data_migration_table_fixture, test_resource_validation) {
     validate_topic_resource_state({
       {"alias-of-topic-1",
        data_migrations::migrated_resource_state::metadata_locked},
+    });
+}
+
+TEST_F_CORO(data_migration_table_fixture, test_cloud_topic_unmount_rejected) {
+    auto cloud_topics = create_topic_vector({"cloud-topic-1"});
+    co_await populate_topic_table_with_topics(
+      cloud_topics, /*cloud_topic_enabled=*/true);
+
+    data_migrations::outbound_migration odm{
+      .topics = cloud_topics.copy(), .groups = {}};
+
+    auto r = co_await try_create_migration(odm.copy());
+    EXPECT_TRUE(r.has_error());
+    EXPECT_EQ(r.error(), cluster::errc::data_migration_invalid_resources);
+
+    validate_topic_resource_state({
+      {"cloud-topic-1",
+       data_migrations::migrated_resource_state::non_restricted},
     });
 }


### PR DESCRIPTION
We're not shipping mount and unmount support for cloud topics before the next release, so let's specifically ban it and provide better errors where we can.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

