### PR TITLE
security/oidc: trim whitespace from comma-separated group claims

### DIFF
--- a/src/v/security/BUILD
+++ b/src/v/security/BUILD
@@ -132,6 +132,7 @@ redpanda_cc_library(
     implementation_deps = [
         "//src/v/random:secure_random",
         "//src/v/thirdparty/krb5",
+        "@abseil-cpp//absl/strings",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/v/security/oidc_principal_mapping_applicator.cc
+++ b/src/v/security/oidc_principal_mapping_applicator.cc
@@ -10,6 +10,7 @@
 
 #include "security/oidc_principal_mapping_applicator.h"
 
+#include "absl/strings/str_split.h"
 #include "container/chunked_vector.h"
 #include "security/acl.h"
 #include "security/logger.h"
@@ -40,8 +41,13 @@ get_group_claim(const json::Pointer& p, const jwt& jwt) {
           string_claim.value());
 
         chunked_vector<std::string_view> string_claim_parsed;
-        boost::split(
-          string_claim_parsed, string_claim.value(), boost::is_any_of(","));
+
+        auto parts = absl::StrSplit(string_claim.value(), ',');
+
+        for (auto claim : parts) {
+            string_claim_parsed.push_back(absl::StripAsciiWhitespace(claim));
+        }
+
         return string_claim_parsed;
     }
 

--- a/src/v/security/tests/oidc_principal_mapping_test.cc
+++ b/src/v/security/tests/oidc_principal_mapping_test.cc
@@ -311,10 +311,31 @@ BOOST_AUTO_TEST_CASE(test_get_group_claim_comma_with_spaces) {
     auto groups = std::move(result).value();
     BOOST_REQUIRE_EQUAL(groups.size(), 3);
     // Note: boost::split includes the spaces
-    // TODO: Update this so that leading/trailing spaces are trimmed.
     BOOST_CHECK_EQUAL(groups[0], "admin");
-    BOOST_CHECK_EQUAL(groups[1], " developers");
-    BOOST_CHECK_EQUAL(groups[2], " users");
+    BOOST_CHECK_EQUAL(groups[1], "developers");
+    BOOST_CHECK_EQUAL(groups[2], "users");
+}
+
+BOOST_AUTO_TEST_CASE(test_get_group_claim_comma_with_spaces_before) {
+    // Test: Comma-separated string with spaces around commas
+    auto jwt = make_test_jwt(R"({
+        "iss": "http://example.com",
+        "sub": "user123",
+        "groups": "admin ,developers ,users"
+    })");
+    BOOST_REQUIRE(jwt.has_value());
+
+    json::Pointer group_pointer("/groups");
+    auto result = security::oidc::detail::get_group_claim(
+      group_pointer, jwt.assume_value());
+
+    BOOST_REQUIRE(result.has_value());
+    auto groups = std::move(result).value();
+    BOOST_REQUIRE_EQUAL(groups.size(), 3);
+    // Note: boost::split includes the spaces
+    BOOST_CHECK_EQUAL(groups[0], "admin");
+    BOOST_CHECK_EQUAL(groups[1], "developers");
+    BOOST_CHECK_EQUAL(groups[2], "users");
 }
 
 BOOST_AUTO_TEST_CASE(test_apply_nested_group_policy_none_simple) {


### PR DESCRIPTION
When group claims are provided as comma-separated strings, trim leading and trailing whitespace from each individual group name after splitting. This handles cases where claims contain spaces around delimiters like "admin, developers, users".

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
