### PR TITLE
ossl: Remove no longer needed debug log line

### DIFF
--- a/src/v/crypto/ossl_context_service.cc
+++ b/src/v/crypto/ossl_context_service.cc
@@ -142,11 +142,6 @@ initialize_result<initialize_thread_return> initialize_worker_thread(
     // thread instance so any use of OpenSSL within the thread worker (krb5)
     // uses the appropriately initialiazed context
     auto old_context = OSSL_LIB_CTX_set0_default(ctx);
-    vlog(
-      lg.debug,
-      "thread worker context: {}, replacing {}",
-      fmt::ptr(ctx),
-      fmt::ptr(old_context));
     auto init_return = initialize_openssl(
       ctx, module_path, conf_file, fips_mode);
 
@@ -232,11 +227,6 @@ public:
         // supply nullptr to the OSSL_LIB_CTX parameter to use the thread local
         // context
         _old_context = OSSL_LIB_CTX_set0_default(_shard_ctx.get());
-        vlog(
-          lg.debug,
-          "Created new shard context for {} replacing {}",
-          fmt::ptr(_shard_ctx.get()),
-          fmt::ptr(_old_context));
         auto init_resp = co_await _thread_worker.submit([this] {
             return initialize_openssl(
               _shard_ctx.get(), _module_path, _config_file, _fips_mode);
@@ -261,12 +251,6 @@ public:
         _fips_provider.reset();
         if (_old_context != nullptr) {
             auto replaced_context = OSSL_LIB_CTX_set0_default(_old_context);
-            vlog(
-              lg.debug,
-              "Reverted to old context {} and received back {} (expecting {})",
-              fmt::ptr(_old_context),
-              fmt::ptr(replaced_context),
-              fmt::ptr(_shard_ctx.get()));
             vassert(
               replaced_context == _shard_ctx.get(),
               "Replacing original context returns unexpected library context");


### PR DESCRIPTION
It gets treated as a backtrace by our DT backtrace decoding script.

Remove as it's no longer needed.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

