### PR TITLE
Data migrations bugfixes

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -245,6 +245,11 @@ ss::future<> controller::wire_up() {
       .then([this] { _probe.start(); });
 }
 
+// If you add a new parameter here to refer to a service created after
+// controller, consider how it is going to be stopped and destructed. A common
+// workaround is to pass shared pointer(s) to instance(s) of a sharded
+// container, and then to make sure triggering global abort source will allow to
+// stop their gates.
 ss::future<> controller::start(
   cluster_discovery& discovery,
   ss::abort_source& shard0_as,
@@ -255,7 +260,7 @@ ss::future<> controller::start(
   ss::shared_ptr<cluster::cloud_metadata::offsets_recovery_requestor>
     offsets_recovery,
   std::chrono::milliseconds application_start_time,
-  ss::sharded<std::unique_ptr<cluster::data_migrations::group_proxy>>&
+  ss::sharded<cluster::data_migrations::group_proxy>&
     data_migrations_group_proxy,
   ss::sharded<cloud_topics::state_accessors>* ct_state) {
     /**
@@ -349,7 +354,7 @@ ss::future<> controller::start(
       std::ref(_stm),
       std::ref(_partition_leaders),
       ss::sharded_parameter([&data_migrations_group_proxy] {
-          return std::ref(*data_migrations_group_proxy.local());
+          return data_migrations_group_proxy.local_shared();
       }),
       std::ref(_connections),
       ss::sharded_parameter(
@@ -366,7 +371,7 @@ ss::future<> controller::start(
     co_await _data_migration_router.start(
       _raft0->self().id(),
       ss::sharded_parameter([&data_migrations_group_proxy] {
-          return std::ref(*data_migrations_group_proxy.local());
+          return data_migrations_group_proxy.local_shared();
       }),
       std::ref(_shard_table),
       std::ref(_metadata_cache),
@@ -380,7 +385,7 @@ ss::future<> controller::start(
       ss::sharded_parameter(
         [this] { return std::ref(_partition_manager.local()); }),
       ss::sharded_parameter([&data_migrations_group_proxy] {
-          return std::ref(*data_migrations_group_proxy.local());
+          return data_migrations_group_proxy.local_shared();
       }),
       ss::sharded_parameter([this] { return std::ref(_as.local()); }));
     {
@@ -879,7 +884,13 @@ ss::future<> controller::start(
       std::ref(_tp_frontend.local()),
       std::ref(_tp_state.local()),
       std::ref(_shard_table.local()),
-      std::ref(*data_migrations_group_proxy.local()),
+      ss::sharded_parameter([&data_migrations_group_proxy] {
+          // ss::sharded::start copies all parameters on all shards before
+          // checking shard number, and copying an ss::shared_ptr on a wrong
+          // shard is a no-no. Use ss::sharded_parameter to only copy the lambda
+          // and invoke it on each shard individually.
+          return data_migrations_group_proxy.local_shared();
+      }),
       _cloud_storage_api.local_is_initialized()
         ? std::make_optional(std::ref(_cloud_storage_api.local()))
         : std::nullopt,

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -246,7 +246,7 @@ public:
       ss::shared_ptr<cluster::cloud_metadata::producer_id_recovery_manager>,
       ss::shared_ptr<cluster::cloud_metadata::offsets_recovery_requestor>,
       std::chrono::milliseconds application_start_time,
-      ss::sharded<std::unique_ptr<cluster::data_migrations::group_proxy>>&,
+      ss::sharded<cluster::data_migrations::group_proxy>&,
       ss::sharded<cloud_topics::state_accessors>* ct_state = nullptr);
 
     // prevents controller from accepting new requests

--- a/src/v/cluster/data_migration_backend.cc
+++ b/src/v/cluster/data_migration_backend.cc
@@ -98,7 +98,7 @@ backend::backend(
   topics_frontend& topics_frontend,
   topic_table& topic_table,
   shard_table& shard_table,
-  group_proxy& group_proxy,
+  ss::shared_ptr<group_proxy> group_proxy,
   std::optional<std::reference_wrapper<cloud_storage::remote>>
     cloud_storage_api,
   std::optional<std::reference_wrapper<cloud_storage::topic_mount_handler>>
@@ -113,7 +113,7 @@ backend::backend(
   , _topics_frontend(topics_frontend)
   , _topic_table(topic_table)
   , _shard_table(shard_table)
-  , _group_proxy(group_proxy)
+  , _group_proxy(std::move(group_proxy))
   , _cloud_storage_api(cloud_storage_api)
   , _topic_mount_handler(topic_mount_handler)
   , _as(as) {}
@@ -263,7 +263,7 @@ backend::get_entities_status(id migration_id) {
          * build the map again.
          */
         if (group_map_result.has_error()) {
-            co_await _group_proxy.assure_topic_exists(
+            co_await _group_proxy->assure_topic_exists(
               model::time_from_now(10s));
             group_map_result = build_migration_group_map(meta);
         }
@@ -1865,7 +1865,7 @@ backend::build_migration_group_map(const migration_metadata& metadata) const {
       metadata.migration);
 
     for (const auto& group : groups) {
-        auto partition = _group_proxy.partition_for(group);
+        auto partition = _group_proxy->partition_for(group);
         if (!partition) {
             vlog(
               dm_log.warn,

--- a/src/v/cluster/data_migration_backend.h
+++ b/src/v/cluster/data_migration_backend.h
@@ -48,7 +48,7 @@ public:
       topics_frontend& topics_frontend,
       topic_table& topic_table,
       shard_table& shard_table,
-      group_proxy& group_proxy,
+      ss::shared_ptr<group_proxy> group_proxy,
       std::optional<std::reference_wrapper<cloud_storage::remote>>
         _cloud_storage_api,
       std::optional<std::reference_wrapper<cloud_storage::topic_mount_handler>>
@@ -493,7 +493,7 @@ private:
     topics_frontend& _topics_frontend;
     topic_table& _topic_table;
     shard_table& _shard_table;
-    group_proxy& _group_proxy;
+    ss::shared_ptr<group_proxy> _group_proxy;
     std::optional<std::reference_wrapper<cloud_storage::remote>>
       _cloud_storage_api;
     std::optional<std::reference_wrapper<cloud_storage::topic_mount_handler>>

--- a/src/v/cluster/data_migration_frontend.cc
+++ b/src/v/cluster/data_migration_frontend.cc
@@ -43,7 +43,7 @@ frontend::frontend(
   ss::sharded<features::feature_table>& features,
   ss::sharded<controller_stm>& stm,
   ss::sharded<partition_leaders_table>& leaders,
-  group_proxy& group_proxy,
+  ss::shared_ptr<group_proxy> group_proxy,
   ss::sharded<rpc::connection_cache>& connections,
   std::optional<std::reference_wrapper<cloud_storage::topic_mount_handler>>
     topic_mount_handler,
@@ -54,7 +54,7 @@ frontend::frontend(
   , _features(features.local())
   , _controller(stm)
   , _leaders_table(leaders.local())
-  , _group_proxy(group_proxy)
+  , _group_proxy(std::move(group_proxy))
   , _connections(connections.local())
   , _topic_mount_handler(topic_mount_handler)
   , _as(as)
@@ -262,7 +262,7 @@ ss::future<result<id>> frontend::do_create_migration(data_migration migration) {
           [](const auto& migration) { return !empty(migration.groups); },
           migration)) {
         auto deadline = model::timeout_clock::now() + _operation_timeout;
-        if (!co_await _group_proxy.assure_topic_exists(deadline)) {
+        if (!co_await _group_proxy->assure_topic_exists(deadline)) {
             vlog(
               dm_log.warn,
               "data migration involving consumer groups failed to create "

--- a/src/v/cluster/data_migration_frontend.h
+++ b/src/v/cluster/data_migration_frontend.h
@@ -39,7 +39,7 @@ public:
       ss::sharded<features::feature_table>&,
       ss::sharded<controller_stm>&,
       ss::sharded<partition_leaders_table>&,
-      group_proxy& group_proxy,
+      ss::shared_ptr<group_proxy> group_proxy,
       ss::sharded<rpc::connection_cache>&,
       std::optional<std::reference_wrapper<cloud_storage::topic_mount_handler>>,
       ss::sharded<ss::abort_source>&);
@@ -103,7 +103,7 @@ private:
     features::feature_table& _features;
     ss::sharded<controller_stm>& _controller;
     partition_leaders_table& _leaders_table;
-    group_proxy& _group_proxy;
+    ss::shared_ptr<group_proxy> _group_proxy;
     rpc::connection_cache& _connections;
     std::optional<std::reference_wrapper<cloud_storage::topic_mount_handler>>
       _topic_mount_handler;

--- a/src/v/cluster/data_migration_group_proxy.h
+++ b/src/v/cluster/data_migration_group_proxy.h
@@ -17,39 +17,90 @@
 #include "model/fundamental.h"
 #include "model/timeout_clock.h"
 
+#include <memory>
+
 namespace cluster::data_migrations {
 
 /*
- * Abstract class for a proxy component to operate kafka layer consumer groups
- * from data migration components.
+ * Abstract class wrapper for a proxy component to operate kafka layer consumer
+ * groups from data migration components.
  */
 class group_proxy {
 public:
-    virtual ~group_proxy() = default;
+    class impl {
+    public:
+        virtual ~impl() = default;
 
-    virtual std::optional<model::partition_id>
-    partition_for(const kafka::group_id& group) = 0;
+        virtual std::optional<model::partition_id>
+        partition_for(const kafka::group_id& group) = 0;
 
-    virtual ss::future<result<model::offset>> set_blocked_for_groups(
-      const model::ntp& co_ntp,
-      const chunked_vector<kafka::group_id>&,
-      bool to_block,
-      model::revision_id revision_id)
-      = 0;
+        virtual ss::future<result<model::offset>> set_blocked_for_groups(
+          const model::ntp& co_ntp,
+          const chunked_vector<kafka::group_id>&,
+          bool to_block,
+          model::revision_id revision_id)
+          = 0;
 
-    virtual ss::future<std::error_code> delete_groups(
+        virtual ss::future<std::error_code> delete_groups(
+          const model::ntp& co_ntp,
+          const chunked_vector<kafka::group_id>& groups,
+          model::revision_id revision_id)
+          = 0;
+
+        virtual ss::future<bool>
+        assure_topic_exists(model::timeout_clock::time_point deadline) = 0;
+
+        virtual ss::future<get_group_offsets_reply>
+        get_group_offsets(get_group_offsets_request&& req) = 0;
+
+        virtual ss::future<set_group_offsets_reply>
+        set_group_offsets(set_group_offsets_request&& req) = 0;
+    };
+
+    explicit group_proxy(std::unique_ptr<impl> impl)
+      : _impl(std::move(impl)) {}
+
+    std::optional<model::partition_id>
+    partition_for(const kafka::group_id& group) {
+        if (_gate.is_closed()) {
+            return std::nullopt;
+        }
+        return _impl->partition_for(group);
+    }
+
+    ss::future<result<model::offset>> set_blocked_for_groups(
       const model::ntp& co_ntp,
       const chunked_vector<kafka::group_id>& groups,
-      model::revision_id revision_id)
-      = 0;
+      bool to_block,
+      model::revision_id revision_id) {
+        return _impl->set_blocked_for_groups(
+          co_ntp, groups, to_block, revision_id);
+    }
 
-    virtual ss::future<bool>
-    assure_topic_exists(model::timeout_clock::time_point deadline) = 0;
+    ss::future<std::error_code> delete_groups(
+      const model::ntp& co_ntp,
+      const chunked_vector<kafka::group_id>& groups,
+      model::revision_id revision_id) {
+        return _impl->delete_groups(co_ntp, groups, revision_id);
+    }
 
-    virtual ss::future<get_group_offsets_reply>
-    get_group_offsets(get_group_offsets_request&& req) = 0;
+    ss::future<bool>
+    assure_topic_exists(model::timeout_clock::time_point deadline) {
+        return _impl->assure_topic_exists(deadline);
+    }
 
-    virtual ss::future<set_group_offsets_reply>
-    set_group_offsets(set_group_offsets_request&& req) = 0;
+    ss::future<get_group_offsets_reply>
+    get_group_offsets(get_group_offsets_request&& req) {
+        return _impl->get_group_offsets(std::move(req));
+    }
+
+    ss::future<set_group_offsets_reply>
+    set_group_offsets(set_group_offsets_request&& req) {
+        return _impl->set_group_offsets(std::move(req));
+    }
+
+private:
+    std::unique_ptr<impl> _impl;
 };
+
 } // namespace cluster::data_migrations

--- a/src/v/cluster/data_migration_group_proxy.h
+++ b/src/v/cluster/data_migration_group_proxy.h
@@ -17,6 +17,9 @@
 #include "model/fundamental.h"
 #include "model/timeout_clock.h"
 
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/gate.hh>
+
 #include <memory>
 
 namespace cluster::data_migrations {
@@ -60,6 +63,8 @@ public:
     explicit group_proxy(std::unique_ptr<impl> impl)
       : _impl(std::move(impl)) {}
 
+    ss::future<> stop() { return _gate.close(); }
+
     std::optional<model::partition_id>
     partition_for(const kafka::group_id& group) {
         if (_gate.is_closed()) {
@@ -73,7 +78,9 @@ public:
       const chunked_vector<kafka::group_id>& groups,
       bool to_block,
       model::revision_id revision_id) {
-        return _impl->set_blocked_for_groups(
+        auto holder = _gate.hold();
+        co_return co_await _impl->set_blocked_for_groups(
+
           co_ntp, groups, to_block, revision_id);
     }
 
@@ -81,26 +88,31 @@ public:
       const model::ntp& co_ntp,
       const chunked_vector<kafka::group_id>& groups,
       model::revision_id revision_id) {
-        return _impl->delete_groups(co_ntp, groups, revision_id);
+        auto holder = _gate.hold();
+        co_return co_await _impl->delete_groups(co_ntp, groups, revision_id);
     }
 
     ss::future<bool>
     assure_topic_exists(model::timeout_clock::time_point deadline) {
-        return _impl->assure_topic_exists(deadline);
+        auto holder = _gate.hold();
+        co_return co_await _impl->assure_topic_exists(deadline);
     }
 
     ss::future<get_group_offsets_reply>
     get_group_offsets(get_group_offsets_request&& req) {
-        return _impl->get_group_offsets(std::move(req));
+        auto holder = _gate.hold();
+        co_return co_await _impl->get_group_offsets(std::move(req));
     }
 
     ss::future<set_group_offsets_reply>
     set_group_offsets(set_group_offsets_request&& req) {
-        return _impl->set_group_offsets(std::move(req));
+        auto holder = _gate.hold();
+        co_return co_await _impl->set_group_offsets(std::move(req));
     }
 
 private:
     std::unique_ptr<impl> _impl;
+    ss::gate _gate;
 };
 
 } // namespace cluster::data_migrations

--- a/src/v/cluster/data_migration_router.cc
+++ b/src/v/cluster/data_migration_router.cc
@@ -37,13 +37,13 @@ static constexpr std::chrono::milliseconds max_backoff(60);
 static constexpr std::chrono::milliseconds request_timeout(10);
 router::router(
   model::node_id self,
-  group_proxy& group_proxy,
+  ss::shared_ptr<group_proxy> group_proxy,
   ss::sharded<shard_table>& shard_table,
   ss::sharded<metadata_cache>& metadata_cache,
   ss::sharded<rpc::connection_cache>& connection_cache,
   ss::sharded<partition_leaders_table>& leaders,
   ss::abort_source& as)
-  : _group_proxy(group_proxy)
+  : _group_proxy(std::move(group_proxy))
   , _get_group_offsets_handler{.parent = *this}
   , _get_group_offsets_router(
       shard_table,
@@ -112,7 +112,7 @@ ss::future<get_group_offsets_reply> router::get_group_offsets_handler::process(
   ss::shard_id shard, get_group_offsets_request req) {
     co_return co_await parent.container().invoke_on(
       shard, [req = std::move(req)](router& r) mutable {
-          return r._group_proxy.get_group_offsets(std::move(req));
+          return r._group_proxy->get_group_offsets(std::move(req));
       });
 }
 
@@ -134,7 +134,7 @@ ss::future<set_group_offsets_reply> router::set_group_offsets_handler::process(
   ss::shard_id shard, set_group_offsets_request req) {
     co_return co_await parent.container().invoke_on(
       shard, [req = std::move(req)](router& r) mutable {
-          return r._group_proxy.set_group_offsets(std::move(req));
+          return r._group_proxy->set_group_offsets(std::move(req));
       });
 }
 

--- a/src/v/cluster/data_migration_router.h
+++ b/src/v/cluster/data_migration_router.h
@@ -34,7 +34,7 @@ class router : public ss::peering_sharded_service<router> {
 public:
     router(
       model::node_id,
-      group_proxy&,
+      ss::shared_ptr<group_proxy>,
       ss::sharded<shard_table>&,
       ss::sharded<metadata_cache>&,
       ss::sharded<rpc::connection_cache>&,
@@ -50,7 +50,7 @@ public:
     set_group_offsets(set_group_offsets_request&& req);
 
 private:
-    group_proxy& _group_proxy;
+    ss::shared_ptr<group_proxy> _group_proxy;
 
     struct get_group_offsets_handler {
         using proto_t = data_migrations_client_protocol;

--- a/src/v/cluster/data_migration_worker.cc
+++ b/src/v/cluster/data_migration_worker.cc
@@ -46,12 +46,12 @@ worker::worker(
   model::node_id self,
   partition_leaders_table& leaders_table,
   partition_manager& partition_manager,
-  group_proxy& group_proxy,
+  ss::shared_ptr<group_proxy> group_proxy,
   ss::abort_source& as)
   : _self(self)
   , _leaders_table(leaders_table)
   , _partition_manager(partition_manager)
-  , _group_proxy(group_proxy)
+  , _group_proxy(std::move(group_proxy))
   , _as(as)
   , _as_sub(_as.subscribe([this]() noexcept { abort_all(); }))
   , _operation_timeout(5s)
@@ -338,7 +338,7 @@ ss::future<errc> worker::do_work(
           "nothing to do with data partitions in cut_over, they are also being "
           "deleted by topic work");
         // todo: shift to a new "cleanup" stage?
-        auto del_res = co_await _group_proxy.delete_groups(
+        auto del_res = co_await _group_proxy->delete_groups(
           ntp, otwi.groups, running_work.work->revision_id);
         // invalid_data_migration_state may indicate group already deleted
         if (
@@ -395,7 +395,7 @@ ss::future<result<model::offset, errc>> worker::block_groups(
   const chunked_vector<kafka::group_id>& groups,
   bool block,
   model::revision_id revision_id) {
-    auto res = co_await _group_proxy.set_blocked_for_groups(
+    auto res = co_await _group_proxy->set_blocked_for_groups(
       ntp, groups, block, revision_id);
     if (res.has_value()) {
         co_return res.value();

--- a/src/v/cluster/data_migration_worker.h
+++ b/src/v/cluster/data_migration_worker.h
@@ -38,7 +38,7 @@ public:
       model::node_id,
       partition_leaders_table&,
       partition_manager&,
-      group_proxy&,
+      ss::shared_ptr<group_proxy>,
       ss::abort_source&);
     ss::future<> stop();
 
@@ -160,7 +160,7 @@ private:
     model::node_id _self;
     partition_leaders_table& _leaders_table;
     partition_manager& _partition_manager;
-    group_proxy& _group_proxy;
+    ss::shared_ptr<group_proxy> _group_proxy;
     ss::abort_source& _as;
     ss::optimized_optional<ss::abort_source::subscription> _as_sub;
 

--- a/src/v/kafka/server/data_migration_group_proxy_impl.h
+++ b/src/v/kafka/server/data_migration_group_proxy_impl.h
@@ -24,7 +24,7 @@ namespace kafka {
  * components.
  */
 class data_migration_group_proxy_impl final
-  : public cluster::data_migrations::group_proxy {
+  : public cluster::data_migrations::group_proxy::impl {
 public:
     data_migration_group_proxy_impl(
       coordinator_ntp_mapper& coordinator_ntp_mapper,

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1339,6 +1339,7 @@ ss::future<> admin_server::throw_on_error(
             throw ss::httpd::base_exception(
               fmt::format("Too many requests: {}", ec.message()),
               ss::http::reply::status_type::too_many_requests);
+        case cluster::errc::topic_already_exists:
         case cluster::errc::topic_not_exists:
         case cluster::errc::transform_does_not_exist:
         case cluster::errc::transform_invalid_update:

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -312,7 +312,7 @@ private:
     metrics::internal_metric_groups _metrics;
     ss::sharded<metrics::public_metrics_group_service> _public_metrics;
     std::unique_ptr<kafka::rm_group_proxy_impl> _rm_group_proxy;
-    ss::sharded<std::unique_ptr<cluster::data_migrations::group_proxy>>
+    ss::sharded<cluster::data_migrations::group_proxy>
       _data_migrations_group_proxy;
 
     ss::sharded<resources::cpu_profiler> _cpu_profiler;

--- a/src/v/ssx/single_fiber_executor.h
+++ b/src/v/ssx/single_fiber_executor.h
@@ -234,7 +234,7 @@ public:
         if (_running) {
             vassert(
               _running->handle == std::nullopt,
-              "abort_running() should have aborted it");
+              "abort_unfulfilled() should have aborted it");
             _pending.emplace(std::forward<Func>(func));
             f.emplace(_pending->promise.get_future());
         } else {

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -332,8 +332,8 @@ class DataMigrationsApiTest(DataMigrationTestMixin):
             assert False
         except requests.exceptions.HTTPError as e:
             assert e.response.json() == {
-                "message": "Unexpected cluster error: The topic has already been created",
-                "code": 500,
+                "message": "The topic has already been created",
+                "code": 400,
             }
 
     @cluster(num_nodes=3, log_allow_list=MIGRATION_LOG_ALLOW_LIST)


### PR DESCRIPTION
1. Make sure `data_migration_group_proxy` is not destructed before data migration components which use it. Like with other higher-level components (HLCs) used by controller components (CCs), the following trick is employed:
- shared pointers to instances of the HLC are passed to controller::start and held by the CCs;
- when the main abort source is triggered HLC aims to stop operations, and CCs do not make new calls to HLC;
- then HLCs are shut down before controller, but thanks to shared pointers individual instances (with their gates closed) are not destroyed (yes, ugly!);
- CCs and constructor are stopped, shared pointers are destructed and so are HLC instances.

2. Reply HTTP 400 not 500 to admin endpoints when the underlying error is `cluster::errc::topic_already_exists`. It deflakes data migration tests, and is consistent with existing HTTP 400 on `cluster::errc::topic_not_exists`.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
### Improvements
* Reply HTTP 400 not 500 to admin endpoints when the underlying error is `cluster::errc::topic_already_exists`. It deflakes data migration tests, and is consistent with existing HTTP 400 on `cluster::errc::topic_not_exists`.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
