### PR TITLE
build: add seastar perf test targets to bazel build

### DIFF
--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -727,6 +727,33 @@ cc_library(
     ],
 )
 
+[
+    cc_binary(
+        name = name,
+        testonly = True,
+        srcs = ["tests/perf/" + name + ".cc"],
+        tags = ["seastar_perf"],
+        visibility = ["//visibility:public"],
+        deps = [":benchmark"] + extra_deps,
+    )
+    for name, extra_deps in [
+        ("allocator_perf", []),
+        (
+            "container_perf",
+            ["@boost//:container"],
+        ),
+        ("coroutine_perf", []),
+        ("fair_queue_perf", []),
+        (
+            "future_util_perf",
+            ["@boost//:range"],
+        ),
+        ("metrics_perf", []),
+        ("perf_tests_perf", []),
+        ("rpc_perf", []),
+    ]
+]
+
 cc_binary(
     name = "iotune",
     srcs = [


### PR DESCRIPTION
Add cc_binary targets for all seastar benchmark-framework-based perf
tests to the injected seastar BUILD file. This makes it possible to
build and run seastar's perf tests (allocator, container, coroutine,
fair_queue, future_util, metrics, perf_tests, rpc) directly via bazel
without needing a separate cmake build of seastar.

Especially relevant since the cmake and bazel builds vary in important ways.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Improvements

* none