### PR TITLE
ct/l1/lsm: add gate hold to replicate_and_wait

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/lsm/stm.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/stm.cc
@@ -84,6 +84,10 @@ ss::future<std::expected<model::term_id, stm::errc>> stm::sync(
 
 ss::future<std::expected<model::offset, stm::errc>> stm::replicate_and_wait(
   model::term_id term, model::record_batch batch, ss::abort_source& as) {
+    auto gh = _gate.try_hold();
+    if (!gh) {
+        co_return std::unexpected(errc::shutting_down);
+    }
     constexpr auto replicate_timeout = 10s;
     auto opts = raft::replicate_options(
       raft::consistency_level::quorum_ack,


### PR DESCRIPTION
We're seeing issues with replication triggering a heap-use-after-free. While there are known issues with lifecycles of STMs[1], having this gate should still help in some cases.

[1] https://github.com/redpanda-data/redpanda/pull/25279

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
