### PR TITLE
[v25.3.x] CORE-15290 cl/tests: fix flaky bad_describe_config_response test

### DIFF
--- a/src/v/cluster_link/tests/source_topic_syncer_test.cc
+++ b/src/v/cluster_link/tests/source_topic_syncer_test.cc
@@ -558,8 +558,6 @@ protected:
 };
 
 TEST_F_CORO(invalid_describe_configs_test, bad_describe_config_response) {
-    co_await fixture()->upsert_link(get_default_metadata());
-
     _describe_configs_results.emplace_back(
       kafka::describe_configs_result{
         .error_code = kafka::error_code::topic_authorization_failed});


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/29639
