### PR TITLE
bazel/packaging: correct hwloc binary names

### DIFF
--- a/bazel/packaging/BUILD
+++ b/bazel/packaging/BUILD
@@ -99,6 +99,8 @@ redpanda_deb_package(
     package_name = "redpanda-tuner",
     out = "redpanda-tuner.deb",
     description = "Redpanda tuner",
+    hwloc_calc = "@hwloc//:hwloc_calc",
+    hwloc_distrib = "@hwloc//:hwloc_distrib",
     include_sysroot_libs = False,
     install_path = "/usr",
     systemd_service = "scripts/redpanda-tuner.service",

--- a/bazel/packaging/packaging.bzl
+++ b/bazel/packaging/packaging.bzl
@@ -550,20 +550,20 @@ def _deb_package_impl(ctx):
         })
         inputs.append(package_content.iotune)
 
-    # Add hwloc-calc
+    # Add hwloc-calc (named hwloc-calc-redpanda for rpk compatibility)
     if package_content.hwloc_calc != None:
         package_files.append({
             "path": ctx.attr.install_path + "/bin",
-            "name": "hwloc-calc",
+            "name": "hwloc-calc-redpanda",
             "source": package_content.hwloc_calc.path,
         })
         inputs.append(package_content.hwloc_calc)
 
-    # Add hwloc-distrib
+    # Add hwloc-distrib (named hwloc-distrib-redpanda for rpk compatibility)
     if package_content.hwloc_distrib != None:
         package_files.append({
             "path": ctx.attr.install_path + "/bin",
-            "name": "hwloc-distrib",
+            "name": "hwloc-distrib-redpanda",
             "source": package_content.hwloc_distrib.path,
         })
         inputs.append(package_content.hwloc_distrib)


### PR DESCRIPTION

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
