### PR TITLE
`cloud_topics`: downgrade log lines in `write_request_scheduler`

### DIFF
--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
@@ -248,7 +248,7 @@ schedule_result<Clock> scheduler_context<Clock>::try_schedule_upload(
                 if (try_split_group(gid)) {
                     vlog(cd_log.trace, "Split group {}", gid);
                 } else {
-                    vlog(cd_log.info, "Failed to split group {}", gid);
+                    vlog(cd_log.debug, "Failed to split group {}", gid);
                 }
             } else if (next_stage_bytes == 0) {
                 // Merge: next stage is empty, can work together with buddy
@@ -271,7 +271,7 @@ schedule_result<Clock> scheduler_context<Clock>::try_schedule_upload(
                         }
                     } else {
                         vlog(
-                          cd_log.info,
+                          cd_log.debug,
                           "Failed to merge group {}, group size: {}",
                           gid,
                           grp_size);


### PR DESCRIPTION
These are quite noisy at `INFO`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
