### PR TITLE
serde: improve forwarding to avoid unnecessary copies

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/leader_router.cc
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.cc
@@ -440,9 +440,7 @@ leader_router::metastore_partition(const model::topic_id_partition& tp) const {
     if (!md) {
         return std::nullopt;
     }
-    iobuf temp;
-    write(temp, tp);
-    auto bytes = iobuf_to_bytes(temp);
+    auto bytes = iobuf_to_bytes(serde::to_iobuf(tp));
     auto partition = murmur2(bytes.data(), bytes.size())
                      % md->get().get_configuration().partition_count;
     return model::partition_id{static_cast<int32_t>(partition)};

--- a/src/v/cluster/topic_configuration.cc
+++ b/src/v/cluster/topic_configuration.cc
@@ -75,7 +75,7 @@ storage::ntp_config topic_configuration::make_ntp_config(
       remote_rev};
 }
 
-void topic_configuration::serde_write(iobuf& out) {
+void topic_configuration::serde_write(iobuf& out) const {
     using serde::write;
     write(out, tp_ns);
     write(out, partition_count);

--- a/src/v/cluster/topic_configuration.h
+++ b/src/v/cluster/topic_configuration.h
@@ -92,7 +92,7 @@ struct topic_configuration
 
     topic_properties properties;
 
-    void serde_write(iobuf& out);
+    void serde_write(iobuf& out) const;
     void serde_read(iobuf_parser& in, const serde::header& h);
 
     friend std::ostream& operator<<(std::ostream&, const topic_configuration&);

--- a/src/v/container/interval_set.h
+++ b/src/v/container/interval_set.h
@@ -117,7 +117,7 @@ public:
         using serde::read_nested;
         return read_nested(in, is.set_, bytes_left_limit);
     }
-    friend void write(iobuf& out, interval_set is) {
+    friend void write_nested(iobuf& out, interval_set is) {
         using serde::write;
         return write(out, std::move(is.set_));
     }

--- a/src/v/datalake/coordinator/frontend.cc
+++ b/src/v/datalake/coordinator/frontend.cc
@@ -246,9 +246,7 @@ frontend::coordinator_partition(const model::topic& topic) const {
     if (!md) {
         return std::nullopt;
     }
-    iobuf temp;
-    write(temp, topic);
-    auto bytes = iobuf_to_bytes(temp);
+    auto bytes = iobuf_to_bytes(serde::to_iobuf(topic));
     auto partition = murmur2(bytes.data(), bytes.size())
                      % md->get().get_configuration().partition_count;
     return model::partition_id{static_cast<int32_t>(partition)};

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -224,7 +224,7 @@ public:
         return read_nested(in, t._value, bytes_left_limit);
     }
 
-    friend void write(iobuf& out, topic t) {
+    friend void write_nested(iobuf& out, topic t) {
         using serde::write;
         return write(out, std::move(t._value));
     }
@@ -369,7 +369,7 @@ struct topic_partition {
         read_nested(in, tp.partition, bytes_left_limit);
     }
 
-    friend void write(iobuf& out, topic_partition tp) {
+    friend void write_nested(iobuf& out, topic_partition tp) {
         using serde::write;
 
         write(out, std::move(tp.topic));
@@ -413,7 +413,7 @@ struct ntp {
         read_nested(in, ntp.tp, bytes_left_limit);
     }
 
-    friend void write(iobuf& out, ntp ntp) {
+    friend void write_nested(iobuf& out, ntp ntp) {
         using serde::write;
 
         write(out, std::move(ntp.ns));
@@ -605,7 +605,7 @@ struct topic_id_partition {
         read_nested(in, tp.partition, bytes_left_limit);
     }
 
-    friend void write(iobuf& out, topic_id_partition tp) {
+    friend void write_nested(iobuf& out, topic_id_partition tp) {
         using serde::write;
 
         write(out, tp.topic_id);

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -269,7 +269,7 @@ struct broker_shard {
         return H::combine(std::move(h), s.node_id(), s.shard);
     }
 
-    friend void write(iobuf& out, broker_shard bs) {
+    friend void write_nested(iobuf& out, broker_shard bs) {
         using serde::write;
         write(out, bs.node_id);
         write(out, bs.shard);
@@ -370,7 +370,7 @@ struct topic_namespace {
         return H::combine(std::move(h), tp_ns.ns, tp_ns.tp);
     }
 
-    friend void write(iobuf& out, topic_namespace t) {
+    friend void write_nested(iobuf& out, topic_namespace t) {
         using serde::write;
         write(out, std::move(t.ns));
         write(out, std::move(t.tp));
@@ -665,7 +665,7 @@ public:
 
     bool operator==(const iceberg_mode&) const = default;
 
-    friend void write(iobuf& out, const iceberg_mode& m);
+    friend void write_nested(iobuf& out, const iceberg_mode& m);
 
     friend void read_nested(
       iobuf_parser& in, iceberg_mode& m, const std::size_t bytes_left_limit);

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -53,7 +53,7 @@ void read_nested(
     serde::read_nested(in, ts._v, bytes_left_limit);
 }
 
-void write(iobuf& out, timestamp ts) { serde::write(out, ts._v); }
+void write_nested(iobuf& out, timestamp ts) { serde::write(out, ts._v); }
 
 std::ostream& operator<<(std::ostream& os, const topic_partition_view& tp) {
     fmt::print(os, "{{{}/{}}}", tp.topic(), tp.partition());
@@ -614,7 +614,7 @@ iceberg_mode iceberg_mode::key_value
 iceberg_mode iceberg_mode::value_schema_id_prefix
   = iceberg_mode::make<iceberg_mode::variant::value_schema_id_prefix>();
 
-void write(iobuf& out, const iceberg_mode& m) {
+void write_nested(iobuf& out, const iceberg_mode& m) {
     using serde::write;
     write(out, m.kind());
     if (m.kind() == iceberg_mode::variant::value_schema_latest) {

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -423,7 +423,7 @@ public:
         attrs._attributes = serde::read_nested<uint64_t>(in, bytes_left_limit);
     }
 
-    friend inline void write(iobuf& out, record_batch_attributes el) {
+    friend inline void write_nested(iobuf& out, record_batch_attributes el) {
         serde::write(out, static_cast<uint64_t>(el._attributes.to_ullong()));
     }
 

--- a/src/v/model/timestamp.h
+++ b/src/v/model/timestamp.h
@@ -83,7 +83,7 @@ public:
     friend std::ostream& operator<<(std::ostream&, timestamp);
 
     // ADL helpers for interfacing with the serde library.
-    friend void write(iobuf& out, timestamp ts);
+    friend void write_nested(iobuf& out, timestamp ts);
     friend void
     read_nested(iobuf_parser& in, timestamp& ts, const size_t bytes_left_limit);
 

--- a/src/v/model/transform.cc
+++ b/src/v/model/transform.cc
@@ -173,7 +173,7 @@ std::ostream& operator<<(std::ostream& os, const transform_metadata& meta) {
 
 void transform_metadata::serde_write(iobuf& out) const {
     serde::write(out, name);
-    write(out, input_topic);
+    serde::write(out, input_topic);
     serde::write(out, output_topics);
     serde::write(out, environment);
     serde::write(out, uuid);

--- a/src/v/raft/heartbeats.h
+++ b/src/v/raft/heartbeats.h
@@ -282,7 +282,7 @@ struct full_heartbeat_reply {
         read_nested(in, req.data, bytes_left_limit);
     }
 
-    friend inline void write(iobuf& out, full_heartbeat_reply req) {
+    friend inline void write_nested(iobuf& out, full_heartbeat_reply req) {
         using serde::write;
         write(out, req.group);
         write(out, req.result);
@@ -307,7 +307,7 @@ struct full_heartbeat {
         read_nested(in, fh.group, bytes_left_limit);
         read_nested(in, fh.data, bytes_left_limit);
     }
-    friend inline void write(iobuf& out, full_heartbeat fh) {
+    friend inline void write_nested(iobuf& out, full_heartbeat fh) {
         using serde::write;
         write(out, fh.group);
         write(out, fh.data);

--- a/src/v/serde/envelope_for_each_field.h
+++ b/src/v/serde/envelope_for_each_field.h
@@ -12,6 +12,7 @@
 #include "serde/envelope.h"
 
 #include <tuple>
+#include <utility>
 
 namespace serde {
 
@@ -20,14 +21,25 @@ constexpr inline auto envelope_to_tuple(T&& t) {
     return t.serde_fields();
 }
 
+template<typename T>
+constexpr inline auto envelope_to_tuple(const T& t) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    return std::apply(
+      [](auto&... args) { return std::tie(std::as_const(args)...); },
+      const_cast<T&>(t).serde_fields());
+}
+
 template<typename Fn>
 concept check_for_more_fn = requires(Fn&& fn, int& f) {
     { fn(f) } -> std::convertible_to<bool>;
 };
 
-template<is_envelope T, typename Fn>
-inline auto envelope_for_each_field(T& t, Fn&& fn) {
-    std::apply([&](auto&&... args) { (fn(args), ...); }, envelope_to_tuple(t));
+template<typename T, typename Fn>
+requires is_envelope<std::decay_t<T>>
+inline auto envelope_for_each_field(T&& t, Fn&& fn) {
+    std::apply(
+      [&](auto&&... args) { (fn(std::forward_like<T>(args)), ...); },
+      envelope_to_tuple(t));
 }
 
 template<is_envelope T, check_for_more_fn Fn>

--- a/src/v/serde/rw/array.h
+++ b/src/v/serde/rw/array.h
@@ -21,12 +21,18 @@
 
 namespace serde {
 
-template<typename T, std::size_t Size>
-void tag_invoke(tag_t<write_tag>, iobuf& out, std::array<T, Size> t) {
-    static_assert(t.size() <= std::numeric_limits<serde_size_t>::max());
+template<typename A>
+requires requires {
+    []<typename T, std::size_t Size>(std::array<T, Size>) {
+    }(std::declval<std::remove_cvref_t<A>>());
+}
+void tag_invoke(tag_t<write_tag>, iobuf& out, A&& t) {
+    static_assert(
+      std::tuple_size_v<std::remove_cvref_t<A>>
+      <= std::numeric_limits<serde_size_t>::max());
     write(out, static_cast<serde_size_t>(t.size()));
     for (auto& el : t) {
-        write(out, el);
+        write(out, std::forward_like<A>(el));
     }
 }
 

--- a/src/v/serde/rw/bytes.h
+++ b/src/v/serde/rw/bytes.h
@@ -14,7 +14,7 @@
 
 namespace serde {
 
-inline void tag_invoke(tag_t<write_tag>, iobuf& out, bytes t) {
+inline void tag_invoke(tag_t<write_tag>, iobuf& out, const bytes& t) {
     write<serde_size_t>(out, t.size());
     out.append(t.data(), t.size());
 }

--- a/src/v/serde/rw/chrono.h
+++ b/src/v/serde/rw/chrono.h
@@ -114,7 +114,7 @@ void tag_invoke(
 }
 
 template<typename Clock, typename Duration>
-void write(iobuf&, std::chrono::time_point<Clock, Duration> t) {
+void write_nested(iobuf&, std::chrono::time_point<Clock, Duration> t) {
     static_assert(
       base::unsupported_type<decltype(t)>::value,
       "Time point serialization is risky and can have unintended "

--- a/src/v/serde/rw/envelope.h
+++ b/src/v/serde/rw/envelope.h
@@ -94,7 +94,7 @@ void tag_invoke(
 
 template<typename T>
 requires is_envelope<std::decay_t<T>>
-void tag_invoke(tag_t<write_tag>, iobuf& out, T t) {
+void tag_invoke(tag_t<write_tag>, iobuf& out, T&& t) {
     using Type = std::decay_t<T>;
 
     write(out, Type::redpanda_serde_version);
@@ -113,7 +113,7 @@ void tag_invoke(tag_t<write_tag>, iobuf& out, T t) {
         t.serde_write(out);
     } else {
         envelope_for_each_field(
-          t, [&out](auto& f) { write(out, std::move(f)); });
+          t, [&out](auto& f) { write(out, std::forward_like<T>(f)); });
     }
 
     const auto written_size = out.size_bytes() - size_before;

--- a/src/v/serde/rw/map.h
+++ b/src/v/serde/rw/map.h
@@ -52,19 +52,20 @@ void tag_invoke(
     }
 }
 
-void tag_invoke(tag_t<write_tag>, iobuf& out, Map auto t) {
-    using Type = std::decay_t<decltype(t)>;
+template<typename M>
+requires Map<std::decay_t<M>>
+void tag_invoke(tag_t<write_tag>, iobuf& out, M&& t) {
     if (unlikely(t.size() > std::numeric_limits<serde_size_t>::max())) {
         throw serde_exception(fmt_with_ctx(
           ssx::sformat,
           "serde: {} size {} exceeds serde_size_t",
-          type_str<Type>(),
+          type_str<std::decay_t<M>>(),
           t.size()));
     }
     write(out, static_cast<serde_size_t>(t.size()));
     for (auto& v : t) {
         write(out, v.first);
-        write(out, std::move(v.second));
+        write(out, std::forward_like<M>(v.second));
     }
 }
 

--- a/src/v/serde/rw/optional.h
+++ b/src/v/serde/rw/optional.h
@@ -15,11 +15,14 @@
 
 namespace serde {
 
-template<typename T>
-void tag_invoke(tag_t<write_tag>, iobuf& out, std::optional<T> t) {
+template<typename O>
+requires requires {
+    []<typename T>(std::optional<T>) {}(std::declval<std::remove_cvref_t<O>>());
+}
+void tag_invoke(tag_t<write_tag>, iobuf& out, O&& t) {
     if (t) {
         write(out, true);
-        write(out, std::move(t.value()));
+        write(out, std::forward_like<O>(t.value()));
     } else {
         write(out, false);
     }

--- a/src/v/serde/rw/pair.h
+++ b/src/v/serde/rw/pair.h
@@ -11,12 +11,18 @@
 
 #include "serde/rw/rw.h"
 
+#include <utility>
+
 namespace serde {
 
-template<typename T1, typename T2>
-void tag_invoke(tag_t<write_tag>, iobuf& out, const std::pair<T1, T2>& p) {
-    write(out, p.first);
-    write(out, p.second);
+template<typename P>
+requires requires {
+    []<typename T1, typename T2>(std::pair<T1, T2>) {
+    }(std::declval<std::remove_cvref_t<P>>());
+}
+void tag_invoke(tag_t<write_tag>, iobuf& out, P&& p) {
+    write(out, std::forward_like<P>(p.first));
+    write(out, std::forward_like<P>(p.second));
 }
 
 template<typename T1, typename T2>

--- a/src/v/serde/rw/rw.h
+++ b/src/v/serde/rw/rw.h
@@ -10,11 +10,15 @@
 #pragma once
 
 #include "base/vlog.h"
+#include "bytes/iobuf.h"
 #include "serde/read_header.h"
 #include "serde/rw/tags.h"
 #include "serde/serde_exception.h"
 #include "serde/type_str.h"
 #include "ssx/sformat.h"
+
+#include <type_traits>
+#include <utility>
 
 namespace serde {
 
@@ -57,8 +61,45 @@ std::decay_t<T> read(iobuf_parser& in) {
 }
 
 template<typename T>
-void write(iobuf& b, T x) {
-    write_tag(b, std::forward<T>(x));
+concept has_nonmember_write_nested_lv = requires(const T& t, iobuf& out) {
+    { write_nested(out, t) } -> std::same_as<void>;
+};
+
+template<typename T>
+concept has_nonmember_write_nested_rv = requires(T&& t, iobuf& out) {
+    { write_nested(out, std::move(t)) } -> std::same_as<void>;
+};
+
+template<typename T>
+concept has_nonmember_write_nested = []() consteval {
+    // `write_nested` must be defined either for both lvalue and rvalue T or for
+    // neither.
+    static_assert(
+      has_nonmember_write_nested_lv<T> == has_nonmember_write_nested_rv<T>);
+    return has_nonmember_write_nested_lv<T>;
+}();
+
+// Two functions just to be able to specify T explicitly when calling.
+template<typename T, bool IsRvalue = true>
+requires(!std::is_reference_v<T>)
+void write(iobuf& b, T&& x) {
+    if constexpr (has_nonmember_write_nested<T>) {
+        // NOLINTNEXTLINE(bugprone-move-forwarding-reference)
+        write_nested(b, std::move(x));
+    } else {
+        // NOLINTNEXTLINE(bugprone-move-forwarding-reference)
+        write_tag(b, std::move(x));
+    }
+}
+
+template<typename T, bool IsRvalue = false>
+requires(!std::is_reference_v<T>)
+void write(iobuf& b, const T& x) {
+    if constexpr (has_nonmember_write_nested<T>) {
+        write_nested(b, x);
+    } else {
+        write_tag(b, x);
+    }
 }
 
 template<typename T>

--- a/src/v/serde/rw/set.h
+++ b/src/v/serde/rw/set.h
@@ -51,7 +51,9 @@ void tag_invoke(
     }
 }
 
-void tag_invoke(tag_t<write_tag>, iobuf& out, SetNotMap auto t) {
+template<typename S>
+requires SetNotMap<std::decay_t<S>>
+void tag_invoke(tag_t<write_tag>, iobuf& out, S&& t) {
     using Type = std::decay_t<decltype(t)>;
     if (unlikely(t.size() > std::numeric_limits<serde_size_t>::max())) {
         throw serde_exception(fmt_with_ctx(

--- a/src/v/serde/rw/tristate_rw.h
+++ b/src/v/serde/rw/tristate_rw.h
@@ -14,15 +14,18 @@
 
 namespace serde {
 
-template<typename T>
-void tag_invoke(tag_t<write_tag>, iobuf& out, tristate<T> t) {
+template<typename TS>
+requires requires {
+    []<typename T>(tristate<T>) {}(std::declval<std::remove_cvref_t<TS>>());
+}
+void tag_invoke(tag_t<write_tag>, iobuf& out, TS&& t) {
     if (t.is_disabled()) {
         write<int8_t>(out, -1);
     } else if (!t.has_optional_value()) {
         write<int8_t>(out, 0);
     } else {
         write<int8_t>(out, 1);
-        write(out, std::move(t.value()));
+        write(out, std::forward_like<TS>(t.value()));
     }
 }
 

--- a/src/v/serde/rw/uuid.h
+++ b/src/v/serde/rw/uuid.h
@@ -16,7 +16,7 @@
 
 namespace serde {
 
-inline void tag_invoke(tag_t<write_tag>, iobuf& out, uuid_t t) {
+inline void tag_invoke(tag_t<write_tag>, iobuf& out, const uuid_t& t) {
     out.append(t.uuid().data, uuid_t::length);
 }
 

--- a/src/v/serde/rw/variant.h
+++ b/src/v/serde/rw/variant.h
@@ -98,14 +98,17 @@ struct variant : public std::variant<Types...> {
     using type::valueless_by_exception;
 };
 
-template<typename... T>
-void tag_invoke(tag_t<write_tag>, iobuf& out, variant<T...> v) {
+template<typename V>
+requires requires {
+    []<typename... T>(variant<T...>) {}(std::declval<std::remove_cvref_t<V>>());
+}
+void tag_invoke(tag_t<write_tag>, iobuf& out, V&& v) {
     write<size_t>(
-      out, std::variant_size_v<typename std::decay_t<decltype(v)>::type>);
+      out, std::variant_size_v<typename std::remove_cvref_t<V>::type>);
     write<size_t>(out, v.index());
     std::visit(
-      [&out]<typename V>(V&& v) { write(out, std::forward<V>(v)); },
-      std::move(v));
+      [&out]<typename T>(T&& t) { write(out, std::forward<T>(t)); },
+      std::forward<V>(v));
 }
 
 namespace detail {

--- a/src/v/serde/rw/vector.h
+++ b/src/v/serde/rw/vector.h
@@ -55,17 +55,19 @@ void tag_invoke(
     t.shrink_to_fit();
 }
 
-void tag_invoke(tag_t<write_tag>, iobuf& out, Vector auto t) {
+template<typename V>
+requires Vector<std::decay_t<V>>
+void tag_invoke(tag_t<write_tag>, iobuf& out, V&& t) {
     if (unlikely(t.size() > std::numeric_limits<serde_size_t>::max())) {
         throw serde_exception(fmt_with_ctx(
           ssx::sformat,
           "serde: {} size {} exceeds serde_size_t",
-          type_str<decltype(t)>(),
+          type_str<std::decay_t<V>>(),
           t.size()));
     }
     write(out, static_cast<serde_size_t>(t.size()));
     for (auto& el : t) {
-        write(out, std::move(el));
+        write(out, std::forward_like<V>(el));
     }
 }
 

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -58,7 +58,7 @@ struct custom_read_write {
         ++el._x;
     }
 
-    friend inline void write(iobuf& out, custom_read_write el) {
+    friend inline void write_nested(iobuf& out, custom_read_write el) {
         ++el._x;
         serde::write(out, el._x);
     }
@@ -922,6 +922,8 @@ SEASTAR_THREAD_TEST_CASE(absl_node_hash_map) {
 SEASTAR_THREAD_TEST_CASE(absl_flat_hash_map) {
     map_test<absl::flat_hash_map>();
 }
+
+SEASTAR_THREAD_TEST_CASE(chunked_hash_map_) { map_test<chunked_hash_map>(); }
 
 SEASTAR_THREAD_TEST_CASE(absl_node_hash_set) {
     set_test<absl::node_hash_set>();

--- a/src/v/storage/offset_translator_state.cc
+++ b/src/v/storage/offset_translator_state.cc
@@ -349,7 +349,7 @@ struct persisted_batch {
         serde::read_nested(in, b.length, bytes_left_limit);
     }
 
-    friend inline void write(iobuf& out, const persisted_batch& b) {
+    friend inline void write_nested(iobuf& out, const persisted_batch& b) {
         serde::write(out, b.base_offset);
         serde::write(out, b.length);
     }

--- a/src/v/utils/xid.cc
+++ b/src/v/utils/xid.cc
@@ -117,7 +117,7 @@ void read_nested(iobuf_parser& in, xid& id, const size_t bytes_left_limit) {
     serde::read_nested(in, id._data, bytes_left_limit);
 }
 
-void write(iobuf& out, xid id) { serde::write(out, id._data); }
+void write_nested(iobuf& out, xid id) { serde::write(out, id._data); }
 
 std::istream& operator>>(std::istream& i, xid& id) {
     ss::sstring s;

--- a/src/v/utils/xid.h
+++ b/src/v/utils/xid.h
@@ -81,7 +81,7 @@ public:
     friend void
     read_nested(iobuf_parser& in, xid& id, const size_t bytes_left_limit);
 
-    friend void write(iobuf& out, xid id);
+    friend void write_nested(iobuf& out, xid id);
 
     template<typename H>
     friend H AbslHashValue(H h, const xid& id) {


### PR DESCRIPTION
Make write functions for generic types accept both lvalues and rvalues and forward them correctly. Previously, many write functions took arguments by value or used std::move unconditionally, which could silently make copies or force moves on lvalues.

For correct overload resolution write functions:
- write() was split into lvalue/rvalue overloads with proper forwarding
- Customly writable types to implement write_nested() instead of write()
- These need to accept both lvalues and rvalues, potentially using separate implementations

before:
```
test                                 iters            runtime     allocs      tasks       inst     cycles
health_bench.original                   35     3.61ms ± 1.40%     34.000      0.000  7733252.1   19704363
health_bench.original_unlimited         21    23.66ms ± 5.66%    317.524      0.000  242812182  129403578
health_bench.current                    30     8.61ms ± 0.54%    654.000      0.000   68837764   47032090

test                                                                  iters            runtime     allocs      tasks       inst     cycles   overhead
node_health_report.serialize_many_partitions                            267     3.10ms ± 0.28%     86.000      0.000   61820309   16995062        0.0
node_health_report.serialize_many_topics                                119     5.98ms ± 0.35%    112.000      0.000  120400896   32761202        0.0
node_health_report.serialize_many_topics_replicated_partitions           59    11.82ms ± 0.51%    220.000      0.000  214411200   64701993        0.0
node_health_report.deserialize_many_partitions                          108     5.28ms ± 0.07%  30159.000      0.000  132842339   28902673        0.0
node_health_report.deserialize_many_topics                               55     8.96ms ± 0.05%  100063.00      0.000  224252865   49035994        0.0
node_health_report.deserialize_many_topics_replicated_partitions         28    17.75ms ± 0.09%  100063.00      0.000  435988815   97135628        0.0
```

after:
```
test                                 iters            runtime     allocs      tasks       inst     cycles
health_bench.original                   38     3.23ms ± 1.57%     34.000      0.000  7733315.5   17662028
health_bench.original_unlimited         22    22.60ms ± 3.83%    308.000      0.000  242816744  123676606
health_bench.current                    32     8.45ms ± 4.62%    654.000      0.000   68849980   46187880

test                                                                  iters            runtime     allocs      tasks       inst     cycles   overhead
node_health_report.serialize_many_partitions                            285     2.65ms ± 0.22%     86.000      0.000   51240469   14501537        0.0
node_health_report.serialize_many_topics                                136     4.36ms ± 0.29%    112.000      0.000   88796571   23865908        0.0
node_health_report.serialize_many_topics_replicated_partitions           61     9.55ms ± 0.03%    220.000      0.000  172622991   52281185        0.0
node_health_report.deserialize_many_partitions                          109     5.32ms ± 0.20%  30159.000      0.000  132855240   29112395        0.0
node_health_report.deserialize_many_topics                               57     9.17ms ± 0.09%  100063.00      0.000  224258478   50158169        0.0
node_health_report.deserialize_many_topics_replicated_partitions         28    18.00ms ± 0.03%  100063.00      0.000  435996443   98497513        0.0
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
