### PR TITLE
[CORE-14844] `cloud_storage`: deflake `test_remote_partition_read_cached_index`

### DIFF
--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -1114,9 +1114,10 @@ FIXTURE_TEST(test_remote_partition_read_cached_index, cloud_storage_fixture) {
         auto headers_read
           = reader.consume(slow_consumer(), model::timeout_clock::now() + 10ms)
               .get();
-        // We expect the consumer to consume the first batch, then stall
-        // then consume the second batch and bail out due to timeout.
-        BOOST_REQUIRE_EQUAL(headers_read.size(), 2);
+        // We expect the consumer to consume the first batch, then stall,
+        // then _maybe_ consume the second batch before bailing out due to
+        // timeout.
+        BOOST_REQUIRE_GT(headers_read.size(), 0);
     }
 }
 


### PR DESCRIPTION
This can flake depending on timing, if we hit the deadline before consuming the second batch:

```
DEBUG 2026-01-21 03:15:28,587 [shard 0:main] cloud_storage - [fiber719 kafka/test-topic/42] - remote_partition.cc:384 - We're over-budget, stopping, config: start_offset:5, max_offset:44, min_bytes:0, max_bytes:4096, strict_max_bytes:false, type_filter: {nullopt}, first_timestamp:{nullopt}, bytes_consumed:1779, over_budget:false, abortable:false, client_address:{nullopt}, deadline exceeded.
src/v/cloud_storage/tests/remote_partition_test.cc(1119): fatal error: in "test_remote_partition_read_cached_index": critical check headers_read.size() == 2 has failed [1 != 2]
```

Change the condition to expect more than 0 batches consumed instead of exactly two.


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
