### PR TITLE
[CORE-15468] `pandaproxy`: check `is_initialized()` before calling `reset()`

### DIFF
--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -154,7 +154,9 @@ ss::future<> api::stop() {
     if (_store) {
         co_await _store->stop();
     }
-    co_await enable_qualified_subjects::reset();
+    if (enable_qualified_subjects::is_initialized()) {
+        co_await enable_qualified_subjects::reset();
+    }
     vlog(srlog.debug, "Stopped schema registry API...");
 }
 


### PR DESCRIPTION
Calling `reset()` here if `api::start()` wasn't invoked can cause a crash.

Looks like this is possible if `construct_single_service()` is called, but startup is terminated before `_schema_registry->start()` is called.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
