### PR TITLE
`rptest`: enable `DEBUG` logs for `cloud_topics-compaction` in `RNOT`

### DIFF
--- a/tests/rptest/fuzz/random_node_operations_test.py
+++ b/tests/rptest/fuzz/random_node_operations_test.py
@@ -50,6 +50,7 @@ class RandomNodeOperationsTest(RandomNodeOperationsBase):
                     "kafka": "debug",
                     "reconciler": "debug",
                     "cloud_topics": "debug",
+                    "cloud_topics-compaction": "debug",
                 },
             ),
         )

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1136,6 +1136,7 @@ class LoggingConfig:
     # assumed it was always supported/does not require special handling.
     LOGGER_GENESIS: dict[str, RedpandaVersionTriple] = {
         "datalake": (24, 3, 1),
+        "cloud_topics-compaction": (26, 1, 1),
     }
 
     def __init__(self, default_level: str, logger_levels: dict[str, str] = {}) -> None:

--- a/tests/rptest/tests/random_node_operations_smoke_test.py
+++ b/tests/rptest/tests/random_node_operations_smoke_test.py
@@ -283,8 +283,6 @@ class RandomNodeOperationsBase(PreallocNodesTest):
                 auto_assign_node_id=True,
                 omit_seeds_on_idx_one=False,
             )
-            admin = Admin(self.redpanda)
-            admin.set_log_level("cloud_topics-compaction", "trace")
 
     def _alter_local_topic_retention_bytes(self, topic: str, retention_bytes: int):
         rpk = RpkTool(self.redpanda)
@@ -918,6 +916,7 @@ class RedpandaNodeOperationsSmokeTest(RandomNodeOperationsBase):
                     "kafka": "debug",
                     "reconciler": "debug",
                     "cloud_topics": "debug",
+                    "cloud_topics-compaction": "debug",
                     "offset_translator": "trace",
                 },
             ),


### PR DESCRIPTION
## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
