### PR TITLE
coordinated compaction  improvements

### DIFF
--- a/src/v/raft/compaction_coordinator.cc
+++ b/src/v/raft/compaction_coordinator.cc
@@ -62,20 +62,21 @@ compaction_coordinator::compaction_coordinator(
 }
 
 void compaction_coordinator::on_leadership_change(
-  std::optional<vnode> new_leader_id) {
+  std::optional<vnode> new_leader_id, model::term_id new_term) {
+    cancel_timer();
     bool new_is_leader = (new_leader_id && *new_leader_id == _self);
-    if (new_is_leader != _is_leader) {
-        _is_leader = new_is_leader;
-        if (_is_leader) {
-            arm_timer_if_needed(true);
-        } else {
-            cancel_timer();
-        }
+    _need_force_update = new_is_leader
+                         && (!_leader_term_id || new_term > *_leader_term_id);
+    if (new_is_leader) {
+        _leader_term_id = {new_term};
+        arm_timer_if_needed(true);
+    } else {
+        _leader_term_id = std::nullopt;
     }
 }
 
 void compaction_coordinator::on_group_configuration_change() {
-    if (_started && _is_leader) {
+    if (_started && _leader_term_id) {
         recalculate_group_offsets();
     }
 }
@@ -124,7 +125,7 @@ compaction_coordinator::do_distribute_group_offsets(
     // We may be a follower lagging behind, so our MCCO or even max offset
     // may be below MTRO. Fix that: any log below MTRO, even not replicated
     // yet, is cleanly compacted. Same for MXFO/MXRO.
-    on_local_replica_offsets_update(req.mtro, req.mxro);
+    record_updated_local_replica_offsets(req.mtro, req.mxro);
 
     return distribute_compaction_mtro_reply{
       .success = distribute_compaction_mtro_reply::is_success::yes};
@@ -180,13 +181,17 @@ void compaction_coordinator::on_ntp_config_change() {
 }
 
 void compaction_coordinator::update_local_replica_offsets() {
-    on_local_replica_offsets_update(
+    bool updated = record_updated_local_replica_offsets(
       _log->cleanly_compacted_prefix_offset(),
       _log->transaction_free_prefix_offset());
+    if (_leader_term_id && updated) {
+        recalculate_group_offsets();
+    }
 }
 
 void compaction_coordinator::collect_all_replica_offsets() {
-    if (!_is_leader || _raft_as.abort_requested() || _raft_bg.is_closed()) {
+    if (
+      !_leader_term_id || _raft_as.abort_requested() || _raft_bg.is_closed()) {
         return;
     }
     update_local_replica_offsets();
@@ -281,7 +286,7 @@ ss::future<> compaction_coordinator::get_and_process_replica_offsets(
       = *maybe_remote_replica_offsets->mcco;
     fs_it->second.max_transaction_free_offset
       = *maybe_remote_replica_offsets->mxfo;
-    if (_is_leader) [[likely]] {
+    if (_leader_term_id) [[likely]] {
         recalculate_group_offsets();
     }
 }
@@ -314,7 +319,8 @@ compaction_coordinator::get_remote_replica_offsets(vnode node_id) {
     co_return reply.value();
 }
 
-void compaction_coordinator::on_local_replica_offsets_update(
+// returns whether recorded offsets were changed
+bool compaction_coordinator::record_updated_local_replica_offsets(
   model::offset new_mcco, model::offset new_mxfo) {
     bool mcco_updated = bump_offset_value(
       &compaction_coordinator::_local_mcco,
@@ -324,12 +330,14 @@ void compaction_coordinator::on_local_replica_offsets_update(
       &compaction_coordinator::_local_mxfo,
       new_mxfo,
       "local max transaction free offset");
-    if (_is_leader && (mcco_updated || mxfo_updated)) {
-        recalculate_group_offsets();
-    }
+    return mcco_updated || mxfo_updated;
 }
 
 void compaction_coordinator::send_group_offsets_to_followers() {
+    vlog(
+      _logger.debug,
+      "compaction coordinator planning to distribute group offsets in {}",
+      group_offsets_send_delay);
     for (const auto& [node_id, fstate] : _fstates) {
         ssx::background = fstate.coordinated_compaction_offsets_sender->submit(
           [this, holder = _raft_bg.hold(), node_id](
@@ -399,8 +407,7 @@ compaction_coordinator::send_group_offsets_to_follower(vnode node_id) {
 }
 
 void compaction_coordinator::recalculate_group_offsets() {
-    vassert(
-      _is_leader, "only leader can recalculate max tombstone remove offset");
+    vassert(_leader_term_id, "only leader can recalculate group offsets");
     model::offset new_mtro = _local_mcco;
     model::offset new_mxro = _local_mxfo;
     for (const auto& [node_id, fstate] : _fstates) {
@@ -436,13 +443,15 @@ void compaction_coordinator::update_group_offsets(
       &compaction_coordinator::_mxro,
       new_mxro,
       "max transaction remove offset");
-    if (mtro_updated || mxro_updated) {
-        on_group_offsets_update();
-    }
-}
-
-void compaction_coordinator::on_group_offsets_update() {
-    if (_is_leader) {
+    if (
+      _leader_term_id && (mtro_updated || mxro_updated || _need_force_update)) {
+        // Reset the flag now. If sending updated offsets to followers fails,
+        // we will retry later anyway. Retries may be cancelled
+        // a) on leadership change, where the flag will be reset back to true;
+        // or
+        // b) on a further call to `update_group_offsets` due to
+        // MTRO/MXRO change.
+        _need_force_update = false;
         send_group_offsets_to_followers();
     }
     _log->stm_manager()->set_max_tombstone_remove_offset(
@@ -451,11 +460,14 @@ void compaction_coordinator::on_group_offsets_update() {
       model::prev_offset(_mxro));
 }
 
-void compaction_coordinator::cancel_timer() { _timer.cancel(); }
+void compaction_coordinator::cancel_timer() {
+    vlog(_logger.debug, "canceling compaction coordinator timer");
+    _timer.cancel();
+}
 
 void compaction_coordinator::arm_timer_if_needed(bool jitter_only) {
     if (
-      !_started || !_is_leader || _raft_as.abort_requested()
+      !_started || !_leader_term_id || _raft_as.abort_requested()
       || _raft_bg.is_closed()) {
         return;
     }

--- a/src/v/raft/compaction_coordinator.h
+++ b/src/v/raft/compaction_coordinator.h
@@ -74,7 +74,8 @@ public:
       ss::gate& bg);
 
     // handle leadership changes
-    void on_leadership_change(std::optional<vnode> new_leader_id);
+    void on_leadership_change(
+      std::optional<vnode> new_leader_id, model::term_id new_term);
 
     // handle group configuration changes (e.g. new nodes added to the group)
     void on_group_configuration_change();
@@ -107,9 +108,6 @@ private:
     // from leader (on a follower) or from calculated values (on leader)
     void update_group_offsets(model::offset new_mtro, model::offset new_mxro);
 
-    // notify storage and followers (if leader) about MTRO and/or MXRO update
-    void on_group_offsets_update();
-
     // Ideally should be push-, not pull-based, but currently storage doesn't
     // provide such functionality. This is the entry point for periodic MCCO
     // and MXFO collection, which may trigger MTRO and MXRO update in turn.
@@ -129,7 +127,7 @@ private:
     get_and_process_replica_offsets(vnode node_id, ss::abort_source& op_as);
     ss::future<std::optional<get_compaction_mcco_reply>>
     get_remote_replica_offsets(vnode node_id);
-    void on_local_replica_offsets_update(
+    bool record_updated_local_replica_offsets(
       model::offset new_mcco, model::offset new_mxfo);
 
     // the next 2 functions are for sending MTRO and MXRO to followers
@@ -197,8 +195,8 @@ private:
     model::offset _mtro;
     model::offset _mxro;
 
-    // current leader, std::nullopt if no leader
-    bool _is_leader{false};
+    // current leadership term, std::nullopt if not leader
+    std::optional<model::term_id> _leader_term_id;
 
     // cancels the timer when consensus' abort source is triggered
     ss::optimized_optional<ss::abort_source::subscription> _as_sub;
@@ -210,7 +208,8 @@ private:
     // prevent RPC storm at startup
     bool _has_seen_a_leader{false};
 
-    // force sending the same MTRO to followers, as recipients may have changed
+    // force sending the same MTRO to followers, as recipients may have missed
+    // the last update due to a leadership change
     bool _need_force_update{false};
 
     bool _started{false};

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -3305,7 +3305,7 @@ void consensus::trigger_leadership_notification() {
         // can make progress.
         _follower_recovery_state->yield();
     }
-    _compaction_coordinator.on_leadership_change(_leader_id);
+    _compaction_coordinator.on_leadership_change(_leader_id, _term);
     _leadership_changed.broadcast();
 }
 

--- a/src/v/raft/tests/BUILD
+++ b/src/v/raft/tests/BUILD
@@ -504,7 +504,6 @@ redpanda_cc_gtest(
     srcs = [
         "coordinated_compaction_test.cc",
     ],
-    flaky = True,
     deps = [
         "//src/v/model",
         "//src/v/raft",

--- a/src/v/raft/tests/coordinated_compaction_test.cc
+++ b/src/v/raft/tests/coordinated_compaction_test.cc
@@ -14,13 +14,13 @@
 #include "test_utils/async.h"
 #include "test_utils/test.h"
 
-#include <seastar/core/circular_buffer.hh>
 #include <seastar/core/loop.hh>
 
 #include <fmt/ranges.h>
 
 #include <algorithm>
 #include <ranges>
+#include <system_error>
 #include <utility>
 
 using namespace raft;
@@ -48,21 +48,34 @@ public:
       size_t record_size,
       chunked_vector<model::offset>& last_data_offsets) {
         auto leader_id = co_await wait_for_leader(10s);
-        auto& leader_node = node(leader_id);
+        auto leader_node = &node(leader_id);
         for (int _ : std::views::iota(0, segments_count)) {
             vlog(logger().info, "Replicating...");
-            auto r = co_await leader_node.raft()->replicate(
-              make_batches(batches_per_segment, records_per_batch, record_size),
-              replicate_options(consistency_level::quorum_ack, 10s));
-            vlog(logger().info, "Replicated...");
-            ASSERT_FALSE_CORO(r.has_error());
-            auto last_data_offset = r.value().last_offset;
-            last_data_offsets.push_back(last_data_offset);
+
+            model::offset last_data_offset{};
+            for (int attempt = 0; attempt < 5; ++attempt) {
+                auto r = co_await leader_node->raft()->replicate(
+                  make_batches(
+                    batches_per_segment, records_per_batch, record_size),
+                  replicate_options(consistency_level::quorum_ack, 10s));
+                if (r.has_value()) {
+                    last_data_offset = r.value().last_offset;
+                    break;
+                }
+                ASSERT_EQ_CORO(r.error(), raft::errc::not_leader);
+                vlog(
+                  logger().info,
+                  "Not leader anymore while replicating, retrying...");
+                leader_id = co_await wait_for_leader(10s);
+                leader_node = &node(leader_id);
+            }
+            RPTEST_REQUIRE_NE_CORO(last_data_offset, model::offset{});
+
             vlog(
               logger().info,
               "last_data_offset: {}, dirty_offset: {}",
               last_data_offset,
-              leader_node.raft()->dirty_offset());
+              leader_node->raft()->dirty_offset());
 
             // make sure all fully replicated
             RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [this, last_data_offset] {
@@ -75,7 +88,7 @@ public:
                         "node {} committed_offset: {}",
                         node_id,
                         committed_offset);
-                      return committed_offset == last_data_offset;
+                      return committed_offset >= last_data_offset;
                   });
             });
 
@@ -85,6 +98,8 @@ public:
                   auto& n = node(node_id);
                   return n.raft()->log()->force_roll();
               });
+
+            last_data_offsets.push_back(last_data_offset);
         }
     }
 
@@ -125,11 +140,11 @@ public:
         co_await n.raft()->log()->housekeeping(std::move(cfg));
     }
 
-    template<typename MtroPredicate, typename MxroPredicate>
-    bool check_group_offsets_on_all_nodes(
-      MtroPredicate&& mtro_pred, MxroPredicate&& mxro_pred) {
+    template<typename Range, typename MtroPredicate, typename MxroPredicate>
+    bool check_group_offsets_on_nodes(
+      Range&& ids, MtroPredicate&& mtro_pred, MxroPredicate&& mxro_pred) {
         return std::ranges::all_of(
-          all_ids(),
+          std::forward<Range>(ids),
           [this,
            mtro_pred = std::forward<MtroPredicate>(mtro_pred),
            mxro_pred = std::forward<MxroPredicate>(mxro_pred)](
@@ -151,25 +166,25 @@ public:
 
     template<typename Predicate>
     bool check_group_offsets_on_all_nodes(Predicate&& pred) {
-        return check_group_offsets_on_all_nodes(pred, pred);
+        return check_group_offsets_on_nodes(all_ids(), pred, pred);
     }
 
     ss::future<> transfer_leadership_to(model::node_id target) {
-        auto current_leader = co_await wait_for_leader(10s);
-        if (current_leader == target) {
-            co_return;
+        auto start = model::timeout_clock::now();
+        while (true) {
+            auto current_leader = co_await wait_for_leader(start + 30s);
+            if (current_leader == target) {
+                co_return;
+            }
+            vlog(
+              logger().info,
+              "Transferring leadership from {} to {}",
+              current_leader,
+              target);
+            auto raft = node(current_leader).raft();
+            std::ignore = co_await raft->transfer_leadership(
+              {.group = raft->group(), .target = target, .timeout = 10s});
         }
-        vlog(
-          logger().info,
-          "Transferring leadership from {} to {}",
-          current_leader,
-          target);
-        auto raft = node(current_leader).raft();
-        auto r = co_await raft->transfer_leadership(
-          {.group = raft->group(), .target = target, .timeout = 10s});
-        ASSERT_TRUE_CORO(r.success);
-        current_leader = co_await wait_for_leader(10s);
-        ASSERT_EQ_CORO(current_leader, target);
     }
 
     // does not support concurrent isolations of nodes or any other dispatch
@@ -221,15 +236,18 @@ public:
     }
 
     // sleep enough time for all coordinators to exchange MCCOs and MTROs
-    ss::future<> wait_for_coordination() {
+    auto coordination_delay() {
         auto& node0coco
           = node(model::node_id{0}).raft()->get_compaction_coordinator();
-        co_await ss::sleep(
-          compaction_coordinator::test_accessor::local_offsets_getting_delay(
-            node0coco)
-          + compaction_coordinator::test_accessor::
-            group_offsets_distribution_delay()
-          + 1s);
+        auto delay
+          = compaction_coordinator::test_accessor::local_offsets_getting_delay(
+              node0coco)
+            + compaction_coordinator::test_accessor::
+              group_offsets_distribution_delay();
+        // in case leader gets re-elected during the wait
+        delay = 2 * delay + 1s;
+        vlog(logger().info, "coordination delay is {}", delay);
+        return delay;
     }
 };
 
@@ -248,7 +266,7 @@ TEST_F_CORO(coco_fixture, test_stalled_recovery) {
     co_await added_node.init_and_start({});
 
     // allow to recover only up to offset 20
-    added_node.f_injectable_log()->set_append_delay([this, &added_node]() {
+    added_node.f_injectable_log()->set_append_delay([this, &added_node] {
         if (added_node.raft().get()->dirty_offset() >= model::offset{20}) {
             throw std::runtime_error("simulated failure");
         }
@@ -285,7 +303,7 @@ TEST_F_CORO(coco_fixture, test_stalled_recovery) {
           "Waiting for recovery, target_offset: {}, recovered_offset: {}",
           target_offset,
           recovered_offset);
-        return recovered_offset == target_offset;
+        return recovered_offset >= target_offset;
     });
 
     // cleanly compact the log on original nodes
@@ -296,29 +314,29 @@ TEST_F_CORO(coco_fixture, test_stalled_recovery) {
       });
 
     // make sure local mcco & mxfo on each compaction coordinator are updated
-    RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [this, old_node_ids] {
-        return std::ranges::all_of(
-          old_node_ids, [this](model::node_id node_id) {
-              const auto& raft = node(node_id).raft();
-              const auto& coco = raft->get_compaction_coordinator();
-              auto mcco = coco.get_local_max_cleanly_compacted_offset();
-              auto mxfo = coco.get_local_max_transaction_free_offset();
-              auto committed_offset = raft->committed_offset();
-              vlog(
-                logger().info,
-                "on node {} max cleanly compacted offset: {}, max tx free "
-                "offset: {}, committed_offset: {}",
-                node_id,
-                mcco,
-                mxfo,
-                committed_offset);
-              auto first_uncommitted = model::next_offset(committed_offset);
-              return mcco >= first_uncommitted && mxfo >= first_uncommitted;
-          });
-    });
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      coordination_delay(), [this, old_node_ids, &last_data_offsets] {
+          return std::ranges::all_of(
+            old_node_ids, [this, &last_data_offsets](model::node_id node_id) {
+                const auto& raft = node(node_id).raft();
+                const auto& coco = raft->get_compaction_coordinator();
+                auto mcco = coco.get_local_max_cleanly_compacted_offset();
+                auto mxfo = coco.get_local_max_transaction_free_offset();
+                vlog(
+                  logger().info,
+                  "on node {} max cleanly compacted offset: {}, max tx free "
+                  "offset: {}, last_data_offsets[0]: {}",
+                  node_id,
+                  mcco,
+                  mxfo,
+                  last_data_offsets[0]);
+                return mcco > last_data_offsets[0]
+                       && mxfo >= last_data_offsets[0];
+            });
+      });
 
     // allow to fully recover
-    added_node.f_injectable_log()->set_append_delay([]() { return 0s; });
+    added_node.f_injectable_log()->set_append_delay([] { return 0s; });
 
     // wait until recovery fully catches up
     RPTEST_REQUIRE_EVENTUALLY_CORO(
@@ -335,20 +353,22 @@ TEST_F_CORO(coco_fixture, test_stalled_recovery) {
 
     // make sure MTRO remains min because the new node is uncompacted and
     // has been inited from uncompacted log
-    co_await wait_for_coordination();
-    ASSERT_TRUE_CORO(check_group_offsets_on_all_nodes(
-      [](model::offset mtro) { return mtro <= model::offset{0}; }));
+    RPTEST_REQUIRE_EVENTUALLY_CORO(coordination_delay(), [this] {
+        return check_group_offsets_on_all_nodes(
+          [](model::offset mtro) { return mtro <= model::offset{0}; });
+    });
 
     // run compaction on the new node
     co_await run_compaction(added_node);
 
     // make sure MTRO advanced to last_data_offset on all nodes
-    RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [this, &last_data_offsets] {
-        return check_group_offsets_on_all_nodes(
-          [&last_data_offsets](model::offset mtro) {
-              return mtro >= last_data_offsets.back();
-          });
-    });
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      coordination_delay(), [this, &last_data_offsets] {
+          return check_group_offsets_on_all_nodes(
+            [&last_data_offsets](model::offset mtro) {
+                return mtro >= last_data_offsets.back();
+            });
+      });
 }
 
 TEST_F_CORO(coco_fixture, test_leadership_change) {
@@ -393,6 +413,51 @@ TEST_F_CORO(coco_fixture, test_leadership_change) {
     });
 }
 
+TEST_F_CORO(coco_fixture, test_leadership_change_during_distribution) {
+    int initial_size = 3;
+    co_await create_simple_group(initial_size);
+    co_await transfer_leadership_to(model::node_id{1});
+
+    // replicate some data
+    chunked_vector<model::offset> last_data_offsets;
+    co_await make_batches_and_replicate(1, 1, 10, 128, last_data_offsets);
+
+    co_await run_compaction(node(model::node_id{0}), last_data_offsets[0]);
+    co_await run_compaction(node(model::node_id{1}), last_data_offsets[0]);
+    co_await run_compaction(node(model::node_id{2}), last_data_offsets[0]);
+
+    // make sure MTRO advanced to last_data_offset on the leader only
+    RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [this, &last_data_offsets] {
+        return retry_with_leader(
+          model::timeout_clock::now() + 10s,
+          [this, &last_data_offsets](raft_node_instance& leader_node) {
+              bool coordinated_on_leader = check_group_offsets_on_nodes(
+                std::views::single(leader_node.get_vnode().id()),
+                [&last_data_offsets](model::offset mtro) {
+                    return mtro >= model::next_offset(last_data_offsets[0]);
+                },
+                [&last_data_offsets](model::offset mxro) {
+                    return mxro >= model::next_offset(last_data_offsets[0]);
+                });
+              // and transfer leadership to another node before the old leader
+              // distributes MTRO/MXRO knowledge
+              if (coordinated_on_leader) {
+                  return leader_node.raft()->step_down("test").then_wrapped(
+                    [](auto) { return true; });
+              }
+              return ssx::now(false);
+          });
+    });
+
+    // make sure MTRO advanced to last_data_offset on all nodes
+    RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [this, &last_data_offsets] {
+        return check_group_offsets_on_all_nodes(
+          [&last_data_offsets](model::offset mtro) {
+              return mtro >= model::next_offset(last_data_offsets[0]);
+          });
+    });
+}
+
 TEST_F_CORO(coco_fixture, test_node_isolation) {
     int initial_size = 3;
     co_await create_simple_group(initial_size);
@@ -411,19 +476,21 @@ TEST_F_CORO(coco_fixture, test_node_isolation) {
     }
 
     // make sure MTRO remains min because one of the nodes is isolated
-    co_await wait_for_coordination();
-    ASSERT_TRUE_CORO(check_group_offsets_on_all_nodes(
-      [](model::offset mtro) { return mtro <= model::offset{0}; }));
+    RPTEST_REQUIRE_EVENTUALLY_CORO(coordination_delay(), [this] {
+        return check_group_offsets_on_all_nodes(
+          [](model::offset mtro) { return mtro <= model::offset{0}; });
+    });
 
     de_isolate_node(model::node_id{2});
 
     // make sure MTRO advanced to last_data_offset on all nodes
-    RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [this, &last_data_offsets] {
-        return check_group_offsets_on_all_nodes(
-          [&last_data_offsets](model::offset mtro) {
-              return mtro == model::next_offset(last_data_offsets[2]);
-          });
-    });
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      coordination_delay(), [this, &last_data_offsets] {
+          return check_group_offsets_on_all_nodes(
+            [&last_data_offsets](model::offset mtro) {
+                return mtro == model::next_offset(last_data_offsets[2]);
+            });
+      });
 }
 
 TEST_F_CORO(coco_fixture, test_decommission) {
@@ -470,8 +537,7 @@ TEST_F_CORO(coco_fixture, test_decommission2) {
     co_await run_compaction(node(model::node_id{2}), last_data_offsets[2]);
 
     // victim node prevents tombstone removal
-    co_await wait_for_coordination();
-    RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [this] {
+    RPTEST_REQUIRE_EVENTUALLY_CORO(coordination_delay(), [this] {
         return check_group_offsets_on_all_nodes(
           [](model::offset mtro) { return mtro <= model::offset{0}; });
     });
@@ -480,12 +546,13 @@ TEST_F_CORO(coco_fixture, test_decommission2) {
     co_await drop_node(model::node_id{3});
 
     // make sure MTRO advanced to last_data_offset on all nodes
-    RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [this, &last_data_offsets] {
-        return check_group_offsets_on_all_nodes(
-          [&last_data_offsets](model::offset mtro) {
-              return mtro >= last_data_offsets[2];
-          });
-    });
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      coordination_delay(), [this, &last_data_offsets] {
+          return check_group_offsets_on_all_nodes(
+            [&last_data_offsets](model::offset mtro) {
+                return mtro >= last_data_offsets[2];
+            });
+      });
 }
 
 TEST_F_CORO(coco_fixture, test_decommission_during_mtro_distribution) {
@@ -522,7 +589,7 @@ TEST_F_CORO(coco_fixture, test_decommission_during_mtro_distribution) {
     node(model::node_id{0}).reset_dispatch_handlers();
 
     // smoke test: make sure no exceptions are thrown and system is stable
-    co_await wait_for_coordination();
+    co_await ss::sleep(coordination_delay());
 }
 
 TEST_F_CORO(coco_fixture, unclean_compaction) {
@@ -545,10 +612,11 @@ TEST_F_CORO(coco_fixture, unclean_compaction) {
         }
     }
 
-    co_await wait_for_coordination();
-
     // make sure MTRO remains min because no clean compaction happened
-    ASSERT_TRUE_CORO(check_group_offsets_on_all_nodes(
-      [](model::offset mtro) { return mtro <= model::offset{0}; },
-      [](model::offset mxro) { return mxro > model::offset{1}; }));
+    RPTEST_REQUIRE_EVENTUALLY_CORO(coordination_delay(), [this] {
+        return check_group_offsets_on_nodes(
+          all_ids(),
+          [](model::offset mtro) { return mtro <= model::offset{0}; },
+          [](model::offset mxro) { return mxro > model::offset{1}; });
+    });
 }


### PR DESCRIPTION
https://redpandadata.atlassian.net/browse/CORE-15445

An update to group offsets may be lost due to leadership transfers.

We previously tolerated it: partitions are typically written into and compacted, so coordination offsets often move and a new update will get through.

However, it is difficult to test this way. Fix the functionality and the test.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
