### PR TITLE
[ENG-960] rpk changes for user-based quotas

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/quotas/alter.go
+++ b/src/go/rpk/pkg/cli/cluster/quotas/alter.go
@@ -11,6 +11,8 @@ package quotas
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -49,8 +51,8 @@ This command allows you to add or delete a client quota.
 A client quota consists of an entity (to whom the quota is applied) and a quota 
 type (what is being applied).
 
-There are two entity types supported by Redpanda: client ID and client ID 
-prefix.
+There are three entity types supported by Redpanda: user, client ID, and 
+client ID prefix.
 
 Assigning quotas to default entity types is possible using the '--default' flag.
 
@@ -95,8 +97,8 @@ Remove quota (producer_byte_rate) from client ID 'foo':
 				}
 				k, v := split[0], split[1]
 				k = strings.ToLower(k)
-				if !anyValidTypes[k] {
-					out.Die("name type %q is invalid (allowed: client-id, client-id-prefix)", split[0])
+				if _, ok := anyValidTypes[k]; !ok {
+					out.Die("name type %q is invalid (allowed: %v)", k, strings.Join(slices.Collect(maps.Keys(anyValidTypes)), ", "))
 				}
 				nameMap[k] = true
 				entity = append(entity, kadm.ClientQuotaEntityComponent{
@@ -105,8 +107,8 @@ Remove quota (producer_byte_rate) from client ID 'foo':
 				})
 			}
 			for _, def := range defaults {
-				if !defaultValidTypes[def] {
-					out.Die("default type %q is invalid (allowed: client-id)", def)
+				if _, ok := defaultValidTypes[def]; !ok {
+					out.Die("default type %q is invalid (allowed: %v)", def, strings.Join(slices.Collect(maps.Keys(defaultValidTypes)), ", "))
 				}
 				if nameMap[def] {
 					out.Die("default type %q was previously defined in --name, you can only set it once", def)

--- a/src/go/rpk/pkg/cli/cluster/quotas/describe.go
+++ b/src/go/rpk/pkg/cli/cluster/quotas/describe.go
@@ -11,6 +11,8 @@ package quotas
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -88,8 +90,8 @@ Describe client quotas for a given client ID prefix 'bar.':
 				}
 				k, v := split[0], split[1]
 				k = strings.ToLower(k)
-				if !anyValidTypes[k] {
-					out.Die("name type %q is invalid (allowed: client-id, client-id-prefix)", split[0])
+				if _, ok := anyValidTypes[k]; !ok {
+					out.Die("name type %q is invalid (allowed: %v)", k, strings.Join(slices.Collect(maps.Keys(anyValidTypes)), ", "))
 				}
 				reqQuotas = append(reqQuotas, kadm.DescribeClientQuotaComponent{
 					Type:      k,
@@ -99,8 +101,8 @@ Describe client quotas for a given client ID prefix 'bar.':
 			}
 			for _, def := range defaults {
 				k := strings.ToLower(def)
-				if !defaultValidTypes[k] {
-					out.Die("default type %q is invalid (allowed: client-id)", def)
+				if _, ok := defaultValidTypes[k]; !ok {
+					out.Die("default type %q is invalid (allowed: %v)", def, strings.Join(slices.Collect(maps.Keys(defaultValidTypes)), ", "))
 				}
 				reqQuotas = append(reqQuotas, kadm.DescribeClientQuotaComponent{
 					Type:      k,
@@ -109,8 +111,8 @@ Describe client quotas for a given client ID prefix 'bar.':
 			}
 			for _, a := range anyFlag {
 				k := strings.ToLower(a)
-				if !anyValidTypes[k] {
-					out.Die("'any' type %q is invalid (allowed: client-id, client-id-prefix)", a)
+				if _, ok := anyValidTypes[k]; !ok {
+					out.Die("'any' type %q is invalid (allowed: %v)", a, strings.Join(slices.Collect(maps.Keys(anyValidTypes)), ", "))
 				}
 				reqQuotas = append(reqQuotas, kadm.DescribeClientQuotaComponent{
 					Type:      k,

--- a/src/go/rpk/pkg/cli/cluster/quotas/quotas.go
+++ b/src/go/rpk/pkg/cli/cluster/quotas/quotas.go
@@ -38,22 +38,18 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 }
 
 // anyValidTypes are the types allowed in --name and --any flags.
-var anyValidTypes = map[string]bool{
-	// Supported by Redpanda.
-	"client-id":        true,
-	"client-id-prefix": true,
-	// Not supported by Redpanda yet.
-	"user": true,
-	"ip":   true,
+var anyValidTypes = map[string]struct{}{
+	"client-id":        {},
+	"client-id-prefix": {},
+	"user":             {},
+	// IP is not supported by Redpanda yet.
 }
 
 // defaultValidTypes are the types allowed in --default flag.
-var defaultValidTypes = map[string]bool{
-	// Supported by Redpanda.
-	"client-id": true,
-	// Not supported by Redpanda yet.
-	"user": true,
-	"ip":   true,
+var defaultValidTypes = map[string]struct{}{
+	"client-id": {},
+	"user":      {},
+	// IP is not supported by Redpanda yet.
 }
 
 type entityData struct {

--- a/tests/rptest/tests/rpk_cluster_quota_test.py
+++ b/tests/rptest/tests/rpk_cluster_quota_test.py
@@ -36,9 +36,12 @@ class RpkClusterQuotaTest(RedpandaTest):
         self._rpk.alter_cluster_quotas(
             name=["client-id-prefix=foo-"], add=["consumer_byte_rate=2222"]
         )
+        self._rpk.alter_cluster_quotas(
+            name=["user=bar"], add=["controller_mutation_rate=512"]
+        )
 
         q2 = self._rpk.describe_cluster_quotas()
-        assert len(q2["quotas"]) == 2  # Quick check, just that we have something.
+        assert len(q2["quotas"]) == 3  # Quick check, just that we have something.
 
         # Same values, NoOp:
         import1 = """
@@ -71,14 +74,28 @@ class RpkClusterQuotaTest(RedpandaTest):
                "value":"11111"
             }
          ]
-      }
+      },
+      {
+         "entity":[
+            {
+               "name":"bar",
+               "type":"user"
+            }
+         ],
+         "values":[
+            {
+               "key":"controller_mutation_rate",
+               "value":"512"
+            }
+         ]
+      },
    ]
 }
 """
         out = self._rpk.import_cluster_quota(import1, output_format="text")
         assert "No changes detected from import" in out
 
-        # Remove 1 (default client-id), Add 1 (producer byte rate).
+        # Remove 2 (default client-id and user), Add 1 (producer byte rate).
         import2 = """
 {
    "quotas":[
@@ -121,6 +138,9 @@ class RpkClusterQuotaTest(RedpandaTest):
             assertChanges(
                 out, "client-id=<default>", "producer_byte_rate", old="11111", new="-"
             )  # New Value as '-' means it was deleted
+            assertChanges(
+                out, "user=bar", "controller_mutation_rate", old="512", new="-"
+            )
             assertChanges(
                 out, "client-id-prefix=foo-", "producer_byte_rate", old="-", new="3333"
             )


### PR DESCRIPTION
Techincally speaking, rpk already supports user
based quotas, this commit only fixes a few code
smells and adds the user type to our rpk ducktape
test.

### Example

```
$ rpk cluster quotas alter --add consumer_byte_rate=200000 --default user
ENTITY          STATUS
user=<default>  OK

$ rpk cluster quotas alter --add controller_mutation_rate=512,consumer_byte_rate=200000 --name user=foo
ENTITY    STATUS
user=foo  OK

$ rpk cluster quotas describe
user=<default>
        consumer_byte_rate=200000

client-id-prefix=bar-
        consumer_byte_rate=200000

user=foo
        consumer_byte_rate=200000
        controller_mutation_rate=512
```

_Note: `client-id-prefix` was added before, just here for illustration purposes_
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
