### PR TITLE
lsm/io: write tmp and rename cloud data files

### DIFF
--- a/src/v/lsm/io/BUILD
+++ b/src/v/lsm/io/BUILD
@@ -62,6 +62,7 @@ redpanda_cc_library(
         "//src/v/lsm/core/internal:files",
         "//src/v/ssx:future_util",
         "//src/v/utils:retry_chain_node",
+        "//src/v/utils:uuid",
     ],
     deps = [
         ":persistence",

--- a/src/v/lsm/io/cloud_persistence.cc
+++ b/src/v/lsm/io/cloud_persistence.cc
@@ -19,6 +19,7 @@
 #include "lsm/io/persistence.h"
 #include "ssx/future-util.h"
 #include "utils/retry_chain_node.h"
+#include "utils/uuid.h"
 
 #include <seastar/core/fstream.hh>
 #include <seastar/core/reactor.hh>
@@ -377,10 +378,14 @@ private:
       uint64_t content_length,
       ss::input_stream<char> input_stream,
       std::filesystem::path filepath) {
+        auto temp_path = fmt::format(
+          "{}.tmp.{}", filepath.native(), uuid_t::create());
+
+        // Download to temp file so we can swap below.
         auto file = ss::open_file_dma(
-          filepath.native(),
+          temp_path,
           ss::open_flags::create | ss::open_flags::rw
-            | ss::open_flags::truncate);
+            | ss::open_flags::exclusive);
         auto output_stream
           = co_await ss::with_file_close_on_failure(
               std::move(file),
@@ -400,9 +405,24 @@ private:
                     }
                     return fut;
                 });
+
         co_await ss::copy(input_stream, output_stream)
           .finally([&output_stream] { return output_stream.close(); })
           .finally([&input_stream] { return input_stream.close(); });
+
+        auto rename_fut = co_await ss::coroutine::as_future(
+          ss::rename_file(temp_path, filepath.native()));
+        if (rename_fut.failed()) {
+            auto ex = rename_fut.get_exception();
+            co_await ss::remove_file(temp_path).then_wrapped(
+              [](ss::future<> fut) { fut.ignore_ready_future(); });
+            throw io_error_exception(
+              "Rename from {} to {} failed: {}",
+              temp_path,
+              filepath.native(),
+              ex);
+        }
+
         co_return content_length;
     }
 


### PR DESCRIPTION
We previously wrote SST files to the desired paths directly, meaning
that that:
1. if there is more than one instance of a database mounted on the same
   staging directory, we can end up trying to download the same file
   concurrently, and they could trample over each other and we end up
   seeing a truncated read (e.g. getting a 0 CRC)
2. on non-graceful restart, we could end up with partial files on disk,
   and end up reading a partial SST

The former will be particularly visible in some upcoming work for cloud
topic read replicas, where we have instances of a single cloud-backed
database on multiple shards.

To mitigate this, this updates save_locally() to write to a temp file
and then rename.

Longer term we should probably use the cloud cache so we also get space
management, but at least with this we can avoid seeing CRC errors when
reading in ducktape.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
