### PR TITLE
CORE-15290 cl/tests: fix flaky bad_describe_config_response test

### DIFF
--- a/src/v/cluster_link/tests/source_topic_syncer_test.cc
+++ b/src/v/cluster_link/tests/source_topic_syncer_test.cc
@@ -558,8 +558,6 @@ protected:
 };
 
 TEST_F_CORO(invalid_describe_configs_test, bad_describe_config_response) {
-    co_await fixture()->upsert_link(get_default_metadata());
-
     _describe_configs_results.emplace_back(
       kafka::describe_configs_result{
         .error_code = kafka::error_code::topic_authorization_failed});


### PR DESCRIPTION
The test was calling upsert_link(get_default_metadata()) twice, once at the start and once after setting up the mock responses. Since get_default_metadata() generates a new UUID on each call, the second call replaced the link with a fresh one that had an empty mirror_topics state. The test then timed out waiting for mirror_topics to contain the topic that had been successfully mirrored under the first link's UUID.

Fixes https://redpandadata.atlassian.net/browse/CORE-15290

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
