### PR TITLE
Revert "cpd: Run datalake test on 7 nodes"

### DIFF
--- a/tests/rptest/perf/datalake_test.py
+++ b/tests/rptest/perf/datalake_test.py
@@ -66,7 +66,7 @@ class DatalakeTest(RedpandaTest):
 
         return msg
 
-    @cluster(num_nodes=7)
+    @cluster(num_nodes=6)
     @matrix(cloud_storage_type=supported_storage_types())
     def test_omb(self, cloud_storage_type: str) -> None:
         topic_name = "atestingtopic"
@@ -152,6 +152,8 @@ class DatalakeTest(RedpandaTest):
                 workload=(workload, validator),
                 topology="ensemble",
                 local_payload_dir=payloads,
+                # Share the omb driver node with the iceberg catalog node. Both do hardly anything and this saves us a node.
+                node=dl.catalog_service.get_node(0),
             )
             benchmark.start()
             benchmark_time_min = benchmark.benchmark_time_mins() + 5


### PR DESCRIPTION
This reverts commit da1bb6bc7663a549d9b85563ced681887ebd0af2.

Seems this didn't cause flakiness but rather the low timeout did.

Revert back to 6 nodes to save some money.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


* none

