### PR TITLE
dt/scale: Add cloud topics to many_partitions_test.py

### DIFF
--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -9,6 +9,7 @@
 
 import concurrent.futures
 import math
+import re
 import time
 from collections import Counter
 from typing import Any, Callable
@@ -73,6 +74,11 @@ STRESS_DATA_SIZE = 1024 * 1024 * 1024 * 100
 # counts.
 STOP_TIMEOUT = 60 * 5
 CLOUD_TOPICS_STOP_TIMEOUT = 60 * 10
+
+# TODO: suppress this log in the reconciler
+METASTORE_TRANSPORT_LOG_ALLOW_LIST = [
+    re.compile(r"reconciler - .*std::runtime_error .*metastore::errc::transport_error"),
+]
 
 
 class ManyPartitionsTest(PreallocNodesTest):
@@ -843,7 +849,10 @@ class ManyPartitionsTest(PreallocNodesTest):
             topic_partitions_per_shard=topic_partitions_per_shard,
         )
 
-    @cluster(num_nodes=12, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    @cluster(
+        num_nodes=12,
+        log_allow_list=RESTART_LOG_ALLOW_LIST + METASTORE_TRANSPORT_LOG_ALLOW_LIST,
+    )
     @parametrize(
         mib_per_partition=DEFAULT_MIB_PER_PARTITION,
         topic_partitions_per_shard=DEFAULT_PARTITIONS_PER_SHARD,
@@ -858,7 +867,10 @@ class ManyPartitionsTest(PreallocNodesTest):
             topic_partitions_per_shard=topic_partitions_per_shard,
         )
 
-    @cluster(num_nodes=12, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    @cluster(
+        num_nodes=12,
+        log_allow_list=RESTART_LOG_ALLOW_LIST + METASTORE_TRANSPORT_LOG_ALLOW_LIST,
+    )
     @parametrize(
         mib_per_partition=DEFAULT_MIB_PER_PARTITION,
         topic_partitions_per_shard=DEFAULT_PARTITIONS_PER_SHARD,

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -15,7 +15,7 @@ from collections import Counter
 from typing import Any, Callable
 from ducktape.cluster.cluster import ClusterNode
 import numpy
-from ducktape.mark import parametrize
+from ducktape.mark import ignore, parametrize  # type: ignore[reportUnknownVariableType]
 from ducktape.utils.util import TimeoutError, wait_until
 
 from rptest.clients.rpk import RpkException, RpkTool
@@ -867,6 +867,7 @@ class ManyPartitionsTest(PreallocNodesTest):
             topic_partitions_per_shard=topic_partitions_per_shard,
         )
 
+    @ignore  # TODO: Evaluate parameters and turn this back on
     @cluster(
         num_nodes=12,
         log_allow_list=RESTART_LOG_ALLOW_LIST + METASTORE_TRANSPORT_LOG_ALLOW_LIST,

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -21,14 +21,22 @@ from rptest.clients.rpk import RpkException, RpkTool
 from rptest.services.cluster import cluster
 from rptest.services.kgo_repeater_service import repeater_traffic
 from rptest.services.kgo_verifier_services import (
-    KgoVerifierConsumerGroupConsumer,
+    KgoVerifierMultiConsumerGroupConsumer,
+    KgoVerifierMultiProducer,
+    KgoVerifierMultiRandomConsumer,
+    KgoVerifierParams,
     KgoVerifierProducer,
-    KgoVerifierRandomConsumer,
 )
 from ducktape.tests.test import TestContext
 from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
 from rptest.services.openmessaging_benchmark_configs import OMBSampleConfigurations
-from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, LoggingConfig
+from rptest.clients.types import TopicSpec
+from rptest.services.redpanda import (
+    CLOUD_TOPICS_CONFIG_STR,
+    RESTART_LOG_ALLOW_LIST,
+    LoggingConfig,
+    SISettings,
+)
 from rptest.services.rpk_consumer import RpkConsumer
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.utils.scale_parameters import ScaleParameters
@@ -59,9 +67,12 @@ DEFAULT_PARTITIONS_MEMORY_ALLOCATION_PERCENT = int(
 # of data to write.
 STRESS_DATA_SIZE = 1024 * 1024 * 1024 * 100
 
-# When running with tiered storage, it's been observed that shutdown can take
-# on the order of a few minutes.
+# When running with tiered storage or cloud topics, it's been observed that
+# shutdown can take on the order of a few minutes.  Cloud topics housekeeping
+# (metastore sync, epoch advancement) can further extend this at high partition
+# counts.
 STOP_TIMEOUT = 60 * 5
+CLOUD_TOPICS_STOP_TIMEOUT = 60 * 10
 
 
 class ManyPartitionsTest(PreallocNodesTest):
@@ -144,6 +155,7 @@ class ManyPartitionsTest(PreallocNodesTest):
             **kwargs,
         )
         self.rpk = RpkTool(self.redpanda)
+        self._stop_timeout = STOP_TIMEOUT
 
     def _all_elections_done(self, topic_names: list[str], p_per_topic: int):
         any_incomplete = False
@@ -326,7 +338,7 @@ class ManyPartitionsTest(PreallocNodesTest):
                         self.redpanda.restart_nodes,
                         nodes=[node],
                         start_timeout=self.EXPECT_START_TIME,
-                        stop_timeout=STOP_TIMEOUT,
+                        stop_timeout=self._stop_timeout,
                     )
                 )
 
@@ -347,7 +359,7 @@ class ManyPartitionsTest(PreallocNodesTest):
         self.logger.info(f"Single node restart on node {node.name}")
         node_id = self.redpanda.idx(node)
 
-        self.redpanda.stop_node(node, timeout=STOP_TIMEOUT)
+        self.redpanda.stop_node(node, timeout=self._stop_timeout)
 
         # Wait for leaderships to stabilize on the surviving nodes
         wait_until(
@@ -523,7 +535,6 @@ class ManyPartitionsTest(PreallocNodesTest):
         # Now that we've tested basic ability to form consensus and survive some
         # restarts, move on to a more general stress test.
         self.logger.info("Entering traffic stress test")
-        target_topic: str = topic_names[0]
 
         # Assume fetches will be 10MB, the franz-go default
         fetch_bytes_per_partition = 10 * 1024 * 1024
@@ -567,26 +578,35 @@ class ManyPartitionsTest(PreallocNodesTest):
         )
         expect_transmit_time = max(expect_transmit_time, 30)
 
-        for tn in topic_names:
-            self.logger.info(
-                f"Writing {write_bytes_per_topic} bytes to {tn} with a deadline of {expect_transmit_time}s"
+        params_per_topic = [
+            KgoVerifierParams(
+                topic=tn,
+                msg_size=msg_size,
+                msg_count=msg_count_per_topic,
             )
-            t1 = time.time()
-            producer = KgoVerifierProducer(
-                self.test_context,
-                self.redpanda,
-                tn,
-                msg_size,
-                msg_count_per_topic,
-                custom_node=[self.preallocated_nodes[0]],
-            )
-            producer.start()
-            producer.wait(timeout_sec=expect_transmit_time)
-            self.free_preallocated_nodes()
-            duration = time.time() - t1
-            self.logger.info(
-                f"Wrote {write_bytes_per_topic} bytes to {tn} in {duration}s, bandwidth {(write_bytes_per_topic / duration) / (1024 * 1024)}MB/s"
-            )
+            for tn in topic_names
+        ]
+
+        self.logger.info(
+            f"Writing {write_bytes_per_topic} bytes to each of {len(topic_names)} topics "
+            f"with a deadline of {expect_transmit_time}s"
+        )
+        t1 = time.time()
+        producer = KgoVerifierMultiProducer(
+            self.test_context,
+            self.redpanda,
+            params_per_topic,
+            custom_node=[self.preallocated_nodes[0]],
+        )
+        producer.start()
+        producer.wait(timeout_sec=expect_transmit_time)
+        self.free_preallocated_nodes()
+        duration = time.time() - t1
+        total_bytes = write_bytes_per_topic * len(topic_names)
+        self.logger.info(
+            f"Wrote {total_bytes} bytes across {len(topic_names)} topics in {duration}s, "
+            f"bandwidth {(total_bytes / duration) / (1024 * 1024)}MB/s"
+        )
 
         stress_msg_size = 32768
         stress_data_size = STRESS_DATA_SIZE
@@ -595,23 +615,29 @@ class ManyPartitionsTest(PreallocNodesTest):
             stress_data_size = 2e9
 
         stress_msg_count = int(stress_data_size / stress_msg_size)
-        fast_producer = KgoVerifierProducer(
+        stress_params = [
+            KgoVerifierParams(
+                topic=tn,
+                msg_size=stress_msg_size,
+                msg_count=stress_msg_count,
+            )
+            for tn in topic_names
+        ]
+        fast_producer = KgoVerifierMultiProducer(
             self.test_context,
             self.redpanda,
-            target_topic,
-            stress_msg_size,
-            stress_msg_count,
+            stress_params,
             custom_node=[self.preallocated_nodes[0]],
         )
         fast_producer.start()
 
-        # Don't start consumers until the producer has written out its first
+        # Don't start consumers until all producers have written out their first
         # checkpoint with valid ranges.
         wait_until(
-            lambda: fast_producer.produce_status.acked > 0,
+            lambda: all(p.produce_status.acked > 0 for p in fast_producer.producers),
             timeout_sec=30,
             backoff_sec=1.0,
-            err_msg="Waiting for producer checkpoint",
+            err_msg="Waiting for producer checkpoints",
         )
 
         rand_ios = 100
@@ -620,14 +646,13 @@ class ManyPartitionsTest(PreallocNodesTest):
             rand_parallel = 10
             rand_ios = 10
 
-        rand_consumer = KgoVerifierRandomConsumer(
+        rand_consumer = KgoVerifierMultiRandomConsumer(
             self.test_context,
             self.redpanda,
-            target_topic,
-            msg_size=0,
+            stress_params,
             rand_read_msgs=rand_ios,
             parallel=rand_parallel,
-            nodes=[self.preallocated_nodes[1]],
+            custom_node=[self.preallocated_nodes[1]],
         )
         rand_consumer.start(clean=False)
         rand_consumer.wait()
@@ -652,26 +677,37 @@ class ManyPartitionsTest(PreallocNodesTest):
             # minutes during these events.
             expect_transmit_time += 600
 
-        verifier = KgoVerifierConsumerGroupConsumer(
+        verify_params = [
+            KgoVerifierParams(
+                topic=tn,
+                msg_size=0,
+                msg_count=0,
+                seq_max_msgs=max_msgs,
+            )
+            for tn in topic_names
+        ]
+        verifier = KgoVerifierMultiConsumerGroupConsumer(
             self.test_context,
             self.redpanda,
-            target_topic,
-            0,
+            verify_params,
             readers=math.ceil(scale.partition_limit / 5000),
-            max_msgs=max_msgs,
-            nodes=[self.preallocated_nodes[2]],
+            custom_node=[self.preallocated_nodes[2]],
         )
         verifier.start(clean=False)
 
         verifier.wait(timeout_sec=expect_transmit_time)
-        assert verifier.consumer_status.validator.invalid_reads == 0
-        if not scale.tiered_storage_enabled:
-            assert (
-                verifier.consumer_status.validator.valid_reads
-                >= fast_producer.produce_status.acked + msg_count_per_topic
-            ), (
-                f"{verifier.consumer_status.validator.valid_reads} >= {fast_producer.produce_status.acked} + {msg_count_per_topic}"
-            )
+        for i, v in enumerate(verifier.consumers):
+            assert v.consumer_status.validator.invalid_reads == 0
+            if not scale.tiered_storage_enabled:
+                assert (
+                    v.consumer_status.validator.valid_reads
+                    >= fast_producer.producers[i].produce_status.acked
+                    + msg_count_per_topic
+                ), (
+                    f"topic {topic_names[i]}: "
+                    f"{v.consumer_status.validator.valid_reads} >= "
+                    f"{fast_producer.producers[i].produce_status.acked} + {msg_count_per_topic}"
+                )
 
         self.free_preallocated_nodes()
 
@@ -808,6 +844,37 @@ class ManyPartitionsTest(PreallocNodesTest):
         )
 
     @cluster(num_nodes=12, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    @parametrize(
+        mib_per_partition=DEFAULT_MIB_PER_PARTITION,
+        topic_partitions_per_shard=DEFAULT_PARTITIONS_PER_SHARD,
+    )
+    def test_many_partitions_cloud_topics(
+        self, mib_per_partition: float, topic_partitions_per_shard: int
+    ):
+        self._test_many_partitions(
+            compacted=False,
+            cloud_topics_enabled=True,
+            mib_per_partition=mib_per_partition,
+            topic_partitions_per_shard=topic_partitions_per_shard,
+        )
+
+    @cluster(num_nodes=12, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    @parametrize(
+        mib_per_partition=DEFAULT_MIB_PER_PARTITION,
+        topic_partitions_per_shard=DEFAULT_PARTITIONS_PER_SHARD,
+    )
+    def test_many_partitions_cloud_topics_tiered_storage(
+        self, mib_per_partition: float, topic_partitions_per_shard: int
+    ):
+        self._test_many_partitions(
+            compacted=False,
+            tiered_storage_enabled=True,
+            cloud_topics_enabled=True,
+            mib_per_partition=mib_per_partition,
+            topic_partitions_per_shard=topic_partitions_per_shard,
+        )
+
+    @cluster(num_nodes=12, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_omb(self):
         scale = ScaleParameters(
             self.redpanda,
@@ -839,6 +906,7 @@ class ManyPartitionsTest(PreallocNodesTest):
         mib_per_partition: float,
         topic_partitions_per_shard: int,
         tiered_storage_enabled: bool = False,
+        cloud_topics_enabled: bool = False,
     ):
         """
         Validate that redpanda works with partition counts close to its resource
@@ -870,6 +938,10 @@ class ManyPartitionsTest(PreallocNodesTest):
         # Scale tests are not run on debug builds
         assert not self.debug_mode
 
+        self._stop_timeout = (
+            CLOUD_TOPICS_STOP_TIMEOUT if cloud_topics_enabled else STOP_TIMEOUT
+        )
+
         replication_factor = 3
 
         scale = ScaleParameters(
@@ -881,11 +953,25 @@ class ManyPartitionsTest(PreallocNodesTest):
             partition_memory_reserve_percentage=DEFAULT_PARTITIONS_MEMORY_ALLOCATION_PERCENT,
         )
 
-        # Run with one huge topic: it is more stressful for redpanda when clients
-        # request the metadata for many partitions at once, and the simplest way
-        # to get traffic generators to do that without the clients supporting
-        # writing to arrays of topics is to put all the partitions into one topic.
-        n_topics = 1
+        # When cloud topics are enabled but tiered storage is not, we still
+        # need SISettings for the object store backend that cloud topics use.
+        if cloud_topics_enabled and not tiered_storage_enabled:
+            cloud_si_settings = SISettings(
+                self.test_context,
+                cloud_storage_enable_remote_read=False,
+                cloud_storage_enable_remote_write=False,
+                fast_uploads=True,
+            )
+            self.redpanda.set_si_settings(cloud_si_settings)
+
+        # By default run with one huge topic for maximum metadata stress. It is
+        # more stressful for redpanda when clients request the metadata for
+        # many partitions at once, and the simplest way to get traffic
+        # generators to do that without the clients supporting writing to
+        # arrays of topics is to put all the partitions into one topic. When
+        # cloud topics are enabled, split into two topics (regular + cloud) to
+        # exercise mixed-mode operation.
+        n_topics = 2 if cloud_topics_enabled else 1
 
         # Partitions per topic
         n_partitions = int(scale.partition_limit / n_topics)
@@ -923,11 +1009,24 @@ class ManyPartitionsTest(PreallocNodesTest):
             }
         )
 
+        if cloud_topics_enabled:
+            self.redpanda.add_extra_rp_conf({CLOUD_TOPICS_CONFIG_STR: True})
+
         self.redpanda.start()
 
         self.logger.info("Entering topic creation")
-        topic_names = [f"scale_{i:06d}" for i in range(0, n_topics)]
-        for tn in topic_names:
+        regular_topic_names: list[str] = []
+        cloud_topic_names: list[str] = []
+
+        if cloud_topics_enabled:
+            regular_topic_names = ["scale_000000"]
+            cloud_topic_names = ["cloud_000001"]
+        else:
+            regular_topic_names = [f"scale_{i:06d}" for i in range(0, n_topics)]
+
+        topic_names = regular_topic_names + cloud_topic_names
+
+        for tn in regular_topic_names:
             self.logger.info(f"Creating topic {tn} with {n_partitions} partitions")
             config: dict[str, Any] = {
                 "segment.bytes": scale.segment_size,
@@ -948,6 +1047,25 @@ class ManyPartitionsTest(PreallocNodesTest):
                 tn, partitions=n_partitions, replicas=replication_factor, config=config
             )
 
+        for tn in cloud_topic_names:
+            self.logger.info(
+                f"Creating cloud topic {tn} with {n_partitions} partitions"
+            )
+            # Cloud topics manage retention via the object store; local
+            # retention is not applicable.
+            cloud_config: dict[str, Any] = {
+                "segment.bytes": scale.segment_size,
+                "retention.bytes": scale.retention_bytes,
+                TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD,
+                "cleanup.policy": "compact,delete" if compacted else "delete",
+            }
+            self.rpk.create_topic(
+                tn,
+                partitions=n_partitions,
+                replicas=replication_factor,
+                config=cloud_config,
+            )
+
         self.logger.info("Awaiting elections...")
         wait_until(
             lambda: self._all_elections_done(topic_names, n_partitions),
@@ -964,7 +1082,7 @@ class ManyPartitionsTest(PreallocNodesTest):
 
         if scale.tiered_storage_enabled:
             self.logger.info("Entering tiered storage warmup")
-            for tn in topic_names:
+            for tn in regular_topic_names:
                 self._tiered_storage_warmup(scale, tn)
 
         self.logger.info("Entering initial traffic test, writes + random reads")

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -1526,3 +1526,10 @@ class KgoVerifierMultiConsumerGroupConsumer(KgoVerifierMultiService):
         ]
 
         super().__init__(context, redpanda, topics, consumers, custom_node=custom_node)
+
+    @property
+    def consumers(self) -> Sequence[KgoVerifierConsumerGroupConsumer]:
+        assert all(
+            isinstance(s, KgoVerifierConsumerGroupConsumer) for s in self._services
+        )
+        return cast(Sequence[KgoVerifierConsumerGroupConsumer], self._services)


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

What it says on the tin. General idea is to leave the structure of the test suite largely unchanged, adding a mode where instead of one topic with `many` partitions, we have one regular topic (local-only or tiered) and one cloud topic, each with `many / 2` partitions. This change is strictly additive. Existing test cases should be unchanged.

CDT runs:

### test_many_partitions_cloud_topics

- [x] [AWS](https://buildkite.com/redpanda/redpanda/builds/81170#019c9bc9-245d-4d0d-9004-a009f729553a)
   - Failure is a transport error talking to metastore. Transient and [likely logged at too-high severity](https://github.com/redpanda-data/redpanda/pull/29725). 
   - Tests pass
- [x] [Azure](https://buildkite.com/redpanda/redpanda/builds/81197#019c9cf3-c3c4-4967-8008-fa7a01b0a924)
   - [Mixed bag](https://ci-artifacts.dev.vectorized.cloud/production-devprod/redpanda/81197/019c9cf3-c3c4-4967-8008-fa7a01b0a924/vbuild/ducktape/results/2026-02-27--001/report.html)
   - Similar deal to AWS for passing tests, but quite a few more of these transport errors. 
   - One failure on what looks like the cloud topic partitions don't finish electing leaders after a minute post restart.
   - **NOTE**: we don't currently run scale tests in Azure nightlies, so this aspect is a bit of a wash as of today.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
