### PR TITLE
ct/l1/lsm: avoid segfault after opening fails

### DIFF
--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -903,6 +903,9 @@ db_domain_manager::gate_and_open_reads() {
         // Shutting down.
         co_return std::unexpected(rpc::errc::not_leader);
     }
+    if (!db_ || db_->needs_reopen()) {
+        co_return std::unexpected(rpc::errc::not_leader);
+    }
     co_return gate_read_lock{
       .gate = std::move(*gate_res),
       .db_lock = std::move(fut.get()),
@@ -1087,7 +1090,7 @@ db_domain_manager::restore_domain(rpc::restore_domain_request req) {
         };
     }
     // No-op, we're already restored!
-    if (db_->get_domain_uuid() == req.new_uuid) {
+    if (db_ && db_->get_domain_uuid() == req.new_uuid) {
         co_return rpc::restore_domain_reply{
           .ec = rpc::errc::ok,
         };
@@ -1097,6 +1100,11 @@ db_domain_manager::restore_domain(rpc::restore_domain_request req) {
     // resetting it.
     auto lock_res = co_await exclusive_db_lock();
     if (!lock_res.has_value()) {
+        co_return rpc::restore_domain_reply{
+          .ec = rpc::errc::not_leader,
+        };
+    }
+    if (!db_ || db_->needs_reopen()) {
         co_return rpc::restore_domain_reply{
           .ec = rpc::errc::not_leader,
         };

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.h
@@ -87,9 +87,8 @@ private:
     // reopening it if needed (e.g. the underlying Raft term has changed since
     // the last open).
     //
-    // Once called, callers should expect that db_ is at least set, though it
-    // is possible that it will still need to be reopened (e.g. because of a
-    // domain restore).
+    // Even upon success, callers should check the database is still opened
+    // with the database lock.
     ss::future<std::expected<void, rpc::errc>> maybe_open_db();
 
     // Should be called and held when resetting the database instance to ensure


### PR DESCRIPTION
There was previously the following race:

A: calls gate_and_open_reads(); finishes maybe_open_db() and then waits
   for database lock
-: leadership changes
B: calls gate_and_open_reads(); maybe_open_db() tries to reopen database
   with the database lock
B: closes database and resets the pointer, and for some reason (e.g.
   another leadership change) fails to sync, returning an error without
   setting db_
A: acquires the database lock and dereferences the null database

This commit fixes this by updating calls to maybe_open_db() to check the db before dereferencing.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
