### PR TITLE
nodes_decom_test: deflake decom_status (CORE-15073)

### DIFF
--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -123,6 +123,19 @@ class NodesDecommissioningTest(PreallocNodesTest):
 
         return total_partitions
 
+    def _topic_replica_nodes(self, topic: str) -> list[ClusterNode]:
+        """Return the cluster nodes that host at least one replica of the
+        given topic."""
+        rpk = RpkTool(self.redpanda)
+        node_ids: set[int] = set()
+        for p in rpk.describe_topic(topic):
+            node_ids.update(p.replicas)
+        return [
+            cluster_node
+            for cluster_node in [self.redpanda.get_node_by_id(n) for n in node_ids]
+            if cluster_node is not None
+        ]
+
     def _partitions_moving(self, node=None):
         reconfigurations = self.admin.list_reconfigurations(node=node)
         return len(reconfigurations) > 0
@@ -446,7 +459,13 @@ class NodesDecommissioningTest(PreallocNodesTest):
         self.start_redpanda()
         self._create_topics(replication_factors=[3])
         self.start_producer()
-        to_decommission = random.choice(self.redpanda.nodes)
+        # Choose a node that actually hosts replicas of self._topic so
+        # that the decommission status will include partitions for it.
+        topic_nodes = self._topic_replica_nodes(self._topic)
+        assert topic_nodes, (
+            "It should be impossible for a topic to have no replicas coinciding with nodes in the cluster"
+        )
+        to_decommission = random.choice(topic_nodes)
         to_decommission_id = self.redpanda.node_id(to_decommission)
         self.logger.info(
             f"decommissioning node: {to_decommission_id}",


### PR DESCRIPTION
Decom status relied on self._topic being in the decommissioning status report. The cluster is 4 node and self._topic is rf=3, so its possible for the decommissioning node to not have any replicas of self._topic.

Quick fix to have the test choose a node to decom from the list of cluster nodes which actually host a replica of self._topic

fixes [CORE-15073](https://redpandadata.atlassian.net/browse/CORE-15073)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-15073]: https://redpandadata.atlassian.net/browse/CORE-15073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ