### PR TITLE
ct/frontend: Protect against delete race with tidp

### DIFF
--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -210,6 +210,19 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "topic_id_partition",
+    hdrs = [
+        "topic_id_partition.h",
+    ],
+    visibility = [":__subpackages__"],
+    deps = [
+        ":state_accessors",
+        "//src/v/cluster",
+        "//src/v/model",
+    ],
+)
+
+redpanda_cc_library(
     name = "cluster_services_interface",
     hdrs = [
         "cluster_services.h",

--- a/src/v/cloud_topics/frontend/BUILD
+++ b/src/v/cloud_topics/frontend/BUILD
@@ -25,6 +25,7 @@ redpanda_cc_library(
     implementation_deps = [
         "//src/v/cloud_storage:types",
         "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics:topic_id_partition",
         "//src/v/cloud_topics/level_one/metastore",
         "//src/v/cloud_topics/level_zero/common:producer_queue",
         "//src/v/cloud_topics/level_zero/stm:ctp_stm",

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -283,7 +283,7 @@ frontend::make_reader(cloud_topic_log_reader_config cfg) {
         // this roundabout way of doing it.
         auto tidp = topic_id_partition();
         if (!tidp) {
-            throw ss::abort_requested_exception();
+            throw topic_config_not_found_exception(ntp());
         }
         co_return storage::translating_reader{
           model::record_batch_reader(make_l1_reader(cfg, *tidp))};
@@ -416,7 +416,7 @@ frontend::l1_timequery(storage::timequery_config cfg) {
     auto l1_metastore = ct_state->local().get_l1_metastore();
     auto tidp = topic_id_partition();
     if (!tidp) {
-        throw ss::abort_requested_exception();
+        throw topic_config_not_found_exception(ntp());
     }
     // I don't love this, but we clamp min/max offsets by the kafka start offset
     // and the LSO/HWM, but we can ignore the max offset for L1 because we never

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -22,6 +22,7 @@
 #include "cloud_topics/level_zero/stm/placeholder.h"
 #include "cloud_topics/logger.h"
 #include "cloud_topics/state_accessors.h"
+#include "cloud_topics/topic_id_partition.h"
 #include "cluster/metadata_cache.h"
 #include "cluster/partition.h"
 #include "cluster/rm_stm_types.h"
@@ -170,20 +171,6 @@ get_aborted_transactions_local(
     co_return target;
 }
 
-model::topic_id_partition
-get_topic_id_partition(const ss::lw_shared_ptr<cluster::partition>& partition) {
-    const auto& ntp = partition->ntp();
-    auto ct_state = partition->get_cloud_topics_state();
-    auto metadata_cache = ct_state->local().get_metadata_cache();
-    auto topic_cfg = metadata_cache->get_topic_cfg(
-      model::topic_namespace_view(ntp));
-    if (!topic_cfg || !topic_cfg->tp_id) {
-        throw std::runtime_error(
-          fmt::format("no topic ID found for cloud topic {}", ntp));
-    }
-    return model::topic_id_partition{*topic_cfg->tp_id, ntp.tp.partition};
-}
-
 } // namespace
 
 frontend::frontend(
@@ -294,8 +281,12 @@ frontend::make_reader(cloud_topic_log_reader_config cfg) {
         // we're hacking around. Maybe the `translating_reader` should take
         // responsibility for returning aborted transactions directly instead of
         // this roundabout way of doing it.
+        auto tidp = topic_id_partition();
+        if (!tidp) {
+            throw ss::abort_requested_exception();
+        }
         co_return storage::translating_reader{
-          model::record_batch_reader(make_l1_reader(cfg))};
+          model::record_batch_reader(make_l1_reader(cfg, *tidp))};
     }
     co_return storage::translating_reader{
       model::record_batch_reader(make_l0_reader(cfg)),
@@ -332,7 +323,7 @@ bool frontend::cache_enabled() const {
     return true;
 }
 
-model::topic_id_partition frontend::topic_id_partition() const {
+std::optional<model::topic_id_partition> frontend::topic_id_partition() const {
     return get_topic_id_partition(_partition);
 }
 
@@ -355,7 +346,10 @@ ss::future<size_t> frontend::size_bytes() {
     auto l1_metastore = ct_state->local().get_l1_metastore();
 
     auto tidp = topic_id_partition();
-    auto size_res = co_await l1_metastore->get_size(tidp);
+    if (!tidp) {
+        co_return 0;
+    }
+    auto size_res = co_await l1_metastore->get_size(*tidp);
     if (!size_res.has_value()) {
         vlog(
           cd_log.warn,
@@ -374,14 +368,13 @@ ss::future<size_t> frontend::size_bytes() {
     co_return size_res.value().size + l0_size;
 }
 
-std::unique_ptr<model::record_batch_reader::impl>
-frontend::make_l1_reader(const cloud_topic_log_reader_config& cfg) const {
+std::unique_ptr<model::record_batch_reader::impl> frontend::make_l1_reader(
+  const cloud_topic_log_reader_config& cfg,
+  model::topic_id_partition tidp) const {
     auto ct_state = _partition->get_cloud_topics_state();
     auto l1_metastore = ct_state->local().get_l1_metastore();
     auto l1_io = ct_state->local().get_l1_io();
     auto l1_reader_probe = ct_state->local().get_l1_reader_probe();
-
-    auto tidp = topic_id_partition();
 
     return std::make_unique<level_one_log_reader_impl>(
       cfg, _partition->ntp(), tidp, l1_metastore, l1_io, l1_reader_probe);
@@ -422,13 +415,16 @@ frontend::l1_timequery(storage::timequery_config cfg) {
     auto ct_state = _partition->get_cloud_topics_state();
     auto l1_metastore = ct_state->local().get_l1_metastore();
     auto tidp = topic_id_partition();
+    if (!tidp) {
+        throw ss::abort_requested_exception();
+    }
     // I don't love this, but we clamp min/max offsets by the kafka start offset
     // and the LSO/HWM, but we can ignore the max offset for L1 because we never
     // upload anything less than LSO to L1.
     std::ignore = cfg.max_offset;
     // Go query our start offset from the L1 metastore
     auto result = co_await l1_metastore->get_first_ge(
-      tidp, model::offset_cast(cfg.min_offset), cfg.time);
+      *tidp, model::offset_cast(cfg.min_offset), cfg.time);
     if (!result.has_value()) {
         if (
           result.error() == l1::metastore::errc::out_of_range
@@ -560,7 +556,6 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
   chunked_vector<model::record_batch> cache_batches,
   raft::replicate_options opts) {
     const auto& ntp = partition->ntp();
-    auto tidp = get_topic_id_partition(partition);
     // The default errc that will cause the client to retry the operation
     constexpr auto default_errc = raft::errc::timeout;
     /*
@@ -689,17 +684,22 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
         // which case it's not stored) or from the log replay. The
         // simplest solution in this case is to skip caching.
         if (res.value().last_term >= model::term_id{0}) {
-            update_batches(
-              cache_batches,
-              kafka::offset_cast(res.value().last_offset),
-              res.value().last_term);
-            for (const auto& b : cache_batches) {
-                vlog(
-                  cd_log.trace,
-                  "Putting batch to cache: {}, term: {}",
-                  b.base_offset(),
-                  b.term());
-                api->cache_put(tidp, b);
+            // Topic config may already be gone if the topic is being
+            // deleted; skip caching in that case.
+            auto tidp = get_topic_id_partition(partition);
+            if (tidp) {
+                update_batches(
+                  cache_batches,
+                  kafka::offset_cast(res.value().last_offset),
+                  res.value().last_term);
+                for (const auto& b : cache_batches) {
+                    vlog(
+                      cd_log.trace,
+                      "Putting batch to cache: {}, term: {}",
+                      b.base_offset(),
+                      b.term());
+                    api->cache_put(*tidp, b);
+                }
             }
         } else {
             vlog(
@@ -803,16 +803,20 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
     }
     auto ret_offset = model::offset(result.value().last_offset());
     if (!rb_copy.empty()) {
-        update_batches(rb_copy, ret_offset, result.value().last_term);
+        // Topic config may already be gone if the topic is being
+        // deleted; skip caching in that case.
         auto tidp = topic_id_partition();
-        for (const auto& b : rb_copy) {
-            vlog(
-              cd_log.trace,
-              "Putting batch for {} to cache: {}, term: {}",
-              ntp(),
-              b.base_offset(),
-              b.term());
-            _data_plane->cache_put(tidp, b);
+        if (tidp) {
+            update_batches(rb_copy, ret_offset, result.value().last_term);
+            for (const auto& b : rb_copy) {
+                vlog(
+                  cd_log.trace,
+                  "Putting batch for {} to cache: {}, term: {}",
+                  ntp(),
+                  b.base_offset(),
+                  b.term());
+                _data_plane->cache_put(*tidp, b);
+            }
         }
     }
     co_return ret_offset;
@@ -889,7 +893,10 @@ frontend::get_leader_epoch_last_offset(model::term_id term) const {
     auto ct_state = _partition->get_cloud_topics_state();
     auto l1_metastore = ct_state->local().get_l1_metastore();
     auto tidp = topic_id_partition();
-    auto l1_res = co_await l1_metastore->get_end_offset_for_term(tidp, term);
+    if (!tidp) {
+        co_return std::nullopt;
+    }
+    auto l1_res = co_await l1_metastore->get_end_offset_for_term(*tidp, term);
     if (!l1_res.has_value()) {
         switch (l1_res.error()) {
         case l1::metastore::errc::out_of_range:

--- a/src/v/cloud_topics/frontend/frontend.h
+++ b/src/v/cloud_topics/frontend/frontend.h
@@ -212,13 +212,17 @@ private:
 
     bool cache_enabled() const;
 
-    model::topic_id_partition topic_id_partition() const;
+    /// Returns nullopt when the topic config has been removed from the
+    /// topic_table (e.g. during deletion) but the partition has not yet
+    /// been shut down.
+    std::optional<model::topic_id_partition> topic_id_partition() const;
 
     std::unique_ptr<model::record_batch_reader::impl>
     make_l0_reader(const cloud_topic_log_reader_config& cfg) const;
 
-    std::unique_ptr<model::record_batch_reader::impl>
-    make_l1_reader(const cloud_topic_log_reader_config& cfg) const;
+    std::unique_ptr<model::record_batch_reader::impl> make_l1_reader(
+      const cloud_topic_log_reader_config& cfg,
+      model::topic_id_partition tidp) const;
 
     ss::lw_shared_ptr<cluster::partition> _partition;
     data_plane_api* _data_plane;

--- a/src/v/cloud_topics/level_zero/frontend_reader/BUILD
+++ b/src/v/cloud_topics/level_zero/frontend_reader/BUILD
@@ -23,6 +23,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_zero/stm:placeholder",
         "//src/v/cluster",
         "//src/v/config",
+        "//src/v/ssx:future_util",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/v/cloud_topics/level_zero/frontend_reader/BUILD
+++ b/src/v/cloud_topics/level_zero/frontend_reader/BUILD
@@ -18,6 +18,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics:log_reader_config",
         "//src/v/cloud_topics:logger",
         "//src/v/cloud_topics:state_accessors",
+        "//src/v/cloud_topics:topic_id_partition",
         "//src/v/cloud_topics:types",
         "//src/v/cloud_topics/level_zero/stm:placeholder",
         "//src/v/cluster",

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -19,6 +19,7 @@
 #include "cluster/partition.h"
 #include "config/configuration.h"
 #include "model/timeout_clock.h"
+#include "ssx/future-util.h"
 
 #include <seastar/coroutine/maybe_yield.hh>
 
@@ -51,8 +52,13 @@ level_zero_log_reader_impl::do_load_slice(
     try {
         return read_some(deadline);
     } catch (...) {
-        vlog(
-          _log.error, "Reader caught exception: {}", std::current_exception());
+        auto ex = std::current_exception();
+        vlogl(
+          _log,
+          ssx::is_shutdown_exception(ex) ? ss::log_level::debug
+                                         : ss::log_level::error,
+          "Reader caught exception: {}",
+          ex);
         set_end_of_stream();
         throw;
     }

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -15,7 +15,7 @@
 #include "cloud_topics/level_zero/stm/placeholder.h"
 #include "cloud_topics/logger.h"
 #include "cloud_topics/state_accessors.h"
-#include "cluster/metadata_cache.h"
+#include "cloud_topics/topic_id_partition.h"
 #include "cluster/partition.h"
 #include "config/configuration.h"
 #include "model/timeout_clock.h"
@@ -29,32 +29,6 @@
 #include <variant>
 
 namespace cloud_topics {
-namespace {
-
-/// Thrown when the topic config is no longer available, e.g. because the
-/// topic has been deleted from the topic_table but the partition has not
-/// yet been shut down. Caught in do_load_slice to end the stream
-/// gracefully instead of propagating as a hard error.
-struct topic_config_not_found final : std::runtime_error {
-    using std::runtime_error::runtime_error;
-};
-
-model::topic_id_partition
-get_topic_id_partition(const ss::lw_shared_ptr<cluster::partition>& partition) {
-    const auto& ntp = partition->ntp();
-    auto ct_state = partition->get_cloud_topics_state();
-    auto metadata_cache = ct_state->local().get_metadata_cache();
-    auto topic_cfg = metadata_cache->get_topic_cfg(
-      model::topic_namespace_view(ntp));
-    if (!topic_cfg) {
-        throw topic_config_not_found(
-          fmt::format("no config found for cloud topic {}", ntp));
-    }
-    return model::topic_id_partition{
-      topic_cfg->tp_id.value(), ntp.tp.partition};
-}
-
-} // namespace
 
 level_zero_log_reader_impl::level_zero_log_reader_impl(
   const cloud_topic_log_reader_config& cfg,
@@ -76,10 +50,6 @@ level_zero_log_reader_impl::do_load_slice(
   model::timeout_clock::time_point deadline) {
     try {
         return read_some(deadline);
-    } catch (const topic_config_not_found& e) {
-        vlog(_log.debug, "Reader ending stream: {}", e.what());
-        set_end_of_stream();
-        return ss::make_ready_future<model::record_batch_reader::storage_t>();
     } catch (...) {
         vlog(
           _log.error, "Reader caught exception: {}", std::current_exception());
@@ -107,7 +77,7 @@ level_zero_log_reader_impl::read_some(
     // This closes the race window between replicate() completing (HWM
     // advance) and cache_put() running on the write continuation.
     if (cache_enabled() && _ctp->is_leader()) {
-        auto tidp = get_topic_id_partition(_ctp);
+        auto tidp = require_topic_id_partition();
         auto wait_deadline = model::timeout_clock::now()
                              + std::chrono::milliseconds(25);
         try {
@@ -205,7 +175,7 @@ level_zero_log_reader_impl::maybe_read_batches_from_cache() {
         return ret;
     }
 
-    auto tidp = get_topic_id_partition(_ctp);
+    auto tidp = require_topic_id_partition();
 
     /*
      * Fetch batches from the cache starting at `_next_offset` until we hit a
@@ -328,7 +298,7 @@ ss::future<std::expected<chunked_circular_buffer<model::record_batch>, errc>>
 level_zero_log_reader_impl::materialize_batches(
   chunked_circular_buffer<local_log_batch> unhydrated,
   model::timeout_clock::time_point deadline) {
-    auto tidp = get_topic_id_partition(_ctp);
+    auto tidp = require_topic_id_partition();
     // Cherry-pick enough L0 meta batches to materialize.
     chunked_vector<cloud_topics::extent_meta> to_materialize;
     auto unhydrated_it = unhydrated.begin();
@@ -486,6 +456,15 @@ level_zero_log_reader_impl::materialize_batches(
       "Materialized {} batches from the L0 meta batches",
       hydrated.size());
     co_return hydrated;
+}
+
+model::topic_id_partition
+level_zero_log_reader_impl::require_topic_id_partition() const {
+    auto tidp = get_topic_id_partition(_ctp);
+    if (!tidp) {
+        throw ss::abort_requested_exception();
+    }
+    return *tidp;
 }
 
 bool level_zero_log_reader_impl::cache_enabled() const {

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -462,7 +462,7 @@ model::topic_id_partition
 level_zero_log_reader_impl::require_topic_id_partition() const {
     auto tidp = get_topic_id_partition(_ctp);
     if (!tidp) {
-        throw ss::abort_requested_exception();
+        throw topic_config_not_found_exception(_ctp->ntp());
     }
     return *tidp;
 }

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
@@ -107,6 +107,11 @@ private:
 
     bool cache_enabled() const;
 
+    /// Look up the topic_id_partition for this reader's partition.
+    /// Throws ss::abort_requested_exception if the topic config has been
+    /// removed (e.g. topic deletion race).
+    model::topic_id_partition require_topic_id_partition() const;
+
     // Prepare a local log reader configuration for reading placeholder and
     // other metadata batches from the CTP.
     storage::local_log_reader_config ctp_read_config() const;

--- a/src/v/cloud_topics/topic_id_partition.h
+++ b/src/v/cloud_topics/topic_id_partition.h
@@ -14,9 +14,28 @@
 #include "cluster/partition.h"
 #include "model/fundamental.h"
 
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/sstring.hh>
+
+#include <fmt/format.h>
+
 #include <optional>
 
 namespace cloud_topics {
+
+/// Thrown when the topic config lookup fails, which can occur when the topic
+/// config has been removed from the topic_table but a partition operation is
+/// still in flight.
+struct topic_config_not_found_exception final : ss::abort_requested_exception {
+    explicit topic_config_not_found_exception(const model::ntp& ntp)
+      : _msg(
+          fmt::format(
+            "topic config not found for {} (topic likely deleted)", ntp)) {}
+    const char* what() const noexcept override { return _msg.c_str(); }
+
+private:
+    ss::sstring _msg;
+};
 
 /// Look up the topic_id_partition for a cloud-topics partition.
 /// Returns nullopt when the topic config has been removed from the

--- a/src/v/cloud_topics/topic_id_partition.h
+++ b/src/v/cloud_topics/topic_id_partition.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "cloud_topics/state_accessors.h"
+#include "cluster/metadata_cache.h"
+#include "cluster/partition.h"
+#include "model/fundamental.h"
+
+#include <optional>
+
+namespace cloud_topics {
+
+/// Look up the topic_id_partition for a cloud-topics partition.
+/// Returns nullopt when the topic config has been removed from the
+/// topic_table (e.g. during deletion) but the partition has not yet
+/// been shut down.
+inline std::optional<model::topic_id_partition>
+get_topic_id_partition(const ss::lw_shared_ptr<cluster::partition>& partition) {
+    const auto& ntp = partition->ntp();
+    auto ct_state = partition->get_cloud_topics_state();
+    auto metadata_cache = ct_state->local().get_metadata_cache();
+    auto topic_cfg = metadata_cache->get_topic_cfg(
+      model::topic_namespace_view(ntp));
+    if (!topic_cfg || !topic_cfg->tp_id) {
+        return std::nullopt;
+    }
+    return model::topic_id_partition{*topic_cfg->tp_id, ntp.tp.partition};
+}
+
+} // namespace cloud_topics


### PR DESCRIPTION
When a topic is deleted, there's a window when its information is
removed from the topic table but partitions have not yet all shut down.
In this window, topic id partition lookup can fail. This change adjusts
cloud topics to deal with the window.

All callsites that look up topic_id_partition and their handling:

L0 reader: This was originally improperly fixed in https://github.com/redpanda-data/redpanda/pull/29684. Readers
should propagate abort conditions. This change causes the abort to be
propagated.

frontend::make_reader (L1 path): Throws abort_requested_exception.

frontend::l1_timequery: Throws abort_requested_exception. It's like a
special kind of read.

frontend::size_bytes: Returns 0.

frontend::get_leader_epoch_last_offset: Returns nullopt, which will map
to offset -1 "unknown".

frontend::do_upload_and_replicate, frontend::replicate: Skips cache put
post-replicate.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
