### PR TITLE
SR Context: add GET/DELETE /contexts endpoints

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -1274,6 +1274,79 @@
         }
       }
     },
+    "/contexts": {
+      "get": {
+        "summary": "List all contexts.",
+        "operationId": "get_contexts",
+        "parameters": [],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      }
+    },
+    "/contexts/{context}": {
+      "delete": {
+        "summary": "Delete a context.",
+        "description": "Deletes the specified context if it is empty. Subjects must be permanently deleted before the context can be deleted.",
+        "operationId": "delete_context",
+        "parameters": [
+          {
+            "name": "context",
+            "description": "The context to delete (e.g., .staging). Cannot delete the default context.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found: Context not found",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity: Context not empty",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      }
+    },
     "/security/acls": {
       "get": {
         "summary": "List ACLs",

--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -164,6 +164,8 @@ struct reply_error_category final : std::error_category {
             return "One or more references exist to the schema";
         case reply_error_code::subject_version_schema_id_already_exists:
             return "Schema already registered with another id";
+        case reply_error_code::context_not_empty:
+            return "The specified context is not empty";
         case reply_error_code::write_collision:
             return "write_collision";
         case reply_error_code::zookeeper_error:

--- a/src/v/pandaproxy/error.h
+++ b/src/v/pandaproxy/error.h
@@ -95,6 +95,7 @@ enum class reply_error_code : uint16_t {
     subject_version_operation_not_permitted = 42205,
     subject_version_has_references = 42206,
     subject_version_schema_id_already_exists = 42207,
+    context_not_empty = 42211,
     write_collision = 50301,
     zookeeper_error = 50001,
     kafka_error = 50002,

--- a/src/v/pandaproxy/schema_registry/BUILD
+++ b/src/v/pandaproxy/schema_registry/BUILD
@@ -204,6 +204,7 @@ redpanda_cc_library(
         "//src/v/bytes:iobuf_parser",
         "//src/v/cluster",
         "//src/v/config",
+        "//src/v/container:chunked_hash_map",
         "//src/v/container:chunked_vector",
         "//src/v/container:json",
         "//src/v/json",

--- a/src/v/pandaproxy/schema_registry/authorization.cc
+++ b/src/v/pandaproxy/schema_registry/authorization.cc
@@ -10,9 +10,11 @@
 
 #include "pandaproxy/schema_registry/authorization.h"
 
+#include "container/chunked_hash_map.h"
 #include "pandaproxy/api/api-doc/schema_registry.json.hh"
 #include "pandaproxy/parsing/httpd.h"
 #include "pandaproxy/schema_registry/service.h"
+#include "pandaproxy/schema_registry/sharded_store.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "security/acl.h"
 #include "security/audit/audit_log_manager.h"
@@ -102,6 +104,9 @@ void check_authenticated(
 
 const auto subject_resource_type = ssx::sformat(
   "{}", security::resource_type::sr_subject);
+
+const auto registry_resource_type = ssx::sformat(
+  "{}", security::resource_type::sr_registry);
 
 using audit_resources = chunked_vector<security::audit::resource_detail>;
 
@@ -260,6 +265,120 @@ void handle_get_subjects_authz(
     // authorized subjects.
     // If there are any unauthorized subjects, generate failed audit event with
     // them.
+    audit_authz(
+      rq,
+      operation_name,
+      auth_result.value(),
+      true,
+      op,
+      std::move(passing_results));
+
+    if (!failing_results.empty()) {
+        audit_authz(
+          rq,
+          operation_name,
+          auth_result.value(),
+          false,
+          op,
+          std::move(failing_results));
+    }
+}
+
+ss::future<> handle_get_contexts_authz(
+  const server::request_t& rq,
+  sharded_store& store,
+  std::optional<request_auth_result>& auth_result,
+  chunked_vector<context>& contexts) {
+    const auto& operation_name
+      = ss::httpd::schema_registry_json::get_contexts.operations.nickname;
+    constexpr auto op = security::acl_operation::describe;
+
+    if (!auth_result.has_value()) {
+        co_return;
+    }
+
+    check_authenticated(rq, operation_name, op, *auth_result);
+
+    auto params = detail::auth_params{rq};
+
+    auto has_registry_describe = rq.service().authorizor().authorized(
+      registry_resource{},
+      op,
+      params.principal,
+      params.host,
+      security::superuser_required::no,
+      auth_result.value().get_groups());
+
+    auto all_subjects = co_await store.get_subjects(include_deleted::yes);
+
+    auto passing_results = audit_resources{};
+    auto failing_results = audit_resources{};
+
+    // Pass 1: Iterate subjects once, check authorization, track accessible
+    // contexts. Audit entries match the actual ACL checks performed.
+    auto allowed_contexts = chunked_hash_set<context>{};
+    auto non_empty_contexts = chunked_hash_set<context>{};
+
+    for (const auto& ctx_sub : all_subjects) {
+        // Track that this context has subjects
+        if (!non_empty_contexts.contains(ctx_sub.ctx)) {
+            non_empty_contexts.insert(ctx_sub.ctx);
+        }
+
+        // Skip if we already know this context is accessible
+        if (allowed_contexts.contains(ctx_sub.ctx)) {
+            continue;
+        }
+
+        auto res = rq.service().authorizor().authorized(
+          ctx_sub,
+          op,
+          params.principal,
+          params.host,
+          security::superuser_required::no,
+          auth_result.value().get_groups());
+
+        if (res.is_authorized()) {
+            passing_results.emplace_back(
+              ctx_sub.to_string(), subject_resource_type);
+            allowed_contexts.insert(ctx_sub.ctx);
+        } else {
+            failing_results.emplace_back(
+              ctx_sub.to_string(), subject_resource_type);
+        }
+    }
+
+    // Pass 2: Filter contexts list. For empty contexts, check registry access.
+    auto result_contexts = chunked_vector<context>{};
+    auto has_empty_contexts = false;
+
+    for (const auto& ctx : contexts) {
+        auto has_subjects = non_empty_contexts.contains(ctx);
+
+        if (!has_subjects) {
+            // Empty context: requires sr_registry describe access
+            has_empty_contexts = true;
+            if (has_registry_describe.is_authorized()) {
+                result_contexts.push_back(ctx);
+            }
+        } else if (allowed_contexts.contains(ctx)) {
+            result_contexts.push_back(ctx);
+        }
+    }
+
+    // Audit the registry resource check once (if any empty contexts existed)
+    if (has_empty_contexts) {
+        if (has_registry_describe.is_authorized()) {
+            passing_results.emplace_back(
+              registry_resource{}(), registry_resource_type);
+        } else {
+            failing_results.emplace_back(
+              registry_resource{}(), registry_resource_type);
+        }
+    }
+
+    contexts = std::move(result_contexts);
+
     audit_authz(
       rq,
       operation_name,

--- a/src/v/pandaproxy/schema_registry/authorization.h
+++ b/src/v/pandaproxy/schema_registry/authorization.h
@@ -13,8 +13,11 @@
 #include "container/chunked_vector.h"
 #include "pandaproxy/schema_registry/auth.h"
 #include "pandaproxy/schema_registry/fwd.h"
+#include "pandaproxy/schema_registry/types.h"
 #include "pandaproxy/server.h"
 #include "security/request_auth.h"
+
+#include <seastar/core/future.hh>
 
 #include <string_view>
 
@@ -37,6 +40,16 @@ void handle_get_subjects_authz(
   const server::request_t& rq,
   std::optional<request_auth_result>& auth_result,
   chunked_vector<context_subject>& subjects);
+
+/// Handles authorization for GET /contexts by filtering the contexts vector
+/// to only include contexts the user is authorized to see.
+/// - Contexts with subjects: user needs describe access to at least one subject
+/// - Empty contexts: user needs sr_registry describe access
+ss::future<> handle_get_contexts_authz(
+  const server::request_t& rq,
+  sharded_store& store,
+  std::optional<request_auth_result>& auth_result,
+  chunked_vector<context>& contexts);
 
 /// Handles authorization for config/mode endpoints that operate on either
 /// a context (e.g., PUT /config/:.ctx:) or a subject (e.g., PUT

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -92,6 +92,8 @@ struct error_category final : std::error_category {
             return "Internal server error";
         case error_code::writes_disabled:
             return "Writes to Schema Registry are disabled";
+        case error_code::context_not_empty:
+            return "The specified context is not empty";
         }
         return "(unrecognized error)";
     }
@@ -156,6 +158,8 @@ struct error_category final : std::error_category {
             return reply_error_code::internal_server_error; // 500
         case error_code::writes_disabled:
             return reply_error_code::precondition_failed; // 412
+        case error_code::context_not_empty:
+            return reply_error_code::context_not_empty; // 42211
         }
         return {};
     }

--- a/src/v/pandaproxy/schema_registry/error.h
+++ b/src/v/pandaproxy/schema_registry/error.h
@@ -45,6 +45,7 @@ enum class error_code {
     acl_invalid,
     internal_server_error,
     writes_disabled,
+    context_not_empty,
 };
 
 std::error_code make_error_code(error_code);

--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -234,6 +234,12 @@ inline error_info writes_disabled() {
       error_code::writes_disabled, "Writes to Schema Registry are disabled"};
 }
 
+inline error_info context_not_empty(const context& ctx) {
+    return error_info{
+      error_code::context_not_empty,
+      fmt::format("The specified context '{}' is not empty.", ctx())};
+}
+
 inline bool failed_subject_schema_lookup(std::error_code ec) {
     return ec == error_code::subject_not_found
            || ec == error_code::subject_version_not_found;

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -1232,4 +1232,50 @@ delete_security_acls(server::request_t rq, server::reply_t rp) {
     co_return rp;
 }
 
+ss::future<server::reply_t> get_contexts(
+  server::request_t rq,
+  server::reply_t rp,
+  std::optional<request_auth_result> auth_result) {
+    parse_accept_header(rq, rp);
+
+    co_await rq.service().writer().read_sync();
+
+    auto contexts
+      = co_await rq.service().schema_store().get_materialized_contexts();
+
+    co_await enterprise::handle_get_contexts_authz(
+      rq, rq.service().schema_store(), auth_result, contexts);
+
+    auto contexts_str = std::move(contexts) | std::views::as_rvalue
+                        | std::ranges::views::transform([](context&& ctx) {
+                              return ss::sstring{std::move(ctx)};
+                          })
+                        | std::ranges::to<chunked_vector<ss::sstring>>();
+
+    auto resp = ppj::rjson_serialize_iobuf(std::move(contexts_str));
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
+    co_return rp;
+}
+
+ss::future<server::reply_t>
+delete_context(server::request_t rq, server::reply_t rp) {
+    parse_accept_header(rq, rp);
+
+    auto ctx_str = parse::request_param<ss::sstring>(*rq.req, "context");
+    auto ctx = context{ctx_str};
+
+    if (ctx == default_context) {
+        throw as_exception(
+          error_info{
+            error_code::subject_version_operation_not_permitted,
+            "Cannot delete the default context"});
+    }
+
+    co_await rq.service().writer().delete_context(ctx);
+
+    rp.rep->set_status(ss::http::reply::status_type::no_content);
+    co_return rp;
+}
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/handlers.h
+++ b/src/v/pandaproxy/schema_registry/handlers.h
@@ -121,4 +121,12 @@ ss::future<ctx_server<service>::reply_t> post_security_acls(
 ss::future<ctx_server<service>::reply_t> delete_security_acls(
   ctx_server<service>::request_t, ctx_server<service>::reply_t);
 
+ss::future<ctx_server<service>::reply_t> get_contexts(
+  ctx_server<service>::request_t rq,
+  ctx_server<service>::reply_t rp,
+  std::optional<request_auth_result> auth_result);
+
+ss::future<ctx_server<service>::reply_t> delete_context(
+  ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -516,6 +516,41 @@ ss::future<bool> seq_writer::delete_mode(context_subject ctx_sub) {
       });
 }
 
+ss::future<std::optional<bool>>
+seq_writer::do_delete_context(context ctx, model::offset write_at) {
+    vlog(srlog.debug, "delete_context ctx={} offset={}", ctx, write_at);
+
+    if (auto is_materialized = co_await _store.is_context_materialized(ctx);
+        !is_materialized) {
+        throw as_exception(
+          error_info{
+            error_code::subject_not_found,
+            fmt::format("Context '{}' not found", ctx())});
+    }
+
+    auto has_subjects = co_await _store.has_subjects(ctx, include_deleted::yes);
+    if (has_subjects) {
+        throw as_exception(context_not_empty(ctx));
+    }
+
+    auto rb = batch_builder{write_at};
+    auto key = context_key{.seq{write_at}, .node{_node_id}, .ctx{ctx}};
+    rb.add_raw_kv(to_json_iobuf(std::move(key)), std::nullopt);
+
+    if (co_await produce_and_apply(write_at, std::move(rb).build())) {
+        co_return true;
+    } else {
+        co_return std::nullopt;
+    }
+}
+
+ss::future<> seq_writer::delete_context(context ctx) {
+    co_await sequenced_write(
+      [ctx{std::move(ctx)}](model::offset write_at, seq_writer& seq) {
+          return seq.do_delete_context(ctx, write_at);
+      });
+}
+
 /// Impermanent delete: update a version with is_deleted=true
 ss::future<std::optional<bool>> seq_writer::do_delete_subject_version(
   context_subject sub, schema_version version, model::offset write_at) {

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -78,6 +78,8 @@ public:
 
     ss::future<bool> delete_mode(context_subject ctx_sub);
 
+    ss::future<> delete_context(context ctx);
+
     ss::future<bool>
     delete_subject_version(context_subject sub, schema_version version);
 
@@ -112,6 +114,9 @@ private:
 
     ss::future<std::optional<bool>>
     do_delete_mode(context_subject ctx_sub, model::offset write_at);
+
+    ss::future<std::optional<bool>>
+    do_delete_context(context ctx, model::offset write_at);
 
     ss::future<std::optional<bool>> do_delete_subject_version(
       context_subject sub, schema_version version, model::offset write_at);

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -246,6 +246,20 @@ server::routes_t get_schema_registry_routes(ss::gate& gate, one_shot& es) {
       get_subjects));
 
     routes.routes.emplace_back(wrap(
+      ss::httpd::schema_registry_json::get_contexts,
+      auth::level::user,
+      std::nullopt,
+      auth::deferred{},
+      get_contexts));
+
+    routes.routes.emplace_back(wrap(
+      ss::httpd::schema_registry_json::delete_context,
+      auth::level::superuser,
+      acl_operation::remove,
+      registry_resource{},
+      delete_context));
+
+    routes.routes.emplace_back(wrap(
       ss::httpd::schema_registry_json::get_subject_versions,
       auth::level::user,
       acl_operation::describe,

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -3057,6 +3057,11 @@ class AuditLogTestSchemaRegistryACLs(AuditLogTestSchemaRegistryBase):
     def assert_in(self, member, container, msg=None):
         assert member in container, msg or f"{member!r} not found in {container!r}"
 
+    def assert_not_in(self, member, container, msg=None):
+        assert member not in container, (
+            msg or f"{member!r} unexpectedly found in {container!r}"
+        )
+
     def _create_acl(
         self, resource, resource_type, pattern_type, operation, permission="ALLOW"
     ):
@@ -3535,6 +3540,192 @@ class AuditLogTestSchemaRegistryACLs(AuditLogTestSchemaRegistryBase):
             "subject-level config access",
         )
         self.assert_equal(len(records), 1)
+
+    @skip_fips_mode
+    @cluster(num_nodes=5)
+    @matrix(audit_transport_mode=get_audit_modes())
+    def test_sr_audit_get_contexts(self, audit_transport_mode):
+        self.redpanda.set_cluster_config(
+            {"schema_registry_enable_qualified_subjects": True}, expect_restart=True
+        )
+        self.setup_cluster()
+
+        schema_data = json.dumps({"schema": schema1_def})
+
+        # Create subjects in different contexts
+        staging_subject = ":.staging:topic-a"
+        prod_subject = ":.prod:topic-b"
+        default_subject = "topic-c"
+
+        # Register schemas
+        for subject in [staging_subject, prod_subject, default_subject]:
+            result = self.sr_client.post_subjects_subject_versions(
+                subject=subject, data=schema_data, auth=self.super_auth
+            )
+            self.assert_equal(result.status_code, 200)
+
+        # Superuser should see all contexts
+        result = self.sr_client.get_contexts(auth=self.super_auth)
+        self.assert_equal(result.status_code, 200)
+        contexts = result.json()
+        self.assert_in(".", contexts)
+        self.assert_in(".staging", contexts)
+        self.assert_in(".prod", contexts)
+
+        # Grant describe ACL only for staging subject
+        self._post_acl(
+            self._create_acl(staging_subject, "SUBJECT", "LITERAL", "DESCRIBE")
+        )
+
+        # User should only see .staging context (has access to staging_subject)
+        result = self.sr_client.get_contexts(auth=self.user_auth)
+        self.assert_equal(result.status_code, 200)
+        contexts = result.json()
+        self.assert_in(".staging", contexts)
+        self.assert_not_in(".", contexts)
+        self.assert_not_in(".prod", contexts)
+
+        # Verify audit log shows subject checks performed
+        # Successful: staging_subject (authorized)
+        records = self.find_matching_record(
+            lambda record: self.match_api_record(
+                record,
+                path="contexts",
+                resources={"name": staging_subject, "type": "subject"},
+                status_id=StatusID.SUCCESS,
+                operation="get_contexts",
+            ),
+            lambda record_count: record_count >= 1,
+            "get_contexts authorized subject",
+        )
+        self.assert_equal(len(records), 1)
+
+        # Failed: other subjects (not authorized)
+        # The audit should contain the subjects that were checked and failed
+        records = self.find_matching_record(
+            lambda record: self.match_api_record(
+                record,
+                path="contexts",
+                resources=[
+                    {"name": prod_subject, "type": "subject"},
+                    {"name": default_subject, "type": "subject"},
+                ],
+                status_id=StatusID.FAILURE,
+                operation="get_contexts",
+            ),
+            lambda record_count: record_count >= 1,
+            "get_contexts unauthorized subjects",
+        )
+        self.assert_equal(len(records), 1)
+
+    @skip_fips_mode
+    @cluster(num_nodes=5)
+    @matrix(audit_transport_mode=get_audit_modes())
+    def test_sr_audit_delete_context(self, audit_transport_mode):
+        self.redpanda.set_cluster_config(
+            {"schema_registry_enable_qualified_subjects": True}, expect_restart=True
+        )
+        self.setup_cluster()
+
+        schema_data = json.dumps({"schema": schema1_def})
+        ctx = ".testctx"
+        ctx_subject = f":{ctx}:topic-a"
+
+        # Create a schema in a custom context (materializes the context)
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=ctx_subject, data=schema_data, auth=self.super_auth
+        )
+        self.assert_equal(result.status_code, 200)
+
+        # Superuser should see the context
+        result = self.sr_client.get_contexts(auth=self.super_auth)
+        self.assert_equal(result.status_code, 200)
+        self.assert_in(ctx, result.json())
+
+        # Make the context empty by deleting the subject (soft then hard delete)
+        result = self.sr_client.delete_subject(
+            subject=ctx_subject, auth=self.super_auth
+        )
+        self.assert_equal(result.status_code, 200)
+        result = self.sr_client.delete_subject(
+            subject=ctx_subject, permanent=True, auth=self.super_auth
+        )
+        self.assert_equal(result.status_code, 200)
+
+        # Superuser should still see the empty context
+        result = self.sr_client.get_contexts(auth=self.super_auth)
+        self.assert_equal(result.status_code, 200)
+        self.assert_in(ctx, result.json())
+
+        # User without permissions should not see the empty context
+        result = self.sr_client.get_contexts(auth=self.user_auth)
+        self.assert_equal(result.status_code, 200)
+        self.assert_not_in(ctx, result.json())
+        self.assert_not_in(".prod", result.json())
+
+        # Grant sr_registry DESCRIBE - user should now see empty context
+        self._post_acl(self._create_acl("", "REGISTRY", "LITERAL", "DESCRIBE"))
+
+        result = self.sr_client.get_contexts(auth=self.user_auth)
+        self.assert_equal(result.status_code, 200)
+        self.assert_in(ctx, result.json())
+
+        # Verify audit log shows registry resource check for empty context
+        records = self.find_matching_record(
+            lambda record: self.match_api_record(
+                record,
+                path="contexts",
+                resources={"name": "", "type": "registry"},
+                status_id=StatusID.SUCCESS,
+                operation="get_contexts",
+            ),
+            lambda record_count: record_count >= 1,
+            "get_contexts with registry describe for empty context",
+        )
+        self.assert_equal(len(records), 1)
+
+        # User with only DESCRIBE cannot delete context
+        result = self.sr_client.delete_context(ctx, auth=self.user_auth)
+        self.assert_equal(result.status_code, 403)
+
+        # Verify audit log shows failed delete attempt
+        records = self.find_matching_record(
+            lambda record: self.match_api_record(
+                record,
+                path=f"contexts/{ctx}",
+                resources={"name": "", "type": "registry"},
+                status_id=StatusID.FAILURE,
+                operation="delete_context",
+            ),
+            lambda record_count: record_count >= 1,
+            "delete_context unauthorized",
+        )
+        self.assert_equal(len(records), 1)
+
+        # Grant sr_registry DELETE (maps to remove permission) - user can delete
+        self._post_acl(self._create_acl("", "REGISTRY", "LITERAL", "DELETE"))
+
+        result = self.sr_client.delete_context(ctx, auth=self.user_auth)
+        self.assert_equal(result.status_code, 204)
+
+        # Verify audit log shows successful delete
+        records = self.find_matching_record(
+            lambda record: self.match_api_record(
+                record,
+                path=f"contexts/{ctx}",
+                resources={"name": "", "type": "registry"},
+                status_id=StatusID.SUCCESS,
+                operation="delete_context",
+            ),
+            lambda record_count: record_count >= 1,
+            "delete_context authorized",
+        )
+        self.assert_equal(len(records), 1)
+
+        # Context should no longer be visible
+        result = self.sr_client.get_contexts(auth=self.super_auth)
+        self.assert_equal(result.status_code, 200)
+        self.assert_not_in(ctx, result.json())
 
     @skip_fips_mode
     @cluster(num_nodes=5)

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -3785,29 +3785,19 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         subjects are treated as if they are in the default context.
         """
 
-        # Register a schema in the default context first
-        result = self.sr_client.post_subjects_subject_versions(
-            subject="normal-subject", data=json.dumps({"schema": schema1_def})
-        )
-        self.assert_equal(result.status_code, requests.codes.ok)
-        self.assert_equal(result.json()["id"], 1)
-
-        # Register a DIFFERENT schema with qualified-looking subject name
-        # Flag OFF: Same context as above, so gets id=2 (shared counter)
-        # Flag ON: Would be in .ctx context with independent counter, gets id=1
-        # TODO: once implemented, we could make this test simpler by just using the `GET /contexts`
-        # API instead of using schema ID allocation behaviour to verify that these subjects land in
-        # different contexts.
+        # Register a schema with qualified-looking subject name
+        # Flag OFF: treated as literal subject name in default context
+        # Flag ON: would create a separate .ctx context
         qualified_subject = ":.ctx:my-subject"
         result = self.sr_client.post_subjects_subject_versions(
-            subject=qualified_subject, data=json.dumps({"schema": schema2_def})
+            subject=qualified_subject, data=json.dumps({"schema": schema1_def})
         )
         self.assert_equal(result.status_code, requests.codes.ok)
-        self.assert_equal(
-            result.json()["id"],
-            2,
-            "Expected id=2 proving shared counter with default context",
-        )
+
+        # Verify only the default context exists (no .ctx context was created)
+        result = self.sr_client.get_contexts()
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json(), ["."])
 
 
 class SchemaRegistryModeNotMutableTest(SchemaRegistryEndpoints):
@@ -5424,23 +5414,11 @@ class SchemaRegistryContextTest(SchemaRegistryEndpoints):
         )
         self.assert_equal(result.status_code, requests.codes.ok)
 
-        # Verify CONTEXT record was written
-        # TODO: This test can be simplified with GET /contexts support later
-        # instead of relying on log lines.
-        write_pattern = f"Writing CONTEXT record for ctx={ctx}"
-        wait_until(
-            lambda: self.redpanda.search_log_any(write_pattern),
-            timeout_sec=10,
-            err_msg=f"Failed to find write log: {write_pattern}",
-        )
-
-        # Verify CONTEXT record was replayed (key contains "keytype: CONTEXT")
-        replay_pattern = f"keytype: CONTEXT.*context: {ctx}"
-        wait_until(
-            lambda: self.redpanda.search_log_any(replay_pattern),
-            timeout_sec=10,
-            err_msg=f"Failed to find replay log: {replay_pattern}",
-        )
+        # Verify context was persisted (CONTEXT record written and consumed)
+        result = self.sr_client.get_contexts()
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_in(".", result.json())
+        self.assert_in(ctx, result.json())
 
     @cluster(num_nodes=1)
     def test_context_unqualified_references(self):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1220,6 +1220,14 @@ class SchemaRegistryRedpandaClient:
             **kwargs,
         )
 
+    def get_contexts(self, headers: Headers = HTTP_GET_HEADERS, **kwargs: Any):
+        return self.request("GET", "contexts", headers=headers, **kwargs)
+
+    def delete_context(
+        self, context: str, headers: Headers = HTTP_DELETE_HEADERS, **kwargs: Any
+    ):
+        return self.request("DELETE", f"contexts/{context}", headers=headers, **kwargs)
+
     def create_acl(
         self,
         principal,
@@ -5517,6 +5525,66 @@ class SchemaRegistryContextTest(SchemaRegistryEndpoints):
             ),
         )
         self.assert_equal(result.status_code, 200)
+
+    @cluster(num_nodes=1)
+    def test_context_list_delete(self):
+        """Test GET /contexts and DELETE /contexts/{context} endpoints."""
+
+        # Initially, only the default context should be listed
+        result = self.sr_client.get_contexts()
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json(), ["."])
+
+        # Register a schema in a custom context
+        ctx = ".test-ctx"
+        ctx_subject = f":{ctx}:test-sub"
+
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=ctx_subject, data=json.dumps({"schema": schema1_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Now both contexts should be listed
+        result = self.sr_client.get_contexts()
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_in(".", result.json())
+        self.assert_in(ctx, result.json())
+
+        # Try to delete the custom context (should fail - not empty)
+        result = self.sr_client.delete_context(ctx)
+        self.assert_equal(result.status_code, 422)
+        self.assert_equal(result.json()["error_code"], 42211)
+
+        # Soft-delete the subject
+        result = self.sr_client.delete_subject(subject=ctx_subject)
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Try to delete context again (should still fail - has soft-deleted subjects)
+        result = self.sr_client.delete_context(ctx)
+        self.assert_equal(result.status_code, 422)
+        self.assert_equal(result.json()["error_code"], 42211)
+
+        # Permanently delete the subject
+        result = self.sr_client.delete_subject(subject=ctx_subject, permanent=True)
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Now delete the context (should succeed)
+        result = self.sr_client.delete_context(ctx)
+        self.assert_equal(result.status_code, 204)
+
+        # Only default context should remain
+        result = self.sr_client.get_contexts()
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json(), ["."])
+
+        # Try to delete the default context (should fail with 422)
+        # Use URL-encoded dot (%2E) since "." has special meaning in URL paths
+        result = self.sr_client.delete_context("%2E")
+        self.assert_equal(result.status_code, 422)
+
+        # Try to delete a non-existent context (should fail with 404)
+        result = self.sr_client.delete_context(".nonexistent")
+        self.assert_equal(result.status_code, 404)
 
 
 class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):


### PR DESCRIPTION
This adds two new endpoints:
- `GET /contexts`: Lists all (materialized) contexts.
- `DELETE /contexts/{context}`: Deletes the specified context if it is empty. Subjects must be permanently deleted before the context can be deleted.

See the commit messages for details.

Fixes https://redpandadata.atlassian.net/browse/CORE-15184
Fixes https://redpandadata.atlassian.net/browse/CORE-15186

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
