### PR TITLE
ct/lsm: Fix shutdown delay due to bad ordering and bad retries

### DIFF
--- a/src/v/lsm/core/exceptions.h
+++ b/src/v/lsm/core/exceptions.h
@@ -71,4 +71,14 @@ public:
       : base_exception(fmt::format(msg, std::forward<T>(args)...)) {}
 };
 
+inline bool is_abort_exception(const std::exception_ptr& e) {
+    try {
+        std::rethrow_exception(e);
+    } catch (const abort_requested_exception&) {
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
 } // namespace lsm

--- a/src/v/lsm/db/impl.cc
+++ b/src/v/lsm/db/impl.cc
@@ -290,7 +290,17 @@ void impl::maybe_schedule_compaction() {
         auto task = do_flush().then_wrapped([this](ss::future<> f) {
             if (f.failed()) {
                 auto ex = f.get_exception();
-                vlog(log.warn, "flush_task_end error=\"{}\"", ex);
+                bool is_abort = is_abort_exception(ex);
+                vlog(
+                  log.warn,
+                  "flush_task_end is_abort={} error=\"{}\"",
+                  is_abort,
+                  ex);
+                if (is_abort) {
+                    _flush_task = std::nullopt;
+                    _background_work_finished_signal.broken(ex);
+                    return;
+                }
             } else {
                 // Notify all waiters that work has been finished.
                 _background_work_finished_signal.broadcast();
@@ -314,7 +324,17 @@ void impl::maybe_schedule_compaction() {
         auto task = do_compaction().then_wrapped([this](ss::future<> f) {
             if (f.failed()) {
                 auto ex = f.get_exception();
-                vlog(log.warn, "compaction_task_end error=\"{}\"", ex);
+                bool is_abort = is_abort_exception(ex);
+                vlog(
+                  log.warn,
+                  "compaction_task_end is_abort={} error=\"{}\"",
+                  is_abort,
+                  ex);
+                if (is_abort) {
+                    _compaction_task = std::nullopt;
+                    _background_work_finished_signal.broken(ex);
+                    return;
+                }
             } else {
                 // Notify all waiters that work has been finished.
                 _background_work_finished_signal.broadcast();

--- a/src/v/lsm/io/BUILD
+++ b/src/v/lsm/io/BUILD
@@ -60,6 +60,7 @@ redpanda_cc_library(
         "//src/v/config",
         "//src/v/lsm/core:exceptions",
         "//src/v/lsm/core/internal:files",
+        "//src/v/ssx:future_util",
         "//src/v/utils:retry_chain_node",
     ],
     deps = [

--- a/src/v/lsm/io/cloud_persistence.cc
+++ b/src/v/lsm/io/cloud_persistence.cc
@@ -17,11 +17,13 @@
 #include "lsm/core/internal/files.h"
 #include "lsm/io/file_io.h"
 #include "lsm/io/persistence.h"
+#include "ssx/future-util.h"
 #include "utils/retry_chain_node.h"
 
 #include <seastar/core/fstream.hh>
 #include <seastar/core/reactor.hh>
 
+#include <exception>
 #include <memory>
 
 namespace lsm::io {
@@ -126,8 +128,12 @@ public:
         } catch (const std::system_error& err) {
             throw io_error_exception(err.code(), "io error closing: {}", err);
         } catch (...) {
-            throw io_error_exception(
-              "io error closing: {}", std::current_exception());
+            auto ex = std::current_exception();
+            if (ssx::is_shutdown_exception(ex)) {
+                throw abort_requested_exception(
+                  "shutdown exception while closing: {}", ex);
+            }
+            throw io_error_exception("io error closing: {}", ex);
         }
     }
 
@@ -218,8 +224,12 @@ public:
             throw io_error_exception(
               e.code(), "io error downloading file: {}", e);
         } catch (...) {
-            throw io_error_exception(
-              "io error downloading file: {}", std::current_exception());
+            auto ex = std::current_exception();
+            if (ssx::is_shutdown_exception(ex)) {
+                throw abort_requested_exception(
+                  "shutdown exception while downloading file: {}", ex);
+            }
+            throw io_error_exception("io error downloading file: {}", ex);
         }
         if (check_result(result)) {
             co_return co_await open_local_reader(filepath);
@@ -255,8 +265,12 @@ public:
             throw io_error_exception(
               e.code(), "io error opening file writer: {}", e);
         } catch (...) {
-            throw io_error_exception(
-              "io error opening file writer: {}", std::current_exception());
+            auto ex = std::current_exception();
+            if (ssx::is_shutdown_exception(ex)) {
+                throw abort_requested_exception(
+                  "shutdown exception while opening file writer: {}", ex);
+            }
+            throw io_error_exception("io error opening file writer: {}", ex);
         }
     }
 
@@ -279,8 +293,12 @@ public:
                   e.code(), "io error removing file: {}", e);
             }
         } catch (...) {
-            throw io_error_exception(
-              "io error removing file: {}", std::current_exception());
+            auto ex = std::current_exception();
+            if (ssx::is_shutdown_exception(ex)) {
+                throw abort_requested_exception(
+                  "shutdown exception while removing file: {}", ex);
+            }
+            throw io_error_exception("io error removing file: {}", ex);
         }
         check_result(result);
     }
@@ -296,8 +314,12 @@ public:
         try {
             result = co_await _remote->list_objects(_bucket, rtc, _prefix);
         } catch (...) {
-            throw io_error_exception(
-              "io error listing files: {}", std::current_exception());
+            auto ex = std::current_exception();
+            if (ssx::is_shutdown_exception(ex)) {
+                throw abort_requested_exception(
+                  "shutdown exception while listing files: {}", ex);
+            }
+            throw io_error_exception("io error listing files: {}", ex);
         }
         if (result.has_error()) {
             throw io_error_exception(
@@ -342,9 +364,13 @@ private:
             throw io_error_exception(
               e.code(), "io error opening file reader: {}", e);
         } catch (...) {
+            auto ex = std::current_exception();
+            if (ssx::is_shutdown_exception(ex)) {
+                throw abort_requested_exception(
+                  "shutdown exception while listing files: {}", ex);
+            }
             throw io_error_exception(
-              "io error opening staging file reader: {}",
-              std::current_exception());
+              "io error opening staging file reader: {}", ex);
         }
     }
     ss::future<uint64_t> save_locally(


### PR DESCRIPTION
Shutdown of the L1 domain manager can be delayed by the following sequence:

0. An LSM flush is in flight.
1. Redpanda shutdown begins.
2. Cloud I/O is shutdown: uploads to cloud storage fail with shutdown exceptions.
3. The leader_router closes its gate and waits for the flush to finish.
4. The flush task fails and immediately retries via maybe_schedule_compaction(). The retry fails instantly (cloud I/O is dead), so this loops thousands of times. Meanwhile impl::flush() waits on a condition variable that is only signaled on success, so it blocks for the full 30s flush timeout.
5. The leader_router doesn't shutdown because the flush_domain request hasn't released the gate.
6. The domain manager isn't shut down because the leader_router shuts down first, so the domain manager's abort source (which would cancel the flush) isn't triggered.

There are two problems:
1. Cloud I/O is a dependency of the LSM subsystem, but it shuts down first. This reverse-order shutdown happens because we shut down cloud I/O before partitions in order to abort in-flight tiered storage readers.
2. The flush retries even when the error is a permanent failure like a shutdown exception.

This change fixes 2 by propagating the shutdown exception from cloud I/O and aborting background flushes and compactions during shutdown, waking their waiters with a broken cvar.

This change does not address 1, as other subsystems (tiered storage) depend on cloud I/O being severed before partition shutdown.

Fixes CORE-14555

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
