### PR TITLE
bazel: update seastar to 4073a7c0

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -302,7 +302,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "ejgNqy8RRekyIoUTFC8LXmOsKvRKzTyxLCwtORd1/qA=",
+        "bzlTransitiveDigest": "CjdOuMogKhd6gSdef3vZ+UuC9JiGX28veZU7rqEG9bk=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -482,9 +482,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "29c95e2ec964e63d18f6dc37938daab642fa4197887f6c5a66e95b2ee439e295",
-              "strip_prefix": "seastar-804949ce1b428e17ec920bdf17f94cc4ebc6104f",
-              "url": "https://github.com/redpanda-data/seastar/archive/804949ce1b428e17ec920bdf17f94cc4ebc6104f.tar.gz"
+              "sha256": "d3fc945436fc89e37976de1b2c451cee56f581715928219aba31f49b7bf18b0d",
+              "strip_prefix": "seastar-4073a7c0e56bec74f5b674c50f949d1d268bdf7c",
+              "url": "https://github.com/redpanda-data/seastar/archive/4073a7c0e56bec74f5b674c50f949d1d268bdf7c.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -167,12 +167,13 @@ def data_dependency():
         url = "https://github.com/redpanda-data/CRoaring/archive/c433d1c70c10fb2e40f049e019e2abbcafa6e69d.tar.gz",
     )
 
+    # branch: v26.1.x
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "29c95e2ec964e63d18f6dc37938daab642fa4197887f6c5a66e95b2ee439e295",
-        strip_prefix = "seastar-804949ce1b428e17ec920bdf17f94cc4ebc6104f",
-        url = "https://github.com/redpanda-data/seastar/archive/804949ce1b428e17ec920bdf17f94cc4ebc6104f.tar.gz",
+        sha256 = "d3fc945436fc89e37976de1b2c451cee56f581715928219aba31f49b7bf18b0d",
+        strip_prefix = "seastar-4073a7c0e56bec74f5b674c50f949d1d268bdf7c",
+        url = "https://github.com/redpanda-data/seastar/archive/4073a7c0e56bec74f5b674c50f949d1d268bdf7c.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
## Summary

Update Seastar dependency to latest commit from v26.1.x branch.

- Previous SHA: 804949ce1b42
- New SHA: 4073a7c0e56b

### Changes included:
- reactor_backend: Fix another busy spin bug in epoll
- tests: Add unit test for epoll busy spin bug
- change where newline is emitted

[Compare changes](https://github.com/redpanda-data/seastar/compare/804949ce1b428e17ec920bdf17f94cc4ebc6104f...4073a7c0e56bec74f5b674c50f949d1d268bdf7c)

## Backports Required

- [x] none - not applicable

## Release Notes

* none