### PR TITLE
pandaproxy/sr: add global_context compatibility fallback

### DIFF
--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -170,6 +170,14 @@ has_references(const context_subject& sub, schema_version ver) {
 error_info no_reference_found_for(
   const subject_schema& schema, const context_subject& sub, schema_version ver);
 
+inline error_info compatibility_not_found(const context& ctx) {
+    return error_info{
+      error_code::compatibility_not_found,
+      fmt::format(
+        "Context '{}' does not have context-level compatibility configured",
+        ctx)};
+}
+
 inline error_info compatibility_not_found(const context_subject& sub) {
     return error_info{
       error_code::compatibility_not_found,

--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -186,6 +186,13 @@ inline error_info compatibility_not_found(const context_subject& sub) {
         sub)};
 }
 
+inline error_info mode_not_found(const context& ctx) {
+    return error_info{
+      error_code::mode_not_found,
+      fmt::format(
+        "Context '{}' does not have context-level mode configured", ctx)};
+}
+
 inline error_info mode_not_found(const context_subject& sub) {
     return error_info{
       error_code::mode_not_found,

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -492,11 +492,15 @@ ss::future<server::reply_t> delete_config_subject(
 
 ss::future<server::reply_t> get_mode(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
+    auto fallback = parse::query_param<std::optional<default_to_global>>(
+                      *rq.req, "defaultToGlobal")
+                      .value_or(default_to_global::no);
 
     // Ensure we see latest writes
     co_await rq.service().writer().read_sync();
 
-    auto res = co_await rq.service().schema_store().get_mode(default_context);
+    auto res = co_await rq.service().schema_store().get_mode(
+      default_context, fallback);
 
     auto resp = ppj::rjson_serialize_iobuf(mode_req_rep{.mode = res});
     log_response(*rq.req, resp);
@@ -545,7 +549,8 @@ ss::future<server::reply_t> get_mode_subject(
 
     mode res;
     if (ctx_sub.is_context_only()) {
-        res = co_await rq.service().schema_store().get_mode(ctx_sub.ctx);
+        res = co_await rq.service().schema_store().get_mode(
+          ctx_sub.ctx, fallback);
     } else {
         res = co_await rq.service().schema_store().get_mode(ctx_sub, fallback);
     }
@@ -608,7 +613,8 @@ ss::future<server::reply_t> delete_mode_subject(
     mode m{};
     try {
         if (ctx_sub.is_context_only()) {
-            m = co_await rq.service().schema_store().get_mode(ctx_sub.ctx);
+            m = co_await rq.service().schema_store().get_mode(
+              ctx_sub.ctx, default_to_global::no);
         } else {
             m = co_await rq.service().schema_store().get_mode(
               ctx_sub, default_to_global::no);

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -313,12 +313,15 @@ ss::future<schema_resolution_result> resolve_schema_id(
 ss::future<server::reply_t>
 get_config(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
+    auto fallback = parse::query_param<std::optional<default_to_global>>(
+                      *rq.req, "defaultToGlobal")
+                      .value_or(default_to_global::no);
 
     // Ensure we see latest writes
     co_await rq.service().writer().read_sync();
 
     auto res = co_await rq.service().schema_store().get_compatibility(
-      default_context);
+      default_context, fallback);
 
     auto resp = ppj::rjson_serialize_iobuf(get_config_req_rep{.compat = res});
     log_response(*rq.req, resp);
@@ -365,7 +368,7 @@ ss::future<server::reply_t> get_config_subject(
     compatibility_level res;
     if (ctx_sub.is_context_only()) {
         res = co_await rq.service().schema_store().get_compatibility(
-          ctx_sub.ctx);
+          ctx_sub.ctx, fallback);
     } else {
         res = co_await rq.service().schema_store().get_compatibility(
           ctx_sub, fallback);
@@ -463,7 +466,7 @@ ss::future<server::reply_t> delete_config_subject(
     try {
         if (ctx_sub.is_context_only()) {
             lvl = co_await rq.service().schema_store().get_compatibility(
-              ctx_sub.ctx);
+              ctx_sub.ctx, default_to_global::no);
         } else {
             lvl = co_await rq.service().schema_store().get_compatibility(
               ctx_sub, default_to_global::no);

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -322,7 +322,8 @@ ss::future<std::optional<bool>> seq_writer::do_write_config(
             existing = co_await _store.get_compatibility(
               sub, default_to_global::no);
         } else {
-            existing = co_await _store.get_compatibility(sub.ctx);
+            existing = co_await _store.get_compatibility(
+              sub.ctx, default_to_global::no);
         }
         if (existing == compat) {
             co_return false;

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -127,7 +127,7 @@ ss::future<> seq_writer::check_mutable(
   const context& ctx, const std::optional<subject>& sub) {
     auto mode = sub ? co_await _store.get_mode(
                         {ctx, *sub}, default_to_global::yes)
-                    : co_await _store.get_mode(ctx);
+                    : co_await _store.get_mode(ctx, default_to_global::yes);
     if (mode == mode::read_only) {
         throw as_exception(mode_is_readonly(ctx, sub));
     }
@@ -408,10 +408,10 @@ ss::future<std::optional<bool>> seq_writer::do_write_mode(
 
     try {
         // Check for no-op case
-        mode existing = !ctx_sub.is_context_only()
-                          ? co_await _store.get_mode(
-                              ctx_sub, default_to_global::no)
-                          : co_await _store.get_mode(ctx_sub.ctx);
+        mode existing
+          = !ctx_sub.is_context_only()
+              ? co_await _store.get_mode(ctx_sub, default_to_global::no)
+              : co_await _store.get_mode(ctx_sub.ctx, default_to_global::no);
         if (existing == m) {
             co_return false;
         }

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -609,8 +609,9 @@ ss::future<bool> sharded_store::delete_subject_version(
     co_return result;
 }
 
-ss::future<mode> sharded_store::get_mode(context ctx) {
-    co_return _store.local().get_mode(ctx).value();
+ss::future<mode>
+sharded_store::get_mode(context ctx, default_to_global fallback) {
+    co_return _store.local().get_mode(ctx, fallback).value();
 }
 
 ss::future<mode>

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -662,8 +662,9 @@ sharded_store::get_context_mode_written_at(context ctx) {
     co_return _store.local().get_context_mode_written_at(ctx).value();
 }
 
-ss::future<compatibility_level> sharded_store::get_compatibility(context ctx) {
-    co_return _store.local().get_compatibility(ctx).value();
+ss::future<compatibility_level>
+sharded_store::get_compatibility(context ctx, default_to_global fallback) {
+    co_return _store.local().get_compatibility(ctx, fallback).value();
 }
 
 ss::future<compatibility_level> sharded_store::get_compatibility(

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -179,12 +179,14 @@ public:
     ss::future<chunked_vector<seq_marker>>
     get_context_mode_written_at(context ctx);
 
-    ///\brief Get the compatibility level of a context.
-    ss::future<compatibility_level> get_compatibility(context ctx);
+    ///\brief Get the compatibility level for a context, or fallback to global.
+    ss::future<compatibility_level>
+    get_compatibility(context ctx, default_to_global fallback);
 
     ///\brief Get the compatibility level for a subject, or fallback to global.
     ss::future<compatibility_level>
     get_compatibility(context_subject sub, default_to_global fallback);
+
     ///\brief Set the compatibility level of a context.
     ss::future<bool> set_compatibility(
       seq_marker marker, context ctx, compatibility_level compatibility);

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -152,7 +152,7 @@ public:
     ss::future<bool> delete_subject_version(
       context_subject sub, schema_version version, force f = force::no);
     ///\brief Get the mode of a context.
-    ss::future<mode> get_mode(context ctx);
+    ss::future<mode> get_mode(context ctx, default_to_global fallback);
 
     ///\brief Get the mode for a subject, or fallback to global.
     ss::future<mode> get_mode(context_subject sub, default_to_global fallback);

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -677,15 +677,23 @@ public:
 
     ///\brief Get the compatibility level of a context.
     result<compatibility_level>
-    get_compatibility(const context& ctx, default_to_global) const {
-        // TODO: Implement proper fallback behavior for context
-        auto it = _context_stores.find(ctx);
-        if (
-          it == _context_stores.end()
-          || !it->second._compatibility.has_value()) {
-            return compatibility_level::backward;
+    get_compatibility(const context& ctx, default_to_global fallback) const {
+        // Check context's own config
+        if (auto it = _context_stores.find(ctx);
+            it != _context_stores.end()
+            && it->second._compatibility.has_value()) {
+            return it->second._compatibility.value();
         }
-        return *it->second._compatibility;
+
+        // Default contexts always return a value, never
+        // an error. Other contexts enter this block only when
+        // fallback is enabled; otherwise they reach the
+        // error return below.
+        if (fallback || ctx == default_context) {
+            return default_top_level_compat;
+        }
+
+        return compatibility_not_found(ctx);
     }
 
     ///\brief Get the compatibility level for a subject, or fallback to global.

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -699,17 +699,21 @@ public:
     ///\brief Get the compatibility level for a subject, or fallback to global.
     result<compatibility_level> get_compatibility(
       const context_subject& sub, default_to_global fallback) const {
+        // Check subject's own config (if the subject exists)
         auto sub_it_res = get_subject_iter(sub, include_deleted::no);
-        if (sub_it_res.has_error()) {
-            return compatibility_not_found(sub);
+        if (sub_it_res.has_value()) {
+            auto sub_it = std::move(sub_it_res).assume_value();
+            auto compat = sub_it->second.compatibility;
+            if (compat) {
+                return compat.value();
+            }
         }
-        auto sub_it = std::move(sub_it_res).assume_value();
-        auto compat = sub_it->second.compatibility;
-        if (compat) {
-            return compat.value();
-        } else if (fallback) {
+
+        // Fall through to context-level compatibility if fallback is enabled.
+        if (fallback) {
             return get_compatibility(sub.ctx, fallback);
         }
+
         return compatibility_not_found(sub);
     }
 

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -685,11 +685,20 @@ public:
             return it->second._compatibility.value();
         }
 
-        // Default contexts always return a value, never
+        // Default and global contexts always return a value, never
         // an error. Other contexts enter this block only when
         // fallback is enabled; otherwise they reach the
-        // error return below.
-        if (fallback || ctx == default_context) {
+        // error return below. Within this block, non-global contexts
+        // consult global_context first, and if that has no value,
+        // return the hard-coded default.
+        if (fallback || ctx == default_context || ctx == global_context) {
+            if (fallback && ctx != global_context) {
+                if (auto global_it = _context_stores.find(global_context);
+                    global_it != _context_stores.end()
+                    && global_it->second._compatibility.has_value()) {
+                    return *global_it->second._compatibility;
+                }
+            }
             return default_top_level_compat;
         }
 
@@ -709,8 +718,10 @@ public:
             }
         }
 
-        // Fall through to context-level compatibility if fallback is enabled.
-        if (fallback) {
+        // Fall through to context-level compatibility.
+        // global_context subjects always fall through; other contexts only fall
+        // through when fallback is set.
+        if (sub.ctx == global_context || fallback) {
             return get_compatibility(sub.ctx, fallback);
         }
 

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -605,12 +605,23 @@ public:
     }
 
     ///\brief Get the mode of a context.
-    result<mode> get_mode(const context& ctx, default_to_global) const {
-        auto it = _context_stores.find(ctx);
-        if (it == _context_stores.end() || !it->second._mode.has_value()) {
-            return mode::read_write;
+    result<mode>
+    get_mode(const context& ctx, default_to_global fallback) const {
+        // Check context's own mode
+        if (auto it = _context_stores.find(ctx);
+            it != _context_stores.end() && it->second._mode.has_value()) {
+            return it->second._mode.value();
         }
-        return *it->second._mode;
+
+        // Default contexts always return a value, never
+        // an error. Other contexts enter this block only when
+        // fallback is enabled; otherwise they reach the
+        // error return below.
+        if (fallback || ctx == default_context) {
+            return default_top_level_mode;
+        }
+
+        return mode_not_found(ctx);
     }
 
     ///\brief Get the mode for a subject, or fallback to global.

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -605,7 +605,7 @@ public:
     }
 
     ///\brief Get the mode of a context.
-    result<mode> get_mode(const context& ctx) const {
+    result<mode> get_mode(const context& ctx, default_to_global) const {
         auto it = _context_stores.find(ctx);
         if (it == _context_stores.end() || !it->second._mode.has_value()) {
             return mode::read_write;
@@ -620,7 +620,7 @@ public:
         if (sub_it && (sub_it.assume_value())->second.mode.has_value()) {
             return (sub_it.assume_value())->second.mode.value();
         } else if (fallback) {
-            return get_mode(sub.ctx);
+            return get_mode(sub.ctx, fallback);
         }
         return mode_not_found(sub);
     }

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -676,7 +676,9 @@ public:
     }
 
     ///\brief Get the compatibility level of a context.
-    result<compatibility_level> get_compatibility(const context& ctx) const {
+    result<compatibility_level>
+    get_compatibility(const context& ctx, default_to_global) const {
+        // TODO: Implement proper fallback behavior for context
         auto it = _context_stores.find(ctx);
         if (
           it == _context_stores.end()
@@ -698,7 +700,7 @@ public:
         if (compat) {
             return compat.value();
         } else if (fallback) {
-            return get_compatibility(sub.ctx);
+            return get_compatibility(sub.ctx, fallback);
         }
         return compatibility_not_found(sub);
     }

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -613,11 +613,20 @@ public:
             return it->second._mode.value();
         }
 
-        // Default contexts always return a value, never
+        // Default and global contexts always return a value, never
         // an error. Other contexts enter this block only when
         // fallback is enabled; otherwise they reach the
-        // error return below.
-        if (fallback || ctx == default_context) {
+        // error return below. Within this block, non-global contexts
+        // consult global_context first, and if that has no value,
+        // return the hard-coded default.
+        if (fallback || ctx == default_context || ctx == global_context) {
+            if (fallback && ctx != global_context) {
+                if (auto global_it = _context_stores.find(global_context);
+                    global_it != _context_stores.end()
+                    && global_it->second._mode.has_value()) {
+                    return *global_it->second._mode;
+                }
+            }
             return default_top_level_mode;
         }
 
@@ -630,7 +639,11 @@ public:
         auto sub_it = get_subject_iter(sub, include_deleted::yes);
         if (sub_it && (sub_it.assume_value())->second.mode.has_value()) {
             return (sub_it.assume_value())->second.mode.value();
-        } else if (fallback) {
+        }
+        // Fall through to context-level mode.
+        // global_context subjects always fall through; other contexts only fall
+        // through when fallback is set.
+        if (sub.ctx == global_context || fallback) {
             return get_mode(sub.ctx, fallback);
         }
         return mode_not_found(sub);

--- a/src/v/pandaproxy/schema_registry/test/compatibility_3rdparty.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_3rdparty.cc
@@ -144,13 +144,17 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store_3rdparty) {
 
     // Test mode default
     BOOST_REQUIRE_EQUAL(
-      c._store.get_mode(pps::default_context).get(), pps::mode::read_write);
+      c._store.get_mode(pps::default_context, pps::default_to_global::yes)
+        .get(),
+      pps::mode::read_write);
 
     // Test mode READONLY
     BOOST_REQUIRE_NO_THROW(
       c(make_record_batch(mode_key_0, mode_value_ro, base_offset++)).get());
     BOOST_REQUIRE_EQUAL(
-      c._store.get_mode(pps::default_context).get(), pps::mode::read_only);
+      c._store.get_mode(pps::default_context, pps::default_to_global::yes)
+        .get(),
+      pps::mode::read_only);
 
     // Test mode no subject, no fallback
     BOOST_REQUIRE_EXCEPTION(
@@ -177,7 +181,9 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store_3rdparty) {
     BOOST_REQUIRE_NO_THROW(
       c(make_record_batch(mode_key_0, mode_value_rw, base_offset++)).get());
     BOOST_REQUIRE_EQUAL(
-      c._store.get_mode(pps::default_context).get(), pps::mode::read_write);
+      c._store.get_mode(pps::default_context, pps::default_to_global::yes)
+        .get(),
+      pps::mode::read_write);
 
     // test mode subject override
     BOOST_REQUIRE_NO_THROW(

--- a/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
@@ -157,7 +157,8 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
     BOOST_REQUIRE_THROW(c(bad_schema_magic.copy()).get(), pps::exception);
 
     BOOST_REQUIRE(
-      s.get_compatibility(pps::default_context).get()
+      s.get_compatibility(pps::default_context, pps::default_to_global::yes)
+        .get()
       == pps::compatibility_level::backward);
     BOOST_REQUIRE(
       s.get_compatibility(subject0, pps::default_to_global::yes).get()

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -23,6 +23,131 @@
 namespace pp = pandaproxy;
 namespace pps = pp::schema_registry;
 
+// default_context, no fallback
+// Resolution: default_context config → hardcoded default
+// (global_context is never consulted with no_fallback)
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_default_context_config_no_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto no_fallback = pps::default_to_global::no;
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_compatibility(pps::default_context, no_fallback).get()
+      == pps::default_top_level_compat);
+
+    auto expected = pps::compatibility_level::full;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, pps::default_context, expected)
+        .get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(pps::default_context, no_fallback).get()
+      == expected);
+
+    BOOST_REQUIRE(store.clear_compatibility(pps::default_context).get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(pps::default_context, no_fallback).get()
+      == pps::default_top_level_compat);
+}
+
+// default_context, fallback enabled
+// Resolution: default_context config → hardcoded default
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_default_context_config_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto fallback = pps::default_to_global::yes;
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_compatibility(pps::default_context, fallback).get()
+      == pps::default_top_level_compat);
+
+    auto expected = pps::compatibility_level::none;
+    BOOST_REQUIRE(
+      store
+        .set_compatibility(
+          dummy_marker, pandaproxy::schema_registry::default_context, expected)
+        .get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(pps::default_context, fallback).get()
+      == expected);
+
+    BOOST_REQUIRE(store.clear_compatibility(pps::default_context).get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(pps::default_context, fallback).get()
+      == pps::default_top_level_compat);
+}
+
+// non-default context, no fallback
+// Resolution: context config → error (no hardcoded default for non-default
+// contexts)
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_nondefault_context_config_no_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto no_fallback = pps::default_to_global::no;
+    auto ctx = pps::context{".ctx"};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE_EXCEPTION(
+      store.get_compatibility(ctx, no_fallback).get(),
+      pps::exception,
+      [](const pps::exception& e) {
+          return e.code() == pps::error_code::compatibility_not_found;
+      });
+
+    auto expected = pps::compatibility_level::full;
+    BOOST_REQUIRE(store.set_compatibility(dummy_marker, ctx, expected).get());
+
+    BOOST_REQUIRE(store.get_compatibility(ctx, no_fallback).get() == expected);
+
+    BOOST_REQUIRE(store.clear_compatibility(ctx).get());
+
+    BOOST_REQUIRE_EXCEPTION(
+      store.get_compatibility(ctx, no_fallback).get(),
+      pps::exception,
+      [](const pps::exception& e) {
+          return e.code() == pps::error_code::compatibility_not_found;
+      });
+}
+
+// non-default context, fallback enabled
+// Resolution: context config → hardcoded default
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_nondefault_context_config_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto fallback = pps::default_to_global::yes;
+    auto ctx = pps::context{".ctx"};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx, fallback).get()
+      == pps::default_top_level_compat);
+
+    auto expected = pps::compatibility_level::forward;
+    BOOST_REQUIRE(store.set_compatibility(dummy_marker, ctx, expected).get());
+    BOOST_REQUIRE(store.get_compatibility(ctx, fallback).get() == expected);
+
+    BOOST_REQUIRE(store.clear_compatibility(ctx).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx, fallback).get()
+      == pps::default_top_level_compat);
+}
+
 SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
     pps::sharded_store store;
     store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -87,6 +87,74 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_default_context_config_fallback) {
       == pps::default_top_level_compat);
 }
 
+// subject in default_context, no fallback
+// Resolution: subject config → error (no context or global fallback)
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_subject_default_context_config_no_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto no_fallback = pps::default_to_global::no;
+    auto ctx_sub = pps::context_subject{
+      pps::default_context, pps::subject{"sub"}};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE_EXCEPTION(
+      store.get_compatibility(ctx_sub, no_fallback).get(),
+      pps::exception,
+      [](const pps::exception& e) {
+          return e.code() == pps::error_code::compatibility_not_found;
+      });
+
+    auto expected = pps::compatibility_level::full;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, ctx_sub, expected).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, no_fallback).get() == expected);
+}
+
+// subject in default_context, fallback enabled
+// Resolution: subject config → default_context config → hardcoded default
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_subject_default_context_config_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto fallback = pps::default_to_global::yes;
+    auto subject = pps::subject{"sub"};
+    auto ctx = pps::default_context;
+    auto ctx_sub = pps::context_subject{ctx, subject};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get()
+      == pps::default_top_level_compat);
+
+    auto expected1 = pps::compatibility_level::forward;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, pps::default_context, expected1)
+        .get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected1);
+
+    auto expected2 = pps::compatibility_level::none;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, ctx_sub, expected2).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected2);
+
+    BOOST_REQUIRE(store.clear_compatibility(dummy_marker, ctx_sub).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected1);
+
+    BOOST_REQUIRE(store.clear_compatibility(pps::default_context).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get()
+      == pps::default_top_level_compat);
+}
+
 // non-default context, no fallback
 // Resolution: context config → error (no hardcoded default for non-default
 // contexts)
@@ -145,6 +213,81 @@ SEASTAR_THREAD_TEST_CASE(
     BOOST_REQUIRE(store.clear_compatibility(ctx).get());
     BOOST_REQUIRE(
       store.get_compatibility(ctx, fallback).get()
+      == pps::default_top_level_compat);
+}
+
+// subject in non-default context, no fallback
+// Resolution: subject config → error (no context or global fallback)
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_subject_nondefault_context_config_no_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto no_fallback = pps::default_to_global::no;
+    auto ctx = pps::context{".ctx"};
+    auto ctx_sub = pps::context_subject{ctx, pps::subject{"sub"}};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE_EXCEPTION(
+      store.get_compatibility(ctx_sub, no_fallback).get(),
+      pps::exception,
+      [](const pps::exception& e) {
+          return e.code() == pps::error_code::compatibility_not_found;
+      });
+
+    auto expected = pps::compatibility_level::full;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, ctx_sub, expected).get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, no_fallback).get() == expected);
+
+    BOOST_REQUIRE(store.clear_compatibility(dummy_marker, ctx_sub).get());
+
+    BOOST_REQUIRE_EXCEPTION(
+      store.get_compatibility(ctx_sub, no_fallback).get(),
+      pps::exception,
+      [](const pps::exception& e) {
+          return e.code() == pps::error_code::compatibility_not_found;
+      });
+}
+
+// subject in non-default context, fallback enabled
+// Resolution: subject config → context config → hardcoded default
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_subject_nondefault_context_config_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto fallback = pps::default_to_global::yes;
+    auto ctx = pps::context{".ctx"};
+    auto ctx_sub = pps::context_subject{ctx, pps::subject{"subject"}};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get()
+      == pps::default_top_level_compat);
+
+    auto expected1 = pps::compatibility_level::forward;
+    BOOST_REQUIRE(store.set_compatibility(dummy_marker, ctx, expected1).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected1);
+
+    auto expected2 = pps::compatibility_level::none;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, ctx_sub, expected2).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected2);
+
+    BOOST_REQUIRE(store.clear_compatibility(dummy_marker, ctx_sub).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected1);
+
+    BOOST_REQUIRE(store.clear_compatibility(ctx).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get()
       == pps::default_top_level_compat);
 }
 

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -56,7 +56,8 @@ SEASTAR_THREAD_TEST_CASE(
 }
 
 // default_context, fallback enabled
-// Resolution: default_context config → hardcoded default
+// Resolution: default_context config → global_context config → hardcoded
+// default
 SEASTAR_THREAD_TEST_CASE(test_sharded_store_default_context_config_fallback) {
     pps::sharded_store store;
     store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
@@ -69,18 +70,35 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_default_context_config_fallback) {
       store.get_compatibility(pps::default_context, fallback).get()
       == pps::default_top_level_compat);
 
-    auto expected = pps::compatibility_level::none;
+    auto expected1 = pps::compatibility_level::full;
     BOOST_REQUIRE(
       store
         .set_compatibility(
-          dummy_marker, pandaproxy::schema_registry::default_context, expected)
+          dummy_marker, pandaproxy::schema_registry::global_context, expected1)
         .get());
 
     BOOST_REQUIRE(
       store.get_compatibility(pps::default_context, fallback).get()
-      == expected);
+      == expected1);
+
+    auto expected2 = pps::compatibility_level::none;
+    BOOST_REQUIRE(
+      store
+        .set_compatibility(
+          dummy_marker, pandaproxy::schema_registry::default_context, expected2)
+        .get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(pps::default_context, fallback).get()
+      == expected2);
 
     BOOST_REQUIRE(store.clear_compatibility(pps::default_context).get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(pps::default_context, fallback).get()
+      == expected1);
+
+    BOOST_REQUIRE(store.clear_compatibility(pps::global_context).get());
 
     BOOST_REQUIRE(
       store.get_compatibility(pps::default_context, fallback).get()
@@ -115,7 +133,8 @@ SEASTAR_THREAD_TEST_CASE(
 }
 
 // subject in default_context, fallback enabled
-// Resolution: subject config → default_context config → hardcoded default
+// Resolution: subject config → default_context config → global_context config →
+// hardcoded default
 SEASTAR_THREAD_TEST_CASE(
   test_sharded_store_subject_default_context_config_fallback) {
     pps::sharded_store store;
@@ -132,24 +151,35 @@ SEASTAR_THREAD_TEST_CASE(
       store.get_compatibility(ctx_sub, fallback).get()
       == pps::default_top_level_compat);
 
-    auto expected1 = pps::compatibility_level::forward;
+    auto expected1 = pps::compatibility_level::full;
     BOOST_REQUIRE(
-      store.set_compatibility(dummy_marker, pps::default_context, expected1)
+      store.set_compatibility(dummy_marker, pps::global_context, expected1)
         .get());
     BOOST_REQUIRE(
       store.get_compatibility(ctx_sub, fallback).get() == expected1);
 
-    auto expected2 = pps::compatibility_level::none;
+    auto expected2 = pps::compatibility_level::forward;
     BOOST_REQUIRE(
-      store.set_compatibility(dummy_marker, ctx_sub, expected2).get());
+      store.set_compatibility(dummy_marker, pps::default_context, expected2)
+        .get());
     BOOST_REQUIRE(
       store.get_compatibility(ctx_sub, fallback).get() == expected2);
 
+    auto expected3 = pps::compatibility_level::none;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, ctx_sub, expected3).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected3);
+
     BOOST_REQUIRE(store.clear_compatibility(dummy_marker, ctx_sub).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected2);
+
+    BOOST_REQUIRE(store.clear_compatibility(pps::default_context).get());
     BOOST_REQUIRE(
       store.get_compatibility(ctx_sub, fallback).get() == expected1);
 
-    BOOST_REQUIRE(store.clear_compatibility(pps::default_context).get());
+    BOOST_REQUIRE(store.clear_compatibility(pps::global_context).get());
     BOOST_REQUIRE(
       store.get_compatibility(ctx_sub, fallback).get()
       == pps::default_top_level_compat);
@@ -191,7 +221,7 @@ SEASTAR_THREAD_TEST_CASE(
 }
 
 // non-default context, fallback enabled
-// Resolution: context config → hardcoded default
+// Resolution: context config → global_context config → hardcoded default
 SEASTAR_THREAD_TEST_CASE(
   test_sharded_store_nondefault_context_config_fallback) {
     pps::sharded_store store;
@@ -206,11 +236,20 @@ SEASTAR_THREAD_TEST_CASE(
       store.get_compatibility(ctx, fallback).get()
       == pps::default_top_level_compat);
 
-    auto expected = pps::compatibility_level::forward;
-    BOOST_REQUIRE(store.set_compatibility(dummy_marker, ctx, expected).get());
-    BOOST_REQUIRE(store.get_compatibility(ctx, fallback).get() == expected);
+    auto expected1 = pps::compatibility_level::full;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, pps::global_context, expected1)
+        .get());
+    BOOST_REQUIRE(store.get_compatibility(ctx, fallback).get() == expected1);
+
+    auto expected2 = pps::compatibility_level::forward;
+    BOOST_REQUIRE(store.set_compatibility(dummy_marker, ctx, expected2).get());
+    BOOST_REQUIRE(store.get_compatibility(ctx, fallback).get() == expected2);
 
     BOOST_REQUIRE(store.clear_compatibility(ctx).get());
+    BOOST_REQUIRE(store.get_compatibility(ctx, fallback).get() == expected1);
+
+    BOOST_REQUIRE(store.clear_compatibility(pps::global_context).get());
     BOOST_REQUIRE(
       store.get_compatibility(ctx, fallback).get()
       == pps::default_top_level_compat);
@@ -254,7 +293,8 @@ SEASTAR_THREAD_TEST_CASE(
 }
 
 // subject in non-default context, fallback enabled
-// Resolution: subject config → context config → hardcoded default
+// Resolution: subject config → context config → global_context config →
+// hardcoded default
 SEASTAR_THREAD_TEST_CASE(
   test_sharded_store_subject_nondefault_context_config_fallback) {
     pps::sharded_store store;
@@ -270,12 +310,152 @@ SEASTAR_THREAD_TEST_CASE(
       store.get_compatibility(ctx_sub, fallback).get()
       == pps::default_top_level_compat);
 
-    auto expected1 = pps::compatibility_level::forward;
-    BOOST_REQUIRE(store.set_compatibility(dummy_marker, ctx, expected1).get());
+    auto expected1 = pps::compatibility_level::full;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, pps::global_context, expected1)
+        .get());
     BOOST_REQUIRE(
       store.get_compatibility(ctx_sub, fallback).get() == expected1);
 
-    auto expected2 = pps::compatibility_level::none;
+    auto expected2 = pps::compatibility_level::forward;
+    BOOST_REQUIRE(store.set_compatibility(dummy_marker, ctx, expected2).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected2);
+
+    auto expected3 = pps::compatibility_level::none;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, ctx_sub, expected3).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected3);
+
+    BOOST_REQUIRE(store.clear_compatibility(dummy_marker, ctx_sub).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected2);
+
+    BOOST_REQUIRE(store.clear_compatibility(ctx).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected1);
+
+    BOOST_REQUIRE(store.clear_compatibility(pps::global_context).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get()
+      == pps::default_top_level_compat);
+}
+
+// global_context, no fallback
+// Resolution: global_context config → hardcoded default
+// (no_fallback is a no-op; global_context is already the top of the chain)
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_global_context_config_no_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto no_fallback = pps::default_to_global::no;
+    auto ctx = pandaproxy::schema_registry::global_context;
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx, no_fallback).get()
+      == pps::default_top_level_compat);
+
+    auto expected = pps::compatibility_level::full;
+    BOOST_REQUIRE(store.set_compatibility(dummy_marker, ctx, expected).get());
+
+    BOOST_REQUIRE(store.get_compatibility(ctx, no_fallback).get() == expected);
+
+    BOOST_REQUIRE(store.clear_compatibility(ctx).get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx, no_fallback).get()
+      == pps::default_top_level_compat);
+}
+
+// global_context, fallback enabled
+// Resolution: global_context config → hardcoded default
+// (fallback flag is a no-op; global_context is already the top of the chain)
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_global_context_config_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto fallback = pps::default_to_global::yes;
+    auto ctx = pps::global_context;
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx, fallback).get()
+      == pps::default_top_level_compat);
+
+    auto expected = pps::compatibility_level::full;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, pps::global_context, expected)
+        .get());
+    BOOST_REQUIRE(store.get_compatibility(ctx, fallback).get() == expected);
+
+    BOOST_REQUIRE(store.clear_compatibility(pps::global_context).get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx, fallback).get()
+      == pps::default_top_level_compat);
+}
+
+// subject in global_context, no fallback
+// Resolution: subject config → hardcoded default
+// (global_context subjects fallback to the hardcoded default even with
+// no_fallback)
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_subject_global_context_no_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto no_fallback = pps::default_to_global::no;
+    auto subject = pps::subject{"sub"};
+    auto ctx = pps::global_context;
+    auto ctx_sub = pps::context_subject{ctx, subject};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, no_fallback).get()
+      == pps::default_top_level_compat);
+
+    auto expected = pps::compatibility_level::full;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, ctx_sub, expected).get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, no_fallback).get() == expected);
+
+    BOOST_REQUIRE(store.clear_compatibility(dummy_marker, ctx_sub).get());
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, no_fallback).get()
+      == pps::default_top_level_compat);
+}
+
+// subject in global_context, fallback enabled
+// Resolution: subject config → global_context config → hardcoded default
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_subject_global_context_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto fallback = pps::default_to_global::yes;
+    auto ctx = pps::global_context;
+    auto ctx_sub = pps::context_subject{ctx, pps::subject{"subject"}};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get()
+      == pps::default_top_level_compat);
+
+    auto expected1 = pps::compatibility_level::full;
+    BOOST_REQUIRE(
+      store.set_compatibility(dummy_marker, pps::global_context, expected1)
+        .get());
+    BOOST_REQUIRE(
+      store.get_compatibility(ctx_sub, fallback).get() == expected1);
+
+    auto expected2 = pps::compatibility_level::forward;
     BOOST_REQUIRE(
       store.set_compatibility(dummy_marker, ctx_sub, expected2).get());
     BOOST_REQUIRE(
@@ -285,7 +465,7 @@ SEASTAR_THREAD_TEST_CASE(
     BOOST_REQUIRE(
       store.get_compatibility(ctx_sub, fallback).get() == expected1);
 
-    BOOST_REQUIRE(store.clear_compatibility(ctx).get());
+    BOOST_REQUIRE(store.clear_compatibility(pps::global_context).get());
     BOOST_REQUIRE(
       store.get_compatibility(ctx_sub, fallback).get()
       == pps::default_top_level_compat);

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -471,6 +471,261 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_subject_global_context_fallback) {
       == pps::default_top_level_compat);
 }
 
+// default_context mode, no fallback
+// Resolution: default_context mode → hardcoded default
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_default_context_mode_no_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto no_fallback = pps::default_to_global::no;
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_mode(pps::default_context, no_fallback).get()
+      == pps::default_top_level_mode);
+
+    auto expected = pps::mode::read_only;
+    BOOST_REQUIRE(
+      store
+        .set_mode(dummy_marker, pps::default_context, expected, pps::force::no)
+        .get());
+
+    BOOST_REQUIRE(
+      store.get_mode(pps::default_context, no_fallback).get() == expected);
+
+    BOOST_REQUIRE(store.clear_mode(pps::default_context, pps::force::no).get());
+
+    BOOST_REQUIRE(
+      store.get_mode(pps::default_context, no_fallback).get()
+      == pps::default_top_level_mode);
+}
+
+// default_context mode, fallback enabled
+// Resolution: default_context mode → hardcoded default
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_default_context_mode_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto fallback = pps::default_to_global::yes;
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_mode(pps::default_context, fallback).get()
+      == pps::default_top_level_mode);
+
+    auto expected = pps::mode::import;
+    BOOST_REQUIRE(
+      store
+        .set_mode(dummy_marker, pps::default_context, expected, pps::force::no)
+        .get());
+
+    BOOST_REQUIRE(
+      store.get_mode(pps::default_context, fallback).get() == expected);
+
+    BOOST_REQUIRE(store.clear_mode(pps::default_context, pps::force::no).get());
+
+    BOOST_REQUIRE(
+      store.get_mode(pps::default_context, fallback).get()
+      == pps::default_top_level_mode);
+}
+
+// non-default context mode, no fallback
+// Resolution: context mode → error
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_nondefault_context_mode_no_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto no_fallback = pps::default_to_global::no;
+    auto ctx = pps::context{".ctx"};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE_EXCEPTION(
+      store.get_mode(ctx, no_fallback).get(),
+      pps::exception,
+      [](const pps::exception& e) {
+          return e.code() == pps::error_code::mode_not_found;
+      });
+
+    auto expected = pps::mode::read_only;
+    BOOST_REQUIRE(
+      store.set_mode(dummy_marker, ctx, expected, pps::force::no).get());
+
+    BOOST_REQUIRE(store.get_mode(ctx, no_fallback).get() == expected);
+
+    BOOST_REQUIRE(store.clear_mode(ctx, pps::force::no).get());
+
+    BOOST_REQUIRE_EXCEPTION(
+      store.get_mode(ctx, no_fallback).get(),
+      pps::exception,
+      [](const pps::exception& e) {
+          return e.code() == pps::error_code::mode_not_found;
+      });
+}
+
+// non-default context mode, fallback enabled
+// Resolution: context mode → hardcoded default
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_nondefault_context_mode_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto fallback = pps::default_to_global::yes;
+    auto ctx = pps::context{".ctx"};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_mode(ctx, fallback).get() == pps::default_top_level_mode);
+
+    auto expected = pps::mode::import;
+    BOOST_REQUIRE(
+      store.set_mode(dummy_marker, ctx, expected, pps::force::no).get());
+    BOOST_REQUIRE(store.get_mode(ctx, fallback).get() == expected);
+
+    BOOST_REQUIRE(store.clear_mode(ctx, pps::force::no).get());
+    BOOST_REQUIRE(
+      store.get_mode(ctx, fallback).get() == pps::default_top_level_mode);
+}
+
+// subject in default_context mode, no fallback
+// Resolution: subject mode → error
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_subject_default_context_mode_no_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto no_fallback = pps::default_to_global::no;
+    auto ctx_sub = pps::context_subject{
+      pps::default_context, pps::subject{"sub"}};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE_EXCEPTION(
+      store.get_mode(ctx_sub, no_fallback).get(),
+      pps::exception,
+      [](const pps::exception& e) {
+          return e.code() == pps::error_code::mode_not_found;
+      });
+
+    auto expected = pps::mode::read_only;
+    BOOST_REQUIRE(
+      store.set_mode(dummy_marker, ctx_sub, expected, pps::force::no).get());
+    BOOST_REQUIRE(store.get_mode(ctx_sub, no_fallback).get() == expected);
+}
+
+// subject in default_context mode, fallback enabled
+// Resolution: subject mode → default_context mode → hardcoded default
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_subject_default_context_mode_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto fallback = pps::default_to_global::yes;
+    auto subject = pps::subject{"sub"};
+    auto ctx = pps::default_context;
+    auto ctx_sub = pps::context_subject{ctx, subject};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_mode(ctx_sub, fallback).get() == pps::default_top_level_mode);
+
+    auto expected1 = pps::mode::read_only;
+    BOOST_REQUIRE(
+      store
+        .set_mode(dummy_marker, pps::default_context, expected1, pps::force::no)
+        .get());
+    BOOST_REQUIRE(store.get_mode(ctx_sub, fallback).get() == expected1);
+
+    auto expected2 = pps::mode::import;
+    BOOST_REQUIRE(
+      store.set_mode(dummy_marker, ctx_sub, expected2, pps::force::no).get());
+    BOOST_REQUIRE(store.get_mode(ctx_sub, fallback).get() == expected2);
+
+    BOOST_REQUIRE(
+      store.clear_mode(dummy_marker, ctx_sub, pps::force::no).get());
+    BOOST_REQUIRE(store.get_mode(ctx_sub, fallback).get() == expected1);
+
+    BOOST_REQUIRE(store.clear_mode(pps::default_context, pps::force::no).get());
+    BOOST_REQUIRE(
+      store.get_mode(ctx_sub, fallback).get() == pps::default_top_level_mode);
+}
+
+// subject in non-default context mode, no fallback
+// Resolution: subject mode → error
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_subject_nondefault_context_mode_no_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto no_fallback = pps::default_to_global::no;
+    auto ctx = pps::context{".ctx"};
+    auto ctx_sub = pps::context_subject{ctx, pps::subject{"sub"}};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE_EXCEPTION(
+      store.get_mode(ctx_sub, no_fallback).get(),
+      pps::exception,
+      [](const pps::exception& e) {
+          return e.code() == pps::error_code::mode_not_found;
+      });
+
+    auto expected = pps::mode::read_only;
+    BOOST_REQUIRE(
+      store.set_mode(dummy_marker, ctx_sub, expected, pps::force::no).get());
+
+    BOOST_REQUIRE(store.get_mode(ctx_sub, no_fallback).get() == expected);
+
+    BOOST_REQUIRE(
+      store.clear_mode(dummy_marker, ctx_sub, pps::force::no).get());
+
+    BOOST_REQUIRE_EXCEPTION(
+      store.get_mode(ctx_sub, no_fallback).get(),
+      pps::exception,
+      [](const pps::exception& e) {
+          return e.code() == pps::error_code::mode_not_found;
+      });
+}
+
+// subject in non-default context mode, fallback enabled
+// Resolution: subject mode → context mode → hardcoded default
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_subject_nondefault_context_mode_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto fallback = pps::default_to_global::yes;
+    auto ctx = pps::context{".ctx"};
+    auto ctx_sub = pps::context_subject{ctx, pps::subject{"subject"}};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_mode(ctx_sub, fallback).get() == pps::default_top_level_mode);
+
+    auto expected1 = pps::mode::read_only;
+    BOOST_REQUIRE(
+      store.set_mode(dummy_marker, ctx, expected1, pps::force::no).get());
+    BOOST_REQUIRE(store.get_mode(ctx_sub, fallback).get() == expected1);
+
+    auto expected2 = pps::mode::import;
+    BOOST_REQUIRE(
+      store.set_mode(dummy_marker, ctx_sub, expected2, pps::force::no).get());
+    BOOST_REQUIRE(store.get_mode(ctx_sub, fallback).get() == expected2);
+
+    BOOST_REQUIRE(
+      store.clear_mode(dummy_marker, ctx_sub, pps::force::no).get());
+    BOOST_REQUIRE(store.get_mode(ctx_sub, fallback).get() == expected1);
+
+    BOOST_REQUIRE(store.clear_mode(ctx, pps::force::no).get());
+    BOOST_REQUIRE(
+      store.get_mode(ctx_sub, fallback).get() == pps::default_top_level_mode);
+}
+
 SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
     pps::sharded_store store;
     store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -502,7 +502,8 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_default_context_mode_no_fallback) {
 }
 
 // default_context mode, fallback enabled
-// Resolution: default_context mode → hardcoded default
+// Resolution: default_context mode → global_context mode → hardcoded
+// default
 SEASTAR_THREAD_TEST_CASE(test_sharded_store_default_context_mode_fallback) {
     pps::sharded_store store;
     store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
@@ -515,16 +516,30 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_default_context_mode_fallback) {
       store.get_mode(pps::default_context, fallback).get()
       == pps::default_top_level_mode);
 
-    auto expected = pps::mode::import;
+    auto expected1 = pps::mode::read_only;
     BOOST_REQUIRE(
       store
-        .set_mode(dummy_marker, pps::default_context, expected, pps::force::no)
+        .set_mode(dummy_marker, pps::global_context, expected1, pps::force::no)
         .get());
 
     BOOST_REQUIRE(
-      store.get_mode(pps::default_context, fallback).get() == expected);
+      store.get_mode(pps::default_context, fallback).get() == expected1);
+
+    auto expected2 = pps::mode::import;
+    BOOST_REQUIRE(
+      store
+        .set_mode(dummy_marker, pps::default_context, expected2, pps::force::no)
+        .get());
+
+    BOOST_REQUIRE(
+      store.get_mode(pps::default_context, fallback).get() == expected2);
 
     BOOST_REQUIRE(store.clear_mode(pps::default_context, pps::force::no).get());
+
+    BOOST_REQUIRE(
+      store.get_mode(pps::default_context, fallback).get() == expected1);
+
+    BOOST_REQUIRE(store.clear_mode(pps::global_context, pps::force::no).get());
 
     BOOST_REQUIRE(
       store.get_mode(pps::default_context, fallback).get()
@@ -567,7 +582,7 @@ SEASTAR_THREAD_TEST_CASE(
 }
 
 // non-default context mode, fallback enabled
-// Resolution: context mode → hardcoded default
+// Resolution: context mode → global_context mode → hardcoded default
 SEASTAR_THREAD_TEST_CASE(test_sharded_store_nondefault_context_mode_fallback) {
     pps::sharded_store store;
     store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
@@ -580,12 +595,22 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_nondefault_context_mode_fallback) {
     BOOST_REQUIRE(
       store.get_mode(ctx, fallback).get() == pps::default_top_level_mode);
 
-    auto expected = pps::mode::import;
+    auto expected1 = pps::mode::read_only;
     BOOST_REQUIRE(
-      store.set_mode(dummy_marker, ctx, expected, pps::force::no).get());
-    BOOST_REQUIRE(store.get_mode(ctx, fallback).get() == expected);
+      store
+        .set_mode(dummy_marker, pps::global_context, expected1, pps::force::no)
+        .get());
+    BOOST_REQUIRE(store.get_mode(ctx, fallback).get() == expected1);
+
+    auto expected2 = pps::mode::import;
+    BOOST_REQUIRE(
+      store.set_mode(dummy_marker, ctx, expected2, pps::force::no).get());
+    BOOST_REQUIRE(store.get_mode(ctx, fallback).get() == expected2);
 
     BOOST_REQUIRE(store.clear_mode(ctx, pps::force::no).get());
+    BOOST_REQUIRE(store.get_mode(ctx, fallback).get() == expected1);
+
+    BOOST_REQUIRE(store.clear_mode(pps::global_context, pps::force::no).get());
     BOOST_REQUIRE(
       store.get_mode(ctx, fallback).get() == pps::default_top_level_mode);
 }
@@ -617,7 +642,8 @@ SEASTAR_THREAD_TEST_CASE(
 }
 
 // subject in default_context mode, fallback enabled
-// Resolution: subject mode → default_context mode → hardcoded default
+// Resolution: subject mode → default_context mode → global_context mode →
+// hardcoded default
 SEASTAR_THREAD_TEST_CASE(
   test_sharded_store_subject_default_context_mode_fallback) {
     pps::sharded_store store;
@@ -636,20 +662,30 @@ SEASTAR_THREAD_TEST_CASE(
     auto expected1 = pps::mode::read_only;
     BOOST_REQUIRE(
       store
-        .set_mode(dummy_marker, pps::default_context, expected1, pps::force::no)
+        .set_mode(dummy_marker, pps::global_context, expected1, pps::force::no)
         .get());
     BOOST_REQUIRE(store.get_mode(ctx_sub, fallback).get() == expected1);
 
     auto expected2 = pps::mode::import;
     BOOST_REQUIRE(
-      store.set_mode(dummy_marker, ctx_sub, expected2, pps::force::no).get());
+      store
+        .set_mode(dummy_marker, pps::default_context, expected2, pps::force::no)
+        .get());
     BOOST_REQUIRE(store.get_mode(ctx_sub, fallback).get() == expected2);
+
+    auto expected3 = pps::mode::read_write;
+    BOOST_REQUIRE(
+      store.set_mode(dummy_marker, ctx_sub, expected3, pps::force::no).get());
+    BOOST_REQUIRE(store.get_mode(ctx_sub, fallback).get() == expected3);
 
     BOOST_REQUIRE(
       store.clear_mode(dummy_marker, ctx_sub, pps::force::no).get());
-    BOOST_REQUIRE(store.get_mode(ctx_sub, fallback).get() == expected1);
+    BOOST_REQUIRE(store.get_mode(ctx_sub, fallback).get() == expected2);
 
     BOOST_REQUIRE(store.clear_mode(pps::default_context, pps::force::no).get());
+    BOOST_REQUIRE(store.get_mode(ctx_sub, fallback).get() == expected1);
+
+    BOOST_REQUIRE(store.clear_mode(pps::global_context, pps::force::no).get());
     BOOST_REQUIRE(
       store.get_mode(ctx_sub, fallback).get() == pps::default_top_level_mode);
 }
@@ -692,7 +728,8 @@ SEASTAR_THREAD_TEST_CASE(
 }
 
 // subject in non-default context mode, fallback enabled
-// Resolution: subject mode → context mode → hardcoded default
+// Resolution: subject mode → context mode → global_context mode →
+// hardcoded default
 SEASTAR_THREAD_TEST_CASE(
   test_sharded_store_subject_nondefault_context_mode_fallback) {
     pps::sharded_store store;
@@ -709,7 +746,150 @@ SEASTAR_THREAD_TEST_CASE(
 
     auto expected1 = pps::mode::read_only;
     BOOST_REQUIRE(
+      store
+        .set_mode(dummy_marker, pps::global_context, expected1, pps::force::no)
+        .get());
+    BOOST_REQUIRE(store.get_mode(ctx_sub, fallback).get() == expected1);
+
+    auto expected2 = pps::mode::import;
+    BOOST_REQUIRE(
+      store.set_mode(dummy_marker, ctx, expected2, pps::force::no).get());
+    BOOST_REQUIRE(store.get_mode(ctx_sub, fallback).get() == expected2);
+
+    auto expected3 = pps::mode::read_write;
+    BOOST_REQUIRE(
+      store.set_mode(dummy_marker, ctx_sub, expected3, pps::force::no).get());
+    BOOST_REQUIRE(store.get_mode(ctx_sub, fallback).get() == expected3);
+
+    BOOST_REQUIRE(
+      store.clear_mode(dummy_marker, ctx_sub, pps::force::no).get());
+    BOOST_REQUIRE(store.get_mode(ctx_sub, fallback).get() == expected2);
+
+    BOOST_REQUIRE(store.clear_mode(ctx, pps::force::no).get());
+    BOOST_REQUIRE(store.get_mode(ctx_sub, fallback).get() == expected1);
+
+    BOOST_REQUIRE(store.clear_mode(pps::global_context, pps::force::no).get());
+    BOOST_REQUIRE(
+      store.get_mode(ctx_sub, fallback).get() == pps::default_top_level_mode);
+}
+
+// global_context mode, no fallback
+// Resolution: global_context mode → hardcoded default
+// (no_fallback is a no-op; global_context is already the top of the chain)
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_global_context_mode_no_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto no_fallback = pps::default_to_global::no;
+    auto ctx = pps::global_context;
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_mode(ctx, no_fallback).get() == pps::default_top_level_mode);
+
+    auto expected = pps::mode::read_only;
+    BOOST_REQUIRE(
+      store.set_mode(dummy_marker, ctx, expected, pps::force::no).get());
+
+    BOOST_REQUIRE(store.get_mode(ctx, no_fallback).get() == expected);
+
+    BOOST_REQUIRE(store.clear_mode(ctx, pps::force::no).get());
+
+    BOOST_REQUIRE(
+      store.get_mode(ctx, no_fallback).get() == pps::default_top_level_mode);
+}
+
+// global_context mode, fallback enabled
+// Resolution: global_context mode → hardcoded default
+// (fallback flag is a no-op; global_context is already the top of the chain)
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_global_context_mode_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto fallback = pps::default_to_global::yes;
+    auto ctx = pps::global_context;
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_mode(ctx, fallback).get() == pps::default_top_level_mode);
+
+    auto expected = pps::mode::read_only;
+    BOOST_REQUIRE(
+      store
+        .set_mode(dummy_marker, pps::global_context, expected, pps::force::no)
+        .get());
+    BOOST_REQUIRE(store.get_mode(ctx, fallback).get() == expected);
+
+    BOOST_REQUIRE(store.clear_mode(pps::global_context, pps::force::no).get());
+    BOOST_REQUIRE(
+      store.get_mode(ctx, fallback).get() == pps::default_top_level_mode);
+}
+
+// subject in global_context mode, no fallback
+// Resolution: subject mode → global_context mode → hardcoded default
+// (global_context subjects always fall through regardless of fallback flag)
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_subject_global_context_mode_no_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto no_fallback = pps::default_to_global::no;
+    auto subject = pps::subject{"sub"};
+    auto ctx = pps::global_context;
+    auto ctx_sub = pps::context_subject{ctx, subject};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_mode(ctx_sub, no_fallback).get()
+      == pps::default_top_level_mode);
+
+    auto expected1 = pps::mode::import;
+    BOOST_REQUIRE(
       store.set_mode(dummy_marker, ctx, expected1, pps::force::no).get());
+    BOOST_REQUIRE(store.get_mode(ctx_sub, no_fallback).get() == expected1);
+
+    auto expected2 = pps::mode::read_only;
+    BOOST_REQUIRE(
+      store.set_mode(dummy_marker, ctx_sub, expected2, pps::force::no).get());
+
+    BOOST_REQUIRE(store.get_mode(ctx_sub, no_fallback).get() == expected2);
+
+    BOOST_REQUIRE(
+      store.clear_mode(dummy_marker, ctx_sub, pps::force::no).get());
+
+    BOOST_REQUIRE(store.get_mode(ctx_sub, no_fallback).get() == expected1);
+
+    BOOST_REQUIRE(store.clear_mode(ctx, pps::force::no).get());
+
+    BOOST_REQUIRE(
+      store.get_mode(ctx_sub, no_fallback).get()
+      == pps::default_top_level_mode);
+}
+
+// subject in global_context mode, fallback enabled
+// Resolution: subject mode → global_context mode → hardcoded default
+SEASTAR_THREAD_TEST_CASE(
+  test_sharded_store_subject_global_context_mode_fallback) {
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    auto fallback = pps::default_to_global::yes;
+    auto ctx = pps::global_context;
+    auto ctx_sub = pps::context_subject{ctx, pps::subject{"subject"}};
+    pps::seq_marker dummy_marker;
+
+    BOOST_REQUIRE(
+      store.get_mode(ctx_sub, fallback).get() == pps::default_top_level_mode);
+
+    auto expected1 = pps::mode::read_only;
+    BOOST_REQUIRE(
+      store
+        .set_mode(dummy_marker, pps::global_context, expected1, pps::force::no)
+        .get());
     BOOST_REQUIRE(store.get_mode(ctx_sub, fallback).get() == expected1);
 
     auto expected2 = pps::mode::import;
@@ -721,7 +901,7 @@ SEASTAR_THREAD_TEST_CASE(
       store.clear_mode(dummy_marker, ctx_sub, pps::force::no).get());
     BOOST_REQUIRE(store.get_mode(ctx_sub, fallback).get() == expected1);
 
-    BOOST_REQUIRE(store.clear_mode(ctx, pps::force::no).get());
+    BOOST_REQUIRE(store.clear_mode(pps::global_context, pps::force::no).get());
     BOOST_REQUIRE(
       store.get_mode(ctx_sub, fallback).get() == pps::default_top_level_mode);
 }

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -723,7 +723,7 @@ BOOST_AUTO_TEST_CASE(test_store_subject_compat_fallback) {
 BOOST_AUTO_TEST_CASE(test_store_invalid_subject_compat) {
     // Setting and getting a compatibility for a non-existant subject should
     // fail
-    auto fallback = pps::default_to_global::yes;
+    auto fallback = pps::default_to_global::no;
 
     pps::seq_marker dummy_marker;
     pps::compatibility_level expected{pps::compatibility_level::backward};

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -1031,11 +1031,14 @@ BOOST_AUTO_TEST_CASE(test_store_context_mode) {
     auto test_ctx = pps::context{".test"};
     pps::seq_marker dummy_marker;
     auto s = pps::store{pps::is_mutable::yes};
+    auto fallback = pps::default_to_global::yes;
 
     // Default mode is read_write
     BOOST_REQUIRE(
-      s.get_mode(pps::default_context).value() == pps::mode::read_write);
-    BOOST_REQUIRE(s.get_mode(test_ctx).value() == pps::mode::read_write);
+      s.get_mode(pps::default_context, fallback).value()
+      == pps::mode::read_write);
+    BOOST_REQUIRE(
+      s.get_mode(test_ctx, fallback).value() == pps::mode::read_write);
 
     // Set mode on default context
     BOOST_REQUIRE(s.set_mode(
@@ -1045,20 +1048,24 @@ BOOST_AUTO_TEST_CASE(test_store_context_mode) {
                      pps::force::no)
                     .value());
     BOOST_REQUIRE(
-      s.get_mode(pps::default_context).value() == pps::mode::read_only);
-    BOOST_REQUIRE(s.get_mode(test_ctx).value() == pps::mode::read_write);
+      s.get_mode(pps::default_context, fallback).value()
+      == pps::mode::read_only);
+    BOOST_REQUIRE(
+      s.get_mode(test_ctx, fallback).value() == pps::mode::read_write);
 
     // Set different mode on test context
     BOOST_REQUIRE(
       s.set_mode(dummy_marker, test_ctx, pps::mode::import, pps::force::no)
         .value());
     BOOST_REQUIRE(
-      s.get_mode(pps::default_context).value() == pps::mode::read_only);
-    BOOST_REQUIRE(s.get_mode(test_ctx).value() == pps::mode::import);
+      s.get_mode(pps::default_context, fallback).value()
+      == pps::mode::read_only);
+    BOOST_REQUIRE(s.get_mode(test_ctx, fallback).value() == pps::mode::import);
 
     // Clear mode returns to default
     BOOST_REQUIRE(s.clear_mode(test_ctx, pps::force::no).value());
-    BOOST_REQUIRE(s.get_mode(test_ctx).value() == pps::mode::read_write);
+    BOOST_REQUIRE(
+      s.get_mode(test_ctx, fallback).value() == pps::mode::read_write);
 }
 
 BOOST_AUTO_TEST_CASE(test_store_context_mode_written_at) {

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -635,19 +635,25 @@ BOOST_AUTO_TEST_CASE(test_store_global_compat) {
     pps::compatibility_level expected{pps::compatibility_level::backward};
     pps::store s;
     BOOST_REQUIRE(
-      s.get_compatibility(pps::default_context).value() == expected);
+      s.get_compatibility(pps::default_context, pps::default_to_global::yes)
+        .value()
+      == expected);
 
     // duplicate should return false
     BOOST_REQUIRE(s.clear_compatibility(pps::default_context).value() == false);
     BOOST_REQUIRE(
-      s.get_compatibility(pps::default_context).value() == expected);
+      s.get_compatibility(pps::default_context, pps::default_to_global::yes)
+        .value()
+      == expected);
 
     expected = pps::compatibility_level::full_transitive;
     BOOST_REQUIRE(
       s.set_compatibility(dummy_marker, pps::default_context, expected).value()
       == true);
     BOOST_REQUIRE(
-      s.get_compatibility(pps::default_context).value() == expected);
+      s.get_compatibility(pps::default_context, pps::default_to_global::yes)
+        .value()
+      == expected);
 }
 
 BOOST_AUTO_TEST_CASE(test_store_subject_compat) {
@@ -661,7 +667,8 @@ BOOST_AUTO_TEST_CASE(test_store_subject_compat) {
       pps::compatibility_level::backward};
     pps::store s;
     BOOST_REQUIRE(
-      s.get_compatibility(pps::default_context).value() == global_expected);
+      s.get_compatibility(pps::default_context, fallback).value()
+      == global_expected);
     s.insert({subject0, string_def0.share()});
 
     auto sub_expected = pps::compatibility_level::backward;
@@ -686,7 +693,8 @@ BOOST_AUTO_TEST_CASE(test_store_subject_compat) {
     BOOST_REQUIRE(
       s.get_compatibility(subject0, fallback).value() == sub_expected);
     BOOST_REQUIRE(
-      s.get_compatibility(pps::default_context).value() == global_expected);
+      s.get_compatibility(pps::default_context, fallback).value()
+      == global_expected);
 
     // Clearing compatibility should fallback to global
     BOOST_REQUIRE(
@@ -1105,13 +1113,14 @@ BOOST_AUTO_TEST_CASE(test_store_context_config) {
     auto test_ctx = pps::context{".test"};
     pps::seq_marker dummy_marker;
     auto s = pps::store{pps::is_mutable::yes};
+    auto fallback = pps::default_to_global::yes;
 
     // Default config is backward compatibility
     BOOST_REQUIRE(
-      s.get_compatibility(pps::default_context).value()
+      s.get_compatibility(pps::default_context, fallback).value()
       == pps::compatibility_level::backward);
     BOOST_REQUIRE(
-      s.get_compatibility(test_ctx).value()
+      s.get_compatibility(test_ctx, fallback).value()
       == pps::compatibility_level::backward);
 
     // Set config on default context
@@ -1120,10 +1129,10 @@ BOOST_AUTO_TEST_CASE(test_store_context_config) {
          dummy_marker, pps::default_context, pps::compatibility_level::full)
         .value());
     BOOST_REQUIRE(
-      s.get_compatibility(pps::default_context).value()
+      s.get_compatibility(pps::default_context, fallback).value()
       == pps::compatibility_level::full);
     BOOST_REQUIRE(
-      s.get_compatibility(test_ctx).value()
+      s.get_compatibility(test_ctx, fallback).value()
       == pps::compatibility_level::backward);
 
     // Set different config on test context
@@ -1131,15 +1140,16 @@ BOOST_AUTO_TEST_CASE(test_store_context_config) {
                      dummy_marker, test_ctx, pps::compatibility_level::none)
                     .value());
     BOOST_REQUIRE(
-      s.get_compatibility(pps::default_context).value()
+      s.get_compatibility(pps::default_context, fallback).value()
       == pps::compatibility_level::full);
     BOOST_REQUIRE(
-      s.get_compatibility(test_ctx).value() == pps::compatibility_level::none);
+      s.get_compatibility(test_ctx, fallback).value()
+      == pps::compatibility_level::none);
 
     // Clear config returns to default
     BOOST_REQUIRE(s.clear_compatibility(test_ctx).value());
     BOOST_REQUIRE(
-      s.get_compatibility(test_ctx).value()
+      s.get_compatibility(test_ctx, fallback).value()
       == pps::compatibility_level::backward);
 }
 

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -163,6 +163,7 @@ using subject = named_type<ss::sstring, struct subject_tag>;
 /// separation, and so on. By default, schemas are stored under the "." context.
 using context = named_type<ss::sstring, struct context_tag>;
 inline const context default_context{"."};
+inline const context global_context{".__GLOBAL"};
 
 /// Whether qualified subject parsing is enabled. Captured at SR startup.
 using enable_qualified_subjects

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -703,6 +703,10 @@ enum class compatibility_level {
     full_transitive,
 };
 
+/// The hard-coded compatibility level returned when no explicit config is set
+/// at any level in the fallback chain.
+inline constexpr auto default_top_level_compat = compatibility_level::backward;
+
 constexpr std::string_view to_string_view(compatibility_level v) {
     switch (v) {
     case compatibility_level::none:

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -708,6 +708,10 @@ enum class compatibility_level {
 /// at any level in the fallback chain.
 inline constexpr auto default_top_level_compat = compatibility_level::backward;
 
+/// The hard-coded mode returned when no explicit mode is set
+/// at any level in the fallback chain.
+inline constexpr auto default_top_level_mode = mode::read_write;
+
 constexpr std::string_view to_string_view(compatibility_level v) {
     switch (v) {
     case compatibility_level::none:

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -3496,7 +3496,7 @@ class AuditLogTestSchemaRegistryACLs(AuditLogTestSchemaRegistryBase):
 
         # Context-level access with only sr_subject ACL should fail
         result = self.sr_client.get_config_subject(
-            subject=context_only, auth=self.user_auth
+            subject=context_only, fallback=True, auth=self.user_auth
         )
         self.assert_equal(result.status_code, 403)
 
@@ -3505,14 +3505,14 @@ class AuditLogTestSchemaRegistryACLs(AuditLogTestSchemaRegistryBase):
 
         # Context-level: audit should show registry resource
         result = self.sr_client.get_config_subject(
-            subject=context_only, auth=self.user_auth
+            subject=context_only, fallback=True, auth=self.user_auth
         )
         self.assert_equal(result.status_code, 200)
 
         records = self.find_matching_record(
             lambda record: self.match_api_record(
                 record,
-                path=f"config/{context_only}",
+                path=f"config/{context_only}?defaultToGlobal=true",
                 resources={"name": "", "type": "registry"},
                 status_id=StatusID.SUCCESS,
                 operation="get_config_subject",


### PR DESCRIPTION
Previously, the schema registry's `GET /config` and `GET /config/{subject}` endpoints did not support the global context (`.__GLOBAL`) fallback tier. When no context-level compatibility config was set, lookups returned the hardcoded default directly, ignoring any config set on the global context. This diverges from the reference implementation's fallback hierarchy, where `.__GLOBAL` sits between per-context config and the hardcoded default.

This PR implements the full multi-tier fallback chain. With the `defaultToGlobal` query parameter enabled:
- default_context:  default → global → hardcoded
- non-default context: context → global → hardcoded
- global_context: global → hardcoded
- subject in default_context: subject → default → global → hardcoded
- subject in non-default: subject → context → global → hardcoded
- subject in global_context: subject → global → hardcoded

With the `defaultToGlobal` query parameter disabled, only the default context and the global context resolve to the hardcoded default; all other lookups return compatibility_not_found.

`GET /config` and `GET /config/{subject}` now consult the global context (`.__GLOBAL`) when `defaultToGlobal=true` and no context-level config is set. Users who have set compatibility on `.__GLOBAL` will see it reflected in lookups from other contexts.

Part of [CORE-15192](https://redpandadata.atlassian.net/browse/CORE-15192).

Additionally, this change also fixes a bug where attempting to retrieve a config for non-existent subjects immediately returned a not found error (regardless of the `defaultToGlobal` parameter), which did not match the reference implementation.

## Backports Required
- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
### Bug Fixes
- Compatibility lookups on non-existent subjects can now fall through to context-level resolution with `defaultToGlobal=true` instead of always returning an error.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-15192]: https://redpandadata.atlassian.net/browse/CORE-15192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ