### PR TITLE
ct/reconciler: Mark multipart init failure benign

### DIFF
--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -630,10 +630,8 @@ reconciler<Clock>::make_context(const l1::object_id& oid) {
     auto upload_result = co_await _l1_io->create_multipart_upload(
       oid, cloud_storage_clients::multipart_upload::min_part_size, &_as);
     if (!upload_result.has_value()) {
-        co_return std::unexpected(
-          reconcile_error(
-            "Failed to initiate multipart upload: {}", upload_result.error())
-            .non_benign());
+        co_return std::unexpected(reconcile_error(
+          "Failed to initiate multipart upload: {}", upload_result.error()));
     }
     ctx.upload = std::move(upload_result).value();
 


### PR DESCRIPTION
A failure of a multipart upload to start is likely transient and is handled by reconciler retries. Permanent failures, like a bad bucket name or part size, will cause systemic permanent problems that should be obvious. Let it be benign.

The instance that prompted this change is a "race" in shutdown where we stop cloud io early and the reconciler couldn't get a cloud io client for the multipart, but it also can't tell that the system is shutting down (it hasn't been shutdown yet and the gate closed exception has been thrown away).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none