### PR TITLE
cloud_storage_clients: make s3 url style optional

### DIFF
--- a/src/v/cloud_io/tests/s3_imposter.cc
+++ b/src/v/cloud_io/tests/s3_imposter.cc
@@ -551,7 +551,10 @@ s3_imposter_fixture::get_object(const ss::sstring& url) const {
 }
 
 ss::sstring s3_imposter_fixture::url_base() const {
-    switch (conf.url_style) {
+    if (!conf.url_style.has_value()) {
+        return fmt::format("");
+    }
+    switch (*conf.url_style) {
     case cloud_storage_clients::s3_url_style::virtual_host:
         return fmt::format("");
     case cloud_storage_clients::s3_url_style::path:

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -70,8 +70,9 @@ struct s3_configuration : common_configuration {
     std::optional<cloud_roles::public_key_str> access_key;
     /// AWS secret key, optional if configuration uses temporary credentials
     std::optional<cloud_roles::private_key_str> secret_key;
-    /// AWS URL style, either virtual-hosted-style or path-style.
-    s3_url_style url_style = s3_url_style::virtual_host;
+    /// AWS URL style, either virtual-hosted-style or path-style. Nullopt means
+    /// that the style needs to be determined with self-configuration.
+    std::optional<s3_url_style> url_style = std::nullopt;
     /// Whether the s3-compatible backend is GCS. Used in the client pool to
     /// select between s3_client and gcs_client at client creation time.
     bool is_gcs{false};

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -509,7 +509,7 @@ request_creator::make_gcs_batch_delete_request(
 }
 
 std::string request_creator::make_host(const plain_bucket_name& name) const {
-    switch (_ap_style) {
+    switch (_ap_style.value()) {
     case s3_url_style::virtual_host:
         // Host: bucket-name.s3.region-code.amazonaws.com
         return fmt::format("{}.{}", name(), _ap());
@@ -521,7 +521,7 @@ std::string request_creator::make_host(const plain_bucket_name& name) const {
 
 std::string request_creator::make_target(
   const plain_bucket_name& name, const object_key& key) const {
-    switch (_ap_style) {
+    switch (_ap_style.value()) {
     case s3_url_style::virtual_host:
         // Target: /homepage.html
         return fmt::format("/{}", key().string());
@@ -907,8 +907,6 @@ s3_client::s3_client(
 
 ss::future<result<client_self_configuration_output, error_outcome>>
 s3_client::self_configure() {
-    auto result = s3_self_configuration_result{
-      .url_style = s3_url_style::virtual_host};
     // Oracle cloud storage only supports path-style requests
     // (https://www.oracle.com/ca-en/cloud/storage/object-storage/faq/#category-amazon),
     // but self-configuration will misconfigure to virtual-host style due to a
@@ -926,8 +924,7 @@ s3_client::self_configure() {
     if (
       backend == model::cloud_storage_backend::oracle_s3_compat
       || backend == model::cloud_storage_backend::minio) {
-        result.url_style = s3_url_style::path;
-        co_return result;
+        co_return s3_self_configuration_result{.url_style = s3_url_style::path};
     }
 
     // Also handle possibly inferred backend.
@@ -935,8 +932,7 @@ s3_client::self_configure() {
     if (
       inferred_backend == model::cloud_storage_backend::oracle_s3_compat
       || inferred_backend == model::cloud_storage_backend::minio) {
-        result.url_style = s3_url_style::path;
-        co_return result;
+        co_return s3_self_configuration_result{.url_style = s3_url_style::path};
     }
 
     // Test virtual host style addressing, fall back to path if necessary.
@@ -948,10 +944,11 @@ s3_client::self_configure() {
     if (!bucket_config.value().has_value()) {
         vlog(
           s3_log.warn,
-          "Could not self-configure S3 Client, {} is not set. Defaulting to {}",
-          bucket_config.name(),
-          result.url_style);
-        co_return result;
+          "Could not self-configure S3 Client, {} is not set. Defaulting to "
+          "virtual_host",
+          bucket_config.name());
+        co_return s3_self_configuration_result{
+          .url_style = s3_url_style::virtual_host};
     }
 
     // TODO: Review this code. It is likely buggy when Remote Read Replicas are
@@ -963,12 +960,15 @@ s3_client::self_configure() {
 
     // Test virtual_host style.
     vassert(
-      _requestor._ap_style == s3_url_style::virtual_host,
-      "_ap_style should be virtual host by default before self configuration "
+      !_requestor._ap_style.has_value()
+        || _requestor._ap_style == s3_url_style::virtual_host,
+      "_ap_style should be unset or virtual host before self configuration "
       "begins");
+    _requestor._ap_style = s3_url_style::virtual_host;
     if (co_await self_configure_test(bucket)) {
-        // Virtual-host style request succeeded.
-        co_return result;
+        // Virtual host style request succeeded.
+        co_return s3_self_configuration_result{
+          .url_style = s3_url_style::virtual_host};
     }
 
     // fips mode can only work in virtual_host mode, so if the above test failed
@@ -980,10 +980,9 @@ s3_client::self_configure() {
 
     // Test path style.
     _requestor._ap_style = s3_url_style::path;
-    result.url_style = _requestor._ap_style;
     if (co_await self_configure_test(bucket)) {
         // Path style request succeeded.
-        co_return result;
+        co_return s3_self_configuration_result{.url_style = s3_url_style::path};
     }
 
     // Both addressing styles failed.

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -122,7 +122,7 @@ private:
 
     access_point_uri _ap;
 
-    s3_url_style _ap_style;
+    std::optional<s3_url_style> _ap_style;
     /// Applies credentials to http requests by adding headers and signing
     /// request payload. Shared pointer so that the credentials can be rotated
     /// through the client pool.

--- a/src/v/redpanda/tests/fixture.cc
+++ b/src/v/redpanda/tests/fixture.cc
@@ -395,7 +395,10 @@ void redpanda_thread_fixture::configure(
               .set_value(std::make_optional(s3_config->server_addr.host()));
             config.get("cloud_storage_url_style")
               .set_value(std::make_optional([&] {
-                  switch (s3_config->url_style) {
+                  if (!s3_config->url_style.has_value()) {
+                      return config::s3_url_style::virtual_host;
+                  }
+                  switch (*s3_config->url_style) {
                   case cloud_storage_clients::s3_url_style::virtual_host:
                       return config::s3_url_style::virtual_host;
                   case cloud_storage_clients::s3_url_style::path:


### PR DESCRIPTION
Allow url_style to be explicitly unset (std::nullopt) to indicate that self-configuration needs to determine the addressing style, rather than implicitly defaulting to virtual_host. This makes the self-configuration logic more explicit about whether the URL style has been configured.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
