### PR TITLE
Partition balancer minimum tick interval

### DIFF
--- a/src/v/cluster/BUILD
+++ b/src/v/cluster/BUILD
@@ -764,6 +764,7 @@ redpanda_cc_library(
         "//src/v/ssx:checkpoint_mutex",
         "//src/v/ssx:event",
         "//src/v/ssx:future_util",
+        "//src/v/ssx:minimum_interval_timer",
         "//src/v/ssx:mutex",
         "//src/v/ssx:rate_limited_function",
         "//src/v/ssx:semaphore",

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -821,7 +821,8 @@ ss::future<> controller::start(
         .partition_autobalancing_min_size_threshold.bind(),
       config::shard_local_cfg().node_status_interval.bind(),
       config::shard_local_cfg().raft_learner_recovery_rate.bind(),
-      config::shard_local_cfg().partition_autobalancing_topic_aware.bind());
+      config::shard_local_cfg().partition_autobalancing_topic_aware.bind(),
+      config::shard_local_cfg().health_monitor_max_metadata_age.bind());
     co_await _partition_balancer.invoke_on(
       partition_balancer_backend::shard, &partition_balancer_backend::start);
 

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -125,6 +125,8 @@ void members_backend::handle_single_update(
         _new_updates.broadcast();
         return;
     case node_update_type::decommissioned:
+        // decom -> recom -> decom, make sure the recom gets removed
+        stop_node_recommissioning(update.id);
         _updates.emplace_back(update);
         stop_node_addition(update.id);
         _new_updates.broadcast();
@@ -599,6 +601,14 @@ void members_backend::stop_node_decommissioning(model::node_id id) {
     std::erase_if(_updates, [id](update_meta& meta) {
         return meta.update.id == id
                && meta.update.type == node_update_type::decommissioned;
+    });
+}
+
+void members_backend::stop_node_recommissioning(model::node_id id) {
+    // remove all pending recommissioned updates for this node
+    std::erase_if(_updates, [id](update_meta& meta) {
+        return meta.update.id == id
+               && meta.update.type == node_update_type::recommissioned;
     });
 }
 

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -84,6 +84,7 @@ private:
     ss::future<> handle_updates();
     void handle_single_update(members_manager::node_update);
     void stop_node_decommissioning(model::node_id);
+    void stop_node_recommissioning(model::node_id id);
     void stop_node_addition(model::node_id id);
     void handle_reallocation_finished(model::node_id);
 

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -375,22 +375,30 @@ ss::future<> partition_balancer_backend::do_tick() {
         co_return;
     }
 
+    // consume force refresh, return it on failure
     const bool force_refresh_this_tick
       = _cur_term->_force_health_report_refresh;
+    _cur_term->_force_health_report_refresh = false;
+
+    auto reset_force_refresh = ss::defer([this, force_refresh_this_tick] {
+        _cur_term->_force_health_report_refresh |= force_refresh_this_tick;
+    });
 
     auto health_report = co_await _health_monitor.get_cluster_health(
       cluster_report_filter{},
       force_refresh(force_refresh_this_tick),
       model::timeout_clock::now() + controller_stm_sync_timeout);
-    _cur_term->_force_health_report_refresh = false;
 
     if (!health_report) {
         vlog(
           clusterlog.info,
           "unable to get health report - {}",
           health_report.error().message());
+        // return whats been taken on failure
         co_return;
     }
+
+    reset_force_refresh.cancel();
 
     if (_raft0->term() != _cur_term->id) {
         vlog(clusterlog.debug, "lost leadership, exiting");

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -28,6 +28,7 @@
 #include "features/feature_table.h"
 #include "model/metadata.h"
 #include "random/generators.h"
+#include "ssx/future-util.h"
 #include "ssx/minimum_interval_timer.h"
 #include "utils/stable_iterator_adaptor.h"
 
@@ -35,6 +36,7 @@
 #include <seastar/core/shared_ptr.hh>
 
 #include <chrono>
+#include <exception>
 #include <optional>
 #include <utility>
 
@@ -92,7 +94,7 @@ partition_balancer_backend::partition_balancer_backend(
   , _raft_learner_recovery_rate(std::move(raft_learner_recovery_rate))
   , _topic_aware(std::move(topic_aware))
   , _health_monitor_max_metadata_age(std::move(health_monitor_max_metadata_age))
-  , _timer{_health_monitor_max_metadata_age(), [this] { tick(); }} {
+  , _timer{_health_monitor_max_metadata_age(), [this]() { return tick(); }} {
     // if the minimum interval changes, quick update the timer accordingly
     _health_monitor_max_metadata_age.watch([this] {
         if (_gate.is_closed()) {
@@ -291,47 +293,45 @@ void partition_balancer_backend::on_health_monitor_update(
     }
 }
 
-void partition_balancer_backend::tick() {
-    ssx::background
-      = ssx::spawn_with_gate_then(
-          _gate,
-          [this] {
-              if (_tick_in_progress) {
-                  vlog(
-                    clusterlog.debug,
-                    "skipping tick, tick already in progress");
-                  return ss::now();
-              }
+ss::future<> partition_balancer_backend::tick() {
+    if (_gate.is_closed()) {
+        vlog(clusterlog.debug, "skipping tick, shutting down");
+        co_return;
+    }
 
-              _tick_in_progress = ss::abort_source{};
-              return do_tick().finally([this] {
-                  _tick_in_progress = {};
-                  maybe_rearm_timer(
-                    _cur_term && _cur_term->_force_health_report_refresh);
-              });
-          })
-          .handle_exception_type([](balancer_tick_aborted_exception& e) {
-              vlog(clusterlog.info, "tick aborted, reason: {}", e.what());
-          })
-          .handle_exception_type(
-            [this](topic_table::concurrent_modification_error& e) {
-                vlog(
-                  clusterlog.debug,
-                  "concurrent modification of topics table: {}, rescheduling "
-                  "tick",
-                  e.what());
-                maybe_rearm_timer(true);
-            })
-          .handle_exception_type([this](iterator_stability_violation& e) {
-              vlog(
-                clusterlog.debug,
-                "iterator_stability_violation: {}, rescheduling tick",
-                e.what());
-              maybe_rearm_timer(true);
-          })
-          .handle_exception([](const std::exception_ptr& e) {
-              vlog(clusterlog.warn, "tick error: {}", e);
-          });
+    auto holder = _gate.hold();
+    auto units = co_await _lock.get_units();
+
+    vassert(
+      !_tick_in_progress,
+      "invariant violated, there should only ever be one tick in progress");
+
+    _tick_in_progress = ss::abort_source{};
+    auto cleanup_holder = ss::defer([this] {
+        _tick_in_progress = std::nullopt;
+        maybe_rearm_timer(_cur_term && _cur_term->_force_health_report_refresh);
+    });
+
+    try {
+        co_await do_tick();
+    } catch (const balancer_tick_aborted_exception& e) {
+        vlog(clusterlog.info, "tick aborted, reason: {}", e.what());
+    } catch (const topic_table::concurrent_modification_error& e) {
+        vlog(
+          clusterlog.debug,
+          "concurrent modification of topics table: {}, rescheduling "
+          "tick",
+          e.what());
+        maybe_rearm_timer(true);
+    } catch (const iterator_stability_violation& e) {
+        vlog(
+          clusterlog.debug,
+          "iterator_stability_violation: {}, rescheduling tick",
+          e.what());
+        maybe_rearm_timer(true);
+    } catch (...) {
+        vlog(clusterlog.warn, "tick error: {}", std::current_exception());
+    }
 }
 
 ss::future<> partition_balancer_backend::stop() {
@@ -353,8 +353,6 @@ ss::future<> partition_balancer_backend::do_tick() {
         vlog(clusterlog.debug, "not leader, skipping tick");
         co_return;
     }
-
-    auto units = co_await _lock.get_units();
 
     if (!_raft0->is_leader()) {
         vlog(clusterlog.debug, "lost leadership, exiting");
@@ -379,6 +377,7 @@ ss::future<> partition_balancer_backend::do_tick() {
 
     const bool force_refresh_this_tick
       = _cur_term->_force_health_report_refresh;
+
     auto health_report = co_await _health_monitor.get_cluster_health(
       cluster_report_filter{},
       force_refresh(force_refresh_this_tick),

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -28,6 +28,7 @@
 #include "features/feature_table.h"
 #include "model/metadata.h"
 #include "random/generators.h"
+#include "ssx/minimum_interval_timer.h"
 #include "utils/stable_iterator_adaptor.h"
 
 #include <seastar/core/coroutine.hh>
@@ -35,6 +36,7 @@
 
 #include <chrono>
 #include <optional>
+#include <utility>
 
 using namespace std::chrono_literals;
 using planner_status = cluster::partition_balancer_planner::status;
@@ -64,7 +66,8 @@ partition_balancer_backend::partition_balancer_backend(
   config::binding<std::optional<size_t>> min_partition_size_threshold,
   config::binding<std::chrono::milliseconds> node_status_interval,
   config::binding<size_t> raft_learner_recovery_rate,
-  config::binding<bool> topic_aware)
+  config::binding<bool> topic_aware,
+  config::binding<std::chrono::milliseconds> health_monitor_max_metadata_age)
   : _raft0(std::move(raft0))
   , _controller_stm(controller_stm.local())
   , _feature_table(feature_table.local())
@@ -88,7 +91,16 @@ partition_balancer_backend::partition_balancer_backend(
   , _node_status_interval(std::move(node_status_interval))
   , _raft_learner_recovery_rate(std::move(raft_learner_recovery_rate))
   , _topic_aware(std::move(topic_aware))
-  , _timer([this] { tick(); }) {}
+  , _health_monitor_max_metadata_age(std::move(health_monitor_max_metadata_age))
+  , _timer{_health_monitor_max_metadata_age(), [this] { tick(); }} {
+    // if the minimum interval changes, quick update the timer accordingly
+    _health_monitor_max_metadata_age.watch([this] {
+        if (_gate.is_closed()) {
+            return;
+        }
+        _timer.set_minimum_interval(_health_monitor_max_metadata_age());
+    });
+}
 
 bool partition_balancer_backend::is_enabled() const {
     return is_leader() && !config::node().recovery_mode_enabled();
@@ -155,26 +167,24 @@ void partition_balancer_backend::maybe_rearm_timer(bool now) {
     if (config::node().recovery_mode_enabled()) {
         return;
     }
-    auto schedule_at = now ? clock_t::now() : clock_t::now() + _tick_interval();
-    auto duration_ms = [](clock_t::time_point time_point) {
-        return std::chrono::duration_cast<std::chrono::milliseconds>(
-                 time_point - clock_t::now())
-          .count();
-    };
-    if (_timer.armed()) {
-        schedule_at = std::min(schedule_at, _timer.get_timeout());
-        _timer.rearm(schedule_at);
-        vlog(
-          clusterlog.debug,
-          "Tick rescheduled to run in: {}ms",
-          duration_ms(schedule_at));
-    } else if (_lock.waiters() == 0) {
-        _timer.arm(schedule_at);
-        vlog(
-          clusterlog.debug,
-          "Tick scheduled to run in: {}ms",
-          duration_ms(schedule_at));
-    }
+
+    const auto now_timepoint = ss::lowres_clock::now();
+    auto to_schedule_at = now ? now_timepoint
+                              : now_timepoint + _tick_interval();
+    _timer.request_tick(to_schedule_at);
+
+    auto calculate_readable_delta =
+      [&now_timepoint](ss::lowres_clock::time_point later) {
+          return std::chrono::duration_cast<std::chrono::milliseconds>(
+                   later - now_timepoint)
+            .count();
+      };
+
+    vlog(
+      clusterlog.debug,
+      "partition_balancer tick requested in {}ms, maybe scheduled in: {}ms",
+      calculate_readable_delta(to_schedule_at),
+      _timer.get_scheduled_time().transform(calculate_readable_delta));
 }
 
 void partition_balancer_backend::on_members_update(

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -158,6 +158,7 @@ ss::future<std::error_code> partition_balancer_backend::request_rebalance() {
 
     vlog(clusterlog.info, "requesting on demand rebalance");
     _cur_term->_ondemand_rebalance_requested = true;
+    _cur_term->_force_health_report_refresh = true;
     maybe_rearm_timer(/*now=*/true);
     co_return errc::success;
 }

--- a/src/v/cluster/partition_balancer_backend.h
+++ b/src/v/cluster/partition_balancer_backend.h
@@ -78,7 +78,7 @@ public:
     ss::future<std::error_code> request_rebalance();
 
 private:
-    void tick();
+    ss::future<> tick();
     ss::future<> do_tick();
 
     /// If now, rearms to run immediately, else rearms to _tick_interval or

--- a/src/v/cluster/partition_balancer_backend.h
+++ b/src/v/cluster/partition_balancer_backend.h
@@ -19,6 +19,7 @@
 #include "features/enterprise_features.h"
 #include "model/fundamental.h"
 #include "raft/consensus.h"
+#include "ssx/minimum_interval_timer.h"
 #include "ssx/mutex.h"
 
 #include <seastar/core/sharded.hh>
@@ -53,7 +54,9 @@ public:
       config::binding<std::optional<size_t>> min_partition_size_threshold,
       config::binding<std::chrono::milliseconds> node_status_interval,
       config::binding<size_t> raft_learner_recovery_rate,
-      config::binding<bool> topic_aware);
+      config::binding<bool> topic_aware,
+      config::binding<std::chrono::milliseconds>
+        health_monitor_max_metadata_age);
 
     void start();
     ss::future<> stop();
@@ -115,10 +118,11 @@ private:
     config::binding<std::chrono::milliseconds> _node_status_interval;
     config::binding<size_t> _raft_learner_recovery_rate;
     config::binding<bool> _topic_aware;
+    config::binding<std::chrono::milliseconds> _health_monitor_max_metadata_age;
 
     ssx::mutex _lock{"partition_balancer_backend::lock"};
     ss::gate _gate;
-    ss::timer<clock_t> _timer;
+    ssx::tail_minimum_interval_timer _timer;
     notification_id_type _topic_table_updates;
     notification_id_type _member_updates;
     notification_id_type _health_monitor_updates;

--- a/src/v/ssx/BUILD
+++ b/src/v/ssx/BUILD
@@ -344,3 +344,19 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "minimum_interval_timer",
+    srcs = [
+        "minimum_interval_timer.cc",
+    ],
+    hdrs = [
+        "minimum_interval_timer.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":future_util",
+        "//src/v/base",
+        "@seastar",
+    ],
+)

--- a/src/v/ssx/minimum_interval_timer.cc
+++ b/src/v/ssx/minimum_interval_timer.cc
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "ssx/minimum_interval_timer.h"
+
+namespace ssx {
+
+template class minimum_interval_timer<
+  minimum_interval_timer_type::tail,
+  ss::lowres_clock>;
+
+} // namespace ssx

--- a/src/v/ssx/minimum_interval_timer.h
+++ b/src/v/ssx/minimum_interval_timer.h
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "base/seastarx.h"
+#include "base/vassert.h"
+#include "ssx/future-util.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/timer.hh>
+#include <seastar/core/weak_ptr.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+#include <chrono>
+#include <optional>
+
+namespace ssx {
+
+// A timer with utilities for limiting the maximum frequency of timer firings
+// details:
+// 1. This timer guarantees that after a tick terminates, no additional tick
+//    will fire sooner than a provided minimum duration
+//
+// 2. A ticks termination is determined by the destruction of a guard which is
+//    passed to the timer's callback
+//
+// 3. Ticks will be rescheduled to the earliest possible time according to the
+//    following rules
+//    a. no scheduled tick may be closer than the provided minimum duration to
+//       the prior tick
+//    b. no tick may be scheduled in the past
+//    c. no tick may be scheduled while another tick is ongoing
+//       i. the request to schedule will be noted, and a rescheduling attempt
+//          will occur on termination of the inflight tick (unless cancelled)
+template<typename Clock>
+class minimum_interval_timer_base
+  : public ss::weakly_referencable<minimum_interval_timer_base<Clock>> {
+private: // internal type definitions
+    // convenience wrapper on time_point with a magic value (max) to stand in as
+    // 'invalid'
+    struct next_requested_time_point {
+    private:
+        using time_point = Clock::time_point;
+        static constexpr auto unscheduled_time = time_point::max();
+
+    public:
+        time_point time;
+
+        next_requested_time_point()
+          : time{unscheduled_time} {}
+
+        // NOLINTNEXTLINE(hicpp-explicit-conversions)
+        next_requested_time_point(time_point time)
+          : time{time} {}
+
+        bool is_requested() const { return time != time_point::max(); }
+        void reset() { time = unscheduled_time; }
+    };
+
+protected: // types, type aliases and friends
+    // using this instead of ss::defer because the type of defer bound to
+    // a member of an incomplete template is a beast
+    //
+    // holds a weak reference to its parent timer, on destruction invokes
+    // on_guard_close
+    struct close_guard {
+        // weak because the lifecycle of user spawned fibers should NOT be tied
+        // to the timer that happens to have spawned them (to keep the pointer
+        // valid)
+        ss::weak_ptr<minimum_interval_timer_base> parent;
+
+        explicit close_guard(ss::weak_ptr<minimum_interval_timer_base> parent)
+          : parent(std::move(parent)) {}
+
+        close_guard(const close_guard&) = delete;
+        close_guard& operator=(const close_guard&) = delete;
+        close_guard(close_guard&&) = default;
+        close_guard& operator=(close_guard&&) = default;
+
+        ~close_guard() noexcept {
+            if (!parent) {
+                return;
+            }
+            parent->on_guard_close();
+        }
+    };
+
+    using self_t = minimum_interval_timer_base<Clock>;
+    using clock_t = Clock;
+    using time_point_t = typename Clock::time_point;
+    using duration_t = typename Clock::duration;
+
+public: // publicly usable types
+    using callback_t = ss::noncopyable_function<void(close_guard)>;
+
+private:
+    // underlying timer, holds the timepoint of the next tick if requested, and
+    // if theres no other tick in flight
+    ss::timer<Clock> _timer;
+
+    // last completion time as governed by on_guard_close
+    time_point_t _last_fired{time_point_t::min()};
+
+    // minimum duration between _last_fired and subsequent ticks
+    duration_t _minimum_interval;
+
+    // buffers the next tick request while a tick is currently inflight
+    next_requested_time_point _next_requested{};
+
+    // guard to track if theres a tick in flight, gets reset by close_guard on
+    // destruction
+    bool _is_in_flight{false};
+
+private: // detail methods for close_guard
+    void on_guard_close() {
+        // closing of the guard signifies that the tick has completed
+        // in flight is obviously now false, last fired is now, and if there is
+        // a backlogged request resend it now
+        _is_in_flight = false;
+        _last_fired = clock_t::now();
+        if (_next_requested.is_requested()) {
+            // request tick will consume _next_requested
+            request_tick(_next_requested.time);
+        }
+    }
+
+    // close_guard factory
+    close_guard open_in_flight_guard() {
+        vassert(!_is_in_flight, "inflight guard should never be opened twice");
+        _is_in_flight = true;
+        return close_guard{this->weak_from_this()};
+    }
+
+public:
+    explicit minimum_interval_timer_base(duration_t minimum_interval) noexcept
+      : _minimum_interval{minimum_interval} {}
+
+    /**
+     * Requests a tick to occur at the specified point in time.
+     *
+     * Schedules the timer if appropriate to do so.
+     *
+     * The timer will never be rescheduled while a tick is ongoing, but the
+     *     request will be noted and retried on timer completion
+     *
+     * The timer may never be scheduled to fire closer than _minimum_interval to
+     *     _last_fired
+     *
+     * The timer may never be scheduled to fire in the past
+     *
+     * The timer will be rescheduled to the soonest point in time that does
+     *     not violate these constraints
+     */
+    void request_tick(time_point_t requested_time) {
+        // store requested, bail out if theres a tick in flight
+        _next_requested = std::min(requested_time, _next_requested.time);
+        if (_is_in_flight) {
+            return;
+        }
+
+        // no tick is in flight, consume the requested time and attempt to
+        // reschedule the underlying _timer
+        requested_time = _next_requested.time;
+        _next_requested.reset();
+
+        requested_time = std::max(requested_time, clock_t::now());
+
+        // grab the next tick time point or infinity
+        const auto next_scheduled_time = _timer.armed() ? _timer.get_timeout()
+                                                        : time_point_t::max();
+
+        const auto soonest_allowable_time = _last_fired + _minimum_interval;
+
+        // take lesser of the current schedule and requested schedule, bounded
+        // by the minimum allowable interval
+        auto to_reschedule_at = std::min(requested_time, next_scheduled_time);
+        to_reschedule_at = std::max(to_reschedule_at, soonest_allowable_time);
+
+        if (to_reschedule_at != next_scheduled_time) {
+            _timer.rearm(to_reschedule_at);
+        }
+    }
+
+    // convenience method for requesting a tick some duration from now
+    void request_tick(std::chrono::milliseconds from_now) {
+        return request_tick(
+          clock_t::now() + std::chrono::duration_cast<duration_t>(from_now));
+    }
+
+    // change the minimum interval.
+    // increasing the minimum_interval will move the next tick back if necessary
+    // decreasing the minimum_interval will not reschedule the next tick any
+    // sooner
+    void set_minimum_interval(std::chrono::milliseconds minimum_interval) {
+        _minimum_interval = std::chrono::duration_cast<duration_t>(
+          minimum_interval);
+        // kick the timeout further into the future if the timeout is now
+        // inappropriately close to the last tick
+        if (_timer.armed()) {
+            request_tick(_timer.get_timeout());
+        }
+    }
+
+    // sets the callback, replaces & discards any prior callback
+    void set_callback(callback_t&& callback) {
+        _timer.set_callback([this, callback = std::move(callback)] {
+            std::invoke(callback, open_in_flight_guard());
+        });
+    }
+
+    // cancels any requested or scheduled ticks
+    void cancel() {
+        _next_requested.reset();
+        _timer.cancel();
+    }
+
+    // gets the timepoint of the next scheduled tick
+    // note that ticks in _next_requested are not scheduled, because their exact
+    // time is not yet known
+    std::optional<time_point_t> get_scheduled_time() const {
+        if (_timer.armed()) {
+            return _timer.get_timeout();
+        }
+        return std::nullopt;
+    }
+
+    // if nothing changes, will there eventually be another tick?
+    bool is_tick_requested() const {
+        return _next_requested.is_requested() || _timer.armed();
+    }
+};
+
+enum class minimum_interval_timer_type : int8_t { head, tail };
+
+// wrappers for the two most common use cases
+// head: a tick is complete as soon as the timer fires
+// tail: a tick is complete when the user provided operation is complete
+template<minimum_interval_timer_type timer_type, typename Clock>
+class minimum_interval_timer : private minimum_interval_timer_base<Clock> {
+    using base = minimum_interval_timer_base<Clock>;
+
+private: // type aliases
+    using callback_t = ss::noncopyable_function<void(void)>;
+    using async_callback_t = ss::noncopyable_function<ss::future<>()>;
+
+private: // internal only helper functions
+    void set_sync_callback(callback_t callback) {
+        auto wrapped_cb = [callback = std::move(callback)](
+                            base::close_guard deferred_function) {
+            // head timer, invoke the guard now
+            if constexpr (timer_type == minimum_interval_timer_type::head) {
+                // force destruction to invoke the
+                // callback immediately
+                auto(std::move(deferred_function));
+            }
+            callback();
+            // tail timer, the guard will invoke itself
+        };
+
+        base::set_callback(std::move(wrapped_cb));
+    }
+
+    void set_async_callback(async_callback_t callback) {
+        auto wrapped_cb = [callback = std::move(callback)](
+                            base::close_guard deferred_function) {
+            // head timer, we just destruct the close_guard right away
+            if constexpr (timer_type == minimum_interval_timer_type::head) {
+                {
+                    // force destruction to invoke the
+                    // callback immediately
+                    auto(std::move(deferred_function));
+                }
+                ssx::background = callback();
+                return;
+            }
+            // tail timer, attach the close guard to the user provided function
+            // s.t. it can be completed after
+            ssx::background = callback().finally(
+              [deferred_function = std::move(deferred_function)] {});
+        };
+
+        base::set_callback(std::move(wrapped_cb));
+    }
+
+public:
+    using minimum_interval_timer_base<Clock>::cancel;
+    using minimum_interval_timer_base<Clock>::get_scheduled_time;
+    using minimum_interval_timer_base<Clock>::is_tick_requested;
+    using minimum_interval_timer_base<Clock>::request_tick;
+    using minimum_interval_timer_base<Clock>::set_minimum_interval;
+
+    explicit minimum_interval_timer(
+      std::chrono::milliseconds minimum_interval) noexcept
+      : base(
+          std::chrono::duration_cast<typename base::duration_t>(
+            minimum_interval)) {}
+
+    template<typename Func>
+    requires std::is_invocable_v<Func>
+    minimum_interval_timer(
+      std::chrono::milliseconds minimum_interval, Func callback) noexcept
+      : base(
+          std::chrono::duration_cast<typename base::duration_t>(
+            minimum_interval)) {
+        this->set_callback(std::move(callback));
+    }
+
+    // set the callback of the timer
+    // accepts void(void) or ss::future<void>(void) callbacks
+    // the caller is responsible for maintaining the lifetime guarantees of
+    //     their own callbacks with regard to non-timer memory
+    // namely, it is permissible to destroy the timer while a user callback is
+    //     in flight, but the timer will not guarantee consistency of any other
+    //     memory. If the user snaps [this] on an async callback, it is
+    //     advisable that the user also cancels the timer on close, and use a
+    //     gate + cancellation token to ensure graceful completion of their
+    //     callback fibers
+    template<typename Func>
+    requires std::is_invocable_v<Func>
+    void set_callback(Func func) {
+        using result_t = std::invoke_result_t<Func>;
+        if constexpr (std::is_void_v<result_t>) {
+            set_sync_callback(std::move(func));
+        } else {
+            static_assert(
+              std::is_same_v<result_t, ss::future<>>,
+              "if not void returning must return ss::future<>");
+            set_async_callback(std::move(func));
+        }
+    }
+};
+
+// ticks complete right when the timer fires
+using head_minimum_interval_timer
+  = minimum_interval_timer<minimum_interval_timer_type::head, ss::lowres_clock>;
+
+// ticks complete when the user operation completes
+using tail_minimum_interval_timer
+  = minimum_interval_timer<minimum_interval_timer_type::tail, ss::lowres_clock>;
+
+} // namespace ssx

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -377,3 +377,19 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "minimum_interval_timer_test",
+    timeout = "short",
+    srcs = [
+        "minimum_interval_timer_test.cc",
+    ],
+    deps = [
+        "//src/v/ssx:minimum_interval_timer",
+        "//src/v/test_utils:async",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/ssx/tests/minimum_interval_timer_test.cc
+++ b/src/v/ssx/tests/minimum_interval_timer_test.cc
@@ -1,0 +1,887 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "ssx/minimum_interval_timer.h"
+#include "test_utils/async.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/manual_clock.hh>
+#include <seastar/util/later.hh>
+
+using namespace std::chrono_literals;
+using namespace ::testing;
+
+namespace ssx {
+
+namespace {
+
+constexpr auto arbitrary_interval = 1ms;
+constexpr auto minimum_interval = 100ms;
+
+constexpr const char* should_have_fired_message = "Expected timer to fire";
+constexpr const char* should_be_scheduled_message = "Timer should be scheduled";
+
+// move the clock forward and yield so the timer can fire
+ss::future<> advance_and_yield(std::chrono::milliseconds ms) {
+    ss::manual_clock::advance(ms);
+    co_await tests::drain_task_queue();
+}
+
+} // namespace
+
+class head_minimum_interval_timer_fixture : public seastar_test {
+public:
+    using timer_type = minimum_interval_timer<
+      minimum_interval_timer_type::head,
+      ss::manual_clock>;
+
+    ss::future<> SetUpAsync() override { co_return; }
+
+    ss::future<> TearDownAsync() override {
+        co_await tests::drain_task_queue();
+    }
+
+    void setup_callback() {
+        _timer.set_callback([this] {
+            _tick_count++;
+            _last_tick_time = ss::manual_clock::now();
+        });
+    }
+
+    int tick_count() const { return _tick_count; }
+
+    ss::manual_clock::time_point last_tick_time() const {
+        return _last_tick_time;
+    }
+
+    timer_type& timer() { return _timer; }
+
+private:
+    timer_type _timer{minimum_interval};
+    int _tick_count{0};
+    ss::manual_clock::time_point _last_tick_time{
+      ss::manual_clock::time_point::min()};
+};
+
+// ============================================================================
+// 1. Basic Scheduling Tests
+// ============================================================================
+
+TEST_F_CORO(
+  head_minimum_interval_timer_fixture, basic_scheduling_with_time_point) {
+    auto now = ss::manual_clock::now();
+    auto target_time = now + 200ms;
+
+    timer().request_tick(target_time);
+
+    auto scheduled_time = timer().get_scheduled_time();
+    EXPECT_TRUE(scheduled_time.has_value()) << should_be_scheduled_message;
+    EXPECT_EQ(*scheduled_time, target_time)
+      << "Scheduling with a particular time point should yield that time point";
+    co_return;
+}
+
+TEST_F_CORO(
+  head_minimum_interval_timer_fixture, basic_scheduling_with_duration) {
+    auto now = ss::manual_clock::now();
+
+    timer().request_tick(300ms);
+
+    auto scheduled_time = timer().get_scheduled_time();
+    EXPECT_TRUE(scheduled_time.has_value()) << should_be_scheduled_message;
+    EXPECT_EQ(*scheduled_time, now + 300ms)
+      << "Scheduling with a duration should yield a scheduled time of now() "
+         "plus the provided duration";
+    co_return;
+}
+
+// ============================================================================
+// 2. Minimum Interval Enforcement Tests
+// ============================================================================
+
+TEST_F_CORO(
+  head_minimum_interval_timer_fixture,
+  minimum_interval_not_enforced_from_start) {
+    auto now = ss::manual_clock::now();
+    timer().request_tick(now);
+
+    auto scheduled = timer().get_scheduled_time();
+    EXPECT_TRUE(scheduled.has_value()) << should_be_scheduled_message;
+    EXPECT_EQ(*scheduled, now)
+      << "The first scheduling of bounded timer should have no restrictions";
+    co_return;
+}
+
+TEST_F_CORO(
+  head_minimum_interval_timer_fixture, minimum_interval_enforced_after_firing) {
+    setup_callback();
+
+    // burn the first tick so we have a 'last ticked' which is not -inf
+    timer().request_tick(0ms);
+    co_await advance_and_yield(arbitrary_interval);
+    EXPECT_EQ(tick_count(), 1) << should_have_fired_message;
+
+    auto now_after_fire = ss::manual_clock::now();
+
+    // Try to schedule too soon after firing (30ms < 100ms minimum)
+    timer().request_tick(now_after_fire + 30ms);
+
+    // Should be scheduled at minimum interval from last fire
+    auto scheduled = timer().get_scheduled_time();
+    EXPECT_TRUE(scheduled.has_value()) << should_be_scheduled_message;
+    EXPECT_EQ(*scheduled, now_after_fire + minimum_interval)
+      << "A timer for which the user attempts to reschedule below the minimum "
+         "interval should instead be rescheduled to a minimum interval after "
+         "the last tick time";
+}
+
+TEST_F_CORO(head_minimum_interval_timer_fixture, minimum_interval_exactly_met) {
+    setup_callback();
+    auto now = ss::manual_clock::now();
+
+    timer().request_tick(now + minimum_interval);
+    co_await advance_and_yield(minimum_interval);
+    EXPECT_EQ(tick_count(), 1) << should_have_fired_message;
+
+    timer().request_tick(minimum_interval);
+
+    auto scheduled = timer().get_scheduled_time();
+    EXPECT_TRUE(scheduled.has_value())
+      << "Timer should have accepted a reschedule to exactly the minimum "
+         "interval";
+    EXPECT_EQ(*scheduled, ss::manual_clock::now() + minimum_interval)
+      << "Timer should be rescheduled to exactly the minimum interval";
+
+    co_return;
+}
+
+// ============================================================================
+// 3. Rescheduling Logic Tests
+// ============================================================================
+
+TEST_F_CORO(head_minimum_interval_timer_fixture, reschedule_to_earlier_time) {
+    auto now = ss::manual_clock::now();
+    timer().request_tick(now + 1s);
+
+    // Request earlier time
+    timer().request_tick(now + 200ms);
+
+    auto scheduled = timer().get_scheduled_time();
+    EXPECT_TRUE(scheduled.has_value()) << should_be_scheduled_message;
+
+    EXPECT_EQ(*scheduled, now + 200ms)
+      << "Timer's rescheduled value should equal the earlier provided time";
+    co_return;
+}
+
+TEST_F_CORO(
+  head_minimum_interval_timer_fixture, reschedule_to_later_time_keeps_current) {
+    auto now = ss::manual_clock::now();
+
+    timer().request_tick(now + 200ms);
+
+    auto original_time = timer().get_scheduled_time();
+    EXPECT_TRUE(original_time) << should_be_scheduled_message;
+
+    timer().request_tick(now + 500ms);
+
+    auto scheduled = timer().get_scheduled_time();
+    EXPECT_EQ(scheduled, original_time)
+      << "Timer should have honored the originally scheduled time";
+    co_return;
+}
+
+// ============================================================================
+// 4. Past Time Handling Tests
+// ============================================================================
+
+TEST_F_CORO(
+  head_minimum_interval_timer_fixture, scheduling_in_past_adjusts_to_now) {
+    ss::manual_clock::advance(1s);
+    auto now = ss::manual_clock::now();
+
+    // Try to schedule in the past
+    auto past_time = now - 500ms;
+    timer().request_tick(past_time);
+
+    auto scheduled = timer().get_scheduled_time();
+    EXPECT_TRUE(scheduled.has_value()) << should_be_scheduled_message;
+    EXPECT_EQ(*scheduled, now)
+      << "A timer scheduled in the past should floor to \"now\"";
+    co_return;
+}
+
+TEST_F_CORO(
+  head_minimum_interval_timer_fixture,
+  past_time_still_respects_minimum_interval) {
+    setup_callback();
+    timer().set_minimum_interval(200ms);
+
+    timer().request_tick(200ms);
+    co_await advance_and_yield(200ms);
+
+    EXPECT_EQ(tick_count(), 1) << should_have_fired_message;
+    auto last_tick_time = this->last_tick_time();
+    timer().request_tick(last_tick_time - 100ms);
+
+    auto scheduled = timer().get_scheduled_time();
+    EXPECT_TRUE(scheduled.has_value()) << should_be_scheduled_message;
+
+    EXPECT_EQ(*scheduled, last_tick_time + 200ms)
+      << "Next tick time should respect minimum interval, even if scheduled in "
+         "the past";
+    co_return;
+}
+
+// ============================================================================
+// 5. Minimum Interval Updates Tests
+// ============================================================================
+
+TEST_F_CORO(head_minimum_interval_timer_fixture, decrease_minimum_interval) {
+    setup_callback();
+    timer().set_minimum_interval(200ms);
+
+    auto now = ss::manual_clock::now();
+    timer().request_tick(now + 300ms);
+    auto original_time = timer().get_scheduled_time();
+    EXPECT_TRUE(original_time) << should_be_scheduled_message;
+
+    // Decrease minimum interval
+    timer().set_minimum_interval(50ms);
+
+    // Existing schedule should remain unchanged
+    EXPECT_EQ(timer().get_scheduled_time(), original_time)
+      << "Lowering the minimum interval should not lower the currently "
+         "scheduled time";
+
+    // New scheduling should use shorter interval
+    timer().request_tick(now + 60ms);
+    auto scheduled = timer().get_scheduled_time();
+    EXPECT_TRUE(scheduled.has_value()) << should_be_scheduled_message;
+    EXPECT_EQ(*scheduled, now + 60ms)
+      << "Scheduling requests after lowering the minimum interval should use "
+         "the new minimum interval";
+    co_return;
+}
+
+TEST_F_CORO(
+  head_minimum_interval_timer_fixture,
+  increase_minimum_interval_after_recent_fire) {
+    setup_callback();
+
+    timer().request_tick(ss::manual_clock::now() + 50ms);
+
+    co_await advance_and_yield(50ms);
+    EXPECT_EQ(tick_count(), 1) << should_have_fired_message;
+
+    auto last_tick_time = this->last_tick_time();
+    timer().request_tick(last_tick_time + 100ms);
+
+    auto scheduled_before = timer().get_scheduled_time();
+    EXPECT_TRUE(scheduled_before.has_value()) << should_be_scheduled_message;
+
+    timer().set_minimum_interval(500ms);
+
+    auto scheduled = timer().get_scheduled_time();
+    EXPECT_TRUE(scheduled.has_value()) << should_be_scheduled_message;
+
+    auto expected_min = last_tick_time + 500ms;
+    EXPECT_EQ(*scheduled, expected_min)
+      << "Timer should be rescheduled to respect new minimum from last fire";
+}
+
+// ============================================================================
+// 6. Edge Cases Tests
+// ============================================================================
+
+TEST_F_CORO(head_minimum_interval_timer_fixture, initial_state) {
+    EXPECT_FALSE(timer().get_scheduled_time().has_value())
+      << "Timer should not be scheduled initially";
+    co_return;
+}
+
+TEST_F_CORO(head_minimum_interval_timer_fixture, is_tick_requested_lifecycle) {
+    setup_callback();
+
+    EXPECT_FALSE(timer().is_tick_requested())
+      << "No tick should be requested initially";
+
+    timer().request_tick(ss::manual_clock::now() + 200ms);
+    EXPECT_TRUE(timer().is_tick_requested())
+      << "Tick should be requested after request_tick";
+
+    timer().cancel();
+    EXPECT_FALSE(timer().is_tick_requested())
+      << "No tick should be requested after cancel";
+
+    timer().request_tick(0ms);
+    co_await advance_and_yield(arbitrary_interval);
+    EXPECT_EQ(tick_count(), 1) << should_have_fired_message;
+    EXPECT_FALSE(timer().is_tick_requested())
+      << "No tick should be requested after firing with no new request";
+    co_return;
+}
+
+TEST_F_CORO(head_minimum_interval_timer_fixture, zero_minimum_interval) {
+    setup_callback();
+    timer().set_minimum_interval(0ms);
+
+    auto now = ss::manual_clock::now();
+
+    timer().request_tick(now);
+    auto scheduled = timer().get_scheduled_time();
+    EXPECT_TRUE(scheduled.has_value()) << should_be_scheduled_message;
+    EXPECT_EQ(*scheduled, now)
+      << "With zero minimum interval, we should be immediately scheduled";
+
+    // manual clock advancement fires expired timers, the tick should fire
+    ss::manual_clock::advance(0ms);
+    EXPECT_EQ(tick_count(), 1) << should_have_fired_message;
+
+    co_return;
+}
+
+// ============================================================================
+// 7. Additional Tests
+// ============================================================================
+
+TEST_F_CORO(head_minimum_interval_timer_fixture, constructor_with_callback) {
+    // Create timer with callback in constructor
+    int local_tick_count = 0;
+    timer_type timer_with_cb(
+      minimum_interval, [&local_tick_count] { local_tick_count++; });
+
+    timer_with_cb.request_tick(ss::manual_clock::now());
+    co_await advance_and_yield(minimum_interval);
+
+    EXPECT_EQ(local_tick_count, 1)
+      << "The timer should have bound to the callback provided at construction";
+    timer_with_cb.cancel();
+}
+
+TEST_F_CORO(head_minimum_interval_timer_fixture, set_callback_replaces_prior) {
+    int first_callback_count = 0;
+    int second_callback_count = 0;
+
+    timer().set_callback([&first_callback_count] { first_callback_count++; });
+    timer().set_callback([&second_callback_count] { second_callback_count++; });
+
+    timer().request_tick(ss::manual_clock::now());
+    co_await advance_and_yield(minimum_interval);
+
+    EXPECT_EQ(first_callback_count, 0)
+      << "Replaced callback should not have fired";
+    EXPECT_EQ(second_callback_count, 1)
+      << "Replacement callback should have fired";
+    co_return;
+}
+
+TEST_F_CORO(
+  head_minimum_interval_timer_fixture, rapid_tick_requests_respect_interval) {
+    setup_callback();
+
+    // Make multiple rapid requests
+    for (int i = 0; i < 5; i++) {
+        timer().request_tick(ss::manual_clock::now());
+        co_await advance_and_yield(10ms);
+    }
+
+    // Should only have fired once due to minimum interval
+    EXPECT_EQ(tick_count(), 1)
+      << "Rapid requests should respect minimum interval";
+}
+
+TEST_F_CORO(
+  head_minimum_interval_timer_fixture, interval_between_successive_fires) {
+    setup_callback();
+
+    timer().request_tick(ss::manual_clock::now());
+    co_await advance_and_yield(arbitrary_interval);
+    EXPECT_EQ(tick_count(), 1) << should_have_fired_message;
+    auto first_tick_time = last_tick_time();
+
+    timer().request_tick(ss::manual_clock::now());
+
+    co_await advance_and_yield(minimum_interval);
+    EXPECT_EQ(tick_count(), 2) << "Expected timer to fire again";
+    auto second_tick_time = last_tick_time();
+
+    auto interval = second_tick_time - first_tick_time;
+    EXPECT_GE(interval, minimum_interval)
+      << "Actual time between ticks should be at least the minimum interval";
+}
+
+// ============================================================================
+// 8. Head Bounded Timer - Async Callback Tests
+// ============================================================================
+
+TEST_F_CORO(
+  head_minimum_interval_timer_fixture, async_request_tick_inside_callback) {
+    ss::condition_variable callback_done{};
+    int local_tick_count = 0;
+    timer().set_callback(
+      [this, &local_tick_count, &callback_done](this auto) -> ss::future<> {
+          local_tick_count++;
+          // The head timer's close_guard is already destroyed, so request_tick
+          // should schedule normally (no in-flight blocking).
+          timer().request_tick(ss::manual_clock::now() + minimum_interval);
+
+          auto scheduled = timer().get_scheduled_time();
+          EXPECT_TRUE(scheduled.has_value())
+            << "request_tick inside an async head callback should schedule the "
+               "next tick";
+          callback_done.signal();
+          co_return;
+      });
+
+    timer().request_tick(ss::manual_clock::now());
+    co_await advance_and_yield(minimum_interval);
+    co_await callback_done.wait();
+
+    EXPECT_EQ(local_tick_count, 1) << should_have_fired_message;
+}
+
+TEST_F_CORO(
+  head_minimum_interval_timer_fixture, async_fires_again_while_prev_running) {
+    // An async head callback that blocks on a condition variable.
+    // The timer should be able to fire a second time while the first callback
+    // is still "running" because head timers complete at invocation time.
+    ss::condition_variable hold_first_open{};
+    int local_tick_count = 0;
+    timer().set_callback(
+      [&local_tick_count, &hold_first_open](this auto) -> ss::future<> {
+          local_tick_count++;
+          if (local_tick_count == 1) {
+              co_await hold_first_open.wait();
+          }
+      });
+
+    // First tick — callback will suspend
+    timer().request_tick(ss::manual_clock::now());
+    co_await advance_and_yield(minimum_interval);
+
+    EXPECT_EQ(local_tick_count, 1) << should_have_fired_message;
+
+    // Second tick — should fire even though the first callback is suspended
+    timer().request_tick(ss::manual_clock::now());
+    co_await advance_and_yield(minimum_interval);
+
+    EXPECT_EQ(local_tick_count, 2)
+      << "Head timer should fire again while previous async callback is still "
+         "running";
+
+    // Release the first callback so there are no abandoned futures
+    hold_first_open.signal();
+}
+
+// ============================================================================
+// 9. Tail Bounded Timer - Sync Callback Tests
+// ============================================================================
+
+class tail_minimum_interval_timer_fixture : public seastar_test {
+public:
+    using timer_type = minimum_interval_timer<
+      minimum_interval_timer_type::tail,
+      ss::manual_clock>;
+
+    // Callbacks advance the clock by this amount to simulate execution time.
+    // Tests can then deduce when the tick was considered complete from the
+    // next scheduled time.
+    static constexpr auto simulated_work_duration = 50ms;
+
+    ss::future<> SetUpAsync() override { co_return; }
+    ss::future<> TearDownAsync() override {
+        // ensure that there are no trailing .finally callbacks on test
+        // completion
+        co_await tests::drain_task_queue();
+    }
+
+    void setup_sync_callback() {
+        _timer.set_callback([this] {
+            _tick_count++;
+            ss::manual_clock::advance(simulated_work_duration);
+        });
+    }
+
+    void setup_async_callback() {
+        _timer.set_callback([this](this auto) -> ss::future<> {
+            _tick_count++;
+
+            co_await tests::drain_task_queue();
+            callback_entered.signal();
+            co_await callback_release.wait();
+            ss::manual_clock::advance(simulated_work_duration);
+        });
+    }
+
+    // waits until the user defined async is inflight
+    ss::future<> wait_for_callback_inflight(int count_before = 0) {
+        co_await callback_entered.wait();
+        EXPECT_EQ(tick_count(), count_before + 1) << should_have_fired_message;
+    }
+
+    // forces the callback to finish so there's no abandoned futures
+    ss::future<> finish_callback() {
+        callback_release.signal();
+        co_await tests::drain_task_queue();
+    }
+
+    // start the callback and finish it so there's no abandoned futures
+    ss::future<> start_and_finish_callback(int count_before = 0) {
+        co_await wait_for_callback_inflight(count_before);
+        co_await finish_callback();
+    }
+
+    int tick_count() const { return _tick_count; }
+
+    timer_type& timer() { return _timer; }
+
+protected:
+    // callback signals this to tell the test fiber it is in flight
+    ss::condition_variable callback_entered{};
+    // test signals this to tell the callback fiber it can finish
+    ss::condition_variable callback_release{};
+
+private:
+    timer_type _timer{minimum_interval};
+    int _tick_count{0};
+};
+
+TEST_F_CORO(tail_minimum_interval_timer_fixture, sync_callback_fires) {
+    setup_sync_callback();
+    timer().request_tick(ss::manual_clock::now());
+    co_await advance_and_yield(minimum_interval);
+    EXPECT_EQ(tick_count(), 1) << should_have_fired_message;
+}
+
+TEST_F_CORO(
+  tail_minimum_interval_timer_fixture, sync_interval_measured_from_completion) {
+    setup_sync_callback();
+    auto start = ss::manual_clock::now();
+    timer().request_tick(0ms);
+    co_await advance_and_yield(minimum_interval);
+    EXPECT_EQ(tick_count(), 1) << should_have_fired_message;
+
+    // Request next tick immediately
+    timer().request_tick(ss::manual_clock::now());
+
+    auto scheduled = timer().get_scheduled_time();
+    EXPECT_TRUE(scheduled.has_value()) << should_be_scheduled_message;
+
+    // callback advances time by simulated_work_duration
+    // so start + minimum interval is tick start
+    // tick end is tick_start + simulated_work_duration
+    auto tick_completion = start + minimum_interval + simulated_work_duration;
+    EXPECT_EQ(*scheduled, tick_completion + minimum_interval)
+      << "Minimum interval should be measured from callback completion, not "
+         "invocation";
+}
+
+TEST_F_CORO(
+  tail_minimum_interval_timer_fixture,
+  sync_request_during_callback_is_deferred) {
+    bool did_fire{false};
+    std::optional<ss::manual_clock::time_point> scheduled_during_callback;
+    timer().set_callback([this, &scheduled_during_callback, &did_fire] {
+        did_fire = true;
+        ss::manual_clock::advance(simulated_work_duration);
+        timer().request_tick(ss::manual_clock::now() + 200ms);
+        scheduled_during_callback = timer().get_scheduled_time();
+    });
+
+    timer().request_tick(ss::manual_clock::now());
+    co_await advance_and_yield(minimum_interval);
+    EXPECT_TRUE(did_fire) << should_have_fired_message;
+
+    EXPECT_FALSE(scheduled_during_callback.has_value())
+      << "Request during tail sync callback should be deferred while in-flight";
+
+    auto scheduled = timer().get_scheduled_time();
+    EXPECT_TRUE(scheduled.has_value())
+      << "Deferred request should be scheduled after callback completes";
+    EXPECT_EQ(scheduled.value(), ss::manual_clock::now() + 200ms);
+}
+
+// ============================================================================
+// 10. Tail Bounded Timer - Async In-Flight Behavior
+// ============================================================================
+
+TEST_F_CORO(tail_minimum_interval_timer_fixture, async_callback_fires) {
+    setup_async_callback();
+    timer().request_tick(ss::manual_clock::now());
+    ss::manual_clock::advance(arbitrary_interval);
+    co_await start_and_finish_callback();
+}
+
+TEST_F_CORO(
+  tail_minimum_interval_timer_fixture, not_scheduled_during_in_flight) {
+    setup_async_callback();
+    timer().request_tick(ss::manual_clock::now());
+    ss::manual_clock::advance(arbitrary_interval);
+    co_await wait_for_callback_inflight();
+
+    EXPECT_FALSE(timer().get_scheduled_time().has_value())
+      << "Timer should not report a scheduled time while async op is "
+         "in-flight";
+
+    co_await finish_callback();
+}
+
+TEST_F_CORO(
+  tail_minimum_interval_timer_fixture,
+  request_during_in_flight_deferred_until_completion) {
+    setup_async_callback();
+    timer().request_tick(ss::manual_clock::now());
+    ss::manual_clock::advance(arbitrary_interval);
+
+    co_await wait_for_callback_inflight();
+
+    timer().request_tick(ss::manual_clock::now() + 200ms);
+
+    EXPECT_FALSE(timer().get_scheduled_time().has_value())
+      << "Timer should not schedule while in-flight";
+
+    co_await finish_callback();
+
+    auto scheduled = timer().get_scheduled_time();
+    EXPECT_TRUE(scheduled.has_value())
+      << "Deferred request should be scheduled after async op completes";
+}
+
+TEST_F_CORO(
+  tail_minimum_interval_timer_fixture, no_reschedule_without_pending_request) {
+    setup_async_callback();
+    timer().request_tick(ss::manual_clock::now());
+    ss::manual_clock::advance(arbitrary_interval);
+    co_await this->start_and_finish_callback();
+    EXPECT_FALSE(timer().get_scheduled_time().has_value())
+      << "Timer should not be scheduled after completion with no pending "
+         "request";
+}
+
+TEST_F_CORO(
+  tail_minimum_interval_timer_fixture,
+  is_tick_requested_with_pending_during_in_flight) {
+    setup_async_callback();
+    timer().request_tick(ss::manual_clock::now());
+    ss::manual_clock::advance(arbitrary_interval);
+    co_await wait_for_callback_inflight();
+
+    // In-flight with no pending request: timer is not armed (it already fired)
+    // and _next_requested was consumed when the tick was scheduled
+    EXPECT_FALSE(timer().is_tick_requested())
+      << "No tick should be requested during in-flight with no pending request";
+    EXPECT_FALSE(timer().get_scheduled_time().has_value())
+      << "Timer should not be armed during in-flight";
+
+    // Request during in-flight: _next_requested gets set but timer stays
+    // unarmed
+    timer().request_tick(ss::manual_clock::now() + 200ms);
+    EXPECT_TRUE(timer().is_tick_requested())
+      << "Tick should be requested when pending request exists during "
+         "in-flight";
+    EXPECT_FALSE(timer().get_scheduled_time().has_value())
+      << "Timer should not be armed during in-flight even with pending request";
+
+    co_await finish_callback();
+    co_return;
+}
+
+// ============================================================================
+// 11. Tail Bounded Timer - Minimum Interval From Completion
+// ============================================================================
+
+TEST_F_CORO(
+  tail_minimum_interval_timer_fixture,
+  async_interval_measured_from_completion) {
+    setup_async_callback();
+    auto start = ss::manual_clock::now();
+    timer().request_tick(start);
+    ss::manual_clock::advance(arbitrary_interval);
+    co_await wait_for_callback_inflight();
+
+    timer().request_tick(ss::manual_clock::now());
+
+    co_await finish_callback();
+
+    auto scheduled = timer().get_scheduled_time();
+    EXPECT_TRUE(scheduled.has_value()) << should_be_scheduled_message;
+
+    // tick_start = start + arbitrary_interval
+    // tick end = tick_start + simulated_work_duration
+    auto tick_completion = start + arbitrary_interval + simulated_work_duration;
+    EXPECT_EQ(*scheduled, tick_completion + minimum_interval)
+      << "Minimum interval should be measured from async completion, not "
+         "invocation";
+}
+
+TEST_F_CORO(
+  tail_minimum_interval_timer_fixture,
+  increase_minimum_interval_during_in_flight) {
+    setup_async_callback();
+    timer().request_tick(ss::manual_clock::now());
+    ss::manual_clock::advance(arbitrary_interval);
+    co_await wait_for_callback_inflight();
+
+    // Request a tick and then increase the minimum interval while in-flight.
+    // The pending request gets replayed in on_guard_close after _last_fired is
+    // set, so the new (larger) minimum interval should apply.
+    timer().request_tick(ss::manual_clock::now() + 10ms);
+    timer().set_minimum_interval(500ms);
+
+    co_await finish_callback();
+
+    auto completion_time = ss::manual_clock::now();
+    auto scheduled = timer().get_scheduled_time();
+    EXPECT_TRUE(scheduled.has_value()) << should_be_scheduled_message;
+    EXPECT_EQ(*scheduled, completion_time + 500ms)
+      << "Deferred request replayed after completion should respect the new "
+         "minimum interval";
+    co_return;
+}
+
+// ============================================================================
+// 12. Tail Bounded Timer - Multiple Requests and Cancellation
+// ============================================================================
+
+TEST_F_CORO(
+  tail_minimum_interval_timer_fixture, earliest_request_wins_during_in_flight) {
+    setup_async_callback();
+    timer().request_tick(ss::manual_clock::now());
+    ss::manual_clock::advance(arbitrary_interval);
+    co_await wait_for_callback_inflight();
+
+    auto now = ss::manual_clock::now();
+    timer().request_tick(now + 500ms);
+    timer().request_tick(now + 200ms);
+    timer().request_tick(now + 800ms);
+
+    co_await finish_callback();
+
+    auto scheduled = timer().get_scheduled_time();
+    EXPECT_TRUE(scheduled.has_value()) << should_be_scheduled_message;
+    EXPECT_EQ(*scheduled, now + 200ms)
+      << "Earliest of multiple in-flight requests should be used";
+}
+
+TEST_F_CORO(tail_minimum_interval_timer_fixture, cancel_during_in_flight) {
+    setup_async_callback();
+    timer().request_tick(ss::manual_clock::now());
+    ss::manual_clock::advance(arbitrary_interval);
+    co_await wait_for_callback_inflight();
+
+    timer().request_tick(ss::manual_clock::now() + 200ms);
+    timer().cancel();
+
+    co_await finish_callback();
+
+    EXPECT_FALSE(timer().get_scheduled_time().has_value())
+      << "Cancel during in-flight should prevent deferred request from "
+         "scheduling";
+    EXPECT_EQ(tick_count(), 1) << "No additional tick should fire after cancel";
+}
+
+// ============================================================================
+// 13. Tail Bounded Timer - Sequential Ticks
+// ============================================================================
+
+TEST_F_CORO(
+  tail_minimum_interval_timer_fixture,
+  sequential_async_ticks_respect_interval) {
+    setup_async_callback();
+
+    // First tick
+    timer().request_tick(0ms);
+    ss::manual_clock::advance(arbitrary_interval);
+
+    // Complete first async op
+    co_await start_and_finish_callback();
+    auto first_completion = ss::manual_clock::now();
+
+    // Second tick — request immediately after first completes
+    timer().request_tick(first_completion);
+
+    auto scheduled = timer().get_scheduled_time();
+    EXPECT_TRUE(scheduled.has_value()) << should_be_scheduled_message;
+    EXPECT_GE(*scheduled, first_completion + minimum_interval)
+      << "Second tick should respect minimum interval from first completion";
+
+    // advance is a scheduling point because incrementing time processes expired
+    // timers, be sure to grab the tick count BEFORE the callback fires
+    auto count_before_second = tick_count();
+    ss::manual_clock::advance(minimum_interval);
+
+    // Complete second async op
+    co_await start_and_finish_callback(count_before_second);
+    auto second_completion = ss::manual_clock::now();
+
+    auto interval = second_completion - first_completion;
+    EXPECT_GE(interval, minimum_interval)
+      << "Interval between completions should be at least the minimum "
+         "interval";
+}
+
+// ============================================================================
+// 14. Tail Bounded Timer - Timer dies before callback
+// ============================================================================
+
+// The goal of this test is to show that a timer can be destructed while one of
+// its spawned callbacks is in flight. This is in answer to a timer internal,
+// where timer attaches a callback to a .finally on the user provided callback.
+// Because this .finally may call back into the timer, destruction of the timer
+// may lead to a use after free. This test checks that the current
+// implementation of the timer guards against this.
+TEST_F_CORO(tail_minimum_interval_timer_fixture, timer_dies_before_callback) {
+    ss::condition_variable wait_for_in_flight{};
+    ss::condition_variable hold_callback_open{};
+    bool callback_is_in_flight{false};
+    {
+        timer_type local_timer{
+          minimum_interval,
+          [&wait_for_in_flight, &hold_callback_open, &callback_is_in_flight](
+            this auto) -> ss::future<> {
+              callback_is_in_flight = true;
+              wait_for_in_flight.signal();
+              co_await hold_callback_open.wait();
+              callback_is_in_flight = false;
+          }};
+
+        local_timer.request_tick(ss::manual_clock::now());
+        ss::manual_clock::advance(minimum_interval);
+        co_await wait_for_in_flight.wait();
+
+        EXPECT_TRUE(callback_is_in_flight) << "Callback should be in progress";
+    }
+    // the timer has been destructed
+
+    hold_callback_open.signal();
+    co_await tests::drain_task_queue();
+
+    // there are actually three points in time which are relevant
+    // A: the destruction time of the timer
+    // B: the completion of the user provided callback
+    //        this is indistinguishable from the point at which
+    //        callback_is_in_flight becomes false
+    // C: the destruction of the timer's close_guard
+    //        this occurs in a .finally after completion of the user callback
+    // This test is checking that when A occurs before C, nothing bad happens
+    // The below check is that B has completed, which is distinct from C because
+    // there may be a scheduling point on a .finally
+    // Because, though, we have called tests::drain_task_queue, we can know that
+    // the C has occurred here as well
+    EXPECT_FALSE(callback_is_in_flight)
+      << "Callback should have completed after signalling and draining";
+
+    // if nothing awful has happened by now, the test has passed
+}
+
+} // namespace ssx


### PR DESCRIPTION
Partition balancer will overcorrect for cluster imbalance if ticks complete faster than it can receive feedback from health reports.

This is because the partition balancer planner is stateless, with the only parameters it takes being configuration and the health reports. If the planner makes decisions based on stale data, it can correct for the same cluster imbalance multiple times, thus creating a new cluster imbalance.

This leads to oscillation, where the partition balancer will push partitions back and forth.

This PR corrects this by setting the minimum interval between partition balancer ticks to be the health report refresh time.

EDIT:
This pr also changes members backend to properly perform recommission -> decommission on the same node. Now, decommission will remove relevant (old) recommission entries from its work queue.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
### Improvements

* prevent partition balancer oscillations

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
