### PR TITLE
ctp_stm: reset seen epoch window on term change

### DIFF
--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -406,17 +406,17 @@ ctp_stm::fence_epoch(cluster_epoch e) {
     }
     auto term = _raft->confirmed_term();
     while (true) {
-        if (_state.epoch_in_window(e)) {
+        if (_state.epoch_in_window(term, e)) {
             // Case 1.1. Same epoch, need to acquire read-lock.
             // Case 1.2. This epoch is out of order. We can accept it if it lies
             //           in [previous-epoch, max-seen-epoch) range. We also need
             //           to acquire a read fence as in 1.1.
             auto unit = co_await ss::get_units(_lock, 1, _as);
-            if (_state.epoch_in_window(e)) {
+            if (_state.epoch_in_window(term, e)) {
                 co_return cluster_epoch_fence{
                   .unit = std::move(unit), .term = term};
             }
-        } else if (_state.epoch_above_window(e)) {
+        } else if (_state.epoch_above_window(term, e)) {
             // Case 2. New epoch, need to acquire write-lock.
             auto epoch_update_lock = _epoch_update_lock.try_get_units();
             if (!epoch_update_lock) {
@@ -431,9 +431,11 @@ ctp_stm::fence_epoch(cluster_epoch e) {
               _lock, ss::semaphore::max_counter(), _as);
 
             std::optional<cluster_epoch_fence> epoch_fence_opt;
-            if (_state.epoch_in_window(e) || _state.epoch_above_window(e)) {
+            if (
+              _state.epoch_in_window(term, e)
+              || _state.epoch_above_window(term, e)) {
                 vlog(_log.debug, "Bumping max seen epoch to {}", e);
-                _state.advance_max_seen_epoch(e);
+                _state.advance_max_seen_epoch(term, e);
                 // Demote to reader lock after max_seen_epoch is updated.
                 unit.return_units(unit.count() - 1);
                 epoch_fence_opt.emplace(std::move(unit), term);

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -75,8 +75,8 @@ public:
 
     const ctp_stm_state& state() const noexcept { return _state; }
 
-    void advance_max_seen_epoch(cluster_epoch epoch) {
-        _state.advance_max_seen_epoch(epoch);
+    void advance_max_seen_epoch(model::term_id term, cluster_epoch epoch) {
+        _state.advance_max_seen_epoch(term, epoch);
     }
 
     ss::future<std::expected<cluster_epoch_fence, stale_cluster_epoch>>

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
@@ -15,9 +15,16 @@
 
 namespace cloud_topics {
 
-void ctp_stm_state::advance_max_seen_epoch(cluster_epoch epoch) noexcept {
-    if (epoch > _max_seen_epoch) {
-        _previous_seen_epoch = _max_seen_epoch.value_or(epoch);
+void ctp_stm_state::advance_max_seen_epoch(
+  model::term_id term, cluster_epoch epoch) noexcept {
+    if (term >= _seen_window_term && epoch > _max_seen_epoch) {
+        if (term > _seen_window_term) {
+            // If this is a new term, reset the window.
+            _previous_seen_epoch = epoch;
+            _seen_window_term = term;
+        } else {
+            _previous_seen_epoch = _max_seen_epoch.value_or(epoch);
+        }
         _max_seen_epoch = epoch;
     }
 }
@@ -47,7 +54,14 @@ ctp_stm_state::get_previous_seen_epoch() const noexcept {
     return _previous_seen_epoch;
 }
 
-bool ctp_stm_state::epoch_in_window(cluster_epoch epoch) const noexcept {
+bool ctp_stm_state::epoch_in_window(
+  model::term_id term, cluster_epoch epoch) const noexcept {
+    // If the term is newer then treat the window as unset.
+    if (term > _seen_window_term) {
+        auto end = _max_applied_epoch.value_or(cluster_epoch::min());
+        auto begin = _previous_applied_epoch.value_or(end);
+        return epoch >= begin && epoch <= end;
+    }
     // NOTE: the window should move forward with _max_seen_epoch.
     // If _max_seen_epoch is greater than _max_applied_epoch then
     // the window should be [_previous_seen_epoch, _max_seen_epoch].
@@ -60,7 +74,13 @@ bool ctp_stm_state::epoch_in_window(cluster_epoch epoch) const noexcept {
     return epoch >= begin && epoch <= end;
 }
 
-bool ctp_stm_state::epoch_above_window(cluster_epoch epoch) const noexcept {
+bool ctp_stm_state::epoch_above_window(
+  model::term_id term, cluster_epoch epoch) const noexcept {
+    // If the term changed, treat it as unset.
+    if (term > _seen_window_term) {
+        auto end = _max_applied_epoch.value_or(cluster_epoch::min());
+        return epoch > end;
+    }
     auto end = _max_seen_epoch.value_or(
       _max_applied_epoch.value_or(cluster_epoch::min()));
     return epoch > end;
@@ -72,13 +92,6 @@ ctp_stm_state::estimate_inactive_epoch() const noexcept {
 }
 
 void ctp_stm_state::advance_epoch(cluster_epoch epoch, model::offset offset) {
-    // The STM works on both leader and followers, on a leader the
-    // max_seen_epoch epoch is updated by the fencing mechanism.
-    // On the follower the max_seen_epoch epoch has to follow the max epoch.
-    if (epoch > _max_seen_epoch) {
-        _previous_seen_epoch = _max_seen_epoch.value_or(epoch);
-        _max_seen_epoch = epoch;
-    }
     // Register new epoch
     if (epoch > _max_applied_epoch.value_or(cluster_epoch::min())) {
         // A new max epoch requires the sliding window of epoch values in flight

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
@@ -48,7 +48,8 @@ public:
 
     /// This is invoked in the write path before the batch with new
     /// epoch value is even replicated.
-    void advance_max_seen_epoch(cluster_epoch epoch) noexcept;
+    void
+    advance_max_seen_epoch(model::term_id term, cluster_epoch epoch) noexcept;
 
     // Set the new start offset for the partition.
     //
@@ -91,9 +92,11 @@ public:
     std::optional<cluster_epoch> estimate_min_epoch() const noexcept;
 
     /// Return true if the epoch can be replicated
-    bool epoch_in_window(cluster_epoch epoch) const noexcept;
+    bool
+    epoch_in_window(model::term_id term, cluster_epoch epoch) const noexcept;
     /// Return true if the epoch is above the current window
-    bool epoch_above_window(cluster_epoch epoch) const noexcept;
+    bool
+    epoch_above_window(model::term_id term, cluster_epoch epoch) const noexcept;
 
     /// Estimate inactive epoch
     std::optional<cluster_epoch> estimate_inactive_epoch() const noexcept;
@@ -135,6 +138,10 @@ public:
     fmt::iterator format_to(fmt::iterator) const;
 
 private:
+    /// The term at which the *_seen_epochs are for, due to the sliding window
+    /// having the ability to diverge, we only track it within a single term,
+    /// then reset the window to avoid nasty edge cases when leadership changes.
+    model::term_id _seen_window_term;
     /// The max epoch after the current in flight requests are applied.
     ///
     /// This is required because of the pipelining of requests in the STM.

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
@@ -37,15 +37,16 @@ TEST(ctp_stm_state_test, advance_max_seen_epoch) {
     ct::cluster_epoch epoch1(10);
     ct::cluster_epoch epoch2(20);
     ct::cluster_epoch epoch3(5);
+    model::term_id term(1);
 
-    state.advance_max_seen_epoch(epoch1);
+    state.advance_max_seen_epoch(term, epoch1);
     EXPECT_EQ(state.get_max_seen_epoch().value(), epoch1);
 
-    state.advance_max_seen_epoch(epoch2);
+    state.advance_max_seen_epoch(term, epoch2);
     EXPECT_EQ(state.get_max_seen_epoch().value(), epoch2);
 
     // Should not go backwards
-    state.advance_max_seen_epoch(epoch3);
+    state.advance_max_seen_epoch(term, epoch3);
     EXPECT_EQ(state.get_max_seen_epoch().value(), epoch2);
 }
 
@@ -57,26 +58,29 @@ TEST(ctp_stm_state_test, advance_epoch) {
 
     state.advance_epoch(epoch1, model::offset(1));
     EXPECT_EQ(state.get_max_applied_epoch().value(), epoch1);
-    EXPECT_EQ(state.get_max_seen_epoch().value(), epoch1);
+    // advance_epoch does not update the seen window
+    EXPECT_FALSE(state.get_max_seen_epoch().has_value());
 
     state.advance_epoch(epoch2, model::offset(2));
     EXPECT_EQ(state.get_max_applied_epoch().value(), epoch2);
-    EXPECT_EQ(state.get_max_seen_epoch().value(), epoch2);
+    EXPECT_FALSE(state.get_max_seen_epoch().has_value());
 
     // Should not go backwards
     state.advance_epoch(epoch3, model::offset(3));
     EXPECT_EQ(state.get_max_applied_epoch().value(), epoch2);
-    EXPECT_EQ(state.get_max_seen_epoch().value(), epoch2);
+    EXPECT_FALSE(state.get_max_seen_epoch().has_value());
 }
 
 TEST(ctp_stm_state_test, advance_epoch_on_a_follower) {
-    // On a follower the max_seen_epoch should also be updated
+    // On a follower, advance_epoch only updates the applied window,
+    // not the seen window. The seen window is only managed through
+    // advance_max_seen_epoch on the leader path.
     ct::ctp_stm_state state;
     ct::cluster_epoch advance_epoch(20);
 
     state.advance_epoch(advance_epoch, model::offset(1));
 
-    EXPECT_EQ(state.get_max_seen_epoch().value(), advance_epoch);
+    EXPECT_FALSE(state.get_max_seen_epoch().has_value());
     EXPECT_EQ(state.get_max_applied_epoch().value(), advance_epoch);
 }
 
@@ -171,6 +175,7 @@ kafka::offset operator""_offset(unsigned long long v) {
 
 TEST(ctp_stm_state_test, sliding_window_issue) {
     ct::ctp_stm_state state;
+    model::term_id term(1);
 
     kafka::offset hwm = 0_offset;
 
@@ -193,17 +198,17 @@ TEST(ctp_stm_state_test, sliding_window_issue) {
     // get the write lock before we can start our window
     EXPECT_EQ(estimate_inactive_epoch(), std::nullopt);
     // Start our epochs at 2
-    EXPECT_FALSE(state.epoch_in_window(2_epoch));
+    EXPECT_FALSE(state.epoch_in_window(term, 2_epoch));
 
     // Write lock grabbed, max epoch can be advanced!
-    state.advance_max_seen_epoch(2_epoch);
+    state.advance_max_seen_epoch(term, 2_epoch);
 
     // Now epoch 0 is in the window
-    EXPECT_TRUE(state.epoch_in_window(2_epoch));
+    EXPECT_TRUE(state.epoch_in_window(term, 2_epoch));
     // Epoch 1 is not in the window
-    EXPECT_FALSE(state.epoch_in_window(1_epoch));
+    EXPECT_FALSE(state.epoch_in_window(term, 1_epoch));
     // Nor is 3
-    EXPECT_FALSE(state.epoch_in_window(3_epoch));
+    EXPECT_FALSE(state.epoch_in_window(term, 3_epoch));
 
     // Now the batch that was replicated with offset 0
     apply_replicated(2_epoch);
@@ -213,7 +218,7 @@ TEST(ctp_stm_state_test, sliding_window_issue) {
     EXPECT_EQ(estimate_inactive_epoch(), 1_epoch);
 
     // Let's now add another batch at epoch 2
-    EXPECT_TRUE(state.epoch_in_window(2_epoch));
+    EXPECT_TRUE(state.epoch_in_window(term, 2_epoch));
     apply_replicated(2_epoch);
 
     // Reconciler now runs
@@ -222,19 +227,19 @@ TEST(ctp_stm_state_test, sliding_window_issue) {
     // Our epoch window hasn't moved
     EXPECT_EQ(estimate_inactive_epoch(), 1_epoch);
 
-    EXPECT_FALSE(state.epoch_in_window(5_epoch));
+    EXPECT_FALSE(state.epoch_in_window(term, 5_epoch));
 
     // Epoch is bumped, our window should now be [2, 5]
-    state.advance_max_seen_epoch(5_epoch);
+    state.advance_max_seen_epoch(term, 5_epoch);
 
     // This is our new epoch
-    EXPECT_TRUE(state.epoch_in_window(5_epoch));
+    EXPECT_TRUE(state.epoch_in_window(term, 5_epoch));
     // Our previous epoch is good still
-    EXPECT_TRUE(state.epoch_in_window(2_epoch));
+    EXPECT_TRUE(state.epoch_in_window(term, 2_epoch));
     // And so is something in between (unlikely in real life, but just to show)
-    EXPECT_TRUE(state.epoch_in_window(3_epoch));
+    EXPECT_TRUE(state.epoch_in_window(term, 3_epoch));
     // Something below is still bad
-    EXPECT_FALSE(state.epoch_in_window(1_epoch));
+    EXPECT_FALSE(state.epoch_in_window(term, 1_epoch));
 
     // Still not safe to GC, we accept stuff at epoch 0
     EXPECT_EQ(estimate_inactive_epoch(), 1_epoch);
@@ -250,12 +255,12 @@ TEST(ctp_stm_state_test, sliding_window_issue) {
     EXPECT_EQ(estimate_inactive_epoch(), 1_epoch);
 
     // Now we start to replicate to the epoch to 10 (write lock grabbed)
-    state.advance_max_seen_epoch(10_epoch);
-    EXPECT_TRUE(state.epoch_in_window(10_epoch));
-    EXPECT_TRUE(state.epoch_in_window(5_epoch));
-    EXPECT_TRUE(state.epoch_in_window(8_epoch));
-    EXPECT_FALSE(state.epoch_in_window(0_epoch));
-    EXPECT_FALSE(state.epoch_in_window(4_epoch));
+    state.advance_max_seen_epoch(term, 10_epoch);
+    EXPECT_TRUE(state.epoch_in_window(term, 10_epoch));
+    EXPECT_TRUE(state.epoch_in_window(term, 5_epoch));
+    EXPECT_TRUE(state.epoch_in_window(term, 8_epoch));
+    EXPECT_FALSE(state.epoch_in_window(term, 0_epoch));
+    EXPECT_FALSE(state.epoch_in_window(term, 4_epoch));
 
     apply_replicated(10_epoch);
 
@@ -268,11 +273,11 @@ TEST(ctp_stm_state_test, sliding_window_issue) {
     EXPECT_EQ(estimate_inactive_epoch(), 4_epoch);
 
     // Now we bump the window again, but haven't replicated it yet.
-    state.advance_max_seen_epoch(15_epoch);
-    EXPECT_TRUE(state.epoch_in_window(10_epoch));
-    EXPECT_TRUE(state.epoch_in_window(15_epoch));
-    EXPECT_TRUE(state.epoch_in_window(12_epoch));
-    EXPECT_FALSE(state.epoch_in_window(9_epoch));
+    state.advance_max_seen_epoch(term, 15_epoch);
+    EXPECT_TRUE(state.epoch_in_window(term, 10_epoch));
+    EXPECT_TRUE(state.epoch_in_window(term, 15_epoch));
+    EXPECT_TRUE(state.epoch_in_window(term, 12_epoch));
+    EXPECT_FALSE(state.epoch_in_window(term, 9_epoch));
 
     EXPECT_EQ(estimate_inactive_epoch(), 4_epoch);
 
@@ -356,6 +361,7 @@ TEST(ctp_stm_state_test, l0_simulation) {
     };
     // We simulate the operations for a single partition in l0
     l0_simulation_state universe;
+    model::term_id term(1);
 
     {
         std::vector<uploaded_l0_file_batch> batches{
@@ -399,12 +405,13 @@ TEST(ctp_stm_state_test, l0_simulation) {
         std::vector<std::function<void()>> possible_operations;
         // If there are batches to upload, let's do it.
         if (!universe.uploaded_batches.empty()) {
-            possible_operations.emplace_back([&universe, &oplog] {
+            possible_operations.emplace_back([&universe, &oplog, term] {
                 auto batch = universe.uploaded_batches.front();
                 universe.uploaded_batches.pop_front();
-                if (!universe.stm.epoch_in_window(batch.epoch)) {
-                    universe.stm.advance_max_seen_epoch(batch.epoch);
-                    ASSERT_TRUE(universe.stm.epoch_in_window(batch.epoch));
+                if (!universe.stm.epoch_in_window(term, batch.epoch)) {
+                    universe.stm.advance_max_seen_epoch(term, batch.epoch);
+                    ASSERT_TRUE(
+                      universe.stm.epoch_in_window(term, batch.epoch));
                 }
                 placeholder_batch placeholder{
                   .epoch = batch.epoch, .offset = universe.hwm++};

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -150,11 +150,8 @@ TEST_F_CORO(ctp_stm_fixture, test_basic) {
     ASSERT_TRUE_CORO(res.has_value());
 
     auto max_epoch = api(node(*get_leader())).get_max_epoch();
-    auto max_seen_epoch = api(node(*get_leader())).get_max_seen_epoch();
     ASSERT_TRUE_CORO(max_epoch.has_value());
-    ASSERT_TRUE_CORO(max_seen_epoch.has_value());
     ASSERT_EQ_CORO(max_epoch.value(), ct::cluster_epoch{1});
-    ASSERT_EQ_CORO(max_seen_epoch.value(), ct::cluster_epoch{1});
 
     gc_epoch = co_await api(node(*get_leader())).get_inactive_epoch();
     ASSERT_TRUE_CORO(gc_epoch);
@@ -178,11 +175,8 @@ TEST_F_CORO(ctp_stm_fixture, test_fencing) {
     ASSERT_TRUE_CORO(res.has_value());
 
     auto max_epoch = api(node(*get_leader())).get_max_epoch();
-    auto max_seen_epoch = api(node(*get_leader())).get_max_seen_epoch();
     ASSERT_TRUE_CORO(max_epoch.has_value());
-    ASSERT_TRUE_CORO(max_seen_epoch.has_value());
     ASSERT_EQ_CORO(max_epoch.value(), ct::cluster_epoch{2});
-    ASSERT_EQ_CORO(max_seen_epoch.value(), ct::cluster_epoch{2});
 
     // Acquire the fence for epoch 2 (should succeed)
     {
@@ -240,11 +234,8 @@ TEST_F_CORO(ctp_stm_fixture, test_last_reconciled_offset) {
     ASSERT_TRUE_CORO(res2.has_value());
 
     auto max_epoch = api(node(*get_leader())).get_max_epoch();
-    auto max_seen_epoch = api(node(*get_leader())).get_max_seen_epoch();
     ASSERT_TRUE_CORO(max_epoch.has_value());
-    ASSERT_TRUE_CORO(max_seen_epoch.has_value());
     ASSERT_EQ_CORO(max_epoch.value(), ct::cluster_epoch{2});
-    ASSERT_EQ_CORO(max_seen_epoch.value(), ct::cluster_epoch{2});
 
     auto gc_epoch_before
       = co_await api(node(*get_leader())).get_inactive_epoch();
@@ -258,13 +249,10 @@ TEST_F_CORO(ctp_stm_fixture, test_last_reconciled_offset) {
     co_await api(node(*get_leader()))
       .advance_reconciled_offset(kafka::offset{0}, model::no_timeout, as);
 
-    // Check that max and max_seen_epochs remain the same
+    // Check that max applied epoch remains the same
     auto max_epoch_after = api(node(*get_leader())).get_max_epoch();
-    auto max_seen_epoch_after = api(node(*get_leader())).get_max_seen_epoch();
     ASSERT_TRUE_CORO(max_epoch_after.has_value());
-    ASSERT_TRUE_CORO(max_seen_epoch_after.has_value());
     ASSERT_EQ_CORO(max_epoch_after.value(), ct::cluster_epoch{2});
-    ASSERT_EQ_CORO(max_seen_epoch_after.value(), ct::cluster_epoch{2});
 
     // Check that first epoch to remove has moved forward
     auto gc_epoch_after
@@ -279,9 +267,7 @@ TEST_F_CORO(ctp_stm_fixture, test_last_reconciled_offset) {
       .advance_reconciled_offset(kafka::offset{1}, model::no_timeout, as);
 
     max_epoch_after = api(node(*get_leader())).get_max_epoch();
-    max_seen_epoch_after = api(node(*get_leader())).get_max_seen_epoch();
     ASSERT_TRUE_CORO(max_epoch_after.has_value());
-    ASSERT_TRUE_CORO(max_seen_epoch_after.has_value());
 
     // We know that b2 started epoch 2 but we don't yet know where it ends
     gc_epoch_after = co_await api(node(*get_leader())).get_inactive_epoch();
@@ -314,11 +300,8 @@ TEST_F_CORO(ctp_stm_fixture, test_truncate_all_epochs) {
     }
 
     auto max_epoch = api(node(*get_leader())).get_max_epoch();
-    auto max_seen_epoch = api(node(*get_leader())).get_max_seen_epoch();
     ASSERT_TRUE_CORO(max_epoch.has_value());
-    ASSERT_TRUE_CORO(max_seen_epoch.has_value());
     ASSERT_EQ_CORO(max_epoch.value(), last_epoch);
-    ASSERT_EQ_CORO(max_seen_epoch.value(), last_epoch);
     // Nothing yet reconciled
     auto inactive_epoch
       = co_await api(node(*get_leader())).get_inactive_epoch();
@@ -473,11 +456,8 @@ TEST_F_CORO(ctp_stm_fixture, test_snapshot) {
     ASSERT_TRUE_CORO(res.has_value());
 
     auto max_epoch = api(node(*get_leader())).get_max_epoch();
-    auto max_seen_epoch = api(node(*get_leader())).get_max_seen_epoch();
     ASSERT_TRUE_CORO(max_epoch.has_value());
-    ASSERT_TRUE_CORO(max_seen_epoch.has_value());
     ASSERT_EQ_CORO(max_epoch.value(), ct::cluster_epoch{2});
-    ASSERT_EQ_CORO(max_seen_epoch.value(), ct::cluster_epoch{2});
 
     auto& leader = node(*get_leader());
     auto stm = get_stm<0>(leader);
@@ -600,11 +580,8 @@ TEST_F_CORO(ctp_stm_fixture, test_previous_epoch_fencing_with_lro) {
 
     // Verify epochs are established
     auto max_epoch = leader_api.get_max_epoch();
-    auto max_seen_epoch = leader_api.get_max_seen_epoch();
     ASSERT_TRUE_CORO(max_epoch.has_value());
-    ASSERT_TRUE_CORO(max_seen_epoch.has_value());
     ASSERT_EQ_CORO(max_epoch.value(), ct::cluster_epoch{3});
-    ASSERT_EQ_CORO(max_seen_epoch.value(), ct::cluster_epoch{3});
 
     // Get the previous epoch (should be epoch 2, the previous
     // max_applied_epoch)
@@ -860,4 +837,96 @@ TEST_F_CORO(
       << " incorrectly accepted stale epoch 11. "
       << "This indicates the bug where in-memory _max_seen_epoch "
       << "is stale after regaining leadership.";
+}
+
+TEST_F_CORO(
+  ctp_stm_fixture,
+  test_unfenced_high_epoch_causes_stale_window_after_leadership_change) {
+    // Bug reproduction: a leader that fences a high epoch but doesn't
+    // replicate a batch for it, then loses leadership, retains a stale
+    // _max_seen_epoch. When it regains leadership the window is
+    // artificially wide and old (now-invalid) epochs are accepted.
+    //
+    // Scenario:
+    // 1. Node0 (leader) fences+replicates epochs 0-5
+    // 2. Node0 fences epoch 100 (bumps _max_seen_epoch to 100)
+    //    but does NOT replicate a batch for it
+    // 3. Leadership transfers to Node1
+    // 4. Node1 fences+replicates epochs 6, 7, 8
+    // 5. Node0 (follower) applies 6, 7, 8 via STM but _max_seen_epoch
+    //    stays at 100 because 8 < 100
+    // 6. Leadership transfers back to Node0
+    // 7. Node0 tries to fence epoch 5:
+    //    BUG:   seen window [5, 100] → accepted
+    //    FIXED: falls back to applied window [7, 8] → rejected
+
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+
+    auto initial_leader_id = get_leader().value();
+    vlog(ct::cd_log.info, "Initial leader: {}", initial_leader_id);
+    auto& node0 = node(initial_leader_id);
+
+    // Step 1: Fence and replicate epochs 0 through 5
+    for (int i = 0; i <= 5; i++) {
+        bool success = co_await replicate_with_epoch(
+          node0, ct::cluster_epoch{i}, model::offset{i}, i);
+        ASSERT_TRUE_CORO(success);
+    }
+
+    // Step 2: Fence epoch 100 but do NOT replicate a batch for it.
+    // This bumps _max_seen_epoch to 100 on Node0 making the seen
+    // window [5, 100].
+    {
+        auto fence_100 = co_await api(node0).fence_epoch(
+          ct::cluster_epoch{100});
+        ASSERT_TRUE_CORO(fence_100.has_value());
+        // Let the fence guard drop without replicating.
+    }
+
+    auto max_seen = api(node0).get_max_seen_epoch();
+    ASSERT_TRUE_CORO(max_seen.has_value());
+    ASSERT_EQ_CORO(max_seen.value(), ct::cluster_epoch{100});
+
+    // Step 3: Transfer leadership to a different node.
+    node0.raft()->block_new_leadership();
+    co_await node0.raft()->step_down("test_induced_failover");
+    co_await wait_for_leader(10s);
+    auto new_leader_id = get_leader().value();
+    ASSERT_NE_CORO(new_leader_id, initial_leader_id);
+    vlog(ct::cd_log.info, "New leader: {}", new_leader_id);
+
+    auto& node1 = node(new_leader_id);
+
+    // Step 4: Fence and replicate epochs 6, 7, 8 on the new leader.
+    for (int i = 6; i <= 8; i++) {
+        bool success = co_await replicate_with_epoch(
+          node1, ct::cluster_epoch{i}, model::offset{i}, i);
+        ASSERT_TRUE_CORO(success);
+    }
+
+    // Step 5: Node0 (follower) applies 6, 7, 8. Because 8 < 100
+    // the stale _max_seen_epoch is never overwritten.
+
+    // Step 6: Transfer leadership back to Node0.
+    node0.raft()->unblock_new_leadership();
+    co_await node1.raft()->transfer_leadership(
+      raft::transfer_leadership_request{
+        .group = node1.raft()->group(),
+        .target = initial_leader_id,
+        .timeout = 10s});
+
+    co_await wait_for_leader(10s);
+    ASSERT_EQ_CORO(*get_leader(), initial_leader_id);
+
+    // Step 7: Try to fence epoch 5 on the returned leader.
+    // Applied window is now [7, 8] so this must be rejected.
+    auto stale_fence
+      = co_await api(node(initial_leader_id)).fence_epoch(ct::cluster_epoch{5});
+
+    ASSERT_FALSE_CORO(stale_fence.has_value())
+      << "Leader " << initial_leader_id
+      << " incorrectly accepted stale epoch 5. "
+      << "The in-memory seen window [5, 100] survived the leadership "
+      << "change, allowing an epoch that is below the applied window [7, 8].";
 }


### PR DESCRIPTION
The CTP STM tracks a "seen window" of cluster epochs that
have been fenced by the leader but may not yet be applied.
This window is used to accept or reject incoming epoch fence
requests.

When a leader fences a high epoch (e.g. 762) but loses
leadership before replicating a batch for it, the seen
window remains artificially wide (e.g. [55, 762]). If
leadership later returns to this node, the stale seen
window causes the STM to incorrectly accept epochs that
the applied window has already moved past. This can lead
to an assertion failure in the epoch_window_checker when
a batch with a now-invalid epoch is applied to the log.

Fix this by tracking which raft term the seen window was
set in (_seen_window_term). When fence_epoch runs in a
newer term, epoch_in_window and epoch_above_window fall
back to the applied window instead of the potentially
stale seen window. advance_max_seen_epoch resets the
window on term transitions.

The apply path (advance_epoch) no longer updates the seen
window at all, since it is exclusively a leader-side
concept managed through the fencing mechanism.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
