### PR TITLE
ct: add loop for flushing metastore

### DIFF
--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -25,6 +25,18 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "test_fixture_cfg",
+    hdrs = [
+        "test_fixture_cfg.h",
+    ],
+    visibility = [
+        "//src/v/cloud_topics/tests:__pkg__",
+        "//src/v/redpanda:__pkg__",
+        "//src/v/redpanda/tests:__pkg__",
+    ],
+)
+
+redpanda_cc_library(
     name = "types",
     srcs = [
         "types.cc",
@@ -80,6 +92,7 @@ redpanda_cc_library(
         ":cluster_services_interface",
         ":data_plane_impl",
         "//src/v/cloud_topics/housekeeper:manager",
+        "//src/v/cloud_topics/level_one/metastore:flush_loop",
         "//src/v/cloud_topics/level_one/metastore:topic_purger",
         "//src/v/cloud_topics/level_zero/gc:level_zero_gc",
         "//src/v/cloud_topics/manager",

--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -15,6 +15,7 @@
 #include "cloud_topics/data_plane_impl.h"
 #include "cloud_topics/housekeeper/manager.h"
 #include "cloud_topics/level_one/compaction/scheduler.h"
+#include "cloud_topics/level_one/metastore/flush_loop.h"
 #include "cloud_topics/level_one/metastore/topic_purger.h"
 #include "cloud_topics/level_zero/gc/level_zero_gc.h"
 #include "cloud_topics/manager/manager.h"
@@ -44,7 +45,8 @@ ss::future<> app::construct(
   ss::sharded<cluster::metadata_cache>* metadata_cache,
   ss::sharded<rpc::connection_cache>* connection_cache,
   cloud_storage_clients::bucket_name bucket,
-  ss::sharded<storage::api>* storage) {
+  ss::sharded<storage::api>* storage,
+  bool skip_flush_loop) {
     data_plane = co_await make_data_plane(
       ssx::sformat("{}::data_plane", _logger_name),
       remote,
@@ -102,6 +104,13 @@ ss::future<> app::construct(
       &controller->get_topics_state(),
       &controller->get_topics_frontend());
 
+    if (!skip_flush_loop) {
+        co_await construct_service(
+          flush_loop_manager, ss::sharded_parameter([this] {
+              return &replicated_metastore.local();
+          }));
+    }
+
     co_await construct_service(
       reconciler,
       ss::sharded_parameter([this] { return &l1_io.local(); }),
@@ -151,6 +160,10 @@ ss::future<> app::start() {
     co_await housekeeper_manager.invoke_on_all(&housekeeper_manager::start);
     co_await compaction_scheduler->start();
     co_await l0_gc.invoke_on_all(&level_zero_gc::start);
+    if (flush_loop_manager.local_is_initialized()) {
+        co_await flush_loop_manager.invoke_on_all(
+          &l1::flush_loop_manager::start);
+    }
 
     // When start is called, we must have registered all the callbacks before
     // this as starting the manager will invoke callbacks for partitions already
@@ -173,6 +186,22 @@ ss::future<> app::wire_up_notifications() {
             purge_mgr.enqueue_loop_reset(needs_loop);
         });
     });
+    if (flush_loop_manager.local_is_initialized()) {
+        co_await flush_loop_manager.invoke_on_all([this](auto& flm) {
+            manager.local().on_l1_domain_leader(
+              [&flm](
+                const model::ntp& ntp,
+                const auto&,
+                const auto& partition) noexcept {
+                  if (ntp.tp.partition != model::partition_id{0}) {
+                      return;
+                  }
+                  auto needs_loop = l1::flush_loop_manager::needs_loop{
+                    bool(partition)};
+                  flm.enqueue_loop_reset(needs_loop);
+              });
+        });
+    }
     co_await housekeeper_manager.invoke_on_all([this](auto& hm) {
         manager.local().on_ctp_partition_leader(
           [&hm](

--- a/src/v/cloud_topics/app.h
+++ b/src/v/cloud_topics/app.h
@@ -40,6 +40,7 @@ class level_zero_gc;
 class housekeeper_manager;
 
 namespace l1 {
+class flush_loop_manager;
 class topic_purger_manager;
 } // namespace l1
 
@@ -63,7 +64,8 @@ public:
       ss::sharded<cluster::metadata_cache>*,
       ss::sharded<rpc::connection_cache>*,
       cloud_storage_clients::bucket_name,
-      ss::sharded<storage::api>*);
+      ss::sharded<storage::api>*,
+      bool skip_flush_loop = true);
 
     ss::future<> start();
 
@@ -92,6 +94,7 @@ private:
     ss::sharded<l1::domain_supervisor> domain_supervisor;
     ss::sharded<l1::leader_router> l1_metastore_router;
     ss::sharded<l1::topic_purger_manager> topic_purge_manager;
+    ss::sharded<l1::flush_loop_manager> flush_loop_manager;
     ss::sharded<cloud_topics_manager> manager;
     ss::sharded<level_zero_gc> l0_gc;
     ss::sharded<housekeeper_manager> housekeeper_manager;

--- a/src/v/cloud_topics/app.h
+++ b/src/v/cloud_topics/app.h
@@ -65,7 +65,7 @@ public:
       ss::sharded<rpc::connection_cache>*,
       cloud_storage_clients::bucket_name,
       ss::sharded<storage::api>*,
-      bool skip_flush_loop = true);
+      bool skip_flush_loop = false);
 
     ss::future<> start();
 

--- a/src/v/cloud_topics/level_one/metastore/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/BUILD
@@ -350,6 +350,30 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "flush_loop",
+    srcs = [
+        "flush_loop.cc",
+    ],
+    hdrs = [
+        "flush_loop.h",
+    ],
+    implementation_deps = [
+        ":metastore",
+        "//src/v/base",
+        "//src/v/cloud_topics:logger",
+        "//src/v/config",
+        "//src/v/ssx:semaphore",
+        "//src/v/ssx:time",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "//src/v/ssx:actor",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "extent_metadata_reader",
     srcs = [
         "extent_metadata_reader.cc",

--- a/src/v/cloud_topics/level_one/metastore/flush_loop.cc
+++ b/src/v/cloud_topics/level_one/metastore/flush_loop.cc
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "cloud_topics/level_one/metastore/flush_loop.h"
+
+#include "base/vlog.h"
+#include "cloud_topics/level_one/metastore/metastore.h"
+#include "cloud_topics/logger.h"
+#include "config/configuration.h"
+#include "ssx/semaphore.h"
+#include "ssx/time.h"
+
+namespace cloud_topics::l1 {
+
+// Loop that flushes the metastore periodically until stopped.
+class flush_loop {
+public:
+    explicit flush_loop(
+      metastore* metastore,
+      config::binding<std::chrono::milliseconds> flush_interval)
+      : metastore_(metastore)
+      , flush_interval_(std::move(flush_interval)) {
+        flush_interval_.watch([this] { sem_.signal(); });
+    }
+
+    void start() {
+        ssx::spawn_with_gate(gate_, [this] { return run_loop(); });
+    }
+
+    ss::future<> stop_and_wait() {
+        vlog(cd_log.debug, "Metastore flush loop stopping...");
+        as_.request_abort();
+        sem_.broken();
+        co_await gate_.close();
+        vlog(cd_log.debug, "Metastore flush loop stopped");
+    }
+
+private:
+    ss::future<> run_loop() {
+        const auto retry_interval = ssx::duration::seconds(10);
+        while (!as_.abort_requested()) {
+            auto start = ssx::instant::from_chrono(ss::lowres_clock::now());
+            auto res = co_await metastore_->flush();
+            auto finish = ssx::instant::from_chrono(ss::lowres_clock::now());
+
+            ssx::duration sleep_duration;
+            if (!res.has_value()) {
+                vlog(
+                  cd_log.warn,
+                  "Failed to flush metastore, retrying in {}: {}",
+                  retry_interval,
+                  res.error());
+                sleep_duration = retry_interval;
+            } else {
+                auto flush_interval = ssx::duration::from_chrono(
+                  flush_interval_());
+                auto flush_time = finish - start;
+                sleep_duration = flush_interval - flush_time;
+            }
+
+            if (sleep_duration > ssx::duration::zero()) {
+                try {
+                    co_await sem_.wait(
+                      sleep_duration.to_chrono<std::chrono::milliseconds>(),
+                      std::max(sem_.current(), size_t(1)));
+                } catch (const ss::semaphore_timed_out&) {
+                    // Time to wake up! Continue onto the next iteration.
+                } catch (...) {
+                    auto eptr = std::current_exception();
+                    auto log_lvl = ssx::is_shutdown_exception(eptr)
+                                     ? ss::log_level::debug
+                                     : ss::log_level::warn;
+                    vlogl(
+                      cd_log,
+                      log_lvl,
+                      "Metastore flush loop hit exception while sleeping: {}",
+                      eptr);
+                }
+            }
+        }
+    }
+
+    ss::gate gate_;
+    ss::abort_source as_;
+    metastore* metastore_;
+    config::binding<std::chrono::milliseconds> flush_interval_;
+    ssx::semaphore sem_{0, "flush_loop"};
+};
+
+flush_loop_manager::flush_loop_manager(metastore* metastore)
+  : metastore_(metastore) {}
+
+flush_loop_manager::~flush_loop_manager() = default;
+
+ss::future<> flush_loop_manager::reset_flush_loop(
+  flush_loop_manager::needs_loop needs_loop) {
+    if (!needs_loop) {
+        // We should not have a running loop. Stop it if one exists.
+        if (flush_loop_) {
+            auto loop = std::exchange(flush_loop_, nullptr);
+            auto stop_fut = co_await ss::coroutine::as_future(
+              loop->stop_and_wait());
+            if (stop_fut.failed()) {
+                auto ex = stop_fut.get_exception();
+                vlog(cd_log.error, "Stopping flush loop failed: {}", ex);
+            }
+        }
+        co_return;
+    }
+    if (flush_loop_) {
+        // We need a loop and already have one.
+        co_return;
+    }
+    auto loop = std::make_unique<flush_loop>(
+      metastore_,
+      config::shard_local_cfg().cloud_topics_long_term_flush_interval.bind());
+    loop->start();
+    flush_loop_ = std::move(loop);
+}
+
+void flush_loop_manager::enqueue_loop_reset(
+  flush_loop_manager::needs_loop needs_loop) {
+    tell(needs_loop);
+}
+
+ss::future<>
+flush_loop_manager::process(flush_loop_manager::needs_loop needs_loop) {
+    return reset_flush_loop(needs_loop);
+}
+
+void flush_loop_manager::on_error(std::exception_ptr ex) noexcept {
+    vlog(cd_log.error, "Unexpected flush loop manager error: {}", ex);
+}
+
+ss::future<> flush_loop_manager::stop() {
+    co_await actor::stop();
+    if (flush_loop_) {
+        auto fut = co_await ss::coroutine::as_future(
+          flush_loop_->stop_and_wait());
+        if (fut.failed()) {
+            auto ex = fut.get_exception();
+            vlog(cd_log.error, "Error stopping flush loop manager: {}", ex);
+        }
+    }
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/flush_loop.h
+++ b/src/v/cloud_topics/level_one/metastore/flush_loop.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "base/seastarx.h"
+#include "ssx/actor.h"
+
+#include <seastar/core/future.hh>
+
+#include <memory>
+
+namespace cloud_topics::l1 {
+
+class metastore;
+class flush_loop;
+
+// Manages a loop to flush the metastore that runs only on leadership of
+// partition 0 of the metastore topic. Under the hood, each flush will request
+// flushes of each partition, so it's sufficient to only run this on one
+// partition.
+//
+// TODO: it may be worth having each domain independently flush (e.g. if
+// there's a lull in traffic), and then have this loop request flushes if there
+// hasn't been a domain flush within some time bound. Giving some control to
+// individual domain could help us avoid potential added latencies that may
+// come from flushing while the domain is serving a high volume of requests.
+class flush_loop_manager
+  : public ssx::actor<
+      ss::bool_class<struct flush_needs_loop_tag>,
+      1,
+      ssx::overflow_policy::drop_oldest> {
+public:
+    using needs_loop = ss::bool_class<struct flush_needs_loop_tag>;
+
+    explicit flush_loop_manager(metastore* metastore);
+    ~flush_loop_manager() override;
+
+    // Enqueues a reset of the loop such that eventually a flush_loop will be
+    // running if needs_loop is true, or not running if false.
+    void enqueue_loop_reset(needs_loop needs);
+
+    ss::future<> stop() override;
+
+protected:
+    ss::future<> process(needs_loop needs) override;
+    void on_error(std::exception_ptr ex) noexcept override;
+
+private:
+    ss::future<> reset_flush_loop(needs_loop needs);
+
+    metastore* metastore_;
+    std::unique_ptr<flush_loop> flush_loop_;
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -41,9 +41,16 @@ public:
 
     bool is_lsm_backend() const { return GetParam() == metastore_backend::lsm; }
 
+    cloud_topics::test_fixture_cfg fixture_cfg() const {
+        return {
+          .use_lsm_metastore = is_lsm_backend(),
+          // Skip flushing since tests may exercise flushing.
+          .skip_flush_loop = true,
+        };
+    }
     void SetUp() override {
         for (size_t i = 0; i < num_brokers; i++) {
-            add_node(is_lsm_backend());
+            add_node(fixture_cfg());
         }
         wait_for_all_members(5s).get();
     }
@@ -1007,7 +1014,7 @@ TEST_P(ReplicatedMetastoreTest, TestBasicFlushAndRestore) {
     // Restart all nodes.
     // NOTE: the added nodes get the same node IDs 0, 1, 2.
     for (size_t i = 0; i < num_brokers; i++) {
-        add_node(is_lsm_backend());
+        add_node(fixture_cfg());
     }
     wait_for_all_members(5s).get();
 

--- a/src/v/cloud_topics/test_fixture_cfg.h
+++ b/src/v/cloud_topics/test_fixture_cfg.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+namespace cloud_topics {
+
+// Configuration for cloud topics test fixtures.
+struct test_fixture_cfg {
+    bool use_lsm_metastore{true};
+    bool skip_flush_loop{false};
+};
+
+} // namespace cloud_topics

--- a/src/v/cloud_topics/tests/BUILD
+++ b/src/v/cloud_topics/tests/BUILD
@@ -7,6 +7,7 @@ redpanda_test_cc_library(
     deps = [
         "//src/v/cloud_io/tests:s3_imposter",
         "//src/v/cloud_topics:app",
+        "//src/v/cloud_topics:test_fixture_cfg",
         "//src/v/cloud_topics/level_one/metastore:simple_stm",
         "//src/v/cluster/tests:cluster_test_fixture",
         "//src/v/kafka/server/tests:kafka_test_utils",

--- a/src/v/cloud_topics/tests/cluster_fixture.h
+++ b/src/v/cloud_topics/tests/cluster_fixture.h
@@ -14,6 +14,7 @@
 #include "cloud_topics/app.h"
 #include "cloud_topics/level_one/metastore/lsm/stm.h"
 #include "cloud_topics/level_one/metastore/simple_stm.h"
+#include "cloud_topics/test_fixture_cfg.h"
 #include "cluster/tests/cluster_test_fixture.h"
 #include "kafka/server/tests/produce_consume_utils.h"
 #include "model/fundamental.h"
@@ -39,7 +40,7 @@ public:
             remove_node_application(id);
         }
     }
-    void add_node(bool use_lsm_metastore = true) {
+    void add_node(cloud_topics::test_fixture_cfg ct_test_cfg = {}) {
         static constexpr int kafka_port_base = 9092;
         static constexpr int rpc_port_base = 11000;
         auto [s3_conf, a_conf, cs_conf] = get_cloud_storage_configurations(
@@ -60,7 +61,7 @@ public:
           /*cloud_topics_enabled=*/true,
           /*cluster_linking_enabled=*/false,
           /*seed_node_id=*/model::node_id{0},
-          use_lsm_metastore);
+          ct_test_cfg);
     }
 
     ss::future<kafka_produce_transport*> make_producer(model::node_id id) {

--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -122,7 +122,7 @@ public:
       bool iceberg_enabled = false,
       bool cloud_topics_enabled = false,
       bool cluster_linking_enabled = false,
-      bool use_lsm_metastore = false) {
+      cloud_topics::test_fixture_cfg ct_test_cfg = {}) {
         return std::make_unique<redpanda_thread_fixture>(
           node_id,
           kafka_port,
@@ -142,7 +142,7 @@ public:
           iceberg_enabled,
           cloud_topics_enabled,
           cluster_linking_enabled,
-          use_lsm_metastore);
+          ct_test_cfg);
     }
 
     void add_node(
@@ -163,7 +163,7 @@ public:
       bool iceberg_enabled = false,
       bool cloud_topics_enabled = false,
       bool cluster_linking_enabled = false,
-      bool use_lsm_metastore = true) {
+      cloud_topics::test_fixture_cfg ct_test_cfg = {}) {
         _instances.emplace(
           node_id,
           make_redpanda_fixture(
@@ -182,7 +182,7 @@ public:
             iceberg_enabled,
             cloud_topics_enabled,
             cluster_linking_enabled,
-            use_lsm_metastore));
+            ct_test_cfg));
     }
 
     application* get_node_application(model::node_id id) {
@@ -225,7 +225,7 @@ public:
       bool cloud_topics_enabled = false,
       bool cluster_linking_enabled = false,
       model::node_id seed_node_id = model::node_id{0},
-      bool use_lsm_metastore = true) {
+      cloud_topics::test_fixture_cfg ct_test_cfg = {}) {
         std::vector<config::seed_server> seeds = {};
         if (!empty_seed_starts_cluster_val || node_id != 0) {
             seeds.push_back(
@@ -250,7 +250,7 @@ public:
           iceberg_enabled,
           cloud_topics_enabled,
           cluster_linking_enabled,
-          use_lsm_metastore);
+          ct_test_cfg);
         return get_node_application(node_id);
     }
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4579,6 +4579,13 @@ configuration::configuration()
       "term storage.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5min)
+  , cloud_topics_long_term_flush_interval(
+      *this,
+      "cloud_topics_long_term_flush_interval",
+      "Time interval at which long term storage metadata is flushed to object "
+      "storage.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      10min)
   , cloud_topics_epoch_service_epoch_increment_interval(
       *this,
       "cloud_topics_epoch_service_epoch_increment_interval",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -790,6 +790,7 @@ public:
     bounded_property<uint64_t> cloud_topics_compaction_key_map_memory;
     property<std::chrono::milliseconds>
       cloud_topics_long_term_garbage_collection_interval;
+    property<std::chrono::milliseconds> cloud_topics_long_term_flush_interval;
     property<std::chrono::milliseconds>
       cloud_topics_epoch_service_epoch_increment_interval;
     property<std::chrono::milliseconds>

--- a/src/v/redpanda/BUILD
+++ b/src/v/redpanda/BUILD
@@ -30,6 +30,7 @@ redpanda_cc_library(
         "//src/v/cloud_storage",
         "//src/v/cloud_storage_clients",
         "//src/v/cloud_topics:app",
+        "//src/v/cloud_topics:test_fixture_cfg",
         "//src/v/cloud_topics/level_one/metastore:leader_router",
         "//src/v/cloud_topics/level_one/metastore:simple_stm",
         "//src/v/cloud_topics/level_one/metastore/lsm:stm",

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -14,6 +14,7 @@
 #include "base/seastarx.h"
 #include "cloud_storage/fwd.h"
 #include "cloud_topics/app.h"
+#include "cloud_topics/test_fixture_cfg.h"
 #include "cluster/archival/fwd.h"
 #include "cluster/config_manager.h"
 #include "cluster/fwd.h"
@@ -97,7 +98,9 @@ public:
       std::optional<YAML::Node> audit_log_client_cfg = std::nullopt);
     void check_environment();
     void wire_up_and_start(
-      ::stop_signal&, bool test_mode = false, bool use_lsm_metastore = true);
+      ::stop_signal&,
+      bool test_mode = false,
+      cloud_topics::test_fixture_cfg ct_test_cfg = {});
     void post_start_tasks();
 
     void init_crashtracker(::stop_signal& app_signal);
@@ -224,13 +227,16 @@ private:
     void start_bootstrap_services();
 
     // Constructs services across shards meant for Redpanda runtime.
-    void
-    wire_up_runtime_services(model::node_id node_id, ::stop_signal& app_signal);
+    void wire_up_runtime_services(
+      model::node_id node_id,
+      ::stop_signal& app_signal,
+      cloud_topics::test_fixture_cfg ct_test_cfg);
     void configure_admin_server(model::node_id);
     void wire_up_redpanda_services(
       model::node_id,
       ::stop_signal& app_signal,
-      std::optional<cloud_storage_clients::bucket_name>& bucket_name);
+      std::optional<cloud_storage_clients::bucket_name>& bucket_name,
+      cloud_topics::test_fixture_cfg ct_test_cfg);
 
     void load_feature_table_snapshot();
 
@@ -239,7 +245,9 @@ private:
     // Starts the services meant for Redpanda runtime. Must be called after
     // having constructed the subsystems via the corresponding `wire_up` calls.
     void start_runtime_services(
-      cluster::cluster_discovery&, ::stop_signal&, bool use_lsm_metastore);
+      cluster::cluster_discovery&,
+      ::stop_signal&,
+      cloud_topics::test_fixture_cfg ct_test_cfg);
     void start_kafka(const model::node_id&, ::stop_signal&);
     void add_runtime_rpc_services(rpc::rpc_server&, bool start_raft_rpc_early);
 

--- a/src/v/redpanda/application_bootstrap.cc
+++ b/src/v/redpanda/application_bootstrap.cc
@@ -385,7 +385,9 @@ void application::start_bootstrap_services() {
 }
 
 void application::wire_up_and_start(
-  ::stop_signal& app_signal, bool test_mode, bool use_lsm_metastore) {
+  ::stop_signal& app_signal,
+  bool test_mode,
+  cloud_topics::test_fixture_cfg ct_test_cfg) {
     // Setup the app level abort service
     construct_service(_as).get();
 
@@ -510,7 +512,7 @@ void application::wire_up_and_start(
       node_id,
       storage.local().get_cluster_uuid());
 
-    wire_up_runtime_services(node_id, app_signal);
+    wire_up_runtime_services(node_id, app_signal, ct_test_cfg);
 
     if (test_mode) {
         // When running inside a unit test fixture, we may fast-forward
@@ -545,7 +547,7 @@ void application::wire_up_and_start(
         controller->set_ready().get();
     }
 
-    start_runtime_services(cd, app_signal, use_lsm_metastore);
+    start_runtime_services(cd, app_signal, ct_test_cfg);
 
     if (_proxy_config && !config::node().recovery_mode_enabled) {
         _proxy->start().get();

--- a/src/v/redpanda/application_runtime.cc
+++ b/src/v/redpanda/application_runtime.cc
@@ -38,9 +38,11 @@
 #include <seastar/core/metrics.hh>
 
 void application::wire_up_runtime_services(
-  model::node_id node_id, ::stop_signal& app_signal) {
+  model::node_id node_id,
+  ::stop_signal& app_signal,
+  cloud_topics::test_fixture_cfg ct_test_cfg) {
     std::optional<cloud_storage_clients::bucket_name> bucket;
-    wire_up_redpanda_services(node_id, app_signal, bucket);
+    wire_up_redpanda_services(node_id, app_signal, bucket, ct_test_cfg);
     if (_proxy_config) {
         construct_single_service(
           _proxy,

--- a/src/v/redpanda/application_services.cc
+++ b/src/v/redpanda/application_services.cc
@@ -82,7 +82,8 @@ make_upload_controller_config(ss::scheduling_group sg, uint64_t fs_avail);
 void application::wire_up_redpanda_services(
   model::node_id node_id,
   ::stop_signal& app_signal,
-  std::optional<cloud_storage_clients::bucket_name>& bucket_name) {
+  std::optional<cloud_storage_clients::bucket_name>& bucket_name,
+  cloud_topics::test_fixture_cfg ct_test_cfg) {
     ss::smp::invoke_on_all([] {
         resources::available_memory::local().register_metrics();
     }).get();
@@ -717,7 +718,8 @@ void application::wire_up_redpanda_services(
             &metadata_cache,
             &_connection_cache,
             bucket_name.value(),
-            &storage)
+            &storage,
+            ct_test_cfg.skip_flush_loop)
           .get();
     }
 

--- a/src/v/redpanda/application_start.cc
+++ b/src/v/redpanda/application_start.cc
@@ -57,13 +57,13 @@
 void application::start_runtime_services(
   cluster::cluster_discovery& cd,
   ::stop_signal& app_signal,
-  bool use_lsm_metastore) {
+  cloud_topics::test_fixture_cfg ct_test_cfg) {
     // single instance
     node_status_backend.invoke_on_all(&cluster::node_status_backend::start)
       .get();
     syschecks::systemd_message("Starting the partition manager").get();
     partition_manager
-      .invoke_on_all([this, use_lsm_metastore](cluster::partition_manager& pm) {
+      .invoke_on_all([this, ct_test_cfg](cluster::partition_manager& pm) {
           pm.register_factory<cluster::tm_stm_factory>();
           pm.register_factory<cluster::id_allocator_stm_factory>();
           pm.register_factory<transform::transform_offsets_stm_factory>();
@@ -89,7 +89,7 @@ void application::start_runtime_services(
             config::shard_local_cfg().iceberg_enabled());
           if (config::shard_local_cfg().cloud_topics_enabled()) {
               pm.register_factory<cloud_topics::l0::ctp_stm_factory>();
-              if (use_lsm_metastore) {
+              if (ct_test_cfg.use_lsm_metastore) {
                   pm.register_factory<cloud_topics::l1::lsm_stm_factory>();
               } else {
                   pm.register_factory<cloud_topics::l1::stm_factory>();

--- a/src/v/redpanda/tests/BUILD
+++ b/src/v/redpanda/tests/BUILD
@@ -45,6 +45,7 @@ redpanda_test_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/cloud_io/tests:s3_imposter",
+        "//src/v/cloud_topics:test_fixture_cfg",
         "//src/v/redpanda:application",
         "//src/v/test_utils:async",
         "@seastar",

--- a/src/v/redpanda/tests/fixture.cc
+++ b/src/v/redpanda/tests/fixture.cc
@@ -95,7 +95,7 @@ redpanda_thread_fixture::redpanda_thread_fixture(
   bool iceberg_enabled,
   bool enable_cloud_topics,
   bool development_cluster_linking_enabled,
-  bool use_lsm_metastore)
+  cloud_topics::test_fixture_cfg ct_test_cfg)
   : app(ssx::sformat("redpanda-{}", node_id()))
   , proxy_port(proxy_port)
   , schema_reg_port(schema_reg_port)
@@ -103,7 +103,7 @@ redpanda_thread_fixture::redpanda_thread_fixture(
   , data_dir(std::move(base_dir))
   , remove_on_shutdown(remove_on_shutdown)
   , app_signal(std::make_unique<::stop_signal>())
-  , use_lsm_metastore(use_lsm_metastore) {
+  , ct_test_cfg(ct_test_cfg) {
     configure(
       node_id,
       kafka_port,
@@ -133,7 +133,7 @@ redpanda_thread_fixture::redpanda_thread_fixture(
           }),
           audit_log_client_config(kafka_port));
         app.check_environment();
-        app.wire_up_and_start(*app_signal, true, use_lsm_metastore);
+        app.wire_up_and_start(*app_signal, true, ct_test_cfg);
     } catch (...) {
         // shutdown half-initialized app nicely so that its destructor doesn't
         // assert and the exception bubbles up
@@ -335,7 +335,7 @@ void redpanda_thread_fixture::restart(should_wipe w) {
     }).get();
     app.initialize(proxy_config(), proxy_client_config());
     app.check_environment();
-    app.wire_up_and_start(*app_signal, true, use_lsm_metastore);
+    app.wire_up_and_start(*app_signal, true, ct_test_cfg);
 }
 
 void redpanda_thread_fixture::configure(

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -13,6 +13,7 @@
 #include "cloud_io/tests/s3_imposter.h"
 #include "cloud_storage/configuration.h"
 #include "cloud_storage_clients/configuration.h"
+#include "cloud_topics/test_fixture_cfg.h"
 #include "cluster/archival/types.h"
 #include "cluster/cluster_utils.h"
 #include "cluster/controller.h"      // IWYU pragma: keep; public member devex
@@ -87,7 +88,7 @@ public:
       bool iceberg_enabled = false,
       bool enable_cloud_topics = false,
       bool development_cluster_linking_enabled = false,
-      bool use_lsm_metastore = false);
+      cloud_topics::test_fixture_cfg ct_test_cfg = {});
 
     // creates single node with default configuration
     redpanda_thread_fixture();
@@ -290,5 +291,5 @@ public:
     ss::sharded<kafka::server> proto;
     bool remove_on_shutdown;
     std::unique_ptr<::stop_signal> app_signal;
-    bool use_lsm_metastore{true};
+    cloud_topics::test_fixture_cfg ct_test_cfg{};
 };


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Adds a loop that runs on metastore topic partition 0 to periodically call flush() on the metastore. Some tests may prefer not to run this loop, so I've plumbed in a struct through the app to allow test fixtures to disable it.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
