### PR TITLE
Implement cross-segment prefetching for small segments in cloud storage reads

### DIFF
--- a/src/v/cloud_storage/materialized_resources.cc
+++ b/src/v/cloud_storage/materialized_resources.cc
@@ -305,9 +305,7 @@ materialized_resources::get_partition_reader_units(
     return get_units_abortable(_mem_units, sz, as);
 }
 
-ss::future<segment_units>
-materialized_resources::get_segment_units(model::opt_abort_source_t as) {
-    auto sz = projected_remote_segment_memory_usage();
+void materialized_resources::maybe_trim_segments(ssize_t sz) {
     if (_mem_units.available_units() <= sz) {
         // Update metrics counter if we are trying to acquire units while
         // saturated
@@ -315,8 +313,22 @@ materialized_resources::get_segment_units(model::opt_abort_source_t as) {
 
         trim_segments(max_memory_utilization() / 2);
     }
+}
+
+ss::future<segment_units>
+materialized_resources::get_segment_units(model::opt_abort_source_t as) {
+    auto sz = projected_remote_segment_memory_usage();
+    maybe_trim_segments(sz);
     auto semaphore_units = co_await get_units_abortable(_mem_units, sz, as);
     co_return segment_units{std::move(semaphore_units)};
+}
+
+std::optional<segment_units> materialized_resources::try_get_segment_units() {
+    auto sz = projected_remote_segment_memory_usage();
+    maybe_trim_segments(sz);
+
+    return _mem_units.try_get_units(sz).transform(
+      [](auto u) { return segment_units{std::move(u)}; });
 }
 
 void materialized_resources::trim_segment_readers(size_t target_free) {

--- a/src/v/cloud_storage/materialized_resources.h
+++ b/src/v/cloud_storage/materialized_resources.h
@@ -71,6 +71,7 @@ public:
     get_partition_reader_units(model::opt_abort_source_t as);
 
     ss::future<segment_units> get_segment_units(model::opt_abort_source_t as);
+    std::optional<segment_units> try_get_segment_units();
 
     materialized_manifest_cache& get_materialized_manifest_cache();
 
@@ -119,6 +120,10 @@ private:
     /// Synchronous scan of segments for eviction, reads+modifies _materialized
     /// and writes victims to _eviction_list
     void trim_segments(std::optional<size_t>);
+
+    /// Triggers a segment trim if the free memory units is less than the
+    /// provided parameter.
+    void maybe_trim_segments(ssize_t);
 
     // List of segments to offload, accumulated during trim_segments
     using offload_list_t

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -546,6 +546,23 @@ private:
         }
     }
 
+    /// Set the current segment reader and trigger prefetch for upcoming small
+    /// segments
+    void set_current_reader(
+      std::unique_ptr<remote_segment_batch_reader> reader,
+      model::offset next_offset,
+      const partition_manifest& manifest) {
+        _seg_reader = std::move(reader);
+        _next_segment_base_offset = next_offset;
+
+        if (_seg_reader) {
+            _partition->maybe_prefetch_small_segments(
+              manifest,
+              _next_segment_base_offset,
+              _seg_reader->get_segment_size());
+        }
+    }
+
     ss::future<> init_cursor(cloud_storage::cloud_log_reader_config config) {
         auto segment_unit = co_await _partition->materialized()
                               .get_segment_units(config.abort_source);
@@ -670,8 +687,7 @@ private:
           std::move(segment_unit),
           std::move(segment_reader_unit));
         if (reader) {
-            _seg_reader = std::move(reader);
-            _next_segment_base_offset = next_offset;
+            set_current_reader(std::move(reader), next_offset, manifest);
             return;
         }
         vlog(
@@ -840,8 +856,10 @@ private:
                     std::move(segment_unit),
                     std::move(segment_reader_unit),
                     _next_segment_base_offset);
-                _next_segment_base_offset = new_next_offset;
-                _seg_reader = std::move(new_reader);
+                set_current_reader(
+                  std::move(new_reader),
+                  new_next_offset,
+                  maybe_manifest.value());
             }
             if (maybe_manifest.has_value() && _seg_reader != nullptr) {
                 vassert(
@@ -1552,6 +1570,92 @@ void remote_partition::offload_segment(model::offset o) {
 
 materialized_resources& remote_partition::materialized() {
     return _api.materialized();
+}
+
+void remote_partition::maybe_prefetch_small_segments(
+  const partition_manifest& manifest,
+  model::offset next_segment_base_offset,
+  size_t current_segment_size) {
+    auto max_segments
+      = config::shard_local_cfg().cloud_storage_prefetch_segments_max();
+    if (max_segments == 0) {
+        return;
+    }
+    if (next_segment_base_offset == model::offset{}) {
+        // In this case the reader is likely at the last segment in the
+        // manifest. So there is nothing to prefetch at the moment.
+        return;
+    }
+
+    auto chunk_size
+      = config::shard_local_cfg().cloud_storage_cache_chunk_size();
+    if (current_segment_size > chunk_size) {
+        return;
+    }
+
+    auto prefetch_bytes_left = std::max(
+      chunk_size * config::shard_local_cfg().cloud_storage_chunk_prefetch(),
+      chunk_size);
+    size_t segments_prefetched = 0;
+
+    auto it = manifest.segment_containing(next_segment_base_offset);
+    while (it != manifest.end() && prefetch_bytes_left > 0
+           && segments_prefetched < max_segments) {
+        if (it->size_bytes > chunk_size) {
+            // Prefetching for segments larger than a chunk is handled in the
+            // chunks_api.
+            break;
+        }
+        if (it->size_bytes > prefetch_bytes_left) {
+            break;
+        }
+
+        ssx::spawn_with_gate(
+          _gate, [this, m = *it]() { return do_prefetch_small_segment(m); });
+
+        prefetch_bytes_left -= it->size_bytes;
+        ++segments_prefetched;
+        ++it;
+    }
+
+    vlog(
+      _ctxlog.trace,
+      "Prefetched {} small segments ahead of offset {}",
+      segments_prefetched,
+      next_segment_base_offset);
+}
+
+ss::future<> remote_partition::do_prefetch_small_segment(segment_meta meta) {
+    try {
+        if (_segments.contains(meta.base_offset)) {
+            // Assume that this is a duplicate pre-fetch and avoid adding
+            // waiters to the hydration queues.
+            co_return;
+        }
+
+        auto segment_units = materialized().try_get_segment_units();
+        if (!segment_units) {
+            co_return;
+        }
+
+        auto path = _manifest_view->stm_manifest().generate_segment_path(
+          meta, _manifest_view->path_provider());
+        auto iter = get_or_materialize_segment(
+          path, meta, std::move(*segment_units));
+
+        auto segment = iter->second->segment;
+        co_await segment->hydrate();
+        co_await segment->prefetch_first_chunk();
+    } catch (...) {
+        auto eptr = std::current_exception();
+        if (!ssx::is_shutdown_exception(eptr)) {
+            vlog(
+              _ctxlog.warn,
+              "Small segment prefetch failed for {}: {}",
+              meta.base_offset,
+              eptr);
+        }
+    }
 }
 
 cache_usage_target remote_partition::get_cache_usage_target() const {

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -151,6 +151,10 @@ public:
     // vs segment-based storage in the cache.
     cache_usage_target get_cache_usage_target() const;
 
+    /// Returns the number of currently materialized segments.
+    /// Used in unit tests
+    size_t materialized_segment_count() const { return _segments.size(); }
+
 private:
     friend struct materialized_segment_state;
 
@@ -207,6 +211,14 @@ private:
     /// iterator)
     iterator get_or_materialize_segment(
       const remote_segment_path& path, const segment_meta&, segment_units);
+
+    /// Prefetch small segments ahead of the current read position.
+    /// Called by the reader when transitioning segments.
+    void maybe_prefetch_small_segments(
+      const partition_manifest& manifest,
+      model::offset next_segment_base_offset,
+      size_t current_segment_size);
+    ss::future<> do_prefetch_small_segment(segment_meta meta);
 
     model::ntp _ntp;
     retry_chain_node _rtc;

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -1031,13 +1031,21 @@ ss::future<> remote_segment::do_hydrate(
             // download failed, we may not be able to progress. So we
             // fallback to old format where the full segment was downloaded,
             // and try to hydrate again.
-            if (ex.path == _index_path && !_fallback_mode) {
-                vlog(
-                  _ctxlog.info,
-                  "failed to download index with error [{}], switching to "
-                  "fallback mode and retrying hydration.",
-                  ex);
-                switch_to_legacy_mode();
+            if (ex.path == _index_path) {
+                if (!_fallback_mode) {
+                    vlog(
+                      _ctxlog.info,
+                      "failed to download index with error [{}], switching to "
+                      "fallback mode and retrying hydration.",
+                      ex);
+                    switch_to_legacy_mode();
+                }
+                // In legacy mode the index is never downloaded. So if
+                // `_fallback_mode = fallback_mode::yes` here its because we are
+                // racing with a concurrent hydration request. Hence it should
+                // be fine to re-enter the wait list so we can be notified when
+                // the legacy hydration finishes.
+
                 return do_hydrate(as, deadline).then([] {
                     // This is an empty file to match the type returned by
                     // `fut`. The result is discarded immediately so it is
@@ -1047,9 +1055,7 @@ ss::future<> remote_segment::do_hydrate(
             }
 
             // If the download failure was something other than the index,
-            // OR if we are in the fallback mode already or if we are
-            // working with old format, rethrow the exception and let the
-            // upper layer handle it.
+            // rethrow the exception and let the upper layer handle it.
             return ss::make_exception_future<ss::file>(ex);
         })
       .discard_result();

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -1130,6 +1130,14 @@ ss::future<> remote_segment::hydrate_chunk(chunk_start_offset_t start_offset) {
     _ts_probe.on_chunks_hydration(1);
 }
 
+ss::future<> remote_segment::prefetch_first_chunk() {
+    if (!is_legacy_mode_engaged() && _chunks_api.has_value()) {
+        return _chunks_api->hydrate_chunk(chunk_start_offset_t{0})
+          .discard_result();
+    }
+    return ss::now();
+}
+
 ss::future<ss::file>
 remote_segment::materialize_chunk(chunk_start_offset_t chunk_start) {
     auto res = co_await _cache.get(get_path_to_chunk(chunk_start));

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -125,6 +125,9 @@ public:
     /// files are written to cache.
     ss::future<> hydrate_chunk(chunk_start_offset_t start_offset);
 
+    /// Prefetch the first chunk of the segment using the chunks API.
+    ss::future<> prefetch_first_chunk();
+
     /// Loads the segment chunk file from cache into an open file handle. If the
     /// file is not present in cache, the returned file handle is unopened.
     ss::future<ss::file> materialize_chunk(chunk_start_offset_t);
@@ -430,6 +433,8 @@ public:
     bool reads_from_segment(const remote_segment& segm) const {
         return &segm == _seg.get();
     }
+
+    size_t get_segment_size() const { return _seg->get_segment_size(); }
 
     bool is_stopped() const { return _stopped; }
 

--- a/src/v/cloud_storage/tests/BUILD
+++ b/src/v/cloud_storage/tests/BUILD
@@ -388,6 +388,7 @@ redpanda_cc_btest(
         "//src/v/model",
         "//src/v/ssx:future_util",
         "//src/v/storage",
+        "//src/v/test_utils:scoped_config",
         "//src/v/test_utils:seastar_boost",
         "//src/v/utils:retry_chain_node",
         "@boost//:test",

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -40,6 +40,7 @@
 #include "storage/types.h"
 #include "test_utils/async.h"
 #include "test_utils/boost_fixture.h"
+#include "test_utils/scoped_config.h"
 #include "utils/retry_chain_node.h"
 
 #include <seastar/core/future.hh>
@@ -2540,4 +2541,196 @@ FIXTURE_TEST(test_out_of_range_spillover_query, cloud_storage_fixture) {
     BOOST_TEST_REQUIRE(timequery(*this, base, model::timestamp(100), 3 * 6));
     BOOST_TEST_REQUIRE(
       timequery(*this, segments[2].base_offset, model::timestamp(100), 3 * 6));
+}
+
+// Test that small segment prefetch is disabled when config is 0
+FIXTURE_TEST(test_small_segment_prefetch_disabled, cloud_storage_fixture) {
+    scoped_config cfg;
+    cfg.get("cloud_storage_prefetch_segments_max").set_value(uint16_t{0});
+
+    auto segments = setup_s3_imposter(*this, 5, 2);
+    auto base = segments.front().base_offset;
+    auto first_seg_max = segments.front().max_offset;
+
+    size_t max_segment_size = 0;
+    for (const auto& s : segments) {
+        max_segment_size = std::max(max_segment_size, s.bytes.size());
+    }
+    cfg.get("cloud_storage_cache_chunk_size")
+      .set_value((uint64_t)2 * max_segment_size);
+
+    auto manifest = hydrate_manifest(api.local(), bucket_name);
+    partition_probe probe(manifest.get_ntp());
+
+    auto manifest_view = ss::make_shared<async_manifest_view>(
+      api, cache, manifest, bucket_name, path_provider);
+    auto manifest_view_stop = ss::defer(
+      [&manifest_view] { manifest_view->stop().get(); });
+    manifest_view->start().get();
+
+    auto partition = ss::make_shared<remote_partition>(
+      manifest_view, api.local(), cache.local(), bucket_name, probe);
+    auto partition_stop = ss::defer([&partition] { partition->stop().get(); });
+    partition->start().get();
+
+    BOOST_REQUIRE_EQUAL(partition->materialized_segment_count(), 0);
+
+    cloud_log_reader_config reader_config(
+      model::offset_cast(base), model::offset_cast(first_seg_max));
+    auto reader = partition->make_reader(reader_config).get().reader;
+    auto headers = reader.consume(test_consumer(), model::no_timeout).get();
+    std::move(reader).release();
+    BOOST_REQUIRE(!headers.empty());
+
+    // With prefetch disabled, we should only have the segment being read
+    // materialized (1 segment).
+    BOOST_REQUIRE_EQUAL(partition->materialized_segment_count(), 1);
+}
+
+// Test that small segment prefetch triggers when enabled and validates
+// that segments are materialized
+FIXTURE_TEST(test_small_segment_prefetch_enabled, cloud_storage_fixture) {
+    scoped_config cfg;
+    cfg.get("cloud_storage_prefetch_segments_max").set_value(uint16_t{3});
+    // Set chunk prefetch to 0 to isolate small segment prefetch behavior
+    cfg.get("cloud_storage_chunk_prefetch").set_value(uint16_t{0});
+
+    auto segments = setup_s3_imposter(*this, 5, 2);
+    auto base = segments.front().base_offset;
+    auto first_seg_max = segments.front().max_offset;
+
+    auto manifest = hydrate_manifest(api.local(), bucket_name);
+    partition_probe probe(manifest.get_ntp());
+
+    auto manifest_view = ss::make_shared<async_manifest_view>(
+      api, cache, manifest, bucket_name, path_provider);
+    auto manifest_view_stop = ss::defer(
+      [&manifest_view] { manifest_view->stop().get(); });
+    manifest_view->start().get();
+
+    auto partition = ss::make_shared<remote_partition>(
+      manifest_view, api.local(), cache.local(), bucket_name, probe);
+    auto partition_stop = ss::defer([&partition] { partition->stop().get(); });
+    partition->start().get();
+
+    BOOST_REQUIRE_EQUAL(partition->materialized_segment_count(), 0);
+
+    // Read just the first segment this should trigger prefetch of subsequent
+    // small segments.
+    cloud_log_reader_config reader_config(
+      model::offset_cast(base), model::offset_cast(first_seg_max));
+    auto reader = partition->make_reader(reader_config).get().reader;
+    auto headers = reader.consume(test_consumer(), model::no_timeout).get();
+    std::move(reader).release();
+    BOOST_REQUIRE_EQUAL(headers.size(), 2);
+
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+        // 1 read, 3 prefetched
+        return partition->materialized_segment_count() == 4;
+    });
+}
+
+// Test that prefetch respects the segment count limit
+FIXTURE_TEST(test_small_segment_prefetch_count_limit, cloud_storage_fixture) {
+    scoped_config cfg;
+    // Limit prefetch to 2 segments
+    cfg.get("cloud_storage_prefetch_segments_max").set_value(uint16_t{2});
+    cfg.get("cloud_storage_chunk_prefetch").set_value(uint16_t{0});
+
+    // Create 10 small segments
+    auto segments = setup_s3_imposter(*this, 10, 2);
+    auto base = segments.front().base_offset;
+    auto first_seg_max = segments.front().max_offset;
+
+    size_t max_segment_size = 0;
+    for (const auto& s : segments) {
+        max_segment_size = std::max(max_segment_size, s.bytes.size());
+    }
+    cfg.get("cloud_storage_cache_chunk_size")
+      .set_value((uint64_t)2 * max_segment_size);
+
+    auto manifest = hydrate_manifest(api.local(), bucket_name);
+    partition_probe probe(manifest.get_ntp());
+
+    auto manifest_view = ss::make_shared<async_manifest_view>(
+      api, cache, manifest, bucket_name, path_provider);
+    auto manifest_view_stop = ss::defer(
+      [&manifest_view] { manifest_view->stop().get(); });
+    manifest_view->start().get();
+
+    auto partition = ss::make_shared<remote_partition>(
+      manifest_view, api.local(), cache.local(), bucket_name, probe);
+    auto partition_stop = ss::defer([&partition] { partition->stop().get(); });
+    partition->start().get();
+
+    BOOST_REQUIRE_EQUAL(partition->materialized_segment_count(), 0);
+
+    cloud_log_reader_config reader_config(
+      model::offset_cast(base), model::offset_cast(first_seg_max));
+    auto reader = partition->make_reader(reader_config).get().reader;
+    auto headers = reader.consume(test_consumer(), model::no_timeout).get();
+    std::move(reader).release();
+    BOOST_REQUIRE(!headers.empty());
+
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+        // 1 read, 2 pre-fetched
+        return partition->materialized_segment_count() == 3;
+    });
+}
+
+// Test that prefetch stops at large segments
+FIXTURE_TEST(
+  test_small_segment_prefetch_stops_at_large, cloud_storage_fixture) {
+    scoped_config cfg;
+    cfg.get("cloud_storage_prefetch_segments_max").set_value(uint16_t{10});
+    cfg.get("cloud_storage_cache_chunk_size").set_value(uint64_t{1024});
+    cfg.get("cloud_storage_chunk_prefetch").set_value(uint16_t{0});
+
+    batch_t data_batch{1, model::record_batch_type::raft_data, {128}};
+    std::vector<batch_t> small_seg{data_batch, data_batch};
+    std::vector<batch_t> large_seg;
+    for (int i = 0; i < 20; i++) {
+        large_seg.push_back(data_batch);
+    }
+
+    std::vector<std::vector<batch_t>> raw_segments{
+      small_seg,
+      small_seg,
+      // Prefetching should stop here.
+      large_seg,
+      small_seg,
+      small_seg,
+    };
+
+    auto segments = setup_s3_imposter(*this, raw_segments);
+    auto base = segments.front().base_offset;
+    auto first_seg_max = segments.front().max_offset;
+
+    auto manifest = hydrate_manifest(api.local(), bucket_name);
+    partition_probe probe(manifest.get_ntp());
+
+    auto manifest_view = ss::make_shared<async_manifest_view>(
+      api, cache, manifest, bucket_name, path_provider);
+    auto manifest_view_stop = ss::defer(
+      [&manifest_view] { manifest_view->stop().get(); });
+    manifest_view->start().get();
+
+    auto partition = ss::make_shared<remote_partition>(
+      manifest_view, api.local(), cache.local(), bucket_name, probe);
+    auto partition_stop = ss::defer([&partition] { partition->stop().get(); });
+    partition->start().get();
+
+    BOOST_REQUIRE_EQUAL(partition->materialized_segment_count(), 0);
+
+    cloud_log_reader_config reader_config(
+      model::offset_cast(base), model::offset_cast(first_seg_max));
+    auto reader = partition->make_reader(reader_config).get().reader;
+    auto headers = reader.consume(test_consumer(), model::no_timeout).get();
+    std::move(reader).release();
+    BOOST_REQUIRE(!headers.empty());
+
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+        // 1 read, 1 pre-fetched
+        return partition->materialized_segment_count() == 2;
+    });
 }

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3086,6 +3086,13 @@ configuration::configuration()
       "Number of chunks to prefetch ahead of every downloaded chunk",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       0)
+  , cloud_storage_prefetch_segments_max(
+      *this,
+      "cloud_storage_prefetch_segments_max",
+      "Maximum number of small segments (size <= chunk size) to prefetch ahead "
+      "during sequential reads. Set to 0 to disable cross-segment prefetch.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      3)
   , cloud_storage_cache_num_buckets(
       *this,
       "cloud_storage_cache_num_buckets",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -533,6 +533,7 @@ struct configuration final : public config_store {
     enum_property<model::cloud_storage_chunk_eviction_strategy>
       cloud_storage_chunk_eviction_strategy;
     property<uint16_t> cloud_storage_chunk_prefetch;
+    property<uint16_t> cloud_storage_prefetch_segments_max;
     bounded_property<uint32_t> cloud_storage_cache_num_buckets;
     bounded_property<std::optional<double>, numeric_bounds>
       cloud_storage_cache_trim_threshold_percent_size;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
The existing chunk prefetching works well for large segments but doesn't help when reading many small segments. Previously, each small segment required a sequential round-trip to cloud storage, significantly reducing throughput.

This PR adds the ability to prefetch upcoming small segments (size <= chunk size) in parallel when reading sequentially. When the reader transitions to a new small segment, it spawns background tasks to hydrate the next few segments, reducing wait time for subsequent reads.

Will be running some performance tests against these changes shortly.

Fixes [CORE-13342](https://redpandadata.atlassian.net/browse/CORE-13342)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
### Features
* adds the `cloud_storage_prefetch_segments_max` cluster config which can be used to enable small segment prefetching in cloud storage.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-13342]: https://redpandadata.atlassian.net/browse/CORE-13342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ