### PR TITLE
tests: Increase timeout in aio_limit_test

### DIFF
--- a/tests/rptest/tests/aio_limit_test.py
+++ b/tests/rptest/tests/aio_limit_test.py
@@ -46,4 +46,4 @@ class AioLimitTest(RedpandaTest):
         )
         producer.start()
         # RP shouldn't crash and still be able to handle the low rate
-        producer.wait(timeout_sec=80)
+        producer.wait(timeout_sec=180)


### PR DESCRIPTION
We shouldn't be close to the actual timeout but seeing some flakes.

Bump the timeout to see whether that resolves the issue.

Fixes CORE-15282

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


* none

