### PR TITLE
ts: Don't allow space management to evict compact only topics from the local storage

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -4302,6 +4302,13 @@ void disk_log_impl::set_cloud_gc_offset(model::offset offset) {
           config().ntp());
         return;
     }
+    if (config().is_compaction_only()) {
+        vlog(
+          stlog.debug,
+          "Ignoring request to set GC offset for compaction-only partition {}",
+          config().ntp());
+        return;
+    }
     _cloud_gc_offset = offset;
 }
 
@@ -4341,6 +4348,14 @@ disk_log_impl::get_reclaimable_offsets(gc_config cfg) {
         vlog(
           stlog.debug,
           "Reporting no reclaimable space for exempt partition {}",
+          config().ntp());
+        co_return res;
+    }
+
+    if (config().is_compaction_only()) {
+        vlog(
+          stlog.debug,
+          "Reporting no reclaimable space for compaction-only partition {}",
           config().ntp());
         co_return res;
     }

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -188,6 +188,14 @@ public:
         return model::is_deletion_enabled(cleanup_policy());
     }
 
+    /// If compaction is enabled but deletion is not (compaction-only topic).
+    /// Such topics should retain all local data indefinitely.
+    bool is_compaction_only() const {
+        const auto policy = cleanup_policy();
+        return model::is_compaction_enabled(policy)
+               && !model::is_deletion_enabled(policy);
+    }
+
     ss::sstring work_directory() const {
         return ssx::sformat("{}/{}_{}", _base_dir, _ntp.path(), _revision_id);
     }


### PR DESCRIPTION
This behavior can be surprising/unexpected.
The compact only topics are not evicting local data normally, but with space management enabled in low disk space situation they can.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none