### PR TITLE
tests/dt: deflake WriteCachingFailureInjectionE2ETest.test_crash_all

### DIFF
--- a/tests/rptest/tests/write_caching_fi_e2e_test.py
+++ b/tests/rptest/tests/write_caching_fi_e2e_test.py
@@ -76,13 +76,31 @@ class WriteCachingFailureInjectionE2ETest(RedpandaTest):
         if use_transactions:
             num_msg_per_round //= 10
 
+        def get_lost_offsets():
+            lost = consumer.consumer_status.validator.lost_offsets
+            if lost is None:
+                return 0
+            return lost.get("0", 0)
+
         total_produced = 0
         total_lost = 0
         prev_hwm = 0
+        prev_lost_offsets = 0
         for round_ix in range(0, num_restart_rounds + 1):
             if round_ix > 0:
                 self._crash_and_restart_cluster()
                 self._wait_for_leader()
+
+                # Wait for consumer to observe the lost offsets from crash/restart
+                if not use_transactions:
+                    wait_until(
+                        lambda: get_lost_offsets() > prev_lost_offsets,
+                        timeout_sec=60,
+                        backoff_sec=1,
+                        err_msg=f"Timed out waiting for lost offsets. Previous: {prev_lost_offsets}",
+                    )
+                    prev_lost_offsets = get_lost_offsets()
+
                 hwm = next(self.rpk.describe_topic(self.topic)).high_watermark
                 if use_transactions:
                     # Calculating lost messages based on the watermark when


### PR DESCRIPTION
The problem is that sometimes the consumer doesn’t realize there was
a data loss. Data might get produced before it notices that the offsets
rolled back.

Typical happy path is
```
loop:
  produce(1500)
  total_records_produced += 1500
  wait_for_consumption(total_records_produced)
  crash_restart_all_brokers()
```
In the flaky failures, the test doesn’t wait for the consumer to notice
that the offsets rolled back. It immediately produces another batch of
1500 messages. Consumer sees the epoch bump, assumes the offsets are
still valid, and tries to resume from offset 1500, but there’s no data
there, so it just hangs and the total consumed count never increases.

Fixes: https://redpandadata.atlassian.net/browse/CORE-13458

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
