### PR TITLE
ct: Do not skip batch cache reading

### DIFF
--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -9,6 +9,7 @@
  */
 #include "cloud_topics/level_zero/frontend_reader/level_zero_reader.h"
 
+#include "base/vassert.h"
 #include "cloud_topics/data_plane_api.h"
 #include "cloud_topics/errc.h"
 #include "cloud_topics/level_zero/stm/placeholder.h"
@@ -320,6 +321,9 @@ level_zero_log_reader_impl::materialize_batches(
           },
           [](const cloud_topics::extent_meta& meta) {
               return meta.byte_range_size();
+          },
+          [](const local_log_batch::cached_batch&) -> size_t {
+              vunreachable("Unexpected cached_batch state");
           });
         if (is_over_limit_with_bytes(hydrated_batch_size)) {
             // If the next meta batch exceeds the max bytes limit, we stop
@@ -343,6 +347,24 @@ level_zero_log_reader_impl::materialize_batches(
         if (
           auto* meta = std::get_if<cloud_topics::extent_meta>(
             &unhydrated_it->data)) {
+            // Try the batch cache before scheduling an S3 download.
+            // This prevents gap amplification where a single evicted
+            // cache entry causes all subsequent batches in this read
+            // to bypass the cache.
+            if (cache_enabled()) {
+                auto cached = _ct_api->cache_get(
+                  tidp, kafka::offset_cast(meta->base_offset));
+                if (cached.has_value()) {
+                    vlog(
+                      _log.trace,
+                      "Cache hit for extent at offset {} during "
+                      "materialize",
+                      meta->base_offset);
+                    unhydrated_it->data = local_log_batch::cached_batch{
+                      .batch = std::move(cached.value())};
+                    continue;
+                }
+            }
             materialize_bytes += meta->byte_range_size;
             to_materialize.push_back(*meta);
             vlog(
@@ -350,40 +372,47 @@ level_zero_log_reader_impl::materialize_batches(
         }
     }
     size_t materialize_count = to_materialize.size();
-    vlog(
-      _log.trace,
-      "Invoking 'materialize' for {}: {} bytes, {} batches to materialize",
-      _ctp->ntp(),
-      materialize_bytes,
-      materialize_count);
-    // Ask data layer to bring data from the cloud storage.
-    auto mat_res = co_await _ct_api->materialize(
-      _ctp->ntp(),
-      materialize_bytes,
-      std::move(to_materialize),
-      deadline,
-      _config.abort_source);
-    if (!mat_res.has_value()) {
-        if (mat_res.error() == errc::shutting_down) {
-            vlog(_log.debug, "Materialize aborted due to shutdown");
-            throw ss::abort_requested_exception();
+    // Only invoke the data plane when there are extents that missed the
+    // batch cache. When every extent was a cache hit the vector is empty
+    // and we can skip the (potentially expensive) S3 round-trip entirely.
+    chunked_vector<model::record_batch> batches;
+    if (!to_materialize.empty()) {
+        vlog(
+          _log.trace,
+          "Invoking 'materialize' for {}: {} bytes, {} batches to "
+          "materialize",
+          _ctp->ntp(),
+          materialize_bytes,
+          materialize_count);
+        // Ask data layer to bring data from the cloud storage.
+        auto mat_res = co_await _ct_api->materialize(
+          _ctp->ntp(),
+          materialize_bytes,
+          std::move(to_materialize),
+          deadline,
+          _config.abort_source);
+        if (!mat_res.has_value()) {
+            if (mat_res.error() == errc::shutting_down) {
+                vlog(_log.debug, "Materialize aborted due to shutdown");
+                throw ss::abort_requested_exception();
+            }
+            if (mat_res.error() == errc::timeout) {
+                vlog(_log.debug, "Materialize aborted due to timeout");
+                co_return std::unexpected(errc::timeout);
+            }
+            throw std::runtime_error(fmt_with_ctx(
+              fmt::format,
+              "Failed to materialize batches from the cloud storage: {}",
+              mat_res.error().message()));
         }
-        if (mat_res.error() == errc::timeout) {
-            vlog(_log.debug, "Materialize aborted due to timeout");
-            co_return std::unexpected(errc::timeout);
+        batches = std::move(mat_res.value());
+        if (batches.size() != materialize_count) {
+            throw std::runtime_error(fmt_with_ctx(
+              fmt::format,
+              "Materialized unexpected number of batches: {}, expected: {}",
+              batches.size(),
+              materialize_count));
         }
-        throw std::runtime_error(
-          fmt::format(
-            "Failed to materialize batches from the cloud storage: {}",
-            mat_res.error().message()));
-    }
-    auto batches = std::move(mat_res.value());
-    if (batches.size() != materialize_count) {
-        throw std::runtime_error(
-          fmt::format(
-            "Materialized unexpected number of batches: {}, expected: {}",
-            batches.size(),
-            materialize_count));
     }
     // Merge our selected subset of unhydrated batches with the materialized
     // batches, preserving control batches from the local log.
@@ -420,6 +449,12 @@ level_zero_log_reader_impl::materialize_batches(
                 local_batch_header,
                 std::move(payload),
                 model::record_batch::tag_ctor_ng{});
+          },
+          [](local_log_batch::cached_batch& cb) {
+              // Cache hit resolved during the collection loop above.
+              // The batch is already fully formed (apply_placeholder_to_batch
+              // was applied before cache_put on the path that populated it).
+              return std::move(cb.batch);
           });
         hydrated.push_back(std::move(batch));
         co_await ss::coroutine::maybe_yield();

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
@@ -94,7 +94,15 @@ private:
         // placeholder batches we extract out the extent_meta to be hydrated
         // later.
         using payload = iobuf;
-        std::variant<cloud_topics::extent_meta, payload> data;
+
+        // A cached_batch holds a fully-formed batch resolved from
+        // the record batch cache during materialize_batches(), avoiding an
+        // S3 download when a previous cache miss caused the fast cache path
+        // to be skipped.
+        struct cached_batch {
+            model::record_batch batch;
+        };
+        std::variant<cloud_topics::extent_meta, payload, cached_batch> data;
     };
 
     bool cache_enabled() const;


### PR DESCRIPTION
if the gap is encountered. Currently, the level zero reader stops reading from the record batch cache if a single batch is missing. When the batchis missing the reader fetches the remaining batches from the cloud or the cloud storage cache. This is problematic because the reader consumes batches from older to newer offsets. It's quite likely that the first batch that it tries to read is either evicted due to memory pressure or it was evicted explicitly because the reader races with reconciliation. A single missing batch causes many L0 downloads.

This explains the issue that we observed when around 10% of all reads were served not fromthe batch cache but from the cloud (on a leader).

This commit fixes the issue by allowing the reader to read from the batch cache even in presense of gaps.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none