### PR TITLE
ct/rr [2/3]: add major components for cloud topic read replicas

### DIFF
--- a/src/v/cloud_topics/level_one/common/BUILD
+++ b/src/v/cloud_topics/level_one/common/BUILD
@@ -91,6 +91,7 @@ redpanda_cc_library(
     visibility = [
         "//src/v/cloud_topics:__pkg__",
         "//src/v/cloud_topics/level_one:__subpackages__",
+        "//src/v/cloud_topics/read_replica:__pkg__",
     ],
     deps = [
         ":abstract_io",

--- a/src/v/cloud_topics/read_replica/BUILD
+++ b/src/v/cloud_topics/read_replica/BUILD
@@ -3,6 +3,48 @@ load("//bazel:build.bzl", "redpanda_cc_library")
 package(default_visibility = ["//src/v/cloud_topics/read_replica:__subpackages__"])
 
 redpanda_cc_library(
+    name = "metadata_provider",
+    hdrs = [
+        "metadata_provider.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":partition_metadata",
+        "//src/v/model",
+    ],
+)
+
+redpanda_cc_library(
+    name = "metadata_manager",
+    srcs = [
+        "metadata_manager.cc",
+    ],
+    hdrs = [
+        "metadata_manager.h",
+        "partition_metadata.h",
+    ],
+    implementation_deps = [
+        ":snapshot_manager",
+        ":state_refresh_loop",
+        ":stm",
+        "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics/level_one/metastore:manifest_io",
+        "//src/v/ssx:work_queue",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":metadata_provider",
+        ":partition_metadata",
+        "//src/v/cloud_storage:remote_label",
+        "//src/v/cluster",
+        "//src/v/cluster/utils:partition_change_notifier_api",
+        "//src/v/container:chunked_hash_map",
+        "//src/v/model",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "partition_metadata",
     hdrs = [
         "partition_metadata.h",

--- a/src/v/cloud_topics/read_replica/BUILD
+++ b/src/v/cloud_topics/read_replica/BUILD
@@ -12,6 +12,7 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         "//src/v/cloud_topics:logger",
+        "//src/v/model:batch_builder",
         "//src/v/serde",
         "//src/v/ssx:future_util",
     ],

--- a/src/v/cloud_topics/read_replica/BUILD
+++ b/src/v/cloud_topics/read_replica/BUILD
@@ -3,6 +3,27 @@ load("//bazel:build.bzl", "redpanda_cc_library")
 package(default_visibility = ["//src/v/cloud_topics/read_replica:__subpackages__"])
 
 redpanda_cc_library(
+    name = "snapshot_metastore",
+    srcs = [
+        "snapshot_metastore.cc",
+    ],
+    hdrs = [
+        "snapshot_metastore.h",
+    ],
+    implementation_deps = [
+        "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics/level_one/metastore/lsm:keys",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/cloud_topics/level_one/metastore",
+        "//src/v/cloud_topics/level_one/metastore/lsm:state_reader",
+        "//src/v/lsm",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "stm",
     srcs = [
         "stm.cc",

--- a/src/v/cloud_topics/read_replica/BUILD
+++ b/src/v/cloud_topics/read_replica/BUILD
@@ -3,6 +3,19 @@ load("//bazel:build.bzl", "redpanda_cc_library")
 package(default_visibility = ["//src/v/cloud_topics/read_replica:__subpackages__"])
 
 redpanda_cc_library(
+    name = "partition_metadata",
+    hdrs = [
+        "partition_metadata.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/cloud_storage_clients",
+        "//src/v/model",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "snapshot_metastore",
     srcs = [
         "snapshot_metastore.cc",

--- a/src/v/cloud_topics/read_replica/BUILD
+++ b/src/v/cloud_topics/read_replica/BUILD
@@ -87,6 +87,39 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "state_refresh_loop",
+    srcs = [
+        "state_refresh_loop.cc",
+    ],
+    hdrs = [
+        "state_refresh_loop.h",
+    ],
+    implementation_deps = [
+        ":snapshot_metastore",
+        "//src/v/bytes:iobuf",
+        "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics/level_one/metastore:manifest_io",
+        "//src/v/cloud_topics/level_one/metastore:metastore_manifest",
+        "//src/v/config",
+        "//src/v/hashing:murmur",
+        "//src/v/model",
+        "//src/v/model:batch_builder",
+        "//src/v/serde",
+        "//src/v/ssx:sleep_abortable",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":snapshot_manager",
+        ":stm",
+        "//src/v/cloud_storage:remote_label",
+        "//src/v/cloud_storage_clients",
+        "//src/v/utils:detailed_error",
+        "//src/v/utils:prefix_logger",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "stm",
     srcs = [
         "stm.cc",

--- a/src/v/cloud_topics/read_replica/BUILD
+++ b/src/v/cloud_topics/read_replica/BUILD
@@ -16,6 +16,56 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "snapshot_provider",
+    hdrs = [
+        "snapshot_provider.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/cloud_topics/level_one/metastore:domain_uuid",
+        "//src/v/lsm",
+        "//src/v/model",
+        "//src/v/utils:detailed_error",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
+    name = "snapshot_manager",
+    srcs = [
+        "snapshot_manager.cc",
+    ],
+    hdrs = [
+        "snapshot_manager.h",
+    ],
+    implementation_deps = [
+        ":snapshot_metastore",
+        "//src/v/base",
+        "//src/v/cloud_io:remote",
+        "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics/level_one/common:file_io",
+        "//src/v/cloud_topics/level_one/metastore:manifest_io",
+        "//src/v/config",
+        "//src/v/lsm/io:cloud_persistence",
+        "//src/v/ssx:future_util",
+        "//src/v/ssx:sleep_abortable",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":snapshot_provider",
+        "//src/v/cloud_storage_clients",
+        "//src/v/cloud_topics/level_one/metastore:domain_uuid",
+        "//src/v/container:chunked_hash_map",
+        "//src/v/lsm",
+        "//src/v/model",
+        "//src/v/ssx:semaphore",
+        "//src/v/utils:detailed_error",
+        "//src/v/utils:prefix_logger",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "snapshot_metastore",
     srcs = [
         "snapshot_metastore.cc",

--- a/src/v/cloud_topics/read_replica/metadata_manager.cc
+++ b/src/v/cloud_topics/read_replica/metadata_manager.cc
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/read_replica/metadata_manager.h"
+
+#include "cloud_topics/logger.h"
+#include "cloud_topics/read_replica/snapshot_manager.h"
+#include "cloud_topics/read_replica/state_refresh_loop.h"
+#include "cloud_topics/read_replica/stm.h"
+#include "cluster/partition.h"
+#include "cluster/partition_manager.h"
+#include "ssx/work_queue.h"
+
+namespace cloud_topics::read_replica {
+
+metadata_manager::metadata_manager(
+  std::unique_ptr<cluster::partition_change_notifier> notifier,
+  ss::sharded<cluster::partition_manager>& partition_mgr,
+  snapshot_manager* snapshot_mgr,
+  ss::sharded<cloud_io::remote>& remote,
+  ss::sharded<cluster::topic_table>& topics)
+  : notifier_(std::move(notifier))
+  , partition_mgr_(partition_mgr)
+  , topic_table_(topics)
+  , queue_([](const std::exception_ptr& ex) {
+      vlog(cd_log.warn, "Metadata manager work queue error: {}", ex);
+  })
+  , snapshot_mgr_(snapshot_mgr)
+  , remote_(remote) {}
+
+metadata_manager::~metadata_manager() = default;
+
+void metadata_manager::start() {
+    using notif_type = cluster::partition_change_notifier::notification_type;
+    using partition_state = cluster::partition_change_notifier::partition_state;
+    using notify_current
+      = cluster::partition_change_notifier::notify_current_state;
+
+    notification_ = notifier_->register_partition_notifications(
+      [this](
+        notif_type type,
+        const model::ntp& ntp,
+        std::optional<partition_state> state) {
+          on_partition_notification(type, ntp, std::move(state));
+      },
+      notify_current::yes);
+}
+
+ss::future<> metadata_manager::stop() {
+    vlog(cd_log.info, "Metadata manager stopping");
+
+    // Unregister notifications first so we don't get more calls to start new
+    // refresh loop.
+    if (notification_) {
+        vlog(cd_log.info, "Unregistering notifications");
+        auto id = std::exchange(notification_, std::nullopt).value();
+        notifier_->unregister_partition_notifications(id);
+        vlog(cd_log.info, "Unregistered notifications");
+    }
+
+    // Stop the queue to prevent new refresh_loops from being added.
+    vlog(cd_log.info, "Shutting down queue");
+    co_await queue_.shutdown();
+    for (auto& [ntp, loop] : refresh_loops_) {
+        if (loop) {
+            vlog(cd_log.debug, "Stopping refresh loop for {}", ntp);
+            co_await loop->stop_and_wait();
+            vlog(cd_log.debug, "Stopped refresh loop for {}", ntp);
+        }
+    }
+    vlog(cd_log.info, "Shut down queue");
+    refresh_loops_.clear();
+    metadata_.clear();
+    vlog(cd_log.info, "Metadata manager stopped");
+}
+
+void metadata_manager::on_partition_notification(
+  cluster::partition_change_notifier::notification_type type,
+  const model::ntp& ntp,
+  std::optional<cluster::partition_change_notifier::partition_state> state) {
+    using notif_type = cluster::partition_change_notifier::notification_type;
+
+    std::optional<cluster::topic_configuration> config
+      = state.and_then([](auto state) { return std::move(state.topic_cfg); })
+          .or_else([this, &ntp] {
+              return topic_table_.local().get_topic_cfg({ntp.ns, ntp.tp.topic});
+          });
+    if (!config) {
+        // The topic was likely deleted.
+        metadata_.erase(ntp);
+        enqueue_refresh_loop_stop(ntp);
+        return;
+    }
+    if (!config->is_cloud_topic() || !config->is_read_replica()) {
+        return;
+    }
+    auto remote_label = config->properties.remote_label;
+    if (!remote_label) {
+        vlog(cd_log.error, "Missing remote label: {}", ntp);
+        return;
+    }
+    if (!config->tp_id) {
+        vlog(cd_log.error, "Missing topic ID: {}", ntp);
+        return;
+    }
+    std::optional<model::term_id> term_opt;
+    if (state && state->is_leader) {
+        term_opt = state->term;
+    }
+    const auto& tp_id = *config->tp_id;
+    switch (type) {
+    case notif_type::partition_replica_assigned:
+        on_partition_change(ntp, tp_id, /*has_partition=*/true);
+        on_leadership_change(ntp, tp_id, *remote_label, term_opt);
+        break;
+    case notif_type::partition_replica_unassigned:
+        on_partition_change(ntp, tp_id, /*has_partition=*/false);
+        on_leadership_change(ntp, tp_id, *remote_label, std::nullopt);
+        break;
+    case notif_type::leadership_change:
+        on_leadership_change(ntp, tp_id, *remote_label, term_opt);
+        break;
+    case notif_type::partition_properties_change:
+        break;
+    }
+}
+
+void metadata_manager::on_leadership_change(
+  const model::ntp& ntp,
+  const model::topic_id& topic_id,
+  const cloud_storage::remote_label& remote_label,
+  std::optional<model::term_id> term) {
+    if (term.has_value()) {
+        auto partition = partition_mgr_.local().get(ntp);
+        if (partition) {
+            enqueue_refresh_loop(
+              std::move(partition), term.value(), topic_id, remote_label);
+        } else {
+            vlog(
+              cd_log.error,
+              "Missing managed partition on becoming leader: {}",
+              ntp);
+        }
+
+        auto p_meta = metadata_.find(ntp);
+        if (p_meta != metadata_.end()) {
+            p_meta->second.last_leadership_time = ss::lowres_clock::now();
+        } else {
+            vlog(
+              cd_log.error,
+              "Missing partition metadata on becoming leader: {}",
+              ntp);
+        }
+    } else {
+        enqueue_refresh_loop_stop(ntp);
+    }
+}
+
+void metadata_manager::on_partition_change(
+  const model::ntp& ntp, const model::topic_id& topic_id, bool has_partition) {
+    if (has_partition) {
+        auto partition = partition_mgr_.local().get(ntp);
+        if (!partition) {
+            vlog(
+              cd_log.error,
+              "Missing partition on registering partition: {}",
+              ntp);
+            return;
+        }
+        auto bucket = partition->get_read_replica_bucket();
+        model::topic_id_partition tidp{topic_id, ntp.tp.partition};
+        partition_metadata metadata{
+          .creation_time = ss::lowres_clock::now(),
+          .tidp = tidp,
+          .bucket = bucket,
+        };
+        metadata_.insert_or_assign(ntp, std::move(metadata));
+    } else {
+        metadata_.erase(ntp);
+    }
+}
+
+void metadata_manager::enqueue_refresh_loop(
+  ss::lw_shared_ptr<cluster::partition> partition,
+  model::term_id term,
+  model::topic_id topic_id,
+  cloud_storage::remote_label remote_label) {
+    queue_.submit(
+      [this, partition, topic_id, term, remote_label]() mutable
+        -> ss::future<> {
+          start_refresh_loop(
+            std::move(partition), term, topic_id, remote_label);
+          return ss::make_ready_future();
+      });
+}
+
+void metadata_manager::enqueue_refresh_loop_stop(const model::ntp& ntp) {
+    queue_.submit(
+      [this, ntp]() -> ss::future<> { return stop_refresh_loop(ntp); });
+}
+
+std::optional<partition_metadata>
+metadata_manager::get_metadata(const model::ntp& ntp) const {
+    auto it = metadata_.find(ntp);
+    if (it == metadata_.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+void metadata_manager::start_refresh_loop(
+  ss::lw_shared_ptr<cluster::partition> partition,
+  model::term_id term,
+  model::topic_id topic_id,
+  cloud_storage::remote_label remote_label) {
+    model::topic_id_partition tidp{topic_id, partition->ntp().tp.partition};
+    auto& stm_manager = partition->raft()->stm_manager();
+    auto stm_ptr = stm_manager->get<stm>();
+    auto loop = std::make_unique<state_refresh_loop>(
+      term,
+      tidp,
+      std::move(stm_ptr),
+      snapshot_mgr_,
+      partition->get_read_replica_bucket(),
+      remote_label,
+      remote_.local());
+
+    loop->start();
+    refresh_loops_.emplace(partition->ntp(), std::move(loop));
+}
+
+ss::future<> metadata_manager::stop_refresh_loop(model::ntp ntp) {
+    auto it = refresh_loops_.find(ntp);
+    if (it == refresh_loops_.end()) {
+        co_return;
+    }
+    auto loop = std::move(it->second);
+    refresh_loops_.erase(it);
+    co_await loop->stop_and_wait();
+}
+
+} // namespace cloud_topics::read_replica

--- a/src/v/cloud_topics/read_replica/metadata_manager.h
+++ b/src/v/cloud_topics/read_replica/metadata_manager.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "cloud_topics/read_replica/metadata_provider.h"
+#include "cloud_topics/read_replica/partition_metadata.h"
+#include "cluster/utils/partition_change_notifier.h"
+#include "container/chunked_hash_map.h"
+#include "model/fundamental.h"
+#include "ssx/work_queue.h"
+
+#include <seastar/core/sharded.hh>
+
+namespace cloud_io {
+class remote;
+} // namespace cloud_io
+
+namespace cloud_topics::l1 {
+class manifest_io;
+} // namespace cloud_topics::l1
+
+namespace cluster {
+class partition;
+class partition_manager;
+class topic_table;
+} // namespace cluster
+
+namespace cloud_topics::read_replica {
+
+class state_refresh_loop;
+class snapshot_manager;
+
+// Manages partition metadata, listening for manage and unmanage commands for
+// partitions of read replica cloud topics.
+class metadata_manager : public metadata_provider {
+public:
+    metadata_manager(
+      std::unique_ptr<cluster::partition_change_notifier> notifier,
+      ss::sharded<cluster::partition_manager>& partition_mgr,
+      snapshot_manager* snapshot_mgr,
+      ss::sharded<cloud_io::remote>& remote,
+      ss::sharded<cluster::topic_table>& topics);
+
+    metadata_manager(const metadata_manager&) = delete;
+    metadata_manager& operator=(const metadata_manager&) = delete;
+    metadata_manager(metadata_manager&&) = delete;
+    metadata_manager& operator=(metadata_manager&&) = delete;
+
+    // Needs to be defined in .cc file where state_refresh_loop is complete
+    ~metadata_manager();
+
+    // Start the metadata manager and begin receiving notifications.
+    // Should be called after all dependencies are ready.
+    void start();
+
+    // Stop the metadata manager and unregister notifications.
+    ss::future<> stop() override;
+
+    // Implement metadata_provider interface
+    std::optional<partition_metadata>
+    get_metadata(const model::ntp&) const override;
+
+private:
+    void on_partition_notification(
+      cluster::partition_change_notifier::notification_type type,
+      const model::ntp& ntp,
+      std::optional<cluster::partition_change_notifier::partition_state> state);
+
+    void enqueue_refresh_loop(
+      ss::lw_shared_ptr<cluster::partition> partition,
+      model::term_id term,
+      model::topic_id topic_id,
+      cloud_storage::remote_label);
+    void enqueue_refresh_loop_stop(const model::ntp&);
+
+    // Reset refresh loop for a partition (start/stop based on leadership)
+    void start_refresh_loop(
+      ss::lw_shared_ptr<cluster::partition> partition,
+      model::term_id term,
+      model::topic_id topic_id,
+      cloud_storage::remote_label);
+    ss::future<> stop_refresh_loop(model::ntp ntp);
+
+    void on_leadership_change(
+      const model::ntp&,
+      const model::topic_id& tidp,
+      const cloud_storage::remote_label&,
+      std::optional<model::term_id>);
+    void on_partition_change(
+      const model::ntp&, const model::topic_id& tidp, bool has_partition);
+
+    // This gets notified when there is a read replica cloud topic partition on
+    // this shard.
+    std::unique_ptr<cluster::partition_change_notifier> notifier_;
+    std::optional<cluster::notification_id_type> notification_;
+
+    ss::sharded<cluster::partition_manager>& partition_mgr_;
+    ss::sharded<cluster::topic_table>& topic_table_;
+
+    // Tracks active state refresh loops (leader-only)
+    chunked_hash_map<model::ntp, std::unique_ptr<state_refresh_loop>>
+      refresh_loops_;
+
+    // Work queue to serialize refresh loop operations
+    ssx::work_queue queue_;
+
+    // Dependencies for creating refresh loops
+    snapshot_manager* snapshot_mgr_;
+    ss::sharded<cloud_io::remote>& remote_;
+
+    chunked_hash_map<model::ntp, partition_metadata> metadata_;
+};
+
+} // namespace cloud_topics::read_replica

--- a/src/v/cloud_topics/read_replica/metadata_provider.h
+++ b/src/v/cloud_topics/read_replica/metadata_provider.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "cloud_topics/read_replica/partition_metadata.h"
+#include "model/fundamental.h"
+
+#include <optional>
+
+namespace cloud_topics::read_replica {
+
+// Abstract interface for accessing partition metadata.
+// Implemented by metadata_manager to provide read-only metadata queries.
+class metadata_provider {
+public:
+    virtual ~metadata_provider() = default;
+    virtual ss::future<> stop() = 0;
+
+    // Query metadata for a partition.
+    // Returns std::nullopt if partition is not registered.
+    virtual std::optional<partition_metadata>
+    get_metadata(const model::ntp&) const = 0;
+};
+
+} // namespace cloud_topics::read_replica

--- a/src/v/cloud_topics/read_replica/partition_metadata.h
+++ b/src/v/cloud_topics/read_replica/partition_metadata.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "model/fundamental.h"
+
+namespace cloud_topics::read_replica {
+
+// Metadata tracked on each replica of each partition. This is expected to be
+// managed for every read replica partition on a shard, and used to query
+// metastore with some bounded staleness.
+struct partition_metadata {
+public:
+    // The time the partition began being managed by this shard. This is
+    // tracked so that we can ensure we get a database snapshot later than this
+    // value, ensuring the view of the partition is later than those prior from
+    // other shards.
+    ss::lowres_clock::time_point creation_time;
+
+    // The last time at which this partition became a leader. This is tracked
+    // so that we can ensure we get a database snapshot later than this value,
+    // ensuring the view of the partition is later than those prior from
+    // previous leadership.
+    std::optional<ss::lowres_clock::time_point> last_leadership_time;
+
+    model::topic_id_partition tidp;
+    cloud_storage_clients::bucket_name bucket;
+    // TODO: additional bucket-specific configs?
+
+    ss::lowres_clock::time_point earliest_snapshot_time() const {
+        if (last_leadership_time) {
+            return std::max(creation_time, *last_leadership_time);
+        }
+        return creation_time;
+    }
+};
+
+} // namespace cloud_topics::read_replica

--- a/src/v/cloud_topics/read_replica/snapshot_manager.cc
+++ b/src/v/cloud_topics/read_replica/snapshot_manager.cc
@@ -1,0 +1,379 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/read_replica/snapshot_manager.h"
+
+#include "base/vlog.h"
+#include "cloud_storage_clients/types.h"
+#include "cloud_topics/level_one/common/file_io.h"
+#include "cloud_topics/logger.h"
+#include "cloud_topics/read_replica/snapshot_metastore.h"
+#include "config/configuration.h"
+#include "lsm/io/cloud_persistence.h"
+#include "ssx/future-util.h"
+#include "ssx/sleep_abortable.h"
+
+#include <seastar/coroutine/as_future.hh>
+
+#include <exception>
+
+using namespace std::chrono_literals;
+
+namespace cloud_topics::read_replica {
+
+// Starts a loop that periodically refreshes the database and can be signaled
+// to refresh immediately if needed.
+class database_refresher {
+public:
+    database_refresher(
+      std::filesystem::path staging_directory,
+      cloud_storage_clients::bucket_name bucket,
+      cloud_io::remote* remote,
+      cloud_io::cache* cache,
+      l1::domain_uuid);
+
+    void start();
+    ss::future<> stop_and_wait();
+
+    // Tells the refresher to refresh immediately. If the refresh loop is
+    // sleeping, it wakes up immediately to refresh.
+    void signal_refresh();
+
+    // Waits for the database to be refreshed starting at a point at or later
+    // than the input time, and returns a snapshot of the database.
+    using errc = snapshot_provider::errc;
+    using error = snapshot_provider::error;
+    ss::future<std::expected<snapshot_handle, error>> get_newer_snapshot(
+      ss::lowres_clock::time_point min_refresh_time,
+      ss::lowres_clock::duration timeout,
+      std::optional<lsm::sequence_number> min_seqno);
+
+    // Test helper: returns the start time of the last successful refresh.
+    ss::lowres_clock::time_point last_refresh_time() const {
+        return last_refreshed_at_;
+    }
+
+private:
+    // The loop in charge of opening and refreshing the database.
+    ss::future<> run_loop();
+
+    ss::future<> open_or_refresh();
+
+    ss::gate gate_;
+    ss::abort_source as_;
+
+    // TODO: integrate with the cloud cache?
+    const std::filesystem::path staging_directory_;
+    const cloud_storage_clients::bucket_name bucket_;
+    cloud_io::remote* remote_;
+    l1::domain_uuid domain_uuid_;
+    prefix_logger logger_;
+
+    std::optional<lsm::database> db_;
+    std::unique_ptr<l1::file_io> io_;
+
+    // Used to sleep in between refreshing the database, but can be interrupted
+    // if callers need a refresh now.
+    ssx::named_semaphore<> sleep_sem_{0, "refresh_sleep_sem"};
+
+    // Used to wait for refreshes and indicate that callers are waiting on
+    // database refreshes.
+    ss::condition_variable refreshed_cv_;
+
+    // The last time we started a refresh that succeeded.
+    ss::lowres_clock::time_point last_refreshed_at_{
+      ss::lowres_clock::time_point::min()};
+};
+
+database_refresher::database_refresher(
+  std::filesystem::path staging_directory,
+  cloud_storage_clients::bucket_name bucket,
+  cloud_io::remote* remote,
+  cloud_io::cache* cache,
+  l1::domain_uuid domain_uuid)
+  : staging_directory_(std::move(staging_directory))
+  , bucket_(std::move(bucket))
+  , remote_(remote)
+  , domain_uuid_(domain_uuid)
+  , logger_(
+      cd_log, fmt::format("database_refresher {}, {}", domain_uuid_, bucket_))
+  , io_(
+      std::make_unique<l1::file_io>(
+        staging_directory_, remote_, bucket_, cache)) {}
+
+void database_refresher::start() {
+    ssx::spawn_with_gate(gate_, [this] { return run_loop(); });
+}
+
+ss::future<> database_refresher::stop_and_wait() {
+    vlog(logger_.debug, "Stopping");
+    as_.request_abort();
+    sleep_sem_.broken();
+    refreshed_cv_.broken();
+    co_await gate_.close();
+    if (db_) {
+        co_await db_->close();
+    }
+    vlog(logger_.debug, "Stopped");
+}
+
+void database_refresher::signal_refresh() { sleep_sem_.signal(); }
+
+ss::future<> database_refresher::open_or_refresh() {
+    vlog(logger_.debug, "{}", db_.has_value() ? "Refreshing" : "Opening");
+    if (db_.has_value()) {
+        co_await db_->refresh();
+        vlog(logger_.debug, "Refreshed to seqno {}", db_->max_applied_seqno());
+        co_return;
+    }
+    cloud_storage_clients::object_key domain_prefix{
+      domain_cloud_prefix(domain_uuid_)};
+    auto data_persist = co_await lsm::io::open_cloud_data_persistence(
+      staging_directory_,
+      remote_,
+      bucket_,
+      domain_prefix,
+      ss::sstring(domain_uuid_()));
+    auto meta_persist = co_await lsm::io::open_cloud_metadata_persistence(
+      remote_, bucket_, domain_prefix);
+    lsm::io::persistence io{
+      .data = std::move(data_persist),
+      .metadata = std::move(meta_persist),
+    };
+    // NOTE: passing the max epoch allows us to find the latest manifest in the
+    // domain.
+    auto db = co_await lsm::database::open(
+      lsm::options{
+        .database_epoch = lsm::internal::database_epoch::max(),
+        .readonly = true,
+        // TODO: tuning.
+      },
+      std::move(io));
+    vlog(logger_.debug, "Opened with seqno {}", db.max_applied_seqno());
+    db_ = std::move(db);
+}
+
+ss::future<> database_refresher::run_loop() {
+    while (!gate_.is_closed()) {
+        // Capture the time before refresh completes so we have an accurate
+        // idea of when the refresh was started, and can therefore make
+        // accurate claims about the staleness of the database.
+        auto refresh_time = ss::lowres_clock::now();
+        auto refresh_fut = co_await ss::coroutine::as_future(open_or_refresh());
+        if (refresh_fut.failed()) {
+            auto ex = refresh_fut.get_exception();
+            auto lvl = ssx::is_shutdown_exception(ex) ? ss::log_level::debug
+                                                      : ss::log_level::warn;
+            vlogl(logger_, lvl, "Exception while refreshing database: {}", ex);
+            co_await ssx::sleep_abortable(1s, as_);
+            continue;
+        }
+        last_refreshed_at_ = refresh_time;
+        refreshed_cv_.broadcast();
+        if (refreshed_cv_.has_waiters()) {
+            // There are still waiters whose predicates were not satisfied
+            // (e.g., waiting for a future min_refresh_time). Sleep briefly
+            // before refreshing again to avoid busy-looping.
+            auto sleep_fut = co_await ss::coroutine::as_future(
+              ssx::sleep_abortable(100ms, as_));
+            if (sleep_fut.failed()) {
+                auto ex = sleep_fut.get_exception();
+                vlog(logger_.debug, "Error sleeping: {}", ex);
+            }
+            continue;
+        }
+        auto sync_interval
+          = config::shard_local_cfg()
+              .cloud_storage_readreplica_manifest_sync_timeout_ms();
+        try {
+            // Wait to timeout or get signaled by someone in need of an
+            // immediate refresh.
+            co_await sleep_sem_.wait(sync_interval);
+        } catch (const ss::semaphore_timed_out&) {
+            // Sync interval has elapsed, time to refresh.
+            continue;
+        } catch (...) {
+            // Expected at shutdown.
+            auto ex = std::current_exception();
+            vlog(
+              logger_.debug, "Exception thrown from sleep semaphore: {}", ex);
+        }
+    }
+    vlog(logger_.debug, "Database refresher run_loop exiting");
+}
+
+ss::future<std::expected<snapshot_handle, snapshot_provider::error>>
+database_refresher::get_newer_snapshot(
+  ss::lowres_clock::time_point min_refresh_time,
+  ss::lowres_clock::duration timeout,
+  std::optional<lsm::sequence_number> min_seqno) {
+    auto gh = gate_.try_hold();
+    if (!gh.has_value()) {
+        co_return std::unexpected(error(errc::shutting_down));
+    }
+    vlog(
+      logger_.debug,
+      "Waiting for snapshot newer than {}, seqno {}",
+      min_refresh_time.time_since_epoch(),
+      min_seqno);
+    auto has_fresh_snapshot = [this, min_refresh_time, min_seqno] {
+        return db_ && last_refreshed_at_ >= min_refresh_time
+               && (!min_seqno || db_->max_applied_seqno() >= *min_seqno);
+    };
+    if (!has_fresh_snapshot()) {
+        try {
+            signal_refresh();
+            co_await refreshed_cv_.when(timeout, std::move(has_fresh_snapshot));
+        } catch (const ss::condition_variable_timed_out&) {
+            co_return std::unexpected(
+              error(errc::io_error, "Timed out waiting for fresh snapshot"));
+        } catch (...) {
+            auto ex = std::current_exception();
+            co_return std::unexpected(
+              error(errc::shutting_down, "Shutting down: {}", ex));
+        }
+    }
+    auto seqno = db_->max_applied_seqno();
+    vlog(logger_.debug, "Returning snapshot seqno {}", seqno);
+    co_return snapshot_handle{
+      .metastore = std::make_unique<snapshot_metastore>(
+        std::move(*gh), db_->create_snapshot()),
+      .seqno = seqno,
+      .io = io_.get(),
+    };
+}
+
+snapshot_manager::snapshot_manager(
+  std::filesystem::path staging_dir,
+  cloud_io::remote* remote,
+  cloud_io::cache* cache)
+  : staging_dir_(std::move(staging_dir))
+  , remote_(remote)
+  , cache_(cache) {}
+
+ss::future<std::expected<snapshot_handle, snapshot_manager::error>>
+snapshot_manager::get_snapshot(
+  l1::domain_uuid domain_uuid,
+  cloud_storage_clients::bucket_name bucket,
+  ss::lowres_clock::time_point earliest_refresh,
+  std::optional<lsm::sequence_number> min_seqno,
+  ss::lowres_clock::duration timeout) {
+    auto gh = gate_.try_hold();
+    if (!gh.has_value()) {
+        co_return std::unexpected(error(errc::shutting_down));
+    }
+    auto db_it = databases_.find(domain_uuid);
+    if (db_it == databases_.end()) {
+        auto [it, inserted] = databases_.try_emplace(domain_uuid);
+        vassert(inserted, "Expected new entry to be inserted");
+
+        auto& entry = it->second;
+        entry.refresher = std::make_unique<database_refresher>(
+          staging_dir_, bucket, remote_, cache_, domain_uuid);
+
+        // Set up the timer so that when it fires (after enough of an idle
+        // period) it cleans up the database.
+        entry.idle_timer = std::make_unique<ss::timer<ss::lowres_clock>>();
+        entry.idle_timer->set_callback([this, domain_uuid] {
+            auto it = databases_.find(domain_uuid);
+            if (it == databases_.end()) {
+                return;
+            }
+            if (it->second.num_waiters != 0) {
+                // This shouldn't happen, but in case it does, be conservative
+                // and exit without destructing anything.
+                vlog(
+                  cd_log.error,
+                  "Idle callback called for {} with {} active waiters",
+                  domain_uuid,
+                  it->second.num_waiters);
+                return;
+            }
+            // Make sure to not clobber over the timer while we're running the
+            // callback.
+            auto db = std::move(it->second.refresher);
+            auto t = std::move(it->second.idle_timer);
+            databases_.erase(it);
+            ssx::spawn_with_gate(
+              gate_, [db = std::move(db), t = std::move(t)] mutable {
+                  return db->stop_and_wait().finally(
+                    [db = std::move(db), t = std::move(t)] mutable {});
+              });
+        });
+
+        entry.refresher->start();
+        db_it = it;
+    }
+    // The database is no longer idle if we're accessing it, so cancel the
+    // timer.
+    db_it->second.idle_timer->cancel();
+    ++db_it->second.num_waiters;
+
+    auto& db_refresher = db_it->second.refresher;
+    auto snap_handle = co_await db_refresher->get_newer_snapshot(
+      earliest_refresh, timeout, min_seqno);
+
+    // Refresh the lookup after the above scheduling point.
+    db_it = databases_.find(domain_uuid);
+
+    // The only thing that can remove this database is the idle timer callback,
+    // and that should only ever be called if there are no fibers running
+    // through getting a snapshot (which is what we're doing right now).
+    vassert(
+      db_it != databases_.end(), "Database removed with waiter in flight");
+    --db_it->second.num_waiters;
+
+    // Only the last fiber to exit this method should arm the timer, ensuring
+    // that other fibers don't arm this while we're waiting for a new snapshot
+    // and stop the refresher out from under us.
+    if (db_it->second.num_waiters == 0) {
+        auto sync_interval
+          = config::shard_local_cfg()
+              .cloud_storage_readreplica_manifest_sync_timeout_ms();
+        db_it->second.idle_timer->arm(
+          ss::lowres_clock::now() + sync_interval * 2);
+    }
+    if (!snap_handle.has_value()) {
+        co_return std::unexpected(snap_handle.error());
+    }
+    co_return std::move(snap_handle.value());
+}
+
+ss::future<> snapshot_manager::stop() {
+    vlog(cd_log.info, "Stopping read replica snapshot manager");
+
+    // Cancel all timers first so they don't kick off background cleanup of any
+    // of our databases.
+    for (auto& [uuid, entry] : databases_) {
+        entry.idle_timer->cancel();
+    }
+    co_await gate_.close();
+
+    // Stop all databases.
+    auto dbs = std::move(databases_);
+    for (auto& [uuid, db] : dbs) {
+        co_await db.refresher->stop_and_wait();
+        db.refresher.reset();
+    }
+    vlog(cd_log.info, "Stopped read replica snapshot manager");
+}
+
+std::optional<ss::lowres_clock::time_point>
+snapshot_manager::last_refresh_time(l1::domain_uuid domain) const {
+    auto it = databases_.find(domain);
+    if (it == databases_.end()) {
+        return std::nullopt;
+    }
+    return it->second.refresher->last_refresh_time();
+}
+
+snapshot_manager::database_entry::~database_entry() = default;
+
+} // namespace cloud_topics::read_replica

--- a/src/v/cloud_topics/read_replica/snapshot_manager.h
+++ b/src/v/cloud_topics/read_replica/snapshot_manager.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "cloud_topics/level_one/metastore/domain_uuid.h"
+#include "cloud_topics/read_replica/snapshot_provider.h"
+#include "container/chunked_hash_map.h"
+#include "lsm/lsm.h"
+#include "model/fundamental.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/timer.hh>
+
+#include <chrono>
+#include <expected>
+
+namespace cloud_io {
+class remote;
+class cache;
+} // namespace cloud_io
+
+namespace cloud_topics::read_replica {
+
+class database_refresher;
+class snapshot_manager : public snapshot_provider {
+public:
+    explicit snapshot_manager(
+      std::filesystem::path, cloud_io::remote*, cloud_io::cache*);
+
+    ss::future<std::expected<snapshot_handle, error>> get_snapshot(
+      l1::domain_uuid,
+      cloud_storage_clients::bucket_name,
+      ss::lowres_clock::time_point min_refresh_time,
+      std::optional<lsm::sequence_number> min_seqno,
+      ss::lowres_clock::duration timeout) override;
+
+    ss::future<> stop() override;
+
+    // Test helper: returns the last refresh time for a domain, or nullopt if
+    // domain doesn't exist
+    std::optional<ss::lowres_clock::time_point>
+    last_refresh_time(l1::domain_uuid domain) const;
+
+private:
+    ss::gate gate_;
+    const std::filesystem::path staging_dir_;
+    cloud_io::remote* remote_;
+    cloud_io::cache* cache_;
+
+    struct database_entry {
+        database_entry() = default;
+        ~database_entry();
+        database_entry(database_entry&&) noexcept = default;
+        database_entry& operator=(database_entry&&) noexcept = default;
+        database_entry(const database_entry&) = delete;
+        database_entry& operator=(const database_entry&) = delete;
+
+        // A database backing a given metastore domain. The database is
+        // periodically refreshed with state from cloud.
+        std::unique_ptr<database_refresher> refresher;
+
+        // Timer used to detect when a given database hasn't been accessed in
+        // long enough to be cleaned up.
+        std::unique_ptr<ss::timer<ss::lowres_clock>> idle_timer;
+
+        // Counter of the number of callers waiting in get_snapshot(). If this
+        // remains zero for long enough, the database entry is cleaned up.
+        size_t num_waiters{0};
+    };
+
+    // Refresh loops maintained per domain.
+    chunked_hash_map<l1::domain_uuid, database_entry> databases_;
+};
+
+} // namespace cloud_topics::read_replica

--- a/src/v/cloud_topics/read_replica/snapshot_metastore.cc
+++ b/src/v/cloud_topics/read_replica/snapshot_metastore.cc
@@ -1,0 +1,333 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/read_replica/snapshot_metastore.h"
+
+#include "cloud_topics/level_one/metastore/lsm/keys.h"
+#include "cloud_topics/logger.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace cloud_topics::read_replica {
+
+namespace {
+
+l1::metastore::errc
+log_and_convert(const l1::state_reader::error& e, std::string_view prefix) {
+    using enum l1::state_reader::errc;
+    ss::log_level lvl{};
+    switch (e.e) {
+    case io_error:
+        lvl = ss::log_level::warn;
+        break;
+    case corruption:
+        lvl = ss::log_level::error;
+        break;
+    case shutting_down:
+        lvl = ss::log_level::debug;
+        break;
+    }
+    vlogl(cd_log, lvl, "{}{}", prefix, e);
+    return l1::metastore::errc::transport_error;
+}
+
+} // namespace
+
+snapshot_metastore::snapshot_metastore(
+  ss::gate::holder gh, lsm::snapshot snapshot)
+  : gate_holder_(std::move(gh))
+  , reader_(std::move(snapshot)) {}
+
+ss::future<std::expected<l1::metastore::object_response, l1::metastore::errc>>
+snapshot_metastore::get_first_ge(
+  const model::topic_id_partition& tidp, kafka::offset offset) {
+    auto extent_result = co_await reader_.get_extent_ge(tidp, offset);
+    if (!extent_result.has_value()) {
+        co_return std::unexpected(
+          log_and_convert(extent_result.error(), "Error getting extent: "));
+    }
+    if (!extent_result.value().has_value()) {
+        co_return std::unexpected(errc::out_of_range);
+    }
+
+    const auto& extent = *extent_result.value();
+    auto obj_result = co_await reader_.get_object(extent.oid);
+    if (!obj_result.has_value()) {
+        co_return std::unexpected(
+          log_and_convert(obj_result.error(), "Error getting object: "));
+    }
+    if (!obj_result.value().has_value()) {
+        co_return std::unexpected(errc::out_of_range);
+    }
+    const auto& obj = *obj_result.value();
+    co_return object_response{
+      .oid = extent.oid,
+      .footer_pos = obj.footer_pos,
+      .object_size = obj.object_size,
+      .first_offset = extent.base_offset,
+      .last_offset = extent.last_offset,
+    };
+}
+
+ss::future<std::expected<l1::metastore::object_response, l1::metastore::errc>>
+snapshot_metastore::get_first_ge(
+  const model::topic_id_partition& tidp,
+  kafka::offset offset,
+  model::timestamp ts) {
+    auto extents_result = co_await reader_.get_inclusive_extents(
+      tidp, offset, std::nullopt);
+
+    if (!extents_result.has_value()) {
+        co_return std::unexpected(
+          log_and_convert(extents_result.error(), "Error getting extents: "));
+    }
+    if (!extents_result.value().has_value()) {
+        co_return std::unexpected(errc::out_of_range);
+    }
+
+    auto gen = extents_result.value()->get_rows();
+    while (auto row_ref = co_await gen()) {
+        const auto& row_result = row_ref->get();
+        if (!row_result.has_value()) {
+            co_return std::unexpected(
+              log_and_convert(row_result.error(), "Error iterating extents: "));
+        }
+        const auto& row = row_result.value();
+        const auto& extent = row.val;
+        if (extent.max_timestamp >= ts) {
+            auto obj_result = co_await reader_.get_object(extent.oid);
+            if (!obj_result.has_value()) {
+                co_return std::unexpected(log_and_convert(
+                  obj_result.error(), "Error getting object: "));
+            }
+            if (!obj_result.value().has_value()) {
+                co_return std::unexpected(errc::out_of_range);
+            }
+            const auto& obj = *obj_result.value();
+
+            auto key = l1::extent_row_key::decode(row.key);
+            if (!key.has_value()) {
+                vlog(cd_log.error, "Failed to decode extent: {}", row.key);
+                co_return std::unexpected(errc::transport_error);
+            }
+
+            co_return object_response{
+              .oid = extent.oid,
+              .footer_pos = obj.footer_pos,
+              .object_size = obj.object_size,
+              .first_offset = key->base_offset,
+              .last_offset = extent.last_offset,
+            };
+        }
+    }
+
+    co_return std::unexpected(errc::out_of_range);
+}
+
+ss::future<std::expected<kafka::offset, l1::metastore::errc>>
+snapshot_metastore::get_end_offset_for_term(
+  const model::topic_id_partition& tidp, model::term_id term) {
+    auto result = co_await reader_.get_term_end(tidp, term);
+    if (!result.has_value()) {
+        co_return std::unexpected(
+          log_and_convert(result.error(), "Error getting term end: "));
+    }
+    if (!result.value().has_value()) {
+        co_return std::unexpected(errc::out_of_range);
+    }
+    co_return *result.value();
+}
+
+ss::future<std::expected<model::term_id, l1::metastore::errc>>
+snapshot_metastore::get_term_for_offset(
+  const model::topic_id_partition& tidp, kafka::offset offset) {
+    auto result = co_await reader_.get_term_le(tidp, offset);
+    if (!result.has_value()) {
+        co_return std::unexpected(
+          log_and_convert(result.error(), "Error getting term: "));
+    }
+    if (!result.value().has_value()) {
+        co_return std::unexpected(errc::out_of_range);
+    }
+    co_return result.value()->term_id;
+}
+
+ss::future<std::expected<l1::metastore::offsets_response, l1::metastore::errc>>
+snapshot_metastore::get_offsets(const model::topic_id_partition& tidp) {
+    auto result = co_await reader_.get_metadata(tidp);
+    if (!result.has_value()) {
+        co_return std::unexpected(
+          log_and_convert(result.error(), "Error getting metadata: "));
+    }
+    if (!result.value().has_value()) {
+        co_return std::unexpected(errc::missing_ntp);
+    }
+    const auto& metadata = *result.value();
+    co_return offsets_response{
+      .start_offset = metadata.start_offset,
+      .next_offset = metadata.next_offset,
+    };
+}
+
+ss::future<std::expected<l1::metastore::size_response, l1::metastore::errc>>
+snapshot_metastore::get_size(const model::topic_id_partition& tidp) {
+    auto result = co_await reader_.get_metadata(tidp);
+    if (!result.has_value()) {
+        co_return std::unexpected(
+          log_and_convert(result.error(), "Error getting metadata: "));
+    }
+    if (!result.value().has_value()) {
+        co_return std::unexpected(errc::missing_ntp);
+    }
+    co_return size_response{.size = result.value()->size};
+}
+
+ss::future<std::expected<
+  std::unique_ptr<l1::metastore::object_metadata_builder>,
+  l1::metastore::errc>>
+snapshot_metastore::object_builder() {
+    co_return std::unexpected(errc::invalid_request);
+}
+
+ss::future<std::expected<l1::metastore::add_response, l1::metastore::errc>>
+snapshot_metastore::add_objects(
+  const object_metadata_builder&, const term_offset_map_t&) {
+    co_return std::unexpected(errc::invalid_request);
+}
+
+ss::future<std::expected<void, l1::metastore::errc>>
+snapshot_metastore::replace_objects(const object_metadata_builder&) {
+    co_return std::unexpected(errc::invalid_request);
+}
+
+ss::future<std::expected<void, l1::metastore::errc>>
+snapshot_metastore::set_start_offset(
+  const model::topic_id_partition&, kafka::offset) {
+    co_return std::unexpected(errc::invalid_request);
+}
+
+ss::future<
+  std::expected<l1::metastore::topic_removal_response, l1::metastore::errc>>
+snapshot_metastore::remove_topics(const chunked_vector<model::topic_id>&) {
+    co_return std::unexpected(errc::invalid_request);
+}
+
+ss::future<std::expected<kafka::offset, l1::metastore::errc>>
+snapshot_metastore::get_first_offset_for_bytes(
+  const model::topic_id_partition&, uint64_t) {
+    co_return std::unexpected(errc::invalid_request);
+}
+
+ss::future<std::expected<void, l1::metastore::errc>>
+snapshot_metastore::compact_objects(
+  const object_metadata_builder&, const compaction_map_t&) {
+    co_return std::unexpected(errc::invalid_request);
+}
+
+ss::future<
+  std::expected<l1::metastore::compaction_info_response, l1::metastore::errc>>
+snapshot_metastore::get_compaction_info(const compaction_info_spec&) {
+    co_return std::unexpected(errc::invalid_request);
+}
+
+ss::future<
+  std::expected<l1::metastore::compaction_info_map, l1::metastore::errc>>
+snapshot_metastore::get_compaction_infos(
+  const chunked_vector<compaction_info_spec>&) {
+    co_return std::unexpected(errc::invalid_request);
+}
+
+ss::future<
+  std::expected<l1::metastore::extent_metadata_response, l1::metastore::errc>>
+snapshot_metastore::get_extent_metadata_forwards(
+  const model::topic_id_partition& tidp,
+  kafka::offset min_offset,
+  kafka::offset max_offset,
+  size_t max_num_extents,
+  include_object_metadata include_obj_meta) {
+    auto extents_result = co_await reader_.get_inclusive_extents(
+      tidp, min_offset, max_offset);
+    if (!extents_result.has_value()) {
+        co_return std::unexpected(log_and_convert(
+          extents_result.error(), "Error getting extents forwards: "));
+    }
+    if (!extents_result.value().has_value()) {
+        co_return std::unexpected(errc::out_of_range);
+    }
+
+    extent_metadata_vec extents;
+    bool end_of_stream = true;
+    auto gen = extents_result.value()->get_rows();
+    while (auto row_ref = co_await gen()) {
+        const auto& row_result = row_ref->get();
+        if (!row_result.has_value()) {
+            co_return std::unexpected(log_and_convert(
+              row_result.error(), "Error iterating extents forwards: "));
+        }
+        auto key = l1::extent_row_key::decode(row_result.value().key);
+        if (!key.has_value()) {
+            vlog(
+              cd_log.error,
+              "Failed to decode extent: {}",
+              row_result.value().key);
+            co_return std::unexpected(errc::transport_error);
+        }
+        const auto& val = row_result.value().val;
+        extent_metadata em{
+          .base_offset = key->base_offset,
+          .last_offset = val.last_offset,
+          .max_timestamp = val.max_timestamp,
+        };
+        if (include_obj_meta) {
+            auto obj_result = co_await reader_.get_object(val.oid);
+            if (!obj_result.has_value()) {
+                co_return std::unexpected(log_and_convert(
+                  obj_result.error(), "Error getting object metadata: "));
+            }
+            if (!obj_result.value().has_value()) {
+                vlog(
+                  cd_log.error, "Object {} metadata is missing: {}", val.oid);
+                co_return std::unexpected(errc::transport_error);
+            }
+            const auto& obj = *obj_result.value();
+            em.object_info = extent_object_info{
+              .oid = val.oid,
+              .footer_pos = obj.footer_pos,
+              .object_size = obj.object_size,
+            };
+        }
+        extents.push_back(std::move(em));
+        if (extents.size() >= max_num_extents) {
+            end_of_stream = false;
+            break;
+        }
+    }
+    co_return extent_metadata_response{
+      .extents = std::move(extents), .end_of_stream = end_of_stream};
+}
+
+ss::future<
+  std::expected<l1::metastore::extent_metadata_response, l1::metastore::errc>>
+snapshot_metastore::get_extent_metadata_backwards(
+  const model::topic_id_partition&, kafka::offset, kafka::offset, size_t) {
+    co_return std::unexpected(errc::invalid_request);
+}
+
+ss::future<std::expected<std::nullopt_t, l1::metastore::errc>>
+snapshot_metastore::flush() {
+    co_return std::unexpected(errc::invalid_request);
+}
+
+ss::future<std::expected<std::nullopt_t, l1::metastore::errc>>
+snapshot_metastore::restore(const cloud_storage::remote_label&) {
+    co_return std::unexpected(errc::invalid_request);
+}
+
+} // namespace cloud_topics::read_replica

--- a/src/v/cloud_topics/read_replica/snapshot_metastore.h
+++ b/src/v/cloud_topics/read_replica/snapshot_metastore.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "cloud_topics/level_one/metastore/lsm/state_reader.h"
+#include "cloud_topics/level_one/metastore/metastore.h"
+#include "lsm/lsm.h"
+
+#include <seastar/core/gate.hh>
+
+namespace cloud_topics::read_replica {
+
+/// \brief Implements the metastore interface backed by a single LSM snapshot.
+///
+/// This is meant to be used in the context of a single partition. As such, it
+/// operates only on a single domain of the metastore.
+///
+/// Some read-oriented interface methods (extent metadata, size-based offset
+/// lookup, compaction info) are left unimplemented because they only serve
+/// write-side processes such as retention and compaction. All write methods
+/// (add_objects, replace_objects, set_start_offset, compact_objects, etc.) are
+/// also unimplemented since this is a read-only snapshot.
+class snapshot_metastore : public l1::metastore {
+public:
+    explicit snapshot_metastore(ss::gate::holder, lsm::snapshot snapshot);
+
+    ss::future<std::expected<object_response, errc>>
+    get_first_ge(const model::topic_id_partition&, kafka::offset) override;
+
+    ss::future<std::expected<std::unique_ptr<object_metadata_builder>, errc>>
+    object_builder() override;
+
+    ss::future<std::expected<offsets_response, errc>>
+    get_offsets(const model::topic_id_partition&) override;
+
+    ss::future<std::expected<size_response, errc>>
+    get_size(const model::topic_id_partition&) override;
+
+    ss::future<std::expected<add_response, errc>> add_objects(
+      const object_metadata_builder&, const term_offset_map_t&) override;
+
+    ss::future<std::expected<void, errc>>
+    replace_objects(const object_metadata_builder&) override;
+
+    ss::future<std::expected<void, errc>>
+    set_start_offset(const model::topic_id_partition&, kafka::offset) override;
+
+    ss::future<std::expected<topic_removal_response, errc>>
+    remove_topics(const chunked_vector<model::topic_id>&) override;
+
+    // Timestamp-based query - implemented for timequery support.
+    ss::future<std::expected<object_response, errc>> get_first_ge(
+      const model::topic_id_partition&,
+      kafka::offset,
+      model::timestamp) override;
+
+    ss::future<std::expected<kafka::offset, errc>> get_first_offset_for_bytes(
+      const model::topic_id_partition&, uint64_t size) override;
+
+    ss::future<std::expected<kafka::offset, errc>> get_end_offset_for_term(
+      const model::topic_id_partition&, model::term_id) override;
+
+    ss::future<std::expected<model::term_id, errc>> get_term_for_offset(
+      const model::topic_id_partition&, kafka::offset) override;
+
+    ss::future<std::expected<void, errc>> compact_objects(
+      const object_metadata_builder&, const compaction_map_t&) override;
+
+    ss::future<std::expected<compaction_info_response, errc>>
+    get_compaction_info(const compaction_info_spec&) override;
+
+    ss::future<std::expected<compaction_info_map, errc>>
+    get_compaction_infos(const chunked_vector<compaction_info_spec>&) override;
+
+    ss::future<std::expected<extent_metadata_response, errc>>
+    get_extent_metadata_forwards(
+      const model::topic_id_partition&,
+      kafka::offset,
+      kafka::offset,
+      size_t,
+      include_object_metadata) override;
+
+    ss::future<std::expected<extent_metadata_response, errc>>
+    get_extent_metadata_backwards(
+      const model::topic_id_partition&,
+      kafka::offset,
+      kafka::offset,
+      size_t) override;
+
+    ss::future<std::expected<std::nullopt_t, errc>> flush() override;
+
+    ss::future<std::expected<std::nullopt_t, errc>>
+    restore(const cloud_storage::remote_label&) override;
+
+private:
+    // Gate holder that ensures we don't destruct the owner of the underlying
+    // LSM snapshot.
+    ss::gate::holder gate_holder_;
+
+    // Reader that owns and operates on a given LSM snapshot.
+    l1::state_reader reader_;
+};
+
+} // namespace cloud_topics::read_replica

--- a/src/v/cloud_topics/read_replica/snapshot_provider.h
+++ b/src/v/cloud_topics/read_replica/snapshot_provider.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "cloud_topics/level_one/metastore/domain_uuid.h"
+#include "lsm/lsm.h"
+#include "model/fundamental.h"
+#include "utils/detailed_error.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/lowres_clock.hh>
+
+#include <expected>
+
+namespace cloud_topics::l1 {
+class io;
+} // namespace cloud_topics::l1
+
+namespace cloud_topics::read_replica {
+
+class snapshot_metastore;
+
+// Encapsulates a snapshot of a domain within a metastore, returned by a given
+// snapshot provider. Must be destroyed before the snapshot provider that
+// provided it is destroyed.
+struct snapshot_handle {
+    std::unique_ptr<snapshot_metastore> metastore;
+    std::optional<lsm::sequence_number> seqno;
+
+    // Meant to be used alongside this snapshot, with the expectation that the
+    // extents returned by `metastore` refer to objects accessible by this IO.
+    l1::io* io;
+};
+
+// Interface for providing access to state in object storage of a given
+// metastore domain with some bounded staleness.
+class snapshot_provider {
+public:
+    enum class errc {
+        io_error,
+        shutting_down,
+    };
+    using error = detailed_error<errc>;
+
+    virtual ~snapshot_provider() = default;
+    virtual ss::future<> stop() = 0;
+
+    // Returns a snapshot for the given domain and bucket that was taken at or
+    // after the given refresh time, and had a sequence number greater than or
+    // equal to that inputted.
+    //
+    // If the criteria are already met, this should return immediately with the
+    // latest snapshot. Otherwise, triggers a refresh of the underlying
+    // database and returns the latest snapshot once complete. As such, callers
+    // should be cautious about calling this with a time at or around now() to
+    // avoid constantly triggering refreshes, only doing so to ensure
+    // consistency across lifecycle events (e.g.  changing leadership,
+    // partition movement, etc).
+    //
+    // TODO: it might be nice if this didn't leak domains as an abstraction,
+    // and instead the interface took remote_label and topic_id_partition.
+    virtual ss::future<std::expected<snapshot_handle, error>> get_snapshot(
+      l1::domain_uuid domain,
+      cloud_storage_clients::bucket_name bucket,
+      ss::lowres_clock::time_point min_refresh_time,
+      std::optional<lsm::sequence_number> min_seqno,
+      ss::lowres_clock::duration timeout)
+      = 0;
+};
+
+} // namespace cloud_topics::read_replica
+
+template<>
+struct fmt::formatter<cloud_topics::read_replica::snapshot_provider::errc>
+  : fmt::formatter<std::string_view> {
+    using errc = cloud_topics::read_replica::snapshot_provider::errc;
+
+    auto format(errc e, fmt::format_context& ctx) const {
+        std::string_view name;
+        switch (e) {
+        case errc::io_error:
+            name = "io_error";
+            break;
+        case errc::shutting_down:
+            name = "shutting_down";
+            break;
+        }
+        return fmt::formatter<std::string_view>::format(name, ctx);
+    }
+};

--- a/src/v/cloud_topics/read_replica/state_refresh_loop.cc
+++ b/src/v/cloud_topics/read_replica/state_refresh_loop.cc
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/read_replica/state_refresh_loop.h"
+
+#include "bytes/iobuf.h"
+#include "cloud_topics/level_one/metastore/manifest_io.h"
+#include "cloud_topics/logger.h"
+#include "cloud_topics/read_replica/snapshot_manager.h"
+#include "cloud_topics/read_replica/snapshot_metastore.h"
+#include "cloud_topics/read_replica/stm.h"
+#include "config/configuration.h"
+#include "hashing/murmur.h"
+#include "serde/rw/rw.h"
+#include "ssx/sleep_abortable.h"
+
+#include <seastar/coroutine/as_future.hh>
+
+namespace cloud_topics::read_replica {
+
+namespace {
+state_refresh_loop::errc translate_stm_errc(stm::errc e) {
+    using enum stm::errc;
+    switch (e) {
+    case not_leader:
+        return state_refresh_loop::errc::not_leader;
+    case raft_error:
+        return state_refresh_loop::errc::replication_error;
+    case shutting_down:
+        return state_refresh_loop::errc::io_error;
+    }
+}
+
+ss::future<std::expected<update_metadata_update, state_refresh_loop::error>>
+build_update(
+  const l1::domain_uuid& domain,
+  snapshot_handle& snap,
+  const model::topic_id_partition& tidp) {
+    auto& metastore = *snap.metastore;
+    auto offsets_res = co_await metastore.get_offsets(tidp);
+    if (!offsets_res.has_value()) {
+        using enum l1::metastore::errc;
+        switch (offsets_res.error()) {
+        case missing_ntp:
+        case out_of_range:
+            // The partition isn't in the metastore (yet). Treat it as empty.
+            co_return update_metadata_update{
+              .domain = domain,
+              .seqno = snap.seqno,
+              .start_offset = kafka::offset{0},
+              .next_offset = kafka::offset{0},
+              .latest_term = model::term_id{0},
+            };
+        case invalid_request:
+        case transport_error:
+            co_return std::unexpected(
+              state_refresh_loop::error(
+                state_refresh_loop::errc::io_error,
+                "Failed to get offsets: {}",
+                offsets_res.error()));
+        }
+    }
+    auto term_res = co_await metastore.get_term_for_offset(
+      tidp, offsets_res->next_offset);
+    if (!term_res.has_value()) {
+        co_return std::unexpected(
+          state_refresh_loop::error(
+            state_refresh_loop::errc::io_error,
+            "Failed to get term: {}",
+            term_res.error()));
+    }
+    co_return update_metadata_update{
+      .domain = domain,
+      .seqno = snap.seqno,
+      .start_offset = offsets_res->start_offset,
+      .next_offset = offsets_res->next_offset,
+      .latest_term = term_res.value(),
+    };
+}
+
+} // namespace
+
+void state_refresh_loop::log_error(
+  std::string_view prefix, state_refresh_loop::error e) {
+    ss::log_level lvl{};
+    switch (e.e) {
+    case errc::metastore_manifest_error:
+        lvl = ss::log_level::error;
+        break;
+    case errc::io_error:
+    case errc::replication_error:
+        lvl = ss::log_level::warn;
+        break;
+    case errc::not_leader:
+        lvl = ss::log_level::debug;
+        break;
+    }
+    vlogl(logger_, lvl, "{}{}", prefix, e);
+}
+
+state_refresh_loop::state_refresh_loop(
+  model::term_id expected_term,
+  model::topic_id_partition tidp,
+  ss::shared_ptr<stm> stm,
+  snapshot_manager* snapshot_mgr,
+  cloud_storage_clients::bucket_name bucket,
+  cloud_storage::remote_label remote_label,
+  cloud_io::remote& remote)
+  : expected_term_(expected_term)
+  , tidp_(tidp)
+  , stm_(std::move(stm))
+  , snapshot_mgr_(snapshot_mgr)
+  , bucket_(std::move(bucket))
+  , remote_label_(remote_label)
+  , remote_(remote)
+  , metastore_manifest_io_(std::make_unique<l1::manifest_io>(remote_, bucket_))
+  , logger_(
+      cd_log,
+      fmt::format(
+        "tidp: {}, expected_term: {}, bucket: {}, remote label: {}",
+        tidp,
+        expected_term_,
+        bucket,
+        remote_label_)) {}
+
+state_refresh_loop::~state_refresh_loop() = default;
+
+void state_refresh_loop::start() {
+    ssx::spawn_with_gate(gate_, [this] { return run_loop(); });
+}
+
+ss::future<> state_refresh_loop::stop_and_wait() {
+    as_.request_abort();
+    co_await gate_.close();
+}
+
+ss::future<> state_refresh_loop::run_loop() {
+    auto sync_interval
+      = config::shard_local_cfg()
+          .cloud_storage_readreplica_manifest_sync_timeout_ms();
+    auto log_exit = ss::defer([&] { vlog(logger_.debug, "Exiting loop"); });
+
+    // First, if we haven't replicated anything before, figure out what domain
+    // this partition should sync with.
+    l1::domain_uuid domain = stm_->domain();
+    while (domain().is_nil() && !as_.abort_requested() && is_leader()) {
+        auto domain_res = co_await discover_domain();
+        if (!domain_res) {
+            log_error("Failed to discover domain: ", domain_res.error());
+            co_await ssx::sleep_abortable(1s, as_);
+            continue;
+        }
+        domain = domain_res.value();
+    }
+
+    // Refresh right away, given we just became leader and want to get an
+    // up-to-date view of state.
+    auto next_min_refresh = ss::lowres_clock::now();
+    while (!as_.abort_requested() && is_leader()) {
+        auto sync_res = co_await refresh_state_from_cloud(
+          domain, next_min_refresh);
+        if (!sync_res) {
+            log_error("Failed to sync metadata: ", sync_res.error());
+            co_await ssx::sleep_abortable(1s, as_);
+            continue;
+        }
+        // Now that we've replicated, cache the time so that in our next
+        // iteration (after sleeping) we'll get a fresher snapshot than the one
+        // we just refreshed with, but one not so new that we're constantly
+        // forcing a database refresh.
+        next_min_refresh = ss::lowres_clock::now();
+        co_await ssx::sleep_abortable(sync_interval, as_);
+    }
+}
+
+bool state_refresh_loop::is_leader() const {
+    auto raft = stm_->raft();
+    return raft->is_leader() && raft->confirmed_term() == expected_term_;
+}
+
+ss::future<std::expected<l1::domain_uuid, state_refresh_loop::error>>
+state_refresh_loop::discover_domain() {
+    vlog(logger_.debug, "Discovering domain");
+    auto manifest_res = co_await metastore_manifest_io_
+                          ->download_metastore_manifest(remote_label_);
+    if (!manifest_res.has_value()) {
+        errc out_e{};
+        switch (manifest_res.error().e) {
+            using enum l1::manifest_io::errc;
+        case not_found:
+        case timedout:
+        case failed:
+            out_e = errc::io_error;
+            break;
+        case shutting_down:
+            out_e = errc::not_leader;
+            break;
+        }
+        co_return std::unexpected(
+          std::move(manifest_res.error())
+            .wrap(std::move(out_e), "Failed to download metastore manifest"));
+    }
+
+    auto& manifest = manifest_res.value();
+    if (manifest.domains.empty()) {
+        co_return std::unexpected(error(
+          errc::metastore_manifest_error, "Metastore manifest has no domains"));
+    }
+    if (manifest.partitioning_strategy != "murmur") {
+        co_return std::unexpected(error(
+          errc::metastore_manifest_error,
+          "Unsupported partitioning strategy in manifest: {}",
+          manifest.partitioning_strategy));
+    }
+
+    // Hash the topic_id_partition to find the domain index
+    iobuf temp;
+    serde::write(temp, tidp_);
+    auto bytes = iobuf_to_bytes(temp);
+    auto idx = murmur2(bytes.data(), bytes.size()) % manifest.domains.size();
+    auto domain = manifest.domains[idx];
+    vlog(
+      logger_.debug,
+      "Discovered domain {} (index {} of {})",
+      domain,
+      idx,
+      manifest.domains.size());
+    co_return domain;
+}
+
+ss::future<std::expected<void, state_refresh_loop::error>>
+state_refresh_loop::refresh_state_from_cloud(
+  l1::domain_uuid domain, ss::lowres_clock::time_point min_refresh_time) {
+    auto term_res = co_await stm_->sync(std::chrono::seconds(30), as_);
+    if (!term_res.has_value()) {
+        auto e = translate_stm_errc(term_res.error().e);
+        co_return std::unexpected(
+          std::move(term_res.error())
+            .wrap(std::move(e), "Failed to sync for term {}", expected_term_));
+    }
+    if (term_res.value() != expected_term_) {
+        co_return std::unexpected(error(
+          errc::not_leader,
+          "Current term: {}, expected: {}",
+          term_res.value(),
+          expected_term_));
+    }
+    auto sync_interval
+      = config::shard_local_cfg()
+          .cloud_storage_readreplica_manifest_sync_timeout_ms();
+    auto last_seqno = stm_->get_state().seqno;
+    auto snapshot_res = co_await snapshot_mgr_->get_snapshot(
+      domain, bucket_, min_refresh_time, last_seqno, sync_interval);
+    if (!snapshot_res.has_value()) {
+        co_return std::unexpected(
+          state_refresh_loop::error(
+            state_refresh_loop::errc::io_error,
+            "Failed to get snapshot: {}",
+            snapshot_res.error()));
+    }
+    auto build_res = co_await build_update(domain, snapshot_res.value(), tidp_);
+    if (!build_res.has_value()) {
+        co_return std::unexpected(build_res.error());
+    }
+    auto& update = build_res.value();
+
+    const auto& state = stm_->get_state();
+    if (!update.can_apply(state)) {
+        vlog(
+          logger_.debug,
+          "Metadata update can't be updated, likely a no-op: update: {}, "
+          "state: {}",
+          update,
+          state);
+        co_return std::expected<void, state_refresh_loop::error>();
+    }
+    auto replicate_res = co_await stm_->update(
+      expected_term_, std::move(update), as_);
+    if (!replicate_res.has_value()) {
+        auto e = translate_stm_errc(replicate_res.error().e);
+        co_return std::unexpected(
+          state_refresh_loop::error(
+            e, "Failed to replicate metadata: {}", replicate_res.error()));
+    }
+
+    co_return std::expected<void, state_refresh_loop::error>();
+}
+
+} // namespace cloud_topics::read_replica

--- a/src/v/cloud_topics/read_replica/state_refresh_loop.h
+++ b/src/v/cloud_topics/read_replica/state_refresh_loop.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "cloud_storage/remote_label.h"
+#include "cloud_topics/read_replica/stm.h"
+#include "utils/detailed_error.h"
+#include "utils/prefix_logger.h"
+
+namespace cloud_io {
+class remote;
+} // namespace cloud_io
+
+namespace cloud_topics::l1 {
+class manifest_io;
+} // namespace cloud_topics::l1
+
+namespace cloud_topics::read_replica {
+
+class snapshot_manager;
+
+// Loop that runs for the duration of a given term on the leader. This loop is
+// in charge of reading state from object storage about the given partition and
+// replicating that state via the state machine.
+class state_refresh_loop {
+public:
+    enum class errc {
+        metastore_manifest_error,
+        replication_error,
+        io_error,
+        not_leader,
+    };
+    using error = detailed_error<errc>;
+    state_refresh_loop(
+      model::term_id expected_term,
+      model::topic_id_partition tidp,
+      ss::shared_ptr<stm> stm,
+      snapshot_manager* snapshot_mgr,
+      cloud_storage_clients::bucket_name bucket,
+      cloud_storage::remote_label remote_label,
+      cloud_io::remote& remote);
+
+    ~state_refresh_loop();
+
+    void start();
+    ss::future<> stop_and_wait();
+
+private:
+    bool is_leader() const;
+    void log_error(std::string_view prefix, error);
+
+    // Runs a loop that periodically gets a snapshot, determines the partition
+    // state with it, and replicates the state so that it can be used to serve
+    // the synchronous bits of the Kafka API.
+    ss::future<> run_loop();
+
+    // Discover the domain UUID for this partition from the source cluster's
+    // metastore manifest.
+    ss::future<std::expected<l1::domain_uuid, error>> discover_domain();
+
+    // Read state from cloud database and replicate to STM.
+    ss::future<std::expected<void, error>> refresh_state_from_cloud(
+      l1::domain_uuid domain, ss::lowres_clock::time_point min_refresh_time);
+
+    ss::gate gate_;
+    ss::abort_source as_;
+    model::term_id expected_term_;
+    model::topic_id_partition tidp_;
+    ss::shared_ptr<stm> stm_;
+    snapshot_manager* snapshot_mgr_;
+    cloud_storage_clients::bucket_name bucket_;
+    cloud_storage::remote_label remote_label_;
+    cloud_io::remote& remote_;
+    std::unique_ptr<l1::manifest_io> metastore_manifest_io_;
+    prefix_logger logger_;
+};
+
+} // namespace cloud_topics::read_replica
+
+template<>
+struct fmt::formatter<cloud_topics::read_replica::state_refresh_loop::errc>
+  : fmt::formatter<std::string_view> {
+    using errc = cloud_topics::read_replica::state_refresh_loop::errc;
+
+    auto format(errc e, fmt::format_context& ctx) const {
+        std::string_view name;
+        switch (e) {
+        case errc::metastore_manifest_error:
+            name = "metastore_manifest_error";
+            break;
+        case errc::replication_error:
+            name = "replication_error";
+            break;
+        case errc::io_error:
+            name = "io_error";
+            break;
+        case errc::not_leader:
+            name = "not_leader";
+            break;
+        }
+        return fmt::formatter<std::string_view>::format(name, ctx);
+    }
+};

--- a/src/v/cloud_topics/read_replica/stm.cc
+++ b/src/v/cloud_topics/read_replica/stm.cc
@@ -11,8 +11,10 @@
 #include "cloud_topics/read_replica/stm.h"
 
 #include "cloud_topics/logger.h"
+#include "model/batch_builder.h"
 #include "model/record_batch_types.h"
 #include "serde/async.h"
+#include "serde/rw/rw.h"
 #include "ssx/future-util.h"
 
 #include <seastar/coroutine/as_future.hh>
@@ -112,6 +114,21 @@ ss::future<std::expected<model::term_id, stm::error>> stm::sync(
         co_return std::unexpected(error(errc::not_leader, "Failed to sync"));
     }
     co_return _insync_term;
+}
+
+ss::future<std::expected<model::offset, stm::error>> stm::update(
+  model::term_id term, update_metadata_update update, ss::abort_source& as) {
+    iobuf key_buf;
+    serde::write(key_buf, update_key::update_metadata);
+    iobuf value_buf;
+    serde::write(value_buf, update);
+    model::batch_builder builder;
+    builder.set_batch_type(model::record_batch_type::ct_read_replica_stm);
+    builder.set_base_offset(model::offset{0});
+    builder.add_record(
+      {.key = std::move(key_buf), .value = std::move(value_buf)});
+    auto batch = builder.build_sync();
+    co_return co_await replicate_and_wait(term, std::move(batch), as);
 }
 
 ss::future<std::expected<model::offset, stm::error>> stm::replicate_and_wait(

--- a/src/v/cloud_topics/read_replica/stm.h
+++ b/src/v/cloud_topics/read_replica/stm.h
@@ -121,13 +121,6 @@ public:
       std::optional<std::reference_wrapper<ss::abort_source>> as
       = std::nullopt);
 
-    // Replicates the given batch and waits for it to finish applying.
-    // Success indicates the batch was replicated and applied, but does not
-    // guarantee the update semantically succeeded (e.g., if it was rejected
-    // due to stale data).
-    ss::future<std::expected<model::offset, error>> replicate_and_wait(
-      model::term_id term, model::record_batch batch, ss::abort_source& as);
-
     // Accessors for current state.
     const state& get_state() const { return state_; }
     l1::domain_uuid domain() const { return state_.domain; }
@@ -137,6 +130,13 @@ public:
     get_initial_recovery_policy() const final {
         return raft::stm_initial_recovery_policy::read_everything;
     }
+
+    /// Serializes the update into a record batch and replicates it through
+    /// Raft. Waits for the batch to be applied before returning. The update
+    /// is applied only if can_apply() passes during do_apply(); callers
+    /// should check can_apply() beforehand to avoid unnecessary replication.
+    ss::future<std::expected<model::offset, error>>
+    update(model::term_id term, update_metadata_update, ss::abort_source& as);
 
 protected:
     ss::future<> do_apply(const model::record_batch&) override;
@@ -152,6 +152,13 @@ protected:
     ss::future<iobuf> take_raft_snapshot() final;
 
 private:
+    // Replicates the given batch and waits for it to finish applying.
+    // Success indicates the batch was replicated and applied, but does not
+    // guarantee the update semantically succeeded (e.g., if it was rejected
+    // due to stale data).
+    ss::future<std::expected<model::offset, error>> replicate_and_wait(
+      model::term_id term, model::record_batch batch, ss::abort_source& as);
+
     // The deterministic state managed by this STM.
     state state_;
 };

--- a/src/v/cloud_topics/read_replica/tests/BUILD
+++ b/src/v/cloud_topics/read_replica/tests/BUILD
@@ -1,0 +1,49 @@
+load("//bazel:test.bzl", "redpanda_cc_gtest", "redpanda_test_cc_library")
+
+redpanda_test_cc_library(
+    name = "db_utils",
+    hdrs = [
+        "db_utils.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/cloud_io:remote",
+        "//src/v/cloud_storage_clients",
+        "//src/v/cloud_topics/level_one/metastore:domain_uuid",
+        "//src/v/cloud_topics/level_one/metastore/lsm:state_reader",
+        "//src/v/cloud_topics/level_one/metastore/lsm:state_update",
+        "//src/v/cloud_topics/level_one/metastore/lsm:write_batch_row",
+        "//src/v/container:chunked_hash_map",
+        "//src/v/lsm",
+        "//src/v/lsm/io:cloud_persistence",
+        "//src/v/model",
+        "//src/v/ssx:time",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "snapshot_manager_test",
+    timeout = "short",
+    srcs = [
+        "snapshot_manager_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        ":db_utils",
+        "//src/v/cloud_io:remote",
+        "//src/v/cloud_io/tests:s3_imposter",
+        "//src/v/cloud_io/tests:scoped_remote",
+        "//src/v/cloud_topics/level_one/metastore:domain_uuid",
+        "//src/v/cloud_topics/read_replica:snapshot_manager",
+        "//src/v/cloud_topics/read_replica:snapshot_metastore",
+        "//src/v/lsm",
+        "//src/v/test_utils:gtest",
+        "//src/v/test_utils:scoped_config",
+        "//src/v/test_utils:tmp_dir",
+        "@googletest//:gtest",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/cloud_topics/read_replica/tests/BUILD
+++ b/src/v/cloud_topics/read_replica/tests/BUILD
@@ -47,3 +47,36 @@ redpanda_cc_gtest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "state_refresh_loop_test",
+    timeout = "short",
+    srcs = [
+        "state_refresh_loop_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        ":db_utils",
+        "//src/v/cloud_io:remote",
+        "//src/v/cloud_io/tests:s3_imposter",
+        "//src/v/cloud_io/tests:scoped_remote",
+        "//src/v/cloud_storage_clients",
+        "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics/level_one/metastore:domain_uuid",
+        "//src/v/cloud_topics/level_one/metastore:manifest_io",
+        "//src/v/cloud_topics/level_one/metastore:metastore_manifest",
+        "//src/v/cloud_topics/level_one/metastore:state_update",
+        "//src/v/cloud_topics/read_replica:snapshot_manager",
+        "//src/v/cloud_topics/read_replica:state_refresh_loop",
+        "//src/v/cloud_topics/read_replica:stm",
+        "//src/v/lsm",
+        "//src/v/raft/tests:raft_fixture",
+        "//src/v/test_utils:async",
+        "//src/v/test_utils:gtest",
+        "//src/v/test_utils:scoped_config",
+        "//src/v/test_utils:tmp_dir",
+        "@googletest//:gtest",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/cloud_topics/read_replica/tests/db_utils.h
+++ b/src/v/cloud_topics/read_replica/tests/db_utils.h
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "cloud_io/remote.h"
+#include "cloud_storage_clients/types.h"
+#include "cloud_topics/level_one/metastore/domain_uuid.h"
+#include "cloud_topics/level_one/metastore/lsm/state_reader.h"
+#include "cloud_topics/level_one/metastore/lsm/state_update.h"
+#include "cloud_topics/level_one/metastore/lsm/write_batch_row.h"
+#include "container/chunked_hash_map.h"
+#include "lsm/io/cloud_persistence.h"
+#include "lsm/lsm.h"
+#include "model/fundamental.h"
+#include "ssx/time.h"
+
+#include <seastar/core/future.hh>
+
+#include <filesystem>
+#include <optional>
+
+using namespace std::chrono_literals;
+
+namespace cloud_topics::read_replica::test_utils {
+
+// Opens or retrieves a cached writer database for the given domain.
+inline ss::future<lsm::database*> get_or_create_writer_db(
+  l1::domain_uuid domain,
+  const std::filesystem::path& staging_base,
+  cloud_io::remote* remote,
+  const cloud_storage_clients::bucket_name& bucket,
+  chunked_hash_map<l1::domain_uuid, std::unique_ptr<lsm::database>>& dbs) {
+    lsm::internal::database_epoch epoch = lsm::internal::database_epoch{1};
+    auto it = dbs.find(domain);
+    if (it != dbs.end()) {
+        co_return it->second.get();
+    }
+
+    auto cloud_prefix = l1::domain_cloud_prefix(domain);
+    cloud_storage_clients::object_key domain_prefix{cloud_prefix};
+
+    auto data_persist = co_await lsm::io::open_cloud_data_persistence(
+      staging_base, remote, bucket, domain_prefix, ss::sstring(domain()));
+    auto meta_persist = co_await lsm::io::open_cloud_metadata_persistence(
+      remote, bucket, domain_prefix);
+
+    lsm::io::persistence io{
+      .data = std::move(data_persist),
+      .metadata = std::move(meta_persist),
+    };
+
+    auto db = co_await lsm::database::open(
+      lsm::options{
+        .database_epoch = epoch,
+        .readonly = false,
+      },
+      std::move(io));
+
+    auto [db_it, inserted] = dbs.emplace(
+      domain, std::make_unique<lsm::database>(std::move(db)));
+    co_return db_it->second.get();
+}
+
+// Writes L1 metastore data with semantic offset tracking. Creates one
+// new_object with one extent and term state. Offsets are expected to be
+// contiguous with previous writes.
+inline ss::future<lsm::sequence_number> write_metastore_data(
+  lsm::database* db,
+  const model::topic_id_partition& tidp,
+  kafka::offset base_offset,
+  kafka::offset last_offset,
+  model::term_id term,
+  std::optional<ss::lowres_clock::duration> flush_timeout = std::nullopt) {
+    l1::new_object new_obj;
+    new_obj.oid = l1::object_id{uuid_t::create()};
+    new_obj.footer_pos = 1000;
+    new_obj.object_size = 2000;
+
+    // Build the objects.
+    l1::new_object::metadata extent_meta{
+      .base_offset = base_offset,
+      .last_offset = last_offset,
+      .max_timestamp = model::timestamp::now(),
+      .filepos = 0,
+      .len = 1000,
+    };
+    new_obj.extent_metas[tidp.topic_id].emplace(tidp.partition, extent_meta);
+
+    // Build the terms.
+    l1::term_state_update_t term_updates;
+    term_updates[tidp].push_back(
+      l1::term_start{
+        .term_id = term,
+        .start_offset = base_offset,
+      });
+
+    // Pre-register the object so add_objects can reference it.
+    l1::preregister_objects_db_update prereg;
+    prereg.object_ids.push_back(new_obj.oid);
+    prereg.registered_at = model::timestamp::now();
+    {
+        auto snap = db->create_snapshot();
+        l1::state_reader reader(std::move(snap));
+        chunked_vector<l1::write_batch_row> rows;
+        auto result = co_await prereg.build_rows(reader, rows);
+        if (!result.has_value()) {
+            throw std::runtime_error(
+              fmt::format(
+                "Failed to build preregister rows: {}", result.error()));
+        }
+        auto current_seqno = db->max_applied_seqno().value_or(
+          lsm::sequence_number{0});
+        auto wb = db->create_write_batch();
+        for (auto& row : rows) {
+            current_seqno = lsm::sequence_number{current_seqno() + 1};
+            wb.put(row.key, std::move(row.value), current_seqno);
+        }
+        co_await db->apply(std::move(wb));
+    }
+
+    l1::add_objects_db_update update;
+    update.new_objects.push_back(std::move(new_obj));
+    update.new_terms = std::move(term_updates);
+
+    // Build the rows for our update.
+    auto snap = db->create_snapshot();
+    l1::state_reader reader(std::move(snap));
+    chunked_vector<l1::write_batch_row> rows;
+    auto build_result = co_await update.build_rows(reader, rows);
+    if (!build_result.has_value()) {
+        throw std::runtime_error(
+          fmt::format("Failed to build rows: {}", build_result.error()));
+    }
+    // Write the rows to the DB and flush to ensure the update lands in
+    // object storage.
+    auto current_seqno = db->max_applied_seqno().value_or(
+      lsm::sequence_number{0});
+    auto wb = db->create_write_batch();
+    for (auto& row : rows) {
+        current_seqno = lsm::sequence_number{current_seqno() + 1};
+        wb.put(row.key, std::move(row.value), current_seqno);
+    }
+    co_await db->apply(std::move(wb));
+    auto timeout = flush_timeout.value_or(30s);
+    auto deadline = ssx::instant::from_chrono(
+      ss::lowres_clock::now() + timeout);
+    co_await db->flush(deadline);
+    co_return current_seqno;
+}
+
+} // namespace cloud_topics::read_replica::test_utils

--- a/src/v/cloud_topics/read_replica/tests/snapshot_manager_test.cc
+++ b/src/v/cloud_topics/read_replica/tests/snapshot_manager_test.cc
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_io/tests/s3_imposter.h"
+#include "cloud_io/tests/scoped_remote.h"
+#include "cloud_topics/level_one/metastore/domain_uuid.h"
+#include "cloud_topics/read_replica/snapshot_manager.h"
+#include "cloud_topics/read_replica/snapshot_metastore.h"
+#include "cloud_topics/read_replica/tests/db_utils.h"
+#include "lsm/lsm.h"
+#include "test_utils/tmp_dir.h"
+
+#include <seastar/core/coroutine.hh>
+
+#include <gtest/gtest.h>
+
+using namespace cloud_topics;
+
+using namespace std::chrono_literals;
+
+namespace {
+
+const auto domain = l1::domain_uuid(uuid_t::create());
+const auto test_tidp = model::topic_id_partition{
+  model::topic_id{uuid_t::create()}, model::partition_id{0}};
+using o = kafka::offset;
+
+} // namespace
+class SnapshotManagerTest
+  : public ::testing::Test
+  , public s3_imposter_fixture {
+public:
+    void SetUp() override {
+        set_expectations_and_listen({});
+        sr_ = cloud_io::scoped_remote::create(10, conf);
+        config::shard_local_cfg()
+          .cloud_storage_readreplica_manifest_sync_timeout_ms.set_value(500ms);
+        staging_dir_ = std::make_unique<temporary_dir>("snapshot_manager_test");
+
+        // Writer and reader use separate staging directories - they communicate
+        // only through S3.
+        writer_staging_dir_ = staging_dir_->get_path() / "writer";
+        reader_staging_dir_ = staging_dir_->get_path() / "reader";
+        snapshot_mgr_ = std::make_unique<read_replica::snapshot_manager>(
+          reader_staging_dir_, &sr_->remote.local(), nullptr);
+    }
+
+    void TearDown() override {
+        for (auto& [domain, db_ptr] : writer_dbs_) {
+            db_ptr->close().get();
+        }
+        writer_dbs_.clear();
+        if (snapshot_mgr_) {
+            snapshot_mgr_->stop().get();
+            snapshot_mgr_.reset();
+        }
+        sr_.reset();
+    }
+
+    // Helper to write data to a domain's database using L1 metastore semantics
+    ss::future<lsm::sequence_number>
+    write_data(l1::domain_uuid domain, kafka::offset base, kafka::offset last) {
+        auto* db = co_await read_replica::test_utils::get_or_create_writer_db(
+          domain,
+          writer_staging_dir_,
+          &sr_->remote.local(),
+          bucket_name,
+          writer_dbs_);
+        // Convert start_idx and count to kafka offsets
+        co_return co_await read_replica::test_utils::write_metastore_data(
+          db, test_tidp, base, last, model::term_id{1});
+    }
+
+    ss::future<> close_writer(l1::domain_uuid domain) {
+        auto it = writer_dbs_.find(domain);
+        if (it != writer_dbs_.end()) {
+            co_await it->second->close();
+            writer_dbs_.erase(it);
+        }
+    }
+
+    ss::future<std::expected<
+      read_replica::snapshot_handle,
+      read_replica::snapshot_provider::error>>
+    get_snapshot(
+      l1::domain_uuid domain,
+      ss::lowres_clock::time_point min_refresh_time
+      = ss::lowres_clock::time_point::min(),
+      std::optional<lsm::sequence_number> min_seqno = std::nullopt,
+      ss::lowres_clock::duration timeout = 2s) {
+        co_return co_await snapshot_mgr_->get_snapshot(
+          domain, bucket_name, min_refresh_time, min_seqno, timeout);
+    }
+
+    read_replica::snapshot_handle check_get_snapshot(
+      l1::domain_uuid domain,
+      ss::lowres_clock::time_point min_refresh_time
+      = ss::lowres_clock::time_point::min(),
+      std::optional<lsm::sequence_number> min_seqno = std::nullopt,
+      ss::lowres_clock::duration timeout = 2s) {
+        auto res
+          = get_snapshot(domain, min_refresh_time, min_seqno, timeout).get();
+        EXPECT_TRUE(res.has_value()) << fmt::format("Error: {}", res.error());
+        return std::move(res.value());
+    }
+
+protected:
+    std::unique_ptr<temporary_dir> staging_dir_;
+    std::filesystem::path writer_staging_dir_;
+    std::filesystem::path reader_staging_dir_;
+    std::unique_ptr<cloud_io::scoped_remote> sr_;
+    std::unique_ptr<read_replica::snapshot_manager> snapshot_mgr_;
+    chunked_hash_map<l1::domain_uuid, std::unique_ptr<lsm::database>>
+      writer_dbs_;
+};
+
+TEST_F(SnapshotManagerTest, WaitForRefreshSeqnoNotNewEnough) {
+    auto initial_seqno = write_data(domain, o{0}, o{3}).get();
+
+    // Get initial snapshot.
+    auto s1 = check_get_snapshot(domain);
+    EXPECT_EQ(s1.seqno, initial_seqno);
+    auto refresh_time_1 = snapshot_mgr_->last_refresh_time(domain);
+    ASSERT_TRUE(refresh_time_1.has_value());
+
+    // Write more data to increase seqno and get another snapshot at that
+    // snapshot.
+    auto new_seqno = write_data(domain, o{4}, o{5}).get();
+    EXPECT_GT(new_seqno, initial_seqno);
+    auto s2 = check_get_snapshot(
+      domain, ss::lowres_clock::time_point::min(), new_seqno);
+    EXPECT_EQ(s2.seqno, new_seqno);
+
+    // Refresh time should advance because we requested a newer seqno.
+    auto refresh_time_2 = snapshot_mgr_->last_refresh_time(domain);
+    ASSERT_TRUE(refresh_time_2.has_value());
+    EXPECT_GT(*refresh_time_2, *refresh_time_1);
+}
+
+TEST_F(SnapshotManagerTest, WaitForRefreshTimeNotNewEnough) {
+    write_data(domain, o{0}, o{3}).get();
+
+    // Get initial snapshot.
+    auto s1 = check_get_snapshot(domain);
+    auto refresh_time_1 = snapshot_mgr_->last_refresh_time(domain);
+    ASSERT_TRUE(refresh_time_1.has_value());
+
+    // Write more data
+    auto new_seqno = write_data(domain, o{4}, o{5}).get();
+    EXPECT_GT(new_seqno, s1.seqno);
+
+    // Request snapshot with a time that it definitely doesn't have (some time
+    // in the future). This should trigger a refresh.
+    auto future_time = ss::lowres_clock::now() + 200ms;
+    auto s2 = check_get_snapshot(domain, future_time);
+    EXPECT_EQ(s2.seqno, new_seqno);
+
+    // Refresh time should advance because we requested a newer refresh time.
+    auto refresh_time_2 = snapshot_mgr_->last_refresh_time(domain);
+    ASSERT_TRUE(refresh_time_2.has_value());
+    EXPECT_GT(*refresh_time_2, *refresh_time_1);
+}
+
+TEST_F(SnapshotManagerTest, WaitForRefreshTimeoutWhenSeqnoUnavailable) {
+    auto initial_seqno = write_data(domain, o{0}, o{3}).get();
+    check_get_snapshot(domain);
+    auto refresh_time_before = snapshot_mgr_->last_refresh_time(domain);
+    ASSERT_TRUE(refresh_time_before.has_value());
+
+    // Request an impossibly high seqno. This should time out.
+    auto impossible_seqno = lsm::sequence_number{initial_seqno() + 1000};
+    auto res
+      = get_snapshot(
+          domain, ss::lowres_clock::time_point::min(), impossible_seqno, 50ms)
+          .get();
+    ASSERT_FALSE(res.has_value());
+    EXPECT_EQ(res.error().e, read_replica::snapshot_provider::errc::io_error);
+
+    // Even if we didn't get a new enough snapshot, we should have still
+    // triggered a refresh.
+    auto refresh_time_after = snapshot_mgr_->last_refresh_time(domain);
+    ASSERT_TRUE(refresh_time_after.has_value());
+    EXPECT_GE(*refresh_time_after, *refresh_time_before);
+}
+
+TEST_F(SnapshotManagerTest, NoWaitSnapshotAlreadyAvailable) {
+    auto seqno = write_data(domain, o{0}, o{3}).get();
+    auto s1 = check_get_snapshot(domain);
+    EXPECT_EQ(s1.seqno, seqno);
+
+    auto refresh_time_1 = snapshot_mgr_->last_refresh_time(domain);
+    ASSERT_TRUE(refresh_time_1.has_value());
+
+    // Get a snapshot with a refresh time we know we have already.
+    auto s2 = check_get_snapshot(domain, *refresh_time_1);
+    EXPECT_EQ(s1.seqno, s2.seqno);
+
+    // Refresh time should be unchanged (no refresh occurred).
+    auto refresh_time_2 = snapshot_mgr_->last_refresh_time(domain);
+    EXPECT_EQ(refresh_time_1, refresh_time_2);
+
+    // Now try with a seqno we know we already have. This should also not
+    // trigger a refresh.
+    auto s3 = check_get_snapshot(
+      domain, ss::lowres_clock::time_point::min(), seqno);
+    EXPECT_EQ(s3.seqno, seqno);
+    auto refresh_time_3 = snapshot_mgr_->last_refresh_time(domain);
+    EXPECT_EQ(refresh_time_1, refresh_time_3);
+}
+
+TEST_F(SnapshotManagerTest, IdleCleanup_AfterTimeout) {
+    write_data(domain, o{0}, o{3}).get();
+
+    ss::lowres_clock::time_point refresh_time_1;
+    {
+        auto s = check_get_snapshot(domain);
+        refresh_time_1 = *snapshot_mgr_->last_refresh_time(domain);
+        // Destruct the snapshot handle.
+    }
+    // Wait for idle timer to fire, letting the database refresher shutdown.
+    ss::sleep(2s).get();
+
+    // Access again. We should have cleaned up the database, and therefore
+    // required a refresh.
+    check_get_snapshot(domain);
+    auto refresh_time_2 = snapshot_mgr_->last_refresh_time(domain);
+    ASSERT_TRUE(refresh_time_2.has_value());
+    EXPECT_GT(*refresh_time_2, refresh_time_1);
+}
+
+TEST_F(SnapshotManagerTest, ConcurrentFirstTimeCallsShareRefresh) {
+    write_data(domain, o{0}, o{3}).get();
+
+    auto future_time = ss::lowres_clock::now() + 200ms;
+    auto fut1 = get_snapshot(domain, future_time);
+    auto fut2 = get_snapshot(domain, future_time);
+    auto fut3 = get_snapshot(domain, future_time);
+    auto s1 = std::move(fut1).get();
+    auto s2 = std::move(fut2).get();
+    auto s3 = std::move(fut3).get();
+
+    ASSERT_TRUE(s1.has_value());
+    ASSERT_TRUE(s2.has_value());
+    ASSERT_TRUE(s3.has_value());
+
+    // All should have the same seqno.
+    EXPECT_EQ(s1->seqno, s2->seqno);
+    EXPECT_EQ(s2->seqno, s3->seqno);
+}
+
+TEST_F(SnapshotManagerTest, GetSnapshotAfterStopReturnsError) {
+    write_data(domain, o{0}, o{3}).get();
+    close_writer(domain).get();
+
+    // Stop the snapshot manager.
+    snapshot_mgr_->stop().get();
+    auto cleanup = ss::defer([this] { snapshot_mgr_.reset(); });
+
+    auto res = get_snapshot(domain).get();
+    ASSERT_FALSE(res.has_value());
+    EXPECT_EQ(
+      res.error().e, read_replica::snapshot_provider::errc::shutting_down);
+}

--- a/src/v/cloud_topics/read_replica/tests/state_refresh_loop_test.cc
+++ b/src/v/cloud_topics/read_replica/tests/state_refresh_loop_test.cc
@@ -1,0 +1,384 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_io/remote.h"
+#include "cloud_io/tests/s3_imposter.h"
+#include "cloud_io/tests/scoped_remote.h"
+#include "cloud_topics/level_one/metastore/domain_uuid.h"
+#include "cloud_topics/level_one/metastore/manifest_io.h"
+#include "cloud_topics/level_one/metastore/metastore_manifest.h"
+#include "cloud_topics/logger.h"
+#include "cloud_topics/read_replica/snapshot_manager.h"
+#include "cloud_topics/read_replica/state_refresh_loop.h"
+#include "cloud_topics/read_replica/stm.h"
+#include "cloud_topics/read_replica/tests/db_utils.h"
+#include "lsm/lsm.h"
+#include "raft/tests/raft_fixture.h"
+#include "test_utils/async.h"
+#include "test_utils/scoped_config.h"
+#include "test_utils/test.h"
+#include "test_utils/tmp_dir.h"
+
+#include <seastar/core/coroutine.hh>
+
+#include <gmock/gmock.h>
+
+using namespace cloud_topics;
+using namespace cloud_topics::read_replica;
+using namespace std::chrono_literals;
+
+namespace {
+
+using o = kafka::offset;
+
+auto state_matches(
+  const l1::domain_uuid& expected_domain,
+  std::optional<lsm::sequence_number> expected_seqno,
+  kafka::offset expected_start_offset,
+  kafka::offset expected_next_offset,
+  model::term_id expected_term) {
+    using testing::AllOf;
+    using testing::Eq;
+    using testing::Field;
+    using testing::Optional;
+
+    return AllOf(
+      Field("domain", &state::domain, Eq(expected_domain)),
+      Field("seqno", &state::seqno, Eq(expected_seqno)),
+      Field("start_offset", &state::start_offset, Eq(expected_start_offset)),
+      Field("next_offset", &state::next_offset, Eq(expected_next_offset)),
+      Field("latest_term", &state::latest_term, Eq(expected_term)));
+}
+
+class StateRefreshLoopTest
+  : public raft::stm_raft_fixture<stm>
+  , public s3_imposter_fixture {
+public:
+    StateRefreshLoopTest()
+      : reader_staging_base_dir_("state_refresh_loop_test") {}
+
+    struct refresh_node {
+        ss::shared_ptr<stm> stm_ptr;
+        cloud_io::remote* remote;
+        const cloud_storage_clients::bucket_name& bucket;
+        std::filesystem::path staging_path;
+        ss::abort_source as;
+        std::unique_ptr<snapshot_manager> snapshot_mgr;
+        std::unique_ptr<state_refresh_loop> refresh_loop;
+
+        refresh_node(
+          ss::shared_ptr<stm> stm,
+          cloud_io::remote* r,
+          const cloud_storage_clients::bucket_name& b,
+          std::filesystem::path staging)
+          : stm_ptr(std::move(stm))
+          , remote(r)
+          , bucket(b)
+          , staging_path(std::move(staging)) {
+            snapshot_mgr = std::make_unique<snapshot_manager>(
+              staging_path, remote, nullptr);
+        }
+
+        void start_refresh_loop(
+          model::term_id term,
+          const model::topic_id_partition& tidp,
+          const cloud_storage::remote_label& remote_label) {
+            refresh_loop = std::make_unique<state_refresh_loop>(
+              term,
+              tidp,
+              stm_ptr,
+              snapshot_mgr.get(),
+              bucket,
+              remote_label,
+              *remote);
+            refresh_loop->start();
+        }
+
+        ss::future<> stop_refresh_loop() {
+            if (refresh_loop) {
+                co_await refresh_loop->stop_and_wait();
+                refresh_loop.reset();
+            }
+        }
+
+        ss::future<> stop_snapshot_mgr() {
+            if (snapshot_mgr) {
+                co_await snapshot_mgr->stop();
+            }
+        }
+    };
+
+    void SetUp() override {
+        set_expectations_and_listen({});
+
+        cfg_.get("election_timeout_ms").set_value(1000ms);
+        cfg_.get("raft_heartbeat_interval_ms").set_value(100ms);
+        cfg_.get("cloud_storage_readreplica_manifest_sync_timeout_ms")
+          .set_value(100ms);
+
+        sr_ = cloud_io::scoped_remote::create(10, conf);
+
+        test_tidp_ = model::topic_id_partition{
+          model::topic_id{uuid_t::create()}, model::partition_id{0}};
+        test_remote_label_ = cloud_storage::remote_label{
+          model::cluster_uuid{uuid_t::create()}};
+
+        writer_staging_dir_ = std::filesystem::path{"state_refresh_loop_test"}
+                              / "writer";
+
+        // Call base class SetUpAsync to initialize raft fixture
+        raft::raft_fixture::SetUpAsync().get();
+
+        // Create nodes with STMs
+        for (auto i = 0; i < 3; ++i) {
+            add_node(model::node_id(i), model::revision_id(0));
+        }
+
+        int node_idx = 0;
+        for (auto& [id, node_ptr] : nodes()) {
+            node_ptr->initialise(all_vnodes()).get();
+            auto* raft = node_ptr->raft().get();
+            raft::state_machine_manager_builder builder;
+            auto stm_ptr = builder.create_stm<stm>(cd_log, raft);
+            node_ptr->start(std::move(builder)).get();
+
+            // Create refresh node with staging directory
+            auto node_staging_path = reader_staging_base_dir_.get_path()
+                                     / fmt::format("node_{}", node_idx++);
+            std::filesystem::create_directories(node_staging_path);
+            refresh_nodes_[id] = std::make_unique<refresh_node>(
+              stm_ptr, &sr_->remote.local(), bucket_name, node_staging_path);
+        }
+    }
+
+    stm_shptrs_t create_stms(
+      raft::state_machine_manager_builder& builder,
+      raft::raft_node_instance& node) override {
+        return builder.create_stm<stm>(cd_log, node.raft().get());
+    }
+
+    void TearDown() override {
+        for (auto& [id, node_ptr] : refresh_nodes_) {
+            node_ptr->stop_refresh_loop().get();
+            node_ptr->stop_snapshot_mgr().get();
+        }
+
+        for (auto& [domain, db_ptr] : writer_dbs_) {
+            db_ptr->close().get();
+        }
+        writer_dbs_.clear();
+        raft::stm_raft_fixture<stm>::TearDownAsync().get();
+        refresh_nodes_.clear();
+        sr_.reset();
+    }
+
+    refresh_node* wait_get_leader() {
+        wait_for_leader(raft::default_timeout()).get();
+        for (auto& [id, node_ptr] : nodes()) {
+            if (node_ptr && node_ptr->raft()->is_leader()) {
+                auto it = refresh_nodes_.find(id);
+                if (it != refresh_nodes_.end()) {
+                    return it->second.get();
+                }
+            }
+        }
+        return nullptr;
+    }
+
+    ss::future<> upload_metastore_manifest(
+      const cloud_storage::remote_label& remote_label,
+      l1::metastore_manifest manifest) {
+        l1::manifest_io io{sr_->remote.local(), bucket_name};
+        auto result = co_await io.upload_metastore_manifest(
+          remote_label, std::move(manifest));
+        if (!result.has_value()) {
+            throw std::runtime_error(
+              fmt::format("Failed to upload manifest: {}", result.error()));
+        }
+    }
+
+    ss::future<l1::domain_uuid> upload_single_domain_manifest() {
+        auto domain = l1::domain_uuid(uuid_t::create());
+        l1::metastore_manifest manifest;
+        manifest.partitioning_strategy = "murmur";
+        manifest.domains.push_back(domain);
+        co_await upload_metastore_manifest(
+          test_remote_label_, std::move(manifest));
+        co_return domain;
+    }
+
+    ss::future<lsm::sequence_number> write_metastore_data(
+      l1::domain_uuid domain,
+      const model::topic_id_partition& tidp,
+      o base_offset,
+      o last_offset,
+      model::term_id term) {
+        auto* db = co_await test_utils::get_or_create_writer_db(
+          domain,
+          writer_staging_dir_,
+          &sr_->remote.local(),
+          bucket_name,
+          writer_dbs_);
+        co_return co_await test_utils::write_metastore_data(
+          db, tidp, base_offset, last_offset, term);
+    }
+
+    ss::future<> wait_for_stm_domain(
+      ss::shared_ptr<stm> stm, const l1::domain_uuid& expected_domain) {
+        RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [&] {
+            return stm->has_domain() && stm->domain() == expected_domain;
+        });
+    }
+
+    ss::future<> wait_for_stm_state_update(
+      ss::shared_ptr<stm> stm, lsm::sequence_number min_seqno) {
+        RPTEST_REQUIRE_EVENTUALLY_CORO(
+          10s, [&] { return stm->get_state().seqno >= min_seqno; });
+    }
+
+protected:
+    temporary_dir reader_staging_base_dir_;
+    absl::node_hash_map<model::node_id, std::unique_ptr<refresh_node>>
+      refresh_nodes_;
+    scoped_config cfg_;
+    std::unique_ptr<cloud_io::scoped_remote> sr_;
+    chunked_hash_map<l1::domain_uuid, std::unique_ptr<lsm::database>>
+      writer_dbs_;
+    std::filesystem::path writer_staging_dir_;
+    model::topic_id_partition test_tidp_;
+    cloud_storage::remote_label test_remote_label_;
+};
+
+} // namespace
+
+TEST_F(StateRefreshLoopTest, DiscoverDomain) {
+    auto* leader_node = wait_get_leader();
+    auto leader_stm = leader_node->stm_ptr;
+
+    // Verify STM has no domain initially.
+    ASSERT_FALSE(leader_stm->has_domain());
+
+    auto leader_term = leader_stm->raft()->term();
+    leader_node->start_refresh_loop(
+      leader_term, test_tidp_, test_remote_label_);
+
+    // Sleep briefly to let loop attempt discovery.
+    ss::sleep(500ms).get();
+    ASSERT_FALSE(leader_stm->has_domain());
+
+    // Create and upload metastore manifest and wait for the refresh loop to
+    // discover the domain.
+    auto domain = upload_single_domain_manifest().get();
+
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+        return leader_stm->has_domain() && leader_stm->domain() == domain;
+    });
+
+    // Before writing anything to object storage the refresh loop should just
+    // replicated the domain and nothing else.
+    ASSERT_THAT(
+      leader_stm->get_state(),
+      state_matches(domain, std::nullopt, o{0}, o{0}, model::term_id{0}));
+
+    auto seqno = write_metastore_data(
+                   domain, test_tidp_, o{0}, o{9}, model::term_id{1})
+                   .get();
+    wait_for_stm_state_update(leader_stm, seqno).get();
+    ASSERT_THAT(
+      leader_stm->get_state(),
+      state_matches(domain, seqno, o{0}, o{10}, model::term_id{1}));
+}
+
+TEST_F(StateRefreshLoopTest, PeriodicRefresh) {
+    auto* leader_node = wait_get_leader();
+    auto leader_stm = leader_node->stm_ptr;
+    auto domain = upload_single_domain_manifest().get();
+
+    // Write a few times and ensure that the state refresh loop catches up.
+    auto initial_seqno = write_metastore_data(
+                           domain, test_tidp_, o{0}, o{4}, model::term_id{1})
+                           .get();
+
+    leader_node->start_refresh_loop(
+      leader_stm->raft()->term(), test_tidp_, test_remote_label_);
+    wait_for_stm_state_update(leader_stm, initial_seqno).get();
+    ASSERT_THAT(
+      leader_stm->get_state(),
+      state_matches(domain, initial_seqno, o{0}, o{5}, model::term_id{1}));
+
+    // Another update.
+    auto second_seqno = write_metastore_data(
+                          domain, test_tidp_, o{5}, o{11}, model::term_id{1})
+                          .get();
+    wait_for_stm_state_update(leader_stm, second_seqno).get();
+    ASSERT_THAT(
+      leader_stm->get_state(),
+      state_matches(domain, second_seqno, o{0}, o{12}, model::term_id{1}));
+
+    // Another update.
+    auto third_seqno = write_metastore_data(
+                         domain, test_tidp_, o{12}, o{14}, model::term_id{2})
+                         .get();
+    wait_for_stm_state_update(leader_stm, third_seqno).get();
+    ASSERT_THAT(
+      leader_stm->get_state(),
+      state_matches(domain, third_seqno, o{0}, o{15}, model::term_id{2}));
+
+    // Wait for all nodes to catch up.
+    for (auto& [id, node_ptr] : refresh_nodes_) {
+        wait_for_stm_state_update(node_ptr->stm_ptr, third_seqno).get();
+        ASSERT_THAT(
+          node_ptr->stm_ptr->get_state(),
+          state_matches(domain, third_seqno, o{0}, o{15}, model::term_id{2}));
+    }
+}
+
+TEST_F(StateRefreshLoopTest, OnlyOnTerm) {
+    auto* leader_node = wait_get_leader();
+    auto leader_stm = leader_node->stm_ptr;
+    auto domain = upload_single_domain_manifest().get();
+
+    leader_node->start_refresh_loop(
+      leader_stm->raft()->term(), test_tidp_, test_remote_label_);
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+        return leader_stm->has_domain() && leader_stm->domain() == domain;
+    });
+
+    auto seqno = write_metastore_data(
+                   domain, test_tidp_, o{0}, o{9}, model::term_id{1})
+                   .get();
+    wait_for_stm_state_update(leader_stm, seqno).get();
+    ASSERT_THAT(
+      leader_stm->get_state(),
+      state_matches(domain, seqno, o{0}, o{10}, model::term_id{1}));
+
+    // Step down and wait a bit -- our refreshes should stop because the term
+    // has changed.
+    leader_stm->raft()->step_down("test").get();
+    auto second_seqno = write_metastore_data(
+                          domain, test_tidp_, o{10}, o{11}, model::term_id{1})
+                          .get();
+    ss::sleep(500ms).get();
+    ASSERT_THAT(
+      leader_stm->get_state(),
+      state_matches(domain, seqno, o{0}, o{10}, model::term_id{1}));
+
+    // Restart the refresh loop in the new term on the new leader.
+    leader_node->stop_refresh_loop().get();
+    leader_node = wait_get_leader();
+    leader_stm = leader_node->stm_ptr;
+    leader_node->start_refresh_loop(
+      leader_stm->raft()->term(), test_tidp_, test_remote_label_);
+    leader_stm = leader_node->stm_ptr;
+    wait_for_stm_state_update(leader_stm, second_seqno).get();
+    ASSERT_THAT(
+      leader_stm->get_state(),
+      state_matches(domain, second_seqno, o{0}, o{12}, model::term_id{1}));
+}


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This PR introduces the major components that comprise cloud topic read replicas.

The `read_replica_stm` replicates Kafka-facing metadata across replicas: partition offsets and terms. It also includes the domain UUID and the LSM database sequence number at the time of metadata collection, allowing consumers to request fresher database snapshots when needed.

The `snapshot_manager` maintains `database_refresher` instances per domain, each periodically pulling the latest LSM state from object storage. It serves snapshot requests with bounded staleness guarantees: snapshots must be newer than when the partition was created on this shard, newer than when leadership started, or newer than a specific sequence number from the STM.

The `snapshot_metastore` wraps LSM database snapshots to implement the metastore interface. It translates metastore queries into `state_reader` operations on the underlying snapshot, using the same query logic as the source cluster's `db_domain_manager` but adapted for snapshot-based access.

On the leader, the `state_refresh_loop` discoveres the domain UUID if it hasn't already, gets a fresh snapshot from the snapshot manager to create a `snapshot_metastore`, and uses it to query and then replicate partition metadata.

The `metadata_manager` listens to partition manage/unmanage events, starting `state_refresh_loops` for leader partitions and tracking `partition_metadata` (bucket name and tidp for knowing what to query, creation time and leadership time as snapshot staleness bounds) for all managed partitions. This metadata is cached for easy access during the read path.

The `cloud_topic_read_replica` partition proxy impl plugs the read replica infrastructure into the Kafka API. It returns synchronous state (offsets) from the STM, creates log readers using `snapshot_metastore` instances from the `snapshot_manager`, and supports timequery and epoch queries through metastore lookups.

An `accessors` helper contains the `metadata_provider` and `snapshot_provider` interfaces (corresponding to the respective managers), allowing these services to be passed through various layers (e.g., from `cluster::partition` to the Kafka `partition_proxy`) without circular dependencies, similar to the existing `state_accessors` pattern for vanilla cloud topics.

Component diagram:

```
   ┌─────────────────────┐         ┌─────────────────────┐
   │  Object Storage     │         │    Controller       │
   │  (Source Cluster)   │         │                     │
   └──────────┬──────────┘         └──────────┬──────────┘
              │ refresh                       │ manage/unmanage
              ▼                               ▼
        ┌──────────────────────────────────────────────┐
        │         Per-Shard Singletons                 │
        │                                              │
        │  ┌──────────────────┐  ┌─────────────────┐   │
        │  │ snapshot_manager │  │ metadata_manager│   │
        │  │  - LSM snapshots │  │  - partition    │   │
        │  └────┬─────────┬───┘  │    metadata     │   │
        │       │         │      └────┬────────────┘   │
        └───────┼─────────┼───────────┼────────────────┘
                │         │           │
                │         │           │ starts/stops
                │         │           ▼
                │         │    ┌──────────────────┐
                │         │    │ LEADER ONLY:     │
                │         └───►│state_refresh_loop│
                │  snapshots   │                  │
                │              └────────┬─────────┘
                │                       │
                │                       │ Raft replicate
                │                       ▼
                │              ┌─────────────────────┐
                │              │  read_replica_stm   │
                │              │  (all replicas)     │
                │              └─────────┬───────────┘
                │                        │
                │ snapshots              │
                └───────────────────────►│
                                         ▼
                        ┌─────────────────────────────────┐
                        │    partition_proxy              │
                        │    (all replicas)               │
                        │  ┌───────────────────────────┐  │
                        │  │ Uses:                     │  │
                        │  │ • STM (metadata)          │  │
                        │  │ • metadata_mgr (bounds)   │  │
                        │  │ • snapshot_mgr (data)     │  │
                        │  └───────────────────────────┘  │
                        └────────────┬────────────────────┘
                                     │
                                     ▼
                              Kafka Clients
```

Based on https://github.com/redpanda-data/redpanda/pull/29636

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
