### PR TITLE
`csc`: multipart logging tweaks

### DIFF
--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -1355,7 +1355,7 @@ remote::initiate_multipart_upload(
 
     // Create the multipart_upload with the wrapped state
     auto upload = ss::make_shared<cloud_storage_clients::multipart_upload>(
-      std::move(wrapped_state), part_size);
+      std::move(wrapped_state), part_size, log);
 
     co_return upload;
 }

--- a/src/v/cloud_storage_clients/multipart_upload.cc
+++ b/src/v/cloud_storage_clients/multipart_upload.cc
@@ -12,11 +12,9 @@
 
 #include "base/vassert.h"
 #include "base/vlog.h"
-#include "cloud_storage_clients/logger.h"
 #include "ssx/future-util.h"
 
 #include <seastar/coroutine/as_future.hh>
-#include <seastar/util/log.hh>
 
 namespace cloud_storage_clients {
 
@@ -66,9 +64,12 @@ private:
 };
 
 multipart_upload::multipart_upload(
-  ss::shared_ptr<multipart_upload_state> state, size_t part_size)
+  ss::shared_ptr<multipart_upload_state> state,
+  size_t part_size,
+  ss::logger& logger)
   : _state(std::move(state))
-  , _part_size(part_size) {}
+  , _part_size(part_size)
+  , _logger(logger) {}
 
 multipart_upload::~multipart_upload() {
     vassert(
@@ -100,7 +101,7 @@ ss::future<> multipart_upload::put(iobuf data) {
         // Lazy initialization: only initialize on first part upload
         if (!_multipart_initialized) {
             vlog(
-              s3_log.debug,
+              _logger.debug,
               "Initializing multipart upload for first part (size: {})",
               _part_size);
             co_await _state->initialize_multipart();
@@ -108,7 +109,7 @@ ss::future<> multipart_upload::put(iobuf data) {
         }
 
         vlog(
-          s3_log.debug,
+          _logger.debug,
           "Uploading part {} (size: {})",
           _part_number,
           part_data.size_bytes());
@@ -127,7 +128,7 @@ ss::future<> multipart_upload::complete() {
     // the total data is less than part_size, use regular put_object instead
     if (!_multipart_initialized) {
         vlog(
-          s3_log.debug,
+          _logger.debug,
           "Small file optimization: using single put_object (size: {})",
           _buffer.size_bytes());
         co_await _state->upload_as_single_object(std::move(_buffer));
@@ -137,7 +138,7 @@ ss::future<> multipart_upload::complete() {
     // Upload final part if any data remains
     if (_buffer.size_bytes() > 0) {
         vlog(
-          s3_log.debug,
+          _logger.debug,
           "Uploading final part {} (size: {})",
           _part_number,
           _buffer.size_bytes());
@@ -146,7 +147,7 @@ ss::future<> multipart_upload::complete() {
         if (fut.failed()) {
             auto ex = fut.get_exception();
             vlogl(
-              s3_log,
+              _logger,
               ssx::is_shutdown_exception(ex) ? ss::log_level::warn
                                              : ss::log_level::error,
               "Multipart upload final part failed, aborting: {}",
@@ -157,13 +158,15 @@ ss::future<> multipart_upload::complete() {
     }
     // Complete the multipart upload
     vlog(
-      s3_log.debug, "Completing multipart upload ({} parts)", _part_number - 1);
+      _logger.debug,
+      "Completing multipart upload ({} parts)",
+      _part_number - 1);
     auto fut = co_await ss::coroutine::as_future(
       _state->complete_multipart_upload());
     if (fut.failed()) {
         auto ex = fut.get_exception();
         vlogl(
-          s3_log,
+          _logger,
           ssx::is_shutdown_exception(ex) ? ss::log_level::warn
                                          : ss::log_level::error,
           "Multipart upload completion failed, aborting: {}",
@@ -176,7 +179,7 @@ ss::future<> multipart_upload::complete() {
 ss::future<> multipart_upload::abort() {
     if (_finalized) {
         // Already finalized - this is idempotent
-        vlog(s3_log.debug, "abort() called on already finalized upload");
+        vlog(_logger.debug, "abort() called on already finalized upload");
         co_return;
     }
 
@@ -186,13 +189,13 @@ ss::future<> multipart_upload::abort() {
         co_return;
     }
 
-    vlog(s3_log.debug, "Aborting multipart upload");
+    vlog(_logger.debug, "Aborting multipart upload");
     try {
         co_await _state->abort_multipart_upload();
     } catch (...) {
         // Log but don't propagate abort failures - we're already aborting
         vlog(
-          s3_log.warn,
+          _logger.warn,
           "Abort multipart upload failed: {}",
           std::current_exception());
     }
@@ -203,7 +206,7 @@ ss::future<> multipart_upload::abort_on_error() {
       _state->abort_multipart_upload());
     if (fut.failed()) {
         vlog(
-          s3_log.warn,
+          _logger.warn,
           "Failed to abort multipart upload after completion failure: {}",
           fut.get_exception());
     }

--- a/src/v/cloud_storage_clients/multipart_upload.cc
+++ b/src/v/cloud_storage_clients/multipart_upload.cc
@@ -13,6 +13,7 @@
 #include "base/vassert.h"
 #include "base/vlog.h"
 #include "cloud_storage_clients/logger.h"
+#include "ssx/future-util.h"
 
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/util/log.hh>
@@ -144,8 +145,10 @@ ss::future<> multipart_upload::complete() {
           _state->upload_part(_part_number++, std::move(_buffer)));
         if (fut.failed()) {
             auto ex = fut.get_exception();
-            vlog(
-              s3_log.error,
+            vlogl(
+              s3_log,
+              ssx::is_shutdown_exception(ex) ? ss::log_level::warn
+                                             : ss::log_level::error,
               "Multipart upload final part failed, aborting: {}",
               ex);
             co_await abort_on_error();
@@ -159,8 +162,12 @@ ss::future<> multipart_upload::complete() {
       _state->complete_multipart_upload());
     if (fut.failed()) {
         auto ex = fut.get_exception();
-        vlog(
-          s3_log.error, "Multipart upload completion failed, aborting: {}", ex);
+        vlogl(
+          s3_log,
+          ssx::is_shutdown_exception(ex) ? ss::log_level::warn
+                                         : ss::log_level::error,
+          "Multipart upload completion failed, aborting: {}",
+          ex);
         co_await abort_on_error();
         std::rethrow_exception(ex);
     }

--- a/src/v/cloud_storage_clients/multipart_upload.h
+++ b/src/v/cloud_storage_clients/multipart_upload.h
@@ -18,6 +18,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/util/log.hh>
 
 #include <memory>
 
@@ -115,9 +116,11 @@ public:
     ///
     /// \param state Backend-specific state implementation
     /// \param part_size Size of each part in bytes
+    /// \param logger Logger to use for diagnostics
     explicit multipart_upload(
       ss::shared_ptr<multipart_upload_state> state,
-      size_t part_size = min_part_size);
+      size_t part_size,
+      ss::logger& logger);
 
     ~multipart_upload() override;
 
@@ -175,6 +178,7 @@ private:
 
     ss::shared_ptr<multipart_upload_state> _state;
     size_t _part_size;
+    ss::logger& _logger;
     iobuf _buffer;
     size_t _part_number{1};
     bool _multipart_initialized{false};

--- a/src/v/cloud_storage_clients/tests/multipart_upload_test.cc
+++ b/src/v/cloud_storage_clients/tests/multipart_upload_test.cc
@@ -26,6 +26,7 @@
 using namespace cloud_storage_clients;
 using namespace cloud_storage_clients::tests;
 
+static ss::logger test_log("multipart_upload_test");
 static constexpr size_t test_part_size = 5_MiB;
 
 SEASTAR_THREAD_TEST_CASE(test_multipart_upload_basic) {
@@ -79,7 +80,7 @@ SEASTAR_THREAD_TEST_CASE(test_multipart_upload_basic) {
 
     BOOST_REQUIRE(state_result.has_value());
     auto upload = ss::make_shared<multipart_upload>(
-      std::move(state_result.value()), test_part_size);
+      std::move(state_result.value()), test_part_size, test_log);
 
     // Write 6 MiB of data (should trigger one part upload immediately)
     auto data = ::tests::random_iobuf(6_MiB);
@@ -129,7 +130,7 @@ SEASTAR_THREAD_TEST_CASE(test_multipart_upload_small_file_optimization) {
 
     BOOST_REQUIRE(state_result.has_value());
     auto upload = ss::make_shared<multipart_upload>(
-      std::move(state_result.value()), test_part_size);
+      std::move(state_result.value()), test_part_size, test_log);
 
     // Write only 3 MiB (less than part_size)
     auto data = ::tests::random_iobuf(3_MiB);
@@ -190,7 +191,7 @@ SEASTAR_THREAD_TEST_CASE(test_multipart_upload_abort) {
 
     BOOST_REQUIRE(state_result.has_value());
     auto upload = ss::make_shared<multipart_upload>(
-      std::move(state_result.value()), test_part_size);
+      std::move(state_result.value()), test_part_size, test_log);
 
     // Write data to trigger multipart initialization
     auto data = ::tests::random_iobuf(6_MiB);
@@ -269,7 +270,7 @@ SEASTAR_THREAD_TEST_CASE(test_multipart_upload_complete_error_in_body) {
 
     BOOST_REQUIRE(state_result.has_value());
     auto upload = ss::make_shared<multipart_upload>(
-      std::move(state_result.value()), test_part_size);
+      std::move(state_result.value()), test_part_size, test_log);
 
     // Write exactly 5 MiB (triggers first part upload, no leftover)
     auto data = ::tests::random_iobuf(5_MiB);

--- a/src/v/cloud_topics/level_one/common/fake_io.cc
+++ b/src/v/cloud_topics/level_one/common/fake_io.cc
@@ -16,6 +16,8 @@
 
 namespace cloud_topics::l1 {
 
+static ss::logger fake_io_log("fake_io");
+
 // In-memory multipart upload state for testing.
 class fake_multipart_state final
   : public cloud_storage_clients::multipart_upload_state {
@@ -155,7 +157,7 @@ fake_io::create_multipart_upload(
   object_id oid, size_t part_size, ss::abort_source*) {
     auto state = ss::make_shared<fake_multipart_state>(oid, _storage);
     auto upload = ss::make_shared<cloud_storage_clients::multipart_upload>(
-      std::move(state), part_size);
+      std::move(state), part_size, fake_io_log);
     co_return upload;
 }
 

--- a/src/v/cloud_topics/reconciler/tests/test_utils.h
+++ b/src/v/cloud_topics/reconciler/tests/test_utils.h
@@ -20,12 +20,15 @@
 #include "model/tests/random_batch.h"
 
 #include <seastar/core/future.hh>
+#include <seastar/util/log.hh>
 
 #include <expected>
 #include <optional>
 #include <stdexcept>
 
 namespace cloud_topics::reconciler::test {
+
+static ss::logger test_log("reconciler_test");
 
 class fake_source : public source {
 public:
@@ -192,7 +195,7 @@ public:
         auto state = ss::make_shared<unreliable_multipart_state>(
           oid, *this, _fail_upload_part, _fail_complete, _fail_abort);
         auto upload = ss::make_shared<cloud_storage_clients::multipart_upload>(
-          std::move(state), part_size);
+          std::move(state), part_size, test_log);
         co_return upload;
     }
 


### PR DESCRIPTION
* Log at `WARN` instead of `ERROR` during shutdown (https://ci-artifacts.dev.vectorized.cloud/production-devprod/redpanda/80940/019c8c9f-495c-4230-8be2-ac96c1e13db1/vbuild/ducktape/results/2026-02-23--001/report.html)
* Construct `multipart_upload` with a `logger&` instead of hardcoding use of the `s3_log`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
