### PR TITLE
lsm: fix incorrect file filtering on get()

### DIFF
--- a/src/v/lsm/db/tests/impl_test.cc
+++ b/src/v/lsm/db/tests/impl_test.cc
@@ -27,6 +27,7 @@ namespace {
 namespace io = lsm::io;
 using lsm::internal::file_handle;
 using lsm::internal::operator""_seqno;
+using lsm::internal::operator""_key;
 
 class proxy_data_persistence : public io::data_persistence {
 public:
@@ -487,6 +488,43 @@ TEST_F(ImplTest, ExplicitSnapshot) {
     EXPECT_TRUE(matches_shadow(shadow, snap->get()));
     EXPECT_FALSE(matches_shadow(shadow, nullptr));
     EXPECT_TRUE(matches_shadow());
+}
+
+// Regression test for a bug where we previously wouldn't filter on file bounds
+// properly, which would previously show up as missing rows in snapshot::get().
+TEST_F(ImplTest, GetFindsKeysWithDifferentSeqno) {
+    // Write row "aaa" at seqno 1 and flush it so it ends up in a file.
+    {
+        auto batch = ss::make_lw_shared<lsm::db::memtable>();
+        batch->put("aaa@1"_key, iobuf::from("value_for_aaa"));
+        _db->apply(std::move(batch)).get();
+    }
+    _db->flush().get();
+    ASSERT_EQ(max_persisted_seqno(), 1_seqno);
+
+    {
+        auto batch = ss::make_lw_shared<lsm::db::memtable>();
+        batch->put("zzz@2"_key, iobuf::from("value_for_zzz"));
+        _db->apply(std::move(batch)).get();
+    }
+    ASSERT_EQ(max_applied_seqno(), 2_seqno);
+
+    // Create snapshot with seqno 2.
+    auto snap_opt = _db->create_snapshot();
+    ASSERT_TRUE(snap_opt);
+    auto snap = std::move(*snap_opt);
+    ASSERT_EQ(snap->seqno(), 2_seqno);
+
+    // Sanity check that iteration finds "aaa".
+    auto iter = _db->create_iterator({.snapshot = snap.get()}).get();
+    iter->seek_to_first().get();
+    ASSERT_TRUE(iter->valid());
+    EXPECT_EQ(iter->key(), "aaa@1"_key);
+
+    // Lookup the "aaa" at the snapshot's seqno, as is done in snapshot::get().
+    // This would previously skip the file containing "aaa" at seqno 1.
+    auto result = _db->get("aaa@2"_key).get();
+    EXPECT_FALSE(result.is_missing());
 }
 
 } // namespace

--- a/src/v/lsm/db/tests/version_set_test.cc
+++ b/src/v/lsm/db/tests/version_set_test.cc
@@ -22,6 +22,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
+
 namespace {
 
 using lsm::internal::operator""_level;
@@ -84,14 +86,26 @@ public:
         size_t file_size = builder.file_size();
         builder.close().get();
         auto edit = _version_set->new_edit();
+        auto min_seqno = std::ranges::min_element(
+                           spec.keys,
+                           std::less<>(),
+                           [](lsm::internal::key_view k) { return k.seqno(); })
+                           ->seqno();
+        auto max_seqno = std::ranges::max_element(
+                           spec.keys,
+                           std::less<>(),
+                           [](lsm::internal::key_view k) { return k.seqno(); })
+                           ->seqno();
         edit->add_file({
           .level = spec.level,
           .file_handle = {.id = spec.id},
           .file_size = file_size,
           .smallest = spec.keys.front(),
           .largest = spec.keys.back(),
+          .oldest_seqno = min_seqno,
+          .newest_seqno = max_seqno,
         });
-        edit->set_last_seqno(0_seqno);
+        edit->set_last_seqno(max_seqno);
         _version_set->log_and_apply(std::move(edit)).get();
     }
 
@@ -388,41 +402,72 @@ TEST_F(VersionSetTest, Get) {
       .id = 1_file_id,
       .level = 2_level,
       .keys = {
-        "b"_key,
-        "c"_key,
-        "d"_key,
-        "e"_key,
+        "b@1"_key,
+        "c@1"_key,
+        "d@1"_key,
+        "e@1"_key,
       },
     });
     add_sst({
       .id = 2_file_id,
       .level = 1_level,
       .keys = {
-        "a"_key,
-        "b"_key,
-        "c"_key,
-        "d"_key,
+        "a@2"_key,
+        "b@2"_key,
+        "c@2"_key,
+        "d@2"_key,
       },
     });
     add_sst({
       .id = 3_file_id,
       .level = 1_level,
       .keys = {
-        "w"_key,
-        "x"_key,
-        "y"_key,
-        "z"_key,
+        "w@2"_key,
+        "x@2"_key,
+        "y@2"_key,
+        "z@2"_key,
       },
     });
     auto& vset = version_set();
     lsm::db::version::get_stats stats;
-    auto result = vset.current()->get("a"_key, &stats).get();
-    EXPECT_THAT(result, IsLookupValue("a"_key, 1_level));
-    result = vset.current()->get("e"_key, &stats).get();
-    EXPECT_THAT(result, IsLookupValue("e"_key, 2_level));
-    result = vset.current()->get("b"_key, &stats).get();
-    EXPECT_THAT(result, IsLookupValue("b"_key, 1_level));
-    result = vset.current()->get("j"_key, &stats).get();
+    auto result = vset.current()->get("a@2"_key, &stats).get();
+    EXPECT_THAT(result, IsLookupValue("a@2"_key, 1_level));
+    result = vset.current()->get("e@1"_key, &stats).get();
+    EXPECT_THAT(result, IsLookupValue("e@1"_key, 2_level));
+    result = vset.current()->get("b@2"_key, &stats).get();
+    EXPECT_THAT(result, IsLookupValue("b@2"_key, 1_level));
+    result = vset.current()->get("j@1"_key, &stats).get();
+    EXPECT_THAT(result, IsMissing());
+}
+
+TEST_F(VersionSetTest, GetOverlappingUserKey) {
+    // Test a scenario with `get` where a level has the same user key split
+    // across multiple files. This is a rare but valid case.
+    add_sst({
+      .id = 2_file_id,
+      .level = 1_level,
+      .keys = {
+        "a@3"_key,
+        "a@2"_key,
+      },
+    });
+    add_sst({
+      .id = 3_file_id,
+      .level = 1_level,
+      .keys = {
+        "a@1"_key,
+        "b@2"_key,
+      },
+    });
+    auto& vset = version_set();
+    lsm::db::version::get_stats stats;
+    auto result = vset.current()->get("a@4"_key, &stats).get();
+    EXPECT_THAT(result, IsLookupValue("a@3"_key, 1_level));
+    result = vset.current()->get("a@1"_key, &stats).get();
+    EXPECT_THAT(result, IsLookupValue("a@1"_key, 1_level));
+    result = vset.current()->get("b@2"_key, &stats).get();
+    EXPECT_THAT(result, IsLookupValue("b@2"_key, 1_level));
+    result = vset.current()->get("j@1"_key, &stats).get();
     EXPECT_THAT(result, IsMissing());
 }
 

--- a/src/v/lsm/db/version_set.cc
+++ b/src/v/lsm/db/version_set.cc
@@ -427,11 +427,17 @@ ss::future<> version::for_each_overlapping(
   internal::key_view target,
   absl::FunctionRef<ss::future<ss::stop_iteration>(
     internal::level, ss::lw_shared_ptr<file_meta_data>)> fn) {
+    // NOTE: it is critical to use user keys to find overlapping files, since
+    // the internal keys include sequence numbers and result in incorrect file
+    // bound overlap checks.
+    auto user_key = target.user_key();
     // Search level-0 from newest to oldest
     chunked_vector<ss::lw_shared_ptr<file_meta_data>> tmp;
     tmp.reserve(_files[0_level].size());
     for (const auto& file : _files[0_level]) {
-        if (target >= file->smallest && target <= file->largest) {
+        if (
+          user_key >= file->smallest.user_key()
+          && user_key <= file->largest.user_key()) {
             tmp.push_back(file);
         }
     }
@@ -456,10 +462,13 @@ ss::future<> version::for_each_overlapping(
         if (files.empty()) {
             continue;
         }
+        // We binary search on the internal key not user key because
+        // if there is a key split across files we need to skip newer
+        // key versions.
         size_t index = find_file(files, target);
         if (index < files.size()) {
             const auto& file = files[index];
-            if (target < file->smallest) {
+            if (user_key < file->smallest.user_key()) {
                 // All of file is past any data for the key
             } else {
                 auto stop = co_await fn(level, file);


### PR DESCRIPTION
We would previously incorrectly filter files based on internal keys, rather than on user key. This meant that we could previously call get() at seqno 2 for a persisted row written at seqno 1 and end up returning that the row was missing.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
