### PR TITLE
`config`: deprecated config purging

### DIFF
--- a/src/v/cluster/archival/tests/BUILD
+++ b/src/v/cluster/archival/tests/BUILD
@@ -94,7 +94,6 @@ redpanda_cc_gtest(
         "//src/v/storage",
         "//src/v/storage/tests:disk_log_builder",
         "//src/v/test_utils:gtest",
-        "//src/v/test_utils:scoped_config",
         "//src/v/utils:available_promise",
         "@googletest//:gtest",
         "@seastar",

--- a/src/v/cluster/archival/tests/archival_metadata_stm_gtest.cc
+++ b/src/v/cluster/archival/tests/archival_metadata_stm_gtest.cc
@@ -14,7 +14,6 @@
 #include "cluster/archival/archival_metadata_stm.h"
 #include "model/record.h"
 #include "raft/tests/raft_fixture.h"
-#include "test_utils/scoped_config.h"
 #include "test_utils/test.h"
 #include "utils/available_promise.h"
 
@@ -512,9 +511,6 @@ TEST_F_CORO(
   archival_metadata_stm_gtest_fixture, test_archival_stm_error_propagation) {
     ss::abort_source never_abort;
 
-    auto s_cfg = scoped_config{};
-    s_cfg.get("cloud_storage_disable_metadata_consistency_checks")
-      .set_value(false);
     co_await start();
 
     std::vector<cloud_storage::segment_meta> good_segment;
@@ -607,9 +603,6 @@ TEST_F_CORO(
     auto timeout = 30s;
     auto deadline = ss::lowres_clock::now() + timeout;
 
-    auto s_cfg = scoped_config{};
-    s_cfg.get("cloud_storage_disable_metadata_consistency_checks")
-      .set_value(false);
     co_await start();
 
     std::vector<cloud_storage::segment_meta> good_segment;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -170,11 +170,6 @@ configuration::configuration()
       "replies.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
-  , enable_coproc(*this, "enable_coproc")
-  , coproc_max_inflight_bytes(*this, "coproc_max_inflight_bytes")
-  , coproc_max_ingest_bytes(*this, "coproc_max_ingest_bytes")
-  , coproc_max_batch_size(*this, "coproc_max_batch_size")
-  , coproc_offset_flush_interval_ms(*this, "coproc_offset_flush_interval_ms")
   , data_transforms_enabled(
       *this,
       "data_transforms_enabled",
@@ -396,8 +391,6 @@ configuration::configuration()
       "headers.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
-  , seed_server_meta_topic_partitions(
-      *this, "seed_server_meta_topic_partitions")
   , raft_heartbeat_interval_ms(
       *this,
       "raft_heartbeat_interval_ms",
@@ -427,8 +420,6 @@ configuration::configuration()
       {.visibility = visibility::tunable},
       3)
 
-  , min_version(*this, "min_version")
-  , max_version(*this, "max_version")
   , raft_max_recovery_memory(
       *this,
       "raft_max_recovery_memory",
@@ -439,7 +430,6 @@ configuration::configuration()
        .visibility = visibility::tunable},
       std::nullopt,
       {.min = 32_MiB})
-  , raft_recovery_default_read_size(*this, "raft_recovery_default_read_size")
   , raft_enable_lw_heartbeat(
       *this,
       "raft_enable_lw_heartbeat",
@@ -553,8 +543,6 @@ configuration::configuration()
        .visibility = visibility::tunable},
       std::chrono::seconds(60 * 5),
       {.min = std::chrono::seconds(1)})
-  , use_scheduling_groups(*this, "use_scheduling_groups")
-  , enable_admin_api(*this, "enable_admin_api")
   , default_num_windows(
       *this,
       "default_num_windows",
@@ -575,9 +563,6 @@ configuration::configuration()
       "Quota manager GC frequency in milliseconds.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::chrono::milliseconds(30000))
-  , target_quota_byte_rate(*this, "target_quota_byte_rate")
-  , target_fetch_quota_byte_rate(*this, "target_fetch_quota_byte_rate")
-  , kafka_admin_topic_api_rate(*this, "kafka_admin_topic_api_rate")
   , cluster_id(
       *this,
       "cluster_id",
@@ -701,19 +686,12 @@ configuration::configuration()
       "controls the number retries.",
       {.visibility = visibility::tunable},
       30)
-  , tm_sync_timeout_ms(*this, "tm_sync_timeout_ms")
-  , tx_registry_sync_timeout_ms(*this, "tx_registry_sync_timeout_ms")
-  , tm_violation_recovery_policy(*this, "tm_violation_recovery_policy")
-  , rm_sync_timeout_ms(*this, "rm_sync_timeout_ms")
-  , find_coordinator_timeout_ms(*this, "find_coordinator_timeout_ms")
-  , seq_table_min_size(*this, "seq_table_min_size")
   , tx_timeout_delay_ms(
       *this,
       "tx_timeout_delay_ms",
       "Delay before scheduling the next check for timed out transactions.",
       {.visibility = visibility::user},
       1000ms)
-  , rm_violation_recovery_policy(*this, "rm_violation_recovery_policy")
   , fetch_reads_debounce_timeout(
       *this,
       "fetch_reads_debounce_timeout",
@@ -797,7 +775,6 @@ configuration::configuration()
       "milliseconds.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       100ms)
-  , alter_topic_cfg_timeout_ms(*this, "alter_topic_cfg_timeout_ms")
   , log_cleanup_policy(
       *this,
       "log_cleanup_policy",
@@ -819,10 +796,6 @@ configuration::configuration()
        .visibility = visibility::user},
       model::timestamp_type::create_time,
       {model::timestamp_type::create_time, model::timestamp_type::append_time})
-  , log_message_timestamp_alert_before_ms(
-      *this, "log_message_timestamp_alert_before_ms")
-  , log_message_timestamp_alert_after_ms(
-      *this, "log_message_timestamp_alert_after_ms")
   , log_message_timestamp_before_max_ms(
       *this,
       "log_message_timestamp_before_max_ms",
@@ -905,7 +878,6 @@ configuration::configuration()
       "Use separate scheduler group to handle parsing Kafka protocol requests",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       true)
-  , metadata_status_wait_timeout_ms(*this, "metadata_status_wait_timeout_ms")
   , kafka_tcp_keepalive_idle_timeout_seconds(
       *this,
       "kafka_tcp_keepalive_timeout",
@@ -1107,8 +1079,6 @@ configuration::configuration()
       "when this is set to `true`.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
-  , log_compaction_adjacent_merge_self_compaction_count(
-      *this, "log_compaction_adjacent_merge_self_compaction_count")
   , log_compaction_merge_max_segments_per_range(
       *this,
       "log_compaction_merge_max_segments_per_range",
@@ -1129,8 +1099,6 @@ configuration::configuration()
       "compaction.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::nullopt)
-  , log_compaction_disable_tx_batch_removal(
-      *this, "log_compaction_disable_tx_batch_removal")
   , log_compaction_tx_batch_removal_enabled(
       *this,
       "log_compaction_tx_batch_removal_enabled",
@@ -1179,9 +1147,6 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       1,
       {.min = 1, .oddeven = odd_even_constraint::odd})
-  , transaction_coordinator_replication(
-      *this, "transaction_coordinator_replication")
-  , id_allocator_replication(*this, "id_allocator_replication")
   , transaction_coordinator_partitions(
       *this,
       "transaction_coordinator_partitions",
@@ -1235,8 +1200,6 @@ configuration::configuration()
       {.needs_restart = needs_restart::no,
        .visibility = visibility::deprecated},
       10s)
-  , create_topic_timeout_ms(*this, "create_topic_timeout_ms")
-  , wait_for_leader_timeout_ms(*this, "wait_for_leader_timeout_ms")
   , default_topic_partitions(
       *this,
       "default_topic_partitions",
@@ -1267,7 +1230,6 @@ configuration::configuration()
       "Timeout for append entry requests issued while replicating entries.",
       {.visibility = visibility::tunable},
       3s)
-  , recovery_append_timeout_ms(*this, "recovery_append_timeout_ms")
   , raft_replicate_batch_window_size(
       *this,
       "raft_replicate_batch_window_size",
@@ -1302,8 +1264,6 @@ configuration::configuration()
       "`seastar::smp_service_group` documentation).",
       {.visibility = visibility::tunable},
       std::nullopt)
-  , raft_max_concurrent_append_requests_per_follower(
-      *this, "raft_max_concurrent_append_requests_per_follower")
   , write_caching_default(
       *this,
       "write_caching_default",
@@ -1607,7 +1567,6 @@ configuration::configuration()
       "for the log reader.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::nullopt)
-  , tx_registry_log_capacity(*this, "tx_registry_log_capacity")
   , id_allocator_log_capacity(
       *this,
       "id_allocator_log_capacity",
@@ -1740,8 +1699,6 @@ configuration::configuration()
       "Interval between iterations of controller backend housekeeping loop.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1s)
-  , node_management_operation_timeout_ms(
-      *this, "node_management_operation_timeout_ms")
   , kafka_request_max_bytes(
       *this,
       "kafka_request_max_bytes",
@@ -1863,10 +1820,6 @@ configuration::configuration()
        .visibility = visibility::user},
       {},
       validate_connection_rate)
-  , kafka_client_group_byte_rate_quota(
-      *this, "kafka_client_group_byte_rate_quota")
-  , kafka_client_group_fetch_byte_rate_quota(
-      *this, "kafka_client_group_fetch_byte_rate_quota")
   , kafka_rpc_server_tcp_recv_buf(
       *this,
       "kafka_rpc_server_tcp_recv_buf",
@@ -2147,8 +2100,6 @@ configuration::configuration()
       "Timeout for IAM role related operations (ms)",
       {.visibility = visibility::tunable},
       30s)
-  , cloud_storage_reconciliation_ms(
-      *this, "cloud_storage_reconciliation_interval_ms")
   , cloud_storage_upload_loop_initial_backoff_ms(
       *this,
       "cloud_storage_upload_loop_initial_backoff_ms",
@@ -2601,8 +2552,6 @@ configuration::configuration()
       "violations. Normally, this options should be disabled.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
-  , cloud_storage_disable_metadata_consistency_checks(
-      *this, "cloud_storage_disable_metadata_consistency_checks")
   , cloud_storage_disable_archival_stm_rw_fence(
       *this,
       "cloud_storage_disable_archival_stm_rw_fence",
@@ -3230,8 +3179,6 @@ configuration::configuration()
       "Disable reusable preallocated buffers for LZ4 decompression.",
       {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
       false)
-  , full_raft_configuration_recovery_pattern(
-      *this, "full_raft_configuration_recovery_pattern")
   , enable_auto_rebalance_on_node_add(
       *this,
       "enable_auto_rebalance_on_node_add",
@@ -3350,7 +3297,6 @@ configuration::configuration()
       "Enable automatic leadership rebalancing.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       true)
-  , leader_balancer_mode(*this, "leader_balancer_mode")
   , leader_balancer_idle_timeout(
       *this,
       "leader_balancer_idle_timeout",
@@ -3654,7 +3600,6 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       std::nullopt,
       {.min = 1})
-  , kafka_throughput_throttling_v2(*this, "kafka_throughput_throttling_v2")
   , kafka_throughput_replenish_threshold(
       *this,
       "kafka_throughput_replenish_threshold",
@@ -3668,13 +3613,6 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::nullopt,
       {.min = 1})
-  , kafka_quota_balancer_window(*this, "kafka_quota_balancer_window_ms")
-  , kafka_quota_balancer_node_period(
-      *this, "kafka_quota_balancer_node_period_ms")
-  , kafka_quota_balancer_min_shard_throughput_ratio(
-      *this, "kafka_quota_balancer_min_shard_throughput_ratio")
-  , kafka_quota_balancer_min_shard_throughput_bps(
-      *this, "kafka_quota_balancer_min_shard_throughput_bps")
   , kafka_throughput_controlled_api_keys(
       *this,
       "kafka_throughput_controlled_api_keys",
@@ -3793,8 +3731,6 @@ configuration::configuration()
       "subject.",
       {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
       false)
-  , schema_registry_protobuf_renderer_v2(
-      *this, "schema_registry_protobuf_renderer_v2")
   , pp_sr_smp_max_non_local_requests(
       *this,
       "pp_sr_smp_max_non_local_requests",
@@ -3829,8 +3765,6 @@ configuration::configuration()
       {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       0.5,
       {.min = 0.0, .max = 1.0})
-  , kafka_memory_batch_size_estimate_for_fetch(
-      *this, "kafka_memory_batch_size_estimate_for_fetch")
   , cpu_profiler_enabled(
       *this,
       "cpu_profiler_enabled",
@@ -4463,8 +4397,6 @@ configuration::configuration()
       "Option to explicitly disable enforcement of datalake disk space usage",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       true)
-  , datalake_disk_space_monitor_interval(
-      *this, "datalake_disk_space_monitor_interval")
   , datalake_scratch_space_size_bytes(
       *this,
       "datalake_scratch_space_size_bytes",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -129,13 +129,6 @@ struct configuration final : public config_store {
     bounded_property<std::optional<int>> rpc_server_tcp_send_buf;
     bounded_property<int> rpc_client_connections_per_peer;
     property<bool> rpc_server_compress_replies;
-    // Coproc
-    deprecated_property enable_coproc;
-    deprecated_property coproc_max_inflight_bytes;
-    deprecated_property coproc_max_ingest_bytes;
-    deprecated_property coproc_max_batch_size;
-    deprecated_property coproc_offset_flush_interval_ms;
-
     // Data Transforms
     property<bool> data_transforms_enabled;
     property<std::chrono::milliseconds> data_transforms_commit_interval_ms;
@@ -165,14 +158,10 @@ struct configuration final : public config_store {
     property<bool> admin_api_require_auth;
 
     // Raft
-    deprecated_property seed_server_meta_topic_partitions;
     bounded_property<std::chrono::milliseconds> raft_heartbeat_interval_ms;
     bounded_property<std::chrono::milliseconds> raft_heartbeat_timeout_ms;
     property<size_t> raft_heartbeat_disconnect_failures;
-    deprecated_property min_version;
-    deprecated_property max_version;
     bounded_property<std::optional<size_t>> raft_max_recovery_memory;
-    deprecated_property raft_recovery_default_read_size;
     property<bool> raft_enable_lw_heartbeat;
     bounded_property<size_t> raft_recovery_concurrency_per_shard;
     property<std::optional<size_t>> raft_replica_max_pending_flush_bytes;
@@ -188,14 +177,9 @@ struct configuration final : public config_store {
     bounded_property<size_t> usage_num_windows;
     bounded_property<std::chrono::seconds> usage_window_width_interval_sec;
     bounded_property<std::chrono::seconds> usage_disk_persistance_interval_sec;
-    deprecated_property use_scheduling_groups;
-    deprecated_property enable_admin_api;
     bounded_property<int16_t> default_num_windows;
     bounded_property<std::chrono::milliseconds> default_window_sec;
     property<std::chrono::milliseconds> quota_manager_gc_sec;
-    deprecated_property target_quota_byte_rate;
-    deprecated_property target_fetch_quota_byte_rate;
-    deprecated_property kafka_admin_topic_api_rate;
     property<std::optional<ss::sstring>> cluster_id;
     property<bool> disable_metrics;
     property<bool> disable_public_metrics;
@@ -212,14 +196,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> metadata_dissemination_interval_ms;
     property<std::chrono::milliseconds> metadata_dissemination_retry_delay_ms;
     property<int16_t> metadata_dissemination_retries;
-    deprecated_property tm_sync_timeout_ms;
-    deprecated_property tx_registry_sync_timeout_ms;
-    deprecated_property tm_violation_recovery_policy;
-    deprecated_property rm_sync_timeout_ms;
-    deprecated_property find_coordinator_timeout_ms;
-    deprecated_property seq_table_min_size;
     property<std::chrono::milliseconds> tx_timeout_delay_ms;
-    deprecated_property rm_violation_recovery_policy;
     property<std::chrono::milliseconds> fetch_reads_debounce_timeout;
     enum_property<model::fetch_read_strategy> fetch_read_strategy;
     bounded_property<size_t> fetch_max_read_concurrency;
@@ -229,11 +206,8 @@ struct configuration final : public config_store {
     bounded_property<double, numeric_bounds>
       fetch_pid_target_utilization_fraction;
     property<std::chrono::milliseconds> fetch_pid_max_debounce_ms;
-    deprecated_property alter_topic_cfg_timeout_ms;
     property<model::cleanup_policy_bitflags> log_cleanup_policy;
     enum_property<model::timestamp_type> log_message_timestamp_type;
-    deprecated_property log_message_timestamp_alert_before_ms;
-    deprecated_property log_message_timestamp_alert_after_ms;
     bounded_property<std::chrono::milliseconds>
       log_message_timestamp_before_max_ms;
     bounded_property<std::chrono::milliseconds>
@@ -245,7 +219,6 @@ struct configuration final : public config_store {
     property<bool> use_fetch_scheduler_group;
     property<bool> use_produce_scheduler_group;
     property<bool> use_kafka_handler_scheduler_group;
-    deprecated_property metadata_status_wait_timeout_ms;
     property<std::chrono::seconds> kafka_tcp_keepalive_idle_timeout_seconds;
     property<std::chrono::seconds> kafka_tcp_keepalive_probe_interval_seconds;
     property<uint32_t> kafka_tcp_keepalive_probes;
@@ -270,19 +243,15 @@ struct configuration final : public config_store {
     property<bool> log_disable_housekeeping_for_tests;
     property<bool> log_compaction_use_sliding_window;
     property<bool> log_compaction_pause_use_sliding_window;
-    deprecated_property log_compaction_adjacent_merge_self_compaction_count;
     property<std::optional<uint32_t>>
       log_compaction_merge_max_segments_per_range;
     property<std::optional<uint32_t>> log_compaction_merge_max_ranges;
-    deprecated_property log_compaction_disable_tx_batch_removal;
     property<bool> log_compaction_tx_batch_removal_enabled;
     // same as retention.size in kafka - TODO: size not implemented
     property<std::optional<size_t>> retention_bytes;
     property<int32_t> group_topic_partitions;
     bounded_property<int16_t> default_topic_replication;
     bounded_property<int16_t> minimum_topic_replication;
-    deprecated_property transaction_coordinator_replication;
-    deprecated_property id_allocator_replication;
     property<int32_t> transaction_coordinator_partitions;
     property<model::cleanup_policy_bitflags>
       transaction_coordinator_cleanup_policy;
@@ -294,19 +263,15 @@ struct configuration final : public config_store {
     // same as transaction.max.timeout.ms in Apache Kafka.
     property<std::chrono::milliseconds> transaction_max_timeout_ms;
     property<std::chrono::seconds> tx_log_stats_interval_s;
-    deprecated_property create_topic_timeout_ms;
-    deprecated_property wait_for_leader_timeout_ms;
     property<int32_t> default_topic_partitions;
     property<bool> disable_batch_cache;
     property<std::chrono::milliseconds> raft_election_timeout_ms;
     property<std::chrono::milliseconds> kafka_group_recovery_timeout_ms;
     property<std::chrono::milliseconds> replicate_append_timeout_ms;
-    deprecated_property recovery_append_timeout_ms;
     property<size_t> raft_replicate_batch_window_size;
     property<size_t> raft_learner_recovery_rate;
     property<bool> raft_recovery_throttle_disable_dynamic_mode;
     property<std::optional<uint32_t>> raft_smp_max_non_local_requests;
-    deprecated_property raft_max_concurrent_append_requests_per_follower;
     enum_property<model::write_caching_mode> write_caching_default;
 
     property<size_t> reclaim_min_size;
@@ -345,7 +310,6 @@ struct configuration final : public config_store {
     bounded_property<int16_t> storage_reserve_min_segments;
     property<std::optional<uint32_t>> debug_load_slice_warning_depth;
 
-    deprecated_property tx_registry_log_capacity;
     property<int16_t> id_allocator_log_capacity;
     property<int16_t> id_allocator_batch_size;
     property<bool> enable_sasl;
@@ -365,7 +329,6 @@ struct configuration final : public config_store {
     property<bool> kafka_enable_partition_reassignment;
     property<std::chrono::milliseconds>
       controller_backend_housekeeping_interval_ms;
-    deprecated_property node_management_operation_timeout_ms;
     property<uint32_t> kafka_request_max_bytes;
     property<uint32_t> kafka_batch_max_bytes;
     property<std::vector<ss::sstring>> kafka_nodelete_topics;
@@ -386,8 +349,6 @@ struct configuration final : public config_store {
     property<std::optional<uint32_t>> kafka_connections_max;
     property<std::optional<uint32_t>> kafka_connections_max_per_ip;
     property<std::vector<ss::sstring>> kafka_connections_max_overrides;
-    deprecated_property kafka_client_group_byte_rate_quota;
-    deprecated_property kafka_client_group_fetch_byte_rate_quota;
     bounded_property<std::optional<int>> kafka_rpc_server_tcp_recv_buf;
     bounded_property<std::optional<int>> kafka_rpc_server_tcp_send_buf;
     bounded_property<std::optional<size_t>> kafka_rpc_server_stream_recv_buf;
@@ -423,7 +384,6 @@ struct configuration final : public config_store {
       cloud_storage_azure_managed_identity_id;
     property<std::chrono::milliseconds>
       cloud_storage_roles_operation_timeout_ms;
-    deprecated_property cloud_storage_reconciliation_ms;
     property<std::chrono::milliseconds>
       cloud_storage_upload_loop_initial_backoff_ms;
     property<std::chrono::milliseconds>
@@ -498,7 +458,6 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds>
       cloud_storage_topic_purge_grace_period_ms;
     property<bool> cloud_storage_disable_upload_consistency_checks;
-    deprecated_property cloud_storage_disable_metadata_consistency_checks;
     property<bool> cloud_storage_disable_archival_stm_rw_fence;
     property<std::chrono::milliseconds> cloud_storage_hydration_timeout_ms;
     property<bool> cloud_storage_disable_remote_labels_for_tests;
@@ -599,7 +558,6 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> kafka_qdc_depth_update_ms;
     property<size_t> zstd_decompress_workspace_bytes;
     property<bool> lz4_decompress_reusable_buffers_disabled;
-    deprecated_property full_raft_configuration_recovery_pattern;
     property<bool> enable_auto_rebalance_on_node_add;
 
     enterprise<enum_property<model::partition_autobalancing_mode>>
@@ -620,7 +578,6 @@ struct configuration final : public config_store {
     property<bool> partition_autobalancing_topic_aware;
 
     property<bool> enable_leader_balancer;
-    deprecated_property leader_balancer_mode;
     property<std::chrono::milliseconds> leader_balancer_idle_timeout;
     property<std::chrono::milliseconds> leader_balancer_mute_timeout;
     property<std::chrono::milliseconds> leader_balancer_node_mute_timeout;
@@ -682,13 +639,8 @@ struct configuration final : public config_store {
     bounded_property<std::optional<int64_t>> kafka_throughput_limit_node_in_bps;
     bounded_property<std::optional<int64_t>>
       kafka_throughput_limit_node_out_bps;
-    deprecated_property kafka_throughput_throttling_v2;
     bounded_property<std::optional<int64_t>>
       kafka_throughput_replenish_threshold;
-    deprecated_property kafka_quota_balancer_window;
-    deprecated_property kafka_quota_balancer_node_period;
-    deprecated_property kafka_quota_balancer_min_shard_throughput_ratio;
-    deprecated_property kafka_quota_balancer_min_shard_throughput_bps;
     property<std::vector<ss::sstring>> kafka_throughput_controlled_api_keys;
     property<std::vector<throughput_control_group>> kafka_throughput_control;
 
@@ -708,13 +660,11 @@ struct configuration final : public config_store {
     enterprise<property<bool>> schema_registry_enable_authorization;
     property<bool> schema_registry_always_normalize;
     property<bool> schema_registry_enable_qualified_subjects;
-    deprecated_property schema_registry_protobuf_renderer_v2;
     property<std::optional<uint32_t>> pp_sr_smp_max_non_local_requests;
     bounded_property<size_t> max_in_flight_schema_registry_requests_per_shard;
     bounded_property<size_t> max_in_flight_pandaproxy_requests_per_shard;
 
     bounded_property<double, numeric_bounds> kafka_memory_share_for_fetch;
-    deprecated_property kafka_memory_batch_size_estimate_for_fetch;
     // debug controls
     property<bool> cpu_profiler_enabled;
     bounded_property<std::chrono::milliseconds> cpu_profiler_sample_period_ms;
@@ -807,7 +757,6 @@ struct configuration final : public config_store {
       datalake_scheduler_time_slice_ms;
     bounded_property<size_t> datalake_translator_flush_bytes;
     property<bool> datalake_disk_space_monitor_enable;
-    deprecated_property datalake_disk_space_monitor_interval;
     property<size_t> datalake_scratch_space_size_bytes;
     bounded_property<double, numeric_bounds>
       datalake_scratch_space_soft_limit_size_percent;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -842,6 +842,8 @@ bool development_feature_property<T>::development_features_enabled(
     return conf.development_features_enabled();
 }
 
+std::unique_ptr<configuration> make_config();
+
 configuration& shard_local_cfg();
 
 } // namespace config

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -593,7 +593,7 @@ static ss::future<chunked_vector<resp_resource_t>> alter_broker_configuration(
         }
 
         // Validate contents of the request
-        config::configuration cfg;
+        auto cfg = config::make_config();
         for (const auto& i : req.upsert) {
             // Decode to a YAML object because that's what the property
             // interface expects.
@@ -602,7 +602,7 @@ static ss::future<chunked_vector<resp_resource_t>> alter_broker_configuration(
             const auto& yaml_value = i.value;
             auto val = YAML::Load(yaml_value);
 
-            if (!cfg.contains(i.key)) {
+            if (!cfg->contains(i.key)) {
                 responses.push_back(
                   make_error_alter_config_resource_response<resp_resource_t>(
                     resource,
@@ -611,7 +611,7 @@ static ss::future<chunked_vector<resp_resource_t>> alter_broker_configuration(
                 errored = true;
                 continue;
             }
-            auto& property = cfg.get(i.key);
+            auto& property = cfg->get(i.key);
             try {
                 property.set_value(val);
             } catch (...) {

--- a/src/v/kafka/server/tests/quota_manager_bench.cc
+++ b/src/v/kafka/server/tests/quota_manager_bench.cc
@@ -89,10 +89,6 @@ struct throughput_test_case {
 };
 
 future<size_t> run_tc(throughput_test_case tc) {
-    co_await ss::smp::invoke_on_all([fetch_tp{tc.fetch_tp}]() {
-        config::shard_local_cfg().target_fetch_quota_byte_rate.set_value(
-          fetch_tp);
-    });
     co_await test_quota_manager(total_requests / ss::smp::count, tc.use_unique);
     co_return total_requests;
 }

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -2176,12 +2176,12 @@ admin_server::patch_cluster_config_handler(
         // the real live configuration object, that will be updated
         // by config_manager much after config is written to controller
         // log.
-        config::configuration cfg;
+        auto cfg = config::make_config();
 
         // Populate the temporary config object with existing values
         config::shard_local_cfg().for_each(
           [&cfg](const config::base_property& p) {
-              auto& tmp_p = cfg.get(p.name());
+              auto& tmp_p = cfg->get(p.name());
               tmp_p = p;
           });
 
@@ -2200,11 +2200,11 @@ admin_server::patch_cluster_config_handler(
             // just a few lines above.
             auto val = YAML::Load(yaml_value);
 
-            if (!cfg.contains(yaml_name)) {
+            if (!cfg->contains(yaml_name)) {
                 errors[yaml_name] = "Unknown property";
                 continue;
             }
-            auto& property = cfg.get(yaml_name);
+            auto& property = cfg->get(yaml_name);
 
             try {
                 auto validation_err = property.validate(val);
@@ -2285,8 +2285,8 @@ admin_server::patch_cluster_config_handler(
         }
 
         for (const auto& key : update.remove) {
-            if (cfg.contains(key)) {
-                cfg.get(key).reset();
+            if (cfg->contains(key)) {
+                cfg->get(key).reset();
             } else {
                 errors[key] = "Unknown property";
             }
@@ -2295,7 +2295,7 @@ admin_server::patch_cluster_config_handler(
         // After checking each individual property, check for
         // any multi-property validation errors
         config_multi_property_validation(
-          auth_state.get_username(), _schema_registry, update, cfg, errors);
+          auth_state.get_username(), _schema_registry, update, *cfg, errors);
 
         if (!errors.empty()) {
             json::StringBuffer buf;


### PR DESCRIPTION
* Remove `deprecated_property`s
* Use heap allocation for configuration in validation sites

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
