### PR TITLE
CORE-15456 Support Group ACLs in Schema Registry

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -49,8 +49,8 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.65.0
 	github.com/redpanda-data/common-go/proto v0.0.0-20250820120127-9b518fca5ecf
-	github.com/redpanda-data/common-go/rpadmin v0.2.1
-	github.com/redpanda-data/common-go/rpsr v0.1.2
+	github.com/redpanda-data/common-go/rpadmin v0.2.2
+	github.com/redpanda-data/common-go/rpsr v0.1.3
 	github.com/redpanda-data/protoc-gen-go-mcp v0.0.0-20250812151819-7e5d5fef8241
 	github.com/rs/xid v1.6.0
 	github.com/safchain/ethtool v0.6.2

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -255,10 +255,10 @@ github.com/redpanda-data/common-go/net v0.1.0 h1:JnJioRJuL961r1QXiJQ1tW9+yEaJfu8
 github.com/redpanda-data/common-go/net v0.1.0/go.mod h1:iOdNkjxM7a1T8F3cYHTaKIPFCHzzp/ia6TN+Z+7Tt5w=
 github.com/redpanda-data/common-go/proto v0.0.0-20250820120127-9b518fca5ecf h1:Oe0Sc3+/37Xgdpze7klkWyvB6eAt/nuUhrn93Rd4ESA=
 github.com/redpanda-data/common-go/proto v0.0.0-20250820120127-9b518fca5ecf/go.mod h1:GMoRcdMz6CIpr+8vKrSJvr8fJDlojETRV45BD6A0DvU=
-github.com/redpanda-data/common-go/rpadmin v0.2.1 h1:N3GUI3d1h661Nta6Jc4MyaVKWxRIg28yO4MG912gCXQ=
-github.com/redpanda-data/common-go/rpadmin v0.2.1/go.mod h1:qmu76v7RRKgEXLS3UXxZ8KDpObtSNq6RinOIejJNWzw=
-github.com/redpanda-data/common-go/rpsr v0.1.2 h1:DThUeyfBH8fkL9WoP1sEbRhT2NVV22zmsTpcCtzfusQ=
-github.com/redpanda-data/common-go/rpsr v0.1.2/go.mod h1:2j2416onosg5FKaKz52NooRE+q/9EJqQn0kyTcTXWHc=
+github.com/redpanda-data/common-go/rpadmin v0.2.2 h1:xD31YJBkUs9Z/KkZUIkVRHKk/EQ6MrPAvgiFUVcFFu0=
+github.com/redpanda-data/common-go/rpadmin v0.2.2/go.mod h1:qmu76v7RRKgEXLS3UXxZ8KDpObtSNq6RinOIejJNWzw=
+github.com/redpanda-data/common-go/rpsr v0.1.3 h1:mcjp7MeJylONI0H4MlrUEPEVOZpPNQGzWqcdd1QIAv4=
+github.com/redpanda-data/common-go/rpsr v0.1.3/go.mod h1:2j2416onosg5FKaKz52NooRE+q/9EJqQn0kyTcTXWHc=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525 h1:vskZrV6q8W8flL0Ud23AJUYAd8ZgTadO45+loFnG2G0=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525/go.mod h1:3YqAM7pgS5vW/EH7naCjFqnAajSgi0f0CfMe1HGhLxQ=
 github.com/redpanda-data/protoc-gen-go-mcp v0.0.0-20250812151819-7e5d5fef8241 h1:5wh/iAcLndnLllK/O2lVAVb6MGuz+9H59ZQGBfjxxlU=

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -405,6 +405,7 @@ from_string_view<principal_type>(std::string_view str) {
         to_string_view(principal_type::ephemeral_user),
         principal_type::ephemeral_user)
       .match(to_string_view(principal_type::role), principal_type::role)
+      .match(to_string_view(principal_type::group), principal_type::group)
       .default_match(std::nullopt);
 }
 

--- a/src/v/security/tests/authorizer_test.cc
+++ b/src/v/security/tests/authorizer_test.cc
@@ -3204,4 +3204,174 @@ TEST(AUTHORIZER_TEST, authz_sr_context_subject_patterns) {
     }
 }
 
+// Tests for Group principal parsing and validation
+TEST(AUTHORIZER_TEST, parse_group_principal_from_string_view) {
+    // Test the fixed from_string_view<principal_type> function
+    auto user_type = from_string_view<principal_type>("user");
+    ASSERT_TRUE(user_type.has_value());
+    EXPECT_EQ(*user_type, principal_type::user);
+
+    auto group_type = from_string_view<principal_type>("group");
+    ASSERT_TRUE(group_type.has_value());
+    EXPECT_EQ(*group_type, principal_type::group);
+
+    auto role_type = from_string_view<principal_type>("role");
+    ASSERT_TRUE(role_type.has_value());
+    EXPECT_EQ(*role_type, principal_type::role);
+
+    auto ephemeral_type = from_string_view<principal_type>("ephemeral user");
+    ASSERT_TRUE(ephemeral_type.has_value());
+    EXPECT_EQ(*ephemeral_type, principal_type::ephemeral_user);
+
+    // Test invalid type
+    auto invalid_type = from_string_view<principal_type>("invalid");
+    EXPECT_FALSE(invalid_type.has_value());
+}
+
+TEST(AUTHORIZER_TEST, parse_group_principal_from_string) {
+    // Test basic Group principal parsing
+    auto group1 = acl_principal::from_string("Group:developers");
+    EXPECT_EQ(group1.type(), principal_type::group);
+    EXPECT_EQ(group1.name(), "developers");
+
+    // Test Group with hyphens
+    auto group2 = acl_principal::from_string("Group:my-team");
+    EXPECT_EQ(group2.type(), principal_type::group);
+    EXPECT_EQ(group2.name(), "my-team");
+
+    // Test Group with underscores
+    auto group3 = acl_principal::from_string("Group:team_123");
+    EXPECT_EQ(group3.type(), principal_type::group);
+    EXPECT_EQ(group3.name(), "team_123");
+
+    // Test Group with mixed case
+    auto group4 = acl_principal::from_string("Group:TeamLead");
+    EXPECT_EQ(group4.type(), principal_type::group);
+    EXPECT_EQ(group4.name(), "TeamLead");
+
+    // Test that wildcard groups throw exception (only users can be wildcards)
+    EXPECT_THROW(acl_principal::from_string("Group:*"), acl_conversion_error);
+
+    // Test empty group name throws
+    EXPECT_THROW(acl_principal::from_string("Group:"), std::exception);
+
+    // Verify User principal with wildcard still works
+    auto wildcard_user = acl_principal::from_string("User:*");
+    EXPECT_EQ(wildcard_user.type(), principal_type::user);
+    EXPECT_TRUE(wildcard_user.wildcard());
+
+    // Verify User principal without wildcard
+    auto user1 = acl_principal::from_string("User:alice");
+    EXPECT_EQ(user1.type(), principal_type::user);
+    EXPECT_EQ(user1.name(), "alice");
+    EXPECT_FALSE(user1.wildcard());
+}
+
+TEST(AUTHORIZER_TEST, authorize_with_group_principal_acls) {
+    // Create test principals
+    auto user = acl_principal(principal_type::user, "alice");
+    auto group = acl_principal(principal_type::group, "developers");
+    auto host = acl_host("192.168.1.1");
+    const model::topic topic("dev-topic");
+
+    // Create ACL for Group:developers
+    acl_entry allow_read(
+      group, acl_wildcard_host, acl_operation::read, acl_permission::allow);
+
+    // Create resource and binding
+    resource_pattern resource(
+      resource_type::topic, topic(), pattern_type::literal);
+    std::vector<acl_binding> bindings;
+    bindings.emplace_back(resource, allow_read);
+
+    // Setup authorizer
+    role_store roles;
+    auto auth = make_test_instance(authorizer::allow_empty_matches::no, &roles);
+    auth.add_bindings(bindings);
+
+    // Test authorization with user who is in the group
+    auto result = auth.authorized(
+      topic,
+      acl_operation::read,
+      user,
+      host,
+      security::superuser_required::no,
+      {group});
+
+    // Verify authorization succeeded
+    EXPECT_TRUE(bool(result));
+    EXPECT_EQ(result.acl, allow_read);
+    EXPECT_EQ(result.group, group);
+    EXPECT_EQ(result.principal, user);
+
+    // Test authorization without group membership fails
+    auto result_no_group = auth.authorized(
+      topic,
+      acl_operation::read,
+      user,
+      host,
+      security::superuser_required::no,
+      {});
+
+    EXPECT_FALSE(bool(result_no_group));
+}
+
+TEST(AUTHORIZER_TEST, group_principal_acl_deny_precedence) {
+    // Create test principals
+    auto user = acl_principal(principal_type::user, "bob");
+    auto blocked_group = acl_principal(principal_type::group, "blocked");
+    auto host = acl_host("192.168.1.1");
+    const model::topic topic("sensitive-topic");
+
+    // Create DENY ACL for Group:blocked
+    acl_entry deny_write(
+      blocked_group,
+      acl_wildcard_host,
+      acl_operation::write,
+      acl_permission::deny);
+
+    // Create ALLOW ACL for User:bob
+    acl_entry allow_write(
+      user, acl_wildcard_host, acl_operation::write, acl_permission::allow);
+
+    // Create resource and bindings
+    resource_pattern resource(
+      resource_type::topic, topic(), pattern_type::literal);
+    std::vector<acl_binding> bindings;
+    bindings.emplace_back(resource, deny_write);
+    bindings.emplace_back(resource, allow_write);
+
+    // Setup authorizer
+    role_store roles;
+    auto auth = make_test_instance(authorizer::allow_empty_matches::no, &roles);
+    auth.add_bindings(bindings);
+
+    // Test: User bob is in blocked group - DENY should win
+    auto result_with_group = auth.authorized(
+      topic,
+      acl_operation::write,
+      user,
+      host,
+      security::superuser_required::no,
+      {blocked_group});
+
+    // DENY via group should take precedence over user ALLOW
+    EXPECT_FALSE(bool(result_with_group));
+    EXPECT_EQ(result_with_group.acl, deny_write);
+    EXPECT_EQ(result_with_group.group, blocked_group);
+
+    // Test: User bob without blocked group - ALLOW should work
+    auto result_without_group = auth.authorized(
+      topic,
+      acl_operation::write,
+      user,
+      host,
+      security::superuser_required::no,
+      {});
+
+    EXPECT_TRUE(bool(result_without_group));
+    EXPECT_EQ(result_without_group.acl, allow_write);
+    EXPECT_FALSE(result_without_group.group.has_value());
+}
+
 } // namespace security

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -7567,6 +7567,301 @@ class SchemaRegistryACLTest(SchemaRegistryEndpoints):
         # Verify ACL no longer exists eventually
         self.await_acl_count(0)
 
+    @cluster(num_nodes=3)
+    def test_group_acl_creation(self):
+        """
+        Test that Group principal ACLs can be created
+        """
+        # Create Group ACLs with various configurations
+        group_acls = [
+            self._create_test_acl(
+                principal="Group:developers",
+                resource="dev-subject",
+                resource_type="SUBJECT",
+                operation="READ",
+                permission="ALLOW",
+            ),
+            self._create_test_acl(
+                principal="Group:admins",
+                resource="*",
+                resource_type="REGISTRY",
+                operation="ALL",
+                permission="ALLOW",
+            ),
+            self._create_test_acl(
+                principal="Group:blocked",
+                resource="secret-subject",
+                resource_type="SUBJECT",
+                operation="WRITE",
+                permission="DENY",
+            ),
+        ]
+
+        # POST should succeed
+        response = self.sr_client.post_security_acls(group_acls)
+        self.assert_equal(
+            response.status_code, 201, f"Failed to create Group ACLs: {response.text}"
+        )
+
+        # Verify ACLs were created
+        self.await_acl_count(3)
+
+        # GET and verify principals
+        response = self.sr_client.get_security_acls()
+        self.assert_equal(response.status_code, 200)
+        acls = response.json()
+
+        principals = {acl["principal"] for acl in acls}
+        self.assert_in("Group:developers", principals)
+        self.assert_in("Group:admins", principals)
+        self.assert_in("Group:blocked", principals)
+
+        # Verify ACL details
+        for acl in acls:
+            if acl["principal"] == "Group:developers":
+                self.assert_equal(acl["resource"], "dev-subject")
+                self.assert_equal(acl["resource_type"], "SUBJECT")
+                self.assert_equal(acl["operation"], "READ")
+                self.assert_equal(acl["permission"], "ALLOW")
+            elif acl["principal"] == "Group:admins":
+                self.assert_equal(acl["resource"], "*")
+                self.assert_equal(acl["resource_type"], "REGISTRY")
+                self.assert_equal(acl["operation"], "ALL")
+            elif acl["principal"] == "Group:blocked":
+                self.assert_equal(acl["resource"], "secret-subject")
+                self.assert_equal(acl["permission"], "DENY")
+
+    @cluster(num_nodes=3)
+    def test_group_acl_query_filtering(self):
+        """Test querying ACLs with Group principal filters"""
+
+        # Create mix of User and Group ACLs
+        acls = [
+            self._create_test_acl(
+                principal="User:alice", resource="alice-subject", operation="WRITE"
+            ),
+            self._create_test_acl(
+                principal="Group:developers",
+                resource="dev-subject",
+                operation="READ",
+            ),
+            self._create_test_acl(
+                principal="Group:developers",
+                resource="dev-registry",
+                resource_type="REGISTRY",
+                operation="DESCRIBE",
+            ),
+            self._create_test_acl(
+                principal="Group:admins",
+                resource="*",
+                resource_type="REGISTRY",
+                operation="ALL",
+            ),
+        ]
+
+        response = self.sr_client.post_security_acls(acls)
+        self.assert_equal(response.status_code, 201)
+        self.await_acl_count(4)
+
+        # Query for Group:developers ACLs only
+        response = self.sr_client.get_security_acls(
+            params={"principal": "Group:developers"}
+        )
+        self.assert_equal(response.status_code, 200)
+        filtered_acls = response.json()
+        self.assert_equal(len(filtered_acls), 2)
+
+        for acl in filtered_acls:
+            self.assert_equal(acl["principal"], "Group:developers")
+
+        # Query for all Group principals
+        response = self.sr_client.get_security_acls()
+        self.assert_equal(response.status_code, 200)
+        all_acls = response.json()
+
+        group_acls = [acl for acl in all_acls if acl["principal"].startswith("Group:")]
+        self.assert_equal(len(group_acls), 3)
+
+        # Query for specific resource
+        response = self.sr_client.get_security_acls(params={"resource": "dev-subject"})
+        self.assert_equal(response.status_code, 200)
+        resource_acls = response.json()
+        self.assert_equal(len(resource_acls), 1)  # Group:developers
+
+    @cluster(num_nodes=3)
+    def test_group_acl_deletion(self):
+        """Test deleting Group ACLs with various filter combinations"""
+
+        # Create multiple Group ACLs
+        acls = [
+            self._create_test_acl(
+                principal="Group:team_a", resource="subject_a", operation="READ"
+            ),
+            self._create_test_acl(
+                principal="Group:team_a", resource="subject_b", operation="WRITE"
+            ),
+            self._create_test_acl(
+                principal="Group:team_b", resource="subject_a", operation="READ"
+            ),
+        ]
+
+        response = self.sr_client.post_security_acls(acls)
+        self.assert_equal(response.status_code, 201)
+        self.await_acl_count(3)
+
+        # Delete all team_a ACLs using principal filter
+        delete_filter = [{"principal": "Group:team_a"}]
+
+        response = self.sr_client.delete_security_acls(delete_filter)
+        self.assert_equal(response.status_code, 200)
+        deleted = response.json()
+        self.assert_equal(len(deleted), 2)
+
+        # Verify only team_b ACL remains
+
+        self.await_acl_count(1)
+
+        response = self.sr_client.get_security_acls()
+        self.assert_equal(response.status_code, 200)
+        remaining = response.json()
+        self.logger.info(f"Remaining: {remaining}")
+        self.assert_equal(remaining[0]["principal"], "Group:team_b")
+
+    @cluster(num_nodes=3)
+    def test_mixed_user_and_group_acls(self):
+        """Test Schema Registry with both User and Group ACLs"""
+
+        mixed_acls = [
+            self._create_test_acl(
+                principal="User:alice", resource="user-subject", operation="WRITE"
+            ),
+            self._create_test_acl(
+                principal="Group:readers",
+                resource="shared-subject",
+                operation="READ",
+            ),
+            self._create_test_acl(
+                principal="User:bob", resource="shared-subject", operation="WRITE"
+            ),
+            self._create_test_acl(
+                principal="Group:admins",
+                resource="*",
+                resource_type="REGISTRY",
+                operation="ALL",
+            ),
+        ]
+
+        # Create all ACLs
+        response = self.sr_client.post_security_acls(mixed_acls)
+        self.assert_equal(response.status_code, 201)
+        self.await_acl_count(4)
+
+        # Verify all ACLs exist
+        response = self.sr_client.get_security_acls()
+        self.assert_equal(response.status_code, 200)
+        acls = response.json()
+
+        principals = {acl["principal"] for acl in acls}
+        self.assert_equal(len(principals), 4)
+        self.assert_in("User:alice", principals)
+        self.assert_in("User:bob", principals)
+        self.assert_in("Group:readers", principals)
+        self.assert_in("Group:admins", principals)
+
+        # Verify resource distribution
+        subject_acls = [acl for acl in acls if acl["resource_type"] == "SUBJECT"]
+        registry_acls = [acl for acl in acls if acl["resource_type"] == "REGISTRY"]
+        self.assert_equal(len(subject_acls), 3)
+        self.assert_equal(len(registry_acls), 1)
+
+    @cluster(num_nodes=3)
+    def test_group_acl_validation(self):
+        """Test validation rules specific to Group principals"""
+
+        # Test wildcard group (should fail)
+        wildcard_group_acl = [self._create_test_acl(principal="Group:*")]
+        response = self.sr_client.post_security_acls(wildcard_group_acl)
+        self.assert_equal(
+            response.status_code,
+            400,
+            f"Wildcard group should fail but got {response.status_code}: {response.text}",
+        )
+        self.assert_in("wildcard", response.text.lower())
+
+        # Test empty group name (should fail)
+        empty_group_acl = [self._create_test_acl(principal="Group:")]
+        response = self.sr_client.post_security_acls(empty_group_acl)
+        self.assert_equal(
+            response.status_code,
+            400,
+            f"Empty group should fail but got {response.status_code}",
+        )
+
+        # Test valid group names with special characters
+        valid_groups = [
+            "Group:my-team",
+            "Group:team_123",
+            "Group:UPPERCASE_GROUP",
+            "Group:mixed_Case-123",
+        ]
+
+        for group in valid_groups:
+            acl = [
+                self._create_test_acl(
+                    principal=group, resource=f"test-{group.replace(':', '-')}"
+                )
+            ]
+            response = self.sr_client.post_security_acls(acl)
+            self.assert_equal(
+                response.status_code,
+                201,
+                f"Valid group {group} should be accepted but got {response.status_code}: {response.text}",
+            )
+
+    @cluster(num_nodes=3)
+    @matrix(scale=[1, 100])
+    def test_group_acl_scale(self, scale):
+        """Test Group ACL operations at scale"""
+
+        # Create N Group ACLs
+        acls = [
+            self._create_test_acl(
+                principal=f"Group:team_{i}",
+                resource=f"subject_{i}",
+                operation="READ",
+            )
+            for i in range(scale)
+        ]
+
+        # Test creation performance
+        response = self.sr_client.post_security_acls(acls)
+        self.assert_equal(
+            response.status_code,
+            201,
+            f"Failed to create {scale} Group ACLs: {response.text}",
+        )
+
+        # Verify all created
+        self.await_acl_count(scale)
+
+        # Test query performance
+        response = self.sr_client.get_security_acls()
+        self.assert_equal(response.status_code, 200)
+        all_acls = response.json()
+        self.assert_equal(len(all_acls), scale)
+
+        # Verify all are Group principals
+        for acl in all_acls:
+            assert acl["principal"].startswith("Group:team_"), (
+                f"Unexpected principal: {acl['principal']}"
+            )
+
+        # Test deletion performance
+        response = self.sr_client.delete_security_acls(acls)
+        self.assert_equal(response.status_code, 200)
+        deleted = response.json()
+        self.assert_equal(len(deleted), scale)
+
 
 class ACLTestEndpoint:
     """Base class for ACL-protected endpoints"""


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Enable Group principal support for Schema Registry ACLs with comprehensive testing.

This PR ensures that Group-based ACLs work correctly for enterprise customers with the `group_based_authorization` feature enabled. It includes a bug fix, extensive C++ unit tests, and Python integration tests for end-to-end validation.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
