### PR TITLE
`storage`: remove a bunch of unnecessary `is_linked()` checks

### DIFF
--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -328,10 +328,6 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         auto housekeeping_lock_holder
           = co_await current_log.housekeeping_lock.get_units();
 
-        if (!current_log.link.is_linked()) {
-            continue;
-        }
-
         // Set up timer-based preemption: if compaction exceeds the configured
         // timeout and a priority partition needs compaction, abort so priority
         // partitions can be serviced. If no priority partition needs
@@ -513,14 +509,8 @@ ss::future<> log_manager::gc_loop() {
 
                 auto housekeeping_lock_holder
                   = co_await log_meta.housekeeping_lock.get_units();
-                if (!log_meta.link.is_linked()) {
-                    continue;
-                }
 
                 co_await log_meta.handle->apply_segment_ms();
-                if (!log_meta.link.is_linked()) {
-                    continue;
-                }
 
                 auto ntp = log_meta.handle->config().ntp();
                 auto usage = co_await log_meta.handle->disk_usage(
@@ -605,10 +595,6 @@ ss::future<> log_manager::apply_segment_ms_to_logs(compaction_list_type& logs) {
         // log->apply_segment_ms() with gc fibre.
         auto housekeeping_lock_holder
           = co_await current_log.housekeeping_lock.get_units();
-
-        if (!current_log.link.is_linked()) {
-            continue;
-        }
 
         // NOTE: apply_segment_ms holds _compaction_housekeeping_gate, that
         // prevents the removal of the parent object. this makes awaiting
@@ -724,10 +710,6 @@ log_manager::priority_housekeeping_scan(model::timestamp collection_threshold) {
         auto housekeeping_lock_holder
           = co_await current_log.housekeeping_lock.get_units();
 
-        if (!current_log.link.is_linked()) {
-            continue;
-        }
-
         co_await do_housekeeping(current_log, collection_threshold);
     }
 }
@@ -736,10 +718,6 @@ ss::future<> log_manager::do_housekeeping(
   log_housekeeping_meta& meta,
   model::timestamp collection_threshold,
   model::opt_abort_source_t preempt_source) {
-    if (!meta.link.is_linked()) {
-        co_return;
-    }
-
     auto ntp = meta.handle->config().ntp();
     auto ntp_sanitizer_cfg = _config.maybe_get_ntp_sanitizer_config(ntp);
 


### PR DESCRIPTION
A few facts:

1. The underlying `log_housekeeping_meta` handle is stored via a `unique_ptr` in `_logs`.
2. `intrusive_list_hook` is of type `auto_unlink`, meaning entries in an `intrusive_list` are unlinked automatically when the underlying object is destructed.
3. Before we destruct `log_housekeeping_meta` handles anywhere (`shutdown()` or `remove()`), we wait on the `meta`'s `gate` to `close()`.
4. We _always_ hold a `meta`'s `gate` when interacting with it in a section of code with scheduling points.

Therefore, none of these `is_linked()` checks would ever be able to return anything but `true`, since there is no way the underlying `handle` could be destructed while its gate is held.

Clean up the code here by removing all the unnecessary checks.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
