### PR TITLE
ci: improve claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
           allowed_bots: ""
           allowed_non_write_users: ""
           # NOTE: uncomment github_token to test changes in a PR before merge with bot `github-actions`; comment out before merge so bot will be `claude`
-          github_token: ${{ github.token }}
+          # github_token: ${{ github.token }}
           show_full_output: false
           track_progress: false
           use_commit_signing: true

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,19 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 1
           persist-credentials: false
-      - run: gh auth setup-git
-        env:
-          GH_TOKEN: ${{ github.token }}
       - uses: anthropics/claude-code-action@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: ""
           allowed_non_write_users: ""
-          github_token: ${{ github.token }}  # needed to test changes to this file in a PR before merge
+          # NOTE: uncomment github_token to test changes in a PR before merge with bot `github-actions`; comment out before merge so bot will be `claude`
+          github_token: ${{ github.token }}
           show_full_output: false
           track_progress: false
           use_commit_signing: true
@@ -38,23 +33,16 @@ jobs:
             --max-turns 30
             --disallowed-tools "WebFetch,WebSearch"
             --allowed-tools "
+              mcp__github__add_issue_comment,
               mcp__github_inline_comment__create_inline_comment,
               mcp__github_ci__get_ci_status,
               mcp__github_ci__get_workflow_run_details,
               mcp__github_ci__download_job_log,
-              Bash(gh issue *),
-              Bash(gh pr *),
+              Bash(gh issue view *),
+              Bash(gh pr diff *),
+              Bash(gh pr view *),
               Bash(gh search *)"
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
-            WORKFLOW RUN URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-            Please review this pull request with a focus on:
-              - Code quality and best practices
-              - Potential bugs or issues
-              - Security implications
-              - Performance considerations
-
-            Provide detailed feedback using inline comments for specific issues.
-            Include a link to workflow run URL in the final review comment.
+            PR_NUMBER: ${{ github.event.pull_request.number }}
+            Review the PR. The code of the PR is already checked out. Use `gh pr view` to get details about the PR. Use `gh pr diff` to get diff of the PR. Focus on code quality, potential bugs, security implications, and performance issues. Suggest improvements where appropriate. Use the `mcp__github_inline_comment__create_inline_comment` tool for line-specific issues. Use the `mcp__github__add_issue_comment` tool for final review comment on PR.


### PR DESCRIPTION
## Summary

Following on PR #29488
- Adjust bash tool permissions so claude has more tools available to get context for review
- Add `mcp__github__add_issue_comment` tool for posting final review comments on PRs
- Add comment for how to use `github_token` input to test `claude-code-review.yml` changes in a PR
- Remove workflow run URL since link to workflow is in PR checks web UI.
- Simplify the review prompt into a concise single-line instruction instead of verbose multi-line format

## Test plan
- [ ] Trigger workflow on a test PR and verify Claude can still review code using inline comments
- [ ] Verify final review comment is posted via `mcp__github__add_issue_comment`
- [ ] Confirm restricted bash permissions work correctly for `gh pr diff` and `gh pr view`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none