### PR TITLE
ct/compaction: Set part size cloud_topics_upload_part_size

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/sink.cc
+++ b/src/v/cloud_topics/level_one/compaction/sink.cc
@@ -86,8 +86,10 @@ compaction_sink::compaction_sink(
   metastore* metastore,
   ss::abort_source& as,
   config::binding<size_t> max_object_size,
+  size_t upload_part_size,
   object_builder::options opts)
   : _max_object_size(std::move(max_object_size))
+  , _upload_part_size(upload_part_size)
   , _tp(tp)
   , _dirty_range_intervals(dirty_range_intervals)
   , _removable_tombstone_ranges(removable_tombstone_ranges)
@@ -152,7 +154,7 @@ compaction_sink::initialize_builder(kafka::offset object_base_offset) {
     auto oid = std::move(oid_res).value();
 
     auto upload_res = co_await _io->create_multipart_upload(
-      oid, cloud_storage_clients::multipart_upload::min_part_size, &_as);
+      oid, _upload_part_size, &_as);
 
     if (!upload_res.has_value()) {
         std::ignore = _metadata_builder->remove_pending_object(oid);

--- a/src/v/cloud_topics/level_one/compaction/sink.h
+++ b/src/v/cloud_topics/level_one/compaction/sink.h
@@ -36,6 +36,7 @@ public:
       l1::metastore*,
       ss::abort_source&,
       config::binding<size_t> max_object_size,
+      size_t upload_part_size,
       object_builder::options = {});
 
     ss::future<bool>
@@ -59,6 +60,9 @@ public:
 private:
     // The target maximum L1 object size that will be built.
     config::binding<size_t> _max_object_size;
+
+    // The part size used for multipart uploads.
+    size_t _upload_part_size;
 
     // Initializes the `_inflight_object` with a multipart upload.
     ss::future<> initialize_builder(kafka::offset);

--- a/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
@@ -128,7 +128,8 @@ ss::future<> do_compact(
       io,
       metastore,
       as,
-      config::mock_binding<size_t>(128_MiB));
+      config::mock_binding<size_t>(128_MiB),
+      16_MiB);
     auto reducer = compaction::sliding_window_reducer(
       std::move(src), std::move(sink));
 

--- a/src/v/cloud_topics/level_one/compaction/worker.cc
+++ b/src/v/cloud_topics/level_one/compaction/worker.cc
@@ -43,6 +43,7 @@ compaction_worker::compaction_worker(
   })
   , _poll_interval(
       config::shard_local_cfg().cloud_topics_compaction_interval_ms.bind())
+  , _upload_part_size(config::shard_local_cfg().cloud_topics_upload_part_size())
   , _worker_manager(worker_manager)
   , _io(io)
   , _metastore(metastore)
@@ -237,6 +238,7 @@ ss::future<> compaction_worker::compact_log(log_compaction_meta* log) {
       _metastore,
       _as,
       config::shard_local_cfg().cloud_topics_compaction_max_object_size.bind(),
+      _upload_part_size,
       l1::object_builder::options{
         .indexing_interval
         = config::shard_local_cfg().cloud_topics_l1_indexing_interval(),

--- a/src/v/cloud_topics/level_one/compaction/worker.h
+++ b/src/v/cloud_topics/level_one/compaction/worker.h
@@ -184,6 +184,10 @@ private:
     // The interval on which the worker polls for new work.
     config::binding<std::chrono::milliseconds> _poll_interval;
 
+    // Captured at construction so that changing the config at runtime does not
+    // take effect without a restart.
+    size_t _upload_part_size;
+
     // Owned by `scheduler`.
     worker_manager* _worker_manager;
 


### PR DESCRIPTION
Configures compaction's part size in the same way as reconciliation's.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
