### PR TITLE
ducktape: re-raise ValueError on malformed metrics

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -4806,6 +4806,12 @@ class RedpandaService(Service, RedpandaServiceABC):
                     metrics[key],
                     current + int(sum(s.value for s in ms.samples)),
                 )
+        except ValueError as e:
+            # CORE-15466: ValueError from prometheus_client parser indicates
+            # malformed metrics output from Redpanda - this is a bug, don't
+            # swallow it
+            self.logger.warning(f"ValueError while getting metrics on shutdown - {e}")
+            raise
         except Exception as e:
             self.logger.warning(f"Cannot check metrics on shutdown - {e}")
 


### PR DESCRIPTION
We observed metrics corruption with invalid characters in metric names. This change
makes `ValueError` from the prometheus_client parser bubble up instead of being
swallowed in `_update_usage_stats`, so tests will fail if Redpanda produces malformed
metrics output.

I tested various malformed metrics and they all throw `ValueError`.

[CORE-15466]

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

[CORE-15466]: https://redpandadata.atlassian.net/browse/CORE-15466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ