### PR TITLE
[v25.3.x] gh: Remove michael-redpanda from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,7 +17,7 @@ licenses           @emaxerrno
 #
 # crypto
 #
-/src/v/crypto              @michael-redpanda
+/src/v/crypto              @redpanda-data/core-enterprise
 
 #
 # rpk
@@ -55,5 +55,5 @@ licenses           @emaxerrno
 #
 # automatically tag docs team and API reviewers for any changes to our public proto files
 #
-/proto/redpanda/core/admin/v2/*.proto    @redpanda-data/documentation @rockwotj @michael-redpanda
-/proto/redpanda/core/common/*.proto      @redpanda-data/documentation @rockwotj @michael-redpanda
+/proto/redpanda/core/admin/v2/*.proto    @redpanda-data/documentation @rockwotj @redpanda-data/core-enterprise
+/proto/redpanda/core/common/*.proto      @redpanda-data/documentation @rockwotj @redpanda-data/core-enterprise


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/29617
