### PR TITLE
[v25.3.x] direct_consumer: move offset update logic to fetch_next

### DIFF
--- a/src/v/kafka/client/direct_consumer/api_types.h
+++ b/src/v/kafka/client/direct_consumer/api_types.h
@@ -69,8 +69,10 @@ struct fetched_partition_data {
     // the following have reasonable defaults
     chunked_vector<model::record_batch> data{};
     kafka::error_code error = kafka::error_code::none;
-    std::optional<chunked_vector<aborted_transaction>> aborted_transactions;
-    subscription_epoch subscription_epoch;
+    std::optional<chunked_vector<aborted_transaction>> aborted_transactions{
+      std::nullopt};
+    subscription_epoch
+      subscription_epoch; // should always be set but no invalid value
     size_t size_bytes{0};
 };
 
@@ -93,6 +95,14 @@ struct source_partition_offsets {
     kafka::offset last_stable_offset{model::offset_cast(model::invalid_lso)};
     // The timestamp that the fetch response was received by the client
     ss::lowres_clock::time_point last_offset_update_timestamp{};
+
+    // check all except timestamp, useful for checking if offsets have changed
+    // over time
+    bool are_offsets_equal(const source_partition_offsets& other) const {
+        return log_start_offset == other.log_start_offset
+               && high_watermark == other.high_watermark
+               && last_stable_offset == other.last_stable_offset;
+    }
 };
 
 struct partition_offset {

--- a/src/v/kafka/client/direct_consumer/direct_consumer.cc
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.cc
@@ -118,15 +118,10 @@ void direct_consumer::update_configuration(configuration cfg) {
 
 std::optional<source_partition_offsets>
 direct_consumer::get_source_offsets(model::topic_partition_view tp) const {
-    auto it = _subscriptions.find(tp.topic);
-    if (it == _subscriptions.end()) {
-        return std::nullopt;
-    }
-    auto p_it = it->second.find(tp.partition);
-    if (p_it == it->second.end()) {
-        return std::nullopt;
-    }
-    return p_it->second.last_known_source_offsets;
+    return find_subscription(tp.topic, tp.partition)
+      .transform([](std::reference_wrapper<const subscription> sub) {
+          return sub.get().last_known_source_offsets;
+      });
 }
 
 ss::future<> direct_consumer::update_fetchers(
@@ -231,8 +226,9 @@ fetcher& direct_consumer::get_fetcher(model::node_id id) {
     return *it->second;
 }
 
-std::optional<subscription_epoch> direct_consumer::find_subscription_epoch(
-  const model::topic& topic, model::partition_id partition_id) {
+std::optional<std::reference_wrapper<const direct_consumer::subscription>>
+direct_consumer::find_subscription(
+  const model::topic& topic, model::partition_id partition_id) const {
     auto t_it = _subscriptions.find(topic);
     if (t_it == _subscriptions.end()) {
         return std::nullopt;
@@ -243,9 +239,30 @@ std::optional<subscription_epoch> direct_consumer::find_subscription_epoch(
     if (p_it == p_map.end()) {
         return std::nullopt;
     }
-    return p_it->second.subscription_epoch;
+    return p_it->second;
 }
 
+std::optional<std::reference_wrapper<direct_consumer::subscription>>
+direct_consumer::find_subscription(
+  const model::topic& topic, model::partition_id partition_id) {
+    auto t_it = _subscriptions.find(topic);
+    if (t_it == _subscriptions.end()) {
+        return std::nullopt;
+    }
+    auto& p_map = t_it->second;
+    auto p_it = p_map.find(partition_id);
+    if (p_it == p_map.end()) {
+        return std::nullopt;
+    }
+    return p_it->second;
+}
+
+std::optional<subscription_epoch> direct_consumer::find_subscription_epoch(
+  const model::topic& topic, model::partition_id partition_id) const {
+    return find_subscription(topic, partition_id).transform([](auto sub) {
+        return sub.get().subscription_epoch;
+    });
+}
 ss::future<> direct_consumer::start() {
     if (_started) {
         co_return;

--- a/src/v/kafka/client/direct_consumer/direct_consumer.cc
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.cc
@@ -13,10 +13,13 @@
 #include "kafka/client/direct_consumer/api_types.h"
 #include "kafka/client/direct_consumer/data_queue.h"
 #include "kafka/client/direct_consumer/fetcher.h"
+#include "kafka/protocol/errors.h"
 #include "model/validation.h"
 #include "ssx/future-util.h"
 
 #include <algorithm>
+#include <chrono>
+#include <functional>
 
 namespace kafka::client {
 
@@ -37,28 +40,54 @@ direct_consumer::direct_consumer(
 
 ss::future<fetches>
 direct_consumer::fetch_next(std::chrono::milliseconds timeout) {
+    // ss::lowres_clock's resolution is around the duration of task_quota and
+    // default task_quota is 500us
+    // adds a reasonable minimum timeout to calls to pop
+    static constexpr auto minimum_timeout = std::chrono::milliseconds{1};
     if (!_started) [[unlikely]] {
         throw std::runtime_error("Direct consumer is not started");
     }
     auto holder = _gate.hold();
+    auto deadline = ss::lowres_clock::now() + timeout;
+
     try {
-        auto maybe_response_to_filter = co_await _fetched_data_queue->pop(
-          timeout);
-        if (maybe_response_to_filter.has_error()) {
+        // we'll keep attempting to pluck from the queue until the timeout is
+        // exhausted
+        while (ss::lowres_clock::now() < deadline) {
+            // either the remaining timeout or a small but reasonable minimum
+            // timeout
+            auto timeout_remaining = std::max(
+              std::chrono::duration_cast<std::chrono::milliseconds>(
+                deadline - ss::lowres_clock::now()),
+              minimum_timeout);
+
+            auto maybe_response_to_filter = co_await _fetched_data_queue->pop(
+              timeout_remaining);
+            if (maybe_response_to_filter.has_error()) {
+                co_return maybe_response_to_filter;
+            }
+
+            // the remainder is synchronous, no lock is needed
+            auto& response_to_filter = maybe_response_to_filter.value();
+
+            // filters if needed, will modify response in place
+            filter_fetch_data(response_to_filter);
+
+            // if the filters have removed everything, there are no updates.
+            // poll the queue again
+            if (response_to_filter.empty()) {
+                continue;
+            }
+
             co_return maybe_response_to_filter;
         }
-
-        // the remainder is synchronous, no lock is needed
-        auto& response_to_filter = maybe_response_to_filter.value();
-        filter_stale_subscriptions(response_to_filter);
-        co_return maybe_response_to_filter;
-
     } catch (ss::condition_variable_timed_out&) {
         co_return chunked_vector<fetched_topic_data>{};
     }
+    co_return chunked_vector<fetched_topic_data>{};
 }
 
-void direct_consumer::filter_stale_subscriptions(
+void direct_consumer::filter_fetch_data(
   chunked_vector<fetched_topic_data>& responses_to_filter) {
     // for each topic, remove stale partitions
     for (auto& topic_data : responses_to_filter) {
@@ -66,25 +95,35 @@ void direct_consumer::filter_stale_subscriptions(
 
         auto non_stale_subsegment = std::ranges::partition(
           partition_data,
-          [this, &topic_data](const fetched_partition_data& data) mutable {
-              auto maybe_current_subscription_epoch = find_subscription_epoch(
-                topic_data.topic, data.partition_id);
+          [this,
+           &topic_data](const fetched_partition_data& partition_data) mutable {
+              auto maybe_subscription = find_subscription(
+                topic_data.topic, partition_data.partition_id);
 
               vlog(
                 _cluster->logger().debug,
-                "current subscription epoch: {}, found request epoch: {}",
-                maybe_current_subscription_epoch,
-                data.subscription_epoch);
+                "tp: {}/{}, current subscription epoch: {}, found request "
+                "epoch: {}",
+                topic_data.topic,
+                partition_data.partition_id,
+                partition_data.subscription_epoch,
+                maybe_subscription.transform([](const subscription& sub) {
+                    return sub.subscription_epoch;
+                }));
 
-              bool is_stale = data.subscription_epoch
-                              != maybe_current_subscription_epoch;
-              if (is_stale) {
-                  topic_data.total_bytes -= data.size_bytes;
+              // if the fetch is stale, no further checks required, remove it
+              if (is_partition_data_stale(partition_data, maybe_subscription)) {
+                  // adjust the size calculation given that data is potentially
+                  // being dropped
+                  topic_data.total_bytes -= partition_data.size_bytes;
+                  return false;
               }
-              // negate s.t. stale records accumulate at the back of the
-              // chunked_vector, allows for them to be removed with
-              // erase_to_end
-              return !is_stale;
+
+              vassert(
+                maybe_subscription,
+                "nullopt implies stale and should have been handled above");
+              return update_and_filter_offsets(
+                topic_data.topic, partition_data, *maybe_subscription);
           });
 
         auto erase_iterator = partition_data.end()
@@ -101,6 +140,89 @@ void direct_consumer::filter_stale_subscriptions(
 
     responses_to_filter.erase_to_end(
       responses_to_filter.end() - non_empty_subsegment.size());
+}
+
+bool direct_consumer::is_partition_data_stale(
+  const fetched_partition_data& partition_data,
+  const std::optional<subscription>& maybe_subscription) {
+    if (!maybe_subscription) {
+        return true;
+    }
+    return partition_data.subscription_epoch
+           != maybe_subscription->subscription_epoch;
+}
+
+bool direct_consumer::update_and_filter_offsets(
+  model::topic topic_name,
+  const fetched_partition_data& partition_data,
+  subscription& subscription) {
+    // rules
+    // if there is data attached, don't filter it
+    // if there is new offset info, don't filter it
+    // if the response is an error, don't filter it
+
+    source_partition_offsets spo{
+      .log_start_offset = partition_data.start_offset,
+      .high_watermark = partition_data.high_watermark,
+      .last_stable_offset = partition_data.last_stable_offset,
+      .last_offset_update_timestamp = ss::lowres_clock::now()};
+
+    // the response is an error, send it back to the consumer with
+    // no updates to state
+    if (partition_data.error != kafka::error_code::none) {
+        return true;
+    }
+
+    // not an update, screen it out after updating last seen
+    if (
+      spo.are_offsets_equal(subscription.last_known_source_offsets)
+      && partition_data.data.empty()) {
+        subscription.last_known_source_offsets.last_offset_update_timestamp
+          = ss::lowres_clock::now();
+        return false;
+    }
+
+    // log expectations on offsets, update then return
+    if (
+      subscription.last_known_source_offsets.log_start_offset
+      > spo.log_start_offset) {
+        vlog(
+          _cluster->logger().error,
+          "{}/{} log start offset should never move backward, current: "
+          "{}, "
+          "found: {}",
+          topic_name,
+          partition_data.partition_id,
+          subscription.last_known_source_offsets.log_start_offset,
+          spo.log_start_offset);
+    }
+    if (
+      subscription.last_known_source_offsets.high_watermark
+      > spo.high_watermark) {
+        vlog(
+          _cluster->logger().warn,
+          "{}/{} high watermark should not normally move backward, "
+          "current: "
+          "{}, found: {}",
+          topic_name,
+          partition_data.partition_id,
+          subscription.last_known_source_offsets.high_watermark,
+          spo.high_watermark);
+    }
+    if (
+      subscription.last_known_source_offsets.last_stable_offset
+      > spo.last_stable_offset) {
+        vlog(
+          _cluster->logger().error,
+          "{}/{} last known stable should never move backward, "
+          "current: {}, found: {}",
+          topic_name,
+          partition_data.partition_id,
+          subscription.last_known_source_offsets.last_stable_offset,
+          spo.last_stable_offset);
+    }
+    subscription.last_known_source_offsets = spo;
+    return true;
 }
 
 void direct_consumer::update_configuration(configuration cfg) {
@@ -365,24 +487,6 @@ ss::future<> direct_consumer::handle_metadata_update() {
 
 void direct_consumer::on_metadata_update(const metadata_update&) {
     ssx::spawn_with_gate(_gate, [this] { return handle_metadata_update(); });
-}
-
-void direct_consumer::maybe_update_source_partition_offsets(
-  model::topic_partition_view tp, source_partition_offsets offsets) {
-    auto it = _subscriptions.find(tp.topic);
-    if (it == _subscriptions.end()) {
-        return;
-    }
-    auto p_it = it->second.find(tp.partition);
-    if (p_it == it->second.end()) {
-        return;
-    }
-    auto& sub = p_it->second;
-    if (
-      offsets.last_offset_update_timestamp
-      > sub.last_known_source_offsets.last_offset_update_timestamp) {
-        sub.last_known_source_offsets = offsets;
-    }
 }
 
 direct_consumer::~direct_consumer() = default;

--- a/src/v/kafka/client/direct_consumer/direct_consumer.cc
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.cc
@@ -84,6 +84,7 @@ direct_consumer::fetch_next(std::chrono::milliseconds timeout) {
     } catch (ss::condition_variable_timed_out&) {
         co_return chunked_vector<fetched_topic_data>{};
     }
+    // fallthrough loop case
     co_return chunked_vector<fetched_topic_data>{};
 }
 
@@ -93,7 +94,7 @@ void direct_consumer::filter_fetch_data(
     for (auto& topic_data : responses_to_filter) {
         auto& partition_data = topic_data.partitions;
 
-        auto non_stale_subsegment = std::ranges::partition(
+        auto to_remove_subsegment = std::ranges::partition(
           partition_data,
           [this,
            &topic_data](const fetched_partition_data& partition_data) mutable {
@@ -126,20 +127,18 @@ void direct_consumer::filter_fetch_data(
                 topic_data.topic, partition_data, *maybe_subscription);
           });
 
-        auto erase_iterator = partition_data.end()
-                              - non_stale_subsegment.size();
-
+        // erase everything that is stale
+        auto erase_iterator = to_remove_subsegment.begin();
         partition_data.erase_to_end(erase_iterator);
     }
 
     // remove newly empty topics
-    auto non_empty_subsegment = std::ranges::partition(
+    auto empty_subsegment = std::ranges::partition(
       responses_to_filter, [](const fetched_topic_data& topic_data) {
           return !topic_data.partitions.empty();
       });
 
-    responses_to_filter.erase_to_end(
-      responses_to_filter.end() - non_empty_subsegment.size());
+    responses_to_filter.erase_to_end(empty_subsegment.begin());
 }
 
 bool direct_consumer::is_partition_data_stale(

--- a/src/v/kafka/client/direct_consumer/direct_consumer.cc
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.cc
@@ -122,7 +122,8 @@ void direct_consumer::filter_fetch_data(
 
               vassert(
                 maybe_subscription,
-                "nullopt implies stale and should have been handled above");
+                "offset filtering requires that unassigned subscriptions have "
+                "already been filtered out");
               return update_and_filter_offsets(
                 topic_data.topic, partition_data, *maybe_subscription);
           });

--- a/src/v/kafka/client/direct_consumer/direct_consumer.h
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.h
@@ -170,8 +170,14 @@ private:
 
     fetcher& get_fetcher(model::node_id id);
 
-    std::optional<subscription_epoch> find_subscription_epoch(
+    std::optional<std::reference_wrapper<const subscription>> find_subscription(
+      const model::topic& topic, model::partition_id partition_id) const;
+
+    std::optional<std::reference_wrapper<subscription>> find_subscription(
       const model::topic& topic, model::partition_id partition_id);
+
+    std::optional<subscription_epoch> find_subscription_epoch(
+      const model::topic& topic, model::partition_id partition_id) const;
 
     void filter_stale_subscriptions(
       chunked_vector<fetched_topic_data>& responses_to_filter);

--- a/src/v/kafka/client/direct_consumer/direct_consumer.h
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.h
@@ -51,6 +51,8 @@ class data_queue;
  *
  */
 class direct_consumer {
+    friend class consumer_test_mock;
+
 public:
     struct configuration {
         int32_t min_bytes{1};
@@ -179,11 +181,20 @@ private:
     std::optional<subscription_epoch> find_subscription_epoch(
       const model::topic& topic, model::partition_id partition_id) const;
 
-    void filter_stale_subscriptions(
-      chunked_vector<fetched_topic_data>& responses_to_filter);
+    void
+    filter_fetch_data(chunked_vector<fetched_topic_data>& responses_to_filter);
 
-    void maybe_update_source_partition_offsets(
-      model::topic_partition_view tp, source_partition_offsets offsets);
+    static bool is_partition_data_stale(
+      const fetched_partition_data& partition_data,
+      const std::optional<subscription>& maybe_subscription);
+
+    // update offsets and last seen
+    // returns true -> fetch was an update keep it in the fetched data
+    //         false -> the fetch contained no new information, drop it
+    bool update_and_filter_offsets(
+      model::topic topic_name,
+      const fetched_partition_data& partition_data,
+      subscription& subscription);
 
     cluster* _cluster;
 

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -463,7 +463,7 @@ fetcher::process_fetch_response(
     // assignment updates are not blocked by a longstanding fetch. At this
     // point, all inconsistent fetch responses should be discarded
     for (auto& topic_response : resp.data.responses) {
-        auto consistent_subrange = std::ranges::partition(
+        auto inconsistent_subrange = std::ranges::partition(
           topic_response.partitions,
           [this, &topic_response, &epochs](partition_data& partition_response) {
               return is_consistent_fetcher_epoch(
@@ -471,8 +471,7 @@ fetcher::process_fetch_response(
                 partition_response.partition_index,
                 epochs);
           });
-        topic_response.partitions.erase_to_end(
-          topic_response.partitions.end() - consistent_subrange.size());
+        topic_response.partitions.erase_to_end(inconsistent_subrange.begin());
     } // all responses now belong to consistent tps
 
     // For fetch session maintenance, the goal is to omit partitions from each

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -16,6 +16,7 @@
 #include "kafka/client/direct_consumer/data_queue.h"
 #include "kafka/client/direct_consumer/direct_consumer.h"
 #include "kafka/client/errors.h"
+#include "kafka/protocol/errors.h"
 #include "kafka/protocol/types.h"
 #include "model/fundamental.h"
 #include "ssx/async_algorithm.h"
@@ -301,9 +302,6 @@ bool fetcher::maybe_update_fetch_offset(
     }
 
     auto& fetch_state = maybe_fetch_state->get();
-    if (fetch_state.fetch_offset == kafka::next_offset(last_received)) {
-        return false;
-    }
     vlog(
       logger().trace,
       "[broker: {}] Updating {}/{} fetch offset from {} to {} {{hwm: {}}}",
@@ -313,6 +311,10 @@ bool fetcher::maybe_update_fetch_offset(
       fetch_state.fetch_offset,
       kafka::next_offset(last_received),
       high_watermark);
+
+    if (fetch_state.fetch_offset == kafka::next_offset(last_received)) {
+        return false;
+    }
     fetch_state.high_watermark = high_watermark;
     fetch_state.fetch_offset = kafka::next_offset(last_received);
     // we updated the fetch offset, so we should sync to with the broker's
@@ -502,139 +504,19 @@ fetcher::process_fetch_response(
         topic_data.partitions.reserve(topic_response.partitions.size());
 
         for (auto& part_response : topic_response.partitions) {
-            fetched_partition_data part_data{};
-            part_data.error = part_response.error_code;
-            part_data.partition_id = part_response.partition_index;
-
-            auto maybe_epoch_set = find_epoch_set(
-              topic_data.topic, part_response.partition_index, epochs);
-            vassert(
-              maybe_epoch_set.has_value(),
-              "tp should be found in snapshotted epochs if the response is "
-              "epoch consistent");
-            part_data.subscription_epoch
-              = maybe_epoch_set.value().subscription_epoch;
-
-            if (part_response.error_code != kafka::error_code::none) {
-                _parent->with_probe(increment_fetch_errors);
-                if (
-                  part_response.error_code
-                  == kafka::error_code::offset_out_of_range) {
-                    vlog(
-                      logger().warn,
-                      "[broker: {}] {}/{} fetch returned: {}, resetting "
-                      "offset with policy: {}",
-                      _id,
-                      topic_data.topic,
-                      part_data.partition_id,
-                      part_response.error_code,
-                      _parent->_config.reset_policy);
-                    reset_partition_offset(
-                      model::topic_partition_view(
-                        topic_data.topic, part_data.partition_id));
-                    continue;
-                }
-                if (is_retriable_error(part_response.error_code)) {
-                    vlog(
-                      logger().debug,
-                      "[broker: {}] {}/{} retriable fetch error: {}",
-                      _id,
-                      topic_data.topic,
-                      part_data.partition_id,
-                      part_response.error_code);
-
-                    result.needs_metadata_update = true;
-                    // skip partition in the result, but mark that we
-                    // need to update metadata
-                    // so that we can retry fetching it later
-                    continue;
-                }
-                vlog(
-                  logger().warn,
-                  "[broker: {}] {}/{} fetch error: {}",
-                  _id,
-                  topic_data.topic,
-                  part_data.partition_id,
-                  part_response.error_code);
-
-                // this partition errored, so any pending incremental fetches
-                // should be retried
-                dirty_partitions[topic_data.topic].insert(
-                  part_data.partition_id);
-            } else {
-                part_data.start_offset = model::offset_cast(
-                  part_response.log_start_offset);
-                part_data.high_watermark = model::offset_cast(
-                  part_response.high_watermark);
-                part_data.last_stable_offset = model::offset_cast(
-                  part_response.last_stable_offset);
-                part_data.leader_epoch
-                  = part_response.current_leader.leader_epoch;
-                part_data.aborted_transactions = std::move(
-                  part_response.aborted_transactions);
-
-                vlog(
-                  logger().trace,
-                  "[broker: {}] topic: {}, partition fetch response: {}",
-                  _id,
-                  topic_data.topic,
-                  part_response);
-
-                // if no records, just emplace the offset updates
-                // if records, handle size calculation and fetch offsets updates
-                if (
-                  !part_response.records.has_value()
-                  || part_response.records->is_end_of_stream()) {
-                    // these still go on the queue as they probably contain
-                    // information about a prefix truncation
-                    vlog(
-                      logger().debug,
-                      "[broker: {}] tp: {}/{}, received recordless response",
-                      _id,
-                      topic_data.topic,
-                      part_data.partition_id);
-                } else {
-                    // from here, there is actual data to be process, render it
-                    // accordingly
-                    auto partition_response_size
-                      = part_response.records->size_bytes();
-                    part_data.size_bytes = partition_response_size;
-                    topic_data.total_bytes += partition_response_size;
-                    part_data.data = co_await reader_to_chunked_vector(
-                      std::move(part_response.records.value()));
-
-                    bool updated_offset = maybe_update_fetch_offset(
-                      topic_data.topic,
-                      part_data.partition_id,
-                      model::offset_cast(part_data.data.back().last_offset()),
-                      part_data.high_watermark);
-                    if (!updated_offset) {
-                        // This implies a mistake in the fetch logic. A response
-                        // that is
-                        // 1. consistent
-                        // 2. record bearing
-                        // 3. redundant
-                        // should not occur and can be considered a
-                        // non-monatomic fetch
-                        vlog(
-                          logger().error,
-                          "[broker: {}] tp: {}/{} received a record bearing "
-                          "fetch "
-                          "that did not update fetch offsets",
-                          _id,
-                          topic_data.topic,
-                          part_data.partition_id);
-                        // record will still go on the queue, but with records
-                        // emptied in case it contains a start offset update
-                        topic_data.total_bytes -= partition_response_size;
-                        part_data.size_bytes = 0u;
-                        part_data.data.clear();
-                    }
-                    dirty_partitions[topic_data.topic].insert(
-                      part_data.partition_id);
-                }
+            auto maybe_fetched_partition_data
+              = co_await process_partition_response(
+                topic_data.topic,
+                std::move(part_response),
+                epochs,
+                result,
+                dirty_partitions);
+            if (maybe_fetched_partition_data) {
+                topic_data.total_bytes
+                  += maybe_fetched_partition_data->size_bytes;
+                topic_data.partitions.emplace_back(
+                  *std::move(maybe_fetched_partition_data));
             }
-            topic_data.partitions.push_back(std::move(part_data));
         }
         result.total_bytes += topic_data.total_bytes;
         if (topic_data.partitions.empty()) {
@@ -717,6 +599,200 @@ fetcher::process_fetch_response(
     co_return result;
 }
 
+ss::future<std::optional<fetched_partition_data>>
+fetcher::process_partition_response(
+  const model::topic& topic,
+  partition_data partition_response,
+  const topic_partition_map<epoch_set>& epochs,
+  fetch_response_content& result,
+  chunked_hash_map<model::topic, absl::flat_hash_set<model::partition_id>>&
+    dirty_partitions) {
+    vlog(
+      logger().trace,
+      "[broker: {}] topic: {}, partition fetch response: {}",
+      _id,
+      topic,
+      partition_response);
+
+    // the response will be consumed, grab some vars for logs
+    const auto partition_id = partition_response.partition_index;
+
+    // pull the records from the response if present
+    chunked_vector<model::record_batch> response_records{};
+    size_t response_size{0};
+    if (
+      partition_response.records.has_value()
+      && !partition_response.records->is_end_of_stream()) {
+        response_size = partition_response.records->size_bytes();
+        response_records = co_await reader_to_chunked_vector(
+          std::move(partition_response.records.value()));
+    }
+
+    // null this out as the records are already consumed
+    partition_response.records = std::nullopt;
+
+    fetched_partition_data part_data{};
+    part_data.error = partition_response.error_code;
+    part_data.partition_id = partition_response.partition_index;
+
+    auto maybe_epoch_set = find_epoch_set(
+      topic, partition_response.partition_index, epochs);
+
+    vassert(
+      maybe_epoch_set,
+      "All partition response handling assumes that fetch responses have been "
+      "filtered to consistent fetch reponses. Consistency demands that a tps "
+      "epoch_set must present.");
+
+    auto actions = do_process_partition_response(
+      std::move(partition_response),
+      std::move(response_records),
+      response_size,
+      *maybe_epoch_set);
+
+    if (actions.error != kafka::error_code::none) {
+        _parent->with_probe(increment_fetch_errors);
+        const bool is_retriable = is_retriable_error(actions.error);
+        const auto level = is_retriable ? ss::log_level::debug
+                                        : ss::log_level::warn;
+        vlogl(
+          logger(),
+          level,
+          "[broker: {}] {}/{} fetch returned error: {}",
+          _id,
+          topic,
+          partition_id,
+          actions.error);
+    }
+    if (actions.should_reset_offsets) {
+        reset_partition_offset(
+          model::topic_partition_view{topic, partition_id});
+    }
+    if (actions.should_update_metadata) {
+        vlog(
+          logger().trace,
+          "[broker: {}] {}/{} requesting metadata update",
+          _id,
+          topic,
+          partition_id);
+        result.needs_metadata_update = true;
+    }
+    if (actions.is_dirty) {
+        vlog(
+          logger().trace,
+          "[broker: {}] {}/{} is dirty, will attempt to add to next fetch",
+          _id,
+          topic,
+          partition_id);
+        dirty_partitions[topic].insert(part_data.partition_id);
+    }
+    if (actions.maybe_fetched_partition_data.has_value()) {
+        auto& fetched_partition_data = *actions.maybe_fetched_partition_data;
+
+        // if the fetched data is empty, its probably an offset update
+        // notification, log it
+        if (fetched_partition_data.data.empty()) {
+            vlog(
+              logger().debug,
+              "[broker: {}] tp: {}/{}, received recordless response",
+              _id,
+              topic,
+              part_data.partition_id);
+        } else {
+            // otherwise, update fetch offsets
+            bool updated_offset = maybe_update_fetch_offset(
+              topic,
+              part_data.partition_id,
+              model::offset_cast(
+                fetched_partition_data.data.back().last_offset()),
+              part_data.high_watermark);
+
+            if (!updated_offset) {
+                // This implies a mistake in the fetch logic. A response
+                // that is
+                // 1. consistent
+                // 2. record bearing
+                // 3. redundant
+                // should not occur and can be considered a
+                // non-monatomic fetch
+                vlog(
+                  logger().error,
+                  "[broker: {}] tp: {}/{} received a record bearing "
+                  "fetch "
+                  "that did not update fetch offsets",
+                  _id,
+                  topic,
+                  part_data.partition_id);
+                // record will still go on the queue, but with records
+                // emptied in case it contains a start offset update
+                // topic_data.total_bytes -= partition_response_size;
+                part_data.size_bytes = 0u;
+                part_data.data.clear();
+            }
+        }
+    }
+
+    co_return std::move(actions.maybe_fetched_partition_data);
+}
+
+fetcher::partition_response_actions fetcher::do_process_partition_response(
+  partition_data partition_response,
+  chunked_vector<model::record_batch> response_batches,
+  size_t response_size,
+  fetcher::epoch_set epoch_set) {
+    // this was done to keep this method synchronous
+    vassert(
+      !partition_response.records.has_value(),
+      "a precondition of calling this function is moving the records into the "
+      "response_batches vector");
+
+    partition_response_actions output_actions{};
+    output_actions.error = partition_response.error_code;
+
+    fetched_partition_data output_partition_data{};
+    output_partition_data.error = partition_response.error_code;
+    output_partition_data.partition_id = partition_response.partition_index;
+    output_partition_data.subscription_epoch = epoch_set.subscription_epoch;
+
+    if (partition_response.error_code != kafka::error_code::none) {
+        if (
+          partition_response.error_code
+          == kafka::error_code::offset_out_of_range) {
+            output_actions.should_reset_offsets = true;
+            return output_actions;
+        }
+        if (is_retriable_error(partition_response.error_code)) {
+            output_actions.should_update_metadata = true;
+            output_actions.is_dirty = true;
+            return output_actions;
+        }
+
+        output_actions.is_dirty = true;
+        output_actions.maybe_fetched_partition_data = std::move(
+          output_partition_data);
+        return output_actions;
+    }
+    output_partition_data.start_offset = model::offset_cast(
+      partition_response.log_start_offset);
+    output_partition_data.high_watermark = model::offset_cast(
+      partition_response.high_watermark);
+    output_partition_data.last_stable_offset = model::offset_cast(
+      partition_response.last_stable_offset);
+    output_partition_data.leader_epoch
+      = partition_response.current_leader.leader_epoch;
+    output_partition_data.aborted_transactions = std::move(
+      partition_response.aborted_transactions);
+
+    output_partition_data.size_bytes = response_size;
+    output_partition_data.data = std::move(response_batches);
+    if (!output_partition_data.data.empty()) {
+        output_actions.is_dirty = true;
+    }
+    output_actions.maybe_fetched_partition_data = std::move(
+      output_partition_data);
+    return output_actions;
+}
+
 void fetcher::reset_partition_offset(model::topic_partition_view tp) {
     auto t_it = _partitions.find(tp.topic);
     if (t_it == _partitions.end()) {
@@ -726,8 +802,16 @@ void fetcher::reset_partition_offset(model::topic_partition_view tp) {
     if (p_it == t_it->second.end()) {
         return;
     }
+    auto new_epoch = next_epoch();
+    vlog(
+      logger().info,
+      "[broker: {}] {} resetting fetch offsets, epoch {} -> {}",
+      _id,
+      tp,
+      p_it->second.fetcher_epoch,
+      new_epoch);
     p_it->second.fetch_offset = std::nullopt;
-    p_it->second.fetcher_epoch = next_epoch();
+    p_it->second.fetcher_epoch = new_epoch;
 }
 
 namespace {
@@ -925,6 +1009,7 @@ ss::future<> fetcher::assign_partition(
     _partitions_updated.signal();
     co_return;
 }
+
 ss::future<std::optional<kafka::offset>>
 fetcher::unassign_partition(model::topic_partition_view tp_v) {
     auto lock = co_await _state_lock.get_units();

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -17,6 +17,7 @@
 #include "kafka/client/direct_consumer/direct_consumer.h"
 #include "kafka/client/errors.h"
 #include "kafka/protocol/types.h"
+#include "model/fundamental.h"
 #include "ssx/async_algorithm.h"
 #include "ssx/future-util.h"
 
@@ -151,7 +152,8 @@ ss::future<fetcher::partitions_with_epoch> fetcher::collect_partitions() {
         co_await ssx::async_for_each_counter(
           cnt,
           partitions,
-          [&to_process, &ret, inc = _session_state.incremental()](auto& p_fs) {
+          [this, &topic, &to_process, &ret, inc = _session_state.incremental()](
+            auto& p_fs) {
               partition_fetch_state& fetch_state = p_fs.second;
               ret.epochs[to_process.topic].insert_or_assign(
                 fetch_state.partition_id,
@@ -171,6 +173,12 @@ ss::future<fetcher::partitions_with_epoch> fetcher::collect_partitions() {
                 };
 
               if (inc && should_skip(fetch_state)) {
+                  vlog(
+                    logger().trace,
+                    "[broker: {}] skipping tp {}/{} in incremental include",
+                    _id,
+                    topic,
+                    p_fs.first);
                   // session should be up to date, so we can omit this
                   // partition from the request
                   return;
@@ -239,6 +247,7 @@ ss::future<fetch_request> fetcher::make_fetch_request(
               [this, &f_topic](const partition_fetch_state& f_state) {
                   fetch_partition f_partition;
                   f_partition.partition = f_state.partition_id;
+
                   f_partition.fetch_offset = kafka::offset_cast(
                     *f_state.fetch_offset);
                   f_partition.last_fetched_epoch = f_state.current_leader_epoch;
@@ -292,6 +301,9 @@ bool fetcher::maybe_update_fetch_offset(
     }
 
     auto& fetch_state = maybe_fetch_state->get();
+    if (fetch_state.fetch_offset == kafka::next_offset(last_received)) {
+        return false;
+    }
     vlog(
       logger().trace,
       "[broker: {}] Updating {}/{} fetch offset from {} to {} {{hwm: {}}}",
@@ -551,26 +563,16 @@ fetcher::process_fetch_response(
                 dirty_partitions[topic_data.topic].insert(
                   part_data.partition_id);
             } else {
-                source_partition_offsets offsets{
-                  .log_start_offset = model::offset_cast(
-                    part_response.log_start_offset),
-                  .high_watermark = model::offset_cast(
-                    part_response.high_watermark),
-                  .last_stable_offset = model::offset_cast(
-                    part_response.last_stable_offset),
-                  .last_offset_update_timestamp = ss::lowres_clock::now(),
-                };
-                part_data.start_offset = offsets.log_start_offset;
-                part_data.high_watermark = offsets.high_watermark;
-                part_data.last_stable_offset = offsets.last_stable_offset;
+                part_data.start_offset = model::offset_cast(
+                  part_response.log_start_offset);
+                part_data.high_watermark = model::offset_cast(
+                  part_response.high_watermark);
+                part_data.last_stable_offset = model::offset_cast(
+                  part_response.last_stable_offset);
                 part_data.leader_epoch
                   = part_response.current_leader.leader_epoch;
                 part_data.aborted_transactions = std::move(
                   part_response.aborted_transactions);
-
-                _parent->maybe_update_source_partition_offsets(
-                  {topic_data.topic, part_response.partition_index},
-                  std::move(offsets));
 
                 vlog(
                   logger().trace,
@@ -579,33 +581,70 @@ fetcher::process_fetch_response(
                   topic_data.topic,
                   part_response);
 
+                // if no records, just emplace the offset updates
+                // if records, handle size calculation and fetch offsets updates
                 if (
                   !part_response.records.has_value()
                   || part_response.records->is_end_of_stream()) {
-                    continue;
-                }
-                auto partition_response_size
-                  = part_response.records->size_bytes();
-                part_data.size_bytes = partition_response_size;
-                topic_data.total_bytes += partition_response_size;
-                part_data.data = co_await reader_to_chunked_vector(
-                  std::move(part_response.records.value()));
+                    // these still go on the queue as they probably contain
+                    // information about a prefix truncation
+                    vlog(
+                      logger().debug,
+                      "[broker: {}] tp: {}/{}, received recordless response",
+                      _id,
+                      topic_data.topic,
+                      part_data.partition_id);
+                } else {
+                    // from here, there is actual data to be process, render it
+                    // accordingly
+                    auto partition_response_size
+                      = part_response.records->size_bytes();
+                    part_data.size_bytes = partition_response_size;
+                    topic_data.total_bytes += partition_response_size;
+                    part_data.data = co_await reader_to_chunked_vector(
+                      std::move(part_response.records.value()));
 
-                bool updated_offset = maybe_update_fetch_offset(
-                  topic_data.topic,
-                  part_data.partition_id,
-                  model::offset_cast(part_data.data.back().last_offset()),
-                  part_data.high_watermark);
-                if (!updated_offset) {
-                    continue;
+                    bool updated_offset = maybe_update_fetch_offset(
+                      topic_data.topic,
+                      part_data.partition_id,
+                      model::offset_cast(part_data.data.back().last_offset()),
+                      part_data.high_watermark);
+                    if (!updated_offset) {
+                        // This implies a mistake in the fetch logic. A response
+                        // that is
+                        // 1. consistent
+                        // 2. record bearing
+                        // 3. redundant
+                        // should not occur and can be considered a
+                        // non-monatomic fetch
+                        vlog(
+                          logger().error,
+                          "[broker: {}] tp: {}/{} received a record bearing "
+                          "fetch "
+                          "that did not update fetch offsets",
+                          _id,
+                          topic_data.topic,
+                          part_data.partition_id);
+                        // record will still go on the queue, but with records
+                        // emptied in case it contains a start offset update
+                        topic_data.total_bytes -= partition_response_size;
+                        part_data.size_bytes = 0u;
+                        part_data.data.clear();
+                    }
+                    dirty_partitions[topic_data.topic].insert(
+                      part_data.partition_id);
                 }
-                dirty_partitions[topic_data.topic].insert(
-                  part_data.partition_id);
             }
             topic_data.partitions.push_back(std::move(part_data));
         }
         result.total_bytes += topic_data.total_bytes;
         if (topic_data.partitions.empty()) {
+            vassert(
+              topic_data.total_bytes == 0,
+              "fetched_topic_data::total_size should be the sum of all "
+              "contained fetched_partition_data::size_bytes. If "
+              "topic_data::partitions is empty, total_size must necessarily be "
+              "0");
             continue;
         }
         result.topics.push_back(std::move(topic_data));

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -740,7 +740,8 @@ fetcher::partition_response_actions fetcher::do_process_partition_response(
   chunked_vector<model::record_batch> response_batches,
   size_t response_size,
   fetcher::epoch_set epoch_set) {
-    // this was done to keep this method synchronous
+    // Record deserialization is async, extract the records before calling this
+    // method
     vassert(
       !partition_response.records.has_value(),
       "a precondition of calling this function is moving the records into the "
@@ -909,7 +910,9 @@ ss::future<kafka::error_code> fetcher::maybe_initialise_fetch_offsets(
               response_topic.topic, response_partition.partition_id);
             vassert(
               maybe_fetch_state.has_value(),
-              "fetch state should be found if the tp is consistent");
+              "Initializing list offsets should be performed behind a "
+              "partition consistency check. The partition must be assigned to "
+              "be consistent, which means the fetcher state must be found.");
             auto& fetch_state = maybe_fetch_state->get();
 
             vlog(

--- a/src/v/kafka/client/direct_consumer/fetcher.h
+++ b/src/v/kafka/client/direct_consumer/fetcher.h
@@ -9,15 +9,18 @@
  * by the Apache License, Version 2.0
  */
 #pragma once
+#include "absl/container/flat_hash_set.h"
 #include "base/format_to.h"
 #include "container/chunked_vector.h"
 #include "container/intrusive_list_helpers.h"
 #include "kafka/client/direct_consumer/api_types.h"
 #include "kafka/client/direct_consumer/data_queue.h"
+#include "kafka/protocol/errors.h"
 #include "kafka/protocol/fetch.h"
 #include "kafka/protocol/list_offset.h"
 #include "kafka/protocol/types.h"
 #include "model/fundamental.h"
+#include "model/record.h"
 #include "utils/mutex.h"
 #include "utils/prefix_logger.h"
 
@@ -28,6 +31,8 @@
 #include <fmt/format.h>
 
 #include <optional>
+
+class fetcher_accessor;
 
 namespace kafka::client {
 class direct_consumer;
@@ -298,6 +303,42 @@ private:
       fetch_response resp,
       const topic_partition_map<epoch_set>& epochs,
       const chunked_vector<partitions_to_process>& partitions);
+
+    ss::future<std::optional<fetched_partition_data>>
+    process_partition_response(
+      const model::topic& topic,
+      partition_data partition_data,
+      const topic_partition_map<epoch_set>& epochs,
+      /* in&out */ fetch_response_content& result,
+      /* in&out */
+      chunked_hash_map<model::topic, absl::flat_hash_set<model::partition_id>>&
+        dirty_partitions);
+
+    struct partition_response_actions {
+        // error if any
+        kafka::error_code error{kafka::error_code::none};
+        // should the partition's fetch offsets be reset s.t. they will be set
+        // on the next list offsets
+        bool should_reset_offsets{false};
+        // indicates that the entire fetch needs a metadata update, probably a
+        // leadership transfer
+        bool should_update_metadata{false};
+        // should the fetch be included in the next round of incremental fetch
+        // requests
+        bool is_dirty{false};
+        // if present, this fetch data will be added to the response queue
+        std::optional<fetched_partition_data> maybe_fetched_partition_data{
+          std::nullopt};
+    };
+
+    // unit testable function to make decisions on what update actions should be
+    // done considering given response
+    static partition_response_actions do_process_partition_response(
+      partition_data partition_data,
+      chunked_vector<model::record_batch> response_batches,
+      size_t response_size,
+      epoch_set epoch_set);
+
     /**
      * Returns false if the partition was not found or the fetch offset was
      * not updated.
@@ -334,6 +375,8 @@ private:
      */
     fetcher_epoch _epoch{0};
     ss::abort_source _as;
+
+    friend class ::fetcher_accessor;
 };
 } // namespace kafka::client
 

--- a/src/v/kafka/client/direct_consumer/tests/BUILD
+++ b/src/v/kafka/client/direct_consumer/tests/BUILD
@@ -79,3 +79,26 @@ redpanda_cc_gtest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "fetcher_test",
+    timeout = "short",
+    srcs = [
+        "fetcher_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/container:chunked_vector",
+        "//src/v/kafka/client:types",
+        "//src/v/kafka/client/direct_consumer",
+        "//src/v/kafka/protocol",
+        "//src/v/kafka/server/tests:kafka_test_utils",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/test_utils:gtest",
+        "@fmt",
+        "@googletest//:gtest",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/kafka/client/direct_consumer/tests/direct_consumer_fixture_test.cc
+++ b/src/v/kafka/client/direct_consumer/tests/direct_consumer_fixture_test.cc
@@ -10,11 +10,14 @@
  */
 
 #include "kafka/client/direct_consumer/tests/direct_consumer_fixture.h"
+#include "model/fundamental.h"
 #include "redpanda/tests/fixture.h"
 
 #include <seastar/util/defer.hh>
 
 #include <fmt/format.h>
+
+#include <unordered_map>
 
 using namespace kafka::client;
 using ConsumerFixture = kafka::client::tests::consumer_fixture;
@@ -26,13 +29,33 @@ ss::logger logger{"direct-consumer-test"};
 
 TEST_P(BasicConsumerFixture, TestBasicConsumption) {
     assign_partitions(make_assignment(topic, {0, 1, 2}));
+    { // assert on intial updates, we should see each partition at most once,
+      // but maybe not at all
+        std::unordered_map<model::topic_partition, int> times_seen;
+        for (int i = 0; i < 10; ++i) {
+            auto fetched = consumer->fetch_next(100ms).get();
+            ASSERT_TRUE(fetched.has_value())
+              << "fetch should not have an error";
 
-    // no data should be available immediately, as the topic is empty
-    for (int i = 0; i < 10; ++i) {
-        auto fetched = consumer->fetch_next(100ms).get();
-        ASSERT_TRUE(fetched.value().empty());
+            for (auto& topic_data : fetched.value()) {
+                for (auto& partition_data : topic_data.partitions) {
+                    ASSERT_EQ(partition_data.size_bytes, 0);
+                    ASSERT_EQ(partition_data.data.size(), 0);
+                    ASSERT_EQ(partition_data.high_watermark, kafka::offset{0});
+                    ASSERT_EQ(
+                      partition_data.last_stable_offset, kafka::offset{0});
+                    ASSERT_EQ(partition_data.start_offset, kafka::offset{0});
+                    int& seen_counter = times_seen[model::topic_partition{
+                      topic_data.topic, partition_data.partition_id}];
+                    ++seen_counter;
+                }
+            }
+        }
+        ASSERT_TRUE(times_seen.size() <= 3);
+        for (auto [tp, counter] : times_seen) {
+            ASSERT_EQ(counter, 1);
+        }
     }
-
     // produce some data
     produce_to_partition(topic, 0, 1000).get();
     produce_to_partition(topic, 1, 400).get();
@@ -79,7 +102,6 @@ TEST_P(BasicConsumerFixture, TestBasicConsumption) {
         .last_offset(),
       model::offset(1019));
 }
-
 TEST_P(BasicConsumerFixture, TestBasicLeadershipTransfer) {
     // constants
     constexpr uint first_produce_count = 10;
@@ -609,11 +631,6 @@ TEST_F(FetchSessionFixture, TestFetchRequestContents) {
     assign_partitions(make_assignment(
       topic, initial_assignment | std::ranges::to<std::vector<int>>()));
 
-    for (int i = 0; i < 10; ++i) {
-        auto fetched = consumer->fetch_next(100ms).get();
-        ASSERT_TRUE(fetched.value().empty());
-    }
-
     constexpr int64_t n = 100;
 
     for (auto i : all_partitions) {
@@ -695,11 +712,6 @@ TEST_F(FetchSessionFixture, TestFetchRequestUnassignContents) {
 
     assign_partitions(make_assignment(
       topic, initial_assignment | std::ranges::to<std::vector<int>>()));
-
-    for (int i = 0; i < 10; ++i) {
-        auto fetched = consumer->fetch_next(100ms).get();
-        ASSERT_TRUE(fetched.value().empty());
-    }
 
     constexpr int64_t n = 100;
 

--- a/src/v/kafka/client/direct_consumer/tests/direct_consumer_test.cc
+++ b/src/v/kafka/client/direct_consumer/tests/direct_consumer_test.cc
@@ -494,8 +494,7 @@ init_offsets(reassign_direction direction) {
  * 3. let dc fetch data
  * 4. unassign ntp
  * 5. reassign ntp with reassignment_offset
- * 6. check the first call to fetch_next is a empty fetch (was filtered out)
- * 7. drain all fetches, check we see only 50 - reassignment offset
+ * 6. drain all fetches, check we see only 50 - reassignment offset
  */
 void epoch_filtering_test(
   consumer_test_mock* self, reassign_direction direction) {
@@ -549,26 +548,11 @@ void epoch_filtering_test(
     consumer.unassign_topics({test_topic}).get();
     consumer.assign_partitions(get_assignment(reassignment_offset)).get();
 
-    // 6. check the first call to fetch_next is an empty fetch (was filtered)
-    auto filtered_fetch_result = consumer.fetch_next(5s).get();
-    ASSERT_TRUE(filtered_fetch_result.has_value());
-    auto filtered_fetch = std::move(filtered_fetch_result).value();
-    int found_partition_count{0};
-
-    for (auto& topic_data : filtered_fetch) {
-        for (auto& partition_data : topic_data.partitions) {
-            std::ignore = partition_data;
-            ++found_partition_count;
-            ASSERT_EQ(topic_data.total_bytes, 0);
-        }
-    }
-    ASSERT_EQ(found_partition_count, 0);
-
     const size_t expected_size = (batch_count * batch_size)
                                  - static_cast<int64_t>(reassignment_offset);
     const model::offset final_offset{batch_count * batch_size - 1};
 
-    // 7. drain all fetches, check we see only 50 - reassignment_offset
+    // 6. drain all fetches, check we see only 50 - reassignment_offset
     RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
         return self->fetch_and_append_to_map(all_batches, consumer).then([&] {
             auto& ntp_batches = all_batches[test_topic][model::partition_id(0)];
@@ -654,9 +638,12 @@ TEST_F(consumer_test_mock, TestOffsetResetPolicy) {
         .next_offset = std::nullopt, // no offset set, should reset to latest
       });
     consumer.assign_partitions(std::move(new_assignment)).get();
+    // fetch will update offsets, but offer no data
     auto data = consumer.fetch_next(std::chrono::seconds(1)).get();
-    // fetch should be empty, because the fetch offset was reset to latest
-    ASSERT_EQ(data.value().size(), 0);
+    for (auto& topic_data : data.value()) {
+        ASSERT_EQ(topic_data.total_bytes, 0)
+          << "should not find any batches on empty initial fetch";
+    }
     // add more data to partition 1
     make_data_available(test_topic, 1, 6);
     fetch_and_append_to_map(all_batches, consumer).get();

--- a/src/v/kafka/client/direct_consumer/tests/fetcher_test.cc
+++ b/src/v/kafka/client/direct_consumer/tests/fetcher_test.cc
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/client/direct_consumer/api_types.h"
+#include "kafka/client/direct_consumer/direct_consumer.h"
+#include "kafka/client/direct_consumer/fetcher.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/types.h"
+#include "model/record.h"
+#include "model/tests/random_batch.h"
+#include "test_utils/test.h"
+
+#include <gtest/gtest.h>
+
+#include <iterator>
+
+using namespace kafka;
+using namespace kafka::client;
+
+namespace {
+
+const aborted_transaction default_aborted_transaction = aborted_transaction{
+  .producer_id = kafka::producer_id{101}, .first_offset = int64_t{8}};
+
+const model::partition_id default_partition_id{1};
+
+ss::future<std::pair<chunked_vector<model::record_batch>, size_t>>
+get_random_batches() {
+    auto random_batches = co_await model::test::make_random_batches(
+      model::offset(0));
+
+    chunked_vector<model::record_batch> to_return{};
+    std::ranges::move(std::move(random_batches), std::back_inserter(to_return));
+
+    auto number_of_batches = to_return.size();
+    co_return std::pair{std::move(to_return), number_of_batches};
+}
+
+partition_data get_default_partition_data() {
+    // numbers are mostly arbitrary, assigned to avoid duplicate values
+    return partition_data{
+      .partition_index = model::partition_id{default_partition_id},
+      .error_code = kafka::error_code::none,
+      .high_watermark = model::offset{13},
+      .last_stable_offset = model::offset{7},
+      .log_start_offset = model::offset{5},
+      .aborted_transactions
+      = std::optional<chunked_vector<aborted_transaction>>{chunked_vector<
+        aborted_transaction>({default_aborted_transaction})},
+      .preferred_read_replica = model::node_id{27},
+      .records = std::optional<kafka::batch_reader>{std::nullopt},
+      .diverging_epoch
+      = diverging_epoch_end_offset{.epoch = kafka::leader_epoch{52}, .end_offset = model::offset{6}},
+      .current_leader
+      = leader_id_and_epoch{.leader_id = model::node_id{19}, .leader_epoch = kafka::leader_epoch{67}},
+      .snapshot_id
+      = snapshot_id{.end_offset = model::offset(11), .epoch = kafka::leader_epoch{63}},
+      .unknown_tags = tagged_fields{},
+      .has_to_be_included = bool{false}};
+}
+
+void assert_defaults(const fetched_partition_data& data) {
+    auto default_partition_data = get_default_partition_data();
+
+    ASSERT_EQ(data.partition_id, default_partition_data.partition_index);
+    ASSERT_EQ(
+      data.leader_epoch, default_partition_data.current_leader.leader_epoch);
+    ASSERT_EQ(
+      data.start_offset,
+      model::offset_cast(default_partition_data.log_start_offset));
+    ASSERT_EQ(
+      data.high_watermark,
+      model::offset_cast(default_partition_data.high_watermark));
+    ASSERT_EQ(
+      data.last_stable_offset,
+      model::offset_cast(default_partition_data.last_stable_offset));
+
+    ASSERT_TRUE(data.aborted_transactions.has_value());
+    ASSERT_EQ(
+      default_partition_data.aborted_transactions->size(),
+      data.aborted_transactions->size());
+    ASSERT_EQ(data.aborted_transactions->size(), 1);
+    ASSERT_EQ(
+      default_partition_data.aborted_transactions->at(0).producer_id,
+      data.aborted_transactions->at(0).producer_id);
+    ASSERT_EQ(
+      default_partition_data.aborted_transactions->at(0).first_offset,
+      data.aborted_transactions->at(0).first_offset);
+}
+} // namespace
+
+class fetcher_accessor {
+public:
+    static fetcher::epoch_set default_epoch_set;
+
+    static void do_process_partition_smoke() {
+        auto partition_data = get_default_partition_data();
+        auto [batches, size] = get_random_batches().get();
+
+        auto actions = fetcher::do_process_partition_response(
+          std::move(partition_data),
+          std::move(batches),
+          size,
+          default_epoch_set);
+
+        ASSERT_FALSE(actions.should_reset_offsets);
+        ASSERT_FALSE(actions.should_update_metadata);
+        ASSERT_EQ(actions.error, kafka::error_code::none);
+        ASSERT_TRUE(actions.is_dirty);
+        ASSERT_TRUE(actions.maybe_fetched_partition_data.has_value());
+
+        auto& fetched_partition_data
+          = actions.maybe_fetched_partition_data.value();
+
+        assert_defaults(fetched_partition_data);
+        ASSERT_EQ(
+          fetched_partition_data.subscription_epoch,
+          default_epoch_set.subscription_epoch);
+        ASSERT_EQ(fetched_partition_data.size_bytes, size);
+        ASSERT_EQ(fetched_partition_data.data.size(), size);
+    }
+
+    static void do_process_partition_retriable() {
+        auto partition_data = get_default_partition_data();
+        partition_data.error_code = kafka::error_code::not_leader_for_partition;
+        auto [batches, size] = get_random_batches().get();
+
+        auto actions = fetcher::do_process_partition_response(
+          std::move(partition_data),
+          std::move(batches),
+          size,
+          default_epoch_set);
+
+        ASSERT_FALSE(actions.should_reset_offsets);
+        ASSERT_TRUE(actions.should_update_metadata);
+        ASSERT_EQ(actions.error, kafka::error_code::not_leader_for_partition);
+        ASSERT_TRUE(actions.is_dirty);
+        ASSERT_FALSE(actions.maybe_fetched_partition_data.has_value());
+    }
+
+    static void do_process_partition_out_of_bounds() {
+        auto partition_data = get_default_partition_data();
+        partition_data.error_code = kafka::error_code::offset_out_of_range;
+        auto [batches, size] = get_random_batches().get();
+
+        auto actions = fetcher::do_process_partition_response(
+          std::move(partition_data),
+          std::move(batches),
+          size,
+          default_epoch_set);
+
+        ASSERT_TRUE(actions.should_reset_offsets);
+        ASSERT_FALSE(actions.should_update_metadata);
+        ASSERT_EQ(actions.error, kafka::error_code::offset_out_of_range);
+        ASSERT_FALSE(actions.is_dirty);
+        ASSERT_FALSE(actions.maybe_fetched_partition_data.has_value());
+    }
+
+    static void do_process_partition_unknown_error() {
+        auto partition_data = get_default_partition_data();
+        partition_data.error_code = kafka::error_code::unknown_server_error;
+        auto [batches, size] = get_random_batches().get();
+
+        auto actions = fetcher::do_process_partition_response(
+          std::move(partition_data),
+          std::move(batches),
+          size,
+          default_epoch_set);
+
+        ASSERT_FALSE(actions.should_reset_offsets);
+        ASSERT_FALSE(actions.should_update_metadata);
+        ASSERT_EQ(actions.error, kafka::error_code::unknown_server_error);
+        ASSERT_TRUE(actions.is_dirty);
+        ASSERT_TRUE(actions.maybe_fetched_partition_data.has_value());
+
+        auto& fetched_partition_data
+          = actions.maybe_fetched_partition_data.value();
+
+        ASSERT_EQ(fetched_partition_data.size_bytes, 0);
+        ASSERT_EQ(fetched_partition_data.data.size(), 0);
+        ASSERT_EQ(
+          fetched_partition_data.error,
+          kafka::error_code::unknown_server_error);
+        ASSERT_EQ(
+          fetched_partition_data.subscription_epoch,
+          default_epoch_set.subscription_epoch);
+        ::fetched_partition_data expected{};
+        expected.partition_id = default_partition_id;
+
+        // check that the remainder of the fields are initialized as per
+        // defaults
+        ASSERT_EQ(fetched_partition_data.partition_id, expected.partition_id);
+        ASSERT_EQ(fetched_partition_data.leader_epoch, expected.leader_epoch);
+        ASSERT_EQ(fetched_partition_data.start_offset, expected.start_offset);
+        ASSERT_EQ(
+          fetched_partition_data.high_watermark, expected.high_watermark);
+        ASSERT_EQ(
+          fetched_partition_data.last_stable_offset,
+          expected.last_stable_offset);
+    }
+
+    static void do_process_partition_empty() {
+        auto partition_data = get_default_partition_data();
+
+        auto actions = fetcher::do_process_partition_response(
+          std::move(partition_data), {}, 0, default_epoch_set);
+
+        ASSERT_FALSE(actions.should_reset_offsets);
+        ASSERT_FALSE(actions.should_update_metadata);
+        ASSERT_EQ(actions.error, kafka::error_code::none);
+        ASSERT_FALSE(actions.is_dirty);
+        ASSERT_TRUE(actions.maybe_fetched_partition_data.has_value());
+
+        auto& fetched_partition_data
+          = actions.maybe_fetched_partition_data.value();
+
+        assert_defaults(fetched_partition_data);
+        ASSERT_EQ(
+          fetched_partition_data.subscription_epoch,
+          default_epoch_set.subscription_epoch);
+        ASSERT_EQ(fetched_partition_data.size_bytes, 0);
+        ASSERT_EQ(fetched_partition_data.data.size(), 0);
+    }
+};
+
+fetcher::epoch_set fetcher_accessor::default_epoch_set = {
+  fetcher::fetcher_epoch{111}, subscription_epoch{777}};
+
+TEST(FetcherSuite, DoProcessPartitionSmoke) {
+    fetcher_accessor::do_process_partition_smoke();
+}
+TEST(FetcherSuite, DoProcessPartitionEmpty) {
+    fetcher_accessor::do_process_partition_empty();
+}
+TEST(FetcherSuite, DoProcessPartitionOutOfBounds) {
+    fetcher_accessor::do_process_partition_out_of_bounds();
+}
+TEST(FetcherSuite, DoProcessPartitionRetriable) {
+    fetcher_accessor::do_process_partition_retriable();
+}
+TEST(FetcherSuite, DoProcessPartitionUnknownError) {
+    fetcher_accessor::do_process_partition_unknown_error();
+}


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28309 

These changes have baked for over a month without issue in dev. Backporting