### PR TITLE
rm_stm: snapshot producer state on prefix truncation

### DIFF
--- a/src/v/cluster/producer_state.cc
+++ b/src/v/cluster/producer_state.cc
@@ -530,8 +530,7 @@ bool producer_state::has_transaction_expired() const {
            || ms_since_last_update() > _transaction_state->timeout_ms();
 }
 
-producer_state_snapshot
-producer_state::snapshot(kafka::offset log_start_offset) const {
+producer_state_snapshot producer_state::snapshot() const {
     producer_state_snapshot snapshot;
     snapshot.id = _id;
     snapshot.group = _group;
@@ -548,14 +547,8 @@ producer_state::snapshot(kafka::offset log_start_offset) const {
         }
         auto kafka_offset
           = req->_result.get_shared_future().get().value().last_offset;
-        // offsets older than log start are no longer interesting.
-        if (kafka_offset >= log_start_offset) {
-            snapshot.finished_requests.emplace_back(
-              req->_first_sequence,
-              req->_last_sequence,
-              kafka_offset,
-              req->term());
-        }
+        snapshot.finished_requests.emplace_back(
+          req->_first_sequence, req->_last_sequence, kafka_offset, req->term());
     }
     if (_transaction_state) {
         snapshot.transaction_state = *_transaction_state;

--- a/src/v/cluster/producer_state.h
+++ b/src/v/cluster/producer_state.h
@@ -226,7 +226,7 @@ public:
 
     std::optional<seq_t> last_sequence_number() const;
 
-    producer_state_snapshot snapshot(kafka::offset log_start_offset) const;
+    producer_state_snapshot snapshot() const;
 
     ss::lowres_system_clock::time_point get_last_update_timestamp() const {
         return _last_updated_ts;

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -2123,9 +2123,15 @@ ss::future<raft::stm_snapshot> rm_stm::do_take_local_snapshot(
     stm_snapshot.highest_producer_id = _highest_producer_id;
     // producers state (includes idempotent and transactional producers)
     for (const auto& [_, state] : _producers) {
-        auto snapshot = state->snapshot(start_kafka_offset);
-        if (!snapshot.finished_requests.empty()) {
-            stm_snapshot.producers.push_back(std::move(snapshot));
+        auto snap = state->snapshot();
+        // Discard finished requests below the local snapshot start offset,
+        // they are no longer relevant.
+        std::erase_if(
+          snap.finished_requests, [start_kafka_offset](const auto& req) {
+              return req.last_offset < start_kafka_offset;
+          });
+        if (!snap.finished_requests.empty()) {
+            stm_snapshot.producers.push_back(std::move(snap));
         }
     }
 

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -2293,7 +2293,46 @@ ss::future<> rm_stm::do_remove_persistent_state() {
     co_return co_await raft::persisted_stm<>::remove_persistent_state();
 }
 
-ss::future<> rm_stm::apply_raft_snapshot(const iobuf&) {
+ss::future<iobuf>
+rm_stm::take_raft_snapshot(model::offset last_included_offset) {
+    // this is always called under apply lock, so we can be sure
+    // that no concurrent modifications to the state are happening via apply
+    // path.
+    auto units = co_await _state_lock.hold_write_lock();
+    tx::raft_snapshot snapshot;
+    auto kafka_offset = from_log_offset(last_included_offset);
+    for (const auto& [_, state] : _producers) {
+        if (state->transaction_state()) {
+            // we donot need to include transactional producers for two reasons:
+            // 1. eviction offset honors LSO, so every transaction under LSO is
+            // sealed (committed or aborted).
+            // 2. Sequence numbers reset for every new transaction, so we will
+            // not lose any information about the producer by not including
+            // transactional producers in the snapshot.
+            continue;
+        }
+        auto producer_snap = state->snapshot();
+        std::erase_if(
+          producer_snap.finished_requests, [kafka_offset](const auto& req) {
+              return req.last_offset > kafka_offset;
+          });
+        if (producer_snap.finished_requests.empty()) {
+            continue;
+        }
+        snapshot.producers.push_back(std::move(producer_snap));
+    }
+    vlog(
+      _ctx_log.trace,
+      "taking raft snapshot at offset: {}, producers: {}",
+      last_included_offset,
+      snapshot.producers.size());
+    iobuf result;
+    co_await serde::write_async(result, std::move(snapshot));
+    co_return result;
+}
+
+ss::future<> rm_stm::apply_raft_snapshot(const iobuf& buf) {
+    auto local_buf = buf.copy();
     auto units = co_await _state_lock.hold_write_lock();
     vlog(
       _ctx_log.info,
@@ -2301,6 +2340,38 @@ ss::future<> rm_stm::apply_raft_snapshot(const iobuf&) {
       _raft->start_offset());
     _aborted_tx_state = {};
     co_await reset_producers();
+
+    if (!local_buf.empty()) {
+        auto parser = iobuf_parser{std::move(local_buf)};
+        auto snapshot = co_await serde::read_async<tx::raft_snapshot>(parser);
+        vlog(
+          _ctx_log.debug,
+          "Restoring {} idempotent producers from raft snapshot",
+          snapshot.producers.size());
+        for (auto& entry : snapshot.producers) {
+            auto pid = entry.id;
+            _highest_producer_id = std::max(_highest_producer_id, pid.get_id());
+            auto producer = ss::make_lw_shared<producer_state>(
+              _ctx_log,
+              [this](model::producer_identity pid) {
+                  cleanup_producer_state(pid);
+              },
+              std::move(entry));
+            try {
+                _producer_state_manager.local().register_producer(
+                  *producer, _vcluster_id);
+                _producers.emplace(pid.get_id(), producer);
+            } catch (const cache_full_error& e) {
+                vlog(
+                  _ctx_log.warn,
+                  "unable to register producer {} with vcluster: {} - {}",
+                  pid,
+                  _vcluster_id,
+                  e.what());
+            }
+        }
+    }
+
     set_next(_raft->start_offset());
     co_return;
 }

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -212,9 +212,7 @@ public:
 
     uint64_t get_local_snapshot_size() const override;
 
-    ss::future<iobuf> take_raft_snapshot(model::offset) final {
-        co_return iobuf{};
-    }
+    ss::future<iobuf> take_raft_snapshot(model::offset) final;
 
     const producers_t& get_producers() const { return _producers; }
 

--- a/src/v/cluster/rm_stm_types.h
+++ b/src/v/cluster/rm_stm_types.h
@@ -363,6 +363,17 @@ struct tx_snapshot_v6
 
 using tx_snapshot = tx_snapshot_v6;
 
+/// Snapshot of idempotent producer state for inclusion in raft snapshots.
+struct raft_snapshot
+  : serde::
+      envelope<raft_snapshot, serde::version<0>, serde::compat_version<0>> {
+    chunked_vector<producer_state_snapshot> producers;
+    // Aborted state is excluded: raft snapshots represent the truncated,
+    // non-consumable portion of the log, so aborted state is irrelevant.
+
+    auto serde_fields() { return std::tie(producers); }
+};
+
 }; // namespace cluster::tx
 
 namespace reflection {

--- a/src/v/cluster/tests/rm_stm_test_fixture.h
+++ b/src/v/cluster/tests/rm_stm_test_fixture.h
@@ -88,6 +88,10 @@ struct rm_stm_test_fixture : simple_raft_fixture {
           .get();
     }
 
+    auto take_raft_snapshot(model::offset last_included_offset) {
+        return _stm->take_raft_snapshot(last_included_offset);
+    }
+
     auto apply_raft_snapshot(const iobuf& buf) {
         return _stm->apply_raft_snapshot(buf);
     }

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -1164,3 +1164,51 @@ FIXTURE_TEST(test_tx_compaction_last_producer_batch, rm_stm_test_fixture) {
         BOOST_REQUIRE(!seen_placeholder_batch_pid_zero);
     }
 }
+
+// Verifies that idempotent producer state survives a raft snapshot
+// roundtrip (take + apply). After restoring, the producers should be
+// present and the highest_producer_id should be derived from the
+// snapshot entries. Additionally, the restored producers should be able
+// to continue producing without sequence errors.
+FIXTURE_TEST(test_raft_snapshot_roundtrip, rm_stm_test_fixture) {
+    auto& stm = start_and_disable_auto_abort();
+
+    auto pid1 = model::producer_identity{1, 0};
+    auto pid2 = model::producer_identity{5, 0};
+    auto pid3 = model::producer_identity{10, 0};
+
+    for (auto pid : {pid1, pid2, pid3}) {
+        auto rreader = make_batches(pid, 0, 5, false);
+        auto offset_r = replicate_all(stm, std::move(rreader)).get();
+        BOOST_REQUIRE((bool)offset_r);
+    }
+
+    RPTEST_REQUIRE_EVENTUALLY(
+      1s, [&] { return stm.highest_producer_id() == pid3.get_id(); });
+    BOOST_REQUIRE_EQUAL(producers().size(), 3);
+
+    auto committed_offset = _raft->committed_offset();
+
+    // force a snapshot and restore from it.
+    _raft->snapshot_and_truncate_log(committed_offset).get();
+    auto snapshot = take_raft_snapshot(committed_offset).get();
+    apply_raft_snapshot(snapshot).get();
+
+    // All producers should be restored
+    BOOST_REQUIRE_EQUAL(producers().size(), 3);
+    BOOST_REQUIRE(producers().contains(pid1.get_id()));
+    BOOST_REQUIRE(producers().contains(pid2.get_id()));
+    BOOST_REQUIRE(producers().contains(pid3.get_id()));
+
+    // highest_producer_id should be derived from snapshot entries
+    BOOST_REQUIRE_EQUAL(stm.highest_producer_id(), pid3.get_id());
+
+    // Verify producers can continue producing after restore.
+    // Sequence numbers pick up where they left off (5), so producing
+    // with first_seq=5 should succeed.
+    for (auto pid : {pid1, pid2, pid3}) {
+        auto rreader = make_batches(pid, 5, 5, false);
+        auto offset_r = replicate_all(stm, std::move(rreader)).get();
+        BOOST_REQUIRE((bool)offset_r);
+    }
+}

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -684,7 +684,7 @@ cluster::tx::tx_snapshot_v5 make_tx_snapshot_v5() {
       tests::random_producer_state, 50, ctx_logger);
     chunked_vector<cluster::tx::producer_state_snapshot_deprecated> snapshots;
     for (const auto& producer : producers) {
-        auto snapshot = producer->snapshot(kafka::offset{0});
+        auto snapshot = producer->snapshot();
         cluster::tx::producer_state_snapshot_deprecated old_snapshot;
         for (auto& req : snapshot.finished_requests) {
             old_snapshot.finished_requests.push_back(

--- a/tests/rptest/transactions/idempotency_test.py
+++ b/tests/rptest/transactions/idempotency_test.py
@@ -38,6 +38,16 @@ class IdempotentProducerRecoveryTest(RedpandaTest):
             name="test", partition_count=1, replication_factor=1
         )
 
+    def get_producer_count(self):
+        """Returns the total idempotent producer cache size across all nodes."""
+        metrics = self.redpanda.metrics_sample(
+            "idempotency_pid_cache_size", self.redpanda.started_nodes()
+        )
+        assert metrics, "No metrics samples found"
+        total = sum(int(s.value) for s in metrics.samples)
+        self.redpanda.logger.debug(f"producer cache size: {total}")
+        return total
+
     def wait_for_eviction(self, active_producers_remaining, expected_to_be_evicted):
         def do_wait():
             samples = [
@@ -156,3 +166,74 @@ class IdempotentProducerRecoveryTest(RedpandaTest):
 
         # Ensure producer can recover.
         produce_some()
+
+    @cluster(num_nodes=1)
+    def test_producer_state_survives_prefix_truncation(self):
+        """Verifies that idempotent producer state is preserved across
+        log prefix truncation (delete-records). After truncation the broker
+        should still know about the producers that were active before."""
+        num_producers = 5
+        rpk = RpkTool(self.redpanda)
+        rpk.create_topic(
+            self.test_topic.name,
+            self.test_topic.partition_count,
+            self.test_topic.replication_factor,
+        )
+
+        producers = []
+        for _ in range(num_producers):
+            p = ck.Producer(
+                {
+                    "bootstrap.servers": self.redpanda.brokers(),
+                    "enable.idempotence": True,
+                }
+            )
+            producers.append(p)
+
+        def on_delivery(err, _):
+            assert err is None, err
+
+        # Produce with each producer so the broker registers them.
+        for p in producers:
+            for i in range(100):
+                p.produce(self.test_topic.name, str(i), str(i), on_delivery=on_delivery)
+            p.flush()
+
+        count_before = self.get_producer_count()
+        assert count_before == num_producers, (
+            f"Expected {num_producers} producers, got {count_before}"
+        )
+
+        # Get the high watermark and prefix truncate up to it.
+        offsets = rpk.describe_topic(self.test_topic.name)
+        hw = None
+        for o in offsets:
+            if o.id == 0:
+                hw = o.high_watermark
+                break
+        assert hw is not None
+
+        response = rpk.trim_prefix(self.test_topic.name, hw, partitions=[0])
+        assert len(response) == 1
+        assert response[0].error_msg == "", f"Err: {response[0].error_msg}"
+
+        # Wait for the truncation to be applied.
+        def truncation_applied():
+            offsets = rpk.describe_topic(self.test_topic.name)
+            for o in offsets:
+                if o.id == 0:
+                    return o.start_offset >= hw
+            return False
+
+        wait_until(
+            truncation_applied,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Prefix truncation did not complete",
+        )
+
+        # Verify producer count is retained after truncation.
+        count_after = self.get_producer_count()
+        assert count_after == num_producers, (
+            f"Expected {num_producers} producers after truncation, got {count_after}"
+        )


### PR DESCRIPTION
Without this, upon prefix truncation we are losing producer state.
Subsequent retried requests are resulting in out_of_order requests
because the broker accepts the first request it sees from an unknown
producer. We have this problem today but no one really complained about
it but seems like this problem is more pronounced in cloud topics that
prefix truncate more aggressively.

With this commit, we snapshot producer state upon prefix truncation,
this ensures we remember each producer that was active prior to the
truncation event. Upon applying the snapshot the producers are subject
to usual limit/ttl checks so may be evicted as normal.

Do note that the snapshot does not capture aborted transaction state
from the prefix truncated portion of the log, this is ok because there
is no data to consume, so the aborted state doesn't matter.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
