### PR TITLE
ct: mark cloud topics enabled as needing a restart

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4506,7 +4506,7 @@ configuration::configuration()
       true,
       "cloud_topics_enabled",
       "Enable cloud topics.",
-      meta{.needs_restart = needs_restart::no, .visibility = visibility::user},
+      meta{.needs_restart = needs_restart::yes, .visibility = visibility::user},
       false)
   , cloud_topics_produce_batching_size_threshold(
       *this,

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -1544,7 +1544,9 @@ class DataMigrationsApiTest(DataMigrationTestMixin):
         different storage backend and don't support mount/unmount operations.
         """
         # Enable cloud topics feature
-        self.redpanda.set_cluster_config({"cloud_topics_enabled": True})
+        self.redpanda.set_cluster_config(
+            {"cloud_topics_enabled": True}, expect_restart=True
+        )
 
         # Create a cloud topic
         rpk = RpkTool(self.redpanda)

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -62,6 +62,8 @@ class NodesDecommissioningTest(PreallocNodesTest):
             retention_local_trim_interval=5_000,
         )
 
+        extra_rp_conf[CLOUD_TOPICS_CONFIG_STR] = True
+
         super(NodesDecommissioningTest, self).__init__(
             test_context=test_context,
             num_brokers=5,
@@ -378,20 +380,6 @@ class NodesDecommissioningTest(PreallocNodesTest):
 
         self.redpanda.start(
             auto_assign_node_id=new_bootstrap, omit_seeds_on_idx_one=not new_bootstrap
-        )
-
-        # Enable cloud topics
-        self.redpanda.enable_development_feature_support()
-        self.redpanda.set_cluster_config(
-            values={
-                CLOUD_TOPICS_CONFIG_STR: True,
-                "cloud_topics_disable_reconciliation_loop": True,
-            }
-        )
-        self.redpanda.restart_nodes(
-            nodes=self.redpanda.nodes,
-            auto_assign_node_id=new_bootstrap,
-            omit_seeds_on_idx_one=not new_bootstrap,
         )
 
     @cluster(
@@ -966,8 +954,10 @@ class NodesDecommissioningTest(PreallocNodesTest):
             self.logger.info(f"decommissioning node: {node_id}")
             self._decommission(node_id)
             wait_until(
-                lambda: self._partitions_moving(node=survivor_node)
-                or self._node_removed(node_id, survivor_node),
+                lambda: (
+                    self._partitions_moving(node=survivor_node)
+                    or self._node_removed(node_id, survivor_node)
+                ),
                 timeout_sec=60,
                 backoff_sec=1,
             )

--- a/tests/rptest/tests/random_node_operations_smoke_test.py
+++ b/tests/rptest/tests/random_node_operations_smoke_test.py
@@ -236,6 +236,16 @@ class RandomNodeOperationsBase(PreallocNodesTest):
                 }
             )
 
+        if with_cloud_topics:
+            self.redpanda.add_extra_rp_conf(
+                {
+                    CLOUD_TOPICS_CONFIG_STR: True,
+                    # Set both compaction intervals for cloud topics compaction tests
+                    "log_compaction_interval_ms": 5000,
+                    "cloud_topics_compaction_interval_ms": 5000,
+                },
+            )
+
         if compaction_mode == CompactionMode.CHUNKED_SLIDING_WINDOW:
             # This may not be recognized on certain nodes in mixed-version run.
             environment = {"__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"}
@@ -268,21 +278,6 @@ class RandomNodeOperationsBase(PreallocNodesTest):
         self.redpanda.await_feature(
             "membership_change_controller_cmds", "active", timeout_sec=30
         )
-
-        if with_cloud_topics:
-            self.redpanda.set_cluster_config(
-                values={
-                    CLOUD_TOPICS_CONFIG_STR: True,
-                    # Set both compaction intervals for cloud topics compaction tests
-                    "log_compaction_interval_ms": 5000,
-                    "cloud_topics_compaction_interval_ms": 5000,
-                }
-            )
-            self.redpanda.restart_nodes(
-                nodes=self.redpanda.nodes,
-                auto_assign_node_id=True,
-                omit_seeds_on_idx_one=False,
-            )
 
     def _alter_local_topic_retention_bytes(self, topic: str, retention_bytes: int):
         rpk = RpkTool(self.redpanda)


### PR DESCRIPTION
Because it does - we gate stuff in application on this property

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
