### PR TITLE
CORE-15183 SR Context: Implement parent-context-based reference handling

### DIFF
--- a/src/v/datalake/tests/record_schema_resolver_test.cc
+++ b/src/v/datalake/tests/record_schema_resolver_test.cc
@@ -270,7 +270,8 @@ message NestedMessage {
                            schema_type::protobuf,
                            {schema_reference{
                              .name = "simple.proto",
-                             .sub = subject{"simple_schema"},
+                             .sub = context_subject_reference::unqualified(
+                               "simple_schema"),
                              .version = schema_version{0}}},
                            std::optional<schema_metadata>{}}})
                      .get();

--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -599,11 +599,12 @@ avro::ValidSchema compile_avro_schema(
 ss::future<collected_schema> collect_references(
   schema_getter& store, collected_schema collected, subject_schema sub_schema) {
     for (const auto& ref : sub_schema.def().refs()) {
+        auto resolved_sub = ref.sub.resolve(sub_schema.sub().ctx);
         auto avro_ref_name = avro::Name{ref.name};
         if (!collected.contains(avro_ref_name)) {
             try {
                 auto ss = co_await store.get_subject_schema(
-                  ref.sub, ref.version, include_deleted::yes);
+                  resolved_sub, ref.version, include_deleted::yes);
 
                 // Pass the collected schemas to avoid recompiling already
                 // compiled schemas and to detect redefinitions of the same
@@ -620,12 +621,12 @@ ss::future<collected_schema> collect_references(
                 collected.insert(
                   avro_ref_name,
                   std::move(compiled_schema),
-                  ref.sub,
+                  resolved_sub,
                   ref.version);
             } catch (const exception& e) {
                 if (failed_subject_schema_lookup(e.code())) {
-                    throw as_exception(
-                      no_reference_found_for(sub_schema, ref.sub, ref.version));
+                    throw as_exception(no_reference_found_for(
+                      sub_schema, resolved_sub, ref.version));
                 }
                 throw;
             }
@@ -636,7 +637,7 @@ ss::future<collected_schema> collect_references(
             // throwing an exception.
             auto existing_source = collected.get_source(avro_ref_name);
             if (existing_source
-                && (existing_source->first != ref.sub
+                && (existing_source->first != resolved_sub
                     || existing_source->second != ref.version)) {
                 vlog(
                   srlog.warn,
@@ -646,7 +647,7 @@ ss::future<collected_schema> collect_references(
                   "indicate different subjects defining schemas with the same "
                   "fully qualified name.",
                   avro_ref_name.fullname(),
-                  ref.sub,
+                  resolved_sub,
                   ref.version,
                   existing_source->first,
                   existing_source->second);

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -283,12 +283,13 @@ std::string_view as_string_view(const json::Value& v) {
 
 ss::future<> check_references(sharded_store& store, subject_schema schema) {
     for (const auto& ref : schema.def().refs()) {
-        co_await store.get_id(ref.sub, ref.version)
+        auto resolved_sub = ref.sub.resolve(schema.sub().ctx);
+        co_await store.get_id(resolved_sub, ref.version)
           .discard_result()
           .handle_exception_type([&](const exception& e) {
               if (failed_subject_schema_lookup(e.code())) {
                   throw as_exception(
-                    no_reference_found_for(schema, ref.sub, ref.version));
+                    no_reference_found_for(schema, resolved_sub, ref.version));
               }
               throw;
           });

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -445,15 +445,16 @@ ss::future<pb::FileDescriptorProto> build_file_with_refs(
         if (dp.FindFileByName(ref.name)) {
             continue;
         }
+        auto resolved_sub = ref.sub.resolve(schema.sub().ctx);
         try {
             auto dep_ss = co_await store.get_subject_schema(
-              ref.sub, ref.version, include_deleted::yes);
+              resolved_sub, ref.version, include_deleted::yes);
             co_await build_file_with_refs(
               dp, store, ref.name, std::move(dep_ss.schema), normalize::no);
         } catch (const exception& e) {
             if (failed_subject_schema_lookup(e.code())) {
                 throw as_exception(
-                  no_reference_found_for(schema, ref.sub, ref.version));
+                  no_reference_found_for(schema, resolved_sub, ref.version));
             }
             throw;
         }

--- a/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
+++ b/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
@@ -243,7 +243,8 @@ public:
             return true;
         }
         case state::reference_subject: {
-            _schema.refs.back().sub = context_subject::from_string(sv);
+            _schema.refs.back().sub = context_subject_reference::from_string(
+              sv);
             _state = state::reference;
             return true;
         }
@@ -318,7 +319,8 @@ public:
         case state::reference: {
             _state = state::references;
             const auto& reference{_schema.refs.back()};
-            return !reference.name.empty() && reference.sub != invalid_subject
+            return !reference.name.empty()
+                   && reference.sub.sub != invalid_subject
                    && reference.version != invalid_schema_version;
         }
         case state::metadata: {

--- a/src/v/pandaproxy/schema_registry/requests/test/get_subject_versions_version.cc
+++ b/src/v/pandaproxy/schema_registry/requests/test/get_subject_versions_version.cc
@@ -24,7 +24,7 @@ SEASTAR_THREAD_TEST_CASE(test_post_subject_versions_version_response) {
       R"({"type":"record","name":"test","fields":[{"type":"string","name":"field1"},{"type":"com.acme.Referenced","name":"int"}]})",
       pps::schema_type::avro,
       {{{"com.acme.Referenced"},
-        pps::subject{"childSubject"},
+        pps::context_subject_reference::unqualified("childSubject"),
         pps::schema_version{1}}},
       {}};
     const pps::subject sub{"imported-ref"};

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -246,10 +246,16 @@ ss::future<> sharded_store::process_marked_schemas() {
                         auto [sub, schema] = std::move(canonical).destructure();
                         store.upsert_schema(id, std::move(schema), false);
                     })
-                    .handle_exception([](const std::exception_ptr&) {
+                    .handle_exception([id](const std::exception_ptr& ep) {
                         // processing attempt failed on marked schema. This is
                         // not an issue of forward references. Ignore error and
                         // keep schema in the store as-is
+                        vlog(
+                          srlog.debug,
+                          "process_marked_schemas failed for ctx={} id={}: {}",
+                          id.ctx,
+                          id.id,
+                          ep);
                     });
               });
           });

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -236,7 +236,8 @@ ss::future<> sharded_store::process_marked_schemas() {
                       return ss::now();
                   }
                   return make_canonical_schema(
-                           {{}, std::move(schema).assume_value()},
+                           {context_subject{id.ctx, subject{}},
+                            std::move(schema).assume_value()},
                            normalize::no,
                            false)
                     .then([id, &store](auto canonical) {

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -548,7 +548,8 @@ public:
             return true;
         }
         case state::reference_subject: {
-            _schema.refs.back().sub = context_subject::from_string(sv);
+            _schema.refs.back().sub = context_subject_reference::from_string(
+              sv);
             _state = state::reference;
             return true;
         }
@@ -653,7 +654,7 @@ public:
         case state::reference: {
             _state = state::references;
             const auto& ref{_schema.refs.back()};
-            return !ref.name.empty() && ref.sub != invalid_subject
+            return !ref.name.empty() && ref.sub.sub != invalid_subject
                    && ref.version != invalid_schema_version;
         }
         case state::metadata: {

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -426,7 +426,9 @@ public:
         schema_id_set references;
         for (const auto& s : _schemas) {
             for (const auto& r : s.second.definition.refs()) {
-                if (r.sub == sub && (!ver.has_value() || r.version == *ver)) {
+                if (
+                  r.sub.resolve(s.first.ctx) == sub
+                  && (!ver.has_value() || r.version == *ver)) {
                     references.insert(s.first);
                 }
             }

--- a/src/v/pandaproxy/schema_registry/test/avro_schema_references.cc
+++ b/src/v/pandaproxy/schema_registry/test/avro_schema_references.cc
@@ -78,7 +78,9 @@ TEST_F(AvroSchemaReferencesTest, RegisterWithReferences) {
 })",
       schema_type::avro,
       {schema_reference{
-        .name = ref_name, .sub = ref_sub, .version = schema_version(1)}},
+        .name = ref_name,
+        .sub = {ref_sub, is_qualified::no},
+        .version = schema_version(1)}},
       {}};
 
     // Register the referenced schema (should not throw)
@@ -116,7 +118,7 @@ TEST_F(AvroSchemaReferencesTest, DiamondDependencies) {
         schema_type::avro,
         {schema_reference{
           .name = "com.example.Base",
-          .sub = subject("BaseSubject"),
+          .sub = context_subject_reference::unqualified("BaseSubject"),
           .version = schema_version(1)}},
         {}},
       schema_version{1});
@@ -130,7 +132,7 @@ TEST_F(AvroSchemaReferencesTest, DiamondDependencies) {
         schema_type::avro,
         {schema_reference{
           .name = "com.example.Base",
-          .sub = subject("BaseSubject"),
+          .sub = context_subject_reference::unqualified("BaseSubject"),
           .version = schema_version(1)}},
         {}},
       schema_version{1});
@@ -147,11 +149,11 @@ TEST_F(AvroSchemaReferencesTest, DiamondDependencies) {
         schema_type::avro,
         {schema_reference{
            .name = "com.example.Left",
-           .sub = subject("LeftSubject"),
+           .sub = context_subject_reference::unqualified("LeftSubject"),
            .version = schema_version(1)},
          schema_reference{
            .name = "com.example.Right",
-           .sub = subject("RightSubject"),
+           .sub = context_subject_reference::unqualified("RightSubject"),
            .version = schema_version(1)}},
         {}},
       schema_version{1});
@@ -181,7 +183,7 @@ TEST_F(AvroSchemaReferencesTest, TransitiveReferences) {
         schema_type::avro,
         {schema_reference{
           .name = "com.example.Country",
-          .sub = subject("CountrySubject"),
+          .sub = context_subject_reference::unqualified("CountrySubject"),
           .version = schema_version(1)}},
         {}},
       schema_version{1});
@@ -195,7 +197,7 @@ TEST_F(AvroSchemaReferencesTest, TransitiveReferences) {
         schema_type::avro,
         {schema_reference{
           .name = "com.example.Address",
-          .sub = subject("AddressSubject"),
+          .sub = context_subject_reference::unqualified("AddressSubject"),
           .version = schema_version(1)}},
         {}},
       schema_version{1});
@@ -220,7 +222,7 @@ TEST_F(AvroSchemaReferencesTest, PrimitiveTypeReference) {
         schema_type::avro,
         {schema_reference{
           .name = "com.example.CustomString",
-          .sub = subject("StringSubject"),
+          .sub = context_subject_reference::unqualified("StringSubject"),
           .version = schema_version(1)}},
         {}},
       schema_version{1});
@@ -282,7 +284,7 @@ TEST_F(AvroSchemaReferencesTest, SameNameDifferentSubjectsInIsolation) {
         schema_type::avro,
         {schema_reference{
           .name = "com.example.Shared",
-          .sub = subject("SubjectD"),
+          .sub = context_subject_reference::unqualified("SubjectD"),
           .version = schema_version(1)}},
         {}},
       schema_version{1});
@@ -296,7 +298,7 @@ TEST_F(AvroSchemaReferencesTest, SameNameDifferentSubjectsInIsolation) {
         schema_type::avro,
         {schema_reference{
           .name = "com.example.Shared",
-          .sub = subject("SubjectE"),
+          .sub = context_subject_reference::unqualified("SubjectE"),
           .version = schema_version(1)}},
         {}},
       schema_version{1});
@@ -314,11 +316,11 @@ TEST_F(AvroSchemaReferencesTest, SameNameDifferentSubjectsInIsolation) {
         schema_type::avro,
         {schema_reference{
            .name = "com.example.B",
-           .sub = subject("SubjectB"),
+           .sub = context_subject_reference::unqualified("SubjectB"),
            .version = schema_version(1)},
          schema_reference{
            .name = "com.example.C",
-           .sub = subject("SubjectC"),
+           .sub = context_subject_reference::unqualified("SubjectC"),
            .version = schema_version(1)}},
         {}},
       schema_version{1});

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -124,7 +124,9 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_missing_nested_reference_error_subject) {
       pps::schema_definition{
         R"(syntax = "proto3"; import "c.proto"; message B { C c = 1; })",
         pps::schema_type::protobuf,
-        {{"c.proto", pps::subject{"subject-for-C"}, pps::schema_version{1}}},
+        {{"c.proto",
+          pps::context_subject_reference::unqualified("subject-for-C"),
+          pps::schema_version{1}}},
         {}}};
 
     auto schema_a = pps::subject_schema{
@@ -132,7 +134,9 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_missing_nested_reference_error_subject) {
       pps::schema_definition{
         R"(syntax = "proto3"; import "b.proto"; message A { B b = 1; })",
         pps::schema_type::protobuf,
-        {{"b.proto", pps::subject{"subject-for-B"}, pps::schema_version{1}}},
+        {{"b.proto",
+          pps::context_subject_reference::unqualified("subject-for-B"),
+          pps::schema_version{1}}},
         {}}};
 
     store.insert(schema_b.share(), pps::schema_version{1});

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.h
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.h
@@ -44,7 +44,9 @@ message Test2 {
   Simple id =  1;
 })",
   pps::schema_type::protobuf,
-  {{"simple", pps::subject{"simple.proto"}, pps::schema_version{1}}},
+  {{"simple",
+    pps::context_subject_reference::unqualified("simple.proto"),
+    pps::schema_version{1}}},
   {}};
 
 const auto imported_again = pps::schema_definition{
@@ -57,7 +59,9 @@ message Test3 {
   Test2 id =  1;
 })",
   pps::schema_type::protobuf,
-  {{"imported", pps::subject{"imported.proto"}, pps::schema_version{1}}},
+  {{"imported",
+    pps::context_subject_reference::unqualified("imported.proto"),
+    pps::schema_version{1}}},
   {}};
 
 const auto imported_twice = pps::schema_definition{
@@ -71,8 +75,12 @@ message Test3 {
   Test2 id =  1;
 })",
   pps::schema_type::protobuf,
-  {{"simple", pps::subject{"simple.proto"}, pps::schema_version{1}},
-   {"imported", pps::subject{"imported.proto"}, pps::schema_version{1}}},
+  {{"simple",
+    pps::context_subject_reference::unqualified("simple.proto"),
+    pps::schema_version{1}},
+   {"imported",
+    pps::context_subject_reference::unqualified("imported.proto"),
+    pps::schema_version{1}}},
   {}};
 
 const auto nested = pps::schema_definition{

--- a/src/v/pandaproxy/schema_registry/test/context_subject.cc
+++ b/src/v/pandaproxy/schema_registry/test/context_subject.cc
@@ -108,4 +108,71 @@ TEST_F(ContextSubjectTest, FlagOffUnqualifiedUsesDefaultContext) {
     EXPECT_EQ(ctx_sub.sub(), "plain-topic");
 }
 
+class ContextSubjectReferenceTest : public ::testing::Test {
+protected:
+    void SetUp() override { enable_qualified_subjects::set_local(true); }
+    void TearDown() override { enable_qualified_subjects::reset_local(); }
+};
+
+TEST_F(ContextSubjectReferenceTest, FromString) {
+    // Unqualified subjects: qualified=false
+    auto unqual = context_subject_reference::from_string("subject-for-C");
+    EXPECT_EQ(
+      unqual.sub, (context_subject{default_context, subject{"subject-for-C"}}));
+    EXPECT_FALSE(unqual.qualified);
+
+    // Qualified subjects: qualified=true
+    auto qual = context_subject_reference::from_string(":.ctx:subject-for-C");
+    EXPECT_EQ(
+      qual.sub, (context_subject{context{".ctx"}, subject{"subject-for-C"}}));
+    EXPECT_TRUE(qual.qualified);
+
+    // Explicit default context is still qualified
+    auto default_qual = context_subject_reference::from_string(
+      ":.:subject-for-C");
+    EXPECT_EQ(
+      default_qual.sub,
+      (context_subject{default_context, subject{"subject-for-C"}}));
+    EXPECT_TRUE(default_qual.qualified);
+
+    // Subject in the default context with dot prefix is unqualified
+    auto default_ctx_with_dot = context_subject_reference::from_string(
+      ":.something");
+    EXPECT_EQ(default_ctx_with_dot.qualified, is_qualified::no);
+    EXPECT_EQ(
+      default_ctx_with_dot.sub,
+      (context_subject{default_context, subject{":.something"}}));
+}
+
+TEST_F(ContextSubjectReferenceTest, Resolve) {
+    auto parent_ctx = context{".parent"};
+
+    // Unqualified: inherits parent's context
+    auto unqual = context_subject_reference::from_string("subject-for-C");
+    EXPECT_EQ(
+      unqual.resolve(parent_ctx),
+      (context_subject{parent_ctx, subject{"subject-for-C"}}));
+
+    // Qualified: keeps its own context
+    auto qual = context_subject_reference::from_string(":.other:subject-for-C");
+    EXPECT_EQ(
+      qual.resolve(parent_ctx),
+      (context_subject{context{".other"}, subject{"subject-for-C"}}));
+}
+
+TEST_F(ContextSubjectReferenceTest, ToStringRoundTrip) {
+    auto inputs = {
+      "simple-subject",
+      ":.:default-context-subject",
+      ":.ctx:qualified-subject",
+      ":.default-context-with-dot",
+    };
+    // Unqualified round-trip
+    for (const auto& input : inputs) {
+        SCOPED_TRACE(input);
+        auto got = context_subject_reference::from_string(input).to_string();
+        EXPECT_EQ(got, input);
+    }
+}
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
+++ b/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
@@ -327,7 +327,7 @@ FIXTURE_TEST(schema_registry_post_avro_references, pandaproxy_test_fixture) {
 })",
         pps::schema_type::avro,
         {{"com.redpanda.company",
-          pps::subject{"company-value"},
+          pps::context_subject_reference::unqualified("company-value"),
           pps::schema_version{1}}},
         {}}}};
 

--- a/src/v/pandaproxy/schema_registry/test/protobuf_schema_references.cc
+++ b/src/v/pandaproxy/schema_registry/test/protobuf_schema_references.cc
@@ -72,7 +72,9 @@ message Test { Dep d = 1; })";
                         schema_definition{
                           test_schema,
                           schema_type::protobuf,
-                          {{"dep.proto", dep_ctx_a, schema_version{1}}},
+                          {{"dep.proto",
+                            {dep_ctx_a, is_qualified::yes},
+                            schema_version{1}}},
                           {}}})
                       .get();
 
@@ -84,7 +86,9 @@ message Test { Dep d = 1; })";
                         schema_definition{
                           test_schema,
                           schema_type::protobuf,
-                          {{"dep.proto", dep_ctx_b, schema_version{1}}},
+                          {{"dep.proto",
+                            {dep_ctx_b, is_qualified::yes},
+                            schema_version{1}}},
                           {}}})
                       .get();
 

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -56,7 +56,9 @@ const auto expected_schema_value = schema_value{
     schema_definition{
       R"({"type":"string"})",
       schema_type::avro,
-      {{{"name"}, subject{"subject"}, schema_version{1}}},
+      {{{"name"},
+        context_subject_reference::unqualified("subject"),
+        schema_version{1}}},
       {}}},
   .version{schema_version{1}},
   .id{schema_id{1}},
@@ -374,8 +376,9 @@ TEST_F(StorageTest, SerdeContextSubject) {
               R"({"type":"string"})",
               schema_type::avro,
               {{{"ref-name"},
-                context_subject{
-                  context{".ref-context"}, subject{"ref-subject"}},
+                {context_subject{
+                   context{".ref-context"}, subject{"ref-subject"}},
+                 is_qualified::yes},
                 schema_version{2}}},
               {}}},
           .version{schema_version{1}},

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -333,7 +333,7 @@ const auto referencer = pps::subject_schema{
     pps::schema_type::json,
     {pps::schema_reference{
       .name = "example.com/referenced.json",
-      .sub{referenced.sub()},
+      .sub = pps::context_subject_reference::unqualified("referenced"),
       .version = pps::schema_version{1}}},
     {}}};
 
@@ -344,7 +344,7 @@ const auto referencer_wrong_sub = pps::subject_schema{
     referencer.def().type(),
     {pps::schema_reference{
       .name = "example.com/referenced.json",
-      .sub{"wrong_sub"},
+      .sub = pps::context_subject_reference::unqualified("wrong_sub"),
       .version = pps::schema_version{1}}},
     {}}};
 

--- a/src/v/pandaproxy/schema_registry/types.cc
+++ b/src/v/pandaproxy/schema_registry/types.cc
@@ -83,10 +83,12 @@ fmt::iterator schema_metadata::format_to(fmt::iterator it) const {
     return fmt::format_to(it, "{{ properties: {{ {} }} }}", properties);
 }
 
-context_subject context_subject::from_string(std::string_view input) {
+namespace {
+std::pair<context_subject, is_qualified> parse_subject(std::string_view input) {
     // If qualified subject parsing is disabled, treat everything as literal
     if (!enable_qualified_subjects::get()) {
-        return context_subject{default_context, subject{input}};
+        return {
+          context_subject{default_context, subject{input}}, is_qualified::no};
     }
 
     // Check for qualified syntax: starts with ":."
@@ -98,12 +100,49 @@ context_subject context_subject::from_string(std::string_view input) {
             auto ctx_str = input.substr(1, second_colon - 1);
             auto sub_str = input.substr(second_colon + 1);
 
-            return context_subject{context{ctx_str}, subject{sub_str}};
+            return {
+              context_subject{context{ctx_str}, subject{sub_str}},
+              is_qualified::yes};
         }
     }
 
     // Default case: unqualified subject or invalid qualified syntax
-    return context_subject{default_context, subject{input}};
+    return {context_subject{default_context, subject{input}}, is_qualified::no};
+}
+} // namespace
+
+context_subject context_subject::from_string(std::string_view input) {
+    return parse_subject(input).first;
+}
+
+context_subject_reference
+context_subject_reference::from_string(std::string_view input) {
+    auto [sub, qualified] = parse_subject(input);
+    return context_subject_reference{
+      .sub = std::move(sub),
+      .qualified = qualified,
+    };
+}
+
+context_subject
+context_subject_reference::resolve(const context& parent_ctx) const {
+    if (qualified) {
+        // Qualified reference: use its own context
+        return sub;
+    }
+    // Unqualified reference: inherit parent's context
+    return context_subject{parent_ctx, sub.sub};
+}
+
+ss::sstring context_subject_reference::to_string() const {
+    return ssx::sformat("{}", *this);
+}
+
+fmt::iterator context_subject_reference::format_to(fmt::iterator it) const {
+    if (qualified) {
+        return fmt::format_to(it, ":{}:{}", sub.ctx, sub.sub);
+    }
+    return fmt::format_to(it, "{}", sub);
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -273,7 +273,7 @@ struct schema_reference {
     operator<(const schema_reference& lhs, const schema_reference& rhs);
 
     ss::sstring name;
-    context_subject sub{invalid_subject};
+    context_subject_reference sub{invalid_subject, is_qualified::no};
     schema_version version{invalid_schema_version};
 };
 

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -39,6 +39,7 @@ using default_to_global = ss::bool_class<struct default_to_global_tag>;
 using force = ss::bool_class<struct force_tag>;
 using normalize = ss::bool_class<struct normalize_tag>;
 using verbose = ss::bool_class<struct verbose_tag>;
+using is_qualified = ss::bool_class<struct is_qualified_tag>;
 
 template<typename E>
 std::enable_if_t<std::is_enum_v<E>, std::optional<E>>
@@ -208,6 +209,50 @@ struct context_subject {
 };
 
 inline const context_subject invalid_subject{default_context, subject{""}};
+
+/// A reference subject that may be qualified or unqualified.
+/// Unqualified references are resolved relative to a parent schema's context.
+struct context_subject_reference {
+    /// Parse from a string while detecting qualification status
+    static context_subject_reference from_string(std::string_view input);
+
+    /// Helper for testing to create a simple unqualified reference
+    static context_subject_reference unqualified(std::string_view input) {
+        return context_subject_reference{
+          context_subject{default_context, subject{ss::sstring(input)}},
+          is_qualified::no};
+    }
+
+    /// Resolve relative to a parent context.
+    /// - If qualified: returns sub as-is
+    /// - If unqualified: returns context_subject{parent_ctx, sub.sub}
+    context_subject resolve(const context& parent_ctx) const;
+
+    /// Serialize back to original form (qualified or unqualified)
+    ss::sstring to_string() const;
+
+    fmt::iterator format_to(fmt::iterator it) const;
+
+    friend bool operator==(
+      const context_subject_reference& lhs,
+      const context_subject_reference& rhs)
+      = default;
+
+    /// Comparison is done by string representation for compatibility with the
+    /// reference implementation where normalization sorts references by string.
+    friend auto operator<=>(
+      const context_subject_reference& lhs,
+      const context_subject_reference& rhs) {
+        return lhs.to_string() <=> rhs.to_string();
+    }
+
+    /// The subject as parsed
+    context_subject sub{invalid_subject};
+
+    /// True if the original string was qualified (e.g., ":.:subject" instead of
+    /// "subject")
+    is_qualified qualified{false};
+};
 
 ///\brief The version of the schema registered with a subject.
 ///

--- a/src/v/wasm/schema_registry_module.cc
+++ b/src/v/wasm/schema_registry_module.cc
@@ -82,7 +82,11 @@ read_encoded_schema_def(ffi::reader* r) {
         auto name = r->read_sized_string();
         auto sub = r->read_sized_string();
         auto v = int(r->read_varint());
-        refs.emplace_back(name, subject(sub), schema_version(v));
+        refs.emplace_back(
+          name,
+          pandaproxy::schema_registry::context_subject_reference::from_string(
+            sub),
+          schema_version(v));
     }
     return {std::move(def), *type, std::move(refs), {}};
 }

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -5434,6 +5434,90 @@ class SchemaRegistryContextTest(SchemaRegistryEndpoints):
             err_msg=f"Failed to find replay log: {replay_pattern}",
         )
 
+    @cluster(num_nodes=1)
+    def test_context_unqualified_references(self):
+        base_schema = schema_proto_def
+        dependent_schema = schema_proto_dependee_def
+
+        ctx = ".unqual-ref-ctx"
+
+        # 1. Register base schema in a non-default context
+        base_subject = f":{ctx}:base-subject"
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=base_subject,
+            data=json.dumps({"schema": base_schema, "schemaType": "PROTOBUF"}),
+        )
+        self.assert_equal(result.status_code, 200)
+
+        # 2. Register dependent schema in SAME context with UNQUALIFIED reference
+        # The reference "base-subject" should resolve to ":.unqual-ref-ctx:base-subject"
+        dependent_subject = f":{ctx}:dependent-subject"
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=dependent_subject,
+            data=json.dumps(
+                {
+                    "schema": dependent_schema,
+                    "schemaType": "PROTOBUF",
+                    "references": [
+                        {
+                            "name": "schema_proto.proto",
+                            "subject": "base-subject",  # UNQUALIFIED - should inherit context
+                            "version": 1,
+                        }
+                    ],
+                }
+            ),
+        )
+        self.assert_equal(result.status_code, 200)
+
+        # 3. Verify the referenced-by relationship exists
+        result = self.sr_client.get_subjects_subject_versions_version_referenced_by(
+            subject=base_subject, version=1
+        )
+        self.assert_equal(result.status_code, 200)
+        self.assert_equal(result.json(), [2])  # dependent_subject v1 has schema id 2
+
+        # 4. Test that unqualified references in DEFAULT context don't find
+        # schemas from other contexts
+        default_dependent_subject = "default-ctx-dependent"
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=default_dependent_subject,
+            data=json.dumps(
+                {
+                    "schema": dependent_schema,
+                    "schemaType": "PROTOBUF",
+                    "references": [
+                        {
+                            "name": "schema_proto.proto",
+                            "subject": "base-subject",  # UNQUALIFIED - resolves to default context
+                            "version": 1,
+                        }
+                    ],
+                }
+            ),
+        )
+        # Should fail because "base-subject" doesn't exist in default context
+        self.assert_equal(result.status_code, 422)
+
+        # 5. Test qualified cross-context reference works
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=default_dependent_subject,
+            data=json.dumps(
+                {
+                    "schema": dependent_schema,
+                    "schemaType": "PROTOBUF",
+                    "references": [
+                        {
+                            "name": "schema_proto.proto",
+                            "subject": base_subject,  # QUALIFIED - explicit context
+                            "version": 1,
+                        }
+                    ],
+                }
+            ),
+        )
+        self.assert_equal(result.status_code, 200)
+
 
 class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
     """


### PR DESCRIPTION
Schema references are now handled differently depending on whether they were specified using qualified (e.g. `:.:sub1`) or unqualified (e.g., `sub1`) syntax.

Unqualified references are resolved relative to the parent schema's context, to help with the migration of one registry's default context over to another registry's non-default context.

Fixes https://redpandadata.atlassian.net/browse/CORE-15183

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
