### PR TITLE
[CORE-15482] `config`: change `log_compaction_tx_batch_removal_enabled` default

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1115,7 +1115,9 @@ configuration::configuration()
       "delete.retention.ms, and only if the topic's cleanup.policy "
       "allows compaction.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      false)
+      true,
+      property<bool>::noop_validator,
+      legacy_default<bool>(false, legacy_version{17}))
   , retention_bytes(
       *this,
       "retention_bytes",

--- a/src/v/storage/tests/compaction_e2e_multinode_test.cc
+++ b/src/v/storage/tests/compaction_e2e_multinode_test.cc
@@ -375,6 +375,7 @@ FIXTURE_TEST(segment_tx_flags_compaction_disabled, compaction_multinode_test) {
       .set_value(std::make_optional<uint32_t>(0));
     cfg.get("log_compaction_merge_max_ranges")
       .set_value(std::make_optional<uint32_t>(0));
+    cfg.get("log_compaction_tx_batch_removal_enabled").set_value(false);
 
     const model::topic topic{"tapioca"};
     model::node_id id{0};


### PR DESCRIPTION
`true` for clusters created with `>= v26.1.1`, `false` otherwise.

The plan for the future is to remove this `legacy_default` for `v26.2` and make it `true` by default: see https://redpandadata.atlassian.net/browse/CORE-15483.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
