### PR TITLE
schema_registry/test: lower json recursion depth locally

### DIFF
--- a/src/v/pandaproxy/schema_registry/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/test/BUILD
@@ -360,6 +360,7 @@ redpanda_cc_btest(
         ":store_fixture",
         "//src/v/pandaproxy/schema_registry:core",
         "//src/v/test_utils:seastar_boost",
+        "//src/v/test_utils:test_env",
         "@abseil-cpp//absl/container:flat_hash_set",
         "@boost//:test",
         "@fmt",

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -17,6 +17,7 @@
 #include "pandaproxy/schema_registry/test/compatibility_common.h"
 #include "pandaproxy/schema_registry/test/store_fixture.h"
 #include "pandaproxy/schema_registry/types.h"
+#include "test_utils/test_env.h"
 
 #include <seastar/core/sstring.hh>
 #include <seastar/testing/thread_test_case.hh>
@@ -2376,7 +2377,7 @@ SEASTAR_THREAD_TEST_CASE(test_object_recursion_depths) {
     // With validation disabled, setting the limit above ~130 causes corruption
     // of the heap due to stack overflow, which typically manifests as a crash
     // during Seastar shutdown, or during is_superset.
-    constexpr int max_test_depth = 30;
+    const int max_test_depth = test_env::is_on_ci() ? 30 : 17;
 
     for (int depth = 1; depth <= max_test_depth; ++depth) {
         BOOST_TEST_MESSAGE(fmt::format("Testing depth {}", depth));

--- a/src/v/security/tests/BUILD
+++ b/src/v/security/tests/BUILD
@@ -12,7 +12,7 @@ redpanda_test_cc_library(
         "//src/v/security:license",
         "//src/v/test_utils:random",
         "//src/v/test_utils:random_bytes",
-        "@abseil-cpp//absl/strings",
+        "//src/v/test_utils:test_env",
     ],
 )
 

--- a/src/v/security/tests/license_utils.h
+++ b/src/v/security/tests/license_utils.h
@@ -10,18 +10,13 @@
 
 #pragma once
 
-#include "absl/strings/match.h"
 #include "security/license.h"
+#include "test_utils/test_env.h"
 
 namespace security::testing {
 
 constexpr std::string_view skip_no_license_msg
   = "Skipping the test without a valid license";
-
-inline bool is_on_ci() {
-    const char* ci_env = std::getenv("CI");
-    return ci_env && absl::EqualsIgnoreCase(ci_env, "true");
-}
 
 /// Retrieves and constructs a license from an environment variable. If the
 /// environment variable is missing, std::nullopt is returned outside of CI
@@ -31,7 +26,7 @@ inline std::optional<security::license>
 get_test_license(const char* env_var = "REDPANDA_SAMPLE_LICENSE") {
     const char* sample_valid_license = std::getenv(env_var);
     if (sample_valid_license == nullptr) {
-        if (is_on_ci()) {
+        if (test_env::is_on_ci()) {
             throw std::runtime_error{fmt::format(
               "Expecting the {} env var in the CI environment", env_var)};
         }

--- a/src/v/test_utils/BUILD
+++ b/src/v/test_utils/BUILD
@@ -246,6 +246,7 @@ redpanda_test_cc_library(
     ],
     implementation_deps = [
         "//src/v/random:generators",
+        "@abseil-cpp//absl/strings",
     ],
     visibility = ["//visibility:public"],
 )

--- a/src/v/test_utils/test_env.cc
+++ b/src/v/test_utils/test_env.cc
@@ -11,6 +11,7 @@
 
 #include "test_utils/test_env.h"
 
+#include "absl/strings/match.h"
 #include "random/generators.h"
 
 #include <cstdlib>
@@ -53,6 +54,11 @@ std::string getenv_default(
     std::string name{name_sv};
     const char* v = std::getenv(name.c_str());
     return v ? v : test_env::getenv(name + "_DEFAULT", default_value);
+}
+
+bool is_on_ci() noexcept {
+    const char* ci_env = std::getenv("CI");
+    return ci_env && absl::EqualsIgnoreCase(ci_env, "true");
 }
 
 } // namespace test_env

--- a/src/v/test_utils/test_env.h
+++ b/src/v/test_utils/test_env.h
@@ -41,4 +41,8 @@ getenv(std::string_view name, std::string_view default_value = "") noexcept;
 std::string getenv_default(
   std::string_view name, std::string_view default_value = "") noexcept;
 
+// Returns true if running in a CI environment.
+// Checks if the CI environment variable is set to "true" (case-insensitive).
+bool is_on_ci() noexcept;
+
 } // namespace test_env


### PR DESCRIPTION
Locally the test is failing with a stack overflow at a lower recursion limit, likely because of machine/OS/build-type differences.

So, lower the limit to ensure that tests pass locally, while still keeping the limit as is for CI to pick up any regressions.

Related to: https://github.com/redpanda-data/redpanda/pull/29290

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
