### PR TITLE
[CORE-14828] Cloud Topics: Expand housekeeper to detect idle partitions and bump epochs accordingly.

### DIFF
--- a/src/v/cloud_topics/housekeeper/BUILD
+++ b/src/v/cloud_topics/housekeeper/BUILD
@@ -9,6 +9,7 @@ redpanda_cc_library(
     deps = [
         "//src/v/base",
         "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics:types",
         "//src/v/cloud_topics/level_one/metastore",
         "//src/v/config",
         "//src/v/model",
@@ -26,6 +27,8 @@ redpanda_cc_library(
         ":housekeeper",
         "//src/v/base",
         "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics:state_accessors",
+        "//src/v/cloud_topics/frontend",
         "//src/v/cloud_topics/level_one/metastore",
         "//src/v/cloud_topics/level_zero/stm:ctp_stm_api",
         "//src/v/cluster",

--- a/src/v/cloud_topics/housekeeper/housekeeper.cc
+++ b/src/v/cloud_topics/housekeeper/housekeeper.cc
@@ -19,6 +19,8 @@
 #include <chrono>
 #include <exception>
 
+using namespace std::chrono_literals;
+
 namespace cloud_topics {
 
 housekeeper::housekeeper(
@@ -75,11 +77,47 @@ ss::future<> housekeeper::do_housekeeping() {
     co_await sync_start_offset();
 }
 
+ss::future<> housekeeper::do_bump_epoch() {
+    auto curr_partition_epoch = _l0_metastore->estimate_inactive_epoch(_tidp);
+
+    if (curr_partition_epoch != _last_epoch) {
+        vlog(
+          cd_log.debug,
+          "{}: Epoch made progress ({} -> {}), nothing to do.",
+          _tidp,
+          _last_epoch,
+          curr_partition_epoch);
+        _last_epoch = curr_partition_epoch;
+        co_return;
+    }
+
+    vlog(
+      cd_log.debug,
+      "{}: Partition idle since last housekeeping interval, "
+      "force the epoch to advance.",
+      _tidp);
+
+    auto new_epoch = co_await _l0_metastore->get_current_cluster_epoch(
+      _tidp, &_as);
+    if (!new_epoch.has_value()) {
+        co_return;
+    }
+    vlog(
+      cd_log.debug,
+      "{}: Advance epoch: {} -> {}",
+      _tidp,
+      curr_partition_epoch,
+      new_epoch);
+    co_await _l0_metastore->advance_epoch(_tidp, new_epoch.value(), &_as);
+    co_await _l0_metastore->sync_to_next_placeholder(_tidp, &_as);
+}
+
 ss::future<> housekeeper::do_loop() {
     simple_time_jitter<ss::lowres_clock> jitter(_loop_interval());
     co_await ss::sleep_abortable<ss::lowres_clock>(jitter.next_duration(), _as);
     try {
         co_await do_housekeeping();
+        co_await do_bump_epoch();
     } catch (...) {
         auto ex = std::current_exception();
         vlogl(
@@ -92,7 +130,6 @@ ss::future<> housekeeper::do_loop() {
 }
 
 namespace {
-
 void handle_error(l1::metastore::errc ec) {
     switch (ec) {
     case l1::metastore::errc::missing_ntp:
@@ -122,9 +159,9 @@ ss::future<kafka::offset> housekeeper::do_bytes_retention(size_t size) {
 
 ss::future<kafka::offset>
 housekeeper::do_time_retention(std::chrono::milliseconds duration) {
-    // It's important that we get the offsets before the timequery, as the data
-    // could change after the timequery, and this way we ensure we don't delete
-    // all the data.
+    // It's important that we get the offsets before the timequery, as the
+    // data could change after the timequery, and this way we ensure we
+    // don't delete all the data.
     auto offsets_result = co_await _l1_metastore->get_offsets(_tidp);
     if (!offsets_result.has_value()) {
         handle_error(offsets_result.error());

--- a/src/v/cloud_topics/housekeeper/housekeeper.h
+++ b/src/v/cloud_topics/housekeeper/housekeeper.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_topics/level_one/metastore/metastore.h"
+#include "cloud_topics/types.h"
 #include "config/property.h"
 #include "model/fundamental.h"
 
@@ -118,6 +119,8 @@ public:
     // Public for testing.
     ss::future<> do_housekeeping();
 
+    ss::future<> do_bump_epoch();
+
 private:
     ss::future<> do_loop();
     ss::future<kafka::offset> do_bytes_retention(size_t size);
@@ -134,6 +137,8 @@ private:
     config::binding<std::chrono::milliseconds> _loop_interval;
     ss::gate _gate;
     ss::abort_source _as;
+
+    std::optional<cloud_topics::cluster_epoch> _last_epoch;
 };
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/housekeeper/housekeeper.h
+++ b/src/v/cloud_topics/housekeeper/housekeeper.h
@@ -59,6 +59,24 @@ public:
         virtual kafka::offset
         get_max_allowed_start_offset(const model::topic_id_partition&)
           = 0;
+
+        virtual std::optional<cloud_topics::cluster_epoch>
+        estimate_inactive_epoch(const model::topic_id_partition&) noexcept = 0;
+
+        virtual ss::future<std::optional<cloud_topics::cluster_epoch>>
+        get_current_cluster_epoch(
+          const model::topic_id_partition&, ss::abort_source*) noexcept
+          = 0;
+
+        virtual ss::future<> advance_epoch(
+          const model::topic_id_partition& tidp,
+          cloud_topics::cluster_epoch,
+          ss::abort_source*) noexcept
+          = 0;
+
+        virtual ss::future<> sync_to_next_placeholder(
+          const model::topic_id_partition& tidp, ss::abort_source*) noexcept
+          = 0;
     };
 
     // A wrapper around a source of configuration for a give topic id +

--- a/src/v/cloud_topics/housekeeper/manager.cc
+++ b/src/v/cloud_topics/housekeeper/manager.cc
@@ -10,9 +10,11 @@
 
 #include "cloud_topics/housekeeper/manager.h"
 
+#include "cloud_topics/frontend/frontend.h"
 #include "cloud_topics/housekeeper/housekeeper.h"
 #include "cloud_topics/level_zero/stm/ctp_stm_api.h"
 #include "cloud_topics/logger.h"
+#include "cloud_topics/state_accessors.h"
 #include "config/configuration.h"
 #include "model/timeout_clock.h"
 #include "utils/retry_chain_node.h"
@@ -64,6 +66,59 @@ public:
         return lowest_pinned.value();
     }
 
+    std::optional<cloud_topics::cluster_epoch> estimate_inactive_epoch(
+      const model::topic_id_partition& tidp) noexcept override {
+        try {
+            return get_api(tidp).estimate_inactive_epoch();
+        } catch (...) {
+            auto ex = std::current_exception();
+            vlog(cd_log.warn, "Error collecting inactive epoch... {}", ex);
+            return std::nullopt;
+        }
+    }
+    ss::future<std::optional<cloud_topics::cluster_epoch>>
+    get_current_cluster_epoch(
+      const model::topic_id_partition& tidp,
+      ss::abort_source* as) noexcept override {
+        auto res = co_await get_frontend(tidp).get_current_epoch(*as);
+        if (!res.has_value()) {
+            co_return std::nullopt;
+        }
+        co_return res.value();
+    }
+
+    ss::future<> advance_epoch(
+      const model::topic_id_partition& tidp,
+      cloud_topics::cluster_epoch epoch,
+      ss::abort_source* as) noexcept override {
+        try {
+            auto res = co_await get_api(tidp).advance_epoch(
+              epoch, model::timeout_clock::now() + 5s, *as);
+            if (!res.has_value()) {
+                throw std::runtime_error(fmt::format("{}", res.error()));
+            }
+        } catch (...) {
+            auto ex = std::current_exception();
+            vlog(cd_log.warn, "Error advancing epoch: {}", ex);
+        }
+    }
+
+    ss::future<> sync_to_next_placeholder(
+      const model::topic_id_partition& tidp,
+      ss::abort_source* as) noexcept override {
+        try {
+            auto res = co_await get_api(tidp).sync_to_next_placeholder(
+              model::timeout_clock::now() + 5s, *as);
+            if (!res.has_value()) {
+                throw std::runtime_error(fmt::format("{}", res.error()));
+            }
+        } catch (...) {
+            auto ex = std::current_exception();
+            vlog(cd_log.warn, "Error advancing LRLO to epoch window: {}", ex);
+        }
+        co_return;
+    }
+
 private:
     ctp_stm_api get_api(const model::topic_id_partition& tidp) {
         auto& state = _state->at(tidp);
@@ -72,6 +127,17 @@ private:
             throw std::runtime_error(fmt::format("no ctp_stm for {}", tidp));
         }
         return ctp_stm_api(stm);
+    }
+
+    cloud_topics::frontend get_frontend(const model::topic_id_partition& tidp) {
+        auto& state = _state->at(tidp);
+        auto ct_state = state.partition->get_cloud_topics_state();
+        if (ct_state == nullptr || !ct_state->local_is_initialized()) {
+            throw std::runtime_error(
+              fmt::format("no cloud topics state for {}", tidp));
+        }
+        return cloud_topics::frontend{
+          state.partition, ct_state->local().get_data_plane()};
     }
 
     chunked_hash_map<model::topic_id_partition, housekeeper_manager::state>*

--- a/src/v/cloud_topics/housekeeper/tests/housekeeper_test.cc
+++ b/src/v/cloud_topics/housekeeper/tests/housekeeper_test.cc
@@ -205,8 +205,8 @@ public:
           &_l0_metastore,
           &_l1_metastore,
           _config_impl.get(),
-          config::mock_binding(1ms)};
-    };
+          config::mock_binding<std::chrono::milliseconds>(1ms)};
+    }
 
     kafka::offset start_offset() const { return _l0_metastore.start_offset(); }
 
@@ -254,6 +254,28 @@ public:
         objects.push_back(std::move(obj));
         handle_error(_l1_metastore.add_objects(objects, term_map).get());
     }
+
+    // Epoch-related test helpers
+    void set_estimated_inactive_epoch(
+      std::optional<cloud_topics::cluster_epoch> epoch) {
+        _l0_metastore.set_estimated_inactive_epoch(epoch);
+    }
+
+    void set_current_cluster_epoch(
+      std::optional<cloud_topics::cluster_epoch> epoch) {
+        _l0_metastore.set_current_cluster_epoch(epoch);
+    }
+
+    const std::vector<cloud_topics::cluster_epoch>&
+    advance_epoch_calls() const {
+        return _l0_metastore.advance_epoch_calls();
+    }
+
+    size_t sync_to_next_placeholder_calls() const {
+        return _l0_metastore.sync_to_next_placeholder_calls();
+    }
+
+    void reset_epoch_call_tracking() { _l0_metastore.reset_call_tracking(); }
 
 private:
     model::topic_id_partition _tidp{
@@ -699,4 +721,122 @@ TEST_F(HousekeeperTest, MaxAllowedStartOffsetDoesNotLimitWhenHigher) {
     housekeeper.do_housekeeping().get();
     // Should advance to 50 as normal, not limited by max_allowed
     EXPECT_EQ(start_offset(), kafka::offset{50});
+}
+
+// Tests for do_bump_epoch()
+
+TEST_F(HousekeeperTest, BumpEpochProgressNaturally) {
+    // When the estimated_inactive_epoch changes between calls, the housekeeper
+    // should NOT force an epoch advance.
+    auto housekeeper = make_housekeeper({});
+
+    set_estimated_inactive_epoch(cloud_topics::cluster_epoch{1});
+    set_current_cluster_epoch(cloud_topics::cluster_epoch{5});
+
+    // First call - epoch changes from initial (nullopt/min) to 1
+    housekeeper.do_bump_epoch().get();
+    EXPECT_TRUE(advance_epoch_calls().empty());
+    EXPECT_EQ(sync_to_next_placeholder_calls(), 0);
+
+    // Change the estimated epoch before next call
+    set_estimated_inactive_epoch(cloud_topics::cluster_epoch{2});
+
+    // Second call - epoch changed again, so no forced advance
+    housekeeper.do_bump_epoch().get();
+    EXPECT_TRUE(advance_epoch_calls().empty());
+    EXPECT_EQ(sync_to_next_placeholder_calls(), 0);
+}
+
+TEST_F(HousekeeperTest, BumpEpochIdleTriggersAdvance) {
+    // When estimated_inactive_epoch stays the same across a housekeeping
+    // interval, housekeeper should force an epoch advance.
+    auto housekeeper = make_housekeeper({});
+
+    set_estimated_inactive_epoch(cloud_topics::cluster_epoch{1});
+    set_current_cluster_epoch(cloud_topics::cluster_epoch{5});
+
+    // First call - initializes _last_epoch
+    housekeeper.do_bump_epoch().get();
+    EXPECT_TRUE(advance_epoch_calls().empty());
+
+    // Second call - same epoch, should trigger advance
+    housekeeper.do_bump_epoch().get();
+    ASSERT_EQ(advance_epoch_calls().size(), 1);
+    EXPECT_EQ(advance_epoch_calls()[0], cloud_topics::cluster_epoch{5});
+    EXPECT_EQ(sync_to_next_placeholder_calls(), 1);
+}
+
+TEST_F(HousekeeperTest, BumpEpochGetCurrentEpochReturnsNullopt) {
+    // When get_current_cluster_epoch returns nullopt, we should not call
+    // advance_epoch even if the partition is idle.
+    auto housekeeper = make_housekeeper({});
+
+    set_estimated_inactive_epoch(cloud_topics::cluster_epoch{1});
+    set_current_cluster_epoch(std::nullopt); // Simulate failure to get epoch
+
+    // First call - initializes _last_epoch
+    housekeeper.do_bump_epoch().get();
+    EXPECT_TRUE(advance_epoch_calls().empty());
+
+    // Second call - idle but get_current_cluster_epoch returns nullopt
+    housekeeper.do_bump_epoch().get();
+    EXPECT_TRUE(advance_epoch_calls().empty());
+    EXPECT_EQ(sync_to_next_placeholder_calls(), 0);
+}
+
+TEST_F(HousekeeperTest, BumpEpochForcedAdvanceKeepsLastEpoch) {
+    // After a forced epoch advance, _last_epoch is NOT updated. When the
+    // estimated epoch catches up to reflect the advance, the next call sees
+    // that as natural progress (no forced advance needed).
+    auto housekeeper = make_housekeeper({});
+
+    set_estimated_inactive_epoch(cloud_topics::cluster_epoch{1});
+    set_current_cluster_epoch(cloud_topics::cluster_epoch{5});
+
+    // First call - initializes _last_epoch to 1
+    housekeeper.do_bump_epoch().get();
+
+    // Second call - same epoch, triggers forced advance
+    housekeeper.do_bump_epoch().get();
+    ASSERT_EQ(advance_epoch_calls().size(), 1);
+    EXPECT_EQ(sync_to_next_placeholder_calls(), 1);
+
+    // Simulate the estimated epoch catching up (as would happen after advance)
+    set_estimated_inactive_epoch(cloud_topics::cluster_epoch{5});
+    reset_epoch_call_tracking();
+
+    // Next call sees epoch progress (1 -> 5), so no forced advance
+    housekeeper.do_bump_epoch().get();
+    EXPECT_TRUE(advance_epoch_calls().empty());
+    EXPECT_EQ(sync_to_next_placeholder_calls(), 0);
+}
+
+TEST_F(HousekeeperTest, BumpEpochMultipleIdleCycles) {
+    // Test multiple idle cycles - after advancing, if the partition goes idle
+    // again, it should trigger another advance.
+    auto housekeeper = make_housekeeper({});
+
+    set_estimated_inactive_epoch(cloud_topics::cluster_epoch{1});
+    set_current_cluster_epoch(cloud_topics::cluster_epoch{5});
+
+    // First cycle: init -> advance
+    housekeeper.do_bump_epoch().get();
+    housekeeper.do_bump_epoch().get();
+    ASSERT_EQ(advance_epoch_calls().size(), 1);
+    EXPECT_EQ(advance_epoch_calls()[0], cloud_topics::cluster_epoch{5});
+
+    // Simulate epoch catching up after forced advance, with new cluster epoch
+    set_estimated_inactive_epoch(cloud_topics::cluster_epoch{5});
+    set_current_cluster_epoch(cloud_topics::cluster_epoch{10});
+    reset_epoch_call_tracking();
+
+    // Sees progress (1 -> 5) since _last_epoch was preserved at 1
+    housekeeper.do_bump_epoch().get();
+    EXPECT_TRUE(advance_epoch_calls().empty());
+
+    // Second cycle: idle again (epoch 5 unchanged) -> advance to 10
+    housekeeper.do_bump_epoch().get();
+    ASSERT_EQ(advance_epoch_calls().size(), 1);
+    EXPECT_EQ(advance_epoch_calls()[0], cloud_topics::cluster_epoch{10});
+    EXPECT_EQ(sync_to_next_placeholder_calls(), 1);
 }

--- a/src/v/cloud_topics/housekeeper/tests/housekeeper_test.cc
+++ b/src/v/cloud_topics/housekeeper/tests/housekeeper_test.cc
@@ -60,14 +60,80 @@ public:
         return _max_allowed_start_offset;
     }
 
+    std::optional<cloud_topics::cluster_epoch> estimate_inactive_epoch(
+      const model::topic_id_partition&) noexcept override {
+        return _estimated_inactive_epoch;
+    }
+
+    ss::future<std::optional<cloud_topics::cluster_epoch>>
+    get_current_cluster_epoch(
+      const model::topic_id_partition&, ss::abort_source*) noexcept override {
+        co_return _current_cluster_epoch;
+    }
+
+    ss::future<> advance_epoch(
+      const model::topic_id_partition& tidp,
+      cloud_topics::cluster_epoch epoch,
+      ss::abort_source*) noexcept override {
+        if (tidp == _tidp) {
+            _advance_epoch_calls.push_back(epoch);
+        }
+        co_return;
+    }
+
+    ss::future<> sync_to_next_placeholder(
+      const model::topic_id_partition& tidp,
+      ss::abort_source*) noexcept override {
+        if (tidp == _tidp) {
+            ++_sync_to_next_placeholder_calls;
+        }
+        co_return;
+    }
+
     void set_max_allowed_start_offset(kafka::offset offset) {
         _max_allowed_start_offset = offset;
+    }
+
+    // Setters for epoch-related test configuration
+    void set_estimated_inactive_epoch(
+      std::optional<cloud_topics::cluster_epoch> epoch) {
+        _estimated_inactive_epoch = epoch;
+    }
+
+    void set_current_cluster_epoch(
+      std::optional<cloud_topics::cluster_epoch> epoch) {
+        _current_cluster_epoch = epoch;
+    }
+
+    // Accessors for verifying calls
+    const std::vector<cloud_topics::cluster_epoch>&
+    advance_epoch_calls() const {
+        return _advance_epoch_calls;
+    }
+
+    size_t sync_to_next_placeholder_calls() const {
+        return _sync_to_next_placeholder_calls;
+    }
+
+    void reset_call_tracking() {
+        _advance_epoch_calls.clear();
+        _sync_to_next_placeholder_calls = 0;
     }
 
 private:
     model::topic_id_partition _tidp;
     kafka::offset _start_offset;
     kafka::offset _max_allowed_start_offset;
+
+    // Epoch-related state
+    std::optional<cloud_topics::cluster_epoch> _estimated_inactive_epoch
+      = cloud_topics::cluster_epoch::min();
+    std::optional<cloud_topics::cluster_epoch> _current_cluster_epoch
+      = cloud_topics::cluster_epoch{1};
+
+    // Call tracking
+    std::vector<cloud_topics::cluster_epoch> _advance_epoch_calls;
+    size_t _sync_to_next_placeholder_calls{0};
 };
 
 struct simple_retention_config {

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
@@ -138,12 +138,17 @@ ctp_stm_api::advance_reconciled_offset(
     if (lro <= get_last_reconciled_offset()) {
         co_return std::monostate{};
     }
-    vlog(_log.debug, "Replicating ctp_stm_cmd::advance_reconciled_offset");
+
+    auto lrlo = _stm->_raft->log()->to_log_offset(kafka::offset_cast(lro));
+
+    vlog(
+      _log.debug,
+      "Replicating ctp_stm_cmd::advance_reconciled_offset{{lro:{} lrlo:{}}}",
+      lro,
+      lrlo);
 
     storage::record_batch_builder builder(
       model::record_batch_type::ctp_stm_command, model::offset(0));
-
-    auto lrlo = _stm->_raft->log()->to_log_offset(kafka::offset_cast(lro));
     builder.add_raw_kv(
       serde::to_iobuf(advance_reconciled_offset_cmd::key),
       serde::to_iobuf(advance_reconciled_offset_cmd(lro, lrlo)));

--- a/tests/rptest/tests/cloud_topics/l0_gc_test.py
+++ b/tests/rptest/tests/cloud_topics/l0_gc_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from typing import TypeAlias, cast
+from typing import Any, TypeAlias, cast
 
 from rptest.clients.admin.v2 import Admin, l0_gc_pb
 from rptest.context.cloud_storage import CloudStorageType
@@ -32,13 +32,14 @@ from rptest.util import expect_exception
 
 
 class CloudTopicsL0GCTestBase(RedpandaTest):
-    def __init__(self, test_context: TestContext):
+    def __init__(self, test_context: TestContext, extra_conf: dict[str, Any] = {}):
         self.test_context = test_context
         si_settings = SISettings(
             test_context=test_context,
             cloud_storage_max_connections=10,
             cloud_storage_enable_remote_read=False,
             cloud_storage_enable_remote_write=False,
+            cloud_storage_housekeeping_interval_ms=1000,
             fast_uploads=True,
         )
         extra_rp_conf = {
@@ -51,6 +52,7 @@ class CloudTopicsL0GCTestBase(RedpandaTest):
             "cloud_topics_short_term_gc_interval": 2000,
             "cloud_topics_short_term_gc_backoff_interval": 10000,
         }
+        extra_rp_conf.update(extra_conf)
         super().__init__(
             test_context=test_context,
             extra_rp_conf=extra_rp_conf,
@@ -108,6 +110,32 @@ class CloudTopicsL0GCTest(CloudTopicsL0GCTestBase):
             retry_on_exc=True,
         )
 
+    @cluster(num_nodes=4)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
+    def test_idle_housekeeping(self, cloud_storage_type: CloudStorageType):
+        self.topics = [
+            TopicSpec(partition_count=2),
+            TopicSpec(
+                # more partitions to show per-partition epoch bump
+                partition_count=4
+            ),
+        ]
+        self.create_topics(self.topics)
+        self.logger.debug(
+            "Produce to only one topic, so only the housekeeping loop can progress the max collectible epoch"
+        )
+        self.produce_some(topics=[self.topics[0].name])
+
+        self.logger.debug(
+            f"GC should still make progress because the housekeeping loop kicks in and bumps the epoch on each {self.topics[1].name} partition"
+        )
+        wait_until(
+            lambda: self.get_num_objects_deleted() > 0,
+            timeout_sec=30,
+            backoff_sec=5,
+            retry_on_exc=True,
+        )
+
 
 GcStatus: TypeAlias = l0_gc_pb.Status
 StatusReport: TypeAlias = dict[int, dict[int, GcStatus] | str]
@@ -117,6 +145,15 @@ class CloudTopicsL0GCAdminTest(CloudTopicsL0GCTestBase):
     """
     Integration: Admin API rpcs for starting and stopping level zero garbage collection.
     """
+
+    def __init__(self, test_context: TestContext):
+        # Use a long housekeeping interval so that the housekeeper does not
+        # auto-advance epochs during the test; we want to observe the effect
+        # of manually bumping a specific partition's epoch via Admin rpc.
+        extra_conf = {
+            "cloud_storage_housekeeping_interval_ms": 10 * 60 * 60 * 1000,
+        }
+        super().__init__(test_context=test_context, extra_conf=extra_conf)
 
     @property
     def l0_gc_client(self):


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Builds on #29536

Also introduces a new cluster config `cloud_topics_idle_partition_timeout`, which controls the duration across which a cloud topic partitions epoch can remain unchanged before the housekeeper will force it to the current cluster epoch.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
