### PR TITLE
[WIP] Check more invariants when in strict validation mode

### DIFF
--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -218,6 +218,7 @@ struct ntp_produce_request {
     model::timestamp_type timestamp_type;
     std::chrono::milliseconds message_timestamp_before_max_ms;
     std::chrono::milliseconds message_timestamp_after_max_ms;
+    bool is_compacted;
 };
 
 ss::future<produce_response::partition> do_produce_topic_partition(
@@ -232,7 +233,8 @@ ss::future<produce_response::partition> do_produce_topic_partition(
        .message_timestamp_after_max_ms = req.message_timestamp_after_max_ms,
        .probe = octx.rctx.probe(),
        .ntp = req.ntp,
-       .client_id = octx.rctx.header().client_id});
+       .client_id = octx.rctx.header().client_id,
+       .is_compacted = req.is_compacted});
 
     if (validate_batch_res.has_value()) {
         co_return finalize_request_with_error_code(
@@ -373,6 +375,7 @@ struct topic_configuration_context {
     std::chrono::milliseconds message_timestamp_before_max_ms;
     std::chrono::milliseconds message_timestamp_after_max_ms;
     const cluster::topic_properties* properties;
+    bool is_compacted;
 };
 
 /**
@@ -405,6 +408,7 @@ partition_produce_stages produce_topic_partition(
         = cfg_ctx.message_timestamp_before_max_ms,
         .message_timestamp_after_max_ms
         = cfg_ctx.message_timestamp_after_max_ms,
+        .is_compacted = cfg_ctx.is_compacted,
       },
       std::move(dispatch));
     return partition_produce_stages{
@@ -493,6 +497,9 @@ produce_topic(produce_ctx& octx, produce_request::topic& topic) {
         octx.rctx.metadata_cache()
           .get_default_message_timestamp_after_max_ms()),
       .properties = &topic_cfg.properties,
+      .is_compacted = model::is_compaction_enabled(
+        topic_cfg.properties.cleanup_policy_bitflags.value_or(
+          octx.rctx.metadata_cache().get_default_cleanup_policy_bitflags())),
     };
 
     std::vector<ss::future<produce_response::partition>> partitions_produced;
@@ -636,6 +643,9 @@ partition_produce_stages produce_single_partition(
         octx.rctx.metadata_cache()
           .get_default_message_timestamp_after_max_ms()),
       .properties = &topic_cfg.properties,
+      .is_compacted = model::is_compaction_enabled(
+        topic_cfg.properties.cleanup_policy_bitflags.value_or(
+          octx.rctx.metadata_cache().get_default_cleanup_policy_bitflags())),
     };
     return produce_topic_partition(octx, topic, part, cfg_ctx);
 }

--- a/src/v/kafka/server/handlers/produce_validation.cc
+++ b/src/v/kafka/server/handlers/produce_validation.cc
@@ -12,6 +12,7 @@
 #include "kafka/server/handlers/produce_validation.h"
 
 #include "kafka/protocol/logger.h"
+#include "model/record_utils.h"
 #include "ssx/sformat.h"
 
 namespace {
@@ -148,12 +149,14 @@ void maybe_set_max_timestamp(
 // `INVALID_RECORD` error code and message are returned.
 std::optional<error_code_and_msg> iterate_over_records(
   const model::record_batch& b,
-  ss::noncopyable_function<ss::stop_iteration(model::record)> f) {
+  ss::noncopyable_function<ss::stop_iteration(model::record_metadata)>&& f,
+  bool is_strict_validation = false) {
     dassert(
       !b.compressed(),
       "Cannot iterate over records within a compressed batch.");
+
     try {
-        b.for_each_record(std::move(f));
+        b.for_each_record_metadata(std::move(f), is_strict_validation);
     } catch (const std::exception& e) {
         vlog(
           klog.error,
@@ -175,7 +178,7 @@ std::expected<model::timestamp, error_code_and_msg>
 compute_max_timestamp(const model::record_batch& b) {
     int64_t max_timestamp_delta = 0;
 
-    auto res = iterate_over_records(b, [&](model::record r) mutable {
+    auto res = iterate_over_records(b, [&](model::record_metadata r) mutable {
         max_timestamp_delta = std::max(
           r.timestamp_delta(), max_timestamp_delta);
         return ss::stop_iteration::no;
@@ -203,11 +206,13 @@ validate_records_and_compute_max_timestamp(
   std::chrono::milliseconds message_timestamp_before_max_ms,
   std::chrono::milliseconds message_timestamp_after_max_ms,
   kafka::kafka_probe& probe,
-  const model::ntp& ntp) {
+  const model::ntp& ntp,
+  bool is_strict_validation = false) {
     std::optional<error_code_and_msg> res;
     int64_t max_timestamp = -1;
     auto iterable_res = iterate_over_records(
-      iterable_batch_ref, [&](model::record r) mutable {
+      iterable_batch_ref,
+      [&](model::record_metadata r) mutable {
           auto timestamp = model::timestamp{
             b.header().first_timestamp() + r.timestamp_delta()};
           auto offset = b.base_offset() + model::offset_delta(r.offset_delta());
@@ -224,7 +229,8 @@ validate_records_and_compute_max_timestamp(
 
           return res.has_value() ? ss::stop_iteration::yes
                                  : ss::stop_iteration::no;
-      });
+      },
+      is_strict_validation);
 
     if (iterable_res.has_value()) {
         // Prefer to return an error describing an invalid format rather than an
@@ -431,7 +437,8 @@ std::optional<error_code_and_msg> validate_batch(
           message_timestamp_before_max_ms,
           message_timestamp_after_max_ms,
           probe,
-          ntp);
+          ntp,
+          true);
 
         if (!max_ts_res.has_value()) {
             return max_ts_res.error();

--- a/src/v/kafka/server/handlers/produce_validation.cc
+++ b/src/v/kafka/server/handlers/produce_validation.cc
@@ -207,7 +207,8 @@ validate_records_and_compute_max_timestamp(
   std::chrono::milliseconds message_timestamp_after_max_ms,
   kafka::kafka_probe& probe,
   const model::ntp& ntp,
-  bool is_strict_validation = false) {
+  bool is_strict_validation = false,
+  bool is_compacted = false) {
     std::optional<error_code_and_msg> res;
     int64_t max_timestamp = -1;
     int32_t expected_offset = 0;
@@ -227,6 +228,17 @@ validate_records_and_compute_max_timestamp(
                   expected_offset,
                   ntp,
                   r.offset_delta(),
+                  expected_offset)};
+              return ss::stop_iteration::yes;
+          }
+
+          if (is_compacted && r.key_length() < 0) [[unlikely]] {
+              res = error_code_and_msg{
+                .err = error_code::invalid_record,
+                .msg = ssx::sformat(
+                  "Compacted partition {} requires a key for all "
+                  "records, but record at offset {} has a null key",
+                  ntp,
                   expected_offset)};
               return ss::stop_iteration::yes;
           }
@@ -378,7 +390,8 @@ std::optional<error_code_and_msg> validate_batch(
   std::chrono::milliseconds message_timestamp_after_max_ms,
   kafka::kafka_probe& probe,
   const model::ntp& ntp,
-  std::optional<std::string_view> client_id) {
+  std::optional<std::string_view> client_id,
+  bool is_compacted) {
     std::optional<error_code_and_msg> res{std::nullopt};
     const auto broker_time = model::timestamp::now();
     const auto has_iterable_batch = iterable_batch_ref.has_value();
@@ -516,6 +529,7 @@ std::optional<error_code_and_msg> validate_batch(
         //    a batch will have a `max_timestamp` set in `strict` mode.
         // 3. Check record timestamps.
         // 4. Validate record offset monotonicity.
+        // 5. Reject null keys for compacted topics.
 
         dassert(
           has_iterable_batch,
@@ -537,7 +551,8 @@ std::optional<error_code_and_msg> validate_batch(
           message_timestamp_after_max_ms,
           probe,
           ntp,
-          true);
+          true,
+          is_compacted);
 
         if (!max_ts_res.has_value()) {
             return max_ts_res.error();
@@ -593,7 +608,8 @@ validate_batch(const validation_args& args) {
       args.message_timestamp_after_max_ms,
       args.probe,
       args.ntp,
-      args.client_id);
+      args.client_id,
+      args.is_compacted);
 }
 
 namespace testing {
@@ -601,6 +617,22 @@ namespace testing {
 std::optional<error_code_and_msg> validate_batch_header_strict(
   const model::record_batch& batch, const model::ntp& ntp) {
     return ::kafka::validate_batch_header_strict(batch, ntp);
+}
+
+std::expected<model::timestamp, error_code_and_msg> validate_records_strict(
+  model::record_batch& batch, const model::ntp& ntp, bool is_compacted) {
+    kafka::kafka_probe probe;
+    return ::kafka::validate_records_and_compute_max_timestamp(
+      batch,
+      batch,
+      model::timestamp::now(),
+      model::timestamp_type::create_time,
+      std::chrono::milliseconds::max(),
+      std::chrono::milliseconds::max(),
+      probe,
+      ntp,
+      true,
+      is_compacted);
 }
 
 } // namespace testing

--- a/src/v/kafka/server/handlers/produce_validation.cc
+++ b/src/v/kafka/server/handlers/produce_validation.cc
@@ -210,9 +210,27 @@ validate_records_and_compute_max_timestamp(
   bool is_strict_validation = false) {
     std::optional<error_code_and_msg> res;
     int64_t max_timestamp = -1;
+    int32_t expected_offset = 0;
     auto iterable_res = iterate_over_records(
       iterable_batch_ref,
       [&](model::record_metadata r) mutable {
+          // Note: this is not a hard failure in Apache Kafka. Rather it'll
+          // re-write the batch to remove this inconsistency. We don't re-write
+          // batches so treating it as a hard-failure seems reasonable.
+          if (is_strict_validation && r.offset_delta() != expected_offset++)
+            [[unlikely]] {
+              res = error_code_and_msg{
+                .err = error_code::invalid_record,
+                .msg = ssx::sformat(
+                  "Record at index {} in batch for partition {} has "
+                  "offset_delta {}, expected {}",
+                  expected_offset,
+                  ntp,
+                  r.offset_delta(),
+                  expected_offset)};
+              return ss::stop_iteration::yes;
+          }
+
           auto timestamp = model::timestamp{
             b.header().first_timestamp() + r.timestamp_delta()};
           auto offset = b.base_offset() + model::offset_delta(r.offset_delta());
@@ -269,6 +287,82 @@ bool should_decompress(
         // Perform all strict checks.
         return true;
     }
+}
+
+std::optional<error_code_and_msg> validate_batch_header_strict(
+  const model::record_batch& batch, const model::ntp& ntp) {
+    const auto& hdr = batch.header();
+
+    if (hdr.base_offset != model::offset(0)) [[unlikely]] {
+        return error_code_and_msg{
+          .err = error_code::invalid_record,
+          .msg = ssx::sformat(
+            "Batch for partition {} has non-zero base_offset: {}",
+            ntp,
+            hdr.base_offset)};
+    }
+
+    if (hdr.record_count <= 0) [[unlikely]] {
+        return error_code_and_msg{
+          .err = error_code::invalid_record,
+          .msg = ssx::sformat(
+            "Batch for partition {} has invalid record count: {}",
+            ntp,
+            hdr.record_count)};
+    }
+
+    if (hdr.last_offset_delta < 0) [[unlikely]] {
+        return error_code_and_msg{
+          .err = error_code::invalid_record,
+          .msg = ssx::sformat(
+            "Batch for partition {} has invalid last_offset_delta: {}",
+            ntp,
+            hdr.last_offset_delta)};
+    }
+
+    if (hdr.last_offset_delta + 1 != hdr.record_count) [[unlikely]] {
+        return error_code_and_msg{
+          .err = error_code::invalid_record,
+          .msg = ssx::sformat(
+            "Batch for partition {} has inconsistent offset range "
+            "(last_offset_delta={}) and record count ({})",
+            ntp,
+            hdr.last_offset_delta,
+            hdr.record_count)};
+    }
+
+    if (hdr.attrs.is_control()) [[unlikely]] {
+        return error_code_and_msg{
+          .err = error_code::invalid_record,
+          .msg = ssx::sformat(
+            "Clients are not allowed to write control records in "
+            "partition {}",
+            ntp)};
+    }
+
+    if (hdr.attrs.timestamp_type() == model::timestamp_type::append_time)
+      [[unlikely]] {
+        return error_code_and_msg{
+          .err = error_code::invalid_record,
+          .msg = ssx::sformat(
+            "Batch for partition {} has invalid timestamp type "
+            "LOG_APPEND_TIME set by producer",
+            ntp)};
+    }
+
+    if (hdr.producer_id >= 0 && hdr.base_sequence < 0) [[unlikely]] {
+        return error_code_and_msg{
+          .err = error_code::invalid_record,
+          .msg = ssx::sformat(
+            "Batch for partition {} with producer_id {} has an invalid "
+            "sequence number: {}",
+            ntp,
+            hdr.producer_id,
+            hdr.base_sequence),
+        };
+    }
+
+    return std::nullopt;
 }
 
 // `iterable_batch_ref` is guaranteed to be a iterable, decompressed version of
@@ -416,16 +510,21 @@ std::optional<error_code_and_msg> validate_batch(
     }
     case mode::strict: {
         // The following checks are performed in `strict` mode:
-        // 1. Iterate over records and set max_timestamp. It is guaranteed that
-        // a batch will have a `max_timestamp` set in `strict` mode.
-        // 2. Check record timestamps.
-        // TODO: validate offsets, control batches, versioning, etc.
-        // See checks present here:
-        // github.com/apache/kafka/blob/trunk/storage/src/main/java/org/apache/kafka/storage/internals/log/LogValidator.java#L438
+        // 1. Validate batch header fields (offsets, record count, control
+        //    batch, timestamp type).
+        // 2. Iterate over records and set max_timestamp. It is guaranteed that
+        //    a batch will have a `max_timestamp` set in `strict` mode.
+        // 3. Check record timestamps.
+        // 4. Validate record offset monotonicity.
 
         dassert(
           has_iterable_batch,
           "Batch must be iterable in kafka_produce_batch_validation::strict.");
+
+        res = validate_batch_header_strict(batch, ntp);
+        if (res.has_value()) {
+            return res;
+        }
 
         // Validate records and compute max timestamp in one pass.
         std::optional<model::timestamp> max_ts{std::nullopt};
@@ -496,5 +595,14 @@ validate_batch(const validation_args& args) {
       args.ntp,
       args.client_id);
 }
+
+namespace testing {
+
+std::optional<error_code_and_msg> validate_batch_header_strict(
+  const model::record_batch& batch, const model::ntp& ntp) {
+    return ::kafka::validate_batch_header_strict(batch, ntp);
+}
+
+} // namespace testing
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/produce_validation.h
+++ b/src/v/kafka/server/handlers/produce_validation.h
@@ -48,4 +48,10 @@ struct validation_args {
 ss::future<std::optional<error_code_and_msg>>
 validate_batch(const validation_args&);
 
+namespace testing {
+
+std::optional<error_code_and_msg>
+validate_batch_header_strict(const model::record_batch&, const model::ntp&);
+
+} // namespace testing
 } // namespace kafka

--- a/src/v/kafka/server/handlers/produce_validation.h
+++ b/src/v/kafka/server/handlers/produce_validation.h
@@ -42,6 +42,7 @@ struct validation_args {
     kafka::kafka_probe& probe;
     const model::ntp& ntp;
     std::optional<std::string_view> client_id;
+    bool is_compacted;
 };
 
 // Entry point for batch validation.
@@ -52,6 +53,9 @@ namespace testing {
 
 std::optional<error_code_and_msg>
 validate_batch_header_strict(const model::record_batch&, const model::ntp&);
+
+std::expected<model::timestamp, error_code_and_msg> validate_records_strict(
+  model::record_batch&, const model::ntp&, bool is_compacted);
 
 } // namespace testing
 } // namespace kafka

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -228,6 +228,23 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "produce_validation_test",
+    timeout = "short",
+    srcs = [
+        "produce_validation_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/kafka/server",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/storage:record_batch_builder",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "consumer_group_recovery_test",
     timeout = "short",
     srcs = [

--- a/src/v/kafka/server/tests/produce_validation_test.cc
+++ b/src/v/kafka/server/tests/produce_validation_test.cc
@@ -1,0 +1,107 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/server/handlers/produce_validation.h"
+#include "model/namespace.h"
+#include "model/record.h"
+#include "model/tests/random_batch.h"
+#include "storage/record_batch_builder.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+const model::ntp test_ntp(
+  model::kafka_namespace, model::topic("test-topic"), model::partition_id(0));
+
+model::record_batch make_batch(int num_records = 3) {
+    return model::test::make_random_batch(
+      model::test::record_batch_spec{
+        .offset = model::offset(0),
+        .allow_compression = false,
+        .count = num_records,
+      });
+}
+
+model::record_batch make_batch_mutate_header(
+  std::function<void(model::record_batch_header&)> mutate) {
+    auto batch = make_batch();
+    mutate(batch.header());
+    batch.header().reset_size_checksum_metadata(batch.data());
+    return batch;
+}
+
+} // namespace
+
+class ValidateBatchHeaderStrictTest : public ::testing::Test {};
+
+TEST_F(ValidateBatchHeaderStrictTest, RejectNonZeroBaseOffset) {
+    auto batch = make_batch_mutate_header(
+      [](auto& hdr) { hdr.base_offset = model::offset(42); });
+    auto res = kafka::testing::validate_batch_header_strict(batch, test_ntp);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->err, kafka::error_code::invalid_record);
+}
+
+TEST_F(ValidateBatchHeaderStrictTest, RejectZeroRecordCount) {
+    auto batch = make_batch_mutate_header(
+      [](auto& hdr) { hdr.record_count = 0; });
+    auto res = kafka::testing::validate_batch_header_strict(batch, test_ntp);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->err, kafka::error_code::invalid_record);
+}
+
+TEST_F(ValidateBatchHeaderStrictTest, RejectNegativeLastOffsetDelta) {
+    auto batch = make_batch_mutate_header(
+      [](auto& hdr) { hdr.last_offset_delta = -1; });
+    auto res = kafka::testing::validate_batch_header_strict(batch, test_ntp);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->err, kafka::error_code::invalid_record);
+}
+
+TEST_F(ValidateBatchHeaderStrictTest, RejectOffsetCountMismatch) {
+    auto batch = make_batch_mutate_header(
+      [](auto& hdr) { hdr.last_offset_delta = 10; });
+    auto res = kafka::testing::validate_batch_header_strict(batch, test_ntp);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->err, kafka::error_code::invalid_record);
+}
+
+TEST_F(ValidateBatchHeaderStrictTest, RejectControlBatch) {
+    auto batch = make_batch_mutate_header(
+      [](auto& hdr) { hdr.attrs.set_control_type(); });
+    auto res = kafka::testing::validate_batch_header_strict(batch, test_ntp);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->err, kafka::error_code::invalid_record);
+}
+
+TEST_F(ValidateBatchHeaderStrictTest, RejectAppendTimeAttribute) {
+    auto batch = make_batch_mutate_header([](auto& hdr) {
+        hdr.attrs.set_timestamp_type(model::timestamp_type::append_time);
+    });
+    auto res = kafka::testing::validate_batch_header_strict(batch, test_ntp);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->err, kafka::error_code::invalid_record);
+}
+
+TEST_F(ValidateBatchHeaderStrictTest, RejectNegativeSequenceNum) {
+    auto batch = make_batch_mutate_header([](auto& hdr) {
+        hdr.producer_id = 1;
+        hdr.base_sequence = -3;
+    });
+    auto res = kafka::testing::validate_batch_header_strict(batch, test_ntp);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->err, kafka::error_code::invalid_record);
+}
+
+TEST_F(ValidateBatchHeaderStrictTest, AcceptValidBatch) {
+    auto batch = make_batch();
+    auto res = kafka::testing::validate_batch_header_strict(batch, test_ntp);
+    EXPECT_FALSE(res.has_value());
+}

--- a/src/v/kafka/server/tests/produce_validation_test.cc
+++ b/src/v/kafka/server/tests/produce_validation_test.cc
@@ -37,6 +37,24 @@ model::record_batch make_batch_mutate_header(
     return batch;
 }
 
+model::record_batch make_batch_with_null_keys(int num_records = 3) {
+    storage::record_batch_builder builder(
+      model::record_batch_type::raft_data, model::offset(0));
+    for (int i = 0; i < num_records; ++i) {
+        builder.add_raw_kv(std::nullopt, iobuf::from("value"));
+    }
+    return std::move(builder).build();
+}
+
+model::record_batch make_batch_with_keys(int num_records = 3) {
+    storage::record_batch_builder builder(
+      model::record_batch_type::raft_data, model::offset(0));
+    for (int i = 0; i < num_records; ++i) {
+        builder.add_raw_kv(iobuf::from("key"), iobuf::from("value"));
+    }
+    return std::move(builder).build();
+}
+
 } // namespace
 
 class ValidateBatchHeaderStrictTest : public ::testing::Test {};
@@ -104,4 +122,25 @@ TEST_F(ValidateBatchHeaderStrictTest, AcceptValidBatch) {
     auto batch = make_batch();
     auto res = kafka::testing::validate_batch_header_strict(batch, test_ntp);
     EXPECT_FALSE(res.has_value());
+}
+
+class ValidateRecordsStrictTest : public ::testing::Test {};
+
+TEST_F(ValidateRecordsStrictTest, RejectNullKeysForCompactedTopic) {
+    auto batch = make_batch_with_null_keys();
+    auto res = kafka::testing::validate_records_strict(batch, test_ntp, true);
+    ASSERT_FALSE(res.has_value());
+    EXPECT_EQ(res.error().err, kafka::error_code::invalid_record);
+}
+
+TEST_F(ValidateRecordsStrictTest, AcceptNullKeysForNonCompactedTopic) {
+    auto batch = make_batch_with_null_keys();
+    auto res = kafka::testing::validate_records_strict(batch, test_ntp, false);
+    EXPECT_TRUE(res.has_value());
+}
+
+TEST_F(ValidateRecordsStrictTest, AcceptKeysForCompactedTopic) {
+    auto batch = make_batch_with_keys();
+    auto res = kafka::testing::validate_records_strict(batch, test_ntp, true);
+    EXPECT_TRUE(res.has_value());
 }

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -136,6 +136,32 @@ private:
     iobuf _value;
 };
 
+/// \brief A lightweight view of a record's metadata fields (attributes,
+/// timestamp_delta, offset_delta) without key, value, or headers.
+class record_metadata {
+public:
+    record_metadata(
+      int32_t size_bytes,
+      record_attributes attributes,
+      int64_t timestamp_delta,
+      int32_t offset_delta) noexcept
+      : _size_bytes(size_bytes)
+      , _attributes(attributes)
+      , _timestamp_delta(timestamp_delta)
+      , _offset_delta(offset_delta) {}
+
+    int32_t size_bytes() const { return _size_bytes; }
+    record_attributes attributes() const { return _attributes; }
+    int64_t timestamp_delta() const { return _timestamp_delta; }
+    int32_t offset_delta() const { return _offset_delta; }
+
+private:
+    int32_t _size_bytes;
+    record_attributes _attributes;
+    int64_t _timestamp_delta;
+    int32_t _offset_delta;
+};
+
 /// \brief
 // DefaultRecord(int sizeInBytes,
 //               byte attributes,
@@ -886,6 +912,36 @@ public:
                     return;
                 }
             }
+        }
+    }
+
+    /**
+     * Iterate over record metadata.
+     *
+     * Note that we don't need to fully parse a record to get the information in
+     * `record_metadata`. Hence its optional here and only used in cases where a
+     * user wants to validate that the entire record is correctly formatted.
+     */
+    template<typename Func>
+    void
+    for_each_record_metadata(Func f, bool fully_parse_records = false) const {
+        const auto rc = record_count();
+        auto parser = iobuf_const_parser(data());
+        int32_t i = 0;
+        for (; i < rc; ++i) {
+            auto res = f(
+              model::parse_record_metadata_from_buffer(
+                parser, fully_parse_records));
+            if (res == ss::stop_iteration::yes) {
+                break;
+            }
+        }
+
+        if (i == rc && parser.bytes_left()) [[unlikely]] {
+            throw std::out_of_range(
+              fmt::format(
+                "Record metadata iteration stopped with {} bytes remaining",
+                parser.bytes_left()));
         }
     }
 

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -224,19 +224,21 @@ public:
       , _value(std::move(value).value_or(iobuf{}))
       , _headers(std::move(hdrs)) {
         _size_bytes = static_cast<int32_t>(
-          sizeof(model::record_attributes::type)   //
-          + vint::vint_size(_timestamp_delta)      //
-          + vint::vint_size(_offset_delta)         //
-          + _key_size + vint::vint_size(_key_size) //
-          + _val_size + vint::vint_size(_val_size) //
+          sizeof(model::record_attributes::type)
+          + vint::vint_size(_timestamp_delta) + vint::vint_size(_offset_delta)
+          + vint::vint_size(_key_size) + std::max<int32_t>(_key_size, 0)
+          + vint::vint_size(_val_size) + std::max<int32_t>(_val_size, 0)
+          + vint::vint_size(static_cast<int64_t>(_headers.size()))
           + std::accumulate(
             _headers.begin(),
             _headers.end(),
             size_t(0),
             [](size_t acc, const record_header& h) {
-                return acc + h.memory_usage();
-            }) //
-        );
+                return acc + vint::vint_size(h.key_size())
+                       + std::max<int32_t>(h.key_size(), 0)
+                       + vint::vint_size(h.value_size())
+                       + std::max<int32_t>(h.value_size(), 0);
+            }));
     }
 
     // Size in bytes of everything except the size_bytes field.

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -137,29 +137,35 @@ private:
 };
 
 /// \brief A lightweight view of a record's metadata fields (attributes,
-/// timestamp_delta, offset_delta) without key, value, or headers.
+/// timestamp_delta, offset_delta, key_length) without key data, value, or
+/// headers.
 class record_metadata {
 public:
     record_metadata(
       int32_t size_bytes,
       record_attributes attributes,
       int64_t timestamp_delta,
-      int32_t offset_delta) noexcept
+      int32_t offset_delta,
+      int32_t key_length) noexcept
       : _size_bytes(size_bytes)
       , _attributes(attributes)
       , _timestamp_delta(timestamp_delta)
-      , _offset_delta(offset_delta) {}
+      , _offset_delta(offset_delta)
+      , _key_length(key_length) {}
 
     int32_t size_bytes() const { return _size_bytes; }
     record_attributes attributes() const { return _attributes; }
     int64_t timestamp_delta() const { return _timestamp_delta; }
     int32_t offset_delta() const { return _offset_delta; }
+    // A return of -1 indicates a null key.
+    int32_t key_length() const { return _key_length; }
 
 private:
     int32_t _size_bytes;
     record_attributes _attributes;
     int64_t _timestamp_delta;
     int32_t _offset_delta;
+    int32_t _key_length;
 };
 
 /// \brief

--- a/src/v/model/record_utils.cc
+++ b/src/v/model/record_utils.cc
@@ -258,4 +258,81 @@ void append_record_to_buffer(iobuf& a, const model::record& r) {
     }
 }
 
+model::record_metadata parse_record_metadata_from_buffer(
+  iobuf_const_parser& p, bool fully_parse_record) {
+    auto [record_size, attr] = parse_record_meta_from_buffer(p);
+    auto [timestamp_delta, tv] = p.read_varlong();
+    auto [offset_delta, ov] = p.read_varlong();
+
+    if (!fully_parse_record) {
+        auto total_bytes_read = 1 + tv + ov;
+        if (record_size <= total_bytes_read) [[unlikely]] {
+            throw std::out_of_range(
+              fmt::format(
+                "Expected record size {} to be greater than bytes read {}",
+                record_size,
+                total_bytes_read));
+        }
+        p.skip(record_size - total_bytes_read);
+    } else {
+        auto start = p.bytes_consumed() - (tv + ov);
+        auto [key_length, kv] = p.read_varlong();
+        if (key_length > record_size) [[unlikely]] {
+            throw std::out_of_range(
+              fmt::format(
+                "Expected key length {} but record has only {} bytes in total",
+                key_length,
+                record_size));
+        }
+        if (key_length > 0) {
+            p.skip(key_length);
+        }
+        auto [value_length, vv] = p.read_varlong();
+        if (value_length > record_size) [[unlikely]] {
+            throw std::out_of_range(
+              fmt::format(
+                "Expected value length {} but record has only {} bytes in "
+                "total",
+                value_length,
+                record_size));
+        }
+        if (value_length > 0) {
+            p.skip(value_length);
+        }
+        auto [header_count, hcv] = p.read_varlong();
+        if (static_cast<size_t>(header_count) > p.bytes_left()) [[unlikely]] {
+            throw std::out_of_range(
+              fmt::format(
+                "Expected {} headers, but only {} bytes left",
+                header_count,
+                p.bytes_left()));
+        }
+        for (int64_t i = 0; i < header_count; ++i) {
+            auto [hk_len, hkv] = p.read_varlong();
+            if (hk_len > 0) {
+                p.skip(hk_len);
+            }
+            auto [hv_len, hvv] = p.read_varlong();
+            if (hv_len > 0) {
+                p.skip(hv_len);
+            }
+        }
+        // record_size includes the 1-byte attr already consumed above.
+        auto bytes_parsed = p.bytes_consumed() - start + 1;
+        if (bytes_parsed != static_cast<size_t>(record_size)) [[unlikely]] {
+            throw std::out_of_range(
+              fmt::format(
+                "Record size mismatch: expected {} but parsed {} bytes",
+                record_size,
+                bytes_parsed));
+        }
+    }
+    return {
+      static_cast<int32_t>(record_size),
+      model::record_attributes(attr),
+      static_cast<int64_t>(timestamp_delta),
+      static_cast<int32_t>(offset_delta),
+    };
+}
+
 } // namespace model

--- a/src/v/model/record_utils.cc
+++ b/src/v/model/record_utils.cc
@@ -263,9 +263,10 @@ model::record_metadata parse_record_metadata_from_buffer(
     auto [record_size, attr] = parse_record_meta_from_buffer(p);
     auto [timestamp_delta, tv] = p.read_varlong();
     auto [offset_delta, ov] = p.read_varlong();
+    auto [key_length, kv] = p.read_varlong();
 
     if (!fully_parse_record) {
-        auto total_bytes_read = 1 + tv + ov;
+        auto total_bytes_read = 1 + tv + ov + kv;
         if (record_size <= total_bytes_read) [[unlikely]] {
             throw std::out_of_range(
               fmt::format(
@@ -275,8 +276,7 @@ model::record_metadata parse_record_metadata_from_buffer(
         }
         p.skip(record_size - total_bytes_read);
     } else {
-        auto start = p.bytes_consumed() - (tv + ov);
-        auto [key_length, kv] = p.read_varlong();
+        auto start = p.bytes_consumed() - (tv + ov + kv);
         if (key_length > record_size) [[unlikely]] {
             throw std::out_of_range(
               fmt::format(
@@ -332,6 +332,7 @@ model::record_metadata parse_record_metadata_from_buffer(
       model::record_attributes(attr),
       static_cast<int64_t>(timestamp_delta),
       static_cast<int32_t>(offset_delta),
+      static_cast<int32_t>(key_length),
     };
 }
 

--- a/src/v/model/record_utils.h
+++ b/src/v/model/record_utils.h
@@ -19,6 +19,7 @@ namespace model {
 struct record_batch_header;
 class record_batch;
 class record;
+class record_metadata;
 
 void crc_record_batch_header(crc::crc32c&, const record_batch_header&);
 
@@ -32,5 +33,11 @@ uint32_t internal_header_only_crc(const record_batch_header&);
 model::record parse_one_record_from_buffer(iobuf_parser& parser);
 model::record parse_one_record_copy_from_buffer(iobuf_const_parser& parser);
 void append_record_to_buffer(iobuf& a, const model::record& r);
+
+// \brief Parses record metadata
+// If `fully_parse_record` is false then only a few fields are parsed from the
+// record. Otherwise all fields are fully parsed and validated.
+model::record_metadata parse_record_metadata_from_buffer(
+  iobuf_const_parser& p, bool fully_parse_record);
 
 } // namespace model

--- a/src/v/model/tests/record_batch_test.cc
+++ b/src/v/model/tests/record_batch_test.cc
@@ -143,6 +143,88 @@ TEST_F(RecordBatchTest, ParseRecordMetadataFullParse) {
     check_parse_record_metadata(true);
 }
 
+namespace {
+// Serialize a record and verify that the size_bytes prefix matches the actual
+// serialized body length.
+void check_serialization_size(const model::record& r) {
+    iobuf buf;
+    model::append_record_to_buffer(buf, r);
+
+    auto parser = iobuf_const_parser(buf);
+    auto [written_size, _] = parser.read_varlong();
+    auto body_size = static_cast<int64_t>(parser.bytes_left());
+
+    EXPECT_EQ(r.size_bytes(), written_size);
+    EXPECT_EQ(r.size_bytes(), body_size);
+}
+} // namespace
+
+TEST_F(RecordBatchTest, RecordSizeBytesWithKeyAndValue) {
+    auto r = model::record(
+      model::record_attributes(0),
+      0,
+      0,
+      iobuf::from("key"),
+      iobuf::from("value"),
+      {});
+    check_serialization_size(r);
+}
+
+TEST_F(RecordBatchTest, RecordSizeBytesWithNullKey) {
+    auto r = model::record(
+      model::record_attributes(0),
+      0,
+      0,
+      std::nullopt,
+      iobuf::from("value"),
+      {});
+    check_serialization_size(r);
+}
+
+TEST_F(RecordBatchTest, RecordSizeBytesWithNullValue) {
+    auto r = model::record(
+      model::record_attributes(0), 0, 0, iobuf::from("key"), std::nullopt, {});
+    check_serialization_size(r);
+}
+
+TEST_F(RecordBatchTest, RecordSizeBytesWithNullKeyAndValue) {
+    auto r = model::record(
+      model::record_attributes(0), 0, 0, std::nullopt, std::nullopt, {});
+    check_serialization_size(r);
+}
+
+TEST_F(RecordBatchTest, RecordSizeBytesWithEmptyKey) {
+    auto r = model::record(
+      model::record_attributes(0), 0, 0, iobuf{}, iobuf::from("value"), {});
+    check_serialization_size(r);
+}
+
+TEST_F(RecordBatchTest, RecordSizeBytesWithHeaders) {
+    std::vector<model::record_header> headers;
+    headers.emplace_back(3, iobuf::from("hdr"), 2, iobuf::from("hv"));
+    auto r = model::record(
+      model::record_attributes(0),
+      0,
+      0,
+      iobuf::from("key"),
+      iobuf::from("value"),
+      std::move(headers));
+    check_serialization_size(r);
+}
+
+TEST_F(RecordBatchTest, RecordSizeBytesWithNullHeaderValues) {
+    std::vector<model::record_header> headers;
+    headers.emplace_back(3, iobuf::from("hdr"), -1, iobuf{});
+    auto r = model::record(
+      model::record_attributes(0),
+      0,
+      0,
+      iobuf::from("key"),
+      iobuf::from("value"),
+      std::move(headers));
+    check_serialization_size(r);
+}
+
 class RecordBatchCompressionTest
   : public ::testing::TestWithParam<model::compression> {};
 

--- a/src/v/model/tests/record_batch_test.cc
+++ b/src/v/model/tests/record_batch_test.cc
@@ -111,6 +111,38 @@ TEST_F(RecordBatchTest, TestCorruptedRecordBytes) {
     EXPECT_THROW(f.get(), std::out_of_range);
 }
 
+namespace {
+void check_parse_record_metadata(bool fully_parse) {
+    constexpr int num_records = 10;
+    auto b = model::test::make_random_batch(
+      model::offset(0), num_records, false);
+
+    std::vector<std::pair<int64_t, int32_t>> expected;
+    auto it = model::record_batch_iterator::create(b);
+    while (it.has_next()) {
+        auto r = it.next();
+        expected.emplace_back(r.timestamp_delta(), r.offset_delta());
+    }
+    ASSERT_EQ(expected.size(), num_records);
+
+    auto parser = iobuf_const_parser(b.data());
+    for (int i = 0; i < num_records; ++i) {
+        auto r = model::parse_record_metadata_from_buffer(parser, fully_parse);
+        EXPECT_EQ(r.timestamp_delta(), expected[i].first);
+        EXPECT_EQ(r.offset_delta(), expected[i].second);
+    }
+    EXPECT_EQ(parser.bytes_left(), 0);
+}
+} // namespace
+
+TEST_F(RecordBatchTest, ParseRecordMetadataSkipFields) {
+    check_parse_record_metadata(false);
+}
+
+TEST_F(RecordBatchTest, ParseRecordMetadataFullParse) {
+    check_parse_record_metadata(true);
+}
+
 class RecordBatchCompressionTest
   : public ::testing::TestWithParam<model::compression> {};
 

--- a/src/v/model/tests/record_batch_test.cc
+++ b/src/v/model/tests/record_batch_test.cc
@@ -117,19 +117,21 @@ void check_parse_record_metadata(bool fully_parse) {
     auto b = model::test::make_random_batch(
       model::offset(0), num_records, false);
 
-    std::vector<std::pair<int64_t, int32_t>> expected;
+    std::vector<std::tuple<int64_t, int32_t, int32_t>> expected;
     auto it = model::record_batch_iterator::create(b);
     while (it.has_next()) {
         auto r = it.next();
-        expected.emplace_back(r.timestamp_delta(), r.offset_delta());
+        expected.emplace_back(
+          r.timestamp_delta(), r.offset_delta(), r.key_size());
     }
     ASSERT_EQ(expected.size(), num_records);
 
     auto parser = iobuf_const_parser(b.data());
     for (int i = 0; i < num_records; ++i) {
         auto r = model::parse_record_metadata_from_buffer(parser, fully_parse);
-        EXPECT_EQ(r.timestamp_delta(), expected[i].first);
-        EXPECT_EQ(r.offset_delta(), expected[i].second);
+        EXPECT_EQ(r.timestamp_delta(), std::get<0>(expected[i]));
+        EXPECT_EQ(r.offset_delta(), std::get<1>(expected[i]));
+        EXPECT_EQ(r.key_length(), std::get<2>(expected[i]));
     }
     EXPECT_EQ(parser.bytes_left(), 0);
 }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Requires https://github.com/redpanda-data/redpanda/pull/29577 to be merged first.

The goal of this PR is to bring our strict validation mode for produced batches in parity with Apache Kafka's validation as much as possible. To that end the tables below list out the batch and record validation checks Kafka currently does and compares them to what RP does post-PR.

## Batch-level checks (header only, no decompression)

| Check | Kafka | Redpanda strict | Redpanda relaxed | Redpanda legacy |
|---|---|---|---|---|
| Batch CRC validation | `UnifiedLog.java:1538` `batch.isValid()` — always | Not done in produce validation (done in Raft layer) | Same | Same |
| Batch size vs max message size | `UnifiedLog.java:1530` — always | Not done here (checked at request handler level) | Same | Same |
| Base offset must be 0 (CLIENT, V2+) | `UnifiedLog.java:1490` `baseOffset() != 0` | `produce_validation.cc:309` `base_offset != 0` | No | No |
| Record count > 0 | `LogValidator.java:461` `count <= 0` | `produce_validation.cc:318` `record_count <= 0` | No | No |
| Valid offset range | `LogValidator.java:453` `countFromOffsets <= 0` | `produce_validation.cc:327` `last_offset_delta < 0` | No | No |
| Offset range matches record count | `LogValidator.java:467` `countFromOffsets != count` | `produce_validation.cc:336` `last_offset_delta + 1 != record_count` | No | No |
| Control batch rejected from clients | `LogValidator.java:474` `isControlBatch()` | `produce_validation.cc:347` `is_control()` | No | No |
| LOG_APPEND_TIME in batch attrs rejected | `LogValidator.java:563` `timestampType() == LOG_APPEND_TIME` | `produce_validation.cc:356` `timestamp_type() == append_time` | No | No |
| Negative base sequence with producer ID | `LogValidator.java:479` `baseSequence() < 0` | `produce_validation.cc:366` `producer_id >= 0 && base_sequence < 0` | No | No |
| Transactional requires V2 | `LogValidator.java:487` | N/A (always V2) | N/A | N/A |
| Idempotent requires V2 | `LogValidator.java:490` | N/A (always V2) | N/A | N/A |
| Consistent magic across batches | `LogValidator.java:437` `validateBatch()` | N/A (always V2) | N/A | N/A |
| No empty batch sets | `LogValidator.java:138` `getFirstBatchAndMaybeValidateNoMoreBatches()` | Not checked | Not checked | Not checked |
| Exactly one batch (V2/compressed) | `LogValidator.java:138` | Not checked | Not checked | Not checked |

### Record-level checks (requires decompression for compressed batches)

| Check | Kafka | Redpanda strict | Redpanda relaxed | Redpanda legacy |
|---|---|---|---|---|
| Record offset monotonicity (0, 1, 2, ...) | Soft check — non-compliance triggers recompression, not rejection | `produce_validation.cc:221` — hard rejects with `INVALID_RECORD` | No | No |
| Compacted topic must have key | `LogValidator.java:540` `!record.hasKey()` | `produce_validation.cc:235` `is_compacted && key_length() < 0` | No | No |
| CREATE_TIME timestamp range validation | `LogValidator.java:557` per-record `recordHasInvalidTimestamp` | `produce_validation.cc:250` per-record `validate_timestamp` | Per-record if decompressed (`produce_validation.cc:487`), else batch-level (`produce_validation.cc:509`) | Batch-level only (`produce_validation.cc:421`) |
| Record magic matches batch magic | `LogValidator.java:503` `!record.hasMagic()` | N/A (V2 has no per-record magic) | N/A | N/A |
| Record CRC (V0/V1 compressed inner) | `LogValidator.java:493` `record.ensureValid()` | N/A (V2 has no per-record CRC) | N/A | N/A |
| Nested compression | `LogValidator.java:579` `validateRecordCompression()` | Not checked | Not checked | Not checked |

### Timestamp handling

| Behavior | Kafka | Redpanda strict | Redpanda relaxed | Redpanda legacy |
|---|---|---|---|---|
| Compute max_timestamp from records | Always | Always (always decompresses, `produce_validation.cc:546`) | Only if max_timestamp missing or uncompressed (`produce_validation.cc:487`) | Only if uncompressed (`produce_validation.cc:411`) |
| Set APPEND_TIME | Overrides max_timestamp with broker time | `produce_validation.cc:564` `maybe_set_max_timestamp` | `produce_validation.cc:503` | `produce_validation.cc:419` |
| Guarantee max_timestamp is set | Yes | Yes | Yes | No (warns if unset, `produce_validation.cc:434`) |

### Decompression behavior

| Mode | When compressed batches are decompressed | Reference |
|---|---|---|
| Kafka | Always (validation and offset assignment require iteration) | `LogValidator.java:138` |
| Redpanda strict | Always | `produce_validation.cc:300` `should_decompress` |
| Redpanda relaxed | Only if `max_timestamp` is missing | `produce_validation.cc:298` |
| Redpanda legacy | Never | `produce_validation.cc:295` |


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
