### PR TITLE
bazel: simplify lto flags

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -132,6 +132,19 @@ build:san-all  --//bazel:sanitizer_mode=all
 build:san-all     --copt=-fsanitize=address,undefined,vptr,function,alignment
 build:san-all  --linkopt=-fsanitize=address,undefined,vptr,function,alignment
 
+# LTO mixin: enable LTO for C++ and Rust. Usually mixed in with
+# PGO + release, but should work with any.
+build:lto --copt -flto=thin
+build:lto --linkopt -flto=thin
+build:lto --@rules_rust//rust/settings:lto=fat
+build:lto --@rules_rust//rust/settings:extra_rustc_flag=-Ccodegen-units=1
+# I've seen others claim these flags help with LTO and the final binary, but these also
+# require a specific version of clang and I don't really want to tie rustc version with
+# clang version.
+# build:lto --@rules_rust//rust/settings:extra_rustc_flag=-Clinker-plugin-lto
+# build:lto --@rules_rust//rust/settings:extra_rustc_flag=-Cembed-bitcode=yes
+# build:lto --@rules_rust//rust/settings:extra_rustc_flag=-Clink-arg=-fuse-ld=lld
+
 ################################################
 # PRIMARY BUILD MODES
 #
@@ -251,23 +264,10 @@ build:release --host_cxxopt=-U_LIBCPP_HARDENING_MODE
 build:release --cxxopt=-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_NONE
 build:release --host_cxxopt=-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_NONE
 
-# Separate PGO configs to be combined with release
-
-# Enable LTO only in PGO build to save time in other builds
-build:pgo-base --//src/v/redpanda:lto=True
-build:pgo-base --copt -flto=thin
-build:pgo-base --@rules_rust//rust/settings:lto=fat
-build:pgo-base --@rules_rust//rust/settings:extra_rustc_flag=-Ccodegen-units=1
-# I've seen others claim these flags help with LTO and the final binary, but these also
-# require a specific version of clang and I don't really want to tie rustc version with
-# clang version.
-# build:pgo-base --@rules_rust//rust/settings:extra_rustc_flag=-Clinker-plugin-lto
-# build:pgo-base --@rules_rust//rust/settings:extra_rustc_flag=-Cembed-bitcode=yes
-# build:pgo-base --@rules_rust//rust/settings:extra_rustc_flag=-Clink-arg=-fuse-ld=lld
 
 # Instrumentation/training step
 # Empty arg is intentional, we provide the path via env var at run time
-build:pgo-instrument --config=pgo-base --fdo_instrument=
+build:pgo-instrument --config=lto --fdo_instrument=
 
 # Final/Optimization build step
 
@@ -278,7 +278,7 @@ build:pgo-instrument --config=pgo-base --fdo_instrument=
 
 # bazel seems to pass -fprofile-correction unconditionally but that only exists
 # in gcc so need to make clang ignore it
-build:pgo-optimize --config=pgo-base --copt -Wno-ignored-optimization-argument
+build:pgo-optimize --config=lto --copt -Wno-ignored-optimization-argument
 
 
 build:stamp --stamp --workspace_status_command=./bazel/stamp_vars.sh

--- a/src/v/redpanda/BUILD
+++ b/src/v/redpanda/BUILD
@@ -124,20 +124,6 @@ redpanda_cc_library(
     ],
 )
 
-# Enable or disable (thin) LTO for the redpanda binary (only)
-bool_flag(
-    name = "lto",
-    build_setting_default = False,
-)
-
-config_setting(
-    name = "use_lto",
-    flag_values = {
-        ":lto": "true",
-    },
-    visibility = ["//visibility:public"],
-)
-
 # Enable or disable --emit-relocs for the redpanda binary (only)
 bool_flag(
     name = "emit_relocs",
@@ -158,14 +144,6 @@ redpanda_cc_binary(
         "main.cc",
     ],
     linkopts =
-        select({
-            ":use_lto": [
-                "-flto=thin",
-                "-ffat-lto-objects",
-            ],
-            "//conditions:default": [
-            ],
-        }) +
         select({
             ":use_emit_relocs": [
                 "-Wl,--emit-relocs",


### PR DESCRIPTION
Introduce --config=lto mixin which sets -flto=thin for C++ compile and link. Remove src/v/redpanda specific handling of the link flag, we pass this to all links now. This is effectively a no-op as lld will use LTO mode when inputs have only IR anyway.

You can mix --config=lto with other build modes (most usefully, release) even without PGO.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


* none
