### PR TITLE
rpk: logger-level improvements

### DIFF
--- a/src/go/rpk/pkg/cli/redpanda/admin/config/BUILD
+++ b/src/go/rpk/pkg/cli/redpanda/admin/config/BUILD
@@ -13,6 +13,7 @@ go_library(
         "@com_github_redpanda_data_common_go_rpadmin//:rpadmin",
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",
+        "@org_golang_x_sync//errgroup",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/src/go/rpk/pkg/cli/redpanda/admin/config/BUILD
+++ b/src/go/rpk/pkg/cli/redpanda/admin/config/BUILD
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "config",
@@ -9,7 +9,21 @@ go_library(
         "//src/go/rpk/pkg/adminapi",
         "//src/go/rpk/pkg/config",
         "//src/go/rpk/pkg/out",
+        "//src/go/rpk/pkg/redpanda",
+        "@com_github_redpanda_data_common_go_rpadmin//:rpadmin",
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "config_test",
+    srcs = ["config_test.go"],
+    embed = [":config"],
+    deps = [
+        "@com_github_redpanda_data_common_go_rpadmin//:rpadmin",
+        "@com_github_spf13_afero//:afero",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/src/go/rpk/pkg/cli/redpanda/admin/config/config.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/config/config.go
@@ -6,14 +6,23 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
 
+	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/redpanda"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 )
 
 // NewCommand returns the config admin command.
@@ -75,10 +84,12 @@ func newLogLevelCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 }
 
 func newLogLevelSetCommand(fs afero.Fs, p *config.Params) *cobra.Command {
-	var host string
-	var level string
-	var expirySeconds int
-
+	var (
+		host          string
+		level         string
+		expirySeconds int
+		helpLoggers   bool
+	)
 	cmd := &cobra.Command{
 		Use:   "set [LOGGERS...]",
 		Short: "Set broker logger's log level",
@@ -93,36 +104,51 @@ It is optional to specify a logger; if you do not, this command will prompt
 from the set of available loggers.
 
 The special logger "all" enables all loggers. Alternatively, you can specify
-many loggers at once. To see all possible loggers, run the following command:
-
-  redpanda --help-loggers
+many loggers at once.
 
 This command accepts loggers that it does not know of to ensure you can
 independently update your redpanda installations from rpk. The success or
 failure of enabling each logger is individually printed.
-`,
 
+You can use --help-loggers to display available loggers:
+
+  rpk redpanda admin config log-level set --help-loggers [--host <HOST>]
+`,
+		ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+			return defaultLoggers, cobra.ShellCompDirectiveNoFileComp
+		},
 		Run: func(cmd *cobra.Command, loggers []string) {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 
+			if helpLoggers {
+				printLoggers(cmd.Context(), fs, p, host)
+				return
+			}
+
+			if host == "" {
+				out.Die("required flag \"host\" not set")
+			}
+
 			cl, err := adminapi.NewHostClient(fs, p, host)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
+			availableLoggers := discoverLoggers(cmd.Context(), cl, fs)
+
 			switch len(loggers) {
 			case 0:
-				choices := append([]string{"all"}, possibleLoggers...)
+				choices := append([]string{"all"}, availableLoggers...)
 				pick, err := out.Pick(choices, "Which logger would you like to set (all selects everything)?")
 				out.MaybeDie(err, "unable to pick logger: %v", err)
 				if pick == "all" {
-					loggers = possibleLoggers
+					loggers = availableLoggers
 				} else {
 					loggers = []string{pick}
 				}
 
 			case 1:
 				if loggers[0] == "all" {
-					loggers = possibleLoggers
+					loggers = availableLoggers
 				}
 			}
 
@@ -159,33 +185,158 @@ failure of enabling each logger is individually printed.
 		},
 	}
 
-	cmd.Flags().StringVarP(&level, "level", "l", "debug", "log level to set (error, warn, info, debug, trace)")
-	cmd.Flags().IntVarP(&expirySeconds, "expiry-seconds", "e", 300, "seconds to persist this log level override before redpanda reverts to its previous settings (if 0, persist until shutdown)")
-
-	cmd.Flags().StringVar(&host, "host", "", "either a hostname or an index into rpk.admin_api.addresses config section to select the hosts to issue the request to")
-	cobra.MarkFlagRequired(cmd.Flags(), "host")
+	cmd.Flags().BoolVar(&helpLoggers, "help-loggers", false, "Display the list of available loggers")
+	cmd.Flags().StringVarP(&level, "level", "l", "debug", "Log level to set (error, warn, info, debug, trace)")
+	cmd.Flags().IntVarP(&expirySeconds, "expiry-seconds", "e", 300, "Seconds to persist this log level override before redpanda reverts to its previous settings (if 0, persist until shutdown)")
+	cmd.Flags().StringVar(&host, "host", "", "Either a hostname or an index into rpk.admin_api.addresses config section to select the hosts to issue the request to")
 
 	return cmd
 }
 
-// List of possible loggers to set; more can be added in the future.
-// To generate this list, run 'redpanda --help-loggers'.
-var possibleLoggers = []string{
+// parseHelpLoggersOutput parses the output of 'redpanda --help-loggers'.
+// It looks for the "Available loggers:" header, then collects all subsequent
+// indented lines as logger names.
+func parseHelpLoggersOutput(output string) ([]string, error) {
+	const header = "Available loggers:"
+	lines := strings.Split(output, "\n")
+	headerIdx := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == header {
+			headerIdx = i
+			break
+		}
+	}
+	if headerIdx == -1 {
+		return nil, fmt.Errorf("header %q not found in output", header)
+	}
+	// Collect indented lines after the header
+	var loggers []string
+	for _, line := range lines[headerIdx+1:] {
+		if line == "" {
+			continue
+		}
+		// Stop at first non-indented line
+		if len(line) > 0 && line[0] != ' ' && line[0] != '\t' {
+			break
+		}
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			loggers = append(loggers, trimmed)
+		}
+	}
+	if len(loggers) == 0 {
+		return nil, fmt.Errorf("no loggers found in output")
+	}
+	sort.Strings(loggers)
+	return loggers, nil
+}
+
+// loggersFromBinary attempts to discover available loggers by running the
+// local redpanda binary with --help-loggers. This only works on Linux.
+func loggersFromBinary(ctx context.Context, fs afero.Fs) ([]string, error) {
+	if runtime.GOOS != "linux" {
+		return nil, fmt.Errorf("binary discovery only supported on linux")
+	}
+	installDir, err := redpanda.FindInstallDir(fs)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find redpanda install directory: %v", err)
+	}
+	bin := filepath.Join(installDir, "bin", "redpanda")
+	output, err := exec.CommandContext(ctx, bin, "--help-loggers").Output()
+	if err != nil {
+		return nil, fmt.Errorf("unable to run %s --help-loggers: %v", bin, err)
+	}
+	return parseHelpLoggersOutput(string(output))
+}
+
+// printLoggers discovers and prints the available loggers. If --host is not
+// set, it uses the first admin address from the profile so we can query the
+// API without requiring --host.
+func printLoggers(ctx context.Context, fs afero.Fs, p *config.RpkProfile, host string) {
+	adminHost := host
+	if adminHost == "" {
+		if addrs := p.AdminAPI.Addresses; len(addrs) > 0 {
+			adminHost = addrs[0]
+		}
+	}
+
+	available := defaultLoggers
+	if adminHost != "" {
+		cl, err := adminapi.NewHostClient(fs, p, adminHost)
+		if err == nil {
+			available = discoverLoggers(ctx, cl, fs)
+		}
+	}
+	tw := out.NewTable("LOGGER")
+	defer tw.Flush()
+	for _, l := range available {
+		tw.Print(l)
+	}
+}
+
+// discoverLoggers returns the list of available loggers using a fallback chain:
+// local binary -> Admin API -> hardcoded default list.
+func discoverLoggers(ctx context.Context, cl *rpadmin.AdminAPI, fs afero.Fs) []string {
+	// Attempt 1: Local binary (Linux only).
+	loggers, err := loggersFromBinary(ctx, fs)
+	if err == nil && len(loggers) > 0 {
+		return loggers
+	}
+	zap.L().Sugar().Debugf("Unable to discover loggers from local binary: %v; trying Admin API", err)
+
+	// Attempt 2: Admin API.
+	levels, err := cl.GetLogLevels(ctx)
+	if err == nil && len(levels) > 0 {
+		names := make([]string, 0, len(levels))
+		for _, l := range levels {
+			if l.Name != "" {
+				names = append(names, l.Name)
+			}
+		}
+		sort.Strings(names)
+		return names
+	}
+	zap.L().Sugar().Debugf("Unable to discover loggers from Admin API: %v; using default list", err)
+
+	// Attempt 3: Hardcoded fallback.
+	return defaultLoggers
+}
+
+// defaultLoggers is the fallback list of loggers used when dynamic discovery
+// fails. To regenerate this list, run 'redpanda --help-loggers'.
+var defaultLoggers = []string{
 	"abs",
+	"admin/proxy/client",
+	"admin/proxy/service",
 	"admin_api_server",
+	"admin_api_server/broker_service",
+	"admin_api_server/cluster_service",
+	"admin_api_server/internal_breakglass_service",
+	"admin_api_server/internal_debug_service",
+	"admin_api_server/security_service",
 	"archival",
 	"archival-ctrl",
 	"assert",
+	"auditing",
 	"client_config",
 	"client_pool",
+	"cloud_io",
 	"cloud_roles",
 	"cloud_storage",
+	"cloud_topics",
+	"cloud_topics-compaction",
 	"cluster",
 	"compaction_ctrl",
 	"compression",
+	"config",
+	"connectrpc",
 	"controller_rate_limiter_log",
 	"cpu_profiler",
+	"crash-reporter",
+	"crash_tracker",
+	"data-migrate",
 	"datalake",
+	"debug-bundle-service",
+	"dl_backlog_controller",
 	"dns_resolver",
 	"exception",
 	"fault_injector",
@@ -197,27 +348,50 @@ var possibleLoggers = []string{
 	"io",
 	"json",
 	"kafka",
+	"kafka-cg",
+	"kafka/authz",
 	"kafka/client",
+	"kafka/data/rpc",
+	"kafka_data",
+	"kafka_quotas",
 	"kvstore",
+	"level_zero_gc_service",
+	"lsm",
 	"main",
 	"metrics-reporter",
+	"net_tls",
 	"offset_translator",
+	"ossl-library-context-service",
 	"pandaproxy",
+	"pandaproxy/requests",
 	"r/heartbeat",
 	"raft",
+	"reconciler",
 	"request_auth",
 	"resource_mgmt",
 	"resources",
 	"rpc",
 	"s3",
-	"scheduler",
+	"schemaregistry",
+	"schemaregistry/requests",
 	"scollectd",
 	"seastar",
+	"seastar-tls",
 	"seastar_memory",
 	"security",
 	"serde",
+	"shadow_link",
+	"shadow_link_internal_service",
+	"shadow_link_service",
 	"storage",
 	"storage-gc",
+	"storage-resources",
 	"syschecks",
+	"transform",
+	"transform/logging",
+	"transform/rpc",
+	"transform/stm",
 	"tx",
+	"tx-migration",
+	"wasm",
 }

--- a/src/go/rpk/pkg/cli/redpanda/admin/config/config.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/config/config.go
@@ -169,18 +169,19 @@ You can use --help-loggers to display available loggers:
 			}
 
 			if len(successes) > 0 {
-				fmt.Println("SUCCESSES")
+				tw := out.NewTable("SUCCESS")
 				for _, success := range successes {
-					fmt.Println(success)
+					tw.Print(success)
 				}
-				fmt.Println()
+				tw.Flush()
 			}
 			if len(failures) > 0 {
-				fmt.Println("FAILURES")
-				for _, failure := range failures {
-					fmt.Printf("%s: %v\n", failure.logger, failure.err)
-				}
 				fmt.Println()
+				tw := out.NewTable("FAILURE", "ERROR")
+				for _, f := range failures {
+					tw.Print(f.logger, f.err)
+				}
+				tw.Flush()
 			}
 		},
 	}

--- a/src/go/rpk/pkg/cli/redpanda/admin/config/config.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/config/config.go
@@ -9,11 +9,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
@@ -23,6 +25,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 )
 
 // NewCommand returns the config admin command.
@@ -153,23 +156,41 @@ You can use --help-loggers to display available loggers:
 				}
 			}
 
-			type failure struct {
+			type result struct {
 				logger string
 				err    error
 			}
-			var failures []failure
-			var successes []string
+			g, ctx := errgroup.WithContext(cmd.Context())
+			g.SetLimit(20)
 
+			var (
+				mu      sync.Mutex
+				results []result
+			)
 			for _, logger := range loggers {
-				err := cl.SetLogLevel(cmd.Context(), logger, level, expirySeconds)
-				if err != nil {
-					failures = append(failures, failure{logger, err})
+				g.Go(func() error {
+					err := cl.SetLogLevel(ctx, logger, level, expirySeconds)
+					mu.Lock()
+					results = append(results, result{logger, err})
+					mu.Unlock()
+					return nil
+				})
+			}
+			g.Wait()
+
+			var (
+				failures  []result
+				successes []string
+			)
+			for _, r := range results {
+				if r.err != nil {
+					failures = append(failures, r)
 				} else {
-					successes = append(successes, logger)
+					successes = append(successes, r.logger)
 				}
 			}
-
 			if len(successes) > 0 {
+				sort.Strings(successes)
 				tw := out.NewTable("SUCCESS")
 				for _, success := range successes {
 					tw.Print(success)
@@ -177,12 +198,16 @@ You can use --help-loggers to display available loggers:
 				tw.Flush()
 			}
 			if len(failures) > 0 {
-				fmt.Println()
+				sort.Slice(failures, func(i, j int) bool { return failures[i].logger < failures[j].logger })
+				if len(successes) > 0 {
+					fmt.Println()
+				}
 				tw := out.NewTable("FAILURE", "ERROR")
 				for _, f := range failures {
 					tw.Print(f.logger, f.err)
 				}
 				tw.Flush()
+				os.Exit(1)
 			}
 		},
 	}

--- a/src/go/rpk/pkg/cli/redpanda/admin/config/config.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/config/config.go
@@ -120,6 +120,7 @@ You can use --help-loggers to display available loggers:
 		Run: func(cmd *cobra.Command, loggers []string) {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
+			config.CheckExitCloudAdmin(p)
 
 			if helpLoggers {
 				printLoggers(cmd.Context(), fs, p, host)

--- a/src/go/rpk/pkg/cli/redpanda/admin/config/config_test.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/config/config_test.go
@@ -1,0 +1,141 @@
+package config
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/redpanda-data/common-go/rpadmin"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseHelpLoggersOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "standard output with header",
+			input: `Available loggers:
+    abs
+    admin_api_server
+    raft
+    storage
+`,
+			want: []string{"abs", "admin_api_server", "raft", "storage"},
+		},
+		{
+			name: "full output with preamble",
+			input: `Welcome to the Redpanda community!
+
+Documentation: https://docs.redpanda.com - Product documentation site
+GitHub Discussion: https://github.com/redpanda-data/redpanda/discussions - Longer, more involved discussions
+Support: https://support.redpanda.com - Contact the support team privately
+Slack: https://redpanda.com/slack - Chat about all things Redpanda. Join the conversation!
+Twitter: https://twitter.com/redpandadata - All the latest Redpanda news!
+
+Available loggers:
+    abs
+    admin_api_server
+    raft
+    storage
+`,
+			want: []string{"abs", "admin_api_server", "raft", "storage"},
+		},
+		{
+			name:    "only non-indented lines",
+			input:   "abs\nadmin_api_server\nraft\n",
+			wantErr: true,
+		},
+		{
+			name:    "indented lines without header",
+			input:   "    abs\n    raft\n",
+			wantErr: true,
+		},
+		{
+			name:    "empty output",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "only header",
+			input:   "Available loggers:\n",
+			wantErr: true,
+		},
+		{
+			name: "extra blank lines",
+			input: `Available loggers:
+
+    raft
+
+    storage
+
+`,
+			want: []string{"raft", "storage"},
+		},
+		{
+			name:  "unsorted input returns sorted",
+			input: "Available loggers:\n    storage\n    abs\n    raft\n",
+			want:  []string{"abs", "raft", "storage"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseHelpLoggersOutput(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDiscoverLoggers_APISuccess(t *testing.T) {
+	loggers := []rpadmin.LoggerLevel{
+		{Name: "storage", Level: "info"},
+		{Name: "abs", Level: "debug"},
+		{Name: "raft", Level: "warn"},
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/loggers" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(loggers)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
+
+	cl, err := rpadmin.NewClient([]string{ts.URL}, nil, new(rpadmin.NopAuth), false)
+	require.NoError(t, err)
+
+	// Binary discovery fails (MemMapFs has no redpanda binary), so
+	// discoverLoggers falls through to the Admin API, which succeeds.
+	got := discoverLoggers(t.Context(), cl, afero.NewMemMapFs())
+	require.Equal(t, []string{"abs", "raft", "storage"}, got)
+}
+
+func TestDiscoverLoggers_APIFailsFallsBackToDefault(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	cl, err := rpadmin.NewClient([]string{ts.URL}, nil, new(rpadmin.NopAuth), false)
+	require.NoError(t, err)
+
+	got := discoverLoggers(t.Context(), cl, afero.NewMemMapFs())
+	require.Equal(t, defaultLoggers, got)
+}
+
+func TestDefaultLoggersIsSorted(t *testing.T) {
+	// Just to make sure that when we manually add a logger we keep it sorted.
+	require.True(t, sort.StringsAreSorted(defaultLoggers), "defaultLoggers must be sorted")
+}


### PR DESCRIPTION
This PR improves the execution of the command `rpk redpanda admin config log-level set`, changes:

  - `log-level set` now discovers available loggers dynamically instead of relying on a hardcoded list that gets outdated as Redpanda evolves.
    - Loggers are discovered using a fallback chain: local redpanda binary (Linux only) ->
  Admin API -> built-in default list.
  - Added `--help-loggers` flag to display the discovered loggers.
    - The --host flag is not required for --help-loggers; when omitted, it uses the first admin address from the rpk profile
  - Log levels are now set concurrently (bounded to 20 workers) instead of sequentially.
  - Updated the built-in default logger list from ~50 to ~90 entries based on the nightly version of Redpanda.
  - Added tab completion support for logger names.
  - The command output now uses `out.NewTable` for consistent formatting

### Examples

**New --help-loggers output**

```
$ rpk redpanda admin config log-level set --help-loggers --host localhost:9644
LOGGER
abs
admin/proxy/client
admin/proxy/service
admin_api_server
...
```

**New set output**
```
$ rpk redpanda admin config log-level set raft storage kafka --host localhost:9644

SUCCESS
kafka
raft
storage
```

Fixes #15206 

Fixes UX-8 and Fixes UX-95

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Improvements

* `rpk redpanda admin config log-level set`: now dynamically discovers available loggers from the local Redpanda binary or the Admin API.
* `rpk redpanda admin config log-level set`: Added --help-loggers flag to display the list of available loggers without setting any log level.

