### PR TITLE
compaction/test: speedup debug mode compaction_e2e_test

### DIFF
--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -1749,7 +1749,11 @@ TEST_F(CompactionFixtureParamTest, TestSegmentConcatenation) {
                                 // concatenation works on its own without
                                 // considering compaction.
     auto batches_per_segment = 100;
+#ifdef NDEBUG
     auto records_per_batch = 100;
+#else
+    auto records_per_batch = 20;
+#endif
     generate_data(
       num_segments, cardinality, batches_per_segment, records_per_batch)
       .get();
@@ -1879,7 +1883,11 @@ TEST_F(CompactionFixtureTest, TestAdjacentCompactionMultipleRanges) {
     auto num_segments = 10;
     auto cardinality = 10;
     auto batches_per_segment = 100;
+#ifdef NDEBUG
     auto records_per_batch = 100;
+#else
+    auto records_per_batch = 20;
+#endif
     map_t latest_kv_map;
 
     // Write some data in different terms. Adjacent compaction should be able to
@@ -1887,7 +1895,11 @@ TEST_F(CompactionFixtureTest, TestAdjacentCompactionMultipleRanges) {
     // invalid iterators or running into other issues.
     auto raft = partition->raft();
     auto orig_term = raft->term();
+#ifdef NDEBUG
     auto num_raft_terms = 5;
+#else
+    auto num_raft_terms = 3;
+#endif
 
     int term_idx = 0;
     while (raft->term()() < orig_term() + num_raft_terms) {


### PR DESCRIPTION
Reduce test parameters for two slow tests in debug builds. These tests contributed to a CI timeout.

TestSegmentConcatenation:
- records_per_batch: 100 -> 20 (5x data reduction)
- Runtime: 24s -> 5s (locally, anecdotally)

TestAdjacentCompactionMultipleRanges:
- records_per_batch: 100 -> 20 (5x data reduction)
- num_raft_terms: 5 -> 3 (most test time was spent in election activity, not data I/O)
- Runtime: 15s -> 6s (ditto)

Overall debug test suite runtime reduced from ~88s to ~52s in an ad hoc measurement.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
