### PR TITLE
[v25.3.x] kafka/client: fix race condition in direct_consumer_test

### DIFF
--- a/src/v/kafka/client/direct_consumer/tests/direct_consumer_test.cc
+++ b/src/v/kafka/client/direct_consumer/tests/direct_consumer_test.cc
@@ -646,10 +646,14 @@ TEST_F(consumer_test_mock, TestOffsetResetPolicy) {
     }
     // add more data to partition 1
     make_data_available(test_topic, 1, 6);
-    fetch_and_append_to_map(all_batches, consumer).get();
-    ASSERT_EQ(
-      all_batches[test_topic][model::partition_id(1)].front().base_offset(),
-      model::offset(430));
+    auto& p1_batches = all_batches[test_topic][model::partition_id(1)];
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+        return fetch_and_append_to_map(all_batches, consumer).then([&] {
+            return !p1_batches.empty();
+        });
+    });
+
+    ASSERT_EQ(p1_batches.front().base_offset(), model::offset(430));
 }
 TEST_F(consumer_test_mock, TestFetchErrorPropagation) {
     prepare_cluster();


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/29527
