### PR TITLE
[CORE-15194] schema_registry: add subject query param to GET /schemas/ids/{id} 

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -454,6 +454,13 @@
             "required": false,
             "type": "string",
             "description": "Redpanda version 25.2 or later. For Avro and Protobuf schemas only. Supported values: an empty string `''` returns the schema in its current format (default), and `serialized` (Protobuf only) returns the schema in its Base64-encoded wire binary format. Unsupported values return a 501 error."
+          },
+          {
+            "name": "subject",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Optional qualified subject to search for the schema under. Use <:.context:> for context-only lookup, or <:.context:subject> to also verify the schema is associated with that subject. Defaults to searching the default context if unspecified."
           }
         ],
         "produces": [

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -9,6 +9,7 @@
 
 #include "handlers.h"
 
+#include "base/vassert.h"
 #include "bytes/iobuf_parser.h"
 #include "cluster/controller.h"
 #include "cluster/security_frontend.h"
@@ -151,6 +152,153 @@ to_non_context_schema_ids(const chunked_vector<context_schema_id>& ids) {
            | std::ranges::views::transform(
              [](const context_schema_id& ctx_id) { return ctx_id.id; })
            | std::ranges::to<chunked_vector<schema_id>>();
+}
+
+struct schema_resolution_result {
+    context_schema_id ctx_id;
+    chunked_vector<context_subject> matched_subjects;
+
+    bool found() const { return !matched_subjects.empty(); }
+};
+
+/// Resolve a schema ID within a single context, optionally filtering by
+/// subject.
+ss::future<schema_resolution_result> resolve_schema_id_simple(
+  sharded_store& store, schema_id id, const context_subject& ctx_sub) {
+    vassert(
+      (ctx_sub.ctx != default_context) || (ctx_sub.sub().empty()),
+      "resolve_schema_id_simple should not be called with default context and "
+      "non-empty subject");
+
+    vlog(
+      srlog.debug,
+      "Resolving schema ID {} in context '{}'{}",
+      id,
+      ctx_sub.ctx,
+      ctx_sub.sub().empty()
+        ? ""
+        : ss::format(" (with subject '{}')", ctx_sub.sub()));
+
+    const context_schema_id ctx_id{ctx_sub.ctx, id};
+    auto schema_subjects = co_await store.get_schema_subjects(
+      ctx_id, include_deleted::yes);
+    // If a subject is provided, filter the schema_subjects to only that subject
+    // (if it exists)
+    if (!ctx_sub.sub().empty()) {
+        vlog(
+          srlog.debug,
+          "Filtering schema subjects for subject '{}'",
+          ctx_sub.sub());
+        schema_subjects = std::ranges::contains(schema_subjects, ctx_sub)
+                            ? decltype(schema_subjects){ctx_sub}
+                            : decltype(schema_subjects){};
+    }
+
+    schema_resolution_result result{
+      .ctx_id = ctx_id, .matched_subjects = std::move(schema_subjects)};
+
+    vlog(
+      srlog.debug,
+      "Schema ID {} was {} in context '{}'{}",
+      id,
+      result.found() ? "found" : "not found",
+      ctx_sub.ctx,
+      ctx_sub.sub().empty()
+        ? ""
+        : ss::format(" (with subject '{}')", ctx_sub.sub()));
+
+    co_return result;
+}
+
+/// Resolve a schema ID by searching across contexts and subjects. This function
+/// assumes that the subject is non-empty.
+/// The search order is:
+/// 1. Default context with provided subject
+/// 2. Other contexts with provided subject
+/// 3. Default context without subject restriction
+ss::future<schema_resolution_result> resolve_schema_id_extended(
+  sharded_store& store, schema_id id, const subject& subject) {
+    vassert(
+      !subject().empty(),
+      "resolve_schema_id_extended should only be called with non-empty "
+      "subject");
+
+    vlog(
+      srlog.debug,
+      "Performing an extended search to resolve schema ID {} with subject "
+      "'{}'.",
+      id,
+      subject());
+
+    // First, try default context with the provided subject
+    if (context_subject ctx_sub{default_context, subject};
+        co_await store.has_version(ctx_sub, id, include_deleted::yes)) {
+        vlog(
+          srlog.debug,
+          "Schema ID {} was found in default context with subject '{}'",
+          id,
+          subject());
+        co_return schema_resolution_result{
+          .ctx_id = context_schema_id{default_context, id},
+          .matched_subjects = {std::move(ctx_sub)}};
+    }
+
+    // Next, try other (non-default) contexts with the provided subject
+    auto contexts = co_await store.get_materialized_contexts();
+    for (const auto& ctx : contexts) {
+        if (ctx == default_context) {
+            continue;
+        }
+
+        if (context_subject ctx_sub{ctx, subject};
+            co_await store.has_version(ctx_sub, id, include_deleted::yes)) {
+            vlog(
+              srlog.debug,
+              "Schema ID {} was found in context '{}' with subject '{}'",
+              id,
+              ctx,
+              subject());
+            co_return schema_resolution_result{
+              .ctx_id = context_schema_id{ctx, id},
+              .matched_subjects = {std::move(ctx_sub)}};
+        }
+    }
+
+    // Finally, try default context without subject restriction
+    auto default_ctx_subjects = co_await store.get_schema_subjects(
+      {default_context, id}, include_deleted::yes);
+    if (!default_ctx_subjects.empty()) {
+        vlog(
+          srlog.debug,
+          "Schema ID {} was found in default context without subject "
+          "restriction",
+          id);
+        co_return schema_resolution_result{
+          .ctx_id = context_schema_id{default_context, id},
+          .matched_subjects = {std::move(default_ctx_subjects)}};
+    }
+
+    vlog(
+      srlog.debug,
+      "Schema ID {} was not found in any context with subject '{}' or in "
+      "default "
+      "context without subject restriction",
+      id,
+      subject());
+    co_return schema_resolution_result{
+      .ctx_id = context_schema_id{default_context, id}, .matched_subjects = {}};
+}
+
+/// Resolve a schema ID with the provided context and subject, performing
+/// an extended search if necessary.
+ss::future<schema_resolution_result> resolve_schema_id(
+  sharded_store& store, schema_id id, const context_subject& ctx_sub) {
+    auto perform_extended_search
+      = (ctx_sub.ctx == default_context && !ctx_sub.sub().empty());
+    co_return co_await (
+      perform_extended_search
+        ? resolve_schema_id_extended(store, id, ctx_sub.sub)
+        : resolve_schema_id_simple(store, id, ctx_sub));
 }
 
 } // namespace
@@ -486,20 +634,27 @@ ss::future<server::reply_t> get_schemas_ids_id(
     const auto format = parse_output_format(*rq.req);
 
     co_await rq.service().writer().read_sync();
-    auto subjects = co_await rq.service().schema_store().get_schema_subjects(
-      id, include_deleted::yes);
 
-    enterprise::handle_get_schemas_ids_id_authz(rq, auth_result, subjects);
+    // Parse optional subject query parameter to extract context
+    auto subject_param = parse::query_param<std::optional<ss::sstring>>(
+                           *rq.req, "subject")
+                           .value_or("");
 
-    // With deferred schema validation, there might be a schema that
-    // had invalid references. These might have already been posted, so
-    // we need to sync
-    co_await rq.service().writer().read_sync();
+    auto ctx_sub = context_subject::from_string(subject_param);
 
-    auto def = co_await get_or_load(rq, [&rq, id, format]() {
-        return rq.service().schema_store().get_schema_definition(id, format);
-    });
+    auto result = co_await resolve_schema_id(
+      rq.service().schema_store(), id, ctx_sub);
 
+    // Subject-based deferred authz (handles 403 vs 404)
+    enterprise::handle_get_schemas_ids_id_authz(
+      rq, auth_result, result.matched_subjects);
+
+    if (!result.found()) {
+        throw as_exception(not_found(id));
+    }
+
+    auto def = co_await rq.service().schema_store().get_schema_definition(
+      result.ctx_id, format);
     auto resp = ppj::rjson_serialize_iobuf(
       get_schemas_ids_id_response{.definition{std::move(def)}});
     log_response(*rq.req, resp);
@@ -576,7 +731,8 @@ ss::future<server::reply_t> get_subjects(
     auto res = co_await rq.service().schema_store().get_subjects(
       inc_del, subject_prefix);
 
-    // Handle AuthZ - Filters res for the subjects the user is allowed to see
+    // Handle AuthZ - Filters res for the subjects the user is allowed to
+    // see
     enterprise::handle_get_subjects_authz(rq, auth_result, res);
 
     // Convert context_subject to qualified string format for JSON response
@@ -627,7 +783,8 @@ post_subject(server::request_t rq, server::reply_t rp) {
     const auto format = parse_output_format(*rq.req);
     vlog(
       srlog.debug,
-      "post_subject subject='{}', normalize='{}', deleted='{}', format='{}'",
+      "post_subject subject='{}', normalize='{}', deleted='{}', "
+      "format='{}'",
       ctx_sub,
       norm,
       inc_del,
@@ -790,7 +947,8 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
                 throw exception(
                   error_code::schema_incompatible,
                   fmt::format(
-                    "Schema being registered is incompatible with an earlier "
+                    "Schema being registered is incompatible with an "
+                    "earlier "
                     "schema for subject \"{}\", details: [{}]",
                     ctx_sub,
                     fmt::join(compat.messages, ", ")));
@@ -990,7 +1148,8 @@ compatibility_subject_version(server::request_t rq, server::reply_t rp) {
     auto unparsed = co_await rjson_parse(
       *rq.req, post_subject_versions_request_handler<>{ctx_sub});
 
-    // Must read, in case we have the subject in cache with an outdated config
+    // Must read, in case we have the subject in cache with an outdated
+    // config
     co_await rq.service().writer().read_sync();
 
     vlog(

--- a/src/v/pandaproxy/schema_registry/test/context_subject.cc
+++ b/src/v/pandaproxy/schema_registry/test/context_subject.cc
@@ -45,13 +45,15 @@ TEST_F(ContextSubjectTest, FromString) {
       context_subject::from_string(":.ctx:a:b:c"),
       (context_subject{context{".ctx"}, subject{"a:b:c"}}));
 
-    // Invalid qualified syntax falls back to unqualified
+    // Invalid qualified syntax (no dot after colon) falls back to unqualified
     EXPECT_EQ(
       context_subject::from_string(":no-dot"),
       (context_subject{default_context, subject{":no-dot"}}));
+
+    // Context-only form without trailing colon: ":.ctx" (empty subject)
     EXPECT_EQ(
       context_subject::from_string(":.no-second-colon"),
-      (context_subject{default_context, subject{":.no-second-colon"}}));
+      (context_subject{context{".no-second-colon"}, subject{""}}));
 }
 
 TEST_F(ContextSubjectTest, ToStringAndRoundTrip) {
@@ -135,13 +137,11 @@ TEST_F(ContextSubjectReferenceTest, FromString) {
       (context_subject{default_context, subject{"subject-for-C"}}));
     EXPECT_TRUE(default_qual.qualified);
 
-    // Subject in the default context with dot prefix is unqualified
-    auto default_ctx_with_dot = context_subject_reference::from_string(
-      ":.something");
-    EXPECT_EQ(default_ctx_with_dot.qualified, is_qualified::no);
+    // Context-only form without second colon: :.something is qualified
+    auto ctx_only = context_subject_reference::from_string(":.something");
+    EXPECT_EQ(ctx_only.qualified, is_qualified::yes);
     EXPECT_EQ(
-      default_ctx_with_dot.sub,
-      (context_subject{default_context, subject{":.something"}}));
+      ctx_only.sub, (context_subject{context{".something"}, subject{""}}));
 }
 
 TEST_F(ContextSubjectReferenceTest, Resolve) {
@@ -165,7 +165,7 @@ TEST_F(ContextSubjectReferenceTest, ToStringRoundTrip) {
       "simple-subject",
       ":.:default-context-subject",
       ":.ctx:qualified-subject",
-      ":.default-context-with-dot",
+      ":.ctx-only:",
     };
     // Unqualified round-trip
     for (const auto& input : inputs) {

--- a/src/v/pandaproxy/schema_registry/types.cc
+++ b/src/v/pandaproxy/schema_registry/types.cc
@@ -96,14 +96,20 @@ std::pair<context_subject, is_qualified> parse_subject(std::string_view input) {
         // Find the second colon that separates context from subject
         auto second_colon = input.find(':', 2);
 
-        if (second_colon != std::string_view::npos) {
-            auto ctx_str = input.substr(1, second_colon - 1);
-            auto sub_str = input.substr(second_colon + 1);
-
+        if (second_colon == std::string_view::npos) {
+            // No second colon, so only context is provided
             return {
-              context_subject{context{ctx_str}, subject{sub_str}},
+              context_subject{context{input.substr(1)}, subject{}},
               is_qualified::yes};
         }
+
+        // Both context and subject are provided
+        auto ctx_str = input.substr(1, second_colon - 1);
+        auto sub_str = input.substr(second_colon + 1);
+
+        return {
+          context_subject{context{ctx_str}, subject{sub_str}},
+          is_qualified::yes};
     }
 
     // Default case: unqualified subject or invalid qualified syntax

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1000,10 +1000,17 @@ class SchemaRegistryRedpandaClient:
             "GET", "schemas/types", headers=headers, tls_enabled=tls_enabled, **kwargs
         )
 
-    def get_schemas_ids_id(self, id, format=None, headers=HTTP_GET_HEADERS, **kwargs):
-        format_arg = f"?format={format}" if format is not None else ""
+    def get_schemas_ids_id(
+        self, id, format=None, subject=None, headers=HTTP_GET_HEADERS, **kwargs
+    ):
+        params = []
+        if format is not None:
+            params.append(f"format={format}")
+        if subject is not None:
+            params.append(f"subject={subject}")
+        query_string = f"?{'&'.join(params)}" if params else ""
         return self.request(
-            "GET", f"schemas/ids/{id}{format_arg}", headers=headers, **kwargs
+            "GET", f"schemas/ids/{id}{query_string}", headers=headers, **kwargs
         )
 
     def get_schemas_ids_id_versions(self, id, headers=HTTP_GET_HEADERS, **kwargs):
@@ -5563,6 +5570,140 @@ class SchemaRegistryContextTest(SchemaRegistryEndpoints):
         # Try to delete a non-existent context (should fail with 404)
         result = self.sr_client.delete_context(".nonexistent")
         self.assert_equal(result.status_code, 404)
+
+    @cluster(num_nodes=1)
+    def test_get_schema_by_id_with_subject(self):
+        """Test GET /schemas/ids/{id} with subject query parameter for context lookup."""
+
+        # === SETUP ===
+        # Register in default context
+        result = self.sr_client.post_subjects_subject_versions(
+            subject="sub1", data=json.dumps({"schema": schema1_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        default_id1 = result.json()["id"]  # ID 1
+
+        # Register another schema in default context
+        result = self.sr_client.post_subjects_subject_versions(
+            subject="sub2", data=json.dumps({"schema": schema2_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Register in ctx1 context (same subject name, different context)
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=":.ctx1:sub1", data=json.dumps({"schema": schema1_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        ctx1_id1 = result.json()["id"]  # ID 1 in ctx1
+
+        # Register unique subject only in ctx1 (for cross-context search test)
+        # This subject name does NOT exist in default context
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=":.ctx1:unique-sub", data=json.dumps({"schema": schema3_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        ctx1_unique_id = result.json()["id"]  # ID 2 in ctx1
+
+        # Register a third schema in ctx1 to create an ID that doesn't exist in default
+        # (for testing "ID only exists in non-default context")
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=":.ctx1:ctx-only-sub",
+            data=json.dumps({"schema": simple_proto_def, "schemaType": "PROTOBUF"}),
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        ctx1_only_id = result.json()["id"]  # ID 3 in ctx1, no ID 3 in default
+
+        # === Test: Subject portion empty (sub().empty()) ===
+        self.logger.info("Testing: Subject portion empty")
+
+        # 1a. No subject param at all - uses default context
+        result = self.sr_client.get_schemas_ids_id(id=default_id1)
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["schema"], schema1_def)
+
+        # 1b. Context-only param ":.ctx1:" - uses ctx1, no subject restriction
+        result = self.sr_client.get_schemas_ids_id(id=ctx1_id1, subject=":.ctx1:")
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["schema"], schema1_def)
+
+        # 1c. Explicit default context-only ":.:" - uses default, no subject restriction
+        result = self.sr_client.get_schemas_ids_id(id=default_id1, subject=":.:")
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["schema"], schema1_def)
+
+        # === Test: Non-default context (qualified, no cross-context search) ===
+        self.logger.info("Testing: Non-default context")
+
+        # 2a. Non-default context - schema found
+        result = self.sr_client.get_schemas_ids_id(id=ctx1_id1, subject=":.ctx1:sub1")
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["schema"], schema1_def)
+
+        # 2b. Non-default context - wrong subject for ID (no fallback for non-default ctx)
+        result = self.sr_client.get_schemas_ids_id(
+            id=ctx1_id1, subject=":.ctx1:wrong-sub"
+        )
+        self.assert_equal(result.status_code, requests.codes.not_found)
+
+        # 2c. Non-default context - context doesn't exist
+        result = self.sr_client.get_schemas_ids_id(
+            id=default_id1, subject=":.nonexistent:sub1"
+        )
+        self.assert_equal(result.status_code, requests.codes.not_found)
+
+        # === Test: Default context (implicit or explicit), schema found ===
+        self.logger.info("Testing: Default context, schema found")
+
+        # 3a. Unqualified subject exists in default context
+        result = self.sr_client.get_schemas_ids_id(id=default_id1, subject="sub1")
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["schema"], schema1_def)
+
+        # 3b. Explicit default context (:.:) - same behavior as unqualified
+        result = self.sr_client.get_schemas_ids_id(id=default_id1, subject=":.:sub1")
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["schema"], schema1_def)
+
+        # === Test: Cross-context search ===
+        self.logger.info("Testing: Cross-context search")
+
+        # 4a. Unqualified subject "unique-sub" not in default, but exists in ctx1
+        # Should find it via cross-context search
+        result = self.sr_client.get_schemas_ids_id(
+            id=ctx1_unique_id, subject="unique-sub"
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["schema"], schema3_def)
+
+        # 4b. Explicit default context (:.:) also triggers cross-context search
+        result = self.sr_client.get_schemas_ids_id(
+            id=ctx1_unique_id, subject=":.:unique-sub"
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["schema"], schema3_def)
+
+        # === Test: Fallback without subject restriction ===
+        self.logger.info("Testing: Fallback without subject restriction")
+
+        # 5a. Subject "nonexistent-sub" doesn't exist anywhere, but ID exists in default
+        # Should fallback to returning schema without subject check
+        result = self.sr_client.get_schemas_ids_id(
+            id=default_id1, subject="nonexistent-sub"
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["schema"], schema1_def)
+
+        # === ERROR CASES ===
+        self.logger.info("Testing error cases")
+
+        # 6a. Schema ID doesn't exist at all
+        result = self.sr_client.get_schemas_ids_id(id=99999)
+        self.assert_equal(result.status_code, requests.codes.not_found)
+
+        # 6b. Schema ID exists only in ctx1, no subject param (looks in default only)
+        # ctx1_only_id (ID 3) only exists in ctx1, not in default context (which only has IDs 1-2)
+        result = self.sr_client.get_schemas_ids_id(id=ctx1_only_id)
+        self.assert_equal(result.status_code, requests.codes.not_found)
 
 
 class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -8720,44 +8720,12 @@ class GetStatusReady(ACLTestEndpoint):
         return {"name": "", "type": "registry"}
 
 
-class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
+class SchemaRegistryAclAuthzTestBase(SchemaRegistryEndpoints):
     """
-    Verify that schema registry endpoints are protected by the correct ACL resource and operation.
+    Base class providing shared ACL test infrastructure (setup, helpers) without test methods.
     """
 
-    ENDPOINTS = [
-        GetConfigEndpoint,
-        PutConfigEndpoint,
-        GetConfigSubjectEndpoint,
-        PutConfigSubjectEndpoint,
-        DeleteConfigSubject,
-        GetMode,
-        PutMode,
-        GetModeSubject,
-        PutModeSubject,
-        DeleteModeSubject,
-        PostSubjectVersions,
-        GetSchemasIdsIdVersions,
-        GetSchemasIdsIdSubjects,
-        GetSubjectVersions,
-        PostSubject,
-        GetSubjectVersionsVersion,
-        GetSubjectVersionsVersionSchema,
-        GetSubjectVersionsVersionReferencedBy,
-        DeleteSubject,
-        DeleteSubjectVersion,
-        CompatibilitySubjectVersion,
-        # Tested separately:
-        # GET_SCHEMAS_TYPES             - no ACLs required
-        # SCHEMA_REGISTRY_STATUS_READY  - no ACLs required
-        # GET_SCHEMAS_IDS_ID            - custom ACL handling
-        # GET_SUBJECTS                  - custom ACL handling
-        # GET_SECURITY_ACLS             - kafka cluster ACL required
-        # POST_SECURITY_ACLS            - kafka cluster ACL required
-        # DELETE_SECURITY_ACLS          - kafka cluster ACL required
-    ]
-
-    def __init__(self, context):
+    def __init__(self, context, extra_rp_conf: dict | None = None, **kwargs):
         security = SecurityConfig()
         security.enable_sasl = True
         security.endpoint_authn_method = "sasl"
@@ -8766,11 +8734,13 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
         schema_registry_config.authn_method = "http_basic"
         schema_registry_config.mode_mutability = True
 
-        super(SchemaRegistryAclAuthzTest, self).__init__(
+        super().__init__(
             context,
             security=security,
             num_brokers=1,
             schema_registry_config=schema_registry_config,
+            extra_rp_conf=extra_rp_conf,
+            **kwargs,
         )
 
         superuser = self.redpanda.SUPERUSER_CREDENTIALS
@@ -8857,6 +8827,44 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
         self.redpanda.set_cluster_config(
             {"schema_registry_enable_authorization": "True"}
         )
+
+
+class SchemaRegistryAclAuthzTest(SchemaRegistryAclAuthzTestBase):
+    """
+    Verify that schema registry endpoints are protected by the correct ACL resource and operation.
+    """
+
+    ENDPOINTS = [
+        GetConfigEndpoint,
+        PutConfigEndpoint,
+        GetConfigSubjectEndpoint,
+        PutConfigSubjectEndpoint,
+        DeleteConfigSubject,
+        GetMode,
+        PutMode,
+        GetModeSubject,
+        PutModeSubject,
+        DeleteModeSubject,
+        PostSubjectVersions,
+        GetSchemasIdsIdVersions,
+        GetSchemasIdsIdSubjects,
+        GetSubjectVersions,
+        PostSubject,
+        GetSubjectVersionsVersion,
+        GetSubjectVersionsVersionSchema,
+        GetSubjectVersionsVersionReferencedBy,
+        DeleteSubject,
+        DeleteSubjectVersion,
+        CompatibilitySubjectVersion,
+        # Tested separately:
+        # GET_SCHEMAS_TYPES             - no ACLs required
+        # SCHEMA_REGISTRY_STATUS_READY  - no ACLs required
+        # GET_SCHEMAS_IDS_ID            - custom ACL handling
+        # GET_SUBJECTS                  - custom ACL handling
+        # GET_SECURITY_ACLS             - kafka cluster ACL required
+        # POST_SECURITY_ACLS            - kafka cluster ACL required
+        # DELETE_SECURITY_ACLS          - kafka cluster ACL required
+    ]
 
     def _get_endpoint_by_name(self, name: str) -> ACLTestEndpoint:
         for endpoint in self.ENDPOINTS:

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -9305,3 +9305,201 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryAclAuthzTestBase):
             self.redpanda.set_cluster_config(
                 {"schema_registry_enable_authorization": True}
             )
+
+
+class SchemaRegistryContextAuthzTest(SchemaRegistryAclAuthzTestBase):
+    """
+    Authorization tests for context-qualified subject functionality.
+
+    These tests verify that Schema Registry correctly enforces ACL authorization
+    when using context-qualified subjects and the subject query parameter.
+    """
+
+    def __init__(self, context: TestContext, **kwargs: Any):
+        super().__init__(
+            context,
+            extra_rp_conf={"schema_registry_enable_qualified_subjects": True},
+            **kwargs,
+        )
+
+    def _setup_test_schemas(self):
+        """Create schemas used by all authorization tests."""
+        schema_data = json.dumps({"schema": schema1_def})
+        schema_data_2 = json.dumps({"schema": schema2_def})
+
+        # sub1 and sub2 in default context share the same schema
+        result = self.sr_client.post_subjects_subject_versions(
+            "sub1", data=schema_data, auth=self.super_auth
+        )
+        self.assert_equal(result.status_code, 200)
+        self.schema_id_default_ctx = result.json()["id"]
+
+        result = self.sr_client.post_subjects_subject_versions(
+            "sub2", data=schema_data, auth=self.super_auth
+        )
+        self.assert_equal(result.status_code, 200)
+        self.assert_equal(result.json()["id"], self.schema_id_default_ctx)
+
+        # :.ctx1:sub1 also has the same schema
+        result = self.sr_client.post_subjects_subject_versions(
+            ":.ctx1:sub1", data=schema_data, auth=self.super_auth
+        )
+        self.assert_equal(result.status_code, 200)
+        self.schema_id_ctx1 = result.json()["id"]
+
+        # :.ctx1:sub2 also has the same schema
+        result = self.sr_client.post_subjects_subject_versions(
+            ":.ctx1:sub2", data=schema_data, auth=self.super_auth
+        )
+        self.assert_equal(result.status_code, 200)
+        self.assert_equal(result.json()["id"], self.schema_id_ctx1)
+
+        # :.ctx1:unique-sub has a different schema (only exists in ctx1)
+        result = self.sr_client.post_subjects_subject_versions(
+            ":.ctx1:unique-sub", data=schema_data_2, auth=self.super_auth
+        )
+        self.assert_equal(result.status_code, 200)
+        self.unique_id_ctx1 = result.json()["id"]
+
+    def setUp(self):
+        super().setUp()
+        self._setup_test_schemas()
+
+    @cluster(num_nodes=1)
+    def test_subject_param_authorized_and_unauthorized(self):
+        """
+        GET /schemas/ids/{id}?subject=sub2 fails when user only has READ on sub1,
+        even though both subjects reference the same schema.
+        Authorization checks only the specified subject.
+        GET /schemas/ids/{id}?subject=sub1 succeeds when user has READ on sub1.
+        """
+        self._post_acl(self._create_acl("sub1", "SUBJECT", "LITERAL", "READ"))
+        result = self.sr_client.get_schemas_ids_id(
+            self.schema_id_default_ctx, subject="sub2", auth=self.user_auth
+        )
+        self.assert_equal(result.status_code, 403)
+
+        result = self.sr_client.get_schemas_ids_id(
+            self.schema_id_default_ctx, subject="sub1", auth=self.user_auth
+        )
+        self.assert_equal(result.status_code, 200)
+        self.assert_equal(result.json()["schema"], schema1_def)
+
+    @cluster(num_nodes=1)
+    def test_context_qualified_subject_with_matching_acl(self):
+        """
+        GET /schemas/ids/{id}?subject=:.ctx1:sub1 succeeds when user has READ
+        on the context-qualified subject :.ctx1:sub1.
+        """
+        self._post_acl(self._create_acl(":.ctx1:sub1", "SUBJECT", "LITERAL", "READ"))
+        result = self.sr_client.get_schemas_ids_id(
+            self.schema_id_ctx1, subject=":.ctx1:sub1", auth=self.user_auth
+        )
+        self.assert_equal(result.status_code, 200)
+        self.assert_equal(result.json()["schema"], schema1_def)
+
+    @cluster(num_nodes=1)
+    def test_context_qualified_subject_without_acl_on_that_context(self):
+        """
+        GET /schemas/ids/{id}?subject=:.ctx1:sub2 fails when user has READ on
+        sub1 (default context) but not on :.ctx1:sub2.
+        """
+        self._post_acl(self._create_acl("sub1", "SUBJECT", "LITERAL", "READ"))
+        result = self.sr_client.get_schemas_ids_id(
+            self.schema_id_ctx1, subject=":.ctx1:sub2", auth=self.user_auth
+        )
+        self.assert_equal(result.status_code, 403)
+
+    @cluster(num_nodes=1)
+    def test_cross_context_search_finds_subject_in_non_default_context(self):
+        """
+        GET /schemas/ids/{id}?subject=unique-sub succeeds when the subject only
+        exists in ctx1 as :.ctx1:unique-sub and user has READ on :.ctx1:unique-sub.
+        Cross-context search finds the subject in the non-default context.
+        """
+        self._post_acl(
+            self._create_acl(":.ctx1:unique-sub", "SUBJECT", "LITERAL", "READ")
+        )
+        result = self.sr_client.get_schemas_ids_id(
+            self.unique_id_ctx1, subject="unique-sub", auth=self.user_auth
+        )
+        self.assert_equal(result.status_code, 200)
+        self.assert_equal(result.json()["schema"], schema2_def)
+
+    @cluster(num_nodes=1)
+    def test_cross_context_search_no_auth_on_found_context(self):
+        """
+        GET /schemas/ids/{id}?subject=unique-sub fails when the subject is found
+        via cross-context search in ctx1 but user has DENY on :.ctx1:unique-sub.
+        """
+        self._post_acl(
+            self._create_acl(":.ctx1:unique-sub", "SUBJECT", "LITERAL", "READ", "DENY")
+        )
+        result = self.sr_client.get_schemas_ids_id(
+            self.unique_id_ctx1, subject="unique-sub", auth=self.user_auth
+        )
+        self.assert_equal(result.status_code, 403)
+
+    @cluster(num_nodes=1)
+    def test_context_only_param_with_auth_on_ctx_subject(self):
+        """
+        GET /schemas/ids/{id}?subject=:.ctx1: succeeds when user has READ on
+        at least one subject in ctx1 (:.ctx1:sub1).
+        Context-only param checks all subjects in that context.
+        """
+        self._post_acl(self._create_acl(":.ctx1:sub1", "SUBJECT", "LITERAL", "READ"))
+        result = self.sr_client.get_schemas_ids_id(
+            self.schema_id_ctx1, subject=":.ctx1:", auth=self.user_auth
+        )
+        self.assert_equal(result.status_code, 200)
+        self.assert_equal(result.json()["schema"], schema1_def)
+
+    @cluster(num_nodes=1)
+    def test_context_only_param_without_auth_on_any_ctx_subject(self):
+        """
+        GET /schemas/ids/{id}?subject=:.ctx1: fails when user has no READ
+        permission on any subject in ctx1.
+        """
+        # Only grant access to default context subject, not ctx1
+        self._post_acl(self._create_acl("sub1", "SUBJECT", "LITERAL", "READ"))
+        result = self.sr_client.get_schemas_ids_id(
+            self.schema_id_ctx1, subject=":.ctx1:", auth=self.user_auth
+        )
+        self.assert_equal(result.status_code, 403)
+
+    @cluster(num_nodes=1)
+    def test_prefix_acl_covers_context_qualified_subject(self):
+        """
+        GET /schemas/ids/{id}?subject=:.ctx1:sub1 succeeds when user has a
+        PREFIX ACL on :.ctx1: which covers all subjects in that context.
+        """
+        self._post_acl(self._create_acl(":.ctx1:", "SUBJECT", "PREFIXED", "READ"))
+        result = self.sr_client.get_schemas_ids_id(
+            self.schema_id_ctx1, subject=":.ctx1:sub1", auth=self.user_auth
+        )
+        self.assert_equal(result.status_code, 200)
+        self.assert_equal(result.json()["schema"], schema1_def)
+
+        result = self.sr_client.get_schemas_ids_id(
+            self.schema_id_ctx1, subject=":.ctx1:sub2", auth=self.user_auth
+        )
+        self.assert_equal(result.status_code, 200)
+        self.assert_equal(result.json()["schema"], schema1_def)
+
+        result = self.sr_client.get_schemas_ids_id(
+            self.unique_id_ctx1, subject=":.ctx1:unique-sub", auth=self.user_auth
+        )
+        self.assert_equal(result.status_code, 200)
+        self.assert_equal(result.json()["schema"], schema2_def)
+
+    @cluster(num_nodes=1)
+    def test_nonexistent_schema_id_returns_403_not_404(self):
+        """
+        GET /schemas/ids/{id}?subject=sub1 returns 403 (not 404) for non-existent
+        schema ID when user lacks authorization. This prevents information leakage
+        about whether a schema ID exists.
+        """
+        result = self.sr_client.get_schemas_ids_id(
+            99999, subject="sub1", auth=self.user_auth
+        )
+        self.assert_equal(result.status_code, 403)


### PR DESCRIPTION
Add an optional `subject` query parameter to the `GET /schemas/ids/{id}` endpoint. This allows specifying the context for schema lookup by extracting the context from the provided subject name (e.g., `:.myctx:mysubject`).

Fixes [CORE-15194](https://redpandadata.atlassian.net/browse/CORE-15194)
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-15194]: https://redpandadata.atlassian.net/browse/CORE-15194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ