### PR TITLE
 datalake: cache resolved iceberg types

### DIFF
--- a/src/v/datalake/coordinator/coordinator.cc
+++ b/src/v/datalake/coordinator/coordinator.cc
@@ -431,7 +431,7 @@ struct coordinator::main_table_schema_provider
 
     ss::future<checked<iceberg::struct_type, coordinator::errc>>
     get_record_type(record_schema_components comps) const final {
-        std::optional<resolved_type> val_type;
+        std::optional<shared_resolved_type_t> val_type;
         if (comps.val_identifier) {
             auto type_res = co_await parent.type_resolver_.resolve_identifier(
               comps.val_identifier.value());

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -42,7 +42,8 @@ static std::unique_ptr<type_resolver> make_type_resolver(
   const model::iceberg_mode& mode,
   model::topic_view topic_name,
   schema::registry& sr,
-  schema_cache& cache) {
+  schema_cache& cache,
+  resolved_type_cache& type_cache) {
     switch (mode.kind()) {
     case model::iceberg_mode::variant::disabled:
         vassert(
@@ -51,7 +52,7 @@ static std::unique_ptr<type_resolver> make_type_resolver(
     case model::iceberg_mode::variant::key_value:
         return std::make_unique<binary_type_resolver>();
     case model::iceberg_mode::variant::value_schema_id_prefix:
-        return std::make_unique<record_schema_resolver>(sr, cache);
+        return std::make_unique<record_schema_resolver>(sr, cache, type_cache);
     case model::iceberg_mode::variant::value_schema_latest:
         auto subject = pandaproxy::schema_registry::subject(
           fmt::format("{}-value", topic_name));
@@ -63,7 +64,8 @@ static std::unique_ptr<type_resolver> make_type_resolver(
           subject,
           mode.protobuf_full_name(),
           config::shard_local_cfg().iceberg_latest_schema_cache_ttl_ms.bind(),
-          cache);
+          cache,
+          type_cache);
     }
 }
 
@@ -166,11 +168,16 @@ datalake_manager::datalake_manager(
   , _location_provider(cloud_io->local().provider(), bucket_name)
   , _schema_registry(schema::registry::make_default(sr_api))
   , _catalog_factory(std::move(catalog_factory))
-  // TODO: The cache size is currently arbitrary. Figure out a more reasoned
-  // size and allocate a share of the datalake memory semaphore to this cache.
+  // TODO: The two following cache configs were arbitrarily choosen. Figure out
+  // a more reasoned size and allocate a share of the datalake memory semaphore
+  // to this cache.
   , _schema_cache(
       std::make_unique<chunked_schema_cache>(
         chunked_schema_cache::cache_t::config{
+          .cache_size = 50, .small_size = 10}))
+  , _resolved_type_cache(
+      std::make_unique<chunked_resolved_type_cache>(
+        chunked_resolved_type_cache::cache_t::config{
           .cache_size = 50, .small_size = 10}))
   , _as(as)
   , _sg(sg)
@@ -262,6 +269,7 @@ ss::future<> datalake_manager::start() {
     });
 
     _schema_cache->start();
+    _resolved_type_cache->start();
     _backlog_controller = std::make_unique<backlog_controller>(
       [this] { return total_translation_backlog(); }, _sg);
     co_await _backlog_controller->start();
@@ -565,6 +573,7 @@ ss::future<> datalake_manager::shutdown() {
     co_await _scheduler.stop();
     co_await std::move(f);
     _schema_cache->stop();
+    _resolved_type_cache->stop();
     vlog(datalake_log.debug, "Stopped datalake manager...");
 }
 
@@ -624,7 +633,11 @@ ss::future<> datalake_manager::handle_translator_state_change(
 
     auto mode = partition->topic_cfg->properties.iceberg_mode;
     auto type_resolver = make_type_resolver(
-      mode, ntp.tp.topic, *_schema_registry, *_schema_cache);
+      mode,
+      ntp.tp.topic,
+      *_schema_registry,
+      *_schema_cache,
+      *_resolved_type_cache);
     auto record_translator = make_record_translator(mode);
     auto table_creator = translation::make_default_table_creator(
       _coordinator_frontend->local());

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -175,6 +175,7 @@ private:
     std::unique_ptr<iceberg::catalog> _catalog;
     std::unique_ptr<datalake::schema_manager> _schema_mgr;
     std::unique_ptr<datalake::schema_cache> _schema_cache;
+    std::unique_ptr<datalake::resolved_type_cache> _resolved_type_cache;
     std::unique_ptr<backlog_controller> _backlog_controller;
     chunked_hash_map<model::ntp, ss::lw_shared_ptr<class translation_probe>>
       _translation_probe_by_ntp;

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -231,7 +231,7 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
         record_schema_components comps{
           .key_identifier = std::nullopt,
           .val_identifier = val_type.has_value()
-                              ? std::make_optional(val_type->id)
+                              ? std::make_optional((*val_type)->id)
                               : std::nullopt,
         };
         auto writer_iter = _writers.find(comps);

--- a/src/v/datalake/record_schema_resolver.cc
+++ b/src/v/datalake/record_schema_resolver.cc
@@ -73,11 +73,9 @@ checked<resolved_type, type_resolver::errc> translate_avro_schema(
 
 checked<resolved_type, type_resolver::errc> translate_protobuf_schema(
   const ppsr::protobuf_schema_definition& pb_def,
-  ppsr::schema_id id,
-  std::vector<int32_t> protobuf_offsets,
+  schema_identifier&& id,
   shared_schema_t schema) {
-    // TODO: maybe there's another caching opportunity here.
-    auto d_res = descriptor(pb_def, protobuf_offsets);
+    auto d_res = descriptor(pb_def, id.protobuf_offsets.value());
     if (d_res.has_error()) {
         vlog(
           datalake_log.error,
@@ -90,8 +88,7 @@ checked<resolved_type, type_resolver::errc> translate_protobuf_schema(
         auto type = iceberg::type_to_iceberg(*d).value();
         return resolved_type{
           .schema = resolved_schema(*d, std::move(schema)),
-          .id
-          = {.schema_id = id, .protobuf_offsets = std::move(protobuf_offsets)},
+          .id = std::move(id),
           .type = std::move(type),
         };
     } catch (...) {
@@ -109,7 +106,6 @@ checked<resolved_type, type_resolver::errc> translate_json_schema(
         auto& doc = document(json_def());
         auto fc = iceberg::conversion::json_schema::frontend{};
         // todo figure out
-        // todo is this cached anywhere?
         auto json_schema = fc.compile(
           doc, "https://example.com/schema.json", std::nullopt);
         auto iceberg_ir = iceberg::type_to_ir(json_schema);
@@ -151,61 +147,8 @@ checked<resolved_type, type_resolver::errc> translate_json_schema(
     }
 }
 
-struct schema_translating_visitor {
-    schema_translating_visitor(
-      iobuf b, ppsr::schema_id id, shared_schema_t schema)
-      : buf_no_id(std::move(b))
-      , id(id)
-      , schema(std::move(schema)) {}
-    // Buffer without the schema ID.
-    iobuf buf_no_id;
-    ppsr::schema_id id;
-    shared_schema_t schema;
-
-    checked<type_and_buf, type_resolver::errc>
-    operator()(const ppsr::avro_schema_definition& avro_def) {
-        auto tr_res = translate_avro_schema(avro_def, id, schema);
-        if (tr_res.has_error()) {
-            return tr_res.error();
-        }
-        return type_and_buf{
-          .type = std::move(tr_res.value()),
-          .parsable_buf = std::move(buf_no_id)};
-    }
-
-    checked<type_and_buf, type_resolver::errc>
-    operator()(const ppsr::protobuf_schema_definition& pb_def) {
-        auto offsets_res = get_proto_offsets(buf_no_id);
-        if (offsets_res.has_error()) {
-            return type_resolver::errc::bad_input;
-        }
-        auto offsets = std::move(offsets_res.value());
-
-        auto tr_res = translate_protobuf_schema(
-          pb_def, id, std::move(offsets.protobuf_offsets), schema);
-        if (tr_res.has_error()) {
-            return tr_res.error();
-        }
-
-        return type_and_buf{
-          .type = std::move(tr_res.value()),
-          .parsable_buf = std::move(offsets.shared_message_data)};
-    }
-
-    checked<type_and_buf, type_resolver::errc>
-    operator()(const ppsr::json_schema_definition& json_def) {
-        auto tr_res = translate_json_schema(json_def, id);
-        if (tr_res.has_error()) {
-            return tr_res.error();
-        }
-        return type_and_buf{
-          .type = std::move(tr_res.value()),
-          .parsable_buf = std::move(buf_no_id)};
-    }
-};
-
 struct from_identifier_visitor {
-    from_identifier_visitor(schema_identifier ident, shared_schema_t schema)
+    from_identifier_visitor(schema_identifier&& ident, shared_schema_t&& schema)
       : ident(std::move(ident))
       , schema(std::move(schema)) {}
 
@@ -217,7 +160,8 @@ struct from_identifier_visitor {
         if (ident.protobuf_offsets) {
             return type_resolver::errc::bad_input;
         }
-        return translate_avro_schema(avro_def, ident.schema_id, schema);
+        return translate_avro_schema(
+          avro_def, ident.schema_id, std::move(schema));
     }
     checked<resolved_type, type_resolver::errc>
     operator()(const ppsr::protobuf_schema_definition& pb_def) {
@@ -225,10 +169,7 @@ struct from_identifier_visitor {
             return type_resolver::errc::bad_input;
         }
         return translate_protobuf_schema(
-          pb_def,
-          ident.schema_id,
-          std::move(ident.protobuf_offsets.value()),
-          schema);
+          pb_def, std::move(ident), std::move(schema));
     }
     checked<resolved_type, type_resolver::errc>
     operator()(const ppsr::json_schema_definition& json_def) {
@@ -275,36 +216,91 @@ ss::future<checked<shared_schema_t, type_resolver::errc>> get_schema(
     co_return std::move(shared_schema);
 }
 
+checked<shared_resolved_type_t, type_resolver::errc> get_resolved_type(
+  schema_identifier&& ident,
+  shared_schema_t&& schema,
+  std::optional<std::reference_wrapper<resolved_type_cache>> cache) {
+    if (cache.has_value()) {
+        auto cached_val = cache->get().get_value(ident);
+        if (cached_val) {
+            return *cached_val;
+        }
+    }
+
+    auto* schema_ptr = schema.get();
+    auto resolve_res = schema_ptr->visit(
+      from_identifier_visitor{std::move(ident), std::move(schema)});
+    if (resolve_res.has_error()) {
+        return resolve_res.error();
+    }
+
+    auto shared_val = ss::make_shared<resolved_type>(
+      std::move(resolve_res.value()));
+    if (cache.has_value()) {
+        cache->get().try_insert(shared_val->id, shared_val);
+    }
+
+    return shared_val;
+}
+
 } // namespace
 
-chunked_schema_cache::chunked_schema_cache(
-  chunked_schema_cache::cache_t::config c)
+template<typename Key, typename Value>
+struct datalake_cache_traits;
+
+template<>
+struct datalake_cache_traits<
+  pandaproxy::schema_registry::schema_id,
+  pandaproxy::schema_registry::valid_schema> {
+    static constexpr const char* metrics_group_name = "datalake:schema_cache";
+    static constexpr const char* item_label = "a schema";
+};
+
+template<>
+struct datalake_cache_traits<schema_identifier, resolved_type> {
+    static constexpr const char* metrics_group_name
+      = "datalake:resolved_type_cache";
+    static constexpr const char* item_label = "an Iceberg type";
+};
+
+template<typename Key, typename Value>
+chunked_datalake_cache<Key, Value>::chunked_datalake_cache(
+  typename cache_t::config c)
   : cache_(c) {}
 
-void chunked_schema_cache::start() { setup_metrics(); }
+template<typename Key, typename Value>
+void chunked_datalake_cache<Key, Value>::start() {
+    setup_metrics();
+}
 
-void chunked_schema_cache::stop() { metrics_.clear(); }
+template<typename Key, typename Value>
+void chunked_datalake_cache<Key, Value>::stop() {
+    metrics_.clear();
+}
 
-ss::optimized_optional<
-  ss::shared_ptr<pandaproxy::schema_registry::valid_schema>>
-chunked_schema_cache::get_value(
-  const pandaproxy::schema_registry::schema_id& id) {
+template<typename Key, typename Value>
+ss::optimized_optional<ss::shared_ptr<Value>>
+chunked_datalake_cache<Key, Value>::get_value(const key_t& id) {
     return cache_.get_value(id);
 }
-bool chunked_schema_cache::try_insert(
+
+template<typename Key, typename Value>
+bool chunked_datalake_cache<Key, Value>::try_insert(
   const key_t& key, ss::shared_ptr<val_t> val) {
     return cache_.try_insert(key, std::move(val));
 }
 
-void chunked_schema_cache::setup_metrics() {
+template<typename Key, typename Value>
+void chunked_datalake_cache<Key, Value>::setup_metrics() {
     namespace sm = ss::metrics;
+    using traits = datalake_cache_traits<Key, Value>;
 
     if (config::shard_local_cfg().disable_metrics()) {
         return;
     }
 
     metrics_.add_group(
-      prometheus_sanitize::metrics_name("datalake:schema_cache"),
+      prometheus_sanitize::metrics_name(traits::metrics_group_name),
       {
         sm::make_counter(
           "misses",
@@ -312,16 +308,26 @@ void chunked_schema_cache::setup_metrics() {
               auto stats = cache_.stat();
               return stats.access_count - stats.hit_count;
           },
-          sm::description("The number of times a schema wasn't in the cache.")),
+          sm::description(
+            fmt::format(
+              "The number of times {} wasn't in the cache.",
+              traits::item_label))),
         sm::make_counter(
           "hits",
           [this] {
               auto stats = cache_.stat();
               return stats.hit_count;
           },
-          sm::description("The number of times a schema was in the cache.")),
+          sm::description(
+            fmt::format(
+              "The number of times {} was in the cache.", traits::item_label))),
       });
 }
+
+template class chunked_datalake_cache<
+  pandaproxy::schema_registry::schema_id,
+  pandaproxy::schema_registry::valid_schema>;
+template class chunked_datalake_cache<schema_identifier, resolved_type>;
 
 resolved_schema::resolved_schema(ss::shared_ptr<iceberg::json_conversion_ir> ir)
   : shared_schema_(std::move(ir))
@@ -343,7 +349,7 @@ std::ostream& operator<<(std::ostream& o, const type_resolver::errc& e) {
 
 type_and_buf type_and_buf::make_raw_binary(std::optional<iobuf> b) {
     return type_and_buf{
-      .type = std::nullopt,
+      .type = {},
       .parsable_buf = std::move(b),
     };
 }
@@ -353,7 +359,7 @@ binary_type_resolver::resolve_buf_type(std::optional<iobuf> b) const {
     co_return type_and_buf::make_raw_binary(std::move(b));
 }
 
-ss::future<checked<resolved_type, type_resolver::errc>>
+ss::future<checked<shared_resolved_type_t, type_resolver::errc>>
 binary_type_resolver::resolve_identifier(schema_identifier) const {
     // method is not expected to be called, as this resolver always returns
     // nullopt type.
@@ -368,7 +374,7 @@ test_binary_type_resolver::resolve_buf_type(std::optional<iobuf> b) const {
     co_return co_await binary_type_resolver::resolve_buf_type(std::move(b));
 }
 
-ss::future<checked<resolved_type, type_resolver::errc>>
+ss::future<checked<shared_resolved_type_t, type_resolver::errc>>
 test_binary_type_resolver::resolve_identifier(schema_identifier id) const {
     if (injected_error_.has_value()) {
         co_return *injected_error_;
@@ -400,22 +406,61 @@ record_schema_resolver::resolve_buf_type(std::optional<iobuf> b) const {
         co_return schema_res.error();
     }
 
-    auto shared_schema = schema_res.value();
-    co_return shared_schema->visit(
-      schema_translating_visitor{
-        std::move(buf_no_id), schema_id, shared_schema});
+    struct ident_and_buf {
+        schema_identifier ident;
+        iobuf parsable_buf;
+    };
+
+    auto ident_res
+      = schema_res.value()->visit(
+        ss::
+          make_visitor(
+            [&](const ppsr::protobuf_schema_definition&)
+              -> checked<ident_and_buf, type_resolver::errc> {
+                auto offsets_res = get_proto_offsets(buf_no_id);
+                if (offsets_res.has_error()) {
+                    return type_resolver::errc::bad_input;
+                }
+                auto offsets = std::move(offsets_res.value());
+                return ident_and_buf{
+            .ident = {.schema_id = schema_id,
+                      .protobuf_offsets = std::move(offsets.protobuf_offsets)},
+            .parsable_buf = std::move(offsets.shared_message_data),
+          };
+            },
+            [&](const auto&) -> checked<ident_and_buf, type_resolver::errc> {
+                return ident_and_buf{
+                  .ident
+                  = {.schema_id = schema_id, .protobuf_offsets = std::nullopt},
+                  .parsable_buf = std::move(buf_no_id),
+                };
+            }));
+    if (ident_res.has_error()) {
+        co_return ident_res.error();
+    }
+    auto [ident, parsable_buf] = std::move(ident_res.value());
+
+    auto resolve_res = get_resolved_type(
+      std::move(ident), std::move(schema_res.value()), resolved_type_cache_);
+    if (resolve_res.has_error()) {
+        co_return resolve_res.error();
+    }
+
+    co_return type_and_buf{
+      .type = std::move(resolve_res.value()),
+      .parsable_buf = std::move(parsable_buf),
+    };
 }
 
-ss::future<checked<resolved_type, type_resolver::errc>>
+ss::future<checked<shared_resolved_type_t, type_resolver::errc>>
 record_schema_resolver::resolve_identifier(schema_identifier ident) const {
     auto schema_res = co_await get_schema(&sr_, cache_, ident.schema_id);
     if (schema_res.has_error()) {
         co_return schema_res.error();
     }
 
-    auto shared_schema = schema_res.value();
-    co_return shared_schema->visit(
-      from_identifier_visitor{std::move(ident), shared_schema});
+    co_return get_resolved_type(
+      std::move(ident), std::move(schema_res.value()), resolved_type_cache_);
 }
 
 latest_subject_schema_resolver::latest_subject_schema_resolver(
@@ -423,12 +468,14 @@ latest_subject_schema_resolver::latest_subject_schema_resolver(
   ppsr::subject subject,
   std::optional<ss::sstring> protobuf_message_name,
   config::binding<std::chrono::milliseconds> cache_duration,
-  std::optional<std::reference_wrapper<schema_cache>> sc)
+  std::optional<std::reference_wrapper<schema_cache>> sc,
+  std::optional<std::reference_wrapper<resolved_type_cache>> rc)
   : sr_(&sr)
   , subject_(std::move(subject))
   , protobuf_message_name_(std::move(protobuf_message_name))
   , cache_ttl_(std::move(cache_duration))
-  , cache_(sc) {}
+  , cache_(sc)
+  , resolved_type_cache_(rc) {}
 
 namespace {
 
@@ -461,8 +508,7 @@ latest_subject_schema_resolver::resolve_buf_type(std::optional<iobuf> b) const {
     if (schema_lookup_cache_.age(now) < cache_ttl) {
         if (schema_lookup_cache_.entry().has_value()) {
             co_return type_and_buf{
-              .type = std::make_optional(
-                schema_lookup_cache_.entry().value().copy()),
+              .type = schema_lookup_cache_.entry().value(),
               .parsable_buf = std::move(b),
             };
         } else {
@@ -513,12 +559,11 @@ latest_subject_schema_resolver::resolve_buf_type(std::optional<iobuf> b) const {
           schema_res.error(), last_sync_time);
         co_return schema_res.error();
     }
-    auto shared_schema = schema_res.value();
-    auto resolve_res = shared_schema->visit(
+
+    auto schema_id_res = schema_res.value()->visit(
       ss::make_visitor(
-        [this, &latest_schema, &shared_schema](
-          const ppsr::protobuf_schema_definition& pb_def)
-          -> checked<resolved_type, type_resolver::errc> {
+        [this, &latest_schema](const ppsr::protobuf_schema_definition& pb_def)
+          -> checked<schema_identifier, type_resolver::errc> {
             std::vector<int32_t> offsets;
             if (const auto& explicit_name = protobuf_message_name_) {
                 auto res = compute_message_offsets(pb_def, *explicit_name);
@@ -529,19 +574,28 @@ latest_subject_schema_resolver::resolve_buf_type(std::optional<iobuf> b) const {
             } else {
                 offsets = {0};
             }
-            return translate_protobuf_schema(
-              pb_def, latest_schema.id, offsets, std::move(shared_schema));
+            return schema_identifier{
+              .schema_id = latest_schema.id,
+              .protobuf_offsets = std::move(offsets),
+            };
         },
-        [&latest_schema,
-         &shared_schema](const ppsr::avro_schema_definition& def)
-          -> checked<resolved_type, type_resolver::errc> {
-            return translate_avro_schema(
-              def, latest_schema.id, std::move(shared_schema));
-        },
-        [&latest_schema](const ppsr::json_schema_definition& def)
-          -> checked<resolved_type, type_resolver::errc> {
-            return translate_json_schema(def, latest_schema.id);
+        [&latest_schema](
+          const auto&) -> checked<schema_identifier, type_resolver::errc> {
+            return schema_identifier{
+              .schema_id = latest_schema.id,
+              .protobuf_offsets = std::nullopt,
+            };
         }));
+    if (schema_id_res.has_error()) {
+        schema_lookup_cache_ = schema_lookup_cache(
+          schema_id_res.error(), last_sync_time);
+        co_return schema_id_res.error();
+    }
+
+    auto resolve_res = get_resolved_type(
+      std::move(schema_id_res.value()),
+      std::move(schema_res.value()),
+      resolved_type_cache_);
     if (resolve_res.has_error()) {
         schema_lookup_cache_ = schema_lookup_cache(
           resolve_res.error(), last_sync_time);
@@ -555,7 +609,7 @@ latest_subject_schema_resolver::resolve_buf_type(std::optional<iobuf> b) const {
       "Updated latest schema cache for subject {} and schema ID {}",
       subject_,
       latest_schema.id);
-    schema_lookup_cache_ = schema_lookup_cache(resolved.copy(), last_sync_time);
+    schema_lookup_cache_ = schema_lookup_cache(resolved, last_sync_time);
 
     co_return type_and_buf{
       .type = std::move(resolved),
@@ -563,23 +617,16 @@ latest_subject_schema_resolver::resolve_buf_type(std::optional<iobuf> b) const {
     };
 }
 
-ss::future<checked<resolved_type, type_resolver::errc>>
+ss::future<checked<shared_resolved_type_t, type_resolver::errc>>
 latest_subject_schema_resolver::resolve_identifier(
   schema_identifier ident) const {
     auto schema_res = co_await get_schema(sr_, cache_, ident.schema_id);
     if (schema_res.has_error()) {
         co_return schema_res.error();
     }
-    auto shared_schema = schema_res.value();
-    co_return shared_schema->visit(
-      from_identifier_visitor{std::move(ident), shared_schema});
+
+    co_return get_resolved_type(
+      std::move(ident), std::move(schema_res.value()), resolved_type_cache_);
 }
 
-resolved_type resolved_type::copy() const {
-    return {
-      .schema = schema,
-      .id = id,
-      .type = iceberg::make_copy(type),
-    };
-}
 } // namespace datalake

--- a/src/v/datalake/record_schema_resolver.h
+++ b/src/v/datalake/record_schema_resolver.h
@@ -35,10 +35,11 @@ class Descriptor;
 
 namespace datalake {
 
-class schema_cache {
+template<typename Key, typename Value>
+class datalake_cache {
 public:
-    using key_t = pandaproxy::schema_registry::schema_id;
-    using val_t = pandaproxy::schema_registry::valid_schema;
+    using key_t = Key;
+    using val_t = Value;
 
     virtual ss::optimized_optional<ss::shared_ptr<val_t>>
     get_value(const key_t&) = 0;
@@ -47,15 +48,18 @@ public:
     virtual void start() = 0;
     virtual void stop() = 0;
 
-    virtual ~schema_cache() = default;
+    virtual ~datalake_cache() = default;
 };
 
-class chunked_schema_cache : public schema_cache {
+template<typename Key, typename Value>
+class chunked_datalake_cache : public datalake_cache<Key, Value> {
 public:
+    using key_t = Key;
+    using val_t = Value;
     using cache_t = utils::chunked_kv_cache<key_t, val_t>;
 
-    explicit chunked_schema_cache(cache_t::config config);
-    ~chunked_schema_cache() override = default;
+    explicit chunked_datalake_cache(typename cache_t::config config);
+    ~chunked_datalake_cache() override = default;
 
     ss::optimized_optional<ss::shared_ptr<val_t>>
     get_value(const key_t&) override;
@@ -70,6 +74,13 @@ private:
 
     void setup_metrics();
 };
+
+using schema_cache = datalake_cache<
+  pandaproxy::schema_registry::schema_id,
+  pandaproxy::schema_registry::valid_schema>;
+using chunked_schema_cache = chunked_datalake_cache<
+  pandaproxy::schema_registry::schema_id,
+  pandaproxy::schema_registry::valid_schema>;
 
 using shared_schema_t
   = ss::shared_ptr<pandaproxy::schema_registry::valid_schema>;
@@ -111,12 +122,19 @@ struct resolved_type {
     // Iceberg-compatible type. Note, the field IDs may not necessarily
     // correspond to their final IDs in the catalog.
     iceberg::field_type type;
-
-    resolved_type copy() const;
 };
 
+using shared_resolved_type_t = ss::shared_ptr<const resolved_type>;
+
+// Note that the resolved type cache needs to be keyed by the
+// `schema_identifier` which can only be fully determined once the schema is
+// known. Hence the resolved type can't be stored inline to the schema cache.
+using resolved_type_cache = datalake_cache<schema_identifier, resolved_type>;
+using chunked_resolved_type_cache
+  = chunked_datalake_cache<schema_identifier, resolved_type>;
+
 struct type_and_buf {
-    std::optional<resolved_type> type;
+    std::optional<shared_resolved_type_t> type;
 
     // Part of a record field (key or value) that conforms to the given Iceberg
     // field type.
@@ -140,7 +158,7 @@ public:
     virtual ss::future<checked<type_and_buf, errc>>
     resolve_buf_type(std::optional<iobuf> b) const = 0;
     // TODO(iceberg): This should be it's own interface.
-    virtual ss::future<checked<resolved_type, errc>>
+    virtual ss::future<checked<shared_resolved_type_t, errc>>
       resolve_identifier(schema_identifier) const = 0;
     virtual ~type_resolver() = default;
 };
@@ -152,7 +170,7 @@ public:
     ss::future<checked<type_and_buf, type_resolver::errc>>
     resolve_buf_type(std::optional<iobuf> b) const override;
 
-    ss::future<checked<resolved_type, errc>>
+    ss::future<checked<shared_resolved_type_t, errc>>
       resolve_identifier(schema_identifier) const override;
     ~binary_type_resolver() override = default;
 };
@@ -162,7 +180,7 @@ public:
     ss::future<checked<type_and_buf, type_resolver::errc>>
     resolve_buf_type(std::optional<iobuf> b) const override;
 
-    ss::future<checked<resolved_type, errc>>
+    ss::future<checked<shared_resolved_type_t, errc>>
       resolve_identifier(schema_identifier) const override;
     ~test_binary_type_resolver() override = default;
     void set_fail_requests(type_resolver::errc e) { injected_error_ = e; }
@@ -177,20 +195,25 @@ class record_schema_resolver : public type_resolver {
 public:
     explicit record_schema_resolver(
       schema::registry& sr,
-      std::optional<std::reference_wrapper<schema_cache>> sc = std::nullopt)
+      std::optional<std::reference_wrapper<schema_cache>> sc = std::nullopt,
+      std::optional<std::reference_wrapper<resolved_type_cache>> rc
+      = std::nullopt)
       : sr_(sr)
-      , cache_(sc) {}
+      , cache_(sc)
+      , resolved_type_cache_(rc) {}
 
     ss::future<checked<type_and_buf, type_resolver::errc>>
     resolve_buf_type(std::optional<iobuf> b) const override;
 
-    ss::future<checked<resolved_type, errc>>
+    ss::future<checked<shared_resolved_type_t, errc>>
       resolve_identifier(schema_identifier) const override;
     ~record_schema_resolver() override = default;
 
 private:
     schema::registry& sr_;
     std::optional<std::reference_wrapper<schema_cache>> cache_;
+    std::optional<std::reference_wrapper<resolved_type_cache>>
+      resolved_type_cache_;
 };
 
 // latest_subject_schema_resolver is a schema resolver that uses the latest
@@ -206,7 +229,8 @@ public:
       pandaproxy::schema_registry::subject subject,
       std::optional<ss::sstring> protobuf_message_name,
       config::binding<std::chrono::milliseconds> cache_ttl,
-      std::optional<std::reference_wrapper<schema_cache>> sc);
+      std::optional<std::reference_wrapper<schema_cache>> sc,
+      std::optional<std::reference_wrapper<resolved_type_cache>> rc);
     latest_subject_schema_resolver(const latest_subject_schema_resolver&)
       = delete;
     latest_subject_schema_resolver(latest_subject_schema_resolver&&) = delete;
@@ -220,7 +244,7 @@ public:
     ss::future<checked<type_and_buf, type_resolver::errc>>
     resolve_buf_type(std::optional<iobuf> b) const override;
 
-    ss::future<checked<resolved_type, errc>>
+    ss::future<checked<shared_resolved_type_t, errc>>
       resolve_identifier(schema_identifier) const override;
 
 private:
@@ -229,13 +253,15 @@ private:
     std::optional<ss::sstring> protobuf_message_name_;
     config::binding<std::chrono::milliseconds> cache_ttl_;
     std::optional<std::reference_wrapper<schema_cache>> cache_;
+    std::optional<std::reference_wrapper<resolved_type_cache>>
+      resolved_type_cache_;
 
     class schema_lookup_cache {
     public:
         schema_lookup_cache() = default;
 
         schema_lookup_cache(
-          checked<resolved_type, type_resolver::errc> entry,
+          checked<shared_resolved_type_t, type_resolver::errc> entry,
           ss::lowres_clock::time_point timestamp)
           : entry_(std::move(entry))
           , last_update_(timestamp) {}
@@ -252,12 +278,13 @@ private:
             return timestamp - last_update_;
         }
 
-        const checked<resolved_type, type_resolver::errc>& entry() const {
+        const checked<shared_resolved_type_t, type_resolver::errc>&
+        entry() const {
             return entry_;
         }
 
     private:
-        checked<resolved_type, type_resolver::errc> entry_
+        checked<shared_resolved_type_t, type_resolver::errc> entry_
           = errc::registry_error;
         ss::lowres_clock::time_point last_update_;
     };

--- a/src/v/datalake/record_translator.cc
+++ b/src/v/datalake/record_translator.cc
@@ -133,7 +133,7 @@ std::ostream& operator<<(std::ostream& o, const record_translator::errc& e) {
 }
 
 record_type
-default_translator::build_type(std::optional<resolved_type> val_type) {
+default_translator::build_type(std::optional<shared_resolved_type_t> val_type) {
     if (val_type.has_value()) {
         return structured_translator.build_type(std::move(val_type));
     }
@@ -145,7 +145,7 @@ default_translator::translate_data(
   model::partition_id pid,
   kafka::offset o,
   std::optional<iobuf> key,
-  const std::optional<resolved_type>& val_type,
+  const std::optional<shared_resolved_type_t>& val_type,
   std::optional<iobuf> parsable_val,
   model::timestamp ts,
   model::timestamp_type ts_t,
@@ -172,7 +172,8 @@ default_translator::translate_data(
       headers);
 }
 
-record_type key_value_translator::build_type(std::optional<resolved_type>) {
+record_type
+key_value_translator::build_type(std::optional<shared_resolved_type_t>) {
     auto ret_type = schemaless_struct_type();
     ret_type.fields.emplace_back(
       iceberg::nested_field::create(
@@ -191,7 +192,7 @@ key_value_translator::translate_data(
   model::partition_id pid,
   kafka::offset o,
   std::optional<iobuf> key,
-  const std::optional<resolved_type>& val_type,
+  const std::optional<shared_resolved_type_t>& val_type,
   std::optional<iobuf> parsable_val,
   model::timestamp ts,
   model::timestamp_type ts_t,
@@ -214,13 +215,14 @@ key_value_translator::translate_data(
     co_return ret_data;
 }
 
-record_type
-structured_data_translator::build_type(std::optional<resolved_type> val_type) {
+record_type structured_data_translator::build_type(
+  std::optional<shared_resolved_type_t> val_type) {
     auto ret_type = schemaless_struct_type();
     std::optional<schema_identifier> val_id;
     if (val_type.has_value()) {
-        val_id = std::move(val_type->id);
-        auto& struct_type = std::get<iceberg::struct_type>(val_type->type);
+        val_id = val_type.value()->id;
+        auto struct_type = std::get<iceberg::struct_type>(
+          iceberg::make_copy(val_type.value()->type));
         // The various schema languages differ significantly in their semantics
         // and best practices around required fields, and Iceberg has its own.
         // By forcing all schema fields to non-required, we provide a maximally
@@ -275,7 +277,7 @@ structured_data_translator::translate_data(
   model::partition_id pid,
   kafka::offset o,
   std::optional<iobuf> key,
-  const std::optional<resolved_type>& val_type,
+  const std::optional<shared_resolved_type_t>& val_type,
   std::optional<iobuf> parsable_val,
   model::timestamp ts,
   model::timestamp_type ts_t,
@@ -296,9 +298,10 @@ structured_data_translator::translate_data(
     // Fill in the internal value field.
     ret_data.fields.emplace_back(std::move(system_data));
 
+    auto& resolved = *val_type.value();
     auto translated_val = co_await std::visit(
-      value_translating_visitor{std::move(*parsable_val), val_type->type},
-      val_type->schema.get_schema_ref());
+      value_translating_visitor{std::move(*parsable_val), resolved.type},
+      resolved.schema.get_schema_ref());
     if (translated_val.has_error()) {
         vlog(
           datalake_log.warn,
@@ -308,7 +311,7 @@ structured_data_translator::translate_data(
     }
 
     auto redpanda_field_idx = get_redpanda_idx(
-      std::get<iceberg::struct_type>(val_type->type));
+      std::get<iceberg::struct_type>(resolved.type));
     // Unwrap the struct fields.
     auto& val_struct = std::get<std::unique_ptr<iceberg::struct_value>>(
       translated_val.value().value());

--- a/src/v/datalake/record_translator.h
+++ b/src/v/datalake/record_translator.h
@@ -34,12 +34,14 @@ public:
     };
     friend std::ostream& operator<<(std::ostream&, const errc&);
 
-    virtual record_type build_type(std::optional<resolved_type> val_type) = 0;
+    virtual record_type
+    build_type(std::optional<shared_resolved_type_t> val_type)
+      = 0;
     virtual ss::future<checked<iceberg::struct_value, errc>> translate_data(
       model::partition_id pid,
       kafka::offset o,
       std::optional<iobuf> key,
-      const std::optional<resolved_type>& val_type,
+      const std::optional<shared_resolved_type_t>& val_type,
       std::optional<iobuf> parsable_val,
       model::timestamp ts,
       model::timestamp_type ts_t,
@@ -50,12 +52,13 @@ public:
 
 class key_value_translator : public record_translator {
 public:
-    record_type build_type(std::optional<resolved_type> val_type) override;
+    record_type
+    build_type(std::optional<shared_resolved_type_t> val_type) override;
     ss::future<checked<iceberg::struct_value, errc>> translate_data(
       model::partition_id pid,
       kafka::offset o,
       std::optional<iobuf> key,
-      const std::optional<resolved_type>& val_type,
+      const std::optional<shared_resolved_type_t>& val_type,
       std::optional<iobuf> parsable_val,
       model::timestamp ts,
       model::timestamp_type ts_t,
@@ -65,12 +68,13 @@ public:
 
 class structured_data_translator : public record_translator {
 public:
-    record_type build_type(std::optional<resolved_type> val_type) override;
+    record_type
+    build_type(std::optional<shared_resolved_type_t> val_type) override;
     ss::future<checked<iceberg::struct_value, errc>> translate_data(
       model::partition_id pid,
       kafka::offset o,
       std::optional<iobuf> key,
-      const std::optional<resolved_type>& val_type,
+      const std::optional<shared_resolved_type_t>& val_type,
       std::optional<iobuf> parsable_val,
       model::timestamp ts,
       model::timestamp_type ts_t,
@@ -84,12 +88,13 @@ public:
 // mode with a topic config! Instead, callers should explicitly choose.
 class default_translator : public record_translator {
 public:
-    record_type build_type(std::optional<resolved_type> val_type) override;
+    record_type
+    build_type(std::optional<shared_resolved_type_t> val_type) override;
     ss::future<checked<iceberg::struct_value, errc>> translate_data(
       model::partition_id pid,
       kafka::offset o,
       std::optional<iobuf> key,
-      const std::optional<resolved_type>& val_type,
+      const std::optional<shared_resolved_type_t>& val_type,
       std::optional<iobuf> parsable_val,
       model::timestamp ts,
       model::timestamp_type ts_t,

--- a/src/v/datalake/tests/record_multiplexer_bench.cc
+++ b/src/v/datalake/tests/record_multiplexer_bench.cc
@@ -394,8 +394,9 @@ class record_multiplexer_bench_fixture
 public:
     record_multiplexer_bench_fixture()
       : _schema_cache({10, 5})
+      , _resolved_type_cache({10, 5})
       , _schema_mgr(catalog, &_features)
-      , _type_resolver(registry, _schema_cache)
+      , _type_resolver(registry, _schema_cache, _resolved_type_cache)
       , _record_gen(&registry)
       , _table_creator(_type_resolver, _schema_mgr) {
         _features.testing_activate_all();
@@ -550,6 +551,7 @@ private:
     std::unordered_set<std::string> _added_names;
     features::feature_table _features;
     datalake::chunked_schema_cache _schema_cache;
+    datalake::chunked_resolved_type_cache _resolved_type_cache;
     datalake::catalog_schema_manager _schema_mgr;
     datalake::record_schema_resolver _type_resolver;
     datalake::tests::record_generator _record_gen;

--- a/src/v/datalake/tests/record_schema_resolver_test.cc
+++ b/src/v/datalake/tests/record_schema_resolver_test.cc
@@ -149,8 +149,8 @@ TEST_F(RecordSchemaResolverTest, TestAvroSchemaHappyPath) {
     ASSERT_FALSE(res.has_error());
     auto& resolved_buf = res.value();
     ASSERT_TRUE(resolved_buf.type.has_value());
-    EXPECT_EQ(1, resolved_buf.type->id.schema_id());
-    EXPECT_FALSE(resolved_buf.type->id.protobuf_offsets.has_value());
+    EXPECT_EQ(1, (*resolved_buf.type)->id.schema_id());
+    EXPECT_FALSE((*resolved_buf.type)->id.protobuf_offsets.has_value());
 
     // Check that the resolved schema looks correct. Note, the field IDs are
     // unimportant since they are assigned outside of the resolver -- it's just
@@ -163,7 +163,7 @@ TEST_F(RecordSchemaResolverTest, TestAvroSchemaHappyPath) {
           nested_field::create(0, "next", field_required::yes, int_type{}));
         return expected_struct;
     }()};
-    EXPECT_EQ(resolved_buf.type->type, expected_type);
+    EXPECT_EQ((*resolved_buf.type)->type, expected_type);
 }
 
 TEST_F(RecordSchemaResolverTest, TestProtobufSchemaHappyPath) {
@@ -179,9 +179,9 @@ TEST_F(RecordSchemaResolverTest, TestProtobufSchemaHappyPath) {
     ASSERT_FALSE(res.has_error());
     auto& resolved_buf = res.value();
     ASSERT_TRUE(resolved_buf.type.has_value());
-    EXPECT_EQ(2, resolved_buf.type->id.schema_id());
-    EXPECT_TRUE(resolved_buf.type->id.protobuf_offsets.has_value());
-    EXPECT_EQ(resolved_buf.type->id.protobuf_offsets.value(), pb_offsets);
+    EXPECT_EQ(2, (*resolved_buf.type)->id.schema_id());
+    EXPECT_TRUE((*resolved_buf.type)->id.protobuf_offsets.has_value());
+    EXPECT_EQ((*resolved_buf.type)->id.protobuf_offsets.value(), pb_offsets);
 
     const auto expected_type = field_type{[] {
         auto expected_struct = struct_type{};
@@ -193,7 +193,7 @@ TEST_F(RecordSchemaResolverTest, TestProtobufSchemaHappyPath) {
             2, "inner_number_1", field_required::no, int_type{}));
         return expected_struct;
     }()};
-    EXPECT_EQ(resolved_buf.type->type, expected_type);
+    EXPECT_EQ((*resolved_buf.type)->type, expected_type);
 }
 
 TEST_F(RecordSchemaResolverTest, TestProtobufSchemaHappyPathNested) {
@@ -210,9 +210,9 @@ TEST_F(RecordSchemaResolverTest, TestProtobufSchemaHappyPathNested) {
     ASSERT_FALSE(res.has_error());
     auto& resolved_buf = res.value();
     ASSERT_TRUE(resolved_buf.type.has_value());
-    EXPECT_EQ(2, resolved_buf.type->id.schema_id());
-    EXPECT_TRUE(resolved_buf.type->id.protobuf_offsets.has_value());
-    EXPECT_EQ(resolved_buf.type->id.protobuf_offsets.value(), pb_offsets);
+    EXPECT_EQ(2, (*resolved_buf.type)->id.schema_id());
+    EXPECT_TRUE((*resolved_buf.type)->id.protobuf_offsets.has_value());
+    EXPECT_EQ((*resolved_buf.type)->id.protobuf_offsets.value(), pb_offsets);
 
     const auto expected_type = field_type{[] {
         auto expected_struct = struct_type{};
@@ -234,7 +234,7 @@ TEST_F(RecordSchemaResolverTest, TestProtobufSchemaHappyPathNested) {
             3, "inner", field_required::no, std::move(inner_struct)));
         return expected_struct;
     }()};
-    EXPECT_EQ(resolved_buf.type->type, expected_type);
+    EXPECT_EQ((*resolved_buf.type)->type, expected_type);
 }
 
 TEST_F(RecordSchemaResolverTest, TestProtobufSchemaReferences) {
@@ -304,7 +304,7 @@ message NestedMessage {
             2, "simple", field_required::no, std::move(simple_struct)));
         return expected_struct;
     }()};
-    EXPECT_EQ(resolved_buf.type->type, expected_type);
+    EXPECT_EQ((*resolved_buf.type)->type, expected_type);
 }
 
 TEST_F(RecordSchemaResolverTest, TestProtobufSchemaHappyPathNoOffsets) {
@@ -319,10 +319,11 @@ TEST_F(RecordSchemaResolverTest, TestProtobufSchemaHappyPathNoOffsets) {
     ASSERT_FALSE(res.has_error());
     auto& resolved_buf = res.value();
     ASSERT_TRUE(resolved_buf.type.has_value());
-    EXPECT_EQ(2, resolved_buf.type->id.schema_id());
-    EXPECT_TRUE(resolved_buf.type->id.protobuf_offsets.has_value());
+    EXPECT_EQ(2, (*resolved_buf.type)->id.schema_id());
+    EXPECT_TRUE((*resolved_buf.type)->id.protobuf_offsets.has_value());
     EXPECT_EQ(
-      resolved_buf.type->id.protobuf_offsets.value(), std::vector<int32_t>{0});
+      (*resolved_buf.type)->id.protobuf_offsets.value(),
+      std::vector<int32_t>{0});
 
     // When there are no protobuf offsets, we return the first descriptor,
     // which in this case translates to an empty struct.
@@ -330,7 +331,7 @@ TEST_F(RecordSchemaResolverTest, TestProtobufSchemaHappyPathNoOffsets) {
         auto expected_struct = struct_type{};
         return expected_struct;
     }()};
-    EXPECT_EQ(resolved_buf.type->type, expected_type);
+    EXPECT_EQ((*resolved_buf.type)->type, expected_type);
 }
 
 TEST_F(RecordSchemaResolverTest, TestProtobufSchemaBadOffsets) {
@@ -357,8 +358,8 @@ TEST_F(RecordSchemaResolverTest, TestJsonSchemaHappyPath) {
     ASSERT_FALSE(res.has_error());
     auto& resolved_buf = res.value();
     ASSERT_TRUE(resolved_buf.type.has_value());
-    EXPECT_EQ(3, resolved_buf.type->id.schema_id());
-    EXPECT_FALSE(resolved_buf.type->id.protobuf_offsets.has_value());
+    EXPECT_EQ(3, (*resolved_buf.type)->id.schema_id());
+    EXPECT_FALSE((*resolved_buf.type)->id.protobuf_offsets.has_value());
 
     // Check that the resolved schema looks correct. Note, the field IDs are
     // unimportant since they are assigned outside of the resolver -- it's just
@@ -373,7 +374,7 @@ TEST_F(RecordSchemaResolverTest, TestJsonSchemaHappyPath) {
             0, "json_value", field_required::no, long_type{}));
         return expected_struct;
     }()};
-    EXPECT_EQ(resolved_buf.type->type, expected_type);
+    EXPECT_EQ((*resolved_buf.type)->type, expected_type);
 }
 
 TEST_F(RecordSchemaResolverTest, TestMissingMagic) {
@@ -405,8 +406,8 @@ TEST_F(RecordSchemaResolverTest, TestSchemaRegistryError) {
     ASSERT_FALSE(res.has_error());
     auto& resolved_buf = res.value();
     ASSERT_TRUE(resolved_buf.type.has_value());
-    EXPECT_EQ(1, resolved_buf.type->id.schema_id());
-    EXPECT_FALSE(resolved_buf.type->id.protobuf_offsets.has_value());
+    EXPECT_EQ(1, (*resolved_buf.type)->id.schema_id());
+    EXPECT_FALSE((*resolved_buf.type)->id.protobuf_offsets.has_value());
 }
 
 TEST_F(RecordSchemaResolverTest, TestLatestSubjectSchema_Protobuf) {
@@ -419,18 +420,19 @@ TEST_F(RecordSchemaResolverTest, TestLatestSubjectSchema_Protobuf) {
       subject("latest-proto"),
       std::nullopt,
       config::mock_binding(std::chrono::milliseconds(0s)),
+      std::nullopt,
       std::nullopt);
     auto res = resolver.resolve_buf_type(buf.copy()).get();
     ASSERT_FALSE(res.has_error());
     auto& resolved_buf = res.value();
     ASSERT_TRUE(resolved_buf.type.has_value());
-    EXPECT_EQ(2, resolved_buf.type->id.schema_id());
+    EXPECT_EQ(2, (*resolved_buf.type)->id.schema_id());
     EXPECT_THAT(
-      resolved_buf.type->id.protobuf_offsets,
+      (*resolved_buf.type)->id.protobuf_offsets,
       testing::Optional(testing::ElementsAre(0)));
 
     const auto expected_type = field_type{struct_type{}};
-    EXPECT_EQ(resolved_buf.type->type, expected_type);
+    EXPECT_EQ((*resolved_buf.type)->type, expected_type);
     EXPECT_THAT(resolved_buf.parsable_buf, testing::Optional(std::ref(buf)));
 }
 
@@ -444,14 +446,15 @@ TEST_F(RecordSchemaResolverTest, TestLatestSubjectSchema_Protobuf_MessageName) {
       subject("latest-proto"),
       "datalake.proto.nested_message.inner_message_t1",
       config::mock_binding(std::chrono::milliseconds(0s)),
+      std::nullopt,
       std::nullopt);
     auto res = resolver.resolve_buf_type(buf.copy()).get();
     ASSERT_FALSE(res.has_error());
     auto& resolved_buf = res.value();
     ASSERT_TRUE(resolved_buf.type.has_value());
-    EXPECT_EQ(2, resolved_buf.type->id.schema_id());
+    EXPECT_EQ(2, (*resolved_buf.type)->id.schema_id());
     EXPECT_THAT(
-      resolved_buf.type->id.protobuf_offsets,
+      (*resolved_buf.type)->id.protobuf_offsets,
       testing::Optional(testing::ElementsAre(2, 0)));
 
     const auto expected_type = field_type{[] {
@@ -464,7 +467,7 @@ TEST_F(RecordSchemaResolverTest, TestLatestSubjectSchema_Protobuf_MessageName) {
             2, "inner_number_1", field_required::no, int_type{}));
         return expected_struct;
     }()};
-    EXPECT_EQ(resolved_buf.type->type, expected_type);
+    EXPECT_EQ((*resolved_buf.type)->type, expected_type);
     EXPECT_THAT(resolved_buf.parsable_buf, testing::Optional(std::ref(buf)));
 }
 
@@ -481,13 +484,14 @@ TEST_F(RecordSchemaResolverTest, TestLatestSubjectSchema_Avro) {
       subject("latest-avro"),
       std::nullopt,
       config::mock_binding(std::chrono::milliseconds(0s)),
+      std::nullopt,
       std::nullopt);
     auto res = resolver.resolve_buf_type(buf.copy()).get();
     ASSERT_FALSE(res.has_error());
     auto& resolved_buf = res.value();
     ASSERT_TRUE(resolved_buf.type.has_value());
-    EXPECT_EQ(1, resolved_buf.type->id.schema_id());
-    EXPECT_EQ(resolved_buf.type->id.protobuf_offsets, std::nullopt);
+    EXPECT_EQ(1, (*resolved_buf.type)->id.schema_id());
+    EXPECT_EQ((*resolved_buf.type)->id.protobuf_offsets, std::nullopt);
 
     const auto expected_type = field_type{[] {
         auto expected_struct = struct_type{};
@@ -497,7 +501,7 @@ TEST_F(RecordSchemaResolverTest, TestLatestSubjectSchema_Avro) {
           nested_field::create(0, "next", field_required::yes, int_type{}));
         return expected_struct;
     }()};
-    EXPECT_EQ(resolved_buf.type->type, expected_type);
+    EXPECT_EQ((*resolved_buf.type)->type, expected_type);
     EXPECT_THAT(resolved_buf.parsable_buf, testing::Optional(std::ref(buf)));
 }
 
@@ -511,13 +515,14 @@ TEST_F(RecordSchemaResolverTest, TestLatestSubjectSchema_Json) {
       subject("latest-json"),
       std::nullopt,
       config::mock_binding(std::chrono::milliseconds(0s)),
+      std::nullopt,
       std::nullopt);
     auto res = resolver.resolve_buf_type(buf.copy()).get();
     ASSERT_FALSE(res.has_error());
     auto& resolved_buf = res.value();
     ASSERT_TRUE(resolved_buf.type.has_value());
-    EXPECT_EQ(3, resolved_buf.type->id.schema_id());
-    EXPECT_EQ(resolved_buf.type->id.protobuf_offsets, std::nullopt);
+    EXPECT_EQ(3, (*resolved_buf.type)->id.schema_id());
+    EXPECT_EQ((*resolved_buf.type)->id.protobuf_offsets, std::nullopt);
 
     const auto expected_type = field_type{[] {
         auto expected_struct = struct_type{};
@@ -529,7 +534,7 @@ TEST_F(RecordSchemaResolverTest, TestLatestSubjectSchema_Json) {
             0, "json_value", field_required::no, long_type{}));
         return expected_struct;
     }()};
-    EXPECT_EQ(resolved_buf.type->type, expected_type);
+    EXPECT_EQ((*resolved_buf.type)->type, expected_type);
     EXPECT_THAT(resolved_buf.parsable_buf, testing::Optional(std::ref(buf)));
 }
 
@@ -694,11 +699,12 @@ TEST(CachedRecordSchemaResolverTest, TestProtobufSchemaCache) {
         ASSERT_FALSE(res.has_error());
         auto& resolved_buf = res.value();
         ASSERT_TRUE(resolved_buf.type.has_value());
-        EXPECT_EQ(2, resolved_buf.type->id.schema_id());
+        EXPECT_EQ(2, (*resolved_buf.type)->id.schema_id());
         ASSERT_EQ(
-          sr->get_count(resolved_buf.type->id.schema_id), expected_sr_count);
-        EXPECT_TRUE(resolved_buf.type->id.protobuf_offsets.has_value());
-        EXPECT_EQ(resolved_buf.type->id.protobuf_offsets.value(), pb_offsets);
+          sr->get_count((*resolved_buf.type)->id.schema_id), expected_sr_count);
+        EXPECT_TRUE((*resolved_buf.type)->id.protobuf_offsets.has_value());
+        EXPECT_EQ(
+          (*resolved_buf.type)->id.protobuf_offsets.value(), pb_offsets);
 
         const auto expected_type = field_type{[] {
             auto expected_struct = struct_type{};
@@ -710,7 +716,7 @@ TEST(CachedRecordSchemaResolverTest, TestProtobufSchemaCache) {
                 2, "inner_number_1", field_required::no, int_type{}));
             return expected_struct;
         }()};
-        EXPECT_EQ(resolved_buf.type->type, expected_type);
+        EXPECT_EQ((*resolved_buf.type)->type, expected_type);
     };
 
     // First access to a schema, should hit the schema registry.
@@ -737,10 +743,10 @@ TEST(CachedRecordSchemaResolverTest, TestAvroSchemaCache) {
         ASSERT_FALSE(res.has_error());
         auto& resolved_buf = res.value();
         ASSERT_TRUE(resolved_buf.type.has_value());
-        EXPECT_EQ(1, resolved_buf.type->id.schema_id());
+        EXPECT_EQ(1, (*resolved_buf.type)->id.schema_id());
         ASSERT_EQ(
-          sr->get_count(resolved_buf.type->id.schema_id), expected_sr_count);
-        EXPECT_FALSE(resolved_buf.type->id.protobuf_offsets.has_value());
+          sr->get_count((*resolved_buf.type)->id.schema_id), expected_sr_count);
+        EXPECT_FALSE((*resolved_buf.type)->id.protobuf_offsets.has_value());
 
         const auto expected_type = field_type{[] {
             auto expected_struct = struct_type{};
@@ -751,7 +757,7 @@ TEST(CachedRecordSchemaResolverTest, TestAvroSchemaCache) {
               nested_field::create(0, "next", field_required::yes, int_type{}));
             return expected_struct;
         }()};
-        EXPECT_EQ(resolved_buf.type->type, expected_type);
+        EXPECT_EQ((*resolved_buf.type)->type, expected_type);
     };
 
     // First access to a schema, should hit the schema registry.
@@ -778,10 +784,10 @@ TEST(CachedRecordSchemaResolverTest, TestJsonSchemaCache) {
         ASSERT_FALSE(res.has_error());
         auto& resolved_buf = res.value();
         ASSERT_TRUE(resolved_buf.type.has_value());
-        EXPECT_EQ(10, resolved_buf.type->id.schema_id());
+        EXPECT_EQ(10, (*resolved_buf.type)->id.schema_id());
         ASSERT_EQ(
-          sr->get_count(resolved_buf.type->id.schema_id), expected_sr_count);
-        EXPECT_FALSE(resolved_buf.type->id.protobuf_offsets.has_value());
+          sr->get_count((*resolved_buf.type)->id.schema_id), expected_sr_count);
+        EXPECT_FALSE((*resolved_buf.type)->id.protobuf_offsets.has_value());
 
         const auto expected_type = field_type{[] {
             auto expected_struct = struct_type{};
@@ -793,7 +799,7 @@ TEST(CachedRecordSchemaResolverTest, TestJsonSchemaCache) {
                 0, "json_value", field_required::no, long_type{}));
             return expected_struct;
         }()};
-        EXPECT_EQ(resolved_buf.type->type, expected_type);
+        EXPECT_EQ((*resolved_buf.type)->type, expected_type);
     };
 
     // First access to a schema, should hit the schema registry.
@@ -826,12 +832,13 @@ TEST(CachedRecordSchemaResolverTest, TestSchemaCacheEviction) {
         ASSERT_FALSE(res.has_error());
         auto& resolved_buf = res.value();
         ASSERT_TRUE(resolved_buf.type.has_value());
-        EXPECT_EQ(schema_id, resolved_buf.type->id.schema_id());
+        EXPECT_EQ(schema_id, (*resolved_buf.type)->id.schema_id());
         ASSERT_EQ(
-          sr->get_count(resolved_buf.type->id.schema_id), expected_sr_count);
-        EXPECT_TRUE(resolved_buf.type->id.protobuf_offsets.has_value());
-        EXPECT_EQ(resolved_buf.type->id.protobuf_offsets.value(), pb_offsets);
-        EXPECT_EQ(resolved_buf.type->type, expected_type);
+          sr->get_count((*resolved_buf.type)->id.schema_id), expected_sr_count);
+        EXPECT_TRUE((*resolved_buf.type)->id.protobuf_offsets.has_value());
+        EXPECT_EQ(
+          (*resolved_buf.type)->id.protobuf_offsets.value(), pb_offsets);
+        EXPECT_EQ((*resolved_buf.type)->type, expected_type);
     };
 
     const auto schema_2_expected_type = field_type{[] {

--- a/src/v/datalake/tests/test_utils.cc
+++ b/src/v/datalake/tests/test_utils.cc
@@ -41,7 +41,7 @@ direct_table_creator::ensure_table(
   record_schema_components comps) const {
     auto table_id = table_id_provider::table_id(topic);
 
-    std::optional<resolved_type> val_type;
+    std::optional<shared_resolved_type_t> val_type;
     if (comps.val_identifier) {
         auto type_res = co_await type_resolver_.resolve_identifier(
           comps.val_identifier.value());


### PR DESCRIPTION
Schema-to-Iceberg type translation is performed for every record during datalake translation. For schemas with many fields or deep nesting, this repeated work becomes a significant cost especially for JSON schemas which require compilation, IR conversion, and Iceberg type construction. 

Not completely happy with this PR as I'd much prefer to unify the schema cache with the resolved type cache. This is since the resolved type cache has a shared reference to a schema and can keep in alive after its been kicked from the schema cache. However, for protobuf a full schema is needed to figure out what resolved type we need. Hence having to separate caches.

The full benchmark results can be found [here](https://gist.github.com/ballard26/faf7c00c87af6cd214fb253b3cfebc61). They are interleaved with the first line being the baseline and the following line being post-PR.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
