### PR TITLE
CORE-15587 proto: allow large TLS certs in shadow link

### DIFF
--- a/bazel/pbgen/main.go
+++ b/bazel/pbgen/main.go
@@ -868,7 +868,7 @@ func (g *implGenerator) generateMessageTraversalHelper(msg protoreflect.MessageD
 				w.Printf(".name = enum_to_string(get_%s()),\n", f.Name())
 				w.Dedent()
 				w.Println("};")
-			} else if f.Kind() == protoreflect.BytesKind {
+			} else if f.Kind() == protoreflect.BytesKind || isIOBuf(f) {
 				w.Printf("found.value = get_%s().share();\n", f.Name())
 			} else {
 				w.Printf("found.value = get_%s();\n", f.Name())

--- a/proto/redpanda/core/common/v1/tls.proto
+++ b/proto/redpanda/core/common/v1/tls.proto
@@ -50,13 +50,16 @@ message TLSFileSettings {
 // Used when providing the TLS information in PEM format
 message TLSPEMSettings {
     // The CA
-    string ca = 1;
+    string ca = 1 [(redpanda.core.pbgen.iobuf) = true];
     // Key and Cert are optional but if one is provided, then both must be
     // The key
-    string key = 2
-        [(google.api.field_behavior) = INPUT_ONLY, debug_redact = true];
+    string key = 2 [
+        (google.api.field_behavior) = INPUT_ONLY,
+        debug_redact = true,
+        (redpanda.core.pbgen.iobuf) = true
+    ];
     // The SHA-256 of the key, in base64 format
     string key_fingerprint = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
     // The cert
-    string cert = 4;
+    string cert = 4 [(redpanda.core.pbgen.iobuf) = true];
 }

--- a/src/v/redpanda/admin/services/shadow_link/BUILD
+++ b/src/v/redpanda/admin/services/shadow_link/BUILD
@@ -5,8 +5,12 @@ redpanda_cc_library(
     srcs = ["converter.cc"],
     hdrs = ["converter.h"],
     implementation_deps = [
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/config",
         "//src/v/crypto",
+        "//src/v/serde/protobuf:rpc",
         "//src/v/utils:base64",
+        "@seastar",
     ],
     visibility = ["//src/v/redpanda/admin/services/shadow_link:__subpackages__"],
     deps = [

--- a/src/v/redpanda/admin/services/shadow_link/converter.cc
+++ b/src/v/redpanda/admin/services/shadow_link/converter.cc
@@ -11,11 +11,18 @@
 
 #include "redpanda/admin/services/shadow_link/converter.h"
 
+#include "bytes/iobuf_parser.h"
 #include "cluster_link/model/types.h"
+#include "config/configuration.h"
 #include "crypto/crypto.h"
+#include "serde/protobuf/rpc.h"
 #include "utils/base64.h"
 
+#include <seastar/core/memory.hh>
+#include <seastar/util/defer.hh>
+
 #include <algorithm>
+#include <new>
 #include <optional>
 #include <stdexcept>
 #include <variant>
@@ -57,6 +64,28 @@ using proto::common::tls_file_settings;
 using proto::common::tls_settings;
 using proto::common::tlspem_settings;
 namespace {
+
+/// Converts an iobuf to ss::sstring for TLS PEM data.
+///
+/// Note: This creates a contiguous allocation which may exceed 128KiB for large
+/// CA bundles. While large allocations are generally discouraged in Seastar,
+/// this is acceptable here because the Seastar TLS layer (set_x509_key, etc.)
+/// requires linearized certificate data anyway.
+ss::sstring iobuf_to_string(const iobuf& buf) {
+    auto sz = buf.size_bytes();
+
+    // Temporarily disable crash-on-allocation-failure so we can convert
+    // std::bad_alloc to an RPC error instead of crashing the broker.
+    try {
+        ss::memory::scoped_system_alloc_fallback fb;
+        iobuf_const_parser p(buf);
+        return p.read_string(sz);
+    } catch (const std::bad_alloc&) {
+        throw serde::pb::rpc::resource_exhausted_exception(
+          ssx::sformat(
+            "TLS certificate data too large to linearize ({} bytes)", sz));
+    }
+}
 
 constexpr auto to_filter_pattern_type(proto::admin::pattern_type p) {
     switch (p) {
@@ -454,13 +483,16 @@ void set_tls_settings(
       },
       [&config](const tlspem_settings& pem) {
           if (!pem.get_ca().empty()) {
-              config.ca = cluster_link::model::tls_value(pem.get_ca());
+              config.ca = cluster_link::model::tls_value(
+                iobuf_to_string(pem.get_ca()));
           }
           if (!pem.get_key().empty()) {
-              config.key = cluster_link::model::tls_value(pem.get_key());
+              config.key = cluster_link::model::tls_value(
+                iobuf_to_string(pem.get_key()));
           }
           if (!pem.get_cert().empty()) {
-              config.cert = cluster_link::model::tls_value(pem.get_cert());
+              config.cert = cluster_link::model::tls_value(
+                iobuf_to_string(pem.get_cert()));
           }
           if (config.key.has_value() != config.cert.has_value()) {
               throw std::invalid_argument(
@@ -612,14 +644,14 @@ struct tls_visitor {
               auto key_digest = bytes_to_base64(
                 crypto::digest(crypto::digest_type::SHA256, key()));
               pem_settings.set_key_fingerprint(std::move(key_digest));
-              pem_settings.set_cert(ss::sstring{cert()});
+              pem_settings.set_cert(iobuf::from(cert()));
           },
           [this, &key, &cert](std::monostate) {
               tlspem_settings pem_settings;
               auto key_digest = bytes_to_base64(
                 crypto::digest(crypto::digest_type::SHA256, key()));
               pem_settings.set_key_fingerprint(std::move(key_digest));
-              pem_settings.set_cert(ss::sstring{cert()});
+              pem_settings.set_cert(iobuf::from(cert()));
               _tls_settings->set_tls_pem_settings(std::move(pem_settings));
           });
     }
@@ -647,7 +679,7 @@ tls_settings create_tls_settings(const cluster_link::model::metadata& md) {
           },
           [&tls](const cluster_link::model::tls_value& value) {
               tlspem_settings pem_settings;
-              pem_settings.set_ca(ss::sstring{value});
+              pem_settings.set_ca(iobuf::from(value()));
               tls.set_tls_pem_settings(std::move(pem_settings));
           });
     }
@@ -1136,7 +1168,7 @@ void merge_input_only_fields(
                   from.connection.key.value(),
                   [&to_pem](
                     const cluster_link::model::tls_value& value) mutable {
-                      to_pem.set_key(ss::sstring{value()});
+                      to_pem.set_key(iobuf::from(value()));
                   },
                   [](const auto&) {
                       throw std::invalid_argument(

--- a/src/v/redpanda/admin/services/shadow_link/tests/converter_test.cc
+++ b/src/v/redpanda/admin/services/shadow_link/tests/converter_test.cc
@@ -434,9 +434,9 @@ TEST(converter_test, create_with_tls_value) {
     proto::admin::shadow_link_client_options shadow_link_client_options;
     proto::common::tls_settings tls_settings;
     proto::common::tlspem_settings tls_pem_settings;
-    tls_pem_settings.set_ca(ss::sstring{ca});
-    tls_pem_settings.set_key(ss::sstring{key});
-    tls_pem_settings.set_cert(ss::sstring{cert});
+    tls_pem_settings.set_ca(iobuf::from(ca));
+    tls_pem_settings.set_key(iobuf::from(key));
+    tls_pem_settings.set_cert(iobuf::from(cert));
     tls_settings.set_tls_pem_settings(std::move(tls_pem_settings));
 
     shadow_link_client_options.set_tls_settings(std::move(tls_settings));
@@ -479,7 +479,7 @@ TEST(converter_test, create_with_tls_value_invalid) {
     proto::admin::shadow_link_client_options shadow_link_client_options;
     proto::common::tls_settings tls_settings;
     proto::common::tlspem_settings tls_pem_settings;
-    tls_pem_settings.set_key(ss::sstring{key});
+    tls_pem_settings.set_key(iobuf::from(key));
 
     tls_settings.set_tls_pem_settings(std::move(tls_pem_settings));
 
@@ -1272,9 +1272,9 @@ TEST(converter_test, test_update_tls_value) {
     admin::set_client_id(current_md);
 
     proto::common::tlspem_settings tls_pem_settings;
-    tls_pem_settings.set_ca("new-ca");
-    tls_pem_settings.set_key("new-key");
-    tls_pem_settings.set_cert("new-cert");
+    tls_pem_settings.set_ca(iobuf::from("new-ca"));
+    tls_pem_settings.set_key(iobuf::from("new-key"));
+    tls_pem_settings.set_cert(iobuf::from("new-cert"));
 
     proto::common::tls_settings tls_settings;
     tls_settings.set_tls_pem_settings(std::move(tls_pem_settings));

--- a/src/v/serde/protobuf/tests/codegen_test.proto
+++ b/src/v/serde/protobuf/tests/codegen_test.proto
@@ -70,6 +70,10 @@ message WellKnownProtos {
     map<string, google.protobuf.Timestamp> timestamp_map = 9;
 }
 
+message IOBufStringField {
+    string large_data = 1 [(redpanda.core.pbgen.iobuf) = true];
+}
+
 message SayGreetingRequest {
     optional string greeting = 1;
 }

--- a/src/v/serde/protobuf/tests/goldens/codegen_test.proto.cc
+++ b/src/v/serde/protobuf/tests/goldens/codegen_test.proto.cc
@@ -1477,6 +1477,156 @@ std::optional<serde::pb::field> well_known_protos::lookup_field(std::span<const 
   return found;
 }
 
+io_buf_string_field::io_buf_string_field() noexcept = default;
+io_buf_string_field::io_buf_string_field(io_buf_string_field&&) noexcept = default;
+io_buf_string_field& io_buf_string_field::operator=(io_buf_string_field&&) noexcept = default;
+io_buf_string_field::~io_buf_string_field() noexcept = default;
+iobuf& io_buf_string_field::get_large_data() { return large_data_; }
+const iobuf& io_buf_string_field::get_large_data() const { return large_data_; }
+void io_buf_string_field::set_large_data(iobuf&& v) { large_data_ = std::move(v); }
+bool io_buf_string_field::operator==(const io_buf_string_field& other) const {
+  return (large_data_ == other.large_data_);
+}
+fmt::iterator io_buf_string_field::format_to(fmt::iterator it) const {
+  return fmt::format_to(it, "{{large_data: {}}}", large_data_);
+}
+seastar::future<> io_buf_string_field::from_proto(serde::pb::wire_format_parser* parser, io_buf_string_field* self) {
+  while (parser->bytes_left() > 0) {
+    auto tag = parser->read_tag();
+    switch (tag.field_number) {
+    case 1: { // large_data
+      self->set_large_data(parser->read_bytes<"example.IOBufStringField.large_data">(tag));
+      break;
+    }
+    default:
+      parser->skip_unknown(tag);
+      break;
+    }
+  }
+  co_return;
+}
+seastar::future<io_buf_string_field> io_buf_string_field::from_proto(iobuf buf) {
+  io_buf_string_field self;
+  serde::pb::wire_format_parser parser{std::move(buf)};
+  co_await from_proto(&parser, &self);
+  parser.check_empty();
+  co_return self;
+}
+seastar::future<iobuf> io_buf_string_field::to_proto() const {
+  iobuf buf;
+  // large_data
+  serde::pb::tag::write({.wire_type = serde::pb::wire_type::length, .field_number = 1}, &buf);
+  serde::pb::write_length(static_cast<int32_t>(get_large_data().size_bytes()), &buf);
+  buf.append(get_large_data().copy());
+  co_return buf;
+}
+seastar::future<iobuf> io_buf_string_field::to_json() const {
+  serde::json::writer w;
+  w.begin_object();
+  w.key("largeData");
+  w.string(get_large_data());
+  w.end_object();
+  co_return std::move(w).finish();
+}
+seastar::future<> io_buf_string_field::from_json(serde::pb::json::peekable_parser* parser, io_buf_string_field* self) {
+  constexpr static auto key_to_field_number = std::to_array<std::pair<std::string_view, int32_t>>({
+    {"largeData", 1},
+    {"large_data", 1},
+  });
+  auto entries = serde::pb::json::object_key_generator(parser);
+  while (auto key = co_await entries()) {
+    auto fields = std::ranges::equal_range(key_to_field_number, *key, std::less<>(), [](const auto& pair) { return pair.first; });
+    if (fields.empty()) {
+      co_await parser->skip_value();
+      continue;
+    }
+    switch (fields.front().second) {
+    case 1: { // large_data
+      co_await parser->next();
+      self->set_large_data(serde::pb::json::read_string_as_bytes(parser));
+      break;
+    }
+    default:
+      vunreachable("codegen error unexpected field number: {}", fields.front().second);
+    }
+  }
+  co_return;
+}
+seastar::future<io_buf_string_field> io_buf_string_field::from_json(iobuf data) {
+  io_buf_string_field self;
+  serde::pb::json::peekable_parser parser(std::move(data));
+  co_await from_json(&parser, &self);
+  co_await serde::pb::json::check_next_eof(&parser);
+  co_return self;
+}
+bool io_buf_string_field::is_valid_field_path(std::span<const ss::sstring> path) {
+  if (path.empty()) { return true; }
+  constexpr auto fields = std::to_array<std::pair<std::string_view, bool(*)(decltype(path))>>({
+    {"large_data", [](auto path) { return path.empty(); }},
+  });
+  for (const auto& [name, is_valid] : fields) {
+    if (path.front() == name) {
+      return is_valid(path.subspan(1));
+    }
+  }
+  return false;
+}
+void io_buf_string_field::apply_field_path_from(std::span<const ss::sstring> path, io_buf_string_field* update) {
+  if (path.empty()) {
+    *this = std::move(*update);
+    return;
+  }
+  constexpr auto fields = std::to_array<std::pair<std::string_view, void(*)(decltype(path), decltype(this), decltype(update))>>({
+    {"large_data", []([[maybe_unused]] auto path, auto* self, auto* update) {
+      self->set_large_data(std::move(update->get_large_data()));
+    }},
+  });
+  for (const auto& [name, apply] : fields) {
+    if (path.front() == name) {
+      return apply(path.subspan(1), this, update);
+    }
+  }
+}
+std::optional<std::vector<int32_t>> io_buf_string_field::convert_field_path_to_numbers(std::span<std::string_view> field_path) const {
+  std::vector<int32_t> numbers;
+  if (convert_field_path_to_numbers(field_path, &numbers)) { return numbers; }
+  return std::nullopt;
+}
+bool io_buf_string_field::convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out) {
+  if (field_path.empty()) {
+    return true;
+  }
+  constexpr static auto key_to_field_number = std::to_array<std::pair<std::string_view, bool(*)(decltype(field_path), decltype(out))>>({
+    {"largeData", [](auto path, auto* out) { out->push_back(1); return path.empty(); }},
+    {"large_data", [](auto path, auto* out) { out->push_back(1); return path.empty(); }},
+  });
+  auto fields = std::ranges::equal_range(key_to_field_number, field_path.front(), std::less<>(), [](const auto& pair) { return pair.first; });
+  if (fields.empty()) {
+    return false;
+  }
+  return fields.front().second(field_path.subspan(1), out);
+}
+std::optional<serde::pb::field> io_buf_string_field::lookup_field(std::span<const int32_t> field_numbers) {
+
+  if (field_numbers.empty()) {
+    return serde::pb::field{.value = static_cast<serde::pb::base_message*>(this)};
+  }
+  serde::pb::field found;
+  switch (field_numbers.front()) {
+  case 1: { // large_data
+    found.value = get_large_data().share();
+    break;
+  }
+  default:
+    return std::nullopt;
+  }
+  if (field_numbers.size() > 1) {
+    if (!std::holds_alternative<serde::pb::base_message*>(found.value)) { return std::nullopt; }
+    return std::get<serde::pb::base_message*>(found.value)->lookup_field(field_numbers.subspan(1));
+  }
+  return found;
+}
+
 say_greeting_request::say_greeting_request() noexcept = default;
 say_greeting_request::say_greeting_request(say_greeting_request&&) noexcept = default;
 say_greeting_request& say_greeting_request::operator=(say_greeting_request&&) noexcept = default;

--- a/src/v/serde/protobuf/tests/goldens/codegen_test.proto.h
+++ b/src/v/serde/protobuf/tests/goldens/codegen_test.proto.h
@@ -35,6 +35,7 @@ class c;
 class super_duper_secret;
 class mask_wrapper;
 class well_known_protos;
+class io_buf_string_field;
 class say_greeting_request;
 class say_greeting_response;
 
@@ -402,6 +403,54 @@ private:
   absl::Time single_timestamp_;
   chunked_vector<absl::Time> repeated_timestamp_;
   chunked_hash_map<ss::sstring, absl::Time> timestamp_map_;
+};
+
+class io_buf_string_field : public serde::pb::base_message {
+public:
+  io_buf_string_field() noexcept;
+  io_buf_string_field(const io_buf_string_field&) = delete;
+  io_buf_string_field& operator=(const io_buf_string_field&) = delete;
+  io_buf_string_field(io_buf_string_field&&) noexcept;
+  io_buf_string_field& operator=(io_buf_string_field&&) noexcept;
+  ~io_buf_string_field() noexcept;
+
+  bool operator==(const io_buf_string_field&) const;
+  fmt::iterator format_to(fmt::iterator) const;
+
+  // Serializes example.IOBufStringField into a protocol buffer, in a way that will not cause stalls for large messages.
+  seastar::future<iobuf> to_proto() const;
+  // Serializes example.IOBufStringField into proto3 JSON, in a way that will not cause stalls for large messages.
+  seastar::future<iobuf> to_json() const;
+  // Deserializes example.IOBufStringField from a protocol buffer, in a way that will not cause stalls for large messages.
+  static seastar::future<io_buf_string_field> from_proto(iobuf);
+  // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
+  // Use the iobuf version instead.
+  static seastar::future<> from_proto(serde::pb::wire_format_parser*, io_buf_string_field*);
+  // Deserializes example.IOBufStringField from json, in a way that will not cause stalls for large messages.
+  static seastar::future<io_buf_string_field> from_json(iobuf);
+  // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
+  // Use the iobuf version instead.
+  static seastar::future<> from_json(serde::pb::json::peekable_parser*, io_buf_string_field*);
+
+  iobuf& get_large_data();
+  const iobuf& get_large_data() const;
+  void set_large_data(iobuf&& v);
+
+  std::string_view full_name() const override { return "example.IOBufStringField"; }
+  // Convert a field path into a path of field numbers.
+  static bool convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out);
+  // Convert a field path into a path of field numbers.
+  std::optional<std::vector<int32_t>> convert_field_path_to_numbers(std::span<std::string_view> field_path) const override;
+  // Look up a field based on the field numbers.
+  std::optional<serde::pb::field> lookup_field(std::span<const int32_t> field_numbers) override;
+
+  // NOTE: This is intended to be used by field_mask only. Do not use directly.
+  static bool is_valid_field_path(std::span<const ss::sstring> path);
+  // NOTE: This is intended to be used by field_mask only. Do not use directly.
+  void apply_field_path_from(std::span<const ss::sstring> path, io_buf_string_field* update);
+
+private:
+  iobuf large_data_;
 };
 
 class say_greeting_request : public serde::pb::base_message {

--- a/src/v/serde/protobuf/tests/round_trip_test.cc
+++ b/src/v/serde/protobuf/tests/round_trip_test.cc
@@ -340,3 +340,36 @@ TEST(ProtobufCompat, DebugRedact) {
     secret.set_value("12345");
     EXPECT_EQ("{value: <redacted>}", fmt::format("{}", secret));
 }
+
+// string fields are limited to 128KiB, but iobuf-backed fields should be able
+// to handle larger sizes. This test verifies that the iobuf-backed field can
+// roundtrip larger data without error and without truncation.
+TEST(ProtobufCompat, RoundtripLargeIOBufString) {
+    const size_t large_size = 150 * 1024;
+    std::string large_data(large_size, 'A');
+
+    proto::example::io_buf_string_field original;
+    original.set_large_data(iobuf::from(large_data));
+
+    // Roundtrip through proto serialization
+    {
+        auto serialized = original.to_proto().get();
+        auto deserialized = proto::example::io_buf_string_field::from_proto(
+                              std::move(serialized))
+                              .get();
+
+        // Verify data is preserved
+        EXPECT_EQ(original, deserialized);
+    }
+
+    // Roundtrip through json serialization
+    {
+        auto serialized = original.to_json().get();
+        auto deserialized = proto::example::io_buf_string_field::from_json(
+                              std::move(serialized))
+                              .get();
+
+        // Verify data is preserved
+        EXPECT_EQ(original, deserialized);
+    }
+}


### PR DESCRIPTION
Shadow link TLS PEM fields (ca, key, cert) were limited to 128KiB
by proto serde's string size limit. Large CA bundles with multiple
certificates could exceed this, causing deserialization failures.

Add (redpanda.core.pbgen.iobuf) = true annotation to these fields
in TLSPEMSettings proto. Update shadow_link converter to use
iobuf_to_string() for conversions. This allows arbitrarily large
PEM data while maintaining sstring API compatibility.

Fixes https://redpandadata.atlassian.net/browse/CORE-15587

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Improvements
* Shadow Linking: allow creating shadow links with TLS settings where the CA/key/cert strings exceed 128KiB.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
