### PR TITLE
`ct`: use `compaction` scheduling group

### DIFF
--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -239,4 +239,9 @@ l1::compaction_scheduler* app::get_compaction_scheduler() {
 
 ss::sharded<level_zero_gc>* app::get_level_zero_gc() { return &l0_gc; }
 
+int64_t app::compaction_backlog() const noexcept {
+    return compaction_scheduler ? compaction_scheduler->compaction_backlog()
+                                : 0;
+}
+
 } // namespace cloud_topics

--- a/src/v/cloud_topics/app.h
+++ b/src/v/cloud_topics/app.h
@@ -78,6 +78,11 @@ public:
     l1::compaction_scheduler* get_compaction_scheduler();
     ss::sharded<level_zero_gc>* get_level_zero_gc();
 
+    // Returns the cloud topics compaction backlog in bytes per shard.
+    // This is the total backlog divided by the number of shards.
+    // Returns 0 if the compaction scheduler is not initialized.
+    int64_t compaction_backlog() const noexcept;
+
     // TODO: add 'get_control_plane_api' etc
 
 private:

--- a/src/v/cloud_topics/level_one/compaction/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/BUILD
@@ -108,6 +108,7 @@ redpanda_cc_library(
         "//src/v/config",
         "//src/v/container:chunked_hash_map",
         "//src/v/model",
+        "//src/v/resource_mgmt:cpu_scheduling",
         "//src/v/resource_mgmt:memory_groups",
         "//src/v/ssx:future_util",
         "//src/v/ssx:work_queue",

--- a/src/v/cloud_topics/level_one/compaction/scheduler.cc
+++ b/src/v/cloud_topics/level_one/compaction/scheduler.cc
@@ -21,6 +21,8 @@
 #include "model/fundamental.h"
 #include "ssx/future-util.h"
 
+#include <seastar/core/smp.hh>
+
 namespace cloud_topics::l1 {
 
 compaction_scheduler::compaction_scheduler(
@@ -78,6 +80,19 @@ bool compaction_scheduler::is_managed(const model::ntp& ntp) const noexcept {
     auto& tidp = it->second;
 
     return _logs.contains(tidp);
+}
+
+int64_t compaction_scheduler::compaction_backlog() const noexcept {
+    int64_t total = 0;
+    for (const auto& log_ptr : _logs) {
+        if (
+          log_ptr->state == log_compaction_meta::log_state::queued
+          && log_ptr->info_and_ts.has_value()) {
+            total += static_cast<int64_t>(
+              log_ptr->info_and_ts->info.dirty_bytes);
+        }
+    }
+    return total / static_cast<int64_t>(ss::smp::count);
 }
 
 void compaction_scheduler::manage_partition(

--- a/src/v/cloud_topics/level_one/compaction/scheduler.h
+++ b/src/v/cloud_topics/level_one/compaction/scheduler.h
@@ -65,6 +65,12 @@ public:
     // Returns `true` iff the provided `tidp` is managed by this scheduler.
     bool is_managed(const model::ntp&) const noexcept;
 
+    // Returns the size of the compaction backlog in bytes. This is the total
+    // backlog of logs in the `queued` state with `info_and_ts` accessible
+    // divided by the number of shards, since cloud compaction work can be
+    // distributed to any shard.
+    int64_t compaction_backlog() const noexcept;
+
     // Pushes a new `tidp` to be managed by this scheduler to the list of
     // `tidp`s. It is the caller's responsibility to ensure the partition is
     // not already managed by this scheduler.

--- a/src/v/cloud_topics/level_one/compaction/tests/scheduler_fixture.h
+++ b/src/v/cloud_topics/level_one/compaction/tests/scheduler_fixture.h
@@ -75,7 +75,8 @@ public:
           ss::sharded_parameter([this] { return &_metastore; }),
           ss::sharded_parameter(
             [this] { return &scheduler->_committer.local(); }),
-          nullptr);
+          nullptr,
+          ss::default_scheduling_group());
         co_await scheduler->_worker_manager._workers.invoke_on_all(
           &l1::compaction_worker::start);
         scheduler->start_bg_loop();

--- a/src/v/cloud_topics/level_one/compaction/tests/worker_manager_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/worker_manager_test.cc
@@ -28,7 +28,12 @@ class WorkerManagerTestFixture : public seastar_test {
 public:
     ss::future<> start_workers(l1::worker_manager& manager) {
         co_await manager._workers.start(
-          &manager, nullptr, nullptr, nullptr, nullptr);
+          &manager,
+          nullptr,
+          nullptr,
+          nullptr,
+          nullptr,
+          ss::default_scheduling_group());
         co_await manager._workers.invoke_on_all(&l1::compaction_worker::start);
     }
 

--- a/src/v/cloud_topics/level_one/compaction/worker.cc
+++ b/src/v/cloud_topics/level_one/compaction/worker.cc
@@ -32,7 +32,8 @@ compaction_worker::compaction_worker(
   io* io,
   metastore* metastore,
   compaction_committer* committer,
-  cluster::metadata_cache* metadata_cache)
+  cluster::metadata_cache* metadata_cache,
+  ss::scheduling_group sg)
   : _worker_update_queue([](const std::exception_ptr& ex) {
       vlog(
         compaction_log.error,
@@ -45,7 +46,8 @@ compaction_worker::compaction_worker(
   , _io(io)
   , _metastore(metastore)
   , _committer(committer)
-  , _metadata_cache(metadata_cache) {
+  , _metadata_cache(metadata_cache)
+  , _compaction_sg(sg) {
     _poll_interval.watch([this]() { _worker_cv.signal(); });
 }
 
@@ -79,8 +81,10 @@ void compaction_worker::start_work_loop() {
     vassert(
       !_work_fut.has_value(),
       "Cannot set value of _work_fut when it already has a value.");
-    _work_fut = ssx::spawn_with_gate_then(
-      _gate, [this]() { return work_loop(); });
+    _work_fut = ssx::spawn_with_gate_then(_gate, [this]() {
+        return ss::with_scheduling_group(
+          _compaction_sg, [this]() { return work_loop(); });
+    });
 }
 
 ss::future<> compaction_worker::work_loop() {

--- a/src/v/cloud_topics/level_one/compaction/worker.h
+++ b/src/v/cloud_topics/level_one/compaction/worker.h
@@ -21,6 +21,8 @@
 #include "config/property.h"
 #include "ssx/work_queue.h"
 
+#include <seastar/core/scheduling.hh>
+
 class WorkerManagerTestFixture;
 
 namespace cloud_topics::l1 {
@@ -44,7 +46,8 @@ public:
       io*,
       metastore*,
       compaction_committer*,
-      cluster::metadata_cache*);
+      cluster::metadata_cache*,
+      ss::scheduling_group);
 
     // Launches background loop.
     ss::future<> start();
@@ -195,6 +198,8 @@ private:
     compaction_committer* _committer;
 
     cluster::metadata_cache* _metadata_cache;
+
+    ss::scheduling_group _compaction_sg;
 
     compaction_worker_probe _probe;
 };

--- a/src/v/cloud_topics/level_one/compaction/worker_manager.cc
+++ b/src/v/cloud_topics/level_one/compaction/worker_manager.cc
@@ -16,6 +16,7 @@
 #include "cloud_topics/level_one/compaction/worker.h"
 #include "cloud_topics/level_one/metastore/replicated_metastore.h"
 #include "model/fundamental.h"
+#include "resource_mgmt/cpu_scheduling.h"
 #include "ssx/future-util.h"
 
 namespace cloud_topics::l1 {
@@ -40,7 +41,8 @@ ss::future<> worker_manager::start() {
       ss::sharded_parameter([this] { return &_io->local(); }),
       ss::sharded_parameter([this] { return &_metastore->local(); }),
       ss::sharded_parameter([this] { return &_committer->local(); }),
-      ss::sharded_parameter([this] { return &_metadata_cache->local(); }));
+      ss::sharded_parameter([this] { return &_metadata_cache->local(); }),
+      scheduling_groups::instance().compaction_sg());
     co_await _workers.invoke_on_all(&compaction_worker::start);
 }
 

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -611,6 +611,7 @@ db_domain_manager::do_get_compaction_info(
       .earliest_dirty_ts = earliest_dirty_ts,
       .compaction_epoch = metadata.compaction_epoch,
       .start_offset = start_offset,
+      .dirty_bytes = dirty_size,
     };
 }
 

--- a/src/v/cloud_topics/level_one/domain/simple_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/simple_domain_manager.cc
@@ -371,7 +371,8 @@ rpc::get_compaction_info_reply simple_domain_manager::do_get_compaction_info(
       .earliest_dirty_ts = get_res->earliest_dirty_ts,
       .compaction_epoch
       = partition_state::compaction_epoch_t{get_res->compaction_epoch()},
-      .start_offset = get_res->start_offset};
+      .start_offset = get_res->start_offset,
+      .dirty_bytes = get_res->dirty_bytes};
 }
 
 ss::future<rpc::get_compaction_info_reply>

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -371,17 +371,20 @@ public:
         // The log's current start_offset. Can be expected to be == 0 for
         // `compact` only topics, might be > 0 for `compact,delete` topics.
         kafka::offset start_offset;
+        // The total size of dirty data in bytes.
+        size_t dirty_bytes{0};
 
         fmt::iterator format_to(fmt::iterator it) const {
             return fmt::format_to(
               it,
               "{{dirty_ratio:{}, earliest_dirty_ts:{}, offsets_response:{}, "
-              "compaction_epoch:{}, start_offset:{}}}",
+              "compaction_epoch:{}, start_offset:{}, dirty_bytes:{}}}",
               dirty_ratio,
               earliest_dirty_ts,
               offsets_response,
               compaction_epoch,
-              start_offset);
+              start_offset,
+              dirty_bytes);
         }
     };
 

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -724,6 +724,7 @@ replicated_metastore::get_compaction_info(const compaction_info_spec& log) {
     resp.compaction_epoch = metastore::compaction_epoch{
       reply.compaction_epoch()};
     resp.start_offset = reply.start_offset;
+    resp.dirty_bytes = reply.dirty_bytes;
 
     co_return resp;
 }
@@ -783,7 +784,8 @@ replicated_metastore::get_compaction_infos(
                               .dirty_ranges = std::move(log_reply.dirty_ranges),
                               .removable_tombstone_ranges = std::move(log_reply.removable_tombstone_ranges)},
                             .compaction_epoch = metastore::compaction_epoch{log_reply.compaction_epoch()},
-                            .start_offset = log_reply.start_offset};
+                            .start_offset = log_reply.start_offset,
+                            .dirty_bytes = log_reply.dirty_bytes};
                           resp.insert_or_assign(log, std::move(log_resp));
                       } else {
                           resp.insert_or_assign(

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -205,7 +205,7 @@ struct extent_metadata
 struct get_compaction_info_reply
   : serde::envelope<
       get_compaction_info_reply,
-      serde::version<1>,
+      serde::version<2>,
       serde::compat_version<0>> {
     auto serde_fields() {
         return std::tie(
@@ -215,7 +215,8 @@ struct get_compaction_info_reply
           dirty_ratio,
           earliest_dirty_ts,
           compaction_epoch,
-          start_offset);
+          start_offset,
+          dirty_bytes);
     }
 
     errc ec;
@@ -225,6 +226,7 @@ struct get_compaction_info_reply
     std::optional<model::timestamp> earliest_dirty_ts;
     partition_state::compaction_epoch_t compaction_epoch;
     kafka::offset start_offset;
+    size_t dirty_bytes{0};
 };
 struct get_compaction_info_request
   : serde::envelope<

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -586,7 +586,8 @@ simple_metastore::get_compaction_offsets(
     return resp;
 }
 
-std::expected<double, metastore::errc> simple_metastore::get_dirty_ratio(
+std::expected<simple_metastore::dirty_stats, metastore::errc>
+simple_metastore::get_dirty_stats(
   const state& state, const model::topic_id_partition& tp) {
     auto prt_ref = state.partition_state(tp);
 
@@ -599,14 +600,12 @@ std::expected<double, metastore::errc> simple_metastore::get_dirty_ratio(
 
     const auto& compaction_state = prt.compaction_state;
 
-    if (!compaction_state.has_value()) {
-        return 1.0;
-    }
-
     // Compute
     size_t total_size{0};
     size_t dirty_size{0};
-    const auto& cleaned_ranges = compaction_state->cleaned_ranges;
+    const auto& cleaned_ranges = compaction_state.has_value()
+                                   ? compaction_state->cleaned_ranges
+                                   : offset_interval_set{};
     for (const auto& extent : prt.extents) {
         total_size += extent.len;
         auto b = extent.base_offset;
@@ -620,9 +619,10 @@ std::expected<double, metastore::errc> simple_metastore::get_dirty_ratio(
         }
     }
 
-    return total_size == 0 ? 0.0
-                           : static_cast<double>(dirty_size)
-                               / static_cast<double>(total_size);
+    double ratio = total_size == 0 ? 0.0
+                                   : static_cast<double>(dirty_size)
+                                       / static_cast<double>(total_size);
+    return dirty_stats{.ratio = ratio, .bytes = dirty_size};
 }
 
 std::expected<std::optional<model::timestamp>, metastore::errc>
@@ -694,9 +694,9 @@ simple_metastore::get_compaction_info(
   const state& state,
   const model::topic_id_partition& tidp,
   model::timestamp ts) {
-    auto dirty_ratio = get_dirty_ratio(state, tidp);
-    if (!dirty_ratio.has_value()) {
-        return std::unexpected(dirty_ratio.error());
+    auto dirty_stats = get_dirty_stats(state, tidp);
+    if (!dirty_stats.has_value()) {
+        return std::unexpected(dirty_stats.error());
     }
 
     auto earliest_dirty_ts = get_earliest_dirty_ts(state, tidp);
@@ -720,11 +720,12 @@ simple_metastore::get_compaction_info(
     }
 
     return compaction_info_response{
-      .dirty_ratio = dirty_ratio.value(),
+      .dirty_ratio = dirty_stats.value().ratio,
       .earliest_dirty_ts = earliest_dirty_ts.value(),
       .offsets_response = std::move(compact_offsets).value(),
       .compaction_epoch = compaction_epoch.value(),
-      .start_offset = log_offsets.value().start_offset};
+      .start_offset = log_offsets.value().start_offset,
+      .dirty_bytes = dirty_stats.value().bytes};
 }
 
 ss::future<std::expected<metastore::compaction_info_map, metastore::errc>>

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -146,8 +146,12 @@ private:
     static std::expected<compaction_offsets_response, errc>
     get_compaction_offsets(
       const state&, const model::topic_id_partition&, model::timestamp);
-    static std::expected<double, errc>
-    get_dirty_ratio(const state&, const model::topic_id_partition&);
+    struct dirty_stats {
+        double ratio;
+        size_t bytes;
+    };
+    static std::expected<dirty_stats, errc>
+    get_dirty_stats(const state&, const model::topic_id_partition&);
     static std::expected<std::optional<model::timestamp>, errc>
     get_earliest_dirty_ts(const state&, const model::topic_id_partition&);
     static std::expected<compaction_epoch, errc>

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -400,6 +400,7 @@ TEST_P(ReplicatedMetastoreTest, TestBasicAdd) {
           cmp_info->offsets_response.dirty_ranges.to_vec(),
           testing::ElementsAre(MatchesRange(o{0}, o{999})));
         EXPECT_FLOAT_EQ(cmp_info->dirty_ratio, 1.0);
+        EXPECT_EQ(cmp_info->dirty_bytes, 500);
         EXPECT_TRUE(cmp_info->earliest_dirty_ts.has_value());
         EXPECT_EQ(cmp_info->compaction_epoch, metastore::compaction_epoch{0});
         EXPECT_EQ(cmp_info->start_offset, o{0});
@@ -492,6 +493,7 @@ TEST_P(ReplicatedMetastoreTest, TestBasicCompact) {
         EXPECT_TRUE(cmp_info->offsets_response.dirty_ranges.empty())
           << fmt::format("{} is not cleaned", tp);
         EXPECT_FLOAT_EQ(cmp_info->dirty_ratio, 0.0);
+        EXPECT_EQ(cmp_info->dirty_bytes, 0);
         EXPECT_TRUE(!cmp_info->earliest_dirty_ts.has_value());
         EXPECT_EQ(cmp_info->compaction_epoch, metastore::compaction_epoch{1});
         EXPECT_EQ(cmp_info->start_offset, o{0});
@@ -931,6 +933,7 @@ TEST_P(ReplicatedMetastoreTest, TestGetCompactionInfos) {
         for (const auto& [log, info] : compaction_infos_res.value()) {
             ASSERT_TRUE(info.has_value());
             ASSERT_DOUBLE_EQ(info->dirty_ratio, 1.0);
+            ASSERT_EQ(info->dirty_bytes, 500);
             ASSERT_EQ(info->compaction_epoch, metastore::compaction_epoch{0});
             ASSERT_EQ(info->start_offset, o{0});
         }
@@ -960,6 +963,7 @@ TEST_P(ReplicatedMetastoreTest, TestGetCompactionInfos) {
         for (const auto& [log, info] : compaction_infos_res.value()) {
             ASSERT_TRUE(info.has_value());
             ASSERT_DOUBLE_EQ(info->dirty_ratio, 0.0);
+            ASSERT_EQ(info->dirty_bytes, 0);
             ASSERT_EQ(info->compaction_epoch, metastore::compaction_epoch{1});
             ASSERT_EQ(info->start_offset, o{0});
         }

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -1532,6 +1532,7 @@ TEST(SimpleMetastoreTest, TestDirtyRatio) {
     auto compaction_info = m.get_compaction_info(to_collect).get();
     ASSERT_TRUE(compaction_info.has_value());
     ASSERT_FLOAT_EQ(compaction_info->dirty_ratio, 1.0);
+    ASSERT_EQ(compaction_info->dirty_bytes, 198);
     ASSERT_EQ(compaction_info->start_offset, 0_o);
 
     // Clean range is now [0, 9]. Only one extent still has dirty offsets.
@@ -1551,6 +1552,7 @@ TEST(SimpleMetastoreTest, TestDirtyRatio) {
     compaction_info = m.get_compaction_info(to_collect).get();
     ASSERT_TRUE(compaction_info.has_value());
     ASSERT_FLOAT_EQ(compaction_info->dirty_ratio, 0.5);
+    ASSERT_EQ(compaction_info->dirty_bytes, 99);
     ASSERT_EQ(compaction_info->start_offset, 0_o);
 
     // Clean range is now [0, 19], the entire log is clean.
@@ -1570,6 +1572,7 @@ TEST(SimpleMetastoreTest, TestDirtyRatio) {
     compaction_info = m.get_compaction_info(to_collect).get();
     ASSERT_TRUE(compaction_info.has_value());
     ASSERT_FLOAT_EQ(compaction_info->dirty_ratio, 0.0);
+    ASSERT_EQ(compaction_info->dirty_bytes, 0);
     ASSERT_EQ(compaction_info->start_offset, 0_o);
 }
 

--- a/src/v/redpanda/application_services.cc
+++ b/src/v/redpanda/application_services.cc
@@ -1049,6 +1049,10 @@ void application::wire_up_redpanda_services(
       ss::sharded_parameter(
         [sg = scheduling_groups::instance().compaction_sg(), fs_avail] {
             return compaction_controller_config(sg, fs_avail);
-        }))
+        }),
+      cloud_topics_app ? storage::backlog_fn([app = cloud_topics_app.get()] {
+          return app->compaction_backlog();
+      })
+                       : storage::backlog_fn(nullptr))
       .get();
 }

--- a/src/v/storage/compaction_controller.cc
+++ b/src/v/storage/compaction_controller.cc
@@ -14,18 +14,28 @@
 #include "storage/api.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/smp.hh>
 
 namespace storage {
 static ss::logger compaction_log{"compaction_ctrl"};
 
 ss::future<int64_t> compaction_backlog_sampler::sample_backlog() {
-    co_return _api.local().log_mgr().compaction_backlog();
+    int64_t local_backlog = _api.local().log_mgr().compaction_backlog();
+    int64_t cloud_backlog = 0;
+    if (_cloud_topics_backlog) {
+        auto fn = _cloud_topics_backlog;
+        cloud_backlog = co_await ss::smp::submit_to(0, std::move(fn));
+    }
+    co_return local_backlog + cloud_backlog;
 }
 
 compaction_controller::compaction_controller(
-  ss::sharded<api>& api, backlog_controller_config cfg)
+  ss::sharded<api>& api,
+  backlog_controller_config cfg,
+  backlog_fn cloud_backlog)
   : _ctrl(
-      std::make_unique<compaction_backlog_sampler>(api),
+      std::make_unique<compaction_backlog_sampler>(
+        api, std::move(cloud_backlog)),
       compaction_log,
       std::move(cfg)) {
     _ctrl.setup_metrics("storage:compaction");

--- a/src/v/storage/compaction_controller.h
+++ b/src/v/storage/compaction_controller.h
@@ -16,23 +16,35 @@
 
 #include <seastar/core/sharded.hh>
 
+#include <functional>
+
 namespace storage {
 
+using backlog_fn = std::function<int64_t()>;
+
 struct compaction_backlog_sampler : public backlog_controller::sampler {
-    explicit compaction_backlog_sampler(ss::sharded<api>& api)
-      : _api(api) {}
+    compaction_backlog_sampler(
+      ss::sharded<api>& api, backlog_fn cloud_topics_backlog = nullptr)
+      : _api(api)
+      , _cloud_topics_backlog(std::move(cloud_topics_backlog)) {}
 
     ss::future<int64_t> sample_backlog() final;
 
 private:
     ss::sharded<api>& _api;
+    // Returns the cloud topics compaction backlog in bytes.
+    // Called on shard 0 where the cloud compaction scheduler runs.
+    backlog_fn _cloud_topics_backlog;
 };
 /**
  * PID controller to controll compaction scheduling and IO shares
  */
 class compaction_controller {
 public:
-    compaction_controller(ss::sharded<api>&, backlog_controller_config);
+    compaction_controller(
+      ss::sharded<api>&,
+      backlog_controller_config,
+      backlog_fn cloud_topics_backlog = nullptr);
 
     ss::future<> start() { return _ctrl.start(); }
     ss::future<> stop() { return _ctrl.stop(); }


### PR DESCRIPTION
Hooks the `compaction` scheduling group into cloud topics, and adds functionality to compute the backlog of compacted logs in cloud topics along with hooking it into the `compaction_controller` PID to control the number of shares allocated to the `compaction` scheduling group.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
