### PR TITLE
schema_registry: add wildcard subject prefix support in get_subjects 

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -682,6 +682,7 @@
           },
           {
             "name": "subjectPrefix",
+            "description": "If specified, only return subjects that start with the given prefix. A plain prefix (e.g. \"my-\") matches subjects in the default context. A context-qualified prefix \":.<context>:<prefix>\" (e.g. \":.my-context:my-\") matches within a specific context. The wildcard context \":*:<prefix>\" (e.g. \":*:my-\") matches across all contexts. Use just the context qualifier (e.g. \":.my-context:\" or \":*:\") to list all subjects in a context.",
             "in": "query",
             "required": false,
             "type": "string"

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -181,7 +181,7 @@ public:
     ///\brief Return a list of subjects.
     chunked_vector<context_subject> get_subjects(
       include_deleted inc_del,
-      const std::optional<ss::sstring>& subject_prefix = std::nullopt) const {
+      std::optional<std::string_view> subject_prefix = std::nullopt) const {
         chunked_vector<context_subject> res;
         res.reserve(_subjects.size());
 

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -184,18 +184,26 @@ public:
       const std::optional<ss::sstring>& subject_prefix = std::nullopt) const {
         chunked_vector<context_subject> res;
         res.reserve(_subjects.size());
-        for (const auto& ctx_sub : _subjects) {
-            if (inc_del || !ctx_sub.second.deleted) {
-                auto has_version = std::ranges::any_of(
-                  ctx_sub.second.versions,
-                  [inc_del](const auto& v) { return inc_del || !v.deleted; });
-                if (
-                  has_version
-                  && ctx_sub.first.starts_with(subject_prefix.value_or(""))) {
-                    res.push_back(ctx_sub.first);
-                }
-            }
-        }
+
+        auto matching_subject_names
+          = _subjects | std::views::filter([inc_del](const auto& s) {
+                return inc_del || !s.second.deleted;
+            })
+            | std::views::filter([inc_del](const auto& s) {
+                  return std::ranges::any_of(
+                    s.second.versions,
+                    [inc_del](const auto& v) { return inc_del || !v.deleted; });
+              })
+            | std::views::filter([&](const auto& s) {
+                  if (!subject_prefix.has_value()) {
+                      return true;
+                  }
+                  return s.first.starts_with(subject_prefix.value());
+              })
+            | std::views::keys;
+
+        std::ranges::copy(matching_subject_names, std::back_inserter(res));
+
         return res;
     }
 

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -187,14 +187,20 @@ public:
         res.reserve(_subjects.size());
 
         constexpr std::string_view WILDCARD_CTX{":*:"};
+        constexpr std::string_view DEFAULT_CTX{":.:"};
         const auto prefix_has_wildcard_ctx = subject_prefix.has_value()
                                              && subject_prefix->starts_with(
                                                WILDCARD_CTX);
+        const auto prefix_has_default_ctx = subject_prefix.has_value()
+                                            && subject_prefix->starts_with(
+                                              DEFAULT_CTX);
 
+        // If the prefix has a wildcard or qualified default context, strip it
+        // for matching purposes
         if (prefix_has_wildcard_ctx) {
-            // If the prefix has a wildcard context, strip the wildcard context
-            // from the prefix for matching purposes
             subject_prefix = subject_prefix->substr(WILDCARD_CTX.size());
+        } else if (prefix_has_default_ctx) {
+            subject_prefix = subject_prefix->substr(DEFAULT_CTX.size());
         }
 
         auto matching_subject_names
@@ -215,6 +221,13 @@ public:
                       // Wildcard context prefix: match subjects across all
                       // contexts by subject name prefix
                       return s.first.sub().starts_with(subject_prefix.value());
+                  } else if (prefix_has_default_ctx) {
+                      // Qualified default context prefix: match only against
+                      // subjects in the default context, which have no context
+                      // prefix in their name
+                      return s.first.ctx == default_context
+                             && s.first.sub().starts_with(
+                               subject_prefix.value());
                   } else {
                       return s.first.starts_with(subject_prefix.value());
                   }
@@ -227,7 +240,9 @@ public:
           srlog.trace,
           "Listing subjects with prefix=\"{}\", mode={}, matched={} subjects",
           original_prefix.value_or("(none)"),
-          prefix_has_wildcard_ctx ? "wildcard" : "normal",
+          (prefix_has_wildcard_ctx  ? "wildcard"
+           : prefix_has_default_ctx ? "default_ctx"
+                                    : "normal"),
           res.size());
 
         return res;

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -182,8 +182,20 @@ public:
     chunked_vector<context_subject> get_subjects(
       include_deleted inc_del,
       std::optional<std::string_view> subject_prefix = std::nullopt) const {
+        const auto original_prefix = subject_prefix;
         chunked_vector<context_subject> res;
         res.reserve(_subjects.size());
+
+        constexpr std::string_view WILDCARD_CTX{":*:"};
+        const auto prefix_has_wildcard_ctx = subject_prefix.has_value()
+                                             && subject_prefix->starts_with(
+                                               WILDCARD_CTX);
+
+        if (prefix_has_wildcard_ctx) {
+            // If the prefix has a wildcard context, strip the wildcard context
+            // from the prefix for matching purposes
+            subject_prefix = subject_prefix->substr(WILDCARD_CTX.size());
+        }
 
         auto matching_subject_names
           = _subjects | std::views::filter([inc_del](const auto& s) {
@@ -198,11 +210,25 @@ public:
                   if (!subject_prefix.has_value()) {
                       return true;
                   }
-                  return s.first.starts_with(subject_prefix.value());
+
+                  if (prefix_has_wildcard_ctx) {
+                      // Wildcard context prefix: match subjects across all
+                      // contexts by subject name prefix
+                      return s.first.sub().starts_with(subject_prefix.value());
+                  } else {
+                      return s.first.starts_with(subject_prefix.value());
+                  }
               })
             | std::views::keys;
 
         std::ranges::copy(matching_subject_names, std::back_inserter(res));
+
+        vlog(
+          srlog.trace,
+          "Listing subjects with prefix=\"{}\", mode={}, matched={} subjects",
+          original_prefix.value_or("(none)"),
+          prefix_has_wildcard_ctx ? "wildcard" : "normal",
+          res.size());
 
         return res;
     }

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -505,25 +505,22 @@ BOOST_AUTO_TEST_CASE(test_store_get_subjects_prefix) {
       std::ranges::contains(
         subjects, pps::context_subject{ctx_other, pps::subject{"banana"}}));
 
-    // TODO: this portion is disabled because the current implementation of
-    // get_subjects does not support explicit default context prefix matching.
-    // Once implemented, re-enable this portion of the test.
-    // // Explicit default context prefix ":.:" matches all default context
-    // // subjects
-    // subjects = s.get_subjects(pps::include_deleted::no, ":.:");
-    // BOOST_REQUIRE_EQUAL(subjects.size(), 3);
-    // BOOST_REQUIRE(
-    //   std::ranges::contains(
-    //     subjects,
-    //     pps::context_subject{pps::default_context, pps::subject{"apple"}}));
-    // BOOST_REQUIRE(
-    //   std::ranges::contains(
-    //     subjects,
-    //     pps::context_subject{pps::default_context, pps::subject{"app"}}));
-    // BOOST_REQUIRE(
-    //   std::ranges::contains(
-    //     subjects,
-    //     pps::context_subject{pps::default_context, pps::subject{"banana"}}));
+    // Explicit default context prefix ":.:" matches all default context
+    // subjects
+    subjects = s.get_subjects(pps::include_deleted::no, ":.:");
+    BOOST_REQUIRE_EQUAL(subjects.size(), 3);
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects,
+        pps::context_subject{pps::default_context, pps::subject{"apple"}}));
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects,
+        pps::context_subject{pps::default_context, pps::subject{"app"}}));
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects,
+        pps::context_subject{pps::default_context, pps::subject{"banana"}}));
 
     // Prefix "app" matches default context "apple" and "app"
     subjects = s.get_subjects(pps::include_deleted::no, "app");

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -575,6 +575,54 @@ BOOST_AUTO_TEST_CASE(test_store_get_subjects_prefix) {
     // Prefix with no matches
     subjects = s.get_subjects(pps::include_deleted::no, "zzz");
     BOOST_REQUIRE(subjects.empty());
+
+    // Wildcard prefix ":*:app" matches subjects named "app*" in all contexts
+    subjects = s.get_subjects(pps::include_deleted::no, ":*:app");
+    BOOST_REQUIRE_EQUAL(subjects.size(), 4);
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects,
+        pps::context_subject{pps::default_context, pps::subject{"apple"}}));
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects,
+        pps::context_subject{pps::default_context, pps::subject{"app"}}));
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects, pps::context_subject{ctx_test, pps::subject{"apple"}}));
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects, pps::context_subject{ctx_other, pps::subject{"apple"}}));
+
+    // Wildcard prefix ":*:apple" matches exact name "apple" across contexts
+    subjects = s.get_subjects(pps::include_deleted::no, ":*:apple");
+    BOOST_REQUIRE_EQUAL(subjects.size(), 3);
+
+    // Wildcard prefix ":*:banana" matches "banana" in default and .other
+    subjects = s.get_subjects(pps::include_deleted::no, ":*:banana");
+    BOOST_REQUIRE_EQUAL(subjects.size(), 2);
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects,
+        pps::context_subject{pps::default_context, pps::subject{"banana"}}));
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects, pps::context_subject{ctx_other, pps::subject{"banana"}}));
+
+    // Wildcard prefix ":*:avocado" matches only .test context
+    subjects = s.get_subjects(pps::include_deleted::no, ":*:avocado");
+    BOOST_REQUIRE_EQUAL(subjects.size(), 1);
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects, pps::context_subject{ctx_test, pps::subject{"avocado"}}));
+
+    // Wildcard prefix ":*:" with empty subject prefix matches all subjects
+    subjects = s.get_subjects(pps::include_deleted::no, ":*:");
+    BOOST_REQUIRE_EQUAL(subjects.size(), 7);
+
+    // Wildcard prefix with no matches
+    subjects = s.get_subjects(pps::include_deleted::no, ":*:zzz");
+    BOOST_REQUIRE(subjects.empty());
 }
 
 BOOST_AUTO_TEST_CASE(test_store_global_compat) {

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -448,6 +448,135 @@ BOOST_AUTO_TEST_CASE(test_store_get_subjects) {
     BOOST_REQUIRE_EQUAL(s.get_subjects(pps::include_deleted::yes).size(), 0);
 }
 
+BOOST_AUTO_TEST_CASE(test_store_get_subjects_prefix) {
+    pps::store s;
+
+    const auto ctx_test = pps::context{".test"};
+    const auto ctx_other = pps::context{".other"};
+
+    // Insert subjects across multiple contexts
+    s.insert(
+      {pps::context_subject{pps::default_context, pps::subject{"apple"}},
+       string_def0.share()});
+    s.insert(
+      {pps::context_subject{pps::default_context, pps::subject{"app"}},
+       int_def0.share()});
+    s.insert(
+      {pps::context_subject{pps::default_context, pps::subject{"banana"}},
+       string_def0.share()});
+    s.insert(
+      {pps::context_subject{ctx_test, pps::subject{"apple"}},
+       string_def0.share()});
+    s.insert(
+      {pps::context_subject{ctx_test, pps::subject{"avocado"}},
+       int_def0.share()});
+    s.insert(
+      {pps::context_subject{ctx_other, pps::subject{"apple"}},
+       string_def0.share()});
+    s.insert(
+      {pps::context_subject{ctx_other, pps::subject{"banana"}},
+       int_def0.share()});
+
+    // No prefix returns all subjects across all contexts
+    auto subjects = s.get_subjects(pps::include_deleted::no);
+    BOOST_REQUIRE_EQUAL(subjects.size(), 7);
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects,
+        pps::context_subject{pps::default_context, pps::subject{"apple"}}));
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects,
+        pps::context_subject{pps::default_context, pps::subject{"app"}}));
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects,
+        pps::context_subject{pps::default_context, pps::subject{"banana"}}));
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects, pps::context_subject{ctx_test, pps::subject{"apple"}}));
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects, pps::context_subject{ctx_test, pps::subject{"avocado"}}));
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects, pps::context_subject{ctx_other, pps::subject{"apple"}}));
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects, pps::context_subject{ctx_other, pps::subject{"banana"}}));
+
+    // TODO: this portion is disabled because the current implementation of
+    // get_subjects does not support explicit default context prefix matching.
+    // Once implemented, re-enable this portion of the test.
+    // // Explicit default context prefix ":.:" matches all default context
+    // // subjects
+    // subjects = s.get_subjects(pps::include_deleted::no, ":.:");
+    // BOOST_REQUIRE_EQUAL(subjects.size(), 3);
+    // BOOST_REQUIRE(
+    //   std::ranges::contains(
+    //     subjects,
+    //     pps::context_subject{pps::default_context, pps::subject{"apple"}}));
+    // BOOST_REQUIRE(
+    //   std::ranges::contains(
+    //     subjects,
+    //     pps::context_subject{pps::default_context, pps::subject{"app"}}));
+    // BOOST_REQUIRE(
+    //   std::ranges::contains(
+    //     subjects,
+    //     pps::context_subject{pps::default_context, pps::subject{"banana"}}));
+
+    // Prefix "app" matches default context "apple" and "app"
+    subjects = s.get_subjects(pps::include_deleted::no, "app");
+    BOOST_REQUIRE_EQUAL(subjects.size(), 2);
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects,
+        pps::context_subject{pps::default_context, pps::subject{"apple"}}));
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects,
+        pps::context_subject{pps::default_context, pps::subject{"app"}}));
+
+    // Prefix "apple" matches only default context "apple"
+    subjects = s.get_subjects(pps::include_deleted::no, "apple");
+    BOOST_REQUIRE_EQUAL(subjects.size(), 1);
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects,
+        pps::context_subject{pps::default_context, pps::subject{"apple"}}));
+
+    // Prefix ":.test:" matches all subjects in the .test context
+    subjects = s.get_subjects(pps::include_deleted::no, ":.test:");
+    BOOST_REQUIRE_EQUAL(subjects.size(), 2);
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects, pps::context_subject{ctx_test, pps::subject{"apple"}}));
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects, pps::context_subject{ctx_test, pps::subject{"avocado"}}));
+
+    // Prefix ":.test:app" matches only .test context "apple"
+    subjects = s.get_subjects(pps::include_deleted::no, ":.test:app");
+    BOOST_REQUIRE_EQUAL(subjects.size(), 1);
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects, pps::context_subject{ctx_test, pps::subject{"apple"}}));
+
+    // Prefix ":.other:" matches all subjects in the .other context
+    subjects = s.get_subjects(pps::include_deleted::no, ":.other:");
+    BOOST_REQUIRE_EQUAL(subjects.size(), 2);
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects, pps::context_subject{ctx_other, pps::subject{"apple"}}));
+    BOOST_REQUIRE(
+      std::ranges::contains(
+        subjects, pps::context_subject{ctx_other, pps::subject{"banana"}}));
+
+    // Prefix with no matches
+    subjects = s.get_subjects(pps::include_deleted::no, "zzz");
+    BOOST_REQUIRE(subjects.empty());
+}
+
 BOOST_AUTO_TEST_CASE(test_store_global_compat) {
     // Setting the retrieving global compatibility should be allowed multiple
     // times

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -211,7 +211,7 @@ struct context_subject {
         return fmt::format_to(it, ":{}:{}", ctx, sub);
     }
 
-    bool starts_with(const ss::sstring& prefix) const {
+    bool starts_with(std::string_view prefix) const {
         return to_string().starts_with(prefix);
     }
 


### PR DESCRIPTION
This PR adds support for the `:*:` wildcard context prefix, which matches against just the subject name across all contexts (e.g. `:*:app` returns all subjects starting with "app" regardless of context). This enables cross-context subject discovery.

Additionally, this PR fixes handling of the qualified default context prefix `":.:"`, which was previously not matched correctly. If the prefix starts with a qualified default context `":.:", it is stripped before matching so that default-context queries resolve as expected.

Includes unit tests covering prefix filtering across default and non-default contexts, wildcard context matching, and qualified default context prefix handling.

Fixes [CORE-15195](https://redpandadata.atlassian.net/browse/CORE-15195)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-15195]: https://redpandadata.atlassian.net/browse/CORE-15195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ