### PR TITLE
rpk/registry: add context list and delete commands

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/prometheus/common v0.65.0
 	github.com/redpanda-data/common-go/proto v0.0.0-20260223115805-73fb9bd9c2c0
 	github.com/redpanda-data/common-go/rpadmin v0.2.4
-	github.com/redpanda-data/common-go/rpsr v0.1.3
+	github.com/redpanda-data/common-go/rpsr v0.1.4
 	github.com/redpanda-data/protoc-gen-go-mcp v0.0.0-20250930092048-a98b94b5957a
 	github.com/rs/xid v1.6.0
 	github.com/safchain/ethtool v0.6.2
@@ -67,13 +67,13 @@ require (
 	github.com/twmb/franz-go/pkg/kadm v1.17.1
 	github.com/twmb/franz-go/pkg/kfake v0.0.0-20251024215757-aea970d4d0d2
 	github.com/twmb/franz-go/pkg/kmsg v1.12.0
-	github.com/twmb/franz-go/pkg/sr v1.5.0
+	github.com/twmb/franz-go/pkg/sr v1.7.0
 	github.com/twmb/franz-go/plugin/kzap v1.1.2
 	github.com/twmb/tlscfg v1.2.1
 	github.com/twmb/types v1.1.6
 	go.uber.org/zap v1.27.1
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546
-	golang.org/x/sync v0.19.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.41.0
 	golang.org/x/term v0.40.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260311181403-84a4fc48630c

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -266,8 +266,8 @@ github.com/redpanda-data/common-go/proto v0.0.0-20260223115805-73fb9bd9c2c0 h1:H
 github.com/redpanda-data/common-go/proto v0.0.0-20260223115805-73fb9bd9c2c0/go.mod h1:4TOyhdEvR/hlk0RjHXzmO0hYmWBpGGI1qiFPNv211O4=
 github.com/redpanda-data/common-go/rpadmin v0.2.4 h1:XM7kfhKokWeLATX4dnLXczjd4sxN2AcJll/KRvE15iA=
 github.com/redpanda-data/common-go/rpadmin v0.2.4/go.mod h1:uOAY10WXPtcDPU0aUdpkqHR+b1BqUvRhlvMf0vha73A=
-github.com/redpanda-data/common-go/rpsr v0.1.3 h1:mcjp7MeJylONI0H4MlrUEPEVOZpPNQGzWqcdd1QIAv4=
-github.com/redpanda-data/common-go/rpsr v0.1.3/go.mod h1:2j2416onosg5FKaKz52NooRE+q/9EJqQn0kyTcTXWHc=
+github.com/redpanda-data/common-go/rpsr v0.1.4 h1:d9lu5q5wyhZWBYR1GnZkq+eZGKU0qoaSwwybRS9Uk2k=
+github.com/redpanda-data/common-go/rpsr v0.1.4/go.mod h1:qVa7b0yaCRdZDn5dcZ9CazqVr4jYbgtOJUywI2X3G3I=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525 h1:vskZrV6q8W8flL0Ud23AJUYAd8ZgTadO45+loFnG2G0=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525/go.mod h1:3YqAM7pgS5vW/EH7naCjFqnAajSgi0f0CfMe1HGhLxQ=
 github.com/redpanda-data/protoc-gen-go-mcp v0.0.0-20250930092048-a98b94b5957a h1:jNHT6Fcy/rBAFnX8rjbwrJ+lSF2Ufa1jqmnCV6m6RKY=
@@ -340,8 +340,8 @@ github.com/twmb/franz-go/pkg/kfake v0.0.0-20251024215757-aea970d4d0d2 h1:Iwo/KHm
 github.com/twmb/franz-go/pkg/kfake v0.0.0-20251024215757-aea970d4d0d2/go.mod h1:d8HaJtUEgZfU2n+Ps/fCtzlFLtgdrlZgTWwvCqQ3eDo=
 github.com/twmb/franz-go/pkg/kmsg v1.12.0 h1:CbatD7ers1KzDNgJqPbKOq0Bz/WLBdsTH75wgzeVaPc=
 github.com/twmb/franz-go/pkg/kmsg v1.12.0/go.mod h1:+DPt4NC8RmI6hqb8G09+3giKObE6uD2Eya6CfqBpeJY=
-github.com/twmb/franz-go/pkg/sr v1.5.0 h1:KQH8veHxKyAjT4U4/rziJnSEfafuluznLoxhrp0yJfo=
-github.com/twmb/franz-go/pkg/sr v1.5.0/go.mod h1:O4o4mUMNfmyEt2HcuM+qZdc6KrcStvjgxWR6Cfvmukw=
+github.com/twmb/franz-go/pkg/sr v1.7.0 h1:wHStlO6aOPWWgZ68ZYcdtQe9tRbkcTc1gRLbgs+8QAA=
+github.com/twmb/franz-go/pkg/sr v1.7.0/go.mod h1:64CsHlsQnyFRq1sYPcCmlRrEG3PlLPb6cDddx2wGr28=
 github.com/twmb/franz-go/plugin/kzap v1.1.2 h1:0arX5xJ0soUPX1LlDay6ZZoxuWkWk1lggQ5M/IgRXAE=
 github.com/twmb/franz-go/plugin/kzap v1.1.2/go.mod h1:53Cl9Uz1pbdOPDvUISIxLrZIWSa2jCuY1bTMauRMBmo=
 github.com/twmb/tlscfg v1.2.1 h1:IU2efmP9utQEIV2fufpZjPq7xgcZK4qu25viD51BB44=
@@ -415,8 +415,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
-golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/src/go/rpk/pkg/cli/registry/BUILD
+++ b/src/go/rpk/pkg/cli/registry/BUILD
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/registry",
     visibility = ["//visibility:public"],
     deps = [
+        "//src/go/rpk/pkg/cli/registry/context",
         "//src/go/rpk/pkg/cli/registry/mode",
         "//src/go/rpk/pkg/cli/registry/schema",
         "//src/go/rpk/pkg/config",

--- a/src/go/rpk/pkg/cli/registry/compatibility_level.go
+++ b/src/go/rpk/pkg/cli/registry/compatibility_level.go
@@ -21,15 +21,15 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
 )
 
-func compatibilityLevelCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func compatibilityLevelCommand(fs afero.Fs, p *config.Params, schemaCtx *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "compatibility-level",
 		Args:  cobra.ExactArgs(0),
 		Short: "Manage global or per-subject compatibility levels",
 	}
 	cmd.AddCommand(
-		compatGetCommand(fs, p),
-		compatSetCommand(fs, p),
+		compatGetCommand(fs, p, schemaCtx),
+		compatSetCommand(fs, p, schemaCtx),
 	)
 	p.InstallFormatFlag(cmd)
 	return cmd
@@ -41,7 +41,7 @@ type compatibilityLevelResponse struct {
 	Err     string `json:"error,omitempty" yaml:"error,omitempty"`
 }
 
-func compatGetCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func compatGetCommand(fs afero.Fs, p *config.Params, schemaCtx *string) *cobra.Command {
 	var global bool
 	cmd := &cobra.Command{
 		Use:   "get [SUBJECT...]",
@@ -63,10 +63,9 @@ per-subject levels.
 			cl, err := schemaregistry.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
 
-			schemaCtx, _ := cmd.Flags().GetString("schema-context")
 			for i, s := range subjects {
 				if s != sr.GlobalSubject {
-					subjects[i] = schemaregistry.QualifySubject(schemaCtx, s)
+					subjects[i] = schemaregistry.QualifySubject(*schemaCtx, s)
 				}
 			}
 			if len(subjects) > 0 && global {
@@ -74,7 +73,7 @@ per-subject levels.
 			}
 			results := cl.Compatibility(cmd.Context(), subjects...)
 			for i := range results {
-				results[i].Subject = schemaregistry.StripContextQualifier(schemaCtx, results[i].Subject)
+				results[i].Subject = schemaregistry.StripContextQualifier(*schemaCtx, results[i].Subject)
 			}
 
 			err = printCompatibilityResult(results, f)
@@ -86,7 +85,7 @@ per-subject levels.
 	return cmd
 }
 
-func compatSetCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func compatSetCommand(fs afero.Fs, p *config.Params, schemaCtx *string) *cobra.Command {
 	var global bool
 	var level string
 	cmd := &cobra.Command{
@@ -104,10 +103,9 @@ func compatSetCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			cl, err := schemaregistry.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
 
-			schemaCtx, _ := cmd.Flags().GetString("schema-context")
 			for i, s := range subjects {
 				if s != sr.GlobalSubject {
-					subjects[i] = schemaregistry.QualifySubject(schemaCtx, s)
+					subjects[i] = schemaregistry.QualifySubject(*schemaCtx, s)
 				}
 			}
 			if len(subjects) > 0 && global {
@@ -119,7 +117,7 @@ func compatSetCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 			results := cl.SetCompatibility(cmd.Context(), sr.SetCompatibility{Level: l}, subjects...)
 			for i := range results {
-				results[i].Subject = schemaregistry.StripContextQualifier(schemaCtx, results[i].Subject)
+				results[i].Subject = schemaregistry.StripContextQualifier(*schemaCtx, results[i].Subject)
 			}
 			err = printCompatibilityResult(results, f)
 			out.MaybeDieErr(err)

--- a/src/go/rpk/pkg/cli/registry/compatibility_level.go
+++ b/src/go/rpk/pkg/cli/registry/compatibility_level.go
@@ -10,15 +10,15 @@
 package registry
 
 import (
-	"context"
 	"fmt"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/sr"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
-	"github.com/spf13/afero"
-	"github.com/spf13/cobra"
-	"github.com/twmb/franz-go/pkg/sr"
 )
 
 func compatibilityLevelCommand(fs afero.Fs, p *config.Params) *cobra.Command {
@@ -52,7 +52,7 @@ Running this command with no subject returns the global level, alternatively
 you can use the --global flag to get the global level at the same time as
 per-subject levels.
 `,
-		Run: func(_ *cobra.Command, subjects []string) {
+		Run: func(cmd *cobra.Command, subjects []string) {
 			f := p.Formatter
 			if h, ok := f.Help([]compatibilityLevelResponse{}); ok {
 				out.Exit(h)
@@ -63,10 +63,19 @@ per-subject levels.
 			cl, err := schemaregistry.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
 
+			schemaCtx, _ := cmd.Flags().GetString("schema-context")
+			for i, s := range subjects {
+				if s != sr.GlobalSubject {
+					subjects[i] = schemaregistry.QualifySubject(schemaCtx, s)
+				}
+			}
 			if len(subjects) > 0 && global {
 				subjects = append(subjects, sr.GlobalSubject)
 			}
-			results := cl.Compatibility(context.Background(), subjects...)
+			results := cl.Compatibility(cmd.Context(), subjects...)
+			for i := range results {
+				results[i].Subject = schemaregistry.StripContextQualifier(schemaCtx, results[i].Subject)
+			}
 
 			err = printCompatibilityResult(results, f)
 			out.MaybeDieErr(err)
@@ -84,7 +93,7 @@ func compatSetCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Use:   "set [SUBJECT...]",
 		Short: "Set the global or per-subject compatibility levels",
 		Long:  compatHelpText,
-		Run: func(_ *cobra.Command, subjects []string) {
+		Run: func(cmd *cobra.Command, subjects []string) {
 			f := p.Formatter
 			if h, ok := f.Help([]compatibilityLevelResponse{}); ok {
 				out.Exit(h)
@@ -94,6 +103,13 @@ func compatSetCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 			cl, err := schemaregistry.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
+
+			schemaCtx, _ := cmd.Flags().GetString("schema-context")
+			for i, s := range subjects {
+				if s != sr.GlobalSubject {
+					subjects[i] = schemaregistry.QualifySubject(schemaCtx, s)
+				}
+			}
 			if len(subjects) > 0 && global {
 				subjects = append(subjects, sr.GlobalSubject)
 			}
@@ -101,7 +117,10 @@ func compatSetCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			err = l.UnmarshalText([]byte(level))
 			out.MaybeDieErr(err)
 
-			results := cl.SetCompatibility(context.Background(), sr.SetCompatibility{Level: l}, subjects...)
+			results := cl.SetCompatibility(cmd.Context(), sr.SetCompatibility{Level: l}, subjects...)
+			for i := range results {
+				results[i].Subject = schemaregistry.StripContextQualifier(schemaCtx, results[i].Subject)
+			}
 			err = printCompatibilityResult(results, f)
 			out.MaybeDieErr(err)
 		},

--- a/src/go/rpk/pkg/cli/registry/context/BUILD
+++ b/src/go/rpk/pkg/cli/registry/context/BUILD
@@ -1,41 +1,36 @@
 load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "schema",
+    name = "context",
     srcs = [
-        "check_compatibility.go",
-        "create.go",
+        "context.go",
         "delete.go",
-        "get.go",
         "list.go",
-        "references.go",
-        "schema.go",
     ],
-    importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/registry/schema",
+    importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/registry/context",
     visibility = ["//visibility:public"],
     deps = [
-        "//src/go/rpk/pkg/cli/registry/context",
+        "//src/go/rpk/pkg/adminapi",
         "//src/go/rpk/pkg/config",
         "//src/go/rpk/pkg/out",
         "//src/go/rpk/pkg/schemaregistry",
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_twmb_franz_go_pkg_sr//:sr",
-        "@com_github_twmb_types//:types",
     ],
 )
 
 go_test(
-    name = "schema_test",
-    size = "small",
-    srcs = [
-        "create_test.go",
-        "schema_test.go",
-    ],
-    embed = [":schema"],
+    name = "context_test",
+    srcs = ["context_test.go"],
     deps = [
+        ":context",
+        "//src/go/rpk/pkg/cli/registry",
+        "//src/go/rpk/pkg/config",
         "@com_github_spf13_afero//:afero",
+        "@com_github_spf13_cobra//:cobra",
         "@com_github_stretchr_testify//require",
         "@com_github_twmb_franz_go_pkg_sr//:sr",
+        "@com_github_twmb_franz_go_pkg_sr//srfake",
     ],
 )

--- a/src/go/rpk/pkg/cli/registry/context/context.go
+++ b/src/go/rpk/pkg/cli/registry/context/context.go
@@ -22,13 +22,14 @@ import (
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
 )
 
-const QualifiedSubjectsConfigKey = "schema_registry_enable_qualified_subjects"
+const qualifiedSubjectsConfigKey = "schema_registry_enable_qualified_subjects"
 
 type contextResponse struct {
-	Name string `json:"name" yaml:"name"`
+	Name          string `json:"name" yaml:"name"`
+	Mode          string `json:"mode" yaml:"mode"`
+	Compatibility string `json:"compatibility" yaml:"compatibility"`
 }
 
 // ListContexts calls cl.Contexts and translates a 404 into a message
@@ -45,38 +46,46 @@ func ListContexts(ctx context.Context, cl *sr.Client) ([]string, error) {
 	return contexts, nil
 }
 
-// CheckQualifiedSubjectsEnabled verifies that the cluster has the
+// checkQualifiedSubjectsEnabled verifies that the cluster has the
 // schema_registry_enable_qualified_subjects config set to true via the
-// Admin API. This is for Redpanda 26.1 clusters where the SR API
-// returns 200 for /contexts.
-func CheckQualifiedSubjectsEnabled(ctx context.Context, fs afero.Fs, profile *config.RpkProfile) error {
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+// Admin API.
+func checkQualifiedSubjectsEnabled(ctx context.Context, fs afero.Fs, profile *config.RpkProfile) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	cl, err := adminapi.NewClient(ctx, fs, profile)
 	if err != nil {
 		return fmt.Errorf("unable to verify schema context support via admin API: %w\nUse --skip-context-check to skip this verification", err)
 	}
-	cfg, err := cl.SingleKeyConfig(ctx, QualifiedSubjectsConfigKey)
+	cfg, err := cl.SingleKeyConfig(ctx, qualifiedSubjectsConfigKey)
 	if err != nil {
 		return fmt.Errorf("unable to verify schema context support via admin API: %w\nUse --skip-context-check to skip this verification", err)
 	}
-	val, exists := cfg[QualifiedSubjectsConfigKey]
+	val, exists := cfg[qualifiedSubjectsConfigKey]
 	if !exists {
-		return fmt.Errorf("schema contexts are not supported by this cluster (config key %q not found)", QualifiedSubjectsConfigKey)
+		return fmt.Errorf("schema contexts are not supported by this cluster (config key %q not found); the cluster may need upgrading", qualifiedSubjectsConfigKey)
 	}
 	enabled, ok := val.(bool)
 	if !ok {
-		return fmt.Errorf("schema contexts are not supported by this cluster (unexpected value for %q: %v)", QualifiedSubjectsConfigKey, val)
+		return fmt.Errorf("schema contexts are not supported by this cluster (unexpected value for %q: %v)", qualifiedSubjectsConfigKey, val)
 	}
 	if !enabled {
-		return fmt.Errorf("schema contexts are not enabled on this cluster; set %s to true", QualifiedSubjectsConfigKey)
+		return fmt.Errorf("schema contexts are not enabled on this cluster; you may enable it using:\n  rpk cluster config set %s true", qualifiedSubjectsConfigKey)
 	}
 	return nil
 }
 
+// IsContextSupported checks whether the cluster supports schema contexts
+// by verifying the admin API feature flag.
+func IsContextSupported(ctx context.Context, fs afero.Fs, profile *config.RpkProfile, skipAdminCheck bool) error {
+	if skipAdminCheck {
+		return nil
+	}
+	return checkQualifiedSubjectsEnabled(ctx, fs, profile)
+}
+
 // ValidateContext validates the schema context name format, loads the
-// profile and SR client, confirms the cluster supports contexts via
-// GET /contexts, and optionally verifies the admin API feature flag.
+// profile, and confirms the cluster supports contexts via the admin API
+// feature flag.
 func ValidateContext(ctx context.Context, schemaCtx string, fs afero.Fs, p *config.Params, skipAdminCheck bool) error {
 	if schemaCtx[0] != '.' {
 		return fmt.Errorf("invalid schema context %q: context names must start with a '.'", schemaCtx)
@@ -88,30 +97,28 @@ func ValidateContext(ctx context.Context, schemaCtx string, fs afero.Fs, p *conf
 	if err != nil {
 		return fmt.Errorf("rpk unable to load config: %w", err)
 	}
-	cl, err := schemaregistry.NewClient(fs, profile)
-	if err != nil {
-		return fmt.Errorf("unable to initialize schema registry client: %w", err)
-	}
-	return CheckContextSupport(ctx, cl.Client, fs, profile, skipAdminCheck)
+	return IsContextSupported(ctx, fs, profile, skipAdminCheck)
 }
 
-// CheckContextSupport checks whether the cluster supports schema contexts by
-// calling GET /contexts and optionally verifying the admin API flag.
-func CheckContextSupport(ctx context.Context, cl *sr.Client, fs afero.Fs, profile *config.RpkProfile, skipAdminCheck bool) error {
-	if _, err := ListContexts(ctx, cl); err != nil {
-		return err
-	}
-	if !skipAdminCheck {
-		return CheckQualifiedSubjectsEnabled(ctx, fs, profile)
-	}
-	return nil
-}
-
-func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func NewCommand(fs afero.Fs, p *config.Params, _ *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "context",
 		Args:  cobra.ExactArgs(0),
 		Short: "Manage schema registry contexts",
+		Long: `Manage schema registry contexts.
+
+Schema contexts provide namespace isolation within the schema registry,
+allowing multiple independent sets of subjects and schemas to coexist.
+
+Before using schema contexts, the cluster must have the
+schema_registry_enable_qualified_subjects configuration set to true. You
+can enable it with:
+
+  rpk cluster config set schema_registry_enable_qualified_subjects true
+
+Use the --schema-context flag on the parent 'registry' command to scope
+operations to a specific context.
+`,
 	}
 	cmd.AddCommand(
 		listCommand(fs, p),

--- a/src/go/rpk/pkg/cli/registry/context/context.go
+++ b/src/go/rpk/pkg/cli/registry/context/context.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package context
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/sr"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
+)
+
+const QualifiedSubjectsConfigKey = "schema_registry_enable_qualified_subjects"
+
+type contextResponse struct {
+	Name string `json:"name" yaml:"name"`
+}
+
+// ListContexts calls cl.Contexts and translates a 404 into a message
+// indicating that the Redpanda cluster does not support schema contexts.
+func ListContexts(ctx context.Context, cl *sr.Client) ([]string, error) {
+	contexts, err := cl.Contexts(ctx)
+	if err != nil {
+		var re *sr.ResponseError
+		if errors.As(err, &re) && re.StatusCode == 404 {
+			return nil, fmt.Errorf("schema registry contexts are not supported by this cluster")
+		}
+		return nil, err
+	}
+	return contexts, nil
+}
+
+// CheckQualifiedSubjectsEnabled verifies that the cluster has the
+// schema_registry_enable_qualified_subjects config set to true via the
+// Admin API. This is for Redpanda 26.1 clusters where the SR API
+// returns 200 for /contexts.
+func CheckQualifiedSubjectsEnabled(ctx context.Context, fs afero.Fs, profile *config.RpkProfile) error {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	cl, err := adminapi.NewClient(ctx, fs, profile)
+	if err != nil {
+		return fmt.Errorf("unable to verify schema context support via admin API: %w\nUse --skip-context-check to skip this verification", err)
+	}
+	cfg, err := cl.SingleKeyConfig(ctx, QualifiedSubjectsConfigKey)
+	if err != nil {
+		return fmt.Errorf("unable to verify schema context support via admin API: %w\nUse --skip-context-check to skip this verification", err)
+	}
+	val, exists := cfg[QualifiedSubjectsConfigKey]
+	if !exists {
+		return fmt.Errorf("schema contexts are not supported by this cluster (config key %q not found)", QualifiedSubjectsConfigKey)
+	}
+	enabled, ok := val.(bool)
+	if !ok {
+		return fmt.Errorf("schema contexts are not supported by this cluster (unexpected value for %q: %v)", QualifiedSubjectsConfigKey, val)
+	}
+	if !enabled {
+		return fmt.Errorf("schema contexts are not enabled on this cluster; set %s to true", QualifiedSubjectsConfigKey)
+	}
+	return nil
+}
+
+// ValidateContext validates the schema context name format, loads the
+// profile and SR client, confirms the cluster supports contexts via
+// GET /contexts, and optionally verifies the admin API feature flag.
+func ValidateContext(ctx context.Context, schemaCtx string, fs afero.Fs, p *config.Params, skipAdminCheck bool) error {
+	if schemaCtx[0] != '.' {
+		return fmt.Errorf("invalid schema context %q: context names must start with a '.'", schemaCtx)
+	}
+	if strings.Contains(schemaCtx, ":") {
+		return fmt.Errorf("invalid schema context %q: context names must not contain ':'", schemaCtx)
+	}
+	profile, err := p.LoadVirtualProfile(fs)
+	if err != nil {
+		return fmt.Errorf("rpk unable to load config: %w", err)
+	}
+	cl, err := schemaregistry.NewClient(fs, profile)
+	if err != nil {
+		return fmt.Errorf("unable to initialize schema registry client: %w", err)
+	}
+	return CheckContextSupport(ctx, cl.Client, fs, profile, skipAdminCheck)
+}
+
+// CheckContextSupport checks whether the cluster supports schema contexts by
+// calling GET /contexts and optionally verifying the admin API flag.
+func CheckContextSupport(ctx context.Context, cl *sr.Client, fs afero.Fs, profile *config.RpkProfile, skipAdminCheck bool) error {
+	if _, err := ListContexts(ctx, cl); err != nil {
+		return err
+	}
+	if !skipAdminCheck {
+		return CheckQualifiedSubjectsEnabled(ctx, fs, profile)
+	}
+	return nil
+}
+
+func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "context",
+		Args:  cobra.ExactArgs(0),
+		Short: "Manage schema registry contexts",
+	}
+	cmd.AddCommand(
+		listCommand(fs, p),
+		deleteCommand(fs, p),
+	)
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/registry/context/context_test.go
+++ b/src/go/rpk/pkg/cli/registry/context/context_test.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"strings"
 	"testing"
 
 	srcontext "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/registry/context"
@@ -124,11 +123,12 @@ func TestContextList(t *testing.T) {
 		require.NoError(t, cmd.Execute())
 	})
 
-	// Split into lines so "." does not false-match inside ".ctx1".
-	lines := strings.Split(strings.TrimSpace(output), "\n")
-	require.Contains(t, lines, ".")
-	require.Contains(t, lines, ".ctx1")
-	require.Contains(t, lines, ".ctx2")
+	// Table output should include header and context names.
+	require.Contains(t, output, "CONTEXT")
+	require.Contains(t, output, "MODE")
+	require.Contains(t, output, "COMPATIBILITY")
+	require.Contains(t, output, ".ctx1")
+	require.Contains(t, output, ".ctx2")
 }
 
 func TestContextListEmpty(t *testing.T) {
@@ -142,7 +142,8 @@ func TestContextListEmpty(t *testing.T) {
 		require.NoError(t, cmd.Execute())
 	})
 
-	require.Equal(t, ".\n", output)
+	// Should show table with at least the default context.
+	require.Contains(t, output, "CONTEXT")
 }
 
 func TestContextListWithSchemaContext(t *testing.T) {
@@ -160,7 +161,7 @@ func TestContextListWithSchemaContext(t *testing.T) {
 	})
 
 	// GET /contexts returns all contexts regardless of --schema-context.
-	require.Contains(t, output, ".")
+	require.Contains(t, output, "CONTEXT")
 	require.Contains(t, output, ".ctx1")
 	require.Contains(t, output, ".ctx2")
 }
@@ -289,7 +290,7 @@ func TestAdminAPICheckFlagEnabled(t *testing.T) {
 	reg.SeedSchema(":.ctx1:my-subject", 1, 1, testSchema)
 
 	admin := fakeAdminAPI(t, map[string]any{
-		srcontext.QualifiedSubjectsConfigKey: true,
+		"schema_registry_enable_qualified_subjects": true,
 	})
 	defer admin.Close()
 
@@ -306,7 +307,7 @@ func TestAdminAPICheckFlagEnabled(t *testing.T) {
 
 func TestAdminAPICheckFlagDisabled(t *testing.T) {
 	admin := fakeAdminAPI(t, map[string]any{
-		srcontext.QualifiedSubjectsConfigKey: false,
+		"schema_registry_enable_qualified_subjects": false,
 	})
 	defer admin.Close()
 
@@ -323,7 +324,7 @@ profiles:
 	profile, err := p.LoadVirtualProfile(fs)
 	require.NoError(t, err)
 
-	err = srcontext.CheckQualifiedSubjectsEnabled(context.Background(), fs, profile)
+	err = srcontext.IsContextSupported(context.Background(), fs, profile, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "schema contexts are not enabled on this cluster")
 }
@@ -377,16 +378,14 @@ func TestSubjectListNoContextColumn(t *testing.T) {
 	reg.SeedSchema("plain-topic", 1, 1, testSchema)
 	reg.SeedSchema("another-topic", 1, 2, testSchema)
 
-	// Simulate a cluster that does not support contexts (404).
-	reg.Intercept(func(w http.ResponseWriter, r *http.Request) bool {
-		if r.URL.Path == "/contexts" {
-			http.Error(w, "Not found", http.StatusNotFound)
-			return true
-		}
-		return false
+	// Simulate a cluster that does not support contexts: admin API
+	// reports qualified_subjects as false.
+	admin := fakeAdminAPI(t, map[string]any{
+		"schema_registry_enable_qualified_subjects": false,
 	})
+	defer admin.Close()
 
-	cmd := setupRegistryTest(t, reg)
+	cmd := setupRegistryTestWithAdmin(t, reg, admin.URL)
 	cmd.SetArgs([]string{"subject", "list"})
 
 	output := captureOutput(func() {
@@ -447,16 +446,14 @@ func TestSchemaListNoContextColumn(t *testing.T) {
 
 	reg.SeedSchema("plain-topic", 1, 1, testSchema)
 
-	// Simulate a cluster that does not support contexts (404).
-	reg.Intercept(func(w http.ResponseWriter, r *http.Request) bool {
-		if r.URL.Path == "/contexts" {
-			http.Error(w, "Not found", http.StatusNotFound)
-			return true
-		}
-		return false
+	// Simulate a cluster that does not support contexts: admin API
+	// reports qualified_subjects as false.
+	admin := fakeAdminAPI(t, map[string]any{
+		"schema_registry_enable_qualified_subjects": false,
 	})
+	defer admin.Close()
 
-	cmd := setupRegistryTest(t, reg)
+	cmd := setupRegistryTestWithAdmin(t, reg, admin.URL)
 	cmd.SetArgs([]string{"schema", "list"})
 
 	output := captureOutput(func() {
@@ -475,7 +472,7 @@ func TestSubjectListContextColumnWithAdminAPI(t *testing.T) {
 	reg.SeedSchema(":.ctx1:my-subject", 1, 2, testSchema)
 
 	admin := fakeAdminAPI(t, map[string]any{
-		srcontext.QualifiedSubjectsConfigKey: true,
+		"schema_registry_enable_qualified_subjects": true,
 	})
 	defer admin.Close()
 

--- a/src/go/rpk/pkg/cli/registry/context/context_test.go
+++ b/src/go/rpk/pkg/cli/registry/context/context_test.go
@@ -1,0 +1,514 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package context_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	srcontext "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/registry/context"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/sr"
+	"github.com/twmb/franz-go/pkg/sr/srfake"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/registry"
+)
+
+var testSchema = sr.Schema{
+	Schema: `{"type":"record","name":"User","fields":[{"name":"id","type":"string"}]}`,
+	Type:   sr.TypeAvro,
+}
+
+func setupRegistryTest(t *testing.T, reg *srfake.Registry) *cobra.Command {
+	t.Helper()
+	fs := afero.NewMemMapFs()
+	cfgBody := fmt.Sprintf(`current_profile: test
+profiles:
+    - name: test
+      schema_registry:
+        addresses:
+            - %s
+`, reg.URL())
+	require.NoError(t, afero.WriteFile(fs, "/tmp/rpk.yaml", []byte(cfgBody), 0o644))
+
+	p := &config.Params{
+		ConfigFlag: "/tmp/rpk.yaml",
+		Formatter:  config.OutFormatter{Kind: "text"},
+	}
+	return registry.NewCommand(fs, p)
+}
+
+func setupRegistryTestWithAdmin(t *testing.T, reg *srfake.Registry, adminURL string) *cobra.Command {
+	t.Helper()
+	fs := afero.NewMemMapFs()
+	cfgBody := fmt.Sprintf(`current_profile: test
+profiles:
+    - name: test
+      schema_registry:
+        addresses:
+            - %s
+      admin_api:
+        addresses:
+            - %s
+`, reg.URL(), adminURL)
+	require.NoError(t, afero.WriteFile(fs, "/tmp/rpk.yaml", []byte(cfgBody), 0o644))
+
+	p := &config.Params{
+		ConfigFlag: "/tmp/rpk.yaml",
+		Formatter:  config.OutFormatter{Kind: "text"},
+	}
+	return registry.NewCommand(fs, p)
+}
+
+// fakeAdminAPI returns an httptest.Server that responds to the
+// cluster_config endpoint with the given config value.
+func fakeAdminAPI(t *testing.T, configValue map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/cluster_config" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(configValue)
+			return
+		}
+		// Return empty JSON for other endpoints (e.g., license checks).
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{})
+	}))
+}
+
+// captureOutput captures stdout during function execution. This is needed
+// because the context commands use fmt.Println/fmt.Printf to write output.
+func captureOutput(f func()) string {
+	r, w, _ := os.Pipe()
+	oldStdout := os.Stdout
+	os.Stdout = w
+	f()
+	w.Close()
+	os.Stdout = oldStdout
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+func TestContextList(t *testing.T) {
+	reg := srfake.New()
+	defer reg.Close()
+
+	reg.SeedSchema("plain-topic", 1, 1, testSchema)
+	reg.SeedSchema(":.ctx1:my-subject", 1, 2, testSchema)
+	reg.SeedSchema(":.ctx2:other-subject", 1, 3, testSchema)
+
+	cmd := setupRegistryTest(t, reg)
+	cmd.SetArgs([]string{"context", "list"})
+
+	output := captureOutput(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	// Split into lines so "." does not false-match inside ".ctx1".
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	require.Contains(t, lines, ".")
+	require.Contains(t, lines, ".ctx1")
+	require.Contains(t, lines, ".ctx2")
+}
+
+func TestContextListEmpty(t *testing.T) {
+	reg := srfake.New()
+	defer reg.Close()
+
+	cmd := setupRegistryTest(t, reg)
+	cmd.SetArgs([]string{"context", "list"})
+
+	output := captureOutput(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	require.Equal(t, ".\n", output)
+}
+
+func TestContextListWithSchemaContext(t *testing.T) {
+	reg := srfake.New()
+	defer reg.Close()
+
+	reg.SeedSchema(":.ctx1:my-subject", 1, 1, testSchema)
+	reg.SeedSchema(":.ctx2:other-subject", 1, 2, testSchema)
+
+	cmd := setupRegistryTest(t, reg)
+	cmd.SetArgs([]string{"--schema-context", ".ctx1", "--skip-context-check", "context", "list"})
+
+	output := captureOutput(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	// GET /contexts returns all contexts regardless of --schema-context.
+	require.Contains(t, output, ".")
+	require.Contains(t, output, ".ctx1")
+	require.Contains(t, output, ".ctx2")
+}
+
+func TestContextDelete(t *testing.T) {
+	reg := srfake.New()
+	defer reg.Close()
+
+	// The rpk command first lists contexts to verify the target exists,
+	// then calls DELETE. Use an interceptor so GET /contexts includes
+	// .ctx1, while the registry has no subjects in that context (so the
+	// DELETE succeeds with 204).
+	reg.Intercept(func(w http.ResponseWriter, r *http.Request) bool {
+		if r.Method == "GET" && r.URL.Path == "/contexts" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode([]string{".", ".ctx1"})
+			return true
+		}
+		return false
+	})
+
+	cmd := setupRegistryTest(t, reg)
+	cmd.SetArgs([]string{"context", "delete", ".ctx1", "--no-confirm"})
+
+	output := captureOutput(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	require.Contains(t, output, `Successfully deleted context ".ctx1".`)
+}
+
+func TestListContextsUnsupported(t *testing.T) {
+	reg := srfake.New()
+	defer reg.Close()
+
+	// Simulate an older Redpanda that returns 404 for GET /contexts.
+	reg.Intercept(func(w http.ResponseWriter, r *http.Request) bool {
+		if r.URL.Path == "/contexts" {
+			http.Error(w, "Not found", http.StatusNotFound)
+			return true
+		}
+		return false
+	})
+
+	cl, err := sr.NewClient(sr.URLs(reg.URL()))
+	require.NoError(t, err)
+
+	_, err = srcontext.ListContexts(context.Background(), cl)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "schema registry contexts are not supported by this cluster")
+}
+
+func TestSubjectListWithSchemaContext(t *testing.T) {
+	reg := srfake.New()
+	defer reg.Close()
+
+	reg.SeedSchema("plain-topic", 1, 1, testSchema)
+	reg.SeedSchema(":.ctx1:my-subject", 1, 2, testSchema)
+	reg.SeedSchema(":.ctx1:another", 1, 3, testSchema)
+	reg.SeedSchema(":.ctx2:other-subject", 1, 4, testSchema)
+
+	cmd := setupRegistryTest(t, reg)
+	cmd.SetArgs([]string{"--schema-context", ".ctx1", "--skip-context-check", "subject", "list"})
+
+	output := captureOutput(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	// Should show only subjects in .ctx1, with qualifier stripped.
+	require.Contains(t, output, "another")
+	require.Contains(t, output, "my-subject")
+	require.NotContains(t, output, "plain-topic")
+	require.NotContains(t, output, "other-subject")
+	// Should NOT contain the context qualifier in the output.
+	require.NotContains(t, output, ":.ctx1:")
+}
+
+func TestSubjectDeleteWithSchemaContext(t *testing.T) {
+	reg := srfake.New()
+	defer reg.Close()
+
+	reg.SeedSchema(":.ctx1:my-subject", 1, 1, testSchema)
+
+	cmd := setupRegistryTest(t, reg)
+	cmd.SetArgs([]string{"--schema-context", ".ctx1", "--skip-context-check", "subject", "delete", "my-subject"})
+
+	output := captureOutput(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	// The display should show the unqualified subject name.
+	require.Contains(t, output, "my-subject")
+	require.NotContains(t, output, ":.ctx1:")
+
+	// Verify the qualified subject was actually deleted.
+	require.False(t, reg.SubjectExists(":.ctx1:my-subject"))
+}
+
+func TestSchemaListWithSchemaContext(t *testing.T) {
+	reg := srfake.New()
+	defer reg.Close()
+
+	reg.SeedSchema("plain-topic", 1, 1, testSchema)
+	reg.SeedSchema(":.ctx1:my-subject", 1, 2, testSchema)
+	reg.SeedSchema(":.ctx2:other-subject", 1, 3, testSchema)
+
+	cmd := setupRegistryTest(t, reg)
+	cmd.SetArgs([]string{"--schema-context", ".ctx1", "--skip-context-check", "schema", "list"})
+
+	output := captureOutput(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	// Should show only schemas in .ctx1, with qualifier stripped.
+	require.Contains(t, output, "my-subject")
+	require.NotContains(t, output, "plain-topic")
+	require.NotContains(t, output, "other-subject")
+	require.NotContains(t, output, ":.ctx1:")
+}
+
+func TestAdminAPICheckFlagEnabled(t *testing.T) {
+	reg := srfake.New()
+	defer reg.Close()
+
+	reg.SeedSchema(":.ctx1:my-subject", 1, 1, testSchema)
+
+	admin := fakeAdminAPI(t, map[string]any{
+		srcontext.QualifiedSubjectsConfigKey: true,
+	})
+	defer admin.Close()
+
+	cmd := setupRegistryTestWithAdmin(t, reg, admin.URL)
+	cmd.SetArgs([]string{"--schema-context", ".ctx1", "subject", "list"})
+
+	output := captureOutput(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	require.Contains(t, output, "my-subject")
+	require.NotContains(t, output, ":.ctx1:")
+}
+
+func TestAdminAPICheckFlagDisabled(t *testing.T) {
+	admin := fakeAdminAPI(t, map[string]any{
+		srcontext.QualifiedSubjectsConfigKey: false,
+	})
+	defer admin.Close()
+
+	fs := afero.NewMemMapFs()
+	cfgBody := fmt.Sprintf(`current_profile: test
+profiles:
+    - name: test
+      admin_api:
+        addresses:
+            - %s
+`, admin.URL)
+	require.NoError(t, afero.WriteFile(fs, "/tmp/rpk.yaml", []byte(cfgBody), 0o644))
+	p := &config.Params{ConfigFlag: "/tmp/rpk.yaml"}
+	profile, err := p.LoadVirtualProfile(fs)
+	require.NoError(t, err)
+
+	err = srcontext.CheckQualifiedSubjectsEnabled(context.Background(), fs, profile)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "schema contexts are not enabled on this cluster")
+}
+
+func TestAdminAPICheckSkipped(t *testing.T) {
+	reg := srfake.New()
+	defer reg.Close()
+
+	reg.SeedSchema(":.ctx1:my-subject", 1, 1, testSchema)
+
+	// No admin API server — would fail without --skip-context-check.
+	cmd := setupRegistryTest(t, reg)
+	cmd.SetArgs([]string{"--schema-context", ".ctx1", "--skip-context-check", "subject", "list"})
+
+	output := captureOutput(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	require.Contains(t, output, "my-subject")
+}
+
+func TestSubjectListContextColumn(t *testing.T) {
+	reg := srfake.New()
+	defer reg.Close()
+
+	reg.SeedSchema("plain-topic", 1, 1, testSchema)
+	reg.SeedSchema(":.ctx1:my-subject", 1, 2, testSchema)
+
+	// Contexts supported + admin check skipped → CONTEXT column should appear.
+	cmd := setupRegistryTest(t, reg)
+	cmd.SetArgs([]string{"--skip-context-check", "subject", "list"})
+
+	output := captureOutput(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	require.Contains(t, output, "CONTEXT")
+	require.Contains(t, output, "SUBJECT")
+	require.Contains(t, output, "default")
+	require.Contains(t, output, ".ctx1")
+	require.Contains(t, output, "plain-topic")
+	require.Contains(t, output, "my-subject")
+	// Raw qualified prefix should not appear.
+	require.NotContains(t, output, ":.ctx1:")
+}
+
+func TestSubjectListNoContextColumn(t *testing.T) {
+	reg := srfake.New()
+	defer reg.Close()
+
+	reg.SeedSchema("plain-topic", 1, 1, testSchema)
+	reg.SeedSchema("another-topic", 1, 2, testSchema)
+
+	// Simulate a cluster that does not support contexts (404).
+	reg.Intercept(func(w http.ResponseWriter, r *http.Request) bool {
+		if r.URL.Path == "/contexts" {
+			http.Error(w, "Not found", http.StatusNotFound)
+			return true
+		}
+		return false
+	})
+
+	cmd := setupRegistryTest(t, reg)
+	cmd.SetArgs([]string{"subject", "list"})
+
+	output := captureOutput(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	require.NotContains(t, output, "CONTEXT")
+	require.Contains(t, output, "another-topic")
+	require.Contains(t, output, "plain-topic")
+}
+
+func TestSubjectListContextColumnHiddenWithSchemaContext(t *testing.T) {
+	reg := srfake.New()
+	defer reg.Close()
+
+	reg.SeedSchema("plain-topic", 1, 1, testSchema)
+	reg.SeedSchema(":.ctx1:my-subject", 1, 2, testSchema)
+
+	// --schema-context filters results → no CONTEXT column.
+	cmd := setupRegistryTest(t, reg)
+	cmd.SetArgs([]string{"--schema-context", ".ctx1", "--skip-context-check", "subject", "list"})
+
+	output := captureOutput(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	require.NotContains(t, output, "CONTEXT")
+	require.Contains(t, output, "my-subject")
+}
+
+func TestSchemaListContextColumn(t *testing.T) {
+	reg := srfake.New()
+	defer reg.Close()
+
+	reg.SeedSchema("plain-topic", 1, 1, testSchema)
+	reg.SeedSchema(":.ctx1:my-subject", 1, 2, testSchema)
+
+	// Contexts supported + admin check skipped → CONTEXT column should appear.
+	cmd := setupRegistryTest(t, reg)
+	cmd.SetArgs([]string{"--skip-context-check", "schema", "list"})
+
+	output := captureOutput(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	require.Contains(t, output, "CONTEXT")
+	require.Contains(t, output, "SUBJECT")
+	require.Contains(t, output, "default")
+	require.Contains(t, output, ".ctx1")
+	require.Contains(t, output, "plain-topic")
+	require.Contains(t, output, "my-subject")
+	require.NotContains(t, output, ":.ctx1:")
+}
+
+func TestSchemaListNoContextColumn(t *testing.T) {
+	reg := srfake.New()
+	defer reg.Close()
+
+	reg.SeedSchema("plain-topic", 1, 1, testSchema)
+
+	// Simulate a cluster that does not support contexts (404).
+	reg.Intercept(func(w http.ResponseWriter, r *http.Request) bool {
+		if r.URL.Path == "/contexts" {
+			http.Error(w, "Not found", http.StatusNotFound)
+			return true
+		}
+		return false
+	})
+
+	cmd := setupRegistryTest(t, reg)
+	cmd.SetArgs([]string{"schema", "list"})
+
+	output := captureOutput(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	require.NotContains(t, output, "CONTEXT")
+	require.Contains(t, output, "plain-topic")
+}
+
+func TestSubjectListContextColumnWithAdminAPI(t *testing.T) {
+	reg := srfake.New()
+	defer reg.Close()
+
+	reg.SeedSchema("plain-topic", 1, 1, testSchema)
+	reg.SeedSchema(":.ctx1:my-subject", 1, 2, testSchema)
+
+	admin := fakeAdminAPI(t, map[string]any{
+		srcontext.QualifiedSubjectsConfigKey: true,
+	})
+	defer admin.Close()
+
+	// No --skip-context-check: the probe verifies both /contexts and admin API.
+	cmd := setupRegistryTestWithAdmin(t, reg, admin.URL)
+	cmd.SetArgs([]string{"subject", "list"})
+
+	output := captureOutput(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	require.Contains(t, output, "CONTEXT")
+	require.Contains(t, output, "default")
+	require.Contains(t, output, ".ctx1")
+	require.Contains(t, output, "plain-topic")
+	require.Contains(t, output, "my-subject")
+}
+
+func TestSchemaListContextColumnHiddenWithSchemaContext(t *testing.T) {
+	reg := srfake.New()
+	defer reg.Close()
+
+	reg.SeedSchema("plain-topic", 1, 1, testSchema)
+	reg.SeedSchema(":.ctx1:my-subject", 1, 2, testSchema)
+
+	// --schema-context filters results → no CONTEXT column.
+	cmd := setupRegistryTest(t, reg)
+	cmd.SetArgs([]string{"--schema-context", ".ctx1", "--skip-context-check", "schema", "list"})
+
+	output := captureOutput(func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	require.NotContains(t, output, "CONTEXT")
+	require.Contains(t, output, "my-subject")
+}

--- a/src/go/rpk/pkg/cli/registry/context/delete.go
+++ b/src/go/rpk/pkg/cli/registry/context/delete.go
@@ -26,7 +26,15 @@ func deleteCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete [CONTEXT]",
 		Short: "Delete a schema registry context",
-		Args:  cobra.ExactArgs(1),
+		Long: `Delete a schema registry context.
+
+A context can only be deleted once all subjects within it have been
+hard deleted. Soft-deleted subjects still block context deletion. Use
+'rpk registry subject delete --permanent' to hard delete subjects first.
+
+The default context "." cannot be deleted.
+`,
+		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			name := args[0]
 			if len(name) == 0 || name[0] != '.' {

--- a/src/go/rpk/pkg/cli/registry/context/delete.go
+++ b/src/go/rpk/pkg/cli/registry/context/delete.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package context
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
+)
+
+func deleteCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var noConfirm bool
+	cmd := &cobra.Command{
+		Use:   "delete [CONTEXT]",
+		Short: "Delete a schema registry context",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			name := args[0]
+			if len(name) == 0 || name[0] != '.' {
+				out.Die("invalid context name %q: context names must start with a '.'", name)
+			}
+
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "rpk unable to load config: %v", err)
+
+			cl, err := schemaregistry.NewClient(fs, p)
+			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
+
+			contexts, err := ListContexts(cmd.Context(), cl.Client)
+			out.MaybeDie(err, "%v", err)
+
+			if !slices.Contains(contexts, name) {
+				out.Die("context %q not found", name)
+			}
+
+			if !noConfirm {
+				confirmed, err := out.Confirm("Confirm deletion of context %q?", name)
+				out.MaybeDie(err, "unable to confirm deletion: %v", err)
+				if !confirmed {
+					out.Exit("Deletion canceled.")
+				}
+			}
+
+			err = cl.DeleteContext(cmd.Context(), name)
+			out.MaybeDie(err, "unable to delete context %q: %v", name, err)
+
+			fmt.Printf("Successfully deleted context %q.\n", name)
+		},
+	}
+	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt")
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/registry/context/list.go
+++ b/src/go/rpk/pkg/cli/registry/context/list.go
@@ -10,11 +10,13 @@
 package context
 
 import (
-	"fmt"
 	"slices"
+	"strings"
+	"sync"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/sr"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
@@ -42,16 +44,70 @@ func listCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "%v", err)
 
 			slices.Sort(contexts)
-			rows := make([]contextResponse, 0, len(contexts))
-			for _, c := range contexts {
-				rows = append(rows, contextResponse{Name: c})
+
+			// Fetch mode and compatibility for each context in parallel.
+			type ctxResult struct {
+				name          string
+				mode          string
+				compatibility string
 			}
+			var (
+				wg      sync.WaitGroup
+				mu      sync.Mutex
+				results []ctxResult
+			)
+			for _, c := range contexts {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+
+					subject := schemaregistry.QualifySubject(c, sr.GlobalSubject)
+
+					modeCtx := sr.WithParams(cmd.Context(), sr.DefaultToGlobal)
+					modeStr := "-"
+					modeResults := cl.Mode(modeCtx, subject)
+					if len(modeResults) > 0 && modeResults[0].Err == nil {
+						modeStr = modeResults[0].Mode.String()
+					}
+
+					compatStr := "-"
+					compatResults := cl.Compatibility(cmd.Context(), subject)
+					if len(compatResults) > 0 && compatResults[0].Err == nil {
+						compatStr = compatResults[0].Level.String()
+					}
+
+					mu.Lock()
+					defer mu.Unlock()
+					results = append(results, ctxResult{
+						name:          c,
+						mode:          modeStr,
+						compatibility: compatStr,
+					})
+				}()
+			}
+			wg.Wait()
+
+			slices.SortFunc(results, func(a, b ctxResult) int {
+				return strings.Compare(a.name, b.name)
+			})
+
+			rows := make([]contextResponse, 0, len(results))
+			for _, r := range results {
+				rows = append(rows, contextResponse{
+					Name:          r.name,
+					Mode:          r.mode,
+					Compatibility: r.compatibility,
+				})
+			}
+
 			if isText, _, s, err := f.Format(rows); !isText {
 				out.MaybeDie(err, "unable to print in the required format %q: %v", f.Kind, err)
 				out.Exit(s)
 			}
-			for _, c := range contexts {
-				fmt.Println(c)
+			tw := out.NewTable("context", "mode", "compatibility")
+			defer tw.Flush()
+			for _, r := range rows {
+				tw.PrintStructFields(r)
 			}
 		},
 	}

--- a/src/go/rpk/pkg/cli/registry/context/list.go
+++ b/src/go/rpk/pkg/cli/registry/context/list.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package context
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
+)
+
+func listCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List schema registry contexts",
+		Args:    cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, _ []string) {
+			f := p.Formatter
+			if h, ok := f.Help([]contextResponse{}); ok {
+				out.Exit(h)
+			}
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "rpk unable to load config: %v", err)
+
+			cl, err := schemaregistry.NewClient(fs, p)
+			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
+
+			contexts, err := ListContexts(cmd.Context(), cl.Client)
+			out.MaybeDie(err, "%v", err)
+
+			slices.Sort(contexts)
+			rows := make([]contextResponse, 0, len(contexts))
+			for _, c := range contexts {
+				rows = append(rows, contextResponse{Name: c})
+			}
+			if isText, _, s, err := f.Format(rows); !isText {
+				out.MaybeDie(err, "unable to print in the required format %q: %v", f.Kind, err)
+				out.Exit(s)
+			}
+			for _, c := range contexts {
+				fmt.Println(c)
+			}
+		},
+	}
+	p.InstallFormatFlag(cmd)
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/registry/mode/get.go
+++ b/src/go/rpk/pkg/cli/registry/mode/get.go
@@ -20,7 +20,7 @@ import (
 	"github.com/twmb/franz-go/pkg/sr"
 )
 
-func getCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func getCommand(fs afero.Fs, p *config.Params, schemaCtx *string) *cobra.Command {
 	var global bool
 	cmd := &cobra.Command{
 		Use:   "get [SUBJECT...]",
@@ -42,10 +42,9 @@ per-subject modes.
 			cl, err := schemaregistry.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
 
-			schemaCtx, _ := cmd.Flags().GetString("schema-context")
 			for i, s := range subjects {
 				if s != sr.GlobalSubject {
-					subjects[i] = schemaregistry.QualifySubject(schemaCtx, s)
+					subjects[i] = schemaregistry.QualifySubject(*schemaCtx, s)
 				}
 			}
 			if len(subjects) > 0 && global {
@@ -54,7 +53,7 @@ per-subject modes.
 			ctx := sr.WithParams(cmd.Context(), sr.DefaultToGlobal)
 			results := cl.Mode(ctx, subjects...)
 			for i := range results {
-				results[i].Subject = schemaregistry.StripContextQualifier(schemaCtx, results[i].Subject)
+				results[i].Subject = schemaregistry.StripContextQualifier(*schemaCtx, results[i].Subject)
 			}
 			exit1, err := printModeResult(f, results)
 			out.MaybeDieErr(err)

--- a/src/go/rpk/pkg/cli/registry/mode/get.go
+++ b/src/go/rpk/pkg/cli/registry/mode/get.go
@@ -42,12 +42,21 @@ per-subject modes.
 			cl, err := schemaregistry.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
 
+			schemaCtx, _ := cmd.Flags().GetString("schema-context")
+			for i, s := range subjects {
+				if s != sr.GlobalSubject {
+					subjects[i] = schemaregistry.QualifySubject(schemaCtx, s)
+				}
+			}
 			if len(subjects) > 0 && global {
 				subjects = append(subjects, sr.GlobalSubject)
 			}
 			ctx := sr.WithParams(cmd.Context(), sr.DefaultToGlobal)
-			modeResult := cl.Mode(ctx, subjects...)
-			exit1, err := printModeResult(f, modeResult)
+			results := cl.Mode(ctx, subjects...)
+			for i := range results {
+				results[i].Subject = schemaregistry.StripContextQualifier(schemaCtx, results[i].Subject)
+			}
+			exit1, err := printModeResult(f, results)
 			out.MaybeDieErr(err)
 			if exit1 {
 				os.Exit(1)

--- a/src/go/rpk/pkg/cli/registry/mode/mode.go
+++ b/src/go/rpk/pkg/cli/registry/mode/mode.go
@@ -19,16 +19,16 @@ import (
 	"github.com/twmb/franz-go/pkg/sr"
 )
 
-func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func NewCommand(fs afero.Fs, p *config.Params, schemaCtx *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mode",
 		Short: "Manage schema registry mode",
 		Args:  cobra.ExactArgs(0),
 	}
 	cmd.AddCommand(
-		getCommand(fs, p),
-		resetCommand(fs, p),
-		setCommand(fs, p),
+		getCommand(fs, p, schemaCtx),
+		resetCommand(fs, p, schemaCtx),
+		setCommand(fs, p, schemaCtx),
 	)
 	p.InstallFormatFlag(cmd)
 	return cmd

--- a/src/go/rpk/pkg/cli/registry/mode/reset.go
+++ b/src/go/rpk/pkg/cli/registry/mode/reset.go
@@ -20,7 +20,7 @@ import (
 	"github.com/twmb/franz-go/pkg/sr"
 )
 
-func resetCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func resetCommand(fs afero.Fs, p *config.Params, schemaCtx *string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "reset [SUBJECT...]",
 		Short: "Reset schema registry mode",
@@ -41,16 +41,15 @@ The command also prints the subject mode before reverting to the global default.
 			cl, err := schemaregistry.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
 
-			schemaCtx, _ := cmd.Flags().GetString("schema-context")
 			for i, s := range subjects {
 				if s != sr.GlobalSubject {
-					subjects[i] = schemaregistry.QualifySubject(schemaCtx, s)
+					subjects[i] = schemaregistry.QualifySubject(*schemaCtx, s)
 				}
 			}
 
 			results := cl.ResetMode(cmd.Context(), subjects...)
 			for i := range results {
-				results[i].Subject = schemaregistry.StripContextQualifier(schemaCtx, results[i].Subject)
+				results[i].Subject = schemaregistry.StripContextQualifier(*schemaCtx, results[i].Subject)
 			}
 			exit1, err := printModeResult(f, results)
 			out.MaybeDieErr(err)

--- a/src/go/rpk/pkg/cli/registry/mode/reset.go
+++ b/src/go/rpk/pkg/cli/registry/mode/reset.go
@@ -17,6 +17,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/sr"
 )
 
 func resetCommand(fs afero.Fs, p *config.Params) *cobra.Command {
@@ -40,8 +41,18 @@ The command also prints the subject mode before reverting to the global default.
 			cl, err := schemaregistry.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
 
-			resetModeResult := cl.ResetMode(cmd.Context(), subjects...)
-			exit1, err := printModeResult(f, resetModeResult)
+			schemaCtx, _ := cmd.Flags().GetString("schema-context")
+			for i, s := range subjects {
+				if s != sr.GlobalSubject {
+					subjects[i] = schemaregistry.QualifySubject(schemaCtx, s)
+				}
+			}
+
+			results := cl.ResetMode(cmd.Context(), subjects...)
+			for i := range results {
+				results[i].Subject = schemaregistry.StripContextQualifier(schemaCtx, results[i].Subject)
+			}
+			exit1, err := printModeResult(f, results)
 			out.MaybeDieErr(err)
 			if exit1 {
 				os.Exit(1)

--- a/src/go/rpk/pkg/cli/registry/mode/set.go
+++ b/src/go/rpk/pkg/cli/registry/mode/set.go
@@ -25,7 +25,7 @@ import (
 
 var supportedModes = []string{"READONLY", "READWRITE", "IMPORT"}
 
-func setCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func setCommand(fs afero.Fs, p *config.Params, schemaCtx *string) *cobra.Command {
 	var modeFlag string
 	var global bool
 	var force bool
@@ -80,10 +80,9 @@ Set the schema registry mode to IMPORT, overriding the emptiness check
 			err = mode.UnmarshalText([]byte(modeFlag))
 			out.MaybeDie(err, "unable to parse mode flag: %v", err)
 
-			schemaCtx, _ := cmd.Flags().GetString("schema-context")
 			for i, s := range subjects {
 				if s != sr.GlobalSubject {
-					subjects[i] = schemaregistry.QualifySubject(schemaCtx, s)
+					subjects[i] = schemaregistry.QualifySubject(*schemaCtx, s)
 				}
 			}
 
@@ -97,7 +96,7 @@ Set the schema registry mode to IMPORT, overriding the emptiness check
 			}
 			results := cl.SetMode(ctx, *mode, subjects...)
 			for i := range results {
-				results[i].Subject = schemaregistry.StripContextQualifier(schemaCtx, results[i].Subject)
+				results[i].Subject = schemaregistry.StripContextQualifier(*schemaCtx, results[i].Subject)
 			}
 
 			exit1, err := printModeResult(f, results)

--- a/src/go/rpk/pkg/cli/registry/mode/set.go
+++ b/src/go/rpk/pkg/cli/registry/mode/set.go
@@ -80,6 +80,13 @@ Set the schema registry mode to IMPORT, overriding the emptiness check
 			err = mode.UnmarshalText([]byte(modeFlag))
 			out.MaybeDie(err, "unable to parse mode flag: %v", err)
 
+			schemaCtx, _ := cmd.Flags().GetString("schema-context")
+			for i, s := range subjects {
+				if s != sr.GlobalSubject {
+					subjects[i] = schemaregistry.QualifySubject(schemaCtx, s)
+				}
+			}
+
 			ctx := cmd.Context()
 			if force {
 				ctx = sr.WithParams(ctx, sr.Force)
@@ -88,9 +95,12 @@ Set the schema registry mode to IMPORT, overriding the emptiness check
 			if len(subjects) > 0 && global {
 				subjects = append(subjects, sr.GlobalSubject)
 			}
-			setModeResult := cl.SetMode(ctx, *mode, subjects...)
+			results := cl.SetMode(ctx, *mode, subjects...)
+			for i := range results {
+				results[i].Subject = schemaregistry.StripContextQualifier(schemaCtx, results[i].Subject)
+			}
 
-			exit1, err := printModeResult(f, setModeResult)
+			exit1, err := printModeResult(f, results)
 			out.MaybeDieErr(err)
 			if exit1 {
 				os.Exit(1)

--- a/src/go/rpk/pkg/cli/registry/registry.go
+++ b/src/go/rpk/pkg/cli/registry/registry.go
@@ -41,11 +41,11 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&schemaCtx, "schema-context", "", "Schema context to use for all registry operations")
 	cmd.PersistentFlags().BoolVar(&skipContextCheck, "skip-context-check", false, "Skip the admin API verification of schema context support")
 	cmd.AddCommand(
-		compatibilityLevelCommand(fs, p),
-		srcontext.NewCommand(fs, p),
-		mode.NewCommand(fs, p),
-		schema.NewCommand(fs, p),
-		subjectCommand(fs, p),
+		compatibilityLevelCommand(fs, p, &schemaCtx),
+		srcontext.NewCommand(fs, p, &schemaCtx),
+		mode.NewCommand(fs, p, &schemaCtx),
+		schema.NewCommand(fs, p, &schemaCtx),
+		subjectCommand(fs, p, &schemaCtx),
 	)
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/registry/registry.go
+++ b/src/go/rpk/pkg/cli/registry/registry.go
@@ -10,22 +10,39 @@
 package registry
 
 import (
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+
+	srcontext "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/registry/context"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/registry/mode"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/registry/schema"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
-	"github.com/spf13/afero"
-	"github.com/spf13/cobra"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 )
 
 func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var (
+		schemaCtx        string
+		skipContextCheck bool
+	)
 	cmd := &cobra.Command{
 		Use:     "registry",
 		Aliases: []string{"sr"},
 		Args:    cobra.ExactArgs(0),
 		Short:   "Commands to interact with the schema registry",
+		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
+			if schemaCtx == "" {
+				return
+			}
+			err := srcontext.ValidateContext(cmd.Context(), schemaCtx, fs, p, skipContextCheck)
+			out.MaybeDie(err, "%v", err)
+		},
 	}
+	cmd.PersistentFlags().StringVar(&schemaCtx, "schema-context", "", "Schema context to use for all registry operations")
+	cmd.PersistentFlags().BoolVar(&skipContextCheck, "skip-context-check", false, "Skip the admin API verification of schema context support")
 	cmd.AddCommand(
 		compatibilityLevelCommand(fs, p),
+		srcontext.NewCommand(fs, p),
 		mode.NewCommand(fs, p),
 		schema.NewCommand(fs, p),
 		subjectCommand(fs, p),

--- a/src/go/rpk/pkg/cli/registry/schema/check_compatibility.go
+++ b/src/go/rpk/pkg/cli/registry/schema/check_compatibility.go
@@ -27,7 +27,7 @@ type compatCheckResponse struct {
 	Messages   []string `json:"messages,omitempty" yaml:"messages,omitempty"`
 }
 
-func newCheckCompatibilityCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func newCheckCompatibilityCommand(fs afero.Fs, p *config.Params, schemaCtx *string) *cobra.Command {
 	var (
 		refs       string
 		schemaFile string
@@ -61,8 +61,7 @@ func newCheckCompatibilityCommand(fs afero.Fs, p *config.Params) *cobra.Command 
 			references, err := parseReferenceFlag(fs, refs)
 			out.MaybeDie(err, "unable to parse reference flag %q: %v", refs, err)
 
-			schemaCtx, _ := cmd.Flags().GetString("schema-context")
-			subject := schemaregistry.QualifySubject(schemaCtx, args[0])
+			subject := schemaregistry.QualifySubject(*schemaCtx, args[0])
 			schema := sr.Schema{
 				Schema:     string(file),
 				Type:       t,

--- a/src/go/rpk/pkg/cli/registry/schema/check_compatibility.go
+++ b/src/go/rpk/pkg/cli/registry/schema/check_compatibility.go
@@ -61,7 +61,8 @@ func newCheckCompatibilityCommand(fs afero.Fs, p *config.Params) *cobra.Command 
 			references, err := parseReferenceFlag(fs, refs)
 			out.MaybeDie(err, "unable to parse reference flag %q: %v", refs, err)
 
-			subject := args[0]
+			schemaCtx, _ := cmd.Flags().GetString("schema-context")
+			subject := schemaregistry.QualifySubject(schemaCtx, args[0])
 			schema := sr.Schema{
 				Schema:     string(file),
 				Type:       t,

--- a/src/go/rpk/pkg/cli/registry/schema/create.go
+++ b/src/go/rpk/pkg/cli/registry/schema/create.go
@@ -23,7 +23,7 @@ import (
 	"github.com/twmb/franz-go/pkg/sr"
 )
 
-func newCreateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func newCreateCommand(fs afero.Fs, p *config.Params, schemaCtx *string) *cobra.Command {
 	var (
 		refs               string
 		schemaFile         string
@@ -104,8 +104,7 @@ Create a schema with metadata properties using JSON format (useful for special c
 			if mProperties != nil {
 				schemaMetadata = &sr.SchemaMetadata{Properties: mProperties}
 			}
-			schemaCtx, _ := cmd.Flags().GetString("schema-context")
-			subject := schemaregistry.QualifySubject(schemaCtx, args[0])
+			subject := schemaregistry.QualifySubject(*schemaCtx, args[0])
 			schema := sr.Schema{
 				Schema:         string(file),
 				Type:           t,
@@ -119,12 +118,12 @@ Create a schema with metadata properties using JSON format (useful for special c
 			// when the user passes a raw qualified subject like
 			// ":.ctx:foo".
 			ctx := cmd.Context()
-			if schemaCtx != "" || strings.HasPrefix(subject, ":") {
+			if *schemaCtx != "" || strings.HasPrefix(subject, ":") {
 				ctx = sr.WithParams(ctx, sr.Subject(subject))
 			}
 			s, err := cl.CreateSchemaWithIDAndVersion(ctx, subject, schema, id, schemaVersion)
 			out.MaybeDie(err, "unable to create schema: %v", err)
-			s.Subject = schemaregistry.StripContextQualifier(schemaCtx, s.Subject)
+			s.Subject = schemaregistry.StripContextQualifier(*schemaCtx, s.Subject)
 
 			err = printSubjectSchemaWithMetadata(f, true, len(mProperties) > 0, s)
 			out.MaybeDieErr(err)

--- a/src/go/rpk/pkg/cli/registry/schema/create.go
+++ b/src/go/rpk/pkg/cli/registry/schema/create.go
@@ -104,7 +104,8 @@ Create a schema with metadata properties using JSON format (useful for special c
 			if mProperties != nil {
 				schemaMetadata = &sr.SchemaMetadata{Properties: mProperties}
 			}
-			subject := args[0]
+			schemaCtx, _ := cmd.Flags().GetString("schema-context")
+			subject := schemaregistry.QualifySubject(schemaCtx, args[0])
 			schema := sr.Schema{
 				Schema:         string(file),
 				Type:           t,
@@ -112,8 +113,18 @@ Create a schema with metadata properties using JSON format (useful for special c
 				SchemaMetadata: schemaMetadata,
 			}
 
-			s, err := cl.CreateSchemaWithIDAndVersion(cmd.Context(), subject, schema, id, schemaVersion)
+			// Pass the subject param so the post-create lookup
+			// (SchemaUsagesByID) is scoped to the right context.
+			// This is needed both when --schema-context is set and
+			// when the user passes a raw qualified subject like
+			// ":.ctx:foo".
+			ctx := cmd.Context()
+			if schemaCtx != "" || strings.HasPrefix(subject, ":") {
+				ctx = sr.WithParams(ctx, sr.Subject(subject))
+			}
+			s, err := cl.CreateSchemaWithIDAndVersion(ctx, subject, schema, id, schemaVersion)
 			out.MaybeDie(err, "unable to create schema: %v", err)
+			s.Subject = schemaregistry.StripContextQualifier(schemaCtx, s.Subject)
 
 			err = printSubjectSchemaWithMetadata(f, true, len(mProperties) > 0, s)
 			out.MaybeDieErr(err)

--- a/src/go/rpk/pkg/cli/registry/schema/delete.go
+++ b/src/go/rpk/pkg/cli/registry/schema/delete.go
@@ -25,7 +25,7 @@ type deleteResponse struct {
 	Version string `json:"version" yaml:"version"`
 }
 
-func newDeleteCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func newDeleteCommand(fs afero.Fs, p *config.Params, schemaCtx *string) *cobra.Command {
 	var sversion string
 	var isPermanent bool
 	cmd := &cobra.Command{
@@ -46,9 +46,8 @@ func newDeleteCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			version, err := parseVersion(sversion)
 			out.MaybeDieErr(err)
 
-			schemaCtx, _ := cmd.Flags().GetString("schema-context")
 			subject := args[0]
-			qualified := schemaregistry.QualifySubject(schemaCtx, subject)
+			qualified := schemaregistry.QualifySubject(*schemaCtx, subject)
 			if isPermanent {
 				err = cl.DeleteSchema(cmd.Context(), qualified, version, sr.SoftDelete)
 				if err == nil || schemaregistry.IsSoftDeleteError(err) {

--- a/src/go/rpk/pkg/cli/registry/schema/delete.go
+++ b/src/go/rpk/pkg/cli/registry/schema/delete.go
@@ -46,16 +46,18 @@ func newDeleteCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			version, err := parseVersion(sversion)
 			out.MaybeDieErr(err)
 
+			schemaCtx, _ := cmd.Flags().GetString("schema-context")
 			subject := args[0]
+			qualified := schemaregistry.QualifySubject(schemaCtx, subject)
 			if isPermanent {
-				err = cl.DeleteSchema(cmd.Context(), subject, version, sr.SoftDelete)
+				err = cl.DeleteSchema(cmd.Context(), qualified, version, sr.SoftDelete)
 				if err == nil || schemaregistry.IsSoftDeleteError(err) {
-					err = cl.DeleteSchema(cmd.Context(), subject, version, sr.HardDelete)
+					err = cl.DeleteSchema(cmd.Context(), qualified, version, sr.HardDelete)
 					out.MaybeDie(err, "unable to perform hard-deletion: %v", err)
 				}
 				out.MaybeDie(err, "unable to perform initial soft-deletion that is required for hard-deletion: %v", err)
 			} else {
-				err = cl.DeleteSchema(cmd.Context(), subject, version, sr.SoftDelete)
+				err = cl.DeleteSchema(cmd.Context(), qualified, version, sr.SoftDelete)
 				out.MaybeDieErr(err)
 			}
 			if isText, _, s, err := f.Format(deleteResponse{subject, sversion}); !isText {

--- a/src/go/rpk/pkg/cli/registry/schema/get.go
+++ b/src/go/rpk/pkg/cli/registry/schema/get.go
@@ -24,7 +24,7 @@ import (
 	"github.com/twmb/franz-go/pkg/sr"
 )
 
-func newGetCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func newGetCommand(fs afero.Fs, p *config.Params, schemaCtx *string) *cobra.Command {
 	var (
 		deleted       bool
 		printSchema   bool
@@ -65,8 +65,6 @@ To print schema metadata properties, use the '--print-metadata' flag.
 			cl, err := schemaregistry.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
 
-			schemaCtx, _ := cmd.Flags().GetString("schema-context")
-
 			var n int
 			if sversion != "" {
 				n++
@@ -93,7 +91,7 @@ To print schema metadata properties, use the '--print-metadata' flag.
 			case sversion != "":
 				version, err := parseVersion(sversion)
 				out.MaybeDieErr(err)
-				qualified := schemaregistry.QualifySubject(schemaCtx, args[0])
+				qualified := schemaregistry.QualifySubject(*schemaCtx, args[0])
 				var params []sr.Param
 				if deleted {
 					params = append(params, sr.ShowDeleted)
@@ -113,8 +111,8 @@ To print schema metadata properties, use the '--print-metadata' flag.
 					params = append(params, sr.ShowDeleted)
 				}
 				if len(args) > 0 {
-					params = append(params, sr.Subject(schemaregistry.QualifySubject(schemaCtx, args[0])))
-				} else if pfx := schemaregistry.ContextSubjectPrefix(schemaCtx); pfx != "" {
+					params = append(params, sr.Subject(schemaregistry.QualifySubject(*schemaCtx, args[0])))
+				} else if pfx := schemaregistry.ContextSubjectPrefix(*schemaCtx); pfx != "" {
 					params = append(params, sr.Subject(pfx))
 				}
 				ctx := cmd.Context()
@@ -124,7 +122,7 @@ To print schema metadata properties, use the '--print-metadata' flag.
 				ss, err = cl.SchemaUsagesByID(ctx, id)
 				out.MaybeDieErr(err)
 				if len(args) > 0 {
-					qualified := schemaregistry.QualifySubject(schemaCtx, args[0])
+					qualified := schemaregistry.QualifySubject(*schemaCtx, args[0])
 					for _, s := range ss {
 						if s.Subject == qualified {
 							ss = []sr.SubjectSchema{s}
@@ -138,7 +136,7 @@ To print schema metadata properties, use the '--print-metadata' flag.
 				out.MaybeDie(err, "unable to read %q: %v", err)
 				t, err := resolveSchemaType(schemaType, schemaFile)
 				out.MaybeDieErr(err)
-				qualified := schemaregistry.QualifySubject(schemaCtx, args[0])
+				qualified := schemaregistry.QualifySubject(*schemaCtx, args[0])
 				s, err := cl.LookupSchema(cmd.Context(), qualified, sr.Schema{
 					Schema: string(file),
 					Type:   t,
@@ -148,7 +146,7 @@ To print schema metadata properties, use the '--print-metadata' flag.
 			}
 
 			for i := range ss {
-				ss[i].Subject = schemaregistry.StripContextQualifier(schemaCtx, ss[i].Subject)
+				ss[i].Subject = schemaregistry.StripContextQualifier(*schemaCtx, ss[i].Subject)
 			}
 			if printSchema {
 				printSchemaString(ss)

--- a/src/go/rpk/pkg/cli/registry/schema/get.go
+++ b/src/go/rpk/pkg/cli/registry/schema/get.go
@@ -65,10 +65,7 @@ To print schema metadata properties, use the '--print-metadata' flag.
 			cl, err := schemaregistry.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
 
-			ctx := cmd.Context()
-			if deleted {
-				ctx = sr.WithParams(cmd.Context(), sr.ShowDeleted)
-			}
+			schemaCtx, _ := cmd.Flags().GetString("schema-context")
 
 			var n int
 			if sversion != "" {
@@ -96,19 +93,43 @@ To print schema metadata properties, use the '--print-metadata' flag.
 			case sversion != "":
 				version, err := parseVersion(sversion)
 				out.MaybeDieErr(err)
-				s, err := cl.SchemaByVersion(ctx, args[0], version)
+				qualified := schemaregistry.QualifySubject(schemaCtx, args[0])
+				var params []sr.Param
+				if deleted {
+					params = append(params, sr.ShowDeleted)
+				}
+				ctx := cmd.Context()
+				if len(params) > 0 {
+					ctx = sr.WithParams(ctx, params...)
+				}
+				s, err := cl.SchemaByVersion(ctx, qualified, version)
 				out.MaybeDieErr(err)
 				ss = []sr.SubjectSchema{s}
 
 			case id != 0:
+				// For ID lookup, combine ShowDeleted and Subject params.
+				var params []sr.Param
+				if deleted {
+					params = append(params, sr.ShowDeleted)
+				}
+				if len(args) > 0 {
+					params = append(params, sr.Subject(schemaregistry.QualifySubject(schemaCtx, args[0])))
+				} else if pfx := schemaregistry.ContextSubjectPrefix(schemaCtx); pfx != "" {
+					params = append(params, sr.Subject(pfx))
+				}
+				ctx := cmd.Context()
+				if len(params) > 0 {
+					ctx = sr.WithParams(ctx, params...)
+				}
 				ss, err = cl.SchemaUsagesByID(ctx, id)
 				out.MaybeDieErr(err)
-				if len(args) == 0 {
-					break
-				}
-				for _, s := range ss {
-					if s.Subject == args[0] {
-						ss = []sr.SubjectSchema{s}
+				if len(args) > 0 {
+					qualified := schemaregistry.QualifySubject(schemaCtx, args[0])
+					for _, s := range ss {
+						if s.Subject == qualified {
+							ss = []sr.SubjectSchema{s}
+							break
+						}
 					}
 				}
 
@@ -117,12 +138,17 @@ To print schema metadata properties, use the '--print-metadata' flag.
 				out.MaybeDie(err, "unable to read %q: %v", err)
 				t, err := resolveSchemaType(schemaType, schemaFile)
 				out.MaybeDieErr(err)
-				s, err := cl.LookupSchema(cmd.Context(), args[0], sr.Schema{
+				qualified := schemaregistry.QualifySubject(schemaCtx, args[0])
+				s, err := cl.LookupSchema(cmd.Context(), qualified, sr.Schema{
 					Schema: string(file),
 					Type:   t,
 				})
 				out.MaybeDieErr(err)
 				ss = []sr.SubjectSchema{s}
+			}
+
+			for i := range ss {
+				ss[i].Subject = schemaregistry.StripContextQualifier(schemaCtx, ss[i].Subject)
 			}
 			if printSchema {
 				printSchemaString(ss)

--- a/src/go/rpk/pkg/cli/registry/schema/list.go
+++ b/src/go/rpk/pkg/cli/registry/schema/list.go
@@ -40,7 +40,7 @@ type schemaResponseWithContext struct {
 	Err     string `json:"error,omitempty" yaml:"error,omitempty"`
 }
 
-func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func newListCommand(fs afero.Fs, p *config.Params, schemaCtx *string) *cobra.Command {
 	var deleted bool
 	cmd := &cobra.Command{
 		Use:     "list [SUBJECT...]",
@@ -57,9 +57,8 @@ func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			cl, err := schemaregistry.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
 
-			schemaCtx, _ := cmd.Flags().GetString("schema-context")
 			skipCheck, _ := cmd.Flags().GetBool("skip-context-check")
-			showCtxCol := schemaCtx == "" && srcontext.CheckContextSupport(cmd.Context(), cl.Client, fs, p, skipCheck) == nil
+			showCtxCol := *schemaCtx == "" && srcontext.IsContextSupported(cmd.Context(), fs, p, skipCheck) == nil
 
 			// Build params: combine ShowDeleted and SubjectPrefix in
 			// one WithParams call (params do not stack).
@@ -69,7 +68,7 @@ func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			}
 			ctx := cmd.Context()
 			if len(subjects) == 0 {
-				if pfx := schemaregistry.ContextSubjectPrefix(schemaCtx); pfx != "" {
+				if pfx := schemaregistry.ContextSubjectPrefix(*schemaCtx); pfx != "" {
 					params = append(params, sr.SubjectPrefix(pfx))
 				}
 				if len(params) > 0 {
@@ -79,7 +78,7 @@ func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				out.MaybeDie(err, "unable to list all subjects: %v", err)
 			} else {
 				for i, s := range subjects {
-					subjects[i] = schemaregistry.QualifySubject(schemaCtx, s)
+					subjects[i] = schemaregistry.QualifySubject(*schemaCtx, s)
 				}
 				if len(params) > 0 {
 					ctx = sr.WithParams(ctx, params...)
@@ -154,13 +153,13 @@ func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			response := []schemaResponse{}
 			for _, res := range results {
 				if res.err != nil {
-					sc := schemaResponse{Subject: schemaregistry.StripContextQualifier(schemaCtx, res.subject), Err: res.err.Error()}
+					sc := schemaResponse{Subject: schemaregistry.StripContextQualifier(*schemaCtx, res.subject), Err: res.err.Error()}
 					response = append(response, sc)
 					continue
 				}
 				for _, s := range res.ss {
 					sc := schemaResponse{
-						Subject: schemaregistry.StripContextQualifier(schemaCtx, s.Subject),
+						Subject: schemaregistry.StripContextQualifier(*schemaCtx, s.Subject),
 						Version: s.Version,
 						ID:      s.ID,
 						Type:    s.Type.String(),

--- a/src/go/rpk/pkg/cli/registry/schema/list.go
+++ b/src/go/rpk/pkg/cli/registry/schema/list.go
@@ -12,16 +12,27 @@ package schema
 import (
 	"sync"
 
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/twmb/franz-go/pkg/sr"
 	"github.com/twmb/types"
+
+	srcontext "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/registry/context"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
 )
 
 type schemaResponse struct {
+	Subject string `json:"subject" yaml:"subject"`
+	Version int    `json:"version,omitempty" yaml:"version,omitempty"`
+	ID      int    `json:"id,omitempty" yaml:"id,omitempty"`
+	Type    string `json:"type,omitempty" yaml:"type,omitempty"`
+	Err     string `json:"error,omitempty" yaml:"error,omitempty"`
+}
+
+type schemaResponseWithContext struct {
+	Context string `json:"context" yaml:"context"`
 	Subject string `json:"subject" yaml:"subject"`
 	Version int    `json:"version,omitempty" yaml:"version,omitempty"`
 	ID      int    `json:"id,omitempty" yaml:"id,omitempty"`
@@ -46,13 +57,33 @@ func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			cl, err := schemaregistry.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
 
-			ctx := cmd.Context()
+			schemaCtx, _ := cmd.Flags().GetString("schema-context")
+			skipCheck, _ := cmd.Flags().GetBool("skip-context-check")
+			showCtxCol := schemaCtx == "" && srcontext.CheckContextSupport(cmd.Context(), cl.Client, fs, p, skipCheck) == nil
+
+			// Build params: combine ShowDeleted and SubjectPrefix in
+			// one WithParams call (params do not stack).
+			var params []sr.Param
 			if deleted {
-				ctx = sr.WithParams(cmd.Context(), sr.ShowDeleted)
+				params = append(params, sr.ShowDeleted)
 			}
+			ctx := cmd.Context()
 			if len(subjects) == 0 {
+				if pfx := schemaregistry.ContextSubjectPrefix(schemaCtx); pfx != "" {
+					params = append(params, sr.SubjectPrefix(pfx))
+				}
+				if len(params) > 0 {
+					ctx = sr.WithParams(ctx, params...)
+				}
 				subjects, err = cl.Subjects(ctx)
 				out.MaybeDie(err, "unable to list all subjects: %v", err)
+			} else {
+				for i, s := range subjects {
+					subjects[i] = schemaregistry.QualifySubject(schemaCtx, s)
+				}
+				if len(params) > 0 {
+					ctx = sr.WithParams(ctx, params...)
+				}
 			}
 
 			type res struct {
@@ -65,8 +96,7 @@ func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				mu      sync.Mutex
 				results []res
 			)
-			for i := range subjects {
-				subject := subjects[i]
+			for _, subject := range subjects {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
@@ -84,18 +114,53 @@ func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 			types.Sort(results)
 
-			// We use literal here to display an empty array when unmarshalling
-			// an empty list.
+			if showCtxCol {
+				response := []schemaResponseWithContext{}
+				for _, res := range results {
+					if res.err != nil {
+						sCtx, bare := schemaregistry.ParseSubjectContext(res.subject)
+						response = append(response, schemaResponseWithContext{
+							Context: schemaregistry.DisplayContext(sCtx),
+							Subject: bare,
+							Err:     res.err.Error(),
+						})
+						continue
+					}
+					for _, s := range res.ss {
+						sCtx, bare := schemaregistry.ParseSubjectContext(s.Subject)
+						response = append(response, schemaResponseWithContext{
+							Context: schemaregistry.DisplayContext(sCtx),
+							Subject: bare,
+							Version: s.Version,
+							ID:      s.ID,
+							Type:    s.Type.String(),
+						})
+					}
+				}
+				types.Sort(response)
+				if isText, _, s, err := f.Format(response); !isText {
+					out.MaybeDie(err, "unable to print in the required format %q: %v", f.Kind, err)
+					out.Exit(s)
+				}
+				tw := out.NewTable("context", "subject", "version", "id", "type", "error")
+				defer tw.Flush()
+				for _, r := range response {
+					tw.PrintStructFields(r)
+				}
+				return
+			}
+
+			// No context column: strip qualifier and use the standard response.
 			response := []schemaResponse{}
 			for _, res := range results {
 				if res.err != nil {
-					sc := schemaResponse{Subject: res.subject, Err: res.err.Error()}
+					sc := schemaResponse{Subject: schemaregistry.StripContextQualifier(schemaCtx, res.subject), Err: res.err.Error()}
 					response = append(response, sc)
 					continue
 				}
 				for _, s := range res.ss {
 					sc := schemaResponse{
-						Subject: s.Subject,
+						Subject: schemaregistry.StripContextQualifier(schemaCtx, s.Subject),
 						Version: s.Version,
 						ID:      s.ID,
 						Type:    s.Type.String(),
@@ -103,6 +168,7 @@ func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 					response = append(response, sc)
 				}
 			}
+			types.Sort(response)
 			if isText, _, s, err := f.Format(response); !isText {
 				out.MaybeDie(err, "unable to print in the required format %q: %v", f.Kind, err)
 				out.Exit(s)

--- a/src/go/rpk/pkg/cli/registry/schema/references.go
+++ b/src/go/rpk/pkg/cli/registry/schema/references.go
@@ -18,7 +18,7 @@ import (
 	"github.com/twmb/franz-go/pkg/sr"
 )
 
-func newReferencesCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func newReferencesCommand(fs afero.Fs, p *config.Params, schemaCtx *string) *cobra.Command {
 	var sversion string
 	var deleted bool
 	cmd := &cobra.Command{
@@ -36,8 +36,6 @@ func newReferencesCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			cl, err := schemaregistry.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
 
-			schemaCtx, _ := cmd.Flags().GetString("schema-context")
-
 			ctx := cmd.Context()
 			if deleted {
 				ctx = sr.WithParams(cmd.Context(), sr.ShowDeleted)
@@ -47,12 +45,12 @@ func newReferencesCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDieErr(err)
 
 			subject := args[0]
-			qualified := schemaregistry.QualifySubject(schemaCtx, subject)
+			qualified := schemaregistry.QualifySubject(*schemaCtx, subject)
 			references, err := cl.SchemaReferences(ctx, qualified, version)
 			out.MaybeDie(err, "unable to check for references of subject %q and version %q: %v", subject, sversion, err)
 
 			for i := range references {
-				references[i].Subject = schemaregistry.StripContextQualifier(schemaCtx, references[i].Subject)
+				references[i].Subject = schemaregistry.StripContextQualifier(*schemaCtx, references[i].Subject)
 			}
 
 			err = printSubjectSchemaWithMetadata(f, false, false, references...)

--- a/src/go/rpk/pkg/cli/registry/schema/references.go
+++ b/src/go/rpk/pkg/cli/registry/schema/references.go
@@ -36,6 +36,8 @@ func newReferencesCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			cl, err := schemaregistry.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
 
+			schemaCtx, _ := cmd.Flags().GetString("schema-context")
+
 			ctx := cmd.Context()
 			if deleted {
 				ctx = sr.WithParams(cmd.Context(), sr.ShowDeleted)
@@ -45,8 +47,13 @@ func newReferencesCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDieErr(err)
 
 			subject := args[0]
-			references, err := cl.SchemaReferences(ctx, subject, version)
+			qualified := schemaregistry.QualifySubject(schemaCtx, subject)
+			references, err := cl.SchemaReferences(ctx, qualified, version)
 			out.MaybeDie(err, "unable to check for references of subject %q and version %q: %v", subject, sversion, err)
+
+			for i := range references {
+				references[i].Subject = schemaregistry.StripContextQualifier(schemaCtx, references[i].Subject)
+			}
 
 			err = printSubjectSchemaWithMetadata(f, false, false, references...)
 			out.MaybeDieErr(err)

--- a/src/go/rpk/pkg/cli/registry/schema/schema.go
+++ b/src/go/rpk/pkg/cli/registry/schema/schema.go
@@ -24,19 +24,19 @@ import (
 
 var supportedTypes = []string{"avro", "protobuf", "json"}
 
-func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func NewCommand(fs afero.Fs, p *config.Params, schemaCtx *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "schema",
 		Args:  cobra.ExactArgs(0),
 		Short: "Manage your schema registry schemas",
 	}
 	cmd.AddCommand(
-		newCheckCompatibilityCommand(fs, p),
-		newCreateCommand(fs, p),
-		newDeleteCommand(fs, p),
-		newGetCommand(fs, p),
-		newListCommand(fs, p),
-		newReferencesCommand(fs, p),
+		newCheckCompatibilityCommand(fs, p, schemaCtx),
+		newCreateCommand(fs, p, schemaCtx),
+		newDeleteCommand(fs, p, schemaCtx),
+		newGetCommand(fs, p, schemaCtx),
+		newListCommand(fs, p, schemaCtx),
+		newReferencesCommand(fs, p, schemaCtx),
 	)
 	p.InstallFormatFlag(cmd)
 	return cmd

--- a/src/go/rpk/pkg/cli/registry/subject.go
+++ b/src/go/rpk/pkg/cli/registry/subject.go
@@ -24,15 +24,15 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
 )
 
-func subjectCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func subjectCommand(fs afero.Fs, p *config.Params, schemaCtx *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "subject",
 		Args:  cobra.ExactArgs(0),
 		Short: "List or delete schema registry subjects",
 	}
 	cmd.AddCommand(
-		subjectListCommand(fs, p),
-		subjectDeleteCommand(fs, p),
+		subjectListCommand(fs, p, schemaCtx),
+		subjectDeleteCommand(fs, p, schemaCtx),
 	)
 	p.InstallFormatFlag(cmd)
 	return cmd
@@ -43,7 +43,7 @@ type subjectWithContext struct {
 	Subject string `json:"subject" yaml:"subject"`
 }
 
-func subjectListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func subjectListCommand(fs afero.Fs, p *config.Params, schemaCtx *string) *cobra.Command {
 	var deleted bool
 	cmd := &cobra.Command{
 		Use:     "list",
@@ -61,15 +61,14 @@ func subjectListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			cl, err := schemaregistry.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
 
-			schemaCtx, _ := cmd.Flags().GetString("schema-context")
 			skipCheck, _ := cmd.Flags().GetBool("skip-context-check")
-			showCtxCol := schemaCtx == "" && srcontext.CheckContextSupport(cmd.Context(), cl.Client, fs, p, skipCheck) == nil
+			showCtxCol := *schemaCtx == "" && srcontext.IsContextSupported(cmd.Context(), fs, p, skipCheck) == nil
 
 			var params []sr.Param
 			if deleted {
 				params = append(params, sr.ShowDeleted)
 			}
-			if pfx := schemaregistry.ContextSubjectPrefix(schemaCtx); pfx != "" {
+			if pfx := schemaregistry.ContextSubjectPrefix(*schemaCtx); pfx != "" {
 				params = append(params, sr.SubjectPrefix(pfx))
 			}
 			ctx := cmd.Context()
@@ -103,7 +102,7 @@ func subjectListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			}
 
 			for i, s := range subjects {
-				subjects[i] = schemaregistry.StripContextQualifier(schemaCtx, s)
+				subjects[i] = schemaregistry.StripContextQualifier(*schemaCtx, s)
 			}
 
 			if isText, _, s, err := f.Format(subjects); !isText {
@@ -125,7 +124,7 @@ type deleteResponse struct {
 	Err      string `json:"error,omitempty" yaml:"error,omitempty"`
 }
 
-func subjectDeleteCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func subjectDeleteCommand(fs afero.Fs, p *config.Params, schemaCtx *string) *cobra.Command {
 	var isPermanent bool
 	cmd := &cobra.Command{
 		Use:   "delete [SUBJECT...]",
@@ -142,8 +141,6 @@ func subjectDeleteCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			cl, err := schemaregistry.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
 
-			schemaCtx, _ := cmd.Flags().GetString("schema-context")
-
 			var (
 				wg      sync.WaitGroup
 				mu      sync.Mutex
@@ -151,7 +148,7 @@ func subjectDeleteCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			)
 
 			for _, subject := range subjects {
-				qualified := schemaregistry.QualifySubject(schemaCtx, subject)
+				qualified := schemaregistry.QualifySubject(*schemaCtx, subject)
 				wg.Add(1)
 				go func() {
 					defer wg.Done()

--- a/src/go/rpk/pkg/cli/registry/subject.go
+++ b/src/go/rpk/pkg/cli/registry/subject.go
@@ -11,16 +11,17 @@ package registry
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"sync"
 
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/twmb/franz-go/pkg/sr"
 
+	srcontext "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/registry/context"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
 )
 
 func subjectCommand(fs afero.Fs, p *config.Params) *cobra.Command {
@@ -35,6 +36,11 @@ func subjectCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	)
 	p.InstallFormatFlag(cmd)
 	return cmd
+}
+
+type subjectWithContext struct {
+	Context string `json:"context" yaml:"context"`
+	Subject string `json:"subject" yaml:"subject"`
 }
 
 func subjectListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
@@ -55,19 +61,55 @@ func subjectListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			cl, err := schemaregistry.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
 
-			ctx := cmd.Context()
+			schemaCtx, _ := cmd.Flags().GetString("schema-context")
+			skipCheck, _ := cmd.Flags().GetBool("skip-context-check")
+			showCtxCol := schemaCtx == "" && srcontext.CheckContextSupport(cmd.Context(), cl.Client, fs, p, skipCheck) == nil
+
+			var params []sr.Param
 			if deleted {
-				ctx = sr.WithParams(cmd.Context(), sr.ShowDeleted)
+				params = append(params, sr.ShowDeleted)
+			}
+			if pfx := schemaregistry.ContextSubjectPrefix(schemaCtx); pfx != "" {
+				params = append(params, sr.SubjectPrefix(pfx))
+			}
+			ctx := cmd.Context()
+			if len(params) > 0 {
+				ctx = sr.WithParams(ctx, params...)
 			}
 
 			subjects, err := cl.Subjects(ctx)
 			out.MaybeDieErr(err)
+			slices.Sort(subjects)
+
+			if showCtxCol {
+				rows := make([]subjectWithContext, 0, len(subjects))
+				for _, s := range subjects {
+					sCtx, bare := schemaregistry.ParseSubjectContext(s)
+					rows = append(rows, subjectWithContext{
+						Context: schemaregistry.DisplayContext(sCtx),
+						Subject: bare,
+					})
+				}
+				if isText, _, s, err := f.Format(rows); !isText {
+					out.MaybeDie(err, "unable to print in the required format %q: %v", f.Kind, err)
+					out.Exit(s)
+				}
+				tw := out.NewTable("context", "subject")
+				defer tw.Flush()
+				for _, r := range rows {
+					tw.PrintStructFields(r)
+				}
+				return
+			}
+
+			for i, s := range subjects {
+				subjects[i] = schemaregistry.StripContextQualifier(schemaCtx, s)
+			}
 
 			if isText, _, s, err := f.Format(subjects); !isText {
 				out.MaybeDie(err, "unable to print in the required format %q: %v", f.Kind, err)
 				out.Exit(s)
 			}
-			sort.Strings(subjects)
 			for _, s := range subjects {
 				fmt.Println(s)
 			}
@@ -100,23 +142,25 @@ func subjectDeleteCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			cl, err := schemaregistry.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
 
+			schemaCtx, _ := cmd.Flags().GetString("schema-context")
+
 			var (
 				wg      sync.WaitGroup
 				mu      sync.Mutex
 				results []deleteResponse
 			)
 
-			for i := range subjects {
-				subject := subjects[i]
+			for _, subject := range subjects {
+				qualified := schemaregistry.QualifySubject(schemaCtx, subject)
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
 					var versions []int
 					var err error
 					if isPermanent {
-						versions, err = cl.DeleteSubject(cmd.Context(), subject, sr.SoftDelete)
+						versions, err = cl.DeleteSubject(cmd.Context(), qualified, sr.SoftDelete)
 						if err == nil || schemaregistry.IsSubjectNotFoundError(err) {
-							versions, err = cl.DeleteSubject(cmd.Context(), subject, sr.HardDelete)
+							versions, err = cl.DeleteSubject(cmd.Context(), qualified, sr.HardDelete)
 							if err != nil {
 								err = fmt.Errorf("unable to perform hard-deletion: %w", err)
 							}
@@ -124,7 +168,7 @@ func subjectDeleteCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 							err = fmt.Errorf("unable to perform initial soft-deletion that is required for hard-deletion: %w", err)
 						}
 					} else {
-						versions, err = cl.DeleteSubject(cmd.Context(), subject, sr.SoftDelete)
+						versions, err = cl.DeleteSubject(cmd.Context(), qualified, sr.SoftDelete)
 					}
 					mu.Lock()
 					defer mu.Unlock()

--- a/src/go/rpk/pkg/schemaregistry/BUILD
+++ b/src/go/rpk/pkg/schemaregistry/BUILD
@@ -1,8 +1,11 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "schemaregistry",
-    srcs = ["client.go"],
+    srcs = [
+        "client.go",
+        "context.go",
+    ],
     importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry",
     visibility = ["//visibility:public"],
     deps = [
@@ -17,4 +20,11 @@ go_library(
         "@com_github_twmb_franz_go_pkg_sr//:sr",
         "@com_github_twmb_franz_go_plugin_kzap//:kzap",
     ],
+)
+
+go_test(
+    name = "schemaregistry_test",
+    srcs = ["context_test.go"],
+    embed = [":schemaregistry"],
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/src/go/rpk/pkg/schemaregistry/context.go
+++ b/src/go/rpk/pkg/schemaregistry/context.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package schemaregistry
+
+import (
+	"strings"
+)
+
+// QualifySubject returns the context-qualified form of a subject name.
+// For example, QualifySubject(".myctx", "topic") returns ":.myctx:topic".
+// When schemaCtx is empty the subject is returned unchanged.
+func QualifySubject(schemaCtx, subject string) string {
+	if schemaCtx == "" {
+		return subject
+	}
+	return ":" + schemaCtx + ":" + subject
+}
+
+// ContextSubjectPrefix returns the prefix string used in the subjectPrefix
+// query parameter to filter subjects belonging to a given context.
+// For example, ContextSubjectPrefix(".myctx") returns ":.myctx:".
+// Returns "" when schemaCtx is empty.
+func ContextSubjectPrefix(schemaCtx string) string {
+	if schemaCtx == "" {
+		return ""
+	}
+	return ":" + schemaCtx + ":"
+}
+
+// StripContextQualifier removes the ":{ctx}:" prefix from a subject name.
+// For example, StripContextQualifier(".myctx", ":.myctx:topic") returns "topic".
+// If the subject does not start with the expected prefix, it is returned unchanged.
+// When schemaCtx is empty the subject is returned unchanged.
+func StripContextQualifier(schemaCtx, subject string) string {
+	if schemaCtx == "" {
+		return subject
+	}
+	pfx := ContextSubjectPrefix(schemaCtx)
+	return strings.TrimPrefix(subject, pfx)
+}
+
+// ParseSubjectContext extracts the context and bare subject from a raw
+// context-qualified subject name. For example:
+//
+//	":.test:my-topic" → (".test", "my-topic")
+//	"plain-topic"     → ("", "plain-topic")
+func ParseSubjectContext(subject string) (schemaCtx, bare string) {
+	rest, ok := strings.CutPrefix(subject, ":")
+	if !ok {
+		return "", subject
+	}
+	// Format is ":{ctx}:{subject}".
+	ctx, bare, ok := strings.Cut(rest, ":")
+	if !ok {
+		return "", subject
+	}
+	return ctx, bare
+}
+
+// DisplayContext returns a human-readable context name. Empty string and "."
+// are shown as "default"; all other values are returned as-is.
+func DisplayContext(schemaCtx string) string {
+	if schemaCtx == "" || schemaCtx == "." {
+		return "default"
+	}
+	return schemaCtx
+}

--- a/src/go/rpk/pkg/schemaregistry/context_test.go
+++ b/src/go/rpk/pkg/schemaregistry/context_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package schemaregistry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQualifySubject(t *testing.T) {
+	tests := []struct {
+		name      string
+		schemaCtx string
+		subject   string
+		want      string
+	}{
+		{"empty context", "", "topic", "topic"},
+		{"with context", ".myctx", "topic", ":.myctx:topic"},
+		{"default context", ".", "topic", ":.:" + "topic"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, QualifySubject(tt.schemaCtx, tt.subject))
+		})
+	}
+}
+
+func TestContextSubjectPrefix(t *testing.T) {
+	require.Equal(t, "", ContextSubjectPrefix(""))
+	require.Equal(t, ":.myctx:", ContextSubjectPrefix(".myctx"))
+	require.Equal(t, ":.:", ContextSubjectPrefix("."))
+}
+
+func TestStripContextQualifier(t *testing.T) {
+	tests := []struct {
+		name      string
+		schemaCtx string
+		subject   string
+		want      string
+	}{
+		{"empty context", "", "topic", "topic"},
+		{"with matching prefix", ".myctx", ":.myctx:topic", "topic"},
+		{"no matching prefix", ".myctx", "topic", "topic"},
+		{"different context prefix", ".myctx", ":.other:topic", ":.other:topic"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, StripContextQualifier(tt.schemaCtx, tt.subject))
+		})
+	}
+}
+
+func TestParseSubjectContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		subject  string
+		wantCtx  string
+		wantBare string
+	}{
+		{"plain subject", "my-topic", "", "my-topic"},
+		{"qualified subject", ":.test:my-topic", ".test", "my-topic"},
+		{"default context", ":.:my-topic", ".", "my-topic"},
+		{"colon but no second colon", ":broken", "", ":broken"},
+		{"empty subject", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCtx, gotBare := ParseSubjectContext(tt.subject)
+			require.Equal(t, tt.wantCtx, gotCtx)
+			require.Equal(t, tt.wantBare, gotBare)
+		})
+	}
+}
+
+func TestDisplayContext(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  string
+		want string
+	}{
+		{"empty", "", "default"},
+		{"dot", ".", "default"},
+		{"named", ".test", ".test"},
+		{"other", ".myctx", ".myctx"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, DisplayContext(tt.ctx))
+		})
+	}
+}


### PR DESCRIPTION
Add `rpk registry context list` and `rpk registry context delete` commands
for managing schema registry contexts. Also add a `--schema-context`
persistent flag on the `registry` parent command so all subcommands
(including compatibility-level) can be scoped to a specific context.

Update compatibility-level get/set to use `cmd.Context()` instead of
`context.Background()` so the schema context propagates correctly.

Includes integration tests using `srfake`.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Features

* Add `rpk registry context list` and `rpk registry context delete` commands for managing schema registry contexts
* Add `--schema-context` flag to `rpk registry` to scope all registry operations to a specific context

## Test Plan

### subject list

| Test Case | Flags | Expected |
|-----------|-------|----------|
| No context, no contexts exist | (none) | Plain list, no CONTEXT column |
| No context, contexts exist | `--skip-context-check` | CONTEXT column with `default`/`.ctx1` |
| With `--schema-context .ctx1` | `--skip-context-check` | Only subjects in `.ctx1`, no qualifier, no CONTEXT column |
| With `--deleted` | `--skip-context-check --schema-context .ctx1` | Shows deleted subjects |
| Raw qualified subject | (none) | Shows `:.ctx1:sub-a` as-is |

### subject delete

| Test Case | Flags | Args | Expected |
|-----------|-------|------|----------|
| No context | (none) | `topic-a` | Deletes `topic-a`, output shows `topic-a` |
| With `--schema-context .ctx1` | `--skip-context-check` | `my-subject` | Deletes `:.ctx1:my-subject`, output shows `my-subject` |
| Raw qualified | (none) | `:.ctx1:my-subject` | Deletes `:.ctx1:my-subject`, output shows raw name |
| Permanent delete | `--permanent --skip-context-check --schema-context .ctx1` | `my-subject` | Hard-deletes |

### schema list

| Test Case | Flags | Expected |
|-----------|-------|----------|
| No context, no contexts exist | (none) | Plain table, no CONTEXT column |
| No context, contexts exist | `--skip-context-check` | CONTEXT column with `default`/`.ctx1` |
| With `--schema-context .ctx1` | `--skip-context-check` | Only `.ctx1` schemas, no CONTEXT column |
| Specific subjects with context | `--skip-context-check --schema-context .ctx1` | `schema list sub-a sub-b` shows both |
| Raw qualified subjects | (none) | `schema list ":.ctx1:sub-a"` shows raw name |

### schema create

| Test Case | Flags | Args | Expected |
|-----------|-------|------|----------|
| No context | `--schema file.avro` | `my-subject` | Creates under `my-subject` |
| With `--schema-context .ctx1` | `--skip-context-check --schema file.avro` | `my-subject` | Creates under `:.ctx1:my-subject`, output shows `my-subject` |
| Raw qualified | `--schema file.avro` | `:.ctx1:my-subject` | Creates under `:.ctx1:my-subject` |

### schema get

| Test Case | Flags | Args | Expected |
|-----------|-------|------|----------|
| By version, no context | `--schema-version latest` | `topic-a` | Returns schema |
| By version, with context | `--skip-context-check --schema-context .ctx1 --schema-version 1` | `my-subject` | Looks up `:.ctx1:my-subject`, output shows `my-subject` |
| By version, raw qualified | `--schema-version 1` | `:.ctx1:my-subject` | Shows raw name |
| By ID, no subject | `--id 1` | (none) | Returns all usages |
| By ID, with context | `--skip-context-check --schema-context .ctx1 --id 2` | (none) | Filters to `.ctx1` |
| By ID + subject, with context | `--skip-context-check --schema-context .ctx1 --id 2` | `my-subject` | Filters to `:.ctx1:my-subject` |
| By schema file, with context | `--skip-context-check --schema-context .ctx1 --schema file.avro` | `my-subject` | Looks up in context |
| `--print-schema` | `--schema-version 1 --schema-context .ctx1` | `my-subject` | Pretty-printed schema |

### schema delete

| Test Case | Flags | Args | Expected |
|-----------|-------|------|----------|
| No context | `--schema-version 1` | `topic-a` | Soft-deletes version 1 |
| With context | `--skip-context-check --schema-context .ctx1 --schema-version 1` | `my-subject` | Deletes, output shows `my-subject` |
| Raw qualified | `--schema-version 1` | `:.ctx1:my-subject` | Deletes using raw name |
| Permanent | `--permanent --skip-context-check --schema-context .ctx1 --schema-version 1` | `my-subject` | Hard-deletes |

### schema references

| Test Case | Flags | Args | Expected |
|-----------|-------|------|----------|
| No context | `--schema-version 1` | `topic-a` | Lists references |
| With context | `--skip-context-check --schema-context .ctx1 --schema-version 1` | `my-subject` | Strips qualifier in output |
| Raw qualified | `--schema-version 1` | `:.ctx1:my-subject` | Uses raw name |

### schema check-compatibility

| Test Case | Flags | Args | Expected |
|-----------|-------|------|----------|
| No context | `--schema file.avro --schema-version latest` | `topic-a` | Checks against `topic-a` |
| With context | `--skip-context-check --schema-context .ctx1 --schema file.avro --schema-version latest` | `my-subject` | Checks against `:.ctx1:my-subject` |
| Raw qualified | `--schema file.avro --schema-version latest` | `:.ctx1:my-subject` | Uses raw name |

### compatibility-level get

| Test Case | Flags | Args | Expected |
|-----------|-------|------|----------|
| Global (no args) | (none) | (none) | Returns global level |
| Per-subject, with context | `--skip-context-check --schema-context .ctx1` | `my-subject` | Shows `my-subject` |
| Per-subject + global | `--skip-context-check --schema-context .ctx1 --global` | `my-subject` | Both rows, global unqualified |
| Raw qualified | (none) | `:.ctx1:my-subject` | Shows raw name |

### compatibility-level set

| Test Case | Flags | Args | Expected |
|-----------|-------|------|----------|
| Global | `--level BACKWARD` | (none) | Sets global level |
| Per-subject, with context | `--skip-context-check --schema-context .ctx1 --level FULL` | `my-subject` | Shows `my-subject` |
| Per-subject + global | `--skip-context-check --schema-context .ctx1 --level FULL --global` | `my-subject` | Both |
| Raw qualified | `--level BACKWARD` | `:.ctx1:my-subject` | Uses raw name |

### mode get

| Test Case | Flags | Args | Expected |
|-----------|-------|------|----------|
| Global (no args) | (none) | (none) | Returns global mode |
| Per-subject, with context | `--skip-context-check --schema-context .ctx1` | `my-subject` | Shows `my-subject` |
| Per-subject + global | `--skip-context-check --schema-context .ctx1 --global` | `my-subject` | Both rows |
| Raw qualified | (none) | `:.ctx1:my-subject` | Shows raw name |

### mode set

| Test Case | Flags | Args | Expected |
|-----------|-------|------|----------|
| Global | `--mode READONLY` | (none) | Sets global mode |
| Per-subject, with context | `--skip-context-check --schema-context .ctx1 --mode READWRITE` | `my-subject` | Sets on `:.ctx1:my-subject` |
| Raw qualified | `--mode READONLY` | `:.ctx1:my-subject` | Uses raw name |

### mode reset

| Test Case | Flags | Args | Expected |
|-----------|-------|------|----------|
| Per-subject, no context | (none) | `topic-a` | Resets mode |
| Per-subject, with context | `--skip-context-check --schema-context .ctx1` | `my-subject` | Resets `:.ctx1:my-subject`, output shows `my-subject` |
| Raw qualified | (none) | `:.ctx1:my-subject` | Uses raw name |

### context list

| Test Case | Flags | Expected |
|-----------|-------|----------|
| Contexts exist | (none) | Lists `.`, `.ctx1`, `.ctx2` |
| Empty registry | (none) | Lists `.` (default only) |
| Unsupported cluster (404) | (none) | Error: "not supported by this cluster" |
| JSON format | `--format json` | `[{"name":"."},{"name":".ctx1"}]` |

### context delete

| Test Case | Flags | Args | Expected |
|-----------|-------|------|----------|
| Valid context | `--no-confirm` | `.ctx1` | Deletes, success message |
| Non-existent context | `--no-confirm` | `.nope` | Error: "context not found" |
| Invalid name (no dot) | `--no-confirm` | `badname` | Error: "must start with '.'" |

### Validation / Edge Cases

| Test Case | Input | Expected |
|-----------|-------|----------|
| `--schema-context` without dot | `--schema-context nope` | Error: "must start with '.'" |
| `--schema-context` with colon | `--schema-context ".a:b"` | Error: "must not contain ':'" |
| Admin API flag disabled | `--schema-context .ctx1` (admin returns false) | Error: "not enabled" |
| Admin API unreachable | `--schema-context .ctx1` (no admin) | Error with wrapped cause |
| `--skip-context-check` bypasses admin | `--schema-context .ctx1 --skip-context-check` | Succeeds |