### PR TITLE
pandaproxy/sr: validate reserved subject names in schema registry

### DIFF
--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -164,6 +164,8 @@ struct reply_error_category final : std::error_category {
             return "One or more references exist to the schema";
         case reply_error_code::subject_version_schema_id_already_exists:
             return "Schema already registered with another id";
+        case reply_error_code::subject_invalid:
+            return "The specified subject is not valid";
         case reply_error_code::context_not_empty:
             return "The specified context is not empty";
         case reply_error_code::write_collision:

--- a/src/v/pandaproxy/error.h
+++ b/src/v/pandaproxy/error.h
@@ -95,6 +95,7 @@ enum class reply_error_code : uint16_t {
     subject_version_operation_not_permitted = 42205,
     subject_version_has_references = 42206,
     subject_version_schema_id_already_exists = 42207,
+    subject_invalid = 42208,
     context_not_empty = 42211,
     write_collision = 50301,
     zookeeper_error = 50001,

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -94,6 +94,8 @@ struct error_category final : std::error_category {
             return "Writes to Schema Registry are disabled";
         case error_code::context_not_empty:
             return "The specified context is not empty";
+        case error_code::subject_invalid:
+            return "The specified subject is not valid";
         }
         return "(unrecognized error)";
     }
@@ -160,6 +162,8 @@ struct error_category final : std::error_category {
             return reply_error_code::precondition_failed; // 412
         case error_code::context_not_empty:
             return reply_error_code::context_not_empty; // 42211
+        case error_code::subject_invalid:
+            return reply_error_code::subject_invalid; // 42208
         }
         return {};
     }

--- a/src/v/pandaproxy/schema_registry/error.h
+++ b/src/v/pandaproxy/schema_registry/error.h
@@ -46,6 +46,7 @@ enum class error_code {
     internal_server_error,
     writes_disabled,
     context_not_empty,
+    subject_invalid,
 };
 
 std::error_code make_error_code(error_code);

--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -234,6 +234,12 @@ inline error_info writes_disabled() {
       error_code::writes_disabled, "Writes to Schema Registry are disabled"};
 }
 
+inline error_info subject_invalid(std::string_view subject) {
+    return error_info{
+      error_code::subject_invalid,
+      fmt::format("The specified subject '{}' is not valid.", subject)};
+}
+
 inline error_info context_not_empty(const context& ctx) {
     return error_info{
       error_code::context_not_empty,

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -416,6 +416,7 @@ ss::future<server::reply_t> put_config_subject(
     parse_accept_header(rq, rp);
     auto ctx_sub = context_subject::from_string(
       parse::request_param<ss::sstring>(*rq.req, "subject"));
+    validate_context_subject(ctx_sub, is_config_or_mode::yes);
 
     enterprise::handle_config_mode_authz(
       rq,
@@ -559,6 +560,7 @@ ss::future<server::reply_t> put_mode_subject(
                  .value_or(force::no);
     auto ctx_sub = context_subject::from_string(
       parse::request_param<ss::sstring>(*rq.req, "subject"));
+    validate_context_subject(ctx_sub, is_config_or_mode::yes);
 
     enterprise::handle_config_mode_authz(
       rq,
@@ -904,6 +906,7 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
     const auto ctx_sub = context_subject::from_string(
       parse::request_param<ss::sstring>(*rq.req, "subject"));
+    validate_context_subject(ctx_sub);
     const auto norm{
       parse::query_param<std::optional<normalize>>(*rq.req, "normalize")
         .value_or(normalize::no)};

--- a/src/v/pandaproxy/schema_registry/test/context_subject.cc
+++ b/src/v/pandaproxy/schema_registry/test/context_subject.cc
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "pandaproxy/schema_registry/error.h"
+#include "pandaproxy/schema_registry/exceptions.h"
 #include "pandaproxy/schema_registry/types.h"
 
 #include <gtest/gtest.h>
@@ -108,6 +110,102 @@ TEST_F(ContextSubjectTest, FlagOffUnqualifiedUsesDefaultContext) {
 
     EXPECT_EQ(ctx_sub.ctx, default_context);
     EXPECT_EQ(ctx_sub.sub(), "plain-topic");
+}
+
+TEST_F(ContextSubjectTest, ValidateSubjectRejectsReservedNames) {
+    // __GLOBAL as subject is always rejected, regardless of context or mode
+    EXPECT_THROW(
+      validate_context_subject({default_context, subject{"__GLOBAL"}}),
+      exception);
+    EXPECT_THROW(
+      validate_context_subject(
+        {default_context, subject{"__GLOBAL"}}, is_config_or_mode::yes),
+      exception);
+    EXPECT_THROW(
+      validate_context_subject({context{".myctx"}, subject{"__GLOBAL"}}),
+      exception);
+
+    // __EMPTY as subject is always rejected
+    EXPECT_THROW(
+      validate_context_subject({default_context, subject{"__EMPTY"}}),
+      exception);
+    EXPECT_THROW(
+      validate_context_subject(
+        {default_context, subject{"__EMPTY"}}, is_config_or_mode::yes),
+      exception);
+    EXPECT_THROW(
+      validate_context_subject({context{".myctx"}, subject{"__EMPTY"}}),
+      exception);
+
+    // .__GLOBAL context is rejected on regular endpoints (with or without
+    // subject)
+    EXPECT_THROW(
+      validate_context_subject({context{".__GLOBAL"}, subject{"some-subject"}}),
+      exception);
+    EXPECT_THROW(
+      validate_context_subject({context{".__GLOBAL"}, subject{""}}), exception);
+
+    // .__GLOBAL context is allowed on config/mode endpoints
+    EXPECT_NO_THROW(validate_context_subject(
+      {context{".__GLOBAL"}, subject{"some-subject"}}, is_config_or_mode::yes));
+    EXPECT_NO_THROW(validate_context_subject(
+      {context{".__GLOBAL"}, subject{""}}, is_config_or_mode::yes));
+
+    // Verify the error code
+    try {
+        validate_context_subject({default_context, subject{"__GLOBAL"}});
+        FAIL() << "Expected exception";
+    } catch (const exception& e) {
+        EXPECT_EQ(e.code(), error_code::subject_invalid);
+    }
+}
+
+TEST_F(ContextSubjectTest, ValidateSubjectAllowsValidNames) {
+    // Normal subjects
+    EXPECT_NO_THROW(
+      validate_context_subject({default_context, subject{"my-topic"}}));
+    EXPECT_NO_THROW(
+      validate_context_subject({context{".staging"}, subject{"my-topic"}}));
+    EXPECT_NO_THROW(validate_context_subject(
+      {default_context, subject{"some.subject.name"}}));
+
+    // Empty subject (context-only form) is not "__EMPTY"
+    EXPECT_NO_THROW(validate_context_subject({context{".myctx"}, subject{""}}));
+    EXPECT_NO_THROW(validate_context_subject({default_context, subject{""}}));
+
+    // Substrings of reserved names are valid
+    EXPECT_NO_THROW(
+      validate_context_subject({default_context, subject{"__GLOBAL_stuff"}}));
+    EXPECT_NO_THROW(
+      validate_context_subject({default_context, subject{"prefix__EMPTY"}}));
+    EXPECT_NO_THROW(
+      validate_context_subject({default_context, subject{"my__GLOBAL"}}));
+
+    // Case-sensitive: lowercase variants are valid
+    EXPECT_NO_THROW(
+      validate_context_subject({default_context, subject{"__global"}}));
+    EXPECT_NO_THROW(
+      validate_context_subject({default_context, subject{"__empty"}}));
+    EXPECT_NO_THROW(
+      validate_context_subject({default_context, subject{"__Global"}}));
+}
+
+TEST_F(ContextSubjectTest, ValidateSubjectConfigModeFlag) {
+    // .__GLOBAL context is allowed on config/mode endpoints
+    EXPECT_NO_THROW(validate_context_subject(
+      {context{".__GLOBAL"}, subject{"some-subject"}}, is_config_or_mode::yes));
+    EXPECT_NO_THROW(validate_context_subject(
+      {context{".__GLOBAL"}, subject{""}}, is_config_or_mode::yes));
+
+    // But reserved subject names are still rejected even on config/mode
+    EXPECT_THROW(
+      validate_context_subject(
+        {context{".__GLOBAL"}, subject{"__GLOBAL"}}, is_config_or_mode::yes),
+      exception);
+    EXPECT_THROW(
+      validate_context_subject(
+        {context{".__GLOBAL"}, subject{"__EMPTY"}}, is_config_or_mode::yes),
+      exception);
 }
 
 class ContextSubjectReferenceTest : public ::testing::Test {

--- a/src/v/pandaproxy/schema_registry/types.cc
+++ b/src/v/pandaproxy/schema_registry/types.cc
@@ -11,6 +11,7 @@
 
 #include "types.h"
 
+#include "errors.h"
 #include "util.h"
 #include "utils/to_string.h"
 
@@ -153,6 +154,20 @@ fmt::iterator context_subject_reference::format_to(fmt::iterator it) const {
         return fmt::format_to(it, ":{}:{}", sub.ctx, sub.sub);
     }
     return fmt::format_to(it, "{}", sub);
+}
+
+void validate_context_subject(
+  const context_subject& ctx_sub, is_config_or_mode config_or_mode) {
+    static constexpr std::string_view global_context_name = ".__GLOBAL";
+    static constexpr std::string_view global_subject_name = "__GLOBAL";
+    static constexpr std::string_view empty_subject_name = "__EMPTY";
+
+    if (
+      ctx_sub.sub() == global_subject_name
+      || ctx_sub.sub() == empty_subject_name
+      || (!config_or_mode && ctx_sub.ctx() == global_context_name)) {
+        throw as_exception(subject_invalid(ctx_sub.to_string()));
+    }
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -40,6 +40,7 @@ using force = ss::bool_class<struct force_tag>;
 using normalize = ss::bool_class<struct normalize_tag>;
 using verbose = ss::bool_class<struct verbose_tag>;
 using is_qualified = ss::bool_class<struct is_qualified_tag>;
+using is_config_or_mode = ss::bool_class<struct is_config_or_mode_tag>;
 
 template<typename E>
 std::enable_if_t<std::is_enum_v<E>, std::optional<E>>
@@ -228,6 +229,14 @@ struct context_subject {
 };
 
 inline const context_subject invalid_subject{default_context, subject{""}};
+
+/// Validate that a context_subject does not use reserved names (__GLOBAL,
+/// __EMPTY). Throws exception with error_code::subject_invalid if invalid.
+/// \param is_config_or_mode If true, allows .__GLOBAL context (used by
+///   config/mode endpoints).
+void validate_context_subject(
+  const context_subject& ctx_sub,
+  is_config_or_mode is_config_or_mode = is_config_or_mode::no);
 
 /// A reference subject that may be qualified or unqualified.
 /// Unqualified references are resolved relative to a parent schema's context.

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1366,6 +1366,9 @@ class SchemaRegistryEndpoints(RedpandaTest):
     def assert_equal(self, first, second, msg=None):
         assert first == second, msg or f"{first} != {second}"
 
+    def assert_not_equal(self, first, second, msg=None):
+        assert first != second, msg or f"{first} == {second}"
+
     def assert_in(self, member, container, msg=None):
         assert member in container, msg or f"{member!r} not found in {container!r}"
 
@@ -6747,6 +6750,60 @@ class SchemaRegistryContextTest(SchemaRegistryEndpoints):
         # Now base can be deleted
         result = self.sr_client.delete_subject(subject=base_subject)
         self.assert_equal(result.status_code, requests.codes.ok)
+
+    @cluster(num_nodes=1)
+    def test_reserved_subject_names_rejected(self):
+        """
+        Verify that reserved subject names (__GLOBAL, __EMPTY) and the
+        reserved context (.__GLOBAL) are rejected on post_subject_versions,
+        put_config_subject, & put_mode_subject.
+
+        The .__GLOBAL context is allowed on config/mode PUT endpoints but
+        rejected on the register endpoint.
+        """
+        schema_data = json.dumps({"schema": schema1_def})
+        config_data = json.dumps({"compatibility": "BACKWARD"})
+        mode_data = json.dumps({"mode": "READWRITE"})
+
+        global_subject = "__GLOBAL"
+        empty_subject = "__EMPTY"
+        global_context = ":.__GLOBAL:"
+        global_context_subject = f"{global_context}subject"
+
+        # Reserved subject names are rejected on all endpoints
+        for subject in [global_subject, empty_subject]:
+            result = self.sr_client.post_subjects_subject_versions(
+                subject=subject, data=schema_data
+            )
+            self.assert_equal(result.status_code, 422)
+            self.assert_equal(result.json()["error_code"], 42208)
+
+            result = self.sr_client.set_config_subject(
+                subject=subject, data=config_data
+            )
+            self.assert_equal(result.status_code, 422)
+            self.assert_equal(result.json()["error_code"], 42208)
+
+            result = self.sr_client.set_mode_subject(subject=subject, data=mode_data)
+            self.assert_equal(result.status_code, 422)
+            self.assert_equal(result.json()["error_code"], 42208)
+
+        # .__GLOBAL context is rejected on register but allowed on
+        # config/mode PUT endpoints (is_config_or_mode::yes)
+        for subject in [global_context, global_context_subject]:
+            result = self.sr_client.post_subjects_subject_versions(
+                subject=subject, data=schema_data
+            )
+            self.assert_equal(result.status_code, 422)
+            self.assert_equal(result.json()["error_code"], 42208)
+
+            result = self.sr_client.set_config_subject(
+                subject=subject, data=config_data
+            )
+            self.assert_not_equal(result.status_code, 422)
+
+            result = self.sr_client.set_mode_subject(subject=subject, data=mode_data)
+            self.assert_not_equal(result.status_code, 422)
 
 
 class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):


### PR DESCRIPTION
Reject subjects named `__GLOBAL` or `__EMPTY` and disallow the `.__GLOBAL` context on non-config/mode endpoints, returning a new `subject_invalid` error (42208). This aligns with the reference implementation and prevents users from accidentally using internal reserved names.

Wire up `validate_context_subject()` calls in all schema registry handlers and add both unit and integration tests covering reserved name rejection and `.__GLOBAL` context behavior on config/mode endpoints.

Part of [CORE-15192](https://redpandadata.atlassian.net/browse/CORE-15192)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* Requests using `__GLOBAL` or `__EMPTY` as subject names now return HTTP 422 with error code 42208.
* The `.__GLOBAL` context is rejected on regular subject endpoints but remains allowed on config/mode endpoints.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-15192]: https://redpandadata.atlassian.net/browse/CORE-15192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ