### PR TITLE
`ct/l1`: add `cloud_topics_reconciler` scheduling group

### DIFF
--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -74,7 +74,7 @@ int_flag(
 
 int_flag(
     name = "scheduling_groups",
-    build_setting_default = 19,
+    build_setting_default = 20,
     make_variable = "SCHEDULING_GROUPS",
 )
 

--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -110,6 +110,7 @@ redpanda_cc_library(
         "//src/v/config",
         "//src/v/container:chunked_vector",
         "//src/v/model",
+        "//src/v/resource_mgmt:cpu_scheduling",
         "//src/v/ssx:sharded_service_container",
         "//src/v/storage",
         "@seastar",

--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -22,6 +22,7 @@
 #include "cluster/cluster_epoch_service.h"
 #include "cluster/controller.h"
 #include "config/node_config.h"
+#include "resource_mgmt/cpu_scheduling.h"
 #include "ssx/sharded_service_container.h"
 
 #include <seastar/core/coroutine.hh>
@@ -105,7 +106,8 @@ ss::future<> app::construct(
     co_await construct_service(
       reconciler,
       ss::sharded_parameter([this] { return &l1_io.local(); }),
-      ss::sharded_parameter([this] { return &replicated_metastore.local(); }));
+      ss::sharded_parameter([this] { return &replicated_metastore.local(); }),
+      scheduling_groups::instance().cloud_topics_reconciler_sg());
 
     co_await construct_service(
       l0_gc,

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -57,7 +57,8 @@ void log_error(
 
 } // namespace
 
-reconciler::reconciler(l1::io* l1_io, l1::metastore* metastore)
+reconciler::reconciler(
+  l1::io* l1_io, l1::metastore* metastore, ss::scheduling_group reconciler_sg)
   : _l1_io(l1_io)
   , _metastore(metastore)
   , _scheduler(
@@ -70,11 +71,15 @@ reconciler::reconciler(l1::io* l1_io, l1::metastore* metastore)
       config::shard_local_cfg()
         .cloud_topics_reconciliation_slowdown_blend.bind(),
       config::shard_local_cfg()
-        .cloud_topics_reconciliation_max_object_size.bind()) {}
+        .cloud_topics_reconciliation_max_object_size.bind())
+  , _reconciler_sg(reconciler_sg) {}
 
 ss::future<> reconciler::start() {
     _probe.setup_metrics();
-    ssx::spawn_with_gate(_gate, [this] { return reconciliation_loop(); });
+    ssx::spawn_with_gate(_gate, [this] {
+        return ss::with_scheduling_group(
+          _reconciler_sg, [this] { return reconciliation_loop(); });
+    });
     co_return;
 }
 

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -25,6 +25,7 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/core/scheduling.hh>
 #include <seastar/core/sharded.hh>
 
 #include <memory>
@@ -87,7 +88,7 @@ struct reconcile_error {
  */
 class reconciler {
 public:
-    reconciler(l1::io*, l1::metastore*);
+    reconciler(l1::io*, l1::metastore*, ss::scheduling_group);
 
     reconciler(const reconciler&) = delete;
     reconciler& operator=(const reconciler&) = delete;
@@ -270,6 +271,7 @@ private:
     ss::abort_source _as;
     reconciler_probe _probe;
     adaptive_interval _scheduler;
+    ss::scheduling_group _reconciler_sg;
 };
 
 } // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
@@ -20,6 +20,8 @@
 #include "model/tests/randoms.h"
 #include "test_utils/metrics.h"
 
+#include <seastar/core/scheduling.hh>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -62,7 +64,8 @@ public:
 private:
     unreliable_io _io;
     unreliable_metastore _metastore;
-    reconciler::reconciler _reconciler{&_io, &_metastore};
+    reconciler::reconciler _reconciler{
+      &_io, &_metastore, ss::default_scheduling_group()};
 };
 
 using ::testing::Gt;

--- a/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
@@ -20,6 +20,7 @@
 #include "model/tests/randoms.h"
 #include "test_utils/scoped_config.h"
 
+#include <seastar/core/scheduling.hh>
 #include <seastar/util/defer.hh>
 
 #include <gtest/gtest.h>
@@ -38,7 +39,7 @@ namespace {
 class ReconcilerTest : public testing::Test {
 public:
     ReconcilerTest()
-      : _reconciler(&_io, &_metastore) {}
+      : _reconciler(&_io, &_metastore, ss::default_scheduling_group()) {}
 
     ss::shared_ptr<fake_source> add_source(
       std::optional<model::topic> tp = std::nullopt,

--- a/src/v/resource_mgmt/cpu_scheduling.h
+++ b/src/v/resource_mgmt/cpu_scheduling.h
@@ -127,6 +127,11 @@ public:
          */
         _cloud_topics_compaction = co_await ss::create_scheduling_group(
           "cloud_topics_compaction", 150);
+        /**
+         * Cloud topics reconciler scheduling group.
+         */
+        _cloud_topics_reconciler = co_await ss::create_scheduling_group(
+          "cloud_topics_reconciler", 150);
     }
 
     ss::scheduling_group admin_sg() { return _admin; }
@@ -170,6 +175,10 @@ public:
 
     ss::scheduling_group cluster_linking_sg() { return _cluster_linking; }
 
+    ss::scheduling_group cloud_topics_reconciler_sg() {
+        return _cloud_topics_reconciler;
+    }
+
     std::vector<std::reference_wrapper<const ss::scheduling_group>>
     all_scheduling_groups() const {
         return {
@@ -190,7 +199,8 @@ public:
           std::cref(_produce),
           std::cref(_ts_read),
           std::cref(_cluster_linking),
-          std::cref(_cloud_topics_compaction)};
+          std::cref(_cloud_topics_compaction),
+          std::cref(_cloud_topics_reconciler)};
     }
 
 private:
@@ -215,4 +225,5 @@ private:
     ss::scheduling_group _ts_read;
     ss::scheduling_group _cluster_linking;
     ss::scheduling_group _cloud_topics_compaction;
+    ss::scheduling_group _cloud_topics_reconciler;
 };


### PR DESCRIPTION
## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
