### PR TITLE
[CORE-14003] dt/ct: Add cloud topic support to Flink tests

### DIFF
--- a/tests/rptest/e2e_tests/flink_scale_test.py
+++ b/tests/rptest/e2e_tests/flink_scale_test.py
@@ -10,26 +10,44 @@ import json
 import time
 from concurrent.futures import ThreadPoolExecutor
 
-from ducktape.mark import parametrize
-from rptest.clients.kafka_cli_tools import KafkaCliTools
+from ducktape.mark import matrix
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.e2e_tests.workload_manager import WorkloadManager
 from rptest.services.cluster import cluster
 from rptest.services.flink import FlinkService
-from rptest.services.redpanda import MetricSamples, MetricsEndpoint
+from rptest.services.redpanda import (
+    MetricSamples,
+    MetricsEndpoint,
+    SISettings,
+    CLOUD_TOPICS_CONFIG_STR,
+)
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.utils.mode_checks import skip_debug_mode
 
 
 class FlinkScaleTests(RedpandaTest):
     def __init__(self, test_context, *args, **kwargs):
+        si_settings = SISettings(
+            test_context,
+            cloud_storage_max_connections=10,
+            cloud_storage_enable_remote_read=False,
+            cloud_storage_enable_remote_write=False,
+            fast_uploads=True,
+        )
+        extra_rp_conf = {
+            CLOUD_TOPICS_CONFIG_STR: True,
+            "enable_cluster_metadata_upload_loop": False,
+        }
         # Init parent
-        super(FlinkScaleTests, self).__init__(test_context)
+        super(FlinkScaleTests, self).__init__(
+            test_context,
+            si_settings=si_settings,
+            extra_rp_conf=extra_rp_conf,
+        )
         self.test_context = test_context
 
         # Prepare client
-        self.kafkacli = KafkaCliTools(self.redpanda)
         self.rpk = RpkTool(self.redpanda)
         # Prepare Workloads
         self.workload_manager = WorkloadManager(self.logger)
@@ -158,7 +176,20 @@ class FlinkScaleTests(RedpandaTest):
             total_commit_requests += metric_per_node[h]["total"]
         return total_commit_requests, metric_per_node
 
-    def _create_topic_swarm(self, flinks, total_workloads, topics_per_workload):
+    def _create_topic(self, spec, cloud_topic=False):
+        config = {"cleanup.policy": "delete"}
+        if cloud_topic:
+            config[TopicSpec.PROPERTY_STORAGE_MODE] = TopicSpec.STORAGE_MODE_CLOUD
+        self.rpk.create_topic(
+            topic=spec.name,
+            partitions=spec.partition_count,
+            replicas=spec.replication_factor,
+            config=config,
+        )
+
+    def _create_topic_swarm(
+        self, flinks, total_workloads, topics_per_workload, cloud_topic=False
+    ):
         # Prepare topic specs
         self.topic_specs = []
         for flink in flinks:
@@ -167,7 +198,8 @@ class FlinkScaleTests(RedpandaTest):
                 for idx_t in range(topics_per_workload):
                     self.topic_specs.append(
                         TopicSpec(
-                            name=f"flink-{hostname}-{idx_w}-{idx_t}", partition_count=1
+                            name=f"flink-{hostname}-{idx_w}-{idx_t}",
+                            partition_count=1,
                         )
                     )
 
@@ -176,7 +208,10 @@ class FlinkScaleTests(RedpandaTest):
         _start = time.time()
         # Use ThreadPoolExecutor to create topics
         with ThreadPoolExecutor(max_workers=15) as executor:
-            executor.map(self.kafkacli.create_topic, self.topic_specs)
+            executor.map(
+                lambda spec: self._create_topic(spec, cloud_topic),
+                self.topic_specs,
+            )
         elapsed = time.time() - _start
         tps = len(self.topic_specs) / elapsed
         self.logger.debug(
@@ -187,9 +222,8 @@ class FlinkScaleTests(RedpandaTest):
 
     @skip_debug_mode
     @cluster(num_nodes=4)
-    @parametrize(unique_topics=True)
-    @parametrize(unique_topics=False)
-    def test_transactions_scale_single_node(self, unique_topics):
+    @matrix(unique_topics=[True, False], cloud_topic=[True, False])
+    def test_transactions_scale_single_node(self, unique_topics, cloud_topic):
         """
         Test uses same workload with different modes to produce
         and consume/process given number of transactions
@@ -218,11 +252,13 @@ class FlinkScaleTests(RedpandaTest):
         flink.start()
 
         if unique_topics:
-            self._create_topic_swarm([flink], total_workloads, 1)
+            self._create_topic_swarm(
+                [flink], total_workloads, 1, cloud_topic=cloud_topic
+            )
         else:
             hostname = flink.hostname
             spec = TopicSpec(name=f"flink-{hostname}-0-0", partition_count=8)
-            self.kafkacli.create_topic(spec)
+            self._create_topic(spec, cloud_topic=cloud_topic)
             self.topic_specs.append(spec)
 
         # Load python workload to target node
@@ -318,7 +354,8 @@ class FlinkScaleTests(RedpandaTest):
 
     @skip_debug_mode
     @cluster(num_nodes=8)
-    def test_transactions_scale_swarm(self):
+    @matrix(cloud_topic=[True, False])
+    def test_transactions_scale_swarm(self, cloud_topic):
         """
         Test uses same workload with different modes to produce
         and consume/process given number of transactions
@@ -378,7 +415,9 @@ class FlinkScaleTests(RedpandaTest):
             target_total_events = 1 * 1024 * 1024
 
         # Create topics
-        self._create_topic_swarm(flinks, workloads_per_node, topics_per_workload)
+        self._create_topic_swarm(
+            flinks, workloads_per_node, topics_per_workload, cloud_topic=cloud_topic
+        )
 
         # Load python workload to target node
         # TODO: Add workload config management

--- a/tests/rptest/tests/flink_basic_test.py
+++ b/tests/rptest/tests/flink_basic_test.py
@@ -11,21 +11,39 @@ import io
 import os
 
 from ducktape.cluster.remoteaccount import RemoteCommandError
+from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
 
-from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.e2e_tests.workload_manager import WorkloadManager
 from rptest.services.cluster import cluster
 from rptest.services.flink import FlinkService
+from rptest.services.redpanda import SISettings, CLOUD_TOPICS_CONFIG_STR
 from rptest.tests.redpanda_test import RedpandaTest
 
 
 class FlinkBasicTests(RedpandaTest):
     def __init__(self, test_context, *args, **kwargs):
+        si_settings = SISettings(
+            test_context,
+            cloud_storage_max_connections=10,
+            cloud_storage_enable_remote_read=False,
+            cloud_storage_enable_remote_write=False,
+            fast_uploads=True,
+        )
+        extra_rp_conf = {
+            CLOUD_TOPICS_CONFIG_STR: True,
+            "enable_cluster_metadata_upload_loop": False,
+        }
+
         # Init parent
-        super(FlinkBasicTests, self).__init__(test_context, log_level="trace")
+        super(FlinkBasicTests, self).__init__(
+            test_context,
+            log_level="trace",
+            si_settings=si_settings,
+            extra_rp_conf=extra_rp_conf,
+        )
 
         # Prepare FlinkService
         self.topic_name = "flink_workload_topic"
@@ -36,12 +54,26 @@ class FlinkBasicTests(RedpandaTest):
             self.redpanda.get_node_memory_mb(),
         )
         # Prepare client
-        self.kafkacli = KafkaCliTools(self.redpanda)
         self.rpk = RpkTool(self.redpanda)
         # Prepare Workloads
         self.workload_manager = WorkloadManager(self.logger)
 
         return
+
+    def setUp(self):
+        self.redpanda.start()
+
+    def _create_initial_topics(self, cloud_topic=False):
+        config = {"cleanup.policy": "delete"}
+        if cloud_topic:
+            config[TopicSpec.PROPERTY_STORAGE_MODE] = TopicSpec.STORAGE_MODE_CLOUD
+        for topic in self.topics:
+            self.rpk.create_topic(
+                topic=topic.name,
+                partitions=topic.partition_count,
+                replicas=topic.replication_factor,
+                config=config,
+            )
 
     def _run_workloads(self, workloads, config, wait_timeout=900):
         """
@@ -123,11 +155,14 @@ class FlinkBasicTests(RedpandaTest):
         return values
 
     @cluster(num_nodes=4)
-    def test_basic_workload(self):
+    @matrix(cloud_topic=[True, False])
+    def test_basic_workload(self, cloud_topic):
         """
         Test starts produce workload and then consume
         No checks for message counts, just job success
         """
+
+        self._create_initial_topics(cloud_topic=cloud_topic)
 
         # Start Flink
         self.flink.start()
@@ -171,11 +206,14 @@ class FlinkBasicTests(RedpandaTest):
         return
 
     @cluster(num_nodes=4)
-    def test_transaction_workload(self):
+    @matrix(cloud_topic=[True, False])
+    def test_transaction_workload(self, cloud_topic):
         """
         Test uses same workload with different modes to produce
         and consume/process given number of transactions
         """
+
+        self._create_initial_topics(cloud_topic=cloud_topic)
 
         def get_max_data_index(data_path, node):
             # Max index and target column


### PR DESCRIPTION
Topics need to be created with the RPK tool now to support cloud topics.

Fixes CORE-14003

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

