### PR TITLE
rptest/clients: remove redundant kubectl config command

### DIFF
--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -148,37 +148,6 @@ class KubectlTool:
                 p = ["env", "PATH=/usr/local/bin:/usr/bin:/bin:/snap/bin"]
                 breakglass_cmd = p + breakglass_cmd
             self._ssh_cmd(breakglass_cmd)
-
-            # Determine the appropriate command for the cloud provider
-            self._redpanda.logger.info(
-                f"Setting up kubectl config for provider: {self._provider}"
-            )
-
-            config_cmd = {
-                "aws": [
-                    "awscli2",
-                    "eks",
-                    "update-kubeconfig",
-                    "--name",
-                    f"redpanda-{self._cluster_id}",
-                    "--region",
-                    self._region,
-                ],
-                "gcp": [
-                    "gcloud",
-                    "container",
-                    "clusters",
-                    "get-credentials",
-                    f"redpanda-{self._cluster_id}",
-                    "--region",
-                    self._region,
-                ],
-                "azure": ["kubectl", "get", "nodes"],
-            }[self._provider]
-
-            # Log the full command to be executed
-            self._redpanda.logger.debug(f"Config command: {config_cmd}")
-            self._ssh_cmd(config_cmd)
             self._kubectl_installed = True
 
     @property


### PR DESCRIPTION
The break-glass script already properly configs kubectl auth so there is no need to do so again here. Futhermore the config here had become stale resulting in it breaking kubectl on GCP.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
