### PR TITLE
ct/reconciler: per-topic scheduling

### DIFF
--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -160,7 +160,7 @@ ss::future<> app::construct(
 
 ss::future<> app::start() {
     co_await data_plane->start();
-    co_await reconciler.invoke_on_all(&reconciler::reconciler::start);
+    co_await reconciler.invoke_on_all(&reconciler::reconciler<>::start);
     co_await domain_supervisor.invoke_on_all(
       [](auto& ds) { return ds.start(); });
     co_await housekeeper_manager.invoke_on_all(&housekeeper_manager::start);
@@ -273,7 +273,7 @@ ss::sharded<l1::domain_supervisor>* app::get_sharded_l1_domain_supervisor() {
     return &domain_supervisor;
 }
 
-ss::sharded<reconciler::reconciler>* app::get_reconciler() {
+ss::sharded<reconciler::reconciler<>>* app::get_reconciler() {
     return &reconciler;
 }
 

--- a/src/v/cloud_topics/app.h
+++ b/src/v/cloud_topics/app.h
@@ -76,7 +76,7 @@ public:
     ss::sharded<l1::leader_router>* get_sharded_l1_metastore_router();
     ss::sharded<state_accessors>* get_state();
     ss::sharded<l1::domain_supervisor>* get_sharded_l1_domain_supervisor();
-    ss::sharded<reconciler::reconciler>* get_reconciler();
+    ss::sharded<reconciler::reconciler<>>* get_reconciler();
     ss::sharded<l1::replicated_metastore>* get_sharded_replicated_metastore();
     l1::compaction_scheduler* get_compaction_scheduler();
     ss::sharded<level_zero_gc>* get_level_zero_gc();
@@ -91,7 +91,7 @@ private:
     ss::sharded<state_accessors> state;
     ss::sharded<l1::file_io> l1_io;
     ss::sharded<l1::replicated_metastore> replicated_metastore;
-    ss::sharded<reconciler::reconciler> reconciler;
+    ss::sharded<reconciler::reconciler<>> reconciler;
     ss::sharded<l1::domain_supervisor> domain_supervisor;
     ss::sharded<l1::leader_router> l1_metastore_router;
     ss::sharded<l1::topic_purger_manager> topic_purge_manager;

--- a/src/v/cloud_topics/reconciler/adaptive_interval.cc
+++ b/src/v/cloud_topics/reconciler/adaptive_interval.cc
@@ -10,11 +10,15 @@
 
 #include "cloud_topics/reconciler/adaptive_interval.h"
 
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/manual_clock.hh>
+
 #include <algorithm>
 
 namespace cloud_topics::reconciler {
 
-adaptive_interval::adaptive_interval(
+template<class Clock>
+adaptive_interval<Clock>::adaptive_interval(
   config::binding<std::chrono::milliseconds> min_interval,
   config::binding<std::chrono::milliseconds> max_interval,
   config::binding<double> target_fill_ratio,
@@ -29,14 +33,15 @@ adaptive_interval::adaptive_interval(
   , _max_object_size(std::move(max_object_size))
   , _current_interval(_min_interval()) {}
 
-void adaptive_interval::adapt(size_t max_bytes_produced) {
+template<class Clock>
+void adaptive_interval<Clock>::adapt(size_t max_bytes_produced) {
     auto target_object_size = static_cast<double>(_max_object_size())
                               * _target_fill_ratio();
 
     // Compute ideal interval based on how far off we were from target.
-    ss::lowres_clock::duration ideal_interval;
+    duration ideal_interval;
     if (max_bytes_produced == 0) {
-        ideal_interval = _max_interval();
+        ideal_interval = duration(_max_interval());
     } else {
         // If actual < target, ratio > 1, so interval increases.
         // If actual > target, ratio < 1, so interval decreases.
@@ -44,7 +49,7 @@ void adaptive_interval::adapt(size_t max_bytes_produced) {
                        / static_cast<double>(max_bytes_produced);
         auto current_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
           _current_interval);
-        ideal_interval = std::chrono::duration_cast<ss::lowres_clock::duration>(
+        ideal_interval = std::chrono::duration_cast<duration>(
           std::chrono::duration<double, std::milli>(
             current_ms.count() * ratio));
     }
@@ -61,16 +66,21 @@ void adaptive_interval::adapt(size_t max_bytes_produced) {
       ideal_interval);
     auto blended_ms = std::chrono::duration<double, std::milli>(
       (1.0 - blend) * current_ms.count() + blend * ideal_ms.count());
-    _current_interval = std::chrono::duration_cast<ss::lowres_clock::duration>(
-      blended_ms);
+    _current_interval = std::chrono::duration_cast<duration>(blended_ms);
 
-    auto min = ss::lowres_clock::duration(_min_interval());
-    auto max = ss::lowres_clock::duration(_max_interval());
+    auto min = duration(_min_interval());
+    auto max = duration(_max_interval());
     _current_interval = std::clamp(_current_interval, min, max);
 }
 
-ss::lowres_clock::duration adaptive_interval::current_interval() const {
+template<class Clock>
+typename adaptive_interval<Clock>::duration
+adaptive_interval<Clock>::current_interval() const {
     return _current_interval;
 }
+
+// Explicit template instantiations.
+template class adaptive_interval<ss::lowres_clock>;
+template class adaptive_interval<ss::manual_clock>;
 
 } // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/adaptive_interval.h
+++ b/src/v/cloud_topics/reconciler/adaptive_interval.h
@@ -35,8 +35,11 @@ namespace cloud_topics::reconciler {
  *
  * To disable adaptive scheduling, set min_interval == max_interval.
  */
+template<class Clock = ss::lowres_clock>
 class adaptive_interval {
 public:
+    using duration = typename Clock::duration;
+
     adaptive_interval(
       config::binding<std::chrono::milliseconds> min_interval,
       config::binding<std::chrono::milliseconds> max_interval,
@@ -56,7 +59,7 @@ public:
     /**
      * Get the current interval to use for the next sleep.
      */
-    ss::lowres_clock::duration current_interval() const;
+    duration current_interval() const;
 
 private:
     config::binding<std::chrono::milliseconds> _min_interval;
@@ -66,7 +69,7 @@ private:
     config::binding<double> _slowdown_blend;
     config::binding<size_t> _max_object_size;
 
-    ss::lowres_clock::duration _current_interval;
+    duration _current_interval;
 };
 
 } // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -64,18 +64,84 @@ reconciler<Clock>::reconciler(
   l1::io* l1_io, l1::metastore* metastore, ss::scheduling_group reconciler_sg)
   : _l1_io(l1_io)
   , _metastore(metastore)
-  , _scheduler(
-      config::shard_local_cfg().cloud_topics_reconciliation_min_interval.bind(),
-      config::shard_local_cfg().cloud_topics_reconciliation_max_interval.bind(),
-      config::shard_local_cfg()
-        .cloud_topics_reconciliation_target_fill_ratio.bind(),
-      config::shard_local_cfg()
-        .cloud_topics_reconciliation_speedup_blend.bind(),
-      config::shard_local_cfg()
-        .cloud_topics_reconciliation_slowdown_blend.bind(),
-      config::shard_local_cfg()
-        .cloud_topics_reconciliation_max_object_size.bind())
   , _reconciler_sg(reconciler_sg) {}
+
+template<class Clock>
+reconciler<Clock>::topic_scheduler_state::topic_scheduler_state(
+  config::binding<std::chrono::milliseconds> min_interval,
+  config::binding<std::chrono::milliseconds> max_interval,
+  config::binding<double> target_fill_ratio,
+  config::binding<double> speedup_blend,
+  config::binding<double> slowdown_blend,
+  config::binding<size_t> max_object_size)
+  : scheduler(
+      std::move(min_interval),
+      std::move(max_interval),
+      std::move(target_fill_ratio),
+      std::move(speedup_blend),
+      std::move(slowdown_blend),
+      std::move(max_object_size))
+  , last_reconciled(Clock::time_point::min()) {}
+
+template<class Clock>
+typename reconciler<Clock>::topic_scheduler_state&
+reconciler<Clock>::get_or_create_topic_scheduler(model::topic_id tid) {
+    auto it = _topic_schedulers.find(tid);
+    if (it != _topic_schedulers.end()) {
+        return it->second;
+    }
+
+    auto [inserted_it, _] = _topic_schedulers.emplace(
+      std::piecewise_construct,
+      std::forward_as_tuple(tid),
+      std::forward_as_tuple(
+        config::shard_local_cfg()
+          .cloud_topics_reconciliation_min_interval.bind(),
+        config::shard_local_cfg()
+          .cloud_topics_reconciliation_max_interval.bind(),
+        config::shard_local_cfg()
+          .cloud_topics_reconciliation_target_fill_ratio.bind(),
+        config::shard_local_cfg()
+          .cloud_topics_reconciliation_speedup_blend.bind(),
+        config::shard_local_cfg()
+          .cloud_topics_reconciliation_slowdown_blend.bind(),
+        config::shard_local_cfg()
+          .cloud_topics_reconciliation_max_object_size.bind()));
+    return inserted_it->second;
+}
+
+template<class Clock>
+typename Clock::duration reconciler<Clock>::compute_next_wait() const {
+    auto default_wait = typename Clock::duration(
+      config::shard_local_cfg().cloud_topics_reconciliation_max_interval());
+
+    if (_topic_schedulers.empty()) {
+        if (_sources.empty()) {
+            return default_wait;
+        }
+        // We have sources but no schedulers yet - they'll be created in
+        // reconcile(). Return min_interval to create them promptly.
+        return typename Clock::duration(
+          config::shard_local_cfg().cloud_topics_reconciliation_min_interval());
+    }
+
+    auto now = Clock::now();
+    auto min_wait = Clock::duration::max();
+
+    for (const auto& [_, scheduler_state] : _topic_schedulers) {
+        auto next_due = scheduler_state.last_reconciled
+                        + scheduler_state.scheduler.current_interval();
+
+        if (next_due <= now) {
+            return Clock::duration::zero();
+        }
+
+        auto wait = next_due - now;
+        min_wait = std::min(min_wait, wait);
+    }
+
+    return std::min(min_wait, default_wait);
+}
 
 template<class Clock>
 ss::future<> reconciler<Clock>::start() {
@@ -113,12 +179,18 @@ void reconciler<Clock>::attach_source(ss::shared_ptr<source> src) {
       src->ntp(),
       src->topic_id_partition());
     _sources.emplace(src->ntp(), src);
+
+    auto& scheduler_state = get_or_create_topic_scheduler(
+      src->topic_id_partition().topic_id);
+    ++scheduler_state.partition_count;
 }
 
 template<class Clock>
 void reconciler<Clock>::detach(const model::ntp& ntp) {
     if (auto it = _sources.find(ntp); it != _sources.end()) {
         vlog(lg.debug, "Detaching partition {}", ntp);
+        auto topic_id = it->second->topic_id_partition().topic_id;
+
         /*
          * This upcall doesn't synchronize with the rest of the reconciler,
          * which means that once a reference to a source is held,
@@ -126,6 +198,14 @@ void reconciler<Clock>::detach(const model::ntp& ntp) {
          * _sources collection.
          */
         _sources.erase(it);
+
+        // Clean up topic scheduler if no partitions remain.
+        if (auto sched_it = _topic_schedulers.find(topic_id);
+            sched_it != _topic_schedulers.end()) {
+            if (--sched_it->second.partition_count == 0) {
+                _topic_schedulers.erase(sched_it);
+            }
+        }
     }
 }
 
@@ -140,8 +220,9 @@ ss::future<> reconciler<Clock>::reconciliation_loop() {
 
     auto deferred = ss::defer(
       [] { vlog(lg.debug, "Reconciliation loop exiting"); });
-    typename Clock::duration next_wait = _scheduler.current_interval();
     while (!_gate.is_closed()) {
+        auto next_wait = compute_next_wait();
+
         try {
             co_await ss::sleep_abortable<Clock>(next_wait, _as);
         } catch (const ss::sleep_aborted&) {
@@ -152,9 +233,6 @@ ss::future<> reconciler<Clock>::reconciliation_loop() {
         if (config::shard_local_cfg()
               .cloud_topics_disable_reconciliation_loop()) {
             vlog(lg.debug, "Reconciliation loop disabled, skipping iteration");
-            next_wait = typename Clock::duration(
-              config::shard_local_cfg()
-                .cloud_topics_reconciliation_max_interval());
             continue;
         }
 
@@ -219,7 +297,6 @@ ss::future<> reconciler<Clock>::reconciliation_loop() {
               "Recoverable error during reconciliation: {}",
               std::current_exception());
         }
-        next_wait = _scheduler.current_interval();
     }
 }
 
@@ -240,23 +317,52 @@ ss::future<> reconciler<Clock>::reconcile() {
         co_return;
     }
 
-    auto source_sets = partition_sources_into_sets(std::move(sources));
+    auto topics = partition_sources_by_topic(std::move(sources));
 
-    // Adapt scheduling interval based on max object size produced.
-    // Note that we slow down if there's nothing to reconcile or if all
-    // objects failed. This is a sort of retry with backoff mechanism.
-    size_t max_bytes_produced = 0;
-    for (auto& source_set : source_sets) {
-        auto bytes = co_await reconcile_source_set(std::move(source_set));
-        max_bytes_produced = std::max(max_bytes_produced, bytes);
+    // Filter to only topics that are due for reconciliation.
+    auto now = Clock::now();
+    chunked_vector<chunked_vector<ss::shared_ptr<source>>> due_topics;
+
+    for (auto& topic_sources : topics) {
+        vassert(!topic_sources.empty(), "Empty topic source set");
+        auto topic_id = topic_sources.front()->topic_id_partition().topic_id;
+        auto& scheduler_state = get_or_create_topic_scheduler(topic_id);
+        auto next_due = scheduler_state.last_reconciled
+                        + scheduler_state.scheduler.current_interval();
+
+        if (now >= next_due) {
+            due_topics.push_back(std::move(topic_sources));
+        }
     }
 
-    _scheduler.adapt(max_bytes_produced);
+    vlog(
+      lg.debug,
+      "Reconciling {} due topics of {} total",
+      due_topics.size(),
+      topics.size());
+
+    if (due_topics.empty()) {
+        co_return;
+    }
+
+    // Reconcile each due topic and update its scheduler.
+    for (auto& topic_sources : due_topics) {
+        auto topic_id = topic_sources.front()->topic_id_partition().topic_id;
+        auto bytes = co_await reconcile_source_set(std::move(topic_sources));
+
+        // Update the topic's scheduler state. Adapt based on max object size
+        // produced. Note that we slow down if there's nothing to reconcile or
+        // if all objects failed. This is a sort of retry with backoff
+        // mechanism.
+        auto& scheduler_state = get_or_create_topic_scheduler(topic_id);
+        scheduler_state.scheduler.adapt(bytes);
+        scheduler_state.last_reconciled = now;
+    }
 }
 
 template<class Clock>
 chunked_vector<chunked_vector<ss::shared_ptr<source>>>
-reconciler<Clock>::partition_sources_into_sets(
+reconciler<Clock>::partition_sources_by_topic(
   chunked_vector<ss::shared_ptr<source>> sources) {
     chunked_hash_map<model::topic_id, chunked_vector<ss::shared_ptr<source>>>
       topic_id_to_sources;
@@ -267,7 +373,7 @@ reconciler<Clock>::partition_sources_into_sets(
 
     vlog(
       lg.debug,
-      "Partitioned sources into {} sets by topic_id",
+      "Partitioned sources into {} topics",
       topic_id_to_sources.size());
 
     chunked_vector<chunked_vector<ss::shared_ptr<source>>> result;

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -28,6 +28,8 @@
 #include "ssx/future-util.h"
 #include "utils/retry_chain_node.h"
 
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/manual_clock.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/util/log.hh>
 
@@ -57,7 +59,8 @@ void log_error(
 
 } // namespace
 
-reconciler::reconciler(
+template<class Clock>
+reconciler<Clock>::reconciler(
   l1::io* l1_io, l1::metastore* metastore, ss::scheduling_group reconciler_sg)
   : _l1_io(l1_io)
   , _metastore(metastore)
@@ -74,7 +77,8 @@ reconciler::reconciler(
         .cloud_topics_reconciliation_max_object_size.bind())
   , _reconciler_sg(reconciler_sg) {}
 
-ss::future<> reconciler::start() {
+template<class Clock>
+ss::future<> reconciler<Clock>::start() {
     _probe.setup_metrics();
     ssx::spawn_with_gate(_gate, [this] {
         return ss::with_scheduling_group(
@@ -83,12 +87,14 @@ ss::future<> reconciler::start() {
     co_return;
 }
 
-ss::future<> reconciler::stop() {
+template<class Clock>
+ss::future<> reconciler<Clock>::stop() {
     _as.request_abort();
     co_await _gate.close();
 }
 
-void reconciler::attach_partition(
+template<class Clock>
+void reconciler<Clock>::attach_partition(
   const model::ntp& ntp,
   model::topic_id_partition tidp,
   data_plane_api* data_plane,
@@ -96,7 +102,8 @@ void reconciler::attach_partition(
     attach_source(make_source(ntp, tidp, data_plane, std::move(partition)));
 }
 
-void reconciler::attach_source(ss::shared_ptr<source> src) {
+template<class Clock>
+void reconciler<Clock>::attach_source(ss::shared_ptr<source> src) {
     if (_sources.contains(src->ntp())) {
         return;
     }
@@ -108,7 +115,8 @@ void reconciler::attach_source(ss::shared_ptr<source> src) {
     _sources.emplace(src->ntp(), src);
 }
 
-void reconciler::detach(const model::ntp& ntp) {
+template<class Clock>
+void reconciler<Clock>::detach(const model::ntp& ntp) {
     if (auto it = _sources.find(ntp); it != _sources.end()) {
         vlog(lg.debug, "Detaching partition {}", ntp);
         /*
@@ -121,7 +129,8 @@ void reconciler::detach(const model::ntp& ntp) {
     }
 }
 
-ss::future<> reconciler::reconciliation_loop() {
+template<class Clock>
+ss::future<> reconciler<Clock>::reconciliation_loop() {
     /*
      * Polling is not particularly efficient, and in practice, we'll probably
      * want to look into receiving upcalls from partitions announcing that new
@@ -131,10 +140,10 @@ ss::future<> reconciler::reconciliation_loop() {
 
     auto deferred = ss::defer(
       [] { vlog(lg.debug, "Reconciliation loop exiting"); });
-    ss::lowres_clock::duration next_wait = _scheduler.current_interval();
+    typename Clock::duration next_wait = _scheduler.current_interval();
     while (!_gate.is_closed()) {
         try {
-            co_await ss::sleep_abortable(next_wait, _as);
+            co_await ss::sleep_abortable<Clock>(next_wait, _as);
         } catch (const ss::sleep_aborted&) {
             // If the sleep was aborted, we can exit our loop
             co_return;
@@ -143,8 +152,9 @@ ss::future<> reconciler::reconciliation_loop() {
         if (config::shard_local_cfg()
               .cloud_topics_disable_reconciliation_loop()) {
             vlog(lg.debug, "Reconciliation loop disabled, skipping iteration");
-            next_wait = config::shard_local_cfg()
-                          .cloud_topics_reconciliation_max_interval.value();
+            next_wait = typename Clock::duration(
+              config::shard_local_cfg()
+                .cloud_topics_reconciliation_max_interval());
             continue;
         }
 
@@ -213,7 +223,8 @@ ss::future<> reconciler::reconciliation_loop() {
     }
 }
 
-ss::future<> reconciler::reconcile() {
+template<class Clock>
+ss::future<> reconciler<Clock>::reconcile() {
     _probe.increment_rounds();
 
     chunked_vector<ss::shared_ptr<source>> sources;
@@ -243,8 +254,9 @@ ss::future<> reconciler::reconcile() {
     _scheduler.adapt(max_bytes_produced);
 }
 
+template<class Clock>
 chunked_vector<chunked_vector<ss::shared_ptr<source>>>
-reconciler::partition_sources_into_sets(
+reconciler<Clock>::partition_sources_into_sets(
   chunked_vector<ss::shared_ptr<source>> sources) {
     chunked_hash_map<model::topic_id, chunked_vector<ss::shared_ptr<source>>>
       topic_id_to_sources;
@@ -266,7 +278,8 @@ reconciler::partition_sources_into_sets(
     return result;
 }
 
-ss::future<size_t> reconciler::reconcile_source_set(
+template<class Clock>
+ss::future<size_t> reconciler<Clock>::reconcile_source_set(
   chunked_vector<ss::shared_ptr<source>> sources) {
     if (sources.empty()) {
         co_return 0;
@@ -405,8 +418,11 @@ ss::future<size_t> reconciler::reconcile_source_set(
     co_return max_bytes_produced;
 }
 
-ss::future<std::expected<reconciler::built_object_metadata, reconcile_error>>
-reconciler::reconcile_sources(
+template<class Clock>
+ss::future<std::expected<
+  typename reconciler<Clock>::built_object_metadata,
+  reconcile_error>>
+reconciler<Clock>::reconcile_sources(
   const l1::object_id& oid,
   const chunked_vector<ss::shared_ptr<source>>& sources) {
     auto ctx_result = co_await make_context();
@@ -462,8 +478,11 @@ reconciler::reconcile_sources(
     co_return result;
 }
 
-ss::future<std::expected<reconciler::built_object_metadata, reconcile_error>>
-reconciler::build_and_put_object(
+template<class Clock>
+ss::future<std::expected<
+  typename reconciler<Clock>::built_object_metadata,
+  reconcile_error>>
+reconciler<Clock>::build_and_put_object(
   const l1::object_id& oid,
   builder_context& ctx,
   const chunked_vector<ss::shared_ptr<source>>& sources) {
@@ -496,8 +515,10 @@ reconciler::build_and_put_object(
     co_return obj_meta;
 }
 
-ss::future<std::expected<reconciler::builder_context, reconcile_error>>
-reconciler::make_context() {
+template<class Clock>
+ss::future<
+  std::expected<typename reconciler<Clock>::builder_context, reconcile_error>>
+reconciler<Clock>::make_context() {
     builder_context ctx;
 
     // Create staging file.
@@ -530,8 +551,11 @@ reconciler::make_context() {
     co_return ctx;
 }
 
-ss::future<std::expected<reconciler::built_object_metadata, reconcile_error>>
-reconciler::build_object(
+template<class Clock>
+ss::future<std::expected<
+  typename reconciler<Clock>::built_object_metadata,
+  reconcile_error>>
+reconciler<Clock>::build_object(
   builder_context& ctx, const chunked_vector<ss::shared_ptr<source>>& sources) {
     const auto max_size = ctx.size_budget;
 
@@ -590,8 +614,9 @@ reconciler::build_object(
     };
 }
 
+template<class Clock>
 ss::future<std::expected<void, reconcile_error>>
-reconciler::put_object(const l1::object_id& oid, builder_context& ctx) {
+reconciler<Clock>::put_object(const l1::object_id& oid, builder_context& ctx) {
     auto metrics_duration = _probe.measure_object_upload_duration();
     auto put_result = co_await _l1_io->put_object(oid, ctx.staging.get(), &_as);
     if (!put_result.has_value()) {
@@ -602,8 +627,9 @@ reconciler::put_object(const l1::object_id& oid, builder_context& ctx) {
     co_return std::expected<void, reconcile_error>{};
 }
 
+template<class Clock>
 ss::future<std::expected<std::optional<consumer_metadata>, reconcile_error>>
-reconciler::add_source_to_object(
+reconciler<Clock>::add_source_to_object(
   builder_context& ctx,
   ss::shared_ptr<source> src,
   kafka::offset start_offset) {
@@ -651,7 +677,8 @@ reconciler::add_source_to_object(
     co_return metadata.value();
 }
 
-std::expected<void, reconcile_error> reconciler::add_object_metadata(
+template<class Clock>
+std::expected<void, reconcile_error> reconciler<Clock>::add_object_metadata(
   const l1::object_id& oid,
   const built_object_metadata& obj_meta,
   l1::metastore::object_metadata_builder* meta_builder) {
@@ -707,7 +734,9 @@ std::expected<void, reconcile_error> reconciler::add_object_metadata(
     return {};
 }
 
-ss::future<std::expected<void, reconcile_error>> reconciler::commit_objects(
+template<class Clock>
+ss::future<std::expected<void, reconcile_error>>
+reconciler<Clock>::commit_objects(
   const chunked_vector<built_object_metadata>& objects,
   std::unique_ptr<l1::metastore::object_metadata_builder> meta_builder) {
     // It's possible to build the terms map as we build the objects, but
@@ -824,5 +853,9 @@ ss::future<std::expected<void, reconcile_error>> reconciler::commit_objects(
         })
       .value_or(std::expected<void, reconcile_error>{});
 }
+
+// Explicit template instantiations.
+template class reconciler<ss::lowres_clock>;
+template class reconciler<ss::manual_clock>;
 
 } // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -123,6 +123,27 @@ private:
     //     topic id partitions.
     chunked_hash_map<model::ntp, ss::shared_ptr<source>> _sources;
 
+    /*
+     * Per-topic scheduler state for adaptive reconciliation intervals.
+     * Each topic maintains its own interval that adapts independently
+     * based on that topic's data rate.
+     */
+    struct topic_scheduler_state {
+        adaptive_interval<Clock> scheduler;
+        typename Clock::time_point last_reconciled;
+        size_t partition_count{0};
+
+        topic_scheduler_state(
+          config::binding<std::chrono::milliseconds> min_interval,
+          config::binding<std::chrono::milliseconds> max_interval,
+          config::binding<double> target_fill_ratio,
+          config::binding<double> speedup_blend,
+          config::binding<double> slowdown_blend,
+          config::binding<size_t> max_object_size);
+    };
+
+    chunked_hash_map<model::topic_id, topic_scheduler_state> _topic_schedulers;
+
 private:
     /*
      * A container for an object in the process of being built.
@@ -252,10 +273,25 @@ private:
       std::unique_ptr<l1::metastore::object_metadata_builder> meta_builder);
 
     /*
-     * Partition sources into sets for reconciliation.
+     * Partition sources by topic for reconciliation.
      */
     chunked_vector<chunked_vector<ss::shared_ptr<source>>>
-    partition_sources_into_sets(chunked_vector<ss::shared_ptr<source>> sources);
+    partition_sources_by_topic(chunked_vector<ss::shared_ptr<source>> sources);
+
+    /*
+     * Get or create a scheduler state for the given topic.
+     * New topics are initialized with last_reconciled = time_point::min()
+     * making them immediately due for reconciliation.
+     */
+    topic_scheduler_state& get_or_create_topic_scheduler(model::topic_id tid);
+
+    /*
+     * Compute the time to wait until the next topic is due for reconciliation.
+     * Returns duration::zero() if any topic is already due.
+     * Returns min_interval if sources exist but no schedulers yet.
+     * Returns max_interval if no sources exist.
+     */
+    typename Clock::duration compute_next_wait() const;
 
     /*
      * Reconcile a set of sources. Creates a metadata builder, maps sources to
@@ -271,7 +307,6 @@ private:
     ss::gate _gate;
     ss::abort_source _as;
     reconciler_probe _probe;
-    adaptive_interval<Clock> _scheduler;
     ss::scheduling_group _reconciler_sg;
 };
 

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -86,6 +86,7 @@ struct reconcile_error {
  * the L1 metastore. Finally, it updates the LRO, based on either
  * its own progress, or a corrected LRO returned from the metastore.
  */
+template<class Clock = ss::lowres_clock>
 class reconciler {
 public:
     reconciler(l1::io*, l1::metastore*, ss::scheduling_group);
@@ -270,7 +271,7 @@ private:
     ss::gate _gate;
     ss::abort_source _as;
     reconciler_probe _probe;
-    adaptive_interval _scheduler;
+    adaptive_interval<Clock> _scheduler;
     ss::scheduling_group _reconciler_sg;
 };
 

--- a/src/v/cloud_topics/reconciler/tests/adaptive_interval_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/adaptive_interval_test.cc
@@ -32,7 +32,7 @@ constexpr double default_slowdown_blend = 0.4;
 // Number of rounds to run when expecting the interval to stabilize.
 constexpr int many_rounds = 10000;
 
-adaptive_interval make_test_scheduler(
+adaptive_interval<> make_test_scheduler(
   std::chrono::milliseconds min_interval = default_min_interval,
   std::chrono::milliseconds max_interval = default_max_interval,
   double target_fill = default_target_fill,
@@ -47,7 +47,7 @@ adaptive_interval make_test_scheduler(
       config::mock_binding<size_t>(max_object_size)};
 }
 
-double interval_ms(const adaptive_interval& scheduler) {
+double interval_ms(const adaptive_interval<>& scheduler) {
     return std::chrono::duration<double, std::milli>(
              scheduler.current_interval())
       .count();
@@ -55,7 +55,7 @@ double interval_ms(const adaptive_interval& scheduler) {
 
 // Run many adaptation rounds at a fixed data rate until interval stabilizes.
 // Each round produces bytes = data_rate * interval, capped at max_object_size.
-void stabilize(adaptive_interval& scheduler, double data_rate_mib_per_sec) {
+void stabilize(adaptive_interval<>& scheduler, double data_rate_mib_per_sec) {
     constexpr double MiB = 1024 * 1024;
     for (int i = 0; i < many_rounds; i++) {
         double interval_sec = interval_ms(scheduler) / 1000.0;

--- a/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
@@ -20,6 +20,7 @@
 #include "model/tests/randoms.h"
 #include "test_utils/metrics.h"
 
+#include <seastar/core/manual_clock.hh>
 #include <seastar/core/scheduling.hh>
 
 #include <gmock/gmock.h>
@@ -55,16 +56,22 @@ public:
         return src;
     }
 
-    void reconcile() { _reconciler.reconcile().get(); }
+    void reconcile() {
+        // Advance the clock to ensure all topics are due for reconciliation.
+        ss::manual_clock::advance(std::chrono::hours(1));
+        _reconciler.reconcile().get();
+    }
 
     unreliable_io& io() { return _io; }
     unreliable_metastore& metastore() { return _metastore; }
-    reconciler::reconciler& reconciler() { return _reconciler; }
+    reconciler::reconciler<ss::manual_clock>& reconciler() {
+        return _reconciler;
+    }
 
 private:
     unreliable_io _io;
     unreliable_metastore _metastore;
-    reconciler::reconciler _reconciler{
+    reconciler::reconciler<ss::manual_clock> _reconciler{
       &_io, &_metastore, ss::default_scheduling_group()};
 };
 

--- a/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
@@ -59,7 +59,14 @@ public:
         return src;
     }
 
-    void reconcile() { _reconciler.reconcile().get(); }
+    void reconcile() {
+        // Advance the clock to ensure all topics are due for reconciliation.
+        ss::manual_clock::advance(std::chrono::hours(1));
+        _reconciler.reconcile().get();
+    }
+
+    // Call reconcile without advancing the clock.
+    void reconcile_without_advancing_clock() { _reconciler.reconcile().get(); }
 
     std::optional<kafka::offset>
     metastore_next_offset(ss::shared_ptr<fake_source> src) {
@@ -72,6 +79,13 @@ public:
 
     unreliable_metastore& metastore() { return _metastore; }
     unreliable_io& io() { return _io; }
+
+    // Advance the manual clock to make topics due for reconciliation.
+    void advance_clock() {
+        // Advance past the max reconciliation interval to ensure topics are
+        // due.
+        ss::manual_clock::advance(std::chrono::hours(1));
+    }
 
 protected:
     unreliable_io _io;
@@ -576,4 +590,63 @@ TEST_F(ReconcilerTest, OffsetAndTimestampTracking) {
                            .get();
     EXPECT_FALSE(obj_beyond_ts.has_value());
     EXPECT_EQ(obj_beyond_ts.error(), l1::metastore::errc::out_of_range);
+}
+
+TEST_F(ReconcilerTest, TopicNotDueIsNotReconciled) {
+    auto src = add_source();
+    src->add_batch({.count = 10});
+
+    // First reconcile - topic is due because it's new (last_reconciled =
+    // time_point::min()).
+    reconcile();
+    EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{9});
+
+    // Add more data.
+    src->add_batch({.count = 10});
+
+    // Reconcile without advancing clock - topic is not due yet.
+    reconcile_without_advancing_clock();
+
+    // LRO should not have advanced because the topic wasn't due.
+    EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{9});
+
+    // Now advance clock and reconcile again.
+    reconcile();
+
+    // Now the data should be reconciled.
+    EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{19});
+}
+
+TEST_F(ReconcilerTest, OnlyDueTopicIsReconciled) {
+    // Create topic1 and reconcile it.
+    const model::topic tp1{"topic1"};
+    const model::topic_id tid1 = model::topic_id::create();
+    auto src1 = add_source(tp1, tid1);
+    src1->add_batch({.count = 10});
+
+    reconcile();
+    EXPECT_EQ(src1->last_reconciled_offset(), kafka::offset{9});
+
+    // Add more data to topic1.
+    src1->add_batch({.count = 10});
+
+    // Now create topic2 - it will be immediately due since it's new.
+    const model::topic tp2{"topic2"};
+    const model::topic_id tid2 = model::topic_id::create();
+    auto src2 = add_source(tp2, tid2);
+    src2->add_batch({.count = 20});
+
+    // Reconcile without advancing clock.
+    // Topic2 should be reconciled (new topic, immediately due).
+    // Topic1 should NOT be reconciled (not due yet).
+    reconcile_without_advancing_clock();
+
+    // Topic1's LRO should not have advanced.
+    EXPECT_EQ(src1->last_reconciled_offset(), kafka::offset{9});
+    // Topic2 should be fully reconciled.
+    EXPECT_EQ(src2->last_reconciled_offset(), kafka::offset{19});
+
+    // Now advance clock and reconcile - topic1 should now be reconciled.
+    reconcile();
+    EXPECT_EQ(src1->last_reconciled_offset(), kafka::offset{19});
 }

--- a/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
@@ -20,6 +20,7 @@
 #include "model/tests/randoms.h"
 #include "test_utils/scoped_config.h"
 
+#include <seastar/core/manual_clock.hh>
 #include <seastar/core/scheduling.hh>
 #include <seastar/util/defer.hh>
 
@@ -75,7 +76,7 @@ public:
 protected:
     unreliable_io _io;
     unreliable_metastore _metastore;
-    reconciler::reconciler _reconciler;
+    reconciler::reconciler<ss::manual_clock> _reconciler;
 };
 
 using ::testing::Optional;


### PR DESCRIPTION
Introduce per-topic scheduling for the reconciler. Using adaptive scheduling, this deals well with high- and low-throughput topics. The tradeoff is that the reconciler must group partitions by topic, and keeps some per-topic state.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
