### PR TITLE
Move hwloc to impl_deps in seastar

### DIFF
--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -606,7 +606,10 @@ cc_library(
     implementation_deps = [
         "@c-ares",
         "@openssl",
-    ],
+    ] + select({
+        ":use_hwloc": ["@hwloc"],
+        "//conditions:default": [],
+    }),
     includes = [
         "include",
         "src",
@@ -662,9 +665,6 @@ cc_library(
         "@protobuf",
         "@yaml-cpp",
     ] + select({
-        ":use_hwloc": ["@hwloc"],
-        "//conditions:default": [],
-    }) + select({
         ":use_io_uring": ["@liburing"],
         "//conditions:default": [],
     }),


### PR DESCRIPTION
Move hwloc out of the regular deps in seastar and into impl_deps, which was enabled by commit 913fcf1bcc2f61b3f0bd3ee40fb379a5b0e743a2 on the seastar side.

This change improves dependency visibility by making hwloc an implementation detail of the seastar library rather than a transitive dependency.

## Changes

- Moved `@hwloc` dependency from regular `deps` list to `implementation_deps` in `bazel/thirdparty/seastar.BUILD`

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none