### PR TITLE
partition_balancer_test: deflake rack awareness

### DIFF
--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -87,7 +87,7 @@ class PartitionBalancerService(EndToEndTest):
 
         def all_partitions_ready():
             try:
-                partitions = list(rpk.describe_topic(topic.name))
+                partitions = list(rpk.describe_topic(topic.name, timeout=5))
             except RpkException:
                 return False
             return (len(partitions) == num_partitions, partitions)


### PR DESCRIPTION
test_rack_awareness runs rpk commands with a cluster that has stopped nodes.

RPK picks its own endpoint for commands, and therefore can pick the stopped node.

Though the test specifies retry for 120s with 1s backoff, the rpk command will execute against the stopped node for 30s before failing. Given this, the test retries 4 times worst case scenario. This means the test may pick the stopped node 4 times in a row approximately (1/6)^4 of test runs.

This pr changes the timeout to be 5 instead of 30s, s.t. RPK will have a substantial number of retries in which it can pick a non-dead node.

This should take us from (1/6)^4 aka ~.1% failure rate to (1/6)^24 (order of 1e-17 %) on this particular issue, at which point we are more likely for the test to fail for unrelated and genuinely anomalous reasons.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
