### PR TITLE
tests/setup: bump packages to avoid pkg_resources include

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -25,7 +25,7 @@ setup(
         "falcon==4.0.2",
         "psutil==5.9.0",
         "numpy==1.26.4",
-        "pygal==3.0",
+        "pygal==3.0.5",
         "pytest==7.1.2",
         "jump-consistent-hash==3.2.0",
         "azure-storage-blob==12.14.1",
@@ -41,7 +41,7 @@ setup(
         "proto-plus==1.26.1",
         "rsa==4.9",
         "python-keycloak==5.8.1",
-        "z3-solver==4.12.2",
+        "z3-solver==4.12.6",
         "hypothesis==6.82",
         "jsonschema==4.10.0",
         "redpanda-polaris-catalog-python==1.0.0.post3",  # See: .github/workflows/publish-apache-polaris-python-client.yml


### PR DESCRIPTION
forward port of https://github.com/redpanda-data/redpanda/pull/29651

pygal is used by OMB, which does not specify which version to use

z3-solver is used in ducktape, 4.12.2 used pkg_resources

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
