### PR TITLE
kafka/fetch: populate_fetch_deadline

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -1075,6 +1075,7 @@ private:
                       .bytes_left = octx.bytes_left,
                       .min_bytes = min_fetch_bytes,
                       .deadline = octx.deadline,
+                      .fetch_deadline = octx.fetch_deadline,
                       .requests = std::move(configs),
                       .srv = octx.rctx.server().local(),
                       .mgr = mgr,


### PR DESCRIPTION
## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x

## Release Notes

### Bug Fixes

* Fixes an issue where kafka clients that don't set a max_wait_ms (such as the schema registry client) would timeout immediately and not return any data.

