### PR TITLE
src/v/raft/tests: mark coordinated_compaction_test as flaky

### DIFF
--- a/src/v/raft/tests/BUILD
+++ b/src/v/raft/tests/BUILD
@@ -504,6 +504,7 @@ redpanda_cc_gtest(
     srcs = [
         "coordinated_compaction_test.cc",
     ],
+    flaky = True,
     deps = [
         "//src/v/model",
         "//src/v/raft",


### PR DESCRIPTION
Mark `coordinated_compaction_test` as flaky to unblock CI while the root cause is investigated.

Relates to [CORE-15445]

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none

[CORE-15445]: https://redpandadata.atlassian.net/browse/CORE-15445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ