### PR TITLE
[v25.1.x] gh: Remove michael-redpanda from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,7 +17,7 @@ licenses           @emaxerrno
 #
 # crypto
 #
-/src/v/crypto              @michael-redpanda
+/src/v/crypto              @redpanda-data/core-enterprise
 
 #
 # rpk


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/29617 