### PR TITLE
CORE-14907 rptest/nodes_decommissioning_test: don't wait for recovery throttler allowance to become positive

### DIFF
--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -870,7 +870,7 @@ class NodesDecommissioningTest(PreallocNodesTest):
             backoff_sec=1,
         )
         # set recovery rate to small value but allow the controller to recover
-        self._set_recovery_rate(10 * 1024)
+        self._set_recovery_rate(10 * 1024, await_rehabilitation=False)
         # throttle recovery
         self.redpanda.clean_node(self.redpanda.nodes[-1], preserve_current_install=True)
         self.redpanda.start_node(self.redpanda.nodes[-1])


### PR DESCRIPTION
Throttler can now borrow from allowance to accommodate for requests larger than allowance per second. Abrupt lowering of the allowance during ongoing recovery may lead to a long rehabilitation, in case there was some overuse of the allowance. Do not wait for it to settle.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
