### PR TITLE
ct: skip syncing start offset if no LRO

### DIFF
--- a/src/v/cloud_topics/housekeeper/housekeeper.cc
+++ b/src/v/cloud_topics/housekeeper/housekeeper.cc
@@ -185,6 +185,10 @@ housekeeper::do_time_retention(std::chrono::milliseconds duration) {
 }
 
 ss::future<> housekeeper::sync_start_offset() {
+    if (_l0_metastore->get_last_reconciled_offset(_tidp) == kafka::offset{}) {
+        // Nothing reconciled, L1 is empty and there's nothing to sync.
+        co_return;
+    }
     auto start_offset = _l0_metastore->get_start_offset(_tidp);
     vlog(cd_log.debug, "Setting {} start offset to {}", _tidp, start_offset);
     auto result = co_await _l1_metastore->set_start_offset(_tidp, start_offset);

--- a/src/v/cloud_topics/housekeeper/housekeeper.h
+++ b/src/v/cloud_topics/housekeeper/housekeeper.h
@@ -50,6 +50,11 @@ public:
         virtual kafka::offset get_start_offset(const model::topic_id_partition&)
           = 0;
 
+        // Get the current last reconciled offset for the partition.
+        virtual kafka::offset
+        get_last_reconciled_offset(const model::topic_id_partition&)
+          = 0;
+
         // Update the start offset to the partition, this must be an
         // idempotent operation.
         virtual ss::future<> set_start_offset(

--- a/src/v/cloud_topics/housekeeper/manager.cc
+++ b/src/v/cloud_topics/housekeeper/manager.cc
@@ -42,6 +42,12 @@ public:
         return api.get_start_offset();
     }
 
+    kafka::offset
+    get_last_reconciled_offset(const model::topic_id_partition& tidp) override {
+        auto api = get_api(tidp);
+        return api.get_last_reconciled_offset();
+    }
+
     ss::future<> set_start_offset(
       const model::topic_id_partition& tidp,
       kafka::offset offset,

--- a/src/v/cloud_topics/housekeeper/tests/housekeeper_test.cc
+++ b/src/v/cloud_topics/housekeeper/tests/housekeeper_test.cc
@@ -43,6 +43,11 @@ public:
         return kafka::offset{0};
     }
 
+    kafka::offset
+    get_last_reconciled_offset(const model::topic_id_partition&) override {
+        return kafka::offset::max();
+    }
+
     ss::future<> set_start_offset(
       const model::topic_id_partition& tidp,
       kafka::offset offset,


### PR DESCRIPTION
I noticed that we end up trying to sync L1 to the start offset, even if there is no data in L1 (shows up as a WARN log).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
