### PR TITLE
ct/kafka: expose L1 partition size through kafka DescribeLogDirs

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -341,6 +341,24 @@ frontend::make_l0_reader(const cloud_topic_log_reader_config& cfg) const {
       cfg, _partition, _data_plane);
 }
 
+ss::future<size_t> frontend::size_bytes() {
+    auto ct_state = _partition->get_cloud_topics_state();
+    auto l1_metastore = ct_state->local().get_l1_metastore();
+
+    auto tidp = topic_id_partition();
+    auto size_res = co_await l1_metastore->get_size(tidp);
+    if (!size_res.has_value()) {
+        vlog(
+          cd_log.warn,
+          "Could not fetch L1 partition size for {}: {}",
+          tidp,
+          size_res.error());
+        co_return 0;
+    }
+
+    co_return size_res.value().size;
+}
+
 std::unique_ptr<model::record_batch_reader::impl>
 frontend::make_l1_reader(const cloud_topic_log_reader_config& cfg) const {
     auto ct_state = _partition->get_cloud_topics_state();

--- a/src/v/cloud_topics/frontend/frontend.h
+++ b/src/v/cloud_topics/frontend/frontend.h
@@ -150,6 +150,8 @@ public:
 
     ss::future<std::error_code> linearizable_barrier();
 
+    ss::future<size_t> size_bytes();
+
 private:
     // All timequeries work by first getting a coarse grained timequery result
     // from metadata indexes, then getting an exact answer using the datapath.

--- a/src/v/kafka/data/cloud_topic_partition.cc
+++ b/src/v/kafka/data/cloud_topic_partition.cc
@@ -230,7 +230,8 @@ size_t cloud_topic_partition::local_size_bytes() const {
     return _partition->size_bytes();
 }
 
-ss::future<std::optional<size_t>> cloud_topic_partition::cloud_size_bytes() {
+ss::future<std::optional<size_t>>
+cloud_topic_partition::cloud_size_bytes() const {
     co_return co_await _fe->size_bytes();
 }
 

--- a/src/v/kafka/data/cloud_topic_partition.cc
+++ b/src/v/kafka/data/cloud_topic_partition.cc
@@ -231,7 +231,7 @@ size_t cloud_topic_partition::local_size_bytes() const {
 }
 
 ss::future<std::optional<size_t>> cloud_topic_partition::cloud_size_bytes() {
-    co_return _partition->cloud_log_size();
+    co_return co_await _fe->size_bytes();
 }
 
 model::offset cloud_topic_partition::offset_lag() const {

--- a/src/v/kafka/data/cloud_topic_partition.cc
+++ b/src/v/kafka/data/cloud_topic_partition.cc
@@ -226,4 +226,16 @@ size_t cloud_topic_partition::estimate_size_between(
     return _fe->estimate_size_between(base, last);
 }
 
+size_t cloud_topic_partition::local_size_bytes() const {
+    return _partition->size_bytes();
+}
+
+std::optional<size_t> cloud_topic_partition::cloud_size_bytes() {
+    return _partition->cloud_log_size();
+}
+
+model::offset cloud_topic_partition::offset_lag() const {
+    return _partition->high_watermark() - _partition->dirty_offset();
+}
+
 } // namespace kafka

--- a/src/v/kafka/data/cloud_topic_partition.cc
+++ b/src/v/kafka/data/cloud_topic_partition.cc
@@ -230,8 +230,8 @@ size_t cloud_topic_partition::local_size_bytes() const {
     return _partition->size_bytes();
 }
 
-std::optional<size_t> cloud_topic_partition::cloud_size_bytes() {
-    return _partition->cloud_log_size();
+ss::future<std::optional<size_t>> cloud_topic_partition::cloud_size_bytes() {
+    co_return _partition->cloud_log_size();
 }
 
 model::offset cloud_topic_partition::offset_lag() const {

--- a/src/v/kafka/data/cloud_topic_partition.h
+++ b/src/v/kafka/data/cloud_topic_partition.h
@@ -95,7 +95,7 @@ public:
     size_t estimate_size_between(kafka::offset, kafka::offset) const final;
 
     size_t local_size_bytes() const override;
-    ss::future<std::optional<size_t>> cloud_size_bytes() override;
+    ss::future<std::optional<size_t>> cloud_size_bytes() const override;
     model::offset offset_lag() const override;
 
 private:

--- a/src/v/kafka/data/cloud_topic_partition.h
+++ b/src/v/kafka/data/cloud_topic_partition.h
@@ -94,6 +94,10 @@ public:
 
     size_t estimate_size_between(kafka::offset, kafka::offset) const final;
 
+    size_t local_size_bytes() const override;
+    std::optional<size_t> cloud_size_bytes() override;
+    model::offset offset_lag() const override;
+
 private:
     ss::lw_shared_ptr<cluster::partition> _partition;
     std::unique_ptr<cloud_topics::frontend> _fe;

--- a/src/v/kafka/data/cloud_topic_partition.h
+++ b/src/v/kafka/data/cloud_topic_partition.h
@@ -95,7 +95,7 @@ public:
     size_t estimate_size_between(kafka::offset, kafka::offset) const final;
 
     size_t local_size_bytes() const override;
-    std::optional<size_t> cloud_size_bytes() override;
+    ss::future<std::optional<size_t>> cloud_size_bytes() override;
     model::offset offset_lag() const override;
 
 private:

--- a/src/v/kafka/data/partition_proxy.h
+++ b/src/v/kafka/data/partition_proxy.h
@@ -97,7 +97,7 @@ public:
         virtual cluster::partition_probe& probe() = 0;
 
         virtual size_t local_size_bytes() const = 0;
-        virtual ss::future<std::optional<size_t>> cloud_size_bytes() = 0;
+        virtual ss::future<std::optional<size_t>> cloud_size_bytes() const = 0;
         virtual model::offset offset_lag() const = 0;
     };
 

--- a/src/v/kafka/data/partition_proxy.h
+++ b/src/v/kafka/data/partition_proxy.h
@@ -188,10 +188,28 @@ public:
         return _impl->replicate(bi, std::move(batch), opts);
     }
 
+    /*
+     * Returns the local on-disk size of the partition.
+     */
     size_t local_size_bytes() const { return _impl->local_size_bytes(); }
+
+    /*
+     * Returns the size of the partition in cloud storage. For example if this
+     * partition is a tiered storage partition the manifest will be used to
+     * compute the size of all segments. This method is used to drive
+     * dashboards, so it should reflect the addressable size of a partition, and
+     * generally should not include data that is unreadable (e.g. data that has
+     * been logically deleted by retention but not yet garbage collected).
+     */
     ss::future<std::optional<size_t>> cloud_size_bytes() const {
         return _impl->cloud_size_bytes();
     }
+
+    /*
+     * This returns the distance between the largest offset fully replicated and
+     * the end of the log. With acks=all the expectation is that this should be
+     * zero. It's calculated as the highwater mark minus the dirty offset.
+     */
     model::offset offset_lag() const { return _impl->offset_lag(); }
 
 private:

--- a/src/v/kafka/data/partition_proxy.h
+++ b/src/v/kafka/data/partition_proxy.h
@@ -97,7 +97,7 @@ public:
         virtual cluster::partition_probe& probe() = 0;
 
         virtual size_t local_size_bytes() const = 0;
-        virtual std::optional<size_t> cloud_size_bytes() = 0;
+        virtual ss::future<std::optional<size_t>> cloud_size_bytes() = 0;
         virtual model::offset offset_lag() const = 0;
     };
 
@@ -189,7 +189,7 @@ public:
     }
 
     size_t local_size_bytes() const { return _impl->local_size_bytes(); }
-    std::optional<size_t> cloud_size_bytes() const {
+    ss::future<std::optional<size_t>> cloud_size_bytes() const {
         return _impl->cloud_size_bytes();
     }
     model::offset offset_lag() const { return _impl->offset_lag(); }

--- a/src/v/kafka/data/partition_proxy.h
+++ b/src/v/kafka/data/partition_proxy.h
@@ -95,6 +95,10 @@ public:
         virtual size_t estimate_size_between(kafka::offset, kafka::offset) const
           = 0;
         virtual cluster::partition_probe& probe() = 0;
+
+        virtual size_t local_size_bytes() const = 0;
+        virtual std::optional<size_t> cloud_size_bytes() = 0;
+        virtual model::offset offset_lag() const = 0;
     };
 
     explicit partition_proxy(std::unique_ptr<impl> impl) noexcept
@@ -183,6 +187,12 @@ public:
       raft::replicate_options opts) {
         return _impl->replicate(bi, std::move(batch), opts);
     }
+
+    size_t local_size_bytes() const { return _impl->local_size_bytes(); }
+    std::optional<size_t> cloud_size_bytes() const {
+        return _impl->cloud_size_bytes();
+    }
+    model::offset offset_lag() const { return _impl->offset_lag(); }
 
 private:
     std::unique_ptr<impl> _impl;

--- a/src/v/kafka/data/replicated_partition.cc
+++ b/src/v/kafka/data/replicated_partition.cc
@@ -757,7 +757,8 @@ size_t replicated_partition::local_size_bytes() const {
     return _partition->size_bytes();
 }
 
-ss::future<std::optional<size_t>> replicated_partition::cloud_size_bytes() {
+ss::future<std::optional<size_t>>
+replicated_partition::cloud_size_bytes() const {
     co_return _partition->cloud_log_size();
 }
 

--- a/src/v/kafka/data/replicated_partition.cc
+++ b/src/v/kafka/data/replicated_partition.cc
@@ -753,4 +753,16 @@ size_t replicated_partition::estimate_size_between(
     return cloud_sz + local_sz;
 }
 
+size_t replicated_partition::local_size_bytes() const {
+    return _partition->size_bytes();
+}
+
+std::optional<size_t> replicated_partition::cloud_size_bytes() {
+    return _partition->cloud_log_size();
+}
+
+model::offset replicated_partition::offset_lag() const {
+    return _partition->high_watermark() - _partition->dirty_offset();
+}
+
 } // namespace kafka

--- a/src/v/kafka/data/replicated_partition.cc
+++ b/src/v/kafka/data/replicated_partition.cc
@@ -757,8 +757,8 @@ size_t replicated_partition::local_size_bytes() const {
     return _partition->size_bytes();
 }
 
-std::optional<size_t> replicated_partition::cloud_size_bytes() {
-    return _partition->cloud_log_size();
+ss::future<std::optional<size_t>> replicated_partition::cloud_size_bytes() {
+    co_return _partition->cloud_log_size();
 }
 
 model::offset replicated_partition::offset_lag() const {

--- a/src/v/kafka/data/replicated_partition.h
+++ b/src/v/kafka/data/replicated_partition.h
@@ -102,7 +102,7 @@ public:
     size_t estimate_size_between(kafka::offset, kafka::offset) const final;
 
     size_t local_size_bytes() const override;
-    ss::future<std::optional<size_t>> cloud_size_bytes() override;
+    ss::future<std::optional<size_t>> cloud_size_bytes() const override;
     model::offset offset_lag() const override;
 
 private:

--- a/src/v/kafka/data/replicated_partition.h
+++ b/src/v/kafka/data/replicated_partition.h
@@ -102,7 +102,7 @@ public:
     size_t estimate_size_between(kafka::offset, kafka::offset) const final;
 
     size_t local_size_bytes() const override;
-    std::optional<size_t> cloud_size_bytes() override;
+    ss::future<std::optional<size_t>> cloud_size_bytes() override;
     model::offset offset_lag() const override;
 
 private:

--- a/src/v/kafka/data/replicated_partition.h
+++ b/src/v/kafka/data/replicated_partition.h
@@ -101,6 +101,10 @@ public:
 
     size_t estimate_size_between(kafka::offset, kafka::offset) const final;
 
+    size_t local_size_bytes() const override;
+    std::optional<size_t> cloud_size_bytes() override;
+    model::offset offset_lag() const override;
+
 private:
     // Returns the Kafka offset corresponding to the lowest offset in the
     // log, including local and cloud storage. Doesn't take into account any

--- a/src/v/kafka/data/rpc/test/deps.h
+++ b/src/v/kafka/data/rpc/test/deps.h
@@ -179,7 +179,7 @@ public:
     size_t local_size_bytes() const override {
         throw std::runtime_error("unimplemented");
     }
-    ss::future<std::optional<size_t>> cloud_size_bytes() override {
+    ss::future<std::optional<size_t>> cloud_size_bytes() const override {
         throw std::runtime_error("unimplemented");
     }
     model::offset offset_lag() const override {

--- a/src/v/kafka/data/rpc/test/deps.h
+++ b/src/v/kafka/data/rpc/test/deps.h
@@ -179,7 +179,7 @@ public:
     size_t local_size_bytes() const override {
         throw std::runtime_error("unimplemented");
     }
-    std::optional<size_t> cloud_size_bytes() override {
+    ss::future<std::optional<size_t>> cloud_size_bytes() override {
         throw std::runtime_error("unimplemented");
     }
     model::offset offset_lag() const override {

--- a/src/v/kafka/data/rpc/test/deps.h
+++ b/src/v/kafka/data/rpc/test/deps.h
@@ -176,6 +176,16 @@ public:
         throw std::runtime_error("unimplemented");
     }
 
+    size_t local_size_bytes() const override {
+        throw std::runtime_error("unimplemented");
+    }
+    std::optional<size_t> cloud_size_bytes() override {
+        throw std::runtime_error("unimplemented");
+    }
+    model::offset offset_lag() const override {
+        throw std::runtime_error("unimplemented");
+    }
+
 private:
     model::offset latest_offset() {
         auto o = model::offset(0);

--- a/src/v/kafka/server/handlers/describe_log_dirs.cc
+++ b/src/v/kafka/server/handlers/describe_log_dirs.cc
@@ -35,7 +35,8 @@ struct log_partition_data {
 using partition_dir_set
   = chunked_hash_map<model::topic, chunked_vector<log_partition_data>>;
 
-static log_partition_data describe_partition(kafka::partition_proxy& p) {
+static ss::future<log_partition_data>
+describe_partition(kafka::partition_proxy& p) {
     auto result = log_partition_data{
       .local = describe_log_dirs_partition{
         .partition_index = p.ntp().tp.partition(),
@@ -44,7 +45,7 @@ static log_partition_data describe_partition(kafka::partition_proxy& p) {
         .is_future_key = false,
       }};
 
-    auto cloud_space = p.cloud_size_bytes();
+    auto cloud_space = co_await p.cloud_size_bytes();
     if (
       cloud_space.has_value()
       && config::shard_local_cfg()
@@ -57,10 +58,10 @@ static log_partition_data describe_partition(kafka::partition_proxy& p) {
         };
     }
 
-    return result;
+    co_return result;
 }
 
-static partition_dir_set collect_mapper(
+static ss::future<partition_dir_set> collect_mapper(
   cluster::partition_manager& pm,
   const std::optional<std::vector<describable_log_dir_topic>>& topics) {
     partition_dir_set ret;
@@ -76,10 +77,10 @@ static partition_dir_set collect_mapper(
             auto proxy = make_partition_proxy(ktp, pm);
             if (proxy) {
                 ret[partition.first.tp.topic].push_back(
-                  describe_partition(*proxy));
+                  co_await describe_partition(*proxy));
             }
         }
-        return ret;
+        co_return ret;
     }
 
     /*
@@ -90,11 +91,11 @@ static partition_dir_set collect_mapper(
             auto ktp = model::ktp(topic.topic, p_id);
             auto proxy = make_partition_proxy(ktp, pm);
             if (proxy) {
-                ret[topic.topic].push_back(describe_partition(*proxy));
+                ret[topic.topic].push_back(co_await describe_partition(*proxy));
             }
         }
     }
-    return ret;
+    co_return ret;
 }
 
 /*

--- a/src/v/kafka/server/handlers/describe_log_dirs.cc
+++ b/src/v/kafka/server/handlers/describe_log_dirs.cc
@@ -35,17 +35,16 @@ struct log_partition_data {
 using partition_dir_set
   = chunked_hash_map<model::topic, chunked_vector<log_partition_data>>;
 
-static log_partition_data describe_partition(cluster::partition& p) {
+static log_partition_data describe_partition(kafka::partition_proxy& p) {
     auto result = log_partition_data{
       .local = describe_log_dirs_partition{
         .partition_index = p.ntp().tp.partition(),
-        .partition_size = static_cast<int64_t>(p.size_bytes()),
-        .offset_lag = std::max(
-          p.high_watermark()() - p.dirty_offset()(), int64_t(0)),
+        .partition_size = static_cast<int64_t>(p.local_size_bytes()),
+        .offset_lag = std::max(p.offset_lag()(), int64_t(0)),
         .is_future_key = false,
       }};
 
-    auto cloud_space = p.cloud_log_size();
+    auto cloud_space = p.cloud_size_bytes();
     if (
       cloud_space.has_value()
       && config::shard_local_cfg()
@@ -53,8 +52,7 @@ static log_partition_data describe_partition(cluster::partition& p) {
         result.remote = describe_log_dirs_partition{
           .partition_index = p.ntp().tp.partition(),
           .partition_size = static_cast<int64_t>(cloud_space.value()),
-          .offset_lag = std::max(
-            p.high_watermark()() - p.dirty_offset()(), int64_t(0)),
+          .offset_lag = std::max(p.offset_lag()(), int64_t(0)),
           .is_future_key = false,
         };
     }
@@ -72,11 +70,14 @@ static partition_dir_set collect_mapper(
      */
     if (!topics) {
         for (const auto& partition : pm.partitions()) {
-            if (partition.first.ns != model::kafka_namespace) {
-                continue;
+            auto ktp = model::ktp(
+              partition.second->ntp().tp.topic,
+              partition.second->ntp().tp.partition);
+            auto proxy = make_partition_proxy(ktp, pm);
+            if (proxy) {
+                ret[partition.first.tp.topic].push_back(
+                  describe_partition(*proxy));
             }
-            ret[partition.first.tp.topic].push_back(
-              describe_partition(*partition.second));
         }
         return ret;
     }
@@ -86,9 +87,10 @@ static partition_dir_set collect_mapper(
      */
     for (const auto& topic : *topics) {
         for (auto p_id : topic.partition_index) {
-            model::ntp ntp(model::kafka_namespace, topic.topic, p_id);
-            if (auto p = pm.get(ntp); p) {
-                ret[topic.topic].push_back(describe_partition(*p));
+            auto ktp = model::ktp(topic.topic, p_id);
+            auto proxy = make_partition_proxy(ktp, pm);
+            if (proxy) {
+                ret[topic.topic].push_back(describe_partition(*proxy));
             }
         }
     }


### PR DESCRIPTION
* Wires up DescribeLogDirs Kafka API to report L1 partition size for cloud topics.
* Doesn't yet incorporate L0 estimates
* Manually tested with `rpk cluster logdirs describe` since its a direct mapping onto the API that is already tested.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
