### PR TITLE
Remove record copying in produce batch validation

### DIFF
--- a/src/v/kafka/server/handlers/produce_validation.cc
+++ b/src/v/kafka/server/handlers/produce_validation.cc
@@ -12,6 +12,7 @@
 #include "kafka/server/handlers/produce_validation.h"
 
 #include "kafka/protocol/logger.h"
+#include "model/record_utils.h"
 #include "ssx/sformat.h"
 
 namespace {
@@ -148,12 +149,14 @@ void maybe_set_max_timestamp(
 // `INVALID_RECORD` error code and message are returned.
 std::optional<error_code_and_msg> iterate_over_records(
   const model::record_batch& b,
-  ss::noncopyable_function<ss::stop_iteration(model::record)> f) {
+  ss::noncopyable_function<ss::stop_iteration(model::record_metadata)>&& f,
+  bool is_strict_validation = false) {
     dassert(
       !b.compressed(),
       "Cannot iterate over records within a compressed batch.");
+
     try {
-        b.for_each_record(std::move(f));
+        b.for_each_record_metadata(std::move(f), is_strict_validation);
     } catch (const std::exception& e) {
         vlog(
           klog.error,
@@ -175,7 +178,7 @@ std::expected<model::timestamp, error_code_and_msg>
 compute_max_timestamp(const model::record_batch& b) {
     int64_t max_timestamp_delta = 0;
 
-    auto res = iterate_over_records(b, [&](model::record r) mutable {
+    auto res = iterate_over_records(b, [&](model::record_metadata r) mutable {
         max_timestamp_delta = std::max(
           r.timestamp_delta(), max_timestamp_delta);
         return ss::stop_iteration::no;
@@ -203,11 +206,13 @@ validate_records_and_compute_max_timestamp(
   std::chrono::milliseconds message_timestamp_before_max_ms,
   std::chrono::milliseconds message_timestamp_after_max_ms,
   kafka::kafka_probe& probe,
-  const model::ntp& ntp) {
+  const model::ntp& ntp,
+  bool is_strict_validation = false) {
     std::optional<error_code_and_msg> res;
     int64_t max_timestamp = -1;
     auto iterable_res = iterate_over_records(
-      iterable_batch_ref, [&](model::record r) mutable {
+      iterable_batch_ref,
+      [&](model::record_metadata r) mutable {
           auto timestamp = model::timestamp{
             b.header().first_timestamp() + r.timestamp_delta()};
           auto offset = b.base_offset() + model::offset_delta(r.offset_delta());
@@ -224,7 +229,8 @@ validate_records_and_compute_max_timestamp(
 
           return res.has_value() ? ss::stop_iteration::yes
                                  : ss::stop_iteration::no;
-      });
+      },
+      is_strict_validation);
 
     if (iterable_res.has_value()) {
         // Prefer to return an error describing an invalid format rather than an
@@ -431,7 +437,8 @@ std::optional<error_code_and_msg> validate_batch(
           message_timestamp_before_max_ms,
           message_timestamp_after_max_ms,
           probe,
-          ntp);
+          ntp,
+          true);
 
         if (!max_ts_res.has_value()) {
             return max_ts_res.error();

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -136,6 +136,32 @@ private:
     iobuf _value;
 };
 
+/// \brief A lightweight view of a record's metadata fields (attributes,
+/// timestamp_delta, offset_delta) without key, value, or headers.
+class record_metadata {
+public:
+    record_metadata(
+      int32_t size_bytes,
+      record_attributes attributes,
+      int64_t timestamp_delta,
+      int32_t offset_delta) noexcept
+      : _size_bytes(size_bytes)
+      , _attributes(attributes)
+      , _timestamp_delta(timestamp_delta)
+      , _offset_delta(offset_delta) {}
+
+    int32_t size_bytes() const { return _size_bytes; }
+    record_attributes attributes() const { return _attributes; }
+    int64_t timestamp_delta() const { return _timestamp_delta; }
+    int32_t offset_delta() const { return _offset_delta; }
+
+private:
+    int32_t _size_bytes;
+    record_attributes _attributes;
+    int64_t _timestamp_delta;
+    int32_t _offset_delta;
+};
+
 /// \brief
 // DefaultRecord(int sizeInBytes,
 //               byte attributes,
@@ -886,6 +912,36 @@ public:
                     return;
                 }
             }
+        }
+    }
+
+    /**
+     * Iterate over record metadata.
+     *
+     * Note that we don't need to fully parse a record to get the information in
+     * `record_metadata`. Hence its optional here and only used in cases where a
+     * user wants to validate that the entire record is correctly formatted.
+     */
+    template<typename Func>
+    void
+    for_each_record_metadata(Func f, bool fully_parse_records = false) const {
+        const auto rc = record_count();
+        auto parser = iobuf_const_parser(data());
+        int32_t i = 0;
+        for (; i < rc; ++i) {
+            auto res = f(
+              model::parse_record_metadata_from_buffer(
+                parser, fully_parse_records));
+            if (res == ss::stop_iteration::yes) {
+                break;
+            }
+        }
+
+        if (i == rc && parser.bytes_left()) [[unlikely]] {
+            throw std::out_of_range(
+              fmt::format(
+                "Record metadata iteration stopped with {} bytes remaining",
+                parser.bytes_left()));
         }
     }
 

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -224,19 +224,21 @@ public:
       , _value(std::move(value).value_or(iobuf{}))
       , _headers(std::move(hdrs)) {
         _size_bytes = static_cast<int32_t>(
-          sizeof(model::record_attributes::type)   //
-          + vint::vint_size(_timestamp_delta)      //
-          + vint::vint_size(_offset_delta)         //
-          + _key_size + vint::vint_size(_key_size) //
-          + _val_size + vint::vint_size(_val_size) //
+          sizeof(model::record_attributes::type)
+          + vint::vint_size(_timestamp_delta) + vint::vint_size(_offset_delta)
+          + vint::vint_size(_key_size) + std::max<int32_t>(_key_size, 0)
+          + vint::vint_size(_val_size) + std::max<int32_t>(_val_size, 0)
+          + vint::vint_size(static_cast<int64_t>(_headers.size()))
           + std::accumulate(
             _headers.begin(),
             _headers.end(),
             size_t(0),
             [](size_t acc, const record_header& h) {
-                return acc + h.memory_usage();
-            }) //
-        );
+                return acc + vint::vint_size(h.key_size())
+                       + std::max<int32_t>(h.key_size(), 0)
+                       + vint::vint_size(h.value_size())
+                       + std::max<int32_t>(h.value_size(), 0);
+            }));
     }
 
     // Size in bytes of everything except the size_bytes field.

--- a/src/v/model/record_utils.cc
+++ b/src/v/model/record_utils.cc
@@ -258,4 +258,81 @@ void append_record_to_buffer(iobuf& a, const model::record& r) {
     }
 }
 
+model::record_metadata parse_record_metadata_from_buffer(
+  iobuf_const_parser& p, bool fully_parse_record) {
+    auto [record_size, attr] = parse_record_meta_from_buffer(p);
+    auto [timestamp_delta, tv] = p.read_varlong();
+    auto [offset_delta, ov] = p.read_varlong();
+
+    if (!fully_parse_record) {
+        auto total_bytes_read = 1 + tv + ov;
+        if (record_size <= total_bytes_read) [[unlikely]] {
+            throw std::out_of_range(
+              fmt::format(
+                "Expected record size {} to be greater than bytes read {}",
+                record_size,
+                total_bytes_read));
+        }
+        p.skip(record_size - total_bytes_read);
+    } else {
+        auto start = p.bytes_consumed() - (tv + ov);
+        auto [key_length, kv] = p.read_varlong();
+        if (key_length > record_size) [[unlikely]] {
+            throw std::out_of_range(
+              fmt::format(
+                "Expected key length {} but record has only {} bytes in total",
+                key_length,
+                record_size));
+        }
+        if (key_length > 0) {
+            p.skip(key_length);
+        }
+        auto [value_length, vv] = p.read_varlong();
+        if (value_length > record_size) [[unlikely]] {
+            throw std::out_of_range(
+              fmt::format(
+                "Expected value length {} but record has only {} bytes in "
+                "total",
+                value_length,
+                record_size));
+        }
+        if (value_length > 0) {
+            p.skip(value_length);
+        }
+        auto [header_count, hcv] = p.read_varlong();
+        if (static_cast<size_t>(header_count) > p.bytes_left()) [[unlikely]] {
+            throw std::out_of_range(
+              fmt::format(
+                "Expected {} headers, but only {} bytes left",
+                header_count,
+                p.bytes_left()));
+        }
+        for (int64_t i = 0; i < header_count; ++i) {
+            auto [hk_len, hkv] = p.read_varlong();
+            if (hk_len > 0) {
+                p.skip(hk_len);
+            }
+            auto [hv_len, hvv] = p.read_varlong();
+            if (hv_len > 0) {
+                p.skip(hv_len);
+            }
+        }
+        // record_size includes the 1-byte attr already consumed above.
+        auto bytes_parsed = p.bytes_consumed() - start + 1;
+        if (bytes_parsed != static_cast<size_t>(record_size)) [[unlikely]] {
+            throw std::out_of_range(
+              fmt::format(
+                "Record size mismatch: expected {} but parsed {} bytes",
+                record_size,
+                bytes_parsed));
+        }
+    }
+    return {
+      static_cast<int32_t>(record_size),
+      model::record_attributes(attr),
+      static_cast<int64_t>(timestamp_delta),
+      static_cast<int32_t>(offset_delta),
+    };
+}
+
 } // namespace model

--- a/src/v/model/record_utils.h
+++ b/src/v/model/record_utils.h
@@ -19,6 +19,7 @@ namespace model {
 struct record_batch_header;
 class record_batch;
 class record;
+class record_metadata;
 
 void crc_record_batch_header(crc::crc32c&, const record_batch_header&);
 
@@ -32,5 +33,11 @@ uint32_t internal_header_only_crc(const record_batch_header&);
 model::record parse_one_record_from_buffer(iobuf_parser& parser);
 model::record parse_one_record_copy_from_buffer(iobuf_const_parser& parser);
 void append_record_to_buffer(iobuf& a, const model::record& r);
+
+// \brief Parses record metadata
+// If `fully_parse_record` is false then only a few fields are parsed from the
+// record. Otherwise all fields are fully parsed and validated.
+model::record_metadata parse_record_metadata_from_buffer(
+  iobuf_const_parser& p, bool fully_parse_record);
 
 } // namespace model

--- a/src/v/model/tests/record_batch_test.cc
+++ b/src/v/model/tests/record_batch_test.cc
@@ -143,6 +143,88 @@ TEST_F(RecordBatchTest, ParseRecordMetadataFullParse) {
     check_parse_record_metadata(true);
 }
 
+namespace {
+// Serialize a record and verify that the size_bytes prefix matches the actual
+// serialized body length.
+void check_serialization_size(const model::record& r) {
+    iobuf buf;
+    model::append_record_to_buffer(buf, r);
+
+    auto parser = iobuf_const_parser(buf);
+    auto [written_size, _] = parser.read_varlong();
+    auto body_size = static_cast<int64_t>(parser.bytes_left());
+
+    EXPECT_EQ(r.size_bytes(), written_size);
+    EXPECT_EQ(r.size_bytes(), body_size);
+}
+} // namespace
+
+TEST_F(RecordBatchTest, RecordSizeBytesWithKeyAndValue) {
+    auto r = model::record(
+      model::record_attributes(0),
+      0,
+      0,
+      iobuf::from("key"),
+      iobuf::from("value"),
+      {});
+    check_serialization_size(r);
+}
+
+TEST_F(RecordBatchTest, RecordSizeBytesWithNullKey) {
+    auto r = model::record(
+      model::record_attributes(0),
+      0,
+      0,
+      std::nullopt,
+      iobuf::from("value"),
+      {});
+    check_serialization_size(r);
+}
+
+TEST_F(RecordBatchTest, RecordSizeBytesWithNullValue) {
+    auto r = model::record(
+      model::record_attributes(0), 0, 0, iobuf::from("key"), std::nullopt, {});
+    check_serialization_size(r);
+}
+
+TEST_F(RecordBatchTest, RecordSizeBytesWithNullKeyAndValue) {
+    auto r = model::record(
+      model::record_attributes(0), 0, 0, std::nullopt, std::nullopt, {});
+    check_serialization_size(r);
+}
+
+TEST_F(RecordBatchTest, RecordSizeBytesWithEmptyKey) {
+    auto r = model::record(
+      model::record_attributes(0), 0, 0, iobuf{}, iobuf::from("value"), {});
+    check_serialization_size(r);
+}
+
+TEST_F(RecordBatchTest, RecordSizeBytesWithHeaders) {
+    std::vector<model::record_header> headers;
+    headers.emplace_back(3, iobuf::from("hdr"), 2, iobuf::from("hv"));
+    auto r = model::record(
+      model::record_attributes(0),
+      0,
+      0,
+      iobuf::from("key"),
+      iobuf::from("value"),
+      std::move(headers));
+    check_serialization_size(r);
+}
+
+TEST_F(RecordBatchTest, RecordSizeBytesWithNullHeaderValues) {
+    std::vector<model::record_header> headers;
+    headers.emplace_back(3, iobuf::from("hdr"), -1, iobuf{});
+    auto r = model::record(
+      model::record_attributes(0),
+      0,
+      0,
+      iobuf::from("key"),
+      iobuf::from("value"),
+      std::move(headers));
+    check_serialization_size(r);
+}
+
 class RecordBatchCompressionTest
   : public ::testing::TestWithParam<model::compression> {};
 

--- a/src/v/model/tests/record_batch_test.cc
+++ b/src/v/model/tests/record_batch_test.cc
@@ -111,6 +111,38 @@ TEST_F(RecordBatchTest, TestCorruptedRecordBytes) {
     EXPECT_THROW(f.get(), std::out_of_range);
 }
 
+namespace {
+void check_parse_record_metadata(bool fully_parse) {
+    constexpr int num_records = 10;
+    auto b = model::test::make_random_batch(
+      model::offset(0), num_records, false);
+
+    std::vector<std::pair<int64_t, int32_t>> expected;
+    auto it = model::record_batch_iterator::create(b);
+    while (it.has_next()) {
+        auto r = it.next();
+        expected.emplace_back(r.timestamp_delta(), r.offset_delta());
+    }
+    ASSERT_EQ(expected.size(), num_records);
+
+    auto parser = iobuf_const_parser(b.data());
+    for (int i = 0; i < num_records; ++i) {
+        auto r = model::parse_record_metadata_from_buffer(parser, fully_parse);
+        EXPECT_EQ(r.timestamp_delta(), expected[i].first);
+        EXPECT_EQ(r.offset_delta(), expected[i].second);
+    }
+    EXPECT_EQ(parser.bytes_left(), 0);
+}
+} // namespace
+
+TEST_F(RecordBatchTest, ParseRecordMetadataSkipFields) {
+    check_parse_record_metadata(false);
+}
+
+TEST_F(RecordBatchTest, ParseRecordMetadataFullParse) {
+    check_parse_record_metadata(true);
+}
+
 class RecordBatchCompressionTest
   : public ::testing::TestWithParam<model::compression> {};
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
`model::record_batch::for_each_record` internally copies all data in each record. This really isn't needed or wanted in batch validation. Instead all that is really needed is the timestamp and offset deltas of each record. This PR changes the produce batch validation path to just parse out these two fields of each record and skip over everything else.

Before this PR:
```
    | test                                       |     iters |           runtime |    allocs |     tasks |      inst |    cycles |
    | -                                          |        -: |                -: |        -: |        -: |        -: |        -: |
    | produce_partition_fixture.1_submitted      |      1298 |  155.92µs ± 0.00% |   206.002 |     0.000 | 1138717.0 |  839553.3 |
    | produce_partition_fixture.1_KiB_submitted  |        99 |  170.12µs ± 0.00% |   206.030 |     0.000 | 1196613.3 |  904472.8 |
    | produce_partition_fixture.4_KiB_submitted  |        27 |  175.35µs ± 0.00% |   206.148 |     0.000 | 1221996.9 |  934508.4 |
    | produce_partition_fixture.8_KiB_submitted  |        14 |  184.96µs ± 0.00% |   206.071 |     0.000 | 1255062.4 |  985105.4 |
    | produce_partition_fixture.1_dispatched     |      1303 |  207.89µs ± 0.00% |   264.068 |    23.038 | 1333748.1 | 1121835.2 |
    | produce_partition_fixture.1_KiB_dispatched |        99 |  243.84µs ± 0.00% |   462.061 |    23.000 | 1604919.2 | 1297880.6 |
    | produce_partition_fixture.4_KiB_dispatched |        27 |  249.86µs ± 0.00% |   462.185 |    23.000 | 1629563.6 | 1331322.7 |
    | produce_partition_fixture.8_KiB_dispatched |        14 |  260.99µs ± 0.00% |   462.929 |    23.143 | 1680685.2 | 1388548.6 |
    | produce_partition_fixture.1_produced       |      1304 |  404.47µs ± 0.00% |   396.669 |   129.457 | 2189375.1 | 2115771.1 |
    | produce_partition_fixture.1_KiB_produced   |        99 |  704.31µs ± 0.00% |   910.788 |   402.960 | 4018930.1 | 3496713.7 |
    | produce_partition_fixture.4_KiB_produced   |        27 |    1.01ms ± 0.00% |  1216.296 |   626.926 | 5405753.9 | 4654244.5 |
    | produce_partition_fixture.8_KiB_produced   |        14 |    1.43ms ± 0.00% |  1622.429 |   923.286 | 7287018.4 | 6180247.2 |
```

After this PR:
```
    | test                                       |     iters |           runtime |    allocs |     tasks |      inst |    cycles |
    | -                                          |        -: |                -: |        -: |        -: |        -: |        -: |
    | produce_partition_fixture.1_submitted      |      1467 |   66.97µs ± 0.00% |     6.000 |     0.000 | 411005.25 |  355761.6 |
    | produce_partition_fixture.1_KiB_submitted  |        94 |   76.23µs ± 0.00% |     6.000 |     0.000 | 450017.20 |  398133.1 |
    | produce_partition_fixture.4_KiB_submitted  |        27 |   76.23µs ± 0.00% |     6.000 |     0.000 | 450017.22 |  400184.3 |
    | produce_partition_fixture.8_KiB_submitted  |        14 |   81.09µs ± 0.00% |     6.000 |     0.000 | 460517.50 |  415534.4 |
    | produce_partition_fixture.1_dispatched     |      1466 |  118.17µs ± 0.00% |    64.005 |    23.000 | 604144.00 |  635594.0 |
    | produce_partition_fixture.1_KiB_dispatched |        98 |  144.28µs ± 0.00% |   262.000 |    23.000 | 852617.63 |  766608.1 |
    | produce_partition_fixture.4_KiB_dispatched |        27 |  147.39µs ± 0.00% |   262.000 |    23.000 | 854440.44 |  778284.8 |
    | produce_partition_fixture.8_KiB_dispatched |        14 |  150.64µs ± 0.00% |   262.000 |    23.000 | 863854.14 |  797258.4 |
    | produce_partition_fixture.1_produced       |      1465 |  314.59µs ± 0.00% |   197.066 |   129.668 | 1461883.0 | 1630931.5 |
    | produce_partition_fixture.1_KiB_produced   |       100 |  644.00µs ± 0.00% |   706.590 |   401.140 | 3265578.4 | 2971754.3 |
    | produce_partition_fixture.4_KiB_produced   |        27 |  914.66µs ± 0.00% |  1019.148 |   628.778 | 4655887.0 | 4149024.8 |
    | produce_partition_fixture.8_KiB_produced   |        14 |    1.39ms ± 0.00% |  1422.000 |   923.857 | 6873481.9 | 6006453.5 |
```
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none 
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
