### PR TITLE
CORE-15196 - Add support for `referenceFormat`

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -461,6 +461,13 @@
             "required": false,
             "type": "string",
             "description": "Optional qualified subject to search for the schema under. Use <:.context:> for context-only lookup, or <:.context:subject> to also verify the schema is associated with that subject. Defaults to searching the default context if unspecified."
+          },
+          {
+            "name": "referenceFormat",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "If set to 'qualified', schema references are returned in context-qualified form. Otherwise, unqualified references are returned."
           }
         ],
         "produces": [

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -96,6 +96,13 @@ output_format parse_output_format(const ss::http::request& req) {
       .value_or(output_format::none);
 }
 
+reference_format parse_reference_format(const ss::http::request& req) {
+    return parse::query_param<std::optional<ss::sstring>>(
+             req, "referenceFormat")
+      .and_then(&from_string_view<reference_format>)
+      .value_or(reference_format::none);
+}
+
 template<ppj::impl::RjsonParseHandler Handler>
 typename ss::future<typename Handler::rjson_parse_result>
 rjson_parse(ss::http::request& req, Handler handler) {
@@ -1046,6 +1053,7 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version(
       parse::query_param<std::optional<include_deleted>>(*rq.req, "deleted")
         .value_or(include_deleted::no)};
     const auto format = parse_output_format(*rq.req);
+    const auto reference_format = parse_reference_format(*rq.req);
 
     co_await rq.service().writer().read_sync();
 
@@ -1061,12 +1069,14 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version(
       std::move(def), format);
 
     auto resp = ppj::rjson_serialize_iobuf(
-      get_subject_versions_version_response{.stored_schema{
-        .schema = {std::move(subject), std::move(formatted_schema)},
-        .version = get_res.version,
-        .id = get_res.id,
-        .deleted = get_res.deleted,
-      }});
+      get_subject_versions_version_response{
+        .stored_schema{
+          .schema = {std::move(subject), std::move(formatted_schema)},
+          .version = get_res.version,
+          .id = get_res.id,
+          .deleted = get_res.deleted,
+        },
+        .format = reference_format});
     log_response(*rq.req, resp);
     rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;

--- a/src/v/pandaproxy/schema_registry/requests/get_subject_versions_version.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_subject_versions_version.h
@@ -13,11 +13,13 @@
 
 #include "json/iobuf_writer.h"
 #include "pandaproxy/schema_registry/rjson.h"
+#include "pandaproxy/schema_registry/types.h"
 
 namespace pandaproxy::schema_registry {
 
 struct get_subject_versions_version_response {
     stored_schema stored_schema;
+    reference_format format{reference_format::none};
 };
 
 template<typename Buffer>
@@ -25,6 +27,7 @@ void rjson_serialize(
   ::json::iobuf_writer<Buffer>& w,
   const get_subject_versions_version_response& res) {
     w.StartObject();
+    bool is_qualified = res.stored_schema.schema.sub().ctx != default_context;
     w.Key("subject");
     w.String(res.stored_schema.schema.sub().to_string());
     w.Key("version");
@@ -36,7 +39,13 @@ void rjson_serialize(
     ::json::rjson_serialize(w, to_string_view(type));
     if (!res.stored_schema.schema.def().refs().empty()) {
         w.Key("references");
-        ::json::rjson_serialize(w, res.stored_schema.schema.def().refs());
+        ::json::rjson_serialize(
+          w,
+          res.stored_schema.schema.def().refs(),
+          is_qualified && res.format == reference_format::qualified
+            ? std::make_optional<std::reference_wrapper<const context>>(
+                res.stored_schema.schema.sub().ctx)
+            : std::nullopt);
     }
     ::json::rjson_serialize(w, res.stored_schema.schema.def().meta());
     w.Key("schema");

--- a/src/v/pandaproxy/schema_registry/rjson.h
+++ b/src/v/pandaproxy/schema_registry/rjson.h
@@ -26,15 +26,38 @@ void rjson_serialize(
 
 template<typename Writer>
 void rjson_serialize(
-  Writer& w, const pandaproxy::schema_registry::schema_reference& ref) {
+  Writer& w,
+  const pandaproxy::schema_registry::schema_reference& ref,
+  std::optional<
+    std::reference_wrapper<const pandaproxy::schema_registry::context>> ctx
+  = std::nullopt) {
     w.StartObject();
     w.Key("name");
     ::json::rjson_serialize(w, ref.name);
     w.Key("subject");
-    w.String(ref.sub.to_string());
+    if (ctx.has_value()) {
+        w.String(ref.sub.resolve(ctx->get()).to_string());
+    } else {
+        w.String(ref.sub.to_string());
+    }
+
     w.Key("version");
     ::json::rjson_serialize(w, ref.version);
     w.EndObject();
+}
+
+template<typename Writer>
+void rjson_serialize(
+  Writer& w,
+  const pandaproxy::schema_registry::schema_definition::references& refs,
+  std::optional<
+    std::reference_wrapper<const pandaproxy::schema_registry::context>> ctx
+  = std::nullopt) {
+    w.StartArray();
+    for (const auto& ref : refs) {
+        rjson_serialize(w, ref, ctx);
+    }
+    w.EndArray();
 }
 
 template<typename Writer>

--- a/src/v/pandaproxy/schema_registry/types.cc
+++ b/src/v/pandaproxy/schema_registry/types.cc
@@ -28,6 +28,10 @@ std::ostream& operator<<(std::ostream& os, const output_format& v) {
     return os << to_string_view(v);
 }
 
+std::ostream& operator<<(std::ostream& os, const reference_format& v) {
+    return os << to_string_view(v);
+}
+
 std::ostream& operator<<(std::ostream& os, const seq_marker& v) {
     if (v.seq.has_value() && v.node.has_value()) {
         fmt::print(

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -124,6 +124,31 @@ from_string_view<output_format>(std::string_view sv) {
 
 std::ostream& operator<<(std::ostream& os, const output_format& of);
 
+enum class reference_format { none = 0, qualified };
+
+constexpr std::string_view to_string_view(reference_format rf) {
+    switch (rf) {
+    case reference_format::qualified:
+        return "qualified";
+    case reference_format::none:
+        break;
+    }
+    return "";
+}
+
+template<>
+inline std::optional<reference_format>
+from_string_view<reference_format>(std::string_view sv) {
+    return string_switch<std::optional<reference_format>>(sv)
+      .match(to_string_view(reference_format::none), reference_format::none)
+      .match(
+        to_string_view(reference_format::qualified),
+        reference_format::qualified)
+      .default_match(std::nullopt);
+}
+
+std::ostream& operator<<(std::ostream& os, const reference_format& rf);
+
 ///\brief Type representing a global resource for ACLs.
 using registry_resource = named_type<ss::sstring, struct registry_resource_tag>;
 

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -844,6 +844,11 @@ def get_normalize_dataset(type: SchemaType) -> TestNormalizeDataset:
     assert False, f"Unsupported schema {type=}"
 
 
+class ReferenceFormat(str, Enum):
+    NONE = ""
+    QUALIFIED = "qualified"
+
+
 class SchemaRegistryRedpandaClient:
     """
     A client for acessing the schema registry.
@@ -1107,11 +1112,19 @@ class SchemaRegistryRedpandaClient:
         )
 
     def get_subjects_subject_versions_version(
-        self, subject, version, format=None, headers=HTTP_GET_HEADERS, **kwargs
+        self,
+        subject,
+        version,
+        format=None,
+        reference_format: ReferenceFormat | None = None,
+        headers=HTTP_GET_HEADERS,
+        **kwargs,
     ):
         params = {}
         if format is not None:
             params["format"] = format
+        if reference_format and reference_format != ReferenceFormat.NONE:
+            params["referenceFormat"] = reference_format.value
         return self.request(
             "GET",
             f"subjects/{subject}/versions/{version}",

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import copy
 import http.client
 import json
 import random
@@ -568,6 +569,13 @@ schema_proto_b64 = (
     "AAUSAwMCBwoMCgUEAAIAARIDAwgJCgwKBQQAAgADEgMDDA1iBnByb3RvMw=="
 )
 
+schema_proto2_def = """
+syntax = "proto3";
+
+message ProtoType2 {
+  string s = 2;
+}"""
+
 schema_avro_def = (
     '{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}]}'
 )
@@ -578,6 +586,17 @@ syntax = "proto3";
 import "schema_proto.proto";
 message Dependee {
   ProtoType p =  1;
+}"""
+
+schema_proto_dependee2_def = """
+syntax = "proto3";
+
+import "schema_proto.proto";
+import "schema_proto2.proto";
+
+message Dependee {
+    ProtoType p1 = 1;
+    ProtoType2 p2 = 2;
 }"""
 
 schema_avro_dependee_def = """
@@ -608,6 +627,14 @@ base_schemas = {
         "schema": schema_avro_def,
         "type": "AVRO",
     },
+}
+
+base2_schemas = {
+    "proto": {
+        "subject": "schema_proto2",
+        "schema": schema_proto2_def,
+        "type": "PROTOBUF",
+    }
 }
 
 not_dependent_schemas = {
@@ -653,6 +680,18 @@ dependent_schemas = {
         "type": "AVRO",
         "id": 6,
     },
+}
+
+multi_dependent_schemas = {
+    "proto": {
+        "subject": "schema_proto_multi_dependee_schema",
+        "schema": schema_proto_dependee2_def,
+        "references": [
+            {"name": "schema_proto.proto", "subject": "schema_proto", "version": 1},
+            {"name": "schema_proto2.proto", "subject": "schema_proto2", "version": 1},
+        ],
+        "type": "PROTOBUF",
+    }
 }
 
 log_config = LoggingConfig(
@@ -6485,6 +6524,129 @@ class SchemaRegistryContextTest(SchemaRegistryEndpoints):
         assert counts_after[(".dev", "false")] == 1, (
             f".dev context undeleted count changed after restart: "
             f"{counts_before.get(('.dev', 'false'), 0)} -> {counts_after.get(('.dev', 'false'), 0)}"
+        )
+
+    def _post_new_schema(self, subject: str, schema: str, context: str | None = None):
+        subject = subject if context is None else f":.{context}:{subject}"
+
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=subject, data=schema
+        )
+
+        self.logger.info(f"result: {result}, {result.text}")
+
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+    @cluster(num_nodes=1)
+    def test_context_reference_format(self):
+        """
+        This test verifies the behavior of the new paramater to
+        GET /subjects/{subject}/versions/{version} that will make unqualified references
+        qualified.
+        """
+        schema_type = "proto"
+
+        base = base_schemas[schema_type]
+        base2 = base2_schemas[schema_type]
+        multi_dependent = multi_dependent_schemas[schema_type]
+
+        ctx = f"ctx-{schema_type}"
+        base_subject = "base"
+        base2_subject = "base2"
+        multi_dependent_subject = "multi-dependent"
+
+        base_data = json.dumps({"schema": base["schema"], "schemaType": base["type"]})
+        base2_data = json.dumps(
+            {"schema": base2["schema"], "schemaType": base2["type"]}
+        )
+
+        self._post_new_schema(subject=base_subject, schema=base_data)
+        self._post_new_schema(subject=base2_subject, schema=base2_data)
+
+        self._post_new_schema(subject=base_subject, schema=base_data, context=ctx)
+        self._post_new_schema(subject=base2_subject, schema=base2_data, context=ctx)
+
+        multi_dependent_default = {
+            "schema": multi_dependent["schema"],
+            "schemaType": multi_dependent["type"],
+            "references": copy.deepcopy(multi_dependent["references"]),
+        }
+        multi_dependent_default["references"][0]["subject"] = base_subject
+        multi_dependent_default["references"][1]["subject"] = base2_subject
+
+        multi_dependent_default_json = json.dumps(multi_dependent_default)
+
+        multi_dependent_context = {
+            "schema": multi_dependent["schema"],
+            "schemaType": multi_dependent["type"],
+            "references": copy.deepcopy(multi_dependent["references"]),
+        }
+        multi_dependent_context["references"][0]["subject"] = f":.{ctx}:{base_subject}"
+        multi_dependent_context["references"][1]["subject"] = base2_subject
+
+        multi_dependent_context_json = json.dumps(multi_dependent_context)
+
+        self._post_new_schema(
+            subject=multi_dependent_subject, schema=multi_dependent_default_json
+        )
+        self._post_new_schema(
+            subject=multi_dependent_subject,
+            schema=multi_dependent_context_json,
+            context=ctx,
+        )
+
+        result = self.sr_client.get_subjects_subject_versions_version(
+            subject=multi_dependent_subject,
+            version=1,
+            reference_format=ReferenceFormat.NONE,
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        result_json = result.json()
+        self.logger.info(f"result_json: {result_json}")
+        self.assert_equal(len(result_json["references"]), 2)
+        self.assert_equal(result_json["references"][0]["subject"], base_subject)
+        self.assert_equal(result_json["references"][1]["subject"], base2_subject)
+
+        result = self.sr_client.get_subjects_subject_versions_version(
+            subject=multi_dependent_subject,
+            version=1,
+            reference_format=ReferenceFormat.QUALIFIED,
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        result_json = result.json()
+        self.logger.info(f"result_json: {result_json}")
+        self.assert_equal(len(result_json["references"]), 2)
+        self.assert_equal(result_json["references"][0]["subject"], base_subject)
+        self.assert_equal(result_json["references"][1]["subject"], base2_subject)
+
+        result = self.sr_client.get_subjects_subject_versions_version(
+            subject=f":.{ctx}:{multi_dependent_subject}",
+            version=1,
+            reference_format=ReferenceFormat.NONE,
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        result_json = result.json()
+        self.logger.info(f"result_json: {result_json}")
+        self.assert_equal(len(result_json["references"]), 2)
+        self.assert_equal(
+            result_json["references"][0]["subject"], f":.{ctx}:{base_subject}"
+        )
+        self.assert_equal(result_json["references"][1]["subject"], base2_subject)
+
+        result = self.sr_client.get_subjects_subject_versions_version(
+            subject=f":.{ctx}:{multi_dependent_subject}",
+            version=1,
+            reference_format=ReferenceFormat.QUALIFIED,
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        result_json = result.json()
+        self.logger.info(f"result_json: {result_json}")
+        self.assert_equal(len(result_json["references"]), 2)
+        self.assert_equal(
+            result_json["references"][0]["subject"], f":.{ctx}:{base_subject}"
+        )
+        self.assert_equal(
+            result_json["references"][1]["subject"], f":.{ctx}:{base2_subject}"
         )
 
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Adds support for the `referenceFormat` option for the `/subjects/{subject}/versions/{version}` endpoint.  If specified as `qualified`, then any unqualified reference subject will be qualified with the context of the parent.  Any other value is ignored.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None