### PR TITLE
self-test: Use multiple shards for the disk self test

### DIFF
--- a/src/v/cluster/self_test/diskcheck.cc
+++ b/src/v/cluster/self_test/diskcheck.cc
@@ -27,6 +27,7 @@
 
 #include <boost/range/irange.hpp>
 
+#include <algorithm>
 #include <cstdint>
 
 namespace cluster::self_test {
@@ -35,18 +36,27 @@ namespace {
 
 enum class read_or_write { read, write };
 
+static const auto five_hundred_us = 500000;
+
 struct shard_benchmark_results {
     metrics write;
     std::optional<metrics> read;
 };
 
 metrics merge_metrics(std::vector<metrics> shard_metrics) {
-    auto merged = std::move(shard_metrics.front());
-    for (size_t i = 1; i < shard_metrics.size(); ++i) {
-        merged.merge_from(shard_metrics[i]);
+    if (shard_metrics.empty()) {
+        // This will be bogus but we should never get here with no metrics
+        // anyway
+        return metrics{five_hundred_us};
     }
 
-    return merged;
+    return std::ranges::fold_left(
+      std::views::drop(shard_metrics, 1),
+      std::move(shard_metrics.front()),
+      [](metrics acc, const metrics& m) {
+          acc.merge_from(m);
+          return acc;
+      });
 }
 
 uint64_t get_next_pos(uint64_t pos, const diskcheck_opts& opts) {
@@ -107,8 +117,7 @@ ss::future<metrics> do_run_benchmark(
     auto irange = boost::irange<uint16_t>(0, opts.parallelism);
     auto start = ss::lowres_clock::now();
     auto start_highres = ss::lowres_system_clock::now();
-    static const auto five_seconds_us = 500000;
-    metrics m{five_seconds_us};
+    metrics m{five_hundred_us};
     co_await ss::parallel_for_each(
       irange, [&start, &files, &m, &opts, &cancelled](uint64_t i) {
           return run_benchmark_fiber<mode>(start, files[i], m, opts, cancelled);

--- a/src/v/cluster/self_test/diskcheck.cc
+++ b/src/v/cluster/self_test/diskcheck.cc
@@ -19,6 +19,7 @@
 #include "utils/directory_walker.h"
 #include "utils/uuid.h"
 
+#include <seastar/core/future-util.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/coroutine/switch_to.hh>
@@ -37,6 +38,15 @@ struct shard_benchmark_results {
     metrics write;
     std::optional<metrics> read;
 };
+
+metrics merge_metrics(std::vector<metrics> shard_metrics) {
+    auto merged = std::move(shard_metrics.front());
+    for (size_t i = 1; i < shard_metrics.size(); ++i) {
+        merged.merge_from(shard_metrics[i]);
+    }
+
+    return merged;
+}
 
 uint64_t get_next_pos(uint64_t pos, const diskcheck_opts& opts) {
     uint64_t next_pos = pos + opts.request_size;
@@ -261,17 +271,49 @@ ss::future<std::vector<self_test_result>> diskcheck::run(diskcheck_opts opts) {
 
 ss::future<std::vector<self_test_result>>
 diskcheck::run_configured_benchmarks(ss::sstring basename) {
-    co_await ss::coroutine::switch_to(_opts.sg);
-    auto shard_result = co_await run_shard_benchmark(
-      std::move(_opts), basename, _cancelled->local());
+    auto active_shards = std::min<std::uint32_t>(
+      _opts.parallelism, ss::smp::count);
+    auto parallelism_per_shard = _opts.parallelism / active_shards;
+    auto remainder = _opts.parallelism % active_shards;
+
+    std::vector<ss::future<shard_benchmark_results>> shard_futures;
+    for (size_t shard_index = 0; shard_index < active_shards; ++shard_index) {
+        auto shard_parallelism = parallelism_per_shard
+                                 + (shard_index < remainder ? 1 : 0);
+        auto local_opts = _opts;
+        local_opts.parallelism = shard_parallelism;
+        local_opts.data_size /= active_shards;
+        shard_futures.push_back(
+          ss::smp::submit_to(
+            shard_index,
+            [local_opts, basename, this](
+              this auto) -> ss::future<shard_benchmark_results> {
+                co_await ss::coroutine::switch_to(local_opts.sg);
+                co_return co_await run_shard_benchmark(
+                  std::move(local_opts), basename, _cancelled->local());
+            }));
+    }
+
+    auto per_shard_results = co_await ss::when_all_succeed(
+      shard_futures.begin(), shard_futures.end());
 
     std::vector<self_test_result> r;
     r.reserve(_opts.skip_read ? 1 : 2);
 
-    auto write_result = shard_result.write.to_st_result();
+    std::vector<metrics> write_shard_results;
+    write_shard_results.reserve(per_shard_results.size());
+    for (auto& shard_result : per_shard_results) {
+        write_shard_results.push_back(std::move(shard_result.write));
+    }
+
+    auto write_result
+      = merge_metrics(std::move(write_shard_results)).to_st_result();
     write_result.name = _opts.name;
     write_result.info = fmt::format(
-      "write run (iodepth: {}, dsync: {})", _opts.parallelism, _opts.dsync);
+      "write run (iodepth: {}, dsync: {}, shards: {})",
+      _opts.parallelism,
+      _opts.dsync,
+      active_shards);
     write_result.test_type = "disk";
     if (_cancelled->abort_requested()) {
         write_result.warning = "Run was manually cancelled";
@@ -279,12 +321,19 @@ diskcheck::run_configured_benchmarks(ss::sstring basename) {
     r.push_back(std::move(write_result));
 
     if (!_opts.skip_read) {
-        vassert(
-          shard_result.read.has_value(),
-          "Expected read benchmark results when skip_read is false");
-        auto read_result = shard_result.read.value().to_st_result();
+        std::vector<metrics> read_shard_results;
+        read_shard_results.reserve(per_shard_results.size());
+        for (auto& shard_result : per_shard_results) {
+            if (shard_result.read.has_value()) {
+                read_shard_results.push_back(
+                  std::move(shard_result.read.value()));
+            }
+        }
+
+        auto read_result
+          = merge_metrics(std::move(read_shard_results)).to_st_result();
         read_result.name = _opts.name;
-        read_result.info = "read run";
+        read_result.info = fmt::format("read run (shards: {})", active_shards);
         read_result.test_type = "disk";
         if (_cancelled->abort_requested()) {
             read_result.warning = "Run was manually cancelled";

--- a/src/v/cluster/self_test/diskcheck.cc
+++ b/src/v/cluster/self_test/diskcheck.cc
@@ -14,12 +14,13 @@
 #include "base/vassert.h"
 #include "base/vlog.h"
 #include "cluster/logger.h"
+#include "cluster/self_test/metrics.h"
 #include "random/generators.h"
 #include "ssx/sformat.h"
 #include "utils/directory_walker.h"
 #include "utils/uuid.h"
 
-#include <seastar/core/future-util.hh>
+#include <seastar/core/aligned_buffer.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/coroutine/switch_to.hh>

--- a/src/v/cluster/self_test/diskcheck.cc
+++ b/src/v/cluster/self_test/diskcheck.cc
@@ -21,12 +21,143 @@
 
 #include <seastar/core/seastar.hh>
 #include <seastar/core/smp.hh>
+#include <seastar/coroutine/switch_to.hh>
 
 #include <boost/range/irange.hpp>
 
 #include <cstdint>
 
 namespace cluster::self_test {
+
+namespace {
+
+enum class read_or_write { read, write };
+
+struct shard_benchmark_results {
+    metrics write;
+    std::optional<metrics> read;
+};
+
+uint64_t get_next_pos(uint64_t pos, const diskcheck_opts& opts) {
+    uint64_t next_pos = pos + opts.request_size;
+    if (next_pos >= opts.file_size()) {
+        return 0;
+    }
+    return next_pos;
+}
+
+ss::future<size_t> write_and_maybe_flush(
+  ss::file& file,
+  uint64_t pos,
+  const std::vector<iovec>& iov,
+  bool dsync,
+  ss::io_intent* intent) {
+    auto bytes_written = co_await file.dma_write(pos, iov, intent);
+    if (dsync) {
+        co_await file.flush();
+    }
+    co_return bytes_written;
+}
+
+template<read_or_write mode>
+ss::future<> run_benchmark_fiber(
+  ss::lowres_clock::time_point start,
+  ss::file& file,
+  metrics& m,
+  const diskcheck_opts& opts,
+  ss::abort_source& cancelled,
+  ss::io_intent* intent) {
+    const auto buf_len = std::min(opts.request_size, 128_KiB);
+    auto buf = ss::allocate_aligned_buffer<char>(buf_len, opts.alignment());
+    random_generators::fill_buffer_randomchars(buf.get(), buf_len);
+
+    std::vector<iovec> iov;
+    iov.reserve(opts.request_size / buf_len);
+    for (size_t offset = 0; offset < opts.request_size; offset += buf_len) {
+        size_t len = std::min(opts.request_size - offset, buf_len);
+        iov.push_back(iovec{buf.get(), len});
+    }
+
+    uint64_t pos = 0;
+    auto stop = start + opts.duration;
+    while (stop > ss::lowres_clock::now() && !cancelled.abort_requested()) {
+        if constexpr (mode == read_or_write::write) {
+            co_await m.measure([&iov, &file, &pos, dsync = opts.dsync, intent] {
+                return write_and_maybe_flush(file, pos, iov, dsync, intent);
+            });
+        } else {
+            co_await m.measure([&iov, &file, &pos, intent] {
+                return file.dma_read(pos, iov, intent);
+            });
+        }
+        pos = get_next_pos(pos, opts);
+    }
+}
+
+template<read_or_write mode>
+ss::future<metrics> do_run_benchmark(
+  std::vector<ss::file>& files,
+  const diskcheck_opts& opts,
+  ss::abort_source& cancelled) {
+    auto irange = boost::irange<uint16_t>(0, opts.parallelism);
+    auto start = ss::lowres_clock::now();
+    auto start_highres = ss::lowres_system_clock::now();
+    static const auto five_seconds_us = 500000;
+    metrics m{five_seconds_us};
+    ss::io_intent intent;
+    ss::timer<ss::lowres_clock> timer;
+    timer.set_callback([&intent] { intent.cancel(); });
+    timer.rearm(start + opts.duration);
+    try {
+        co_await ss::parallel_for_each(
+          irange, [&start, &files, &m, &opts, &cancelled, &intent](uint64_t i) {
+              return run_benchmark_fiber<mode>(
+                start, files[i], m, opts, cancelled, &intent);
+          });
+    } catch (const ss::cancelled_error&) {
+        vlog(clusterlog.debug, "Benchmark completed (duration reached)");
+    }
+    timer.cancel();
+    auto end = ss::lowres_system_clock::now();
+    m.set_start_end_time(start_highres, end);
+    m.set_total_time(end - start_highres);
+    co_return m;
+}
+
+ss::future<shard_benchmark_results> run_shard_benchmark(
+  diskcheck_opts opts, ss::sstring basename, ss::abort_source& cancelled) {
+    auto flags = ss::open_flags::create | ss::open_flags::rw;
+    ss::file_open_options file_opts{
+      .extent_allocation_size_hint = opts.file_size(),
+      .append_is_unlikely = true};
+
+    std::vector<ss::file> files;
+    files.reserve(opts.parallelism);
+    for (size_t i = 0; i < opts.parallelism; ++i) {
+        auto filename = fmt::format(
+          "{}-{}-{}", basename, ss::this_shard_id(), i);
+        vlog(clusterlog.debug, "Creating file: {}", filename);
+        auto file = co_await ss::open_file_dma(filename, flags, file_opts);
+        co_await file.allocate(0, opts.file_size());
+        co_await file.truncate(opts.file_size());
+        co_await file.flush();
+        files.push_back(std::move(file));
+    }
+
+    auto write_metrics = co_await do_run_benchmark<read_or_write::write>(
+      files, opts, cancelled);
+
+    std::optional<metrics> read_result;
+    if (!opts.skip_read) {
+        read_result = co_await do_run_benchmark<read_or_write::read>(
+          files, opts, cancelled);
+    }
+
+    co_return shard_benchmark_results{
+      .write = std::move(write_metrics), .read = std::move(read_result)};
+}
+
+} // namespace
 
 void diskcheck::validate_options(const diskcheck_opts& opts) {
     using namespace std::chrono_literals;
@@ -52,16 +183,21 @@ diskcheck::diskcheck(ss::sharded<node::local_monitor>& nlm)
 ss::future<> diskcheck::start() { return ss::now(); }
 
 ss::future<> diskcheck::stop() {
-    /// If test is currently running, expect `benchmark_aborted_exception`
-    auto f = _gate.close();
-    _as.request_abort();
-    _intent.cancel();
-    return f;
+    if (_cancel_parent.has_value()) {
+        _cancel_parent->request_abort();
+    }
+    co_await _gate.close();
+    if (_cancelled.has_value()) {
+        co_await _cancelled->stop();
+        _cancelled.reset();
+    }
+    _cancel_parent.reset();
 }
 
 void diskcheck::cancel() {
-    _cancelled = true;
-    _intent.cancel();
+    if (_cancel_parent.has_value()) {
+        _cancel_parent->request_abort();
+    }
 }
 
 ss::future<> diskcheck::verify_remaining_space(size_t dataset_size) {
@@ -93,7 +229,13 @@ ss::future<std::vector<self_test_result>> diskcheck::run(diskcheck_opts opts) {
       clusterlog.info,
       "Starting redpanda self-test disk benchmark, with options: {}",
       opts);
-    _cancelled = false;
+    if (_cancelled.has_value()) {
+        co_await _cancelled->stop();
+        _cancelled.reset();
+    }
+    _cancel_parent.emplace();
+    _cancelled.emplace();
+    co_await _cancelled->start(*_cancel_parent);
     _opts = opts;
     if (std::filesystem::exists(_opts.dir)) {
         /// Ensure no leftover large files in the event there was a
@@ -103,12 +245,8 @@ ss::future<std::vector<self_test_result>> diskcheck::run(diskcheck_opts opts) {
     std::filesystem::create_directory(_opts.dir);
     const auto self_test_prefix = "rp-self-test";
     const auto fname = ssx::sformat(
-      "{}/{}-{}-{}",
-      _opts.dir.string(),
-      self_test_prefix,
-      uuid_t::create(),
-      ss::this_shard_id());
-    co_return co_await initialize_benchmark(fname).finally(
+      "{}/{}-{}", _opts.dir.string(), self_test_prefix, uuid_t::create());
+    co_return co_await run_configured_benchmarks(fname).finally(
       [this, &self_test_prefix] {
           vlog(
             clusterlog.debug,
@@ -138,138 +276,39 @@ ss::future<std::vector<self_test_result>> diskcheck::run(diskcheck_opts opts) {
 }
 
 ss::future<std::vector<self_test_result>>
-diskcheck::initialize_benchmark(ss::sstring basename) {
-    auto flags = ss::open_flags::create | ss::open_flags::rw;
-    ss::file_open_options file_opts{
-      .extent_allocation_size_hint = _opts.file_size(),
-      .append_is_unlikely = true};
-    try {
-        std::vector<ss::file> files;
-        for (size_t i = 0; i < _opts.parallelism; ++i) {
-            auto filename = fmt::format("{}-{}", basename, i);
-            vlog(clusterlog.debug, "Creating file: {}", filename);
-            auto file = co_await ss::open_file_dma(filename, flags, file_opts);
-            co_await file.allocate(0, _opts.file_size());
-            co_await file.truncate(_opts.file_size());
-            co_await file.flush();
-            files.push_back(std::move(file));
-        }
-        co_return co_await ss::with_scheduling_group(
-          _opts.sg, [this, &files]() mutable {
-              return run_configured_benchmarks(files);
-          });
-    } catch (const diskcheck_aborted_exception& ex) {
-        vlog(clusterlog.debug, "diskcheck stopped due to call to stop()");
-    }
-    co_return std::vector<self_test_result>{};
-}
+diskcheck::run_configured_benchmarks(ss::sstring basename) {
+    co_await ss::coroutine::switch_to(_opts.sg);
+    auto shard_result = co_await run_shard_benchmark(
+      std::move(_opts), basename, _cancelled->local());
 
-ss::future<std::vector<self_test_result>>
-diskcheck::run_configured_benchmarks(std::vector<ss::file>& files) {
     std::vector<self_test_result> r;
-    auto write_metrics = co_await do_run_benchmark<read_or_write::write>(files);
-    auto result = write_metrics.to_st_result();
-    result.name = _opts.name;
-    result.info = fmt::format(
+    r.reserve(_opts.skip_read ? 1 : 2);
+
+    auto write_result = shard_result.write.to_st_result();
+    write_result.name = _opts.name;
+    write_result.info = fmt::format(
       "write run (iodepth: {}, dsync: {})", _opts.parallelism, _opts.dsync);
-    result.test_type = "disk";
-    if (_cancelled) {
-        result.warning = "Run was manually cancelled";
+    write_result.test_type = "disk";
+    if (_cancelled->abort_requested()) {
+        write_result.warning = "Run was manually cancelled";
     }
-    r.push_back(std::move(result));
+    r.push_back(std::move(write_result));
+
     if (!_opts.skip_read) {
-        auto read_metrics = co_await do_run_benchmark<read_or_write::read>(
-          files);
-        auto result = read_metrics.to_st_result();
-        result.name = _opts.name;
-        result.info = "read run";
-        result.test_type = "disk";
-        if (_cancelled) {
-            result.warning = "Run was manually cancelled";
+        vassert(
+          shard_result.read.has_value(),
+          "Expected read benchmark results when skip_read is false");
+        auto read_result = shard_result.read.value().to_st_result();
+        read_result.name = _opts.name;
+        read_result.info = "read run";
+        read_result.test_type = "disk";
+        if (_cancelled->abort_requested()) {
+            read_result.warning = "Run was manually cancelled";
         }
-        r.push_back(std::move(result));
+        r.push_back(std::move(read_result));
     }
+
     co_return r;
-}
-
-template<diskcheck::read_or_write mode>
-ss::future<metrics> diskcheck::do_run_benchmark(std::vector<ss::file>& files) {
-    auto irange = boost::irange<uint16_t>(0, _opts.parallelism);
-    auto start = ss::lowres_clock::now();
-    auto start_highres = ss::lowres_system_clock::now();
-    static const auto five_seconds_us = 500000;
-    metrics m{five_seconds_us};
-    ss::timer<ss::lowres_clock> timer;
-    timer.set_callback([this] { _intent.cancel(); });
-    timer.rearm(start + _opts.duration);
-    try {
-        co_await ss::parallel_for_each(
-          irange, [this, &start, &files, &m](uint64_t i) {
-              return this->run_benchmark_fiber<mode>(start, files[i], m);
-          });
-    } catch (const ss::cancelled_error&) {
-        /// Expect this to be thrown from cancelled futures via io calls, due to
-        /// _intent.cancel() having been called
-        vlog(clusterlog.debug, "Benchmark completed (duration reached)");
-    }
-    timer.cancel();
-    auto end = ss::lowres_system_clock::now();
-    m.set_start_end_time(start_highres, end);
-    m.set_total_time(end - start_highres);
-    co_return m;
-}
-
-ss::future<size_t> write_and_maybe_flush(
-  ss::file& file,
-  uint64_t pos,
-  const std::vector<iovec>& iov,
-  bool dsync,
-  ss::io_intent* intent) {
-    auto bytes_written = co_await file.dma_write(pos, iov, intent);
-    if (dsync) {
-        co_await file.flush();
-    }
-    co_return bytes_written;
-}
-
-template<diskcheck::read_or_write mode>
-ss::future<> diskcheck::run_benchmark_fiber(
-  ss::lowres_clock::time_point start, ss::file& file, metrics& m) {
-    const auto buf_len = std::min(_opts.request_size, 128_KiB);
-    auto buf = ss::allocate_aligned_buffer<char>(buf_len, _opts.alignment());
-    random_generators::fill_buffer_randomchars(buf.get(), buf_len);
-
-    std::vector<iovec> iov;
-    iov.reserve(_opts.request_size / buf_len);
-    for (size_t offset = 0; offset < _opts.request_size; offset += buf_len) {
-        size_t len = std::min(_opts.request_size - offset, buf_len);
-        iov.push_back(iovec{buf.get(), len});
-    }
-
-    uint64_t pos = 0;
-    auto stop = start + _opts.duration;
-    while (stop > ss::lowres_clock::now() && !_cancelled) {
-        if (unlikely(_as.abort_requested())) {
-            throw diskcheck_aborted_exception();
-        }
-        co_await m.measure([this, &iov, &file, &pos] {
-            if constexpr (mode == read_or_write::write) {
-                return write_and_maybe_flush(
-                  file, pos, iov, _opts.dsync, &_intent);
-            } else {
-                return file.dma_read(pos, iov, &_intent);
-            }
-        });
-        pos = get_next_pos(pos);
-    }
-}
-
-uint64_t diskcheck::get_next_pos(uint64_t pos) {
-    uint64_t next_pos = pos + _opts.request_size;
-    if (next_pos >= _opts.file_size()) {
-        return 0;
-    }
-    return next_pos;
 }
 
 } // namespace cluster::self_test

--- a/src/v/cluster/self_test/diskcheck.cc
+++ b/src/v/cluster/self_test/diskcheck.cc
@@ -47,12 +47,8 @@ uint64_t get_next_pos(uint64_t pos, const diskcheck_opts& opts) {
 }
 
 ss::future<size_t> write_and_maybe_flush(
-  ss::file& file,
-  uint64_t pos,
-  const std::vector<iovec>& iov,
-  bool dsync,
-  ss::io_intent* intent) {
-    auto bytes_written = co_await file.dma_write(pos, iov, intent);
+  ss::file& file, uint64_t pos, const std::vector<iovec>& iov, bool dsync) {
+    auto bytes_written = co_await file.dma_write(pos, iov);
     if (dsync) {
         co_await file.flush();
     }
@@ -65,8 +61,7 @@ ss::future<> run_benchmark_fiber(
   ss::file& file,
   metrics& m,
   const diskcheck_opts& opts,
-  ss::abort_source& cancelled,
-  ss::io_intent* intent) {
+  ss::abort_source& cancelled) {
     const auto buf_len = std::min(opts.request_size, 128_KiB);
     auto buf = ss::allocate_aligned_buffer<char>(buf_len, opts.alignment());
     random_generators::fill_buffer_randomchars(buf.get(), buf_len);
@@ -82,13 +77,12 @@ ss::future<> run_benchmark_fiber(
     auto stop = start + opts.duration;
     while (stop > ss::lowres_clock::now() && !cancelled.abort_requested()) {
         if constexpr (mode == read_or_write::write) {
-            co_await m.measure([&iov, &file, &pos, dsync = opts.dsync, intent] {
-                return write_and_maybe_flush(file, pos, iov, dsync, intent);
+            co_await m.measure([&iov, &file, &pos, dsync = opts.dsync] {
+                return write_and_maybe_flush(file, pos, iov, dsync);
             });
         } else {
-            co_await m.measure([&iov, &file, &pos, intent] {
-                return file.dma_read(pos, iov, intent);
-            });
+            co_await m.measure(
+              [&iov, &file, &pos] { return file.dma_read(pos, iov); });
         }
         pos = get_next_pos(pos, opts);
     }
@@ -104,20 +98,10 @@ ss::future<metrics> do_run_benchmark(
     auto start_highres = ss::lowres_system_clock::now();
     static const auto five_seconds_us = 500000;
     metrics m{five_seconds_us};
-    ss::io_intent intent;
-    ss::timer<ss::lowres_clock> timer;
-    timer.set_callback([&intent] { intent.cancel(); });
-    timer.rearm(start + opts.duration);
-    try {
-        co_await ss::parallel_for_each(
-          irange, [&start, &files, &m, &opts, &cancelled, &intent](uint64_t i) {
-              return run_benchmark_fiber<mode>(
-                start, files[i], m, opts, cancelled, &intent);
-          });
-    } catch (const ss::cancelled_error&) {
-        vlog(clusterlog.debug, "Benchmark completed (duration reached)");
-    }
-    timer.cancel();
+    co_await ss::parallel_for_each(
+      irange, [&start, &files, &m, &opts, &cancelled](uint64_t i) {
+          return run_benchmark_fiber<mode>(start, files[i], m, opts, cancelled);
+      });
     auto end = ss::lowres_system_clock::now();
     m.set_start_end_time(start_highres, end);
     m.set_total_time(end - start_highres);

--- a/src/v/cluster/self_test/diskcheck.h
+++ b/src/v/cluster/self_test/diskcheck.h
@@ -24,7 +24,6 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/gate.hh>
-#include <seastar/core/io_intent.hh>
 #include <seastar/core/lowres_clock.hh>
 
 #include <chrono>

--- a/src/v/cluster/self_test/diskcheck.h
+++ b/src/v/cluster/self_test/diskcheck.h
@@ -17,6 +17,7 @@
 #include "cluster/self_test/metrics.h"
 #include "cluster/self_test_rpc_types.h"
 #include "config/node_config.h"
+#include "ssx/abort_source.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/aligned_buffer.hh>
@@ -28,6 +29,7 @@
 
 #include <chrono>
 #include <exception>
+#include <optional>
 
 namespace cluster::self_test {
 
@@ -35,16 +37,6 @@ class diskcheck_exception : public std::runtime_error {
 public:
     explicit diskcheck_exception(const std::string& msg)
       : std::runtime_error(msg) {}
-};
-class diskcheck_aborted_exception final : public diskcheck_exception {
-public:
-    diskcheck_aborted_exception()
-      : diskcheck_exception("User aborted benchmark") {}
-};
-class diskcheck_misconfigured_exception final : public diskcheck_exception {
-public:
-    explicit diskcheck_misconfigured_exception(const ss::sstring& msg)
-      : diskcheck_exception(msg) {}
 };
 class diskcheck_option_out_of_range final : public diskcheck_exception {
 public:
@@ -92,31 +84,20 @@ public:
     void cancel();
 
 private:
-    enum class read_or_write { read, write };
-
-    ss::future<std::vector<self_test_result>> initialize_benchmark(ss::sstring);
     ss::future<std::vector<self_test_result>>
-    run_configured_benchmarks(std::vector<ss::file>&);
+    run_configured_benchmarks(ss::sstring basename);
 
     ss::future<> verify_remaining_space(size_t dataset_size);
-
-    template<read_or_write mode>
-    ss::future<metrics> do_run_benchmark(std::vector<ss::file>&);
-
-    template<read_or_write mode>
-    ss::future<> run_benchmark_fiber(
-      ss::lowres_clock::time_point start, ss::file& file, metrics& m);
-
-    uint64_t get_next_pos(uint64_t pos);
 
 private:
     /// To ensure test doesn't attempt to take all available disk space
     ss::sharded<node::local_monitor>& _nlm;
 
-    ss::io_intent _intent{};
-    bool _cancelled{false};
-    /// For shutting down service
-    ss::abort_source _as;
+    /// Parent source used for the below sharded abort source
+    std::optional<ss::abort_source> _cancel_parent;
+    /// Abort source to signal all shards to stop running any currently running
+    /// tests
+    std::optional<ssx::sharded_abort_source> _cancelled;
     ss::gate _gate;
     diskcheck_opts _opts;
 };

--- a/src/v/cluster/self_test/diskcheck.h
+++ b/src/v/cluster/self_test/diskcheck.h
@@ -11,23 +11,14 @@
 
 #pragma once
 
-#include "base/likely.h"
 #include "base/seastarx.h"
 #include "cluster/node/local_monitor.h"
-#include "cluster/self_test/metrics.h"
 #include "cluster/self_test_rpc_types.h"
-#include "config/node_config.h"
 #include "ssx/abort_source.h"
 
 #include <seastar/core/abort_source.hh>
-#include <seastar/core/aligned_buffer.hh>
-#include <seastar/core/coroutine.hh>
-#include <seastar/core/file.hh>
 #include <seastar/core/gate.hh>
-#include <seastar/core/lowres_clock.hh>
 
-#include <chrono>
-#include <exception>
 #include <optional>
 
 namespace cluster::self_test {

--- a/src/v/cluster/self_test/metrics.h
+++ b/src/v/cluster/self_test/metrics.h
@@ -16,6 +16,8 @@
 
 #include <seastar/core/lowres_clock.hh>
 
+#include <algorithm>
+
 namespace cluster::self_test {
 
 class omit_metrics_measurement_exception : public std::exception {};
@@ -63,6 +65,16 @@ public:
     }
 
     void set_total_time(ss::lowres_clock::duration t) { _total_time = t; }
+
+    void merge_from(const metrics& other) {
+        _hist += other._hist;
+        _number_of_timeouts += other._number_of_timeouts;
+        _bytes_operated += other._bytes_operated;
+        _num_requests += other._num_requests;
+        _total_time = std::max(_total_time, other._total_time);
+        _start_time = std::min(_start_time, other._start_time);
+        _end_time = std::max(_end_time, other._end_time);
+    }
 
     size_t iops() const {
         const auto secs = std::chrono::duration_cast<std::chrono::seconds>(


### PR DESCRIPTION
Enhances the self test to use all available shards for the disk self test.

This allows for higher IOPS numbers where we were CPU bound previously.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


* none


