### PR TITLE
`cloud_storage_clients`: resize `multipart_upload::as_stream()`

### DIFF
--- a/src/v/cloud_storage_clients/multipart_upload.cc
+++ b/src/v/cloud_storage_clients/multipart_upload.cc
@@ -203,9 +203,10 @@ ss::future<> multipart_upload::abort_on_error() {
 }
 
 ss::output_stream<char> multipart_upload::as_stream() {
+    static constexpr size_t buf_size = 8192;
     auto sink = ss::data_sink(
       std::make_unique<multipart_data_sink_impl>(shared_from_this()));
-    return {std::move(sink), _part_size};
+    return {std::move(sink), buf_size};
 }
 
 } // namespace cloud_storage_clients


### PR DESCRIPTION
`_part_size`, at a minimum, is 5 MiB. This constructor for `ss::output_stream<char>` is trying to allocate a contiguous chunk of memory of that size for buffering writes.

Use a default buffer size of `8192` instead.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
