### PR TITLE
Data migrations test fixes

### DIFF
--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -504,6 +504,7 @@ class DataMigrationsApiTest(DataMigrationTestMixin):
             self.execute_data_migration_action_flaky(
                 in_migration_id, MigrationAction.prepare
             )
+
             self.wait_for_migration_states(in_migration_id, ["preparing"])
             time.sleep(10)
             # still preparing, i.e. stuck
@@ -511,6 +512,13 @@ class DataMigrationsApiTest(DataMigrationTestMixin):
             # and the topic is not there
             self.wait_partitions_disappear([topic.name])
 
+        # Make sure all nodes are back up
+        self.wait_for_migration_states(in_migration_id, ["preparing"])
+        # And make wait a little to process any stalled calls to
+        # `DataMigrationTestMixin.assure_not_deletable` on woken up nodes
+        time.sleep(2)
+
+        with self.finj_thread():
             time_before_final_action = now()
             self.execute_data_migration_action_flaky(
                 in_migration_id, MigrationAction.cancel

--- a/tests/rptest/utils/data_migrations.py
+++ b/tests/rptest/utils/data_migrations.py
@@ -42,7 +42,7 @@ def now():
 
 class DataMigrationTestMixin(RedpandaTest):
     def get_admin(self, redpanda: RedpandaService) -> Admin:
-        return Admin(redpanda, timeout_seconds=5)
+        return Admin(redpanda, timeout_seconds=5, retries_amount=7)
 
     def wait_partitions_appear(
         self, topics: list[TopicSpec], redpanda: RedpandaService | None = None


### PR DESCRIPTION
CORE-14591
- fix a race between failure injector and migration delete check
- retry admin api requests harder when failure injector is around

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
