### PR TITLE
config: add deprecated schema_registry_avro_use_named_references

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3767,15 +3767,7 @@ configuration::configuration()
        .aliases = {"schema_registry_normalize_on_startup"}},
       false)
   , schema_registry_avro_use_named_references(
-      *this,
-      "schema_registry_avro_use_named_references",
-      "When enabled, Avro schemas with external references are compiled using "
-      "named reference resolution instead of schema concatenation. This fixes "
-      "issues with compatibility checks and schema validation for schemas with "
-      "reference dependencies. This config will be deprecated and always "
-      "enabled in v26.1.1.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      false)
+      *this, "schema_registry_avro_use_named_references")
   , schema_registry_enable_qualified_subjects(
       *this,
       "schema_registry_enable_qualified_subjects",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3766,6 +3766,16 @@ configuration::configuration()
        .visibility = visibility::user,
        .aliases = {"schema_registry_normalize_on_startup"}},
       false)
+  , schema_registry_avro_use_named_references(
+      *this,
+      "schema_registry_avro_use_named_references",
+      "When enabled, Avro schemas with external references are compiled using "
+      "named reference resolution instead of schema concatenation. This fixes "
+      "issues with compatibility checks and schema validation for schemas with "
+      "reference dependencies. This config will be deprecated and always "
+      "enabled in v26.1.1.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      false)
   , schema_registry_enable_qualified_subjects(
       *this,
       "schema_registry_enable_qualified_subjects",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -663,7 +663,7 @@ struct configuration final : public config_store {
 
     enterprise<property<bool>> schema_registry_enable_authorization;
     property<bool> schema_registry_always_normalize;
-    property<bool> schema_registry_avro_use_named_references;
+    deprecated_property schema_registry_avro_use_named_references;
     property<bool> schema_registry_enable_qualified_subjects;
     property<std::optional<uint32_t>> pp_sr_smp_max_non_local_requests;
     bounded_property<size_t> max_in_flight_schema_registry_requests_per_shard;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -663,6 +663,7 @@ struct configuration final : public config_store {
 
     enterprise<property<bool>> schema_registry_enable_authorization;
     property<bool> schema_registry_always_normalize;
+    property<bool> schema_registry_avro_use_named_references;
     property<bool> schema_registry_enable_qualified_subjects;
     property<std::optional<uint32_t>> pp_sr_smp_max_non_local_requests;
     bounded_property<size_t> max_in_flight_schema_registry_requests_per_shard;


### PR DESCRIPTION
This config should not be used in 26.1. It was only introduced as a
guard for safely backporting a bug fix behind the config to 25.3.

Pair PR of https://github.com/redpanda-data/redpanda/pull/29627

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
