### PR TITLE
dt: deflake quota management upgrade test

### DIFF
--- a/tests/rptest/tests/quota_management_test.py
+++ b/tests/rptest/tests/quota_management_test.py
@@ -35,7 +35,7 @@ from rptest.services.redpanda import (
     ClusterNode,
 )
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.util import expect_exception
+from rptest.util import expect_exception, wait_until_result
 
 log_config = LoggingConfig(
     "info",
@@ -769,6 +769,15 @@ class QuotaManagementUpgradeTest(EndToEndTest, QuotaManagementUtils):
     def __init__(self, test_context):
         super().__init__(test_context=test_context)
 
+    def alter_quotas(self, body: dict[str, Any], node: ClusterNode | None = None):
+        return wait_until_result(
+            lambda: (True, self.kcl.raw_alter_quotas(body, node=node)),
+            timeout_sec=10,
+            backoff_sec=1,
+            retry_on_exc=True,
+            err_msg="Failed to get a non_throwing alter quotas request",
+        )
+
     def transfer_leadership(self, new_leader: ClusterNode):
         """
         Request leadership transfer of the controller and check that it completes successfully.
@@ -830,7 +839,7 @@ class QuotaManagementUpgradeTest(EndToEndTest, QuotaManagementUtils):
 
         # Sanity check: v25.3 doesn't support user quotas
         self.logger.debug("Verify that user quotas are not supported in older version")
-        res = self.kcl.raw_alter_quotas(alter_user_quota_body)
+        res = self.alter_quotas(alter_user_quota_body)
         assert len(res["Entries"]) == 1, f"Unexpected entries: {res}"
         entry = res["Entries"][0]
         assert entry["ErrorCode"] == 35, f"Unexpected entry: {entry}"
@@ -844,7 +853,7 @@ class QuotaManagementUpgradeTest(EndToEndTest, QuotaManagementUtils):
         wait_for_num_versions(self.redpanda, 2)
 
         self.logger.debug("Verify that during upgrade user quotas are disabled")
-        res = self.kcl.raw_alter_quotas(alter_user_quota_body)
+        res = self.alter_quotas(alter_user_quota_body)
         assert len(res["Entries"]) == 1, f"Unexpected entries: {res}"
         entry = res["Entries"][0]
         assert entry["ErrorCode"] == 35, f"Unexpected entry: {entry}"
@@ -856,7 +865,7 @@ class QuotaManagementUpgradeTest(EndToEndTest, QuotaManagementUtils):
         wait_for_num_versions(self.redpanda, 1)
 
         self.logger.debug("Verify that user quotas are now enabled")
-        res = self.kcl.raw_alter_quotas(alter_user_quota_body, node=second_node)
+        res = self.alter_quotas(alter_user_quota_body, node=second_node)
         assert len(res["Entries"]) == 1, f"Unexpected entries: {res}"
         entry = res["Entries"][0]
         assert entry["ErrorCode"] == 0, f"Unexpected entry: {entry}"


### PR DESCRIPTION
Add a wait_until around alter_quota requests during a rolling upgrade. This is to retry requests that fail with an exception, because a node hasn't properly restarted, yet.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
