### PR TITLE
server: Remove probe log line

### DIFF
--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -286,7 +286,6 @@ ss::future<> server::shutdown_input() {
     for (auto& l : _listeners) {
         l->socket.abort_accept();
     }
-    vlog(_log.debug, "{} - Service probes {}", name(), _probe);
     _as.request_abort_ex(ssx::shutdown_requested_exception{});
 
     return _accept_gate.close().then([this] {


### PR DESCRIPTION
This log line would print the raw pointer probe address which our tests then interpreted as a code address and tried to decode it which resulted in random lines in redpanda_backtraces.log

I don't think this log line is useful so just remove it altogether.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


* none

