### PR TITLE
cluster_link: improve comment for prefix truncation delay logic

### DIFF
--- a/src/v/cluster_link/replication/partition_replicator.cc
+++ b/src/v/cluster_link/replication/partition_replicator.cc
@@ -319,6 +319,7 @@ ss::future<> partition_replicator::fetch_and_replicate() {
 }
 
 ss::future<> partition_replicator::maybe_synchronize_start_offset() {
+    auto shadow_partition_hwm = _sink->high_watermark();
     auto shadow_partition_start_offset = _sink->start_offset();
     auto source_offsets = _source->get_offsets();
 
@@ -333,6 +334,7 @@ ss::future<> partition_replicator::maybe_synchronize_start_offset() {
     }
 
     auto source_start_offset = source_offsets->source_start_offset;
+    auto source_lso = source_offsets->source_lso;
 
     if (source_start_offset <= shadow_partition_start_offset) {
         vlog(
@@ -341,6 +343,29 @@ ss::future<> partition_replicator::maybe_synchronize_start_offset() {
           "shadow: {}",
           source_start_offset,
           shadow_partition_start_offset);
+        co_return;
+    }
+
+    // The source partition may perform a prefix truncation that lands in the
+    // middle of a batch. Redpanda's data replicators will replicate the whole
+    // batch, including data that starts before the start offset. If we prefix
+    // truncate the shadow partition before that batch is replicated, this will
+    // interfere with our ability to replicate the entire batch, leading to data
+    // loss. To prevent being too eager, we only perform prefix truncation when
+    // we know that we have fully replicated all batches up to or past the
+    // source start offset. This means: source_start_offset <
+    // shadow_partition_hwm OR source_start_offset == source_lso.
+    if (
+      source_lso != source_start_offset
+      && source_start_offset > shadow_partition_hwm) {
+        vlog(
+          _log.debug,
+          "Shadow partition has not replicated up to the source start offset "
+          "yet, deferring prefix truncation. source_start_offset: {}, "
+          "source_lso: {}, shadow_partition_hwm: {}",
+          source_start_offset,
+          source_lso,
+          shadow_partition_hwm);
         co_return;
     }
 


### PR DESCRIPTION
Clarifies that the delay prevents data loss when the source partition performs prefix truncation in the middle of a batch. The replicator needs to replicate the entire batch before the shadow partition can safely truncate.

- [x] Run test 1000 times

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
