### PR TITLE
Archival: Fix bugged generation check skipping login in segment_collector

### DIFF
--- a/src/v/cluster/archival/segment_reupload.cc
+++ b/src/v/cluster/archival/segment_reupload.cc
@@ -884,22 +884,27 @@ ss::future<candidate_creation_result> segment_collector::make_upload_candidate(
     //   - the last segment in the list was NOT closed AND
     //   - the last segment is the ONLY segment with gen ID difference
 
-    auto gen_id_diff_view = boost::irange(0ul, _segments.size())
-                            | std::views::filter([this, &current_gen](auto i) {
-                                  return _generations.at(i)
-                                         != current_gen.at(i);
-                              });
+    vassert(
+      _generations.size() == current_gen.size(),
+      "Cached generations should match size of accumulated segments ({} vs {})",
+      _generations.size(),
+      current_gen.size());
 
-    auto skip_gen_id_check = std::accumulate(
-      gen_id_diff_view.begin(),
-      gen_id_diff_view.end(),
-      last_unsealed && !gen_id_diff_view.empty(),
-      std::logical_and{});
+    auto gen_id_diffs = std::views::iota(0ul, _segments.size())
+                        | std::views::transform([&](auto i) -> int {
+                              return _generations.at(i) != current_gen.at(i);
+                          });
+    auto n_diffs = std::ranges::fold_left(gen_id_diffs, 0, std::plus<int>{});
+    auto skip_gen_id_check = last_unsealed && n_diffs == 1
+                             && _generations.back() != current_gen.back();
 
     // If the last collected segment is not closed,
-    if (!skip_gen_id_check && !gen_id_diff_view.empty()) {
+    if (!skip_gen_id_check && n_diffs > 0) {
         std::stringstream sstr;
-        for (auto i : gen_id_diff_view) {
+        for (auto i : std::views::iota(0ul, _segments.size())) {
+            if (_generations.at(i) == current_gen.at(i)) {
+                continue;
+            }
             // Segment was updated concurrently while we were waiting
             // for the locks.
             fmt::print(
@@ -914,8 +919,8 @@ ss::future<candidate_creation_result> segment_collector::make_upload_candidate(
               _sizes.at(i),
               _segments.at(i)->size_bytes());
         }
-        // The segment was updated while we were waiting for the locks.
-        // It's a race condition so we should fail the upload and retry.
+        // One or more segments were updated while we were waiting for the
+        // locks. It's a race condition so we should fail the upload and retry.
         vlog(
           archival_log.info,
           "Segment generation mismatch for {}: {}",

--- a/src/v/cluster/archival/segment_reupload.cc
+++ b/src/v/cluster/archival/segment_reupload.cc
@@ -853,8 +853,9 @@ ss::future<candidate_creation_result> segment_collector::make_upload_candidate(
     }
 
     auto last = _segments.back();
+    // Get the size of the last segment collected _before_ acquiring read locks
+    // because upload size accounting has already taken place at this point.
     auto last_size_bytes = last->size_bytes();
-    auto last_unsealed = last->has_appender();
 
     // Take the locks before opening any readers on the segments.
     auto deadline = std::chrono::steady_clock::now() + segment_lock_duration;
@@ -876,6 +877,8 @@ ss::future<candidate_creation_result> segment_collector::make_upload_candidate(
       _segments.end(),
       std::back_inserter(current_gen),
       [](const auto& seg) { return seg->get_generation_id()(); });
+
+    auto last_unsealed = last->has_appender();
 
     // special case: skip the generation check iff
     //   - the last segment in the list was NOT closed AND

--- a/src/v/cluster/archival/tests/segment_reupload_test.cc
+++ b/src/v/cluster/archival/tests/segment_reupload_test.cc
@@ -1679,6 +1679,115 @@ TEST(SegmentReuploadUnit, test_segment_concurrent_compaction) {
       == candidate_creation_error::concurrency_error);
 }
 
+// When the last collected segment is unsealed (has appender) and multiple
+// segments have generation changes, the upload should still fail with
+// concurrency_error since we can't trust the sealed segments.
+TEST(
+  SegmentReuploadUnit,
+  test_segment_concurrent_compaction_unsealed_tail_multi_gen_change) {
+    cloud_storage::partition_manifest m;
+    m.update(
+       cloud_storage::manifest_format::json, make_manifest_stream(manifest))
+      .get();
+
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    // Three segments aligned with manifest boundaries. The last one
+    // (starting at 30) is the active segment with an appender since no
+    // further segment is created after it.
+    populate_log(
+      b,
+      {.segment_starts = {10, 20, 30},
+       .compacted_segment_indices = {},
+       .last_segment_num_records = 10});
+
+    archival::segment_collector collector{
+      segment_collector_mode::non_compacted_reupload,
+      model::offset{10},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size,
+      model::offset{39}};
+
+    collector.collect_segments();
+    ASSERT_EQ(collector.begin_inclusive(), model::offset{10});
+    ASSERT_EQ(collector.end_inclusive(), model::offset{39});
+
+    auto& segs = b.get_disk_log_impl().segments();
+    ASSERT_TRUE(segs.back()->has_appender());
+
+    // Advance generation on the middle segment AND the last (unsealed)
+    // segment. Two segments have generation changes, so the skip logic
+    // should not apply even though the tail is unsealed.
+    std::next(segs.begin())->get()->advance_generation();
+    segs.back()->advance_generation();
+
+    auto candidate = collector.make_upload_candidate(1s).get();
+    ASSERT_TRUE(std::holds_alternative<candidate_creation_error>(candidate));
+    ASSERT_TRUE(
+      std::get<candidate_creation_error>(candidate)
+      == candidate_creation_error::concurrency_error);
+}
+
+// When the last collected segment is unsealed (has appender) and it is the
+// ONLY segment with a generation change, the upload should proceed. This is
+// expected because the active segment can legitimately change generation as
+// new data is appended.
+TEST(
+  SegmentReuploadUnit,
+  test_segment_concurrent_compaction_unsealed_tail_only_gen_change) {
+    cloud_storage::partition_manifest m;
+    m.update(
+       cloud_storage::manifest_format::json, make_manifest_stream(manifest))
+      .get();
+
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    // Three segments aligned with manifest boundaries. The last one
+    // (starting at 30) is the active segment with an appender since no
+    // further segment is created after it.
+    populate_log(
+      b,
+      {.segment_starts = {10, 20, 30},
+       .compacted_segment_indices = {},
+       .last_segment_num_records = 10});
+
+    archival::segment_collector collector{
+      segment_collector_mode::non_compacted_reupload,
+      model::offset{10},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size,
+      model::offset{39}};
+
+    collector.collect_segments();
+    ASSERT_EQ(collector.begin_inclusive(), model::offset{10});
+    ASSERT_EQ(collector.end_inclusive(), model::offset{39});
+
+    auto& segs = b.get_disk_log_impl().segments();
+    ASSERT_TRUE(segs.back()->has_appender());
+
+    // Only advance generation on the last (unsealed) segment. Since it is
+    // the only segment with a generation change and it has an appender, the
+    // generation check should be skipped.
+    segs.back()->advance_generation();
+
+    auto candidate = collector.make_upload_candidate(1s).get();
+    ASSERT_TRUE(std::holds_alternative<upload_candidate_with_locks>(candidate));
+}
+
 static void validate_non_compacted_collector(archival::segment_collector& c) {
     if (!c.segment_ready_for_upload()) {
         return;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR fixes a bug in the archival segment collection logic where the generation check could be incorrectly skipped, potentially allowing race conditions between segment collection and compaction to go undetected.

- Fixed bugged logic that used std::logical_and on indices instead of boolean values
- Moved has_appender() check to after lock acquisition for better race condition protection
- Tests for edge cases involving unsealed tail segments

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x

## Release Notes

### Bug Fixes

* Fixed buggy race detection logic in archival segment collection that could miss races between collection and compaction.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
