### PR TITLE
ci: upgrade actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -27,7 +27,7 @@ jobs:
       target_milestone: ${{ steps.get_backport_type.outputs.target_milestone }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
@@ -68,7 +68,7 @@ jobs:
     env:
       BACKPORT_BRANCH: ${{ needs.backport-type.outputs.backport_branch }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
@@ -119,7 +119,7 @@ jobs:
         run: |
           backport_commits=$(gh api "repos/$TARGET_FULL_REPO/pulls/$BACKPORT_PR_NUMBER/commits" --paginate --jq '[.[].sha[0:10]]|join(" ")')
           echo "backport_commits=$backport_commits" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: needs.backport-type.outputs.commented_on == 'pr'
         with:
           repository: ${{ steps.user.outputs.username }}/${{ steps.user.outputs.repo }}

--- a/.github/workflows/backport-on-merge.yml
+++ b/.github/workflows/backport-on-merge.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # Find the PR associated with this push, if there is one.
       - uses: jwalton/gh-find-current-pr@v1
         id: findPr

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -43,7 +43,7 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Buf – lint & breaking
         uses: bufbuild/buf-action@v1
         with:
@@ -71,7 +71,7 @@ jobs:
           secret-ids: |
             ,sdlc/prod/github/buf_token
           parse-json-secrets: true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Preprocess proto files for buf publishing
         run: |
           # WORKAROUND: Our Bazel structure puts proto files to live under a "proto/"

--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -30,7 +30,7 @@ jobs:
             ,sdlc/prod/github/actions_bot_token
             ,sdlc/prod/github/buildkite_token
           parse-json-secrets: true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: redpanda-data/sparse-checkout
           token: ${{ env.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -29,7 +29,7 @@ jobs:
             ,sdlc/prod/github/actions_bot_token
             ,sdlc/prod/github/buildkite_token
           parse-json-secrets: true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: redpanda-data/sparse-checkout
           token: ${{ env.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/cloud-installpack-bk-trigger.yml
+++ b/.github/workflows/cloud-installpack-bk-trigger.yml
@@ -20,7 +20,7 @@ jobs:
             ,sdlc/prod/github/actions_bot_token
             ,sdlc/prod/github/buildkite_token
           parse-json-secrets: true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: redpanda-data/sparse-checkout
           token: ${{ env.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/lint-bazel-dependency-graph.yml
+++ b/.github/workflows/lint-bazel-dependency-graph.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: bazel-contrib/setup-bazel@0.15.0
         with:
           # Avoid downloading Bazel every time.

--- a/.github/workflows/lint-bazel-pkg-tool.yml
+++ b/.github/workflows/lint-bazel-pkg-tool.yml
@@ -18,7 +18,7 @@ jobs:
   golangci-lint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: stable

--- a/.github/workflows/lint-cpp.yml
+++ b/.github/workflows/lint-cpp.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: bazel-contrib/setup-bazel@0.15.0
         with:
           # Avoid downloading Bazel every time.

--- a/.github/workflows/lint-golang.yml
+++ b/.github/workflows/lint-golang.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Ruff format --check
         uses: astral-sh/ruff-action@v3
         with:

--- a/.github/workflows/lint-sh.yml
+++ b/.github/workflows/lint-sh.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install shfmt
         env:
           SHFMT_VER: 3.12.0

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -16,5 +16,5 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: yamllint -f github .yamllint .github/workflows/*.yml

--- a/.github/workflows/p.yml
+++ b/.github/workflows/p.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Compile
         working-directory: tests/models
         run: ../../tools/p/p compile

--- a/.github/workflows/publish-apache-polaris-python-client.yml
+++ b/.github/workflows/publish-apache-polaris-python-client.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Polaris project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: 'apache/polaris'
       - name: Set up Python 3.11

--- a/.github/workflows/release-rp-storage-tool.yml
+++ b/.github/workflows/release-rp-storage-tool.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build binary
         run: |
           export DOCKER_BUILDKIT=1

--- a/.github/workflows/rp-storage-tool-checks.yml
+++ b/.github/workflows/rp-storage-tool-checks.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -43,7 +43,7 @@ jobs:
             goarch: arm64
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: stable
@@ -56,7 +56,7 @@ jobs:
         runner: [ubuntu-24.04, macos-15]
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: stable
@@ -66,7 +66,7 @@ jobs:
   check-proto-gen:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: stable

--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -32,7 +32,7 @@ jobs:
     name: Build integration tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -50,7 +50,7 @@ jobs:
     name: Test Golang Transform SDK
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -68,7 +68,7 @@ jobs:
     needs: [test-golang, build-integration-tests]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -104,7 +104,7 @@ jobs:
     name: Test Rust Transform SDK
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Rust
         run: |
           rustup update --no-self-update ${{ env.RUST_VERSION }}
@@ -124,7 +124,7 @@ jobs:
     needs: [test-rust, build-integration-tests]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Rust
         run: |
           rustup update --no-self-update ${{ env.RUST_VERSION }}
@@ -160,7 +160,7 @@ jobs:
     container:
       image: fedora:40
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Clang
         run: dnf install -y clang clang-tools-extra libcxx libcxxabi libcxx-devel libcxxabi-devel cmake
       - name: Run tests
@@ -182,7 +182,7 @@ jobs:
     container:
       image: ghcr.io/webassembly/wasi-sdk:wasi-sdk-24
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build integration tests
         working-directory: src/transform-sdk/cpp/examples
         run: cmake -B build && cmake --build build
@@ -207,7 +207,7 @@ jobs:
     container:
       image: fedora:40
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Clang
         run: dnf install -y clang clang-tools-extra libcxx libcxxabi libcxx-devel libcxxabi-devel cmake git
       - name: Run tests
@@ -229,7 +229,7 @@ jobs:
     container:
       image: ghcr.io/webassembly/wasi-sdk:wasi-sdk-24
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/transform-sdk-release.yml
+++ b/.github/workflows/transform-sdk-release.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: 1.22
@@ -49,7 +49,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Rust
         run: rustup update stable --no-self-update && rustup default stable
       - uses: aws-actions/configure-aws-credentials@v4
@@ -81,7 +81,7 @@ jobs:
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}

--- a/.github/workflows/type-check-python.yaml
+++ b/.github/workflows/type-check-python.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v3
       - uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
jira: [DEVPROD-3744]

Update all GitHub Actions workflow files to use latest actions/checkout@v6 to get latest updates and fixes.

See action release notes: https://github.com/actions/checkout/releases

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x

## Release Notes

* none

[DEVPROD-3744]: https://redpandadata.atlassian.net/browse/DEVPROD-3744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ