### PR TITLE
gha: add claude-code-review.yml workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -48,6 +48,7 @@ jobs:
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
+            WORKFLOW RUN URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
             Please review this pull request with a focus on:
               - Code quality and best practices
@@ -56,3 +57,4 @@ jobs:
               - Performance considerations
 
             Provide detailed feedback using inline comments for specific issues.
+            Include a link to workflow run URL in the final review comment.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,10 +2,10 @@
 name: claude-code-review
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, synchronize, ready_for_review, reopened, labeled]
 jobs:
   claude-review:
-    if: github.event.label.name == 'claude-review'
+    if: contains(github.event.pull_request.labels.*.name, 'claude-review')
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,58 @@
+---
+name: claude-code-review
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+jobs:
+  claude-review:
+    if: github.event.label.name == 'claude-review'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - run: gh auth setup-git
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - uses: anthropics/claude-code-action@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: ""
+          allowed_non_write_users: ""
+          github_token: ${{ github.token }}  # needed to test changes to this file in a PR before merge
+          show_full_output: false
+          track_progress: true
+          use_commit_signing: true
+          additional_permissions: |
+            actions: read
+          claude_args: >
+            --model opus
+            --max-turns 30
+            --disallowed-tools "WebFetch,WebSearch"
+            --allowed-tools "
+              mcp__github_inline_comment__create_inline_comment,
+              mcp__github_ci__get_ci_status,
+              mcp__github_ci__get_workflow_run_details,
+              mcp__github_ci__download_job_log,
+              Bash(gh issue *),
+              Bash(gh pr *),
+              Bash(gh search *)"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request with a focus on:
+              - Code quality and best practices
+              - Potential bugs or issues
+              - Security implications
+              - Performance considerations
+
+            Provide detailed feedback using inline comments for specific issues.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,10 +2,10 @@
 name: claude-code-review
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened, labeled]
+    types: [labeled]
 jobs:
   claude-review:
-    if: contains(github.event.pull_request.labels.*.name, 'claude-review')
+    if: github.event.label.name == 'claude-review'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -29,7 +29,7 @@ jobs:
           allowed_non_write_users: ""
           github_token: ${{ github.token }}  # needed to test changes to this file in a PR before merge
           show_full_output: false
-          track_progress: true
+          track_progress: false
           use_commit_signing: true
           additional_permissions: |
             actions: read


### PR DESCRIPTION
jira: [DEVPROD-3766]

This PR adds a github workflow to run on PRs with github label [claude-review](https://github.com/redpanda-data/redpanda/labels?q=claude-review). The workflow is triggered only when `claude-review` label is added (for cost control). So, to re-review updates to the PR you will need to remove the label and add the label again.

I've gone through several rounds of code review feedback with `claude-review` and i've resolved the older inline discussions and left the last review inline discussions open, starting from https://github.com/redpanda-data/redpanda/pull/29488#pullrequestreview-3753163213, to show how it reviews. For comparison, the copilot review: https://github.com/redpanda-data/redpanda/pull/29488#pullrequestreview-3752968150

Notable behavior:
- uses latest `opus` model
- claude will comment inline, e.g https://github.com/redpanda-data/redpanda/pull/29488#pullrequestreview-3753163213
- detailed claude code report in the run summary, e.g. https://github.com/redpanda-data/redpanda/actions/runs/21687027210?pr=29488#summary-62536731391

Reference:
- https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md
- https://github.com/anthropics/claude-code-action/blob/v1.0.43/examples/pr-review-comprehensive.yml
- https://code.claude.com/docs/en/cli-reference

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

[DEVPROD-3766]: https://redpandadata.atlassian.net/browse/DEVPROD-3766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ