### PR TITLE
[v25.3.x] [CORE-15501] kafka/client: replace circular buffer with chunked equivalent

### DIFF
--- a/src/v/kafka/client/BUILD
+++ b/src/v/kafka/client/BUILD
@@ -326,6 +326,7 @@ redpanda_cc_library(
         "//src/v/bytes:iostream",
         "//src/v/bytes:scattered_message",
         "//src/v/config",
+        "//src/v/container:chunked_circular_buffer",
         "//src/v/container:chunked_hash_map",
         "//src/v/container:chunked_vector",
         "//src/v/hashing:murmur",

--- a/src/v/kafka/client/produce_batcher.h
+++ b/src/v/kafka/client/produce_batcher.h
@@ -13,11 +13,11 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "base/seastarx.h"
+#include "container/chunked_circular_buffer.h"
 #include "kafka/protocol/produce.h"
 #include "model/fundamental.h"
 #include "storage/record_batch_builder.h"
 
-#include <seastar/core/circular_buffer.hh>
 #include <seastar/core/coroutine.hh>
 
 namespace kafka::client {
@@ -124,8 +124,8 @@ private:
     model::compression _c;
     storage::record_batch_builder _builder;
     // TODO(Ben): Maybe these should be a queue for backpressure
-    ss::circular_buffer<client_context> _client_reqs;
-    ss::circular_buffer<broker_context> _broker_reqs;
+    chunked_circular_buffer<client_context> _client_reqs;
+    chunked_circular_buffer<broker_context> _broker_reqs;
 };
 
 } // namespace kafka::client


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/29575
