### PR TITLE
[v25.3.x] kafka: Clamp consume deadline to 5s

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -734,6 +734,14 @@ configuration::configuration()
       "minimum bytes was not reached.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1ms)
+  , kafka_fetch_request_timeout_ms(
+      *this,
+      "kafka_fetch_request_timeout_ms",
+      "Broker-side target for the duration of a single fetch request. The "
+      "broker will try to complete fetches within the specified duration, even "
+      "if it means returning less bytes in the fetch than are available.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      5s)
   , fetch_read_strategy(
       *this,
       "fetch_read_strategy",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -220,6 +220,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> tx_timeout_delay_ms;
     deprecated_property rm_violation_recovery_policy;
     property<std::chrono::milliseconds> fetch_reads_debounce_timeout;
+    property<std::chrono::milliseconds> kafka_fetch_request_timeout_ms;
     enum_property<model::fetch_read_strategy> fetch_read_strategy;
     bounded_property<size_t> fetch_max_read_concurrency;
     bounded_property<double, numeric_bounds> fetch_pid_p_coeff;

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -482,6 +482,7 @@ static ss::future<chunked_vector<read_result>> fetch_ntps(
   chunked_vector<ntp_fetch_config> ntp_fetch_configs,
   read_distribution_probe& read_probe,
   std::optional<model::timeout_clock::time_point> deadline,
+  model::timeout_clock::time_point fetch_deadline,
   const size_t bytes_left,
   fetch_memory_units_manager& units_mgr) {
     size_t total_read_size = 0;
@@ -499,6 +500,15 @@ static ss::future<chunked_vector<read_result>> fetch_ntps(
     for (const auto& _ : config_indexes) {
         results.emplace_back(error_code::none);
     }
+
+    // Ensure fetch_deadline is at least as large as deadline. The deadline is
+    // the point in time at which fetch.max.wait has elapsed. The fetch_deadline
+    // is the point in time before which we want to complete the fetch request.
+    // The fetch_deadline is >= deadline and the storage layer tries to stop
+    // reading if this deadline has been exceeded.
+    fetch_deadline = std::max(
+      deadline.value_or(model::timeout_clock::time_point::min()),
+      fetch_deadline);
 
     co_await ss::max_concurrent_for_each(
       config_indexes,
@@ -525,7 +535,7 @@ static ss::future<chunked_vector<read_result>> fetch_ntps(
                    md_cache,
                    replica_selector,
                    ntp_cfg,
-                   deadline,
+                   fetch_deadline,
                    obligatory_batch_read,
                    units_mgr)
             .then([&, cfg_idx](read_result&& res) {
@@ -573,8 +583,13 @@ public:
         // Specifies the minimum number of bytes this sub-fetch should read
         // before returning.
         size_t min_bytes;
-        // If set then the sub-fetch should return by the specified time_point .
+
+        // Debounce timeout
         std::optional<model::timeout_clock::time_point> deadline;
+
+        // If set then the sub-fetch should return by the specified time_point .
+        model::timeout_clock::time_point fetch_deadline;
+
         // The fetch sub-requests of partitions local to the shard this worker
         // is running on.
         chunked_vector<ntp_fetch_config> requests;
@@ -690,6 +705,7 @@ private:
           std::move(requests),
           _ctx.srv.read_probe(),
           _ctx.deadline,
+          _ctx.fetch_deadline,
           _ctx.bytes_left,
           _ctx.srv.fetch_units_manager());
 
@@ -1478,6 +1494,9 @@ op_context::op_context(request_context&& ctx, ss::smp_service_group ssg)
     if (auto delay = request.debounce_delay(); delay) {
         deadline = model::timeout_clock::now() + delay.value();
     }
+    fetch_deadline
+      = model::timeout_clock::now()
+        + config::shard_local_cfg().kafka_fetch_request_timeout_ms();
 
     if (rctx.header().version() >= api_version{13}) {
         /*

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -195,7 +195,18 @@ struct op_context {
 
     // operation budgets
     size_t bytes_left;
+    // The point in time at which `fetch.max.wait` has elapsed. Used to
+    // implement the kafka semantics by returning when this time has been
+    // reached, even when we have less than min_bytes. Due to slow sub-fetches,
+    // requests may sometimes take much longer, see fetch_deadline.
     std::optional<model::timeout_clock::time_point> deadline;
+    // The point in time before which we want to complete the fetch request.
+    // The fetch_deadline is >= deadline and the storage layer tries to stop
+    // reading if this deadline has been exceeded, if there is known to be more
+    // data to fetch. This deadline exists to try to bound the overall time for
+    // a single fetch request, as Kafka clients time out (and usually retry) if
+    // an individual request takes a long time.
+    model::timeout_clock::time_point fetch_deadline;
 
     // size of response
     size_t response_size;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/29378
