### PR TITLE
resource_mgmt: scheduling groups for cloud_topics metastore

### DIFF
--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -74,7 +74,7 @@ int_flag(
 
 int_flag(
     name = "scheduling_groups",
-    build_setting_default = 20,
+    build_setting_default = 21,
     make_variable = "SCHEDULING_GROUPS",
 )
 

--- a/src/v/redpanda/application_rpc.cc
+++ b/src/v/redpanda/application_rpc.cc
@@ -176,8 +176,8 @@ void application::add_runtime_rpc_services(
     if (config::shard_local_cfg().cloud_topics_enabled() && cloud_topics_app) {
         runtime_services.push_back(
           std::make_unique<cloud_topics::l1::rpc::service>(
-            scheduling_groups::instance().datalake_sg(),
-            smp_service_groups.datalake_sg(),
+            scheduling_groups::instance().cloud_topics_metastore_sg(),
+            smp_service_groups.cloud_topics_metastore_smp_sg(),
             cloud_topics_app->get_sharded_l1_metastore_router()));
     }
     runtime_services.push_back(

--- a/src/v/resource_mgmt/cpu_scheduling.h
+++ b/src/v/resource_mgmt/cpu_scheduling.h
@@ -132,6 +132,11 @@ public:
          */
         _cloud_topics_reconciler = co_await ss::create_scheduling_group(
           "cloud_topics_reconciler", 150);
+        /**
+         * Cloud topics metastore scheduling group.
+         */
+        _cloud_topics_metastore = co_await ss::create_scheduling_group(
+          "cloud_topics_metastore", 1000);
     }
 
     ss::scheduling_group admin_sg() { return _admin; }
@@ -178,6 +183,9 @@ public:
     ss::scheduling_group cloud_topics_reconciler_sg() {
         return _cloud_topics_reconciler;
     }
+    ss::scheduling_group cloud_topics_metastore_sg() {
+        return _cloud_topics_metastore;
+    }
 
     std::vector<std::reference_wrapper<const ss::scheduling_group>>
     all_scheduling_groups() const {
@@ -200,7 +208,8 @@ public:
           std::cref(_ts_read),
           std::cref(_cluster_linking),
           std::cref(_cloud_topics_compaction),
-          std::cref(_cloud_topics_reconciler)};
+          std::cref(_cloud_topics_reconciler),
+          std::cref(_cloud_topics_metastore)};
     }
 
 private:
@@ -226,4 +235,5 @@ private:
     ss::scheduling_group _cluster_linking;
     ss::scheduling_group _cloud_topics_compaction;
     ss::scheduling_group _cloud_topics_reconciler;
+    ss::scheduling_group _cloud_topics_metastore;
 };

--- a/src/v/resource_mgmt/smp_groups.cc
+++ b/src/v/resource_mgmt/smp_groups.cc
@@ -28,6 +28,8 @@ ss::future<> smp_groups::create_groups(config cfg) {
       cfg.datalake_group_max_non_local_requests);
     _cluster_link = co_await create_service_group(
       cfg.cluster_link_group_max_non_local_requests);
+    _cloud_topics_metastore = co_await create_service_group(
+      cfg.cloud_topics_metastore_group_max_non_local_requests);
 }
 
 ss::future<> smp_groups::destroy_groups() {
@@ -38,6 +40,7 @@ ss::future<> smp_groups::destroy_groups() {
     co_await destroy_smp_service_group(*_transform);
     co_await destroy_smp_service_group(*_datalake);
     co_await destroy_smp_service_group(*_cluster_link);
+    co_await destroy_smp_service_group(*_cloud_topics_metastore);
 }
 
 uint32_t

--- a/src/v/resource_mgmt/smp_groups.h
+++ b/src/v/resource_mgmt/smp_groups.h
@@ -37,6 +37,8 @@ public:
           = default_max_nonlocal_requests;
         uint32_t cluster_link_group_max_non_local_requests
           = default_max_nonlocal_requests;
+        uint32_t cloud_topics_metastore_group_max_non_local_requests
+          = default_max_nonlocal_requests;
     };
 
     smp_groups() = default;
@@ -49,6 +51,9 @@ public:
     ss::smp_service_group transform_smp_sg() { return *_transform; }
     ss::smp_service_group datalake_sg() { return *_datalake; }
     ss::smp_service_group cluster_link_smp_sg() { return *_cluster_link; }
+    ss::smp_service_group cloud_topics_metastore_smp_sg() {
+        return *_cloud_topics_metastore;
+    }
 
     ss::future<> destroy_groups();
 
@@ -66,4 +71,5 @@ private:
     std::unique_ptr<ss::smp_service_group> _proxy;
     std::unique_ptr<ss::smp_service_group> _transform;
     std::unique_ptr<ss::smp_service_group> _datalake;
+    std::unique_ptr<ss::smp_service_group> _cloud_topics_metastore;
 };


### PR DESCRIPTION
The metastore is an isolated component that will be serving requests for metadata about L1, which takes network, CPU, and potentially disk resources. As such, carves out a scheduling group for it. For CPU shares I gave it 1000, since it may be used to serve fetches, which also has a scheduling group of 1000 shares.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
