### PR TITLE
iceberg/json_schema: support oneOf for nullable types

### DIFF
--- a/src/v/iceberg/conversion/ir_json.cc
+++ b/src/v/iceberg/conversion/ir_json.cc
@@ -49,7 +49,12 @@ public:
     static type_set none() { return type_set{}; }
 
     void set(json_type t) { bits_.set(index(t)); }
+    void intersect(const type_set& other) { bits_ &= other.bits_; }
     bool test(json_type t) const { return bits_.test(index(t)); }
+
+    bool is_null_only() const {
+        return bits_.count() == 1 && bits_.test(index(json_type::null));
+    }
 
     /// Returns the single non-null type if exactly one is set.
     std::optional<json_type> single_non_null_type() const {
@@ -113,12 +118,56 @@ struct constraint {
 
     // Object properties, keyed by name.
     std::map<std::string, constraint> properties = {};
+    bool additional_properties_allowed = true;
 
     // Array item constraints.
     // - nullopt: no "items" keyword
     // - empty vector: "items": []
     // - non-empty: item schema(s) to validate
     std::optional<std::vector<constraint>> items = std::nullopt;
+
+    conversion_outcome<void> intersect(const constraint& other) {
+        types.intersect(other.types);
+
+        if (format.has_value() && other.format.has_value()) {
+            if (format != other.format) {
+                return conversion_exception(
+                  "Conflicting format annotations across branches");
+            }
+        } else if (other.format.has_value()) {
+            format = other.format;
+        }
+
+        if (!properties.empty() && !other.properties.empty()) {
+            return conversion_exception(
+              "Intersecting constraints with properties on both sides "
+              "is not supported");
+        } else if (!other.properties.empty()) {
+            if (!additional_properties_allowed) {
+                return conversion_exception(
+                  "additionalProperties: false conflicts with properties "
+                  "defined in another branch");
+            }
+            properties = other.properties;
+        } else if (
+          !properties.empty() && !other.additional_properties_allowed) {
+            return conversion_exception(
+              "additionalProperties: false conflicts with properties "
+              "defined in another branch");
+        }
+        additional_properties_allowed = additional_properties_allowed
+                                        && other.additional_properties_allowed;
+
+        if (items.has_value() && other.items.has_value()) {
+            return conversion_exception(
+              "Intersecting constraints with items on both sides is not "
+              "supported");
+        } else if (other.items.has_value()) {
+            items = other.items;
+        }
+
+        return outcome::success();
+    }
 };
 
 /// Context for the resolution phase.
@@ -148,6 +197,48 @@ conversion_outcome<constraint>
 collect(collect_context& ctx, const conversion::json_schema::subschema&);
 
 conversion_outcome<field_type> resolve(resolution_context&, const constraint&);
+
+// This is not full fidelity oneOf support - only T|null is supported.
+// In the general case, oneOf is a XOR over multiple schemas. For T|null
+// it is reduced to OR.
+conversion_outcome<constraint> collect_one_of_t_xor_null(
+  collect_context& ctx,
+  const conversion::json_schema::const_list_view& one_of) {
+    constexpr std::string_view unsupported_one_of_msg
+      = "oneOf keyword is supported only for exclusive T|null structures";
+    if (one_of.size() != 2) {
+        return conversion_exception(std::string{unsupported_one_of_msg});
+    }
+
+    auto c1 = collect(ctx, one_of.at(0));
+    if (c1.has_error()) {
+        return c1.error();
+    }
+    auto c2 = collect(ctx, one_of.at(1));
+    if (c2.has_error()) {
+        return c2.error();
+    }
+
+    // Accept only exclusive oneOf(T, null):
+    // - exactly one branch is null-only
+    // - the non-null branch must not include null
+    const bool c1_is_null_only = c1.value().types.is_null_only();
+    const bool c2_is_null_only = c2.value().types.is_null_only();
+
+    if (c1_is_null_only == c2_is_null_only) {
+        return conversion_exception(std::string{unsupported_one_of_msg});
+    }
+
+    const constraint& non_null_branch = c1_is_null_only ? c2.value()
+                                                        : c1.value();
+    if (non_null_branch.types.test(json_type::null)) {
+        return conversion_exception(std::string{unsupported_one_of_msg});
+    }
+
+    auto c = non_null_branch;
+    c.types.set(json_type::null);
+    return c;
+}
 
 /// Collect item constraints from a JSON Schema array.
 conversion_outcome<std::optional<std::vector<constraint>>> collect_items(
@@ -232,12 +323,14 @@ collect(collect_context& ctx, const conversion::json_schema::subschema& s) {
             c.properties[name] = std::move(prop_constraint.value());
         }
 
-        if (
-          s.additional_properties()
-          && s.additional_properties()->get().boolean_subschema() != false) {
-            return conversion_exception(
-              "Only 'false' subschema is supported "
-              "for additionalProperties keyword");
+        if (s.additional_properties()) {
+            if (s.additional_properties()->get().boolean_subschema() == false) {
+                c.additional_properties_allowed = false;
+            } else {
+                return conversion_exception(
+                  "Only 'false' subschema is supported "
+                  "for additionalProperties keyword");
+            }
         }
     }
 
@@ -248,6 +341,17 @@ collect(collect_context& ctx, const conversion::json_schema::subschema& s) {
             return items_result.error();
         }
         c.items = std::move(items_result.value());
+    }
+
+    if (!s.one_of().empty()) {
+        auto one_of_constraint = collect_one_of_t_xor_null(ctx, s.one_of());
+        if (one_of_constraint.has_error()) {
+            return one_of_constraint.error();
+        }
+        auto intersect_result = c.intersect(one_of_constraint.value());
+        if (intersect_result.has_error()) {
+            return intersect_result.error();
+        }
     }
 
     return c;

--- a/src/v/iceberg/conversion/json_schema/frontend.cc
+++ b/src/v/iceberg/conversion/json_schema/frontend.cc
@@ -300,7 +300,6 @@ constexpr auto banned_keywords = std::to_array({
   "else",
   "allOf",
   "anyOf",
-  "oneOf",
 });
 
 }; // namespace
@@ -526,6 +525,12 @@ public:
         }
 
         if (
+          const auto one_of_node = find_keyword(
+            node, "oneOf", {json_value_type::array})) {
+            compile_one_of(ctx, *sub, *one_of_node);
+        }
+
+        if (
           const auto format_node = find_keyword(
             node, "format", {json_value_type::string})) {
             if (unlikely(ctx.dialect() != dialect::draft7)) {
@@ -656,6 +661,33 @@ public:
             throw std::runtime_error(
               "The items keyword must be an object or an array of objects");
         }
+    }
+
+    void compile_one_of(
+      compile_context& ctx, subschema& sub, const json::Value& node) const {
+        vassert(
+          sub.one_of_.empty(),
+          "oneOf subschema vector should be empty at this point");
+
+        if (!node.IsArray() || node.GetArray().Empty()) {
+            throw std::runtime_error(
+              "The oneOf keyword must be a non-empty array");
+        }
+
+        std::vector<ss::shared_ptr<subschema>> one_of_subschemas;
+        one_of_subschemas.reserve(node.GetArray().Size());
+        for (const auto& item : node.GetArray()) {
+            one_of_subschemas.push_back(compile_subschema(ctx, item));
+        }
+
+        for (size_t i = 0; i < one_of_subschemas.size(); ++i) {
+            auto& one_of_subschema = one_of_subschemas[i];
+            auto [it, inserted] = sub.subschemas_.emplace(
+              fmt::format("oneOf/{}", i), one_of_subschema);
+            vassert(inserted, "unique insertion should have succeeded");
+        }
+
+        sub.one_of_ = std::move(one_of_subschemas);
     }
 };
 

--- a/src/v/iceberg/conversion/json_schema/ir.h
+++ b/src/v/iceberg/conversion/json_schema/ir.h
@@ -303,6 +303,9 @@ public:
                                  : std::nullopt;
     }
 
+    /// \return Subschemas in the "oneOf" keyword if specified.
+    const_list_view one_of() const { return const_list_view(one_of_); }
+
     /// \return Format of this schema object if specified.
     /// See https://www.learnjsonschema.com/2020-12/validation/format
     const std::optional<format>& format() const { return format_; }
@@ -332,6 +335,8 @@ private:
 
     items_t items_;
     ss::shared_ptr<subschema> additional_items_;
+
+    std::vector<ss::shared_ptr<subschema>> one_of_;
 
     std::optional<enum format> format_;
 

--- a/src/v/iceberg/conversion/json_schema/tests/frontend_test.cc
+++ b/src/v/iceberg/conversion/json_schema/tests/frontend_test.cc
@@ -923,6 +923,87 @@ TEST(frontend_test, non_object_or_boolean_subschema) {
         StrEq("Subschema must be an object or a boolean")));
 }
 
+TEST(frontend_test, one_of) {
+    auto schema = frontend{}.compile(
+      parse_json(R"({
+        "$id": "https://example.com/root.json",
+        "oneOf": [
+            { "type": "null" },
+            { "type": "string" },
+            { "type": "integer" }
+        ]
+      })"),
+      "https://example.com/irrelevant-base.json",
+      dialect::draft7);
+
+    auto expected = R"(# (document root)
+  base uri: https://example.com/root.json
+  dialect: http://json-schema.org/draft-07/schema#
+#/oneOf/0
+  base uri: https://example.com/root.json
+  dialect: http://json-schema.org/draft-07/schema#
+  types: [null]
+#/oneOf/1
+  base uri: https://example.com/root.json
+  dialect: http://json-schema.org/draft-07/schema#
+  types: [string]
+#/oneOf/2
+  base uri: https://example.com/root.json
+  dialect: http://json-schema.org/draft-07/schema#
+  types: [integer]
+)";
+
+    ASSERT_EQ(expected, ir_tree_printer::to_string(schema));
+    ASSERT_EQ(schema.root().one_of().size(), 3);
+}
+
+TEST(frontend_test, duplicate_one_of) {
+    // Not required by json schema but we disallow duplicate keywords to reduce
+    // ambiguity.
+    EXPECT_THAT(
+      []() {
+          frontend{}.compile(
+            parse_json(R"({
+              "$id": "https://example.com/root.json",
+              "oneOf": [{ "type": "string" }],
+              "oneOf": [{ "type": "integer" }]
+            })"),
+            "https://example.com/irrelevant-base.json",
+            dialect::draft7);
+      },
+      ThrowsMessage<std::runtime_error>(StrEq("Duplicate keyword: oneOf")));
+}
+
+TEST(frontend_test, one_of_empty_array) {
+    EXPECT_THAT(
+      []() {
+          frontend{}.compile(
+            parse_json(R"({
+              "$id": "https://example.com/root.json",
+              "oneOf": []
+            })"),
+            "https://example.com/irrelevant-base.json",
+            dialect::draft7);
+      },
+      ThrowsMessage<std::runtime_error>(
+        StrEq("The oneOf keyword must be a non-empty array")));
+}
+
+TEST(frontend_test, one_of_non_array) {
+    EXPECT_THAT(
+      []() {
+          frontend{}.compile(
+            parse_json(R"({
+              "$id": "https://example.com/root.json",
+              "oneOf": "not an array"
+            })"),
+            "https://example.com/irrelevant-base.json",
+            dialect::draft7);
+      },
+      ThrowsMessage<std::runtime_error>(
+        StrEq("Invalid type for keyword oneOf. Expected one of: [array].")));
+}
+
 TEST(frontend_test, non_string_dialect) {
     EXPECT_THAT(
       []() {

--- a/src/v/iceberg/conversion/tests/iceberg_json_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_json_tests.cc
@@ -896,7 +896,6 @@ TEST(JsonSchema, BannedKeywords) {
            "dependencies",
            "allOf",
            "anyOf",
-           "oneOf",
            "if",
            "then",
            "else",
@@ -1296,6 +1295,488 @@ TEST_CORO(IcebergValues, ValueObjectNesting) {
             )),
           // key20
           OptionalIcebergPrimitive<string_value>("value2"))));
+}
+
+TEST(JsonSchema, OneOfNullable) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "nullable_field": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ]
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_value()) << result.error().what();
+    ASSERT_EQ(result.value().fields.size(), 1);
+    ASSERT_TRUE(field_matches(
+      result.value().fields[0],
+      "nullable_field",
+      iceberg::string_type{},
+      iceberg::field_required::no));
+}
+
+TEST(JsonSchema, OneOfTypeRefinement) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "field": {
+          "type": ["number", "string", "null"],
+          "oneOf": [
+            { "type": "null" },
+            { "type": "string", "format": "date" }
+          ]
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_value()) << result.error().what();
+    ASSERT_EQ(result.value().fields.size(), 1);
+    ASSERT_TRUE(field_matches(
+      result.value().fields[0],
+      "field",
+      iceberg::date_type{},
+      iceberg::field_required::no));
+}
+
+TEST(JsonSchema, OneOfArbitraryTypes) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "field": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "integer" }
+          ]
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_error());
+    ASSERT_STREQ(
+      "oneOf keyword is supported only for exclusive T|null structures",
+      result.error().what());
+}
+
+TEST(JsonSchema, OneOfThreeBranches) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "field": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "integer" },
+            { "type": "null" }
+          ]
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_error());
+    ASSERT_STREQ(
+      "oneOf keyword is supported only for exclusive T|null structures",
+      result.error().what());
+}
+
+TEST(JsonSchema, OneOfConflictingTypes) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "field": {
+          "type": "number",
+          "oneOf": [
+            { "type": "null" },
+            { "type": "string" }
+          ]
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_error());
+    ASSERT_STREQ(
+      "Type constraint is not sufficient for transforming. Types: []",
+      result.error().what());
+}
+
+TEST(JsonSchema, OneOfRedundantNull) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "field": {
+          "oneOf": [
+            { "type": "null" },
+            { "type": ["string", "null"] }
+          ]
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_error());
+    ASSERT_STREQ(
+      "oneOf keyword is supported only for exclusive T|null structures",
+      result.error().what());
+}
+
+TEST(JsonSchema, OneOfNullableFormatInside) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "field": {
+          "oneOf": [
+            { "type": "null" },
+            { "type": "string", "format": "date" }
+          ]
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_value()) << result.error().what();
+    ASSERT_EQ(result.value().fields.size(), 1);
+    ASSERT_TRUE(field_matches(
+      result.value().fields[0],
+      "field",
+      iceberg::date_type{},
+      iceberg::field_required::no));
+}
+
+TEST(JsonSchema, OneOfNullableFormatOutside) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "field": {
+          "oneOf": [
+            { "type": "null" },
+            { "type": "string" }
+          ],
+          "format": "date"
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_value()) << result.error().what();
+    ASSERT_EQ(result.value().fields.size(), 1);
+    ASSERT_TRUE(field_matches(
+      result.value().fields[0],
+      "field",
+      iceberg::date_type{},
+      iceberg::field_required::no));
+}
+
+TEST(JsonSchema, OneOfNullableFormatInsideAndOutside) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "field": {
+          "oneOf": [
+            { "type": "null" },
+            { "type": "string", "format": "date" }
+          ],
+          "format": "date"
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_value()) << result.error().what();
+    ASSERT_EQ(result.value().fields.size(), 1);
+    ASSERT_TRUE(field_matches(
+      result.value().fields[0],
+      "field",
+      iceberg::date_type{},
+      iceberg::field_required::no));
+}
+
+TEST(JsonSchema, OneOfFormatConflict) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "field": {
+          "oneOf": [
+            { "type": "null" },
+            { "type": "string", "format": "date" }
+          ],
+          "format": "date-time"
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_error());
+    ASSERT_STREQ(
+      "Conflicting format annotations across branches", result.error().what());
+}
+
+TEST(JsonSchema, OneOfProperties) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "field": {
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "properties": {
+                "nested_field": { "type": "string" }
+              }
+            }
+          ]
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_value()) << result.error().what();
+    ASSERT_EQ(result.value().fields.size(), 1);
+    auto expected_field = iceberg::struct_type{};
+    expected_field.fields.push_back(
+      iceberg::nested_field::create(
+        0,
+        "nested_field",
+        iceberg::field_required::no,
+        iceberg::string_type{}));
+    ASSERT_TRUE(field_matches(
+      result.value().fields[0],
+      "field",
+      iceberg::field_type(std::move(expected_field)),
+      iceberg::field_required::no));
+}
+
+TEST(JsonSchema, OneOfPropertiesBothSides) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "field": {
+          "properties": {
+            "nested_field": { "type": "string" }
+          },
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "properties": {
+                "other_field": { "type": "integer" }
+              }
+            }
+          ]
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_error());
+    ASSERT_STREQ(
+      "Intersecting constraints with properties on both sides is not supported",
+      result.error().what());
+}
+
+TEST(JsonSchema, OneOfPropertiesOutside) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "field": {
+          "properties": {
+            "nested_field": { "type": "string" }
+          },
+          "oneOf": [
+            { "type": "null" },
+            { "type": "object" }
+          ]
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_value()) << result.error().what();
+    ASSERT_EQ(result.value().fields.size(), 1);
+    auto expected_field = iceberg::struct_type{};
+    expected_field.fields.push_back(
+      iceberg::nested_field::create(
+        0,
+        "nested_field",
+        iceberg::field_required::no,
+        iceberg::string_type{}));
+    ASSERT_TRUE(field_matches(
+      result.value().fields[0],
+      "field",
+      iceberg::field_type(std::move(expected_field)),
+      iceberg::field_required::no));
+}
+
+TEST(JsonSchema, OneOfAdditionalPropertiesOutside) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "field": {
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "properties": {
+                "nested_field": { "type": "string" }
+              }
+            }
+          ],
+          "additionalProperties": false
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_error());
+    ASSERT_STREQ(
+      "additionalProperties: false conflicts with properties defined in "
+      "another branch",
+      result.error().what());
+}
+
+TEST(JsonSchema, OneOfItems) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "field": {
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          ]
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_value()) << result.error().what();
+    ASSERT_EQ(result.value().fields.size(), 1);
+    ASSERT_TRUE(field_matches(
+      result.value().fields[0],
+      "field",
+      iceberg::list_type::create(
+        0, iceberg::field_required::yes, iceberg::string_type{}),
+      iceberg::field_required::no));
+}
+
+TEST(JsonSchema, OneOfItemsOutside) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "field": {
+          "items": { "type": "string" },
+          "oneOf": [
+            { "type": "null" },
+            { "type": "array" }
+          ]
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_value()) << result.error().what();
+    ASSERT_EQ(result.value().fields.size(), 1);
+    ASSERT_TRUE(field_matches(
+      result.value().fields[0],
+      "field",
+      iceberg::list_type::create(
+        0, iceberg::field_required::yes, iceberg::string_type{}),
+      iceberg::field_required::no));
+}
+
+TEST(JsonSchema, OneOfItemsBothSides) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "field": {
+          "items": { "type": "integer" },
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          ]
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_error());
+    ASSERT_STREQ(
+      "Intersecting constraints with items on both sides is not supported",
+      result.error().what());
+}
+
+TEST(JsonSchema, OneOfAdditionalPropertiesInside) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "field": {
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "additionalProperties": false
+            }
+          ],
+          "properties": {
+            "nested_field": { "type": "string" }
+          }
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_error());
+    ASSERT_STREQ(
+      "additionalProperties: false conflicts with properties defined in "
+      "another branch",
+      result.error().what());
 }
 
 TEST_CORO(IcebergValues, Format) {


### PR DESCRIPTION
Add support for the oneOf keyword, limited to the T|null
pattern used to express nullable fields. Constraints from
oneOf branches are intersected with the parent schema for
types, format, properties, and items. Properties and items
must appear in only one branch; specifying them on both
sides is rejected. Format must either match across branches
or appear in only one.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Improvements

* Iceberg: JSON Schema to Iceberg conversion now supports `oneOf` for expressing nullable fields (`oneOf: [T, null]`).

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
