### PR TITLE
CORE-15189 SR Context: reestablish type safety and fix discovered bugs

### DIFF
--- a/src/v/datalake/record_schema_resolver.cc
+++ b/src/v/datalake/record_schema_resolver.cc
@@ -257,7 +257,7 @@ ss::future<checked<shared_schema_t, type_resolver::errc>> get_schema(
         }
     }
     auto schema_fut = co_await ss::coroutine::as_future(
-      sr->get_valid_schema(id));
+      sr->get_valid_schema({ppsr::default_context, id}));
     if (schema_fut.failed()) {
         auto ex = schema_fut.get_exception();
         vlog(datalake_log.warn, "Error getting schema from registry: {}", ex);
@@ -493,7 +493,8 @@ latest_subject_schema_resolver::resolve_buf_type(std::optional<iobuf> b) const {
 
     auto latest_schema_fut
       = co_await ss::coroutine::as_future<ppsr::stored_schema>(
-        sr_->get_subject_schema(subject_, /*subject_version=*/std::nullopt));
+        sr_->get_subject_schema(
+          {ppsr::default_context, subject_}, /*subject_version=*/std::nullopt));
     if (latest_schema_fut.failed()) {
         auto ex = latest_schema_fut.get_exception();
         vlog(

--- a/src/v/datalake/tests/record_generator.cc
+++ b/src/v/datalake/tests/record_generator.cc
@@ -43,7 +43,8 @@ record_generator::register_avro_schema(
     using namespace pandaproxy::schema_registry;
     auto id_fut = co_await ss::coroutine::as_future(_sr->create_schema(
       subject_schema{
-        subject{"foo"}, schema_definition{schema, schema_type::avro}}));
+        context_subject::unqualified("foo"),
+        schema_definition{schema, schema_type::avro}}));
     if (id_fut.failed()) {
         co_return error{fmt::format(
           "Error creating schema {}: {}", name, id_fut.get_exception())};
@@ -62,7 +63,8 @@ record_generator::register_protobuf_schema(
     using namespace pandaproxy::schema_registry;
     auto id = co_await ss::coroutine::as_future(_sr->create_schema(
       subject_schema{
-        subject{"foo"}, schema_definition{schema, schema_type::protobuf}}));
+        context_subject::unqualified("foo"),
+        schema_definition{schema, schema_type::protobuf}}));
     if (id.failed()) {
         co_return error{fmt::format(
           "Error creating schema {}: {}", name, id.get_exception())};
@@ -221,7 +223,8 @@ record_generator::register_json_schema(
     using namespace pandaproxy::schema_registry;
     auto id = co_await ss::coroutine::as_future(_sr->create_schema(
       subject_schema{
-        subject{"foo"}, schema_definition{schema, schema_type::json}}));
+        context_subject::unqualified("foo"),
+        schema_definition{schema, schema_type::json}}));
     if (id.failed()) {
         co_return error{fmt::format(
           "Error creating schema {}: {}", name, id.get_exception())};

--- a/src/v/datalake/tests/record_schema_resolver_test.cc
+++ b/src/v/datalake/tests/record_schema_resolver_test.cc
@@ -94,42 +94,42 @@ public:
     void SetUp() override {
         auto avro_schema_id = sr->create_schema(
                                   subject_schema{
-                                    subject{"foo-value"},
+                                    context_subject::unqualified("foo-value"),
                                     schema_definition{
                                       avro_record_schema, schema_type::avro}})
                                 .get();
         ASSERT_EQ(1, avro_schema_id.id());
         auto pb_schema_id = sr->create_schema(
                                 subject_schema{
-                                  subject{"foo-value"},
+                                  context_subject::unqualified("foo-value"),
                                   schema_definition{
                                     pb_record_schema, schema_type::protobuf}})
                               .get();
         ASSERT_EQ(2, pb_schema_id.id());
         auto json_schema_id = sr->create_schema(
                                   subject_schema{
-                                    subject{"foo-value"},
+                                    context_subject::unqualified("foo-value"),
                                     schema_definition{
                                       json_record_schema, schema_type::json}})
                                 .get();
         ASSERT_EQ(3, json_schema_id.id());
         avro_schema_id = sr->create_schema(
                              subject_schema{
-                               subject{"latest-avro"},
+                               context_subject::unqualified("latest-avro"),
                                schema_definition{
                                  avro_record_schema, schema_type::avro}})
                            .get();
         ASSERT_EQ(1, avro_schema_id.id());
         pb_schema_id = sr->create_schema(
                            subject_schema{
-                             subject{"latest-proto"},
+                             context_subject::unqualified("latest-proto"),
                              schema_definition{
                                pb_record_schema, schema_type::protobuf}})
                          .get();
         ASSERT_EQ(2, pb_schema_id.id());
         json_schema_id = sr->create_schema(
                              subject_schema{
-                               subject{"latest-json"},
+                               context_subject::unqualified("latest-json"),
                                schema_definition{
                                  json_record_schema, schema_type::json}})
                            .get();
@@ -257,14 +257,14 @@ message NestedMessage {
 )";
     auto pb_schema_id = sr->create_schema(
                             subject_schema{
-                              subject{"simple_schema"},
+                              context_subject::unqualified("simple_schema"),
                               schema_definition{
                                 pb_simple_schema, schema_type::protobuf}})
                           .get();
     ASSERT_EQ(7, pb_schema_id.id());
     pb_schema_id = sr->create_schema(
                        subject_schema{
-                         subject{"references_schema"},
+                         context_subject::unqualified("references_schema"),
                          schema_definition{
                            pb_references_schema,
                            schema_type::protobuf,
@@ -537,9 +537,8 @@ namespace {
 struct counting_store : public pandaproxy::schema_registry::schema_getter {
     counting_store(
       schema::fake_registry& registry,
-      absl::flat_hash_map<
-        pandaproxy::schema_registry::context_schema_id,
-        size_t>& counts)
+      absl::flat_hash_map<pandaproxy::schema_registry::schema_id, size_t>&
+        counts)
       : registry(registry)
       , counts(counts) {}
 
@@ -554,7 +553,8 @@ struct counting_store : public pandaproxy::schema_registry::schema_getter {
     ss::future<pandaproxy::schema_registry::schema_definition>
     get_schema_definition(
       pandaproxy::schema_registry::context_schema_id id) final {
-        counts[id] += 1;
+        vassert(id.ctx == default_context, "unexpected context {}", id.ctx);
+        counts[id.id] += 1;
         auto* getter = co_await registry.getter();
         co_return co_await getter->get_schema_definition(id);
     }
@@ -562,14 +562,14 @@ struct counting_store : public pandaproxy::schema_registry::schema_getter {
     ss::future<std::optional<pandaproxy::schema_registry::schema_definition>>
     maybe_get_schema_definition(
       pandaproxy::schema_registry::context_schema_id id) final {
-        counts[id] += 1;
+        vassert(id.ctx == default_context, "unexpected context {}", id.ctx);
+        counts[id.id] += 1;
         auto* getter = co_await registry.getter();
         co_return co_await getter->maybe_get_schema_definition(id);
     }
 
     schema::fake_registry& registry;
-    absl::flat_hash_map<pandaproxy::schema_registry::context_schema_id, size_t>&
-      counts;
+    absl::flat_hash_map<pandaproxy::schema_registry::schema_id, size_t>& counts;
 };
 
 class counting_registry : public schema::registry {
@@ -610,7 +610,7 @@ public:
         return _registry.get_all();
     }
 
-    size_t get_count(pandaproxy::schema_registry::context_schema_id id) {
+    size_t get_count(pandaproxy::schema_registry::schema_id id) {
         return _counts[id];
     }
 
@@ -618,7 +618,7 @@ public:
 
 private:
     schema::fake_registry _registry{};
-    absl::flat_hash_map<pandaproxy::schema_registry::context_schema_id, size_t>
+    absl::flat_hash_map<pandaproxy::schema_registry::schema_id, size_t>
       _counts{};
     mutable counting_store _store{_registry, _counts};
 };
@@ -632,14 +632,14 @@ std::unique_ptr<counting_registry> make_counting_sr() {
 
     auto avro_schema_id = sr->create_schema(
                               subject_schema{
-                                subject{"foo-value"},
+                                context_subject::unqualified("foo-value"),
                                 schema_definition{
                                   avro_record_schema, schema_type::avro}})
                             .get();
     vassert(1 == avro_schema_id.id(), "failed to registry avro schema");
     auto pb_schema_id = sr->create_schema(
                             subject_schema{
-                              subject{"foo-value"},
+                              context_subject::unqualified("foo-value"),
                               schema_definition{
                                 pb_record_schema, schema_type::protobuf}})
                           .get();
@@ -656,7 +656,7 @@ std::unique_ptr<counting_registry> make_counting_sr() {
     for (auto i = 3; i < 10; i++) {
         auto pb_schema_id = sr->create_schema(
                                 subject_schema{
-                                  subject{"foo-value"},
+                                  context_subject::unqualified("foo-value"),
                                   schema_definition{
                                     get_simple_schema(i),
                                     schema_type::protobuf}})
@@ -665,7 +665,7 @@ std::unique_ptr<counting_registry> make_counting_sr() {
     }
     auto json_schema_id = sr->create_schema(
                               subject_schema{
-                                subject{"foo-value"},
+                                context_subject::unqualified("foo-value"),
                                 schema_definition{
                                   json_record_schema, schema_type::json}})
                             .get();

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -1034,7 +1034,8 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
           .id = insert_result.id,
           .version = insert_result.version};
     } else {
-        response.schema = co_await st.get_schema_definition(response.id);
+        response.schema = co_await st.get_schema_definition(
+          {ctx_sub.ctx, response.id});
     }
 
     auto resp = ppj::rjson_serialize_iobuf(std::move(response));

--- a/src/v/pandaproxy/schema_registry/requests/test/get_subject_versions_version.cc
+++ b/src/v/pandaproxy/schema_registry/requests/test/get_subject_versions_version.cc
@@ -30,7 +30,8 @@ SEASTAR_THREAD_TEST_CASE(test_post_subject_versions_version_response) {
     const pps::subject sub{"imported-ref"};
 
     pps::get_subject_versions_version_response response{.stored_schema{
-      .schema{pps::subject{"imported-ref"}, schema_def.copy()},
+      .schema{
+        pps::context_subject::unqualified("imported-ref"), schema_def.copy()},
       .version{2},
       .id{12},
       .deleted{false}}};

--- a/src/v/pandaproxy/schema_registry/requests/test/post_subject_versions.cc
+++ b/src/v/pandaproxy/schema_registry/requests/test/post_subject_versions.cc
@@ -35,7 +35,7 @@ SEASTAR_THREAD_TEST_CASE(test_post_subject_versions_parser) {
       R"({"type":"record","name":"test","fields":[{"type":"string","name":"field1"},{"type":"com.acme.Referenced","name":"int"}]})",
       pps::schema_type::avro,
       {{.name{"com.acme.Referenced"},
-        .sub{pps::subject{"childSubject"}},
+        .sub{pps::context_subject::unqualified("childSubject")},
         .version{pps::schema_version{1}}}},
       {}};
 
@@ -53,7 +53,7 @@ SEASTAR_THREAD_TEST_CASE(test_post_subject_versions_parser) {
     }
   ]
 })"};
-    const pps::subject sub{"test_subject"};
+    const auto sub = pps::context_subject::unqualified("test_subject");
     const parse_result expected{
       {sub, expected_schema_def.share()}, std::nullopt, std::nullopt};
 
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(test_post_subject_versions_serde_metadata) {
     auto reset_flag = ss::defer(
       [] { pps::enable_qualified_subjects::reset_local(); });
 
-    const pps::subject sub{"test_subject"};
+    const auto sub = pps::context_subject::unqualified("test_subject");
     {
         constexpr std::string_view no_metadata{
           R"({

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -453,7 +453,8 @@ public:
         return std::ranges::any_of(_subjects, [&ids, inc_del](const auto& s) {
             return std::ranges::any_of(
               s.second.versions, [&ids, &s, inc_del](const auto& v) {
-                  return (inc_del || !s.second.deleted) && ids.contains(v.id);
+                  return (inc_del || !s.second.deleted)
+                         && ids.contains({s.first.ctx, v.id});
               });
         });
     }

--- a/src/v/pandaproxy/schema_registry/test/api_bench.cc
+++ b/src/v/pandaproxy/schema_registry/test/api_bench.cc
@@ -49,7 +49,8 @@ ss::sstring make_payload(
 }
 
 pps::context_subject make_subject(int i_sub) {
-    return pps::context_subject{ss::format("TestSubject{}", i_sub)};
+    return pps::context_subject::unqualified(
+      ss::format("TestSubject{}", i_sub));
 }
 
 pps::schema_version middle_version(int n_versions) {

--- a/src/v/pandaproxy/schema_registry/test/avro_schema_references.cc
+++ b/src/v/pandaproxy/schema_registry/test/avro_schema_references.cc
@@ -21,7 +21,7 @@ class AvroSchemaReferencesTest
 public:
     // Register a schema in the store and return the avro_schema_definition
     avro_schema_definition register_schema(
-      const subject& sub,
+      const context_subject& sub,
       const schema_definition& schema_def,
       schema_version version) {
         auto avro_def = make_avro_schema_definition(
@@ -39,9 +39,9 @@ TEST_F(AvroSchemaReferencesTest, RegisterWithReferences) {
     // Regression test: verify that schemas with external references are
     // correctly resolved from the schema store
 
-    const auto ref_sub = subject("AddressSubject");
+    const auto ref_sub = context_subject::unqualified("AddressSubject");
     const auto ref_name = "com.example.types.Address";
-    const auto main_sub = subject("PersonSubject");
+    const auto main_sub = context_subject::unqualified("PersonSubject");
     const auto main_name = "com.example.types.Person";
 
     auto referenced_schema = schema_definition{
@@ -102,7 +102,7 @@ TEST_F(AvroSchemaReferencesTest, DiamondDependencies) {
 
     // Shared base
     register_schema(
-      subject("BaseSubject"),
+      context_subject::unqualified("BaseSubject"),
       schema_definition{
         R"({"type": "record", "name": "Base", "namespace": "com.example",
             "fields": [{"name": "id", "type": "string"}]})",
@@ -111,7 +111,7 @@ TEST_F(AvroSchemaReferencesTest, DiamondDependencies) {
 
     // Left references Base
     register_schema(
-      subject("LeftSubject"),
+      context_subject::unqualified("LeftSubject"),
       schema_definition{
         R"({"type": "record", "name": "Left", "namespace": "com.example",
             "fields": [{"name": "base", "type": "com.example.Base"}]})",
@@ -125,7 +125,7 @@ TEST_F(AvroSchemaReferencesTest, DiamondDependencies) {
 
     // Right also references Base
     register_schema(
-      subject("RightSubject"),
+      context_subject::unqualified("RightSubject"),
       schema_definition{
         R"({"type": "record", "name": "Right", "namespace": "com.example",
             "fields": [{"name": "base", "type": "com.example.Base"}]})",
@@ -139,7 +139,7 @@ TEST_F(AvroSchemaReferencesTest, DiamondDependencies) {
 
     // Top references both
     auto top_valid = register_schema(
-      subject("TopSubject"),
+      context_subject::unqualified("TopSubject"),
       schema_definition{
         R"({"type": "record", "name": "Top", "namespace": "com.example",
             "fields": [
@@ -167,7 +167,7 @@ TEST_F(AvroSchemaReferencesTest, TransitiveReferences) {
 
     // Leaf: Country (no dependencies)
     register_schema(
-      subject("CountrySubject"),
+      context_subject::unqualified("CountrySubject"),
       schema_definition{
         R"({"type": "record", "name": "Country", "namespace": "com.example",
             "fields": [{"name": "code", "type": "string"}]})",
@@ -176,7 +176,7 @@ TEST_F(AvroSchemaReferencesTest, TransitiveReferences) {
 
     // Middle: Address references Country
     register_schema(
-      subject("AddressSubject"),
+      context_subject::unqualified("AddressSubject"),
       schema_definition{
         R"({"type": "record", "name": "Address", "namespace": "com.example",
             "fields": [{"name": "country", "type": "com.example.Country"}]})",
@@ -190,7 +190,7 @@ TEST_F(AvroSchemaReferencesTest, TransitiveReferences) {
 
     // Root: Person references Address (should transitively fetch Country)
     auto person_valid = register_schema(
-      subject("PersonSubject"),
+      context_subject::unqualified("PersonSubject"),
       schema_definition{
         R"({"type": "record", "name": "Person", "namespace": "com.example",
             "fields": [{"name": "address", "type": "com.example.Address"}, {"name": "country", "type": "com.example.Country"}]})",
@@ -209,13 +209,13 @@ TEST_F(AvroSchemaReferencesTest, PrimitiveTypeReference) {
     // Test that we allow referencing primitive types (naming them)
 
     register_schema(
-      subject("StringSubject"),
+      context_subject::unqualified("StringSubject"),
       schema_definition{R"("string")", schema_type::avro},
       schema_version{1});
 
     // Should work - we're giving a name to a primitive type
     auto person_valid = register_schema(
-      subject("PersonSubject"),
+      context_subject::unqualified("PersonSubject"),
       schema_definition{
         R"({"type": "record", "name": "Person", "namespace": "com.example",
             "fields": [{"name": "customString", "type": "com.example.CustomString"}]})",
@@ -259,7 +259,7 @@ TEST_F(AvroSchemaReferencesTest, SameNameDifferentSubjectsInIsolation) {
 
     // Register SubjectD - schema named "Shared" with field_d
     register_schema(
-      subject("SubjectD"),
+      context_subject::unqualified("SubjectD"),
       schema_definition{
         R"({"type": "record", "name": "Shared", "namespace": "com.example",
             "fields": [{"name": "field_d", "type": "string"}]})",
@@ -268,7 +268,7 @@ TEST_F(AvroSchemaReferencesTest, SameNameDifferentSubjectsInIsolation) {
 
     // Register SubjectE - DIFFERENT schema but also named "Shared"
     register_schema(
-      subject("SubjectE"),
+      context_subject::unqualified("SubjectE"),
       schema_definition{
         R"({"type": "record", "name": "Shared", "namespace": "com.example",
             "fields": [{"name": "field_e", "type": "int"}]})",
@@ -277,7 +277,7 @@ TEST_F(AvroSchemaReferencesTest, SameNameDifferentSubjectsInIsolation) {
 
     // Register B - uses Shared from SubjectD
     auto b_schema = register_schema(
-      subject("SubjectB"),
+      context_subject::unqualified("SubjectB"),
       schema_definition{
         R"({"type": "record", "name": "B", "namespace": "com.example",
             "fields": [{"name": "shared", "type": "com.example.Shared"}]})",
@@ -291,7 +291,7 @@ TEST_F(AvroSchemaReferencesTest, SameNameDifferentSubjectsInIsolation) {
 
     // Register C - uses Shared from SubjectE
     auto c_schema = register_schema(
-      subject("SubjectC"),
+      context_subject::unqualified("SubjectC"),
       schema_definition{
         R"({"type": "record", "name": "C", "namespace": "com.example",
             "fields": [{"name": "shared", "type": "com.example.Shared"}]})",
@@ -306,7 +306,7 @@ TEST_F(AvroSchemaReferencesTest, SameNameDifferentSubjectsInIsolation) {
     // Register A which depends on both B and C
     // This should succeed, with a logged warning about the name conflict
     auto a_schema = register_schema(
-      subject("SubjectA"),
+      context_subject::unqualified("SubjectA"),
       schema_definition{
         R"({"type": "record", "name": "A", "namespace": "com.example",
             "fields": [

--- a/src/v/pandaproxy/schema_registry/test/compatibility_3rdparty.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_3rdparty.cc
@@ -108,14 +108,16 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store_3rdparty) {
     BOOST_REQUIRE_NO_THROW(
       c(make_record_batch(config_key_0, config_value_0, base_offset++)).get());
     BOOST_REQUIRE(
-      s.get_compatibility(pps::subject{"subject_0"}, pps::default_to_global::no)
+      s.get_compatibility(
+         pps::context_subject::unqualified("subject_0"),
+         pps::default_to_global::no)
         .get()
       == pps::compatibility_level::backward);
 
     BOOST_REQUIRE_NO_THROW(
       c(make_record_batch(schema_key_0, schema_value_0, base_offset++)).get());
     auto schema_1 = s.get_subject_schema(
-                       pps::subject{"subject_0"},
+                       pps::context_subject::unqualified("subject_0"),
                        pps::schema_version{1},
                        pps::include_deleted::no)
                       .get();
@@ -127,7 +129,10 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store_3rdparty) {
       c(make_record_batch(del_sub_key_0, del_sub_value_0, base_offset++))
         .get());
     BOOST_REQUIRE_EXCEPTION(
-      s.get_versions(pps::subject{"subject_0"}, pps::include_deleted::no).get(),
+      s.get_versions(
+         pps::context_subject::unqualified("subject_0"),
+         pps::include_deleted::no)
+        .get(),
       pps::exception,
       [](const pps::exception& e) {
           return e.code() == pps::error_code::subject_not_found;
@@ -149,7 +154,10 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store_3rdparty) {
 
     // Test mode no subject, no fallback
     BOOST_REQUIRE_EXCEPTION(
-      c._store.get_mode(pps::subject{"subject_0"}, pps::default_to_global::no)
+      c._store
+        .get_mode(
+          pps::context_subject::unqualified("subject_0"),
+          pps::default_to_global::no)
         .get(),
       pps::exception,
       [](const pps::exception& e) {
@@ -158,7 +166,10 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store_3rdparty) {
 
     // Test mode no subject, with fallback
     BOOST_REQUIRE_EQUAL(
-      c._store.get_mode(pps::subject{"subject_0"}, pps::default_to_global::yes)
+      c._store
+        .get_mode(
+          pps::context_subject::unqualified("subject_0"),
+          pps::default_to_global::yes)
         .get(),
       pps ::mode::read_only);
 
@@ -172,13 +183,19 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store_3rdparty) {
     BOOST_REQUIRE_NO_THROW(
       c(make_record_batch(mode_key_sub_0, mode_value_ro, base_offset++)).get());
     BOOST_REQUIRE_EQUAL(
-      c._store.get_mode(pps::subject{"subject_0"}, pps::default_to_global::no)
+      c._store
+        .get_mode(
+          pps::context_subject::unqualified("subject_0"),
+          pps::default_to_global::no)
         .get(),
       pps::mode::read_only);
 
     // test subject is not found
     BOOST_REQUIRE_EXCEPTION(
-      c._store.get_versions(pps::subject{"subject_0"}, pps::include_deleted::no)
+      c._store
+        .get_versions(
+          pps::context_subject::unqualified("subject_0"),
+          pps::include_deleted::no)
         .get(),
       pps::exception,
       [](const pps::exception& e) {
@@ -188,7 +205,9 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store_3rdparty) {
     // test subject is not found
     BOOST_REQUIRE_EXCEPTION(
       c._store
-        .get_versions(pps::subject{"subject_0"}, pps::include_deleted::yes)
+        .get_versions(
+          pps::context_subject::unqualified("subject_0"),
+          pps::include_deleted::yes)
         .get(),
       pps::exception,
       [](const pps::exception& e) {
@@ -198,7 +217,10 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store_3rdparty) {
     // clear mode subject override
     c(make_record_batch(mode_key_sub_0, std::nullopt, base_offset++)).get();
     BOOST_REQUIRE_EXCEPTION(
-      c._store.get_mode(pps::subject{"subject_0"}, pps::default_to_global::no)
+      c._store
+        .get_mode(
+          pps::context_subject::unqualified("subject_0"),
+          pps::default_to_global::no)
         .get(),
       pps::exception,
       [](const pps::exception& e) {

--- a/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
@@ -33,10 +33,14 @@ bool check_compatible(
     pps::sharded_store s;
     return check_compatible(
              pps::make_avro_schema_definition(
-               s, {pps::subject("r"), {r.shared_raw(), pps::schema_type::avro}})
+               s,
+               {pps::context_subject::unqualified("r"),
+                {r.shared_raw(), pps::schema_type::avro}})
                .get(),
              pps::make_avro_schema_definition(
-               s, {pps::subject("w"), {w.shared_raw(), pps::schema_type::avro}})
+               s,
+               {pps::context_subject::unqualified("w"),
+                {w.shared_raw(), pps::schema_type::avro}})
                .get())
       .is_compat;
 }
@@ -46,10 +50,14 @@ pps::compatibility_result check_compatible_verbose(
     pps::sharded_store s;
     return check_compatible(
       pps::make_avro_schema_definition(
-        s, {pps::subject("r"), {r.shared_raw(), pps::schema_type::avro}})
+        s,
+        {pps::context_subject::unqualified("r"),
+         {r.shared_raw(), pps::schema_type::avro}})
         .get(),
       pps::make_avro_schema_definition(
-        s, {pps::subject("w"), {w.shared_raw(), pps::schema_type::avro}})
+        s,
+        {pps::context_subject::unqualified("w"),
+         {w.shared_raw(), pps::schema_type::avro}})
         .get(),
       pps::verbose::yes);
 }
@@ -266,7 +274,7 @@ SEASTAR_THREAD_TEST_CASE(test_avro_schema_definition) {
     pps::sharded_store s;
     auto valid = pps::make_avro_schema_definition(
                    s,
-                   {pps::subject("s2"),
+                   {pps::context_subject::unqualified("s2"),
                     {schema2.shared_raw(), pps::schema_type::avro}})
                    .get();
     static_assert(
@@ -292,7 +300,7 @@ SEASTAR_THREAD_TEST_CASE(test_avro_schema_definition_custom_attributes) {
     pps::sharded_store s;
     auto valid = pps::make_avro_schema_definition(
                    s,
-                   {pps::subject("s2"),
+                   {pps::context_subject::unqualified("s2"),
                     {avro_metadata_schema.shared_raw(),
                      pps::schema_type::avro}})
                    .get();

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -45,14 +45,14 @@ bool check_compatible(
       .get();
     store.insert(
       pandaproxy::schema_registry::subject_schema{
-        pps::subject{"sub"},
+        pps::context_subject::unqualified("sub"),
         pps::schema_definition{writer, pps::schema_type::protobuf}},
       pps::schema_version{1});
     return store.store()
       .is_compatible(
         pps::schema_version{1},
         pps::subject_schema{
-          pps::subject{"sub"},
+          pps::context_subject::unqualified("sub"),
           pps::schema_definition{reader, pps::schema_type::protobuf}})
       .get();
 }
@@ -62,10 +62,14 @@ pps::compatibility_result check_compatible_verbose(
     pps::sharded_store s;
     return check_compatible(
       pps::make_protobuf_schema_definition(
-        s, {pps::subject("r"), {r.shared_raw(), pps::schema_type::protobuf}})
+        s,
+        {pps::context_subject::unqualified("r"),
+         {r.shared_raw(), pps::schema_type::protobuf}})
         .get(),
       pps::make_protobuf_schema_definition(
-        s, {pps::subject("w"), {w.shared_raw(), pps::schema_type::protobuf}})
+        s,
+        {pps::context_subject::unqualified("w"),
+         {w.shared_raw(), pps::schema_type::protobuf}})
         .get(),
       pps::verbose::yes);
 }
@@ -75,7 +79,8 @@ pps::compatibility_result check_compatible_verbose(
 SEASTAR_THREAD_TEST_CASE(test_protobuf_simple) {
     ppstu::store_fixture store;
 
-    auto schema1 = pps::subject_schema{pps::subject{"simple"}, simple.share()};
+    auto schema1 = pps::subject_schema{
+      pps::context_subject::unqualified("simple"), simple.share()};
     store.insert(schema1.share(), pps::schema_version{1});
     auto valid_simple = pps::make_protobuf_schema_definition(
                           store.store(), schema1.share())
@@ -86,7 +91,8 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_simple) {
 SEASTAR_THREAD_TEST_CASE(test_protobuf_nested) {
     ppstu::store_fixture store;
 
-    auto schema1 = pps::subject_schema{pps::subject{"nested"}, nested.share()};
+    auto schema1 = pps::subject_schema{
+      pps::context_subject::unqualified("nested"), nested.share()};
     store.insert(schema1.share(), pps::schema_version{1});
     auto valid_nested = pps::make_protobuf_schema_definition(
                           store.store(), schema1.share())
@@ -101,7 +107,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_failure) {
 
     // imported depends on simple, which han't been inserted
     auto schema1 = pps::subject_schema{
-      pps::subject{"imported"}, imported.share()};
+      pps::context_subject::unqualified("imported"), imported.share()};
     store.insert(schema1.share(), pps::schema_version{1});
     BOOST_REQUIRE_EXCEPTION(
       pps::make_protobuf_schema_definition(store.store(), schema1.share())
@@ -120,7 +126,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_missing_nested_reference_error_subject) {
     ppstu::store_fixture store;
 
     auto schema_b = pps::subject_schema{
-      pps::subject{"subject-for-B"},
+      pps::context_subject::unqualified("subject-for-B"),
       pps::schema_definition{
         R"(syntax = "proto3"; import "c.proto"; message B { C c = 1; })",
         pps::schema_type::protobuf,
@@ -130,7 +136,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_missing_nested_reference_error_subject) {
         {}}};
 
     auto schema_a = pps::subject_schema{
-      pps::subject{"subject-for-A"},
+      pps::context_subject::unqualified("subject-for-A"),
       pps::schema_definition{
         R"(syntax = "proto3"; import "b.proto"; message A { B b = 1; })",
         pps::schema_type::protobuf,
@@ -156,9 +162,10 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_missing_nested_reference_error_subject) {
 SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_not_referenced) {
     ppstu::store_fixture store;
 
-    auto schema1 = pps::subject_schema{pps::subject{"simple"}, simple.share()};
+    auto schema1 = pps::subject_schema{
+      pps::context_subject::unqualified("simple"), simple.share()};
     auto schema2 = pps::subject_schema{
-      pps::subject{"imported"}, imported_no_ref.share()};
+      pps::context_subject::unqualified("imported"), imported_no_ref.share()};
 
     store.insert(schema1.share(), pps::schema_version{1});
 
@@ -178,11 +185,12 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_referenced) {
     ppstu::store_fixture store;
 
     auto schema1 = pps::subject_schema{
-      pps::subject{"simple.proto"}, simple.share()};
+      pps::context_subject::unqualified("simple.proto"), simple.share()};
     auto schema2 = pps::subject_schema{
-      pps::subject{"imported.proto"}, imported.share()};
+      pps::context_subject::unqualified("imported.proto"), imported.share()};
     auto schema3 = pps::subject_schema{
-      pps::subject{"imported-again.proto"}, imported_again.share()};
+      pps::context_subject::unqualified("imported-again.proto"),
+      imported_again.share()};
 
     store.insert(schema1.share(), pps::schema_version{1});
     store.insert(schema2.share(), pps::schema_version{1});
@@ -203,11 +211,12 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_recursive_reference) {
     ppstu::store_fixture store;
 
     auto schema1 = pps::subject_schema{
-      pps::subject{"simple.proto"}, simple.share()};
+      pps::context_subject::unqualified("simple.proto"), simple.share()};
     auto schema2 = pps::subject_schema{
-      pps::subject{"imported.proto"}, imported.share()};
+      pps::context_subject::unqualified("imported.proto"), imported.share()};
     auto schema3 = pps::subject_schema{
-      pps::subject{"imported-twice.proto"}, imported_twice.share()};
+      pps::context_subject::unqualified("imported-twice.proto"),
+      imported_twice.share()};
 
     store.insert(schema1.share(), pps::schema_version{1});
     store.insert(schema2.share(), pps::schema_version{1});
@@ -231,7 +240,7 @@ SEASTAR_THREAD_TEST_CASE(test_binary_protobuf) {
       store.store()
         .make_valid_schema(
           pps::subject_schema{
-            pps::subject{"com.redpanda.Payload.proto"},
+            pps::context_subject::unqualified("com.redpanda.Payload.proto"),
             pps::schema_definition{
               base64_raw_proto, pps::schema_type::protobuf}})
         .get());
@@ -243,7 +252,7 @@ SEASTAR_THREAD_TEST_CASE(test_invalid_binary_protobuf) {
     auto broken_base64_raw_proto = base64_raw_proto.substr(1);
 
     auto schema = pps::subject_schema{
-      pps::subject{"com.redpanda.Payload.proto"},
+      pps::context_subject::unqualified("com.redpanda.Payload.proto"),
       pps::schema_definition{
         broken_base64_raw_proto, pps::schema_type::protobuf}};
 
@@ -251,7 +260,7 @@ SEASTAR_THREAD_TEST_CASE(test_invalid_binary_protobuf) {
       store.store()
         .make_valid_schema(
           pps::subject_schema{
-            pps::subject{"com.redpanda.Payload.proto"},
+            pps::context_subject::unqualified("com.redpanda.Payload.proto"),
             pps::schema_definition{
               broken_base64_raw_proto, pps::schema_type::protobuf}})
         .get(),
@@ -266,7 +275,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_well_known) {
     ppstu::store_fixture store;
 
     auto schema = pps::subject_schema{
-      pps::subject{"test_auto_well_known"},
+      pps::context_subject::unqualified("test_auto_well_known"),
       pps::schema_definition{
         R"(
 syntax =  "proto3";

--- a/src/v/pandaproxy/schema_registry/test/compatibility_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_store.cc
@@ -32,7 +32,7 @@ SEASTAR_THREAD_TEST_CASE(test_avro_basic_backwards_store_compat) {
     s.set_compatibility(
        dummy_marker, pps::default_context, pps::compatibility_level::backward)
       .get();
-    auto sub = pps::subject{"sub"};
+    auto sub = pps::context_subject::unqualified("sub");
     s.upsert(
        dummy_marker,
        pps::subject_schema{sub, schema1.share()},

--- a/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
@@ -35,7 +35,7 @@
 
 namespace pps = pandaproxy::schema_registry;
 
-const pps::subject subject0{"subject0"};
+const auto subject0 = pps::context_subject::unqualified("subject0");
 constexpr pps::topic_key_magic magic0{0};
 constexpr pps::topic_key_magic magic1{1};
 constexpr pps::topic_key_magic magic2{2};
@@ -56,7 +56,7 @@ const pps::schema_definition int_def0{
     {R"({"type": "int"})", pps::schema_type::avro})
     .value()};
 
-inline model::record_batch make_delete_subject_batch(pps::subject sub) {
+inline model::record_batch make_delete_subject_batch(pps::context_subject sub) {
     storage::record_batch_builder rb{
       model::record_batch_type::raft_data, model::offset{0}};
 
@@ -69,7 +69,8 @@ inline model::record_batch make_delete_subject_batch(pps::subject sub) {
 }
 
 inline model::record_batch make_delete_subject_permanently_batch(
-  pps::subject sub, const chunked_vector<pps::schema_version>& versions) {
+  pps::context_subject sub,
+  const chunked_vector<pps::schema_version>& versions) {
     storage::record_batch_builder rb{
       model::record_batch_type::raft_data, model::offset{0}};
 

--- a/src/v/pandaproxy/schema_registry/test/delete_subject_endpoints.cc
+++ b/src/v/pandaproxy/schema_registry/test/delete_subject_endpoints.cc
@@ -31,14 +31,17 @@ FIXTURE_TEST(test_delete_subject, pandaproxy_test_fixture) {
     {
         info("Post a schema as key");
         auto res = post_schema(
-          client, pps::subject{"test-key"}, avro_int_payload);
+          client,
+          pps::context_subject::unqualified("test-key"),
+          avro_int_payload);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
     }
 
     {
         info("Expect version 1");
-        auto res = get_subject_versions(client, pps::subject{"test-key"});
+        auto res = get_subject_versions(
+          client, pps::context_subject::unqualified("test-key"));
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
 
@@ -50,14 +53,17 @@ FIXTURE_TEST(test_delete_subject, pandaproxy_test_fixture) {
     {
         info("Delete version 1");
         auto res = delete_subject_version(
-          client, pps::subject{"test-key"}, pps::schema_version{1});
+          client,
+          pps::context_subject::unqualified("test-key"),
+          pps::schema_version{1});
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
     }
 
     {
         info("Expect subject not_found");
-        auto res = get_subject_versions(client, pps::subject{"test-key"});
+        auto res = get_subject_versions(
+          client, pps::context_subject::unqualified("test-key"));
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::not_found);
     }
@@ -65,7 +71,9 @@ FIXTURE_TEST(test_delete_subject, pandaproxy_test_fixture) {
     {
         info("Expect deleted version 1");
         auto res = get_subject_versions(
-          client, pps::subject{"test-key"}, pps::include_deleted::yes);
+          client,
+          pps::context_subject::unqualified("test-key"),
+          pps::include_deleted::yes);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
 
@@ -78,7 +86,7 @@ FIXTURE_TEST(test_delete_subject, pandaproxy_test_fixture) {
         info("Hard delete version 1");
         auto res = delete_subject_version(
           client,
-          pps::subject{"test-key"},
+          pps::context_subject::unqualified("test-key"),
           pps::schema_version{1},
           pps::permanent_delete::yes);
         BOOST_REQUIRE_EQUAL(
@@ -88,7 +96,9 @@ FIXTURE_TEST(test_delete_subject, pandaproxy_test_fixture) {
     {
         info("Expect sub not found");
         auto res = get_subject_versions(
-          client, pps::subject{"test-key"}, pps::include_deleted::yes);
+          client,
+          pps::context_subject::unqualified("test-key"),
+          pps::include_deleted::yes);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::not_found);
     }
@@ -96,14 +106,17 @@ FIXTURE_TEST(test_delete_subject, pandaproxy_test_fixture) {
     {
         info("Repost a schema as key");
         auto res = post_schema(
-          client, pps::subject{"test-key"}, avro_int_payload);
+          client,
+          pps::context_subject::unqualified("test-key"),
+          avro_int_payload);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
     }
 
     {
         info("Expect version 1");
-        auto res = get_subject_versions(client, pps::subject{"test-key"});
+        auto res = get_subject_versions(
+          client, pps::context_subject::unqualified("test-key"));
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
 
@@ -114,7 +127,8 @@ FIXTURE_TEST(test_delete_subject, pandaproxy_test_fixture) {
 
     {
         info("Delete subject");
-        auto res = delete_subject(client, pps::subject{"test-key"});
+        auto res = delete_subject(
+          client, pps::context_subject::unqualified("test-key"));
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
     }
@@ -129,14 +143,17 @@ FIXTURE_TEST(test_delete_referenced_subject, pandaproxy_test_fixture) {
     {
         info("Post a schema as key");
         auto res = post_schema(
-          client, pps::subject{"int-key"}, avro_int_payload);
+          client,
+          pps::context_subject::unqualified("int-key"),
+          avro_int_payload);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
     }
 
     {
         info("Expect version 1");
-        auto res = get_subject_versions(client, pps::subject{"int-key"});
+        auto res = get_subject_versions(
+          client, pps::context_subject::unqualified("int-key"));
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
 
@@ -149,7 +166,7 @@ FIXTURE_TEST(test_delete_referenced_subject, pandaproxy_test_fixture) {
         info("Post a schema as key, which references the first");
         auto res = post_schema(
           client,
-          pps::subject{"reference-key"},
+          pps::context_subject::unqualified("reference-key"),
           ss::sstring{
             R"(
 {
@@ -170,7 +187,9 @@ FIXTURE_TEST(test_delete_referenced_subject, pandaproxy_test_fixture) {
     {
         info("Delete version 1, expect failure 42206");
         auto res = delete_subject_version(
-          client, pps::subject{"int-key"}, pps::schema_version{1});
+          client,
+          pps::context_subject::unqualified("int-key"),
+          pps::schema_version{1});
         BOOST_REQUIRE_EQUAL(
           res.headers.result(),
           boost::beast::http::status::unprocessable_entity);
@@ -179,7 +198,8 @@ FIXTURE_TEST(test_delete_referenced_subject, pandaproxy_test_fixture) {
 
     {
         info("Delete subject int-key, expect failure 42206 (still referenced)");
-        auto res = delete_subject(client, pps::subject{"int-key"});
+        auto res = delete_subject(
+          client, pps::context_subject::unqualified("int-key"));
         BOOST_REQUIRE_EQUAL(
           res.headers.result(),
           boost::beast::http::status::unprocessable_entity);
@@ -188,14 +208,16 @@ FIXTURE_TEST(test_delete_referenced_subject, pandaproxy_test_fixture) {
 
     {
         info("Delete subject reference-key");
-        auto res = delete_subject(client, pps::subject{"reference-key"});
+        auto res = delete_subject(
+          client, pps::context_subject::unqualified("reference-key"));
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
     }
 
     {
         info("Delete subject int-key (not referenced - soft deleted)");
-        auto res = delete_subject(client, pps::subject{"int-key"});
+        auto res = delete_subject(
+          client, pps::context_subject::unqualified("int-key"));
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
     }

--- a/src/v/pandaproxy/schema_registry/test/mt_sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/mt_sharded_store.cc
@@ -36,7 +36,8 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_cross_shard_def) {
     // subject names and IDs, so they should hash to different shards.
     for (int i = 1; i <= id_n; ++i) {
         auto referenced_schema = pps::subject_schema{
-          pps::subject{fmt::format("simple_{}.proto", i)}, simple.share()};
+          pps::context_subject::unqualified(fmt::format("simple_{}.proto", i)),
+          simple.share()};
         store
           .upsert(
             pps::seq_marker{
@@ -51,7 +52,11 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_cross_shard_def) {
           .get();
     }
 
-    BOOST_REQUIRE(store.has_schema(pps::schema_id{id_n}).get());
+    BOOST_REQUIRE(
+      store
+        .has_schema(
+          pps::context_schema_id{pps::default_context, pps::schema_id{id_n}})
+        .get());
 
     // for each upserted schema, submit a number of concurrent
     // get_schema_definition requests, spreading the requests across cores. the
@@ -67,7 +72,10 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_cross_shard_def) {
           boost::irange(0, num_parallel_requests),
           [&store, i](auto shrd) {
               return ss::smp::submit_to(shrd % ss::smp::count, [&store, i]() {
-                  return store.get_schema_definition(pps::schema_id{i})
+                  return store
+                    .get_schema_definition(
+                      pps::context_schema_id{
+                        pps::default_context, pps::schema_id{i}})
                     .discard_result();
               });
           })

--- a/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
+++ b/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
@@ -79,7 +79,9 @@ FIXTURE_TEST(
     {
         info("Post a schema as key (expect schema_id=1)");
         auto res = post_schema(
-          client, pps::subject{"test-key"}, avro_int_payload);
+          client,
+          pps::context_subject::unqualified("test-key"),
+          avro_int_payload);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
@@ -93,7 +95,9 @@ FIXTURE_TEST(
     {
         info("Repost a schema as key (expect schema_id=1)");
         auto res = post_schema(
-          client, pps::subject{"test-key"}, avro_int_payload);
+          client,
+          pps::context_subject::unqualified("test-key"),
+          avro_int_payload);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
@@ -107,7 +111,9 @@ FIXTURE_TEST(
     {
         info("Repost a schema as value (expect schema_id=1)");
         auto res = post_schema(
-          client, pps::subject{"test-value"}, avro_int_payload);
+          client,
+          pps::context_subject::unqualified("test-value"),
+          avro_int_payload);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
@@ -121,7 +127,9 @@ FIXTURE_TEST(
     {
         info("Post a new schema as key (expect schema_id=2)");
         auto res = post_schema(
-          client, pps::subject{"test-key"}, avro_long_payload);
+          client,
+          pps::context_subject::unqualified("test-key"),
+          avro_long_payload);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
@@ -162,7 +170,7 @@ FIXTURE_TEST(
   "schemaType": "AVRO"
 })"};
 
-    pps::subject subject{"in-version-order"};
+    auto subject = pps::context_subject::unqualified("in-version-order");
     put_config(client, subject, pps::compatibility_level::backward);
 
     {
@@ -214,7 +222,8 @@ FIXTURE_TEST(
 
     {
         info("Post an invalid payload");
-        auto res = post_schema(client, pps::subject{"test-key"}, R"(
+        auto res = post_schema(
+          client, pps::context_subject::unqualified("test-key"), R"(
 {
   "schema": "\"int\"",
   "InvalidField": "AVRO"
@@ -239,7 +248,8 @@ FIXTURE_TEST(
 
     {
         info("Post an invalid schema");
-        auto res = post_schema(client, pps::subject{"test-key"}, R"(
+        auto res = post_schema(
+          client, pps::context_subject::unqualified("test-key"), R"(
 {
   "schema": "not_json",
   "schemaType": "AVRO"
@@ -264,7 +274,8 @@ FIXTURE_TEST(
 
     for (auto i = 0; i < 10; ++i) {
         info("Post a schema as key (expect schema_id=1)");
-        auto res = post_schema(client, pps::subject{"test-key"}, R"(
+        auto res = post_schema(
+          client, pps::context_subject::unqualified("test-key"), R"(
 {
   "schema": "syntax = \"proto3\"; message Simple { string i = 1; }",
   "schemaType": "PROTOBUF"
@@ -280,7 +291,7 @@ FIXTURE_TEST(schema_registry_post_avro_references, pandaproxy_test_fixture) {
     using namespace std::chrono_literals;
 
     const auto company_req = request{pps::subject_schema{
-      pps::subject{"company-value"},
+      pps::context_subject::unqualified("company-value"),
       pps::schema_definition(
         R"({
   "namespace": "com.redpanda",
@@ -304,7 +315,7 @@ FIXTURE_TEST(schema_registry_post_avro_references, pandaproxy_test_fixture) {
         pps::schema_type::avro)}};
 
     const auto employee_req = request{pps::subject_schema{
-      pps::subject{"employee-value"},
+      pps::context_subject::unqualified("employee-value"),
       pps::schema_definition{
         R"({
   "namespace": "com.redpanda",
@@ -359,7 +370,7 @@ FIXTURE_TEST(
 
     const auto simple_req_id_invalid = request{
       pps::subject_schema{
-        pps::subject{"simple-value"},
+        pps::context_subject::unqualified("simple-value"),
         pps::schema_definition(
           R"({
 "namespace": "com.redpanda",
@@ -395,7 +406,7 @@ FIXTURE_TEST(
   schema_registry_post_subjects_version_zero, pandaproxy_test_fixture) {
     const auto simple_req_first = request{
       pps::subject_schema{
-        pps::subject{"simple-value"},
+        pps::context_subject::unqualified("simple-value"),
         pps::schema_definition(
           R"({
 "namespace": "com.redpanda",
@@ -414,7 +425,7 @@ FIXTURE_TEST(
 
     const auto simple_req_second = request{
       pps::subject_schema{
-        pps::subject{"simple-value"},
+        pps::context_subject::unqualified("simple-value"),
         pps::schema_definition(
           R"({
 "namespace": "com.redpanda",
@@ -459,7 +470,8 @@ FIXTURE_TEST(
       to_header_value(ppj::serialization_format::schema_registry_v1_json));
 
     info("Getting versions, expect ([1,2])");
-    res = get_subject_versions(client, pps::subject{"simple-value"});
+    res = get_subject_versions(
+      client, pps::context_subject::unqualified("simple-value"));
     BOOST_REQUIRE_EQUAL(res.headers.result(), boost::beast::http::status::ok);
     BOOST_REQUIRE_EQUAL(res.body, R"([1,2])");
     BOOST_REQUIRE_EQUAL(

--- a/src/v/pandaproxy/schema_registry/test/protobuf_large_alloc.cc
+++ b/src/v/pandaproxy/schema_registry/test/protobuf_large_alloc.cc
@@ -80,7 +80,7 @@ TEST(ProtoLargeAlloc, test_protobuf_memory_stuff) {
     // Size of these schemas is set to around half-megabyte. The exact value is
     // not important, as long as it is significantly larger than the
     // fragmentation interval introduced in fragment_memory
-    const pps::context_subject sub{"test_subject_01"};
+    const auto sub = pps::context_subject::unqualified("test_subject_01");
     const auto large_schema = pps::test_utils::make_proto_schema(sub, 25'000);
     EXPECT_EQ(large_schema.size(), 552841);
 

--- a/src/v/pandaproxy/schema_registry/test/protobuf_utils.cc
+++ b/src/v/pandaproxy/schema_registry/test/protobuf_utils.cc
@@ -33,7 +33,7 @@ std::string sanitize(
     auto psch = pps::make_canonical_protobuf_schema(
                   s.store(),
                   pps::subject_schema{
-                    pps::subject{"foo"},
+                    pps::context_subject::unqualified("foo"),
                     pps::schema_definition{
                       raw_proto, pps::schema_type::protobuf, {}, {}}},
                   norm,

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -32,7 +32,7 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
 
     // Insert simple
     auto referenced_schema = pps::subject_schema{
-      pps::subject{"simple.proto"}, simple.share()};
+      pps::context_subject::unqualified("simple.proto"), simple.share()};
     store
       .upsert(
         pps::seq_marker{
@@ -45,7 +45,7 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
 
     // Insert referenced
     auto importing_schema = pps::subject_schema{
-      pps::subject{"imported.proto"}, imported.share()};
+      pps::context_subject::unqualified("imported.proto"), imported.share()};
 
     store
       .upsert(
@@ -63,11 +63,15 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
     BOOST_REQUIRE_EQUAL(referenced_by.size(), 1);
     BOOST_REQUIRE_EQUAL(referenced_by[0].id, pps::schema_id{2});
 
-    BOOST_REQUIRE(
-      store.is_referenced(pps::subject{"simple.proto"}, pps::schema_version{1})
-        .get());
+    BOOST_REQUIRE(store
+                    .is_referenced(
+                      pps::context_subject::unqualified("simple.proto"),
+                      pps::schema_version{1})
+                    .get());
 
-    auto importing = store.get_schema_definition(pps::schema_id{2}).get();
+    auto importing
+      = store.get_schema_definition({pps::default_context, pps::schema_id{2}})
+          .get();
     BOOST_REQUIRE_EQUAL(importing.refs().size(), 1);
     BOOST_REQUIRE_EQUAL(importing.refs()[0].sub, imported.refs()[0].sub);
     BOOST_REQUIRE_EQUAL(
@@ -86,13 +90,17 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
       .get();
 
     // Soft-deleted should not partake in reference calculations
-    BOOST_REQUIRE(
-      store.referenced_by(pps::subject{"simple.proto"}, pps::schema_version{1})
-        .get()
-        .empty());
-    BOOST_REQUIRE(
-      !store.is_referenced(pps::subject{"simple.proto"}, pps::schema_version{1})
-         .get());
+    BOOST_REQUIRE(store
+                    .referenced_by(
+                      pps::context_subject::unqualified("simple.proto"),
+                      pps::schema_version{1})
+                    .get()
+                    .empty());
+    BOOST_REQUIRE(!store
+                     .is_referenced(
+                       pps::context_subject::unqualified("simple.proto"),
+                       pps::schema_version{1})
+                     .get());
 }
 
 SEASTAR_THREAD_TEST_CASE(test_sharded_store_find_unordered) {
@@ -101,13 +109,13 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_find_unordered) {
     auto stop_store = ss::defer([&store]() { store.stop().get(); });
 
     pps::subject_schema array_unsanitized{
-      pps::subject{"array"},
+      pps::context_subject::unqualified("array"),
       pps::schema_definition{
         R"({"type": "array", "default": [], "items" : "string"})",
         pps::schema_type::avro}};
 
     pps::subject_schema array_sanitized{
-      pps::subject{"array"},
+      pps::context_subject::unqualified("array"),
       pps::schema_definition{
         R"({"type":"array","items":"string","default":[]})",
         pps::schema_type::avro}};
@@ -116,7 +124,7 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_find_unordered) {
 
     // Insert an unsorted schema "onto the topic".
     auto referenced_schema = pps::subject_schema{
-      pps::subject{"simple.proto"}, simple.share()};
+      pps::context_subject::unqualified("simple.proto"), simple.share()};
     store
       .upsert(
         pps::seq_marker{

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -35,7 +35,7 @@ constexpr std::string_view schema_key_sv{
 const auto expected_schema_key = schema_key{
   .seq{model::offset{42}},
   .node{model::node_id{2}},
-  .sub{context_subject{"my-kafka-value"}},
+  .sub{context_subject::unqualified("my-kafka-value")},
   .version{schema_version{1}},
   .magic{topic_key_magic{1}}};
 
@@ -52,7 +52,7 @@ constexpr std::string_view schema_value_sv{
 })"};
 const auto expected_schema_value = schema_value{
   .schema{
-    subject{"my-kafka-value"},
+    context_subject::unqualified("my-kafka-value"),
     schema_definition{
       R"({"type":"string"})",
       schema_type::avro,
@@ -89,7 +89,7 @@ constexpr std::string_view config_key_sub_sv{
 const auto expected_config_key_sub = config_key{
   .seq{model::offset{0}},
   .node{model::node_id{0}},
-  .sub{context_subject{"my-kafka-value"}},
+  .sub{context_subject::unqualified("my-kafka-value")},
   .magic{topic_key_magic{0}}};
 
 constexpr std::string_view config_value_sv{
@@ -106,7 +106,7 @@ constexpr std::string_view config_value_sub_sv{
 })"};
 const auto expected_config_value_sub = config_value{
   .compat = compatibility_level::forward_transitive,
-  .sub{context_subject{"my-kafka-value"}}};
+  .sub{context_subject::unqualified("my-kafka-value")}};
 
 constexpr std::string_view delete_subject_key_sv{
   R"({
@@ -119,14 +119,14 @@ constexpr std::string_view delete_subject_key_sv{
 const auto expected_delete_subject_key = delete_subject_key{
   .seq{model::offset{42}},
   .node{model::node_id{2}},
-  .sub{subject{"my-kafka-value"}}};
+  .sub{context_subject::unqualified("my-kafka-value")}};
 
 constexpr std::string_view delete_subject_value_sv{
   R"({
   "subject": "my-kafka-value"
 })"};
 const auto expected_delete_subject_value = delete_subject_value{
-  .sub{subject{"my-kafka-value"}}};
+  .sub{context_subject::unqualified("my-kafka-value")}};
 
 constexpr std::string_view context_key_sv{
   R"({
@@ -584,7 +584,7 @@ TEST_F(StorageTest, SerdeContextSubject) {
         const auto expected_mode_key_legacy = mode_key{
           .seq{model::offset{22}},
           .node{model::node_id{1}},
-          .sub{context_subject{"my-kafka-value"}},
+          .sub{context_subject::unqualified("my-kafka-value")},
           .magic{topic_key_magic{0}}};
 
         auto key = ppj::impl::rjson_parse(

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -32,9 +32,9 @@ const pps::schema_definition string_def1{
 const pps::schema_definition int_def0{
   pps::make_schema_definition<json::UTF8<>>(sv_int_def0).value(),
   pps::schema_type::avro};
-const pps::subject subject0{"subject0"};
-const pps::subject subject1{"subject1"};
-const pps::subject subject2{"subject2"};
+const auto subject0 = pps::context_subject::unqualified("subject0");
+const auto subject1 = pps::context_subject::unqualified("subject1");
+const auto subject2 = pps::context_subject::unqualified("subject2");
 
 BOOST_AUTO_TEST_CASE(test_store_insert) {
     pps::store s;
@@ -73,13 +73,13 @@ BOOST_AUTO_TEST_CASE(test_store_insert) {
 /// Emulate how `sharded_store` does upserts on `store`
 bool upsert(
   pps::store& store,
-  pps::subject sub,
+  pps::context_subject sub,
   pps::schema_definition def,
   pps::schema_type,
   pps::schema_id id,
   pps::schema_version version,
   pps::is_deleted deleted) {
-    store.upsert_schema(id, std::move(def), false);
+    store.upsert_schema({sub.ctx, id}, std::move(def), false);
     return store.upsert_subject(
       pps::seq_marker{}, std::move(sub), version, id, deleted);
 }
@@ -185,7 +185,8 @@ BOOST_AUTO_TEST_CASE(test_store_upsert_override) {
 BOOST_AUTO_TEST_CASE(test_store_get_schema) {
     pps::store s;
 
-    auto res = s.get_schema_definition(pps::schema_id{1});
+    auto res = s.get_schema_definition(
+      {pps::default_context, pps::schema_id{1}});
     BOOST_REQUIRE(res.has_error());
     auto err = std::move(res).assume_error();
     BOOST_REQUIRE(err.code() == pps::error_code::schema_id_not_found);
@@ -196,7 +197,7 @@ BOOST_AUTO_TEST_CASE(test_store_get_schema) {
     BOOST_REQUIRE_EQUAL(ins_res.id, pps::schema_id{1});
     BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{1});
 
-    res = s.get_schema_definition(ins_res.id);
+    res = s.get_schema_definition({pps::default_context, ins_res.id});
     BOOST_REQUIRE(res.has_value());
 
     auto def = std::move(res).assume_value();
@@ -214,12 +215,14 @@ BOOST_AUTO_TEST_CASE(test_store_get_schema_subject_versions) {
     BOOST_REQUIRE_EQUAL(ins_res.id, pps::schema_id{1});
     BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{1});
 
-    auto versions = s.get_schema_subject_versions(pps::schema_id{1});
+    auto versions = s.get_schema_subject_versions(
+      {pps::default_context, pps::schema_id{1}});
     BOOST_REQUIRE_EQUAL(versions.size(), 1);
     BOOST_REQUIRE_EQUAL(versions[0].sub, subject0);
     BOOST_REQUIRE_EQUAL(versions[0].version, pps::schema_version{1});
 
-    versions = s.get_schema_subject_versions(pps::schema_id{2});
+    versions = s.get_schema_subject_versions(
+      {pps::default_context, pps::schema_id{2}});
     BOOST_REQUIRE(versions.empty());
 
     // Second insert, expect id{2}
@@ -229,7 +232,8 @@ BOOST_AUTO_TEST_CASE(test_store_get_schema_subject_versions) {
     BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{2});
 
     // expect [{schema 2, version 2}]
-    versions = s.get_schema_subject_versions(pps::schema_id{2});
+    versions = s.get_schema_subject_versions(
+      {pps::default_context, pps::schema_id{2}});
     BOOST_REQUIRE_EQUAL(versions.size(), 1);
     BOOST_REQUIRE_EQUAL(versions[0].sub, subject0);
     BOOST_REQUIRE_EQUAL(versions[0].version, pps::schema_version{2});
@@ -243,7 +247,8 @@ BOOST_AUTO_TEST_CASE(test_store_get_schema_subject_versions) {
       pps::is_deleted::yes);
 
     // expect [{{schema 2, version 2}]
-    versions = s.get_schema_subject_versions(pps::schema_id{2});
+    versions = s.get_schema_subject_versions(
+      {pps::default_context, pps::schema_id{2}});
     BOOST_REQUIRE_EQUAL(versions.size(), 1);
     BOOST_REQUIRE_EQUAL(versions[0].sub, subject0);
     BOOST_REQUIRE_EQUAL(versions[0].version, pps::schema_version{2});
@@ -265,7 +270,7 @@ BOOST_AUTO_TEST_CASE(test_store_get_schema_subjects) {
     BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{1});
 
     auto subjects = s.get_schema_subjects(
-      pps::schema_id{1}, pps::include_deleted::no);
+      {pps::default_context, pps::schema_id{1}}, pps::include_deleted::no);
     BOOST_REQUIRE_EQUAL(subjects.size(), 1);
     BOOST_REQUIRE_EQUAL(std::ranges::count_if(subjects, is_equal(subject0)), 1);
 
@@ -282,14 +287,14 @@ BOOST_AUTO_TEST_CASE(test_store_get_schema_subjects) {
     BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{1});
 
     subjects = s.get_schema_subjects(
-      pps::schema_id{1}, pps::include_deleted::no);
+      {pps::default_context, pps::schema_id{1}}, pps::include_deleted::no);
     BOOST_REQUIRE_EQUAL(subjects.size(), 2);
     BOOST_REQUIRE_EQUAL(std::ranges::count_if(subjects, is_equal(subject0)), 1);
     BOOST_REQUIRE_EQUAL(std::ranges::count_if(subjects, is_equal(subject1)), 1);
     BOOST_REQUIRE_EQUAL(std::ranges::count_if(subjects, is_equal(subject2)), 0);
 
     subjects = s.get_schema_subjects(
-      pps::schema_id{2}, pps::include_deleted::no);
+      {pps::default_context, pps::schema_id{2}}, pps::include_deleted::no);
     BOOST_REQUIRE_EQUAL(subjects.size(), 1);
     BOOST_REQUIRE_EQUAL(std::ranges::count_if(subjects, is_equal(subject0)), 0);
     BOOST_REQUIRE_EQUAL(std::ranges::count_if(subjects, is_equal(subject1)), 0);
@@ -305,12 +310,12 @@ BOOST_AUTO_TEST_CASE(test_store_get_schema_subjects) {
       pps::is_deleted::yes);
 
     subjects = s.get_schema_subjects(
-      pps::schema_id{1}, pps::include_deleted::no);
+      {pps::default_context, pps::schema_id{1}}, pps::include_deleted::no);
     BOOST_REQUIRE_EQUAL(subjects.size(), 1);
     BOOST_REQUIRE_EQUAL(std::ranges::count_if(subjects, is_equal(subject1)), 1);
 
     subjects = s.get_schema_subjects(
-      pps::schema_id{1}, pps::include_deleted::yes);
+      {pps::default_context, pps::schema_id{1}}, pps::include_deleted::yes);
     BOOST_REQUIRE_EQUAL(subjects.size(), 2);
     BOOST_REQUIRE_EQUAL(std::ranges::count_if(subjects, is_equal(subject0)), 1);
     BOOST_REQUIRE_EQUAL(std::ranges::count_if(subjects, is_equal(subject1)), 1);

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -47,10 +47,14 @@ pps::compatibility_result check_compatible_verbose(
     pps::sharded_store s;
     return check_compatible(
       pps::make_json_schema_definition(
-        s, {pps::subject("r"), {r.shared_raw(), pps::schema_type::json}})
+        s,
+        {pps::context_subject::unqualified("r"),
+         {r.shared_raw(), pps::schema_type::json}})
         .get(),
       pps::make_json_schema_definition(
-        s, {pps::subject("w"), {w.shared_raw(), pps::schema_type::json}})
+        s,
+        {pps::context_subject::unqualified("w"),
+         {w.shared_raw(), pps::schema_type::json}})
         .get(),
       pps::verbose::yes);
 }
@@ -184,7 +188,8 @@ SEASTAR_THREAD_TEST_CASE(test_make_invalid_json_schema) {
             try {
                 pps::make_canonical_json_schema(
                   f.store(),
-                  {pps::subject{"test"}, {data.def, pps::schema_type::json}})
+                  {pps::context_subject::unqualified("test"),
+                   {data.def, pps::schema_type::json}})
                   .get();
                 BOOST_CHECK_MESSAGE(
                   false, "terminated without an exception for invalid schema");
@@ -282,7 +287,8 @@ SEASTAR_THREAD_TEST_CASE(test_make_valid_json_schema) {
                   f.store(),
                   pps::make_canonical_json_schema(
                     f.store(),
-                    {pps::subject{"test"}, {data, pps::schema_type::json}})
+                    {pps::context_subject::unqualified("test"),
+                     {data, pps::schema_type::json}})
                     .get())
                   .get();
             } catch (...) {
@@ -304,7 +310,7 @@ struct test_references_data {
 };
 
 const auto referenced = pps::subject_schema{
-  pps::subject{"referenced"},
+  pps::context_subject::unqualified("referenced"),
   pps::schema_definition{
     R"({
   "description": "A base schema that defines a number",
@@ -320,7 +326,7 @@ const auto referenced = pps::subject_schema{
     {}}};
 
 const auto referencer = pps::subject_schema{
-  pps::subject{"referencer"},
+  pps::context_subject::unqualified("referencer"),
   pps::schema_definition{
     R"({
   "description": "A schema that references the base schema",
@@ -2190,7 +2196,8 @@ SEASTAR_THREAD_TEST_CASE(test_compatibility_check) {
                  f.store(),
                  pps::make_canonical_json_schema(
                    f.store(),
-                   {pps::subject{"test"}, {schema, pps::schema_type::json}})
+                   {pps::context_subject::unqualified("test"),
+                    {schema, pps::schema_type::json}})
                    .get())
           .get();
     };
@@ -2367,7 +2374,8 @@ SEASTAR_THREAD_TEST_CASE(test_object_recursion_depths) {
                  f.store(),
                  pps::make_canonical_json_schema(
                    f.store(),
-                   {pps::subject{"test"}, {schema, pps::schema_type::json}})
+                   {pps::context_subject::unqualified("test"),
+                    {schema, pps::schema_type::json}})
                    .get())
           .get();
     };
@@ -2468,7 +2476,7 @@ SEASTAR_THREAD_TEST_CASE(test_refs_fixing) {
           f.store(),
           pps::make_canonical_json_schema(
             f.store(),
-            {pps::subject{"test"},
+            {pps::context_subject::unqualified("test"),
              {fmt::format("{}", jsoncons::print(input_schema)),
               pps::schema_type::json}})
             .get())

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -175,18 +175,6 @@ struct context_subject {
       : ctx{std::move(c)}
       , sub{std::move(s)} {}
 
-    // TODO: remove this, it is only for gradual commit-by-commit source code
-    // migration
-    context_subject(subject sub)
-      : ctx{default_context}
-      , sub{std::move(sub)} {}
-
-    // TODO: remove this, it is only for gradual commit-by-commit source code
-    // migration
-    context_subject(ss::sstring sub)
-      : ctx{default_context}
-      , sub{std::move(sub)} {}
-
     friend auto
     operator<=>(const context_subject& lhs, const context_subject& rhs)
       = default;
@@ -572,12 +560,6 @@ inline constexpr schema_id invalid_schema_id{-1};
 
 // A schema id that is valid within a context.
 struct context_schema_id {
-    // TODO: remove this, it is only for gradual commit-by-commit source code
-    // migration
-    context_schema_id(schema_id id)
-      : ctx{default_context}
-      , id{id} {}
-
     context_schema_id(context c, schema_id s)
       : ctx{std::move(c)}
       , id{s} {}

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -200,6 +200,12 @@ struct context_subject {
     /// "subject" (which uses the default context)
     static context_subject from_string(std::string_view input);
 
+    /// Helper for testing to create a simple unqualified subject in the default
+    /// context
+    static context_subject unqualified(std::string_view input) {
+        return {default_context, subject{input}};
+    }
+
     /// Format as qualified subject ":.context:subject" or "subject" if in the
     /// default context
     ss::sstring to_string() const { return ssx::sformat("{}", *this); }

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -686,6 +686,7 @@ struct stored_schema {
     stored_schema share() const {
         return {schema.share(), version, id, deleted};
     }
+    context_schema_id context_id() const { return {schema.sub().ctx, id}; }
 };
 
 ///\brief A mapping of version and schema id for a subject.

--- a/src/v/pandaproxy/schema_registry/validation.cc
+++ b/src/v/pandaproxy/schema_registry/validation.cc
@@ -102,7 +102,8 @@ ss::future<std::optional<ss::sstring>> get_record_name(
         co_return "";
     }
 
-    subject_schema sub_schema{subject("r"), std::move(schema)};
+    subject_schema sub_schema{
+      context_subject{default_context, subject{"r"}}, std::move(schema)};
     switch (sub_schema.type()) {
     case schema_type::avro: {
         auto s = co_await make_avro_schema_definition(
@@ -222,7 +223,9 @@ public:
         // Determine the schema type
         std::optional<schema_definition> schema;
         try {
-            schema.emplace(co_await _api->_store->get_schema_definition(id));
+            schema.emplace(
+              co_await _api->_store->get_schema_definition(
+                {default_context, id}));
         } catch (const exception& ex) {
             vlog(
               srlog.debug,
@@ -273,7 +276,7 @@ public:
         auto sub = make_subject(sns, topic, field, *record_name);
 
         auto has_id = co_await _api->_store->has_version(
-          sub, id, include_deleted::yes);
+          context_subject{default_context, sub}, id, include_deleted::yes);
         if (!has_id) {
             vlog(
               srlog.debug,

--- a/src/v/schema/registry.cc
+++ b/src/v/schema/registry.cc
@@ -79,13 +79,14 @@ public:
     }
     ss::future<ppsr::context_schema_id>
     create_schema(ppsr::subject_schema schema) override {
+        auto ctx = schema.sub().ctx;
         auto [reader, writer] = co_await service();
         co_await writer->read_sync();
         _last_sync_time = ss::lowres_clock::now();
         auto parsed = co_await reader->make_canonical_schema(std::move(schema));
         auto result = co_await writer->write_subject_version(
           {.schema = std::move(parsed)});
-        co_return result.id;
+        co_return ppsr::context_schema_id{std::move(ctx), result.id};
     }
 
 private:
@@ -152,18 +153,20 @@ registry::get_valid_schema(ppsr::context_schema_id schema_id) const {
             co_return std::nullopt;
         }
     }
+    auto ctx_sub = ppsr::context_subject{
+      ppsr::default_context, ppsr::subject("r")};
     switch (schema_def_opt->type()) {
     case ppsr::schema_type::json: {
         co_return co_await ppsr::make_json_schema_definition(
-          *reader, {ppsr::subject("r"), std::move(*schema_def_opt)});
+          *reader, {std::move(ctx_sub), std::move(*schema_def_opt)});
     }
     case ppsr::schema_type::avro: {
         co_return co_await ppsr::make_avro_schema_definition(
-          *reader, {ppsr::subject("r"), std::move(*schema_def_opt)});
+          *reader, {std::move(ctx_sub), std::move(*schema_def_opt)});
     }
     case ppsr::schema_type::protobuf: {
         co_return co_await ppsr::make_protobuf_schema_definition(
-          *reader, {ppsr::subject("r"), std::move(*schema_def_opt)});
+          *reader, {std::move(ctx_sub), std::move(*schema_def_opt)});
     }
     }
 }

--- a/src/v/schema/tests/fake_registry.cc
+++ b/src/v/schema/tests/fake_registry.cc
@@ -58,7 +58,7 @@ ss::future<ppsr::stored_schema> schema::fake_store::get_subject_schema(
 ss::future<ppsr::schema_definition>
 schema::fake_store::get_schema_definition(ppsr::context_schema_id id) {
     for (const auto& s : schemas) {
-        if (s.id == id) {
+        if (s.context_id() == id) {
             co_return s.schema.def().share();
         }
     }
@@ -68,7 +68,7 @@ schema::fake_store::get_schema_definition(ppsr::context_schema_id id) {
 ss::future<std::optional<ppsr::schema_definition>>
 schema::fake_store::maybe_get_schema_definition(ppsr::context_schema_id id) {
     for (const auto& s : schemas) {
-        if (s.id == id) {
+        if (s.context_id() == id) {
             co_return s.schema.def().share();
         }
     }
@@ -103,7 +103,7 @@ schema::fake_registry::create_schema(ppsr::subject_schema unparsed) {
     for (const auto& s : _store.schemas) {
         if (
           same_schema(unparsed, s.schema) && s.schema.sub() == unparsed.sub()) {
-            co_return s.id;
+            co_return s.context_id();
         }
     }
     auto id = ppsr::schema_id(int32_t(_store.schemas.size() + 1));
@@ -123,7 +123,7 @@ schema::fake_registry::create_schema(ppsr::subject_schema unparsed) {
       .id = id,
       .deleted = ppsr::is_deleted::no,
     });
-    co_return _store.schemas.back().id;
+    co_return _store.schemas.back().context_id();
 }
 const std::vector<ppsr::stored_schema>& schema::fake_registry::get_all() {
     maybe_throw_injected_failure();

--- a/src/v/wasm/schema_registry_module.cc
+++ b/src/v/wasm/schema_registry_module.cc
@@ -117,7 +117,8 @@ ss::future<int32_t> schema_registry_module::get_schema_definition_len(
         co_return SCHEMA_REGISTRY_NOT_ENABLED;
     }
     try {
-        auto schema = co_await _sr->get_schema_definition(schema_id);
+        auto schema = co_await _sr->get_schema_definition(
+          {pandaproxy::schema_registry::default_context, schema_id});
         ffi::sizer sizer;
         write_encoded_schema_def(schema, &sizer);
         *size_out = sizer.total();
@@ -134,7 +135,8 @@ ss::future<int32_t> schema_registry_module::get_schema_definition(
         co_return SCHEMA_REGISTRY_NOT_ENABLED;
     }
     try {
-        auto schema = co_await _sr->get_schema_definition(schema_id);
+        auto schema = co_await _sr->get_schema_definition(
+          {pandaproxy::schema_registry::default_context, schema_id});
         ffi::writer writer(buf);
         write_encoded_schema_def(schema, &writer);
         co_return writer.total();
@@ -156,7 +158,8 @@ ss::future<int32_t> schema_registry_module::get_subject_schema_len(
         std::optional<schema_version> v = version == invalid_schema_version
                                             ? std::nullopt
                                             : std::make_optional(version);
-        auto schema = co_await _sr->get_subject_schema(sub, v);
+        auto schema = co_await _sr->get_subject_schema(
+          {default_context, sub}, v);
         ffi::sizer sizer;
         write_encoded_schema_subject(schema, &sizer);
         *size_out = sizer.total();
@@ -180,7 +183,8 @@ ss::future<int32_t> schema_registry_module::get_subject_schema(
         std::optional<schema_version> v = version == invalid_schema_version
                                             ? std::nullopt
                                             : std::make_optional(version);
-        auto schema = co_await _sr->get_subject_schema(sub, v);
+        auto schema = co_await _sr->get_subject_schema(
+          {default_context, sub}, v);
         ffi::writer writer(buf);
         write_encoded_schema_subject(schema, &writer);
         co_return writer.total();
@@ -203,7 +207,7 @@ ss::future<int32_t> schema_registry_module::create_subject_schema(
     using namespace pandaproxy::schema_registry;
     try {
         auto ctx_id = co_await _sr->create_schema(
-          subject_schema(sub, read_encoded_schema_def(&r)));
+          subject_schema({default_context, sub}, read_encoded_schema_def(&r)));
         *out_schema_id = ctx_id.id;
     } catch (const std::exception& ex) {
         vlog(wasm_log.warn, "error registering subject schema: {}", ex);

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -6649,6 +6649,40 @@ class SchemaRegistryContextTest(SchemaRegistryEndpoints):
             result_json["references"][1]["subject"], f":.{ctx}:{base2_subject}"
         )
 
+    @cluster(num_nodes=1)
+    def test_reregister_schema_returns_correct_context_definition(self):
+        """
+        Regression test for context-aware schema definition lookup.
+
+        When re-registering an existing schema, the response should contain
+        the schema definition from the correct context, not from the schema
+        with the same schema ID in the default context.
+        """
+        # Register schema A in .ctx1 - gets ID 1
+        ctx1_subject = ":.ctx1:test-subject"
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=ctx1_subject, data=json.dumps({"schema": schema1_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["id"], 1)
+
+        # Register different schema B in default context - also gets ID 1
+        default_subject = "test-subject"
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=default_subject, data=json.dumps({"schema": schema2_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        self.assert_equal(result.json()["id"], 1)  # Same numeric ID, different context
+
+        # Re-register schema A in .ctx1 (should return existing)
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=ctx1_subject, data=json.dumps({"schema": schema1_def})
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # The returned schema should be schema1_def (from .ctx1), NOT schema2_def
+        self.assert_equal(result.json()["schema"], schema1_def)
+
 
 class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
     """

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -6683,6 +6683,71 @@ class SchemaRegistryContextTest(SchemaRegistryEndpoints):
         # The returned schema should be schema1_def (from .ctx1), NOT schema2_def
         self.assert_equal(result.json()["schema"], schema1_def)
 
+    @cluster(num_nodes=1)
+    def test_context_reference_detection_blocks_deletion(self):
+        """
+        Regression test for context-aware reference detection.
+
+        Schema references within a non-default context should be correctly
+        detected by both the referenced_by API and deletion prevention logic.
+        """
+        ctx = "reftest"
+        base_subject = f":.{ctx}:base"
+        dependent_subject = f":.{ctx}:dependent"
+
+        # Register base schema in context
+        base_data = json.dumps({"schema": simple_proto_def, "schemaType": "PROTOBUF"})
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=base_subject, data=base_data
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Register dependent schema that references base
+        dependent_data = json.dumps(
+            {
+                "schema": imported_proto_def,
+                "schemaType": "PROTOBUF",
+                "references": [
+                    {"name": "simple", "subject": base_subject, "version": 1}
+                ],
+            }
+        )
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=dependent_subject, data=dependent_data
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        dependent_id = result.json()["id"]
+
+        # Part A: referenced_by API should return the dependent schema's ID
+        result = self.sr_client.get_subjects_subject_versions_version_referenced_by(
+            subject=base_subject, version=1
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+        referenced_by = result.json()
+        self.assert_equal(
+            len(referenced_by),
+            1,
+            f"Expected 1 reference, got {len(referenced_by)}",
+        )
+        self.assert_equal(referenced_by[0], dependent_id)
+
+        # Part B: Deletion of base should be blocked (schema is referenced)
+        result = self.sr_client.delete_subject(subject=base_subject)
+        self.assert_equal(
+            result.status_code,
+            requests.codes.unprocessable_entity,
+            "Expected deletion to be blocked due to reference",
+        )
+        self.assert_equal(result.json()["error_code"], 42206)
+
+        # Part C: Delete dependent first, then base should succeed
+        result = self.sr_client.delete_subject(subject=dependent_subject)
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # Now base can be deleted
+        result = self.sr_client.delete_subject(subject=base_subject)
+        self.assert_equal(result.status_code, requests.codes.ok)
+
 
 class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
     """


### PR DESCRIPTION
During the implementation of the Schema Registry Contexts project, I've been using some implicit constructors to avoid having to migrate all of the source code in a single PR. Now that the source code migration is complete, we can remove these implicit constructors to let the compiler help us ensure type safety and catch subtle bugs.

This highlighted two bugs that I've now fixed and added regression tests for.

I've also now audited the code for all explicit usages of the `default_context` to check that it is only used where appropriate, and all usages of it for the contexts-related migration have been cleaned up.

Fixes https://redpandadata.atlassian.net/browse/CORE-15189

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
