### PR TITLE
iobuf: expand fuzz test coverage and refactor reference helpers

### DIFF
--- a/src/v/bytes/tests/BUILD
+++ b/src/v/bytes/tests/BUILD
@@ -108,6 +108,7 @@ redpanda_cc_fuzz_test(
         "//src/v/base",
         "//src/v/bytes:iobuf",
         "//src/v/bytes:scattered_message",
+        "@fmt",
     ],
 )
 

--- a/src/v/bytes/tests/iobuf_fuzz.cc
+++ b/src/v/bytes/tests/iobuf_fuzz.cc
@@ -23,7 +23,6 @@
 
 #include <deque>
 #include <exception>
-#include <numeric>
 #include <ranges>
 #include <stdexcept>
 #include <string_view>
@@ -97,6 +96,12 @@ struct iobuf_and_ref {
     iobuf buf;
     reference_t ref;
 
+    void ref_push_back(std::string_view sv) {
+        if (!sv.empty()) {
+            ref.push_back(sv);
+        }
+    }
+
     void check() const {
         try {
             ::check_equals(buf, ref);
@@ -117,8 +122,9 @@ iobuf_and_ref generate_many_frag_iobuf(std::string_view v) {
         auto frag_size = std::min<size_t>(v[0], v.size() - 1);
         v.remove_prefix(1);
 
-        o.buf.append_fragments(iobuf::from(v.substr(0, frag_size)));
-        o.ref.push_back(v.substr(0, frag_size));
+        auto frag = v.substr(0, frag_size);
+        o.buf.append_fragments(iobuf::from(frag));
+        o.ref_push_back(frag);
         v.remove_prefix(frag_size);
     }
     o.check();
@@ -139,6 +145,56 @@ compare_reference(const reference_t& a, const reference_t& b) {
     return std::lexicographical_compare_three_way(
       a_chars.begin(), a_chars.end(), b_chars.begin(), b_chars.end());
 }
+
+/*
+ * Concatenates reference_t fragments into a single string.
+ */
+std::string reference_to_string(const reference_t& ref) {
+    std::string result;
+    for (const auto& sv : ref) {
+        result.append(sv);
+    }
+    return result;
+}
+
+/*
+ * Does a signed byte-wise lexicographical comparison between a reference
+ * object and a string_view (matches std::string_view::operator<=>).
+ */
+std::strong_ordering
+compare_reference_to_sv(const reference_t& a, std::string_view b) {
+    auto a_str = reference_to_string(a);
+    return std::string_view(a_str) <=> b;
+}
+
+/*
+ * Extract a subrange [pos, pos+len) from a reference_t.
+ * Mirrors iobuf::share(pos, len) semantics.
+ */
+reference_t reference_subrange(const reference_t& ref, size_t pos, size_t len) {
+    reference_t result;
+    if (len == 0) {
+        return result;
+    }
+    size_t remaining = len;
+    for (const auto& sv : ref) {
+        if (pos >= sv.size()) {
+            pos -= sv.size();
+            continue;
+        }
+        auto start = pos;
+        pos = 0;
+        auto take = std::min(sv.size() - start, remaining);
+        if (take > 0) {
+            result.push_back(sv.substr(start, take));
+        }
+        remaining -= take;
+        if (remaining == 0) {
+            break;
+        }
+    }
+    return result;
+}
 } // namespace
 
 /*
@@ -150,6 +206,21 @@ compare_reference(const reference_t& a, const reference_t& b) {
 class iobuf_ops {
     iobuf buf;
     reference_t ref;
+
+    // Helper to push non-empty views to reference
+    // iobuf drops empty fragments, so we want to
+    // drop them on the oracle as well to keep it
+    // in sync.
+    void ref_push_back(std::string_view sv) {
+        if (!sv.empty()) {
+            ref.push_back(sv);
+        }
+    }
+    void ref_push_front(std::string_view sv) {
+        if (!sv.empty()) {
+            ref.push_front(sv);
+        }
+    }
 
 public:
     void moves() {
@@ -168,26 +239,26 @@ public:
 
     void append_char_array(std::string_view payload) {
         buf.append(payload.data(), payload.size());
-        ref.push_back(payload);
+        ref_push_back(payload);
     }
 
     void append_uint8_array(std::string_view payload) {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         auto uint8y_payload = reinterpret_cast<const uint8_t*>(payload.data());
         buf.append(uint8y_payload, payload.size());
-        ref.push_back(payload);
+        ref_push_back(payload);
     }
 
     void append_temporary_buffer(std::string_view payload) {
         buf.append(ss::temporary_buffer<char>(payload.data(), payload.size()));
-        ref.push_back(payload);
+        ref_push_back(payload);
     }
 
     void append_iobuf(std::string_view payload) {
         iobuf tmp;
         tmp.append(payload.data(), payload.size());
         buf.append(std::move(tmp));
-        ref.push_back(payload);
+        ref_push_back(payload);
     }
 
     void append_fragments(std::string_view payload, bool use_small_frags) {
@@ -205,7 +276,7 @@ public:
             iobuf tmp;
             tmp.append(payload.data(), payload.size());
             buf.append_fragments(std::move(tmp));
-            ref.push_back(payload);
+            ref_push_back(payload);
         } else {
             auto g_buf = generate_many_frag_iobuf(payload);
             buf.append_fragments(std::move(g_buf.buf));
@@ -217,14 +288,14 @@ public:
 
     void prepend_temporary_buffer(std::string_view payload) {
         buf.prepend(ss::temporary_buffer<char>(payload.data(), payload.size()));
-        ref.push_front(payload);
+        ref_push_front(payload);
     }
 
     void prepend_iobuf(std::string_view payload) {
         iobuf tmp;
         tmp.append(payload.data(), payload.size());
         buf.prepend(std::move(tmp));
-        ref.push_front(payload);
+        ref_push_front(payload);
     }
 
     void compare_iobufs(std::string_view v, bool use_small_frags) {
@@ -271,33 +342,39 @@ public:
                 throw std::runtime_error("(o_buf == buf) != (o_ref == ref)");
             }
         }
+
+        // Test iobuf::operator<
+        {
+            auto iobuf_res = buf < o_buf;
+            auto ref_res = compare_reference(ref, o_ref)
+                           == std::strong_ordering::less;
+            vassert(iobuf_res == ref_res, "(buf < o_buf) != (ref < o_ref)");
+
+            iobuf_res = o_buf < buf;
+            ref_res = compare_reference(o_ref, ref)
+                      == std::strong_ordering::less;
+            vassert(iobuf_res == ref_res, "(o_buf < buf) != (o_ref < ref)");
+        }
+    }
+
+    void compare_string_view(std::string_view v) {
+        auto iobuf_res = buf <=> v;
+        auto ref_res = compare_reference_to_sv(ref, v);
+        vassert(iobuf_res == ref_res, "(buf <=> sv) != (ref <=> sv)");
     }
 
     void trim_front(size_t size) {
+        auto old_size = buf.size_bytes();
         buf.trim_front(size);
-        while (size && !ref.empty()) {
-            if (size >= ref.front().size()) {
-                size -= ref.front().size();
-                ref.pop_front();
-            } else {
-                ref.front().remove_prefix(size);
-                return;
-            }
-        }
+        size = std::min(size, old_size); // clamp to available
+        ref = reference_subrange(ref, size, old_size - size);
     }
 
     void trim_back(size_t size) {
+        auto old_size = buf.size_bytes();
         buf.trim_back(size);
-        while (size && !ref.empty()) {
-            if (size >= ref.back().size()) {
-                size -= ref.back().size();
-                ref.pop_back();
-            } else {
-                ref.back().remove_suffix(size);
-                size = 0;
-                break;
-            }
-        }
+        size = std::min(size, old_size); // clamp to available
+        ref = reference_subrange(ref, 0, old_size - size);
     }
 
     void clear() {
@@ -305,7 +382,104 @@ public:
         ref.clear();
     }
 
-    void hexdump(size_t size) { auto s = buf.hexdump(size); }
+    void empty_check() {
+        auto ref_empty = ref.empty();
+        vassert(
+          buf.empty() == ref_empty,
+          "buf.empty()={} != ref.empty()={}",
+          buf.empty(),
+          ref_empty);
+    }
+
+    void memory_usage_check() {
+        // Just exercise the method
+        buf.memory_usage();
+    }
+
+    void share_full() {
+        auto shared = buf.share();
+        check_equals(shared, ref);
+    }
+
+    void share_range(uint32_t encoded) {
+        // Lower 16 bits = pos, upper 16 bits = len
+        size_t pos = encoded & 0xFFFF;
+        size_t len = encoded >> 16;
+        auto ref_size = buf.size_bytes();
+        if (pos > ref_size) {
+            return; // invalid range
+        }
+        len = std::min(len, ref_size - pos);
+        auto shared = buf.share(pos, len);
+        check_equals(shared, reference_subrange(ref, pos, len));
+    }
+
+    void append_str(std::string_view payload) {
+        buf.append_str(payload);
+        ref_push_back(payload);
+    }
+
+    void pop_front_op() {
+        if (buf.empty()) {
+            return;
+        }
+        // Get size of first fragment before removing
+        auto frag_size = buf.begin()->size();
+        buf.pop_front();
+        // Remove same amount from reference
+        size_t to_remove = frag_size;
+        while (to_remove > 0 && !ref.empty()) {
+            if (ref.front().size() <= to_remove) {
+                to_remove -= ref.front().size();
+                ref.pop_front();
+            } else {
+                ref.front().remove_prefix(to_remove);
+                to_remove = 0;
+            }
+        }
+    }
+
+    void pop_back_op() {
+        if (buf.empty()) {
+            return;
+        }
+        // Get size of last fragment before removing
+        auto frag_size = buf.rbegin()->size();
+        buf.pop_back();
+        // Remove same amount from reference
+        size_t to_remove = frag_size;
+        while (to_remove > 0 && !ref.empty()) {
+            if (ref.back().size() <= to_remove) {
+                to_remove -= ref.back().size();
+                ref.pop_back();
+            } else {
+                ref.back().remove_suffix(to_remove);
+                to_remove = 0;
+            }
+        }
+    }
+
+    void tail(size_t size) {
+        if (size > buf.size_bytes()) {
+            // tail() throws if size > buffer size, skip invalid ops
+            return;
+        }
+        auto tail_buf = buf.tail(size);
+        check_equals(
+          tail_buf, reference_subrange(ref, buf.size_bytes() - size, size));
+    }
+
+    void hexdump(size_t size) {
+        // clamp hexdump to 100 chars for speed
+        auto limit = std::min(100uz, size);
+        auto s = buf.hexdump(limit);
+        vassert(
+          s.size() <= limit * 6 + 80,
+          "oversized: {} limit {} hex {}",
+          s.size(),
+          limit,
+          s);
+    }
 
     void print() {
         std::stringstream ss;
@@ -397,7 +571,16 @@ enum class op_type : uint8_t {
     append_small_fragments,
     append_uint8_array,
     append_char_array,
-    max = append_char_array,
+    tail,
+    empty_check,
+    memory_usage,
+    share_full,
+    share_range,
+    append_str,
+    pop_front_op,
+    pop_back_op,
+    compare_string_view,
+    max = compare_string_view,
 };
 
 template<>
@@ -443,6 +626,24 @@ struct fmt::formatter<op_type> : formatter<std::string_view> {
                 return "append_uint8_array";
             case op_type::append_char_array:
                 return "append_char_array";
+            case op_type::tail:
+                return "tail";
+            case op_type::empty_check:
+                return "empty_check";
+            case op_type::memory_usage:
+                return "memory_usage";
+            case op_type::share_full:
+                return "share_full";
+            case op_type::share_range:
+                return "share_range";
+            case op_type::append_str:
+                return "append_str";
+            case op_type::pop_front_op:
+                return "pop_front_op";
+            case op_type::pop_back_op:
+                return "pop_back_op";
+            case op_type::compare_string_view:
+                return "compare_string_view";
             }
         }(t);
         return formatter<std::string_view>::format(name, ctx);
@@ -531,6 +732,26 @@ private:
             m_.iobuf_as_scattered();
             return;
 
+        case op_type::empty_check:
+            m_.empty_check();
+            return;
+
+        case op_type::memory_usage:
+            m_.memory_usage_check();
+            return;
+
+        case op_type::share_full:
+            m_.share_full();
+            return;
+
+        case op_type::pop_front_op:
+            m_.pop_front_op();
+            return;
+
+        case op_type::pop_back_op:
+            m_.pop_back_op();
+            return;
+
         default:
             break;
         }
@@ -566,6 +787,10 @@ private:
             m_.hexdump(*op.size);
             return;
 
+        case op_type::tail:
+            m_.tail(*op.size);
+            return;
+
         case op_type::prepend_iobuf:
             m_.prepend_iobuf(op.data);
             return;
@@ -592,6 +817,18 @@ private:
 
         case op_type::append_char_array:
             m_.append_char_array(op.data);
+            return;
+
+        case op_type::share_range:
+            m_.share_range(static_cast<uint32_t>(*op.size));
+            return;
+
+        case op_type::append_str:
+            m_.append_str(op.data);
+            return;
+
+        case op_type::compare_string_view:
+            m_.compare_string_view(op.data);
             return;
 
         default:
@@ -629,13 +866,17 @@ private:
         case op_type::prepend_iobuf:
         case op_type::reserve_memory:
         case op_type::hexdump:
+        case op_type::tail:
         case op_type::prepend_temporary_buffer:
         case op_type::append_fragments:
         case op_type::append_small_fragments:
         case op_type::append_iobuf:
         case op_type::append_temporary_buffer:
         case op_type::append_uint8_array:
-        case op_type::append_char_array: {
+        case op_type::append_char_array:
+        case op_type::share_range:
+        case op_type::append_str:
+        case op_type::compare_string_view: {
             op.size = read<uint32_t>();
             break;
         }
@@ -655,6 +896,8 @@ private:
         case op_type::append_temporary_buffer:
         case op_type::append_uint8_array:
         case op_type::append_char_array:
+        case op_type::append_str:
+        case op_type::compare_string_view:
             vassert(op.size.has_value(), "");
             op.data = {
               pc_,


### PR DESCRIPTION
Expands the iobuf fuzz test to cover more operations and improves the
reference oracle to better match iobuf's behavior with empty fragments.

New operations tested: operator<, share(), tail(), pop_front/back(),
append_str(), empty(), memory_usage(), and operator<=>(string_view).

Bug fixes in the test oracle: trim_front/trim_back now clamp to available
bytes, and empty fragments are no longer added to the reference (matching
iobuf's behavior).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none