### PR TITLE
[CORE-15302] Cloud Storage Clients: Relax multipart/mixed response parsing to align with RFC 2046

### DIFF
--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -1120,6 +1120,25 @@ abs_client::do_batch_delete_objects(
         if (!boundary.has_value()) {
             throw std::runtime_error(boundary.error());
         }
+        if (abs_log.is_enabled(ss::log_level::trace)) {
+            // Log up to 1024 bytes of the response to aid debugging
+            // without dumping the entire (potentially large) multipart
+            // body.
+            auto preview_bytes
+              = iobuf_const_parser(response_buf)
+                  .peek_bytes(
+                    std::min(response_buf.size_bytes(), size_t{1024}));
+            vlog(
+              abs_log.trace,
+              "batch delete response: boundary='{}', body_size={}, "
+              "first_bytes='{}'",
+              boundary.value(),
+              response_buf.size_bytes(),
+              std::string_view(
+                reinterpret_cast<const char*>(preview_bytes.data()),
+                preview_bytes.size()));
+        }
+
         result = parse_batch_delete_response(
           std::move(response_buf), boundary.value(), keys);
     } catch (...) {

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -1588,6 +1588,21 @@ auto gcs_client::do_delete_objects(
         if (!boundary.has_value()) {
             throw std::runtime_error(boundary.error());
         }
+        if (s3_log.is_enabled(ss::log_level::trace)) {
+            auto preview_bytes
+              = iobuf_const_parser(response_buf)
+                  .peek_bytes(
+                    std::min(response_buf.size_bytes(), size_t{1024}));
+            vlog(
+              s3_log.trace,
+              "GCS batch delete response: boundary='{}', body_size={}, "
+              "first_bytes='{}'",
+              boundary.value(),
+              response_buf.size_bytes(),
+              std::string_view(
+                reinterpret_cast<const char*>(preview_bytes.data()),
+                preview_bytes.size()));
+        }
         result = parse_gcs_batch_delete_response(
           std::move(response_buf), boundary.value(), keys);
     } catch (...) {

--- a/src/v/cloud_storage_clients/tests/util_test.cc
+++ b/src/v/cloud_storage_clients/tests/util_test.cc
@@ -529,6 +529,89 @@ TEST(FullMultipartParsing, WithErrors) {
     EXPECT_TRUE(is_ok_results[2]);
 }
 
+TEST(FullMultipartParsing, WithErrorBodies) {
+    using namespace cloud_storage_clients;
+
+    // Reproduce the real Azure response format: successful 202 responses have
+    // no body, but 404 BlobNotFound responses include an XML error body. The
+    // XML body means only a single CRLF appears between the body content and
+    // the next boundary delimiter, which the parser must handle correctly.
+    std::string_view batch_response
+      = "--batchresponse_abc123\r\n"
+        "Content-Type: application/http\r\n"
+        "Content-ID: 0\r\n"
+        "\r\n"
+        "HTTP/1.1 202 Accepted\r\n"
+        "x-ms-delete-type-permanent: true\r\n"
+        "x-ms-request-id: req-0\r\n"
+        "x-ms-version: 2023-01-03\r\n"
+        "Server: Windows-Azure-Blob/1.0\r\n"
+        "\r\n"
+        "--batchresponse_abc123\r\n"
+        "Content-Type: application/http\r\n"
+        "Content-ID: 1\r\n"
+        "\r\n"
+        "HTTP/1.1 404 The specified blob does not exist.\r\n"
+        "x-ms-error-code: BlobNotFound\r\n"
+        "x-ms-request-id: req-1\r\n"
+        "x-ms-version: 2023-01-03\r\n"
+        "Content-Length: 216\r\n"
+        "Content-Type: application/xml\r\n"
+        "Server: Windows-Azure-Blob/1.0\r\n"
+        "\r\n"
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+        "<Error><Code>BlobNotFound</Code>"
+        "<Message>The specified blob does not exist.\n"
+        "RequestId:req-1\n"
+        "Time:2026-02-18T18:57:50.264Z</Message></Error>\r\n"
+        "--batchresponse_abc123\r\n"
+        "Content-Type: application/http\r\n"
+        "Content-ID: 2\r\n"
+        "\r\n"
+        "HTTP/1.1 202 Accepted\r\n"
+        "x-ms-delete-type-permanent: true\r\n"
+        "x-ms-request-id: req-2\r\n"
+        "x-ms-version: 2023-01-03\r\n"
+        "Server: Windows-Azure-Blob/1.0\r\n"
+        "\r\n"
+        "--batchresponse_abc123--\r\n";
+
+    auto buf = iobuf::from(batch_response);
+
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--batchresponse_abc123"));
+
+    std::vector<bool> is_ok_results;
+    std::vector<std::optional<int>> content_ids;
+
+    std::optional<iobuf> part;
+    while ((part = parser.get_part()).has_value()) {
+        iobuf_parser part_parser(std::move(part).value());
+
+        auto mime = util::mime_header::from(part_parser);
+        content_ids.push_back(mime.content_id<int>(convert_cid));
+
+        auto subresponse = util::multipart_subresponse::from(part_parser);
+        is_ok_results.push_back(subresponse.is_ok());
+    }
+
+    ASSERT_EQ(is_ok_results.size(), 3)
+      << "Expected 3 parts (parser must handle sub-responses with bodies)";
+    ASSERT_EQ(content_ids.size(), 3);
+
+    // First: 202 Accepted (no body)
+    EXPECT_EQ(content_ids[0].value(), 0);
+    EXPECT_TRUE(is_ok_results[0]);
+
+    // Second: 404 BlobNotFound (XML body)
+    EXPECT_EQ(content_ids[1].value(), 1);
+    EXPECT_TRUE(is_ok_results[1]) << "404 is OK for delete operations";
+
+    // Third: 202 Accepted (no body, after part with body)
+    EXPECT_EQ(content_ids[2].value(), 2);
+    EXPECT_TRUE(is_ok_results[2]);
+}
+
 // ----------------------------------------------------------------------------
 // Malformed MIME header tests
 // ----------------------------------------------------------------------------
@@ -759,10 +842,12 @@ TEST(MultipartMalformed, BoundaryWithExtraDashes) {
 TEST(MultipartMalformed, MissingCrlfBeforeBoundary) {
     using namespace cloud_storage_clients;
 
-    // Missing CRLF before boundary delimiter
+    // Boundary embedded in content without preceding CRLF. Per RFC 2046,
+    // the CRLF before the boundary is "conceptually attached to the
+    // boundary" and must be present. Without it, the boundary string
+    // is just part of the content.
     std::string_view multipart_data = "--boundary\r\n"
-                                      "First part\r\n"
-                                      "--boundary\r\n" // No CRLF before this
+                                      "First part--boundary\r\n"
                                       "Second part\r\n"
                                       "\r\n"
                                       "--boundary--\r\n";
@@ -772,8 +857,8 @@ TEST(MultipartMalformed, MissingCrlfBeforeBoundary) {
     util::multipart_response_parser parser(
       std::move(buf), ss::sstring("--boundary"));
 
-    // Missing CRLF before boundary is equivalent to finding the boundary in the
-    // message, which is illegal per RFC 2046
+    // The boundary in "First part--boundary" has no preceding CRLF, so the
+    // parser treats it as embedded content and does not split on it
     auto part1 = parser.get_part();
     EXPECT_FALSE(part1.has_value());
 }
@@ -953,4 +1038,165 @@ TEST(FindMultipartBoundary, EmptyBoundaryParameter) {
     EXPECT_FALSE(result.has_value()) << result.value();
     EXPECT_THAT(
       result.error(), testing::HasSubstr("Boundary missing from multipart"));
+}
+
+// ============================================================================
+// Preamble handling tests
+//
+// Per RFC 2046, a multipart body may include a "preamble" before the first
+// boundary delimiter. Per RFC 1341, the CRLF preceding the first boundary is
+// part of the delimiter, so the body often starts with "\r\n--boundary".
+// Azure Blob Storage batch responses and the Azure .NET SDK explicitly handle
+// this case.
+// ============================================================================
+
+TEST(MultipartPreamble, CrlfBeforeBoundary) {
+    using namespace cloud_storage_clients;
+
+    // Body starts with \r\n before the first --boundary (per RFC 1341)
+    std::string_view multipart_data = "\r\n--boundary\r\n"
+                                      "Content-Type: text/plain\r\n"
+                                      "\r\n"
+                                      "Hello World\r\n"
+                                      "\r\n"
+                                      "--boundary--\r\n";
+
+    auto buf = iobuf::from(multipart_data);
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--boundary"));
+
+    auto part = parser.get_part();
+    ASSERT_TRUE(part.has_value());
+
+    auto content = part.value().linearize_to_string();
+    EXPECT_THAT(content, testing::HasSubstr("Content-Type: text/plain"));
+    EXPECT_THAT(content, testing::HasSubstr("Hello World"));
+
+    EXPECT_FALSE(parser.get_part().has_value());
+}
+
+TEST(MultipartPreamble, MultipleCrlfBeforeBoundary) {
+    using namespace cloud_storage_clients;
+
+    // Multiple CRLFs before the boundary
+    std::string_view multipart_data = "\r\n\r\n\r\n--boundary\r\n"
+                                      "Content-ID: 0\r\n"
+                                      "\r\n"
+                                      "Part data\r\n"
+                                      "\r\n"
+                                      "--boundary--\r\n";
+
+    auto buf = iobuf::from(multipart_data);
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--boundary"));
+
+    auto part = parser.get_part();
+    ASSERT_TRUE(part.has_value());
+
+    auto content = part.value().linearize_to_string();
+    EXPECT_THAT(content, testing::HasSubstr("Part data"));
+
+    EXPECT_FALSE(parser.get_part().has_value());
+}
+
+TEST(MultipartPreamble, WhitespaceBeforeBoundary) {
+    using namespace cloud_storage_clients;
+
+    // Whitespace (spaces/tabs) before the boundary
+    std::string_view multipart_data = "  \t --boundary\r\n"
+                                      "Content-ID: 0\r\n"
+                                      "\r\n"
+                                      "Part data\r\n"
+                                      "\r\n"
+                                      "--boundary--\r\n";
+
+    auto buf = iobuf::from(multipart_data);
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--boundary"));
+
+    auto part = parser.get_part();
+    ASSERT_TRUE(part.has_value());
+
+    auto content = part.value().linearize_to_string();
+    EXPECT_THAT(content, testing::HasSubstr("Part data"));
+
+    EXPECT_FALSE(parser.get_part().has_value());
+}
+
+TEST(MultipartPreamble, TextPreambleBeforeBoundary) {
+    using namespace cloud_storage_clients;
+
+    // RFC 2046 allows arbitrary preamble text before the first boundary.
+    // "This is often used to include an explanatory note to non-MIME
+    // conformant readers."
+    std::string_view multipart_data = "This is a preamble.\r\n"
+                                      "--boundary\r\n"
+                                      "Content-ID: 0\r\n"
+                                      "\r\n"
+                                      "First part\r\n"
+                                      "\r\n"
+                                      "--boundary\r\n"
+                                      "Content-ID: 1\r\n"
+                                      "\r\n"
+                                      "Second part\r\n"
+                                      "\r\n"
+                                      "--boundary--\r\n";
+
+    auto buf = iobuf::from(multipart_data);
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--boundary"));
+
+    auto part1 = parser.get_part();
+    ASSERT_TRUE(part1.has_value());
+    EXPECT_THAT(
+      part1.value().linearize_to_string(), testing::HasSubstr("First part"));
+
+    auto part2 = parser.get_part();
+    ASSERT_TRUE(part2.has_value());
+    EXPECT_THAT(
+      part2.value().linearize_to_string(), testing::HasSubstr("Second part"));
+
+    EXPECT_FALSE(parser.get_part().has_value());
+}
+
+TEST(MultipartPreamble, CrlfBeforeBoundaryFullIntegration) {
+    using namespace cloud_storage_clients;
+
+    // Simulate a realistic Azure batch response with leading CRLF
+    std::string_view batch_response = "\r\n--batchresponse_abc123\r\n"
+                                      "Content-Type: application/http\r\n"
+                                      "Content-ID: 0\r\n"
+                                      "\r\n"
+                                      "HTTP/1.1 202 Accepted\r\n"
+                                      "x-ms-request-id: req-0\r\n"
+                                      "\r\n"
+                                      "--batchresponse_abc123\r\n"
+                                      "Content-Type: application/http\r\n"
+                                      "Content-ID: 1\r\n"
+                                      "\r\n"
+                                      "HTTP/1.1 202 Accepted\r\n"
+                                      "x-ms-request-id: req-1\r\n"
+                                      "\r\n"
+                                      "--batchresponse_abc123--\r\n";
+
+    auto buf = iobuf::from(batch_response);
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--batchresponse_abc123"));
+
+    int successful_parts = 0;
+    std::optional<iobuf> part;
+    while ((part = parser.get_part()).has_value()) {
+        iobuf_parser part_parser(std::move(part).value());
+        auto mime = util::mime_header::from(part_parser);
+        auto content_id = mime.content_id<int>(convert_cid);
+        EXPECT_TRUE(content_id.has_value());
+
+        auto subresponse = util::multipart_subresponse::from(part_parser);
+        EXPECT_TRUE(subresponse.is_ok());
+        EXPECT_EQ(subresponse.result(), boost::beast::http::status::accepted);
+
+        successful_parts++;
+    }
+
+    EXPECT_EQ(successful_parts, 2);
 }

--- a/src/v/cloud_storage_clients/util.cc
+++ b/src/v/cloud_storage_clients/util.cc
@@ -403,11 +403,15 @@ std::optional<iobuf> multipart_response_parser::get_part() {
             part_len = 1;
         }
     }
-    // we ran out of bytes before reaching the end delimiter OR/AND the complete
-    // boundary string appeared in the sub-response body (illegal per multipart
-    // grammar laid out in RFC 2046)
+    // We ran out of bytes before reaching the end delimiter, or the
+    // boundary string appeared inside body content without the required
+    // preceding CRLF. Per RFC 2046, boundary delimiters must be preceded
+    // by a CRLF (the CRLF is "conceptually attached to the boundary").
+    // Sub-responses that carry a body (e.g. 404 with XML error content)
+    // will have only a single CRLF between the body and the boundary,
+    // so requiring two CRLFs here would incorrectly reject valid parts.
     if (
-      delim_idx != _delim.size() || line_feed.count() < 2
+      delim_idx != _delim.size() || line_feed.count() < 1
       || _parser.bytes_left() < 2) {
         _done = true;
         return std::nullopt;
@@ -427,6 +431,14 @@ std::optional<iobuf> multipart_response_parser::get_part() {
 }
 
 void multipart_response_parser::advance_to_first_boundary() {
+    // Per RFC 2046, a multipart body may include a preamble before the first
+    // boundary delimiter. Additionally, per RFC 1341 the CRLF preceding the
+    // first boundary is part of the delimiter, meaning the body often starts
+    // with "\r\n--boundary" rather than "--boundary" directly. Azure Blob
+    // Storage batch responses are known to include such leading bytes.
+    //
+    // We scan forward through any preamble content until we find the boundary
+    // delimiter.
     size_t delim_idx = 0;
     while (!_found_first && _parser.bytes_left()) {
         auto c = _parser.consume_type<char>();
@@ -434,8 +446,15 @@ void multipart_response_parser::advance_to_first_boundary() {
             ++delim_idx;
             _found_first = delim_idx == _delim.size();
         } else {
-            // TODO(oren): I think ABS might actually put something here
-            break;
+            // Reset and keep scanning. If we had a partial match
+            // (delim_idx > 0), the current character might be the start of
+            // the real delimiter, so re-check it.
+            if (delim_idx > 0) {
+                delim_idx = 0;
+                if (c == _delim[0]) {
+                    delim_idx = 1;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes (more likely than not):

- CORE-15302
- CORE-8278
- CORE-8491
- CORE-15295
- CORE-14789

RFC 2046 §5.1.1 permits an arbitrary preamble before the first boundary
delimiter ("implementations must ignore" it), and states:

> the CRLF preceding the boundary delimiter line is conceptually
  attached to the boundary

Meaning only a single CRLF is required before each boundary, with a second CRLF
present only when the preceding body part itself ends with a line break.

The commit fixes advance_to_first_boundary() to scan through preamble content
(including leading CRLFs per RFC 1341) instead of aborting on the first
non-boundary byte, and relaxes the get_part() guard from line_feed.count() < 2
to < 1 so that sub-responses carrying a body where only the boundary's own CRLF
precedes the delimiter are no longer incorrectly rejected.

### RFC Detail

[From RFC 2046](https://www.rfc-editor.org/rfc/rfc2046.html):

> There appears to be room for additional information prior to the
   first boundary delimiter line and following the final boundary
   delimiter line.  These areas should generally be left blank, and
   implementations must ignore anything that appears before the first
   boundary delimiter line or after the last one.

> NOTE:  These "preamble" and "epilogue" areas are generally not used
   because of the lack of proper typing of these parts and the lack of
   clear semantics for handling these areas at gateways, particularly
   X.400 gateways.  However, rather than leaving the preamble area
   blank, many MIME implementations have found this to be a convenient
   place to insert an explanatory note for recipients who read the
   message with pre-MIME software, since such notes will be ignored by
   MIME-compliant software.

And

> The boundary delimiter MUST occur at the beginning of a line, i.e.,
   following a CRLF, and the initial CRLF is considered to be attached
   to the boundary delimiter line rather than part of the preceding
   part...

> NOTE:  The CRLF preceding the boundary delimiter line is conceptually
   attached to the boundary so that it is possible to have a part that
   does not end with a CRLF (line  break).  Body parts that must be
   considered to end with line breaks, therefore, must have two CRLFs
   preceding the boundary delimiter line, the first of which is part of
   the preceding body part, and the second of which is part of the
   encapsulation boundary.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
