### PR TITLE
lsm: various fixes and improvements

### DIFF
--- a/src/v/lsm/core/internal/files.cc
+++ b/src/v/lsm/core/internal/files.cc
@@ -19,7 +19,7 @@
 namespace lsm::internal {
 
 ss::sstring sst_file_name(file_handle handle) noexcept {
-    return ss::format("{:020}-{:020}.sst", handle.id(), handle.epoch);
+    return ss::format("{:020}-{:020}.sst", handle.epoch(), handle.id());
 }
 
 std::optional<file_handle>
@@ -35,13 +35,13 @@ parse_sst_file_name(std::string_view filename) noexcept {
     }
     std::array<std::string_view, 2> split = absl::StrSplit(
       stem, absl::MaxSplits('-', 1));
-    auto [str_id, str_epoch] = split;
-    uint64_t raw_id = 0;
-    if (!absl::SimpleAtoi(str_id, &raw_id)) {
-        return std::nullopt;
-    }
+    auto [str_epoch, str_id] = split;
     uint64_t raw_epoch = 0;
     if (!absl::SimpleAtoi(str_epoch, &raw_epoch)) {
+        return std::nullopt;
+    }
+    uint64_t raw_id = 0;
+    if (!absl::SimpleAtoi(str_id, &raw_id)) {
         return std::nullopt;
     }
     return file_handle{

--- a/src/v/lsm/core/internal/keys.cc
+++ b/src/v/lsm/core/internal/keys.cc
@@ -11,6 +11,7 @@
 
 #include "lsm/core/internal/keys.h"
 
+#include "absl/strings/escaping.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_split.h"
 #include "base/vassert.h"
@@ -57,37 +58,27 @@ value_type key::type() const { return key_view{*this}.type(); }
 fmt::iterator key::parts::format_to(fmt::iterator it) const {
     return fmt::format_to(
       it,
-      "internal_key_parts={{key={},seqno={},type={}}}",
-      key,
+      "{{key={},seqno={},type={}}}",
+      absl::Utf8SafeCHexEscape(key()),
       seqno,
-      std::to_underlying(type));
+      type == value_type::tombstone ? "tombstone" : "value");
 }
 
 fmt::iterator key_view::parts::format_to(fmt::iterator it) const {
     return fmt::format_to(
       it,
-      "internal_key_parts={{key={},seqno={},type={}}}",
-      key,
+      "{{key={},seqno={},type={}}}",
+      absl::Utf8SafeCHexEscape(key()),
       seqno,
-      std::to_underlying(type));
+      type == value_type::tombstone ? "tombstone" : "value");
 }
 
 fmt::iterator key::format_to(fmt::iterator it) const {
-    uint64_t encoded; // NOLINT
-    std::memcpy(
-      &encoded, &_value[_value.size() - sizeof(encoded)], sizeof(encoded));
-    encoded = ~ss::be_to_cpu(encoded);
-    return fmt::format_to(
-      it, "internal_key={{user={},suffix=o{:08o}}}", user_key(), encoded);
+    return fmt::format_to(it, "{}", key_view{*this});
 }
 
 fmt::iterator key_view::format_to(fmt::iterator it) const {
-    uint64_t encoded; // NOLINT
-    std::memcpy(
-      &encoded, &_value[_value.size() - sizeof(encoded)], sizeof(encoded));
-    encoded = ~ss::be_to_cpu(encoded);
-    return fmt::format_to(
-      it, "internal_key_view={{user={},suffix=o{:08o}}}", user_key(), encoded);
+    return fmt::format_to(it, "{}", decode());
 }
 
 key::parts key::parts::value(user_key_view key, sequence_number seq_num) {

--- a/src/v/lsm/core/internal/options.h
+++ b/src/v/lsm/core/internal/options.h
@@ -36,7 +36,8 @@ struct options {
     // The scheduling group for background operations in the LSM tree, such as
     // memtable flushing and compaction. Note that this is unused if the
     // database is in readonly mode.
-    ss::scheduling_group compaction_scheduling_group;
+    ss::scheduling_group compaction_scheduling_group
+      = ss::default_scheduling_group();
 
     struct level_config {
         // The level number in the database.

--- a/src/v/lsm/core/internal/tests/files_test.cc
+++ b/src/v/lsm/core/internal/tests/files_test.cc
@@ -21,13 +21,13 @@ using ::testing::Optional;
 
 TEST(Files, SstFileName) {
     EXPECT_EQ(
-      "00000000000000000001-00000000000000000000.sst",
+      "00000000000000000000-00000000000000000001.sst",
       std::string(sst_file_name({1_file_id, 0_db_epoch})));
     EXPECT_EQ(
-      "00000000000000000123-00000000000000000001.sst",
+      "00000000000000000001-00000000000000000123.sst",
       std::string(sst_file_name({123_file_id, 1_db_epoch})));
     EXPECT_EQ(
-      "00000000000000000000-00000000000000000123.sst",
+      "00000000000000000123-00000000000000000000.sst",
       std::string(sst_file_name({0_file_id, 123_db_epoch})));
     EXPECT_EQ(
       "18446744073709551615-18446744073709551615.sst",

--- a/src/v/lsm/db/BUILD
+++ b/src/v/lsm/db/BUILD
@@ -186,6 +186,7 @@ redpanda_cc_library(
     implementation_deps = [
         ":file_utils",
         "//src/v/lsm/core:exceptions",
+        "//src/v/lsm/core/internal:logger",
         "//src/v/lsm/core/internal:merging_iterator",
         "//src/v/lsm/core/internal:two_level_iterator",
         "//src/v/lsm/proto:manifest_redpanda_proto",

--- a/src/v/lsm/db/compaction_task.cc
+++ b/src/v/lsm/db/compaction_task.cc
@@ -109,14 +109,11 @@ ss::future<ss::lw_shared_ptr<version_edit>> do_run_compaction_task(
     }
     compaction_state state{
       // We need to preserve intermediate data between snapshots so we can
-      // surface the correct snapshot isolation. So we use the oldest
-      // snapshot,
-      // otherwise the lastest sequence number because we don't have to
-      // preserve
+      // surface the correct snapshot isolation. So we use the oldest snapshot,
+      // otherwise the lastest sequence number because we don't have to preserve
       // any intermediate versions.
       // Note we can call `value` on `last_seqno` because we have to have
-      // some
-      // data in the database in order to trigger compaction.
+      // some data in the database in order to trigger compaction.
       .smallest_snapshot = snapshots->oldest_seqno().value_or(
         versions->last_seqno().value()),
     };

--- a/src/v/lsm/db/impl.cc
+++ b/src/v/lsm/db/impl.cc
@@ -152,7 +152,9 @@ ss::future<lookup_result> impl::get(internal::key_view key) {
             co_return result;
         }
     }
-    // Lookup in the files
+    // Lookup in the files - it's important that we hold a ref to this version
+    // here so that the version is kept alive and GC doesn't concurrently delete
+    // our file.
     auto current = _versions->current();
     version::get_stats stats{};
     auto result = co_await current->get(key, &stats);
@@ -206,7 +208,8 @@ impl::create_internal_iterator() {
     if (_imm) {
         list.push_back((*_imm)->create_iterator());
     }
-    co_await _versions->current()->add_iterators(&list);
+    auto current = _versions->current();
+    co_await current->add_iterators(&list);
     co_return internal::create_merging_iterator(std::move(list));
 }
 

--- a/src/v/lsm/db/impl.cc
+++ b/src/v/lsm/db/impl.cc
@@ -27,6 +27,7 @@
 
 #include <seastar/core/sleep.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/switch_to.hh>
 
 #include <chrono>
 #include <exception>
@@ -349,6 +350,7 @@ ss::future<> impl::do_flush() {
     if (!_imm) {
         co_return;
     }
+    co_await ss::coroutine::switch_to(_opts->compaction_scheduling_group);
     auto edit = co_await run_flush_task(
       _opts, _persistence.data.get(), _versions.get(), *_imm, &_as);
     if (!edit) {
@@ -370,6 +372,7 @@ ss::future<> impl::do_compaction() {
     if (!compact) {
         co_return;
     }
+    co_await ss::coroutine::switch_to(_opts->compaction_scheduling_group);
     auto edit = co_await run_compaction_task(
       _persistence.data.get(),
       &_snapshots,

--- a/src/v/lsm/db/tests/BUILD
+++ b/src/v/lsm/db/tests/BUILD
@@ -3,10 +3,12 @@ load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_gtest", "redpanda_tes
 
 redpanda_cc_binary(
     name = "db_bench",
+    testonly = True,
     srcs = [
         "db_bench.cc",
     ],
     deps = [
+        ":immutable_tree",
         "//src/v/base",
         "//src/v/bytes:iobuf",
         "//src/v/lsm/core:compression",

--- a/src/v/lsm/db/tests/BUILD
+++ b/src/v/lsm/db/tests/BUILD
@@ -1,5 +1,5 @@
 load("//bazel:build.bzl", "redpanda_cc_binary")
-load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_gtest")
+load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_gtest", "redpanda_test_cc_library")
 
 redpanda_cc_binary(
     name = "db_bench",
@@ -197,6 +197,30 @@ redpanda_cc_gtest(
         "//src/v/lsm/io:memory_persistence",
         "//src/v/lsm/sst:block_cache",
         "//src/v/lsm/sst:builder",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_test_cc_library(
+    name = "immutable_tree",
+    hdrs = ["immutable_tree.h"],
+    deps = [
+        "//src/v/base",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "immutable_tree_test",
+    timeout = "short",
+    srcs = [
+        "immutable_tree_test.cc",
+    ],
+    deps = [
+        ":immutable_tree",
+        "//src/v/base",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
         "@seastar",

--- a/src/v/lsm/db/tests/db_bench.cc
+++ b/src/v/lsm/db/tests/db_bench.cc
@@ -17,6 +17,7 @@
 #include "lsm/core/internal/keys.h"
 #include "lsm/core/internal/options.h"
 #include "lsm/db/impl.h"
+#include "lsm/db/tests/immutable_tree.h"
 #include "lsm/io/disk_persistence.h"
 #include "lsm/io/memory_persistence.h"
 #include "random/generators.h"
@@ -33,7 +34,6 @@
 
 #include <chrono>
 #include <exception>
-#include <map>
 #include <optional>
 #include <string>
 #include <vector>
@@ -136,26 +136,17 @@ struct benchmark_stats {
 
 // Shadow map to track expected database state for verification
 struct shadow_state {
-    std::map<ss::sstring, std::optional<iobuf>> data;
+    using tree_type
+      = lsm::db::immutable_tree<ss::sstring, std::optional<iobuf>>;
+    tree_type data;
 
     void put(ss::sstring key, iobuf value) {
-        data[std::move(key)] = std::move(value);
+        data = data.insert(
+          std::move(key), std::optional<iobuf>(std::move(value)));
     }
 
-    void remove(const ss::sstring& key) { data[key] = std::nullopt; }
-
-    std::optional<iobuf> get(const ss::sstring& key) const {
-        auto it = data.find(key);
-        if (it == data.end()) {
-            return std::nullopt;
-        }
-        return it->second ? std::optional<iobuf>(it->second->copy())
-                          : std::nullopt;
-    }
-
-    bool exists(const ss::sstring& key) const {
-        auto it = data.find(key);
-        return it != data.end() && it->second.has_value();
+    void remove(ss::sstring key) {
+        data = data.insert(std::move(key), std::optional<iobuf>{});
     }
 };
 
@@ -503,17 +494,16 @@ private:
 
             if (_cfg.verify) {
                 stats.verification_checks++;
-                // Check if key exists in shadow map
-                auto it = _shadow.data.find(key);
-                if (it == _shadow.data.end()) {
+                auto* shadow_val = _shadow.data.get(key);
+                if (!shadow_val) {
                     bench_log.error(
                       "Verification failed for key {}: not in shadow map", key);
                     stats.verification_failures++;
-                } else if (!it->second.has_value()) {
+                } else if (!shadow_val->has_value()) {
                     bench_log.error(
                       "Verification failed for key {}: expected deleted", key);
                     stats.verification_failures++;
-                } else if (it->second.value() != value) {
+                } else if (shadow_val->value() != value) {
                     bench_log.error(
                       "Verification failed for key {}: value mismatch", key);
                     stats.verification_failures++;
@@ -640,9 +630,9 @@ private:
 
         if (_cfg.verify) {
             stats.verification_checks++;
-            auto it = _shadow.data.find(key);
+            auto* shadow_val = _shadow.data.get(key);
 
-            if (it == _shadow.data.end()) {
+            if (!shadow_val) {
                 // Key not in shadow map
                 if (result_value) {
                     bench_log.error(
@@ -651,7 +641,7 @@ private:
                       key);
                     stats.verification_failures++;
                 }
-            } else if (!it->second.has_value()) {
+            } else if (!shadow_val->has_value()) {
                 // Key was deleted
                 if (!result.is_missing() && !result.is_tombstone()) {
                     bench_log.error(
@@ -665,7 +655,7 @@ private:
                     bench_log.error(
                       "Verification failed: key {} missing from DB", key);
                     stats.verification_failures++;
-                } else if (it->second.value() != result_value.value()) {
+                } else if (shadow_val->value() != result_value.value()) {
                     bench_log.error(
                       "Verification failed: key {} value mismatch", key);
                     stats.verification_failures++;
@@ -677,64 +667,84 @@ private:
     ss::future<> verify_all(benchmark_stats& stats) {
         bench_log.debug("Performing full verification scan");
 
-        // Build a set of all keys from iterator
-        std::map<ss::sstring, iobuf> db_keys;
         auto iter = co_await _db->create_iterator({});
         co_await iter->seek_to_first();
 
+        // Both the shadow tree and DB iterator produce entries in sorted
+        // order. Walk the shadow tree and advance the DB iterator in
+        // lockstep so we never need to copy the database into a map.
+        co_await _shadow.data.for_each(
+          [&](this auto,
+              const ss::sstring& shadow_key,
+              const std::optional<iobuf>& shadow_val) -> ss::future<> {
+              if (_as.abort_requested()) {
+                  co_return;
+              }
+              // Drain DB entries that sort before this shadow key.
+              while (iter->valid()) {
+                  auto db_key = ss::sstring(iter->key().user_key());
+                  if (db_key >= shadow_key) {
+                      break;
+                  }
+                  stats.verification_checks++;
+                  bench_log.error(
+                    "Verification failed: key {} exists in DB but not in "
+                    "shadow map",
+                    db_key);
+                  stats.verification_failures++;
+                  co_await iter->next();
+              }
+
+              stats.verification_checks++;
+              if (!iter->valid()) {
+                  // DB exhausted; live shadow entries are missing.
+                  if (shadow_val.has_value()) {
+                      bench_log.error(
+                        "Verification failed: key {} missing from DB",
+                        shadow_key);
+                      stats.verification_failures++;
+                  }
+                  co_return;
+              }
+
+              auto db_key = ss::sstring(iter->key().user_key());
+              if (db_key == shadow_key) {
+                  if (!shadow_val.has_value()) {
+                      bench_log.error(
+                        "Verification failed: deleted key {} still exists "
+                        "in DB",
+                        shadow_key);
+                      stats.verification_failures++;
+                  } else if (shadow_val.value() != iter->value()) {
+                      bench_log.error(
+                        "Verification failed: key {} value mismatch",
+                        shadow_key);
+                      stats.verification_failures++;
+                  }
+                  co_await iter->next();
+              } else {
+                  // db_key > shadow_key: shadow entry missing from DB.
+                  if (shadow_val.has_value()) {
+                      bench_log.error(
+                        "Verification failed: key {} missing from DB",
+                        shadow_key);
+                      stats.verification_failures++;
+                  }
+              }
+          });
+
+        // Remaining DB entries not tracked by shadow.
         while (iter->valid()) {
             if (_as.abort_requested()) {
                 co_return;
             }
-            auto key = ss::sstring(iter->key().user_key());
-            auto value = iter->value();
-            db_keys[key] = value.copy();
-            co_await iter->next();
-        }
-
-        // Verify shadow map matches database
-        for (const auto& [key, expected_value_opt] : _shadow.data) {
-            if (_as.abort_requested()) {
-                co_return;
-            }
             stats.verification_checks++;
-
-            if (!expected_value_opt.has_value()) {
-                // Should be deleted
-                if (db_keys.contains(key)) {
-                    bench_log.error(
-                      "Verification failed: deleted key {} still exists in DB",
-                      key);
-                    stats.verification_failures++;
-                }
-            } else {
-                // Should exist with value
-                auto it = db_keys.find(key);
-                if (it == db_keys.end()) {
-                    bench_log.error(
-                      "Verification failed: key {} missing from DB", key);
-                    stats.verification_failures++;
-                } else if (it->second != expected_value_opt.value()) {
-                    bench_log.error(
-                      "Verification failed: key {} value mismatch", key);
-                    stats.verification_failures++;
-                }
-            }
-        }
-
-        // Verify database doesn't have extra keys
-        for (const auto& [key, _] : db_keys) {
-            if (_as.abort_requested()) {
-                co_return;
-            }
-            if (!_shadow.data.contains(key)) {
-                stats.verification_checks++;
-                bench_log.error(
-                  "Verification failed: key {} exists in DB but not in shadow "
-                  "map",
-                  key);
-                stats.verification_failures++;
-            }
+            bench_log.error(
+              "Verification failed: key {} exists in DB but not in "
+              "shadow map",
+              ss::sstring(iter->key().user_key()));
+            stats.verification_failures++;
+            co_await iter->next();
         }
 
         bench_log.debug("Verification scan complete");

--- a/src/v/lsm/db/tests/db_bench.cc
+++ b/src/v/lsm/db/tests/db_bench.cc
@@ -36,6 +36,7 @@
 #include <exception>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace po = boost::program_options;
@@ -229,6 +230,7 @@ public:
     }
 
     ss::future<> teardown() {
+        co_await await_verification();
         if (_db) {
             co_await _db->close();
         }
@@ -301,12 +303,14 @@ private:
             co_await write_key(key, value.copy(), stats);
 
             if (_cfg.verify && (i % _cfg.verify_interval == 0)) {
-                co_await verify_all(stats);
+                co_await maybe_verify(stats);
             }
         }
 
         if (_cfg.verify) {
-            co_await verify_all(stats);
+            co_await await_verification();
+            auto iter = co_await _db->create_iterator({});
+            co_await verify_all(std::move(iter), _shadow.data, stats);
         }
     }
 
@@ -324,12 +328,14 @@ private:
             co_await write_key(key, value.copy(), stats);
 
             if (_cfg.verify && (i % _cfg.verify_interval == 0)) {
-                co_await verify_all(stats);
+                co_await maybe_verify(stats);
             }
         }
 
         if (_cfg.verify) {
-            co_await verify_all(stats);
+            co_await await_verification();
+            auto iter = co_await _db->create_iterator({});
+            co_await verify_all(std::move(iter), _shadow.data, stats);
         }
     }
 
@@ -355,12 +361,14 @@ private:
             co_await write_key(key, std::move(value), stats);
 
             if (_cfg.verify && (i % _cfg.verify_interval == 0)) {
-                co_await verify_all(stats);
+                co_await maybe_verify(stats);
             }
         }
 
         if (_cfg.verify) {
-            co_await verify_all(stats);
+            co_await await_verification();
+            auto iter = co_await _db->create_iterator({});
+            co_await verify_all(std::move(iter), _shadow.data, stats);
         }
     }
 
@@ -384,12 +392,14 @@ private:
             co_await delete_key(key, stats);
 
             if (_cfg.verify && (i % _cfg.verify_interval == 0)) {
-                co_await verify_all(stats);
+                co_await maybe_verify(stats);
             }
         }
 
         if (_cfg.verify) {
-            co_await verify_all(stats);
+            co_await await_verification();
+            auto iter = co_await _db->create_iterator({});
+            co_await verify_all(std::move(iter), _shadow.data, stats);
         }
     }
 
@@ -416,12 +426,14 @@ private:
             co_await delete_key(key, stats);
 
             if (_cfg.verify && (i % _cfg.verify_interval == 0)) {
-                co_await verify_all(stats);
+                co_await maybe_verify(stats);
             }
         }
 
         if (_cfg.verify) {
-            co_await verify_all(stats);
+            co_await await_verification();
+            auto iter = co_await _db->create_iterator({});
+            co_await verify_all(std::move(iter), _shadow.data, stats);
         }
     }
 
@@ -453,12 +465,14 @@ private:
             co_await read_key(key, stats);
 
             if (_cfg.verify && (i % _cfg.verify_interval == 0)) {
-                co_await verify_all(stats);
+                co_await maybe_verify(stats);
             }
         }
 
         if (_cfg.verify) {
-            co_await verify_all(stats);
+            co_await await_verification();
+            auto iter = co_await _db->create_iterator({});
+            co_await verify_all(std::move(iter), _shadow.data, stats);
         }
     }
 
@@ -515,7 +529,9 @@ private:
         }
 
         if (_cfg.verify) {
-            co_await verify_all(stats);
+            co_await await_verification();
+            auto iter = co_await _db->create_iterator({});
+            co_await verify_all(std::move(iter), _shadow.data, stats);
         }
     }
 
@@ -568,12 +584,14 @@ private:
             }
 
             if (_cfg.verify && (i % _cfg.verify_interval == 0)) {
-                co_await verify_all(stats);
+                co_await maybe_verify(stats);
             }
         }
 
         if (_cfg.verify) {
-            co_await verify_all(stats);
+            co_await await_verification();
+            auto iter = co_await _db->create_iterator({});
+            co_await verify_all(std::move(iter), _shadow.data, stats);
         }
     }
 
@@ -664,19 +682,42 @@ private:
         }
     }
 
-    ss::future<> verify_all(benchmark_stats& stats) {
+    ss::future<> maybe_verify(benchmark_stats& stats) {
+        if (!_verify_fut.available()) {
+            co_return;
+        }
+        auto iter = co_await _db->create_iterator({});
+        auto snapshot = _shadow.data;
+        _verify_fut = verify_all(std::move(iter), std::move(snapshot), stats)
+                        .then_wrapped([](ss::future<> f) {
+                            if (f.failed()) {
+                                auto ep = f.get_exception();
+                                bench_log.error(
+                                  "Background verification failed: {}", ep);
+                            }
+                        });
+    }
+
+    ss::future<> await_verification() {
+        return std::exchange(_verify_fut, ss::make_ready_future<>());
+    }
+
+    ss::future<> verify_all(
+      std::unique_ptr<lsm::internal::iterator> iter,
+      shadow_state::tree_type shadow,
+      benchmark_stats& stats) {
         bench_log.debug("Performing full verification scan");
 
-        auto iter = co_await _db->create_iterator({});
         co_await iter->seek_to_first();
 
         // Both the shadow tree and DB iterator produce entries in sorted
         // order. Walk the shadow tree and advance the DB iterator in
         // lockstep so we never need to copy the database into a map.
-        co_await _shadow.data.for_each(
-          [&](this auto,
-              const ss::sstring& shadow_key,
-              const std::optional<iobuf>& shadow_val) -> ss::future<> {
+        co_await shadow.for_each(
+          [&](
+            this auto,
+            const ss::sstring& shadow_key,
+            const std::optional<iobuf>& shadow_val) -> ss::future<> {
               if (_as.abort_requested()) {
                   co_return;
               }
@@ -759,6 +800,7 @@ private:
     std::unique_ptr<lsm::db::impl> _db;
     ss::abort_source _as;
     shadow_state _shadow;
+    ss::future<> _verify_fut = ss::make_ready_future<>();
     lsm::internal::sequence_number _seqno;
 };
 

--- a/src/v/lsm/db/tests/immutable_tree.h
+++ b/src/v/lsm/db/tests/immutable_tree.h
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/shared_ptr.hh>
+
+#include <algorithm>
+#include <functional>
+#include <type_traits>
+#include <vector>
+
+namespace lsm::db {
+
+/// An immutable (persistent) sorted tree.
+///
+/// All mutation operations return a new tree that shares structure with the
+/// original via ss::lw_shared_ptr. This makes it safe to hold references to
+/// old versions of the tree while new versions are created.
+///
+/// Key-value data within each node is shared via ss::lw_shared_ptr so that
+/// path-copying during tree operations only copies pointers, not actual data.
+/// This means neither Key nor Value needs to be copy constructible.
+template<typename Key, typename Value, typename Compare = std::less<Key>>
+class immutable_tree {
+    struct entry {
+        entry(Key k, Value v)
+          : key(std::move(k))
+          , value(std::move(v)) {}
+
+        Key key;
+        Value value;
+    };
+    using entry_ptr = ss::lw_shared_ptr<entry>;
+
+    struct node {
+        node(
+          entry_ptr d,
+          // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+          ss::lw_shared_ptr<node> l,
+          ss::lw_shared_ptr<node> r,
+          int h)
+          : data(std::move(d))
+          , left(std::move(l))
+          , right(std::move(r))
+          , height(h) {}
+
+        entry_ptr data;
+        ss::lw_shared_ptr<node> left;
+        ss::lw_shared_ptr<node> right;
+        int height;
+    };
+    using node_ptr = ss::lw_shared_ptr<node>;
+
+    node_ptr _root;
+    size_t _size = 0;
+    Compare _cmp;
+
+    immutable_tree(node_ptr root, size_t size, Compare cmp)
+      : _root(std::move(root))
+      , _size(size)
+      , _cmp(std::move(cmp)) {}
+
+public:
+    /// Create an empty tree.
+    immutable_tree() = default;
+
+    /// Create an empty tree with a custom comparator.
+    explicit immutable_tree(Compare cmp)
+      : _cmp(std::move(cmp)) {}
+
+    /// Insert a key-value pair, returning a new tree.
+    ///
+    /// If the key already exists, the value is replaced. The original tree
+    /// is not modified.
+    immutable_tree insert(Key key, Value value) const {
+        bool replaced = false;
+        auto e = ss::make_lw_shared<entry>(std::move(key), std::move(value));
+        auto new_root = do_insert(_root, std::move(e), replaced);
+        return {std::move(new_root), replaced ? _size : _size + 1, _cmp};
+    }
+
+    /// Remove a key from the tree, returning a new tree.
+    ///
+    /// If the key does not exist, returns a copy of this tree.
+    immutable_tree remove(const Key& key) const {
+        bool removed = false;
+        auto new_root = do_remove(_root, key, removed);
+        if (!removed) {
+            return *this;
+        }
+        return {std::move(new_root), _size - 1, _cmp};
+    }
+
+    /// Look up a key, returning a pointer to the value or nullptr.
+    const Value* get(const Key& key) const {
+        auto curr = _root;
+        while (curr) {
+            if (_cmp(key, curr->data->key)) {
+                curr = curr->left;
+            } else if (_cmp(curr->data->key, key)) {
+                curr = curr->right;
+            } else {
+                return &curr->data->value;
+            }
+        }
+        return nullptr;
+    }
+
+    /// Iterate over all entries in sorted order.
+    ///
+    /// The callback is invoked as fn(const Key&, const Value&) for each
+    /// entry. Uses an explicit stack instead of recursion.
+    ///
+    /// If the callback returns void, iteration is synchronous. If it
+    /// returns ss::future<>, iteration is asynchronous and the returned
+    /// future must be awaited.
+    template<typename Fn>
+    auto for_each(Fn fn) const {
+        using R = std::invoke_result_t<Fn&, const Key&, const Value&>;
+        if constexpr (std::is_void_v<R>) {
+            if (!_root) {
+                return;
+            }
+            std::vector<node_ptr> stack;
+            stack.reserve(_root->height);
+            auto curr = _root;
+            while (curr || !stack.empty()) {
+                while (curr) {
+                    stack.push_back(curr);
+                    curr = curr->left;
+                }
+                curr = std::move(stack.back());
+                stack.pop_back();
+                fn(curr->data->key, curr->data->value);
+                curr = curr->right;
+            }
+        } else {
+            return do_for_each_async(std::move(fn));
+        }
+    }
+
+    /// The number of entries in the tree.
+    size_t size() const { return _size; }
+
+    /// Whether the tree is empty.
+    bool empty() const { return !_root; }
+
+private:
+    template<typename Fn>
+    ss::future<> do_for_each_async(Fn fn) const {
+        if (!_root) {
+            co_return;
+        }
+        std::vector<node_ptr> stack;
+        stack.reserve(_root->height);
+        auto curr = _root;
+        while (curr || !stack.empty()) {
+            while (curr) {
+                stack.push_back(curr);
+                curr = curr->left;
+            }
+            curr = std::move(stack.back());
+            stack.pop_back();
+            co_await fn(curr->data->key, curr->data->value);
+            curr = curr->right;
+        }
+    }
+
+    static int node_height(const node_ptr& n) { return n ? n->height : 0; }
+
+    static int balance_factor(const node_ptr& n) {
+        return n ? node_height(n->left) - node_height(n->right) : 0;
+    }
+
+    static node_ptr make_node(entry_ptr data, node_ptr left, node_ptr right) {
+        int h = 1 + std::max(node_height(left), node_height(right));
+        return ss::make_lw_shared<node>(
+          std::move(data), std::move(left), std::move(right), h);
+    }
+
+    static node_ptr rotate_right(const node_ptr& y) {
+        const auto& x = y->left;
+        auto new_y = make_node(y->data, x->right, y->right);
+        return make_node(x->data, x->left, std::move(new_y));
+    }
+
+    static node_ptr rotate_left(const node_ptr& x) {
+        const auto& y = x->right;
+        auto new_x = make_node(x->data, x->left, y->left);
+        return make_node(y->data, std::move(new_x), y->right);
+    }
+
+    static node_ptr do_balance(node_ptr n) {
+        int bf = balance_factor(n);
+        if (bf > 1) {
+            // Left-Right case
+            if (balance_factor(n->left) < 0) {
+                auto new_left = rotate_left(n->left);
+                n = make_node(n->data, std::move(new_left), n->right);
+            }
+            return rotate_right(n);
+        }
+        if (bf < -1) {
+            // Right-Left case
+            if (balance_factor(n->right) > 0) {
+                auto new_right = rotate_right(n->right);
+                n = make_node(n->data, n->left, std::move(new_right));
+            }
+            return rotate_left(n);
+        }
+        return n;
+    }
+
+    node_ptr
+    do_insert(const node_ptr& root, entry_ptr e, bool& replaced) const {
+        if (!root) {
+            replaced = false;
+            return make_node(std::move(e), nullptr, nullptr);
+        }
+        if (_cmp(e->key, root->data->key)) {
+            auto new_left = do_insert(root->left, std::move(e), replaced);
+            return do_balance(
+              make_node(root->data, std::move(new_left), root->right));
+        }
+        if (_cmp(root->data->key, e->key)) {
+            auto new_right = do_insert(root->right, std::move(e), replaced);
+            return do_balance(
+              make_node(root->data, root->left, std::move(new_right)));
+        }
+        // Key already exists, replace the value.
+        replaced = true;
+        return make_node(std::move(e), root->left, root->right);
+    }
+
+    static const node_ptr& find_min(const node_ptr& n) {
+        const node_ptr* curr = &n;
+        while ((*curr)->left) {
+            curr = &(*curr)->left;
+        }
+        return *curr;
+    }
+
+    static node_ptr remove_min(const node_ptr& root) {
+        if (!root->left) {
+            return root->right;
+        }
+        auto new_left = remove_min(root->left);
+        return do_balance(
+          make_node(root->data, std::move(new_left), root->right));
+    }
+
+    node_ptr
+    do_remove(const node_ptr& root, const Key& key, bool& removed) const {
+        if (!root) {
+            removed = false;
+            return nullptr;
+        }
+        if (_cmp(key, root->data->key)) {
+            auto new_left = do_remove(root->left, key, removed);
+            if (!removed) {
+                return root;
+            }
+            return do_balance(
+              make_node(root->data, std::move(new_left), root->right));
+        }
+        if (_cmp(root->data->key, key)) {
+            auto new_right = do_remove(root->right, key, removed);
+            if (!removed) {
+                return root;
+            }
+            return do_balance(
+              make_node(root->data, root->left, std::move(new_right)));
+        }
+        // Found the key.
+        removed = true;
+        if (!root->left) {
+            return root->right;
+        }
+        if (!root->right) {
+            return root->left;
+        }
+        // Two children: replace with the in-order successor.
+        const auto& successor = find_min(root->right);
+        auto new_right = remove_min(root->right);
+        return do_balance(
+          make_node(successor->data, root->left, std::move(new_right)));
+    }
+};
+
+} // namespace lsm::db

--- a/src/v/lsm/db/tests/immutable_tree_test.cc
+++ b/src/v/lsm/db/tests/immutable_tree_test.cc
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "gtest/gtest.h"
+#include "lsm/db/tests/immutable_tree.h"
+
+#include <string>
+#include <vector>
+
+namespace {
+
+using tree = lsm::db::immutable_tree<int, std::string>;
+
+std::vector<std::pair<int, std::string>> collect(const tree& t) {
+    std::vector<std::pair<int, std::string>> result;
+    t.for_each(
+      [&](const int& k, const std::string& v) { result.emplace_back(k, v); });
+    return result;
+}
+
+} // namespace
+
+TEST(ImmutableTree, EmptyTree) {
+    tree t;
+    EXPECT_TRUE(t.empty());
+    EXPECT_EQ(t.size(), 0);
+    EXPECT_EQ(t.get(1), nullptr);
+    EXPECT_TRUE(collect(t).empty());
+}
+
+TEST(ImmutableTree, InsertSingle) {
+    tree t;
+    auto t2 = t.insert(1, "one");
+
+    // Original tree is unchanged.
+    EXPECT_TRUE(t.empty());
+
+    EXPECT_EQ(t2.size(), 1);
+    ASSERT_NE(t2.get(1), nullptr);
+    EXPECT_EQ(*t2.get(1), "one");
+}
+
+TEST(ImmutableTree, InsertMultiple) {
+    auto t = tree{}.insert(3, "three").insert(1, "one").insert(2, "two");
+
+    EXPECT_EQ(t.size(), 3);
+
+    auto entries = collect(t);
+    ASSERT_EQ(entries.size(), 3);
+    EXPECT_EQ(entries[0], std::make_pair(1, std::string("one")));
+    EXPECT_EQ(entries[1], std::make_pair(2, std::string("two")));
+    EXPECT_EQ(entries[2], std::make_pair(3, std::string("three")));
+}
+
+TEST(ImmutableTree, InsertDuplicateReplacesValue) {
+    auto t1 = tree{}.insert(1, "one");
+    auto t2 = t1.insert(1, "ONE");
+
+    EXPECT_EQ(t2.size(), 1);
+    ASSERT_NE(t2.get(1), nullptr);
+    EXPECT_EQ(*t2.get(1), "ONE");
+
+    // Original is unchanged.
+    ASSERT_NE(t1.get(1), nullptr);
+    EXPECT_EQ(*t1.get(1), "one");
+}
+
+TEST(ImmutableTree, GetNonExistent) {
+    auto t = tree{}.insert(1, "one").insert(3, "three");
+    EXPECT_EQ(t.get(2), nullptr);
+    EXPECT_EQ(t.get(0), nullptr);
+    EXPECT_EQ(t.get(4), nullptr);
+}
+
+TEST(ImmutableTree, RemoveExisting) {
+    auto t1 = tree{}.insert(1, "one").insert(2, "two").insert(3, "three");
+    auto t2 = t1.remove(2);
+
+    EXPECT_EQ(t2.size(), 2);
+    EXPECT_EQ(t2.get(2), nullptr);
+    ASSERT_NE(t2.get(1), nullptr);
+    ASSERT_NE(t2.get(3), nullptr);
+
+    // Original is unchanged.
+    EXPECT_EQ(t1.size(), 3);
+    ASSERT_NE(t1.get(2), nullptr);
+}
+
+TEST(ImmutableTree, RemoveNonExistent) {
+    auto t1 = tree{}.insert(1, "one");
+    auto t2 = t1.remove(99);
+
+    EXPECT_EQ(t2.size(), 1);
+    ASSERT_NE(t2.get(1), nullptr);
+}
+
+TEST(ImmutableTree, RemoveFromEmpty) {
+    tree t;
+    auto t2 = t.remove(1);
+    EXPECT_TRUE(t2.empty());
+}
+
+TEST(ImmutableTree, RemoveOnlyElement) {
+    auto t1 = tree{}.insert(1, "one");
+    auto t2 = t1.remove(1);
+    EXPECT_TRUE(t2.empty());
+    EXPECT_EQ(t2.get(1), nullptr);
+}
+
+TEST(ImmutableTree, RemoveWithTwoChildren) {
+    // Build a tree where the removed node has two children.
+    auto t = tree{}.insert(2, "two").insert(1, "one").insert(3, "three");
+    auto t2 = t.remove(2);
+
+    EXPECT_EQ(t2.size(), 2);
+    auto entries = collect(t2);
+    ASSERT_EQ(entries.size(), 2);
+    EXPECT_EQ(entries[0].first, 1);
+    EXPECT_EQ(entries[1].first, 3);
+}
+
+TEST(ImmutableTree, ImmutabilityAcrossOperations) {
+    auto t0 = tree{};
+    auto t1 = t0.insert(5, "five");
+    auto t2 = t1.insert(3, "three");
+    auto t3 = t2.insert(7, "seven");
+    auto t4 = t3.remove(5);
+
+    // Each version should be independently valid.
+    EXPECT_EQ(t0.size(), 0);
+    EXPECT_EQ(t1.size(), 1);
+    EXPECT_EQ(t2.size(), 2);
+    EXPECT_EQ(t3.size(), 3);
+    EXPECT_EQ(t4.size(), 2);
+
+    EXPECT_EQ(t4.get(5), nullptr);
+    ASSERT_NE(t4.get(3), nullptr);
+    ASSERT_NE(t4.get(7), nullptr);
+
+    // t3 still has key 5.
+    ASSERT_NE(t3.get(5), nullptr);
+    EXPECT_EQ(*t3.get(5), "five");
+}
+
+TEST(ImmutableTree, SortedInsertionStaysBalanced) {
+    // Insert keys in ascending order (worst case for a naive BST).
+    // If the balancing is wrong this will degenerate into a linked list.
+    tree t;
+    constexpr int n = 1000;
+    for (int i = 0; i < n; ++i) {
+        t = t.insert(i, std::to_string(i));
+    }
+    EXPECT_EQ(t.size(), n);
+
+    // Verify sorted order via for_each.
+    int prev = -1;
+    int count = 0;
+    t.for_each([&](const int& k, const std::string&) {
+        EXPECT_GT(k, prev);
+        prev = k;
+        ++count;
+    });
+    EXPECT_EQ(count, n);
+}
+
+TEST(ImmutableTree, ReverseInsertionStaysBalanced) {
+    tree t;
+    constexpr int n = 1000;
+    for (int i = n - 1; i >= 0; --i) {
+        t = t.insert(i, std::to_string(i));
+    }
+    EXPECT_EQ(t.size(), n);
+
+    auto entries = collect(t);
+    for (int i = 0; i < n; ++i) {
+        EXPECT_EQ(entries[i].first, i);
+    }
+}
+
+TEST(ImmutableTree, InsertAndRemoveMany) {
+    tree t;
+    constexpr int n = 500;
+    for (int i = 0; i < n; ++i) {
+        t = t.insert(i, std::to_string(i));
+    }
+    // Remove even keys.
+    for (int i = 0; i < n; i += 2) {
+        t = t.remove(i);
+    }
+    EXPECT_EQ(t.size(), n / 2);
+
+    // Only odd keys remain.
+    for (int i = 0; i < n; ++i) {
+        if (i % 2 == 0) {
+            EXPECT_EQ(t.get(i), nullptr);
+        } else {
+            ASSERT_NE(t.get(i), nullptr);
+            EXPECT_EQ(*t.get(i), std::to_string(i));
+        }
+    }
+
+    // Verify sorted order.
+    int prev = -1;
+    t.for_each([&](const int& k, const std::string&) {
+        EXPECT_GT(k, prev);
+        prev = k;
+    });
+}
+
+TEST(ImmutableTree, ForEachOnSingleElement) {
+    auto t = tree{}.insert(42, "answer");
+    int count = 0;
+    t.for_each([&](const int& k, const std::string& v) {
+        EXPECT_EQ(k, 42);
+        EXPECT_EQ(v, "answer");
+        ++count;
+    });
+    EXPECT_EQ(count, 1);
+}

--- a/src/v/lsm/db/tests/impl_test.cc
+++ b/src/v/lsm/db/tests/impl_test.cc
@@ -186,6 +186,36 @@ public:
         }
     }
 
+    void delete_random_keys(lsm::db::impl* db = nullptr) {
+        if (_shadow.empty()) {
+            return;
+        }
+        if (!db) {
+            db = _db.get();
+        }
+        auto batch = ss::make_lw_shared<lsm::db::memtable>();
+        auto seqno = db->max_applied_seqno().value_or(0_seqno);
+        std::vector<ss::sstring> keys_to_delete;
+        for (auto& [k, _] : _shadow) {
+            if (random_generators::get_int(0, 3) == 0) {
+                auto key = lsm::internal::key::encode({
+                  .key = lsm::user_key_view(k),
+                  .seqno = ++seqno,
+                  .type = lsm::internal::value_type::tombstone,
+                });
+                batch->remove(std::move(key));
+                keys_to_delete.push_back(k);
+            }
+        }
+        if (keys_to_delete.empty()) {
+            return;
+        }
+        db->apply(std::move(batch)).get();
+        for (auto& k : keys_to_delete) {
+            _shadow.erase(k);
+        }
+    }
+
     testing::AssertionResult matches_shadow(lsm::db::impl* db = nullptr) {
         return matches_shadow(_shadow, nullptr, db);
     }
@@ -343,6 +373,20 @@ TEST_F(ImplTest, Randomized) {
 #endif
     for (int i = 0; i < rounds; ++i) {
         write_at_least(128_KiB);
+        EXPECT_TRUE(matches_shadow());
+    }
+}
+
+TEST_F(ImplTest, RandomizedWithDeletes) {
+#ifndef NDEBUG
+    int rounds = 100;
+#else
+    int rounds = 1000;
+#endif
+    for (int i = 0; i < rounds; ++i) {
+        write_at_least(128_KiB);
+        EXPECT_TRUE(matches_shadow());
+        delete_random_keys();
         EXPECT_TRUE(matches_shadow());
     }
 }

--- a/src/v/lsm/db/tests/split_by_shard.py
+++ b/src/v/lsm/db/tests/split_by_shard.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Split log files by shard number.
+
+Handles multiline logs by attributing continuation lines to the last seen shard.
+
+Usage: python split_by_shard.py <logfile> [output_dir]
+"""
+
+import os
+import re
+import sys
+
+SHARD_RE = re.compile(r"\[shard (\d+):")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <logfile> [output_dir]", file=sys.stderr)
+        sys.exit(1)
+
+    logfile = sys.argv[1]
+    output_dir = sys.argv[2] if len(sys.argv) > 2 else "."
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    files = {}
+    current_shard = None
+
+    with open(logfile) as f:
+        for line in f:
+            m = SHARD_RE.search(line)
+            if m:
+                current_shard = m.group(1)
+            if current_shard is None:
+                continue
+            if current_shard not in files:
+                path = os.path.join(output_dir, f"shard-{current_shard}.log")
+                files[current_shard] = open(path, "w")
+            files[current_shard].write(line)
+
+    for fh in files.values():
+        fh.close()
+
+    for shard in sorted(files, key=int):
+        print(f"shard {shard} -> {files[shard].name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/v/lsm/db/tests/version_set_test.cc
+++ b/src/v/lsm/db/tests/version_set_test.cc
@@ -471,6 +471,51 @@ TEST_F(VersionSetTest, GetOverlappingUserKey) {
     EXPECT_THAT(result, IsMissing());
 }
 
+TEST_F(VersionSetTest, IteratorsKeepVersionFilesLive) {
+    // When add_iterators is called on a version with only L0 files, the
+    // version_lifetime_iterator keeps the version alive. This means
+    // get_live_files() must still report those files even after a new version
+    // is installed that removes them.
+    add_sst({
+      .id = 1_file_id,
+      .level = 0_level,
+      .keys = {"a@1"_key, "b@1"_key},
+    });
+    add_sst({
+      .id = 2_file_id,
+      .level = 0_level,
+      .keys = {"c@1"_key, "d@1"_key},
+    });
+
+    // Create iterators for the current version. Since we only have L0 files,
+    // add_iterators will insert a version_lifetime_iterator that holds a
+    // reference to this version.
+    chunked_vector<std::unique_ptr<lsm::internal::iterator>> iters;
+    version_set().current()->add_iterators(&iters).get();
+
+    // Create a new version that removes both files.
+    auto edit = version_set().new_edit();
+    edit->remove_file(0_level, {.id = 1_file_id});
+    edit->remove_file(0_level, {.id = 2_file_id});
+    edit->set_last_seqno(1_seqno);
+    version_set().log_and_apply(std::move(edit)).get();
+
+    // The current version should have no files.
+    EXPECT_EQ(version_set().current()->num_files(0_level), 0);
+
+    // But get_live_files must still include the old files because the
+    // iterators keep the old version alive.
+    auto live = version_set().get_live_files();
+    EXPECT_TRUE(live.contains({.id = 1_file_id}));
+    EXPECT_TRUE(live.contains({.id = 2_file_id}));
+
+    // Drop the iterators, releasing the version reference.
+    iters.clear();
+
+    // Now the files should no longer be considered live.
+    EXPECT_THAT(version_set().get_live_files(), IsEmpty());
+}
+
 TEST_F(CompactionTest, PickCompactionLevel0ToLevel1) {
     // Add 4 files to L0 to trigger compaction
     add_file(0_level, 1_file_id, "a"_key, "d"_key);

--- a/src/v/lsm/db/version_set.cc
+++ b/src/v/lsm/db/version_set.cc
@@ -483,15 +483,16 @@ ss::future<> version::for_each_overlapping(
 fmt::iterator version::format_to(fmt::iterator it) const {
     // For example:
     //   --- level 1 ---
-    //   17:234['a' .. 'e']
-    //   20:31['a' .. 'e']
+    //   0-17:234['a' .. 'e']
+    //   3-20:31['a' .. 'e']
     for (size_t level = 0; level < _files.size(); ++level) {
         it = fmt::format_to(it, "--- level {} ---\n", level);
         for (const auto& file : _files[level]) {
             it = fmt::format_to(
               it,
-              "{}:{}['{}' .. '{}']\n",
-              file->handle,
+              "{}-{}:{}['{}' .. '{}']\n",
+              file->handle.epoch,
+              file->handle.id,
               file->file_size,
               file->smallest,
               file->largest);
@@ -911,6 +912,26 @@ bool compaction::should_stop_before(internal::key_view key) {
     } else {
         return false;
     }
+}
+
+fmt::iterator compaction::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it,
+      "level={} input_level_files={{{}}} "
+      "output_level_files={{{}}} grandparents={{{}}}",
+      _level,
+      fmt::join(
+        std::views::transform(
+          _inputs[0], [](const auto& file) { return file->handle; }),
+        ","),
+      fmt::join(
+        std::views::transform(
+          _inputs[1], [](const auto& file) { return file->handle; }),
+        ","),
+      fmt::join(
+        std::views::transform(
+          _grandparents, [](const auto& file) { return file->handle; }),
+        ","));
 }
 
 } // namespace lsm::db

--- a/src/v/lsm/db/version_set.cc
+++ b/src/v/lsm/db/version_set.cc
@@ -35,7 +35,7 @@ using internal::operator""_level;
 
 // An internal iterator. For a given version/level pair, yields information
 // about the files in the level. For a given entry, key() is the largest key
-// that occurs in teh file, and value()  is an 16-byte value containing the file
+// that occurs in the file, and value()  is an 16-byte value containing the file
 // number and file size, both encoded using 64bit fixed encoding.
 //
 // NOTE: It's up to the user of this class to ensure the files pointer is kept
@@ -109,6 +109,49 @@ private:
     chunked_vector<ss::lw_shared_ptr<file_meta_data>>* _files;
     uint32_t _index;
     iobuf _value_buf;
+};
+
+// An iterator that keeps a `version` pointer reference alive.
+//
+// This is needed because we use versions that are still alive as
+// knowledge of whether a version is safe to GC. Some cases, like L0 iteration,
+// can use file iterators directly, so in those cases we need some kind of
+// reference to keep L0 files alive.
+class version_lifetime_iterator : public internal::iterator {
+public:
+    explicit version_lifetime_iterator(ss::lw_shared_ptr<version> version)
+      : _version(std::move(version)) {}
+
+    bool valid() const override { return false; }
+
+    ss::future<> seek_to_first() override { return ss::now(); }
+
+    ss::future<> seek_to_last() override { return ss::now(); }
+
+    ss::future<> seek(internal::key_view) override { return ss::now(); }
+
+    ss::future<> next() override {
+        throw invalid_argument_exception(
+          "next() called on version lifetime iterator");
+    }
+
+    ss::future<> prev() override {
+        throw invalid_argument_exception(
+          "prev() called on version lifetime iterator");
+    }
+
+    internal::key_view key() override {
+        throw invalid_argument_exception(
+          "key() called on version lifetime iterator");
+    }
+
+    iobuf value() override {
+        throw invalid_argument_exception(
+          "value() called on version lifetime iterator");
+    }
+
+private:
+    ss::lw_shared_ptr<version> _version;
 };
 
 } // namespace
@@ -234,11 +277,20 @@ ss::future<> version::add_iterators(
     // For levels > 0, we can use a concatenating iterator that sequentially
     // walks through the non-overlapping files in the level, opening them
     // lazily.
+    int non_empty_levels = 0;
     for (const auto& level : std::span(_vset->_options->levels).subspan(1)) {
         if (_files[level.number].empty()) {
             continue;
         }
+        ++non_empty_levels;
         iters->push_back(create_concatenating_iterator(level.number));
+    }
+    // If there are no files outside of L0, we need to keep a reference to
+    // this version to prevent GC from running and assuming there are no files
+    // being used in this version anymore.
+    if (non_empty_levels == 0) {
+        iters->push_back(
+          std::make_unique<version_lifetime_iterator>(shared_from_this()));
     }
 }
 
@@ -806,6 +858,9 @@ version_set::make_input_iterator(compaction* c) {
         }
         if (&inputs == &c->_inputs.front() && c->level() == 0_level) {
             for (auto& file : inputs) {
+                // NOTE: in version::add_iterators we have to ensure that L0
+                // only iterators keep a ref to their version, in this case we
+                // rely on compaction for that.
                 list.push_back(
                   co_await _table_cache->create_iterator(
                     file->handle, file->file_size));

--- a/src/v/lsm/db/version_set.cc
+++ b/src/v/lsm/db/version_set.cc
@@ -12,10 +12,12 @@
 #include "lsm/db/version_set.h"
 
 #include "absl/container/btree_set.h"
+#include "base/vlog.h"
 #include "container/chunked_vector.h"
 #include "lsm/core/exceptions.h"
 #include "lsm/core/internal/files.h"
 #include "lsm/core/internal/keys.h"
+#include "lsm/core/internal/logger.h"
 #include "lsm/core/internal/merging_iterator.h"
 #include "lsm/core/internal/two_level_iterator.h"
 #include "lsm/db/file_utils.h"
@@ -26,6 +28,7 @@
 #include <seastar/coroutine/as_future.hh>
 
 #include <exception>
+#include <memory>
 
 namespace lsm::db {
 
@@ -565,6 +568,7 @@ version_set::version_set(
 }
 
 void version_set::set_current(ss::lw_shared_ptr<version> new_version) {
+    vlog(log.trace, "installing_new_version version=\n{}", *new_version);
     weak_intrusive_list<version>::push_front(&_current, std::move(new_version));
 }
 
@@ -840,6 +844,7 @@ std::optional<compaction> version_set::pick_compaction() {
     // key range next time.
     _compact_pointer[level] = largest;
     c->_edit->set_compact_pointer(level, largest);
+    vlog(log.trace, "picked_compaction compaction={}", *c);
     return c;
 }
 

--- a/src/v/lsm/db/version_set.h
+++ b/src/v/lsm/db/version_set.h
@@ -258,6 +258,8 @@ public:
     // before processing "internal_key".
     bool should_stop_before(internal::key_view key);
 
+    fmt::iterator format_to(fmt::iterator) const;
+
 private:
     friend class version;
     friend class version_set;

--- a/src/v/lsm/db/version_set.h
+++ b/src/v/lsm/db/version_set.h
@@ -270,7 +270,7 @@ private:
       internal::level level)
       : _level(level)
       , _edit(std::move(edit))
-      , _level_ptrs(options->levels.size()) {}
+      , _level_ptrs(/*n=*/options->levels.size(), /*val=*/0) {}
 
     internal::level _level;
     uint64_t _max_output_file_size = 0;


### PR DESCRIPTION
- **lsm/core: better key formatting**
- **lsm/version_set: improve formatting**
- **lsm: restore scheduling groups for compaction**
- **lsm: add a script for splitting logs by shard**
- **lsm: ensure that a reference is kept alive in add_iterators**
- **lsm: use {epoch}-{id}.sst instead of {id}-{epoch}.sst**
- **lsm: add trace logging for new versions + compaction**
- **lsm: improve comment formatting**
- **lsm: expand impl_test randomized test with deletes**
- **lsm: fix uninitialized values for compaction pointers**

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
