### PR TITLE
ct: End to end cluster recovery

### DIFF
--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -19,6 +19,7 @@
 #include "raft/persisted_stm.h"
 #include "ssx/future-util.h"
 #include "ssx/watchdog.h"
+#include "storage/snapshot.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/sleep.hh>
@@ -512,4 +513,34 @@ fmt::iterator epoch_window_checker::format_to(fmt::iterator it) const {
     return fmt::format_to(
       it, "window=[{}, {}], offset={}", _min_epoch, _max_epoch, _latest_offset);
 }
+
+ss::future<> create_ctp_stm_bootstrap_snapshot(
+  const std::filesystem::path& work_directory, kafka::offset start_offset) {
+    // Create empty state with the correct start_offset
+    ctp_stm_state state;
+    state.set_start_offset(start_offset);
+
+    // Create empty epoch checker
+    epoch_window_checker checker;
+
+    // Create the snapshot
+    ctp_stm_snapshot snap{.state = state, .checker = checker};
+    auto data = serde::to_iobuf(snap);
+
+    // The snapshot offset should be one before the start_offset since
+    // the snapshot represents state "up to and including" this offset.
+    // For a partition starting at start_offset, the snapshot should be
+    // at prev_offset(start_offset) (converted to model::offset).
+    auto snapshot_offset = model::prev_offset(model::offset(start_offset()));
+    auto stm_snap = raft::stm_snapshot::create(
+      0, snapshot_offset, std::move(data));
+
+    // Persist using the file-backed snapshot manager
+    storage::simple_snapshot_manager snapshot_mgr(
+      work_directory, ss::sstring(ctp_stm::name));
+
+    co_await raft::file_backed_stm_snapshot::persist_local_snapshot(
+      snapshot_mgr, std::move(stm_snap));
+}
+
 }; // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -515,10 +515,17 @@ fmt::iterator epoch_window_checker::format_to(fmt::iterator it) const {
 }
 
 ss::future<> create_ctp_stm_bootstrap_snapshot(
-  const std::filesystem::path& work_directory, kafka::offset start_offset) {
-    // Create empty state with the correct start_offset
+  const std::filesystem::path& work_directory, ctp_stm_seed_offsets offsets) {
+    // The starting CTP STM state includes start offset
+    // and LRO. The LRO has two components, log offset and kafka offset.
+    // The assumption here is that the partition is re-created and the
+    // offset translator state is empty. Because of that log offset is
+    // equal to kafka offset.
     ctp_stm_state state;
-    state.set_start_offset(start_offset);
+    state.set_start_offset(offsets.start_offset);
+    auto k_lro = kafka::prev_offset(offsets.next_offset);
+    auto l_lro = kafka::offset_cast(k_lro);
+    state.advance_last_reconciled_offset(k_lro, l_lro);
 
     // Create empty epoch checker
     epoch_window_checker checker;
@@ -527,13 +534,9 @@ ss::future<> create_ctp_stm_bootstrap_snapshot(
     ctp_stm_snapshot snap{.state = state, .checker = checker};
     auto data = serde::to_iobuf(snap);
 
-    // The snapshot offset should be one before the start_offset since
-    // the snapshot represents state "up to and including" this offset.
-    // For a partition starting at start_offset, the snapshot should be
-    // at prev_offset(start_offset) (converted to model::offset).
-    auto snapshot_offset = model::prev_offset(model::offset(start_offset()));
-    auto stm_snap = raft::stm_snapshot::create(
-      0, snapshot_offset, std::move(data));
+    // The snapshot offset should be equal to l_lro since the partition is
+    // empty and starting offset is equal to LRO + 1.
+    auto stm_snap = raft::stm_snapshot::create(0, l_lro, std::move(data));
 
     // Persist using the file-backed snapshot manager
     storage::simple_snapshot_manager snapshot_mgr(

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -168,4 +168,15 @@ private:
     model::offset _last_truncation_point;
 };
 
+/// Create a bootstrap snapshot for ctp_stm with the given start offset.
+/// This is used when bootstrapping a partition with a custom start offset
+/// during cluster recovery. The snapshot contains an empty state with
+/// the correct start_offset set.
+///
+/// \param work_directory The partition's work directory
+/// \param start_offset The kafka offset to set as the start offset
+/// \return A future that completes when the snapshot is persisted
+ss::future<> create_ctp_stm_bootstrap_snapshot(
+  const std::filesystem::path& work_directory, kafka::offset start_offset);
+
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -168,15 +168,21 @@ private:
     model::offset _last_truncation_point;
 };
 
-/// Create a bootstrap snapshot for ctp_stm with the given start offset.
+/// Offsets used to seed the re-created ctp_stm_state
+struct ctp_stm_seed_offsets {
+    kafka::offset start_offset;
+    kafka::offset next_offset;
+};
+
+/// Create a bootstrap snapshot for ctp_stm with the given state.
 /// This is used when bootstrapping a partition with a custom start offset
-/// during cluster recovery. The snapshot contains an empty state with
-/// the correct start_offset set.
+/// during cluster recovery. The caller is responsible for seeding the
+/// initial state correctly.
 ///
 /// \param work_directory The partition's work directory
-/// \param start_offset The kafka offset to set as the start offset
+/// \param offsets The initial STM state
 /// \return A future that completes when the snapshot is persisted
 ss::future<> create_ctp_stm_bootstrap_snapshot(
-  const std::filesystem::path& work_directory, kafka::offset start_offset);
+  const std::filesystem::path& work_directory, ctp_stm_seed_offsets offsets);
 
 } // namespace cloud_topics

--- a/src/v/cluster/cloud_metadata/cluster_recovery_backend.cc
+++ b/src/v/cluster/cloud_metadata/cluster_recovery_backend.cc
@@ -346,6 +346,13 @@ ss::future<cluster::errc> cluster_recovery_backend::do_action(
         }
         const auto& metastore_conf = metastore_meta->get_configuration();
         const auto metastore_label = metastore_conf.properties.remote_label;
+
+        // Get metastore for querying partition offsets/terms
+        cloud_topics::l1::metastore* metastore = nullptr;
+        if (_ct_state) {
+            metastore = _ct_state->local().get_l1_metastore();
+        }
+
         topic_configuration_vector topics;
         for (auto& topic_cfg : actions.cloud_topics) {
             if (topic_cfg.is_read_replica()) {
@@ -365,6 +372,114 @@ ss::future<cluster::errc> cluster_recovery_backend::do_action(
                       topic_label,
                       metastore_label);
                 }
+
+                // Query metastore for bootstrap params and set them before
+                // creating the topic
+                if (metastore && topic_cfg.tp_id.has_value()) {
+                    absl::
+                      btree_map<model::partition_id, partition_bootstrap_params>
+                        partition_params;
+
+                    for (int32_t p = 0; p < topic_cfg.partition_count; ++p) {
+                        auto pid = model::partition_id(p);
+                        model::topic_id_partition tidp(
+                          topic_cfg.tp_id.value(), pid);
+
+                        // Get start offset from metastore.
+                        // missing_ntp is expected for new partitions
+                        // that haven't been flushed to the metastore
+                        // yet - treat as empty partition.
+                        auto offsets_res = co_await metastore->get_offsets(
+                          tidp);
+                        if (!offsets_res.has_value()) {
+                            if (
+                              offsets_res.error()
+                              == cloud_topics::l1::metastore::errc::
+                                missing_ntp) {
+                                vlog(
+                                  clusterlog.debug,
+                                  "Partition {} not found in metastore, "
+                                  "starting empty",
+                                  tidp);
+                                continue;
+                            }
+                            vlog(
+                              clusterlog.error,
+                              "Failed to get offsets for {} from metastore: {}",
+                              tidp,
+                              offsets_res.error());
+                            co_return cluster::errc::replication_error;
+                        }
+
+                        // Start offset for a CTP is a next_offset that
+                        // the metastore expects to reconcile.
+                        auto start_offset = offsets_res->next_offset;
+
+                        // Get term for start offset.
+                        // missing_ntp and out_of_range are acceptable
+                        // - use term 0. Other errors are transient and
+                        // worth retrying.
+                        auto term_res = co_await metastore->get_term_for_offset(
+                          tidp, start_offset);
+                        model::term_id initial_term{0};
+                        if (term_res.has_value()) {
+                            initial_term = term_res.value();
+                        } else if (
+                          term_res.error()
+                            == cloud_topics::l1::metastore::errc::missing_ntp
+                          || term_res.error()
+                               == cloud_topics::l1::metastore::errc::
+                                 out_of_range) {
+                            vlog(
+                              clusterlog.debug,
+                              "Term not found for {} offset {}: {}, using "
+                              "term 0",
+                              tidp,
+                              start_offset,
+                              term_res.error());
+                        } else {
+                            vlog(
+                              clusterlog.error,
+                              "Failed to get term for {} offset {} from "
+                              "metastore: {}",
+                              tidp,
+                              start_offset,
+                              term_res.error());
+                            co_return cluster::errc::replication_error;
+                        }
+
+                        partition_params[pid] = partition_bootstrap_params{
+                          kafka::offset_cast(start_offset), initial_term};
+
+                        vlog(
+                          clusterlog.debug,
+                          "Setting bootstrap params for {}/{}: "
+                          "start_offset={}, "
+                          "term={}",
+                          topic_cfg.tp_ns,
+                          pid,
+                          start_offset,
+                          initial_term);
+                    }
+
+                    if (!partition_params.empty()) {
+                        retry_chain_node bootstrap_retry(&parent_retry);
+                        auto ec
+                          = co_await _recovery_manager.set_bootstrap_params(
+                            topic_cfg.tp_ns,
+                            std::move(partition_params),
+                            bootstrap_retry.get_deadline());
+                        if (ec) {
+                            vlog(
+                              clusterlog.error,
+                              "Failed to set bootstrap params for {}: {}",
+                              topic_cfg.tp_ns,
+                              ec);
+                            co_return cluster::errc::replication_error;
+                        }
+                    }
+                }
+
                 topics.emplace_back(std::move(topic_cfg));
                 vlog(
                   clusterlog.debug,

--- a/src/v/cluster/cloud_metadata/cluster_recovery_backend.cc
+++ b/src/v/cluster/cloud_metadata/cluster_recovery_backend.cc
@@ -413,7 +413,8 @@ ss::future<cluster::errc> cluster_recovery_backend::do_action(
 
                         // Start offset for a CTP is a next_offset that
                         // the metastore expects to reconcile.
-                        auto start_offset = offsets_res->next_offset;
+                        auto start_offset = offsets_res->start_offset;
+                        auto next_offset = offsets_res->next_offset;
 
                         // Get term for start offset.
                         // missing_ntp and out_of_range are acceptable
@@ -449,7 +450,9 @@ ss::future<cluster::errc> cluster_recovery_backend::do_action(
                         }
 
                         partition_params[pid] = partition_bootstrap_params{
-                          kafka::offset_cast(start_offset), initial_term};
+                          kafka::offset_cast(start_offset),
+                          kafka::offset_cast(next_offset),
+                          initial_term};
 
                         vlog(
                           clusterlog.debug,

--- a/src/v/cluster/cloud_metadata/tests/controller_snapshot_reconciliation_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/controller_snapshot_reconciliation_test.cc
@@ -502,12 +502,12 @@ TEST_F(
       [&](
         const model::topic_namespace& tp_ns,
         const cluster::topic_properties& props,
-        bool expect_action,
-        std::optional<bool> expect_recovery = std::nullopt) {
+        bool expect_action) {
           cluster::controller_snapshot snap;
           auto& tps = snap.topics.topics[tp_ns];
           tps.metadata.configuration.tp_ns = tp_ns;
           tps.metadata.configuration.properties = props;
+          tps.metadata.revision = model::revision_id{42};
 
           auto actions = reconciler.get_actions(snap);
           ASSERT_EQ(
@@ -525,13 +525,14 @@ TEST_F(
           if (expect_action) {
               ASSERT_EQ(actions.cloud_topics.size(), 1);
               ASSERT_EQ(actions.cloud_topics[0].tp_ns, tp_ns);
-              if (expect_recovery.has_value()) {
-                  // recovery is std::optional<bool>, so we check the effective
-                  // boolean value (nullopt and false are both falsy).
-                  ASSERT_EQ(
-                    actions.cloud_topics[0].properties.recovery.value_or(false),
-                    *expect_recovery);
-              }
+              // Verify that remote_topic_properties is set with the correct
+              // revision for cloud topics.
+              ASSERT_TRUE(actions.cloud_topics[0]
+                            .properties.remote_topic_properties.has_value());
+              ASSERT_EQ(
+                actions.cloud_topics[0]
+                  .properties.remote_topic_properties->remote_revision,
+                model::initial_revision_id{42});
           } else {
               ASSERT_TRUE(actions.cloud_topics.empty());
           }
@@ -539,14 +540,16 @@ TEST_F(
 
     model::topic_namespace tp_ns{model::kafka_namespace, model::topic{"foo"}};
 
-    // Case 1: Cloud topic doesn't exist - should create with recovery=true.
-    check_cloud_topic_action(tp_ns, cloud_topic_properties(), true, true);
+    // Case 1: Cloud topic doesn't exist - should create and set
+    // remote_topic_properties.
+    check_cloud_topic_action(tp_ns, cloud_topic_properties(), true);
 
-    // Case 2: Read-replica cloud topic - should create with recovery=false.
+    // Case 2: Read-replica cloud topic - should create and set
+    // remote_topic_properties.
     model::topic_namespace rr_tp_ns{
       model::kafka_namespace, model::topic{"read_replica"}};
     check_cloud_topic_action(
-      rr_tp_ns, read_replica_cloud_topic_properties(), true, false);
+      rr_tp_ns, read_replica_cloud_topic_properties(), true);
 
     // Case 3: Topic already exists - no action needed.
     // Create a topic in the cluster. The reconciler only checks for topic
@@ -555,8 +558,7 @@ TEST_F(
     model::topic_namespace existing_tp_ns{
       model::kafka_namespace, model::topic{"existing"}};
     add_topic(existing_tp_ns, 1, non_remote_topic_properties()).get();
-    check_cloud_topic_action(
-      existing_tp_ns, cloud_topic_properties(), false, std::nullopt);
+    check_cloud_topic_action(existing_tp_ns, cloud_topic_properties(), false);
 }
 
 TEST_F(

--- a/src/v/cluster/cluster_recovery_manager.cc
+++ b/src/v/cluster/cluster_recovery_manager.cc
@@ -301,6 +301,22 @@ ss::future<cluster::errc> cluster_recovery_manager::replicate_update(
     co_return cluster::errc::success;
 }
 
+ss::future<std::error_code> cluster_recovery_manager::set_bootstrap_params(
+  model::topic_namespace tp_ns,
+  absl::btree_map<model::partition_id, partition_bootstrap_params> params,
+  model::timeout_clock::time_point timeout) {
+    // Note: This command can be applied BEFORE the topic exists.
+    // The bootstrap params are stored in a pending map and will be
+    // consumed when the partition is created by controller_backend.
+    set_partition_bootstrap_params_cmd_data data{
+      .tp_ns = tp_ns, .partition_params = std::move(params)};
+
+    set_partition_bootstrap_params_cmd cmd(tp_ns, std::move(data));
+
+    co_return co_await replicate_and_wait(
+      _controller_stm, _sharded_as, std::move(cmd), timeout);
+}
+
 ss::future<std::error_code>
 cluster_recovery_manager::apply_update(model::record_batch b) {
     auto offset = b.base_offset();
@@ -320,6 +336,10 @@ ss::future<std::error_code> cluster_recovery_manager::apply_to_table(
 }
 ss::future<std::error_code> cluster_recovery_manager::apply_to_table(
   model::offset offset, cluster_recovery_update_cmd cmd) {
+    return dispatch_updates_to_cores(offset, std::move(cmd));
+}
+ss::future<std::error_code> cluster_recovery_manager::apply_to_table(
+  model::offset offset, set_partition_bootstrap_params_cmd cmd) {
     return dispatch_updates_to_cores(offset, std::move(cmd));
 }
 

--- a/src/v/cluster/cluster_recovery_manager.h
+++ b/src/v/cluster/cluster_recovery_manager.h
@@ -64,10 +64,19 @@ public:
       recovery_stage next_stage,
       std::optional<ss::sstring> error_msg = std::nullopt);
 
+    // Set bootstrap parameters for partitions in an existing topic.
+    // Must be called before partitions are materialized by controller_backend.
+    // Used by cluster recovery to specify known offsets.
+    ss::future<std::error_code> set_bootstrap_params(
+      model::topic_namespace,
+      absl::btree_map<model::partition_id, partition_bootstrap_params>,
+      model::timeout_clock::time_point);
+
     // Interface for mux_state_machine.
     static constexpr auto commands = make_commands_list<
       cluster_recovery_init_cmd,
-      cluster_recovery_update_cmd>();
+      cluster_recovery_update_cmd,
+      set_partition_bootstrap_params_cmd>();
 
     bool is_batch_applicable(const model::record_batch& b) const;
     ss::future<std::error_code> apply_update(model::record_batch b);
@@ -79,6 +88,8 @@ public:
     apply_snapshot(model::offset, const controller_snapshot& snap) {
         co_await _recovery_table.invoke_on_all([&snap](auto& table) mutable {
             table.set_recovery_states(snap.cluster_recovery.recovery_states);
+            table.set_pending_bootstrap_params(
+              snap.cluster_recovery.pending_bootstrap_params);
         });
     }
 
@@ -92,6 +103,8 @@ private:
       apply_to_table(model::offset, cluster_recovery_init_cmd);
     ss::future<std::error_code>
       apply_to_table(model::offset, cluster_recovery_update_cmd);
+    ss::future<std::error_code>
+      apply_to_table(model::offset, set_partition_bootstrap_params_cmd);
 
     // NOTE: only sharded to comply with the signature of replicate_and_wait().
     // Still only used on shard-0.

--- a/src/v/cluster/cluster_recovery_reconciler.cc
+++ b/src/v/cluster/cluster_recovery_reconciler.cc
@@ -203,8 +203,14 @@ controller_snapshot_reconciler::get_actions(
             }
             if (tp_config.is_cloud_topic()) {
                 auto new_config = tp_config;
-                if (!new_config.is_read_replica()) {
-                    new_config.properties.recovery = true;
+                if (!new_config.properties.remote_topic_properties
+                       .has_value()) {
+                    auto& remote_props
+                      = new_config.properties.remote_topic_properties.emplace();
+                    remote_props.remote_revision = model::initial_revision_id{
+                      meta.metadata.revision};
+                    remote_props.remote_partition_count
+                      = tp_config.partition_count;
                 }
                 actions.cloud_topics.emplace_back(std::move(new_config));
                 continue;

--- a/src/v/cluster/cluster_recovery_table.cc
+++ b/src/v/cluster/cluster_recovery_table.cc
@@ -71,6 +71,8 @@ std::error_code cluster_recovery_table::apply(
       manifest,
       bucket,
       wait_for_nodes);
+    // Clear any stale bootstrap params from previous recovery attempts
+    _pending_bootstrap_params.clear();
     _states.emplace_back(
       std::move(manifest), std::move(bucket), wait_for_nodes);
     _has_active_recovery.signal();
@@ -107,7 +109,59 @@ cluster_recovery_table::apply(model::offset, cluster_recovery_update_cmd cmd) {
     if (cmd.value.error_msg.has_value()) {
         _states.back().error_msg = std::move(cmd.value.error_msg);
     }
+    // Clear bootstrap params when recovery completes or fails
+    if (
+      cmd.value.stage == recovery_stage::complete
+      || cmd.value.stage == recovery_stage::failed) {
+        if (!_pending_bootstrap_params.empty()) {
+            vlog(
+              clusterlog.debug,
+              "Clearing {} pending bootstrap params as recovery {}",
+              _pending_bootstrap_params.size(),
+              cmd.value.stage);
+            _pending_bootstrap_params.clear();
+        }
+    }
     return errc::success;
+}
+
+std::error_code cluster_recovery_table::apply(
+  model::offset, set_partition_bootstrap_params_cmd cmd) {
+    const auto& tp_ns = cmd.value.tp_ns;
+
+    // Store bootstrap params in the pending map. These will be consumed
+    // when the partition is created by controller_backend.
+    // Note: This command is applied during cluster recovery.
+    for (const auto& [partition_id, params] : cmd.value.partition_params) {
+        model::ntp ntp(tp_ns.ns, tp_ns.tp, partition_id);
+        _pending_bootstrap_params[ntp] = params;
+
+        vlog(
+          clusterlog.debug,
+          "Set pending bootstrap params for {}: offset={}, term={}",
+          ntp,
+          params.start_offset,
+          params.initial_term);
+    }
+
+    return errc::success;
+}
+
+std::optional<partition_bootstrap_params>
+cluster_recovery_table::get_partition_bootstrap_params(
+  const model::ntp& ntp) const {
+    if (auto it = _pending_bootstrap_params.find(ntp);
+        it != _pending_bootstrap_params.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+void cluster_recovery_table::fill_snapshot(controller_snapshot& snap) {
+    snap.cluster_recovery.recovery_states = _states;
+    for (const auto& [ntp, params] : _pending_bootstrap_params) {
+        snap.cluster_recovery.pending_bootstrap_params.emplace(ntp, params);
+    }
 }
 
 } // namespace cluster

--- a/src/v/cluster/cluster_recovery_table.h
+++ b/src/v/cluster/cluster_recovery_table.h
@@ -118,12 +118,25 @@ public:
       wait_for_nodes wait = wait_for_nodes::no);
     std::error_code apply(model::offset offset, cluster_recovery_init_cmd);
     std::error_code apply(model::offset offset, cluster_recovery_update_cmd);
+    std::error_code
+    apply(model::offset offset, set_partition_bootstrap_params_cmd);
 
-    void fill_snapshot(controller_snapshot& snap) {
-        snap.cluster_recovery.recovery_states = _states;
+    /// Returns the bootstrap params for a partition if set.
+    /// Used by controller_backend when creating partitions during recovery.
+    std::optional<partition_bootstrap_params>
+    get_partition_bootstrap_params(const model::ntp& ntp) const;
+
+    const pending_bootstrap_params_t& get_pending_bootstrap_params() const {
+        return _pending_bootstrap_params;
     }
+
+    void fill_snapshot(controller_snapshot& snap);
     void set_recovery_states(std::vector<cluster_recovery_state> states) {
         _states = std::move(states);
+    }
+    void
+    set_pending_bootstrap_params(const pending_bootstrap_params_t& params) {
+        _pending_bootstrap_params.replace(params.values().copy());
     }
 
 private:
@@ -131,6 +144,10 @@ private:
 
     ss::condition_variable _has_active_recovery;
     std::vector<cluster_recovery_state> _states;
+    /// Bootstrap params set during cluster recovery. These are consumed when
+    /// the partition is created and removed from this map when recovery
+    /// completes/fails.
+    pending_bootstrap_params_t _pending_bootstrap_params;
 };
 
 } // namespace cluster

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -103,6 +103,7 @@ inline constexpr int8_t force_partition_reconfiguration_type = 11;
 inline constexpr int8_t update_partition_replicas_cmd_type = 12;
 inline constexpr int8_t set_topic_partitions_disabled_cmd_type = 13;
 inline constexpr int8_t bulk_force_reconfiguration_cmd_type = 14;
+inline constexpr int8_t set_partition_bootstrap_params_cmd_type = 15;
 
 inline constexpr int8_t create_user_cmd_type = 5;
 inline constexpr int8_t delete_user_cmd_type = 6;
@@ -262,6 +263,17 @@ using bulk_force_reconfiguration_cmd = controller_command<
   bulk_force_reconfiguration_cmd_data,
   bulk_force_reconfiguration_cmd_type,
   model::record_batch_type::topic_management_cmd,
+  serde_opts::serde_only>;
+
+/**
+ * Used to set bootstrap parameters for partitions in an existing topic.
+ * Enables cluster recovery to create partitions with known offsets.
+ */
+using set_partition_bootstrap_params_cmd = controller_command<
+  model::topic_namespace,
+  set_partition_bootstrap_params_cmd_data,
+  set_partition_bootstrap_params_cmd_type,
+  model::record_batch_type::cluster_recovery_cmd,
   serde_opts::serde_only>;
 
 using create_user_cmd = controller_command<

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -539,6 +539,7 @@ ss::future<> controller::start(
       std::ref(_tp_frontend),
       std::ref(_storage),
       std::ref(_feature_table),
+      std::ref(_recovery_table),
       ss::sharded_parameter([] {
           return config::shard_local_cfg()
             .controller_backend_housekeeping_interval_ms.bind();

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -269,6 +269,7 @@ controller_backend::controller_backend(
   ss::sharded<topics_frontend>& frontend,
   ss::sharded<storage::api>& storage,
   ss::sharded<features::feature_table>& features,
+  ss::sharded<cluster_recovery_table>& recovery_table,
   config::binding<std::chrono::milliseconds> housekeeping_interval,
   config::binding<std::optional<size_t>> initial_retention_local_target_bytes,
   config::binding<std::optional<std::chrono::milliseconds>>
@@ -287,6 +288,7 @@ controller_backend::controller_backend(
   , _topics_frontend(frontend)
   , _storage(storage)
   , _features(features)
+  , _recovery_table(recovery_table)
   , _self(*config::node().node_id())
   , _data_directory(config::node().data_directory().as_sstring())
   , _housekeeping_interval(std::move(housekeeping_interval))
@@ -1222,6 +1224,8 @@ ss::future<result<ss::stop_iteration>> controller_backend::reconcile_ntp_step(
         auto topic_md = _topics.local().get_topic_metadata_ref(
           model::topic_namespace_view(ntp));
         vassert(topic_md, "topic metadata disappeared for {}", ntp);
+        auto bootstrap_params
+          = _recovery_table.local().get_partition_bootstrap_params(ntp);
         auto ec = co_await create_partition(
           ntp,
           group_id,
@@ -1231,7 +1235,8 @@ ss::future<result<ss::stop_iteration>> controller_backend::reconcile_ntp_step(
           force_reconfiguration{
             replicas_view.update
             && replicas_view.update->is_force_reconfiguration()},
-          topic_md->get());
+          topic_md->get(),
+          std::move(bootstrap_params));
         if (ec) {
             co_return ec;
         }
@@ -1408,7 +1413,8 @@ ss::future<std::error_code> controller_backend::create_partition(
   replicas_t initial_replicas,
   const replicas_revision_map& replica_revision_map,
   force_reconfiguration is_force_reconfigured,
-  const topic_metadata& topic_md) {
+  const topic_metadata& topic_md,
+  std::optional<partition_bootstrap_params> bootstrap_params) {
     vlog(
       clusterlog.debug,
       "[{}] creating partition, log revision: {}, initial_replicas: {}",
@@ -1509,14 +1515,21 @@ ss::future<std::error_code> controller_backend::create_partition(
          * storage and current node is joining replica set. A node is joining
          * replica set if its initial nodes set is empty.
          */
-        if (initial_nodes.empty() && rtp.has_value()) {
-            // reset remote topic properties
-            vlog(
-              clusterlog.info,
-              "[{}] Disabling remote recovery while creating partition "
-              "replica. Current node is added to the replica set as learner.",
-              ntp);
-            rtp.reset();
+        if (initial_nodes.empty()) {
+            if (rtp.has_value()) {
+                // reset remote topic properties
+                vlog(
+                  clusterlog.info,
+                  "[{}] Disabling remote recovery while creating partition "
+                  "replica. Current node is added to the replica set as "
+                  "learner.",
+                  ntp);
+                rtp.reset();
+            }
+            // Bootstrap params should only be used to seed the partition when
+            // the topic is first created. When a replica is added to an
+            // existing partition, bootstrap_params should be reset.
+            bootstrap_params.reset();
         }
         // we use offset as an rev as it is always increasing and it
         // increases while ntp is being created again
@@ -1530,7 +1543,8 @@ ss::future<std::error_code> controller_backend::create_partition(
               std::move(xst_state),
               rtp,
               read_replica_bucket,
-              &cfg);
+              &cfg,
+              bootstrap_params);
 
             _xst_states.erase(ntp);
 

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -205,6 +205,7 @@ public:
       ss::sharded<topics_frontend>&,
       ss::sharded<storage::api>&,
       ss::sharded<features::feature_table>&,
+      ss::sharded<cluster::cluster_recovery_table>&,
       config::binding<std::chrono::milliseconds> housekeeping_interval,
       config::binding<std::optional<size_t>>
         initial_retention_local_target_bytes,
@@ -298,7 +299,9 @@ private:
       replicas_t initial_replicas,
       const replicas_revision_map& replicas_revisions,
       force_reconfiguration is_force_reconfigured,
-      const topic_metadata& topic_md);
+      const topic_metadata& topic_md,
+      std::optional<partition_bootstrap_params> bootstrap_params
+      = std::nullopt);
 
     ss::future<> add_to_shard_table(
       model::ntp,
@@ -392,6 +395,7 @@ private:
     ss::sharded<topics_frontend>& _topics_frontend;
     ss::sharded<storage::api>& _storage;
     ss::sharded<features::feature_table>& _features;
+    ss::sharded<cluster_recovery_table>& _recovery_table;
     model::node_id _self;
     ss::sstring _data_directory;
     config::binding<std::chrono::milliseconds> _housekeeping_interval;

--- a/src/v/cluster/controller_snapshot.h
+++ b/src/v/cluster/controller_snapshot.h
@@ -267,14 +267,17 @@ struct plugins_t
 struct cluster_recovery_t
   : public serde::envelope<
       cluster_recovery_t,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     std::vector<cluster_recovery_state> recovery_states;
+    pending_bootstrap_params_t pending_bootstrap_params;
 
     friend bool operator==(const cluster_recovery_t&, const cluster_recovery_t&)
       = default;
 
-    auto serde_fields() { return std::tie(recovery_states); }
+    auto serde_fields() {
+        return std::tie(recovery_states, pending_bootstrap_params);
+    }
 };
 
 struct client_quotas_t

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -15,6 +15,7 @@
 #include "cloud_storage/remote.h"
 #include "cloud_storage/remote_partition.h"
 #include "cloud_storage/remote_path_provider.h"
+#include "cloud_topics/level_zero/stm/ctp_stm.h"
 #include "cluster/archival/archival_metadata_stm.h"
 #include "cluster/archival/ntp_archiver_service.h"
 #include "cluster/archival/types.h"
@@ -122,7 +123,8 @@ ss::future<consensus_ptr> partition_manager::manage(
   std::optional<xshard_transfer_state> xst_state,
   std::optional<remote_topic_properties> rtp,
   std::optional<cloud_storage_clients::bucket_name> read_replica_bucket,
-  const topic_configuration* topic_cfg) {
+  const topic_configuration* topic_cfg,
+  std::optional<partition_bootstrap_params> bootstrap_params) {
     auto remote_label = topic_cfg ? topic_cfg->properties.remote_label
                                   : std::nullopt;
     auto remote_topic_namespace_override
@@ -154,13 +156,40 @@ ss::future<consensus_ptr> partition_manager::manage(
           remote_topic_namespace_override.value());
     }
 
-    // NOTE: while the source cluster UUIDs of the path providers will
-    // ultimately be the same, this is a different path provider than what will
-    // be used at runtime by the partition. The latter is owned by the archival
-    // metadata STM and its lifecycle is therefore tied to the partition, which
-    // hasn't been constructed yet.
-    // TODO: implement a recovery primitive for cloud topics
-    if (!ntp_cfg.cloud_topic_enabled()) {
+    if (bootstrap_params.has_value()) {
+        // Programmatic bootstrap with custom offset/term.
+        // This is used for creating partitions with arbitrary start offset
+        // without requiring cloud storage.
+        vlog(
+          clusterlog.info,
+          "Bootstrapping partition {} with start offset: {}, term: {}",
+          ntp_cfg.ntp(),
+          bootstrap_params->start_offset,
+          bootstrap_params->initial_term);
+
+        co_await seastar::recursive_touch_directory(ntp_cfg.work_directory());
+
+        co_await raft::details::bootstrap_partition_state(
+          _storage,
+          ntp_cfg,
+          group,
+          bootstrap_params->start_offset,
+          bootstrap_params->initial_term,
+          initial_nodes);
+
+        // For cloud topics, also create the ctp_stm bootstrap snapshot
+        // with the correct start_offset
+        if (ntp_cfg.cloud_topic_enabled()) {
+            co_await cloud_topics::create_ctp_stm_bootstrap_snapshot(
+              std::filesystem::path(ntp_cfg.work_directory()),
+              kafka::offset(bootstrap_params->start_offset()));
+        }
+    } else {
+        // NOTE: while the source cluster UUIDs of the path providers will
+        // ultimately be the same, this is a different path provider than what
+        // will be used at runtime by the partition. The latter is owned by the
+        // archival metadata STM and its lifecycle is therefore tied to the
+        // partition, which hasn't been constructed yet.
         cloud_storage::remote_path_provider path_provider(
           std::move(remote_label), std::move(remote_topic_namespace_override));
         auto dl_result = co_await maybe_download_log(

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -158,8 +158,8 @@ ss::future<consensus_ptr> partition_manager::manage(
 
     if (bootstrap_params.has_value()) {
         // Programmatic bootstrap with custom offset/term.
-        // This is used for creating partitions with arbitrary start offset
-        // without requiring cloud storage.
+        // This is used for creating partitions with arbitrary start
+        // offset during cluster recovery.
         vlog(
           clusterlog.info,
           "Bootstrapping partition {} with start offset: {}, term: {}",
@@ -173,16 +173,18 @@ ss::future<consensus_ptr> partition_manager::manage(
           _storage,
           ntp_cfg,
           group,
-          bootstrap_params->start_offset,
+          bootstrap_params->next_offset,
           bootstrap_params->initial_term,
           initial_nodes);
 
-        // For cloud topics, also create the ctp_stm bootstrap snapshot
-        // with the correct start_offset
         if (ntp_cfg.cloud_topic_enabled()) {
             co_await cloud_topics::create_ctp_stm_bootstrap_snapshot(
               std::filesystem::path(ntp_cfg.work_directory()),
-              kafka::offset(bootstrap_params->start_offset()));
+              cloud_topics::ctp_stm_seed_offsets{
+                .start_offset = model::offset_cast(
+                  bootstrap_params->start_offset),
+                .next_offset = model::offset_cast(
+                  bootstrap_params->next_offset)});
         }
     } else {
         // NOTE: while the source cluster UUIDs of the path providers will

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -102,7 +102,8 @@ public:
       std::optional<xshard_transfer_state>,
       std::optional<remote_topic_properties> = std::nullopt,
       std::optional<cloud_storage_clients::bucket_name> = std::nullopt,
-      const topic_configuration* = nullptr);
+      const topic_configuration* = nullptr,
+      std::optional<partition_bootstrap_params> = std::nullopt);
 
     ss::future<xshard_transfer_state> shutdown(const model::ntp& ntp);
 

--- a/src/v/cluster/tests/controller_state_test.cc
+++ b/src/v/cluster/tests/controller_state_test.cc
@@ -76,3 +76,96 @@ FIXTURE_TEST(test_creating_same_topic_twice, cluster_test_fixture) {
       })
       .get();
 }
+
+FIXTURE_TEST(
+  test_bootstrap_params_propagated_to_partition_manager, cluster_test_fixture) {
+    // Create a single node cluster
+    auto node_0 = create_node_application(model::node_id{0});
+    wait_for_controller_leadership(node_0->controller->self()).get();
+
+    auto& topics_frontend = node_0->controller->get_topics_frontend().local();
+    auto& recovery_table
+      = node_0->controller->get_cluster_recovery_table().local();
+    auto& recovery_manager
+      = node_0->controller->get_cluster_recovery_manager().local();
+
+    // Define test parameters
+    auto tp_ns = model::topic_namespace(test_ns, model::topic("test-topic"));
+    model::partition_id pid(0);
+    model::ntp ntp(tp_ns.ns, tp_ns.tp, pid);
+
+    // Set bootstrap params BEFORE creating the topic
+    model::offset expected_start_offset(1000);
+    model::term_id expected_term(5);
+
+    absl::btree_map<model::partition_id, cluster::partition_bootstrap_params>
+      params;
+    params[pid] = cluster::partition_bootstrap_params{
+      expected_start_offset, expected_term};
+
+    auto ec = recovery_manager
+                .set_bootstrap_params(
+                  tp_ns, std::move(params), model::timeout_clock::now() + 10s)
+                .get();
+
+    BOOST_REQUIRE(!ec);
+
+    // Verify the params are stored in cluster_recovery_table
+    auto stored_params = recovery_table.get_partition_bootstrap_params(ntp);
+    BOOST_REQUIRE(stored_params.has_value());
+    BOOST_REQUIRE_EQUAL(stored_params->start_offset, expected_start_offset);
+    BOOST_REQUIRE_EQUAL(stored_params->initial_term, expected_term);
+
+    // Now create the topic (1 partition, replication factor 1)
+    auto result = topics_frontend
+                    .create_topics(
+                      cluster::without_custom_assignments(
+                        {create_topic_cfg("test-topic", 1, 1)}),
+                      model::timeout_clock::now() + 10s)
+                    .get();
+
+    BOOST_REQUIRE_EQUAL(result.size(), 1);
+    BOOST_REQUIRE_EQUAL(result[0].ec, cluster::errc::success);
+
+    // Wait for the partition to be created and find its shard
+    auto& shard_table = node_0->controller->get_shard_table().local();
+    auto& partition_manager = node_0->partition_manager;
+
+    std::optional<ss::shard_id> partition_shard;
+    tests::cooperative_spin_wait_with_timeout(
+      10s,
+      [&shard_table, &ntp, &partition_shard] {
+          partition_shard = shard_table.shard_for(ntp);
+          return partition_shard.has_value();
+      })
+      .get();
+
+    BOOST_REQUIRE(partition_shard.has_value());
+
+    // Wait for the partition to exist on the correct shard
+    tests::cooperative_spin_wait_with_timeout(
+      10s,
+      [&partition_manager, &ntp, shard = partition_shard.value()] {
+          return partition_manager
+            .invoke_on(
+              shard,
+              [&ntp](cluster::partition_manager& pm) {
+                  return pm.get(ntp) != nullptr;
+              })
+            .get();
+      })
+      .get();
+
+    // The raft start offset should be the bootstrap start_offset
+    auto actual_start_offset = partition_manager
+                                 .invoke_on(
+                                   partition_shard.value(),
+                                   [&ntp](cluster::partition_manager& pm) {
+                                       auto p = pm.get(ntp);
+                                       return p ? p->raft_start_offset()
+                                                : model::offset{};
+                                   })
+                                 .get();
+
+    BOOST_CHECK_EQUAL(actual_start_offset, expected_start_offset);
+}

--- a/src/v/cluster/tests/controller_state_test.cc
+++ b/src/v/cluster/tests/controller_state_test.cc
@@ -95,13 +95,16 @@ FIXTURE_TEST(
     model::ntp ntp(tp_ns.ns, tp_ns.tp, pid);
 
     // Set bootstrap params BEFORE creating the topic
+    // The metastore provides [start_offset, next_offset) range.
+    // The recovered partition should start from next_offset.
     model::offset expected_start_offset(1000);
+    model::offset expected_next_offset(2000);
     model::term_id expected_term(5);
 
     absl::btree_map<model::partition_id, cluster::partition_bootstrap_params>
       params;
     params[pid] = cluster::partition_bootstrap_params{
-      expected_start_offset, expected_term};
+      expected_start_offset, expected_next_offset, expected_term};
 
     auto ec = recovery_manager
                 .set_bootstrap_params(
@@ -114,6 +117,7 @@ FIXTURE_TEST(
     auto stored_params = recovery_table.get_partition_bootstrap_params(ntp);
     BOOST_REQUIRE(stored_params.has_value());
     BOOST_REQUIRE_EQUAL(stored_params->start_offset, expected_start_offset);
+    BOOST_REQUIRE_EQUAL(stored_params->next_offset, expected_next_offset);
     BOOST_REQUIRE_EQUAL(stored_params->initial_term, expected_term);
 
     // Now create the topic (1 partition, replication factor 1)
@@ -156,7 +160,9 @@ FIXTURE_TEST(
       })
       .get();
 
-    // The raft start offset should be the bootstrap start_offset
+    // The raft start offset should be the bootstrap next_offset since the
+    // recovered partition starts from next_offset (empty, first batch will
+    // have offset equal to next_offset).
     auto actual_start_offset = partition_manager
                                  .invoke_on(
                                    partition_shard.value(),
@@ -167,5 +173,5 @@ FIXTURE_TEST(
                                    })
                                  .get();
 
-    BOOST_CHECK_EQUAL(actual_start_offset, expected_start_offset);
+    BOOST_CHECK_EQUAL(actual_start_offset, expected_next_offset);
 }

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -179,6 +179,15 @@ std::ostream& operator<<(std::ostream& o, const configuration_invariants& c) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, const partition_bootstrap_params& p) {
+    fmt::print(
+      o,
+      "{{start_offset: {}, initial_term: {}}}",
+      p.start_offset,
+      p.initial_term);
+    return o;
+}
+
 std::ostream& operator<<(std::ostream& o, const partition_assignment& p_as) {
     fmt::print(
       o,

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -182,8 +182,9 @@ std::ostream& operator<<(std::ostream& o, const configuration_invariants& c) {
 std::ostream& operator<<(std::ostream& o, const partition_bootstrap_params& p) {
     fmt::print(
       o,
-      "{{start_offset: {}, initial_term: {}}}",
+      "{{start_offset: {}, next_offset: {}, initial_term: {}}}",
       p.start_offset,
+      p.next_offset,
       p.initial_term);
     return o;
 }

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -445,6 +445,56 @@ struct configuration_update_reply
     auto serde_fields() { return std::tie(success); }
 };
 
+/// Parameters for bootstrapping a partition with custom initial state.
+/// Used for programmatic partition creation with specific offset/term.
+struct partition_bootstrap_params
+  : serde::envelope<
+      partition_bootstrap_params,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    partition_bootstrap_params() noexcept = default;
+
+    partition_bootstrap_params(
+      model::offset start_offset, model::term_id initial_term)
+      : start_offset(start_offset)
+      , initial_term(initial_term) {}
+
+    /// The starting offset for this partition (min offset of the log)
+    model::offset start_offset{0};
+
+    /// The initial term for Raft consensus
+    model::term_id initial_term{0};
+
+    auto serde_fields() { return std::tie(start_offset, initial_term); }
+
+    friend bool operator==(
+      const partition_bootstrap_params&, const partition_bootstrap_params&)
+      = default;
+
+    friend std::ostream&
+    operator<<(std::ostream&, const partition_bootstrap_params&);
+};
+
+using pending_bootstrap_params_t
+  = chunked_hash_map<model::ntp, partition_bootstrap_params>;
+
+/// Data for setting bootstrap parameters on existing topic partitions.
+/// Used by cluster recovery to specify known offsets for partitions.
+struct set_partition_bootstrap_params_cmd_data
+  : serde::envelope<
+      set_partition_bootstrap_params_cmd_data,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    model::topic_namespace tp_ns;
+    absl::btree_map<model::partition_id, partition_bootstrap_params>
+      partition_params;
+
+    auto serde_fields() { return std::tie(tp_ns, partition_params); }
+
+    friend std::ostream&
+    operator<<(std::ostream&, const set_partition_bootstrap_params_cmd_data&);
+};
+
 /// Partition assignment describes an assignment of all replicas for single NTP.
 /// The replicas are hold in vector of broker_shard.
 struct partition_assignment

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -447,6 +447,8 @@ struct configuration_update_reply
 
 /// Parameters for bootstrapping a partition with custom initial state.
 /// Used for programmatic partition creation with specific offset/term.
+/// The struct also contains a next_offset which is used to initialize
+/// ctp_stm
 struct partition_bootstrap_params
   : serde::envelope<
       partition_bootstrap_params,
@@ -455,17 +457,23 @@ struct partition_bootstrap_params
     partition_bootstrap_params() noexcept = default;
 
     partition_bootstrap_params(
-      model::offset start_offset, model::term_id initial_term)
+      model::offset start_offset,
+      model::offset next_offset,
+      model::term_id initial_term)
       : start_offset(start_offset)
+      , next_offset(next_offset)
       , initial_term(initial_term) {}
 
     /// The starting offset for this partition (min offset of the log)
     model::offset start_offset{0};
+    model::offset next_offset{0};
 
     /// The initial term for Raft consensus
     model::term_id initial_term{0};
 
-    auto serde_fields() { return std::tie(start_offset, initial_term); }
+    auto serde_fields() {
+        return std::tie(start_offset, next_offset, initial_term);
+    }
 
     friend bool operator==(
       const partition_bootstrap_params&, const partition_bootstrap_params&)

--- a/src/v/raft/consensus_utils.cc
+++ b/src/v/raft/consensus_utils.cc
@@ -451,4 +451,76 @@ ss::future<> bootstrap_pre_existing_partition(
       model::offset_delta{ot_state->delta(min_rp_offset)});
 }
 
+ss::future<> bootstrap_partition_state(
+  storage::api& api,
+  const storage::ntp_config& ntp_cfg,
+  raft::group_id group,
+  model::offset start_offset,
+  model::term_id initial_term,
+  std::vector<raft::vnode> initial_nodes) {
+    vlog(
+      raftlog.info,
+      "{} Bootstrap partition state with start_offset: {}, term: {}",
+      ntp_cfg.ntp(),
+      start_offset,
+      initial_term);
+
+    // Set storage start_offset in kvstore
+    vlog(
+      raftlog.debug,
+      "{} Add storage start_offset to the kv-store {}",
+      ntp_cfg.ntp(),
+      start_offset);
+    co_await api.kvs().put(
+      storage::kvstore::key_space::storage,
+      storage::internal::start_offset_key(ntp_cfg.ntp()),
+      reflection::to_iobuf(start_offset));
+
+    // Set Raft latest_known_offset in kvstore
+    // For a partition starting at start_offset with no data yet,
+    // the latest_known_offset is start_offset (the first offset that can
+    // be written).
+    vlog(
+      raftlog.debug,
+      "{} Set latest_known_offset {} to the kv-store",
+      ntp_cfg.ntp(),
+      start_offset);
+    auto key = raft::details::serialize_group_key(
+      group, raft::metadata_key::config_latest_known_offset);
+    co_await api.kvs().put(
+      storage::kvstore::key_space::consensus,
+      key,
+      reflection::to_iobuf(start_offset));
+
+    // Create Raft snapshot
+    raft::group_configuration group_config(
+      std::move(initial_nodes), ntp_cfg.get_revision());
+    raft::snapshot_metadata meta = {
+      // `last_included_index` should be the last offset included in
+      // this fake snapshot. That's why we set it to be the offset
+      // before the start of the log.
+      .last_included_index = model::prev_offset(start_offset),
+      .last_included_term = initial_term,
+      .version = raft::snapshot_metadata::current_version,
+      .latest_configuration = std::move(group_config),
+      .cluster_time = ss::lowres_clock::now(),
+      // No offset translation - delta is always 0
+      .log_start_delta = offset_translator_delta{0},
+    };
+
+    vlog(
+      raftlog.debug,
+      "{} Create snapshot, last_included_index {}, last_included_term {}",
+      ntp_cfg.ntp(),
+      meta.last_included_index,
+      meta.last_included_term);
+
+    storage::simple_snapshot_manager tmp_snapshot_mgr(
+      std::filesystem::path(ntp_cfg.work_directory()),
+      storage::simple_snapshot_manager::default_snapshot_filename);
+
+    co_await raft::details::persist_snapshot(
+      tmp_snapshot_mgr, std::move(meta), iobuf());
+}
+
 } // namespace raft::details

--- a/src/v/raft/consensus_utils.h
+++ b/src/v/raft/consensus_utils.h
@@ -211,4 +211,22 @@ ss::future<> bootstrap_pre_existing_partition(
   model::term_id last_included_term,
   std::vector<raft::vnode> initial_nodes,
   ss::lw_shared_ptr<storage::offset_translator_state> ot_state);
+
+/// Bootstrap partition state with custom offset and term.
+///
+/// Simpler alternative to bootstrap_pre_existing_partition for programmatic
+/// partition creation. Creates:
+/// 1. Raft snapshot with last_included_index = start_offset - 1, term
+/// 2. Storage start_offset in kvstore
+/// 3. Raft latest_known_offset in kvstore
+///
+/// Offset translation delta is always 0 (kafka offset = log offset).
+/// No offset translator state is created.
+ss::future<> bootstrap_partition_state(
+  storage::api& api,
+  const storage::ntp_config& ntp_cfg,
+  raft::group_id group,
+  model::offset start_offset,
+  model::term_id initial_term,
+  std::vector<raft::vnode> initial_nodes);
 } // namespace raft::details

--- a/src/v/raft/tests/BUILD
+++ b/src/v/raft/tests/BUILD
@@ -671,6 +671,23 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "bootstrap_partition_state_test",
+    timeout = "short",
+    srcs = ["bootstrap_partition_state_test.cc"],
+    deps = [
+        "//src/v/base",
+        "//src/v/features",
+        "//src/v/model",
+        "//src/v/raft",
+        "//src/v/storage",
+        "//src/v/test_utils:gtest",
+        "//src/v/test_utils:test_env",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
 redpanda_cc_bench(
     name = "heartbeat_bench_rpbench",
     srcs = ["heartbeat_bench.cc"],

--- a/src/v/raft/tests/bootstrap_partition_state_test.cc
+++ b/src/v/raft/tests/bootstrap_partition_state_test.cc
@@ -1,0 +1,120 @@
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "model/fundamental.h"
+#include "raft/consensus_utils.h"
+#include "storage/api.h"
+#include "storage/kvstore.h"
+#include "storage/segment_utils.h"
+#include "storage/snapshot.h"
+#include "test_utils/test.h"
+#include "test_utils/test_env.h"
+
+#include <seastar/core/seastar.hh>
+
+using namespace std::chrono_literals;
+
+/// Fixture for testing bootstrap_partition_state functionality
+struct bootstrap_partition_state_test : public seastar_test {
+    ss::future<> SetUpAsync() override {
+        _data_dir = test_env::random_dir_path();
+
+        // Configure and start kvstore
+        storage::kvstore_config kv_conf(
+          8192,
+          config::mock_binding(std::chrono::milliseconds(10)),
+          _data_dir,
+          storage::make_sanitized_file_config());
+
+        co_await _storage.start(
+          [kv_conf]() { return kv_conf; },
+          [this]() { return default_log_cfg(); },
+          std::ref(_feature_table));
+        co_await _storage.invoke_on_all(&storage::api::start);
+
+        co_await _feature_table.start();
+        co_await _feature_table.invoke_on_all(
+          [](features::feature_table& f) { f.testing_activate_all(); });
+    }
+
+    ss::future<> TearDownAsync() override {
+        co_await _storage.stop();
+        co_await _feature_table.stop();
+    }
+
+    storage::log_config default_log_cfg() {
+        return storage::log_config(
+          _data_dir,
+          100_MiB,
+          storage::with_cache::yes,
+          storage::make_sanitized_file_config());
+    }
+
+    ss::sstring _data_dir;
+    ss::sharded<storage::api> _storage;
+    ss::sharded<features::feature_table> _feature_table;
+};
+
+TEST_F(bootstrap_partition_state_test, test_bootstrap_partition_state) {
+    // Define test parameters
+    model::ntp ntp(
+      model::ns("test-ns"), model::topic("test-topic"), model::partition_id(0));
+
+    storage::ntp_config ntp_cfg(ntp, _data_dir);
+
+    raft::group_id group(1);
+    model::offset start_offset(1000);
+    model::term_id initial_term(5);
+
+    std::vector<raft::vnode> initial_nodes{
+      raft::vnode{model::node_id(0), model::revision_id(0)}};
+
+    // Create the work directory
+    ss::recursive_touch_directory(ntp_cfg.work_directory()).get();
+
+    // Call bootstrap_partition_state
+    raft::details::bootstrap_partition_state(
+      _storage.local(),
+      ntp_cfg,
+      group,
+      start_offset,
+      initial_term,
+      initial_nodes)
+      .get();
+
+    // Verify the start_offset was set in kvstore
+    auto stored_offset = _storage.local().kvs().get(
+      storage::kvstore::key_space::storage,
+      storage::internal::start_offset_key(ntp));
+
+    ASSERT_TRUE(stored_offset.has_value());
+
+    auto retrieved_offset = reflection::from_iobuf<model::offset>(
+      std::move(stored_offset.value()));
+    EXPECT_EQ(retrieved_offset, start_offset);
+
+    // Verify the latest_known_offset was set in kvstore
+    auto key = raft::details::serialize_group_key(
+      group, raft::metadata_key::config_latest_known_offset);
+    auto stored_latest_offset = _storage.local().kvs().get(
+      storage::kvstore::key_space::consensus, key);
+
+    ASSERT_TRUE(stored_latest_offset.has_value());
+
+    auto retrieved_latest_offset = reflection::from_iobuf<model::offset>(
+      std::move(stored_latest_offset.value()));
+    EXPECT_EQ(retrieved_latest_offset, start_offset);
+
+    // Verify snapshot file was created
+    auto snapshot_path
+      = std::filesystem::path(ntp_cfg.work_directory())
+        / storage::simple_snapshot_manager::default_snapshot_filename;
+
+    EXPECT_TRUE(std::filesystem::exists(snapshot_path));
+}

--- a/tests/rptest/tests/cluster_recovery_test.py
+++ b/tests/rptest/tests/cluster_recovery_test.py
@@ -10,7 +10,7 @@ import random
 import string
 import time
 import pytest
-from typing import Any
+from typing import Any, List
 
 import requests
 
@@ -26,8 +26,10 @@ from rptest.clients.rpk import RPKACLInput, RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
-from rptest.services.redpanda import SISettings
+from rptest.services.redpanda import SISettings, CLOUD_TOPICS_CONFIG_STR
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.admin.v2 import Admin, metastore_pb, ntp_pb
+from connectrpc.errors import ConnectError, ConnectErrorCode
 from rptest.util import wait_until_result
 from rptest.utils.si_utils import quiesce_uploads
 
@@ -959,3 +961,279 @@ class ClusterRecoveryWithNameTest(RedpandaTest):
         if "failed" in state:
             raise RuntimeError(f"Cluster recovery failed with state: {state}")
         return "inactive" in state
+
+
+class PartitionOffsets:
+    """Captured offsets from metastore for verification after recovery."""
+
+    def __init__(self, start_offset: int, next_offset: int):
+        self.start_offset = start_offset
+        self.next_offset = next_offset
+
+    def __repr__(self):
+        return f"PartitionOffsets(start_offset={self.start_offset}, next_offset={self.next_offset})"
+
+
+class CloudTopicsClusterRecoveryTest(RedpandaTest):
+    """
+    Tests for cluster recovery of cloud topics.
+
+    Verifies that when cluster recovery runs for cloud topics:
+    1. The recovery process queries the L1 metastore for partition offsets
+    2. Bootstrap params are set correctly before topic creation
+    3. After recovery, producing new data and reconciliation works correctly
+    """
+
+    message_size = 4 * KiB
+    topic_name = "cloud_topic_recovery_test"
+    partition_count = 3
+
+    def __init__(self, test_context: TestContext):
+        # Configure for both cloud topics and cluster recovery
+        si_settings = SISettings(
+            test_context,
+            cloud_storage_max_connections=10,
+            # Disable tiered storage remote read/write - cloud topics use different paths
+            cloud_storage_enable_remote_read=False,
+            cloud_storage_enable_remote_write=False,
+            fast_uploads=True,
+        )
+
+        extra_rp_conf = {
+            # Enable cloud topics
+            CLOUD_TOPICS_CONFIG_STR: True,
+            # Enable cluster metadata upload for recovery
+            "enable_cluster_metadata_upload_loop": True,
+            "cloud_storage_cluster_metadata_upload_interval_ms": 1000,
+            "controller_snapshot_max_age_sec": 1,
+            # Fast L0 -> L1 reconciliation for testing
+            "cloud_topics_reconciliation_min_interval": 250,
+            "cloud_topics_reconciliation_max_interval": 2000,
+            # Fast metastore flush for testing
+            "cloud_topics_long_term_flush_interval": 2000,
+            # Reduce test time
+            "group_topic_partitions": 2,
+        }
+
+        self.s3_bucket = si_settings.cloud_storage_bucket
+
+        super(CloudTopicsClusterRecoveryTest, self).__init__(
+            test_context=test_context,
+            si_settings=si_settings,
+            extra_rp_conf=extra_rp_conf,
+            num_brokers=3,
+        )
+
+    def _create_cloud_topic(self, rpk: RpkTool) -> None:
+        """Create a cloud topic with the test configuration."""
+        rpk.create_topic(
+            topic=self.topic_name,
+            partitions=self.partition_count,
+            replicas=3,
+            config={
+                TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD,
+                "cleanup.policy": "delete",
+            },
+        )
+
+    def _produce_data(self, msg_count: int = 500) -> None:
+        """Produce test data to the cloud topic."""
+        KgoVerifierProducer.oneshot(
+            self.test_context,
+            self.redpanda,
+            self.topic_name,
+            msg_size=self.message_size,
+            msg_count=msg_count,
+            batch_max_bytes=self.message_size * 8,
+            timeout_sec=60,
+        )
+
+    def _get_metastore_offsets(
+        self, admin: Admin, topic: str, partition: int
+    ) -> PartitionOffsets | None:
+        """
+        Get partition offsets from the L1 metastore.
+        Returns None if the partition is not found in the metastore.
+        """
+        metastore = admin.metastore()
+        req = metastore_pb.GetOffsetsRequest(
+            partition=ntp_pb.TopicPartition(topic=topic, partition=partition)
+        )
+        try:
+            response = metastore.get_offsets(req=req)
+            return PartitionOffsets(
+                start_offset=response.offsets.start_offset,
+                next_offset=response.offsets.next_offset,
+            )
+        except ConnectError as e:
+            if e.code == ConnectErrorCode.NOT_FOUND:
+                return None
+            raise
+
+    def _wait_for_metastore_sync(
+        self,
+        admin: Admin,
+        topic: str,
+        partition: int,
+        expected_min_next_offset: int,
+        timeout_sec: int = 60,
+    ) -> PartitionOffsets:
+        """
+        Wait until the metastore has data for the partition and next_offset
+        reaches at least the expected value.
+        """
+        result: List[PartitionOffsets | None] = [None]
+
+        def check_metastore() -> bool:
+            offsets = self._get_metastore_offsets(admin, topic, partition)
+            result[0] = offsets
+            if offsets is None:
+                return False
+            return offsets.next_offset >= expected_min_next_offset
+
+        wait_until(
+            check_metastore,
+            timeout_sec=timeout_sec,
+            backoff_sec=2,
+            err_msg=lambda: f"Metastore sync timeout for {topic}/{partition}, "
+            f"last offsets: {result[0]}",
+        )
+
+        assert result[0] is not None
+        return result[0]
+
+    def _perform_cluster_recovery(self, rpk: RpkTool) -> None:
+        """
+        Stop the cluster, wipe local data, restart with auto_assign_node_id,
+        and initialize cluster recovery using rpk.
+        """
+        self.logger.info("Stopping cluster for recovery")
+        self.redpanda.stop()
+
+        self.logger.info("Wiping local data on all nodes")
+        for node in self.redpanda.nodes:
+            self.redpanda.remove_local_data(node)
+
+        self.logger.info("Restarting cluster with auto_assign_node_id")
+        self.redpanda.restart_nodes(
+            self.redpanda.nodes,
+            auto_assign_node_id=True,
+            omit_seeds_on_idx_one=False,
+        )
+
+        self.logger.info("Waiting for controller to be ready")
+        self.redpanda._admin.await_stable_leader(
+            "controller",
+            partition=0,
+            namespace="redpanda",
+            timeout_s=60,
+            backoff_s=2,
+        )
+
+        self.logger.info("Starting cluster recovery with rpk")
+        rpk.cluster_recovery_start(wait=True)
+
+    @cluster(num_nodes=4)
+    def test_cloud_topics_recovery_with_bootstrap_params(self):
+        """
+        Test that cloud topics recovery correctly sets bootstrap params
+        and allows producing new data after recovery.
+
+        This test verifies that:
+        1. Cloud topic is created and data is produced
+        2. After cluster recovery, the topic is restored
+        3. New data can be produced to the recovered topic
+        4. New data is reconciled to the metastore correctly
+        """
+        rpk = RpkTool(self.redpanda)
+        admin = Admin(self.redpanda)
+
+        self.logger.info("Creating cloud topic")
+        self._create_cloud_topic(rpk)
+
+        self.logger.info("Producing initial test data")
+        self._produce_data(msg_count=500)
+
+        self.logger.info("Waiting for metastore sync")
+        baseline = {}
+        for part in rpk.describe_topic(self.topic_name):
+            baseline[part.id] = part.high_watermark
+            partition = part.id
+            hwm = part.high_watermark
+            offsets = self._wait_for_metastore_sync(
+                admin,
+                self.topic_name,
+                partition,
+                expected_min_next_offset=hwm,
+                timeout_sec=120,
+            )
+            self.logger.info(
+                f"Metastore offsets for partition {partition}: "
+                f"start_offset={offsets.start_offset}, "
+                f"next_offset={offsets.next_offset}"
+            )
+
+        # Allow time for the metastore manifest to be flushed to S3
+        # after the sync completes.
+        self.logger.info("Waiting 30s for metastore manifest flush")
+        time.sleep(30)
+
+        self.logger.info("Waiting for controller metadata upload")
+        self.redpanda.wait_for_controller_snapshot(self.redpanda.nodes[0])
+
+        self.logger.info("Performing cluster recovery")
+        self._perform_cluster_recovery(rpk)
+
+        rpk = RpkTool(self.redpanda)  # Need new client after restart
+        admin = Admin(self.redpanda)  # Need new admin client after restart
+        topics = set(rpk.list_topics())
+        assert self.topic_name in topics, (
+            f"Topic {self.topic_name} not restored. Available: {topics}"
+        )
+
+        adjustment = {}
+
+        def all_partitions_ready():
+            adjustment.clear()
+            for part in rpk.describe_topic(self.topic_name):
+                adjustment[part.id] = part.high_watermark
+            if len(adjustment) != len(baseline):
+                return False
+            return all(adjustment.get(pid) == hwm for pid, hwm in baseline.items())
+
+        wait_until(
+            all_partitions_ready,
+            timeout_sec=120,
+            backoff_sec=2,
+            err_msg=f"Partitions not ready: baseline={baseline}, adjustment={adjustment}",
+        )
+
+        self.logger.info("Producing new data to recovered topic")
+        self._produce_data(msg_count=500)
+
+        self.logger.info("Waiting for new data to reconcile to metastore")
+        # Update HWM values after producing
+        for part in rpk.describe_topic(self.topic_name):
+            prev_hwm = adjustment[part.id]
+            assert part.high_watermark > prev_hwm, (
+                f"Prev HWM {prev_hwm} >= actual HWM {part.high_watermark}"
+            )
+
+        self.logger.info("Waiting for metastore sync")
+        for part in rpk.describe_topic(self.topic_name):
+            partition = part.id
+            hwm = part.high_watermark
+            offsets = self._wait_for_metastore_sync(
+                admin,
+                self.topic_name,
+                partition,
+                expected_min_next_offset=hwm,
+                timeout_sec=120,
+            )
+            self.logger.info(
+                f"Metastore offsets for partition {partition}: "
+                f"start_offset={offsets.start_offset}, "
+                f"next_offset={offsets.next_offset}"
+            )
+
+        self.logger.info("Cloud topics recovery with bootstrap params test PASSED")

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -482,6 +482,29 @@ def decode_topic_command_serde(k_rdr: Reader, rdr: Reader):
         cmd |= rdr.read_envelope(
             lambda rdr, _: {"replicas": rdr.read_serde_vector(read_broker_shard)}
         )
+    elif cmd["type"] == 15:
+        cmd["type_string"] = "set_partition_bootstrap_params"
+        cmd["namespace"] = k_rdr.read_string()
+        cmd["topic"] = k_rdr.read_string()
+        cmd |= rdr.read_envelope(
+            lambda rdr, _: {
+                "tp_ns": rdr.read_envelope(
+                    lambda rdr, _: {
+                        "namespace": rdr.read_string(),
+                        "topic": rdr.read_string(),
+                    }
+                ),
+                "partition_params": rdr.read_serde_map(
+                    lambda rdr: rdr.read_int32(),  # partition_id (key)
+                    lambda rdr: rdr.read_envelope(  # params (value)
+                        lambda rdr, _: {
+                            "start_offset": rdr.read_int64(),
+                            "initial_term": rdr.read_int64(),
+                        }
+                    ),
+                ),
+            }
+        )
     return cmd
 
 


### PR DESCRIPTION
This PR enables cloud topics cluster recovery to bootstrap partitions with the correct start offset and term from the L1 metastore. When a cloud topics cluster is recovered, partitions now start at their known offsets rather than offset 0, ensuring data consistency without requiring cloud access during partition creation.

### Changes
Core Infrastructure
New Controller Command: `set_partition_bootstrap_params_cmd`

Adds a new controller command to set bootstrap parameters (start_offset, initial_term) for partitions before topic creation
Parameters are stored in `topic_table._pending_bootstrap_params` map keyed by NTP
`topics_frontend::set_bootstrap_params()` provides the API for setting these parameters

### Partition Bootstrap Flow

`controller_backend` fetches bootstrap params from `topic_table` when creating partitions
`partition_manager::manage()` uses bootstrap params to initialize partition state via `bootstrap_partition_state()`
New `raft::bootstrap_partition_state()` function creates initial raft state with known offset/term

### Cluster Recovery Integration

Modified `cluster_recovery_backend.cc` to query L1 metastore for each cloud topic partition's `start_offset` and `term`
Calls `set_bootstrap_params()` before creating recovered cloud topics
Partitions are created with correct offsets from metastore, avoiding cloud access during partition creation


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none