### PR TITLE
ct: hook cloud topics recovery into whole cluster restore

### DIFF
--- a/src/v/cloud_topics/level_one/domain/domain_supervisor.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_supervisor.cc
@@ -101,12 +101,13 @@ public:
         return it->second;
     }
 
-    ss::future<bool> maybe_create_metastore_topic() {
+    ss::future<bool>
+    maybe_create_metastore_topic(std::optional<int> num_partitions) {
         if (_controller->get_topics_state().local().contains(
               model::l1_metastore_nt)) {
             co_return true;
         }
-        co_return co_await create_domains_topic();
+        co_return co_await create_domains_topic(num_partitions);
     }
 
 private:
@@ -186,7 +187,8 @@ private:
         }
     }
 
-    ss::future<bool> create_domains_topic() {
+    ss::future<bool>
+    create_domains_topic(std::optional<int> num_partitions = std::nullopt) {
         auto tp_ns = model::l1_metastore_nt;
         cluster::topic_properties topic_props;
         // Mark all these as disabled
@@ -199,7 +201,8 @@ private:
           = model::cleanup_policy_bitflags::none;
         // NOTE: For now we just have a fixed number of domains for the entire
         // cluster.
-        co_return co_await create_topic(tp_ns, 3, topic_props);
+        co_return co_await create_topic(
+          tp_ns, num_partitions.value_or(3), topic_props);
     }
 
     ss::future<> update_topic(cluster::topic_properties_update update) {
@@ -372,8 +375,9 @@ domain_supervisor::get(const model::ntp& ntp) const {
     return _impl->get(ntp);
 }
 
-ss::future<bool> domain_supervisor::maybe_create_metastore_topic() {
-    return _impl->maybe_create_metastore_topic();
+ss::future<bool> domain_supervisor::maybe_create_metastore_topic(
+  std::optional<int> num_partitions) {
+    return _impl->maybe_create_metastore_topic(num_partitions);
 }
 
 void domain_supervisor::on_domain_leadership_change(

--- a/src/v/cloud_topics/level_one/domain/domain_supervisor.h
+++ b/src/v/cloud_topics/level_one/domain/domain_supervisor.h
@@ -66,7 +66,8 @@ public:
 
     // Creates the L1 metastore topic, returning false if there was an issue
     // while creating.
-    ss::future<bool> maybe_create_metastore_topic();
+    ss::future<bool>
+    maybe_create_metastore_topic(std::optional<int> num_partitions);
 
 private:
     std::unique_ptr<impl> _impl;

--- a/src/v/cloud_topics/level_one/metastore/leader_router.cc
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.cc
@@ -414,8 +414,9 @@ leader_router::leader_router(
 
 ss::future<> leader_router::stop() { return _gate.close(); }
 
-ss::future<bool> leader_router::ensure_topic_exists() {
-    return _domain_supervisor->maybe_create_metastore_topic();
+ss::future<bool>
+leader_router::ensure_topic_exists(std::optional<int> num_partitions) {
+    return _domain_supervisor->maybe_create_metastore_topic(num_partitions);
 }
 std::optional<cloud_storage::remote_label>
 leader_router::metastore_restore_label() const {

--- a/src/v/cloud_topics/level_one/metastore/leader_router.h
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.h
@@ -110,7 +110,11 @@ public:
 
     std::optional<int> num_metastore_partitions() const;
 
-    ss::future<bool> ensure_topic_exists();
+    // Creates the topic (optionally with the given number of partitions, if
+    // provided). Does not validate that the actual number of partitions in
+    // the topic matches if it already exists.
+    ss::future<bool>
+    ensure_topic_exists(std::optional<int> num_partitions = std::nullopt);
 
     // Indicates the location in object storage that this metastore's manifest
     // will be stored.

--- a/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.cc
@@ -38,6 +38,16 @@ replicated_database::errc map_stm_error(stm::errc e) {
         return replicated_database::errc::shutting_down;
     }
 }
+
+replicated_database::error
+wrap_failed_future(std::exception_ptr ex, std::string_view context) {
+    if (ssx::is_shutdown_exception(ex)) {
+        return replicated_database::error(
+          replicated_database::errc::shutting_down);
+    }
+    return replicated_database::error(
+      replicated_database::errc::io_error, "{}: {}", context, ex);
+}
 } // namespace
 
 ss::future<std::expected<
@@ -101,22 +111,39 @@ replicated_database::open(
     cloud_storage_clients::object_key domain_prefix{
       fmt::format("{}", domain_uuid())};
 
-    auto data_persist = co_await lsm::io::open_cloud_data_persistence(
-      staging_directory, remote, bucket, domain_prefix);
-    auto meta_persist = co_await open_replicated_metadata_persistence(
-      s, remote, bucket, domain_uuid, domain_prefix);
+    auto data_persist_fut = co_await ss::coroutine::as_future(
+      lsm::io::open_cloud_data_persistence(
+        staging_directory, remote, bucket, domain_prefix));
+    if (data_persist_fut.failed()) {
+        co_return std::unexpected(wrap_failed_future(
+          data_persist_fut.get_exception(), "Failed to open data persistence"));
+    }
+    auto meta_persist_fut = co_await ss::coroutine::as_future(
+      open_replicated_metadata_persistence(
+        s, remote, bucket, domain_uuid, domain_prefix));
+    if (meta_persist_fut.failed()) {
+        co_return std::unexpected(wrap_failed_future(
+          meta_persist_fut.get_exception(),
+          "Failed to open metadata persistence"));
+    }
     lsm::io::persistence io{
-      .data = std::move(data_persist),
-      .metadata = std::move(meta_persist),
+      .data = std::move(data_persist_fut.get()),
+      .metadata = std::move(meta_persist_fut.get()),
     };
 
     // Open the LSM database using the persisted manifest from the STM.
-    auto db = co_await lsm::database::open(
-      lsm::options{
-        .database_epoch = epoch(),
-        // TODO: tuning.
-      },
-      std::move(io));
+    auto db_fut = co_await ss::coroutine::as_future(
+      lsm::database::open(
+        lsm::options{
+          .database_epoch = epoch(),
+          // TODO: tuning.
+        },
+        std::move(io)));
+    if (db_fut.failed()) {
+        co_return std::unexpected(wrap_failed_future(
+          db_fut.get_exception(), "Failed to open LSM database"));
+    }
+    auto db = db_fut.get();
 
     // Replay the writes in the volatile_buffer as writes to the database.
     // These are writes that were replicated but not yet persisted to the
@@ -151,9 +178,9 @@ replicated_database::open(
             auto write_fut = co_await ss::coroutine::as_future(
               db.apply(std::move(wb)));
             if (write_fut.failed()) {
-                auto ex = write_fut.get_exception();
-                co_return std::unexpected(error(
-                  errc::io_error, "Failed to apply volatile writes: {}", ex));
+                co_return std::unexpected(wrap_failed_future(
+                  write_fut.get_exception(),
+                  "Failed to apply volatile writes"));
             }
         }
     }
@@ -174,12 +201,8 @@ replicated_database::close() {
     finished_apply_cv_.broken();
     auto fut = co_await ss::coroutine::as_future(db_.close());
     if (fut.failed()) {
-        auto ex = fut.get_exception();
-        if (ssx::is_shutdown_exception(ex)) {
-            co_return std::unexpected(error(errc::shutting_down));
-        }
         co_return std::unexpected(
-          error(errc::io_error, "Error closing database: {}", ex));
+          wrap_failed_future(fut.get_exception(), "Error closing database"));
     }
     co_await std::move(gate_fut);
     co_return std::expected<void, error>{};
@@ -300,9 +323,8 @@ replicated_database::flush(std::optional<ss::lowres_clock::duration> timeout) {
                             : ssx::instant::infinite_future();
     auto flush_fut = co_await ss::coroutine::as_future(db_.flush(deadline));
     if (flush_fut.failed()) {
-        auto ex = flush_fut.get_exception();
-        co_return std::unexpected(
-          error(errc::io_error, "Failed to flush to database: {}", ex));
+        co_return std::unexpected(wrap_failed_future(
+          flush_fut.get_exception(), "Failed to flush to database"));
     }
     co_return std::expected<void, error>{};
 }

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -957,18 +957,43 @@ replicated_metastore::restore(const cloud_storage::remote_label& source_label) {
     auto manifest_res = co_await manifest_io_->download_metastore_manifest(
       source_label);
     if (!manifest_res.has_value()) {
-        vlog(
-          cd_log.warn,
-          "Failed to download metastore manifest for cluster {}: {}",
-          source_label,
-          manifest_res.error());
-        co_return std::unexpected(errc::transport_error);
+        if (manifest_res.error().e == manifest_io::errc::not_found) {
+            vlog(
+              cd_log.warn,
+              "Manifest not found for metastore at {}, likely because it was "
+              "not uploaded. Ensuring metastore topic without restoring "
+              "domains",
+              source_label);
+            auto ensure_fut = co_await ss::coroutine::as_future(
+              fe_.ensure_topic_exists());
+            if (ensure_fut.failed()) {
+                auto ex = ensure_fut.get_exception();
+                vlog(
+                  cd_log.warn,
+                  "Error while ensuring metastore topic for restore: {}",
+                  ex);
+                co_return std::unexpected(errc::transport_error);
+            }
+            if (!ensure_fut.get()) {
+                vlog(cd_log.warn, "Ensuring metastore topic did not succeed");
+                co_return std::unexpected(errc::transport_error);
+            }
+            co_return std::nullopt;
+        } else {
+            vlog(
+              cd_log.warn,
+              "Failed to download metastore manifest for cluster {}: {}",
+              source_label,
+              manifest_res.error());
+            co_return std::unexpected(errc::transport_error);
+        }
     }
     auto manifest = std::move(manifest_res.value());
+    int num_domains = static_cast<int>(manifest.domains.size());
 
-    // Ensure the metastore topic exists with the correct number of partitions.
+    // Create the topic if it doesn't exist.
     auto ensure_fut = co_await ss::coroutine::as_future(
-      fe_.ensure_topic_exists());
+      fe_.ensure_topic_exists(num_domains));
     if (ensure_fut.failed()) {
         auto ex = ensure_fut.get_exception();
         vlog(
@@ -986,7 +1011,7 @@ replicated_metastore::restore(const cloud_storage::remote_label& source_label) {
         vlog(cd_log.warn, "Unable to get num metastore partitions for restore");
         co_return std::unexpected(errc::transport_error);
     }
-    if (manifest.domains.size() != static_cast<size_t>(*num_partitions)) {
+    if (num_domains != *num_partitions) {
         vlog(
           cd_log.error,
           "Manifest domain count {} does not match metastore partition count "
@@ -1003,7 +1028,6 @@ replicated_metastore::restore(const cloud_storage::remote_label& source_label) {
         co_return std::unexpected(errc::invalid_request);
     }
 
-    // Restore each partition with its corresponding domain_uuid
     for (int pid = 0; pid < *num_partitions; ++pid) {
         rpc::restore_domain_request req{
           .metastore_partition = model::partition_id{pid},

--- a/src/v/cloud_topics/level_one/metastore/tests/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/tests/BUILD
@@ -79,7 +79,10 @@ redpanda_cc_gtest(
     ],
     cpu = 1,
     deps = [
+        "//src/v/cloud_storage:remote_label",
         "//src/v/cloud_topics:app",
+        "//src/v/cloud_topics/level_one/metastore:manifest_io",
+        "//src/v/cloud_topics/level_one/metastore:metastore_manifest",
         "//src/v/cloud_topics/level_one/metastore:replicated_metastore",
         "//src/v/cloud_topics/level_one/metastore:state",
         "//src/v/cloud_topics/level_one/metastore/lsm:stm",

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -8,6 +8,9 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
+#include "cloud_storage/remote_label.h"
+#include "cloud_topics/level_one/metastore/manifest_io.h"
+#include "cloud_topics/level_one/metastore/metastore_manifest.h"
 #include "cloud_topics/level_one/metastore/replicated_metastore.h"
 #include "cloud_topics/level_one/metastore/tests/state_utils.h"
 #include "cloud_topics/tests/cluster_fixture.h"
@@ -1042,13 +1045,82 @@ TEST_P(ReplicatedMetastoreTest, TestRestoreManifestNotFound) {
     auto& app = get_ct_app(model::node_id{0});
     auto& meta = app.get_sharded_replicated_metastore()->local();
 
-    // Attempt to restore from a non-existent cluster UUID. The manifest
-    // download should fail.
+    // Attempt to restore from a non-existent cluster UUID. The manifest should
+    // be not found and we should create a new topic.
     auto fake_cluster_uuid = model::cluster_uuid{uuid_t::create()};
     cloud_storage::remote_label rl(fake_cluster_uuid);
     auto restore_res = meta.restore(rl).get();
-    ASSERT_FALSE(restore_res.has_value());
-    ASSERT_EQ(restore_res.error(), metastore::errc::transport_error);
+    ASSERT_TRUE(restore_res.has_value());
+}
+
+// Test that restore creates the metastore topic with the correct number of
+// partitions matching the number of domains in the manifest.
+TEST_P(ReplicatedMetastoreTest, TestRestoreCreatesCorrectPartitionCount) {
+    if (GetParam() == metastore_backend::simple) {
+        GTEST_SKIP() << "Restore not supported with simple backend";
+    }
+    auto& app = get_ct_app(model::node_id{0});
+    auto& meta = app.get_sharded_replicated_metastore()->local();
+
+    // Wait for the metastore topic to be created by background initialization.
+    // This helps ensure that there won't be a background recreation of the
+    // metastore topic after we delete it below.
+    for (const auto& node_id : instance_ids()) {
+        auto& tp_state = get_node_application(node_id)
+                           ->controller->get_topics_state()
+                           .local();
+        RPTEST_REQUIRE_EVENTUALLY(10s, [&tp_state] {
+            return tp_state.contains(model::l1_metastore_nt);
+        });
+    }
+
+    // Delete the existing metastore topic.
+    auto& tp_fe = get_node_application(model::node_id{0})
+                    ->controller->get_topics_frontend()
+                    .local();
+    tp_fe.dispatch_delete_topics({model::l1_metastore_nt}, 10s).get();
+    for (const auto& node_id : instance_ids()) {
+        auto& tp_state = get_node_application(node_id)
+                           ->controller->get_topics_state()
+                           .local();
+        RPTEST_REQUIRE_EVENTUALLY(10s, [&tp_state] {
+            return !tp_state.contains(model::l1_metastore_nt);
+        });
+    }
+
+    // Create a manifest with 10 domains and uplaod it.
+    constexpr int expected_partitions = 10;
+    metastore_manifest manifest;
+    manifest.partitioning_strategy = "murmur";
+    for (int i = 0; i < expected_partitions; ++i) {
+        manifest.domains.push_back(domain_uuid{uuid_t::create()});
+    }
+
+    auto* remote = &get_node_application(model::node_id{0})->cloud_io.local();
+    manifest_io mio(*remote, bucket_name);
+    auto fake_cluster_uuid = model::cluster_uuid{uuid_t::create()};
+    cloud_storage::remote_label rl(fake_cluster_uuid);
+    auto upload_res
+      = mio.upload_metastore_manifest(rl, std::move(manifest)).get();
+    ASSERT_TRUE(upload_res.has_value());
+
+    // Restore from the uploaded manifest. Retry until leaders are elected.
+    auto deadline = ss::lowres_clock::now() + 30s;
+    while (ss::lowres_clock::now() < deadline) {
+        auto restore_res = meta.restore(rl).get();
+        if (restore_res.has_value()) {
+            break;
+        }
+        ss::sleep(100ms).get();
+    }
+
+    // Verify the metastore topic was created with the correct partition count.
+    auto& tp_state = get_node_application(model::node_id{0})
+                       ->controller->get_topics_state()
+                       .local();
+    auto cfg = tp_state.get_topic_cfg(model::l1_metastore_nt);
+    ASSERT_TRUE(cfg.has_value());
+    ASSERT_EQ(cfg->partition_count, expected_partitions);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/v/cloud_topics/tests/BUILD
+++ b/src/v/cloud_topics/tests/BUILD
@@ -92,3 +92,27 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "cluster_recovery_test",
+    timeout = "moderate",
+    srcs = [
+        "cluster_recovery_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        ":cluster_fixture",
+        "//src/v/cloud_storage",
+        "//src/v/cluster",
+        "//src/v/cluster/cloud_metadata/tests:cluster_metadata_utils",
+        "//src/v/kafka/server/tests:kafka_test_utils",
+        "//src/v/random:generators",
+        "//src/v/ssx:future_util",
+        "//src/v/ssx:sformat",
+        "//src/v/test_utils:gtest",
+        "//src/v/test_utils:scoped_config",
+        "//src/v/utils:retry_chain_node",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/tests/cluster_recovery_test.cc
+++ b/src/v/cloud_topics/tests/cluster_recovery_test.cc
@@ -1,0 +1,414 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/tests/cluster_fixture.h"
+#include "cluster/cloud_metadata/cluster_manifest.h"
+#include "cluster/cloud_metadata/tests/cluster_metadata_utils.h"
+#include "cluster/cloud_metadata/uploader.h"
+#include "cluster/cluster_recovery_manager.h"
+#include "cluster/cluster_recovery_table.h"
+#include "kafka/server/tests/produce_consume_utils.h"
+#include "ssx/future-util.h"
+#include "ssx/sformat.h"
+#include "test_utils/async.h"
+#include "test_utils/scoped_config.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/gate.hh>
+#include <seastar/util/defer.hh>
+
+#include <gtest/gtest.h>
+
+using namespace cloud_topics;
+using tests::kv_t;
+
+namespace {
+
+ss::logger test_log("cluster_recovery_test");
+
+ss::abort_source never_abort;
+const model::topic topic{"tapioca"};
+const model::topic_namespace nt{model::kafka_namespace, topic};
+const model::node_id n0{0};
+constexpr int num_partitions = 10;
+
+ss::future<> random_sleep_ms(int max_ms) {
+    co_await ss::sleep(random_generators::get_int(max_ms) * 1ms);
+}
+
+struct test_params {
+    bool unstable_controller{false};
+    bool unstable_metastore{false};
+
+    friend std::ostream& operator<<(std::ostream& os, const test_params& p) {
+        return os << fmt::format(
+                 "controller_{}_metastore_{}",
+                 p.unstable_controller ? "unstable" : "stable",
+                 p.unstable_metastore ? "unstable" : "stable");
+    }
+};
+
+} // namespace
+
+// Base class with all helper methods, not parameterized.
+class CloudTopicsClusterRecoveryTestBase : public cluster_fixture {
+public:
+    cloud_topics::test_fixture_cfg fixture_cfg() const {
+        return {
+          .use_lsm_metastore = true,
+          // Skip flushing since tests may exercise flushing.
+          .skip_flush_loop = true,
+        };
+    }
+    void SetUp() {
+        cfg.get("enable_leader_balancer").set_value(false);
+        cfg.get("enable_cluster_metadata_upload_loop").set_value(false);
+        cfg.get("raft_heartbeat_interval_ms").set_value(50ms);
+        cfg.get("raft_heartbeat_timeout_ms").set_value(500ms);
+
+        for (size_t i = 0; i < 3; ++i) {
+            add_node(fixture_cfg());
+        }
+        wait_for_all_members(5s).get();
+    }
+
+    using partition_ptr = ss::lw_shared_ptr<cluster::partition>;
+    ss::future<>
+    wait_for_leader(const model::ntp& ntp, partition_ptr* prt = nullptr) {
+        SCOPED_TRACE(fmt::format("Waiting for leadership of ntp {}", ntp));
+        RPTEST_REQUIRE_EVENTUALLY_CORO(30s, [&] {
+            auto [leader_fx, leader_p] = get_leader(ntp);
+            if (leader_fx != nullptr) {
+                if (prt) {
+                    *prt = std::move(leader_p);
+                }
+                return true;
+            }
+            return false;
+        });
+    }
+
+    ss::future<> leadership_change_fiber(bool& stop, model::ntp ntp) {
+        while (!stop) {
+            co_await random_sleep_ms(5000);
+            try {
+                partition_ptr leader_p;
+                co_await wait_for_leader(ntp, &leader_p);
+                co_await leader_p->raft()->step_down("test");
+            } catch (...) {
+                auto ex = std::current_exception();
+                vlog(
+                  test_log.warn,
+                  "Exception in leader change fiber for {}: {}",
+                  ntp,
+                  ex);
+            }
+            co_await random_sleep_ms(5000);
+        }
+    }
+
+    ss::future<> create_cloud_topic(model::topic t = topic) {
+        cluster::topic_properties props;
+        props.cloud_topic_enabled = true;
+        props.shadow_indexing = model::shadow_indexing_mode::disabled;
+        co_await create_topic(
+          {model::kafka_namespace, t}, num_partitions, 3, props);
+    }
+
+    ss::future<> produce_some() {
+        for (int p = 0; p < num_partitions; ++p) {
+            SCOPED_TRACE(fmt::format("Producing to partition {}", p));
+            model::ntp ntp{
+              model::kafka_namespace, topic, model::partition_id(p)};
+
+            // Find the leader for this partition
+            co_await wait_for_leader(ntp);
+            auto [leader_fx, leader_p] = get_leader(ntp);
+            RPTEST_REQUIRE_CORO(leader_fx != nullptr)
+              << "No leader for partition " << p;
+            auto leader_id = leader_p->raft()->self().id();
+
+            auto* producer = co_await make_producer(leader_id);
+            std::vector<kv_t> records;
+            for (int i = 0; i < 100; ++i) {
+                records.emplace_back(
+                  ssx::sformat("key-{}-{}", p, i),
+                  ssx::sformat("val-{}-{}", p, i));
+            }
+            co_await producer->produce_to_partition(
+              topic, model::partition_id(p), kv_t::sequence(0, 100));
+        }
+    }
+
+    model::topic_id get_topic_id(const model::topic_namespace& nt) {
+        auto& topics_state
+          = get_node_application(n0)->controller->get_topics_state().local();
+        auto& topic_md = topics_state.topics_map().at(nt);
+        auto topic_id = topic_md.get_configuration().tp_id;
+        EXPECT_TRUE(topic_id.has_value());
+        return topic_id.value();
+    }
+
+    ss::future<> wait_for_reconciliation() {
+        auto topic_id = get_topic_id(nt);
+        auto& meta = get_ct_app(n0).get_sharded_replicated_metastore()->local();
+
+        for (int p = 0; p < num_partitions; ++p) {
+            SCOPED_TRACE(
+              fmt::format("Waiting for reconciliation on partition {}", p));
+            model::topic_id_partition tp(topic_id, model::partition_id(p));
+            RPTEST_REQUIRE_EVENTUALLY_CORO(30s, [&]() {
+                return meta.get_offsets(tp).then(
+                  [](auto result) { return result.has_value(); });
+            });
+        }
+    }
+
+    ss::future<> flush_metastore() {
+        auto& meta = get_ct_app(n0).get_sharded_replicated_metastore()->local();
+        auto flush_res = co_await meta.flush();
+        RPTEST_REQUIRE_CORO(flush_res.has_value())
+          << fmt::to_string(flush_res.error());
+    }
+
+    ss::future<> upload_controller_snapshot() {
+        auto& app = *get_node_application(n0);
+        auto& controller_stm = app.controller->get_controller_stm().local();
+        auto raft0
+          = app.partition_manager.local().get(model::controller_ntp)->raft();
+
+        RPTEST_REQUIRE_EVENTUALLY_CORO(
+          5s, [&] { return controller_stm.maybe_write_snapshot(); });
+
+        auto& uploader = app.controller->metadata_uploader().value().get();
+        retry_chain_node retry_node(never_abort, 30s, 1s);
+        cluster::cloud_metadata::cluster_metadata_manifest manifest;
+        manifest.cluster_uuid = app.storage.local().get_cluster_uuid().value();
+        auto upload_res = co_await uploader.upload_next_metadata(
+          raft0->confirmed_term(), manifest, retry_node);
+        RPTEST_REQUIRE_CORO(
+          upload_res == cluster::cloud_metadata::error_outcome::success);
+
+        RPTEST_REQUIRE_CORO(
+          manifest.metadata_id
+          == cluster::cloud_metadata::cluster_metadata_id(0));
+        RPTEST_REQUIRE_CORO(!manifest.controller_snapshot_path.empty());
+    }
+
+    void wipe_cluster() {
+        for (size_t i = 0; i < 3; ++i) {
+            auto n = model::node_id(i);
+            instance(n)->shutdown();
+            std::filesystem::remove_all(instance(n)->data_dir);
+            remove_node_application(n);
+        }
+        for (size_t i = 0; i < 3; ++i) {
+            add_node(fixture_cfg());
+        }
+        wait_for_all_members(5s).get();
+    }
+
+    ss::future<> initialize_recovery() {
+        partition_ptr leader_p;
+        co_await wait_for_leader(model::controller_ntp, &leader_p);
+        auto leader_id = leader_p->raft()->self().id();
+
+        auto& recovery_mgr = get_node_application(leader_id)
+                               ->controller->get_cluster_recovery_manager()
+                               .local();
+        auto recover_err = co_await recovery_mgr.initialize_recovery(
+          bucket_name, std::nullopt);
+        RPTEST_REQUIRE_CORO(recover_err.has_value());
+    }
+
+    ss::future<> wait_for_recovery(
+      std::chrono::seconds timeout, bool expect_failed = false) {
+        auto& rcv_table = get_node_application(n0)
+                            ->controller->get_cluster_recovery_table()
+                            .local();
+        RPTEST_REQUIRE_EVENTUALLY_CORO(
+          timeout, [&rcv_table] { return !rcv_table.is_recovery_active(); });
+        auto current = rcv_table.current_recovery();
+        RPTEST_REQUIRE_CORO(current.has_value());
+        if (expect_failed) {
+            EXPECT_EQ(current->get().stage, cluster::recovery_stage::failed);
+        } else {
+            EXPECT_EQ(current->get().stage, cluster::recovery_stage::complete);
+        }
+    }
+
+protected:
+    scoped_config cfg;
+};
+
+// Parameterized test fixture for tests that vary leadership stability.
+class CloudTopicsClusterRecoveryParamsTest
+  : public CloudTopicsClusterRecoveryTestBase
+  , public ::testing::TestWithParam<test_params> {
+public:
+    void SetUp() override { CloudTopicsClusterRecoveryTestBase::SetUp(); }
+
+    ss::future<> wait_for_recovery() {
+        auto params = GetParam();
+        auto timeout = (params.unstable_controller || params.unstable_metastore)
+                         ? 120s
+                         : 30s;
+        return CloudTopicsClusterRecoveryTestBase::wait_for_recovery(timeout);
+    }
+};
+
+// Non-parameterized test fixture.
+class CloudTopicsClusterRecoveryTest
+  : public CloudTopicsClusterRecoveryTestBase
+  , public ::testing::Test {
+public:
+    void SetUp() override { CloudTopicsClusterRecoveryTestBase::SetUp(); }
+};
+
+TEST_P(CloudTopicsClusterRecoveryParamsTest, TestFullRecovery) {
+    auto params = GetParam();
+
+    // Create the cloud topic and produce data.
+    ASSERT_NO_FATAL_FAILURE(create_cloud_topic().get());
+    ASSERT_NO_FATAL_FAILURE(produce_some().get());
+
+    vlog(test_log.info, "Waiting for reconciliation");
+    ASSERT_NO_FATAL_FAILURE(wait_for_reconciliation().get());
+
+    vlog(test_log.info, "Flushing metastore");
+    ASSERT_NO_FATAL_FAILURE(flush_metastore().get());
+
+    auto* orig_app0 = get_node_application(n0);
+    auto& orig_topics = orig_app0->controller->get_topics_state().local();
+
+    // Capture some metadata from the original cluster to validate after
+    // recovery.
+    const auto orig_uuid = orig_app0->storage.local().get_cluster_uuid();
+    const auto orig_metastore_label = orig_topics
+                                        .get_topic_cfg(model::l1_metastore_nt)
+                                        ->properties.remote_label;
+    ASSERT_TRUE(orig_metastore_label.has_value());
+    const auto orig_tp_id = get_topic_id(nt);
+
+    vlog(test_log.info, "Uploading controller snapshot");
+    ASSERT_NO_FATAL_FAILURE(upload_controller_snapshot().get());
+
+    vlog(test_log.info, "Wiping cluster");
+    wipe_cluster();
+
+    vlog(test_log.info, "Initializing recovery");
+    ASSERT_NO_FATAL_FAILURE(initialize_recovery().get());
+
+    // Start the leadership changes.
+    bool stop = false;
+    std::vector<ss::future<>> futs;
+    auto stop_cleanup = ss::defer([&] {
+        stop = true;
+        ss::when_all_succeed(futs.begin(), futs.end()).get();
+    });
+    if (params.unstable_controller) {
+        futs.emplace_back(leadership_change_fiber(stop, model::controller_ntp));
+    }
+    if (params.unstable_metastore) {
+        model::ntp ntp{
+          model::kafka_internal_namespace,
+          model::l1_metastore_topic,
+          model::partition_id{0}};
+        wait_for_leader(ntp).get();
+        futs.emplace_back(leadership_change_fiber(stop, ntp));
+    }
+
+    // Wait for recovery to complete.
+    vlog(test_log.info, "Waiting for recovery to finish");
+    ASSERT_NO_FATAL_FAILURE(wait_for_recovery().get());
+
+    stop_cleanup.cancel();
+    stop = true;
+    ss::when_all_succeed(futs.begin(), futs.end()).get();
+
+    vlog(test_log.info, "Waiting for controller leader");
+    wait_for_leader(model::controller_ntp).get();
+
+    // Validate the state after recovery.
+    auto* rcv_app0 = get_node_application(n0);
+    auto& rcv_topics = rcv_app0->controller->get_topics_state().local();
+
+    const auto rcv_uuid = rcv_app0->storage.local().get_cluster_uuid();
+    const auto rcv_metastore_label = rcv_topics
+                                       .get_topic_cfg(model::l1_metastore_nt)
+                                       ->properties.remote_label;
+    const auto rcv_ct_label
+      = rcv_topics.get_topic_cfg(nt)->properties.remote_label;
+    const auto rcv_tp_id = get_topic_id(nt);
+    const auto rcv_tp_count = rcv_topics.get_topic_cfg(nt)->partition_count;
+
+    // The cluster UUID is new, but the metastore topic label and cloud topic
+    // labels point at the original cluster, and topic IDs are preserved.
+    EXPECT_NE(orig_uuid, rcv_uuid);
+    EXPECT_EQ(orig_metastore_label, rcv_metastore_label);
+    EXPECT_EQ(rcv_ct_label, orig_metastore_label);
+    EXPECT_EQ(orig_tp_id, rcv_tp_id);
+    EXPECT_EQ(num_partitions, rcv_tp_count);
+    // TODO: check offsets once topic restore is implemented.
+
+    // New topics have their labels pointing at the original cluster UUID too,
+    // indicating that their metadata is in the metastore with that label.
+    vlog(test_log.info, "Creating new topic");
+    model::topic new_topic{"oolong"};
+    create_cloud_topic(new_topic).get();
+    const auto new_ct_label
+      = rcv_topics.get_topic_cfg(nt)->properties.remote_label;
+    EXPECT_EQ(orig_metastore_label, new_ct_label);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  LeadershipVariants,
+  CloudTopicsClusterRecoveryParamsTest,
+  ::testing::Values(
+    test_params{.unstable_controller = false, .unstable_metastore = false},
+    test_params{.unstable_controller = true, .unstable_metastore = false},
+    test_params{.unstable_controller = false, .unstable_metastore = true},
+    test_params{.unstable_controller = true, .unstable_metastore = true}),
+  [](const auto& info) { return fmt::to_string(info.param); });
+
+TEST_F(CloudTopicsClusterRecoveryTest, TestRecoveryWithExistingTopic) {
+    ASSERT_NO_FATAL_FAILURE(create_cloud_topic().get());
+    ASSERT_NO_FATAL_FAILURE(produce_some().get());
+
+    vlog(test_log.info, "Waiting for reconciliation");
+    ASSERT_NO_FATAL_FAILURE(wait_for_reconciliation().get());
+
+    vlog(test_log.info, "Flushing metastore");
+    ASSERT_NO_FATAL_FAILURE(flush_metastore().get());
+
+    auto* orig_app0 = get_node_application(n0);
+    auto& orig_topics = orig_app0->controller->get_topics_state().local();
+    const auto orig_metastore_label = orig_topics
+                                        .get_topic_cfg(model::l1_metastore_nt)
+                                        ->properties.remote_label;
+    ASSERT_TRUE(orig_metastore_label.has_value());
+
+    vlog(test_log.info, "Uploading controller snapshot");
+    ASSERT_NO_FATAL_FAILURE(upload_controller_snapshot().get());
+
+    vlog(test_log.info, "Wiping cluster");
+    wipe_cluster();
+
+    vlog(test_log.info, "Creating topic before recovery");
+    model::topic new_topic{"oolong"};
+    create_cloud_topic(new_topic).get();
+
+    vlog(test_log.info, "Initializing recovery");
+    ASSERT_NO_FATAL_FAILURE(initialize_recovery().get());
+
+    vlog(test_log.info, "Waiting for recovery to fail");
+    ASSERT_NO_FATAL_FAILURE(
+      wait_for_recovery(30s, /*expect_failed=*/true).get());
+}

--- a/src/v/cluster/BUILD
+++ b/src/v/cluster/BUILD
@@ -707,6 +707,8 @@ redpanda_cc_library(
         "//src/v/cloud_storage:types",
         "//src/v/cloud_storage_clients",
         "//src/v/cloud_topics:state_accessors",
+        "//src/v/cloud_topics/level_one/metastore",
+        "//src/v/cloud_topics/level_one/metastore:retry",
         "//src/v/cloud_topics/level_zero/stm:ctp_stm",
         "//src/v/cloud_topics/level_zero/stm:ctp_stm_api",
         "//src/v/cluster_link/model",

--- a/src/v/cluster/cloud_metadata/cluster_recovery_backend.cc
+++ b/src/v/cluster/cloud_metadata/cluster_recovery_backend.cc
@@ -242,6 +242,9 @@ ss::future<cluster::errc> cluster_recovery_backend::do_action(
         }
         break;
     }
+    // TODO: implement
+    case recovery_stage::recovered_cloud_topics_metastore:
+    case recovery_stage::recovered_cloud_topic_data:
     case recovery_stage::recovered_remote_topic_data: {
         retry_chain_node topics_retry(&parent_retry);
         // TODO: batch this up.

--- a/src/v/cluster/cloud_metadata/cluster_recovery_backend.cc
+++ b/src/v/cluster/cloud_metadata/cluster_recovery_backend.cc
@@ -14,6 +14,9 @@
 #include "cloud_storage/remote.h"
 #include "cloud_storage/remote_file.h"
 #include "cloud_storage/types.h"
+#include "cloud_topics/level_one/metastore/metastore.h"
+#include "cloud_topics/level_one/metastore/retry.h"
+#include "cloud_topics/state_accessors.h"
 #include "cluster/cloud_metadata/cluster_manifest.h"
 #include "cluster/cloud_metadata/manifest_downloads.h"
 #include "cluster/cloud_metadata/offsets_recovery_rpc_types.h"
@@ -68,7 +71,8 @@ cluster_recovery_backend::cluster_recovery_backend(
   ss::shared_ptr<producer_id_recovery_manager> producer_id_recovery,
   ss::shared_ptr<offsets_recovery_requestor> offsets_recovery,
   ss::sharded<cluster_recovery_table>& recovery_table,
-  consensus_ptr raft0)
+  consensus_ptr raft0,
+  ss::sharded<cloud_topics::state_accessors>* ct_state)
   : _recovery_manager(mgr)
   , _raft_group_manager(raft_mgr)
   , _remote(remote)
@@ -86,7 +90,8 @@ cluster_recovery_backend::cluster_recovery_backend(
   , _producer_id_recovery(std::move(producer_id_recovery))
   , _offsets_recovery(std::move(offsets_recovery))
   , _recovery_table(recovery_table)
-  , _raft0(std::move(raft0)) {
+  , _raft0(std::move(raft0))
+  , _ct_state(ct_state) {
     vassert(_producer_id_recovery, "expected initialized producer_id_recovery");
     vassert(_offsets_recovery, "expected initialized offsets_recovery");
 }
@@ -242,9 +247,142 @@ ss::future<cluster::errc> cluster_recovery_backend::do_action(
         }
         break;
     }
-    // TODO: implement
-    case recovery_stage::recovered_cloud_topics_metastore:
-    case recovery_stage::recovered_cloud_topic_data:
+    case recovery_stage::recovered_cloud_topics_metastore: {
+        // If the current metastore has the same remote label as the desired
+        // one, we are done. Maybe we finished in a previous term.
+        auto metastore_meta = _topics.get_topic_metadata(
+          model::l1_metastore_nt);
+        if (metastore_meta.has_value()) {
+            const auto& metastore_conf = metastore_meta->get_configuration();
+            const auto metastore_label = metastore_conf.properties.remote_label;
+            if (
+              metastore_label
+              == actions.ct_metastore_topic->properties.remote_label) {
+                // We're done!
+                break;
+            }
+            // Otherwise, proceed to calling restore.
+        }
+        if (!_ct_state) {
+            vlog(
+              clusterlog.error,
+              "Cloud topics not enabled for metastore recovery");
+            co_return cluster::errc::invalid_configuration_update;
+        }
+
+        auto& desired_label
+          = actions.ct_metastore_topic->properties.remote_label;
+        if (!desired_label.has_value()) {
+            vlog(
+              clusterlog.error,
+              "No remote_label in topic config for metastore recovery");
+            co_return cluster::errc::invalid_configuration_update;
+        }
+        for (const auto& [nt, meta] : _topics.topics_map()) {
+            const auto& conf = meta.get_metadata().get_configuration();
+            if (
+              conf.is_cloud_topic()
+              && conf.properties.remote_label != desired_label) {
+                vlog(
+                  clusterlog.error,
+                  "Cloud topic {} has remote label {}; cannot proceed with "
+                  "metastore restore with label {}",
+                  nt,
+                  conf.properties.remote_label,
+                  desired_label);
+                co_return cluster::errc::invalid_configuration_update;
+            }
+        }
+
+        // Restore on the metastore with our desired remote label. This will
+        // create the underlying topic if it doesn't already exist. Retry on
+        // transport errors since leadership may be unstable during recovery.
+        auto* metastore = _ct_state->local().get_l1_metastore();
+        retry_chain_node metastore_retry(60s, 1s, &parent_retry);
+        auto restore_res = co_await cloud_topics::l1::retry_metastore_op(
+          [metastore, &desired_label] {
+              return metastore->restore(*desired_label);
+          },
+          metastore_retry);
+        if (!restore_res.has_value()) {
+            vlog(
+              clusterlog.error,
+              "Metastore restore failed: {}",
+              restore_res.error());
+            co_return cluster::errc::replication_error;
+        }
+
+        // Update the topic config for the metastore topic so further cloud
+        // topics on this cluster get its remote label.
+        retry_chain_node ct_retry(&parent_retry);
+        topic_properties_update update(model::l1_metastore_nt);
+        update.properties.remote_label.op = incremental_update_operation::set;
+        update.properties.remote_label.value = *desired_label;
+        auto update_results = co_await _topics_frontend.update_topic_properties(
+          {std::move(update)}, ct_retry.get_deadline());
+        for (const auto& res : update_results) {
+            if (res.ec != make_error_code(errc::success)) {
+                vlog(
+                  clusterlog.error,
+                  "Failed to update metastore topic properties: {}",
+                  res.ec);
+                co_return res.ec;
+            }
+        }
+        break;
+    }
+    case recovery_stage::recovered_cloud_topic_data: {
+        // Go through each of the cloud topics. If any of them have different
+        // remote_labels than the current metastore, that is problematic.
+        auto metastore_meta = _topics.get_topic_metadata(
+          model::l1_metastore_nt);
+        if (!metastore_meta.has_value()) {
+            vlog(
+              clusterlog.error,
+              "Expected to have restored metastore topic {} before restoring "
+              "cloud topics",
+              model::l1_metastore_nt);
+            co_return cluster::errc::topic_not_exists;
+        }
+        const auto& metastore_conf = metastore_meta->get_configuration();
+        const auto metastore_label = metastore_conf.properties.remote_label;
+        topic_configuration_vector topics;
+        for (auto& topic_cfg : actions.cloud_topics) {
+            if (topic_cfg.is_read_replica()) {
+                topics.emplace_back(std::move(topic_cfg));
+                vlog(
+                  clusterlog.debug,
+                  "Creating read replica cloud topic {}: {}",
+                  topics.back().tp_ns,
+                  topics.back());
+            } else {
+                auto& topic_label = topic_cfg.properties.remote_label;
+                if (topic_cfg.properties.remote_label != metastore_label) {
+                    vlog(
+                      clusterlog.error,
+                      "Cannot create a recovery cloud topic with label {} when "
+                      "metastore label is {}",
+                      topic_label,
+                      metastore_label);
+                }
+                topics.emplace_back(std::move(topic_cfg));
+                vlog(
+                  clusterlog.debug,
+                  "Creating recovery cloud topic {}: {}",
+                  topics.back().tp_ns,
+                  topics.back());
+            }
+        }
+        retry_chain_node ct_retry(&parent_retry);
+        auto results = co_await _topics_frontend.autocreate_topics(
+          std::move(topics), ct_retry.get_timeout());
+        for (const auto& res : results) {
+            if (res.ec != make_error_code(errc::success)) {
+                co_return res.ec;
+            }
+        }
+        break;
+    }
     case recovery_stage::recovered_remote_topic_data: {
         retry_chain_node topics_retry(&parent_retry);
         // TODO: batch this up.

--- a/src/v/cluster/cloud_metadata/cluster_recovery_backend.h
+++ b/src/v/cluster/cloud_metadata/cluster_recovery_backend.h
@@ -28,6 +28,10 @@
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/sharded.hh>
 
+namespace cloud_topics {
+class state_accessors;
+} // namespace cloud_topics
+
 namespace cluster::cloud_metadata {
 
 class offsets_recovery_requestor;
@@ -52,7 +56,8 @@ public:
       ss::shared_ptr<producer_id_recovery_manager> producer_id_recovery,
       ss::shared_ptr<offsets_recovery_requestor> offsets_recovery,
       ss::sharded<cluster_recovery_table>&,
-      consensus_ptr raft0);
+      consensus_ptr raft0,
+      ss::sharded<cloud_topics::state_accessors>* ct_state);
 
     void start();
     ss::future<> stop_and_wait();
@@ -125,6 +130,9 @@ private:
     ss::sharded<cluster_recovery_table>& _recovery_table;
 
     consensus_ptr _raft0;
+
+    // Cloud topics metastore state. Null if cloud_topics isn't enabled.
+    ss::sharded<cloud_topics::state_accessors>* _ct_state;
 };
 
 } // namespace cluster::cloud_metadata

--- a/src/v/cluster/cloud_metadata/tests/BUILD
+++ b/src/v/cluster/cloud_metadata/tests/BUILD
@@ -9,6 +9,7 @@ redpanda_test_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/v/cloud_storage_clients",
         "//src/v/cluster",
         "//src/v/cluster/tests:topic_properties_generator",
         "//src/v/model",
@@ -86,6 +87,7 @@ redpanda_cc_gtest(
         ":cluster_metadata_utils",
         "//src/v/cloud_io/tests:s3_imposter",
         "//src/v/cloud_storage",
+        "//src/v/cloud_storage:remote_label",
         "//src/v/cluster",
         "//src/v/cluster/tests:tx_compaction_utils_gtest",
         "//src/v/config",

--- a/src/v/cluster/cloud_metadata/tests/cluster_metadata_utils.h
+++ b/src/v/cluster/cloud_metadata/tests/cluster_metadata_utils.h
@@ -8,6 +8,7 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
+#include "cloud_storage_clients/types.h"
 #include "cluster/commands.h"
 #include "cluster/partition.h"
 #include "cluster/tests/topic_properties_generator.h"
@@ -73,6 +74,23 @@ inline topic_properties non_remote_topic_properties() {
     props.recovery = false;
     props.read_replica = false;
     props.cleanup_policy_bitflags = model::cleanup_policy_bitflags::deletion;
+    return props;
+}
+
+inline topic_properties cloud_topic_properties() {
+    topic_properties props;
+    props.cloud_topic_enabled = true;
+    props.shadow_indexing = model::shadow_indexing_mode::disabled;
+    props.recovery = std::nullopt;
+    props.read_replica = std::nullopt;
+    props.cleanup_policy_bitflags = model::cleanup_policy_bitflags::deletion;
+    return props;
+}
+
+inline topic_properties read_replica_cloud_topic_properties() {
+    auto props = cloud_topic_properties();
+    props.read_replica = std::make_optional(true);
+    props.read_replica_bucket = "replica-bucket";
     return props;
 }
 

--- a/src/v/cluster/cloud_metadata/tests/controller_snapshot_reconciliation_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/controller_snapshot_reconciliation_test.cc
@@ -9,6 +9,7 @@
  */
 #include "cloud_io/tests/s3_imposter.h"
 #include "cloud_storage/remote.h"
+#include "cloud_storage/remote_label.h"
 #include "cluster/cloud_metadata/tests/cluster_metadata_utils.h"
 #include "cluster/cluster_recovery_reconciler.h"
 #include "cluster/controller_snapshot.h"
@@ -26,6 +27,7 @@
 #include "security/types.h"
 #include "test_utils/async.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 using namespace cluster::cloud_metadata;
@@ -116,6 +118,16 @@ void validate_actions(
     ASSERT_EQ(
       !actions.local_topics.empty(),
       actions_contain(actions, cluster::recovery_stage::recovered_topic_data));
+
+    ASSERT_EQ(
+      actions.ct_metastore_topic.has_value(),
+      actions_contain(
+        actions, cluster::recovery_stage::recovered_cloud_topics_metastore));
+
+    ASSERT_EQ(
+      !actions.cloud_topics.empty(),
+      actions_contain(
+        actions, cluster::recovery_stage::recovered_cloud_topic_data));
 }
 
 } // anonymous namespace
@@ -436,4 +448,171 @@ TEST_F(
     ASSERT_TRUE(found_user) << "User ACL not found in actions";
     ASSERT_TRUE(found_role) << "Role ACL not found in actions";
     ASSERT_TRUE(found_group) << "Group ACL not found in actions";
+}
+
+TEST_F(
+  controller_snapshot_reconciliation_fixture, test_reconcile_metastore_topic) {
+    auto snapshot_label = cloud_storage::remote_label(
+      model::cluster_uuid{uuid_t::create()});
+
+    // Helper to check metastore topic reconciliation behavior.
+    const auto check_metastore_action =
+      [&](const cloud_storage::remote_label& label, bool expect_action) {
+          cluster::controller_snapshot snap;
+          auto& tps = snap.topics.topics[model::l1_metastore_nt];
+          tps.metadata.configuration.tp_ns = model::l1_metastore_nt;
+          tps.metadata.configuration.properties.remote_label = label;
+
+          auto actions = reconciler.get_actions(snap);
+          ASSERT_EQ(
+            actions_contain(
+              actions,
+              cluster::recovery_stage::recovered_cloud_topics_metastore),
+            expect_action);
+          validate_actions(actions);
+
+          ASSERT_EQ(actions.ct_metastore_topic.has_value(), expect_action);
+          if (expect_action) {
+              ASSERT_EQ(
+                actions.ct_metastore_topic->properties.remote_label, label);
+          }
+      };
+
+    // Case 1: Topic doesn't exist - should create with snapshot's label.
+    check_metastore_action(snapshot_label, true);
+
+    // Case 2: Topic exists with different label - should update to snapshot's
+    // label.
+    auto different_label = cloud_storage::remote_label(
+      model::cluster_uuid{uuid_t::create()});
+    cluster::topic_properties props;
+    props.remote_label = different_label;
+    add_topic(model::l1_metastore_nt, 1, props).get();
+
+    check_metastore_action(snapshot_label, true);
+
+    // Case 3: Topic exists with same label - no action needed.
+    check_metastore_action(different_label, false);
+}
+
+TEST_F(
+  controller_snapshot_reconciliation_fixture, test_reconcile_cloud_topics) {
+    // Helper to check cloud topic reconciliation behavior.
+    const auto check_cloud_topic_action =
+      [&](
+        const model::topic_namespace& tp_ns,
+        const cluster::topic_properties& props,
+        bool expect_action,
+        std::optional<bool> expect_recovery = std::nullopt) {
+          cluster::controller_snapshot snap;
+          auto& tps = snap.topics.topics[tp_ns];
+          tps.metadata.configuration.tp_ns = tp_ns;
+          tps.metadata.configuration.properties = props;
+
+          auto actions = reconciler.get_actions(snap);
+          ASSERT_EQ(
+            actions_contain(
+              actions, cluster::recovery_stage::recovered_cloud_topic_data),
+            expect_action);
+          // Cloud topics should NOT trigger remote_topic_data or topic_data
+          // stages.
+          ASSERT_FALSE(actions_contain(
+            actions, cluster::recovery_stage::recovered_remote_topic_data));
+          ASSERT_FALSE(actions_contain(
+            actions, cluster::recovery_stage::recovered_topic_data));
+          validate_actions(actions);
+
+          if (expect_action) {
+              ASSERT_EQ(actions.cloud_topics.size(), 1);
+              ASSERT_EQ(actions.cloud_topics[0].tp_ns, tp_ns);
+              if (expect_recovery.has_value()) {
+                  // recovery is std::optional<bool>, so we check the effective
+                  // boolean value (nullopt and false are both falsy).
+                  ASSERT_EQ(
+                    actions.cloud_topics[0].properties.recovery.value_or(false),
+                    *expect_recovery);
+              }
+          } else {
+              ASSERT_TRUE(actions.cloud_topics.empty());
+          }
+      };
+
+    model::topic_namespace tp_ns{model::kafka_namespace, model::topic{"foo"}};
+
+    // Case 1: Cloud topic doesn't exist - should create with recovery=true.
+    check_cloud_topic_action(tp_ns, cloud_topic_properties(), true, true);
+
+    // Case 2: Read-replica cloud topic - should create with recovery=false.
+    model::topic_namespace rr_tp_ns{
+      model::kafka_namespace, model::topic{"read_replica"}};
+    check_cloud_topic_action(
+      rr_tp_ns, read_replica_cloud_topic_properties(), true, false);
+
+    // Case 3: Topic already exists - no action needed.
+    // Create a topic in the cluster. The reconciler only checks for topic
+    // existence by name, so we use a non-cloud topic since cloud topics
+    // require development feature flags.
+    model::topic_namespace existing_tp_ns{
+      model::kafka_namespace, model::topic{"existing"}};
+    add_topic(existing_tp_ns, 1, non_remote_topic_properties()).get();
+    check_cloud_topic_action(
+      existing_tp_ns, cloud_topic_properties(), false, std::nullopt);
+}
+
+TEST_F(
+  controller_snapshot_reconciliation_fixture,
+  test_reconcile_mixed_topic_types) {
+    using cluster::recovery_stage;
+    cluster::controller_snapshot snap;
+
+    // Metastore topic.
+    auto metastore_label = cloud_storage::remote_label(
+      model::cluster_uuid{uuid_t::create()});
+    auto& metastore_tps = snap.topics.topics[model::l1_metastore_nt];
+    metastore_tps.metadata.configuration.tp_ns = model::l1_metastore_nt;
+    metastore_tps.metadata.configuration.properties.remote_label
+      = metastore_label;
+
+    // Cloud topic.
+    model::topic_namespace cloud_tp_ns{
+      model::kafka_namespace, model::topic{"cloud_topic"}};
+    auto& cloud_tps = snap.topics.topics[cloud_tp_ns];
+    cloud_tps.metadata.configuration.tp_ns = cloud_tp_ns;
+    cloud_tps.metadata.configuration.properties = cloud_topic_properties();
+
+    // Remote topic (tiered storage).
+    model::topic_namespace remote_tp_ns{
+      model::kafka_namespace, model::topic{"remote_topic"}};
+    auto& remote_tps = snap.topics.topics[remote_tp_ns];
+    remote_tps.metadata.configuration.tp_ns = remote_tp_ns;
+    remote_tps.metadata.configuration.properties
+      = uploadable_topic_properties();
+    remote_tps.metadata.revision = model::revision_id{1};
+
+    // Local topic.
+    model::topic_namespace local_tp_ns{
+      model::kafka_namespace, model::topic{"local_topic"}};
+    auto& local_tps = snap.topics.topics[local_tp_ns];
+    local_tps.metadata.configuration.tp_ns = local_tp_ns;
+    local_tps.metadata.configuration.properties = non_remote_topic_properties();
+
+    auto actions = reconciler.get_actions(snap);
+    validate_actions(actions);
+
+    // Validate the stages are present in the expected order.
+    EXPECT_THAT(
+      actions.stages,
+      testing::ElementsAre(
+        recovery_stage::recovered_cloud_topics_metastore,
+        recovery_stage::recovered_cloud_topic_data,
+        recovery_stage::recovered_remote_topic_data,
+        recovery_stage::recovered_topic_data,
+        recovery_stage::recovered_controller_snapshot));
+
+    ASSERT_TRUE(actions.ct_metastore_topic.has_value());
+    ASSERT_EQ(
+      actions.ct_metastore_topic->properties.remote_label, metastore_label);
+    ASSERT_EQ(actions.cloud_topics.size(), 1);
+    ASSERT_EQ(actions.remote_topics.size(), 1);
+    ASSERT_EQ(actions.local_topics.size(), 1);
 }

--- a/src/v/cluster/cluster_recovery_reconciler.cc
+++ b/src/v/cluster/cluster_recovery_reconciler.cc
@@ -45,16 +45,20 @@ int order(recovery_stage s) {
         return 4;
     case recovered_acls:
         return 5;
-    case recovered_remote_topic_data:
+    case recovered_cloud_topics_metastore:
         return 6;
-    case recovered_topic_data:
+    case recovered_cloud_topic_data:
         return 7;
-    case recovered_controller_snapshot:
+    case recovered_remote_topic_data:
         return 8;
-    case recovered_offsets_topic:
+    case recovered_topic_data:
         return 9;
-    case recovered_tx_coordinator:
+    case recovered_controller_snapshot:
         return 10;
+    case recovered_offsets_topic:
+        return 11;
+    case recovered_tx_coordinator:
+        return 12;
     case complete:
         return 100;
     case failed:
@@ -161,6 +165,28 @@ controller_snapshot_reconciler::get_actions(
         }
     }
 
+    if (needs_actions(
+          cur_stage, recovery_stage::recovered_cloud_topics_metastore)) {
+        const auto& snap_tables = snap.topics.topics;
+        auto snap_it = snap_tables.find(model::l1_metastore_nt);
+        if (snap_it != snap_tables.end()) {
+            auto& snap_conf = snap_it->second.metadata.configuration;
+            auto cur_conf = _topic_table.get_topic_cfg(model::l1_metastore_nt);
+            // If the topic exists but with a different remote label, it's
+            // possible we can reset it (e.g. if it's empty).
+            if (
+              !cur_conf
+              || cur_conf->properties.remote_label
+                   != snap_conf.properties.remote_label) {
+                actions.ct_metastore_topic = snap_conf;
+            }
+        }
+        if (actions.ct_metastore_topic.has_value()) {
+            actions.stages.emplace_back(
+              recovery_stage::recovered_cloud_topics_metastore);
+        }
+    }
+
     if (needs_actions(cur_stage, recovery_stage::recovered_topic_data)) {
         const auto& snap_tables = snap.topics.topics;
         for (const auto& [tp_ns, meta] : snap_tables) {
@@ -174,6 +200,14 @@ controller_snapshot_reconciler::get_actions(
                   clusterlog.debug,
                   "Skipping topic recovery for internal topic {}",
                   tp_ns);
+                continue;
+            }
+            if (tp_config.is_cloud_topic()) {
+                auto new_config = tp_config;
+                if (!new_config.is_read_replica()) {
+                    new_config.properties.recovery = true;
+                }
+                actions.cloud_topics.emplace_back(std::move(new_config));
                 continue;
             }
             if (
@@ -197,6 +231,10 @@ controller_snapshot_reconciler::get_actions(
             // Either this is a read replica or no metadata is expected to exist
             // in tiered storage. Just create the topic.
             actions.local_topics.emplace_back(tp_config);
+        }
+        if (!actions.cloud_topics.empty()) {
+            actions.stages.emplace_back(
+              recovery_stage::recovered_cloud_topic_data);
         }
         if (!actions.remote_topics.empty()) {
             actions.stages.emplace_back(

--- a/src/v/cluster/cluster_recovery_reconciler.cc
+++ b/src/v/cluster/cluster_recovery_reconciler.cc
@@ -24,6 +24,50 @@
 
 namespace cluster::cloud_metadata {
 
+// Defines the order in which the recovery stages should be evaluated. This
+// should match the order of generated actions in get_actions().
+//
+// NOTE: unlike the enum values themselves, this is not persisted, and can be
+// used to add new enum values (which must be added to the end) that are
+// executed out of enum value order.
+int order(recovery_stage s) {
+    using enum recovery_stage;
+    switch (s) {
+    case initialized:
+        return 0;
+    case starting:
+        return 1;
+    case recovered_license:
+        return 2;
+    case recovered_cluster_config:
+        return 3;
+    case recovered_users:
+        return 4;
+    case recovered_acls:
+        return 5;
+    case recovered_remote_topic_data:
+        return 6;
+    case recovered_topic_data:
+        return 7;
+    case recovered_controller_snapshot:
+        return 8;
+    case recovered_offsets_topic:
+        return 9;
+    case recovered_tx_coordinator:
+        return 10;
+    case complete:
+        return 100;
+    case failed:
+        return 101;
+    }
+}
+
+// Returns whether, if currently in the given cur_stage, whether we still need
+// actions for the given target stage.
+bool needs_actions(recovery_stage cur_stage, recovery_stage target) {
+    return order(cur_stage) < order(target);
+}
+
 chunked_hash_set<ss::sstring>
 controller_snapshot_reconciler::properties_ignore_list() {
     chunked_hash_set<ss::sstring> ignore_list;
@@ -53,8 +97,8 @@ controller_snapshot_reconciler::get_actions(
     const auto& snap_license = snap.features.snap.license;
     auto existing_license = _feature_table.get_configured_license();
     if (
-      cur_stage < recovery_stage::recovered_license && !existing_license
-      && snap_license.has_value()) {
+      needs_actions(cur_stage, recovery_stage::recovered_license)
+      && !existing_license && snap_license.has_value()) {
         // If there is already a license, it's presumably more up-to-date than
         // whatever is in a snapshot. Otherwise, try using the license.
         actions.license = snap.features.snap.license.value();
@@ -63,7 +107,7 @@ controller_snapshot_reconciler::get_actions(
 
     const auto& snap_config = snap.config.values;
     auto ignore_list = properties_ignore_list();
-    if (cur_stage < recovery_stage::recovered_cluster_config) {
+    if (needs_actions(cur_stage, recovery_stage::recovered_cluster_config)) {
         for (const auto& [snap_k, snap_v] : snap_config) {
             if (ignore_list.contains(snap_k)) {
                 continue;
@@ -80,7 +124,7 @@ controller_snapshot_reconciler::get_actions(
         }
     }
 
-    if (cur_stage < recovery_stage::recovered_users) {
+    if (needs_actions(cur_stage, recovery_stage::recovered_users)) {
         const auto& snap_user_creds = snap.security.user_credentials;
         for (const auto& user : snap_user_creds) {
             if (!_creds.contains(user.username)) {
@@ -92,7 +136,7 @@ controller_snapshot_reconciler::get_actions(
         }
     }
 
-    if (cur_stage < recovery_stage::recovered_acls) {
+    if (needs_actions(cur_stage, recovery_stage::recovered_acls)) {
         const auto& snap_acls = snap.security.acls;
         for (const auto& binding : snap_acls) {
             // TODO: filter those that exist. For now, just pass in everything
@@ -117,7 +161,7 @@ controller_snapshot_reconciler::get_actions(
         }
     }
 
-    if (cur_stage < recovery_stage::recovered_topic_data) {
+    if (needs_actions(cur_stage, recovery_stage::recovered_topic_data)) {
         const auto& snap_tables = snap.topics.topics;
         for (const auto& [tp_ns, meta] : snap_tables) {
             const auto& tp_config = meta.metadata.configuration;

--- a/src/v/cluster/cluster_recovery_reconciler.h
+++ b/src/v/cluster/cluster_recovery_reconciler.h
@@ -47,6 +47,8 @@ public:
         chunked_vector<cluster::user_credential> users;
         chunked_vector<security::acl_binding> acls;
         chunked_vector<cluster::role_recovery> roles;
+        std::optional<topic_configuration> ct_metastore_topic;
+        chunked_vector<topic_configuration> cloud_topics;
         chunked_vector<topic_configuration> remote_topics;
         chunked_vector<topic_configuration> local_topics;
         // TODO: restore wasm plugins/transforms

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -256,7 +256,8 @@ ss::future<> controller::start(
     offsets_recovery,
   std::chrono::milliseconds application_start_time,
   ss::sharded<std::unique_ptr<cluster::data_migrations::group_proxy>>&
-    data_migrations_group_proxy) {
+    data_migrations_group_proxy,
+  ss::sharded<cloud_topics::state_accessors>* ct_state) {
     /**
      * Switch to cluster scheduling group to ensure that all the controller
      * services are started within that scheduling group.
@@ -859,7 +860,8 @@ ss::future<> controller::start(
                 producer_id_recovery,
                 offsets_recovery,
                 std::ref(_recovery_table),
-                _raft0);
+                _raft0,
+                ct_state);
             if (!config::shard_local_cfg()
                    .disable_cluster_recovery_loop_for_tests()) {
                 _recovery_backend->start();

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -43,6 +43,10 @@ namespace cloud_storage {
 class topic_mount_handler;
 }
 
+namespace cloud_topics {
+class state_accessors;
+} // namespace cloud_topics
+
 namespace cluster {
 
 class cluster_discovery;
@@ -242,7 +246,8 @@ public:
       ss::shared_ptr<cluster::cloud_metadata::producer_id_recovery_manager>,
       ss::shared_ptr<cluster::cloud_metadata::offsets_recovery_requestor>,
       std::chrono::milliseconds application_start_time,
-      ss::sharded<std::unique_ptr<cluster::data_migrations::group_proxy>>&);
+      ss::sharded<std::unique_ptr<cluster::data_migrations::group_proxy>>&,
+      ss::sharded<cloud_topics::state_accessors>* ct_state = nullptr);
 
     // prevents controller from accepting new requests
     ss::future<> shutdown_input();

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -159,117 +159,123 @@ ss::future<consensus_ptr> partition_manager::manage(
     // be used at runtime by the partition. The latter is owned by the archival
     // metadata STM and its lifecycle is therefore tied to the partition, which
     // hasn't been constructed yet.
-    cloud_storage::remote_path_provider path_provider(
-      std::move(remote_label), std::move(remote_topic_namespace_override));
-    auto dl_result = co_await maybe_download_log(ntp_cfg, rtp, path_provider);
+    // TODO: implement a recovery primitive for cloud topics
+    if (!ntp_cfg.cloud_topic_enabled()) {
+        cloud_storage::remote_path_provider path_provider(
+          std::move(remote_label), std::move(remote_topic_namespace_override));
+        auto dl_result = co_await maybe_download_log(
+          ntp_cfg, rtp, path_provider);
 
-    auto& [logs_recovered, clean_download, min_offset, max_offset, manifest, ot_state]
-      = dl_result;
-    if (logs_recovered) {
-        vlog(
-          clusterlog.info,
-          "Log download complete, ntp: {}, rev: {}, "
-          "min_offset: {}, max_offset: {}",
-          ntp_cfg.ntp(),
-          ntp_cfg.get_revision(),
-          min_offset,
-          max_offset);
-        if (!clean_download) {
-            vlog(
-              clusterlog.error,
-              "{} partition recovery is not clean, try to delete the topic "
-              "and retry recovery",
-              ntp_cfg.ntp());
-            manifest.disable_permanently();
-        }
-
-        if (min_offset == max_offset && min_offset == model::offset{0}) {
-            // Here two cases are possible:
-            // - Recover failed and we didn't download anything.
-            //   In this case we need to create empty partition and disable
-            //   updates to archival STM to preserve data.
-            // - The manifest was empty. We don't need to do anything, just
-            //   start from an empty slate.
+        auto& [logs_recovered, clean_download, min_offset, max_offset, manifest, ot_state]
+          = dl_result;
+        if (logs_recovered) {
             vlog(
               clusterlog.info,
-              "{} no data in the downloaded segments, empty partition will be "
-              "created",
-              ntp_cfg.ntp());
-
-            if (!clean_download) {
-                // No data was downloaded because of error, in this case it's
-                // not safe to upload data to the cloud. The snapshot should be
-                // created to disable uploads.
-                co_await archival_metadata_stm::make_snapshot(
-                  ntp_cfg, manifest, max_offset);
-            }
-        } else {
-            // Manifest is not empty since we were able to recover some data.
-            auto last_segment = manifest.last_segment();
-            vassert(last_segment.has_value(), "Manifest is empty");
-            auto last_included_term = last_segment->archiver_term;
-
-            vlog(
-              clusterlog.info,
-              "Bootstrap on-disk state for pre existing partition {}. "
-              "Group: {}, "
-              "Min offset: {}, "
-              "Max offset: {}, "
-              "Last included term: {}, ",
+              "Log download complete, ntp: {}, rev: {}, "
+              "min_offset: {}, max_offset: {}",
               ntp_cfg.ntp(),
-              group,
+              ntp_cfg.get_revision(),
               min_offset,
-              max_offset,
-              last_included_term);
-
-            if (min_offset > max_offset) {
-                // No data was downloaded. In this case we're doing shallow
-                // recovery. The dl_result is not populated with data yet so we
-                // have to provide initial delta value.
-                vassert(
-                  manifest.last_segment().has_value(), "Manifest is empty");
-
-                min_offset = model::next_offset(manifest.get_last_offset());
-                max_offset = min_offset;
-                co_await seastar::recursive_touch_directory(
-                  ntp_cfg.work_directory());
+              max_offset);
+            if (!clean_download) {
+                vlog(
+                  clusterlog.error,
+                  "{} partition recovery is not clean, try to delete the topic "
+                  "and retry recovery",
+                  ntp_cfg.ntp());
+                manifest.disable_permanently();
             }
 
-            dl_result.ot_state->add_absolute_delta(
-              model::next_offset(manifest.get_last_offset()),
-              manifest.last_segment()->delta_offset_end);
-
-            co_await raft::details::bootstrap_pre_existing_partition(
-              _storage,
-              ntp_cfg,
-              group,
-              min_offset,
-              max_offset,
-              last_included_term,
-              initial_nodes,
-              dl_result.ot_state);
-
-            // Initialize archival snapshot
-            /*
-             [segment 1] [segment 2] [segment 3]
-                       ^                 ^
-                       |                 |
-                   last_offset      in-sync offset
-
-            Here the ISO is no longer correct because
-            it belongs to the old cluster. We're using last uploaded
-            offset to set up the snapshot.
-            */
-            if (max_offset != model::offset(0)) {
+            if (min_offset == max_offset && min_offset == model::offset{0}) {
+                // Here two cases are possible:
+                // - Recover failed and we didn't download anything.
+                //   In this case we need to create empty partition and disable
+                //   updates to archival STM to preserve data.
+                // - The manifest was empty. We don't need to do anything, just
+                //   start from an empty slate.
                 vlog(
                   clusterlog.info,
-                  "Creating snapshot for {} partition, "
-                  "min_offset: {}, max_offset: {}",
+                  "{} no data in the downloaded segments, empty partition will "
+                  "be "
+                  "created",
+                  ntp_cfg.ntp());
+
+                if (!clean_download) {
+                    // No data was downloaded because of error, in this case
+                    // it's not safe to upload data to the cloud. The snapshot
+                    // should be created to disable uploads.
+                    co_await archival_metadata_stm::make_snapshot(
+                      ntp_cfg, manifest, max_offset);
+                }
+            } else {
+                // Manifest is not empty since we were able to recover some
+                // data.
+                auto last_segment = manifest.last_segment();
+                vassert(last_segment.has_value(), "Manifest is empty");
+                auto last_included_term = last_segment->archiver_term;
+
+                vlog(
+                  clusterlog.info,
+                  "Bootstrap on-disk state for pre existing partition {}. "
+                  "Group: {}, "
+                  "Min offset: {}, "
+                  "Max offset: {}, "
+                  "Last included term: {}, ",
                   ntp_cfg.ntp(),
+                  group,
                   min_offset,
-                  max_offset);
-                co_await archival_metadata_stm::make_snapshot(
-                  ntp_cfg, manifest, model::prev_offset(max_offset));
+                  max_offset,
+                  last_included_term);
+
+                if (min_offset > max_offset) {
+                    // No data was downloaded. In this case we're doing shallow
+                    // recovery. The dl_result is not populated with data yet so
+                    // we have to provide initial delta value.
+                    vassert(
+                      manifest.last_segment().has_value(), "Manifest is empty");
+
+                    min_offset = model::next_offset(manifest.get_last_offset());
+                    max_offset = min_offset;
+                    co_await seastar::recursive_touch_directory(
+                      ntp_cfg.work_directory());
+                }
+
+                dl_result.ot_state->add_absolute_delta(
+                  model::next_offset(manifest.get_last_offset()),
+                  manifest.last_segment()->delta_offset_end);
+
+                co_await raft::details::bootstrap_pre_existing_partition(
+                  _storage,
+                  ntp_cfg,
+                  group,
+                  min_offset,
+                  max_offset,
+                  last_included_term,
+                  initial_nodes,
+                  dl_result.ot_state);
+
+                // Initialize archival snapshot
+                /*
+                 [segment 1] [segment 2] [segment 3]
+                           ^                 ^
+                           |                 |
+                       last_offset      in-sync offset
+
+                Here the ISO is no longer correct because
+                it belongs to the old cluster. We're using last uploaded
+                offset to set up the snapshot.
+                */
+                if (max_offset != model::offset(0)) {
+                    vlog(
+                      clusterlog.info,
+                      "Creating snapshot for {} partition, "
+                      "min_offset: {}, max_offset: {}",
+                      ntp_cfg.ntp(),
+                      min_offset,
+                      max_offset);
+                    co_await archival_metadata_stm::make_snapshot(
+                      ntp_cfg, manifest, model::prev_offset(max_offset));
+                }
             }
         }
     }
@@ -345,6 +351,11 @@ partition_manager::maybe_download_log(
           "Logs can't be downloaded because cloud storage is not configured. "
           "Continue creating {} without downloading the logs.",
           ntp_cfg);
+        co_return cloud_storage::log_recovery_result{};
+    }
+
+    // TODO: implement a recovery primitive for cloud topics.
+    if (ntp_cfg.cloud_topic_enabled()) {
         co_return cloud_storage::log_recovery_result{};
     }
 

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -1207,6 +1207,7 @@ topic_properties topic_table::update_topic_properties(
     incremental_update(
       updated_properties.message_timestamp_after_max_ms,
       overrides.message_timestamp_after_max_ms);
+    incremental_update(updated_properties.remote_label, overrides.remote_label);
     return updated_properties;
 }
 

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -738,6 +738,7 @@ ss::future<topic_result> topics_frontend::do_create_topic(
         co_return result;
     }
 
+    auto is_cloud_topic = assignable_config.cfg.properties.cloud_topic_enabled;
     if (assignable_config.is_read_replica()) {
         if (!assignable_config.cfg.properties.read_replica_bucket) {
             co_return make_error_result(
@@ -768,7 +769,8 @@ ss::future<topic_result> topics_frontend::do_create_topic(
               ->remote_partition_count;
     }
 
-    if (assignable_config.is_recovery_enabled()) {
+    // TODO: implement a recovery primitive for cloud topics.
+    if (assignable_config.is_recovery_enabled() && !is_cloud_topic) {
         // Before running the recovery we need to download topic_manifest.
 
         const auto& bucket_config
@@ -862,8 +864,6 @@ ss::future<topic_result> topics_frontend::do_create_topic(
       && _features.local().is_active(features::feature::remote_labels)
       && !config::shard_local_cfg()
             .cloud_storage_disable_remote_labels_for_tests.value()) {
-        auto is_cloud_topic
-          = assignable_config.cfg.properties.cloud_topic_enabled;
         auto ct_metastore_label
           = _topics.local()
               .get_topic_metadata_ref(model::l1_metastore_nt)

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -862,8 +862,18 @@ ss::future<topic_result> topics_frontend::do_create_topic(
       && _features.local().is_active(features::feature::remote_labels)
       && !config::shard_local_cfg()
             .cloud_storage_disable_remote_labels_for_tests.value()) {
-        auto remote_label = std::make_optional<cloud_storage::remote_label>(
-          _storage.local().get_cluster_uuid().value());
+        auto is_cloud_topic
+          = assignable_config.cfg.properties.cloud_topic_enabled;
+        auto ct_metastore_label
+          = _topics.local()
+              .get_topic_metadata_ref(model::l1_metastore_nt)
+              .and_then([](const topic_metadata& m) {
+                  return m.get_configuration().properties.remote_label;
+              });
+        auto remote_label = is_cloud_topic && ct_metastore_label
+                              ? *ct_metastore_label
+                              : cloud_storage::remote_label(
+                                  _storage.local().get_cluster_uuid().value());
         assignable_config.cfg.properties.remote_label = remote_label;
         vlog(
           clusterlog.debug,

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -53,6 +53,12 @@ std::ostream& operator<<(std::ostream& o, const recovery_stage& s) {
     case recovery_stage::recovered_remote_topic_data:
         o << "recovery_stage::recovered_remote_topic_data";
         break;
+    case recovery_stage::recovered_cloud_topics_metastore:
+        o << "recovery_stage::recovered_cloud_topics_metastore";
+        break;
+    case recovery_stage::recovered_cloud_topic_data:
+        o << "recovery_stage::recovered_cloud_topic_data";
+        break;
     case recovery_stage::recovered_topic_data:
         o << "recovery_stage::recovered_topic_data";
         break;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1914,6 +1914,8 @@ enum class recovery_stage : int8_t {
     recovered_cluster_config = 3,
     recovered_users = 4,
     recovered_acls = 5,
+    recovered_cloud_topics_metastore = 11,
+    recovered_cloud_topic_data = 12,
     recovered_remote_topic_data = 6,
     recovered_topic_data = 7,
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -13,6 +13,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/node_hash_map.h"
+#include "cloud_storage/remote_label.h"
 #include "cluster/cloud_metadata/cluster_manifest.h"
 #include "cluster/cluster_link/errc.h"
 #include "cluster/errc.h"
@@ -562,7 +563,7 @@ struct property_update<tristate<T>>
 struct incremental_topic_updates
   : serde::envelope<
       incremental_topic_updates,
-      serde::version<9>,
+      serde::version<10>,
       serde::compat_version<0>> {
     static constexpr int8_t version_with_data_policy = -1;
     static constexpr int8_t version_with_shadow_indexing = -3;
@@ -657,6 +658,14 @@ struct incremental_topic_updates
     // topics that were created without one.
     property_update<std::optional<model::topic_id>> topic_id;
 
+    // Label used to identify the location of the topic's state in the cloud.
+    //
+    // WARNING: NOT meant for use for Kafka topics! Exercise caution when using
+    // this and make sure that changing this is handled gracefully by the topic
+    // being updated. E.g. can be used for the cloud topics metastore topic
+    // after the logical state of a given topic is restored.
+    property_update<std::optional<cloud_storage::remote_label>> remote_label;
+
     // To allow us to better control use of the deprecated shadow_indexing
     // field, use getters and setters instead.
     const auto& get_shadow_indexing() const { return shadow_indexing; }
@@ -705,7 +714,8 @@ struct incremental_topic_updates
           min_compaction_lag_ms,
           max_compaction_lag_ms,
           message_timestamp_before_max_ms,
-          message_timestamp_after_max_ms);
+          message_timestamp_after_max_ms,
+          remote_label);
     }
 
     friend std::ostream&

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -96,7 +96,7 @@ create_topic_properties_update(
     std::apply(apply_op(op_t::none), update.custom_properties.serde_fields());
 
     static_assert(
-      std::tuple_size_v<decltype(update.properties.serde_fields())> == 42,
+      std::tuple_size_v<decltype(update.properties.serde_fields())> == 43,
       "If you add a property, decide on its default alter config "
       "policy, and handle the update in the loop below");
     static_assert(
@@ -122,6 +122,10 @@ create_topic_properties_update(
     update.properties.remote_read.op = op_t::none;
     update.properties.remote_write.op = op_t::none;
     update.properties.remote_delete.op = op_t::none;
+
+    // remote_label is an internal property used for cluster recovery and should
+    // not be modified via AlterConfigs.
+    update.properties.remote_label.op = op_t::none;
 
     // Legacy
     auto& update_properties_shadow_indexing

--- a/src/v/redpanda/application_start.cc
+++ b/src/v/redpanda/application_start.cc
@@ -157,7 +157,8 @@ void application::start_runtime_services(
         producer_id_recovery_manager,
         std::move(offsets_recovery_requestor),
         redpanda_start_time,
-        _data_migrations_group_proxy)
+        _data_migrations_group_proxy,
+        cloud_topics_app ? cloud_topics_app->get_state() : nullptr)
       .get();
 
     if (archiver_manager.local_is_initialized()) {


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This hooks cloud topics restore into the Whole Cluster Restore machinery. At a high level, cloud topics restore entails two steps:
1. restore the L1 metastore
2. restore the cloud topics, pointing the restored topics at the restored metastore

In restoring the metastore, we restore each domain, and then update the metastore topic config so its remote_label will be that of the original metastore. This sets the metastore up to continue uploading its metastore manifest to the original cluster's location, which will be a nice property to have for discoverability of the metastore (e.g. for read replicas). This updated remote label also serves as an indicator that restore is complete and that subsequent attempts to restore this metastore will be no-ops.

In restoring the cloud topics, all the original cloud topics' properties are preserved, but with the `recovery` property set. There is some additional work that needs to be done to make the restored cloud topics operational (e.g. on restore, they should query the metastore to bootstrap their CTP STMs), but that is left for later work.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
