### PR TITLE
cpd: Add rdkafka based produce throughput bench

### DIFF
--- a/tests/docker/ducktape-deps/librdkafka
+++ b/tests/docker/ducktape-deps/librdkafka
@@ -3,6 +3,8 @@ set -e
 mkdir /opt/librdkafka
 curl -SL "https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.11.1.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka
 cd /opt/librdkafka
+# warmup patch
+curl https://github.com/redpanda-data/librdkafka/commit/9c4f8ea374f9d117c92b2d49ef01416a2c26247e.patch | git apply
 ./configure --enable-gssapi --enable-curl
 make -j$(nproc)
 make install

--- a/tests/rptest/perf/rdkafka_test.py
+++ b/tests/rptest/perf/rdkafka_test.py
@@ -38,6 +38,7 @@ class RdkafkaPerf(RedpandaTest):
             msg_size=self.MSG_SIZE,
             num_nodes=1,
             clients_per_node=1,
+            warmup_msg_count=50000,
             extra_config={
                 "enable.idempotence": "true",
                 "batch.size": "1",
@@ -71,7 +72,7 @@ class RdkafkaPerf(RedpandaTest):
         start_time = time.time()
         iterations = 0
         while (time.time() - start_time) < 90:
-            self.run_workload(spec, 100000, write_metrics=True)
+            self.run_workload(spec, 100000, write_metrics=False)
             iterations += 1
         self.logger.info(f"Warmup complete after {iterations} iteration(s)")
 

--- a/tests/rptest/perf/rdkafka_test.py
+++ b/tests/rptest/perf/rdkafka_test.py
@@ -29,7 +29,7 @@ class RdkafkaPerf(RedpandaTest):
             *args, num_brokers=3, resource_settings=resource_settings, **kwargs
         )
 
-    def run_workload(self, spec: TopicSpec, msg_count: int, free: bool):
+    def run_workload(self, spec: TopicSpec, msg_count: int, write_metrics: bool):
         svc = RdkafkaPerformanceService(
             self.test_context,
             self.redpanda,
@@ -61,15 +61,17 @@ class RdkafkaPerf(RedpandaTest):
         )
         assert m.dr_err == 0, f"Unexpected delivery errors: {m.dr_err}"
 
-        svc.stop()
-        if free:
+        if write_metrics:
+            svc.write_metrics_result(m)
+        else:
+            svc.stop()
             svc.free()
 
     def run_warmup(self, spec: TopicSpec) -> None:
         start_time = time.time()
         iterations = 0
         while (time.time() - start_time) < 90:
-            self.run_workload(spec, 100000, free=True)
+            self.run_workload(spec, 100000, write_metrics=True)
             iterations += 1
         self.logger.info(f"Warmup complete after {iterations} iteration(s)")
 
@@ -80,4 +82,4 @@ class RdkafkaPerf(RedpandaTest):
 
         self.run_warmup(spec)
 
-        self.run_workload(spec, self.MSG_COUNT, free=False)
+        self.run_workload(spec, self.MSG_COUNT, write_metrics=True)

--- a/tests/rptest/perf/rdkafka_test.py
+++ b/tests/rptest/perf/rdkafka_test.py
@@ -1,0 +1,83 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+from typing import Any
+
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.services.rdkafka_performance import RdkafkaPerformanceService
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import ResourceSettings
+
+
+class RdkafkaPerf(RedpandaTest):
+    # Run the test for approximately 2 minutes
+    MSG_COUNT = 1000000
+    MSG_SIZE = 100
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        # Reduce core count to reduce shard variance and noise
+        resource_settings = ResourceSettings(num_cpus=2)
+        super().__init__(
+            *args, num_brokers=3, resource_settings=resource_settings, **kwargs
+        )
+
+    def run_workload(self, spec: TopicSpec, msg_count: int, free: bool):
+        svc = RdkafkaPerformanceService(
+            self.test_context,
+            self.redpanda,
+            topic=spec.name,
+            msg_count=msg_count,
+            msg_size=self.MSG_SIZE,
+            num_nodes=1,
+            clients_per_node=1,
+            extra_config={
+                "enable.idempotence": "true",
+                "batch.size": "1",
+                "linger.ms": "0",
+                # otherwise things become very unstable
+                "queue.buffering.max.messages": "1000",
+            },
+        )
+        svc.start()
+        svc.wait(timeout_sec=300)
+
+        m = svc.metrics()
+
+        expected_messages = msg_count
+
+        assert m.msgs == expected_messages, (
+            f"Expected {expected_messages} messages produced, got {m.msgs}"
+        )
+        assert m.dr == expected_messages, (
+            f"Expected {expected_messages} deliveries, got {m.dr}"
+        )
+        assert m.dr_err == 0, f"Unexpected delivery errors: {m.dr_err}"
+
+        svc.stop()
+        if free:
+            svc.free()
+
+    def run_warmup(self, spec: TopicSpec) -> None:
+        start_time = time.time()
+        iterations = 0
+        while (time.time() - start_time) < 90:
+            self.run_workload(spec, 100000, free=True)
+            iterations += 1
+        self.logger.info(f"Warmup complete after {iterations} iteration(s)")
+
+    @cluster(num_nodes=6)
+    def test_produce(self) -> None:
+        spec = TopicSpec(name="rdkafka", partition_count=36, replication_factor=3)
+        self.client().create_topic(spec)
+
+        self.run_warmup(spec)
+
+        self.run_workload(spec, self.MSG_COUNT, free=False)

--- a/tests/rptest/services/rdkafka_performance.py
+++ b/tests/rptest/services/rdkafka_performance.py
@@ -1,0 +1,340 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from __future__ import annotations
+
+import enum
+import signal
+from dataclasses import dataclass
+from typing import Any
+
+from ducktape.cluster.cluster import ClusterNode
+from ducktape.cluster.remoteaccount import RemoteCommandError
+from ducktape.services.service import Service
+from ducktape.tests.test import TestContext
+from ducktape.utils.util import wait_until
+
+from rptest.services.redpanda_types import (
+    RedpandaServiceForClients,
+    SaslCredentials,
+)
+
+
+@dataclass
+class RdkafkaPerformanceMetrics:
+    """Metrics parsed from the rdkafka_performance ``-u`` table output.
+
+    The table is emitted periodically by the tool.  Each row is a
+    cumulative snapshot.  The :meth:`RdkafkaPerformanceService.metrics`
+    method returns the **last** row (i.e. the final totals).
+
+    Column mapping (producer mode)::
+
+        elapsed | msgs | bytes | rtt | dr | dr_m/s | dr_MB/s |
+        dr_err  | tx_err | outq | offset
+
+    Column mapping (consumer mode)::
+
+        elapsed | msgs | bytes | rtt | m/s | MB/s | rx_err | offset
+
+    """
+
+    elapsed_ms: int
+    """Cumulative wall-clock time in milliseconds."""
+
+    msgs: int
+    """Total messages produced or consumed."""
+
+    bytes: int
+    """Total bytes produced or consumed."""
+
+    rtt: int
+    """Average round-trip time in milliseconds."""
+
+    # -- Producer-specific (None in consumer mode) --
+    dr: int | None = None
+    """Messages delivered (delivery reports OK, producer only)."""
+
+    dr_msgs_per_sec: int | None = None
+    """Delivery rate in msgs/s (producer only)."""
+
+    dr_mb_per_sec: float | None = None
+    """Delivery rate in MB/s (producer only)."""
+
+    dr_err: int | None = None
+    """Delivery report errors (producer only)."""
+
+    tx_err: int | None = None
+    """Produce call failures (producer only)."""
+
+    outq: int | None = None
+    """Current output queue length (producer only)."""
+
+    # -- Consumer-specific (None in producer mode) --
+    msgs_per_sec: int | None = None
+    """Consume rate in msgs/s (consumer only)."""
+
+    mb_per_sec: float | None = None
+    """Consume rate in MB/s (consumer only)."""
+
+    rx_err: int | None = None
+    """Receive errors (consumer only)."""
+
+
+def _parse_table(output: str) -> list[dict[str, str]]:
+    """Parse the ``-u`` pipe-delimited table output into a list of dicts.
+
+    Each dict maps a column header name to its stripped string value.
+    Header rows (re-printed every 20 data rows) are detected and used
+    to key subsequent data rows.
+    """
+    headers: list[str] = []
+    rows: list[dict[str, str]] = []
+
+    for line in output.splitlines():
+        # Every row starts with "| ".
+        if not line.startswith("|"):
+            continue
+
+        cells = [c.strip() for c in line.split("|") if c.strip()]
+
+        # A header row contains non-numeric tokens like "elapsed".
+        if cells and not cells[0].lstrip("-").replace(".", "").isdigit():
+            headers = cells
+        elif headers:
+            row = dict(zip(headers, cells))
+            rows.append(row)
+
+    return rows
+
+
+class RdkafkaPerformanceMode(enum.Enum):
+    PRODUCE = "P"
+    CONSUME = "G"
+
+
+class RdkafkaPerformanceService(Service):
+    """
+    Service to run rdkafka_performance
+    """
+
+    PROCESS_NAME = "rdkafka_performance"
+    EXE = f"/opt/librdkafka/examples/{PROCESS_NAME}"
+
+    LOG_PATH = f"/tmp/{PROCESS_NAME}.log"
+
+    logs = {
+        "rdkafka_performance_output": {
+            "path": LOG_PATH,
+            "collect_default": True,
+        },
+    }
+
+    def __init__(
+        self,
+        context: TestContext,
+        redpanda: RedpandaServiceForClients,
+        topic: str,
+        msg_count: int,
+        msg_size: int = 1024,
+        mode: RdkafkaPerformanceMode = RdkafkaPerformanceMode.PRODUCE,
+        *,
+        group_name: str | None = None,
+        acks: int | None = None,
+        compression: str | None = None,
+        key: str | None = None,
+        rate: float | None = None,
+        partition: int | None = None,
+        # Arbitrary librdkafka -X properties
+        extra_config: dict[str, str] | None = None,
+        sasl_options: SaslCredentials | None = None,
+        enable_tls: bool = False,
+        custom_node: list[ClusterNode] | None = None,
+    ):
+        nodes_to_allocate = 0 if custom_node else 1
+        super().__init__(context, num_nodes=nodes_to_allocate)
+
+        if custom_node is not None:
+            assert not self.nodes
+            self.nodes = custom_node
+
+        if mode == RdkafkaPerformanceMode.CONSUME:
+            assert group_name is not None, "group_name is required in CONSUME mode"
+
+        self._redpanda = redpanda
+        self._topic = topic
+        self._msg_count = msg_count
+        self._msg_size = msg_size
+        self._mode = mode
+        self._group_name = group_name
+        self._acks = acks
+        self._compression = compression
+        self._key = key
+        self._rate = rate
+        self._partition = partition
+        self._extra_config: dict[str, str] = dict(extra_config or {})
+        self._sasl_options = sasl_options
+        self._enable_tls = enable_tls
+        self._pid: int | None = None
+
+        # Auto-detect cloud cluster credentials.
+        if hasattr(redpanda, "GLOBAL_CLOUD_CLUSTER_CONFIG"):
+            security = redpanda.kafka_client_security()
+            if security.sasl_enabled and self._sasl_options is None:
+                self._sasl_options = security.simple_credentials()
+            self._enable_tls = self._enable_tls or security.tls_enabled
+
+    def _build_cmd(self) -> str:
+        """Build the full rdkafka_performance command line."""
+        parts: list[str] = [self.EXE]
+
+        # Mode flag
+        parts.append(f"-{self._mode.value}")
+
+        if self._mode == RdkafkaPerformanceMode.CONSUME:
+            assert self._group_name is not None
+            parts += [self._group_name]
+
+        # Required args
+        parts += ["-b", self._redpanda.brokers()]
+        parts += ["-t", self._topic]
+        parts += ["-c", str(self._msg_count)]
+        parts += ["-s", str(self._msg_size)]
+
+        # Optional native flags
+        if self._acks is not None:
+            parts += ["-a", str(self._acks)]
+        if self._compression is not None:
+            parts += ["-z", self._compression]
+        if self._key is not None:
+            parts += ["-k", self._key]
+        if self._rate is not None:
+            parts += ["-r", str(self._rate)]
+        if self._partition is not None:
+            parts += ["-p", str(self._partition)]
+
+        # Always use table output for machine-parseable metrics.
+        parts.append("-u")
+
+        # Security via -X properties
+        security_props = self._build_security_config()
+        all_extra = {**security_props, **self._extra_config}
+        for prop, val in all_extra.items():
+            parts += ["-X", f"{prop}={val}"]
+
+        return " ".join(parts)
+
+    def _build_security_config(self) -> dict[str, str]:
+        """Return librdkafka -X security properties derived from the
+        authentication state."""
+        props: dict[str, str] = {}
+
+        if self._sasl_options is not None:
+            if self._enable_tls:
+                props["security.protocol"] = "sasl_ssl"
+            else:
+                props["security.protocol"] = "sasl_plaintext"
+            props["sasl.mechanism"] = self._sasl_options.mechanism
+            props["sasl.username"] = self._sasl_options.username
+            props["sasl.password"] = self._sasl_options.password
+
+        elif self._enable_tls:
+            props["security.protocol"] = "ssl"
+
+        return props
+
+    def start_node(self, node: ClusterNode, **kwargs: Any):
+        self.clean_node(node, **kwargs)
+
+        assert self._pid is None
+
+        cmd = self._build_cmd()
+        wrapped_cmd = f"nohup {cmd} >> {self.LOG_PATH} 2>&1 & echo $!"
+
+        self.logger.debug(f"Starting rdkafka_performance: {wrapped_cmd}")
+        pid_str = node.account.ssh_output(wrapped_cmd, timeout_sec=10)
+        self._pid = int(pid_str.strip())
+        self.logger.debug(
+            f"Spawned rdkafka_performance node={node.name} pid={self._pid}"
+        )
+
+    def wait_node(self, node: ClusterNode, timeout_sec: float | None = None) -> bool:
+        timeout = timeout_sec or 600
+        wait_until(
+            lambda: not node.account.exists(f"/proc/{self._pid}"),
+            timeout_sec=timeout,
+            backoff_sec=2,
+            err_msg=(
+                f"rdkafka_performance did not finish within {timeout}s "
+                f"(pid={self._pid})"
+            ),
+        )
+        self._pid = None
+        return True
+
+    def stop_node(self, node: ClusterNode, **kwargs: Any):
+        if self._pid is None:
+            return
+        self.logger.debug(f"Killing pid {self._pid}")
+        try:
+            node.account.signal(self._pid, signal.SIGKILL, allow_fail=False)
+        except RemoteCommandError as e:
+            if "No such process" not in str(e.msg):
+                raise
+        self._pid = None
+
+    def clean_node(self, node: ClusterNode, **kwargs: Any):
+        node.account.kill_process(self.PROCESS_NAME, clean_shutdown=False)
+        node.account.remove(self.LOG_PATH, allow_fail=True)
+
+    def metrics(self, node: ClusterNode) -> RdkafkaPerformanceMetrics:
+        """Parse the last row of the ``-u`` table output.
+
+        Call this after ``wait()`` has returned.  Reads the log file on
+        *node* and returns a :class:`RdkafkaPerformanceMetrics` with the
+        values from the last data row emitted by rdkafka_performance.
+        """
+        output = node.account.ssh_output(f"cat {self.LOG_PATH}", timeout_sec=10).decode(
+            "utf-8"
+        )
+
+        rows = _parse_table(output)
+        if not rows:
+            raise RuntimeError(
+                f"No table rows found in rdkafka_performance output for "
+                f"mode={self._mode.name}. Log content:\n{output}"
+            )
+
+        r = rows[-1]
+
+        # We drop offset. It's not useful at this point
+
+        if self._mode == RdkafkaPerformanceMode.PRODUCE:
+            return RdkafkaPerformanceMetrics(
+                elapsed_ms=int(r["elapsed"]),
+                msgs=int(r["msgs"]),
+                bytes=int(r["bytes"]),
+                rtt=int(r["rtt"]),
+                dr=int(r["dr"]),
+                dr_msgs_per_sec=int(r["dr_m/s"]),
+                dr_mb_per_sec=float(r["dr_MB/s"]),
+                dr_err=int(r["dr_err"]),
+                tx_err=int(r["tx_err"]),
+                outq=int(r["outq"]),
+            )
+        else:
+            return RdkafkaPerformanceMetrics(
+                elapsed_ms=int(r["elapsed"]),
+                msgs=int(r["msgs"]),
+                bytes=int(r["bytes"]),
+                rtt=int(r["rtt"]),
+                msgs_per_sec=int(r["m/s"]),
+                mb_per_sec=float(r["MB/s"]),
+                rx_err=int(r["rx_err"]),
+            )

--- a/tests/rptest/services/rdkafka_performance.py
+++ b/tests/rptest/services/rdkafka_performance.py
@@ -159,6 +159,7 @@ class RdkafkaPerformanceService(Service):
         msg_size: int = 1024,
         mode: RdkafkaPerformanceMode = RdkafkaPerformanceMode.PRODUCE,
         *,
+        warmup_msg_count: int = 0,
         group_name: str | None = None,
         num_nodes: int = 1,
         clients_per_node: int = 3,
@@ -192,6 +193,7 @@ class RdkafkaPerformanceService(Service):
         self._topic = topic
         self._msg_count = msg_count
         self._msg_size = msg_size
+        self._warmup_msg_count = warmup_msg_count
         self._mode = mode
         self._group_name = group_name
         self._clients_per_node = clients_per_node
@@ -220,7 +222,7 @@ class RdkafkaPerformanceService(Service):
                 self._sasl_options = security.simple_credentials()
             self._enable_tls = self._enable_tls or security.tls_enabled
 
-    def _build_cmd(self, msg_count: int) -> str:
+    def _build_cmd(self, msg_count: int, warmup_count: int) -> str:
         """Build the full rdkafka_performance command line."""
         parts: list[str] = [self.EXE]
 
@@ -248,6 +250,8 @@ class RdkafkaPerformanceService(Service):
             parts += ["-r", str(self._rate)]
         if self._partition is not None:
             parts += ["-p", str(self._partition)]
+        if warmup_count > 0:
+            parts += ["-w", str(warmup_count)]
 
         # Always use table output for machine-parseable metrics.
         parts.append("-u")
@@ -263,10 +267,12 @@ class RdkafkaPerformanceService(Service):
     def _instance_log_path(self, client_idx: int) -> str:
         return f"/tmp/{self.PROCESS_NAME}_{client_idx}.log"
 
-    def _instance_message_count(self, node: ClusterNode, client_idx: int) -> int:
+    def _instance_message_count(
+        self, node: ClusterNode, client_idx: int, count: int
+    ) -> int:
         total_instances = len(self.nodes) * self._clients_per_node
-        base_count = self._msg_count // total_instances
-        remainder = self._msg_count % total_instances
+        base_count = count // total_instances
+        remainder = count % total_instances
 
         global_instance_idx = (
             self.nodes.index(node) * self._clients_per_node + client_idx
@@ -302,8 +308,11 @@ class RdkafkaPerformanceService(Service):
         self._instances[node.name] = []
 
         for client_idx in range(self._clients_per_node):
-            msg_count = self._instance_message_count(node, client_idx)
-            cmd = self._build_cmd(msg_count)
+            msg_count = self._instance_message_count(node, client_idx, self._msg_count)
+            warmup_count = self._instance_message_count(
+                node, client_idx, self._warmup_msg_count
+            )
+            cmd = self._build_cmd(msg_count, warmup_count)
             log_path = self._instance_log_path(client_idx)
             wrapped_cmd = f"nohup {cmd} >> {log_path} 2>&1 & echo $!"
 

--- a/tests/rptest/services/rdkafka_performance.py
+++ b/tests/rptest/services/rdkafka_performance.py
@@ -10,9 +10,11 @@
 from __future__ import annotations
 
 import enum
+import json
+import os
 import signal
 import statistics
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Any, Sequence, overload
 
 from ducktape.cluster.cluster import ClusterNode
@@ -143,6 +145,7 @@ class RdkafkaPerformanceService(Service):
     PROCESS_NAME = "rdkafka_performance"
     EXE = f"/opt/librdkafka/examples/{PROCESS_NAME}"
     LOG_PATH = f"/tmp/{PROCESS_NAME}.log"
+    RESULT_FILE_NAME = "result.json"
 
     logs: dict[str, dict[str, str | bool]] = {}
 
@@ -345,6 +348,16 @@ class RdkafkaPerformanceService(Service):
         node.account.remove(self.LOG_PATH, allow_fail=True)
         for client_idx in range(self._clients_per_node):
             node.account.remove(self._instance_log_path(client_idx), allow_fail=True)
+
+    def _result_file_path(self) -> str:
+        result_dir = TestContext.results_dir(self.context, self.context.test_index)
+        os.makedirs(result_dir, exist_ok=True)
+        return os.path.join(result_dir, self.RESULT_FILE_NAME)
+
+    def write_metrics_result(self, metrics: RdkafkaPerformanceMetrics) -> None:
+        with open(self._result_file_path(), "w", encoding="utf-8") as result_file:
+            json.dump(asdict(metrics), result_file, indent=2, sort_keys=True)
+            result_file.write("\n")
 
     def _metrics_for_node_instance(
         self, node: ClusterNode, log_path: str

--- a/tests/rptest/services/rdkafka_performance.py
+++ b/tests/rptest/services/rdkafka_performance.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 
 import enum
 import signal
+import statistics
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Sequence, overload
 
 from ducktape.cluster.cluster import ClusterNode
 from ducktape.cluster.remoteaccount import RemoteCommandError
@@ -87,6 +88,21 @@ class RdkafkaPerformanceMetrics:
     """Receive errors (consumer only)."""
 
 
+@overload
+def _sum_optional(values: Sequence[int | None]) -> int | None: ...
+
+
+@overload
+def _sum_optional(values: Sequence[float | None]) -> float | None: ...
+
+
+def _sum_optional(values: Sequence[int | float | None]) -> int | float | None:
+    present_values = [value for value in values if value is not None]
+    if not present_values:
+        return None
+    return sum(present_values)
+
+
 def _parse_table(output: str) -> list[dict[str, str]]:
     """Parse the ``-u`` pipe-delimited table output into a list of dicts.
 
@@ -126,16 +142,11 @@ class RdkafkaPerformanceService(Service):
 
     PROCESS_NAME = "rdkafka_performance"
     EXE = f"/opt/librdkafka/examples/{PROCESS_NAME}"
-
     LOG_PATH = f"/tmp/{PROCESS_NAME}.log"
 
-    logs = {
-        "rdkafka_performance_output": {
-            "path": LOG_PATH,
-            "collect_default": True,
-        },
-    }
+    logs: dict[str, dict[str, str | bool]] = {}
 
+    # message count is divided across all service instances
     def __init__(
         self,
         context: TestContext,
@@ -146,6 +157,8 @@ class RdkafkaPerformanceService(Service):
         mode: RdkafkaPerformanceMode = RdkafkaPerformanceMode.PRODUCE,
         *,
         group_name: str | None = None,
+        num_nodes: int = 1,
+        clients_per_node: int = 3,
         acks: int | None = None,
         compression: str | None = None,
         key: str | None = None,
@@ -157,7 +170,12 @@ class RdkafkaPerformanceService(Service):
         enable_tls: bool = False,
         custom_node: list[ClusterNode] | None = None,
     ):
-        nodes_to_allocate = 0 if custom_node else 1
+        if num_nodes < 1:
+            raise ValueError(f"num_nodes must be >= 1, got {num_nodes}")
+        if clients_per_node < 1:
+            raise ValueError(f"clients_per_node must be >= 1, got {clients_per_node}")
+
+        nodes_to_allocate = 0 if custom_node else num_nodes
         super().__init__(context, num_nodes=nodes_to_allocate)
 
         if custom_node is not None:
@@ -173,6 +191,7 @@ class RdkafkaPerformanceService(Service):
         self._msg_size = msg_size
         self._mode = mode
         self._group_name = group_name
+        self._clients_per_node = clients_per_node
         self._acks = acks
         self._compression = compression
         self._key = key
@@ -181,7 +200,15 @@ class RdkafkaPerformanceService(Service):
         self._extra_config: dict[str, str] = dict(extra_config or {})
         self._sasl_options = sasl_options
         self._enable_tls = enable_tls
-        self._pid: int | None = None
+        self._instances: dict[str, list[tuple[int, str]]] = {}
+
+        self.logs = {
+            f"rdkafka_performance_output_{client_idx}": {
+                "path": self._instance_log_path(client_idx),
+                "collect_default": True,
+            }
+            for client_idx in range(self._clients_per_node)
+        }
 
         # Auto-detect cloud cluster credentials.
         if hasattr(redpanda, "GLOBAL_CLOUD_CLUSTER_CONFIG"):
@@ -190,7 +217,7 @@ class RdkafkaPerformanceService(Service):
                 self._sasl_options = security.simple_credentials()
             self._enable_tls = self._enable_tls or security.tls_enabled
 
-    def _build_cmd(self) -> str:
+    def _build_cmd(self, msg_count: int) -> str:
         """Build the full rdkafka_performance command line."""
         parts: list[str] = [self.EXE]
 
@@ -204,7 +231,7 @@ class RdkafkaPerformanceService(Service):
         # Required args
         parts += ["-b", self._redpanda.brokers()]
         parts += ["-t", self._topic]
-        parts += ["-c", str(self._msg_count)]
+        parts += ["-c", str(msg_count)]
         parts += ["-s", str(self._msg_size)]
 
         # Optional native flags
@@ -230,6 +257,21 @@ class RdkafkaPerformanceService(Service):
 
         return " ".join(parts)
 
+    def _instance_log_path(self, client_idx: int) -> str:
+        return f"/tmp/{self.PROCESS_NAME}_{client_idx}.log"
+
+    def _instance_message_count(self, node: ClusterNode, client_idx: int) -> int:
+        total_instances = len(self.nodes) * self._clients_per_node
+        base_count = self._msg_count // total_instances
+        remainder = self._msg_count % total_instances
+
+        global_instance_idx = (
+            self.nodes.index(node) * self._clients_per_node + client_idx
+        )
+        if global_instance_idx < remainder:
+            return base_count + 1
+        return base_count
+
     def _build_security_config(self) -> dict[str, str]:
         """Return librdkafka -X security properties derived from the
         authentication state."""
@@ -252,55 +294,68 @@ class RdkafkaPerformanceService(Service):
     def start_node(self, node: ClusterNode, **kwargs: Any):
         self.clean_node(node, **kwargs)
 
-        assert self._pid is None
+        assert node.name not in self._instances
 
-        cmd = self._build_cmd()
-        wrapped_cmd = f"nohup {cmd} >> {self.LOG_PATH} 2>&1 & echo $!"
+        self._instances[node.name] = []
 
-        self.logger.debug(f"Starting rdkafka_performance: {wrapped_cmd}")
-        pid_str = node.account.ssh_output(wrapped_cmd, timeout_sec=10)
-        self._pid = int(pid_str.strip())
-        self.logger.debug(
-            f"Spawned rdkafka_performance node={node.name} pid={self._pid}"
-        )
+        for client_idx in range(self._clients_per_node):
+            msg_count = self._instance_message_count(node, client_idx)
+            cmd = self._build_cmd(msg_count)
+            log_path = self._instance_log_path(client_idx)
+            wrapped_cmd = f"nohup {cmd} >> {log_path} 2>&1 & echo $!"
+
+            pid_str = node.account.ssh_output(wrapped_cmd, timeout_sec=10)
+            pid = int(pid_str.strip())
+            self._instances[node.name].append((pid, log_path))
+            self.logger.debug(
+                f"Spawned rdkafka_performance node={node.name} client={client_idx} "
+                f"pid={pid} msg_count={msg_count}"
+            )
 
     def wait_node(self, node: ClusterNode, timeout_sec: float | None = None) -> bool:
         timeout = timeout_sec or 600
-        wait_until(
-            lambda: not node.account.exists(f"/proc/{self._pid}"),
-            timeout_sec=timeout,
-            backoff_sec=2,
-            err_msg=(
-                f"rdkafka_performance did not finish within {timeout}s "
-                f"(pid={self._pid})"
-            ),
-        )
-        self._pid = None
+        for pid, _ in self._instances[node.name]:
+            wait_until(
+                lambda: not node.account.exists(f"/proc/{pid}"),
+                timeout_sec=timeout,
+                backoff_sec=2,
+                err_msg=(
+                    f"rdkafka_performance did not finish within {timeout}s (pid={pid})"
+                ),
+            )
+        del self._instances[node.name]
         return True
 
     def stop_node(self, node: ClusterNode, **kwargs: Any):
-        if self._pid is None:
+        instances = self._instances.get(node.name)
+        if instances is None:
             return
-        self.logger.debug(f"Killing pid {self._pid}")
-        try:
-            node.account.signal(self._pid, signal.SIGKILL, allow_fail=False)
-        except RemoteCommandError as e:
-            if "No such process" not in str(e.msg):
-                raise
-        self._pid = None
+
+        for pid, _ in instances:
+            self.logger.debug(f"Killing pid {pid}")
+            try:
+                node.account.signal(pid, signal.SIGKILL, allow_fail=False)
+            except RemoteCommandError as e:
+                if "No such process" not in str(e.msg):
+                    raise
+        del self._instances[node.name]
 
     def clean_node(self, node: ClusterNode, **kwargs: Any):
         node.account.kill_process(self.PROCESS_NAME, clean_shutdown=False)
         node.account.remove(self.LOG_PATH, allow_fail=True)
+        for client_idx in range(self._clients_per_node):
+            node.account.remove(self._instance_log_path(client_idx), allow_fail=True)
 
-    def metrics(self, node: ClusterNode) -> RdkafkaPerformanceMetrics:
+    def _metrics_for_node_instance(
+        self, node: ClusterNode, log_path: str
+    ) -> RdkafkaPerformanceMetrics:
         """Parse the last row of the ``-u`` table output.
 
         Call this after ``wait()`` has returned.  Reads the log file on
         *node* and returns a :class:`RdkafkaPerformanceMetrics` with the
         values from the last data row emitted by rdkafka_performance.
         """
-        output = node.account.ssh_output(f"cat {self.LOG_PATH}", timeout_sec=10).decode(
+        output = node.account.ssh_output(f"cat {log_path}", timeout_sec=10).decode(
             "utf-8"
         )
 
@@ -308,7 +363,7 @@ class RdkafkaPerformanceService(Service):
         if not rows:
             raise RuntimeError(
                 f"No table rows found in rdkafka_performance output for "
-                f"mode={self._mode.name}. Log content:\n{output}"
+                f"mode={self._mode.name}, log={log_path}. Log content:\n{output}"
             )
 
         r = rows[-1]
@@ -338,3 +393,61 @@ class RdkafkaPerformanceService(Service):
                 mb_per_sec=float(r["MB/s"]),
                 rx_err=int(r["rx_err"]),
             )
+
+    def metrics(self) -> RdkafkaPerformanceMetrics:
+        """Return metrics across all nodes."""
+
+        instance_metrics = [
+            self._metrics_for_node_instance(
+                service_node, self._instance_log_path(client_idx)
+            )
+            for service_node in self.nodes
+            for client_idx in range(self._clients_per_node)
+        ]
+        if not instance_metrics:
+            raise RuntimeError("No nodes are configured for rdkafka_performance")
+
+        return RdkafkaPerformanceMetrics(
+            elapsed_ms=int(
+                statistics.median(
+                    [current_metrics.elapsed_ms for current_metrics in instance_metrics]
+                )
+            ),
+            msgs=sum(current_metrics.msgs for current_metrics in instance_metrics),
+            bytes=sum(current_metrics.bytes for current_metrics in instance_metrics),
+            rtt=int(
+                statistics.median(
+                    [current_metrics.rtt for current_metrics in instance_metrics]
+                )
+            ),
+            dr=_sum_optional(
+                [current_metrics.dr for current_metrics in instance_metrics]
+            ),
+            dr_msgs_per_sec=_sum_optional(
+                [
+                    current_metrics.dr_msgs_per_sec
+                    for current_metrics in instance_metrics
+                ]
+            ),
+            dr_mb_per_sec=_sum_optional(
+                [current_metrics.dr_mb_per_sec for current_metrics in instance_metrics]
+            ),
+            dr_err=_sum_optional(
+                [current_metrics.dr_err for current_metrics in instance_metrics]
+            ),
+            tx_err=_sum_optional(
+                [current_metrics.tx_err for current_metrics in instance_metrics]
+            ),
+            outq=_sum_optional(
+                [current_metrics.outq for current_metrics in instance_metrics]
+            ),
+            msgs_per_sec=_sum_optional(
+                [current_metrics.msgs_per_sec for current_metrics in instance_metrics]
+            ),
+            mb_per_sec=_sum_optional(
+                [current_metrics.mb_per_sec for current_metrics in instance_metrics]
+            ),
+            rx_err=_sum_optional(
+                [current_metrics.rx_err for current_metrics in instance_metrics]
+            ),
+        )

--- a/tests/rptest/tests/rdkafka_performance_test.py
+++ b/tests/rptest/tests/rdkafka_performance_test.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from typing import Any
+
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.services.rdkafka_performance import (
+    RdkafkaPerformanceMode,
+    RdkafkaPerformanceService,
+)
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class RdkafkaPerformanceSelfTest(RedpandaTest):
+    """Smoke test for the RdkafkaPerformanceService wrapper.
+
+    This validates the service itself (start / wait / metrics parsing),
+    not Redpanda behaviour.
+    """
+
+    MSG_COUNT = 10_000
+    MSG_SIZE = 512
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, num_brokers=1, **kwargs)
+
+    def _run_producer(self, topic: str) -> None:
+        producer = RdkafkaPerformanceService(
+            self.test_context,
+            self.redpanda,
+            topic=topic,
+            msg_count=self.MSG_COUNT,
+            msg_size=self.MSG_SIZE,
+        )
+        producer.start()
+        producer.wait(timeout_sec=60)
+
+        pm = producer.metrics(producer.nodes[0])
+
+        self.logger.debug(f"Rdkafka performance producer metrics: {pm}")
+
+        assert pm.msgs == self.MSG_COUNT, (
+            f"Expected {self.MSG_COUNT} messages produced, got {pm.msgs}"
+        )
+        assert pm.dr == self.MSG_COUNT, (
+            f"Expected {self.MSG_COUNT} deliveries, got {pm.dr}"
+        )
+        assert pm.dr_err == 0, f"Unexpected delivery errors: {pm.dr_err}"
+        assert pm.tx_err == 0, f"Unexpected produce failures: {pm.tx_err}"
+
+    def _run_consumer(self, topic: str) -> None:
+        consumer = RdkafkaPerformanceService(
+            self.test_context,
+            self.redpanda,
+            topic=topic,
+            msg_count=self.MSG_COUNT,
+            msg_size=self.MSG_SIZE,
+            mode=RdkafkaPerformanceMode.CONSUME,
+            group_name="group",
+            extra_config={
+                "auto.offset.reset": "earliest",
+            },
+        )
+        consumer.start()
+        consumer.wait(timeout_sec=60)
+
+        cm = consumer.metrics(consumer.nodes[0])
+
+        self.logger.debug(f"Rdkafka performance consumer metrics: {cm}")
+
+        assert cm.msgs == self.MSG_COUNT, (
+            f"Expected {self.MSG_COUNT} messages consumed, got {cm.msgs}"
+        )
+        assert cm.rx_err == 0, f"Unexpected receive errors: {cm.rx_err}"
+
+        consumer.stop()
+        consumer.free()
+
+    @cluster(num_nodes=3)
+    def test_produce_consume(self) -> None:
+        spec = TopicSpec(
+            name="rdkafka_perf_test", partition_count=1, replication_factor=1
+        )
+        self.client().create_topic(spec)
+
+        self._run_producer(spec.name)
+        self._run_consumer(spec.name)

--- a/tests/rptest/tests/rdkafka_performance_test.py
+++ b/tests/rptest/tests/rdkafka_performance_test.py
@@ -38,11 +38,12 @@ class RdkafkaPerformanceSelfTest(RedpandaTest):
             topic=topic,
             msg_count=self.MSG_COUNT,
             msg_size=self.MSG_SIZE,
+            num_nodes=2,
         )
         producer.start()
         producer.wait(timeout_sec=60)
 
-        pm = producer.metrics(producer.nodes[0])
+        pm = producer.metrics()
 
         self.logger.debug(f"Rdkafka performance producer metrics: {pm}")
 
@@ -71,7 +72,7 @@ class RdkafkaPerformanceSelfTest(RedpandaTest):
         consumer.start()
         consumer.wait(timeout_sec=60)
 
-        cm = consumer.metrics(consumer.nodes[0])
+        cm = consumer.metrics()
 
         self.logger.debug(f"Rdkafka performance consumer metrics: {cm}")
 
@@ -80,10 +81,7 @@ class RdkafkaPerformanceSelfTest(RedpandaTest):
         )
         assert cm.rx_err == 0, f"Unexpected receive errors: {cm.rx_err}"
 
-        consumer.stop()
-        consumer.free()
-
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=4)
     def test_produce_consume(self) -> None:
         spec = TopicSpec(
             name="rdkafka_perf_test", partition_count=1, replication_factor=1

--- a/tests/rptest/tests/rdkafka_performance_test.py
+++ b/tests/rptest/tests/rdkafka_performance_test.py
@@ -38,6 +38,7 @@ class RdkafkaPerformanceSelfTest(RedpandaTest):
             topic=topic,
             msg_count=self.MSG_COUNT,
             msg_size=self.MSG_SIZE,
+            warmup_msg_count=1000,
             num_nodes=2,
         )
         producer.start()


### PR DESCRIPTION
Adds a throughput bench using rdkafka_performance. 

It's mostly tuned to reduce noice (lowered shard count, multiple connections per shard, high partition count).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


* none

