### PR TITLE
ct/l1/domain: batch extent removal

### DIFF
--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -107,6 +107,87 @@ log_and_convert(const replicated_database::error& e, std::string_view prefix) {
     return ret;
 }
 
+// Scans up to `max_count` extents fully below `target_offset` (i.e.
+// whose last_offset < target_offset). Returns target_offset if all
+// such extents fit within `max_count`, otherwise returns the offset just
+// past the last scanned extent.
+ss::future<std::expected<kafka::offset, state_reader::error>>
+scan_extents_below(
+  state_reader& reader,
+  const model::topic_id_partition& tp,
+  kafka::offset target_offset,
+  size_t max_count) {
+    size_t count = 0;
+
+    auto max_to_scan = kafka::prev_offset(target_offset);
+    auto extents_res = co_await reader.get_inclusive_extents(
+      tp, std::nullopt, max_to_scan);
+    if (!extents_res.has_value()) {
+        co_return std::unexpected(std::move(extents_res.error()));
+    }
+
+    if (!extents_res.value().has_value()) {
+        // No extents in range, already at target.
+        co_return target_offset;
+    }
+
+    kafka::offset last_offset{};
+    auto gen = (*extents_res)->get_rows();
+    while (auto row_opt = co_await gen()) {
+        const auto& row = row_opt->get();
+        if (!row.has_value()) {
+            co_return std::unexpected(row.error());
+        }
+        if (row->val.last_offset >= target_offset) {
+            // This extent and beyond includes the exclusive target, do not
+            // include it.
+            break;
+        }
+        ++count;
+        last_offset = row->val.last_offset;
+        if (count >= max_count) {
+            // There are more extents than max_count below target_offset;
+            // return what we scanned up through.
+            co_return kafka::next_offset(last_offset);
+        }
+    }
+    // There are under max_count extents below target_offset.
+    co_return target_offset;
+}
+
+// Counts the total number of extents across all partitions for a topic,
+// returning early once the count exceeds `max`.
+ss::future<std::expected<size_t, state_reader::error>> count_topic_extents(
+  state_reader& reader, const model::topic_id& tid, size_t max) {
+    auto partitions_res = co_await reader.get_partitions_for_topic(tid);
+    if (!partitions_res.has_value()) {
+        co_return std::unexpected(std::move(partitions_res.error()));
+    }
+    size_t count = 0;
+    for (const auto& pid : partitions_res.value()) {
+        model::topic_id_partition tidp(tid, pid);
+        auto extents_res = co_await reader.get_inclusive_extents(
+          tidp, std::nullopt, std::nullopt);
+        if (!extents_res.has_value()) {
+            co_return std::unexpected(std::move(extents_res.error()));
+        }
+        if (!extents_res->has_value()) {
+            continue;
+        }
+        auto gen = extents_res->value().get_rows();
+        while (auto row_opt = co_await gen()) {
+            const auto& row = row_opt->get();
+            if (!row.has_value()) {
+                co_return std::unexpected(row.error());
+            }
+            if (++count > max) {
+                co_return max;
+            }
+        }
+    }
+    co_return count;
+}
+
 } // namespace
 
 db_domain_manager::db_domain_manager(
@@ -746,6 +827,91 @@ db_domain_manager::get_end_offset_for_term(
     };
 }
 
+ss::future<rpc::set_start_offset_reply> db_domain_manager::do_set_start_offset(
+  const gate_writer_locks& locks, rpc::set_start_offset_request req) {
+    static constexpr size_t max_extents_per_batch = 1000;
+
+    const auto target_offset = req.start_offset;
+    kafka::offset current_start_offset{};
+
+    // Get current start offset.
+    {
+        auto reader = state_reader(db_->db().create_snapshot());
+        auto meta_res = co_await reader.get_metadata(req.tp);
+        if (!meta_res.has_value()) {
+            co_return rpc::set_start_offset_reply{
+              .ec = log_and_convert(
+                meta_res.error(), "Error reading metadata for partition: "),
+            };
+        }
+        if (!meta_res->has_value()) {
+            co_return rpc::set_start_offset_reply{
+              .ec = rpc::errc::missing_ntp,
+            };
+        }
+        const auto& meta = meta_res->value();
+        if (req.start_offset > meta.next_offset) {
+            vlog(
+              cd_log.debug,
+              "Rejecting request to set {} start offset to {}, current next "
+              "offset {}",
+              req.tp,
+              req.start_offset,
+              meta.next_offset);
+            co_return rpc::set_start_offset_reply{
+              .ec = rpc::errc::concurrent_requests,
+            };
+        }
+        current_start_offset = meta.start_offset;
+    }
+
+    // Advance start_offset in batches until reaching final target.
+    while (current_start_offset < target_offset) {
+        auto reader = state_reader(db_->db().create_snapshot());
+
+        // Scan through extents to find an intermediate offset in case there
+        // are a ton of extents.
+        auto new_start_res = co_await scan_extents_below(
+          reader, req.tp, target_offset, max_extents_per_batch);
+        if (!new_start_res.has_value()) {
+            co_return rpc::set_start_offset_reply{
+              .ec = log_and_convert(
+                new_start_res.error(), "Error scanning extents: "),
+            };
+        }
+
+        auto update = set_start_offset_db_update{
+          .tp = req.tp,
+          .new_start_offset = new_start_res.value(),
+        };
+
+        chunked_vector<write_batch_row> rows;
+        bool is_no_op = false;
+        auto build_res = co_await update.build_rows(reader, rows, &is_no_op);
+        if (!build_res.has_value()) {
+            co_return rpc::set_start_offset_reply{
+              .ec = log_and_convert(
+                build_res.error(), "Rejecting request to set start offset: "),
+            };
+        }
+        if (is_no_op) {
+            current_start_offset = new_start_res.value();
+            continue;
+        }
+        auto apply_res = co_await write_rows(locks, std::move(rows));
+        if (!apply_res.has_value()) {
+            co_return rpc::set_start_offset_reply{
+              .ec = apply_res.error(),
+            };
+        }
+        current_start_offset = new_start_res.value();
+    }
+
+    co_return rpc::set_start_offset_reply{
+      .ec = rpc::errc::ok,
+    };
+}
+
 ss::future<rpc::set_start_offset_reply>
 db_domain_manager::set_start_offset(rpc::set_start_offset_request req) {
     auto gl_res = co_await gate_and_open_writes();
@@ -754,82 +920,167 @@ db_domain_manager::set_start_offset(rpc::set_start_offset_request req) {
           .ec = gl_res.error(),
         };
     }
+    co_return co_await do_set_start_offset(gl_res.value(), req);
+}
 
-    auto update = set_start_offset_db_update{
-      .tp = req.tp,
-      .new_start_offset = req.start_offset,
-    };
-
+ss::future<std::expected<void, rpc::errc>>
+db_domain_manager::set_partitions_empty(
+  const gate_writer_locks& locks, const model::topic_id& tid) {
     auto reader = state_reader(db_->db().create_snapshot());
+    auto partitions_res = co_await reader.get_partitions_for_topic(tid);
+    if (!partitions_res.has_value()) {
+        co_return std::unexpected(log_and_convert(
+          partitions_res.error(), "Error getting partitions for topic: "));
+    }
+    if (partitions_res.value().empty()) {
+        // No partitions, all done!
+        co_return std::expected<void, rpc::errc>{};
+    }
+
+    // Truncate all partitions that have data.
+    for (const auto& pid : partitions_res.value()) {
+        model::topic_id_partition tidp(tid, pid);
+        auto meta_res = co_await reader.get_metadata(tidp);
+        if (!meta_res.has_value()) {
+            co_return std::unexpected(
+              log_and_convert(meta_res.error(), "Error getting metadata: "));
+        }
+        if (!meta_res->has_value()) {
+            // Partition doesn't exist, skip.
+            continue;
+        }
+        const auto& metadata = (*meta_res).value();
+        if (metadata.start_offset < metadata.next_offset) {
+            auto set_offset_reply = co_await do_set_start_offset(
+              locks,
+              rpc::set_start_offset_request{
+                .tp = tidp,
+                .start_offset = metadata.next_offset,
+              });
+            if (set_offset_reply.ec != rpc::errc::ok) {
+                co_return std::unexpected(set_offset_reply.ec);
+            }
+        }
+    }
+
+    co_return std::expected<void, rpc::errc>{};
+}
+
+ss::future<std::expected<void, rpc::errc>> db_domain_manager::do_remove_topics(
+  const gate_writer_locks& locks, chunked_vector<model::topic_id> topics) {
+    auto reader = state_reader(db_->db().create_snapshot());
+    auto update = remove_topics_db_update{
+      .topics = std::move(topics),
+    };
     chunked_vector<write_batch_row> rows;
     auto build_res = co_await update.build_rows(reader, rows);
     if (!build_res.has_value()) {
-        co_return rpc::set_start_offset_reply{
-          .ec = log_and_convert(
-            build_res.error(), "Rejecting request to set start offset: "),
-        };
+        co_return std::unexpected(log_and_convert(
+          build_res.error(), "Rejecting request to remove topics: "));
     }
-
     if (rows.empty()) {
-        // No-op case: new_start_offset <= current start_offset.
-        co_return rpc::set_start_offset_reply{
-          .ec = rpc::errc::ok,
-        };
+        co_return std::expected<void, rpc::errc>{};
     }
-
-    auto apply_res = co_await write_rows(gl_res.value(), std::move(rows));
-    if (!apply_res.has_value()) {
-        co_return rpc::set_start_offset_reply{
-          .ec = apply_res.error(),
-        };
-    }
-
-    co_return rpc::set_start_offset_reply{
-      .ec = rpc::errc::ok,
-    };
+    co_return co_await write_rows(locks, std::move(rows));
 }
 
 ss::future<rpc::remove_topics_reply>
 db_domain_manager::remove_topics(rpc::remove_topics_request req) {
+    static constexpr size_t max_extents_per_batch = 1000;
     auto gl_res = co_await gate_and_open_writes();
     if (!gl_res.has_value()) {
         co_return rpc::remove_topics_reply{
           .ec = gl_res.error(),
-          .not_removed = std::move(req.topics),
-        };
-    }
-
-    auto update = remove_topics_db_update{
-      .topics = std::move(req.topics),
-    };
-
-    auto reader = state_reader(db_->db().create_snapshot());
-    chunked_vector<write_batch_row> rows;
-    auto build_res = co_await update.build_rows(reader, rows);
-    if (!build_res.has_value()) {
-        co_return rpc::remove_topics_reply{
-          .ec = log_and_convert(
-            build_res.error(), "Rejecting request to remove topics: "),
-          .not_removed = std::move(update.topics),
-        };
-    }
-
-    if (rows.empty()) {
-        // No-op case: no topics to remove or topics don't exist.
-        co_return rpc::remove_topics_reply{
-          .ec = rpc::errc::ok,
           .not_removed = {},
         };
     }
 
-    auto apply_res = co_await write_rows(gl_res.value(), std::move(rows));
-    if (!apply_res.has_value()) {
-        co_return rpc::remove_topics_reply{
-          .ec = apply_res.error(),
-          .not_removed = std::move(update.topics),
-        };
+    auto reader = state_reader(db_->db().create_snapshot());
+    size_t extents_so_far = 0;
+    chunked_vector<model::topic_id> to_delete_so_far;
+
+    auto copy_req_topics_from = [&req](size_t from_idx) {
+        chunked_vector<model::topic_id> not_removed;
+        std::copy(
+          req.topics.begin() + static_cast<long>(from_idx),
+          req.topics.end(),
+          std::back_inserter(not_removed));
+        return not_removed;
+    };
+    for (size_t i = 0; i < req.topics.size(); ++i) {
+        const auto& tid = req.topics.at(i);
+        auto topic_extents_res = co_await count_topic_extents(
+          reader, tid, max_extents_per_batch);
+        if (!topic_extents_res.has_value()) {
+            co_return rpc::remove_topics_reply{
+              .ec = log_and_convert(
+                topic_extents_res.error(),
+                "Error counting extents for topic removal: "),
+              .not_removed = {},
+            };
+        }
+        auto topic_extents = topic_extents_res.value();
+        if (
+          to_delete_so_far.empty() && topic_extents >= max_extents_per_batch) {
+            // This topic is big and it's the first one (we don't have any
+            // other topics accumulated). Delete it on its own by iteratively
+            // emptying its partitions (via set_partitions_empty) and then
+            // removing the remaining topic metadata.
+            auto empty_res = co_await set_partitions_empty(gl_res.value(), tid);
+            if (!empty_res.has_value()) {
+                co_return rpc::remove_topics_reply{
+                  .ec = empty_res.error(),
+                  .not_removed = {},
+                };
+            }
+            auto rm_res = co_await do_remove_topics(
+              gl_res.value(), chunked_vector<model::topic_id>::single(tid));
+            if (!rm_res.has_value()) {
+                co_return rpc::remove_topics_reply{
+                  .ec = rm_res.error(),
+                  .not_removed = {},
+                };
+            }
+            co_return rpc::remove_topics_reply{
+              .ec = rpc::errc::ok,
+              .not_removed = copy_req_topics_from(1),
+            };
+        }
+
+        if (extents_so_far + topic_extents > max_extents_per_batch) {
+            // This topic will put us over our extent limit. Just remove the
+            // topics we've accumulated so far and not this one, expecting that
+            // callers will retry.
+            auto rm_res = co_await do_remove_topics(
+              gl_res.value(), std::move(to_delete_so_far));
+            if (!rm_res.has_value()) {
+                co_return rpc::remove_topics_reply{
+                  .ec = rm_res.error(),
+                  .not_removed = {},
+                };
+            }
+            co_return rpc::remove_topics_reply{
+              .ec = rpc::errc::ok,
+              .not_removed = copy_req_topics_from(i),
+            };
+        }
+
+        to_delete_so_far.push_back(tid);
+        extents_so_far += topic_extents;
     }
 
+    // We've made it through all our topics without hitting the extent limit.
+    // It should be safe to just delete them all.
+    if (!to_delete_so_far.empty()) {
+        auto rm_res = co_await do_remove_topics(
+          gl_res.value(), std::move(to_delete_so_far));
+        if (!rm_res.has_value()) {
+            co_return rpc::remove_topics_reply{
+              .ec = rm_res.error(),
+              .not_removed = {},
+            };
+        }
+    }
     co_return rpc::remove_topics_reply{
       .ec = rpc::errc::ok,
       .not_removed = {},

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.h
@@ -144,6 +144,19 @@ private:
     ss::future<rpc::get_compaction_info_reply> do_get_compaction_info(
       const gate_read_lock&, state_reader&, rpc::get_compaction_info_request);
 
+    ss::future<rpc::set_start_offset_reply> do_set_start_offset(
+      const gate_writer_locks&, rpc::set_start_offset_request);
+
+    // Ensures all partitions for a topic have start_offset == next_offset by
+    // advancing start_offset where needed.
+    ss::future<std::expected<void, rpc::errc>>
+    set_partitions_empty(const gate_writer_locks&, const model::topic_id&);
+
+    // Removes all metadata rows for the given topics. Callers are expected to
+    // ensure that the number of rows deleted is reasonable.
+    ss::future<std::expected<void, rpc::errc>>
+    do_remove_topics(const gate_writer_locks&, chunked_vector<model::topic_id>);
+
     ss::future<> expire_preregistered_objects(chunked_vector<object_id>);
 
     ss::gate gate_;

--- a/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
+++ b/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
@@ -594,6 +594,28 @@ public:
         co_return true;
     }
 
+    // Preregisters objects and adds them via add_objects.
+    void add_preregistered_objects(
+      const model::topic_id_partition& tp,
+      kafka::offset start_offset,
+      size_t count,
+      size_t offsets_per_object,
+      model::term_id term) {
+        auto prereg_reply = initial_manager
+                              ->preregister_objects({
+                                .metastore_partition = model::partition_id(0),
+                                .count = static_cast<uint32_t>(count),
+                              })
+                              .get();
+        ASSERT_EQ(prereg_reply.ec, l1_rpc::errc::ok);
+        l1_rpc::add_objects_request req;
+        req.new_objects = make_new_objects_with_ids(
+          tp, start_offset, offsets_per_object, prereg_reply.object_ids);
+        req.new_terms = make_terms(tp, start_offset, term);
+        auto reply = initial_manager->add_objects(std::move(req)).get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+    }
+
     std::array<std::unique_ptr<domain_manager_node>, num_nodes> dm_nodes;
     scoped_config cfg;
     std::unique_ptr<cloud_io::scoped_remote> sr;
@@ -1126,4 +1148,112 @@ TEST_F(DbDomainManagerTest, TestPreregisteredObjectExpiry) {
 
         co_return co_await all_objects_missing(object_ids);
     });
+}
+
+TEST_F(DbDomainManagerTest, TestSetStartOffsetBatchedExtentRemoval) {
+    auto tp = make_tp();
+
+    // Add 2500 extents (note, internally we remove 1000 at a time).
+    ASSERT_NO_FATAL_FAILURE(add_preregistered_objects(
+      tp, kafka::offset(0), 2500, 1, model::term_id(1)));
+
+    // Truncate everything in one call.
+    l1_rpc::set_start_offset_request set_req{
+      .tp = tp,
+      .start_offset = kafka::offset(2500),
+    };
+    auto set_reply
+      = initial_manager->set_start_offset(std::move(set_req)).get();
+    ASSERT_EQ(set_reply.ec, l1_rpc::errc::ok);
+
+    l1_rpc::get_offsets_request verify_req{.tp = tp};
+    auto verify_reply
+      = initial_manager->get_offsets(std::move(verify_req)).get();
+    ASSERT_EQ(verify_reply.ec, l1_rpc::errc::ok);
+    ASSERT_EQ(verify_reply.start_offset, kafka::offset(2500));
+    ASSERT_EQ(verify_reply.next_offset, kafka::offset(2500));
+
+    l1_rpc::get_size_request size_req{.tp = tp};
+    auto size_reply = initial_manager->get_size(std::move(size_req)).get();
+    ASSERT_EQ(size_reply.ec, l1_rpc::errc::ok);
+    ASSERT_EQ(size_reply.size, 0);
+
+    // Sanity check: the term for the next offset should still be valid.
+    l1_rpc::get_term_for_offset_request term_req{
+      .tp = tp,
+      .offset = kafka::offset(2500),
+    };
+    auto term_reply
+      = initial_manager->get_term_for_offset(std::move(term_req)).get();
+    ASSERT_EQ(term_reply.ec, l1_rpc::errc::ok);
+    ASSERT_EQ(term_reply.term, model::term_id(1));
+}
+
+// Regression test: when the batch boundary falls in the middle of an extent,
+// set_start_offset must not delete that extent.
+TEST_F(DbDomainManagerTest, TestSetStartOffsetMidExtent) {
+    auto tp = make_tp();
+
+    // 1001 extents of 10 offsets each: [0,9], [10,19], ..., [10000,10009].
+    // Enough to exceed the 1000-extent batch limit.
+    ASSERT_NO_FATAL_FAILURE(add_preregistered_objects(
+      tp, kafka::offset(0), 1001, 10, model::term_id(1)));
+
+    // Target offset 9995 lands in the middle of extent [9990, 9999].
+    // The batch scans 1000 extents, ending at [9990,9999]. Without
+    // clamping, the intermediate offset would be next_offset(9999)=10000,
+    // which would incorrectly delete extent [9990,9999].
+    l1_rpc::set_start_offset_request set_req{
+      .tp = tp,
+      .start_offset = kafka::offset(9995),
+    };
+    auto set_reply
+      = initial_manager->set_start_offset(std::move(set_req)).get();
+    ASSERT_EQ(set_reply.ec, l1_rpc::errc::ok);
+
+    l1_rpc::get_offsets_request verify_req{.tp = tp};
+    auto verify_reply
+      = initial_manager->get_offsets(std::move(verify_req)).get();
+    ASSERT_EQ(verify_reply.ec, l1_rpc::errc::ok);
+    ASSERT_EQ(verify_reply.start_offset, kafka::offset(9995));
+    ASSERT_EQ(verify_reply.next_offset, kafka::offset(10010));
+}
+
+TEST_F(DbDomainManagerTest, TestRemoveTopicsBatchedExtentRemoval) {
+    auto small_tp = make_tp();
+    auto large_tp = make_tp();
+
+    // Add small partition.
+    ASSERT_NO_FATAL_FAILURE(add_preregistered_objects(
+      small_tp, kafka::offset(0), 50, 1, model::term_id(1)));
+
+    // Add large partition.
+    ASSERT_NO_FATAL_FAILURE(add_preregistered_objects(
+      large_tp, kafka::offset(0), 2500, 1, model::term_id(1)));
+
+    // Remove both topics, retrying as needed since batching may return
+    // not_removed topics when extent counts exceed the batch limit.
+    chunked_vector<model::topic_id> remaining;
+    remaining.push_back(small_tp.topic_id);
+    remaining.push_back(large_tp.topic_id);
+    while (!remaining.empty()) {
+        l1_rpc::remove_topics_request remove_req;
+        remove_req.topics = std::move(remaining);
+        auto remove_reply
+          = initial_manager->remove_topics(std::move(remove_req)).get();
+        ASSERT_EQ(remove_reply.ec, l1_rpc::errc::ok);
+        remaining = std::move(remove_reply.not_removed);
+    }
+
+    // Verify both partitions no longer exist.
+    {
+        l1_rpc::get_offsets_request req{.tp = small_tp};
+        auto reply = initial_manager->get_offsets(std::move(req)).get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::missing_ntp);
+    }
+    {
+        l1_rpc::get_offsets_request req{.tp = large_tp};
+        auto reply = initial_manager->get_offsets(std::move(req)).get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::missing_ntp);
+    }
 }

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -801,7 +801,13 @@ TEST_P(ReplicatedMetastoreTest, TestSetStartOffset) {
     auto missing_tp = make_tp(999);
     auto set_start_missing = meta.set_start_offset(missing_tp, o{10}).get();
     ASSERT_FALSE(set_start_missing.has_value());
-    ASSERT_EQ(set_start_missing.error(), metastore::errc::invalid_request);
+    if (GetParam() == metastore_backend::simple) {
+        // The simple backend doesn't have finer grained reasons for bad
+        // updates.
+        ASSERT_EQ(set_start_missing.error(), metastore::errc::invalid_request);
+    } else {
+        ASSERT_EQ(set_start_missing.error(), metastore::errc::missing_ntp);
+    }
     ASSERT_NO_FATAL_FAILURE(assert_get_offsets(o{50}, o{100}));
 
     // Set start so it's totally empty
@@ -819,7 +825,7 @@ TEST_P(ReplicatedMetastoreTest, TestBasicRemoveTopics) {
     auto& app = get_ct_app(model::node_id{0});
     auto& meta = app.get_sharded_replicated_metastore()->local();
 
-    static constexpr auto topics_count = 10000;
+    static constexpr auto topics_count = 3000;
     add_objects_for_topics(meta, topics_count, 99).get();
 
     // Sanity check that all topics exist.
@@ -842,11 +848,20 @@ TEST_P(ReplicatedMetastoreTest, TestBasicRemoveTopics) {
         topic_ids_to_remove.push_back(tp.topic_id);
     }
 
-    // Remove all topics.
-    auto remove_res = meta.remove_topics(topic_ids_to_remove).get();
-    ASSERT_TRUE(remove_res.has_value());
-    EXPECT_TRUE(remove_res->not_removed.empty())
-      << remove_res->not_removed.size() << " topics remain";
+    // Remove all topics, retrying as needed since batching may return
+    // not_removed topics when extent counts exceed the batch limit.
+    while (!topic_ids_to_remove.empty()) {
+        auto remove_res = meta.remove_topics(topic_ids_to_remove).get();
+        ASSERT_TRUE(remove_res.has_value());
+        chunked_vector<model::topic_id> remaining;
+        remaining.reserve(remove_res->not_removed.size());
+        for (auto& tid : remove_res->not_removed) {
+            remaining.push_back(tid);
+        }
+        ASSERT_LT(remaining.size(), topic_ids_to_remove.size())
+          << "no progress removing topics";
+        topic_ids_to_remove = std::move(remaining);
+    }
 
     // Verify all topics are gone.
     for (int i = 0; i < topics_count; ++i) {
@@ -896,8 +911,16 @@ TEST_P(ReplicatedMetastoreTest, TestRemoveTopicsWithShuffleLoop) {
             break;
         }
         auto remove_res = meta.remove_topics(topics_to_remove).get();
-        if (
-          !remove_res.has_value() || !remove_res.value().not_removed.empty()) {
+        if (!remove_res.has_value()) {
+            ss::sleep(100ms).get();
+            continue;
+        }
+        if (!remove_res.value().not_removed.empty()) {
+            topics_to_remove.clear();
+            std::copy(
+              remove_res->not_removed.begin(),
+              remove_res->not_removed.end(),
+              std::back_inserter(topics_to_remove));
             ss::sleep(100ms).get();
             continue;
         }

--- a/src/v/cloud_topics/level_one/metastore/topic_purger.cc
+++ b/src/v/cloud_topics/level_one/metastore/topic_purger.cc
@@ -30,7 +30,7 @@ topic_purger::topic_purger(
 
 ss::future<std::expected<void, topic_purger::error>>
 topic_purger::purge_tombstoned_topics(ss::abort_source* as) {
-    static constexpr auto max_topics_per_req = 100;
+    static constexpr auto max_topics_per_req = 10;
     static constexpr auto max_failed_metastore_attempts = 5;
     static constexpr auto max_concurrent_purges = 10;
     while (true) {


### PR DESCRIPTION
Previously set_start_offset and remove_topics could remove unbounded
numbers of extents in single database writes. For partitions with
millions of extents, this caused memory exhaustion and reactor stalls.

This commit batches up extent removal for these calls:
- For set_start_offset, we first find a batch of up to 1000 extents to
  remove at once, getting the offset of that 1000th extent, and then use
  the existing set_start_offset logic on this offset. This is repeated
  until the caller's start offset is reached. This preserves consistency
  across the various metadata types (vs naively deleting 1000 extents
  without touching terms, for example).
- For remove_topics, we iterate through the topics to delete, counting
  extents as we go. If the number of extents so far exceeds 1000
  extents, we delete the topics we've iterated over and return the
  remaining topics that haven't been deleted. If we haven't iterated
  over any yet and we're at our limit, we rely on set_start_offset to
  iteratively truncate to the next_offset and then remove the topic.

Along the way, some other call sites (topic purger and some tests) are
updated to accommodate (either by requesting fewer topic removals at a
time or handling returned not_removed lists appropriately).
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
