### PR TITLE
[CORE-15428] dt: add logging to quota test

### DIFF
--- a/tests/rptest/tests/cluster_quota_test.py
+++ b/tests/rptest/tests/cluster_quota_test.py
@@ -205,27 +205,31 @@ class ClusterRateQuotaTest(RedpandaTest):
         throttle_ms = producer.metrics()["producer-metrics"][
             "produce-throttle-time-max"
         ]
-        assert throttle_ms > 0 and (
-            ignore_max_throttle or throttle_ms <= self.max_throttle_time
-        )
+        assert throttle_ms > 0, f"Expected throttle > 0. Got {throttle_ms} ms"
+        if not ignore_max_throttle:
+            assert throttle_ms <= self.max_throttle_time, (
+                f"Expected throttle <= {self.max_throttle_time}, got {throttle_ms}"
+            )
 
     def check_producer_not_throttled(self, producer):
         throttle_ms = producer.metrics()["producer-metrics"][
             "produce-throttle-time-max"
         ]
-        assert throttle_ms == 0
+        assert throttle_ms == 0, f"Expected 0 ms throttle. Got {throttle_ms} ms"
 
     def check_consumer_throttled(self, consumer):
         throttle_ms = consumer.metrics()["consumer-fetch-manager-metrics"][
             "fetch-throttle-time-max"
         ]
-        assert throttle_ms > 0 and throttle_ms <= self.max_throttle_time
+        assert throttle_ms > 0 and throttle_ms <= self.max_throttle_time, (
+            f"Expected throttle in range (0, {self.max_throttle_time}]. Got {throttle_ms}"
+        )
 
     def check_consumer_not_throttled(self, consumer):
         throttle_ms = consumer.metrics()["consumer-fetch-manager-metrics"][
             "fetch-throttle-time-max"
         ]
-        assert throttle_ms == 0
+        assert throttle_ms == 0, f"Expected 0 ms throttle. Got {throttle_ms} ms"
 
     def produce(self, producer, amount, message=None, timeout_sec=10):
         msg = message if message else self.msg


### PR DESCRIPTION
Fixes: [CORE-15428](https://redpandadata.atlassian.net/browse/CORE-15428)

Add logging to failing test. There is no visibility to the failing test.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-15428]: https://redpandadata.atlassian.net/browse/CORE-15428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ