### PR TITLE
bazel: Enable LTO only in PGO build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -232,17 +232,7 @@ build:secure --config=relro
 build:release --compilation_mode opt
 build:release --config=secure
 build:release --@seastar//:stack_guards=False --@seastar//:debug=False
-build:release --//src/v/redpanda:lto=True
-build:release --copt -flto=thin --copt -ffat-lto-objects
 build:release --copt -g --strip=never
-build:release --@rules_rust//rust/settings:lto=fat
-build:release --@rules_rust//rust/settings:extra_rustc_flag=-Ccodegen-units=1
-# I've seen others claim these flags help with LTO and the final binary, but these also
-# require a specific version of clang and I don't really want to tie rustc version with
-# clang version.
-# build:release --@rules_rust//rust/settings:extra_rustc_flag=-Clinker-plugin-lto
-# build:release --@rules_rust//rust/settings:extra_rustc_flag=-Cembed-bitcode=yes
-# build:release --@rules_rust//rust/settings:extra_rustc_flag=-Clink-arg=-fuse-ld=lld
 # For now, disable the hardened libc++ for release builds for maximum perf 🚀
 build:release --cxxopt=-U_LIBCPP_ASSERTION_SEMANTIC
 build:release --cxxopt=-U_LIBCPP_HARDENING_MODE
@@ -252,9 +242,21 @@ build:release --host_cxxopt=-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_NONE
 
 # Separate PGO configs to be combined with release
 
+# Enable LTO only in PGO build to save time in other builds
+build:pgo-base --//src/v/redpanda:lto=True
+build:pgo-base --copt -flto=thin
+build:pgo-base --@rules_rust//rust/settings:lto=fat
+build:pgo-base --@rules_rust//rust/settings:extra_rustc_flag=-Ccodegen-units=1
+# I've seen others claim these flags help with LTO and the final binary, but these also
+# require a specific version of clang and I don't really want to tie rustc version with
+# clang version.
+# build:pgo-base --@rules_rust//rust/settings:extra_rustc_flag=-Clinker-plugin-lto
+# build:pgo-base --@rules_rust//rust/settings:extra_rustc_flag=-Cembed-bitcode=yes
+# build:pgo-base --@rules_rust//rust/settings:extra_rustc_flag=-Clink-arg=-fuse-ld=lld
+
 # Instrumentation/training step
 # Empty arg is intentional, we provide the path via env var at run time
-build:pgo-instrument --fdo_instrument=
+build:pgo-instrument --config=pgo-base --fdo_instrument=
 
 # Final/Optimization build step
 
@@ -265,7 +267,7 @@ build:pgo-instrument --fdo_instrument=
 
 # bazel seems to pass -fprofile-correction unconditionally but that only exists
 # in gcc so need to make clang ignore it
-build:pgo-optimize --copt -Wno-ignored-optimization-argument
+build:pgo-optimize --config=pgo-base --copt -Wno-ignored-optimization-argument
 
 
 build:stamp --stamp --workspace_status_command=./bazel/stamp_vars.sh


### PR DESCRIPTION
PGO is the main release build so enable LTO only then. Saves some time
in the basic release build.

Also disable fat lto objects. There is no point in using them anymore as
the PGO build isn't shared with anything anyway.

This speeds up both the non-PGO and PGO build and also reduces object
sizes.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none


