### PR TITLE
ci: simplify claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,23 +38,14 @@ jobs:
             --max-turns 30
             --disallowed-tools "WebFetch,WebSearch"
             --allowed-tools "
+              mcp__github__add_issue_comment,
               mcp__github_inline_comment__create_inline_comment,
               mcp__github_ci__get_ci_status,
               mcp__github_ci__get_workflow_run_details,
               mcp__github_ci__download_job_log,
-              Bash(gh issue *),
-              Bash(gh pr *),
-              Bash(gh search *)"
+              Bash(gh pr diff *),
+              Bash(gh pr view *)"
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
-            WORKFLOW RUN URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-            Please review this pull request with a focus on:
-              - Code quality and best practices
-              - Potential bugs or issues
-              - Security implications
-              - Performance considerations
-
-            Provide detailed feedback using inline comments for specific issues.
-            Include a link to workflow run URL in the final review comment.
+            PR_NUMBER: ${{ github.event.pull_request.number }}
+            Review the PR. The code of the PR is already checked out. Use `gh pr view` to get details about the PR. Use `gh pr diff` to get diff of the PR. Focus on code quality, potential bugs, and performance issues. Suggest improvements where appropriate. Use the `mcp__github_inline_comment__create_inline_comment` tool for line-specific issues. Use the `mcp__github__add_issue_comment` tool for final review comment on PR.


### PR DESCRIPTION
## Summary

Following on PR #29488
- Tighten bash tool permissions from broad `gh issue/pr/search` wildcards to specific `gh pr diff` and `gh pr view` commands
- Add `mcp__github__add_issue_comment` tool for posting final review comments on PRs
- Simplify the review prompt into a concise single-line instruction instead of verbose multi-line format

## Test plan
- [ ] Trigger workflow on a test PR and verify Claude can still review code using inline comments
- [ ] Verify final review comment is posted via `mcp__github__add_issue_comment`
- [ ] Confirm restricted bash permissions work correctly for `gh pr diff` and `gh pr view`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none