### PR TITLE
bazel: suppress absl deprecation warnings in protobuf

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -81,6 +81,9 @@ build --per_file_copt=src/v/serde/protobuf/tests/round_trip_test.cc@-Wno-depreca
 build --per_file_copt=src/v/serde/protobuf/tests/parser_test.cc@-Wno-deprecated-declarations
 build --per_file_copt=src/v/iceberg/conversion/tests/iceberg_protobuf_tests.cc@-Wno-deprecated-declarations
 build --per_file_copt=src/v/pandaproxy/schema_registry/protobuf.cc@-Wno-deprecated-declarations
+# Suppress deprecated declarations in the protobuf external module itself
+build --per_file_copt=external/protobuf.*@-Wno-deprecated-declarations
+build --host_per_file_copt=external/protobuf.*@-Wno-deprecated-declarations
 
 # -base configs generally aren't meant to be used directly but are
 # helpers to DRY later user-facing configs


### PR DESCRIPTION
This PR adds compiler flags to suppress deprecated declaration warnings when building the protobuf external module.

The warnings are coming from protobuf's internal use of deprecated APIs (e.g., the `weak()` method in field options), which we cannot modify as it's a third-party dependency. These warnings appear both in target builds and when protobuf is compiled as a build tool (exec configuration).

The fix uses `--per_file_copt` and `--host_per_file_copt` in `.bazelrc` to apply `-Wno-deprecated-declarations` to all files in the protobuf external repository.

These deprecation errors serve no real purpose for us as they are targeting external code we don't control.

Avoids a ton of:

```
INFO: From Compiling src/google/protobuf/compiler/cpp/message.cc [for tool]:
In file included from external/protobuf+/src/google/protobuf/compiler/cpp/message.cc:12:
In file included from bazel-out/k8-opt-exec-ST-d57f47055a04/bin/external/protobuf+/src/google/protobuf/compiler/cpp/_virtual_includes/cpp/google/protobuf/compiler/cpp/message.h:25:
In file included from bazel-out/k8-opt-exec-ST-d57f47055a04/bin/external/protobuf+/src/google/protobuf/compiler/cpp/_virtual_includes/cpp/google/protobuf/compiler/cpp/extension.h:19:
bazel-out/k8-opt-exec-ST-d57f47055a04/bin/external/protobuf+/src/google/protobuf/compiler/cpp/_virtual_includes/names_internal/google/protobuf/compiler/cpp/helpers.h:347:24: warning: 'weak' is deprecated [-Wdeprecated-declarations]
  347 |   if (field->options().weak()) {
      |                        ^
```

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none