### PR TITLE
[v25.3.x] `storage`: manage priority logs in `housekeeping_loop` [take 2]

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1058,6 +1058,13 @@ configuration::configuration()
       "How often to trigger background compaction.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       10s)
+  , log_compaction_max_priority_wait_ms(
+      *this,
+      "log_compaction_max_priority_wait_ms",
+      "Maximum time a priority partition (for example, __consumer_offsets) can "
+      "wait for compaction before preempting regular compaction.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      60min)
   , tombstone_retention_ms(
       *this,
       "tombstone_retention_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -260,6 +260,7 @@ struct configuration final : public config_store {
     // same as log.retention.ms in kafka
     retention_duration_property log_retention_ms;
     property<std::chrono::milliseconds> log_compaction_interval_ms;
+    property<std::chrono::milliseconds> log_compaction_max_priority_wait_ms;
     // same as delete.retention.ms in kafka
     property<std::optional<std::chrono::milliseconds>> tombstone_retention_ms;
     bounded_property<std::optional<double>, numeric_bounds>

--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -318,6 +318,7 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         ":log_manager_probe",
+        "//src/v/ssx:abort_source",
         "//src/v/syschecks",
     ],
     visibility = ["//visibility:public"],

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -21,6 +21,7 @@
 #include "model/timeout_clock.h"
 #include "model/timestamp.h"
 #include "reflection/adl.h"
+#include "ssx/abort_source.h"
 #include "ssx/future-util.h"
 #include "ssx/semaphore.h"
 #include "ssx/watchdog.h"
@@ -1412,7 +1413,15 @@ ss::future<> disk_log_impl::housekeeping(housekeeping_config cfg) {
 ss::future<> disk_log_impl::do_compact(
   compaction::compaction_config compact_cfg,
   std::optional<model::offset> new_start_offset) {
-    compact_cfg.asrc = &_compaction_as;
+    // Need to be able to respect both the config's original abort source (if it
+    // has one), as well as the local _compaction_as.
+    std::optional<ssx::composite_abort_source> composite_as;
+    if (compact_cfg.asrc) {
+        composite_as.emplace(_compaction_as, *compact_cfg.asrc);
+        compact_cfg.asrc = &composite_as->as();
+    } else {
+        compact_cfg.asrc = &_compaction_as;
+    }
 
     auto compact_fut = ss::now();
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -18,6 +18,7 @@
 #include "model/metadata.h"
 #include "model/timestamp.h"
 #include "resource_mgmt/memory_groups.h"
+#include "ssx/abort_source.h"
 #include "ssx/async-clear.h"
 #include "ssx/future-util.h"
 #include "ssx/watchdog.h"
@@ -85,7 +86,6 @@ log_config::log_config(
   , segment_size_jitter(0) // For deterministic behavior in unit tests.
   , compacted_segment_size(config::mock_binding<size_t>(256_MiB))
   , max_compacted_segment_size(config::mock_binding<size_t>(5_GiB))
-
   , retention_bytes(config::mock_binding<std::optional<size_t>>(std::nullopt))
   , compaction_interval(
       config::mock_binding<std::chrono::milliseconds>(std::chrono::minutes(10)))
@@ -227,21 +227,11 @@ ss::future<> log_manager::stop() {
  */
 ss::future<>
 log_manager::housekeeping_scan(model::timestamp collection_threshold) {
-    using bflags = log_housekeeping_meta::bitflags;
-
-    static constexpr auto is_not_set = [](bflags var, auto flag) {
-        return (var & flag) != flag;
-    };
-
     // reset flags for the next two loops, segment_ms and compaction.
     // since there are suspension points during the traversal of _logs_list, the
     // algorithm is: mark the logs visited, rotate _logs_list, op, and loop
     // until empty or reaching a marked log
-    for (auto& log_meta : _logs_list) {
-        log_meta.flags &= ~(
-          bflags::compacted | bflags::lifetime_checked
-          | bflags::compaction_checked | bflags::should_compact);
-    }
+    clear_log_meta_flags(_logs_list);
 
     /*
      * Apply segment ms will roll the active segment if it is old enough. This
@@ -254,34 +244,10 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
      *   compaction is already sequential when this will be unified with
      *   compaction, the whole task could be made concurrent
      */
-    while (!_logs_list.empty()
-           && is_not_set(_logs_list.front().flags, bflags::lifetime_checked)) {
-        if (_abort_source.abort_requested()) {
-            co_return;
-        }
+    co_await apply_segment_ms_to_logs(_logs_list);
 
-        auto& current_log = _logs_list.front();
-        _logs_list.shift_forward();
-
-        current_log.flags |= bflags::lifetime_checked;
-
-        // Hold the housekeeping gate to prevent issues with concurrent removal
-        // of the log meta.
-        auto gate = current_log.housekeeping_gate.hold();
-
-        // Obtain housekeeping lock to prevent concurrency of
-        // log->apply_segment_ms() with gc fibre.
-        auto housekeeping_lock_holder
-          = co_await current_log.housekeeping_lock.get_units();
-
-        if (!current_log.link.is_linked()) {
-            continue;
-        }
-
-        // NOTE: apply_segment_ms holds _compaction_housekeeping_gate, that
-        // prevents the removal of the parent object. this makes awaiting
-        // apply_segment_ms safe against removal of segments from _logs_list
-        co_await current_log.handle->apply_segment_ms();
+    if (_abort_source.abort_requested()) {
+        co_return;
     }
 
     if (
@@ -296,59 +262,7 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         _compaction_hash_key_map = std::move(compaction_map);
     }
 
-    using compaction_heuristic_t = uint64_t;
-
-    // There can be no scheduling points between here and the sorting done
-    // below, as we are holding pointers to log_housekeeping_meta in this
-    // btree_map.
-    // This needs to be sorted in ascending order, as we are pushing `log_meta`s
-    // to the front of the `_log_list`.
-    absl::
-      btree_map<compaction_heuristic_t, chunked_vector<log_housekeeping_meta*>>
-        compaction_heuristic_to_log_metas;
-    for (auto& log_meta : _logs_list) {
-        auto should_compact_log = [](ss::shared_ptr<log> l) {
-            auto needs_compact = l->needs_compaction();
-            if (!needs_compact) {
-                vlog(
-                  gclog.trace,
-                  "{}: dirty ratio ({}) < min.cleanable.dirty.ratio ({}) and "
-                  "time since earliest dirty timestamp does not exceed "
-                  "max.compaction.lag.ms ({}), skipping compaction.",
-                  l->config().ntp(),
-                  l->dirty_ratio(),
-                  l->config().min_cleanable_dirty_ratio(),
-                  l->config().max_compaction_lag_ms());
-            }
-            return needs_compact;
-        };
-
-        const auto compact_log = should_compact_log(log_meta.handle);
-
-        if (compact_log) {
-            log_meta.flags |= bflags::should_compact;
-
-            // Order ntps by compaction heuristic.
-            // Currently, this is just the dirty ratio.
-            auto compute_compaction_heuristic =
-              [](ss::shared_ptr<log> l) -> compaction_heuristic_t {
-                auto res = (100.0 * l->dirty_ratio());
-                return static_cast<compaction_heuristic_t>(res);
-            };
-
-            auto compaction_heuristic_weight = compute_compaction_heuristic(
-              log_meta.handle);
-            compaction_heuristic_to_log_metas[compaction_heuristic_weight]
-              .push_back(&log_meta);
-        }
-    }
-
-    for (const auto& [weight, log_metas] : compaction_heuristic_to_log_metas) {
-        for (auto* meta_ptr : log_metas) {
-            meta_ptr->link.unlink();
-            _logs_list.push_front(*meta_ptr);
-        }
-    }
+    sort_logs_by_compaction_heuristic(_logs_list);
 
     while (
       !_logs_list.empty()
@@ -382,12 +296,6 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
             continue;
         }
 
-        current_log.flags |= bflags::compacted;
-        current_log.last_compaction = ss::lowres_clock::now();
-
-        auto ntp_sanitizer_cfg = _config.maybe_get_ntp_sanitizer_config(
-          current_log.handle->config().ntp());
-
         // Obtain housekeeping lock to prevent concurrency of
         // log->housekeeping() with gc fibre.
         auto housekeeping_lock_holder
@@ -397,87 +305,7 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
             continue;
         }
 
-        // Until we better implement bailing out of compaction, the best thing
-        // we can do for observability is add a watchdog here.
-        auto ntp = current_log.handle->config().ntp();
-        ssx::watchdog wd5m(5min, [ntp] {
-            vlog(
-              gclog.warn, "{}: Housekeeping process exceeding 5 minutes", ntp);
-        });
-
-        // NOTE: housekeeping holds _compaction_housekeeping_gate, that prevents
-        // the removal of the parent object. this makes awaiting housekeeping
-        // safe against removal of segments from _logs_list
-        auto& log = current_log.handle;
-        auto pinned_kafka_offset
-          = current_log.handle->stm_manager()->lowest_pinned_data_offset();
-        std::optional<model::offset> max_unpinned_offset;
-        if (pinned_kafka_offset) {
-            auto local_log_start = log->offsets().start_offset;
-            auto kafka_local_start = model::offset_cast(
-              log->from_log_offset(local_log_start));
-            if (*pinned_kafka_offset >= kafka_local_start) {
-                // Translate the pinned Kafka offset.
-                max_unpinned_offset = model::prev_offset(
-                  log->to_log_offset(kafka::offset_cast(*pinned_kafka_offset)));
-            } else {
-                // The pin falls below the log start, in which case the entire
-                // local log is pinned.
-                max_unpinned_offset = model::prev_offset(
-                  log->offsets().start_offset);
-            }
-        }
-        model::offset max_compactible_offset
-          = current_log.handle->stm_manager()->max_removable_local_log_offset();
-        model::offset max_tombstone_remove_offset
-          = current_log.handle->stm_manager()->max_tombstone_remove_offset();
-        model::offset max_tx_end_remove_offset
-          = current_log.handle->stm_manager()->max_tx_end_remove_offset();
-        model::offset tx_snapshot_offset
-          = current_log.handle->stm_manager()->tx_snapshot_offset();
-        // We clamp the offset up to which we can remove transactional control
-        // batches to the last snapshot taken by the transactional stm. This
-        // ensures that we do not remove control batches that may be needed to
-        // reconstruct the state machine during recovery.
-        model::offset max_tx_remove_offset = std::min(
-          max_tx_end_remove_offset, tx_snapshot_offset);
-
-        vlog(
-          gclog.trace,
-          "{}: max tombstone remove offset: {}, max tx remove offset: {}, max "
-          "tx end remove snapshot: {}, tx_snapshot_offset: {}",
-          ntp,
-          max_tombstone_remove_offset,
-          max_tx_remove_offset,
-          max_tx_end_remove_offset,
-          tx_snapshot_offset);
-        if (
-          max_unpinned_offset
-          && *max_unpinned_offset < max_compactible_offset) {
-            vlog(
-              gclog.debug,
-              "{}: Compaction is pinned by offset: pinned Kafka offset: {}, "
-              "log offsets max unpinned {} < max removable {}",
-              ntp,
-              *pinned_kafka_offset,
-              *max_unpinned_offset,
-              max_compactible_offset);
-            max_compactible_offset = *max_unpinned_offset;
-        }
-        co_await current_log.handle->housekeeping(
-          housekeeping_config::make_config(
-            collection_threshold,
-            _config.retention_bytes(),
-            max_compactible_offset,
-            max_tombstone_remove_offset,
-            max_tx_remove_offset,
-            current_log.handle->config().delete_retention_ms(),
-            current_log.handle->config().delete_retention_ms(),
-            current_log.handle->config().min_compaction_lag_ms(),
-            _abort_source,
-            std::move(ntp_sanitizer_cfg),
-            _compaction_hash_key_map.get()));
-        _probe->housekeeping_log_processed();
+        co_await do_housekeeping(current_log, collection_threshold);
     }
 }
 
@@ -683,6 +511,206 @@ ss::future<> log_manager::gc_loop() {
               });
         }
     }
+}
+
+void log_manager::clear_log_meta_flags(compaction_list_type& logs) {
+    for (auto& log_meta : logs) {
+        log_meta.flags &= ~(
+          bflags::compacted | bflags::lifetime_checked
+          | bflags::compaction_checked | bflags::should_compact);
+    }
+}
+
+ss::future<> log_manager::apply_segment_ms_to_logs(compaction_list_type& logs) {
+    while (!logs.empty()
+           && is_not_set(logs.front().flags, bflags::lifetime_checked)) {
+        if (_abort_source.abort_requested()) {
+            co_return;
+        }
+
+        auto& current_log = logs.front();
+        logs.shift_forward();
+
+        current_log.flags |= bflags::lifetime_checked;
+
+        // Hold the housekeeping gate to prevent issues with concurrent removal
+        // of the log meta.
+        auto gate = current_log.housekeeping_gate.hold();
+
+        // Obtain housekeeping lock to prevent concurrency of
+        // log->apply_segment_ms() with gc fibre.
+        auto housekeeping_lock_holder
+          = co_await current_log.housekeeping_lock.get_units();
+
+        if (!current_log.link.is_linked()) {
+            continue;
+        }
+
+        // NOTE: apply_segment_ms holds _compaction_housekeeping_gate, that
+        // prevents the removal of the parent object. this makes awaiting
+        // apply_segment_ms safe against removal of segments from logs
+        co_await current_log.handle->apply_segment_ms();
+    }
+}
+
+void log_manager::sort_logs_by_compaction_heuristic(
+  compaction_list_type& logs) {
+    using compaction_heuristic_t = uint64_t;
+    // There can be no scheduling points between here and the sorting done
+    // below, as we are holding pointers to log_housekeeping_meta in this
+    // btree_map.
+    // This needs to be sorted in ascending order, as we are pushing `log_meta`s
+    // to the front of `logs`.
+    absl::
+      btree_map<compaction_heuristic_t, chunked_vector<log_housekeeping_meta*>>
+        compaction_heuristic_to_log_metas;
+    for (auto& log_meta : logs) {
+        auto should_compact_log = [](ss::shared_ptr<log> l) {
+            auto needs_compact = l->needs_compaction();
+            if (!needs_compact) {
+                vlog(
+                  gclog.trace,
+                  "{}: dirty ratio ({}) < min.cleanable.dirty.ratio ({}) and "
+                  "time since earliest dirty timestamp does not exceed "
+                  "max.compaction.lag.ms ({}), skipping compaction.",
+                  l->config().ntp(),
+                  l->dirty_ratio(),
+                  l->config().min_cleanable_dirty_ratio(),
+                  l->config().max_compaction_lag_ms());
+            }
+            return needs_compact;
+        };
+
+        const auto compact_log = should_compact_log(log_meta.handle);
+
+        if (compact_log) {
+            log_meta.flags |= bflags::should_compact;
+
+            // Order ntps by compaction heuristic.
+            // Currently, this is just the dirty ratio.
+            auto compute_compaction_heuristic =
+              [](ss::shared_ptr<log> l) -> compaction_heuristic_t {
+                auto res = (100.0 * l->dirty_ratio());
+                return static_cast<compaction_heuristic_t>(res);
+            };
+
+            auto compaction_heuristic_weight = compute_compaction_heuristic(
+              log_meta.handle);
+            compaction_heuristic_to_log_metas[compaction_heuristic_weight]
+              .push_back(&log_meta);
+        }
+    }
+
+    for (const auto& [weight, log_metas] : compaction_heuristic_to_log_metas) {
+        for (auto* meta_ptr : log_metas) {
+            meta_ptr->link.unlink();
+            logs.push_front(*meta_ptr);
+        }
+    }
+}
+
+ss::future<> log_manager::do_housekeeping(
+  log_housekeeping_meta& meta,
+  model::timestamp collection_threshold,
+  model::opt_abort_source_t preempt_source) {
+    if (!meta.link.is_linked()) {
+        co_return;
+    }
+
+    auto ntp = meta.handle->config().ntp();
+    auto ntp_sanitizer_cfg = _config.maybe_get_ntp_sanitizer_config(ntp);
+
+    // Until we better implement bailing out of compaction, the best thing
+    // we can do for observability is add a watchdog here.
+    ssx::watchdog wd5m(5min, [ntp] {
+        vlog(gclog.warn, "{}: Housekeeping process exceeding 5 minutes", ntp);
+    });
+
+    // Create a composite abort source that triggers on shutdown or
+    // preemption. If no preempt_source is provided, just use _abort_source
+    // directly.
+    std::optional<ssx::composite_abort_source> composite_as;
+    auto& as = [this, &preempt_source, &composite_as]() -> ss::abort_source& {
+        if (preempt_source.has_value()) {
+            composite_as.emplace(_abort_source, preempt_source->get());
+            return composite_as->as();
+        }
+        return _abort_source;
+    }();
+
+    // NOTE: housekeeping holds _compaction_housekeeping_gate, that prevents
+    // the removal of the parent object. this makes awaiting housekeeping
+    // safe against removal of segments from _logs_list
+    auto& log = meta.handle;
+    auto pinned_kafka_offset = log->stm_manager()->lowest_pinned_data_offset();
+    std::optional<model::offset> max_unpinned_offset;
+    if (pinned_kafka_offset) {
+        auto local_log_start = log->offsets().start_offset;
+        auto kafka_local_start = model::offset_cast(
+          log->from_log_offset(local_log_start));
+        if (*pinned_kafka_offset >= kafka_local_start) {
+            max_unpinned_offset = model::prev_offset(
+              log->to_log_offset(kafka::offset_cast(*pinned_kafka_offset)));
+        } else {
+            max_unpinned_offset = model::prev_offset(
+              log->offsets().start_offset);
+        }
+    }
+
+    model::offset max_compactible_offset
+      = log->stm_manager()->max_removable_local_log_offset();
+    model::offset max_tombstone_remove_offset
+      = log->stm_manager()->max_tombstone_remove_offset();
+    model::offset max_tx_end_remove_offset
+      = log->stm_manager()->max_tx_end_remove_offset();
+    model::offset tx_snapshot_offset = log->stm_manager()->tx_snapshot_offset();
+    // We clamp the offset up to which we can remove transactional control
+    // batches to the last snapshot taken by the transactional stm. This
+    // ensures that we do not remove control batches that may be needed to
+    // reconstruct the state machine during recovery.
+    model::offset max_tx_remove_offset = std::min(
+      max_tx_end_remove_offset, tx_snapshot_offset);
+
+    vlog(
+      gclog.trace,
+      "{}: max tombstone remove offset: {}, max tx remove offset: {}, max "
+      "tx end remove snapshot: {}, tx_snapshot_offset: {}",
+      ntp,
+      max_tombstone_remove_offset,
+      max_tx_remove_offset,
+      max_tx_end_remove_offset,
+      tx_snapshot_offset);
+
+    if (max_unpinned_offset && *max_unpinned_offset < max_compactible_offset) {
+        vlog(
+          gclog.debug,
+          "{}: Compaction is pinned by offset: pinned Kafka offset: {}, "
+          "log offsets max unpinned {} < max removable {}",
+          ntp,
+          *pinned_kafka_offset,
+          *max_unpinned_offset,
+          max_compactible_offset);
+        max_compactible_offset = *max_unpinned_offset;
+    }
+
+    co_await log->housekeeping(
+      housekeeping_config::make_config(
+        collection_threshold,
+        _config.retention_bytes(),
+        max_compactible_offset,
+        max_tombstone_remove_offset,
+        max_tx_remove_offset,
+        log->config().delete_retention_ms(),
+        log->config().delete_retention_ms(),
+        log->config().min_compaction_lag_ms(),
+        as,
+        std::move(ntp_sanitizer_cfg),
+        _compaction_hash_key_map.get()));
+
+    meta.flags |= log_housekeeping_meta::bitflags::compacted;
+    meta.last_compaction = ss::lowres_clock::now();
+
+    _probe->housekeeping_log_processed();
 }
 
 /**

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -54,6 +54,7 @@
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/thread.hh>
+#include <seastar/core/timer.hh>
 #include <seastar/core/with_scheduling_group.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
@@ -70,8 +71,19 @@
 #include <filesystem>
 #include <functional>
 #include <optional>
+#include <ranges>
 
 using namespace std::chrono_literals;
+
+namespace {
+
+class priority_compaction_exception final : public std::runtime_error {
+public:
+    explicit priority_compaction_exception(const std::string& msg)
+      : std::runtime_error(msg) {}
+};
+
+} // namespace
 
 namespace storage {
 using logs_type = absl::flat_hash_map<model::ntp, log_housekeeping_meta>;
@@ -252,8 +264,8 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
 
     if (
       config::shard_local_cfg().log_compaction_use_sliding_window.value()
-      && !_compaction_hash_key_map && !_logs_list.empty()
-      && is_not_set(_logs_list.front().flags, bflags::compacted)) {
+      && !_compaction_hash_key_map
+      && (!_logs_list.empty() || !_priority_logs_list.empty())) {
         auto compaction_mem_bytes
           = memory_groups().compaction_reserved_memory();
         auto compaction_map
@@ -264,6 +276,9 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
 
     sort_logs_by_compaction_heuristic(_logs_list);
 
+    // Housekeep priority partitions first.
+    co_await priority_housekeeping_scan(collection_threshold);
+
     while (
       !_logs_list.empty()
       && is_not_set(_logs_list.front().flags, bflags::compaction_checked)) {
@@ -271,8 +286,20 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
             co_return;
         }
 
-        auto& current_log = _logs_list.front();
+        // Before each regular housekeeping application, housekeep any priority
+        // logs that need it. This ensures priority partitions (e.g.
+        // __consumer_offsets) are not starved by long-running compactions.
+        if (priority_logs_need_compaction()) {
+            co_await priority_housekeeping_scan(collection_threshold);
+        }
 
+        // Re-check log list size before accessing front() after the above
+        // scheduling point.
+        if (_logs_list.empty()) {
+            co_return;
+        }
+
+        auto& current_log = _logs_list.front();
         _logs_list.shift_forward();
 
         current_log.flags |= bflags::compaction_checked;
@@ -305,7 +332,44 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
             continue;
         }
 
-        co_await do_housekeeping(current_log, collection_threshold);
+        // Set up timer-based preemption: if compaction exceeds the configured
+        // timeout and a priority partition needs compaction, abort so priority
+        // partitions can be serviced. If no priority partition needs
+        // compaction, rearm the timer to check on a shorter interval to check
+        // more frequently after `log_compaction_max_priority_wait_ms` has
+        // already passed.
+        ss::abort_source preempt_as;
+        const auto& ntp = current_log.handle->config().ntp();
+        auto timeout
+          = config::shard_local_cfg().log_compaction_max_priority_wait_ms();
+        ss::timer<ss::lowres_clock> preempt_timer;
+        preempt_timer.set_callback(
+          [this, &preempt_as, &ntp, &preempt_timer, timeout] {
+              bool priority_needs_compaction = priority_logs_need_compaction();
+              if (priority_needs_compaction) {
+                  vlog(
+                    gclog.info,
+                    "{}: compaction exceeded {}ms, preempting for priority "
+                    "partitions",
+                    ntp,
+                    timeout.count());
+                  preempt_as.request_abort_ex(priority_compaction_exception(
+                    "Compaction pre-empted for compaction of priority "
+                    "partition"));
+              } else {
+                  // Rearm at a fraction of the initial timeout
+                  preempt_timer.arm(timeout / 8);
+              }
+          });
+        preempt_timer.arm(timeout);
+
+        try {
+            co_await do_housekeeping(
+              current_log, collection_threshold, preempt_as);
+        } catch (const priority_compaction_exception& e) {
+            // Preempted for priority partition compaction.
+            vlog(gclog.info, "{} - {}", ntp, e);
+        }
     }
 }
 
@@ -609,6 +673,65 @@ void log_manager::sort_logs_by_compaction_heuristic(
     }
 }
 
+bool log_manager::is_priority_ntp(const model::ntp& ntp) const {
+    return model::is_consumer_offsets_topic(ntp);
+}
+
+bool log_manager::priority_logs_need_compaction() const {
+    return std::ranges::any_of(_priority_logs_list, [](const auto& l) {
+        return l.handle->needs_compaction();
+    });
+}
+
+ss::future<>
+log_manager::priority_housekeeping_scan(model::timestamp collection_threshold) {
+    // reset flags for the next two loops, segment_ms and compaction.
+    clear_log_meta_flags(_priority_logs_list);
+
+    co_await apply_segment_ms_to_logs(_priority_logs_list);
+
+    if (_abort_source.abort_requested()) {
+        co_return;
+    }
+
+    sort_logs_by_compaction_heuristic(_priority_logs_list);
+
+    while (!_priority_logs_list.empty()
+           && is_not_set(
+             _priority_logs_list.front().flags, bflags::compaction_checked)) {
+        if (_abort_source.abort_requested()) {
+            co_return;
+        }
+
+        auto& current_log = _priority_logs_list.front();
+        _priority_logs_list.shift_forward();
+
+        current_log.flags |= bflags::compaction_checked;
+
+        auto gate = current_log.housekeeping_gate.hold();
+
+        if (is_not_set(current_log.flags, bflags::should_compact)) {
+            // Still perform gc() here.
+            auto units = current_log.housekeeping_lock.try_get_units();
+            if (units.has_value()) {
+                co_await current_log.handle->gc(
+                  gc_config(collection_threshold, _config.retention_bytes()));
+            }
+
+            continue;
+        }
+
+        auto housekeeping_lock_holder
+          = co_await current_log.housekeeping_lock.get_units();
+
+        if (!current_log.link.is_linked()) {
+            continue;
+        }
+
+        co_await do_housekeeping(current_log, collection_threshold);
+    }
+}
+
 ss::future<> log_manager::do_housekeeping(
   log_housekeeping_meta& meta,
   model::timestamp collection_threshold,
@@ -830,7 +953,18 @@ ss::future<ss::shared_ptr<log>> log_manager::do_manage(
       std::move(translator_batch_types));
     auto [it, success] = _logs.emplace(
       l->config().ntp(), std::make_unique<log_housekeeping_meta>(l));
-    _logs_list.push_back(*it->second);
+
+    // Add to appropriate list based on whether this is a priority NTP.
+    if (is_priority_ntp(l->config().ntp())) {
+        _priority_logs_list.push_back(*it->second);
+        vlog(
+          stlog.debug,
+          "Tracking {} as priority partition for compaction",
+          l->config().ntp());
+    } else {
+        _logs_list.push_back(*it->second);
+    }
+
     update_log_count();
     vassert(success, "Could not keep track of:{} - concurrency issue", l);
     co_return l;

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -314,6 +314,12 @@ private:
     // heuristic.
     void sort_logs_by_compaction_heuristic(compaction_list_type& logs_list);
 
+    // Check if an NTP is a priority partition for compaction.
+    bool is_priority_ntp(const model::ntp& ntp) const;
+
+    // Returns true if any priority logs need compaction.
+    bool priority_logs_need_compaction() const;
+
     // Run housekeeping (gc + compaction) on a single partition.
     // The optional abort source is combined with _abort_source to create
     // a composite that triggers on either (used for timer-based preemption).
@@ -321,6 +327,12 @@ private:
       log_housekeeping_meta& meta,
       model::timestamp collection_threshold,
       model::opt_abort_source_t preempt_source = std::nullopt);
+
+    // Perform housekeeping on any priority partitions that need it. Called
+    // before each regular housekeeping iteration to ensure priority logs aren't
+    // starved.
+    ss::future<>
+    priority_housekeeping_scan(model::timestamp collection_threshold);
 
     disk_space_alert _disk_space_alert{disk_space_alert::ok};
 
@@ -338,6 +350,8 @@ private:
     simple_time_jitter<ss::lowres_clock> _trigger_gc_jitter;
     logs_type _logs;
     compaction_list_type _logs_list;
+    // List of priority partitions managed by housekeeping_loop().
+    compaction_list_type _priority_logs_list;
     batch_cache _batch_cache;
 
     // Hash key-map to use across multiple compactions to reuse reserved memory

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -22,6 +22,7 @@
 #include "features/feature_table.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "model/namespace.h"
 #include "random/simple_time_jitter.h"
 #include "storage/batch_cache.h"
 #include "storage/disk.h"
@@ -260,6 +261,12 @@ public:
     std::optional<batch_cache_index> create_cache(with_cache);
 
 private:
+    using bflags = log_housekeeping_meta::bitflags;
+
+    static bool is_not_set(bflags var, bflags flag) {
+        return (var & flag) != flag;
+    }
+
     using logs_type
       = chunked_hash_map<model::ntp, std::unique_ptr<log_housekeeping_meta>>;
     using compaction_list_type
@@ -293,6 +300,27 @@ private:
     ss::future<> gc_loop();
     bool _gc_triggered{false};
     ssx::semaphore _gc_sem{0, "log_manager::gc"};
+
+    // Clears bitflags for all log metas in the provided list (one of _logs_list
+    // or _priority_logs_list).
+    void clear_log_meta_flags(compaction_list_type&);
+
+    // Iterates over the provided list (one of _logs_list
+    // or _priority_logs_list) and applies `segment.ms` to each.
+    ss::future<> apply_segment_ms_to_logs(compaction_list_type&);
+
+    // Iterates over the provided list (one of _logs_list
+    // or _priority_logs_list) and sorts it based on a defined compaction
+    // heuristic.
+    void sort_logs_by_compaction_heuristic(compaction_list_type& logs_list);
+
+    // Run housekeeping (gc + compaction) on a single partition.
+    // The optional abort source is combined with _abort_source to create
+    // a composite that triggers on either (used for timer-based preemption).
+    ss::future<> do_housekeeping(
+      log_housekeeping_meta& meta,
+      model::timestamp collection_threshold,
+      model::opt_abort_source_t preempt_source = std::nullopt);
 
     disk_space_alert _disk_space_alert{disk_space_alert::ok};
 

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -31,6 +31,7 @@ from rptest.services.redpanda_installer import (
     RedpandaVersionLine,
     RedpandaVersionTriple,
 )
+from rptest.services.admin import Admin
 from rptest.services.redpanda import MetricsEndpoint
 from rptest.tests.partition_movement import PartitionMovementMixin
 from rptest.tests.prealloc_nodes import PreallocNodesTest
@@ -1323,3 +1324,302 @@ class LogCompactionTxRemovalUpgradeFrom25_3_1_Test(
     @cluster(num_nodes=4)
     def test_tx_control_batch_removal_with_upgrade_and_recovery(self):
         self.run_2segment_scenario()
+
+
+class PriorityPartitionCompactionTest(LogCompactionTestBase, PreallocNodesTest):
+    """
+    Tests that priority partitions (e.g. __consumer_offsets) are compacted
+    promptly even when heavy compaction is running on other topics.
+
+    This validates the priority compaction preemption mechanism added to
+    prevent starvation of __consumer_offsets when colocated with heavy
+    compaction workloads.
+    """
+
+    def __init__(self, test_context):
+        self.test_context = test_context
+        # Configure for heavy compaction with small segments.
+        self.extra_rp_conf = {
+            # Start with compaction effectively disabled - will enable later
+            "log_compaction_interval_ms": 3600 * 1000,  # 1 hour
+            "log_segment_size": 1024 * 1024,  # 1 MiB
+            "compacted_log_segment_size": 1024 * 1024,  # 1 MiB
+            "log_compaction_max_priority_wait_ms": 100,
+            "group_topic_partitions": 1,
+            "group_new_member_join_timeout": 3000,
+            "group_initial_rebalance_delay": 0,
+            # Frequent segment rolls
+            "log_segment_ms": 2000,
+            "log_segment_ms_min": 2000,
+            # Disable all forms of shard balancing for this test.
+            "enable_leader_balancer": False,
+            "partition_autobalancing_mode": "off",
+            "core_balancing_on_core_count_change": False,
+            "core_balancing_continuous": False,
+            # Allow altering __consumer_offsets config (e.g. min.cleanable.dirty.ratio)
+            "kafka_nodelete_topics": [],
+        }
+
+        environment = {"__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"}
+
+        super().__init__(
+            test_context=test_context,
+            num_brokers=3,
+            node_prealloc_count=1,
+            extra_rp_conf=self.extra_rp_conf,
+            environment=environment,
+        )
+
+        self.rpk = RpkTool(self.redpanda)
+        self.admin = Admin(self.redpanda)
+
+    def get_consumer_offsets_dirty_bytes(self, nodes=None):
+        """Get dirty segment bytes for __consumer_offsets topic."""
+        return self.redpanda.metric_sum(
+            metric_name="vectorized_storage_log_dirty_segment_bytes",
+            metrics_endpoint=MetricsEndpoint.METRICS,
+            topic="__consumer_offsets",
+            nodes=nodes,
+        )
+
+    def generate_consumer_offset_activity(self, stop_event, num_groups):
+        """
+        Generate activity on __consumer_offsets by creating consumer groups
+        and continuously committing offsets until stop_event is set.
+        """
+        # Create consumers and commit offsets to populate __consumer_offsets
+        consumers = []
+        for group_idx in range(num_groups):
+            group_id = f"test_group_{group_idx}"
+            consumer = ck.Consumer(
+                {
+                    "bootstrap.servers": self.redpanda.brokers(),
+                    "group.id": group_id,
+                    "auto.offset.reset": "earliest",
+                    "enable.auto.commit": False,
+                }
+            )
+            consumer.subscribe([self.topic_spec.name])
+            consumers.append(consumer)
+
+        while not stop_event.is_set():
+            for consumer in consumers:
+                msg = consumer.poll(timeout=0.1)
+                if msg is not None and not msg.error():
+                    try:
+                        consumer.commit(asynchronous=False)
+                    except Exception:
+                        pass  # Ignore commit errors
+
+        for consumer in consumers:
+            consumer.close()
+
+    def move_partition_to_same_shard_as_consumer_offsets(self):
+        """
+        Move the heavy topic partition to the same shard as __consumer_offsets/0
+        on each node. This ensures both partitions are processed by the same
+        housekeeping loop, which is required for the preemption mechanism to work.
+        """
+        co_cores = self._get_current_node_cores(
+            self.admin, "__consumer_offsets", partition_id=0
+        )
+        if not co_cores:
+            return False
+
+        co_shards = {r["node_id"]: r["core"] for r in co_cores}
+        self.redpanda.logger.info(
+            f"__consumer_offsets/0 actual local shard placement: {co_shards}"
+        )
+
+        heavy_cores = self._get_current_node_cores(
+            self.admin, self.topic_spec.name, partition_id=0
+        )
+        if not heavy_cores:
+            return False
+
+        heavy_shards = {r["node_id"]: r["core"] for r in heavy_cores}
+        self.redpanda.logger.info(
+            f"{self.topic_spec.name}/0 actual local shard placement: {heavy_shards}"
+        )
+
+        # Build target assignments: move heavy topic to same cores as __consumer_offsets
+        target_assignments = []
+        needs_move = False
+        for node_id, target_core in co_shards.items():
+            if node_id in heavy_shards:
+                target_assignments.append({"node_id": node_id, "core": target_core})
+                if heavy_shards[node_id] != target_core:
+                    needs_move = True
+                    self.redpanda.logger.info(
+                        f"Will move {self.topic_spec.name}/0 replica on node {node_id} "
+                        f"from core {heavy_shards[node_id]} to core {target_core}"
+                    )
+
+        if not needs_move:
+            self.redpanda.logger.info(
+                "Partitions already on same shards, no move needed"
+            )
+            return True
+
+        self._set_partition_assignments(
+            self.topic_spec.name, partition=0, assignments=target_assignments
+        )
+
+        self._wait_post_move(
+            self.topic_spec.name,
+            partition=0,
+            assignments=target_assignments,
+            timeout_sec=30,
+        )
+
+        return True
+
+    def produce_multiple_rounds(self, rounds=10, msgs_per_round=50000):
+        for round_num in range(rounds):
+            try:
+                producer = KgoVerifierProducer(
+                    context=self.test_context,
+                    redpanda=self.redpanda,
+                    topic=self.topic_spec.name,
+                    msg_size=1024,
+                    msg_count=msgs_per_round,
+                    rate_limit_bps=100 * 1024 * 1024,  # 100 MiBps
+                    key_set_cardinality=500,
+                    custom_node=self.preallocated_nodes,
+                )
+                producer.start()
+                producer.wait(timeout_sec=180)
+            finally:
+                producer.stop()
+
+    def continuous_produce(self, stop_event, msgs_per_batch):
+        """
+        Continuously produce data to the main topic until stop_event is set.
+        This ensures compaction has ongoing work and takes longer to complete.
+        """
+        while not stop_event.is_set():
+            try:
+                producer = KgoVerifierProducer(
+                    context=self.test_context,
+                    redpanda=self.redpanda,
+                    topic=self.topic_spec.name,
+                    msg_size=1024,
+                    msg_count=msgs_per_batch,
+                    rate_limit_bps=50 * 1024 * 1024,  # 50 MiBps
+                    key_set_cardinality=500,
+                    custom_node=self.preallocated_nodes,
+                )
+                producer.start()
+                producer.wait(timeout_sec=60)
+            except Exception:
+                pass  # Ignore errors, keep producing until stopped
+            finally:
+                producer.stop()
+
+    @skip_debug_mode
+    @cluster(num_nodes=4)
+    def test_priority_partition_not_starved(self):
+        """
+        Test that __consumer_offsets is compacted promptly even when heavy
+        compaction is running on other topics.
+
+        This test:
+        1. Creates a topic with heavy compaction workload with
+           compaction disabled during data production
+        2. Starts consumer offset commits
+        3. Enables compaction - heavy compaction and consumer offset activity run
+           concurrently
+        4. Verifies preemption was triggered
+        5. Verifies subsequent compaction still works
+        """
+        self.topic_setup(
+            cleanup_policy=TopicSpec.CLEANUP_COMPACT,
+            replication_factor=3,
+            partition_count=1,
+            min_cleanable_dirty_ratio=0.0,
+        )
+
+        # Compaction is disabled during this phase (interval is 1 hour).
+        self.produce_multiple_rounds()
+
+        # Start consumer offset activity BEFORE enabling compaction.
+        # This creates consumer offset data that will need compaction.
+        stop_event = threading.Event()
+        consumer_thread = threading.Thread(
+            target=self.generate_consumer_offset_activity,
+            args=(stop_event, 30),
+        )
+
+        # Start continuous background production to ensure compaction has
+        # ongoing work. This prevents the heavy compaction from completing
+        # before preemption can be triggered.
+        producer_thread = threading.Thread(
+            target=self.continuous_produce, args=(stop_event, 10000)
+        )
+
+        try:
+            consumer_thread.start()
+            producer_thread.start()
+
+            # Move heavy topic partition to same shard as `__consumer_offsets/0`
+            wait_until(
+                lambda: self.move_partition_to_same_shard_as_consumer_offsets(),
+                timeout_sec=120,
+                backoff_sec=1,
+                retry_on_exc=True,
+                err_msg="Timed out waiting for __consumer_offsets and main topic's partition to be placed on the same shard",
+            )
+
+            # Set min.cleanable.dirty.ratio=0 for __consumer_offsets so it
+            # always needs compaction when there's any dirty data.
+            self.rpk.alter_topic_config(
+                "__consumer_offsets", "min.cleanable.dirty.ratio", 0.0
+            )
+
+            # Enable frequent compactions
+            self.rpk.cluster_config_set("log_compaction_interval_ms", "1000")
+
+            # Check for preemption log message
+            wait_until(
+                lambda: self.redpanda.search_log_any(
+                    "preempting for priority partitions"
+                ),
+                timeout_sec=120,
+                backoff_sec=1,
+                err_msg="Priority compaction preemption was NOT triggered - expected to see 'preempting for priority partitions' in logs",
+            )
+        finally:
+            stop_event.set()
+            consumer_thread.join(timeout=30)
+            producer_thread.join(timeout=30)
+
+        # __consumer_offsets should be compacted quickly (dirty bytes go to 0)
+        # even while heavy compaction is ongoing
+        def consumer_offsets_is_clean():
+            co_dirty = self.get_consumer_offsets_dirty_bytes()
+            heavy_dirty = self.get_dirty_segment_bytes()
+            self.redpanda.logger.debug(
+                f"__consumer_offsets dirty: {co_dirty}, heavy topic dirty: {heavy_dirty}"
+            )
+            return co_dirty == 0
+
+        # Wait for __consumer_offsets to be fully compacted
+        wait_until(
+            consumer_offsets_is_clean,
+            timeout_sec=60,
+            backoff_sec=2,
+            err_msg="__consumer_offsets was not compacted in time",
+        )
+
+        # Set the configured priority wait timeout back to something more reasonable
+        self.rpk.cluster_config_set("log_compaction_max_priority_wait_ms", 3600 * 1000)
+
+        # Verify subsequent compaction on the main topic still make progress after pre-emption
+        initial_rounds = self.get_complete_sliding_window_rounds()
+        self.produce_multiple_rounds()
+        wait_until(
+            lambda: self.get_complete_sliding_window_rounds() > initial_rounds,
+            timeout_sec=120,
+            backoff_sec=1,
+            err_msg="Did not see subsequent compactions after pre-emption.",
+        )


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/29440
