### PR TITLE
[CORE-15540] ct/reconciler: Use multipart uploads

### DIFF
--- a/src/v/cloud_storage_clients/multipart_upload.cc
+++ b/src/v/cloud_storage_clients/multipart_upload.cc
@@ -117,7 +117,7 @@ ss::future<> multipart_upload::put(iobuf data) {
 
 ss::future<> multipart_upload::complete() {
     if (_finalized) {
-        throw std::logic_error("Multipart upload already finalized");
+        co_return;
     }
 
     _finalized = true;

--- a/src/v/cloud_topics/level_one/common/BUILD
+++ b/src/v/cloud_topics/level_one/common/BUILD
@@ -77,6 +77,7 @@ redpanda_cc_library(
     deps = [
         ":object_id",
         "//src/v/bytes:iobuf",
+        "//src/v/cloud_storage_clients",
         "//src/v/container:chunked_vector",
         "//src/v/utils:named_type",
         "@seastar",
@@ -116,6 +117,7 @@ redpanda_cc_library(
         ":object_utils",
         "//src/v/bytes:iobuf",
         "//src/v/bytes:iostream",
+        "//src/v/cloud_storage_clients",
         "@abseil-cpp//absl/container:btree",
         "@seastar",
     ],

--- a/src/v/cloud_topics/level_one/common/abstract_io.h
+++ b/src/v/cloud_topics/level_one/common/abstract_io.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "bytes/iobuf.h"
+#include "cloud_storage_clients/multipart_upload.h"
 #include "cloud_topics/level_one/common/object_id.h"
 #include "container/chunked_vector.h"
 
@@ -94,6 +95,11 @@ public:
     // Delete the specified objects from object storage.
     virtual ss::future<std::expected<void, errc>>
     delete_objects(chunked_vector<object_id>, ss::abort_source*) = 0;
+
+    // Create a multipart upload for streaming data directly to object storage.
+    virtual ss::future<
+      std::expected<cloud_storage_clients::multipart_upload_ref, errc>>
+    create_multipart_upload(object_id, size_t part_size, ss::abort_source*) = 0;
 
 protected:
     // A helper to read a staging file.

--- a/src/v/cloud_topics/level_one/common/fake_io.cc
+++ b/src/v/cloud_topics/level_one/common/fake_io.cc
@@ -11,9 +11,50 @@
 #include "cloud_topics/level_one/common/fake_io.h"
 
 #include "bytes/iostream.h"
+#include "cloud_storage_clients/multipart_upload.h"
 #include "cloud_topics/level_one/common/object_id.h"
 
 namespace cloud_topics::l1 {
+
+// In-memory multipart upload state for testing.
+class fake_multipart_state final
+  : public cloud_storage_clients::multipart_upload_state {
+public:
+    fake_multipart_state(
+      object_id oid, absl::btree_map<object_id, iobuf>& storage)
+      : _oid(oid)
+      , _storage(storage) {}
+
+    ss::future<> initialize_multipart() override { co_return; }
+
+    ss::future<> upload_part(size_t, iobuf data) override {
+        _buffer.append(std::move(data));
+        co_return;
+    }
+
+    ss::future<> complete_multipart_upload() override {
+        _storage.insert_or_assign(_oid, std::move(_buffer));
+        co_return;
+    }
+
+    ss::future<> abort_multipart_upload() override {
+        _buffer.clear();
+        co_return;
+    }
+
+    ss::future<> upload_as_single_object(iobuf data) override {
+        _storage.insert_or_assign(_oid, std::move(data));
+        co_return;
+    }
+
+    bool is_multipart_initialized() const override { return true; }
+    ss::sstring upload_id() const override { return "fake"; }
+
+private:
+    object_id _oid;
+    absl::btree_map<object_id, iobuf>& _storage;
+    iobuf _buffer;
+};
 
 fake_io::fake_io() = default;
 
@@ -107,6 +148,15 @@ chunked_vector<object_id> fake_io::list_objects() const {
         oids.emplace_back(oid);
     }
     return oids;
+}
+
+ss::future<std::expected<cloud_storage_clients::multipart_upload_ref, io::errc>>
+fake_io::create_multipart_upload(
+  object_id oid, size_t part_size, ss::abort_source*) {
+    auto state = ss::make_shared<fake_multipart_state>(oid, _storage);
+    auto upload = ss::make_shared<cloud_storage_clients::multipart_upload>(
+      std::move(state), part_size);
+    co_return upload;
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/fake_io.h
+++ b/src/v/cloud_topics/level_one/common/fake_io.h
@@ -32,6 +32,10 @@ public:
     ss::future<std::expected<void, errc>>
     delete_objects(chunked_vector<object_id>, ss::abort_source*) override;
 
+    ss::future<std::expected<cloud_storage_clients::multipart_upload_ref, errc>>
+    create_multipart_upload(
+      object_id, size_t part_size, ss::abort_source*) override;
+
     // Get a full object that has been put directly from storage
     std::optional<iobuf> get_object(object_id id);
 

--- a/src/v/cloud_topics/level_one/common/file_io.cc
+++ b/src/v/cloud_topics/level_one/common/file_io.cc
@@ -279,4 +279,28 @@ file_io::delete_objects(chunked_vector<object_id> ids, ss::abort_source* as) {
     std::unreachable();
 }
 
+ss::future<std::expected<cloud_storage_clients::multipart_upload_ref, io::errc>>
+file_io::create_multipart_upload(
+  object_id oid, size_t part_size, ss::abort_source* as) {
+    static constexpr auto timeout = 10s;
+    auto key = object_path_factory::level_one_path(oid);
+    auto result_fut = co_await ss::coroutine::as_future(
+      _remote->initiate_multipart_upload(_bucket, key, part_size, timeout));
+    if (result_fut.failed()) {
+        auto ex = result_fut.get_exception();
+        vlog(cd_log.warn, "Error initiating multipart upload: {}", ex);
+        co_return std::unexpected(io::errc::cloud_op_error);
+    }
+    auto result = result_fut.get();
+    if (!result.has_value()) {
+        vlog(
+          cd_log.warn,
+          "Failed to initiate multipart upload for {}: {}",
+          oid,
+          result.error());
+        co_return std::unexpected(io::errc::cloud_op_error);
+    }
+    co_return std::move(result.value());
+}
+
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/file_io.h
+++ b/src/v/cloud_topics/level_one/common/file_io.h
@@ -44,6 +44,10 @@ public:
     ss::future<std::expected<void, errc>>
     delete_objects(chunked_vector<object_id>, ss::abort_source*) override;
 
+    ss::future<std::expected<cloud_storage_clients::multipart_upload_ref, errc>>
+    create_multipart_upload(
+      object_id, size_t part_size, ss::abort_source*) override;
+
 private:
     ss::future<uint64_t> save_to_cache(
       ss::input_stream<char>,

--- a/src/v/cloud_topics/level_one/metastore/tests/garbage_collector_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/garbage_collector_test.cc
@@ -197,6 +197,12 @@ public:
           std::unexpected(errc::cloud_op_error));
     }
 
+    ss::future<std::expected<cloud_storage_clients::multipart_upload_ref, errc>>
+    create_multipart_upload(
+      object_id id, size_t part_size, ss::abort_source* as) override {
+        return underlying_->create_multipart_upload(id, part_size, as);
+    }
+
 private:
     io* underlying_;
 };

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -239,7 +239,6 @@ ss::future<> reconciler<Clock>::reconciliation_loop() {
         // clang-format off
         /*
          * Error Handling
-         * (Props to Claude for the tree diagram)
          *
          * The reconciler uses nested exception boundaries to ensure proper
          * cleanup and partial failure recovery. One object's failure prevents
@@ -252,23 +251,28 @@ ss::future<> reconciler<Clock>::reconciliation_loop() {
          *       └─ FOR EACH OBJECT:
          *          └─ as_future(reconcile_partitions) → catches all exceptions
          *             └─ reconcile_partitions(oid, partitions)
-         *                ├─ make_context() → returns error if staging fails
-         *                │  └─ as_future(output_stream()) → catches, cleans staging
+         *                ├─ make_context(oid) → returns error if multipart
+         *                │    upload initiation fails
          *                │
          *                ├─ as_future(build_and_put_object)
-         *                │  ├─ build_object() → can throw in builder->finish()
-         *                │  └─ put_object() → returns error on upload failure
+         *                │  └─ build_object() → can throw in builder->finish()
+         *                │       or in build_from_reader() (write failures
+         *                │       propagate since the byte stream can't skip
+         *                │       a failed part). On success, finish() +
+         *                │       close_builder() closes the multipart stream,
+         *                │       completing the upload.
          *                │
          *                └─ GUARANTEED CLEANUP (always executed):
-         *                   ├─ ctx.close_builder()   → closes object builder
-         *                   └─ ctx.cleanup_staging() → removes temp file
+         *                   ├─ ctx.cleanup_upload() → aborts multipart if
+         *                   │    not finalized (no-op on success)
+         *                   └─ ctx.close_builder() → closes object builder
          *
          * Failure Scopes:
          * - Single object failures:
-         *   • Staging file creation fails
+         *   • Multipart upload initiation fails
          *   • No data in partitions (empty object)
-         *   • Build or upload exceptions
-         *   • Individual partition read failures
+         *   • Build exceptions (including write/part upload failures)
+         *   • Individual partition reader creation failures
          *   • Object-level metadata failure
          *
          * - Reconciliation round failures:
@@ -280,7 +284,7 @@ ss::future<> reconciler<Clock>::reconciliation_loop() {
          *
          * Resource Guarantees:
          * - Builder is ALWAYS closed if created
-         * - Staging file is ALWAYS removed if created
+         * - Multipart upload is ALWAYS finalized (completed or aborted)
          * - Failures in one object don't leak resources or affect others
          * - Reconciliation will try again next schedule point after failure,
          *   except for shutdown
@@ -531,7 +535,7 @@ ss::future<std::expected<
 reconciler<Clock>::reconcile_sources(
   const l1::object_id& oid,
   const chunked_vector<ss::shared_ptr<source>>& sources) {
-    auto ctx_result = co_await make_context();
+    auto ctx_result = co_await make_context(oid);
     if (!ctx_result.has_value()) {
         co_return std::unexpected(ctx_result.error().with_context(
           "reconciling {} sources into object {}", sources.size(), oid));
@@ -541,7 +545,18 @@ reconciler<Clock>::reconcile_sources(
     auto fut = co_await ss::coroutine::as_future(
       build_and_put_object(oid, ctx, sources));
 
-    // Always cleanup.
+    // Always cleanup: abort multipart if not completed, then close builder.
+    auto cleanup_fut = co_await ss::coroutine::as_future(ctx.cleanup_upload());
+    if (cleanup_fut.failed()) {
+        auto ex = cleanup_fut.get_exception();
+        vlogl(
+          lg,
+          ssx::is_shutdown_exception(ex) ? ss::log_level::debug
+                                         : ss::log_level::warn,
+          "Exception while cleaning up multipart upload: {}",
+          ex);
+    }
+
     auto close_fut = co_await ss::coroutine::as_future(ctx.close_builder());
     if (close_fut.failed()) {
         auto ex = close_fut.get_exception();
@@ -550,17 +565,6 @@ reconciler<Clock>::reconcile_sources(
           ssx::is_shutdown_exception(ex) ? ss::log_level::debug
                                          : ss::log_level::warn,
           "Exception while closing builder: {}",
-          ex);
-    }
-
-    auto cleanup_fut = co_await ss::coroutine::as_future(ctx.cleanup_staging());
-    if (cleanup_fut.failed()) {
-        auto ex = cleanup_fut.get_exception();
-        vlogl(
-          lg,
-          ssx::is_shutdown_exception(ex) ? ss::log_level::debug
-                                         : ss::log_level::warn,
-          "Exception while cleaning up staging: {}",
           ex);
     }
 
@@ -592,7 +596,9 @@ reconciler<Clock>::build_and_put_object(
   const l1::object_id& oid,
   builder_context& ctx,
   const chunked_vector<ss::shared_ptr<source>>& sources) {
-    // Build the object.
+    // Build the object. On success, build_object() calls finish() and then
+    // close_builder(), which closes the multipart stream and completes the
+    // upload.
     auto build_result = co_await build_object(ctx, sources);
     if (!build_result.has_value()) {
         _probe.increment_object_build_failed();
@@ -606,13 +612,6 @@ reconciler<Clock>::build_and_put_object(
           reconcile_error("Skipping put for object {}: no data", oid));
     }
 
-    // Upload the object.
-    auto put_result = co_await put_object(oid, ctx);
-    if (!put_result.has_value()) {
-        _probe.increment_object_upload_failed();
-        co_return std::unexpected(put_result.error());
-    }
-
     _probe.increment_objects_uploaded();
     _probe.add_bytes_reconciled(obj_meta.object_info.size_bytes);
     _probe.record_object_size_bytes(obj_meta.object_info.size_bytes);
@@ -624,31 +623,22 @@ reconciler<Clock>::build_and_put_object(
 template<class Clock>
 ss::future<
   std::expected<typename reconciler<Clock>::builder_context, reconcile_error>>
-reconciler<Clock>::make_context() {
+reconciler<Clock>::make_context(const l1::object_id& oid) {
     builder_context ctx;
 
-    // Create staging file.
-    auto staging_result = co_await _l1_io->create_tmp_file();
-    if (!staging_result.has_value()) {
+    // Initiate multipart upload.
+    auto upload_result = co_await _l1_io->create_multipart_upload(
+      oid, cloud_storage_clients::multipart_upload::min_part_size, &_as);
+    if (!upload_result.has_value()) {
         co_return std::unexpected(
           reconcile_error(
-            "Failed to create staging file: {}", staging_result.error())
+            "Failed to initiate multipart upload: {}", upload_result.error())
             .non_benign());
     }
-    ctx.staging = std::move(staging_result).value();
+    ctx.upload = std::move(upload_result).value();
 
-    // Create output stream and builder.
-    auto stream_fut = co_await ss::coroutine::as_future(
-      ctx.staging->output_stream());
-    if (stream_fut.failed()) {
-        auto ex = stream_fut.get_exception();
-        co_await ctx.cleanup_staging();
-        co_return std::unexpected(
-          reconcile_error("Failed to create output stream: {}", ex)
-            .mark_benign(ssx::is_shutdown_exception(ex)));
-    }
-
-    auto output_stream = stream_fut.get();
+    // Create output stream from multipart upload and builder.
+    auto output_stream = ctx.upload->as_stream();
     ctx.builder = l1::object_builder::create(
       std::move(output_stream),
       l1::object_builder::options{
@@ -725,19 +715,6 @@ reconciler<Clock>::build_object(
 }
 
 template<class Clock>
-ss::future<std::expected<void, reconcile_error>>
-reconciler<Clock>::put_object(const l1::object_id& oid, builder_context& ctx) {
-    auto metrics_duration = _probe.measure_object_upload_duration();
-    auto put_result = co_await _l1_io->put_object(oid, ctx.staging.get(), &_as);
-    if (!put_result.has_value()) {
-        co_return std::unexpected(reconcile_error(
-          "failed to put L1 object {}: {}", oid, put_result.error()));
-    }
-    vlog(lg.debug, "Successfully put L1 object {}", oid);
-    co_return std::expected<void, reconcile_error>{};
-}
-
-template<class Clock>
 ss::future<std::expected<std::optional<consumer_metadata>, reconcile_error>>
 reconciler<Clock>::add_source_to_object(
   builder_context& ctx,
@@ -749,23 +726,14 @@ reconciler<Clock>::add_source_to_object(
       src->ntp(),
       src->last_reconciled_offset());
 
-    std::optional<consumer_metadata> metadata;
-    try {
-        auto reader = co_await src->make_reader(
-          source::reader_config{
-            .start_offset = start_offset,
-            .max_bytes = ctx.size_budget,
-            .as = &_as,
-          });
-        metadata = co_await build_from_reader(
-          src->topic_id_partition(),
-          std::move(reader),
-          ctx.builder.get(),
-          &_probe);
-    } catch (...) {
-        co_return std::unexpected(reconcile_error(
-          "unable to consume from L0 partition: {}", std::current_exception()));
-    }
+    auto reader = co_await src->make_reader(
+      source::reader_config{
+        .start_offset = start_offset,
+        .max_bytes = ctx.size_budget,
+        .as = &_as,
+      });
+    auto metadata = co_await build_from_reader(
+      src->topic_id_partition(), std::move(reader), ctx.builder.get(), &_probe);
 
     if (!metadata.has_value()) {
         vlog(

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -147,15 +147,15 @@ private:
 private:
     /*
      * A container for an object in the process of being built.
-     * Always requires cleanup via close_builder() and cleanup_staging().
+     * Always requires cleanup via cleanup_upload() and close_builder().
      */
     struct builder_context {
-        std::unique_ptr<l1::staging_file> staging;
+        cloud_storage_clients::multipart_upload_ref upload;
         std::unique_ptr<l1::object_builder> builder;
         size_t size_budget{0};
 
-        // Close the builder.
-        // Should be called before cleanup_staging.
+        // Close the builder (closes the underlying stream).
+        // On the success path this completes the multipart upload.
         ss::future<> close_builder() {
             if (builder) {
                 co_await builder->close();
@@ -163,12 +163,11 @@ private:
             }
         }
 
-        // Remove staging file.
-        // Call after upload or an error.
-        ss::future<> cleanup_staging() {
-            if (staging) {
-                co_await staging->remove();
-                staging.reset();
+        // Abort the multipart upload if not already finalized.
+        // No-op if the upload was already completed via close_builder().
+        ss::future<> cleanup_upload() {
+            if (upload && !upload->is_finalized()) {
+                co_await upload->abort();
             }
         }
     };
@@ -220,9 +219,12 @@ private:
 
     /*
      * Create a new builder_context for constructing an L1 object.
-     * Returns an error if staging file or builder creation fails.
+     * Initiates a multipart upload for the given object ID.
+     * Returns an error if multipart upload initiation or builder creation
+     * fails.
      */
-    ss::future<std::expected<builder_context, reconcile_error>> make_context();
+    ss::future<std::expected<builder_context, reconcile_error>>
+    make_context(const l1::object_id& oid);
 
     /*
      * Build an object described by `ctx` and containing data from
@@ -245,13 +247,6 @@ private:
       builder_context& ctx,
       ss::shared_ptr<source> src,
       kafka::offset start_offset);
-
-    /*
-     * Upload an object to cloud storage with the specified id.
-     * Returns an error if the upload fails.
-     */
-    ss::future<std::expected<void, reconcile_error>>
-    put_object(const l1::object_id& oid, builder_context& ctx);
 
     /*
      * Add an object's metadata to the metastore metadata builder.

--- a/src/v/cloud_topics/reconciler/reconciler_probe.cc
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.cc
@@ -58,10 +58,6 @@ void reconciler_probe::setup_metrics() {
           [this] { return _object_build_failed; },
           sm::description("Total objects that failed to build")),
         sm::make_counter(
-          "object_upload_failed",
-          [this] { return _object_upload_failed; },
-          sm::description("Total objects that failed to upload")),
-        sm::make_counter(
           "empty_objects_skipped",
           [this] { return _empty_objects_skipped; },
           sm::description(
@@ -86,13 +82,7 @@ void reconciler_probe::setup_metrics() {
           [this] {
               return _object_build_duration.internal_histogram_logform();
           },
-          sm::description("Duration building L1 objects")),
-        sm::make_histogram(
-          "object_upload_duration_seconds",
-          [this] {
-              return _object_upload_duration.internal_histogram_logform();
-          },
-          sm::description("Duration uploading L1 objects")),
+          sm::description("Duration building and uploading L1 objects")),
         sm::make_histogram(
           "metastore_add_objects_duration_seconds",
           [this] {

--- a/src/v/cloud_topics/reconciler/reconciler_probe.h
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.h
@@ -43,7 +43,6 @@ public:
     }
     void increment_partitions_reconciled() { ++_partitions_reconciled; }
     void increment_object_build_failed() { ++_object_build_failed; }
-    void increment_object_upload_failed() { ++_object_upload_failed; }
     void increment_empty_objects_skipped() { ++_empty_objects_skipped; }
     void increment_metastore_retries() { ++_metastore_retries; }
     void increment_offset_corrections() { ++_offset_corrections; }
@@ -62,18 +61,11 @@ public:
         return _object_build_duration.auto_measure();
     }
 
-    std::unique_ptr<hist_t::measurement> measure_object_upload_duration() {
-        return _object_upload_duration.auto_measure();
-    }
-
     std::unique_ptr<hist_t::measurement>
     measure_metastore_add_objects_duration() {
         return _metastore_add_objects_duration.auto_measure();
     }
 
-    auto get_object_upload_duration_for_tests() const {
-        return _object_upload_duration.internal_histogram_logform();
-    }
     auto get_metastore_add_objects_duration_for_tests() const {
         return _metastore_add_objects_duration.internal_histogram_logform();
     }
@@ -94,7 +86,6 @@ private:
     uint64_t _batches_reconciled{0};
     uint64_t _partitions_reconciled{0};
     uint64_t _object_build_failed{0};
-    uint64_t _object_upload_failed{0};
     uint64_t _empty_objects_skipped{0};
     uint64_t _metastore_retries{0};
     uint64_t _offset_corrections{0};
@@ -102,7 +93,6 @@ private:
     // Histograms.
     hist_t _l0_read_duration;
     hist_t _object_build_duration;
-    hist_t _object_upload_duration;
     hist_t _metastore_add_objects_duration;
     hist_t _object_size_bytes;
     hist_t _sources_per_object;

--- a/src/v/cloud_topics/reconciler/tests/BUILD
+++ b/src/v/cloud_topics/reconciler/tests/BUILD
@@ -20,6 +20,7 @@ redpanda_test_cc_library(
         "test_utils.h",
     ],
     deps = [
+        "//src/v/cloud_storage_clients",
         "//src/v/cloud_topics/level_one/common:fake_io",
         "//src/v/cloud_topics/level_one/metastore:simple",
         "//src/v/cloud_topics/reconciler",

--- a/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
@@ -108,11 +108,6 @@ std::optional<uint64_t> get_object_build_failed() {
       "cloud_topics_reconciler_object_build_failed");
 }
 
-std::optional<uint64_t> get_object_upload_failed() {
-    return test_utils::find_metric_value<uint64_t>(
-      "cloud_topics_reconciler_object_upload_failed");
-}
-
 std::optional<uint64_t> get_empty_objects_skipped() {
     return test_utils::find_metric_value<uint64_t>(
       "cloud_topics_reconciler_empty_objects_skipped");
@@ -142,7 +137,6 @@ TEST_F(ReconcilerMetricsTest, ThroughputCounters) {
     EXPECT_THAT(get_batches_reconciled(), Optional(0));
     EXPECT_THAT(get_partitions_reconciled(), Optional(0));
     EXPECT_THAT(get_object_build_failed(), Optional(0));
-    EXPECT_THAT(get_object_upload_failed(), Optional(0));
     EXPECT_THAT(get_empty_objects_skipped(), Optional(0));
 
     const model::topic tp{"tapioca"};
@@ -165,7 +159,6 @@ TEST_F(ReconcilerMetricsTest, ThroughputCounters) {
     EXPECT_THAT(get_batches_reconciled(), Optional(5));
     EXPECT_THAT(get_bytes_reconciled(), Optional(Gt(0)));
     EXPECT_THAT(get_object_build_failed(), Optional(0));
-    EXPECT_THAT(get_object_upload_failed(), Optional(0));
     EXPECT_THAT(get_empty_objects_skipped(), Optional(0));
 
     auto bytes_after_first = *get_bytes_reconciled();
@@ -178,7 +171,6 @@ TEST_F(ReconcilerMetricsTest, ThroughputCounters) {
     EXPECT_THAT(get_batches_reconciled(), Optional(5));
     EXPECT_THAT(get_bytes_reconciled(), Optional(bytes_after_first));
     EXPECT_THAT(get_object_build_failed(), Optional(0));
-    EXPECT_THAT(get_object_upload_failed(), Optional(0));
     EXPECT_THAT(get_empty_objects_skipped(), Optional(1));
 
     src1->add_batch({.count = 15});
@@ -191,28 +183,26 @@ TEST_F(ReconcilerMetricsTest, ThroughputCounters) {
     EXPECT_THAT(get_batches_reconciled(), Optional(6));
     EXPECT_THAT(get_bytes_reconciled(), Optional(Gt(bytes_after_first)));
     EXPECT_THAT(get_object_build_failed(), Optional(0));
-    EXPECT_THAT(get_object_upload_failed(), Optional(0));
     EXPECT_THAT(get_empty_objects_skipped(), Optional(1));
 }
 
 TEST_F(ReconcilerMetricsTest, FailedObjectsCounter) {
-    EXPECT_THAT(get_object_upload_failed(), Optional(0));
+    EXPECT_THAT(get_objects_uploaded(), Optional(0));
 
     auto src = add_source();
     src->add_batch({.count = 10});
 
-    io().fail_put_object(true);
+    io().fail_complete(true);
 
     reconcile();
 
-    EXPECT_THAT(get_object_upload_failed(), Optional(1));
+    // Object was not uploaded because multipart complete failed.
     EXPECT_THAT(get_objects_uploaded(), Optional(0));
 
-    io().fail_put_object(false);
+    io().fail_complete(false);
 
     reconcile();
 
-    EXPECT_THAT(get_object_upload_failed(), Optional(1));
     EXPECT_THAT(get_objects_uploaded(), Optional(1));
 }
 
@@ -223,9 +213,6 @@ TEST_F(ReconcilerMetricsTest, HistogramMetrics) {
     reconcile();
 
     const auto& probe = reconciler().get_probe_for_tests();
-
-    auto object_upload_duration = probe.get_object_upload_duration_for_tests();
-    EXPECT_GT(object_upload_duration.sample_count, 0);
 
     auto metastore_add_objects_duration
       = probe.get_metastore_add_objects_duration_for_tests();

--- a/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
@@ -383,18 +383,18 @@ TEST_F(ReconcilerTest, MetastoreAddObjectsTransientFailure) {
     EXPECT_THAT(metastore_next_offset(src2), Optional(kafka::offset{10}));
 }
 
-TEST_F(ReconcilerTest, IOStagingFileFailure) {
+TEST_F(ReconcilerTest, IOMultipartInitFailure) {
     auto src = add_source();
     src->add_batch({.count = 10});
 
-    io().fail_create_tmp_file(true);
+    io().fail_create_multipart(true);
 
     reconcile();
 
     EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{});
     EXPECT_EQ(metastore_next_offset(src), std::nullopt);
 
-    io().fail_create_tmp_file(false);
+    io().fail_create_multipart(false);
 
     reconcile();
 
@@ -403,22 +403,77 @@ TEST_F(ReconcilerTest, IOStagingFileFailure) {
     EXPECT_THAT(metastore_next_offset(src), Optional(kafka::offset{10}));
 }
 
-TEST_F(ReconcilerTest, IOPutObjectFailure) {
+TEST_F(ReconcilerTest, IOMultipartCompleteFailure) {
     auto src = add_source();
     src->add_batch({.count = 10});
 
-    io().fail_put_object(true);
+    io().fail_complete(true);
 
     reconcile();
 
     EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{});
     EXPECT_EQ(metastore_next_offset(src), std::nullopt);
 
-    io().fail_put_object(false);
+    io().fail_complete(false);
 
     reconcile();
 
-    // Reconciliation should resume after an IO failure.
+    // Reconciliation should resume after a multipart complete failure.
+    EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{9});
+    EXPECT_THAT(metastore_next_offset(src), Optional(kafka::offset{10}));
+}
+
+TEST_F(ReconcilerTest, IOMultipartPartUploadFailure) {
+    auto src = add_source();
+
+    // Need >5MiB to trigger an intermediate part upload (min_part_size is
+    // 5MiB). 100 uncompressed batches of 64KiB records ≈ 6.4MiB.
+    constexpr auto batch_count = 100;
+    constexpr auto record_count = 1;
+    constexpr auto record_size = 64_KiB;
+    for (size_t i = 0; i < batch_count; ++i) {
+        src->add_batch(
+          {.allow_compression = false,
+           .count = record_count,
+           .record_sizes = std::vector<size_t>(record_count, record_size)});
+    }
+
+    io().fail_upload_part(true);
+
+    reconcile();
+
+    EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{});
+    EXPECT_EQ(metastore_next_offset(src), std::nullopt);
+
+    io().fail_upload_part(false);
+
+    reconcile();
+
+    // After recovery, data should be reconciled.
+    EXPECT_GT(src->last_reconciled_offset(), kafka::offset{0});
+}
+
+TEST_F(ReconcilerTest, IOMultipartAbortFailure) {
+    auto src = add_source();
+    src->add_batch({.count = 10});
+
+    // When complete fails, the multipart_upload::complete() method attempts
+    // to abort via abort_on_error(). If abort also fails, it should be
+    // handled gracefully (the multipart_upload layer catches abort errors).
+    io().fail_complete(true);
+    io().fail_abort(true);
+
+    reconcile();
+
+    EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{});
+    EXPECT_EQ(metastore_next_offset(src), std::nullopt);
+
+    io().fail_complete(false);
+    io().fail_abort(false);
+
+    reconcile();
+
+    // Reconciliation should resume after the combined failure.
     EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{9});
     EXPECT_THAT(metastore_next_offset(src), Optional(kafka::offset{10}));
 }

--- a/src/v/cloud_topics/reconciler/tests/test_utils.h
+++ b/src/v/cloud_topics/reconciler/tests/test_utils.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "cloud_storage_clients/multipart_upload.h"
 #include "cloud_topics/level_one/common/fake_io.h"
 #include "cloud_topics/level_one/metastore/simple_metastore.h"
 #include "cloud_topics/reconciler/reconciliation_source.h"
@@ -115,32 +116,96 @@ private:
     int _fail_add_objects_transiently_count = 0;
 };
 
-class unreliable_io : public l1::fake_io {
+// A multipart upload state that delegates to fake_io's storage
+// but can inject failures at each phase of the multipart protocol.
+class unreliable_multipart_state final
+  : public cloud_storage_clients::multipart_upload_state {
 public:
-    ss::future<std::expected<std::unique_ptr<l1::staging_file>, l1::io::errc>>
-    create_tmp_file() override {
-        if (_fail_create_tmp_file) {
-            co_return std::unexpected(l1::io::errc::file_io_error);
-        }
-        co_return co_await l1::fake_io::create_tmp_file();
-    }
-
-    ss::future<std::expected<void, l1::io::errc>> put_object(
+    unreliable_multipart_state(
       l1::object_id oid,
-      l1::staging_file* file,
-      ss::abort_source* as) override {
-        if (_fail_put_object) {
-            co_return std::unexpected(l1::io::errc::cloud_op_error);
+      l1::fake_io& storage,
+      bool& fail_upload_part,
+      bool& fail_complete,
+      bool& fail_abort)
+      : _oid(oid)
+      , _storage(storage)
+      , _fail_upload_part(fail_upload_part)
+      , _fail_complete(fail_complete)
+      , _fail_abort(fail_abort) {}
+
+    ss::future<> initialize_multipart() override { co_return; }
+
+    ss::future<> upload_part(size_t, iobuf data) override {
+        if (_fail_upload_part) {
+            throw std::runtime_error("Injected upload_part failure");
         }
-        co_return co_await l1::fake_io::put_object(oid, file, as);
+        _buffer.append(std::move(data));
+        co_return;
     }
 
-    void fail_create_tmp_file(bool fail) { _fail_create_tmp_file = fail; }
-    void fail_put_object(bool fail) { _fail_put_object = fail; }
+    ss::future<> complete_multipart_upload() override {
+        if (_fail_complete) {
+            throw std::runtime_error("Injected complete_multipart failure");
+        }
+        _storage.put_object(_oid, std::move(_buffer));
+        co_return;
+    }
+
+    ss::future<> abort_multipart_upload() override {
+        if (_fail_abort) {
+            throw std::runtime_error("Injected abort_multipart failure");
+        }
+        _buffer.clear();
+        co_return;
+    }
+
+    ss::future<> upload_as_single_object(iobuf data) override {
+        if (_fail_complete) {
+            throw std::runtime_error(
+              "Injected upload_as_single_object failure");
+        }
+        _storage.put_object(_oid, std::move(data));
+        co_return;
+    }
+
+    bool is_multipart_initialized() const override { return true; }
+    ss::sstring upload_id() const override { return "unreliable"; }
 
 private:
-    bool _fail_create_tmp_file = false;
-    bool _fail_put_object = false;
+    l1::object_id _oid;
+    l1::fake_io& _storage;
+    bool& _fail_upload_part;
+    bool& _fail_complete;
+    bool& _fail_abort;
+    iobuf _buffer;
+};
+
+class unreliable_io : public l1::fake_io {
+public:
+    ss::future<
+      std::expected<cloud_storage_clients::multipart_upload_ref, l1::io::errc>>
+    create_multipart_upload(
+      l1::object_id oid, size_t part_size, ss::abort_source*) override {
+        if (_fail_create_multipart) {
+            co_return std::unexpected(l1::io::errc::cloud_op_error);
+        }
+        auto state = ss::make_shared<unreliable_multipart_state>(
+          oid, *this, _fail_upload_part, _fail_complete, _fail_abort);
+        auto upload = ss::make_shared<cloud_storage_clients::multipart_upload>(
+          std::move(state), part_size);
+        co_return upload;
+    }
+
+    void fail_create_multipart(bool fail) { _fail_create_multipart = fail; }
+    void fail_upload_part(bool fail) { _fail_upload_part = fail; }
+    void fail_complete(bool fail) { _fail_complete = fail; }
+    void fail_abort(bool fail) { _fail_abort = fail; }
+
+private:
+    bool _fail_create_multipart = false;
+    bool _fail_upload_part = false;
+    bool _fail_complete = false;
+    bool _fail_abort = false;
 };
 
 } // namespace cloud_topics::reconciler::test


### PR DESCRIPTION
Use multipart uploads in the reconciler. Previously, for each L1 object built, the reconciler would create and manage the lifetime of a staging file, in which it built the L1 objects. To use multipart upload, the reconciler no longer needs a staging file, and instead the builder streams the L1 object directly to the multipart upload instance's stream, which handles batching the bytes into parts and uploading them. The reconciler manages the lifecycle of the multipart handle, using it to abort the multipart upload if there's an error, and closing the stream when it cleans up the builder.

I plan to increase the level of parallelism and make the parallelism and part size configurable in a follow-up, which will also include memory accounting for the part sizes and parallelism.

One unfortunate change is the first commit: as the builder always closes its stream because it always needs to be closed, which completes the multipart upload, I had to allow a multipart upload to be completed after it's aborted, as a no-op. Open to alternatives on handling that case.

Fixes CORE-15540

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
