### PR TITLE
rpk: skip revive package name check

### DIFF
--- a/src/go/rpk/.golangci.yml
+++ b/src/go/rpk/.golangci.yml
@@ -91,6 +91,12 @@ linters:
         - name: useless-break
         - name: var-declaration
         - name: var-naming
+          # This rule accepts two slices of strings and one optional slice containing a single map with named parameters
+          # https://revive.run/r#var-naming
+          arguments:
+            - []
+            - []
+            - - skip-package-name-checks: true
         - name: waitgroup-by-value
   exclusions:
     generated: lax

--- a/src/go/rpk/Makefile
+++ b/src/go/rpk/Makefile
@@ -64,7 +64,7 @@ run_gofumpt:
 	$(GOFUMPT_OS_CMD)
 
 install_golangci_lint:
-	@which $(GOLANGCILINTCMD) || (if [ $$? -eq 1 ]; then  echo "golangci-lint not found, installing..."; curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v2.8.0; fi)
+	@which $(GOLANGCILINTCMD) || (if [ $$? -eq 1 ]; then  echo "golangci-lint not found, installing..."; curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v2.9.0; fi)
 
 run_linter:
 	$(GOLANGCILINTCMD) run


### PR DESCRIPTION
We already did a first pass - the remaining
packages are following our command name convention

Also, bumped the Makefile golangci-lint version
to latest.

(cherry picked from commit a30f234f41b61757681dc689c988ef7b0c6c651c)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

