### PR TITLE
[v25.3.x] rptest/omb: update open-messaging benchmark

### DIFF
--- a/tests/docker/ducktape-deps/omb
+++ b/tests/docker/ducktape-deps/omb
@@ -2,5 +2,5 @@
 set -e
 git -C /opt clone https://github.com/redpanda-data/openmessaging-benchmark.git
 cd /opt/openmessaging-benchmark
-git reset --hard 092eb7c78a106906f21288b99b1e2a4c3cfc652a
+git reset --hard 9cff468d5124cc9eb6cfce90798c2c9a5c354f6c
 mvn clean package -DskipTests


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/28646

Python scripts in the older version of OMB depend on pgk_resources, which is missing in recent setuptools, which we install in 25.3.x+ test docker container.