### PR TITLE
bazel: update seastar to 7780db64

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -302,7 +302,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "+L+9LPhfRc8MI1K4twvV67etKF6vkRc/fElG2um5tEw=",
+        "bzlTransitiveDigest": "mp8NMSy00JLanJuxbEpd0tGsz30txJ9kZYeV6VKCiNk=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -482,9 +482,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "d3fc945436fc89e37976de1b2c451cee56f581715928219aba31f49b7bf18b0d",
-              "strip_prefix": "seastar-4073a7c0e56bec74f5b674c50f949d1d268bdf7c",
-              "url": "https://github.com/redpanda-data/seastar/archive/4073a7c0e56bec74f5b674c50f949d1d268bdf7c.tar.gz"
+              "sha256": "b697dbed6afd966feae8bf58a3a3af704cb74ef4ee699c70506533948b23c740",
+              "strip_prefix": "seastar-7780db6428357bca114d405ee2c7c24c52db6901",
+              "url": "https://github.com/redpanda-data/seastar/archive/7780db6428357bca114d405ee2c7c24c52db6901.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -171,9 +171,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "d3fc945436fc89e37976de1b2c451cee56f581715928219aba31f49b7bf18b0d",
-        strip_prefix = "seastar-4073a7c0e56bec74f5b674c50f949d1d268bdf7c",
-        url = "https://github.com/redpanda-data/seastar/archive/4073a7c0e56bec74f5b674c50f949d1d268bdf7c.tar.gz",
+        sha256 = "b697dbed6afd966feae8bf58a3a3af704cb74ef4ee699c70506533948b23c740",
+        strip_prefix = "seastar-7780db6428357bca114d405ee2c7c24c52db6901",
+        url = "https://github.com/redpanda-data/seastar/archive/7780db6428357bca114d405ee2c7c24c52db6901.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
## Summary
- Update Seastar dependency from `4073a7c0e56b` to `7780db642835`
- [Compare changes](https://github.com/redpanda-data/seastar/compare/4073a7c0e56bec74f5b674c50f949d1d268bdf7c...7780db6428357bca114d405ee2c7c24c52db6901)

## Changes
- memory: reduce large allocation warning to debug level in scoped fallback mode
- ci: Disable scheduling_group_nesting test in Alpine workflow
- perf_tests: move perf counters into time_measurement singleton
- perf_tests: move time_measurement class to implementation file
- perf_tests: remove inline/hot attributes from time_measurement methods
- perf_tests: add measurement overhead tracking and warnings
- perf_tests: document overhead column and threshold options
- Add Claude Code project instructions