### PR TITLE
ct/reconciler: Post-multipart improvements

### DIFF
--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -701,6 +701,13 @@ reconciler<Clock>::build_object(
     }
     metas.shrink_to_fit();
 
+    if (metas.empty()) {
+        // Return early without finishing the builder or completing the
+        // multipart upload. The caller's cleanup will abort the upload
+        // and close the builder.
+        co_return built_object_metadata{};
+    }
+
     auto obj_info = co_await ctx.builder->finish().finally(
       [&ctx] { return ctx.close_builder(); });
     vlog(

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -254,13 +254,13 @@ ss::future<> reconciler<Clock>::reconciliation_loop() {
          *                ├─ make_context(oid) → returns error if multipart
          *                │    upload initiation fails
          *                │
-         *                ├─ as_future(build_and_put_object)
-         *                │  └─ build_object() → can throw in builder->finish()
-         *                │       or in build_from_reader() (write failures
-         *                │       propagate since the byte stream can't skip
-         *                │       a failed part). On success, finish() +
-         *                │       close_builder() closes the multipart stream,
-         *                │       completing the upload.
+         *                ├─ as_future(build_object)
+         *                │  └─ can throw in builder->finish() or in
+         *                │     build_from_reader() (write failures propagate
+         *                │     since the byte stream can't skip a failed
+         *                │     part). On success, finish() +
+         *                │     close_builder() closes the multipart stream,
+         *                │     completing the upload.
          *                │
          *                └─ GUARANTEED CLEANUP (always executed):
          *                   ├─ ctx.cleanup_upload() → aborts multipart if
@@ -538,7 +538,7 @@ reconciler<Clock>::reconcile_sources(
     auto ctx = std::move(ctx_result.value());
 
     auto fut = co_await ss::coroutine::as_future(
-      build_and_put_object(oid, ctx, sources));
+      build_object(oid, ctx, sources));
 
     // Always cleanup: abort multipart if not completed, then close builder.
     auto cleanup_fut = co_await ss::coroutine::as_future(ctx.cleanup_upload());
@@ -584,34 +584,6 @@ reconciler<Clock>::reconcile_sources(
 }
 
 template<class Clock>
-ss::future<std::expected<
-  typename reconciler<Clock>::built_object_metadata,
-  reconcile_error>>
-reconciler<Clock>::build_and_put_object(
-  const l1::object_id& oid,
-  builder_context& ctx,
-  const chunked_vector<ss::shared_ptr<source>>& sources) {
-    // Build the object. On success, build_object() calls finish() and then
-    // close_builder(), which closes the multipart stream and completes the
-    // upload.
-    auto build_result = co_await build_object(ctx, sources);
-    if (!build_result.has_value()) {
-        co_return std::unexpected(build_result.error());
-    }
-
-    auto obj_meta = std::move(build_result.value());
-    if (obj_meta.commits.empty()) {
-        co_return std::unexpected(
-          reconcile_error("Skipping put for object {}: no data", oid));
-    }
-
-    _probe.increment_objects_uploaded();
-    _probe.add_bytes_reconciled(obj_meta.object_info.size_bytes);
-    _probe.record_object_size_bytes(obj_meta.object_info.size_bytes);
-    co_return obj_meta;
-}
-
-template<class Clock>
 ss::future<
   std::expected<typename reconciler<Clock>::builder_context, reconcile_error>>
 reconciler<Clock>::make_context(const l1::object_id& oid) {
@@ -647,7 +619,9 @@ ss::future<std::expected<
   typename reconciler<Clock>::built_object_metadata,
   reconcile_error>>
 reconciler<Clock>::build_object(
-  builder_context& ctx, const chunked_vector<ss::shared_ptr<source>>& sources) {
+  const l1::object_id& oid,
+  builder_context& ctx,
+  const chunked_vector<ss::shared_ptr<source>>& sources) {
     const auto max_size = ctx.size_budget;
 
     chunked_vector<commit_info> metas;
@@ -696,7 +670,9 @@ reconciler<Clock>::build_object(
         // Return early without finishing the builder or completing the
         // multipart upload. The caller's cleanup will abort the upload
         // and close the builder.
-        co_return built_object_metadata{};
+        co_return std::unexpected(reconcile_error(
+          "Skipping upload for object {}: no new data from any partition",
+          oid));
     }
 
     auto obj_info = co_await ctx.builder->finish().finally(
@@ -706,6 +682,11 @@ reconciler<Clock>::build_object(
       "Built L1 object from {} partitions ({} partitions were skipped)",
       metas.size(),
       sources.size() - metas.size());
+
+    _probe.increment_objects_uploaded();
+    _probe.add_bytes_reconciled(obj_info.size_bytes);
+    _probe.record_object_size_bytes(obj_info.size_bytes);
+
     co_return built_object_metadata{
       .object_info = std::move(obj_info),
       .commits = std::move(metas),

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -306,8 +306,6 @@ ss::future<> reconciler<Clock>::reconciliation_loop() {
 
 template<class Clock>
 ss::future<> reconciler<Clock>::reconcile() {
-    _probe.increment_rounds();
-
     chunked_vector<ss::shared_ptr<source>> sources;
     // Make a copy of the sources to not worry about concurrent modification.
     for (auto& [_, src] : _sources) {
@@ -418,7 +416,6 @@ ss::future<size_t> reconciler<Clock>::reconcile_source_set(
           lg.warn,
           "Could not create object metadata builder: {}",
           metadata_builder_res.error());
-        _probe.increment_rounds_failed();
         co_return 0;
     }
     auto& metadata_builder = metadata_builder_res.value();
@@ -429,7 +426,6 @@ ss::future<size_t> reconciler<Clock>::reconcile_source_set(
           src->topic_id_partition());
         if (!oid.has_value()) {
             vlog(lg.warn, "Could not get object: {}", oid.error());
-            _probe.increment_rounds_failed();
             co_return 0;
         }
         oid_to_sources[oid.value()].push_back(src);
@@ -521,7 +517,6 @@ ss::future<size_t> reconciler<Clock>::reconcile_source_set(
         log_error(commit_result.error().with_context(
           "Abandoning reconciliation run because the L1 metastore operation "
           "failed"));
-        _probe.increment_rounds_failed();
         co_return 0;
     }
 
@@ -601,13 +596,11 @@ reconciler<Clock>::build_and_put_object(
     // upload.
     auto build_result = co_await build_object(ctx, sources);
     if (!build_result.has_value()) {
-        _probe.increment_object_build_failed();
         co_return std::unexpected(build_result.error());
     }
 
     auto obj_meta = std::move(build_result.value());
     if (obj_meta.commits.empty()) {
-        _probe.increment_empty_objects_skipped();
         co_return std::unexpected(
           reconcile_error("Skipping put for object {}: no data", oid));
     }
@@ -615,8 +608,6 @@ reconciler<Clock>::build_and_put_object(
     _probe.increment_objects_uploaded();
     _probe.add_bytes_reconciled(obj_meta.object_info.size_bytes);
     _probe.record_object_size_bytes(obj_meta.object_info.size_bytes);
-    _probe.record_sources_per_object(obj_meta.commits.size());
-
     co_return obj_meta;
 }
 

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -206,18 +206,6 @@ private:
       const chunked_vector<ss::shared_ptr<source>>& sources);
 
     /*
-     * Build and upload an object with id `oid` using the provided context.
-     * Reads data from `sources` and packages it into the object.
-     * Returns metadata on success, or an error if no data was added or
-     * if the build/upload fails.
-     */
-    ss::future<std::expected<built_object_metadata, reconcile_error>>
-    build_and_put_object(
-      const l1::object_id& oid,
-      builder_context& ctx,
-      const chunked_vector<ss::shared_ptr<source>>& sources);
-
-    /*
      * Create a new builder_context for constructing an L1 object.
      * Initiates a multipart upload for the given object ID.
      * Returns an error if multipart upload initiation or builder creation
@@ -229,12 +217,13 @@ private:
     /*
      * Build an object described by `ctx` and containing data from
      * `sources`, which must all belong to the same L1 domain.
-     *
-     * Returns empty metadata if no data was added to the object.
-     * Returns an error if building fails.
+     * On success, finishes the builder and completes the multipart
+     * upload. Returns an error if no data was added or if building
+     * fails.
      */
     ss::future<std::expected<built_object_metadata, reconcile_error>>
     build_object(
+      const l1::object_id& oid,
       builder_context& ctx,
       const chunked_vector<ss::shared_ptr<source>>& sources);
 

--- a/src/v/cloud_topics/reconciler/reconciler_probe.cc
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.cc
@@ -30,14 +30,6 @@ void reconciler_probe::setup_metrics() {
       {
         // Counters.
         sm::make_counter(
-          "rounds",
-          [this] { return _rounds; },
-          sm::description("Number of reconciliation rounds")),
-        sm::make_counter(
-          "rounds_failed",
-          [this] { return _rounds_failed; },
-          sm::description("Number of reconciliation rounds that failed")),
-        sm::make_counter(
           "objects_uploaded",
           [this] { return _objects_uploaded; },
           sm::description("Total objects uploaded, including orphans")),
@@ -53,15 +45,6 @@ void reconciler_probe::setup_metrics() {
           "partitions_reconciled",
           [this] { return _partitions_reconciled; },
           sm::description("Counts each time a partition contributed a batch")),
-        sm::make_counter(
-          "object_build_failed",
-          [this] { return _object_build_failed; },
-          sm::description("Total objects that failed to build")),
-        sm::make_counter(
-          "empty_objects_skipped",
-          [this] { return _empty_objects_skipped; },
-          sm::description(
-            "Total objects skipped because no data was available")),
         sm::make_counter(
           "metastore_retries",
           [this] { return _metastore_retries; },
@@ -94,11 +77,6 @@ void reconciler_probe::setup_metrics() {
           "object_size_bytes",
           [this] { return _object_size_bytes.internal_histogram_logform(); },
           sm::description("Distribution of built L1 object sizes in bytes")),
-        sm::make_histogram(
-          "sources_per_object",
-          [this] { return _sources_per_object.internal_histogram_logform(); },
-          sm::description(
-            "Distribution of number of sources packed into each L1 object")),
       });
 }
 

--- a/src/v/cloud_topics/reconciler/reconciler_probe.h
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.h
@@ -34,26 +34,18 @@ public:
 
     void setup_metrics();
 
-    void increment_rounds() { ++_rounds; }
-    void increment_rounds_failed() { ++_rounds_failed; }
     void increment_objects_uploaded() { ++_objects_uploaded; }
     void add_bytes_reconciled(uint64_t bytes) { _bytes_reconciled += bytes; }
     void add_batches_reconciled(uint64_t batches) {
         _batches_reconciled += batches;
     }
     void increment_partitions_reconciled() { ++_partitions_reconciled; }
-    void increment_object_build_failed() { ++_object_build_failed; }
-    void increment_empty_objects_skipped() { ++_empty_objects_skipped; }
     void increment_metastore_retries() { ++_metastore_retries; }
     void increment_offset_corrections() { ++_offset_corrections; }
 
     void record_object_size_bytes(uint64_t size) {
         _object_size_bytes.record(size);
     }
-    void record_sources_per_object(uint64_t count) {
-        _sources_per_object.record(count);
-    }
-
     std::unique_ptr<hist_t::measurement> measure_l0_read_duration() {
         return _l0_read_duration.auto_measure();
     }
@@ -72,21 +64,14 @@ public:
     auto get_object_size_bytes_for_tests() const {
         return _object_size_bytes.internal_histogram_logform();
     }
-    auto get_sources_per_object_for_tests() const {
-        return _sources_per_object.internal_histogram_logform();
-    }
 
 private:
     metrics::internal_metric_groups _metrics;
 
-    uint64_t _rounds{0};
-    uint64_t _rounds_failed{0};
     uint64_t _objects_uploaded{0};
     uint64_t _bytes_reconciled{0};
     uint64_t _batches_reconciled{0};
     uint64_t _partitions_reconciled{0};
-    uint64_t _object_build_failed{0};
-    uint64_t _empty_objects_skipped{0};
     uint64_t _metastore_retries{0};
     uint64_t _offset_corrections{0};
 
@@ -95,7 +80,6 @@ private:
     hist_t _object_build_duration;
     hist_t _metastore_add_objects_duration;
     hist_t _object_size_bytes;
-    hist_t _sources_per_object;
 };
 
 } // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
@@ -78,11 +78,6 @@ private:
 using ::testing::Gt;
 using ::testing::Optional;
 
-std::optional<uint64_t> get_reconciliation_rounds() {
-    return test_utils::find_metric_value<uint64_t>(
-      "cloud_topics_reconciler_rounds");
-}
-
 std::optional<uint64_t> get_objects_uploaded() {
     return test_utils::find_metric_value<uint64_t>(
       "cloud_topics_reconciler_objects_uploaded");
@@ -103,16 +98,6 @@ std::optional<uint64_t> get_partitions_reconciled() {
       "cloud_topics_reconciler_partitions_reconciled");
 }
 
-std::optional<uint64_t> get_object_build_failed() {
-    return test_utils::find_metric_value<uint64_t>(
-      "cloud_topics_reconciler_object_build_failed");
-}
-
-std::optional<uint64_t> get_empty_objects_skipped() {
-    return test_utils::find_metric_value<uint64_t>(
-      "cloud_topics_reconciler_empty_objects_skipped");
-}
-
 std::optional<uint64_t> get_metastore_retries() {
     return test_utils::find_metric_value<uint64_t>(
       "cloud_topics_reconciler_metastore_retries");
@@ -123,21 +108,13 @@ std::optional<uint64_t> get_offset_corrections() {
       "cloud_topics_reconciler_offset_corrections");
 }
 
-std::optional<uint64_t> get_rounds_failed() {
-    return test_utils::find_metric_value<uint64_t>(
-      "cloud_topics_reconciler_rounds_failed");
-}
-
 } // namespace
 
 TEST_F(ReconcilerMetricsTest, ThroughputCounters) {
-    EXPECT_THAT(get_reconciliation_rounds(), Optional(0));
     EXPECT_THAT(get_objects_uploaded(), Optional(0));
     EXPECT_THAT(get_bytes_reconciled(), Optional(0));
     EXPECT_THAT(get_batches_reconciled(), Optional(0));
     EXPECT_THAT(get_partitions_reconciled(), Optional(0));
-    EXPECT_THAT(get_object_build_failed(), Optional(0));
-    EXPECT_THAT(get_empty_objects_skipped(), Optional(0));
 
     const model::topic tp{"tapioca"};
     const model::topic_id tid = model::topic_id::create();
@@ -153,37 +130,28 @@ TEST_F(ReconcilerMetricsTest, ThroughputCounters) {
 
     reconcile();
 
-    EXPECT_THAT(get_reconciliation_rounds(), Optional(1));
     EXPECT_THAT(get_objects_uploaded(), Optional(1));
     EXPECT_THAT(get_partitions_reconciled(), Optional(2));
     EXPECT_THAT(get_batches_reconciled(), Optional(5));
     EXPECT_THAT(get_bytes_reconciled(), Optional(Gt(0)));
-    EXPECT_THAT(get_object_build_failed(), Optional(0));
-    EXPECT_THAT(get_empty_objects_skipped(), Optional(0));
 
     auto bytes_after_first = *get_bytes_reconciled();
 
     reconcile();
 
-    EXPECT_THAT(get_reconciliation_rounds(), Optional(2));
     EXPECT_THAT(get_objects_uploaded(), Optional(1));
     EXPECT_THAT(get_partitions_reconciled(), Optional(2));
     EXPECT_THAT(get_batches_reconciled(), Optional(5));
     EXPECT_THAT(get_bytes_reconciled(), Optional(bytes_after_first));
-    EXPECT_THAT(get_object_build_failed(), Optional(0));
-    EXPECT_THAT(get_empty_objects_skipped(), Optional(1));
 
     src1->add_batch({.count = 15});
 
     reconcile();
 
-    EXPECT_THAT(get_reconciliation_rounds(), Optional(3));
     EXPECT_THAT(get_objects_uploaded(), Optional(2));
     EXPECT_THAT(get_partitions_reconciled(), Optional(3));
     EXPECT_THAT(get_batches_reconciled(), Optional(6));
     EXPECT_THAT(get_bytes_reconciled(), Optional(Gt(bytes_after_first)));
-    EXPECT_THAT(get_object_build_failed(), Optional(0));
-    EXPECT_THAT(get_empty_objects_skipped(), Optional(1));
 }
 
 TEST_F(ReconcilerMetricsTest, FailedObjectsCounter) {
@@ -238,18 +206,12 @@ TEST_F(ReconcilerMetricsTest, ObjectMetrics) {
     auto object_size = probe.get_object_size_bytes_for_tests();
     EXPECT_EQ(object_size.sample_count, 1);
 
-    auto sources_per_object = probe.get_sources_per_object_for_tests();
-    EXPECT_EQ(sources_per_object.sample_count, 1);
-
     src1->add_batch({.count = 15});
 
     reconcile();
 
     object_size = probe.get_object_size_bytes_for_tests();
     EXPECT_EQ(object_size.sample_count, 2);
-
-    sources_per_object = probe.get_sources_per_object_for_tests();
-    EXPECT_EQ(sources_per_object.sample_count, 2);
 }
 
 TEST_F(ReconcilerMetricsTest, MetastoreRetries) {
@@ -298,35 +260,4 @@ TEST_F(ReconcilerMetricsTest, OffsetCorrection) {
 
     EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{19});
     EXPECT_THAT(get_offset_corrections(), Optional(1));
-}
-
-TEST_F(ReconcilerMetricsTest, ReconciliationRoundsFailed) {
-    EXPECT_THAT(get_rounds_failed(), Optional(0));
-
-    auto src = add_source();
-
-    // Reconciling with nothing to do is not a failure.
-    reconcile();
-
-    EXPECT_THAT(get_rounds_failed(), Optional(0));
-    EXPECT_THAT(get_objects_uploaded(), Optional(0));
-
-    // OK, now let's do some work and fail it.
-    src->add_batch({.count = 10});
-
-    metastore().fail_add_objects(true);
-
-    reconcile();
-
-    // We create an orphan T_T.
-    EXPECT_THAT(get_rounds_failed(), Optional(1));
-    EXPECT_THAT(get_objects_uploaded(), Optional(1));
-
-    // Finally, let reconciliation succeed.
-    metastore().fail_add_objects(false);
-
-    reconcile();
-
-    EXPECT_THAT(get_rounds_failed(), Optional(1));
-    EXPECT_THAT(get_objects_uploaded(), Optional(2));
 }

--- a/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
@@ -104,6 +104,21 @@ TEST_F(ReconcilerTest, EmptySource) {
     EXPECT_EQ(metastore_next_offset(src), std::nullopt);
 }
 
+TEST_F(ReconcilerTest, EmptyRoundDoesNotUploadObject) {
+    auto src = add_source();
+    src->add_batch({.count = 10});
+    reconcile();
+
+    // First round should upload one object.
+    auto objects_after_first = io().list_objects();
+    EXPECT_EQ(objects_after_first.size(), 1);
+
+    // Second round with no new data should not upload anything.
+    reconcile();
+    auto objects_after_second = io().list_objects();
+    EXPECT_EQ(objects_after_second.size(), objects_after_first.size());
+}
+
 TEST_F(ReconcilerTest, SingleSource) {
     auto src = add_source();
     src->add_batch({.count = 10});


### PR DESCRIPTION
This is three changes that are post-multpart cleanup.

1. Oops we weren't skipping the upload for data-less objects. Fixed.
2. I added a lot of metrics back in the day. Some have been useless. One is more useless post-multipart. Remove them.
3. Merge two methods that don't need to be separate without a separate put step.

This replaces and extends #29688 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
