### PR TITLE
iceberg: json: support schema-valued additionalProperties maps

### DIFF
--- a/src/v/iceberg/conversion/BUILD
+++ b/src/v/iceberg/conversion/BUILD
@@ -210,6 +210,7 @@ redpanda_cc_library(
     implementation_deps = [
         ":time_rfc3339",
         "//src/v/bytes:iobuf_parser",
+        "//src/v/container:chunked_hash_map",
         "//src/v/serde/json:parser",
     ],
     visibility = ["//visibility:public"],

--- a/src/v/iceberg/conversion/ir_json.cc
+++ b/src/v/iceberg/conversion/ir_json.cc
@@ -22,6 +22,7 @@
 #include <array>
 #include <bitset>
 #include <map>
+#include <memory>
 #include <optional>
 #include <utility>
 #include <variant>
@@ -39,15 +40,40 @@ constexpr allow_additional_properties_t allow_additional_properties{};
 struct forbid_additional_properties_t {};
 constexpr forbid_additional_properties_t forbid_additional_properties{};
 
-using additional_properties_policy
-  = std::variant<allow_additional_properties_t, forbid_additional_properties_t>;
+struct constraint;
+
+struct schema_additional_properties {
+    explicit schema_additional_properties(constraint&& schema);
+    ~schema_additional_properties();
+
+    schema_additional_properties(const schema_additional_properties&);
+    schema_additional_properties&
+    operator=(const schema_additional_properties&);
+
+    schema_additional_properties(schema_additional_properties&&) noexcept;
+    schema_additional_properties&
+    operator=(schema_additional_properties&&) noexcept;
+
+    std::unique_ptr<const constraint> schema;
+};
+
+using additional_properties_policy = std::variant<
+  allow_additional_properties_t,
+  forbid_additional_properties_t,
+  schema_additional_properties>;
 
 bool is_additional_properties_forbidden(
   const additional_properties_policy& policy) {
     return ss::visit(
       policy,
       [](allow_additional_properties_t) { return false; },
-      [](forbid_additional_properties_t) { return true; });
+      [](forbid_additional_properties_t) { return true; },
+      [](const schema_additional_properties&) { return false; });
+}
+
+const schema_additional_properties*
+as_schema_additional_properties(const additional_properties_policy& policy) {
+    return std::get_if<schema_additional_properties>(&policy);
 }
 
 /// Set of JSON value types for constraint tracking.
@@ -161,14 +187,17 @@ struct constraint {
             return conversion_exception(
               "Intersecting constraints with properties on both sides "
               "is not supported");
-        } else if (!other.properties.empty()) {
-            if (is_additional_properties_forbidden(additional_properties)) {
-                return conversion_exception(
-                  "additionalProperties: false conflicts with properties "
-                  "defined in another branch");
-            }
-            properties = other.properties;
-        } else if (
+        }
+
+        if (
+          !other.properties.empty()
+          && is_additional_properties_forbidden(additional_properties)) {
+            return conversion_exception(
+              "additionalProperties: false conflicts with properties "
+              "defined in another branch");
+        }
+
+        if (
           !properties.empty()
           && is_additional_properties_forbidden(other.additional_properties)) {
             return conversion_exception(
@@ -176,7 +205,45 @@ struct constraint {
               "defined in another branch");
         }
 
+        const auto* this_additional_properties_schema
+          = as_schema_additional_properties(additional_properties);
+        const auto* other_additional_properties_schema
+          = as_schema_additional_properties(other.additional_properties);
+
         if (
+          this_additional_properties_schema != nullptr
+          && other_additional_properties_schema != nullptr) {
+            return conversion_exception(
+              "Intersecting constraints with additionalProperties on both "
+              "sides is not supported");
+        }
+
+        if (
+          (!properties.empty() && other_additional_properties_schema != nullptr)
+          || (this_additional_properties_schema != nullptr && !other.properties.empty())) {
+            return conversion_exception(
+              "additionalProperties schema conflicts with properties "
+              "defined in another branch");
+        }
+
+        if (
+          (this_additional_properties_schema != nullptr
+           && is_additional_properties_forbidden(other.additional_properties))
+          || (other_additional_properties_schema != nullptr && is_additional_properties_forbidden(additional_properties))) {
+            return conversion_exception(
+              "additionalProperties: false conflicts with "
+              "additionalProperties schema defined in another branch");
+        }
+
+        if (!other.properties.empty()) {
+            properties = other.properties;
+        }
+
+        if (other_additional_properties_schema != nullptr) {
+            additional_properties = *other_additional_properties_schema;
+        } else if (this_additional_properties_schema != nullptr) {
+            // Keep existing schema-valued additionalProperties unchanged.
+        } else if (
           is_additional_properties_forbidden(additional_properties)
           || is_additional_properties_forbidden(other.additional_properties)) {
             additional_properties = forbid_additional_properties;
@@ -195,6 +262,31 @@ struct constraint {
         return outcome::success();
     }
 };
+
+schema_additional_properties::schema_additional_properties(constraint&& s)
+  : schema(std::make_unique<constraint>(std::move(s))) {}
+
+schema_additional_properties::schema_additional_properties(
+  const schema_additional_properties& other)
+  : schema(std::make_unique<constraint>(*other.schema)) {}
+
+schema_additional_properties& schema_additional_properties::operator=(
+  const schema_additional_properties& other) {
+    if (this != &other) {
+        schema = std::make_unique<constraint>(*other.schema);
+    }
+    return *this;
+}
+
+schema_additional_properties::schema_additional_properties(
+  schema_additional_properties&&) noexcept
+  = default;
+
+schema_additional_properties&
+schema_additional_properties::operator=(schema_additional_properties&&) noexcept
+  = default;
+
+schema_additional_properties::~schema_additional_properties() = default;
 
 /// Context for the resolution phase.
 struct resolution_context {
@@ -350,12 +442,27 @@ collect(collect_context& ctx, const conversion::json_schema::subschema& s) {
         }
 
         if (s.additional_properties()) {
-            if (s.additional_properties()->get().boolean_subschema() == false) {
+            const auto& additional_properties
+              = s.additional_properties()->get();
+            if (additional_properties.boolean_subschema() == false) {
                 c.additional_properties = forbid_additional_properties;
-            } else {
+            } else if (additional_properties.boolean_subschema() == true) {
                 return conversion_exception(
-                  "Only 'false' subschema is supported "
+                  "Only 'false' or object subschema is supported "
                   "for additionalProperties keyword");
+            } else {
+                if (!c.properties.empty()) {
+                    return conversion_exception(
+                      "Cannot convert object with both properties and "
+                      "schema-valued additionalProperties");
+                }
+                auto additional_properties_constraint = collect(
+                  ctx, additional_properties);
+                if (additional_properties_constraint.has_error()) {
+                    return additional_properties_constraint.error();
+                }
+                c.additional_properties = schema_additional_properties{
+                  std::move(additional_properties_constraint.value())};
             }
         }
     }
@@ -383,9 +490,29 @@ collect(collect_context& ctx, const conversion::json_schema::subschema& s) {
     return c;
 }
 
-/// Resolve object constraint to Iceberg struct.
-conversion_outcome<struct_type>
+/// Resolve object constraint to Iceberg struct or map.
+conversion_outcome<field_type>
 resolve_object(resolution_context& ctx, const constraint& c) {
+    if (const auto* additional_properties_schema
+        = as_schema_additional_properties(c.additional_properties);
+        additional_properties_schema != nullptr) {
+        vassert(
+          c.properties.empty(),
+          "Cannot resolve to map type with both properties and schema-valued "
+          "additionalProperties");
+
+        auto value_type = resolve(ctx, *additional_properties_schema->schema);
+        if (value_type.has_error()) {
+            return value_type.error();
+        }
+        return map_type::create(
+          placeholder_field_id,
+          string_type{},
+          placeholder_field_id,
+          field_required::no,
+          std::move(value_type.value()));
+    }
+
     struct_type result;
 
     // std::map iterates in sorted key order, giving deterministic field
@@ -430,7 +557,7 @@ resolve_object(resolution_context& ctx, const constraint& c) {
             std::move(*resolved_type)));
     }
 
-    return result;
+    return field_type(std::move(result));
 }
 
 /// Resolve array constraint to Iceberg list.

--- a/src/v/iceberg/conversion/ir_json.cc
+++ b/src/v/iceberg/conversion/ir_json.cc
@@ -24,6 +24,7 @@
 #include <map>
 #include <optional>
 #include <utility>
+#include <variant>
 
 namespace iceberg {
 namespace {
@@ -31,6 +32,23 @@ constexpr iceberg::nested_field::id_t placeholder_field_id{0};
 
 using json_type = conversion::json_schema::json_value_type;
 using json_format = conversion::json_schema::format;
+
+struct allow_additional_properties_t {};
+constexpr allow_additional_properties_t allow_additional_properties{};
+
+struct forbid_additional_properties_t {};
+constexpr forbid_additional_properties_t forbid_additional_properties{};
+
+using additional_properties_policy
+  = std::variant<allow_additional_properties_t, forbid_additional_properties_t>;
+
+bool is_additional_properties_forbidden(
+  const additional_properties_policy& policy) {
+    return ss::visit(
+      policy,
+      [](allow_additional_properties_t) { return false; },
+      [](forbid_additional_properties_t) { return true; });
+}
 
 /// Set of JSON value types for constraint tracking.
 ///
@@ -118,7 +136,8 @@ struct constraint {
 
     // Object properties, keyed by name.
     std::map<std::string, constraint> properties = {};
-    bool additional_properties_allowed = true;
+    additional_properties_policy additional_properties
+      = allow_additional_properties;
 
     // Array item constraints.
     // - nullopt: no "items" keyword
@@ -143,20 +162,27 @@ struct constraint {
               "Intersecting constraints with properties on both sides "
               "is not supported");
         } else if (!other.properties.empty()) {
-            if (!additional_properties_allowed) {
+            if (is_additional_properties_forbidden(additional_properties)) {
                 return conversion_exception(
                   "additionalProperties: false conflicts with properties "
                   "defined in another branch");
             }
             properties = other.properties;
         } else if (
-          !properties.empty() && !other.additional_properties_allowed) {
+          !properties.empty()
+          && is_additional_properties_forbidden(other.additional_properties)) {
             return conversion_exception(
               "additionalProperties: false conflicts with properties "
               "defined in another branch");
         }
-        additional_properties_allowed = additional_properties_allowed
-                                        && other.additional_properties_allowed;
+
+        if (
+          is_additional_properties_forbidden(additional_properties)
+          || is_additional_properties_forbidden(other.additional_properties)) {
+            additional_properties = forbid_additional_properties;
+        } else {
+            additional_properties = allow_additional_properties;
+        }
 
         if (items.has_value() && other.items.has_value()) {
             return conversion_exception(
@@ -325,7 +351,7 @@ collect(collect_context& ctx, const conversion::json_schema::subschema& s) {
 
         if (s.additional_properties()) {
             if (s.additional_properties()->get().boolean_subschema() == false) {
-                c.additional_properties_allowed = false;
+                c.additional_properties = forbid_additional_properties;
             } else {
                 return conversion_exception(
                   "Only 'false' subschema is supported "

--- a/src/v/iceberg/conversion/tests/iceberg_json_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_json_tests.cc
@@ -1142,6 +1142,27 @@ TEST_CORO(IcebergValues, ValueObject) {
         OptionalIcebergPrimitive<long_value>(42)));
 }
 
+TEST_CORO(IcebergValues, ValueObjectDuplicateKeysLastWins) {
+    auto schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+          "key1": {"type": "string"}
+      }
+    })";
+    auto value = R"({"key1": "value1", "key1": "value2"})";
+
+    auto result = co_await to_iceberg_value(schema, value);
+
+    ASSERT_TRUE_CORO(result.has_value()) << result.error().what();
+    auto result_value = std::get<std::unique_ptr<struct_value>>(
+      std::move(result.value()));
+
+    EXPECT_THAT(
+      result_value->fields,
+      ElementsAre(OptionalIcebergPrimitive<string_value>("value2")));
+}
+
 TEST_CORO(IcebergValues, ValueObjectOptionals) {
     auto schema = R"({
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/v/iceberg/conversion/tests/iceberg_json_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_json_tests.cc
@@ -1169,10 +1169,11 @@ TEST_CORO(IcebergValues, ValueObjectOptionals) {
       "type": "object",
       "properties": {
           "key1": {"type": ["string", "null"]},
-          "key2": {"type": ["integer", "null"]}
+          "key2": {"type": ["integer", "null"]},
+          "nullkey": {"type": ["object", "null"]}
       }
     })";
-    auto value = R"({"key1": "value1", "key3": "extra-key"})";
+    auto value = R"({"key1": "value1", "nullkey": null, "key3": "extra-key"})";
 
     auto result = co_await to_iceberg_value(schema, value);
 
@@ -1183,7 +1184,9 @@ TEST_CORO(IcebergValues, ValueObjectOptionals) {
     EXPECT_THAT(
       result_value->fields,
       ElementsAre(
-        OptionalIcebergPrimitive<string_value>("value1"), Eq(std::nullopt)));
+        OptionalIcebergPrimitive<string_value>("value1"),
+        Eq(std::nullopt),
+        Eq(std::nullopt)));
 }
 
 TEST_CORO(IcebergValues, ValueObjectSpuriousCompoundMember) {

--- a/src/v/iceberg/conversion/tests/iceberg_json_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_json_tests.cc
@@ -752,43 +752,6 @@ TEST(JsonSchema, ListWithEmptyItemsAndAdditionalItems) {
       iceberg::field_required::no));
 }
 
-TEST(JsonSchema, AdditionalProperties) {
-    constexpr std::string_view schema = R"({
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "$id": "https://example.com/root.json",
-      "type": "object",
-      "additionalProperties": { "type": "string" }
-    })";
-
-    auto result = to_iceberg_type(schema);
-    ASSERT_TRUE(result.has_error());
-    ASSERT_STREQ(
-      "Only 'false' subschema is supported for additionalProperties keyword",
-      result.error().what());
-}
-
-TEST(JsonSchema, AdditionalPropertiesFalse) {
-    constexpr std::string_view schema = R"({
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "$id": "https://example.com/root.json",
-      "type": "object",
-      "properties": {
-        "field1": { "type": "string" }
-      },
-      "additionalProperties": false
-    })";
-
-    auto result = to_iceberg_type(schema);
-    ASSERT_TRUE(result.has_value()) << result.error().what();
-
-    ASSERT_EQ(result.value().fields.size(), 1);
-    ASSERT_TRUE(field_matches(
-      result.value().fields[0],
-      "field1",
-      iceberg::string_type{},
-      iceberg::field_required::no));
-}
-
 TEST(JsonSchema, Format) {
     // table from format to iceberg type
     constexpr auto test_cases
@@ -1290,6 +1253,223 @@ TEST_CORO(IcebergValues, ValueObjectNesting) {
           OptionalIcebergPrimitive<string_value>("value2"))));
 }
 
+TEST(JsonSchema, AdditionalProperties) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://example.com/root.json",
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    })";
+
+    auto result = to_iceberg_type(schema);
+    ASSERT_TRUE(result.has_value()) << result.error().what();
+
+    ASSERT_EQ(result.value().fields.size(), 1);
+    ASSERT_TRUE(field_matches(
+      result.value().fields[0],
+      "root",
+      iceberg::map_type::create(
+        0,
+        iceberg::string_type{},
+        0,
+        iceberg::field_required::no,
+        iceberg::string_type{}),
+      iceberg::field_required::no));
+}
+
+TEST(JsonSchema, AdditionalPropertiesWithProperties) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://example.com/root.json",
+      "type": "object",
+      "properties": {
+        "field1": { "type": "string" }
+      },
+      "additionalProperties": { "type": "integer" }
+    })";
+
+    auto result = to_iceberg_type(schema);
+    ASSERT_TRUE(result.has_error());
+    ASSERT_STREQ(
+      "Cannot convert object with both properties and schema-valued "
+      "additionalProperties",
+      result.error().what());
+}
+
+TEST(JsonSchema, AdditionalPropertiesFalse) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://example.com/root.json",
+      "type": "object",
+      "properties": {
+        "field1": { "type": "string" }
+      },
+      "additionalProperties": false
+    })";
+
+    auto result = to_iceberg_type(schema);
+    ASSERT_TRUE(result.has_value()) << result.error().what();
+
+    ASSERT_EQ(result.value().fields.size(), 1);
+    ASSERT_TRUE(field_matches(
+      result.value().fields[0],
+      "field1",
+      iceberg::string_type{},
+      iceberg::field_required::no));
+}
+
+TEST(JsonSchema, AdditionalPropertiesTrue) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://example.com/root.json",
+      "type": "object",
+      "additionalProperties": true
+    })";
+
+    auto result = to_iceberg_type(schema);
+    ASSERT_TRUE(result.has_error());
+    ASSERT_STREQ(
+      "Only 'false' or object subschema is supported for "
+      "additionalProperties keyword",
+      result.error().what());
+}
+
+TEST_CORO(IcebergValues, ValueObjectAdditionalProperties) {
+    auto schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    })";
+    auto value = R"({"key1": "value1", "key2": null})";
+
+    auto result = co_await to_iceberg_value(schema, value);
+
+    ASSERT_TRUE_CORO(result.has_value()) << result.error().what();
+    auto result_value = std::get<std::unique_ptr<struct_value>>(
+      std::move(result.value()));
+
+    EXPECT_THAT(
+      result_value->fields,
+      ElementsAre(IcebergMap(UnorderedElementsAre(
+        IcebergKeyValue(
+          IcebergPrimitive<string_value>("key1"),
+          OptionalIcebergPrimitive<string_value>("value1")),
+        IcebergKeyValue(
+          IcebergPrimitive<string_value>("key2"), Eq(std::nullopt))))));
+}
+
+TEST_CORO(IcebergValues, ValueObjectAdditionalPropertiesDuplicateKeys) {
+    auto schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    })";
+    auto value = R"({"key1": "value1", "key1": "value2"})";
+
+    auto result = co_await to_iceberg_value(schema, value);
+
+    ASSERT_TRUE_CORO(result.has_value()) << result.error().what();
+    auto result_value = std::get<std::unique_ptr<struct_value>>(
+      std::move(result.value()));
+
+    EXPECT_THAT(
+      result_value->fields,
+      ElementsAre(IcebergMap(ElementsAre(IcebergKeyValue(
+        IcebergPrimitive<string_value>("key1"),
+        OptionalIcebergPrimitive<string_value>("value2"))))));
+}
+
+TEST_CORO(IcebergValues, ValueObjectAdditionalPropertiesEmpty) {
+    auto schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    })";
+    auto value = R"({})";
+
+    auto result = co_await to_iceberg_value(schema, value);
+
+    ASSERT_TRUE_CORO(result.has_value()) << result.error().what();
+    auto result_value = std::get<std::unique_ptr<struct_value>>(
+      std::move(result.value()));
+
+    EXPECT_THAT(result_value->fields, ElementsAre(IcebergMap(IsEmpty())));
+}
+
+TEST_CORO(IcebergValues, ValueObjectAdditionalPropertiesList) {
+    auto schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "type": "string" }
+      }
+    })";
+    auto value = R"({
+      "key1": ["a", "b"],
+      "key2": ["c"]
+    })";
+
+    auto result = co_await to_iceberg_value(schema, value);
+
+    ASSERT_TRUE_CORO(result.has_value()) << result.error().what();
+    auto result_value = std::get<std::unique_ptr<struct_value>>(
+      std::move(result.value()));
+
+    EXPECT_THAT(
+      result_value->fields,
+      ElementsAre(IcebergMap(UnorderedElementsAre(
+        IcebergKeyValue(
+          IcebergPrimitive<string_value>("key1"),
+          IcebergList(ElementsAre(
+            OptionalIcebergPrimitive<string_value>("a"),
+            OptionalIcebergPrimitive<string_value>("b")))),
+        IcebergKeyValue(
+          IcebergPrimitive<string_value>("key2"),
+          IcebergList(
+            ElementsAre(OptionalIcebergPrimitive<string_value>("c"))))))));
+}
+
+TEST_CORO(IcebergValues, ValueObjectAdditionalPropertiesNesting) {
+    auto schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "nested": { "type": "integer" }
+            }
+          }
+        }
+      }
+    })";
+    auto value = R"({
+      "tags": {
+        "key1": { "nested": 1 },
+        "key2": { "nested": 2 }
+      }
+    })";
+
+    auto result = co_await to_iceberg_value(schema, value);
+
+    ASSERT_TRUE_CORO(result.has_value()) << result.error().what();
+    auto result_value = std::get<std::unique_ptr<struct_value>>(
+      std::move(result.value()));
+
+    EXPECT_THAT(
+      result_value->fields,
+      ElementsAre(IcebergMap(UnorderedElementsAre(
+        IcebergKeyValue(
+          IcebergPrimitive<string_value>("key1"),
+          IcebergStruct(OptionalIcebergPrimitive<long_value>(1))),
+        IcebergKeyValue(
+          IcebergPrimitive<string_value>("key2"),
+          IcebergStruct(OptionalIcebergPrimitive<long_value>(2)))))));
+}
+
 TEST(JsonSchema, OneOfNullable) {
     constexpr std::string_view schema = R"({
       "$schema": "http://json-schema.org/draft-07/schema#",
@@ -1769,6 +1949,91 @@ TEST(JsonSchema, OneOfAdditionalPropertiesInside) {
     ASSERT_STREQ(
       "additionalProperties: false conflicts with properties defined in "
       "another branch",
+      result.error().what());
+}
+
+TEST(JsonSchema, OneOfAdditionalPropertiesSchemaBothSides) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "field": {
+          "additionalProperties": { "type": "string" },
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "additionalProperties": { "type": "integer" }
+            }
+          ]
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_error());
+    ASSERT_STREQ(
+      "Intersecting constraints with additionalProperties on both sides is "
+      "not supported",
+      result.error().what());
+}
+
+TEST(JsonSchema, OneOfAdditionalPropertiesSchemaConflictsWithProperties) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "field": {
+          "additionalProperties": { "type": "string" },
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "properties": {
+                "nested_field": { "type": "integer" }
+              }
+            }
+          ]
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_error());
+    ASSERT_STREQ(
+      "additionalProperties schema conflicts with properties defined in "
+      "another branch",
+      result.error().what());
+}
+
+TEST(
+  JsonSchema,
+  OneOfAdditionalPropertiesFalseConflictsWithAdditionalPropertiesSchema) {
+    constexpr std::string_view schema = R"({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "field": {
+          "additionalProperties": { "type": "string" },
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    })";
+
+    auto result = to_iceberg_type(schema);
+
+    ASSERT_TRUE(result.has_error());
+    ASSERT_STREQ(
+      "additionalProperties: false conflicts with additionalProperties "
+      "schema defined in another branch",
       result.error().what());
 }
 

--- a/src/v/iceberg/conversion/values_json.cc
+++ b/src/v/iceberg/conversion/values_json.cc
@@ -155,6 +155,14 @@ ss::future<> decode_field(
   std::optional<iceberg::value>& v,
   const field_type& ft,
   const json_conversion_ir::struct_field_map_t& field_map) {
+    // The JSON-to-Iceberg conversion assumes input has passed through a JSON
+    // schema validator, so we can be lax about validation. If we see null, we
+    // assume that schema allows null here.
+    if (p.token() == serde::json::token::value_null) {
+        v = std::nullopt;
+        co_return;
+    }
+
     struct field_decoder_visitor {
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
         serde::json::parser& p;

--- a/src/v/iceberg/conversion/values_json.cc
+++ b/src/v/iceberg/conversion/values_json.cc
@@ -11,13 +11,14 @@
 #include "iceberg/conversion/values_json.h"
 
 #include "bytes/iobuf_parser.h"
+#include "container/chunked_hash_map.h"
 #include "iceberg/conversion/conversion_outcome.h"
 #include "iceberg/conversion/ir_json.h"
 #include "iceberg/conversion/time_rfc3339.h"
 #include "iceberg/values.h"
 #include "serde/json/parser.h"
 
-#include <seastar/core/coroutine.hh>
+#include <seastar/core/coroutine.hh> // IWYU pragma: keep
 
 #include <exception>
 #include <memory>
@@ -150,6 +151,12 @@ ss::future<> decode_list(
   const list_type& lt,
   const json_conversion_ir::struct_field_map_t& field_map);
 
+ss::future<> decode_map(
+  serde::json::parser& p,
+  map_value& mv,
+  const map_type& mt,
+  const json_conversion_ir::struct_field_map_t& field_map);
+
 ss::future<> decode_field(
   serde::json::parser& p,
   std::optional<iceberg::value>& v,
@@ -182,9 +189,10 @@ ss::future<> decode_field(
             co_await decode_list(p, *lv, lt, field_map);
             co_return std::move(lv);
         }
-        ss::future<std::optional<value>> operator()(const map_type&) {
-            throw value_conversion_exception(
-              "Map type is not supported in JSON deserialization");
+        ss::future<std::optional<value>> operator()(const map_type& mt) {
+            auto mv = std::make_unique<map_value>();
+            co_await decode_map(p, *mv, mt, field_map);
+            co_return std::move(mv);
         }
     };
 
@@ -283,6 +291,72 @@ ss::future<> decode_list(
 
         co_await decode_field(
           p, lv.elements.emplace_back(), lt.element_field->type, field_map);
+    }
+}
+
+ss::future<> decode_map(
+  serde::json::parser& p,
+  map_value& mv,
+  const map_type& mt,
+  const json_conversion_ir::struct_field_map_t& field_map) {
+    if (p.token() != serde::json::token::start_object) {
+        throw value_conversion_exception(
+          "Expected start of JSON object for map type");
+    }
+
+    if (mt.key_field == nullptr || mt.value_field == nullptr) {
+        throw value_conversion_exception(
+          "Malformed map type in JSON deserialization");
+    }
+
+    auto key_primitive = std::get_if<primitive_type>(&mt.key_field->type);
+    if (
+      key_primitive == nullptr
+      || !std::holds_alternative<string_type>(*key_primitive)) {
+        throw value_conversion_exception(
+          fmt::format(
+            "JSON map decoding only supports string keys, got {}",
+            mt.key_field->type));
+    }
+
+    // Track key -> position to keep last-write-wins semantics in O(1).
+    chunked_hash_map<ss::sstring, size_t> key_to_pos;
+
+    while (true) {
+        if (!co_await p.next()) {
+            throw value_conversion_exception(
+              "Expected key or end of JSON object but got end of input");
+        }
+
+        if (p.token() == serde::json::token::end_object) {
+            co_return;
+        }
+
+        if (p.token() != serde::json::token::key) {
+            throw value_conversion_exception(
+              fmt::format(
+                "Expected key token in JSON object but got {}", p.token()));
+        }
+
+        auto k = p.value_string();
+        auto index_key = k.linearize_to_string();
+
+        if (!co_await p.next()) {
+            throw value_conversion_exception(
+              "Failed to read next JSON token after key");
+        }
+
+        auto pos_it = key_to_pos.find(index_key);
+        if (pos_it != key_to_pos.end()) {
+            co_await decode_field(
+              p, mv.kvs[pos_it->second].val, mt.value_field->type, field_map);
+        } else {
+            auto& kv = mv.kvs.emplace_back();
+            kv.key = primitive_value{string_value{std::move(k)}};
+            auto inserted_pos = mv.kvs.size() - 1;
+            key_to_pos.emplace(std::move(index_key), inserted_pos);
+            co_await decode_field(p, kv.val, mt.value_field->type, field_map);
+        }
     }
 }
 

--- a/src/v/iceberg/conversion/values_json.cc
+++ b/src/v/iceberg/conversion/values_json.cc
@@ -208,7 +208,7 @@ ss::future<> decode_struct(
     while (true) {
         if (!co_await p.next()) {
             throw value_conversion_exception(
-              "Failed to read next JSON token after start object");
+              "Expected key or end of JSON object but got end of input");
         }
 
         if (p.token() == serde::json::token::end_object) {


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
### Improvements
* Support JSON Schema additionalProperties with object sub-schemas, mapping them to Iceberg map types with string keys.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements


-->
