### PR TITLE
[DNM] Draft - Refactor Schema Registry sharded_store/store & Add Global Context to Get Compatibility

### DIFF
--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -164,6 +164,8 @@ struct reply_error_category final : std::error_category {
             return "One or more references exist to the schema";
         case reply_error_code::subject_version_schema_id_already_exists:
             return "Schema already registered with another id";
+        case reply_error_code::subject_invalid:
+            return "The specified subject is not valid";
         case reply_error_code::context_not_empty:
             return "The specified context is not empty";
         case reply_error_code::write_collision:

--- a/src/v/pandaproxy/error.h
+++ b/src/v/pandaproxy/error.h
@@ -95,6 +95,7 @@ enum class reply_error_code : uint16_t {
     subject_version_operation_not_permitted = 42205,
     subject_version_has_references = 42206,
     subject_version_schema_id_already_exists = 42207,
+    subject_invalid = 42208,
     context_not_empty = 42211,
     write_collision = 50301,
     zookeeper_error = 50001,

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -94,6 +94,8 @@ struct error_category final : std::error_category {
             return "Writes to Schema Registry are disabled";
         case error_code::context_not_empty:
             return "The specified context is not empty";
+        case error_code::subject_invalid:
+            return "The specified subject is not valid";
         }
         return "(unrecognized error)";
     }
@@ -160,6 +162,8 @@ struct error_category final : std::error_category {
             return reply_error_code::precondition_failed; // 412
         case error_code::context_not_empty:
             return reply_error_code::context_not_empty; // 42211
+        case error_code::subject_invalid:
+            return reply_error_code::subject_invalid; // 42208
         }
         return {};
     }

--- a/src/v/pandaproxy/schema_registry/error.h
+++ b/src/v/pandaproxy/schema_registry/error.h
@@ -46,6 +46,7 @@ enum class error_code {
     internal_server_error,
     writes_disabled,
     context_not_empty,
+    subject_invalid,
 };
 
 std::error_code make_error_code(error_code);

--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -234,6 +234,12 @@ inline error_info writes_disabled() {
       error_code::writes_disabled, "Writes to Schema Registry are disabled"};
 }
 
+inline error_info subject_invalid(std::string_view subject) {
+    return error_info{
+      error_code::subject_invalid,
+      fmt::format("The specified subject '{}' is not valid.", subject)};
+}
+
 inline error_info context_not_empty(const context& ctx) {
     return error_info{
       error_code::context_not_empty,

--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -170,6 +170,14 @@ has_references(const context_subject& sub, schema_version ver) {
 error_info no_reference_found_for(
   const subject_schema& schema, const context_subject& sub, schema_version ver);
 
+inline error_info compatibility_not_found(const context& ctx) {
+    return error_info{
+      error_code::compatibility_not_found,
+      fmt::format(
+        "Context '{}' does not have context-level compatibility configured",
+        ctx())};
+}
+
 inline error_info compatibility_not_found(const context_subject& sub) {
     return error_info{
       error_code::compatibility_not_found,

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -348,6 +348,7 @@ ss::future<server::reply_t> get_config_subject(
     parse_accept_header(rq, rp);
     auto ctx_sub = context_subject::from_string(
       parse::request_param<ss::sstring>(*rq.req, "subject"));
+    validate_context_subject(ctx_sub, true);
     auto fallback = parse::query_param<std::optional<default_to_global>>(
                       *rq.req, "defaultToGlobal")
                       .value_or(default_to_global::no);
@@ -416,6 +417,7 @@ ss::future<server::reply_t> put_config_subject(
     parse_accept_header(rq, rp);
     auto ctx_sub = context_subject::from_string(
       parse::request_param<ss::sstring>(*rq.req, "subject"));
+    validate_context_subject(ctx_sub, true);
 
     enterprise::handle_config_mode_authz(
       rq,
@@ -443,6 +445,7 @@ ss::future<server::reply_t> delete_config_subject(
     parse_accept_header(rq, rp);
     auto ctx_sub = context_subject::from_string(
       parse::request_param<ss::sstring>(*rq.req, "subject"));
+    validate_context_subject(ctx_sub, true);
 
     enterprise::handle_config_mode_authz(
       rq,
@@ -522,6 +525,7 @@ ss::future<server::reply_t> get_mode_subject(
     parse_accept_header(rq, rp);
     auto ctx_sub = context_subject::from_string(
       parse::request_param<ss::sstring>(*rq.req, "subject"));
+    validate_context_subject(ctx_sub, true);
     auto fallback = parse::query_param<std::optional<default_to_global>>(
                       *rq.req, "defaultToGlobal")
                       .value_or(default_to_global::no);
@@ -559,6 +563,7 @@ ss::future<server::reply_t> put_mode_subject(
                  .value_or(force::no);
     auto ctx_sub = context_subject::from_string(
       parse::request_param<ss::sstring>(*rq.req, "subject"));
+    validate_context_subject(ctx_sub, true);
 
     enterprise::handle_config_mode_authz(
       rq,
@@ -586,6 +591,7 @@ ss::future<server::reply_t> delete_mode_subject(
     parse_accept_header(rq, rp);
     auto ctx_sub = context_subject::from_string(
       parse::request_param<ss::sstring>(*rq.req, "subject"));
+    validate_context_subject(ctx_sub, true);
 
     enterprise::handle_config_mode_authz(
       rq,
@@ -648,6 +654,9 @@ ss::future<server::reply_t> get_schemas_ids_id(
                            .value_or("");
 
     auto ctx_sub = context_subject::from_string(subject_param);
+    if (!subject_param.empty()) {
+        validate_context_subject(ctx_sub);
+    }
 
     auto result = co_await resolve_schema_id(
       rq.service().schema_store(), id, ctx_sub);
@@ -685,6 +694,9 @@ ss::future<server::reply_t> get_schemas_ids_id_schema(
                            .value_or("");
 
     auto ctx_sub = context_subject::from_string(subject_param);
+    if (!subject_param.empty()) {
+        validate_context_subject(ctx_sub);
+    }
 
     auto result = co_await resolve_schema_id(
       rq.service().schema_store(), id, ctx_sub);
@@ -720,6 +732,9 @@ get_schemas_ids_id_versions(server::request_t rq, server::reply_t rp) {
                            .value_or("");
 
     auto ctx_sub = context_subject::from_string(subject_param);
+    if (!subject_param.empty()) {
+        validate_context_subject(ctx_sub);
+    }
 
     auto result = co_await resolve_schema_id(
       rq.service().schema_store(), id, ctx_sub);
@@ -755,6 +770,9 @@ ss::future<ctx_server<service>::reply_t> get_schemas_ids_id_subjects(
                            .value_or("");
 
     auto ctx_sub = context_subject::from_string(subject_param);
+    if (!subject_param.empty()) {
+        validate_context_subject(ctx_sub);
+    }
 
     auto result = co_await resolve_schema_id(
       rq.service().schema_store(), id, ctx_sub);
@@ -821,6 +839,7 @@ get_subject_versions(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
     auto ctx_sub = context_subject::from_string(
       parse::request_param<ss::sstring>(*rq.req, "subject"));
+    validate_context_subject(ctx_sub);
     auto inc_del{
       parse::query_param<std::optional<include_deleted>>(*rq.req, "deleted")
         .value_or(include_deleted::no)};
@@ -842,6 +861,7 @@ post_subject(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
     auto ctx_sub = context_subject::from_string(
       parse::request_param<ss::sstring>(*rq.req, "subject"));
+    validate_context_subject(ctx_sub);
     auto inc_del{
       parse::query_param<std::optional<include_deleted>>(*rq.req, "deleted")
         .value_or(include_deleted::no)};
@@ -904,6 +924,7 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
     const auto ctx_sub = context_subject::from_string(
       parse::request_param<ss::sstring>(*rq.req, "subject"));
+    validate_context_subject(ctx_sub);
     const auto norm{
       parse::query_param<std::optional<normalize>>(*rq.req, "normalize")
         .value_or(normalize::no)};
@@ -1049,6 +1070,7 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version(
     parse_accept_header(rq, rp);
     auto ctx_sub = context_subject::from_string(
       parse::request_param<ss::sstring>(*rq.req, "subject"));
+    validate_context_subject(ctx_sub);
     auto ver = parse::request_param<ss::sstring>(*rq.req, "version");
     auto inc_del{
       parse::query_param<std::optional<include_deleted>>(*rq.req, "deleted")
@@ -1088,6 +1110,7 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version_schema(
     parse_accept_header(rq, rp);
     auto ctx_sub = context_subject::from_string(
       parse::request_param<ss::sstring>(*rq.req, "subject"));
+    validate_context_subject(ctx_sub);
     auto ver = parse::request_param<ss::sstring>(*rq.req, "version");
     auto inc_del{
       parse::query_param<std::optional<include_deleted>>(*rq.req, "deleted")
@@ -1117,6 +1140,7 @@ get_subject_versions_version_referenced_by(
     parse_accept_header(rq, rp);
     auto ctx_sub = context_subject::from_string(
       parse::request_param<ss::sstring>(*rq.req, "subject"));
+    validate_context_subject(ctx_sub);
     auto ver = parse::request_param<ss::sstring>(*rq.req, "version");
 
     co_await rq.service().writer().read_sync();
@@ -1136,6 +1160,7 @@ delete_subject(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
     auto ctx_sub = context_subject::from_string(
       parse::request_param<ss::sstring>(*rq.req, "subject"));
+    validate_context_subject(ctx_sub);
     auto permanent{
       parse::query_param<std::optional<permanent_delete>>(*rq.req, "permanent")
         .value_or(permanent_delete::no)};
@@ -1161,6 +1186,7 @@ delete_subject_version(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
     auto ctx_sub = context_subject::from_string(
       parse::request_param<ss::sstring>(*rq.req, "subject"));
+    validate_context_subject(ctx_sub);
     auto ver = parse::request_param<ss::sstring>(*rq.req, "version");
     auto permanent{
       parse::query_param<std::optional<permanent_delete>>(*rq.req, "permanent")
@@ -1213,6 +1239,7 @@ compatibility_subject_version(server::request_t rq, server::reply_t rp) {
     auto ver = parse::request_param<ss::sstring>(*rq.req, "version");
     auto ctx_sub = context_subject::from_string(
       parse::request_param<ss::sstring>(*rq.req, "subject"));
+    validate_context_subject(ctx_sub);
     auto is_verbose{
       parse::query_param<std::optional<verbose>>(*rq.req, "verbose")
         .value_or(verbose::no)};

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -318,7 +318,7 @@ get_config(server::request_t rq, server::reply_t rp) {
     co_await rq.service().writer().read_sync();
 
     auto res = co_await rq.service().schema_store().get_compatibility(
-      default_context);
+      default_context, default_to_global::no);
 
     auto resp = ppj::rjson_serialize_iobuf(get_config_req_rep{.compat = res});
     log_response(*rq.req, resp);
@@ -363,14 +363,8 @@ ss::future<server::reply_t> get_config_subject(
     // Ensure we see latest writes
     co_await rq.service().writer().read_sync();
 
-    compatibility_level res;
-    if (ctx_sub.is_context_only()) {
-        res = co_await rq.service().schema_store().get_compatibility(
-          ctx_sub.ctx);
-    } else {
-        res = co_await rq.service().schema_store().get_compatibility(
-          ctx_sub, fallback);
-    }
+    auto res = co_await rq.service().schema_store().get_compatibility(
+      ctx_sub, fallback);
 
     auto resp = ppj::rjson_serialize_iobuf(get_config_req_rep{.compat = res});
     log_response(*rq.req, resp);
@@ -463,13 +457,8 @@ ss::future<server::reply_t> delete_config_subject(
 
     compatibility_level lvl{};
     try {
-        if (ctx_sub.is_context_only()) {
-            lvl = co_await rq.service().schema_store().get_compatibility(
-              ctx_sub.ctx);
-        } else {
-            lvl = co_await rq.service().schema_store().get_compatibility(
-              ctx_sub, default_to_global::no);
-        }
+        lvl = co_await rq.service().schema_store().get_compatibility(
+          ctx_sub, default_to_global::no);
     } catch (const exception& e) {
         if (e.code() == error_code::compatibility_not_found) {
             throw as_exception(not_found(ctx_sub));

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -318,12 +318,8 @@ ss::future<std::optional<bool>> seq_writer::do_write_config(
     try {
         // Check for no-op case
         compatibility_level existing;
-        if (!sub.is_context_only()) {
-            existing = co_await _store.get_compatibility(
-              sub, default_to_global::no);
-        } else {
-            existing = co_await _store.get_compatibility(sub.ctx);
-        }
+        existing = co_await _store.get_compatibility(
+          sub, default_to_global::no);
         if (existing == compat) {
             co_return false;
         }
@@ -362,11 +358,7 @@ seq_writer::do_delete_config(context_subject ctx_sub) {
     co_await check_mutable(ctx_sub.ctx, sub_opt);
 
     try {
-        if (ctx_sub.is_context_only()) {
-            co_await _store.get_compatibility(ctx_sub.ctx);
-        } else {
-            co_await _store.get_compatibility(ctx_sub, default_to_global::no);
-        }
+        co_await _store.get_compatibility(ctx_sub, default_to_global::no);
 
     } catch (const exception&) {
         // subject config already blank

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -676,16 +676,25 @@ sharded_store::_get_compatibility(context_subject sub) {
 
 ss::future<compatibility_level>
 sharded_store::get_compatibility(context ctx, default_to_global fallback) {
-    if (auto res = co_await _get_compatibility(ctx); res.has_value()) {
-        co_return res.value();
+    if (ctx != global_context) {
+        if (auto res = co_await _get_compatibility(ctx); res.has_value()) {
+            co_return res.value();
+        }
+
+        if (!fallback) {
+            co_return ctx == default_context || ctx() == ""
+              // Scenarios A, Ca, Cb
+              ? default_top_level_compat
+              // Scenario Cd
+              : throw as_exception(compatibility_not_found(ctx));
+        }
     }
 
-    if (!fallback) {
-        co_return ctx == default_context || ctx() == ""
-          // Scenarios A, Ca, Cb
-          ? default_top_level_compat
-          // Scenario Cd
-          : throw as_exception(compatibility_not_found(ctx));
+    // If the context doesn't have a compatibility level and we're allowed to
+    // fallback, then check the global context's compatibility level.
+    if (auto res = co_await _get_compatibility(global_context);
+        res.has_value()) {
+        co_return res.value();
     }
 
     // Scenarios B, Cf, Da, Db, Dc, Dd, De, Df, Dg
@@ -701,14 +710,18 @@ ss::future<compatibility_level> sharded_store::get_compatibility(
         }
 
         if (
-          res.has_error()
-          && res.error().code() == error_code::subject_not_found) {
+          res.has_error() && res.error().code() == error_code::subject_not_found
+          && sub.ctx != global_context) {
             // Edge case:
             throw as_exception(compatibility_not_found(sub));
         }
 
         if (!fallback) {
-            throw as_exception(compatibility_not_found(sub));
+            co_return sub.ctx == global_context
+              // Scenario Cg
+              ? default_top_level_compat
+              // Scenarios Cc & Ce
+              : throw as_exception(compatibility_not_found(sub));
         }
     }
     // If the subject is context-only, or if the subject doesn't have a

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -18,7 +18,6 @@
 #include "hashing/xx.h"
 #include "pandaproxy/logger.h"
 #include "pandaproxy/schema_registry/avro.h"
-#include "pandaproxy/schema_registry/error.h"
 #include "pandaproxy/schema_registry/errors.h"
 #include "pandaproxy/schema_registry/exceptions.h"
 #include "pandaproxy/schema_registry/json.h"
@@ -662,17 +661,60 @@ sharded_store::get_context_mode_written_at(context ctx) {
     co_return _store.local().get_context_mode_written_at(ctx).value();
 }
 
-ss::future<compatibility_level> sharded_store::get_compatibility(context ctx) {
-    co_return _store.local().get_compatibility(ctx).value();
+ss::future<result<compatibility_level>>
+sharded_store::_get_compatibility(context ctx) {
+    co_return _store.local().get_compatibility(ctx);
+}
+
+ss::future<result<compatibility_level>>
+sharded_store::_get_compatibility(context_subject sub) {
+    auto sub_shard{shard_for(sub)};
+    co_return co_await _store.invoke_on(
+      sub_shard,
+      [sub{std::move(sub)}](store& s) { return s.get_compatibility(sub); });
+}
+
+ss::future<compatibility_level>
+sharded_store::get_compatibility(context ctx, default_to_global fallback) {
+    if (auto res = co_await _get_compatibility(ctx); res.has_value()) {
+        co_return res.value();
+    }
+
+    if (!fallback) {
+        co_return ctx == default_context || ctx() == ""
+          // Scenarios A, Ca, Cb
+          ? default_top_level_compat
+          // Scenario Cd
+          : throw as_exception(compatibility_not_found(ctx));
+    }
+
+    // Scenarios B, Cf, Da, Db, Dc, Dd, De, Df, Dg
+    co_return default_top_level_compat;
 }
 
 ss::future<compatibility_level> sharded_store::get_compatibility(
   context_subject sub, default_to_global fallback) {
-    auto sub_shard{shard_for(sub)};
-    co_return co_await _store.invoke_on(
-      sub_shard, [sub{std::move(sub)}, fallback](store& s) {
-          return s.get_compatibility(sub, fallback).value();
-      });
+    if (!sub.is_context_only()) {
+        auto res = co_await _get_compatibility(sub);
+        if (res.has_value()) {
+            co_return res.value();
+        }
+
+        if (
+          res.has_error()
+          && res.error().code() == error_code::subject_not_found) {
+            // Edge case:
+            throw as_exception(compatibility_not_found(sub));
+        }
+
+        if (!fallback) {
+            throw as_exception(compatibility_not_found(sub));
+        }
+    }
+    // If the subject is context-only, or if the subject doesn't have a
+    // compatibility level and we're allowed to fallback, check the context's
+    // compatibility level
+    co_return co_await get_compatibility(sub.ctx, fallback);
 }
 
 ss::future<bool> sharded_store::set_compatibility(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -709,13 +709,6 @@ ss::future<compatibility_level> sharded_store::get_compatibility(
             co_return res.value();
         }
 
-        if (
-          res.has_error() && res.error().code() == error_code::subject_not_found
-          && sub.ctx != global_context) {
-            // Edge case:
-            throw as_exception(compatibility_not_found(sub));
-        }
-
         if (!fallback) {
             co_return sub.ctx == global_context
               // Scenario Cg

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "container/chunked_vector.h"
+#include "pandaproxy/schema_registry/errors.h"
 #include "pandaproxy/schema_registry/schema_getter.h"
 #include "pandaproxy/schema_registry/types.h"
 
@@ -25,6 +26,9 @@ class store;
 /// subject or schema_id
 class sharded_store final : public schema_getter {
 public:
+    static constexpr auto default_top_level_compat
+      = compatibility_level::backward;
+
     explicit sharded_store() = default;
     ~sharded_store() override = default;
     ss::future<> start(is_mutable mut, ss::smp_service_group sg);
@@ -179,12 +183,14 @@ public:
     ss::future<chunked_vector<seq_marker>>
     get_context_mode_written_at(context ctx);
 
-    ///\brief Get the compatibility level of a context.
-    ss::future<compatibility_level> get_compatibility(context ctx);
+    ///\brief Get the compatibility level for a context, or fallback to global.
+    ss::future<compatibility_level> get_compatibility(
+      context ctx, default_to_global fallback = default_to_global::no);
 
     ///\brief Get the compatibility level for a subject, or fallback to global.
-    ss::future<compatibility_level>
-    get_compatibility(context_subject sub, default_to_global fallback);
+    ss::future<compatibility_level> get_compatibility(
+      context_subject sub, default_to_global fallback = default_to_global::no);
+
     ///\brief Set the compatibility level of a context.
     ss::future<bool> set_compatibility(
       seq_marker marker, context ctx, compatibility_level compatibility);
@@ -255,6 +261,11 @@ private:
       schema_version version,
       schema_id id,
       is_deleted deleted);
+
+    ss::future<result<compatibility_level>> _get_compatibility(context ctx);
+
+    ss::future<result<compatibility_level>>
+    _get_compatibility(context_subject sub);
 
     ss::future<schema_id> project_schema_id(context ctx);
 

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -624,32 +624,39 @@ public:
         return it->second._mode_written_at.copy();
     }
 
-    ///\brief Get the compatibility level of a context.
+    ///\brief Get the compatibility level of a context if it exists.
     result<compatibility_level> get_compatibility(const context& ctx) const {
         auto it = _context_stores.find(ctx);
         if (
-          it == _context_stores.end()
-          || !it->second._compatibility.has_value()) {
-            return compatibility_level::backward;
+          it != _context_stores.end()
+          && it->second._compatibility.has_value()) {
+            return it->second._compatibility.value();
         }
-        return *it->second._compatibility;
+        return compatibility_not_found(ctx);
     }
 
-    ///\brief Get the compatibility level for a subject, or fallback to global.
-    result<compatibility_level> get_compatibility(
-      const context_subject& sub, default_to_global fallback) const {
+    ///\brief Get the compatibility level for a subject if it exists.
+    result<compatibility_level>
+    get_compatibility(const context_subject& sub) const {
         auto sub_it_res = get_subject_iter(sub, include_deleted::no);
         if (sub_it_res.has_error()) {
-            return compatibility_not_found(sub);
+            vlog(
+              srlog.debug,
+              "Subject {} not found when getting compatibility",
+              sub);
+            return not_found(sub);
         }
         auto sub_it = std::move(sub_it_res).assume_value();
         auto compat = sub_it->second.compatibility;
-        if (compat) {
-            return compat.value();
-        } else if (fallback) {
-            return get_compatibility(sub.ctx);
+        if (!compat.has_value()) {
+            vlog(
+              srlog.debug,
+              "Subject {} does not have subject-level compatibility configured",
+              sub);
+            return compatibility_not_found(sub);
         }
-        return compatibility_not_found(sub);
+
+        return compat.value();
     }
 
     ///\brief Set the compatibility level of a context.

--- a/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
@@ -157,7 +157,8 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
     BOOST_REQUIRE_THROW(c(bad_schema_magic.copy()).get(), pps::exception);
 
     BOOST_REQUIRE(
-      s.get_compatibility(pps::default_context).get()
+      s.get_compatibility(pps::default_context, pps::default_to_global::yes)
+        .get()
       == pps::compatibility_level::backward);
     BOOST_REQUIRE(
       s.get_compatibility(subject0, pps::default_to_global::yes).get()

--- a/src/v/pandaproxy/schema_registry/test/context_subject.cc
+++ b/src/v/pandaproxy/schema_registry/test/context_subject.cc
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "pandaproxy/schema_registry/error.h"
+#include "pandaproxy/schema_registry/exceptions.h"
 #include "pandaproxy/schema_registry/types.h"
 
 #include <gtest/gtest.h>
@@ -108,6 +110,94 @@ TEST_F(ContextSubjectTest, FlagOffUnqualifiedUsesDefaultContext) {
 
     EXPECT_EQ(ctx_sub.ctx, default_context);
     EXPECT_EQ(ctx_sub.sub(), "plain-topic");
+}
+
+TEST_F(ContextSubjectTest, ValidateSubjectRejectsReservedNames) {
+    // __GLOBAL as subject is always rejected, regardless of context or mode
+    EXPECT_THROW(
+      validate_context_subject({default_context, subject{"__GLOBAL"}}),
+      exception);
+    EXPECT_THROW(
+      validate_context_subject({default_context, subject{"__GLOBAL"}}, true),
+      exception);
+    EXPECT_THROW(
+      validate_context_subject({context{".myctx"}, subject{"__GLOBAL"}}),
+      exception);
+
+    // __EMPTY as subject is always rejected
+    EXPECT_THROW(
+      validate_context_subject({default_context, subject{"__EMPTY"}}),
+      exception);
+    EXPECT_THROW(
+      validate_context_subject({default_context, subject{"__EMPTY"}}, true),
+      exception);
+    EXPECT_THROW(
+      validate_context_subject({context{".myctx"}, subject{"__EMPTY"}}),
+      exception);
+
+    // .__GLOBAL context is rejected on regular endpoints (with or without
+    // subject)
+    EXPECT_THROW(
+      validate_context_subject({context{".__GLOBAL"}, subject{"some-subject"}}),
+      exception);
+    EXPECT_THROW(
+      validate_context_subject({context{".__GLOBAL"}, subject{""}}), exception);
+
+    // Verify the error code
+    try {
+        validate_context_subject({default_context, subject{"__GLOBAL"}});
+        FAIL() << "Expected exception";
+    } catch (const exception& e) {
+        EXPECT_EQ(e.code(), error_code::subject_invalid);
+    }
+}
+
+TEST_F(ContextSubjectTest, ValidateSubjectAllowsValidNames) {
+    // Normal subjects
+    EXPECT_NO_THROW(
+      validate_context_subject({default_context, subject{"my-topic"}}));
+    EXPECT_NO_THROW(
+      validate_context_subject({context{".staging"}, subject{"my-topic"}}));
+    EXPECT_NO_THROW(validate_context_subject(
+      {default_context, subject{"some.subject.name"}}));
+
+    // Empty subject (context-only form) is not "__EMPTY"
+    EXPECT_NO_THROW(validate_context_subject({context{".myctx"}, subject{""}}));
+    EXPECT_NO_THROW(validate_context_subject({default_context, subject{""}}));
+
+    // Substrings of reserved names are valid
+    EXPECT_NO_THROW(
+      validate_context_subject({default_context, subject{"__GLOBAL_stuff"}}));
+    EXPECT_NO_THROW(
+      validate_context_subject({default_context, subject{"prefix__EMPTY"}}));
+    EXPECT_NO_THROW(
+      validate_context_subject({default_context, subject{"my__GLOBAL"}}));
+
+    // Case-sensitive: lowercase variants are valid
+    EXPECT_NO_THROW(
+      validate_context_subject({default_context, subject{"__global"}}));
+    EXPECT_NO_THROW(
+      validate_context_subject({default_context, subject{"__empty"}}));
+    EXPECT_NO_THROW(
+      validate_context_subject({default_context, subject{"__Global"}}));
+}
+
+TEST_F(ContextSubjectTest, ValidateSubjectConfigModeFlag) {
+    // .__GLOBAL context is allowed on config/mode endpoints
+    EXPECT_NO_THROW(validate_context_subject(
+      {context{".__GLOBAL"}, subject{"some-subject"}}, true));
+    EXPECT_NO_THROW(
+      validate_context_subject({context{".__GLOBAL"}, subject{""}}, true));
+
+    // But reserved subject names are still rejected even on config/mode
+    EXPECT_THROW(
+      validate_context_subject(
+        {context{".__GLOBAL"}, subject{"__GLOBAL"}}, true),
+      exception);
+    EXPECT_THROW(
+      validate_context_subject(
+        {context{".__GLOBAL"}, subject{"__EMPTY"}}, true),
+      exception);
 }
 
 class ContextSubjectReferenceTest : public ::testing::Test {

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -226,6 +226,61 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_context_config) {
       == pps::compatibility_level::backward);
 }
 
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_context_config_written_at) {
+    // Test that config (compatibility) write markers are tracked correctly
+    auto test_ctx = pps::context{".test"};
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    // Initially no write markers
+    auto markers = store.get_context_config_written_at(test_ctx).get();
+    BOOST_REQUIRE(markers.empty());
+
+    // Create distinct markers
+    auto marker1 = pps::seq_marker{
+      .seq = model::offset{10},
+      .node = model::node_id{1},
+      .version = pps::schema_version{0},
+      .key_type = pps::seq_marker_key_type::config};
+    auto marker2 = pps::seq_marker{
+      .seq = model::offset{20},
+      .node = model::node_id{1},
+      .version = pps::schema_version{0},
+      .key_type = pps::seq_marker_key_type::config};
+
+    // Set compatibility on test context, verify marker is tracked
+    BOOST_REQUIRE(
+      store
+        .set_compatibility(
+          marker1, test_ctx, pps::compatibility_level::full)
+        .get());
+    markers = store.get_context_config_written_at(test_ctx).get();
+    BOOST_REQUIRE_EQUAL(markers.size(), 1);
+    BOOST_REQUIRE_EQUAL(markers[0], marker1);
+
+    // Set compatibility again, second marker is added
+    BOOST_REQUIRE(
+      store
+        .set_compatibility(
+          marker2, test_ctx, pps::compatibility_level::none)
+        .get());
+    markers = store.get_context_config_written_at(test_ctx).get();
+    BOOST_REQUIRE_EQUAL(markers.size(), 2);
+    BOOST_REQUIRE_EQUAL(markers[0], marker1);
+    BOOST_REQUIRE_EQUAL(markers[1], marker2);
+
+    // Default context should still have no markers
+    markers
+      = store.get_context_config_written_at(pps::default_context).get();
+    BOOST_REQUIRE(markers.empty());
+
+    // Clear compatibility clears all markers
+    BOOST_REQUIRE(store.clear_compatibility(test_ctx).get());
+    markers = store.get_context_config_written_at(test_ctx).get();
+    BOOST_REQUIRE(markers.empty());
+}
+
 SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
     pps::sharded_store store;
     store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -177,6 +177,55 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_invalid_subject_compat) {
       store.set_compatibility(dummy_marker, subject0, expected).get());
 }
 
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_context_config) {
+    // Test setting and getting compatibility (config) at the context level
+    auto test_ctx = pps::context{".test"};
+    pps::seq_marker dummy_marker;
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    // Default config is backward compatibility
+    BOOST_REQUIRE(
+      store.get_compatibility(pps::default_context).get()
+      == pps::compatibility_level::backward);
+    BOOST_REQUIRE(
+      store.get_compatibility(test_ctx).get()
+      == pps::compatibility_level::backward);
+
+    // Set config on default context
+    BOOST_REQUIRE(
+      store
+        .set_compatibility(
+          dummy_marker, pps::default_context, pps::compatibility_level::full)
+        .get());
+    BOOST_REQUIRE(
+      store.get_compatibility(pps::default_context).get()
+      == pps::compatibility_level::full);
+    BOOST_REQUIRE(
+      store.get_compatibility(test_ctx).get()
+      == pps::compatibility_level::backward);
+
+    // Set different config on test context
+    BOOST_REQUIRE(
+      store
+        .set_compatibility(
+          dummy_marker, test_ctx, pps::compatibility_level::none)
+        .get());
+    BOOST_REQUIRE(
+      store.get_compatibility(pps::default_context).get()
+      == pps::compatibility_level::full);
+    BOOST_REQUIRE(
+      store.get_compatibility(test_ctx).get()
+      == pps::compatibility_level::none);
+
+    // Clear config returns to default
+    BOOST_REQUIRE(store.clear_compatibility(test_ctx).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(test_ctx).get()
+      == pps::compatibility_level::backward);
+}
+
 SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
     pps::sharded_store store;
     store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -154,6 +154,29 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_subject_compat_fallback) {
       store.get_compatibility(subject0, fallback).get() == expected);
 }
 
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_invalid_subject_compat) {
+    // Setting and getting a compatibility for a non-existent subject should
+    // fail
+    auto fallback = pps::default_to_global::yes;
+
+    pps::seq_marker dummy_marker;
+    pps::compatibility_level expected{pps::compatibility_level::backward};
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    BOOST_REQUIRE_EXCEPTION(
+      store.get_compatibility(subject0, fallback).get(),
+      pps::exception,
+      [](const pps::exception& e) {
+          return e.code() == pps::error_code::compatibility_not_found;
+      });
+
+    expected = pps::compatibility_level::backward;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, subject0, expected).get());
+}
+
 SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
     pps::sharded_store store;
     store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -117,6 +117,43 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_subject_compat) {
       store.get_compatibility(subject0, fallback).get() == global_expected);
 }
 
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_subject_compat_fallback) {
+    // A Subject should fallback to the current global setting
+    pps::seq_marker dummy_marker;
+    auto fallback = pps::default_to_global::yes;
+    const pps::schema_version ver1{1};
+
+    pps::compatibility_level expected{pps::compatibility_level::backward};
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    store
+      .upsert(
+        pps::seq_marker{
+          .seq=std::nullopt,
+          .node=std::nullopt,
+          .version=ver1,
+          .key_type=pps::seq_marker_key_type::schema},
+        pps::subject_schema{subject0, string_def0.share()},
+        pps::schema_id{1},
+        ver1,
+        pps::is_deleted::no)
+      .get();
+
+    BOOST_REQUIRE(
+      store.get_compatibility(subject0, fallback).get() == expected);
+
+    expected = pps::compatibility_level::forward;
+    BOOST_REQUIRE(
+      store
+        .set_compatibility(dummy_marker, pps::default_context, expected)
+        .get()
+      == true);
+    BOOST_REQUIRE(
+      store.get_compatibility(subject0, fallback).get() == expected);
+}
+
 SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
     pps::sharded_store store;
     store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -64,7 +64,6 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_subject_compat) {
 
     pps::seq_marker dummy_marker;
     auto fallback = pps::default_to_global::yes;
-    const pps::schema_version ver1{1};
 
     pps::compatibility_level global_expected{
       pps::compatibility_level::backward};
@@ -74,19 +73,6 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_subject_compat) {
 
     BOOST_REQUIRE(
       store.get_compatibility(pps::default_context).get() == global_expected);
-
-    store
-      .upsert(
-        pps::seq_marker{
-          .seq = std::nullopt,
-          .node = std::nullopt,
-          .version = ver1,
-          .key_type = pps::seq_marker_key_type::schema},
-        pps::subject_schema{subject0, string_def0.share()},
-        pps::schema_id{1},
-        ver1,
-        pps::is_deleted::no)
-      .get();
 
     auto sub_expected = pps::compatibility_level::backward;
     BOOST_REQUIRE(
@@ -123,25 +109,11 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_subject_compat_fallback) {
     // A Subject should fallback to the current global setting
     pps::seq_marker dummy_marker;
     auto fallback = pps::default_to_global::yes;
-    const pps::schema_version ver1{1};
 
     pps::compatibility_level expected{pps::compatibility_level::backward};
     pps::sharded_store store;
     store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
     auto stop_store = ss::defer([&store]() { store.stop().get(); });
-
-    store
-      .upsert(
-        pps::seq_marker{
-          .seq = std::nullopt,
-          .node = std::nullopt,
-          .version = ver1,
-          .key_type = pps::seq_marker_key_type::schema},
-        pps::subject_schema{subject0, string_def0.share()},
-        pps::schema_id{1},
-        ver1,
-        pps::is_deleted::no)
-      .get();
 
     BOOST_REQUIRE(
       store.get_compatibility(subject0, fallback).get() == expected);
@@ -153,29 +125,6 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_subject_compat_fallback) {
       == true);
     BOOST_REQUIRE(
       store.get_compatibility(subject0, fallback).get() == expected);
-}
-
-SEASTAR_THREAD_TEST_CASE(test_sharded_store_invalid_subject_compat) {
-    // Setting and getting a compatibility for a non-existent subject should
-    // fail
-    auto fallback = pps::default_to_global::yes;
-
-    pps::seq_marker dummy_marker;
-    pps::compatibility_level expected{pps::compatibility_level::backward};
-    pps::sharded_store store;
-    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
-    auto stop_store = ss::defer([&store]() { store.stop().get(); });
-
-    BOOST_REQUIRE_EXCEPTION(
-      store.get_compatibility(subject0, fallback).get(),
-      pps::exception,
-      [](const pps::exception& e) {
-          return e.code() == pps::error_code::compatibility_not_found;
-      });
-
-    expected = pps::compatibility_level::backward;
-    BOOST_REQUIRE(
-      store.set_compatibility(dummy_marker, subject0, expected).get());
 }
 
 SEASTAR_THREAD_TEST_CASE(test_sharded_store_context_config) {

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -573,6 +573,390 @@ SEASTAR_THREAD_TEST_CASE(
       == store.default_top_level_compat);
 }
 
+// Scenario Dc
+// Verifies the full fallback chain for a subject ("sub") in the default
+// context when fallback is enabled (default_to_global::yes).
+//
+// This is the most complete fallback test — it exercises all four tiers:
+//   subject config → default_context config → global_context config →
+//   hard-coded default
+//
+// Steps (building up the chain, then tearing it down):
+//
+// 1. Initially, nothing is set.
+//    get_compatibility falls through everything to default_top_level_compat.
+//
+// 2. Set global_context compatibility (full).
+//    get_compatibility resolves to global_context value.
+//
+// 3. Set default_context compatibility (forward).
+//    get_compatibility resolves to default_context value, shadowing global.
+//
+// 4. Set subject-level compatibility (none).
+//    get_compatibility resolves to subject value, shadowing both contexts.
+//
+// 5. Clear subject config.
+//    get_compatibility falls back to default_context value (forward).
+//
+// 6. Clear default_context config.
+//    get_compatibility falls back to global_context value (full).
+//
+// 7. Clear global_context config.
+//    get_compatibility falls back to hard-coded default_top_level_compat.
+//
+// This confirms the complete four-tier priority chain: each layer
+// correctly shadows those below it, and clearing a layer reveals
+// the next one down.
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_subject_default_context_config_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto fallback = pps::default_to_global::yes;
+    auto subject = pps::subject{"sub"};
+    auto ctx = pps::default_context;
+    auto ctx_sub = pps::context_subject{ctx, subject};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get()
+      == store.default_top_level_compat);
+
+    auto expected1 = pps::compatibility_level::full;
+    BOOST_REQUIRE(
+      store
+        // TODO: Replace with single set_compatibility(context_subject) overload
+        .set_compatibility(dummy_marker, pps::global_context, expected1)
+        .get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected1);
+
+    auto expected2 = pps::compatibility_level::forward;
+    BOOST_REQUIRE(
+      store
+        // TODO: Replace with single set_compatibility(context_subject) overload
+        .set_compatibility(dummy_marker, pps::default_context, expected2)
+        .get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected2);
+
+    auto expected3 = pps::compatibility_level::none;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, ctx_sub, expected3).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected3);
+
+    BOOST_REQUIRE(store.clear_compatibility(dummy_marker, ctx_sub).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected2);
+
+    BOOST_REQUIRE(
+      // TODO: Replace with single clear_compatibility(context_subject) overload
+      store.clear_compatibility(pps::default_context).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected1);
+
+    BOOST_REQUIRE(
+      // TODO: Replace with single clear_compatibility(context_subject) overload
+      store.clear_compatibility(pps::global_context).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get()
+      == store.default_top_level_compat);
+}
+
+// Scenario Dd
+// Verifies the fallback chain for context-level compatibility in a
+// non-default context (".ctx", subject="") when fallback is enabled
+// (default_to_global::yes).
+//
+// Non-default contexts skip the default_context layer and fall back
+// directly to global_context. The resolution order is:
+//   context config → global_context config → hard-coded default
+//
+// Steps (build up, then tear down):
+//
+// 1. Initially, nothing is set.
+//    get_compatibility falls through to default_top_level_compat.
+//
+// 2. Set global_context compatibility (full).
+//    get_compatibility resolves to global_context value.
+//
+// 3. Set context-level compatibility on ".ctx" (forward).
+//    get_compatibility resolves to the context's own value, shadowing global.
+//
+// 4. Clear ".ctx" config.
+//    get_compatibility falls back to global_context value (full).
+//
+// 5. Clear global_context config.
+//    get_compatibility falls back to hard-coded default_top_level_compat.
+//
+// This confirms that non-default contexts with fallback enabled have a
+// three-tier chain (context → global → default), notably skipping the
+// default_context layer that default-context lookups include.
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_nondefault_context_config_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto fallback = pps::default_to_global::yes;
+    auto ctx = pps::context{".ctx"};
+    auto ctx_sub = pps::context_subject{ctx, pps::subject{""}};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get()
+      == store.default_top_level_compat);
+
+    auto expected1 = pps::compatibility_level::full;
+    BOOST_REQUIRE(
+      store
+        // TODO: Replace with single set_compatibility(context_subject) overload
+        .set_compatibility(dummy_marker, pps::global_context, expected1)
+        .get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected1);
+
+    auto expected2 = pps::compatibility_level::forward;
+    BOOST_REQUIRE(
+      store
+        // TODO: Replace with single set_compatibility(context_subject) overload
+        .set_compatibility(dummy_marker, ctx, expected2)
+        .get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected2);
+
+    // TODO: Replace with single clear_compatibility(context_subject) overload
+    BOOST_REQUIRE(store.clear_compatibility(ctx).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected1);
+
+    BOOST_REQUIRE(
+      // TODO: Replace with single clear_compatibility(context_subject) overload
+      store.clear_compatibility(pps::global_context).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get()
+      == store.default_top_level_compat);
+}
+
+// Scenario De
+// Verifies the full fallback chain for a subject ("subject") in a
+// non-default context (".ctx") when fallback is enabled
+// (default_to_global::yes).
+//
+// This is the most complete fallback test for non-default contexts.
+// The resolution order is:
+//   subject config → context config → global_context config → hard-coded
+//   default
+//
+// Note: unlike the default context equivalent, there is no default_context
+// layer — non-default contexts skip it and fall back directly to global.
+//
+// Steps (build up, then tear down):
+//
+// 1. Initially, nothing is set.
+//    get_compatibility falls through everything to default_top_level_compat.
+//
+// 2. Set global_context compatibility (full).
+//    get_compatibility resolves to global_context value.
+//
+// 3. Set context-level compatibility on ".ctx" (forward).
+//    get_compatibility resolves to context value, shadowing global.
+//
+// 4. Set subject-level compatibility (none).
+//    get_compatibility resolves to subject value, shadowing both.
+//
+// 5. Clear subject config.
+//    get_compatibility falls back to context value (forward).
+//
+// 6. Clear ".ctx" config.
+//    get_compatibility falls back to global_context value (full).
+//
+// 7. Clear global_context config.
+//    get_compatibility falls back to hard-coded default_top_level_compat.
+//
+// This confirms the complete four-tier chain for non-default contexts:
+// subject → context → global → hard-coded default, with each layer
+// correctly shadowing those below and revealing the next on removal.
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_subject_nondefault_context_config_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto fallback = pps::default_to_global::yes;
+    auto ctx = pps::context{".ctx"};
+    auto ctx_sub = pps::context_subject{ctx, pps::subject{"subject"}};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get()
+      == store.default_top_level_compat);
+
+    auto expected1 = pps::compatibility_level::full;
+    BOOST_REQUIRE(
+      store
+        // TODO: Replace with single set_compatibility(context_subject) overload
+        .set_compatibility(dummy_marker, pps::global_context, expected1)
+        .get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected1);
+
+    auto expected2 = pps::compatibility_level::forward;
+    BOOST_REQUIRE(
+      store
+        // TODO: Replace with single set_compatibility(context_subject) overload
+        .set_compatibility(dummy_marker, ctx, expected2)
+        .get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected2);
+
+    auto expected3 = pps::compatibility_level::none;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, ctx_sub, expected3).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected3);
+
+    BOOST_REQUIRE(store.clear_compatibility(dummy_marker, ctx_sub).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected2);
+
+    // TODO: Replace with single clear_compatibility(context_subject) overload
+    BOOST_REQUIRE(store.clear_compatibility(ctx).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected1);
+
+    BOOST_REQUIRE(
+      // TODO: Replace with single clear_compatibility(context_subject) overload
+      store.clear_compatibility(pps::global_context).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get()
+      == store.default_top_level_compat);
+}
+
+// Scenario Df
+// Verifies context-level compatibility for the global context (subject="")
+// when fallback is enabled (default_to_global::yes).
+//
+// Since the global context is already the top of the fallback hierarchy,
+// enabling fallback has no additional effect — the behavior is identical
+// to the no_fallback variant. Resolution is:
+//   global_context config → hard-coded default
+//
+// Steps:
+// 1. Initially, no config is set.
+//    get_compatibility returns default_top_level_compat.
+//
+// 2. Set global_context compatibility (full).
+//    get_compatibility returns the explicitly set value.
+//
+// 3. Clear global_context config.
+//    get_compatibility reverts to default_top_level_compat.
+//
+// This confirms that the fallback flag is a no-op for the global context
+// itself — there is nothing above it to fall back to, so the result is
+// the same regardless of the default_to_global setting.
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_global_context_config_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto fallback = pps::default_to_global::yes;
+    auto ctx = pps::global_context;
+    auto ctx_sub = pps::context_subject{ctx, pps::subject{""}};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get()
+      == store.default_top_level_compat);
+
+    auto expected = pps::compatibility_level::full;
+    BOOST_REQUIRE(
+      store
+        // TODO: Replace with single set_compatibility(context_subject) overload
+        .set_compatibility(dummy_marker, pps::global_context, expected)
+        .get());
+    BOOST_REQUIRE(store.get_compatibility(ctx_sub, fallback).get() == expected);
+
+    BOOST_REQUIRE(
+      // TODO: Replace with single clear_compatibility(context_subject) overload
+      store.clear_compatibility(pps::global_context).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get()
+      == store.default_top_level_compat);
+}
+
+// Scenario Dg
+// Verifies the fallback chain for a subject ("subject") in the global
+// context when fallback is enabled (default_to_global::yes).
+//
+// Subjects in the global context have a three-tier resolution:
+//   subject config → global_context config → hard-coded default
+//
+// Since we're already in the global context, there is no intermediate
+// context layer to traverse — fallback goes straight from subject to
+// global-level config.
+//
+// Steps (build up, then tear down):
+//
+// 1. Initially, nothing is set.
+//    get_compatibility falls through to default_top_level_compat.
+//
+// 2. Set global_context compatibility (full).
+//    get_compatibility resolves to global_context value.
+//
+// 3. Set subject-level compatibility (forward).
+//    get_compatibility resolves to subject value, shadowing global.
+//
+// 4. Clear subject config.
+//    get_compatibility falls back to global_context value (full).
+//
+// 5. Clear global_context config.
+//    get_compatibility falls back to hard-coded default_top_level_compat.
+//
+// This confirms the three-tier chain for subjects in the global context.
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_subject_global_context_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto fallback = pps::default_to_global::yes;
+    auto ctx = pps::global_context;
+    auto ctx_sub = pps::context_subject{ctx, pps::subject{"subject"}};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get()
+      == store.default_top_level_compat);
+
+    auto expected1 = pps::compatibility_level::full;
+    BOOST_REQUIRE(
+      store
+        // TODO: Replace with single set_compatibility(context_subject) overload
+        .set_compatibility(dummy_marker, pps::global_context, expected1)
+        .get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected1);
+
+    auto expected2 = pps::compatibility_level::forward;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, ctx_sub, expected2).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected2);
+
+    BOOST_REQUIRE(store.clear_compatibility(dummy_marker, ctx_sub).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected1);
+
+    BOOST_REQUIRE(
+      // TODO: Replace with single clear_compatibility(context_subject) overload
+      store.clear_compatibility(pps::global_context).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get()
+      == store.default_top_level_compat);
+}
+
 SEASTAR_THREAD_TEST_CASE(test_sharded_store_context_config_written_at) {
     // Test that config (compatibility) write markers are tracked correctly
     auto test_ctx = pps::context{".test"};

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -227,6 +227,403 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_context_config) {
       == pps::compatibility_level::backward);
 }
 
+// Scenarios A, Ca, Cb
+// Verifies context-level compatibility in the default context (subject="")
+// when fallback to global is disabled (default_to_global::no).
+//
+// With no fallback, the resolution is only:
+//   default_context config → hard-coded default
+//
+// Steps:
+// 1. Initially, no config is set.
+//    get_compatibility returns the hard-coded default_top_level_compat
+//    (NOT from global_context — fallback is disabled).
+//
+// 2. Set compatibility on default_context (full).
+//    get_compatibility returns the explicitly set value.
+//
+// 3. Clear default_context config.
+//    get_compatibility reverts to default_top_level_compat.
+//
+// This confirms that with no_fallback, global_context is never consulted
+// and the context resolves only its own config or the hard-coded default.
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_default_context_config_no_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto no_fallback = pps::default_to_global::no;
+    auto ctx_sub = pps::context_subject{pps::default_context, pps::subject{""}};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, no_fallback).get()
+      == store.default_top_level_compat);
+
+    auto expected = pps::compatibility_level::full;
+    BOOST_REQUIRE(
+      store
+        // TODO: Replace with single set_compatibility(context_subject) overload
+        .set_compatibility(dummy_marker, pps::default_context, expected)
+        .get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, no_fallback).get() == expected);
+
+    BOOST_REQUIRE(
+      // TODO: Replace with single clear_compatibility(context_subject) overload
+      store.clear_compatibility(pps::default_context).get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, no_fallback).get()
+      == store.default_top_level_compat);
+}
+
+// Scenarios B, Da, Db
+// Verifies the fallback chain for context-level compatibility in the
+// default context (subject="") when default_to_global::yes is used.
+//
+// The expected resolution order is:
+//   default_context config → global_context config → hard-coded default
+//
+// Steps:
+// 1. Initially, no context or global config is set.
+//    get_compatibility falls back all the way to default_top_level_compat.
+//
+// 2. Set compatibility on global_context (full).
+//    get_compatibility now resolves to the global_context value.
+//
+// 3. Set compatibility on default_context (none).
+//    get_compatibility now resolves to the default_context value,
+//    which takes priority over global_context.
+//
+// 4. Clear default_context config.
+//    get_compatibility falls back to the global_context value again.
+//
+// 5. Clear global_context config.
+//    get_compatibility falls back to the hard-coded default_top_level_compat.
+//
+// This confirms the full fallback chain works correctly and that each
+// layer properly shadows the one below it.
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_default_context_config_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto fallback = pps::default_to_global::yes;
+    auto ctx_sub = pps::context_subject{pps::default_context, pps::subject{""}};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get()
+      == store.default_top_level_compat);
+
+    auto expected1 = pps::compatibility_level::full;
+    BOOST_REQUIRE(
+      store
+        // TODO: Replace with single set_compatibility(context_subject) overload
+        .set_compatibility(
+          dummy_marker, pandaproxy::schema_registry::global_context, expected1)
+        .get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected1);
+
+    auto expected2 = pps::compatibility_level::none;
+    BOOST_REQUIRE(
+      store
+        // TODO: Replace with single set_compatibility(context_subject) overload
+        .set_compatibility(
+          dummy_marker, pandaproxy::schema_registry::default_context, expected2)
+        .get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected2);
+
+    BOOST_REQUIRE(
+      // TODO: Replace with single clear_compatibility(context_subject) overload
+      store.clear_compatibility(pps::default_context).get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected1);
+
+    BOOST_REQUIRE(
+      // TODO: Replace with single clear_compatibility(context_subject) overload
+      store.clear_compatibility(pps::global_context).get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get()
+      == store.default_top_level_compat);
+}
+
+// Scenario Cc
+// Verifies that get_compatibility for a subject in the default context
+// behaves correctly when fallback to the global default is disabled
+// (default_to_global::no):
+//
+// 1. With no compatibility set, get_compatibility throws
+//    compatibility_not_found — it does NOT fall back to any global default.
+// 2. After explicitly setting compatibility on the subject,
+//    get_compatibility returns the value that was set.
+//
+// This ensures the no-fallback path is isolated: subjects only see
+// their own explicitly configured compatibility level.
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_subject_default_context_config_no_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto no_fallback = pps::default_to_global::no;
+    auto ctx_sub = pps::context_subject{
+      pps::default_context, pps::subject{"sub"}};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE_EXCEPTION(
+      store.get_compatibility(ctx_sub, no_fallback).get(),
+      pps::exception,
+      [](const pps::exception& e) {
+          return e.code() == pps::error_code::compatibility_not_found;
+      });
+
+    auto expected = pps::compatibility_level::full;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, ctx_sub, expected).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, no_fallback).get() == expected);
+}
+
+// Scenario Cd
+// Verifies context-level compatibility for a non-default context (".ctx")
+// with subject="" when fallback is disabled (default_to_global::no).
+//
+// Unlike the default context, a non-default context has NO hard-coded
+// default to fall back to. With fallback also disabled, the resolution is:
+//   context config → error (compatibility_not_found)
+//
+// Steps:
+// 1. Initially, no config is set.
+//    get_compatibility throws compatibility_not_found — there is no
+//    implicit default for non-default contexts.
+//
+// 2. Set compatibility on the context (full).
+//    get_compatibility returns the explicitly set value.
+//
+// 3. Clear the context config.
+//    get_compatibility throws compatibility_not_found again.
+//
+// This confirms that non-default contexts are strictly explicit: they
+// have no built-in default and no global fallback, so an unset config
+// is an error rather than a silent default.
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_nondefault_context_config_no_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto no_fallback = pps::default_to_global::no;
+    auto ctx = pps::context{".ctx"};
+    auto ctx_sub = pps::context_subject{ctx, pps::subject{""}};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE_EXCEPTION(
+      store.get_compatibility(ctx_sub, no_fallback).get(),
+      pps::exception,
+      [](const pps::exception& e) {
+          return e.code() == pps::error_code::compatibility_not_found;
+      });
+
+    auto expected = pps::compatibility_level::full;
+    BOOST_REQUIRE(
+      store
+        // TODO: Replace with single set_compatibility(context_subject) overload
+        .set_compatibility(dummy_marker, ctx, expected)
+        .get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, no_fallback).get() == expected);
+
+    BOOST_REQUIRE(
+      // TODO: Replace with single clear_compatibility(context_subject) overload
+      store.clear_compatibility(ctx).get());
+
+    BOOST_REQUIRE_EXCEPTION(
+      store.get_compatibility(ctx_sub, no_fallback).get(),
+      pps::exception,
+      [](const pps::exception& e) {
+          return e.code() == pps::error_code::compatibility_not_found;
+      });
+}
+
+// Scenario Ce
+// Verifies subject-level compatibility for a subject ("sub") in a
+// non-default context (".ctx") when fallback is disabled
+// (default_to_global::no).
+//
+// This is the most restrictive lookup: a specific subject in a non-default
+// context with no fallback. Resolution is:
+//   subject config → error (compatibility_not_found)
+//
+// Steps:
+// 1. Initially, no config is set.
+//    get_compatibility throws compatibility_not_found — no subject config,
+//    no context fallback, no global fallback.
+//
+// 2. Set compatibility directly on the context_subject (full).
+//    get_compatibility returns the explicitly set value.
+//
+// 3. Clear the subject's config.
+//    get_compatibility throws compatibility_not_found again.
+//
+// This confirms that subject-level lookups in non-default contexts are
+// fully isolated when fallback is off: only the subject's own explicit
+// config is used, with no chain to the context or global level.
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_subject_nondefault_context_config_no_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto no_fallback = pps::default_to_global::no;
+    auto ctx = pps::context{".ctx"};
+    auto ctx_sub = pps::context_subject{ctx, pps::subject{"sub"}};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE_EXCEPTION(
+      store.get_compatibility(ctx_sub, no_fallback).get(),
+      pps::exception,
+      [](const pps::exception& e) {
+          return e.code() == pps::error_code::compatibility_not_found;
+      });
+
+    auto expected = pps::compatibility_level::full;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, ctx_sub, expected).get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, no_fallback).get() == expected);
+
+    BOOST_REQUIRE(store.clear_compatibility(dummy_marker, ctx_sub).get());
+
+    BOOST_REQUIRE_EXCEPTION(
+      store.get_compatibility(ctx_sub, no_fallback).get(),
+      pps::exception,
+      [](const pps::exception& e) {
+          return e.code() == pps::error_code::compatibility_not_found;
+      });
+}
+
+// Scenario Cf
+// Verifies context-level compatibility for the global context (subject="")
+// when fallback is disabled (default_to_global::no).
+//
+// The global context is the root of the fallback hierarchy. Even with
+// fallback disabled, it still has the hard-coded default to fall back to.
+// Resolution is:
+//   global_context config → hard-coded default
+//
+// Steps:
+// 1. Initially, no config is set.
+//    get_compatibility returns default_top_level_compat.
+//
+// 2. Set compatibility on global_context (full).
+//    get_compatibility returns the explicitly set value.
+//
+// 3. Clear global_context config.
+//    get_compatibility reverts to default_top_level_compat.
+//
+// This confirms that the global context behaves like the default context
+// in no-fallback mode: it resolves its own config or the hard-coded
+// default. The no_fallback flag is effectively a no-op here since the
+// global context is already the top of the chain.
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_global_context_config_no_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto no_fallback = pps::default_to_global::no;
+    auto ctx = pandaproxy::schema_registry::global_context;
+    auto ctx_sub = pps::context_subject{ctx, pps::subject{""}};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, no_fallback).get()
+      == store.default_top_level_compat);
+
+    auto expected = pps::compatibility_level::full;
+    BOOST_REQUIRE(
+      store
+        // TODO: Replace with single set_compatibility(context_subject) overload
+        .set_compatibility(dummy_marker, ctx, expected)
+        .get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, no_fallback).get() == expected);
+
+    BOOST_REQUIRE(
+      // TODO: Replace with single clear_compatibility(context_subject) overload
+      store.clear_compatibility(ctx).get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, no_fallback).get()
+      == store.default_top_level_compat);
+}
+
+// Scenario Cg
+// Verifies subject-level compatibility for a subject ("sub") in the
+// global context when fallback is disabled (default_to_global::no).
+//
+// Unlike subjects in non-default contexts (which error out when unset),
+// subjects in the global context fall back to the hard-coded default.
+// Resolution is:
+//   subject config → hard-coded default
+//
+// Steps:
+// 1. Initially, no subject config is set.
+//    get_compatibility returns default_top_level_compat — the global
+//    context's implicit baseline applies even with no_fallback.
+//
+// 2. Set compatibility on the subject (full).
+//    get_compatibility returns the explicitly set value.
+//
+// 3. Clear the subject's config.
+//    get_compatibility reverts to default_top_level_compat.
+//
+// This confirms that subjects in the global context inherit the same
+// hard-coded default as the global context itself, even with fallback
+// disabled.
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_subject_global_context_no_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto no_fallback = pps::default_to_global::no;
+    auto subject = pps::subject{"sub"};
+    auto ctx = pps::global_context;
+    auto ctx_sub = pps::context_subject{ctx, subject};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, no_fallback).get()
+      == store.default_top_level_compat);
+
+    // Set global context compatibility
+    auto expected = pps::compatibility_level::full;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, ctx_sub, expected).get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, no_fallback).get() == expected);
+
+    BOOST_REQUIRE(store.clear_compatibility(dummy_marker, ctx_sub).get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, no_fallback).get()
+      == store.default_top_level_compat);
+}
+
 SEASTAR_THREAD_TEST_CASE(test_sharded_store_context_config_written_at) {
     // Test that config (compatibility) write markers are tracked correctly
     auto test_ctx = pps::context{".test"};

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -50,6 +50,73 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_global_compat) {
       store.get_compatibility(pps::default_context).get() == expected);
 }
 
+constexpr std::string_view sv_string_def0{R"({"type":"string"})"};
+const pps::schema_definition string_def0{
+  pps::make_schema_definition<json::UTF8<>>(sv_string_def0).value(),
+  pps::schema_type::avro};
+const auto subject0 = pps::context_subject::unqualified("subject0");
+
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_subject_compat) {
+    // Setting and retrieving a subject compatibility should be allowed multiple
+    // times
+
+    pps::seq_marker dummy_marker;
+    auto fallback = pps::default_to_global::yes;
+    const pps::schema_version ver1{1};
+
+    pps::compatibility_level global_expected{
+      pps::compatibility_level::backward};
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    BOOST_REQUIRE(
+      store.get_compatibility(pps::default_context).get() == global_expected);
+
+    store
+      .upsert(
+        pps::seq_marker{
+          .seq=std::nullopt,
+          .node=std::nullopt,
+          .version=ver1,
+          .key_type=pps::seq_marker_key_type::schema},
+        pps::subject_schema{subject0, string_def0.share()},
+        pps::schema_id{1},
+        ver1,
+        pps::is_deleted::no)
+      .get();
+
+    auto sub_expected = pps::compatibility_level::backward;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, subject0, sub_expected).get()
+      == true);
+    BOOST_REQUIRE(
+      store.get_compatibility(subject0, fallback).get() == sub_expected);
+
+    // duplicate should return false
+    sub_expected = pps::compatibility_level::backward;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, subject0, sub_expected).get()
+      == false);
+    BOOST_REQUIRE(
+      store.get_compatibility(subject0, fallback).get() == sub_expected);
+
+    sub_expected = pps::compatibility_level::full_transitive;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, subject0, sub_expected).get()
+      == true);
+    BOOST_REQUIRE(
+      store.get_compatibility(subject0, fallback).get() == sub_expected);
+    BOOST_REQUIRE(
+      store.get_compatibility(pps::default_context).get() == global_expected);
+
+    // Clearing compatibility should fallback to global
+    BOOST_REQUIRE(
+      store.clear_compatibility(dummy_marker, subject0).get() == true);
+    BOOST_REQUIRE(
+      store.get_compatibility(subject0, fallback).get() == global_expected);
+}
+
 SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
     pps::sharded_store store;
     store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -38,13 +38,15 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_global_compat) {
       store.get_compatibility(pps::default_context).get() == expected);
 
     // duplicate should return false
-    BOOST_REQUIRE(store.clear_compatibility(pps::default_context).get() == false);
+    BOOST_REQUIRE(
+      store.clear_compatibility(pps::default_context).get() == false);
     BOOST_REQUIRE(
       store.get_compatibility(pps::default_context).get() == expected);
 
     expected = pps::compatibility_level::full_transitive;
     BOOST_REQUIRE(
-      store.set_compatibility(dummy_marker, pps::default_context, expected).get()
+      store.set_compatibility(dummy_marker, pps::default_context, expected)
+        .get()
       == true);
     BOOST_REQUIRE(
       store.get_compatibility(pps::default_context).get() == expected);
@@ -76,10 +78,10 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_subject_compat) {
     store
       .upsert(
         pps::seq_marker{
-          .seq=std::nullopt,
-          .node=std::nullopt,
-          .version=ver1,
-          .key_type=pps::seq_marker_key_type::schema},
+          .seq = std::nullopt,
+          .node = std::nullopt,
+          .version = ver1,
+          .key_type = pps::seq_marker_key_type::schema},
         pps::subject_schema{subject0, string_def0.share()},
         pps::schema_id{1},
         ver1,
@@ -131,10 +133,10 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_subject_compat_fallback) {
     store
       .upsert(
         pps::seq_marker{
-          .seq=std::nullopt,
-          .node=std::nullopt,
-          .version=ver1,
-          .key_type=pps::seq_marker_key_type::schema},
+          .seq = std::nullopt,
+          .node = std::nullopt,
+          .version = ver1,
+          .key_type = pps::seq_marker_key_type::schema},
         pps::subject_schema{subject0, string_def0.share()},
         pps::schema_id{1},
         ver1,
@@ -146,8 +148,7 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_subject_compat_fallback) {
 
     expected = pps::compatibility_level::forward;
     BOOST_REQUIRE(
-      store
-        .set_compatibility(dummy_marker, pps::default_context, expected)
+      store.set_compatibility(dummy_marker, pps::default_context, expected)
         .get()
       == true);
     BOOST_REQUIRE(
@@ -184,13 +185,14 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_context_config) {
     pps::sharded_store store;
     store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
     auto stop_store = ss::defer([&store]() { store.stop().get(); });
+    auto fallback = pps::default_to_global::yes;
 
     // Default config is backward compatibility
     BOOST_REQUIRE(
-      store.get_compatibility(pps::default_context).get()
+      store.get_compatibility(pps::default_context, fallback).get()
       == pps::compatibility_level::backward);
     BOOST_REQUIRE(
-      store.get_compatibility(test_ctx).get()
+      store.get_compatibility(test_ctx, fallback).get()
       == pps::compatibility_level::backward);
 
     // Set config on default context
@@ -200,29 +202,28 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_context_config) {
           dummy_marker, pps::default_context, pps::compatibility_level::full)
         .get());
     BOOST_REQUIRE(
-      store.get_compatibility(pps::default_context).get()
+      store.get_compatibility(pps::default_context, fallback).get()
       == pps::compatibility_level::full);
     BOOST_REQUIRE(
-      store.get_compatibility(test_ctx).get()
+      store.get_compatibility(test_ctx, fallback).get()
       == pps::compatibility_level::backward);
 
     // Set different config on test context
+    BOOST_REQUIRE(store
+                    .set_compatibility(
+                      dummy_marker, test_ctx, pps::compatibility_level::none)
+                    .get());
     BOOST_REQUIRE(
-      store
-        .set_compatibility(
-          dummy_marker, test_ctx, pps::compatibility_level::none)
-        .get());
-    BOOST_REQUIRE(
-      store.get_compatibility(pps::default_context).get()
+      store.get_compatibility(pps::default_context, fallback).get()
       == pps::compatibility_level::full);
     BOOST_REQUIRE(
-      store.get_compatibility(test_ctx).get()
+      store.get_compatibility(test_ctx, fallback).get()
       == pps::compatibility_level::none);
 
     // Clear config returns to default
     BOOST_REQUIRE(store.clear_compatibility(test_ctx).get());
     BOOST_REQUIRE(
-      store.get_compatibility(test_ctx).get()
+      store.get_compatibility(test_ctx, fallback).get()
       == pps::compatibility_level::backward);
 }
 
@@ -251,9 +252,7 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_context_config_written_at) {
 
     // Set compatibility on test context, verify marker is tracked
     BOOST_REQUIRE(
-      store
-        .set_compatibility(
-          marker1, test_ctx, pps::compatibility_level::full)
+      store.set_compatibility(marker1, test_ctx, pps::compatibility_level::full)
         .get());
     markers = store.get_context_config_written_at(test_ctx).get();
     BOOST_REQUIRE_EQUAL(markers.size(), 1);
@@ -261,9 +260,7 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_context_config_written_at) {
 
     // Set compatibility again, second marker is added
     BOOST_REQUIRE(
-      store
-        .set_compatibility(
-          marker2, test_ctx, pps::compatibility_level::none)
+      store.set_compatibility(marker2, test_ctx, pps::compatibility_level::none)
         .get());
     markers = store.get_context_config_written_at(test_ctx).get();
     BOOST_REQUIRE_EQUAL(markers.size(), 2);
@@ -271,8 +268,7 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_context_config_written_at) {
     BOOST_REQUIRE_EQUAL(markers[1], marker2);
 
     // Default context should still have no markers
-    markers
-      = store.get_context_config_written_at(pps::default_context).get();
+    markers = store.get_context_config_written_at(pps::default_context).get();
     BOOST_REQUIRE(markers.empty());
 
     // Clear compatibility clears all markers

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -14,6 +14,7 @@
 #include "pandaproxy/schema_registry/protobuf.h"
 #include "pandaproxy/schema_registry/test/compatibility_protobuf.h"
 #include "pandaproxy/schema_registry/types.h"
+#include "pandaproxy/schema_registry/util.h"
 
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/defer.hh>
@@ -22,6 +23,32 @@
 
 namespace pp = pandaproxy;
 namespace pps = pp::schema_registry;
+
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_global_compat) {
+    // Setting and retrieving global compatibility should be allowed multiple
+    // times
+
+    pps::seq_marker dummy_marker;
+    pps::compatibility_level expected{pps::compatibility_level::backward};
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    BOOST_REQUIRE(
+      store.get_compatibility(pps::default_context).get() == expected);
+
+    // duplicate should return false
+    BOOST_REQUIRE(store.clear_compatibility(pps::default_context).get() == false);
+    BOOST_REQUIRE(
+      store.get_compatibility(pps::default_context).get() == expected);
+
+    expected = pps::compatibility_level::full_transitive;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, pps::default_context, expected).get()
+      == true);
+    BOOST_REQUIRE(
+      store.get_compatibility(pps::default_context).get() == expected);
+}
 
 SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
     pps::sharded_store store;

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -453,23 +453,6 @@ BOOST_AUTO_TEST_CASE(test_store_get_subjects) {
     BOOST_REQUIRE_EQUAL(s.get_subjects(pps::include_deleted::yes).size(), 0);
 }
 
-BOOST_AUTO_TEST_CASE(test_store_subject_compat_fallback) {
-    // A Subject should fallback to the current global setting
-    pps::seq_marker dummy_marker;
-    auto fallback = pps::default_to_global::yes;
-
-    pps::compatibility_level expected{pps::compatibility_level::backward};
-    pps::store s;
-    s.insert({subject0, string_def0.share()});
-    BOOST_REQUIRE(s.get_compatibility(subject0, fallback).value() == expected);
-
-    expected = pps::compatibility_level::forward;
-    BOOST_REQUIRE(
-      s.set_compatibility(dummy_marker, pps::default_context, expected).value()
-      == true);
-    BOOST_REQUIRE(s.get_compatibility(subject0, fallback).value() == expected);
-}
-
 BOOST_AUTO_TEST_CASE(test_store_invalid_subject_compat) {
     // Setting and getting a compatibility for a non-existant subject should
     // fail

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -825,54 +825,6 @@ BOOST_AUTO_TEST_CASE(test_store_context_mode_written_at) {
     BOOST_REQUIRE(markers.empty());
 }
 
-BOOST_AUTO_TEST_CASE(test_store_context_config_written_at) {
-    // Test that config (compatibility) write markers are tracked correctly
-    auto test_ctx = pps::context{".test"};
-    pps::store s;
-
-    // Initially no write markers
-    auto markers = s.get_context_config_written_at(test_ctx).value();
-    BOOST_REQUIRE(markers.empty());
-
-    // Create distinct markers
-    auto marker1 = pps::seq_marker{
-      .seq = model::offset{10},
-      .node = model::node_id{1},
-      .version = pps::schema_version{0},
-      .key_type = pps::seq_marker_key_type::config};
-    auto marker2 = pps::seq_marker{
-      .seq = model::offset{20},
-      .node = model::node_id{1},
-      .version = pps::schema_version{0},
-      .key_type = pps::seq_marker_key_type::config};
-
-    // Set compatibility on test context, verify marker is tracked
-    BOOST_REQUIRE(
-      s.set_compatibility(marker1, test_ctx, pps::compatibility_level::full)
-        .value());
-    markers = s.get_context_config_written_at(test_ctx).value();
-    BOOST_REQUIRE_EQUAL(markers.size(), 1);
-    BOOST_REQUIRE_EQUAL(markers[0], marker1);
-
-    // Set compatibility again, second marker is added
-    BOOST_REQUIRE(
-      s.set_compatibility(marker2, test_ctx, pps::compatibility_level::none)
-        .value());
-    markers = s.get_context_config_written_at(test_ctx).value();
-    BOOST_REQUIRE_EQUAL(markers.size(), 2);
-    BOOST_REQUIRE_EQUAL(markers[0], marker1);
-    BOOST_REQUIRE_EQUAL(markers[1], marker2);
-
-    // Default context should still have no markers
-    markers = s.get_context_config_written_at(pps::default_context).value();
-    BOOST_REQUIRE(markers.empty());
-
-    // Clear compatibility clears all markers
-    BOOST_REQUIRE(s.clear_compatibility(test_ctx).value());
-    markers = s.get_context_config_written_at(test_ctx).value();
-    BOOST_REQUIRE(markers.empty());
-}
-
 BOOST_AUTO_TEST_CASE(test_store_context_materialized) {
     pps::store s;
     auto test_ctx = pps::context{".test"};

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -825,49 +825,6 @@ BOOST_AUTO_TEST_CASE(test_store_context_mode_written_at) {
     BOOST_REQUIRE(markers.empty());
 }
 
-BOOST_AUTO_TEST_CASE(test_store_context_config) {
-    // Test setting and getting compatibility (config) at the context level
-    auto test_ctx = pps::context{".test"};
-    pps::seq_marker dummy_marker;
-    auto s = pps::store{pps::is_mutable::yes};
-
-    // Default config is backward compatibility
-    BOOST_REQUIRE(
-      s.get_compatibility(pps::default_context).value()
-      == pps::compatibility_level::backward);
-    BOOST_REQUIRE(
-      s.get_compatibility(test_ctx).value()
-      == pps::compatibility_level::backward);
-
-    // Set config on default context
-    BOOST_REQUIRE(
-      s.set_compatibility(
-         dummy_marker, pps::default_context, pps::compatibility_level::full)
-        .value());
-    BOOST_REQUIRE(
-      s.get_compatibility(pps::default_context).value()
-      == pps::compatibility_level::full);
-    BOOST_REQUIRE(
-      s.get_compatibility(test_ctx).value()
-      == pps::compatibility_level::backward);
-
-    // Set different config on test context
-    BOOST_REQUIRE(s.set_compatibility(
-                     dummy_marker, test_ctx, pps::compatibility_level::none)
-                    .value());
-    BOOST_REQUIRE(
-      s.get_compatibility(pps::default_context).value()
-      == pps::compatibility_level::full);
-    BOOST_REQUIRE(
-      s.get_compatibility(test_ctx).value() == pps::compatibility_level::none);
-
-    // Clear config returns to default
-    BOOST_REQUIRE(s.clear_compatibility(test_ctx).value());
-    BOOST_REQUIRE(
-      s.get_compatibility(test_ctx).value()
-      == pps::compatibility_level::backward);
-}
-
 BOOST_AUTO_TEST_CASE(test_store_context_config_written_at) {
     // Test that config (compatibility) write markers are tracked correctly
     auto test_ctx = pps::context{".test"};

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -453,51 +453,6 @@ BOOST_AUTO_TEST_CASE(test_store_get_subjects) {
     BOOST_REQUIRE_EQUAL(s.get_subjects(pps::include_deleted::yes).size(), 0);
 }
 
-BOOST_AUTO_TEST_CASE(test_store_subject_compat) {
-    // Setting the retrieving a subject compatibility should be allowed multiple
-    // times
-
-    pps::seq_marker dummy_marker;
-    auto fallback = pps::default_to_global::yes;
-
-    pps::compatibility_level global_expected{
-      pps::compatibility_level::backward};
-    pps::store s;
-    BOOST_REQUIRE(
-      s.get_compatibility(pps::default_context).value() == global_expected);
-    s.insert({subject0, string_def0.share()});
-
-    auto sub_expected = pps::compatibility_level::backward;
-    BOOST_REQUIRE(
-      s.set_compatibility(dummy_marker, subject0, sub_expected).value()
-      == true);
-    BOOST_REQUIRE(
-      s.get_compatibility(subject0, fallback).value() == sub_expected);
-
-    // duplicate should return false
-    sub_expected = pps::compatibility_level::backward;
-    BOOST_REQUIRE(
-      s.set_compatibility(dummy_marker, subject0, sub_expected).value()
-      == false);
-    BOOST_REQUIRE(
-      s.get_compatibility(subject0, fallback).value() == sub_expected);
-
-    sub_expected = pps::compatibility_level::full_transitive;
-    BOOST_REQUIRE(
-      s.set_compatibility(dummy_marker, subject0, sub_expected).value()
-      == true);
-    BOOST_REQUIRE(
-      s.get_compatibility(subject0, fallback).value() == sub_expected);
-    BOOST_REQUIRE(
-      s.get_compatibility(pps::default_context).value() == global_expected);
-
-    // Clearing compatibility should fallback to global
-    BOOST_REQUIRE(
-      s.clear_compatibility(dummy_marker, subject0).value() == true);
-    BOOST_REQUIRE(
-      s.get_compatibility(subject0, fallback).value() == global_expected);
-}
-
 BOOST_AUTO_TEST_CASE(test_store_subject_compat_fallback) {
     // A Subject should fallback to the current global setting
     pps::seq_marker dummy_marker;

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -453,24 +453,6 @@ BOOST_AUTO_TEST_CASE(test_store_get_subjects) {
     BOOST_REQUIRE_EQUAL(s.get_subjects(pps::include_deleted::yes).size(), 0);
 }
 
-BOOST_AUTO_TEST_CASE(test_store_invalid_subject_compat) {
-    // Setting and getting a compatibility for a non-existant subject should
-    // fail
-    auto fallback = pps::default_to_global::yes;
-
-    pps::seq_marker dummy_marker;
-    pps::compatibility_level expected{pps::compatibility_level::backward};
-    pps::store s;
-
-    BOOST_REQUIRE_EQUAL(
-      s.get_compatibility(subject0, fallback).error().code(),
-      pps::error_code::compatibility_not_found);
-
-    expected = pps::compatibility_level::backward;
-    BOOST_REQUIRE(
-      s.set_compatibility(dummy_marker, subject0, expected).value());
-}
-
 BOOST_AUTO_TEST_CASE(test_store_delete_subject) {
     const std::vector<pps::schema_version> expected_vers{
       {pps::schema_version{1}, pps::schema_version{2}}};

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -453,29 +453,6 @@ BOOST_AUTO_TEST_CASE(test_store_get_subjects) {
     BOOST_REQUIRE_EQUAL(s.get_subjects(pps::include_deleted::yes).size(), 0);
 }
 
-BOOST_AUTO_TEST_CASE(test_store_global_compat) {
-    // Setting the retrieving global compatibility should be allowed multiple
-    // times
-
-    pps::seq_marker dummy_marker;
-    pps::compatibility_level expected{pps::compatibility_level::backward};
-    pps::store s;
-    BOOST_REQUIRE(
-      s.get_compatibility(pps::default_context).value() == expected);
-
-    // duplicate should return false
-    BOOST_REQUIRE(s.clear_compatibility(pps::default_context).value() == false);
-    BOOST_REQUIRE(
-      s.get_compatibility(pps::default_context).value() == expected);
-
-    expected = pps::compatibility_level::full_transitive;
-    BOOST_REQUIRE(
-      s.set_compatibility(dummy_marker, pps::default_context, expected).value()
-      == true);
-    BOOST_REQUIRE(
-      s.get_compatibility(pps::default_context).value() == expected);
-}
-
 BOOST_AUTO_TEST_CASE(test_store_subject_compat) {
     // Setting the retrieving a subject compatibility should be allowed multiple
     // times

--- a/src/v/pandaproxy/schema_registry/types.cc
+++ b/src/v/pandaproxy/schema_registry/types.cc
@@ -11,6 +11,7 @@
 
 #include "types.h"
 
+#include "errors.h"
 #include "util.h"
 #include "utils/to_string.h"
 
@@ -153,6 +154,20 @@ fmt::iterator context_subject_reference::format_to(fmt::iterator it) const {
         return fmt::format_to(it, ":{}:{}", sub.ctx, sub.sub);
     }
     return fmt::format_to(it, "{}", sub);
+}
+
+void validate_context_subject(
+  const context_subject& ctx_sub, bool is_config_or_mode) {
+    static constexpr std::string_view global_context_name = ".__GLOBAL";
+    static constexpr std::string_view global_subject_name = "__GLOBAL";
+    static constexpr std::string_view empty_subject_name = "__EMPTY";
+
+    if (
+      ctx_sub.sub() == global_subject_name
+      || ctx_sub.sub() == empty_subject_name
+      || (!is_config_or_mode && ctx_sub.ctx() == global_context_name)) {
+        throw as_exception(subject_invalid(ctx_sub.to_string()));
+    }
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -162,6 +162,7 @@ using subject = named_type<ss::sstring, struct subject_tag>;
 /// separation, and so on. By default, schemas are stored under the "." context.
 using context = named_type<ss::sstring, struct context_tag>;
 inline const context default_context{"."};
+inline const context global_context{".__GLOBAL"};
 
 /// Whether qualified subject parsing is enabled. Captured at SR startup.
 using enable_qualified_subjects

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -229,6 +229,13 @@ struct context_subject {
 
 inline const context_subject invalid_subject{default_context, subject{""}};
 
+/// Validate that a context_subject does not use reserved names (__GLOBAL,
+/// __EMPTY). Throws exception with error_code::subject_invalid if invalid.
+/// \param is_config_or_mode If true, allows .__GLOBAL context (used by
+///   config/mode endpoints).
+void validate_context_subject(
+  const context_subject& ctx_sub, bool is_config_or_mode = false);
+
 /// A reference subject that may be qualified or unqualified.
 /// Unqualified references are resolved relative to a parent schema's context.
 struct context_subject_reference {

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -6748,6 +6748,55 @@ class SchemaRegistryContextTest(SchemaRegistryEndpoints):
         result = self.sr_client.delete_subject(subject=base_subject)
         self.assert_equal(result.status_code, requests.codes.ok)
 
+    @cluster(num_nodes=1)
+    def test_reserved_subject_names_rejected(self):
+        """
+        Verify that __GLOBAL and __EMPTY are rejected as subject names,
+        and that .__GLOBAL context is rejected on regular endpoints but
+        allowed on config/mode endpoints.
+        """
+        schema_data = json.dumps({"schema": schema1_def})
+
+        # __GLOBAL as subject name is rejected (register)
+        result = self.sr_client.post_subjects_subject_versions(
+            subject="__GLOBAL", data=schema_data
+        )
+        self.assert_equal(result.status_code, 422)
+        self.assert_equal(result.json()["error_code"], 42208)
+
+        # __EMPTY as subject name is rejected (register)
+        result = self.sr_client.post_subjects_subject_versions(
+            subject="__EMPTY", data=schema_data
+        )
+        self.assert_equal(result.status_code, 422)
+        self.assert_equal(result.json()["error_code"], 42208)
+
+        # __GLOBAL as subject name is rejected (get versions)
+        result = self.sr_client.get_subjects_subject_versions(
+            subject="__GLOBAL"
+        )
+        self.assert_equal(result.status_code, 422)
+        self.assert_equal(result.json()["error_code"], 42208)
+
+        # .__GLOBAL context is rejected on regular endpoints
+        result = self.sr_client.post_subjects_subject_versions(
+            subject=":.__GLOBAL:my-subject", data=schema_data
+        )
+        self.assert_equal(result.status_code, 422)
+        self.assert_equal(result.json()["error_code"], 42208)
+
+        # .__GLOBAL context is allowed on config endpoints
+        result = self.sr_client.get_config_subject(
+            subject=":.__GLOBAL:", fallback=True
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
+        # .__GLOBAL context is allowed on mode endpoints
+        result = self.sr_client.get_mode_subject(
+            subject=":.__GLOBAL:", fallback=True
+        )
+        self.assert_equal(result.status_code, requests.codes.ok)
+
 
 class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
     """


### PR DESCRIPTION
Initial work to add global context support devolved into going into a hole trying to refactor schema registry's sharded_store & store. The intention was to decouple the data access and the fallback/resolution logic from each other, which are currently both handled in the store. I'm attempting to keep the data access store layer simple and lift up the fallback/resolution logic into the sharded_store. Introducing this separation made it easier for me to extend the fallback logic to incorporate the .__GLOBAL context.

I'm also adding extensive testing to enumerate all the different possible scenarios and their expected behaviors, which I gathered by testing against the reference implementation.

This is stacked on top of [29672](https://github.com/redpanda-data/redpanda/pull/29672), so please ignore the first two commits.