### PR TITLE
calibrated strategy for leader balancer

### DIFF
--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -630,14 +630,31 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
         co_return ss::stop_iteration::no;
     }
 
-    auto muted_nodes = collect_muted_nodes(health_report.value());
+    leader_balancer_types::muted_index muted_index{
+      collect_muted_nodes(health_report.value()), {}};
 
-    std::unique_ptr<leader_balancer_strategy> strategy = std::make_unique<
-      leader_balancer_types::calibrated_hill_climbing_strategy>(
-      std::move(index),
-      std::move(group_id_to_topic),
-      leader_balancer_types::muted_index{std::move(muted_nodes), {}},
-      std::move(preference_index));
+    auto mode = config::shard_local_cfg().leader_balancer_mode();
+    std::unique_ptr<leader_balancer_strategy> strategy;
+    switch (mode) {
+    case model::leader_balancer_mode::random:
+        vlog(clusterlog.debug, "using random_hill_climbing strategy");
+        strategy = std::make_unique<
+          leader_balancer_types::random_hill_climbing_strategy>(
+          std::move(index),
+          std::move(group_id_to_topic),
+          std::move(muted_index),
+          std::move(preference_index));
+        break;
+    case model::leader_balancer_mode::calibrated:
+        vlog(clusterlog.debug, "using calibrated_hill_climbing strategy");
+        strategy = std::make_unique<
+          leader_balancer_types::calibrated_hill_climbing_strategy>(
+          std::move(index),
+          std::move(group_id_to_topic),
+          std::move(muted_index),
+          std::move(preference_index));
+        break;
+    }
 
     auto cores = strategy->stats();
 

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -632,12 +632,12 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
 
     auto muted_nodes = collect_muted_nodes(health_report.value());
 
-    std::unique_ptr<leader_balancer_strategy> strategy
-      = std::make_unique<leader_balancer_types::random_hill_climbing_strategy>(
-        std::move(index),
-        std::move(group_id_to_topic),
-        leader_balancer_types::muted_index{std::move(muted_nodes), {}},
-        std::move(preference_index));
+    std::unique_ptr<leader_balancer_strategy> strategy = std::make_unique<
+      leader_balancer_types::calibrated_hill_climbing_strategy>(
+      std::move(index),
+      std::move(group_id_to_topic),
+      leader_balancer_types::muted_index{std::move(muted_nodes), {}},
+      std::move(preference_index));
 
     auto cores = strategy->stats();
 

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -56,8 +56,9 @@ class leader_balancer {
     using clock_type = ss::lowres_clock;
 
     /*
-     * after becoming the raft0 leader apply a delay before the rebalancer
-     * starts in order to give the system some time to stabilize.
+     * After becoming the raft0 leader apply a delay before the rebalancer
+     * starts in order to give the system some time to stabilize. Also, a
+     * recently started node will be muted for this many seconds after start.
      */
     static constexpr clock_type::duration leader_activation_delay = 30s;
 

--- a/src/v/cluster/scheduling/leader_balancer_random.h
+++ b/src/v/cluster/scheduling/leader_balancer_random.h
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <variant>
 
 namespace cluster::leader_balancer_types {
 
@@ -82,9 +83,11 @@ public:
         return std::nullopt;
     }
 
+    void reset() { _replicas_begin = 0; }
+
     void update_index(const reassignment& r) {
         _current_leaders[r.group] = r.to;
-        _replicas_begin = 0;
+        reset();
     }
 
 private:
@@ -99,9 +102,22 @@ private:
     size_t _replicas_begin{0};
 };
 
-class random_hill_climbing_strategy final : public leader_balancer_strategy {
+template<typename T>
+concept climbing_strategy_impl = requires(T& t, const reassignment& r) {
+    typename T::reassignment_score;
+    {
+        t.get_reassignment_score(r)
+    } -> std::same_as<std::optional<typename T::reassignment_score>>;
+    { t.generate_reassignment() } -> std::same_as<std::optional<reassignment>>;
+};
+
+template<typename Impl>
+class climbing_strategy_base : public leader_balancer_strategy {
+protected:
+    using base = climbing_strategy_base<Impl>;
+
 public:
-    random_hill_climbing_strategy(
+    climbing_strategy_base(
       index_type index,
       group_id_to_topic_id g_to_topic,
       muted_index mi,
@@ -114,6 +130,9 @@ public:
       , _etdc(*_group2topic, *_si, *_mi)
       , _eslc(*_si, *_mi)
       , _enlc(*_si) {
+        static_assert(
+          climbing_strategy_impl<Impl>,
+          "Impl must satisfy climbing_strategy_impl concept");
         if (preference_idx) {
             _pinning_constr.emplace(
               *_group2topic, std::move(preference_idx.value()));
@@ -121,60 +140,6 @@ public:
     }
 
     double error() const override { return _eslc.error() + _etdc.error(); }
-
-    /*
-     * Find a group reassignment that reduces total error.
-     */
-    std::optional<reassignment>
-    find_movement(const leader_balancer_types::muted_groups_t& skip) override {
-        for (;;) {
-            auto reassignment_opt = _reassignments.generate_reassignment();
-
-            if (!reassignment_opt) {
-                break;
-            }
-
-            auto reassignment = *reassignment_opt;
-            if (
-              skip.contains(static_cast<uint64_t>(reassignment.group))
-              || _mi->muted_nodes().contains(reassignment.from.node_id)
-              || _mi->muted_nodes().contains(reassignment.to.node_id)) {
-                continue;
-            }
-
-            // Hierarchical optimization: first check if the proposed
-            // reassignment improves the pinning objective (makes the leaders
-            // distribution better conform to the provided pinning
-            // configuration). If the pinning objective remains at the same
-            // level, check balancing objectives.
-
-            if (_pinning_constr) {
-                auto pinning_diff = _pinning_constr->evaluate(reassignment);
-                if (pinning_diff < -error_jitter) {
-                    continue;
-                } else if (pinning_diff > error_jitter) {
-                    return reassignment_opt;
-                }
-            }
-
-            auto shard_load_diff = _etdc.evaluate(reassignment)
-                                   + _eslc.evaluate(reassignment);
-            if (shard_load_diff < -error_jitter) {
-                continue;
-            } else if (shard_load_diff > error_jitter) {
-                return reassignment_opt;
-            }
-
-            auto node_load_diff = _enlc.evaluate(reassignment);
-            if (node_load_diff < -error_jitter) {
-                continue;
-            } else if (node_load_diff > error_jitter) {
-                return reassignment_opt;
-            }
-        }
-
-        return std::nullopt;
-    }
 
     void apply_movement(const reassignment& reassignment) override {
         _etdc.update_index(reassignment);
@@ -190,18 +155,124 @@ public:
      */
     std::vector<shard_load> stats() const override { return _eslc.stats(); }
 
-private:
+protected:
     static constexpr double error_jitter = 0.000001;
 
+    struct reassignment_with_score {
+        reassignment reassignment;
+        Impl::reassignment_score score;
+    };
+
+    std::optional<reassignment> do_find_movement_without_score(
+      const leader_balancer_types::muted_groups_t& skip) {
+        return do_find_movement_with_score(skip).transform(
+          [](auto&& s) { return s.reassignment; });
+    }
+
+    std::optional<reassignment_with_score> do_find_movement_with_score(
+      const leader_balancer_types::muted_groups_t& skip) {
+        for (;;) {
+            auto reassignment_opt
+              = static_cast<Impl&>(*this).generate_reassignment();
+
+            if (!reassignment_opt) {
+                return std::nullopt;
+            }
+
+            auto reassignment = *reassignment_opt;
+            if (
+              skip.contains(static_cast<uint64_t>(reassignment.group))
+              || _mi->muted_nodes().contains(reassignment.from.node_id)
+              || _mi->muted_nodes().contains(reassignment.to.node_id)) {
+                continue;
+            }
+
+            if (
+              auto maybe_score = static_cast<Impl&>(*this)
+                                   .get_reassignment_score(reassignment)) {
+                return {{reassignment, *maybe_score}};
+            }
+        }
+
+        return std::nullopt;
+    }
+
+private:
     std::unique_ptr<muted_index> _mi;
     std::unique_ptr<group_id_to_topic_id> _group2topic;
     std::unique_ptr<shard_index> _si;
-    random_reassignments _reassignments;
 
+protected:
+    random_reassignments _reassignments;
     std::optional<pinning_constraint> _pinning_constr;
     even_topic_distribution_constraint _etdc;
     even_shard_load_constraint _eslc;
     even_node_load_constraint _enlc;
+};
+
+/// A greedy random-walk hill-climbing strategy for leader rebalancing.
+///
+/// On each call to find_movement the strategy draws a random leader
+/// reassignment from the full set of possible moves and returns the first one
+/// that strictly reduces the combined error across a hierarchy of scores:
+///   1. Pinning (leader-preference compliance)
+///   2. Shard-level load balance (even topic distribution + even shard load)
+///   3. Node-level load balance
+/// Each score is only considered if all higher-level scores are not impacted by
+/// the move (i.e. changes are within a small jitter threshold).
+/// Each reassignment is only considered once.
+class random_hill_climbing_strategy final
+  : public climbing_strategy_base<random_hill_climbing_strategy> {
+    friend base;
+
+public:
+    using base::base;
+
+    std::optional<reassignment>
+    find_movement(const leader_balancer_types::muted_groups_t& skip) override {
+        return do_find_movement_without_score(skip);
+    }
+
+private:
+    using reassignment_score = std::monostate;
+
+    // returns score if reassignment is acceptable, nullopt otherwise
+    std::optional<reassignment_score>
+    get_reassignment_score(const reassignment& r) {
+        // Hierarchical optimization: first check if the proposed
+        // reassignment improves the pinning objective (makes the leaders
+        // distribution better conform to the provided pinning
+        // configuration). If the pinning objective remains at the same
+        // level, check balancing objectives.
+        if (_pinning_constr) {
+            auto pinning_diff = _pinning_constr->evaluate(r);
+            if (pinning_diff < -error_jitter) {
+                return std::nullopt;
+            } else if (pinning_diff > error_jitter) {
+                return std::monostate{};
+            }
+        }
+
+        auto shard_load_diff = _etdc.evaluate(r) + _eslc.evaluate(r);
+        if (shard_load_diff < -error_jitter) {
+            return std::nullopt;
+        } else if (shard_load_diff > error_jitter) {
+            return std::monostate{};
+        }
+
+        auto node_load_diff = _enlc.evaluate(r);
+        if (node_load_diff < -error_jitter) {
+            return std::nullopt;
+        } else if (node_load_diff > error_jitter) {
+            return std::monostate{};
+        }
+
+        return std::nullopt;
+    }
+
+    std::optional<reassignment> generate_reassignment() {
+        return this->_reassignments.generate_reassignment();
+    }
 };
 
 } // namespace cluster::leader_balancer_types

--- a/src/v/cluster/scheduling/leader_balancer_random.h
+++ b/src/v/cluster/scheduling/leader_balancer_random.h
@@ -20,8 +20,13 @@
 #include "raft/fundamental.h"
 #include "random/generators.h"
 
+#include <algorithm>
+#include <cmath>
+#include <compare>
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <variant>
@@ -273,6 +278,207 @@ private:
     std::optional<reassignment> generate_reassignment() {
         return this->_reassignments.generate_reassignment();
     }
+};
+
+/// An adaptive hill-climbing strategy that raises the acceptance bar over
+/// time so it preferentially selects high-impact moves. This makes the strategy
+/// spend its early iterations on the most impactful transfers and reduce
+/// repeated moves.
+///
+/// It uses the same hierarchical objective evaluation as
+/// random_hill_climbing_strategy (pinning > shard load > node load),
+/// but runs it in a recalibration loop:
+///   1. Sample ~100 random improving moves and record the best score.
+///   2. Set a threshold at 50 % of that best score.
+///   3. Accept only moves above the threshold until ~100 sub-threshold
+///      (but otherwise improving) moves have been rejected, then
+///      recalibrate.
+class calibrated_hill_climbing_strategy final
+  : public climbing_strategy_base<calibrated_hill_climbing_strategy> {
+    friend base;
+
+public:
+    using base::base;
+
+    /*
+     * Find a group reassignment that reduces total error.
+     */
+    std::optional<reassignment>
+    find_movement(const leader_balancer_types::muted_groups_t& skip) override {
+        // attempt to find a movement under existing calibration
+        if (auto maybe_movement = do_find_movement(skip)) {
+            return maybe_movement;
+        }
+
+        // nothing found under current calibration, recalibrate
+        calibrate(skip);
+
+        // freshly recalibrated, so a not found result will be final
+        return do_find_movement(skip);
+    }
+
+private:
+    struct reassignment_score {
+        double pinning_diff;
+        double shard_load_diff;
+        double node_load_diff;
+
+        std::partial_ordering
+        operator<=>(const reassignment_score& other) const noexcept {
+            if (
+              std::fabs(pinning_diff) > error_jitter
+              || std::fabs(other.pinning_diff) > error_jitter) {
+                return pinning_diff <=> other.pinning_diff;
+            }
+            if (
+              std::fabs(shard_load_diff) > error_jitter
+              || std::fabs(other.shard_load_diff) > error_jitter) {
+                return shard_load_diff <=> other.shard_load_diff;
+            }
+            if (
+              std::fabs(node_load_diff) > error_jitter
+              || std::fabs(other.node_load_diff) > error_jitter) {
+                return node_load_diff <=> other.node_load_diff;
+            }
+            return std::partial_ordering::equivalent;
+        }
+
+        bool operator==(const reassignment_score& other) const& noexcept {
+            return (*this <=> other) == std::partial_ordering::equivalent;
+        }
+    };
+
+    static constexpr reassignment_score worst_score{
+      .pinning_diff = std::numeric_limits<double>::lowest(),
+      .shard_load_diff = std::numeric_limits<double>::lowest(),
+      .node_load_diff = std::numeric_limits<double>::lowest(),
+    };
+
+    struct calibration {
+        reassignment_score min_acceptable_score;
+        size_t remaining_rejections;
+    };
+    static constexpr calibration allow_all_calibration = {
+      .min_acceptable_score = worst_score,
+      .remaining_rejections = std::numeric_limits<size_t>::max(),
+    };
+    static constexpr calibration block_all_calibration = {
+      .min_acceptable_score = worst_score,
+      .remaining_rejections = 0,
+    };
+
+    void calibrate(const leader_balancer_types::muted_groups_t& skip) {
+        // take the best of 100 samples, demand at least half that score
+        constexpr size_t sample_size = 100;
+        constexpr double adjustment_coeff = 0.5;
+        // and use this bar till it's a problem for 100 potential moves
+        constexpr size_t max_rejections_per_calibration = sample_size;
+
+        // de-calibrate temporarily to sample broadly
+        set_calibration(allow_all_calibration);
+
+        reassignment_score best_in_sample = worst_score;
+        for (size_t i = 0; i < sample_size; ++i) {
+            auto maybe_movement = do_find_movement_with_score(skip);
+            if (!maybe_movement) {
+                break;
+            }
+            best_in_sample = std::max(best_in_sample, maybe_movement->score);
+        }
+
+        if (best_in_sample == worst_score) {
+            set_calibration(block_all_calibration);
+        } else {
+            reassignment_score adjusted = {
+              .pinning_diff = adjustment_coeff * best_in_sample.pinning_diff,
+              .shard_load_diff = adjustment_coeff
+                                 * best_in_sample.shard_load_diff,
+              .node_load_diff = adjustment_coeff
+                                * best_in_sample.node_load_diff,
+            };
+            set_calibration(
+              {.min_acceptable_score = adjusted,
+               .remaining_rejections = max_rejections_per_calibration});
+        }
+    }
+
+    void set_calibration(const calibration& c) {
+        _calibration = c;
+        _reassignments.reset();
+    }
+
+    std::optional<reassignment>
+    do_find_movement(const leader_balancer_types::muted_groups_t& skip) {
+        return do_find_movement_without_score(skip);
+    }
+
+    // returns score if reassignment is acceptable, nullopt otherwise
+    std::optional<reassignment_score>
+    get_reassignment_score(const reassignment& r) {
+        const auto& mas = _calibration.min_acceptable_score;
+
+        // A variant of random_hill_climbing_strategy::get_reassignment_score
+        // that takes calibration into account. It only decreases remaining
+        // attempts when a reassignment would not be viable without calibration.
+        if (_pinning_constr) {
+            auto pinning_diff = _pinning_constr->evaluate(r);
+            if (pinning_diff < -error_jitter) {
+                return std::nullopt;
+            } else if (
+              pinning_diff > error_jitter && pinning_diff > mas.pinning_diff) {
+                return {
+                  {.pinning_diff = pinning_diff,
+                   .shard_load_diff = 0,
+                   .node_load_diff = 0}};
+            }
+        }
+        if (mas.pinning_diff > error_jitter) {
+            --_calibration.remaining_rejections;
+            return std::nullopt;
+        }
+
+        auto shard_load_diff = _etdc.evaluate(r) + _eslc.evaluate(r);
+        if (shard_load_diff < -error_jitter) {
+            return std::nullopt;
+        } else if (
+          shard_load_diff > error_jitter
+          && shard_load_diff > mas.shard_load_diff) {
+            return {
+              {.pinning_diff = 0,
+               .shard_load_diff = shard_load_diff,
+               .node_load_diff = 0}};
+        }
+        if (mas.shard_load_diff > error_jitter) {
+            --_calibration.remaining_rejections;
+            return std::nullopt;
+        }
+
+        auto node_load_diff = _enlc.evaluate(r);
+        if (node_load_diff < -error_jitter) {
+            return std::nullopt;
+        } else if (
+          node_load_diff > error_jitter
+          && node_load_diff > mas.node_load_diff) {
+            return {
+              {.pinning_diff = 0,
+               .shard_load_diff = 0,
+               .node_load_diff = node_load_diff}};
+        }
+        if (mas.node_load_diff > error_jitter) {
+            --_calibration.remaining_rejections;
+        }
+        return std::nullopt;
+    }
+
+    std::optional<reassignment> generate_reassignment() {
+        if (_calibration.remaining_rejections == 0) {
+            return std::nullopt;
+        }
+        return _reassignments.generate_reassignment();
+    }
+
+    // force recalibration on first run
+    calibration _calibration = block_all_calibration;
 };
 
 } // namespace cluster::leader_balancer_types

--- a/src/v/cluster/tests/BUILD
+++ b/src/v/cluster/tests/BUILD
@@ -133,6 +133,7 @@ redpanda_test_cc_library(
     name = "leader_balancer_test_utils",
     hdrs = [
         "leader_balancer_constraints_utils.h",
+        "leader_balancer_simulation_utils.h",
         "leader_balancer_test_utils.h",
     ],
     deps = [

--- a/src/v/cluster/tests/BUILD
+++ b/src/v/cluster/tests/BUILD
@@ -251,6 +251,20 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "leader_balancer_simulation_test",
+    timeout = "short",
+    srcs = [
+        "leader_balancer_simulation_test.cc",
+    ],
+    deps = [
+        ":leader_balancer_test_utils",
+        "//src/v/cluster",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
 redpanda_cc_btest(
     name = "metrics_reporter_test",
     timeout = "short",

--- a/src/v/cluster/tests/leader_balancer_bench.cc
+++ b/src/v/cluster/tests/leader_balancer_bench.cc
@@ -11,11 +11,12 @@
 #include "cluster/scheduling/leader_balancer_constraints.h"
 #include "cluster/scheduling/leader_balancer_random.h"
 #include "cluster/scheduling/leader_balancer_types.h"
+#include "leader_balancer_simulation_utils.h"
 #include "leader_balancer_test_utils.h"
 
 #include <seastar/testing/perf_tests.hh>
 
-#include <vector>
+#include <utility>
 
 namespace {
 
@@ -23,6 +24,35 @@ constexpr int node_count = 72;
 constexpr int shards_per_node = 16;  // i.e., cores per node
 constexpr int groups_per_shard = 80; // group == partition in this context
 constexpr int replicas = 3;          // number of replicas
+
+namespace lbt = cluster::leader_balancer_types;
+
+template<
+  std::derived_from<cluster::leader_balancer_strategy> ClimbingStrategy,
+  int node_count>
+void strategy_bench() {
+    auto cluster_data
+      = leader_balancer_test_utils::prepare_simulation_cluster<node_count>();
+
+    auto strategy = ClimbingStrategy(
+      std::move(cluster_data.index),
+      std::move(cluster_data.group_to_topic),
+      std::move(cluster_data.muted_index),
+      std::nullopt);
+
+    lbt::muted_groups_t muted_groups{};
+
+    perf_tests::start_measuring_time();
+    for (;;) {
+        auto movement_opt = strategy.find_movement(muted_groups);
+        if (!movement_opt) {
+            break;
+        }
+        strategy.apply_movement(*movement_opt);
+        muted_groups.add(static_cast<uint64_t>(movement_opt->group));
+    }
+    perf_tests::stop_measuring_time();
+}
 
 /*
  * Measures the time it takes to randomly generate and evaluate every possible
@@ -115,4 +145,12 @@ PERF_TEST(lb, random_eval_all) {
 
 PERF_TEST(lb, random_generator) {
     random_bench<cluster::leader_balancer_types::random_reassignments>();
+}
+
+PERF_TEST(lb, full_simulation_random) {
+    strategy_bench<lbt::random_hill_climbing_strategy, 3>();
+}
+
+PERF_TEST(lb, full_simulation_calibrated) {
+    strategy_bench<lbt::calibrated_hill_climbing_strategy, 3>();
 }

--- a/src/v/cluster/tests/leader_balancer_constraints_test.cc
+++ b/src/v/cluster/tests/leader_balancer_constraints_test.cc
@@ -313,7 +313,7 @@ BOOST_AUTO_TEST_CASE(topic_skew_error) {
 
     auto [o1, g_id_to_t_id1] = index_fn();
     auto [shard_index1, muted_index1] = std::move(o1);
-    auto rhc = lbt::random_hill_climbing_strategy(
+    auto rhc = lbt::calibrated_hill_climbing_strategy(
       leader_balancer_test_utils::copy_cluster_index(shard_index1.shards()),
       std::move(g_id_to_t_id1),
       std::move(muted_index1),
@@ -393,7 +393,7 @@ BOOST_AUTO_TEST_CASE(even_shard_uneven_node_load) {
 
     cluster::leader_balancer_types::shard_index shard_idx(std::move(idx));
 
-    auto strategy = lbt::random_hill_climbing_strategy(
+    auto strategy = lbt::calibrated_hill_climbing_strategy(
       leader_balancer_test_utils::copy_cluster_index(shard_idx.shards()),
       std::move(g2topic),
       cluster::leader_balancer_types::muted_index({}, {}),

--- a/src/v/cluster/tests/leader_balancer_simulation_test.cc
+++ b/src/v/cluster/tests/leader_balancer_simulation_test.cc
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/scheduling/leader_balancer_random.h"
+#include "leader_balancer_simulation_utils.h"
+
+#include <gtest/gtest.h>
+
+namespace lbt = cluster::leader_balancer_types;
+
+constexpr int simulation_runs = 10;
+
+/**
+ * @brief Runs the leader balancer strategy until no more moves are found.
+ * @return The number of leader reassignments performed
+ */
+inline int run_simulation(cluster::leader_balancer_strategy& strategy) {
+    lbt::muted_groups_t muted_groups{};
+    int n_moves = 0;
+    for (;;) {
+        auto movement_opt = strategy.find_movement(muted_groups);
+        if (!movement_opt) {
+            break;
+        }
+        ++n_moves;
+        strategy.apply_movement(*movement_opt);
+        muted_groups.add(static_cast<uint64_t>(movement_opt->group));
+    }
+    return n_moves;
+}
+
+template<
+  std::derived_from<cluster::leader_balancer_strategy> ClimbingStrategy,
+  int node_count>
+double check_simulation_moves_count() {
+    std::vector<int> results;
+    results.reserve(simulation_runs);
+
+    for (int i = 0; i < simulation_runs; ++i) {
+        auto cluster_data
+          = leader_balancer_test_utils::prepare_simulation_cluster<
+            node_count>();
+
+        auto strategy = ClimbingStrategy(
+          std::move(cluster_data.index),
+          std::move(cluster_data.group_to_topic),
+          std::move(cluster_data.muted_index),
+          std::nullopt);
+
+        int n_moves = run_simulation(strategy);
+        results.push_back(n_moves);
+    }
+
+    double sum = std::ranges::fold_left(results, 0.0, std::plus<>{});
+    return sum / static_cast<double>(simulation_runs);
+}
+
+template<int node_count>
+void compare_simulation_moves_count() {
+    auto calibrated_moves = check_simulation_moves_count<
+      lbt::calibrated_hill_climbing_strategy,
+      node_count>();
+    auto random_moves = check_simulation_moves_count<
+      lbt::random_hill_climbing_strategy,
+      node_count>();
+    EXPECT_LT(calibrated_moves, 0.9 * random_moves);
+}
+
+TEST(LeaderBalancerSimulation, CompareMovesCount3) {
+    compare_simulation_moves_count<3>();
+}
+
+TEST(LeaderBalancerSimulation, CompareMovesCount7) {
+    compare_simulation_moves_count<7>();
+}

--- a/src/v/cluster/tests/leader_balancer_simulation_utils.h
+++ b/src/v/cluster/tests/leader_balancer_simulation_utils.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/scheduling/leader_balancer_strategy.h"
+#include "cluster/scheduling/leader_balancer_types.h"
+#include "cluster/tests/leader_balancer_constraints_utils.h"
+#include "cluster/tests/leader_balancer_test_utils.h"
+#include "random/generators.h"
+
+#include <ranges>
+
+namespace leader_balancer_test_utils {
+
+namespace lbt = cluster::leader_balancer_types;
+
+/**
+ * @brief Data needed to construct a leader balancer strategy for simulation.
+ */
+struct simulation_cluster_data {
+    cluster::leader_balancer_strategy::index_type index;
+    lbt::group_id_to_topic_id group_to_topic;
+    lbt::muted_index muted_index;
+};
+
+/**
+ * @brief Prepares cluster data for leader balancer simulation.
+ *
+ * Creates a cluster where the last node starts empty (no leaders).
+ * The returned data can be used to construct a strategy for simulation.
+ *
+ * @tparam node_count The number of nodes in the cluster
+ * @return simulation_cluster_data containing index, group_to_topic mapping, and
+ * muted_index
+ */
+template<int node_count>
+simulation_cluster_data prepare_simulation_cluster() {
+    constexpr auto n_groups = 50000;
+    constexpr auto groups = std::views::iota(0, n_groups);
+    // the last node starts without leaders
+    constexpr auto n_with_leaders = node_count - 1;
+
+    cluster_spec spec(node_count);
+    // reserve generously to allow for randomization imperfections
+    for (auto& node_spec : spec | std::views::take(n_with_leaders)) {
+        constexpr auto expected_leaders_per_node = n_groups / n_with_leaders;
+        node_spec.groups_led.reserve(2 * expected_leaders_per_node);
+    }
+    for (auto& node_spec : spec) {
+        constexpr auto expected_followers_per_node = 2 * n_groups / node_count;
+        node_spec.groups_followed.reserve(2 * expected_followers_per_node);
+    }
+
+    // functions to select random non-last nodes
+    constexpr auto random_excluding_one =
+      []<int total = node_count - 1>(int excluded) {
+          return (random_generators::get_int(1, total - 1) + excluded) % total;
+      };
+    constexpr auto random_excluding_two = [random_excluding_one](
+                                            int excluded1, int excluded2) {
+        // all indexes below are mod (node_count - 1)
+        constexpr auto mod = node_count - 1;
+        // exclude (-1) and (excluded2 - excluded1 - 1)
+        auto unadjusted = random_excluding_one.template operator()<mod - 1>(
+          (excluded2 - excluded1 - 1 + mod) % mod);
+        // adjust, so that the excluded ones are excluded1 and excluded2
+        return (unadjusted + excluded1 + 1) % mod;
+    };
+
+    for (auto g_id : groups) {
+        // Leaders are placed uniformly at random on all nodes but last
+        auto leader_node = random_generators::get_int(0, n_with_leaders - 1);
+        spec[leader_node].groups_led.push_back(g_id);
+
+        // first follower: not with leader, not on last node (see below why)
+        auto flwr1_node = random_excluding_one(leader_node);
+        spec[flwr1_node].groups_followed.push_back(g_id);
+
+        // Second follower: not with leader or with first follower.
+        // For uniform replica distribution place followers onto the last node
+        // with a higher probability. 3 * n_groups / node_count is the expected
+        // number of followers on each node, so 3.0 / node_count is the
+        // probability for each group to have a replica there.
+        bool use_last_node_for_follower = random_generators::get_real<double>()
+                                          <= 3.0 / node_count;
+        auto flwr2_node = use_last_node_for_follower
+                            ? (node_count - 1)
+                            : random_excluding_two(leader_node, flwr1_node);
+        spec[flwr2_node].groups_followed.push_back(g_id);
+    }
+
+    vassert(
+      std::ranges::all_of(
+        spec,
+        [](const auto& node_spec) {
+            constexpr auto expected_replicas_per_node = 3 * n_groups
+                                                        / node_count;
+            auto replicas_per_node = node_spec.groups_led.size()
+                                     + node_spec.groups_followed.size();
+            return expected_replicas_per_node * 0.8 <= replicas_per_node
+                   && replicas_per_node <= 1.3 * expected_replicas_per_node;
+        }),
+      "The number of replicas per node significantly differs from expected");
+
+    auto [shard_index, muted_index] = from_spec(spec, {});
+
+    // group N belongs to topic N % 2,
+    // so that topic affiliation is independent from replica placements
+    auto g_id_to_t_id = group_to_topic_from_spec(
+      {std::from_range,
+       std::array{0, 1} | std::views::transform([&groups](int t_id) {
+           return group_to_ntp_spec::value_type{
+             t_id, {std::from_range, groups | std::views::filter([t_id](int g) {
+                                         return g % 2 == t_id;
+                                     })}};
+       })});
+
+    return {
+      copy_cluster_index(shard_index.shards()),
+      std::move(g_id_to_t_id),
+      std::move(muted_index)};
+}
+
+} // namespace leader_balancer_test_utils

--- a/src/v/cluster/tests/leader_balancer_test.cc
+++ b/src/v/cluster/tests/leader_balancer_test.cc
@@ -28,7 +28,8 @@
 #include <vector>
 
 using index_type = cluster::leader_balancer_strategy::index_type;
-using strategy = cluster::leader_balancer_types::random_hill_climbing_strategy;
+using strategy
+  = cluster::leader_balancer_types::calibrated_hill_climbing_strategy;
 using reassignment = cluster::leader_balancer_strategy::reassignment;
 
 /**

--- a/src/v/cluster/tests/leader_balancer_test_utils.h
+++ b/src/v/cluster/tests/leader_balancer_test_utils.h
@@ -9,6 +9,8 @@
  * by the Apache License, Version 2.0
  */
 
+#pragma once
+
 #include "cluster/scheduling/leader_balancer_strategy.h"
 #include "cluster/scheduling/leader_balancer_types.h"
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3325,6 +3325,23 @@ configuration::configuration()
       "Enable automatic leadership rebalancing.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       true)
+  , leader_balancer_mode(
+      *this,
+      "leader_balancer_mode",
+      "Mode of the leader balancer optimization strategy. "
+      "`calibrated` uses a heuristic that balances leaders based on replica "
+      "counts per shard. `random` randomly moves leaders to reduce load on "
+      "heavily-loaded shards. Legacy values `greedy_balanced_shards` and "
+      "`random_hill_climbing` are treated as `calibrated`.",
+      {.needs_restart = needs_restart::no,
+       .example = model::leader_balancer_mode_to_string(
+         model::leader_balancer_mode::calibrated),
+       .visibility = visibility::user},
+      model::leader_balancer_mode::calibrated,
+      {
+        model::leader_balancer_mode::calibrated,
+        model::leader_balancer_mode::random,
+      })
   , leader_balancer_idle_timeout(
       *this,
       "leader_balancer_idle_timeout",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -581,6 +581,7 @@ struct configuration final : public config_store {
     property<bool> partition_autobalancing_topic_aware;
 
     property<bool> enable_leader_balancer;
+    enum_property<model::leader_balancer_mode> leader_balancer_mode;
     property<std::chrono::milliseconds> leader_balancer_idle_timeout;
     property<std::chrono::milliseconds> leader_balancer_mute_timeout;
     property<std::chrono::milliseconds> leader_balancer_node_mute_timeout;

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -410,6 +410,43 @@ struct convert<model::cloud_storage_backend> {
 };
 
 template<>
+struct convert<model::leader_balancer_mode> {
+    using type = model::leader_balancer_mode;
+
+    // Accept new values plus legacy values for backward compatibility
+    static constexpr auto acceptable_values = std::to_array(
+      {model::leader_balancer_mode_to_string(type::calibrated),
+       model::leader_balancer_mode_to_string(type::random),
+       "greedy_balanced_shards",
+       "random_hill_climbing"});
+
+    static Node encode(const type& rhs) { return Node(fmt::format("{}", rhs)); }
+
+    static bool decode(const Node& node, type& rhs) {
+        auto value = node.as<std::string>();
+
+        if (
+          std::find(acceptable_values.begin(), acceptable_values.end(), value)
+          == acceptable_values.end()) {
+            return false;
+        }
+
+        // Map legacy values to calibrated, only "random" activates random mode
+        rhs = string_switch<type>(std::string_view{value})
+                .match(
+                  model::leader_balancer_mode_to_string(type::calibrated),
+                  type::calibrated)
+                .match(
+                  model::leader_balancer_mode_to_string(type::random),
+                  type::random)
+                .match("greedy_balanced_shards", type::calibrated)
+                .match("random_hill_climbing", type::calibrated);
+
+        return true;
+    }
+};
+
+template<>
 struct convert<std::filesystem::path> {
     using type = std::filesystem::path;
 

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -674,6 +674,8 @@ consteval std::string_view property_type_name() {
                            type,
                            model::cloud_storage_chunk_eviction_strategy>) {
         return "string";
+    } else if constexpr (std::is_same_v<type, model::leader_balancer_mode>) {
+        return "string";
     } else if constexpr (std::is_same_v<
                            type,
                            pandaproxy::schema_registry::

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -200,6 +200,11 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const model::leader_balancer_mode& v) {
+    stringize(w, v);
+}
+
+void rjson_serialize(
   json::Writer<json::StringBuffer>& w, const model::fetch_read_strategy& v) {
     stringize(w, v);
 }

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -97,6 +97,9 @@ void rjson_serialize(
   json::Writer<json::StringBuffer>& w, const model::cloud_storage_backend& v);
 
 void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const model::leader_balancer_mode& v);
+
+void rjson_serialize(
   json::Writer<json::StringBuffer>& w, const model::fetch_read_strategy& v);
 
 void rjson_serialize(

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -502,6 +502,27 @@ inline std::ostream& operator<<(std::ostream& os, cloud_storage_backend csb) {
     }
 }
 
+enum class leader_balancer_mode : uint8_t {
+    calibrated = 0,
+    random = 1,
+};
+
+constexpr const char*
+leader_balancer_mode_to_string(leader_balancer_mode mode) {
+    switch (mode) {
+    case leader_balancer_mode::calibrated:
+        return "calibrated";
+    case leader_balancer_mode::random:
+        return "random";
+    default:
+        throw std::invalid_argument("unknown leader_balancer_mode");
+    }
+}
+
+inline std::ostream& operator<<(std::ostream& os, leader_balancer_mode mode) {
+    return os << leader_balancer_mode_to_string(mode);
+}
+
 enum class cloud_storage_chunk_eviction_strategy {
     eager = 0,
     capped = 1,

--- a/tests/rptest/scale_tests/excessive_leadership_transfers_test.py
+++ b/tests/rptest/scale_tests/excessive_leadership_transfers_test.py
@@ -1,0 +1,779 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+"""
+Scale tests to verify that the leader balancer doesn't cause excessive
+leadership transfers during maintenance mode, decommission/recommission,
+and node restart operations.
+
+These tests validate that leadership transfers don't exceed expected bounds,
+which helps detect issues like excessive leadership transfers.
+"""
+
+from abc import abstractmethod, ABC
+from dataclasses import dataclass
+import random
+from collections import Counter
+from typing import Any, TypedDict
+
+from ducktape.cluster.cluster import ClusterNode
+from ducktape.tests.test import TestContext
+from ducktape.utils.util import wait_until
+
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, LoggingConfig
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.util import repeat_check, wait_until_result
+from rptest.utils.node_operations import NodeDecommissionWaiter
+
+from rptest.clients.types import TopicSpec
+
+
+@dataclass
+class TransferCounts:
+    main: int
+    followup: int
+
+    def total(self) -> int:
+        return self.main + self.followup
+
+
+@dataclass
+class TransferEntry:
+    context: str
+    actual: TransferCounts
+    expected: int
+    leeway: int
+
+
+class IterationStats(TypedDict):
+    node: str
+    transfers: list[TransferEntry]
+
+
+class ExcessiveLeadershipTransfersTestBase(RedpandaTest, ABC):
+    """
+    Base class for leadership transfer tests.
+
+    Provides common functionality for tracking and verifying leadership
+    transfers during various cluster operations.
+    """
+
+    # Leader balancer timing configuration
+    LEADER_BALANCER_PERIOD_MS = 10000  # 10 seconds
+    # Timeout for waiting for cluster to stabilize
+    STABILIZE_TIMEOUT_SEC = 300
+    # Timeout for leader balancer to rebalance
+    LEADER_BALANCE_TIMEOUT_SEC = 600
+    # Polling interval for leadership counts
+    POLL_INTERVAL_SEC = 1
+
+    # Topic configuration
+    TOPIC_NAME_PREFIX = "leadership-transfer-test"
+    TOPICS_COUNT = 30
+    PARTITION_COUNT = 30
+    REPLICATION_FACTOR = 3
+
+    # Leader balancer mode identifiers
+    MODE_CALIBRATED = "calibrated"
+    MODE_RANDOM = "random"
+
+    ITERATIONS_PER_MODE = 5
+
+    # Number of nodes in the cluster
+    NODES = 9
+
+    TEST_NAME: str
+
+    def __init__(
+        self,
+        test_context: TestContext,
+        num_brokers: int = 3,
+        *args: Any,
+        **kwargs: Any,
+    ):
+        kwargs.setdefault("extra_rp_conf", {}).update(
+            {
+                # Enable leader balancer - this is what we're testing
+                "enable_leader_balancer": True,
+                # Fast leader balancer for quicker test iterations
+                "leader_balancer_idle_timeout": self.LEADER_BALANCER_PERIOD_MS,
+                "leader_balancer_mute_timeout": self.LEADER_BALANCER_PERIOD_MS,
+            }
+        )
+
+        kwargs["log_config"] = LoggingConfig(
+            "info",
+            logger_levels={
+                "cluster": "trace",
+                "storage": "warn",
+                "storage-gc": "warn",
+                "raft": "debug",
+            },
+        )
+
+        super().__init__(
+            test_context,
+            num_brokers=num_brokers,
+            *args,
+            **kwargs,
+        )
+
+        self.admin = Admin(self.redpanda)
+
+    def setUp(self):
+        super().setUp()
+        self.redpanda.set_expected_controller_records(None)
+        self._create_topics()
+        self._wait_for_all_leaders_elected()
+        self._wait_for_leadership_stable()
+
+    @abstractmethod
+    def _run_iteration(self) -> IterationStats:
+        pass
+
+    def _create_topics(self):
+        for i in range(self.TOPICS_COUNT):
+            self.client().create_topic(
+                TopicSpec(
+                    name=f"{self.TOPIC_NAME_PREFIX}-{i}",
+                    partition_count=self.PARTITION_COUNT,
+                    replication_factor=self.REPLICATION_FACTOR,
+                )
+            )
+
+    def _get_test_partitions(self) -> list[dict[str, Any]]:
+        """Get all partitions for test topics using admin API."""
+        return [
+            p
+            for p in self.admin.get_cluster_partitions()
+            if p["topic"].startswith(self.TOPIC_NAME_PREFIX)
+        ]
+
+    def _get_partitions_with_leaders(self) -> list[dict[str, Any]]:
+        """Get partitions that have valid leaders."""
+        return [p for p in self._get_test_partitions() if p.get("leader_id", 0) > 0]
+
+    def _get_leadership_distribution(self) -> Counter[int]:
+        """Get mapping of node_id -> leader_count."""
+        return Counter(p["leader_id"] for p in self._get_partitions_with_leaders())
+
+    def _get_total_leaders_on_node(self, node_id: int) -> int:
+        """Get the total number of leaders on a specific node."""
+        return self._get_leadership_distribution()[node_id]
+
+    def _total_partition_count(self) -> int:
+        """Get the total number of partitions across all test topics."""
+        return self.TOPICS_COUNT * self.PARTITION_COUNT
+
+    def _wait_for_all_leaders_elected(self):
+        """Wait until all partitions have elected leaders."""
+        expected = self._total_partition_count()
+
+        def all_leaders_elected():
+            total = len(self._get_partitions_with_leaders())
+            self.logger.debug(f"Total leaders elected: {total}/{expected}")
+            return total == expected
+
+        wait_until(
+            all_leaders_elected,
+            timeout_sec=self.STABILIZE_TIMEOUT_SEC,
+            backoff_sec=5,
+            err_msg=f"Not all {expected} partitions have leaders",
+        )
+
+    def _get_replicas_on_node(self, node_id: int) -> int:
+        """Get the number of replicas on a specific node."""
+        return sum(
+            1
+            for p in self._get_test_partitions()
+            for r in p["replicas"]
+            if r["node_id"] == node_id
+        )
+
+    def _wait_for_node_to_have_leaders(self, node_id: int, min_leaders: int = 5):
+        """
+        Wait for a node to have at least min_leaders leaders.
+        This ensures the leader balancer has started rebalancing to the node
+        after leader_activation_delay expires.
+        See: src/v/cluster/scheduling/leader_balancer.h::leader_activation_delay
+        """
+        self.logger.info(
+            f"Waiting for node {node_id} to have at least {min_leaders} leaders"
+        )
+        wait_until(
+            lambda: self._get_total_leaders_on_node(node_id) >= min_leaders,
+            timeout_sec=120,
+            backoff_sec=5,
+            err_msg=f"Node {node_id} did not get {min_leaders} leaders",
+        )
+        leaders = self._get_total_leaders_on_node(node_id)
+        self.logger.info(f"Node {node_id} now has {leaders} leaders")
+
+    def _get_leadership_changes_metric(
+        self, nodes: list[ClusterNode] | None = None
+    ) -> int:
+        """
+        Get the total successful leader transfers from the leader balancer metric.
+        This metric is node-level and persistent (not lost when partitions move).
+        Only queries running nodes.
+        """
+        metric = self.redpanda.metrics_sample(
+            "vectorized_leader_balancer_leader_transfer_succeeded",
+            nodes=self.redpanda.started_nodes() if nodes is None else nodes,
+        )
+        assert metric, "leader_transfer_succeeded metric not found"
+        ret = int(sum(s.value for s in metric.samples))
+        self.logger.debug(f"leader_transfer_succeeded metric value: {ret}")
+        return ret
+
+    def _wait_for_leadership_stable(self, stability_checks: int = 7) -> int:
+        """
+        Wait for leadership to stabilize (metric unchanged for stability_checks consecutive checks).
+        Uses the leader balancer's leader_transfer_succeeded metric to detect changes.
+        Returns the final metric value.
+        """
+
+        @repeat_check(stability_checks, require_same=True)
+        def is_stable():
+            count = self._get_leadership_changes_metric()
+            self.logger.debug(f"Leadership changes metric: {count}")
+            return True, count
+
+        final_count = wait_until_result(
+            is_stable,
+            timeout_sec=self.LEADER_BALANCE_TIMEOUT_SEC,
+            backoff_sec=self.POLL_INTERVAL_SEC,
+            err_msg="Leadership did not stabilize",
+        )
+        self.logger.info(f"Leadership stable for {stability_checks} consecutive checks")
+        return final_count
+
+    def _do_track_transfers_until_stable(self, initial_count: int) -> int:
+        """
+        Wait for leadership to stabilize and return the total number of transfers
+        since initial_count.
+        """
+        final_count = self._wait_for_leadership_stable(
+            self.LEADER_BALANCER_PERIOD_MS // 1000 + 5
+        )
+        total_transfers = final_count - initial_count
+        self.logger.info(f"Total leadership transfers: {total_transfers}")
+        return total_transfers
+
+    def _track_transfers_until_stable(self, initial_count: int) -> TransferCounts:
+        """
+        Wrapper around _do_track_transfers_until_stable to also verify no moves after switching to random.
+        """
+        return TransferCounts(
+            main=self._do_track_transfers_until_stable(initial_count),
+            followup=self._followup_no_moves_after_switching_to_random(),
+        )
+
+    def _set_leader_balancer_mode(self, mode: str):
+        """Set the leader balancer mode via cluster config."""
+        self.logger.info(f"Setting leader_balancer_mode to '{mode}'")
+        self.redpanda.set_cluster_config(
+            {"leader_balancer_mode": mode}, tolerate_stopped_nodes=True
+        )
+        self._current_balancer_mode = mode
+
+    def _followup_no_moves_after_switching_to_random(self) -> int:
+        """
+        If not already, switch to random mode and verify no leadership moves occur.
+        This validates that the calibrated strategy reached an optimal state.
+        """
+        if self._current_balancer_mode == self.MODE_RANDOM:
+            return 0
+
+        initial_metric = self._get_leadership_changes_metric()
+        self._set_leader_balancer_mode(self.MODE_RANDOM)
+
+        # Wait for stability and check no moves were made
+        moves_after_switch = self._do_track_transfers_until_stable(initial_metric)
+
+        if moves_after_switch > 0:
+            self.logger.warning(
+                f"Unexpected moves after switching to random: {moves_after_switch}"
+            )
+        else:
+            self.logger.info(
+                "No moves after switching to random - calibrated did the full job"
+            )
+
+        self._set_leader_balancer_mode(self.MODE_CALIBRATED)
+        return moves_after_switch
+
+    def _run_iterations_in_mode(self, mode: str) -> list[IterationStats]:
+        stats: list[IterationStats] = []
+        for i in range(self.ITERATIONS_PER_MODE):
+            self.logger.info(
+                f"=== {self.TEST_NAME} {mode} iteration {i + 1}/{self.ITERATIONS_PER_MODE} ==="
+            )
+            self._set_leader_balancer_mode(mode)
+            stats.append(self._run_iteration())
+            self.logger.info(f"=== {mode} iteration {i + 1} completed ===")
+        self._print_avg(mode, stats)
+        return stats
+
+    def _run_calibrated(self):
+        """Run test iterations with calibrated strategy."""
+
+        calibrated_stats = self._run_iterations_in_mode(self.MODE_CALIBRATED)
+        self._assert_all_transfers_bounded(self.MODE_CALIBRATED, calibrated_stats)
+
+    def _run_random(self):
+        """Run test iterations with random strategy."""
+        self._run_iterations_in_mode(self.MODE_RANDOM)
+
+    def _print_avg(self, mode: str, stats_list: list[IterationStats]):
+        """
+        Print summary statistics for a set of iterations.
+        """
+        self.logger.info(
+            f"{self.TEST_NAME} - {mode} iterations summary ({len(stats_list)} iterations):"
+        )
+
+        transfer_totals: Counter[str] = Counter()
+        for i, stats in enumerate(stats_list):
+            self.logger.info(f"  Iteration {i + 1}:")
+            self.logger.info(f"    node: {stats['node']}")
+            for t in stats["transfers"]:
+                actual_total = t.actual.total()
+                self.logger.info(
+                    f"    {t.context}: {actual_total=}, expected={t.expected}, leeway={t.leeway}"
+                )
+                transfer_totals[t.context] += actual_total
+
+        # Print averages with full context for easy grepping
+        n = len(stats_list)
+        self.logger.info(f"  --- Averages ({n} iterations) ---")
+        for context, actual_sum in transfer_totals.items():
+            self.logger.info(
+                f"{self.TEST_NAME} - {mode} {context}: {n=}, avg_moves={actual_sum / n:.1f}"
+            )
+
+    def _assert_all_transfers_bounded(
+        self, mode: str, stats_list: list[IterationStats]
+    ):
+        """
+        Assert that all transfers in stats_list are within bounds.
+        """
+        failures: list[str] = []
+        for i, stats in enumerate(stats_list):
+            for t in stats["transfers"]:
+                max_allowed = t.leeway * t.expected
+                actual_total = t.actual.total()
+                prefix = f"  {self.TEST_NAME} - {mode} iteration {i + 1} {t.context}: "
+                if actual_total > max_allowed:
+                    failures.append(
+                        f"{prefix}{actual_total=} > {max_allowed=} (expected={t.expected}, leeway={t.leeway})"
+                    )
+                if t.actual.followup > 0:
+                    failures.append(
+                        f"{prefix}unexpected moves after switching to random: {t.actual.followup}"
+                    )
+
+        if failures:
+            failure_msg = "\n".join(failures)
+            assert False, f"Transfer bounds exceeded:\n{failure_msg}"
+
+
+class ExcessiveLeadershipTransfersMaintenanceModeTest(
+    ExcessiveLeadershipTransfersTestBase
+):
+    """
+    Test suite to verify that the leader balancer doesn't cause excessive
+    leadership transfers during maintenance mode operations.
+
+    The leader balancer should efficiently rebalance leadership when nodes
+    enter/exit maintenance mode without causing unnecessary churn.
+
+    Each iteration:
+    1. Select a random node
+    2. Enable maintenance mode (drains leaders)
+    3. Track leadership transfers during drain
+    4. Disable maintenance mode
+    5. Track transfers during rebalancing
+    6. Verify transfers are bounded by leader count on the node
+    """
+
+    TEST_NAME = "MaintenanceMode"
+
+    MAINTENANCE_TIMEOUT_SEC = 300
+
+    def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any):
+        super().__init__(
+            test_context,
+            num_brokers=ExcessiveLeadershipTransfersTestBase.NODES,
+            *args,
+            **kwargs,
+        )
+
+    def _in_maintenance_mode(self, node: ClusterNode) -> bool:
+        """Check if a node is in maintenance mode."""
+        status = self.admin.maintenance_status(node)
+        return status["draining"]
+
+    def _maintenance_drain_finished(self, node: ClusterNode) -> bool:
+        """Check if maintenance mode has finished draining."""
+        status = self.admin.maintenance_status(node)
+        return (
+            all([key in status for key in ["finished", "errors", "partitions"]])
+            and status["finished"]
+            and not status["errors"]
+        )
+
+    def _enable_maintenance_mode(self, node: ClusterNode):
+        """Enable maintenance mode on a node and wait for it to drain."""
+        self.logger.info(f"Enabling maintenance mode on {node.name}")
+        self.admin.maintenance_start(node)
+        wait_until(
+            lambda: self._in_maintenance_mode(node),
+            timeout_sec=30,
+            backoff_sec=5,
+            err_msg=f"Node {node.name} did not enter maintenance mode",
+        )
+
+        self.logger.info(f"Waiting for {node.name} to drain leadership")
+        wait_until(
+            lambda: self._maintenance_drain_finished(node),
+            timeout_sec=self.MAINTENANCE_TIMEOUT_SEC,
+            backoff_sec=10,
+            err_msg=f"Node {node.name} maintenance mode did not complete",
+        )
+        self.logger.info(f"Node {node.name} maintenance mode completed")
+
+    def _disable_maintenance_mode(self, node: ClusterNode):
+        """Disable maintenance mode on a node."""
+        self.logger.info(f"Disabling maintenance mode on {node.name}")
+        self.admin.maintenance_stop(node)
+
+        wait_until(
+            lambda: not self._in_maintenance_mode(node),
+            timeout_sec=60,
+            backoff_sec=5,
+            err_msg=f"Node {node.name} did not exit maintenance mode",
+        )
+        self.logger.info(f"Node {node.name} exited maintenance mode")
+
+    def _run_iteration(self) -> IterationStats:
+        """
+        Run a single maintenance mode iteration.
+        Returns stats dict with iteration metrics.
+        """
+        # Choose a random node
+        node = random.choice(self.redpanda.nodes)
+        node_id = self.redpanda.node_id(node)
+        self.logger.info(f"Selected node {node.name} (id={node_id})")
+
+        # Count initial leaders on this node
+        initial_leaders_on_node = self._get_total_leaders_on_node(node_id)
+        self.logger.info(
+            f"Node {node.name} has {initial_leaders_on_node} leaders before maintenance"
+        )
+
+        # Capture initial metric before enabling maintenance
+        initial_metric = self._get_leadership_changes_metric()
+
+        # Enable maintenance mode
+        self._enable_maintenance_mode(node)
+
+        # Track any transfers
+        transfers_on_drain = self._track_transfers_until_stable(initial_metric)
+
+        # Verify node has no leaders after maintenance
+        leaders_after_drain = self._get_total_leaders_on_node(node_id)
+        assert leaders_after_drain == 0, (
+            f"Node {node.name} still has {leaders_after_drain} leaders after maintenance"
+        )
+
+        # Capture initial metric before disabling maintenance
+        initial_metric = self._get_leadership_changes_metric()
+
+        # Disable maintenance mode
+        self._disable_maintenance_mode(node)
+
+        # Track transfers during rebalancing
+        transfers_after_restore = self._track_transfers_until_stable(initial_metric)
+
+        final_leaders_on_node = self._get_total_leaders_on_node(node_id)
+        self.logger.info(
+            f"Node {node.name} has {final_leaders_on_node} leaders after maintenance"
+        )
+
+        return {
+            "node": node.name,
+            "transfers": [
+                TransferEntry(
+                    "during_drain", transfers_on_drain, initial_leaders_on_node, 3
+                ),
+                TransferEntry(
+                    "after_restore", transfers_after_restore, final_leaders_on_node, 3
+                ),
+            ],
+        }
+
+    @cluster(
+        num_nodes=ExcessiveLeadershipTransfersTestBase.NODES,
+        log_allow_list=RESTART_LOG_ALLOW_LIST,
+    )
+    def test_maintenance_mode_calibrated(self):
+        self._run_calibrated()
+
+    @cluster(
+        num_nodes=ExcessiveLeadershipTransfersTestBase.NODES,
+        log_allow_list=RESTART_LOG_ALLOW_LIST,
+    )
+    def test_maintenance_mode_random(self):
+        self._run_random()
+
+
+class ExcessiveLeadershipTransfersDecommissionTest(
+    ExcessiveLeadershipTransfersTestBase
+):
+    """
+    Test that the leader balancer doesn't cause excessive leadership transfers
+    during decommission/recommission operations beyond what's expected from
+    replica movements.
+
+    Each iteration:
+    1. Select a random node to decommission
+    2. Decommission the node (replicas move away)
+    3. Track leadership transfers during decommission
+    4. Recommission a new node (replicas rebalance to it)
+    5. Track transfers during rebalancing
+    6. Verify transfers are bounded by replica movements
+    """
+
+    TEST_NAME = "Decommission"
+
+    DECOMMISSION_TIMEOUT_SEC = 600
+
+    def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any):
+        super().__init__(
+            test_context,
+            num_brokers=ExcessiveLeadershipTransfersTestBase.NODES,
+            *args,
+            **kwargs,
+        )
+
+    def _wait_for_decommission_complete(self, node_id: int):
+        waiter = NodeDecommissionWaiter(
+            self.redpanda,
+            node_id=node_id,
+            logger=self.logger,
+            progress_timeout=120,
+        )
+        waiter.wait_for_removal()
+
+    def _node_is_active(self, node_id: int) -> bool:
+        """Check if a node is active in the cluster."""
+        return any(
+            b["node_id"] == node_id and b["membership_status"] == "active"
+            for b in self.admin.get_brokers()
+        )
+
+    def _run_iteration(self) -> IterationStats:
+        """
+        Run a single decommission/recommission iteration.
+        Returns stats dict with iteration metrics.
+        """
+        # Choose a random node to decommission
+        node = random.choice(self.redpanda.nodes)
+        node_id = self.redpanda.node_id(node)
+        self.logger.info(f"Selected node {node.name} (id={node_id}) for decommission")
+
+        # Count initial state
+        initial_leaders_on_node = self._get_total_leaders_on_node(node_id)
+        initial_replicas_on_node = self._get_replicas_on_node(node_id)
+
+        self.logger.info(
+            f"Node {node.name} has {initial_leaders_on_node} leaders and "
+            f"{initial_replicas_on_node} replicas before decommission"
+        )
+
+        # For decom we'll only compare metrics on surviving nodes
+        surviving_nodes = [
+            n
+            for n in self.redpanda.started_nodes()
+            if self.redpanda.node_id(n) != node_id
+        ]
+        initial_metric = self._get_leadership_changes_metric(nodes=surviving_nodes)
+
+        # Decommission
+        self.logger.info(f"Starting decommission of node {node_id}")
+        self.admin.decommission_broker(node_id)
+        self._wait_for_decommission_complete(node_id)
+        self.logger.info(f"Stopping decommissioned node {node.name}")
+        self.redpanda.stop_node(node)
+
+        # Track leadership transfers until stable
+        total_decom_transfers = self._track_transfers_until_stable(initial_metric)
+
+        # Capture initial metric before recommissioning
+        initial_metric = self._get_leadership_changes_metric()
+
+        # Recommission: restart node with new identity
+        self.logger.info(f"Restarting node {node.name} to recommission")
+        self.redpanda.clean_node(node)
+        self.redpanda.start_node(
+            node, auto_assign_node_id=True, omit_seeds_on_idx_one=False
+        )
+        new_node_id = self.redpanda.node_id(node, force_refresh=True)
+        self.logger.info(f"Node {node.name} rejoined with new id {new_node_id}")
+        wait_until(
+            lambda: self._node_is_active(new_node_id),
+            timeout_sec=60,
+            backoff_sec=5,
+            err_msg=f"Node {node.name} did not become active after restart",
+        )
+
+        # Wait for leadership to actually rebalance to the new node.
+        # This ensures leader_activation_delay has expired and balancer has acted.
+        self._wait_for_node_to_have_leaders(new_node_id, min_leaders=5)
+
+        # Wait for leadership to rebalance to the new node
+        total_recom_transfers = self._track_transfers_until_stable(initial_metric)
+
+        return {
+            "node": node.name,
+            "transfers": [
+                TransferEntry(
+                    "decommission", total_decom_transfers, initial_replicas_on_node, 1
+                ),
+                TransferEntry(
+                    "recommission", total_recom_transfers, initial_replicas_on_node, 1
+                ),
+            ],
+        }
+
+    @cluster(
+        num_nodes=ExcessiveLeadershipTransfersTestBase.NODES,
+        log_allow_list=RESTART_LOG_ALLOW_LIST,
+    )
+    def test_decommission_recommission_calibrated(self):
+        self._run_calibrated()
+
+    @cluster(
+        num_nodes=ExcessiveLeadershipTransfersTestBase.NODES,
+        log_allow_list=RESTART_LOG_ALLOW_LIST,
+    )
+    def test_decommission_recommission_random(self):
+        self._run_random()
+
+
+class ExcessiveLeadershipTransfersRestartTest(ExcessiveLeadershipTransfersTestBase):
+    """
+    Test that the leader balancer doesn't cause excessive leadership transfers
+    during node restart operations.
+
+    The number of leadership transfers should be bounded by the number of
+    replicas on the restarted node:
+    - When node goes down: leaders move away (bounded by leaders on node)
+    - When node comes back: leader balancer moves leaders back
+
+    Each iteration:
+    1. Select a random node to restart
+    2. Stop the node
+    3. Track leadership transfers while node is down
+    4. Start the node
+    5. Track transfers during rebalancing
+    6. Verify transfers are bounded by replica count on the node
+    """
+
+    TEST_NAME = "Restart"
+
+    def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any):
+        super().__init__(
+            test_context,
+            num_brokers=ExcessiveLeadershipTransfersTestBase.NODES,
+            *args,
+            **kwargs,
+        )
+
+    def _run_iteration(self) -> IterationStats:
+        """
+        Run a single node restart iteration.
+        Returns stats dict with iteration metrics.
+        """
+        # Choose a random node to restart
+        node = random.choice(self.redpanda.nodes)
+        node_id = self.redpanda.node_id(node)
+        self.logger.info(f"Selected node {node.name} (id={node_id}) for restart")
+
+        # Count initial state
+        initial_leaders_on_node = self._get_total_leaders_on_node(node_id)
+        initial_replicas_on_node = self._get_replicas_on_node(node_id)
+
+        self.logger.info(
+            f"Node {node.name} has {initial_leaders_on_node} leaders and "
+            f"{initial_replicas_on_node} replicas before restart"
+        )
+
+        # Capture initial metrics
+        surviving_nodes = [
+            n
+            for n in self.redpanda.started_nodes()
+            if self.redpanda.node_id(n) != node_id
+        ]
+        initial_metric = self._get_leadership_changes_metric(nodes=surviving_nodes)
+
+        # Stop the node
+        self.logger.info(f"Stopping node {node.name}")
+        self.redpanda.stop_node(node)
+
+        # Wait for leadership to move away from the stopped node
+        self._wait_for_all_leaders_elected()
+
+        # Track leadership changes while node is down until stable
+        stop_transfers = self._track_transfers_until_stable(initial_metric)
+
+        # Capture initial metric before starting node
+        initial_metric = self._get_leadership_changes_metric()
+
+        # Start the node again
+        self.logger.info(f"Starting node {node.name}")
+        self.redpanda.start_node(node)
+
+        # Wait for leadership to actually rebalance to the restarted node.
+        # This ensures leader_activation_delay has expired and balancer has acted.
+        self._wait_for_node_to_have_leaders(node_id, min_leaders=5)
+
+        # Wait for the cluster to stabilize and leader balancer to rebalance
+        self._wait_for_all_leaders_elected()
+
+        final_replicas_on_node = self._get_replicas_on_node(node_id)
+
+        # Track transfers during rebalancing
+        restart_transfers = self._track_transfers_until_stable(initial_metric)
+
+        return {
+            "node": node.name,
+            "transfers": [
+                TransferEntry("node_stop", stop_transfers, initial_replicas_on_node, 1),
+                TransferEntry(
+                    "node_restart", restart_transfers, final_replicas_on_node, 1
+                ),
+            ],
+        }
+
+    @cluster(
+        num_nodes=ExcessiveLeadershipTransfersTestBase.NODES,
+        log_allow_list=RESTART_LOG_ALLOW_LIST,
+    )
+    def test_restart_calibrated(self):
+        self._run_calibrated()
+
+    @cluster(
+        num_nodes=ExcessiveLeadershipTransfersTestBase.NODES,
+        log_allow_list=RESTART_LOG_ALLOW_LIST,
+    )
+    def test_restart_random(self):
+        self._run_random()

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -65,30 +65,38 @@ class Scale:
         return self._scale == Scale.RELEASE
 
 
-def repeat_check(times: int):
+def repeat_check(times: int, require_same: bool = False):
     def decorator(func):
         """
         Decorator to repeat a check function until it passes for a given number
         of times in a line. The function should accept no arguments and return
         either a tuple where the first element is a boolean
         (for wait_until_result), or just a boolean (for plain wait_until).
+
+        `require_same` controls whether we require the successful result to be the same
         """
 
         def wrapper():
             ret = func()
             is_successful = ret[0] if isinstance(ret, tuple) else ret
             if is_successful:
+                if require_same and wrapper._last_successful_result != ret:
+                    wrapper._last_successful_result = ret
+                    wrapper._passed = 0
                 wrapper._passed += 1
                 if wrapper._passed >= times:
-                    wrapper._passed = 0  # in case we reuse the function
+                    reinit(wrapper)  # in case we reuse the function
                     return ret
                 return False, None if isinstance(ret, tuple) else False
             else:
-                wrapper._passed = 0
+                reinit(wrapper)  # reset on failure
                 return ret
 
-        # init the counter
-        wrapper._passed = 0
+        def reinit(wrapper):
+            wrapper._passed = 0
+            wrapper._last_successful_result = None
+
+        reinit(wrapper)
 
         return wrapper
 


### PR DESCRIPTION
Instead of choosing any move net positive w.r.t. the value function we
assess a few options and set a reasonably high bar for the next few
moves. We recalibrate as long as the bar is set high enough to rule out
too many moves. Eventually no worthful moves are found, so we run out of
moves the same way as the 'random' strategy does.

Performance of the strategy itself:
```
test                               iters            runtime     allocs      tasks       inst     cycles   overhead
lb.full_simulation_random             13    52.29ms ± 9.42%     59.692      0.000  176901102  213779433        0.0
lb.full_simulation_calibrated         13    72.48ms ± 9.07%     59.154      0.000  194573664  306398786        0.0
```

Ducktape results:
```
Decommission - calibrated decommission: n=5, avg_moves=82.6
Decommission - calibrated recommission: n=5, avg_moves=264.2
Decommission - random decommission: n=5, avg_moves=137.6
Decommission - random recommission: n=5, avg_moves=300.4
MaintenanceMode - calibrated during_drain: n=5, avg_moves=52.0
MaintenanceMode - calibrated after_restore: n=5, avg_moves=204.0
MaintenanceMode - random during_drain: n=5, avg_moves=89.4
MaintenanceMode - random after_restore: n=5, avg_moves=202.0
Restart - calibrated node_stop: n=5, avg_moves=60.4
Restart - calibrated node_restart: n=5, avg_moves=207.2
Restart - random node_stop: n=5, avg_moves=65.2
Restart - random node_restart: n=5, avg_moves=237.8
```

Simulation unit test for 3 nodes typically does 20k moves for random and 16.7k moves for calibrated.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Improvements

* Leader balancer improved to issue less moves to reach balanced state

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
