### PR TITLE
rptest/log_compaction_test: increase tx timeout for upgrades while in tx

### DIFF
--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -1039,11 +1039,24 @@ class LogCompactionTxRemovalUpgradeTestBase(LogCompactionTxRemovalTestBase):
         super().__init__(test_context)
         self.initial_version: RedpandaVersion = initial_version
 
+    # Transaction timeout long enough to survive the upgrade phase which
+    # may involve downloading intermediate versions.
+    TX_TIMEOUT_MS = 300000
+
     def setUp(self):
         self.redpanda._installer.start()
         self.redpanda._installer.install(self.redpanda.nodes, self.initial_version)
         self.redpanda.start()
         self.admin = Admin(self.redpanda)
+
+    def make_tx_producer(self, transactional_id):
+        return ck.Producer(
+            {
+                "bootstrap.servers": self.redpanda.brokers(),
+                "transactional.id": transactional_id,
+                "transaction.timeout.ms": self.TX_TIMEOUT_MS,
+            }
+        )
 
     def upgrade_to_version(self, target_version):
         def logical_version():
@@ -1098,12 +1111,7 @@ class LogCompactionTxRemovalUpgradeTestBase(LogCompactionTxRemovalTestBase):
 
         # Produce multiple-segment transactional data without closing transactions.
         producers = [
-            ck.Producer(
-                {
-                    "bootstrap.servers": self.redpanda.brokers(),
-                    "transactional.id": f"tx_producer_{producer_id}",
-                }
-            )
+            self.make_tx_producer(f"tx_producer_{producer_id}")
             for producer_id in [0, 1]
         ]
         for p in producers:
@@ -1173,12 +1181,7 @@ class LogCompactionTxRemovalUpgradeTestBase(LogCompactionTxRemovalTestBase):
         )
 
         # produce tx data in segment 1 and commit around segment 9
-        tx_producer = ck.Producer(
-            {
-                "bootstrap.servers": self.redpanda.brokers(),
-                "transactional.id": "tx_producer",
-            }
-        )
+        tx_producer = self.make_tx_producer("tx_producer")
         tx_producer.init_transactions()
         tx_producer.begin_transaction()
 


### PR DESCRIPTION
CORE-15316
CORE-15434

The test performs upgrades while in idle transactions. Bump tx timeout to accommodate for downloading redpanda binaries to the nodes.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
