### PR TITLE
cloud_storage_clients: fix assert in acquire

### DIFF
--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -289,12 +289,17 @@ ss::future<client_pool::client_lease> client_pool::acquire(
                 };
                 // Use 2-random approach. Pick 2 random shards
                 auto [sid1, sid2] = pick_two_random_shards();
-                auto cnt1 = co_await container().invoke_on(
-                  sid1, clients_in_use);
-                // sid1 == sid2 if we have only two shards
-                auto cnt2 = sid1 == sid2 ? cnt1
-                                         : co_await container().invoke_on(
-                                             sid2, clients_in_use);
+                size_t cnt1 = _capacity;
+                size_t cnt2 = _capacity;
+                try {
+                    cnt1 = co_await container().invoke_on(sid1, clients_in_use);
+                    cnt2 = sid1 == sid2 ? cnt1
+                                        : co_await container().invoke_on(
+                                            sid2, clients_in_use);
+                } catch (const ss::broken_named_semaphore&) {
+                    // Remote shard is shutting down, treat as fully
+                    // utilized so we skip borrowing.
+                }
                 auto [sid, cnt] = cnt1 < cnt2 ? std::tie(sid1, cnt1)
                                               : std::tie(sid2, cnt2);
                 vlog(


### PR DESCRIPTION
The cross-shard borrowing probe now waits on the remote shard's pool_ready_barrier via ss::get_units. When that remote shard is shutting down the barrier is broken, throwing
broken_named_semaphore which propagates back through invoke_on.

The outer catch block silently swallows the exception, but the post-loop checks only handle local shutdown (gate closed / abort requested) and deadline expiry. With the local shard still alive and no deadline set, the vassert on client.has_value() fires.

Fix by catching broken_named_semaphore at the invoke_on call site in the borrowing path. The counts default to _capacity (fully utilized), so borrowing is naturally skipped and the loop continues to the wait path.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
