### PR TITLE
ct: clean up tmp files from L1 staging directory

### DIFF
--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -91,12 +91,15 @@ redpanda_cc_library(
     implementation_deps = [
         ":cluster_services_interface",
         ":data_plane_impl",
+        ":logger",
         ":topic_manifest_upload_manager",
         "//src/v/cloud_topics/housekeeper:manager",
         "//src/v/cloud_topics/level_one/metastore:flush_loop",
         "//src/v/cloud_topics/level_one/metastore:topic_purger",
         "//src/v/cloud_topics/level_zero/gc:level_zero_gc",
         "//src/v/cloud_topics/manager",
+        "//src/v/ssx:future_util",
+        "//src/v/utils:directory_walker",
     ],
     visibility = [
         "//src/v/cloud_topics/frontend:__pkg__",

--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -18,6 +18,7 @@
 #include "cloud_topics/level_one/metastore/flush_loop.h"
 #include "cloud_topics/level_one/metastore/topic_purger.h"
 #include "cloud_topics/level_zero/gc/level_zero_gc.h"
+#include "cloud_topics/logger.h"
 #include "cloud_topics/manager/manager.h"
 #include "cloud_topics/reconciler/reconciler.h"
 #include "cloud_topics/topic_manifest_upload_manager.h"
@@ -25,9 +26,14 @@
 #include "cluster/controller.h"
 #include "config/node_config.h"
 #include "resource_mgmt/cpu_scheduling.h"
+#include "ssx/future-util.h"
 #include "ssx/sharded_service_container.h"
+#include "utils/directory_walker.h"
 
 #include <seastar/core/coroutine.hh>
+
+#include <deque>
+#include <filesystem>
 
 namespace cloud_topics {
 
@@ -166,6 +172,8 @@ ss::future<> app::construct(
 }
 
 ss::future<> app::start() {
+    co_await cleanup_tmp_files();
+
     co_await data_plane->start();
     co_await reconciler.invoke_on_all(&reconciler::reconciler<>::start);
     co_await domain_supervisor.invoke_on_all(
@@ -265,6 +273,76 @@ ss::future<> app::wire_up_notifications() {
                 tidp, std::move(partition));
           });
     });
+}
+
+ss::future<> app::cleanup_tmp_files() {
+    auto staging_dir = config::node().l1_staging_path();
+    std::deque<std::filesystem::path> dirs_to_process;
+    dirs_to_process.push_back(staging_dir);
+
+    // TODO: maybe we should parallelize this.
+    size_t deleted_count = 0;
+    while (!dirs_to_process.empty()) {
+        auto current_dir = std::move(dirs_to_process.front());
+        dirs_to_process.pop_front();
+        auto walk_fut = co_await ss::coroutine::as_future(
+          directory_walker::walk(
+            current_dir.string(),
+            [&current_dir, &dirs_to_process, &deleted_count](
+              this auto, ss::directory_entry entry) -> ss::future<> {
+                auto entry_path = current_dir / entry.name.c_str();
+                if (!entry.type.has_value()) {
+                    vlog(
+                      cd_log.info,
+                      "Skipping cleanup of unknown file type file: {}",
+                      entry_path.string());
+                    co_return;
+                }
+                if (entry.type == ss::directory_entry_type::directory) {
+                    dirs_to_process.push_back(entry_path);
+                    co_return;
+                }
+                if (entry.type == ss::directory_entry_type::regular) {
+                    if (std::string_view(entry.name).contains(".tmp")) {
+                        auto entry_path_str = entry_path.string();
+                        auto rm_fut = co_await ss::coroutine::as_future(
+                          ss::remove_file(entry_path_str));
+                        if (rm_fut.failed()) {
+                            auto ex = rm_fut.get_exception();
+                            auto lvl = ssx::is_shutdown_exception(ex)
+                                         ? ss::log_level::debug
+                                         : ss::log_level::warn;
+                            vlogl(
+                              cd_log,
+                              lvl,
+                              "Failed to delete tmp file {}: {}",
+                              entry_path_str,
+                              ex);
+                            co_return;
+                        }
+                        deleted_count++;
+                    }
+                }
+            }));
+
+        if (walk_fut.failed()) {
+            auto ex = walk_fut.get_exception();
+            auto lvl = ssx::is_shutdown_exception(ex) ? ss::log_level::debug
+                                                      : ss::log_level::warn;
+            vlogl(
+              cd_log, lvl, "Failed to walk directory {}: {}", staging_dir, ex);
+        }
+    }
+
+    if (deleted_count > 0) {
+        vlog(
+          cd_log.info,
+          "Cleanup deleted {} tmp file(s) from {}",
+          deleted_count,
+          staging_dir);
+    } else {
+        vlog(cd_log.debug, "No tmp files found to cleanup in {}", staging_dir);
+    }
 }
 
 ss::future<> app::stop() {

--- a/src/v/cloud_topics/app.h
+++ b/src/v/cloud_topics/app.h
@@ -89,6 +89,9 @@ public:
 private:
     ss::future<> wire_up_notifications();
 
+    // Cleans up the temporary files in the L1 staging directory.
+    ss::future<> cleanup_tmp_files();
+
     ss::sstring _logger_name;
     ss::sharded<level_one_reader_probe> _l1_reader_probe;
     std::unique_ptr<data_plane_api> data_plane;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
    The L1 staging directory is used for L1 object IO and for the LSM-backed
    metastore. It can accumulate tmp files across crashes of the system
    since both of these will write to tmp files before uploading. To
    mitigate, this commit adds a simple walker to app startup to clean this
    directory up.

    I considered doing this with a flat listing when opening up the various
    persistence objects, e.g. running this scoped to individual
    cloud_persistences or file_ios when opening the object. This didn't seem
    tenable for the case where there are multiple such objects on a given
    broker for the same directory, which will be the case for read replicas
    (they will instantiate a cloud-backed persistence per shard).

    This code will go away if/when we start backing these persistence
    objects with the cloud cache, which also cleans up its tmp files at
    startup.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
