### PR TITLE
ct/l1: preregister objects

### DIFF
--- a/src/v/cloud_topics/housekeeper/tests/housekeeper_test.cc
+++ b/src/v/cloud_topics/housekeeper/tests/housekeeper_test.cc
@@ -255,8 +255,11 @@ public:
           _tidp,
           decltype(term_map)::value_type::second_type::single(
             model::term_id{0}, result.next_offset));
+        auto oid = obj.oid;
         chunked_vector<decltype(obj)> objects;
         objects.push_back(std::move(obj));
+        _l1_metastore.preregister_objects(
+          chunked_vector<cloud_topics::l1::object_id>::single(oid));
         handle_error(_l1_metastore.add_objects(objects, term_map).get());
     }
 

--- a/src/v/cloud_topics/level_one/compaction/sink.cc
+++ b/src/v/cloud_topics/level_one/compaction/sink.cc
@@ -140,7 +140,7 @@ compaction_sink::initialize(compaction::sliding_window_reducer::source& src) {
 
 ss::future<>
 compaction_sink::initialize_builder(kafka::offset object_base_offset) {
-    auto oid_res = _metadata_builder->create_object_for(_tp);
+    auto oid_res = co_await _metadata_builder->create_object_for(_tp);
     if (!oid_res.has_value()) {
         vlog(
           compaction_log.error,

--- a/src/v/cloud_topics/level_one/domain/BUILD
+++ b/src/v/cloud_topics/level_one/domain/BUILD
@@ -52,8 +52,10 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics/level_one/common:object_id",
         "//src/v/cloud_topics/level_one/metastore:garbage_collector",
         "//src/v/cloud_topics/level_one/metastore:rpc_types",
+        "//src/v/cloud_topics/level_one/metastore:state_update",
         "//src/v/config",
         "//src/v/container:chunked_hash_map",
         "//src/v/model:batch_builder",

--- a/src/v/cloud_topics/level_one/domain/BUILD
+++ b/src/v/cloud_topics/level_one/domain/BUILD
@@ -97,10 +97,12 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":domain_manager",
+        "//src/v/base",
         "//src/v/cloud_topics/level_one/common:abstract_io",
         "//src/v/cloud_topics/level_one/metastore:rpc_types",
         "//src/v/cloud_topics/level_one/metastore/lsm:replicated_db",
         "//src/v/cloud_topics/level_one/metastore/lsm:stm",
+        "//src/v/model",
         "//src/v/ssx:checkpoint_mutex",
         "@seastar",
     ],

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -1121,8 +1121,12 @@ ss::future<> db_domain_manager::gc_loop() {
         }
         // TODO: make batch size configurable.
         vlog(cd_log.debug, "Running garbage collection now...");
+        auto ttl
+          = config::shard_local_cfg().cloud_topics_preregistered_object_ttl();
+        auto prereg_expiry_cutoff = model::timestamp{
+          model::timestamp::now()() - static_cast<int64_t>(ttl.count())};
         auto gc_res = co_await gc.remove_unreferenced_objects(
-          db_.get(), &as_, 1000);
+          db_.get(), &as_, 1000, prereg_expiry_cutoff);
         if (!gc_res.has_value()) {
             using enum db_garbage_collector::errc;
             switch (gc_res.error().e) {
@@ -1140,8 +1144,12 @@ ss::future<> db_domain_manager::gc_loop() {
                 break;
             }
         }
-        // Drop the database lock while we sleep.
+        // Drop the database lock before expiring stale preregistered objects
+        // and before sleeping, so we don't hold it unnecessarily.
         gl_res = {};
+        if (gc_res.has_value() && !gc_res.value().empty()) {
+            co_await expire_preregistered_objects(std::move(gc_res.value()));
+        }
 
         auto sleep_interval = gc_interval_();
         vlog(
@@ -1330,6 +1338,38 @@ db_domain_manager::get_database_stats() {
     }
 
     co_return result;
+}
+
+ss::future<>
+db_domain_manager::expire_preregistered_objects(chunked_vector<object_id> ids) {
+    auto locks_res = co_await gate_and_open_writes();
+    if (!locks_res.has_value()) {
+        vlog(
+          cd_log.debug,
+          "Not expiring preregistered objects, failed to acquire locks: {}",
+          locks_res.error());
+        co_return;
+    }
+    expire_preregistered_objects_db_update update{.object_ids = std::move(ids)};
+    auto reader = state_reader(db_->db().create_snapshot());
+    chunked_vector<write_batch_row> rows;
+    auto build_res = co_await update.build_rows(reader, rows);
+    if (!build_res.has_value()) {
+        log_and_convert(
+          build_res.error(),
+          "Error building rows for preregistered object expiry: ");
+        co_return;
+    }
+    if (rows.empty()) {
+        co_return;
+    }
+    auto write_res = co_await write_rows(locks_res.value(), std::move(rows));
+    if (!write_res.has_value()) {
+        vlog(
+          cd_log.warn,
+          "Error writing preregistered object expiry rows: {}",
+          write_res.error());
+    }
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -279,6 +279,15 @@ db_domain_manager::get_first_offset_ge(rpc::get_first_offset_ge_request req) {
         };
     }
     const auto& object = object_res.value().value();
+    if (object.is_preregistration) {
+        co_return rpc::get_first_offset_ge_reply{
+          .ec = log_and_convert(
+            state_reader::error(
+              state_reader::errc::corruption,
+              "Extent refers to a preregistered object"),
+            "Error getting object"),
+        };
+    }
     co_return rpc::get_first_offset_ge_reply{
       .ec = rpc::errc::ok,
       .object = rpc::object_metadata{
@@ -351,6 +360,15 @@ db_domain_manager::get_first_timestamp_ge(
             }
             auto key = extent_row_key::decode(extent.key);
             const auto& object = object_res.value().value();
+            if (object.is_preregistration) {
+                co_return rpc::get_first_timestamp_ge_reply{
+                  .ec = log_and_convert(
+                    state_reader::error(
+                      state_reader::errc::corruption,
+                      "Extent refers to a preregistered object"),
+                    "Error getting object"),
+                };
+            }
             co_return rpc::get_first_timestamp_ge_reply{
               .ec = rpc::errc::ok,
               .object = rpc::object_metadata{

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -906,6 +906,45 @@ db_domain_manager::get_extent_metadata(rpc::get_extent_metadata_request req) {
     };
 }
 
+ss::future<rpc::preregister_objects_reply>
+db_domain_manager::preregister_objects(rpc::preregister_objects_request req) {
+    auto gl_res = co_await gate_and_open_writes();
+    if (!gl_res.has_value()) {
+        co_return rpc::preregister_objects_reply{
+          .ec = gl_res.error(),
+        };
+    }
+
+    preregister_objects_db_update update;
+    update.registered_at = model::timestamp::now();
+    update.object_ids.reserve(req.count);
+    for (uint32_t i = 0; i < req.count; ++i) {
+        update.object_ids.push_back(create_object_id());
+    }
+
+    auto reader = state_reader(db_->db().create_snapshot());
+    chunked_vector<write_batch_row> rows;
+    auto build_res = co_await update.build_rows(reader, rows);
+    if (!build_res.has_value()) {
+        co_return rpc::preregister_objects_reply{
+          .ec = log_and_convert(
+            build_res.error(), "Rejecting request to preregister objects: "),
+        };
+    }
+
+    auto apply_res = co_await write_rows(gl_res.value(), std::move(rows));
+    if (!apply_res.has_value()) {
+        co_return rpc::preregister_objects_reply{
+          .ec = apply_res.error(),
+        };
+    }
+
+    co_return rpc::preregister_objects_reply{
+      .ec = rpc::errc::ok,
+      .object_ids = std::move(update.object_ids),
+    };
+}
+
 ss::future<std::expected<ss::rwlock::holder, rpc::errc>>
 db_domain_manager::exclusive_db_lock() {
     auto fut = co_await ss::coroutine::as_future(

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.h
@@ -12,8 +12,10 @@
 #include "cloud_topics/level_one/domain/domain_manager.h"
 #include "cloud_topics/level_one/metastore/lsm/replicated_db.h"
 #include "cloud_topics/level_one/metastore/lsm/stm.h"
+#include "model/timestamp.h"
 #include "ssx/checkpoint_mutex.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/rwlock.hh>
 
 namespace cloud_topics::l1 {
@@ -141,6 +143,8 @@ private:
 
     ss::future<rpc::get_compaction_info_reply> do_get_compaction_info(
       const gate_read_lock&, state_reader&, rpc::get_compaction_info_request);
+
+    ss::future<> expire_preregistered_objects(chunked_vector<object_id>);
 
     ss::gate gate_;
     ss::abort_source as_;

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.h
@@ -87,6 +87,9 @@ public:
     ss::future<std::expected<database_stats, rpc::errc>>
     get_database_stats() override;
 
+    ss::future<rpc::preregister_objects_reply>
+      preregister_objects(rpc::preregister_objects_request) override;
+
 private:
     // Initializes the underlying database for the current term, potentially
     // reopening it if needed (e.g. the underlying Raft term has changed since

--- a/src/v/cloud_topics/level_one/domain/domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.h
@@ -103,6 +103,9 @@ public:
 
     virtual ss::future<std::expected<database_stats, rpc::errc>>
     get_database_stats() = 0;
+
+    virtual ss::future<rpc::preregister_objects_reply>
+      preregister_objects(rpc::preregister_objects_request) = 0;
 };
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/domain/simple_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/simple_domain_manager.cc
@@ -9,9 +9,11 @@
  */
 #include "cloud_topics/level_one/domain/simple_domain_manager.h"
 
+#include "cloud_topics/level_one/common/object_id.h"
 #include "cloud_topics/level_one/metastore/garbage_collector.h"
 #include "cloud_topics/level_one/metastore/rpc_types.h"
 #include "cloud_topics/level_one/metastore/simple_metastore.h"
+#include "cloud_topics/level_one/metastore/state_update.h"
 #include "cloud_topics/logger.h"
 #include "config/configuration.h"
 #include "container/chunked_hash_map.h"
@@ -667,6 +669,54 @@ simple_domain_manager::get_extent_metadata(
       .ec = rpc::errc::ok,
       .extents = meta_to_rpc_extent_metadata(std::move(get_res->extents)),
       .end_of_stream = get_res->end_of_stream};
+}
+
+ss::future<rpc::preregister_objects_reply>
+simple_domain_manager::preregister_objects(
+  rpc::preregister_objects_request req) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return rpc::preregister_objects_reply{
+          .ec = rpc::errc::not_leader,
+        };
+    }
+    auto sync_res = co_await stm_->sync(10s);
+    if (!sync_res.has_value()) {
+        co_return rpc::preregister_objects_reply{
+          .ec = convert_stm_errc(sync_res.error()),
+        };
+    }
+
+    preregister_objects_update update;
+    update.registered_at = model::timestamp::now();
+    update.object_ids.reserve(req.count);
+    for (uint32_t i = 0; i < req.count; ++i) {
+        update.object_ids.push_back(create_object_id());
+    }
+
+    chunked_vector<object_id> reply_ids;
+    reply_ids.reserve(update.object_ids.size());
+    for (const auto& oid : update.object_ids) {
+        reply_ids.push_back(oid);
+    }
+
+    storage::record_batch_builder builder(
+      model::record_batch_type::l1_stm, model::offset{0});
+    builder.add_raw_kv(
+      serde::to_iobuf(preregister_objects_update::key),
+      serde::to_iobuf(std::move(update)));
+    auto repl_res = co_await stm_->replicate_and_wait(
+      sync_res.value(), std::move(builder).build(), as_);
+    if (!repl_res.has_value()) {
+        co_return rpc::preregister_objects_reply{
+          .ec = convert_stm_errc(repl_res.error()),
+        };
+    }
+
+    co_return rpc::preregister_objects_reply{
+      .ec = rpc::errc::ok,
+      .object_ids = std::move(reply_ids),
+    };
 }
 
 ss::future<rpc::flush_domain_reply>

--- a/src/v/cloud_topics/level_one/domain/simple_domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/simple_domain_manager.h
@@ -81,6 +81,9 @@ public:
     ss::future<std::expected<database_stats, rpc::errc>>
     get_database_stats() override;
 
+    ss::future<rpc::preregister_objects_reply>
+      preregister_objects(rpc::preregister_objects_request) override;
+
 private:
     std::optional<ss::gate::holder> maybe_gate();
     ss::future<> gc_loop();

--- a/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
+++ b/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
@@ -152,6 +152,26 @@ chunked_vector<new_object> make_new_objects(
     return objects;
 }
 
+chunked_vector<new_object> make_new_objects_with_ids(
+  const model::topic_id_partition& tp,
+  kafka::offset start_offset,
+  size_t offsets_per_object,
+  const chunked_vector<object_id>& object_ids) {
+    chunked_vector<new_object> objects;
+    objects.reserve(object_ids.size());
+
+    auto next_offset = start_offset;
+    for (const auto& oid : object_ids) {
+        auto base = next_offset;
+        auto last = kafka::offset(next_offset() + offsets_per_object - 1);
+        auto obj = make_new_object(tp, base, last);
+        obj.oid = oid;
+        objects.push_back(std::move(obj));
+        next_offset = kafka::next_offset(last);
+    }
+    return objects;
+}
+
 term_state_update_t make_terms(
   const model::topic_id_partition& tp,
   kafka::offset start_offset,
@@ -187,6 +207,25 @@ void flush_as_manifest(
                                       .get()})
                       .get();
 
+    // Pre-register the object IDs before building the add_objects rows.
+    preregister_objects_db_update prereg_update;
+    prereg_update.registered_at = model::timestamp::now();
+    for (const auto& obj : new_objects) {
+        prereg_update.object_ids.push_back(obj.oid);
+    }
+    {
+        auto prereg_reader = state_reader(cloud_db.create_snapshot());
+        chunked_vector<write_batch_row> prereg_rows;
+        auto prereg_res
+          = prereg_update.build_rows(prereg_reader, prereg_rows).get();
+        ASSERT_TRUE(prereg_res.has_value()) << prereg_res.error();
+        auto wb = cloud_db.create_write_batch();
+        for (auto& r : prereg_rows) {
+            wb.put(r.key, std::move(r.value), lsm::sequence_number{1});
+        }
+        cloud_db.apply(std::move(wb)).get();
+    }
+
     // Build the rows for the given new objects.
     add_objects_db_update update{
       .new_objects = std::move(new_objects),
@@ -201,7 +240,7 @@ void flush_as_manifest(
     // Write them to the database and flush to make it recoverable.
     auto wb = cloud_db.create_write_batch();
     for (auto& r : rows) {
-        wb.put(r.key, std::move(r.value), lsm::sequence_number{1});
+        wb.put(r.key, std::move(r.value), lsm::sequence_number{2});
     }
     cloud_db.apply(std::move(wb)).get();
 
@@ -320,8 +359,16 @@ public:
                 managers.emplace_back(mgr.get());
             }
             for (auto* mgr : managers) {
+                auto prereg = co_await mgr->preregister_objects({
+                  .metastore_partition = model::partition_id(0),
+                  .count = 1,
+                });
+                if (prereg.ec != l1_rpc::errc::ok) {
+                    continue;
+                }
                 l1_rpc::add_objects_request req;
-                req.new_objects = make_new_objects(tp, expected_next, 1, 1);
+                req.new_objects = make_new_objects_with_ids(
+                  tp, expected_next, 1, prereg.object_ids);
                 req.new_terms = make_terms(
                   tp, expected_next, model::term_id(1));
                 futs.emplace_back(mgr->add_objects(std::move(req)));
@@ -406,9 +453,17 @@ public:
                 managers.emplace_back(mgr.get());
             }
             for (auto* mgr : managers) {
+                auto prereg = co_await mgr->preregister_objects({
+                  .metastore_partition = model::partition_id(0),
+                  .count = 1,
+                });
+                if (prereg.ec != l1_rpc::errc::ok) {
+                    continue;
+                }
                 l1_rpc::replace_objects_request req{
                   .metastore_partition = model::partition_id(0),
-                  .new_objects = make_new_objects(tp, offset_to_replace, 1, 1),
+                  .new_objects = make_new_objects_with_ids(
+                    tp, offset_to_replace, 1, prereg.object_ids),
                 };
                 futs.emplace_back(mgr->replace_objects(std::move(req)));
 
@@ -656,16 +711,32 @@ TEST_F(DbDomainManagerTest, TestBasicAddObjects) {
     auto tp = make_tp();
     // Add [0, 29].
     {
+        auto prereg_reply = initial_manager
+                              ->preregister_objects({
+                                .metastore_partition = model::partition_id(0),
+                                .count = 3,
+                              })
+                              .get();
+        ASSERT_EQ(prereg_reply.ec, l1_rpc::errc::ok);
         l1_rpc::add_objects_request req;
-        req.new_objects = make_new_objects(tp, kafka::offset(0), 3, 10);
+        req.new_objects = make_new_objects_with_ids(
+          tp, kafka::offset(0), 10, prereg_reply.object_ids);
         req.new_terms = make_terms(tp, kafka::offset(0), model::term_id(1));
         auto reply = initial_manager->add_objects(std::move(req)).get();
         ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
     }
     // Add [30, 59].
     {
+        auto prereg_reply = initial_manager
+                              ->preregister_objects({
+                                .metastore_partition = model::partition_id(0),
+                                .count = 3,
+                              })
+                              .get();
+        ASSERT_EQ(prereg_reply.ec, l1_rpc::errc::ok);
         l1_rpc::add_objects_request req;
-        req.new_objects = make_new_objects(tp, kafka::offset(30), 3, 10);
+        req.new_objects = make_new_objects_with_ids(
+          tp, kafka::offset(30), 10, prereg_reply.object_ids);
         req.new_terms = make_terms(tp, kafka::offset(30), model::term_id(1));
         auto reply = initial_manager->add_objects(std::move(req)).get();
         ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
@@ -678,8 +749,16 @@ TEST_F(DbDomainManagerTest, TestBasicReplaceObjects) {
     auto tp = make_tp();
     // Add [0, 9] in several batches.
     for (int i = 0; i < 10; ++i) {
+        auto prereg_reply = initial_manager
+                              ->preregister_objects({
+                                .metastore_partition = model::partition_id(0),
+                                .count = 1,
+                              })
+                              .get();
+        ASSERT_EQ(prereg_reply.ec, l1_rpc::errc::ok);
         l1_rpc::add_objects_request req;
-        req.new_objects = make_new_objects(tp, kafka::offset(i), 1, 1);
+        req.new_objects = make_new_objects_with_ids(
+          tp, kafka::offset(i), 1, prereg_reply.object_ids);
         req.new_terms = make_terms(tp, kafka::offset(i), model::term_id(1));
         auto reply = initial_manager->add_objects(std::move(req)).get();
         ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
@@ -687,9 +766,17 @@ TEST_F(DbDomainManagerTest, TestBasicReplaceObjects) {
     validate_metadata(
       tp, kafka::offset(0), kafka::offset(10), exact_next::yes, 10);
     // Replace [0, 9] with one object.
+    auto prereg_reply = initial_manager
+                          ->preregister_objects({
+                            .metastore_partition = model::partition_id(0),
+                            .count = 1,
+                          })
+                          .get();
+    ASSERT_EQ(prereg_reply.ec, l1_rpc::errc::ok);
     l1_rpc::replace_objects_request req{
       .metastore_partition = model::partition_id(0),
-      .new_objects = make_new_objects(tp, kafka::offset(0), 10, 1),
+      .new_objects = make_new_objects_with_ids(
+        tp, kafka::offset(0), 10, prereg_reply.object_ids),
     };
     auto reply = initial_manager->replace_objects(std::move(req)).get();
     ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
@@ -841,7 +928,15 @@ TEST_F(DbDomainManagerTest, TestGarbageCollectionAfterRemoveTopic) {
     auto tp = make_tp();
 
     // Create some object metadata and actually create dummy objects for them.
-    auto new_objects = make_new_objects(tp, kafka::offset(0), 4321, 10);
+    auto prereg_reply = initial_manager
+                          ->preregister_objects({
+                            .metastore_partition = model::partition_id(0),
+                            .count = 4321,
+                          })
+                          .get();
+    ASSERT_EQ(prereg_reply.ec, l1_rpc::errc::ok);
+    auto new_objects = make_new_objects_with_ids(
+      tp, kafka::offset(0), 10, prereg_reply.object_ids);
     auto object_ids = put_dummy_objects(initial_leader->object_io, new_objects);
 
     // Verify objects exist in S3 using remote->object_exists.
@@ -886,8 +981,16 @@ TEST_F(DbDomainManagerTest, TestGetSizeBasic) {
     auto tp = make_tp();
     // Add 3 objects, each with an extent of size 512 bytes.
     {
+        auto prereg_reply = initial_manager
+                              ->preregister_objects({
+                                .metastore_partition = model::partition_id(0),
+                                .count = 3,
+                              })
+                              .get();
+        ASSERT_EQ(prereg_reply.ec, l1_rpc::errc::ok);
         l1_rpc::add_objects_request req;
-        req.new_objects = make_new_objects(tp, kafka::offset(0), 3, 10);
+        req.new_objects = make_new_objects_with_ids(
+          tp, kafka::offset(0), 10, prereg_reply.object_ids);
         req.new_terms = make_terms(tp, kafka::offset(0), model::term_id(1));
         auto reply = initial_manager->add_objects(std::move(req)).get();
         ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
@@ -904,8 +1007,16 @@ TEST_F(DbDomainManagerTest, TestGetSizeAfterReplace) {
     auto tp = make_tp();
     // Add 5 objects, each with an extent of size 512 bytes.
     for (int i = 0; i < 5; ++i) {
+        auto prereg_reply = initial_manager
+                              ->preregister_objects({
+                                .metastore_partition = model::partition_id(0),
+                                .count = 1,
+                              })
+                              .get();
+        ASSERT_EQ(prereg_reply.ec, l1_rpc::errc::ok);
         l1_rpc::add_objects_request req;
-        req.new_objects = make_new_objects(tp, kafka::offset(i), 1, 1);
+        req.new_objects = make_new_objects_with_ids(
+          tp, kafka::offset(i), 1, prereg_reply.object_ids);
         req.new_terms = make_terms(tp, kafka::offset(i), model::term_id(1));
         auto reply = initial_manager->add_objects(std::move(req)).get();
         ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
@@ -920,9 +1031,18 @@ TEST_F(DbDomainManagerTest, TestGetSizeAfterReplace) {
     }
 
     // Replace all 5 extents with 1 extent (also 512 bytes).
+    auto replace_prereg_reply = initial_manager
+                                  ->preregister_objects({
+                                    .metastore_partition = model::partition_id(
+                                      0),
+                                    .count = 1,
+                                  })
+                                  .get();
+    ASSERT_EQ(replace_prereg_reply.ec, l1_rpc::errc::ok);
     l1_rpc::replace_objects_request replace_req{
       .metastore_partition = model::partition_id(0),
-      .new_objects = make_new_objects(tp, kafka::offset(0), 1, 5),
+      .new_objects = make_new_objects_with_ids(
+        tp, kafka::offset(0), 5, replace_prereg_reply.object_ids),
     };
     auto replace_reply
       = initial_manager->replace_objects(std::move(replace_req)).get();

--- a/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
+++ b/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
@@ -1064,3 +1064,36 @@ TEST_F(DbDomainManagerTest, TestGetSizeMissingPartition) {
     auto size_reply = initial_manager->get_size(std::move(size_req)).get();
     ASSERT_EQ(size_reply.ec, l1_rpc::errc::missing_ntp);
 }
+
+TEST_F(DbDomainManagerTest, TestPreregisteredObjectExpiry) {
+    cfg.get("cloud_topics_preregistered_object_ttl").set_value(1ms);
+    cfg.get("cloud_topics_long_term_garbage_collection_interval")
+      .set_value(100ms);
+
+    auto tp = make_tp();
+    auto prereg_reply = initial_manager
+                          ->preregister_objects({
+                            .metastore_partition = model::partition_id(0),
+                            .count = 1,
+                          })
+                          .get();
+    ASSERT_EQ(prereg_reply.ec, l1_rpc::errc::ok);
+
+    // Upload dummy objects to cloud storage so GC can physically delete them.
+    auto new_objects = make_new_objects_with_ids(
+      tp, kafka::offset(0), 1, prereg_reply.object_ids);
+    auto object_ids = put_dummy_objects(initial_leader->object_io, new_objects);
+    for (const auto& oid : object_ids) {
+        ASSERT_TRUE(object_exists(oid).get());
+    }
+
+    initial_manager->start();
+
+    // Eventually a flush should happen after expiry and the objects become
+    // eligible for removal.
+    RPTEST_REQUIRE_EVENTUALLY(30s, [&](this auto) -> ss::future<bool> {
+        co_await initial_manager->flush_domain({});
+
+        co_return co_await all_objects_missing(object_ids);
+    });
+}

--- a/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
+++ b/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
@@ -686,10 +686,10 @@ TEST_F(DbDomainManagerTest, TestBasicReplaceObjects) {
     }
     validate_metadata(
       tp, kafka::offset(0), kafka::offset(10), exact_next::yes, 10);
-    // Replace [0, 9] in with one object.
+    // Replace [0, 9] with one object.
     l1_rpc::replace_objects_request req{
       .metastore_partition = model::partition_id(0),
-      .new_objects = make_new_objects(tp, kafka::offset(0), 1, 10),
+      .new_objects = make_new_objects(tp, kafka::offset(0), 10, 1),
     };
     auto reply = initial_manager->replace_objects(std::move(req)).get();
     ASSERT_EQ(reply.ec, l1_rpc::errc::ok);

--- a/src/v/cloud_topics/level_one/frontend_reader/tests/l1_reader_fixture.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/tests/l1_reader_fixture.h
@@ -63,7 +63,7 @@ protected:
         std::map<model::topic_id_partition, l1::object_id> oid_by_tidp;
         for (auto& [tidp, unused] : batches_by_tidp) {
             oid_by_tidp[tidp]
-              = meta_builder->get_or_create_object_for(tidp).value();
+              = (co_await meta_builder->get_or_create_object_for(tidp)).value();
         }
 
         // Then create output streams and builders for each object.

--- a/src/v/cloud_topics/level_one/frontend_reader/tests/reader_test.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/tests/reader_test.cc
@@ -282,7 +282,7 @@ TEST_F(l1_reader_test, missing_object) {
     // Register object in metastore but don't upload.
     // This is corruption and readers should throw.
     auto builder = _metastore.object_builder().get().value();
-    auto oid = builder->get_or_create_object_for(tidp).value();
+    auto oid = builder->get_or_create_object_for(tidp).get().value();
     builder
       ->add(
         oid,
@@ -329,7 +329,7 @@ TEST_F(l1_reader_test, empty_offset_range) {
     // to cover a non-empty offset range in the metastore.
     auto meta_builder = _metastore.object_builder().get().value();
 
-    auto oid = meta_builder->get_or_create_object_for(tidp).value();
+    auto oid = meta_builder->get_or_create_object_for(tidp).get().value();
 
     auto buf = iobuf{};
     auto builder = l1::object_builder::create(

--- a/src/v/cloud_topics/level_one/metastore/garbage_collector.cc
+++ b/src/v/cloud_topics/level_one/metastore/garbage_collector.cc
@@ -33,6 +33,9 @@ garbage_collector::remove_unreferenced_objects(ss::abort_source* as) {
 
     chunked_vector<object_id> to_remove;
     for (const auto& [oid, obj_entry] : s.objects) {
+        if (obj_entry.is_preregistration) {
+            continue;
+        }
         if (obj_entry.total_data_size != obj_entry.removed_data_size) {
             continue;
         }

--- a/src/v/cloud_topics/level_one/metastore/leader_router.cc
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.cc
@@ -204,6 +204,17 @@ ss::future<rpc::restore_domain_reply> do_restore_domain(
     co_return co_await domain_mgr->restore_domain(std::move(req));
 }
 
+ss::future<rpc::preregister_objects_reply> do_preregister_objects(
+  domain_supervisor& domain_supervisor,
+  const model::ntp& ntp,
+  rpc::preregister_objects_request req) {
+    auto domain_mgr = domain_supervisor.get(ntp);
+    if (!domain_mgr) {
+        co_return rpc::preregister_objects_reply{.ec = rpc::errc::not_leader};
+    }
+    co_return co_await domain_mgr->preregister_objects(std::move(req));
+}
+
 } // namespace
 
 template<auto Func, typename req_t>
@@ -397,6 +408,14 @@ template ss::future<rpc::flush_domain_reply>
 template ss::future<rpc::flush_domain_reply> leader_router::process<
   &leader_router::flush_domain_locally,
   &leader_router::client::flush_domain>(rpc::flush_domain_request, bool);
+
+template ss::future<rpc::preregister_objects_reply>
+  leader_router::remote_dispatch<&leader_router::client::preregister_objects>(
+    rpc::preregister_objects_request, model::node_id);
+template ss::future<rpc::preregister_objects_reply> leader_router::process<
+  &leader_router::preregister_objects_locally,
+  &leader_router::client::preregister_objects>(
+  rpc::preregister_objects_request, bool);
 
 leader_router::leader_router(
   model::node_id self,
@@ -805,6 +824,27 @@ ss::future<rpc::restore_domain_reply> leader_router::restore_domain(
     co_return co_await process<
       &leader_router::restore_domain_locally,
       &client::restore_domain>(std::move(request), bool(local_only_exec));
+}
+
+ss::future<rpc::preregister_objects_reply>
+leader_router::preregister_objects_locally(
+  rpc::preregister_objects_request request,
+  const model::ntp& metastore_ntp,
+  ss::shard_id shard) {
+    co_return co_await container().invoke_on(
+      shard,
+      [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {
+          return do_preregister_objects(
+            *(fe._domain_supervisor), metastore_ntp, std::move(req));
+      });
+}
+
+ss::future<rpc::preregister_objects_reply> leader_router::preregister_objects(
+  rpc::preregister_objects_request request, local_only local_only_exec) {
+    auto holder = _gate.hold();
+    co_return co_await process<
+      &leader_router::preregister_objects_locally,
+      &client::preregister_objects>(std::move(request), bool(local_only_exec));
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/leader_router.h
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.h
@@ -106,6 +106,9 @@ public:
     ss::future<rpc::restore_domain_reply>
       restore_domain(rpc::restore_domain_request, local_only = local_only::no);
 
+    ss::future<rpc::preregister_objects_reply> preregister_objects(
+      rpc::preregister_objects_request, local_only = local_only::no);
+
     std::optional<model::partition_id>
     metastore_partition(const model::topic_id_partition&) const;
 
@@ -217,6 +220,11 @@ private:
 
     ss::future<rpc::restore_domain_reply> restore_domain_locally(
       rpc::restore_domain_request,
+      const model::ntp& metastore_ntp,
+      ss::shard_id);
+
+    ss::future<rpc::preregister_objects_reply> preregister_objects_locally(
+      rpc::preregister_objects_request,
       const model::ntp& metastore_ntp,
       ss::shard_id);
 

--- a/src/v/cloud_topics/level_one/metastore/lsm/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/lsm/BUILD
@@ -262,6 +262,8 @@ redpanda_cc_library(
         ":replicated_db",
         "//src/v/base",
         "//src/v/cloud_topics/level_one/common:object_id",
+        "//src/v/container:chunked_vector",
+        "//src/v/model",
         "//src/v/utils:detailed_error",
         "//src/v/utils:named_type",
         "@seastar",

--- a/src/v/cloud_topics/level_one/metastore/lsm/garbage_collector.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/garbage_collector.cc
@@ -89,7 +89,9 @@ db_garbage_collector::remove_unreferenced_batch(
   replicated_database* db,
   ss::abort_source* as,
   size_t batch_size,
-  std::optional<object_id> start_point) {
+  std::optional<object_id> start_point,
+  model::timestamp prereg_expiry_cutoff,
+  chunked_vector<object_id>& to_expire_out) {
     auto persisted_seqno = db->db().max_persisted_seqno();
     if (!persisted_seqno.has_value()) {
         // Nothing has been persisted yet, cannot remove anything.
@@ -113,6 +115,7 @@ db_garbage_collector::remove_unreferenced_batch(
     }
     auto object_gen = object_range_res.value().get_rows();
     chunked_vector<object_id> to_remove;
+    size_t batch_expire_count = 0;
     std::optional<object_id> next_batch_start{std::nullopt};
     while (auto obj_ref_opt = co_await object_gen()) {
         if (as->abort_requested()) {
@@ -137,6 +140,25 @@ db_garbage_collector::remove_unreferenced_batch(
         auto& obj_entry = obj_row.val.object;
         auto obj_key = object_row_key::decode(obj_row.key);
         auto oid = obj_key->oid;
+
+        if (obj_entry.is_preregistration) {
+            if (obj_entry.last_updated < prereg_expiry_cutoff) {
+                vlog(
+                  cd_log.debug,
+                  "Expiring stale preregistered L1 object: {}",
+                  oid);
+                to_expire_out.emplace_back(oid);
+                ++batch_expire_count;
+                if (to_remove.size() + batch_expire_count == batch_size) {
+                    if (auto next = next_uuid(oid()); next.has_value()) {
+                        next_batch_start = object_id(*next);
+                    }
+                    break;
+                }
+            }
+            continue;
+        }
+
         if (obj_entry.removed_data_size > obj_entry.total_data_size) {
             vlog(
               cd_log.error,
@@ -149,11 +171,10 @@ db_garbage_collector::remove_unreferenced_batch(
             // but don't block the rest of GC.
             continue;
         }
-        // TODO: also consider some timestamp of last update to the object?
         if (obj_entry.removed_data_size == obj_entry.total_data_size) {
             vlog(cd_log.debug, "Deleting L1 object: {}", oid);
             to_remove.emplace_back(oid);
-            if (to_remove.size() == batch_size) {
+            if (to_remove.size() + batch_expire_count == batch_size) {
                 // Set an explicit next starting object if we had more than one
                 // batch of objects so we can make incremental progress.
                 // NOTE: nullopt if UUID_MAX (extremely unlikely overflow)
@@ -164,10 +185,15 @@ db_garbage_collector::remove_unreferenced_batch(
             }
         }
     }
-    if (to_remove.empty()) {
+    if (to_remove.empty() && batch_expire_count == 0) {
         vlog(cd_log.debug, "No objects eligible for garbage collection");
         co_return std::nullopt;
     }
+
+    if (to_remove.empty()) {
+        co_return next_batch_start;
+    }
+
     auto del_res = co_await io_->delete_objects(to_remove.copy(), as);
     if (!del_res.has_value()) {
         co_return std::unexpected(
@@ -192,20 +218,25 @@ db_garbage_collector::remove_unreferenced_batch(
     co_return next_batch_start;
 }
 
-ss::future<std::expected<void, db_garbage_collector::error>>
+ss::future<
+  std::expected<chunked_vector<object_id>, db_garbage_collector::error>>
 db_garbage_collector::remove_unreferenced_objects(
-  replicated_database* db, ss::abort_source* as, size_t batch_size) {
+  replicated_database* db,
+  ss::abort_source* as,
+  size_t batch_size,
+  model::timestamp prereg_expiry_cutoff) {
+    chunked_vector<object_id> to_expire;
     std::optional<object_id> next_start;
     while (!as->abort_requested()) {
         auto batch_res = co_await remove_unreferenced_batch(
-          db, as, batch_size, next_start);
+          db, as, batch_size, next_start, prereg_expiry_cutoff, to_expire);
         if (!batch_res.has_value()) {
             co_return std::unexpected(batch_res.error());
         }
         next_start = batch_res.value();
         if (!next_start.has_value()) {
             // Nothing left to remove.
-            co_return std::expected<void, error>{};
+            co_return to_expire;
         }
     }
     co_return std::unexpected(

--- a/src/v/cloud_topics/level_one/metastore/lsm/garbage_collector.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/garbage_collector.h
@@ -11,6 +11,8 @@
 
 #include "base/seastarx.h"
 #include "cloud_topics/level_one/common/object_id.h"
+#include "container/chunked_vector.h"
+#include "model/timestamp.h"
 #include "utils/detailed_error.h"
 #include "utils/named_type.h"
 
@@ -43,22 +45,33 @@ public:
         io_error,
     };
     using error = detailed_error<errc>;
+
     explicit db_garbage_collector(io* io);
 
-    ss::future<std::expected<void, error>> remove_unreferenced_objects(
-      replicated_database*, ss::abort_source*, size_t batch_size);
+    // Removes all unreferenced objects from cloud storage, and collects stale
+    // preregistered objects that need expiry. Returns the list of object IDs
+    // whose is_preregistration flag should be cleared; the caller is
+    // responsible for writing those rows with appropriate locking.
+    ss::future<std::expected<chunked_vector<object_id>, error>>
+    remove_unreferenced_objects(
+      replicated_database*,
+      ss::abort_source*,
+      size_t batch_size,
+      model::timestamp prereg_expiry_cutoff);
 
 private:
     // Removes the given batch size worth of objects, evaluating objects
     // starting from the given object. Returns the next object that needs to be
-    // evalulated, or std::nullopt if this batch finished all objects in the
-    // database.
+    // evaluated, or std::nullopt if this batch finished all objects in the
+    // database. Appends stale preregistered objects to to_expire_out.
     ss::future<std::expected<std::optional<object_id>, error>>
     remove_unreferenced_batch(
       replicated_database*,
       ss::abort_source*,
       size_t batch_size,
-      std::optional<object_id>);
+      std::optional<object_id>,
+      model::timestamp prereg_expiry_cutoff,
+      chunked_vector<object_id>& to_expire_out);
 
     io* io_;
 };

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
@@ -38,9 +38,11 @@ db_update_error wrap_read_err(
     }
 }
 
-// Checks the input new objects and ensures that they don't already exist in
-// the state. Collects the input extents and objects into the input maps.
-ss::future<std::expected<void, db_update_error>> validate_new_objects_missing(
+// Checks that each new object is pre-registered (exists with
+// is_preregistration=true), then collects extents and committed object
+// entries into the output maps.
+ss::future<std::expected<void, db_update_error>>
+validate_preregistered_and_collect(
   const chunked_vector<new_object>& new_objects,
   state_reader& state,
   sorted_extents_by_tidp_t& out_extents,
@@ -51,9 +53,11 @@ ss::future<std::expected<void, db_update_error>> validate_new_objects_missing(
             co_return std::unexpected(db_update_error(
               invalid_update, fmt::format("Error getting object {}", o.oid)));
         }
-        if (object_res->has_value()) {
+        if (
+          !object_res->has_value() || !object_res->value().is_preregistration) {
             co_return std::unexpected(db_update_error(
-              invalid_update, fmt::format("Object {} already exists", o.oid)));
+              invalid_update,
+              fmt::format("object {} not pre-registered", o.oid)));
         }
         auto data_size = o.collect_extents_by_tidp(&out_extents);
         out_objects.emplace(
@@ -322,7 +326,16 @@ build_object_removal_entries(
         }
         if (obj_res.value().has_value()) {
             auto obj_entry = obj_res.value().value();
+            if (obj_entry.is_preregistration) {
+                co_return std::unexpected(wrap_read_err(
+                  state_reader::error(
+                    state_reader::errc::corruption,
+                    "Unexpected preregistered object: {}",
+                    oid),
+                  "Error getting object for removal"));
+            }
             obj_entry.removed_data_size += removed_size;
+            obj_entry.last_updated = model::timestamp::now();
             updated_old_objects[oid] = obj_entry;
         }
         // If object doesn't exist, skip it (benign).
@@ -344,7 +357,7 @@ add_objects_db_update::build_rows(
     }
     sorted_extents_by_tidp_t new_extents_by_tp;
     chunked_hash_map<object_id, object_entry> new_objects_by_oid;
-    auto new_extents_res = co_await validate_new_objects_missing(
+    auto new_extents_res = co_await validate_preregistered_and_collect(
       new_objects, state, new_extents_by_tp, new_objects_by_oid);
     if (!new_extents_res.has_value()) {
         co_return std::unexpected(std::move(new_extents_res.error()));
@@ -599,10 +612,9 @@ replace_objects_db_update::build_rows(
     if (!validate_res.has_value()) {
         co_return std::unexpected(std::move(validate_res.error()));
     }
-    // Verify new objects don't exist.
     sorted_extents_by_tidp_t new_extents_by_tp;
     chunked_hash_map<object_id, object_entry> new_objects_map;
-    auto new_extents_res = co_await validate_new_objects_missing(
+    auto new_extents_res = co_await validate_preregistered_and_collect(
       new_objects, state, new_extents_by_tp, new_objects_map);
     if (!new_extents_res.has_value()) {
         co_return std::unexpected(std::move(new_extents_res.error()));
@@ -1182,6 +1194,7 @@ expire_preregistered_objects_db_update::build_rows(
         }
         auto entry = obj_res->value();
         entry.is_preregistration = false;
+        entry.last_updated = model::timestamp::now();
         out.emplace_back(
           write_batch_row{
             .key = object_row_key::encode(oid),

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
@@ -63,6 +63,8 @@ ss::future<std::expected<void, db_update_error>> validate_new_objects_missing(
             .removed_data_size = 0,
             .footer_pos = o.footer_pos,
             .object_size = o.object_size,
+            .last_updated = model::timestamp::now(),
+            .is_preregistration = false,
           });
     }
     co_return std::expected<void, db_update_error>{};
@@ -597,7 +599,6 @@ replace_objects_db_update::build_rows(
     if (!validate_res.has_value()) {
         co_return std::unexpected(std::move(validate_res.error()));
     }
-
     // Verify new objects don't exist.
     sorted_extents_by_tidp_t new_extents_by_tp;
     chunked_hash_map<object_id, object_entry> new_objects_map;
@@ -1125,6 +1126,68 @@ remove_objects_db_update::build_rows(
             .key = object_row_key::encode(oid), .value = iobuf{}});
     }
 
+    co_return std::expected<void, db_update_error>{};
+}
+
+ss::future<std::expected<void, db_update_error>>
+preregister_objects_db_update::can_apply(state_reader& reader) const {
+    for (const auto& oid : object_ids) {
+        auto obj_res = co_await reader.get_object(oid);
+        if (!obj_res.has_value()) {
+            co_return std::unexpected(wrap_read_err(
+              std::move(obj_res.error()), "Error getting object {}", oid));
+        }
+        if (obj_res->has_value()) {
+            co_return std::unexpected(db_update_error(
+              invalid_update, fmt::format("object {} already exists", oid)));
+        }
+    }
+    co_return std::expected<void, db_update_error>{};
+}
+
+ss::future<std::expected<void, db_update_error>>
+preregister_objects_db_update::build_rows(
+  state_reader& reader, chunked_vector<write_batch_row>& out) const {
+    auto allowed = co_await can_apply(reader);
+    if (!allowed.has_value()) {
+        co_return std::unexpected(std::move(allowed.error()));
+    }
+    for (const auto& oid : object_ids) {
+        out.emplace_back(
+          write_batch_row{
+            .key = object_row_key::encode(oid),
+            .value = serde::to_iobuf(
+              object_row_value{
+                .object = object_entry{
+                  .last_updated = registered_at,
+                  .is_preregistration = true,
+                },
+              }),
+          });
+    }
+    co_return std::expected<void, db_update_error>{};
+}
+
+ss::future<std::expected<void, db_update_error>>
+expire_preregistered_objects_db_update::build_rows(
+  state_reader& reader, chunked_vector<write_batch_row>& out) const {
+    for (const auto& oid : object_ids) {
+        auto obj_res = co_await reader.get_object(oid);
+        if (!obj_res.has_value()) {
+            co_return std::unexpected(wrap_read_err(
+              std::move(obj_res.error()), "Error getting object {}", oid));
+        }
+        if (!obj_res->has_value() || !obj_res->value().is_preregistration) {
+            continue;
+        }
+        auto entry = obj_res->value();
+        entry.is_preregistration = false;
+        out.emplace_back(
+          write_batch_row{
+            .key = object_row_key::encode(oid),
+            .value = serde::to_iobuf(object_row_value{.object = entry}),
+          });
+    }
     co_return std::expected<void, db_update_error>{};
 }
 

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.h
@@ -106,6 +106,30 @@ struct remove_objects_db_update {
     chunked_vector<object_id> objects;
 };
 
+struct preregister_objects_db_update {
+    /// \brief Returns an error if any oid already exists in state.
+    ss::future<std::expected<void, db_update_error>>
+    can_apply(state_reader&) const;
+
+    /// \brief For each oid not already a committed object, writes an
+    /// object_row_key entry with is_preregistration=true.
+    ss::future<std::expected<void, db_update_error>>
+    build_rows(state_reader&, chunked_vector<write_batch_row>&) const;
+
+    chunked_vector<object_id> object_ids;
+    model::timestamp registered_at;
+};
+
+struct expire_preregistered_objects_db_update {
+    /// \brief For each oid whose object_entry has is_preregistration=true,
+    /// emits an overwrite of object_row_key(oid) with is_preregistration
+    /// cleared. The next GC run picks them up via the removed==total path.
+    ss::future<std::expected<void, db_update_error>>
+    build_rows(state_reader&, chunked_vector<write_batch_row>&) const;
+
+    chunked_vector<object_id> object_ids;
+};
+
 } // namespace cloud_topics::l1
 
 template<>

--- a/src/v/cloud_topics/level_one/metastore/lsm/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/tests/state_update_test.cc
@@ -215,7 +215,17 @@ protected:
         return state_reader(std::move(snap));
     }
 
+    void
+    preregister_new_objects(const chunked_vector<new_object>& new_objects) {
+        chunked_vector<object_id> oids;
+        for (const auto& o : new_objects) {
+            oids.push_back(o.oid);
+        }
+        preregister_objects(std::move(oids), model::timestamp(1000));
+    }
+
     void apply_add_update(add_objects_db_update& update) {
+        preregister_new_objects(update.new_objects);
         auto reader = make_reader();
         chunked_vector<write_batch_row> rows;
         auto result = update.build_rows(reader, rows).get();
@@ -224,12 +234,17 @@ protected:
         auto wb = db_->create_write_batch();
         auto seqno = next_seqno();
         for (const auto& row : rows) {
-            wb.put(row.key, row.value.copy(), seqno);
+            if (row.value.empty()) {
+                wb.remove(row.key, seqno);
+            } else {
+                wb.put(row.key, row.value.copy(), seqno);
+            }
         }
         db_->apply(std::move(wb)).get();
     }
 
     void apply_replace_update(replace_objects_db_update& update) {
+        preregister_new_objects(update.new_objects);
         auto reader = make_reader();
         chunked_vector<write_batch_row> rows;
         auto result = update.build_rows(reader, rows).get();
@@ -489,7 +504,11 @@ protected:
         auto seqno = next_seqno();
         auto wb = db_->create_write_batch();
         for (const auto& row : rows) {
-            wb.put(row.key, row.value.copy(), seqno);
+            if (row.value.empty()) {
+                wb.remove(row.key, seqno);
+            } else {
+                wb.put(row.key, row.value.copy(), seqno);
+            }
         }
         db_->apply(std::move(wb)).get();
     }
@@ -527,6 +546,32 @@ protected:
         ASSERT_TRUE(res.has_value());
         ASSERT_TRUE(res.value().has_value());
         EXPECT_FALSE(res.value()->is_preregistration);
+    }
+
+    void preregister_objects(
+      chunked_vector<object_id> oids, model::timestamp registered_at) {
+        auto update = preregister_objects_db_update{
+          .object_ids = std::move(oids),
+          .registered_at = registered_at,
+        };
+        apply_preregister_update(update);
+    }
+
+    void verify_preregistered_object_exists(object_id oid) {
+        auto reader = make_reader();
+        auto res = reader.get_object(oid).get();
+        ASSERT_TRUE(res.has_value());
+        ASSERT_TRUE(res->has_value());
+        EXPECT_TRUE(res->value().is_preregistration);
+    }
+
+    void verify_preregistered_object_missing(object_id oid) {
+        auto reader = make_reader();
+        auto res = reader.get_object(oid).get();
+        ASSERT_TRUE(res.has_value());
+        if (res->has_value()) {
+            EXPECT_FALSE(res->value().is_preregistration);
+        }
     }
 
     std::optional<lsm::database> db_;
@@ -589,7 +634,8 @@ TEST_F(StateUpdateTest, TestAddObjectsRejectsDuplicateObject) {
     auto result = dupe_update.build_rows(reader, rows).get();
     ASSERT_FALSE(result.has_value());
     EXPECT_EQ(result.error().e, db_update_errc::invalid_update);
-    EXPECT_THAT(fmt::format("{}", result.error()), HasSubstr("already exists"));
+    EXPECT_THAT(
+      fmt::format("{}", result.error()), HasSubstr("not pre-registered"));
 }
 
 TEST_F(StateUpdateTest, TestAddObjectsRejectsEmptyObjects) {
@@ -696,6 +742,10 @@ TEST_F(StateUpdateTest, TestAddObjectsWithCorrections) {
 
     // Try to add misaligned objects starting at offset 50 instead of 100.
     auto new_oid = make_oid();
+    chunked_vector<object_id> prereg_oids;
+    prereg_oids.push_back(new_oid);
+    preregister_objects(std::move(prereg_oids), model::timestamp(1000));
+
     auto misaligned_update = make_add_objects_update(
       {terms(tidp0, {{50, 2}})},
       make_object(new_oid, tp(tidp0, 50, 149).pos(0, 1023)));
@@ -706,12 +756,16 @@ TEST_F(StateUpdateTest, TestAddObjectsWithCorrections) {
       = misaligned_update.build_rows(reader, rows, &corrections).get();
     ASSERT_TRUE(result.has_value());
 
-    // There should be one row generated -- an object entry (checked below).
+    // There should be one row: object entry (all data marked removed).
     EXPECT_EQ(1, rows.size());
     auto wb = db_->create_write_batch();
     auto seqno = next_seqno();
     for (const auto& row : rows) {
-        wb.put(row.key, row.value.copy(), seqno);
+        if (row.value.empty()) {
+            wb.remove(row.key, seqno);
+        } else {
+            wb.put(row.key, row.value.copy(), seqno);
+        }
     }
     db_->apply(std::move(wb)).get();
 
@@ -760,8 +814,13 @@ TEST_F(StateUpdateTest, TestReplaceObjectsBasic) {
 }
 
 TEST_F(StateUpdateTest, TestReplaceObjectsRejectsMissingPartition) {
+    auto oid = make_oid();
+    chunked_vector<object_id> prereg_oids;
+    prereg_oids.push_back(oid);
+    preregister_objects(std::move(prereg_oids), model::timestamp(1000));
+
     auto db_update = make_replace_objects_update(
-      compact_specs{}, make_object(make_oid(), tp(tidp0, 0, 99).pos(0, 1023)));
+      compact_specs{}, make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
     auto reader = make_reader();
     chunked_vector<write_batch_row> rows;
     auto result = db_update.build_rows(reader, rows).get();
@@ -854,7 +913,8 @@ TEST_F(StateUpdateTest, TestReplaceObjectsRejectsDuplicateObject) {
     auto result = db_update.build_rows(reader, rows).get();
     ASSERT_FALSE(result.has_value());
     EXPECT_EQ(result.error().e, db_update_errc::invalid_update);
-    EXPECT_THAT(fmt::format("{}", result.error()), HasSubstr("already exists"));
+    EXPECT_THAT(
+      fmt::format("{}", result.error()), HasSubstr("not pre-registered"));
 }
 
 TEST_F(StateUpdateTest, TestReplaceObjectsRejectsOverlappingCleanedRanges) {
@@ -877,6 +937,11 @@ TEST_F(StateUpdateTest, TestReplaceObjectsRejectsOverlappingCleanedRanges) {
 
     // Now try to add overlapping cleaned range [49-99].
     // epoch=1 because the first compaction incremented it from 0 to 1.
+    auto overlap_oid = make_oid();
+    chunked_vector<object_id> prereg_oids;
+    prereg_oids.push_back(overlap_oid);
+    preregister_objects(std::move(prereg_oids), model::timestamp(1000));
+
     auto db_update = make_replace_objects_update(
       {{compact_spec{
         .tidp = tidp0,
@@ -884,7 +949,7 @@ TEST_F(StateUpdateTest, TestReplaceObjectsRejectsOverlappingCleanedRanges) {
         .epoch = 1,
         .cleaned = {{49, 99, true}},
       }}},
-      make_object(make_oid(), tp(tidp0, 0, 99).pos(0, 511)));
+      make_object(overlap_oid, tp(tidp0, 0, 99).pos(0, 511)));
 
     auto reader = make_reader();
     chunked_vector<write_batch_row> rows;
@@ -903,12 +968,17 @@ TEST_F(StateUpdateTest, TestReplaceObjectsRejectsRemovingUntrackedTombstones) {
       make_object(make_oid(), tp(tidp0, 0, 99).pos(0, 1023)));
 
     // Try to remove tombstones from range [0-49] which doesn't have them.
+    auto tomb_oid = make_oid();
+    chunked_vector<object_id> prereg_oids;
+    prereg_oids.push_back(tomb_oid);
+    preregister_objects(std::move(prereg_oids), model::timestamp(1000));
+
     auto db_update = make_replace_objects_update(
       {{compact_spec{
         .tidp = tidp0,
         .rm_tombstones = {{0, 49}},
       }}},
-      make_object(make_oid(), tp(tidp0, 0, 99).pos(0, 1023)));
+      make_object(tomb_oid, tp(tidp0, 0, 99).pos(0, 1023)));
 
     auto reader = make_reader();
     chunked_vector<write_batch_row> rows;
@@ -981,12 +1051,17 @@ TEST_F(StateUpdateTest, TestReplaceObjectsRejectsCleanedRangeNotAtLogStart) {
     // Try to replace with cleaned range [100-199], but without replacing down
     // to offset 0. This should be rejected because cleaning requires
     // replacing from the start of the log.
+    auto partial_oid = make_oid();
+    chunked_vector<object_id> prereg_oids;
+    prereg_oids.push_back(partial_oid);
+    preregister_objects(std::move(prereg_oids), model::timestamp(1000));
+
     auto db_update = make_replace_objects_update(
       {{compact_spec{
         .tidp = tidp0,
         .cleaned = {{100, 199, false}},
       }}},
-      make_object(make_oid(), tp(tidp0, 100, 199).pos(0, 1023)));
+      make_object(partial_oid, tp(tidp0, 100, 199).pos(0, 1023)));
 
     auto reader = make_reader();
     chunked_vector<write_batch_row> rows;
@@ -1572,4 +1647,97 @@ TEST_F(StateUpdateTest, TestExpirePreregisteredObjectsClearsFlag) {
     verify_object_not_preregistered(oid1);
     // oid2 should be unchanged.
     verify_object_preregistered(oid2);
+}
+
+TEST_F(StateUpdateTest, TestPreregisterObjects) {
+    auto oid1 = make_oid();
+    auto oid2 = make_oid();
+
+    chunked_vector<object_id> oids;
+    oids.push_back(oid1);
+    oids.push_back(oid2);
+    preregister_objects(std::move(oids), model::timestamp(12345));
+
+    verify_preregistered_object_exists(oid1);
+    verify_preregistered_object_exists(oid2);
+}
+
+TEST_F(StateUpdateTest, TestExpirePreregisteredObjects) {
+    auto oid1 = make_oid();
+    auto oid2 = make_oid();
+
+    chunked_vector<object_id> oids;
+    oids.push_back(oid1);
+    oids.push_back(oid2);
+    preregister_objects(std::move(oids), model::timestamp(12345));
+
+    verify_preregistered_object_exists(oid1);
+    verify_preregistered_object_exists(oid2);
+
+    chunked_vector<object_id> expire_oids;
+    expire_oids.push_back(oid1);
+    expire_oids.push_back(oid2);
+    auto expire_update = expire_preregistered_objects_db_update{
+      .object_ids = std::move(expire_oids),
+    };
+    apply_expire_preregistered_update(expire_update);
+
+    // is_preregistration flag should be cleared.
+    verify_preregistered_object_missing(oid1);
+    verify_preregistered_object_missing(oid2);
+
+    // Objects remain as zero-sized entries, now eligible for GC.
+    verify_object_exists(oid1, 0);
+    verify_object_exists(oid2, 0);
+}
+
+TEST_F(StateUpdateTest, TestAddObjectsRequiresPreregistration) {
+    auto oid = make_oid();
+
+    // Attempt to add an object that has NOT been pre-registered.
+    auto update = make_add_objects_update(
+      {terms(tidp0, {{0, 1}})},
+      make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
+    auto reader = make_reader();
+    chunked_vector<write_batch_row> rows;
+    auto result = update.build_rows(reader, rows).get();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().e, db_update_errc::invalid_update);
+}
+
+TEST_F(StateUpdateTest, TestAddObjectsWithPreregistration) {
+    auto oid = make_oid();
+
+    // Pre-register the object first.
+    chunked_vector<object_id> oids;
+    oids.push_back(oid);
+    preregister_objects(std::move(oids), model::timestamp(12345));
+    verify_preregistered_object_exists(oid);
+
+    // Now add the object — call build_rows directly since oid is already
+    // preregistered (add_objects() would preregister again, which is invalid).
+    {
+        auto db_update = make_add_objects_update(
+          {terms(tidp0, {{0, 1}})},
+          make_object(oid, tp(tidp0, 0, 99).pos(0, 1023)));
+        auto reader = make_reader();
+        chunked_vector<write_batch_row> rows;
+        ASSERT_TRUE(db_update.build_rows(reader, rows).get().has_value());
+        auto wb = db_->create_write_batch();
+        auto seqno = next_seqno();
+        for (const auto& row : rows) {
+            if (row.value.empty()) {
+                wb.remove(row.key, seqno);
+            } else {
+                wb.put(row.key, row.value.copy(), seqno);
+            }
+        }
+        db_->apply(std::move(wb)).get();
+    }
+
+    verify_metadata(tidp0, kafka::offset(0), kafka::offset(100));
+    verify_object_exists(oid, 1024);
+
+    // Preregistered row should be cleaned up.
+    verify_preregistered_object_missing(oid);
 }

--- a/src/v/cloud_topics/level_one/metastore/lsm/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/tests/state_update_test.cc
@@ -480,6 +480,55 @@ protected:
         EXPECT_FALSE(res->has_value());
     }
 
+    void apply_preregister_update(preregister_objects_db_update& update) {
+        auto reader = make_reader();
+        chunked_vector<write_batch_row> rows;
+        auto result = update.build_rows(reader, rows).get();
+        ASSERT_TRUE(result.has_value());
+
+        auto seqno = next_seqno();
+        auto wb = db_->create_write_batch();
+        for (const auto& row : rows) {
+            wb.put(row.key, row.value.copy(), seqno);
+        }
+        db_->apply(std::move(wb)).get();
+    }
+
+    void apply_expire_preregistered_update(
+      expire_preregistered_objects_db_update& update) {
+        auto reader = make_reader();
+        chunked_vector<write_batch_row> rows;
+        auto result = update.build_rows(reader, rows).get();
+        ASSERT_TRUE(result.has_value());
+
+        auto seqno = next_seqno();
+        auto wb = db_->create_write_batch();
+        for (const auto& row : rows) {
+            if (row.value.empty()) {
+                wb.remove(row.key, seqno);
+            } else {
+                wb.put(row.key, row.value.copy(), seqno);
+            }
+        }
+        db_->apply(std::move(wb)).get();
+    }
+
+    void verify_object_preregistered(object_id oid) {
+        auto reader = make_reader();
+        auto res = reader.get_object(oid).get();
+        ASSERT_TRUE(res.has_value());
+        ASSERT_TRUE(res.value().has_value());
+        EXPECT_TRUE(res.value()->is_preregistration);
+    }
+
+    void verify_object_not_preregistered(object_id oid) {
+        auto reader = make_reader();
+        auto res = reader.get_object(oid).get();
+        ASSERT_TRUE(res.has_value());
+        ASSERT_TRUE(res.value().has_value());
+        EXPECT_FALSE(res.value()->is_preregistration);
+    }
+
     std::optional<lsm::database> db_;
 };
 
@@ -1465,4 +1514,62 @@ TEST_F(StateUpdateTest, TestRemoveTopicsZerosSize) {
 
     // Metadata should be removed entirely.
     verify_metadata_missing(tidp0);
+}
+
+TEST_F(StateUpdateTest, TestPreregisterObjectsBasic) {
+    auto oid1 = make_oid();
+    auto oid2 = make_oid();
+
+    preregister_objects_db_update update;
+    update.object_ids.push_back(oid1);
+    update.object_ids.push_back(oid2);
+    update.registered_at = model::timestamp::now();
+
+    auto reader = make_reader();
+    auto can_apply_res = update.can_apply(reader).get();
+    ASSERT_TRUE(can_apply_res.has_value());
+
+    apply_preregister_update(update);
+
+    verify_object_preregistered(oid1);
+    verify_object_preregistered(oid2);
+}
+
+TEST_F(StateUpdateTest, TestPreregisterObjectsRejectsDuplicate) {
+    auto oid1 = make_oid();
+
+    preregister_objects_db_update update1;
+    update1.object_ids.push_back(oid1);
+    update1.registered_at = model::timestamp::now();
+    apply_preregister_update(update1);
+
+    preregister_objects_db_update update2;
+    update2.object_ids.push_back(oid1);
+    update2.registered_at = model::timestamp::now();
+    auto reader = make_reader();
+    auto can_apply_res = update2.can_apply(reader).get();
+    EXPECT_FALSE(can_apply_res.has_value());
+}
+
+TEST_F(StateUpdateTest, TestExpirePreregisteredObjectsClearsFlag) {
+    auto oid1 = make_oid();
+    auto oid2 = make_oid();
+
+    preregister_objects_db_update prereg;
+    prereg.object_ids.push_back(oid1);
+    prereg.object_ids.push_back(oid2);
+    prereg.registered_at = model::timestamp::now();
+    apply_preregister_update(prereg);
+
+    verify_object_preregistered(oid1);
+    verify_object_preregistered(oid2);
+
+    expire_preregistered_objects_db_update expire;
+    expire.object_ids.push_back(oid1);
+    apply_expire_preregistered_update(expire);
+
+    // oid1 should have is_preregistration cleared.
+    verify_object_not_preregistered(oid1);
+    // oid2 should be unchanged.
+    verify_object_preregistered(oid2);
 }

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -112,7 +112,7 @@ public:
         // appropriate for the given partition. Potentially shares the object
         // with another partition, if the object is allowed by the metastore to
         // be shared by the other partition.
-        virtual std::expected<object_id, error>
+        virtual ss::future<std::expected<object_id, error>>
         get_or_create_object_for(const model::topic_id_partition&) = 0;
 
         // Creates a new object for the given partition. It is guaranteed that
@@ -123,7 +123,7 @@ public:
         // this particular `object_metadata_builder` only invoke
         // `create_object_for()` and `finish()` for the provided `object_id`
         // within a tightly bounded scope.
-        virtual std::expected<object_id, error>
+        virtual ss::future<std::expected<object_id, error>>
         create_object_for(const model::topic_id_partition&) = 0;
 
         // Removes a pending object from the builder. The object must be in the

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -90,7 +90,7 @@ meta_to_rpc_compact_update(const metastore::compaction_update& update) {
 // objects up by the appropriate metastore topic partition.
 class replicated_object_builder : public metastore::object_metadata_builder {
 public:
-    replicated_object_builder(leader_router& fe)
+    explicit replicated_object_builder(leader_router& fe)
       : object_metadata_builder()
       , fe_(fe) {}
     ~replicated_object_builder() override {}
@@ -100,9 +100,9 @@ public:
       = delete;
     replicated_object_builder& operator=(replicated_object_builder&&) = delete;
 
-    std::expected<object_id, error>
+    ss::future<std::expected<object_id, error>>
     get_or_create_object_for(const model::topic_id_partition&) override;
-    std::expected<object_id, error>
+    ss::future<std::expected<object_id, error>>
     create_object_for(const model::topic_id_partition&) override;
     std::expected<void, error> remove_pending_object(object_id) override;
     std::expected<void, error>
@@ -125,39 +125,53 @@ private:
     chunked_hash_map<model::partition_id, partitioned_objects> partitions_;
 };
 
-std::expected<object_id, replicated_object_builder::error>
+ss::future<std::expected<object_id, replicated_object_builder::error>>
 replicated_object_builder::get_or_create_object_for(
   const model::topic_id_partition& tidp) {
     auto metastore_pid = fe_.metastore_partition(tidp);
     if (!metastore_pid) {
-        return std::unexpected(
+        co_return std::unexpected(
           error{"could not determine metastore partition for "
                 "get_or_create_object_for()"});
     }
     auto& partition_objects = partitions_[*metastore_pid];
-
     if (partition_objects.pending_objects_.empty()) {
         auto oid = create_object_id();
         partition_objects.pending_objects_[oid] = {};
-        return oid;
+        co_return oid;
     }
-    return partition_objects.pending_objects_.begin()->first;
+    co_return partition_objects.pending_objects_.begin()->first;
 }
 
-std::expected<object_id, replicated_object_builder::error>
+ss::future<std::expected<object_id, replicated_object_builder::error>>
+replicated_object_builder::get_or_create_object_for(
+  const model::topic_id_partition& tidp) {
+    auto metastore_pid = fe_.metastore_partition(tidp);
+    if (!metastore_pid) {
+        co_return std::unexpected(
+          error{"could not determine metastore partition for "
+                "get_or_create_object_for()"});
+    }
+    auto& partition_objects = partitions_[*metastore_pid];
+    if (!partition_objects.pending_objects_.empty()) {
+        co_return partition_objects.pending_objects_.begin()->first;
+    }
+    co_return co_await get_or_request_from_pool(*metastore_pid);
+}
+
+ss::future<std::expected<object_id, replicated_object_builder::error>>
 replicated_object_builder::create_object_for(
   const model::topic_id_partition& tidp) {
     auto metastore_pid = fe_.metastore_partition(tidp);
     if (!metastore_pid) {
-        return std::unexpected(
+        co_return std::unexpected(
           error{
             "could not determine metastore partition for create_object_for()"});
     }
     auto& partition_objects = partitions_[*metastore_pid];
-
     auto oid = create_object_id();
     partition_objects.pending_objects_[oid] = {};
-    return oid;
+    co_return oid;
 }
 
 std::expected<void, replicated_object_builder::error>

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -112,6 +112,9 @@ public:
     bool is_empty() const override;
 
 private:
+    ss::future<std::expected<object_id, error>>
+    get_or_request_from_pool(model::partition_id metastore_pid);
+
     friend class cloud_topics::l1::replicated_metastore;
 
     struct partitioned_objects {
@@ -122,25 +125,46 @@ private:
         chunked_vector<metastore::object_metadata> finished_objects_;
     };
     leader_router& fe_;
+    // TODO: let callers decide.
+    static constexpr size_t pool_refill_size = 1;
+    chunked_hash_map<model::partition_id, chunked_vector<object_id>> pool_;
     chunked_hash_map<model::partition_id, partitioned_objects> partitions_;
 };
 
 ss::future<std::expected<object_id, replicated_object_builder::error>>
-replicated_object_builder::get_or_create_object_for(
-  const model::topic_id_partition& tidp) {
-    auto metastore_pid = fe_.metastore_partition(tidp);
-    if (!metastore_pid) {
-        co_return std::unexpected(
-          error{"could not determine metastore partition for "
-                "get_or_create_object_for()"});
+replicated_object_builder::get_or_request_from_pool(
+  model::partition_id metastore_pid) {
+    auto& pool = pool_[metastore_pid];
+    if (pool.empty()) {
+        auto req = rpc::preregister_objects_request{
+          .metastore_partition = metastore_pid,
+          .count = static_cast<uint32_t>(pool_refill_size),
+        };
+        auto reply_fut = co_await ss::coroutine::as_future(
+          fe_.preregister_objects(std::move(req)));
+        if (reply_fut.failed()) {
+            auto ex = reply_fut.get_exception();
+            co_return std::unexpected(
+              error{fmt::format("preregister_objects() failed: {}", ex)});
+        }
+        auto reply = reply_fut.get();
+        if (reply.ec != rpc::errc::ok) {
+            co_return std::unexpected(
+              error{fmt::format("preregister_objects() error: {}", reply.ec)});
+        }
+        if (reply.object_ids.empty()) {
+            co_return std::unexpected(
+              error{fmt::format("preregister_objects() missing object IDs")});
+        }
+        pool = std::move(reply.object_ids);
     }
-    auto& partition_objects = partitions_[*metastore_pid];
-    if (partition_objects.pending_objects_.empty()) {
-        auto oid = create_object_id();
-        partition_objects.pending_objects_[oid] = {};
-        co_return oid;
+    auto oid = pool.back();
+    pool.pop_back();
+    if (pool.empty()) {
+        pool_.erase(metastore_pid);
     }
-    co_return partition_objects.pending_objects_.begin()->first;
+    partitions_[metastore_pid].pending_objects_[oid] = {};
+    co_return oid;
 }
 
 ss::future<std::expected<object_id, replicated_object_builder::error>>
@@ -168,10 +192,7 @@ replicated_object_builder::create_object_for(
           error{
             "could not determine metastore partition for create_object_for()"});
     }
-    auto& partition_objects = partitions_[*metastore_pid];
-    auto oid = create_object_id();
-    partition_objects.pending_objects_[oid] = {};
-    co_return oid;
+    co_return co_await get_or_request_from_pool(*metastore_pid);
 }
 
 std::expected<void, replicated_object_builder::error>

--- a/src/v/cloud_topics/level_one/metastore/rpc.json
+++ b/src/v/cloud_topics/level_one/metastore/rpc.json
@@ -84,6 +84,11 @@
             "name": "restore_domain",
             "input_type": "restore_domain_request",
             "output_type": "restore_domain_reply"
+        },
+        {
+            "name": "preregister_objects",
+            "input_type": "preregister_objects_request",
+            "output_type": "preregister_objects_reply"
         }
     ]
 }

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -443,6 +443,27 @@ struct flush_domain_request
     model::partition_id metastore_partition;
 };
 
+struct preregister_objects_reply
+  : serde::envelope<
+      preregister_objects_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    auto serde_fields() { return std::tie(ec, object_ids); }
+    errc ec{errc::ok};
+    chunked_vector<object_id> object_ids;
+};
+
+struct preregister_objects_request
+  : serde::envelope<
+      preregister_objects_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using resp_t = preregister_objects_reply;
+    auto serde_fields() { return std::tie(metastore_partition, count); }
+    model::partition_id metastore_partition;
+    uint32_t count{0};
+};
+
 } //  namespace cloud_topics::l1::rpc
 
 template<>

--- a/src/v/cloud_topics/level_one/metastore/service.cc
+++ b/src/v/cloud_topics/level_one/metastore/service.cc
@@ -118,4 +118,10 @@ ss::future<restore_domain_reply> service::restore_domain(
       std::move(request), leader_router::local_only::yes);
 }
 
+ss::future<preregister_objects_reply> service::preregister_objects(
+  preregister_objects_request request, ::rpc::streaming_context&) {
+    return _leader_router->local().preregister_objects(
+      std::move(request), leader_router::local_only::yes);
+}
+
 } // namespace cloud_topics::l1::rpc

--- a/src/v/cloud_topics/level_one/metastore/service.h
+++ b/src/v/cloud_topics/level_one/metastore/service.h
@@ -74,6 +74,9 @@ public:
     ss::future<restore_domain_reply>
     restore_domain(restore_domain_request, ::rpc::streaming_context&) override;
 
+    ss::future<preregister_objects_reply> preregister_objects(
+      preregister_objects_request, ::rpc::streaming_context&) override;
+
 private:
     ss::sharded<leader_router>* _leader_router;
 };

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -36,7 +36,7 @@ term_state_update_t make_terms_update(const metastore::term_offset_map_t& m) {
 }
 } // namespace
 
-std::expected<object_id, simple_object_builder::error>
+ss::future<std::expected<object_id, simple_object_builder::error>>
 simple_object_builder::get_or_create_object_for(
   const model::topic_id_partition&) {
     // The simple metastore isn't partitioned at all, so have all partitions
@@ -44,16 +44,16 @@ simple_object_builder::get_or_create_object_for(
     if (pending_objects_.empty()) {
         auto oid = create_object_id();
         pending_objects_[oid] = {};
-        return oid;
+        co_return oid;
     }
-    return pending_objects_.begin()->first;
+    co_return pending_objects_.begin()->first;
 }
 
-std::expected<object_id, simple_object_builder::error>
+ss::future<std::expected<object_id, simple_object_builder::error>>
 simple_object_builder::create_object_for(const model::topic_id_partition&) {
     auto oid = create_object_id();
     pending_objects_[oid] = {};
-    return oid;
+    co_return oid;
 }
 
 std::expected<void, simple_object_builder::error>

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -38,13 +38,11 @@ term_state_update_t make_terms_update(const metastore::term_offset_map_t& m) {
 
 ss::future<std::expected<object_id, simple_object_builder::error>>
 simple_object_builder::get_or_create_object_for(
-  const model::topic_id_partition&) {
+  const model::topic_id_partition& tidp) {
     // The simple metastore isn't partitioned at all, so have all partitions
     // blindly share any existing object.
     if (pending_objects_.empty()) {
-        auto oid = create_object_id();
-        pending_objects_[oid] = {};
-        co_return oid;
+        co_return co_await create_object_for(tidp);
     }
     co_return pending_objects_.begin()->first;
 }
@@ -52,6 +50,12 @@ simple_object_builder::get_or_create_object_for(
 ss::future<std::expected<object_id, simple_object_builder::error>>
 simple_object_builder::create_object_for(const model::topic_id_partition&) {
     auto oid = create_object_id();
+    preregister_objects_update prereg{
+      .registered_at = model::timestamp::now(),
+    };
+    prereg.object_ids.push_back(oid);
+    auto res = prereg.apply(*state_);
+    vassert(res.has_value(), "preregister_objects_update::apply must succeed");
     pending_objects_[oid] = {};
     co_return oid;
 }
@@ -139,7 +143,24 @@ ss::future<std::expected<
   std::unique_ptr<metastore::object_metadata_builder>,
   metastore::errc>>
 simple_metastore::object_builder() {
-    co_return std::make_unique<simple_object_builder>();
+    co_return std::make_unique<simple_object_builder>(&state_);
+}
+
+void simple_metastore::preregister_objects(
+  const chunked_vector<object_id>& object_ids) {
+    preregister_objects_update prereg{
+      .registered_at = model::timestamp::now(),
+    };
+    for (const auto& oid : object_ids) {
+        if (!state_.objects.contains(oid)) {
+            prereg.object_ids.push_back(oid);
+        }
+    }
+    if (prereg.object_ids.empty()) {
+        return;
+    }
+    auto res = prereg.apply(state_);
+    vassert(res.has_value(), "preregister_objects_update::apply must succeed");
 }
 
 ss::future<std::expected<metastore::offsets_response, metastore::errc>>

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -29,9 +29,9 @@ public:
     simple_object_builder& operator=(const simple_object_builder&) = delete;
     simple_object_builder& operator=(simple_object_builder&&) = delete;
 
-    std::expected<object_id, error>
+    ss::future<std::expected<object_id, error>>
     get_or_create_object_for(const model::topic_id_partition&) override;
-    std::expected<object_id, error>
+    ss::future<std::expected<object_id, error>>
     create_object_for(const model::topic_id_partition&) override;
     std::expected<void, error> remove_pending_object(object_id) override;
     std::expected<void, error>

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -21,8 +21,9 @@ namespace cloud_topics::l1 {
 class simple_metastore;
 class simple_object_builder : public metastore::object_metadata_builder {
 public:
-    simple_object_builder()
-      : object_metadata_builder() {}
+    explicit simple_object_builder(state* s)
+      : object_metadata_builder()
+      , state_(s) {}
     ~simple_object_builder() override {}
     simple_object_builder(const simple_object_builder&) = delete;
     simple_object_builder(simple_object_builder&&) = delete;
@@ -44,6 +45,7 @@ public:
 
 private:
     friend class simple_metastore;
+    state* state_;
     chunked_hash_map<object_id, metastore::object_metadata::ntp_metas_list_t>
       pending_objects_;
     chunked_vector<metastore::object_metadata> finished_objects_;
@@ -100,6 +102,8 @@ public:
       const object_metadata_builder&, const compaction_map_t&) override;
     ss::future<std::expected<void, errc>> compact_objects(
       const chunked_vector<object_metadata>&, const compaction_map_t&);
+
+    void preregister_objects(const chunked_vector<object_id>&);
 
     ss::future<std::expected<compaction_offsets_response, errc>>
     get_compaction_offsets(const model::topic_id_partition&, model::timestamp);

--- a/src/v/cloud_topics/level_one/metastore/simple_stm.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_stm.cc
@@ -160,6 +160,19 @@ ss::future<> simple_stm::do_apply(const model::record_batch& batch) {
             maybe_log_update_error(_log, key, o, result);
             break;
         }
+        case update_key::preregister_objects: {
+            auto update = serde::read<preregister_objects_update>(value_parser);
+            auto result = update.apply(state_);
+            maybe_log_update_error(_log, key, o, result);
+            break;
+        }
+        case update_key::expire_preregistered_objects: {
+            auto update = serde::read<expire_preregistered_objects_update>(
+              value_parser);
+            auto result = update.apply(state_);
+            maybe_log_update_error(_log, key, o, result);
+            break;
+        }
         }
     }
 

--- a/src/v/cloud_topics/level_one/metastore/state.h
+++ b/src/v/cloud_topics/level_one/metastore/state.h
@@ -274,16 +274,23 @@ struct topic_state
 // Metadata about a given object that is not specific to any partition.
 struct object_entry
   : public serde::
-      envelope<object_entry, serde::version<0>, serde::compat_version<0>> {
+      envelope<object_entry, serde::version<1>, serde::compat_version<0>> {
     friend bool operator==(const object_entry&, const object_entry&) = default;
     auto serde_fields() {
         return std::tie(
-          total_data_size, removed_data_size, footer_pos, object_size);
+          total_data_size,
+          removed_data_size,
+          footer_pos,
+          object_size,
+          last_updated,
+          is_preregistration);
     }
     size_t total_data_size{0};
     size_t removed_data_size{0};
     size_t footer_pos{0};
     size_t object_size{0};
+    model::timestamp last_updated;
+    bool is_preregistration{false};
 };
 
 // Tracks the state of each topic revision.

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -135,7 +135,13 @@ std::expected<std::monostate, stm_update_error> add_objects_update::can_apply(
     }
     sorted_extents_by_tidp_t new_extents;
     for (const auto& o : new_objects) {
-        if (state.objects.contains(o.oid)) {
+        auto it = state.objects.find(o.oid);
+        if (it == state.objects.end()) {
+            return std::unexpected(
+              stm_update_error{
+                fmt::format("Object {} not pre-registered", o.oid)});
+        }
+        if (!it->second.is_preregistration) {
             return std::unexpected(
               stm_update_error{fmt::format("Object {} already exists", o.oid)});
         }
@@ -361,7 +367,13 @@ replace_objects_update::can_apply(const state& state) {
     }
     sorted_extents_by_tidp_t new_extents_by_tp;
     for (const auto& o : new_objects) {
-        if (state.objects.contains(o.oid)) {
+        auto it = state.objects.find(o.oid);
+        if (it == state.objects.end()) {
+            return std::unexpected(
+              stm_update_error{
+                fmt::format("Object {} not pre-registered", o.oid)});
+        }
+        if (!it->second.is_preregistration) {
             return std::unexpected(
               stm_update_error{fmt::format("Object {} already exists", o.oid)});
         }

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -277,14 +277,14 @@ add_objects_update::apply(state& state) {
     sorted_extents_by_tidp_t extents_by_tp;
     for (const auto& o : new_objects) {
         o.collect_extents_by_tidp(&extents_by_tp);
-        state.objects.emplace(
-          o.oid,
-          object_entry{
-            .total_data_size = 0,
-            .removed_data_size = 0,
-            .footer_pos = o.footer_pos,
-            .object_size = o.object_size,
-          });
+        state.objects[o.oid] = object_entry{
+          .total_data_size = 0,
+          .removed_data_size = 0,
+          .footer_pos = o.footer_pos,
+          .object_size = o.object_size,
+          .last_updated = model::timestamp::now(),
+          .is_preregistration = false,
+        };
     }
     for (const auto& [tidp, extents] : extents_by_tp) {
         auto p_state = state.partition_state(tidp);
@@ -536,14 +536,14 @@ replace_objects_update::apply(state& state) {
     sorted_extents_by_tidp_t new_extents_by_tp;
     for (const auto& o : new_objects) {
         o.collect_extents_by_tidp(&new_extents_by_tp);
-        state.objects.emplace(
-          o.oid,
-          object_entry{
-            .total_data_size = 0,
-            .removed_data_size = 0,
-            .footer_pos = o.footer_pos,
-            .object_size = o.object_size,
-          });
+        state.objects[o.oid] = object_entry{
+          .total_data_size = 0,
+          .removed_data_size = 0,
+          .footer_pos = o.footer_pos,
+          .object_size = o.object_size,
+          .last_updated = model::timestamp::now(),
+          .is_preregistration = false,
+        };
     }
 
     auto contiguous_intervals_by_tp
@@ -854,6 +854,48 @@ remove_topics_update::apply(state& state) {
             }
         }
         state.topic_to_state.erase(t_it);
+    }
+    return std::monostate{};
+}
+
+std::expected<std::monostate, stm_update_error>
+preregister_objects_update::can_apply(const state& s) {
+    for (const auto& oid : object_ids) {
+        if (s.objects.contains(oid)) {
+            return std::unexpected(
+              stm_update_error{fmt::format("object {} already exists", oid)});
+        }
+    }
+    return std::monostate{};
+}
+
+std::expected<std::monostate, stm_update_error>
+preregister_objects_update::apply(state& s) {
+    auto allowed = can_apply(s);
+    if (!allowed.has_value()) {
+        return std::unexpected(allowed.error());
+    }
+    for (const auto& oid : object_ids) {
+        s.objects[oid] = object_entry{
+          .last_updated = registered_at,
+          .is_preregistration = true,
+        };
+    }
+    return std::monostate{};
+}
+
+std::expected<std::monostate, stm_update_error>
+expire_preregistered_objects_update::can_apply(const state&) {
+    return std::monostate{};
+}
+
+std::expected<std::monostate, stm_update_error>
+expire_preregistered_objects_update::apply(state& s) {
+    for (const auto& oid : object_ids) {
+        auto it = s.objects.find(oid);
+        if (it != s.objects.end()) {
+            it->second.is_preregistration = false;
+        }
     }
     return std::monostate{};
 }

--- a/src/v/cloud_topics/level_one/metastore/state_update.h
+++ b/src/v/cloud_topics/level_one/metastore/state_update.h
@@ -27,6 +27,8 @@ enum class update_key : uint8_t {
     set_start_offset = 2,
     remove_objects = 3,
     remove_topics = 4,
+    preregister_objects = 5,
+    expire_preregistered_objects = 6,
 };
 
 using stm_update_error = named_type<ss::sstring, struct update_error_tag>;
@@ -238,6 +240,44 @@ struct remove_topics_update
     chunked_vector<model::topic_id> topics;
 };
 
+struct preregister_objects_update
+  : public serde::envelope<
+      preregister_objects_update,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    friend bool operator==(
+      const preregister_objects_update&, const preregister_objects_update&)
+      = default;
+    auto serde_fields() { return std::tie(object_ids, registered_at); }
+
+    static constexpr auto key{update_key::preregister_objects};
+
+    std::expected<std::monostate, stm_update_error> can_apply(const state&);
+    std::expected<std::monostate, stm_update_error> apply(state&);
+
+    chunked_vector<object_id> object_ids;
+    model::timestamp registered_at;
+};
+
+struct expire_preregistered_objects_update
+  : public serde::envelope<
+      expire_preregistered_objects_update,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    friend bool operator==(
+      const expire_preregistered_objects_update&,
+      const expire_preregistered_objects_update&)
+      = default;
+    auto serde_fields() { return std::tie(object_ids); }
+
+    static constexpr auto key{update_key::expire_preregistered_objects};
+
+    std::expected<std::monostate, stm_update_error> can_apply(const state&);
+    std::expected<std::monostate, stm_update_error> apply(state&);
+
+    chunked_vector<object_id> object_ids;
+};
+
 } // namespace cloud_topics::l1
 
 template<>
@@ -257,6 +297,11 @@ struct fmt::formatter<cloud_topics::l1::update_key> final
             return formatter<string_view>::format("remove_objects", ctx);
         case cloud_topics::l1::update_key::remove_topics:
             return formatter<string_view>::format("remove_topics", ctx);
+        case cloud_topics::l1::update_key::preregister_objects:
+            return formatter<string_view>::format("preregister_objects", ctx);
+        case cloud_topics::l1::update_key::expire_preregistered_objects:
+            return formatter<string_view>::format(
+              "expire_preregistered_objects", ctx);
         }
     }
 };

--- a/src/v/cloud_topics/level_one/metastore/tests/extent_metadata_reader_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/extent_metadata_reader_test.cc
@@ -76,6 +76,13 @@ TEST(SimpleMetastoreTest, TestReadExtentMetadataForwards) {
     os.emplace_back(om_builder(oid3, 100, 1100)
                       .add(tid_a, 20_o, 29_o, 2000_t, 0, data_size)
                       .build());
+    {
+        chunked_vector<object_id> ids;
+        ids.push_back(oid1);
+        ids.push_back(oid2);
+        ids.push_back(oid3);
+        m.preregister_objects(ids);
+    }
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -199,6 +206,13 @@ TEST(SimpleMetastoreTest, TestReadExtentMetadataBackwards) {
     os.emplace_back(om_builder(oid3, 100, 1100)
                       .add(tid_a, 20_o, 29_o, 2000_t, 0, data_size)
                       .build());
+    {
+        chunked_vector<object_id> ids;
+        ids.push_back(oid1);
+        ids.push_back(oid2);
+        ids.push_back(oid3);
+        m.preregister_objects(ids);
+    }
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -322,6 +336,13 @@ TEST(SimpleMetastoreTest, TestGetExtentMetadataEmpty) {
     os.emplace_back(om_builder(oid3, 100, 1100)
                       .add(tid_a, 20_o, 29_o, 2000_t, 0, data_size)
                       .build());
+    {
+        chunked_vector<object_id> ids;
+        ids.push_back(oid1);
+        ids.push_back(oid2);
+        ids.push_back(oid3);
+        m.preregister_objects(ids);
+    }
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());

--- a/src/v/cloud_topics/level_one/metastore/tests/garbage_collector_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/garbage_collector_test.cc
@@ -77,6 +77,24 @@ public:
         auto sync_res = co_await stm->sync(10s);
         ASSERT_TRUE_CORO(sync_res.has_value());
 
+        {
+            preregister_objects_update prereg;
+            prereg.registered_at = model::timestamp::now();
+            for (const auto& o : new_objects) {
+                prereg.object_ids.push_back(o.oid);
+            }
+            storage::record_batch_builder prereg_builder(
+              model::record_batch_type::l1_stm, model::offset{0});
+            prereg_builder.add_raw_kv(
+              serde::to_iobuf(preregister_objects_update::key),
+              serde::to_iobuf(std::move(prereg)));
+            auto prereg_repl = co_await stm->replicate_and_wait(
+              sync_res.value(), std::move(prereg_builder).build(), never_abort);
+            ASSERT_TRUE_CORO(prereg_repl.has_value());
+            sync_res = co_await stm->sync(10s);
+            ASSERT_TRUE_CORO(sync_res.has_value());
+        }
+
         auto update_res = add_objects_update::build(
           stm->state(), std::move(new_objects), std::move(terms));
         ASSERT_TRUE_CORO(update_res.has_value());

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -142,7 +142,7 @@ public:
         auto ret = meta.object_builder().get().value();
         for (int i = 0; i < partitions_count; ++i) {
             auto tp = make_tp(i);
-            auto oid = ret->get_or_create_object_for(tp).value();
+            auto oid = ret->get_or_create_object_for(tp).get().value();
             auto add_res = ret->add(
               oid,
               metastore::object_metadata::ntp_metadata{
@@ -182,7 +182,8 @@ public:
         metastore::term_offset_map_t terms;
         for (int i = 0; i < topics_count; ++i) {
             auto tp = make_topic_p0(i);
-            auto oid = obj_builder->get_or_create_object_for(tp).value();
+            auto oid
+              = (co_await obj_builder->get_or_create_object_for(tp)).value();
             auto add_res = obj_builder->add(
               oid,
               metastore::object_metadata::ntp_metadata{
@@ -227,7 +228,7 @@ TEST_P(ReplicatedMetastoreTest, TestMissingMetastore) {
     // We won't be able to find the partition of the metastore topic because it
     // doesn't exist.
     auto tp = make_tp(0);
-    auto oid = obj_builder->get_or_create_object_for(tp);
+    auto oid = obj_builder->get_or_create_object_for(tp).get();
     ASSERT_FALSE(oid.has_value());
 
     // Adding an object should fail immediately too because the metastore topic
@@ -239,7 +240,7 @@ TEST_P(ReplicatedMetastoreTest, TestMissingMetastore) {
     // since it doesn't exist.
     auto builder_res = meta.object_builder().get();
     ASSERT_TRUE(builder_res.has_value());
-    oid = builder_res.value()->get_or_create_object_for(tp);
+    oid = builder_res.value()->get_or_create_object_for(tp).get();
     ASSERT_TRUE(oid.has_value());
 }
 
@@ -248,7 +249,7 @@ TEST_P(ReplicatedMetastoreTest, TestAddNotFinished) {
     auto& meta = app.get_sharded_replicated_metastore()->local();
     auto tp = make_tp(0);
     auto obj_builder = meta.object_builder().get().value();
-    auto oid = obj_builder->get_or_create_object_for(tp).value();
+    auto oid = obj_builder->get_or_create_object_for(tp).get().value();
     auto add_res = obj_builder->add(
       oid,
       metastore::object_metadata::ntp_metadata{
@@ -272,12 +273,12 @@ TEST_P(ReplicatedMetastoreTest, TestBuilderRemovedObjects) {
     auto ob = m.object_builder().get().value();
 
     // pending object can be removed, but not twice
-    auto oid = ob->get_or_create_object_for(tp).value();
+    auto oid = ob->get_or_create_object_for(tp).get().value();
     ASSERT_TRUE(ob->remove_pending_object(oid).has_value());
     ASSERT_FALSE(ob->remove_pending_object(oid).has_value());
 
     // after removal, object id shouldn't be reused in this builder
-    auto oid2 = ob->get_or_create_object_for(tp).value();
+    auto oid2 = ob->get_or_create_object_for(tp).get().value();
     ASSERT_NE(oid, oid2);
     oid = oid2;
 
@@ -291,12 +292,12 @@ TEST_P(ReplicatedMetastoreTest, TestBuilderRemovedObjects) {
       ob->add(oid, metastore::object_metadata::ntp_metadata{.tidp = tp})
         .has_value());
 
-    oid2 = ob->get_or_create_object_for(tp).value();
+    oid2 = ob->get_or_create_object_for(tp).get().value();
     ASSERT_NE(oid, oid2);
     oid = oid2;
 
     // finished object cannot be removed
-    oid = ob->get_or_create_object_for(tp).value();
+    oid = ob->get_or_create_object_for(tp).get().value();
     ASSERT_TRUE(ob->finish(oid, 0, 0).has_value());
     ASSERT_FALSE(ob->remove_pending_object(oid).has_value());
     ASSERT_FALSE(ob->finish(oid, 0, 0).has_value());
@@ -313,11 +314,11 @@ TEST_P(ReplicatedMetastoreTest, TestBuilderRemoveObjectRemovesPartition) {
 
     // Add and remove an object, setting up potential for an old bug where an
     // empty partition is left behind after removal.
-    auto oid1 = ob->get_or_create_object_for(tp1).value();
+    auto oid1 = ob->get_or_create_object_for(tp1).get().value();
     ASSERT_TRUE(ob->remove_pending_object(oid1).has_value());
 
     // Now add an object as normal.
-    auto oid2 = ob->get_or_create_object_for(tp2).value();
+    auto oid2 = ob->get_or_create_object_for(tp2).get().value();
     auto add_res = ob->add(
       oid2,
       metastore::object_metadata::ntp_metadata{
@@ -549,7 +550,7 @@ TEST_P(ReplicatedMetastoreTest, TestNotLeader) {
             break;
         }
         auto obj_builder = meta.object_builder().get().value();
-        auto oid = obj_builder->get_or_create_object_for(tp).value();
+        auto oid = obj_builder->get_or_create_object_for(tp).get().value();
         kafka::offset next_last{next_to_send() + 99};
         auto add_res = obj_builder->add(
           oid,
@@ -644,7 +645,7 @@ TEST_P(ReplicatedMetastoreTest, TestGetTermForOffset) {
     auto tp = make_tp(0);
 
     auto obj_builder = meta.object_builder().get().value();
-    auto oid1 = obj_builder->get_or_create_object_for(tp).value();
+    auto oid1 = obj_builder->get_or_create_object_for(tp).get().value();
     auto add_res1 = obj_builder->add(
       oid1,
       metastore::object_metadata::ntp_metadata{
@@ -703,7 +704,7 @@ TEST_P(ReplicatedMetastoreTest, TestGetEndOffsetForTerm) {
 
     // Set up initial objects with multiple terms
     auto obj_builder = meta.object_builder().get().value();
-    auto oid1 = obj_builder->get_or_create_object_for(tp).value();
+    auto oid1 = obj_builder->get_or_create_object_for(tp).get().value();
     auto add_res1 = obj_builder->add(
       oid1,
       metastore::object_metadata::ntp_metadata{

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -52,6 +52,7 @@ public:
         };
     }
     void SetUp() override {
+        set_configuration("enable_leader_balancer", false);
         for (size_t i = 0; i < num_brokers; i++) {
             add_node(fixture_cfg());
         }
@@ -237,11 +238,15 @@ TEST_P(ReplicatedMetastoreTest, TestMissingMetastore) {
     ASSERT_FALSE(add_res.has_value());
 
     // Creating an object builder should attempt to create the metastore topic
-    // since it doesn't exist.
+    // since it doesn't exist. After the topic is recreated, leader election may
+    // not have completed yet, so retry until get_or_create_object_for succeeds.
     auto builder_res = meta.object_builder().get();
     ASSERT_TRUE(builder_res.has_value());
-    oid = builder_res.value()->get_or_create_object_for(tp).get();
-    ASSERT_TRUE(oid.has_value());
+    auto new_builder = std::move(builder_res).value();
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&new_builder, &tp] {
+        return new_builder->get_or_create_object_for(tp).then(
+          [](auto r) { return r.has_value(); });
+    });
 }
 
 TEST_P(ReplicatedMetastoreTest, TestAddNotFinished) {

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -966,16 +966,16 @@ TEST(SimpleMetastoreTest, TestObjectBuilder) {
     auto tp_a = model::topic_id_partition::from(tid_a);
 
     // Creating objects for the same partition will result in the same object.
-    auto o_a = ob->get_or_create_object_for(tp_a).value();
-    auto o_a_2 = ob->get_or_create_object_for(tp_a).value();
+    auto o_a = ob->get_or_create_object_for(tp_a).get().value();
+    auto o_a_2 = ob->get_or_create_object_for(tp_a).get().value();
     ASSERT_EQ(o_a, o_a_2);
 
     // Creating objects for different partitions will result in the same
     // object.
     auto tp_b = model::topic_id_partition::from(tid_b);
-    auto o_b = ob->get_or_create_object_for(tp_b).value();
+    auto o_b = ob->get_or_create_object_for(tp_b).get().value();
     ASSERT_EQ(o_a, o_b);
-    auto o_b_2 = ob->get_or_create_object_for(tp_b).value();
+    auto o_b_2 = ob->get_or_create_object_for(tp_b).get().value();
     ASSERT_EQ(o_b, o_b_2);
 
     // Add a partition's metadata to the object.
@@ -984,7 +984,7 @@ TEST(SimpleMetastoreTest, TestObjectBuilder) {
     // Finish the current object. The next object will be different.
     ASSERT_TRUE(ob->finish(o_a, 0, 1000).has_value());
 
-    auto o_a_3 = ob->get_or_create_object_for(tp_a).value();
+    auto o_a_3 = ob->get_or_create_object_for(tp_a).get().value();
     ASSERT_NE(o_a_2, o_a_3);
 
     // We can't release the result until we finish all objects.
@@ -1009,7 +1009,7 @@ TEST(SimpleMetastoreTest, TestObjectBuilderCreatesNewObjects) {
     // Creating objects for the same partition will result in a different object
     // everytime.
     for (size_t i = 0; i < num_objects; ++i) {
-        auto oid_opt = ob->create_object_for(tp);
+        auto oid_opt = ob->create_object_for(tp).get();
         ASSERT_TRUE(oid_opt.has_value());
         auto [_, inserted] = oids.insert(oid_opt.value());
         ASSERT_TRUE(inserted);
@@ -1044,6 +1044,7 @@ TEST(SimpleMetastoreTest, TestObjectBuilderRemovedObjects) {
           ->get_or_create_object_for(
             model::topic_id_partition(
               topic_id, model::partition_id(static_cast<int32_t>(0))))
+          .get()
           .value();
     };
 
@@ -1079,7 +1080,7 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
     auto tp_a = model::topic_id_partition::from(tid_a);
     {
         auto ob = m.object_builder().get().value();
-        auto o_a = ob->get_or_create_object_for(tp_a).value();
+        auto o_a = ob->get_or_create_object_for(tp_a).get().value();
         auto add_res = ob->add(
           o_a,
           metastore::object_metadata::ntp_metadata{
@@ -1105,7 +1106,7 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
     }
     {
         auto ob = m.object_builder().get().value();
-        auto o_a = ob->get_or_create_object_for(tp_a).value();
+        auto o_a = ob->get_or_create_object_for(tp_a).get().value();
         auto add_res = ob->add(
           o_a,
           metastore::object_metadata::ntp_metadata{
@@ -1131,7 +1132,7 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
     }
     {
         auto ob = m.object_builder().get().value();
-        auto o_a = ob->get_or_create_object_for(tp_a).value();
+        auto o_a = ob->get_or_create_object_for(tp_a).get().value();
         auto add_res = ob->add(
           o_a,
           metastore::object_metadata::ntp_metadata{
@@ -1155,7 +1156,7 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
     }
     {
         auto ob = m.object_builder().get().value();
-        auto o_a = ob->get_or_create_object_for(tp_a).value();
+        auto o_a = ob->get_or_create_object_for(tp_a).get().value();
         auto add_res = ob->add(
           o_a,
           metastore::object_metadata::ntp_metadata{

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -70,6 +70,7 @@ TEST(SimpleMetastoreTest, TestGetMissingPartition) {
                    .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                    .add(tid_b, 0_o, 10_o, 2000_t, 100, 199)
                    .build();
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res
       = m.add_objects(
            om_list_t::single(std::move(ometa)),
@@ -112,6 +113,7 @@ TEST(SimpleMetastoreTest, TestAddWithGap) {
         auto ometa = om_builder(oid1, 100, 1100)
                        .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                        .build();
+        m.preregister_objects(chunked_vector<object_id>::single(oid1));
         auto add_res = m.add_objects(
                           om_list_t::single(std::move(ometa)),
                           terms_builder().add(tid_a, 0_tm, 0_o).build())
@@ -131,6 +133,7 @@ TEST(SimpleMetastoreTest, TestAddWithGap) {
         auto ometa = om_builder(oid2, 100, 1100)
                        .add(tid_a, 12_o, 20_o, 2000_t, 0, 99)
                        .build();
+        m.preregister_objects(chunked_vector<object_id>::single(oid2));
         auto add_res = m.add_objects(
                           om_list_t::single(std::move(ometa)),
                           terms_builder().add(tid_a, 0_tm, 12_o).build())
@@ -150,6 +153,7 @@ TEST(SimpleMetastoreTest, TestAddWithGap) {
     auto ometa = om_builder(oid3, 100, 1100)
                    .add(tid_a, 11_o, 20_o, 2000_t, 0, 99)
                    .build();
+    m.preregister_objects(chunked_vector<object_id>::single(oid3));
     auto add_res = m.add_objects(
                       om_list_t::single(std::move(ometa)),
                       terms_builder().add(tid_a, 0_tm, 11_o).build())
@@ -170,6 +174,7 @@ TEST(SimpleMetastoreTest, TestAddWithOverlap) {
         auto ometa = om_builder(oid1, 100, 1100)
                        .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                        .build();
+        m.preregister_objects(chunked_vector<object_id>::single(oid1));
         auto add_res = m.add_objects(
                           chunked_vector<metastore::object_metadata>::single(
                             std::move(ometa)),
@@ -184,6 +189,7 @@ TEST(SimpleMetastoreTest, TestAddWithOverlap) {
         auto ometa = om_builder(oid2, 100, 1100)
                        .add(tid_a, 10_o, 20_o, 2000_t, 0, 99)
                        .build();
+        m.preregister_objects(chunked_vector<object_id>::single(oid2));
         auto add_res = m.add_objects(
                           chunked_vector<metastore::object_metadata>::single(
                             std::move(ometa)),
@@ -197,6 +203,7 @@ TEST(SimpleMetastoreTest, TestAddWithOverlap) {
         auto ometa = om_builder(oid3, 100, 1100)
                        .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                        .build();
+        m.preregister_objects(chunked_vector<object_id>::single(oid3));
         auto add_res = m.add_objects(
                           om_list_t::single(std::move(ometa)),
                           terms_builder().add(tid_a, 0_tm, 0_o).build())
@@ -212,6 +219,7 @@ TEST(SimpleMetastoreTest, TestAddPastBeginning) {
     auto ometa = om_builder(oid1, 100, 1100)
                    .add(tid_a, 1_o, 10_o, 2000_t, 0, 99)
                    .build();
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res = m.add_objects(
                       om_list_t::single(std::move(ometa)),
                       terms_builder().add(tid_a, 0_tm, 0_o).build())
@@ -231,6 +239,13 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetBasic) {
     os.emplace_back(om_builder(oid3, 100, 1100)
                       .add(tid_a, 21_o, 30_o, 2000_t, 0, 99)
                       .build());
+    {
+        chunked_vector<object_id> ids;
+        ids.push_back(oid1);
+        ids.push_back(oid2);
+        ids.push_back(oid3);
+        m.preregister_objects(ids);
+    }
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -271,6 +286,7 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetBelowStart) {
     auto ometa = om_builder(oid1, 100, 1100)
                    .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                    .build();
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res = m.add_objects(
                       om_list_t::single(std::move(ometa)),
                       terms_builder().add(tid_a, 0_tm, 0_o).build())
@@ -294,6 +310,7 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetOutOfRange) {
     auto ometa = om_builder(oid1, 100, 1100)
                    .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                    .build();
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res = m.add_objects(
                       om_list_t::single(std::move(ometa)),
                       terms_builder().add(tid_a, 0_tm, 0_o).build())
@@ -319,6 +336,13 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampBasic) {
     os.emplace_back(om_builder(oid3, 100, 1100)
                       .add(tid_a, 21_o, 30_o, 3999_t, 0, 99)
                       .build());
+    {
+        chunked_vector<object_id> ids;
+        ids.push_back(oid1);
+        ids.push_back(oid2);
+        ids.push_back(oid3);
+        m.preregister_objects(ids);
+    }
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -359,6 +383,7 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampBelowStart) {
     auto ometa = om_builder(oid1, 100, 1100)
                    .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                    .build();
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res = m.add_objects(
                       om_list_t::single(std::move(ometa)),
                       terms_builder().add(tid_a, 0_tm, 0_o).build())
@@ -377,6 +402,7 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampOutOfRange) {
     auto ometa = om_builder(oid1, 100, 1100)
                    .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                    .build();
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res = m.add_objects(
                       om_list_t::single(std::move(ometa)),
                       terms_builder().add(tid_a, 0_tm, 0_o).build())
@@ -399,6 +425,12 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampCustomStart) {
     ometas.push_back(om_builder(oid2, 100, 1100)
                        .add(tid_a, 11_o, 20_o, 1000_t, 0, 99)
                        .build());
+    {
+        chunked_vector<object_id> ids;
+        ids.push_back(oid1);
+        ids.push_back(oid2);
+        m.preregister_objects(ids);
+    }
     auto add_res = m.add_objects(
                       ometas, terms_builder().add(tid_a, 0_tm, 0_o).build())
                      .get();
@@ -432,6 +464,7 @@ TEST(StateUpdateTest, TestReplaceBasic) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -440,6 +473,7 @@ TEST(StateUpdateTest, TestReplaceBasic) {
     om_list_t new_os;
     new_os.emplace_back(
       om_builder(oid2, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    m.preregister_objects(chunked_vector<object_id>::single(oid2));
     auto replace_res = m.replace_objects(new_os).get();
     ASSERT_TRUE(replace_res.has_value());
 
@@ -462,6 +496,12 @@ TEST(StateUpdateTest, TestReplaceMultipleOnePartition) {
                       .add(tid_a, 11_o, 20_o, 2000_t, 0, 99)
                       .add(tid_b, 11_o, 20_o, 2000_t, 0, 99)
                       .build());
+    {
+        chunked_vector<object_id> ids;
+        ids.push_back(oid1);
+        ids.push_back(oid2);
+        m.preregister_objects(ids);
+    }
     auto add_res
       = m.add_objects(
            os,
@@ -472,6 +512,7 @@ TEST(StateUpdateTest, TestReplaceMultipleOnePartition) {
     om_list_t new_os;
     new_os.emplace_back(
       om_builder(oid3, 100, 1100).add(tid_a, 0_o, 20_o, 2000_t, 0, 99).build());
+    m.preregister_objects(chunked_vector<object_id>::single(oid3));
     auto replace_res = m.replace_objects(new_os).get();
     ASSERT_TRUE(replace_res.has_value());
 
@@ -527,6 +568,12 @@ TEST(StateUpdateTest, TestReplaceMultipleMultiplePartitions) {
                       .add(tid_a, 11_o, 20_o, 2000_t, 0, 99)
                       .add(tid_b, 11_o, 20_o, 2000_t, 0, 99)
                       .build());
+    {
+        chunked_vector<object_id> ids;
+        ids.push_back(oid1);
+        ids.push_back(oid2);
+        m.preregister_objects(ids);
+    }
     auto add_res
       = m.add_objects(
            os,
@@ -542,6 +589,7 @@ TEST(StateUpdateTest, TestReplaceMultipleMultiplePartitions) {
                           .add(tid_a, 0_o, 20_o, 2000_t, 0, 99)
                           .add(tid_b, 11_o, 20_o, 2000_t, 0, 99)
                           .build());
+    m.preregister_objects(chunked_vector<object_id>::single(oid3));
     auto replace_res = m.replace_objects(new_os).get();
     ASSERT_TRUE(replace_res.has_value());
 
@@ -591,6 +639,7 @@ TEST(StateUpdateTest, TestReplaceEmptyRequest) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -617,6 +666,7 @@ TEST(StateUpdateTest, TestReplaceEmptyState) {
         new_os.emplace_back(om_builder(oid1, 100, 1100)
                               .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                               .build());
+        m.preregister_objects(chunked_vector<object_id>::single(oid1));
         auto replace_res = m.replace_objects(new_os).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
@@ -628,6 +678,7 @@ TEST(StateUpdateTest, TestReplaceMisaligned) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -639,6 +690,7 @@ TEST(StateUpdateTest, TestReplaceMisaligned) {
         new_os.emplace_back(om_builder(oid2, 100, 1100)
                               .add(tid_a, base_o, last_o, 2000_t, 0, 99)
                               .build());
+        m.preregister_objects(chunked_vector<object_id>::single(oid2));
         auto replace_res = m.replace_objects(new_os).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
@@ -650,6 +702,7 @@ TEST(StateUpdateTest, TestReplaceOneWithMultipleMisaligned) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -662,6 +715,7 @@ TEST(StateUpdateTest, TestReplaceOneWithMultipleMisaligned) {
                               .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                               .add(tid_a, 11_o, 12_o, 2000_t, 0, 99)
                               .build());
+        m.preregister_objects(chunked_vector<object_id>::single(oid2));
         auto replace_res = m.replace_objects(new_os).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
@@ -673,6 +727,7 @@ TEST(StateUpdateTest, TestReplaceOneWithMultipleMisaligned) {
                               .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                               .add(tid_b, 0_o, 10_o, 2000_t, 0, 99)
                               .build());
+        m.preregister_objects(chunked_vector<object_id>::single(oid2));
         auto replace_res = m.replace_objects(new_os).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
@@ -690,6 +745,12 @@ TEST(StateUpdateTest, TestReplaceMultipleMisaligned) {
                       .add(tid_a, 11_o, 20_o, 2000_t, 0, 99)
                       .add(tid_b, 11_o, 20_o, 2000_t, 0, 99)
                       .build());
+    {
+        chunked_vector<object_id> ids;
+        ids.push_back(oid1);
+        ids.push_back(oid2);
+        m.preregister_objects(ids);
+    }
     auto add_res
       = m.add_objects(
            os,
@@ -702,6 +763,7 @@ TEST(StateUpdateTest, TestReplaceMultipleMisaligned) {
         new_os.emplace_back(om_builder(oid3, 100, 1100)
                               .add(tid_a, 0_o, 19_o, 2000_t, 0, 99)
                               .build());
+        m.preregister_objects(chunked_vector<object_id>::single(oid3));
         auto replace_res = m.replace_objects(new_os).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
@@ -713,6 +775,7 @@ TEST(StateUpdateTest, TestReplaceMultipleMisaligned) {
                               .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                               .add(tid_b, 0_o, 19_o, 2000_t, 0, 99)
                               .build());
+        m.preregister_objects(chunked_vector<object_id>::single(oid3));
         auto replace_res = m.replace_objects(new_os).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
@@ -724,6 +787,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsMissingPartition) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100, 1100).add(tid_b, 0_o, 10_o, 2000_t, 0, 99).build());
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_b, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -743,6 +807,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsAllDirty) {
                       .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                       .add(tid_b, 0_o, 10_o, 2000_t, 0, 99)
                       .build());
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res
       = m.add_objects(
            os,
@@ -765,6 +830,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsets) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -779,6 +845,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsets) {
         auto cmb = cm_builder();
         cmb.clean(tid_a, 3_o, 5_o, 3000_t);
         cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{0});
+        m.preregister_objects(chunked_vector<object_id>::single(oid2));
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -825,6 +892,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsets) {
         cmb.clean(tid_a, 0_o, 2_o);
         cmb.remove_tombstones(tid_a, 3_o, 4_o);
         cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{1});
+        m.preregister_objects(chunked_vector<object_id>::single(oid3));
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -850,6 +918,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsets) {
         cmb.clean(tid_a, 6_o, 10_o);
         cmb.remove_tombstones(tid_a, 5_o, 5_o);
         cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{2});
+        m.preregister_objects(chunked_vector<object_id>::single(oid4));
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -867,6 +936,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsNoTombstones) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -881,6 +951,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsNoTombstones) {
         auto cmb = cm_builder();
         cmb.clean(tid_a, 3_o, 5_o);
         cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{0});
+        m.preregister_objects(chunked_vector<object_id>::single(oid2));
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -925,6 +996,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsNoTombstones) {
         auto cmb = cm_builder();
         cmb.clean(tid_a, 0_o, 2_o);
         cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{1});
+        m.preregister_objects(chunked_vector<object_id>::single(oid3));
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -948,6 +1020,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsNoTombstones) {
         auto cmb = cm_builder();
         cmb.clean(tid_a, 6_o, 10_o);
         cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{2});
+        m.preregister_objects(chunked_vector<object_id>::single(oid4));
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -1194,6 +1267,7 @@ TEST(SimpleMetastoreState, TestInvalidTermRequest) {
     os.emplace_back(
       om_builder(oid1, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
     // Make the term misaligned with the extent.
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res = m.add_objects(
                       os, terms_builder().add(tid_a, 0_tm, 1337_o).build())
                      .get();
@@ -1206,6 +1280,7 @@ TEST(SimpleMetastoreTest, TestEndOffsetForEpoch) {
     auto ometa = om_builder(oid1, 200, 1200)
                    .add(tid_a, 0_o, 20_o, 2000_t, 0, 99)
                    .build();
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res = m.add_objects(
                       om_list_t::single(std::move(ometa)),
                       terms_builder()
@@ -1261,6 +1336,7 @@ TEST(SimpleMetastoreTest, TestEpochForOffset) {
     simple_metastore m;
     auto ometa
       = om_builder(oid1, 200, 1200).add(tid_a, 0_o, 9_o, 2000_t, 0, 99).build();
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res = m.add_objects(
                       om_list_t::single(std::move(ometa)),
                       terms_builder()
@@ -1322,6 +1398,13 @@ TEST(SimpleMetastoreTest, TestSetStartAlignedWithExtent) {
     os.emplace_back(om_builder(oid3, 100, 1100)
                       .add(tid_a, 21_o, 30_o, 2000_t, 0, 99)
                       .build());
+    {
+        chunked_vector<object_id> ids;
+        ids.push_back(oid1);
+        ids.push_back(oid2);
+        ids.push_back(oid3);
+        m.preregister_objects(ids);
+    }
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -1365,6 +1448,13 @@ TEST(SimpleMetastoreTest, TestSetStartNotAlignedWithExtent) {
     os.emplace_back(om_builder(oid3, 100, 1100)
                       .add(tid_a, 21_o, 30_o, 2000_t, 0, 99)
                       .build());
+    {
+        chunked_vector<object_id> ids;
+        ids.push_back(oid1);
+        ids.push_back(oid2);
+        ids.push_back(oid3);
+        m.preregister_objects(ids);
+    }
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -1402,6 +1492,7 @@ TEST(SimpleMetastoreTest, TestSetStartEmptyWithTerms) {
     simple_metastore m;
     auto ometa
       = om_builder(oid1, 100, 1100).add(tid_a, 0_o, 9_o, 2000_t, 0, 99).build();
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res = m.add_objects(
                       om_list_t::single(std::move(ometa)),
                       terms_builder()
@@ -1442,6 +1533,7 @@ TEST(SimpleMetastoreTest, TestSetStartWithCompactionState) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100, 1100).add(tid_a, 0_o, 20_o, 2000_t, 0, 99).build());
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -1456,6 +1548,7 @@ TEST(SimpleMetastoreTest, TestSetStartWithCompactionState) {
         auto cmb = cm_builder();
         cmb.clean(tid_a, 5_o, 15_o, 3000_t);
         cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{0});
+        m.preregister_objects(chunked_vector<object_id>::single(oid2));
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -1510,6 +1603,12 @@ TEST(SimpleMetastoreTest, TestDirtyRatio) {
       om_builder(oid1, 100, 10).add(tid_a, 0_o, 9_o, 1000_t, 0, 99).build());
     os.emplace_back(
       om_builder(oid2, 100, 10).add(tid_a, 10_o, 19_o, 2000_t, 0, 99).build());
+    {
+        chunked_vector<object_id> ids;
+        ids.push_back(oid1);
+        ids.push_back(oid2);
+        m.preregister_objects(ids);
+    }
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -1524,6 +1623,7 @@ TEST(SimpleMetastoreTest, TestDirtyRatio) {
         auto cmb = cm_builder();
         cmb.clean(tid_a, 0_o, 5_o, 3000_t);
         cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{0});
+        m.preregister_objects(chunked_vector<object_id>::single(oid3));
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -1545,6 +1645,7 @@ TEST(SimpleMetastoreTest, TestDirtyRatio) {
         auto cmb = cm_builder();
         cmb.clean(tid_a, 6_o, 9_o, 3000_t);
         cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{1});
+        m.preregister_objects(chunked_vector<object_id>::single(oid4));
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -1564,6 +1665,7 @@ TEST(SimpleMetastoreTest, TestDirtyRatio) {
         auto cmb = cm_builder();
         cmb.clean(tid_a, 10_o, 19_o, 3000_t);
         cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{2});
+        m.preregister_objects(chunked_vector<object_id>::single(oid5));
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -1583,6 +1685,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsSingleDirtyAtEnd) {
     os.emplace_back(om_builder(oid1, 100, 1010)
                       .add(tid_a, 0_o, 100_o, 1000_t, 0, 1009)
                       .build());
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -1598,6 +1701,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsSingleDirtyAtEnd) {
         auto cmb = cm_builder();
         cmb.clean(tid_a, 0_o, 99_o, 3000_t);
         cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{0});
+        m.preregister_objects(chunked_vector<object_id>::single(oid2));
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -1633,6 +1737,13 @@ TEST(
       om_builder(oid2, 100, 1100).add(tid_a, 10_o, 19_o, 300_t, 0, 99).build());
     os.emplace_back(
       om_builder(oid3, 100, 1100).add(tid_a, 20_o, 29_o, 500_t, 0, 99).build());
+    {
+        chunked_vector<object_id> ids;
+        ids.push_back(oid1);
+        ids.push_back(oid2);
+        ids.push_back(oid3);
+        m.preregister_objects(ids);
+    }
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -1656,6 +1767,7 @@ TEST(
         auto cmb = cm_builder();
         cmb.clean(tid_a, 0_o, 9_o, 3000_t);
         cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{0});
+        m.preregister_objects(chunked_vector<object_id>::single(oid4));
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -1675,6 +1787,7 @@ TEST(
         auto cmb = cm_builder();
         cmb.clean(tid_a, 10_o, 19_o, 3000_t);
         cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{1});
+        m.preregister_objects(chunked_vector<object_id>::single(oid5));
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -1702,6 +1815,13 @@ TEST(
       om_builder(oid2, 100, 1100).add(tid_a, 10_o, 19_o, 500_t, 0, 99).build());
     os.emplace_back(
       om_builder(oid3, 100, 1100).add(tid_a, 20_o, 29_o, 300_t, 0, 99).build());
+    {
+        chunked_vector<object_id> ids;
+        ids.push_back(oid1);
+        ids.push_back(oid2);
+        ids.push_back(oid3);
+        m.preregister_objects(ids);
+    }
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -1725,6 +1845,7 @@ TEST(
         auto cmb = cm_builder();
         cmb.clean(tid_a, 0_o, 9_o, 3000_t);
         cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{0});
+        m.preregister_objects(chunked_vector<object_id>::single(oid4));
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -1744,6 +1865,7 @@ TEST(
         auto cmb = cm_builder();
         cmb.clean(tid_a, 20_o, 29_o, 3000_t);
         cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{1});
+        m.preregister_objects(chunked_vector<object_id>::single(oid5));
         auto compact_res = m.compact_objects(new_os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -1767,6 +1889,13 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetAfterBytes) {
     os.emplace_back(om_builder(oid3, 100, 1100)
                       .add(tid_a, 21_o, 30_o, 2000_t, 0, data_size)
                       .build());
+    {
+        chunked_vector<object_id> ids;
+        ids.push_back(oid1);
+        ids.push_back(oid2);
+        ids.push_back(oid3);
+        m.preregister_objects(ids);
+    }
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -1797,6 +1926,7 @@ TEST(SimpleMetastoreTest, TestCompactionMultipleDirtyRangesMadeClean) {
         os.emplace_back(om_builder(oid1, 100, 1100)
                           .add(tid_a, 0_o, 20_o, 2000_t, 0, 99)
                           .build());
+        m.preregister_objects(chunked_vector<object_id>::single(oid1));
         auto add_res = m.add_objects(
                           os, terms_builder().add(tid_a, 0_tm, 0_o).build())
                          .get();
@@ -1813,6 +1943,7 @@ TEST(SimpleMetastoreTest, TestCompactionMultipleDirtyRangesMadeClean) {
         auto cmb = cm_builder();
         cmb.clean(tid_a, 5_o, 15_o, 3000_t);
         cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{0});
+        m.preregister_objects(chunked_vector<object_id>::single(oid2));
         auto compact_res = m.compact_objects(os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -1843,6 +1974,7 @@ TEST(SimpleMetastoreTest, TestCompactionMultipleDirtyRangesMadeClean) {
         cmb.clean(tid_a, 0_o, 4_o, 6000_t);
         cmb.clean(tid_a, 16_o, 20_o, 6000_t);
         cmb.set_expected_epoch(tid_a, metastore::compaction_epoch{1});
+        m.preregister_objects(chunked_vector<object_id>::single(oid3));
         auto compact_res = m.compact_objects(os, cmb.build()).get();
         ASSERT_TRUE(compact_res.has_value());
     }
@@ -1871,6 +2003,13 @@ TEST(SimpleMetastoreTest, TestGetExtentMetadataForwards) {
     os.emplace_back(om_builder(oid3, 100, 1100)
                       .add(tid_a, 20_o, 29_o, 2000_t, 0, data_size)
                       .build());
+    {
+        chunked_vector<object_id> ids;
+        ids.push_back(oid1);
+        ids.push_back(oid2);
+        ids.push_back(oid3);
+        m.preregister_objects(ids);
+    }
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -2025,6 +2164,13 @@ TEST(SimpleMetastoreTest, TestGetExtentMetadataBackwards) {
     os.emplace_back(om_builder(oid3, 100, 1100)
                       .add(tid_a, 20_o, 29_o, 2000_t, 0, data_size)
                       .build());
+    {
+        chunked_vector<object_id> ids;
+        ids.push_back(oid1);
+        ids.push_back(oid2);
+        ids.push_back(oid3);
+        m.preregister_objects(ids);
+    }
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -2194,6 +2340,13 @@ TEST(SimpleMetastoreTest, TestGetExtentMetadataEmpty) {
     os.emplace_back(om_builder(oid3, 100, 1100)
                       .add(tid_a, 20_o, 29_o, 2000_t, 0, data_size)
                       .build());
+    {
+        chunked_vector<object_id> ids;
+        ids.push_back(oid1);
+        ids.push_back(oid2);
+        ids.push_back(oid3);
+        m.preregister_objects(ids);
+    }
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -2248,6 +2401,13 @@ TEST(SimpleMetastoreTest, TestGetSizeBasic) {
     os.emplace_back(om_builder(oid3, 100, 1100)
                       .add(tid_a, 20_o, 29_o, 2000_t, 0, data_size_3)
                       .build());
+    {
+        chunked_vector<object_id> ids;
+        ids.push_back(oid1);
+        ids.push_back(oid2);
+        ids.push_back(oid3);
+        m.preregister_objects(ids);
+    }
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -2274,6 +2434,13 @@ TEST(SimpleMetastoreTest, TestGetSizeAfterSetStartOffset) {
     os.emplace_back(om_builder(oid3, 100, 1100)
                       .add(tid_a, 20_o, 29_o, 2000_t, 0, data_size_3)
                       .build());
+    {
+        chunked_vector<object_id> ids;
+        ids.push_back(oid1);
+        ids.push_back(oid2);
+        ids.push_back(oid3);
+        m.preregister_objects(ids);
+    }
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -2323,6 +2490,7 @@ TEST(SimpleMetastoreTest, TestGetSizeMultiplePartitions) {
                       .add(tid_a, 0_o, 9_o, 2000_t, 0, data_size_a)
                       .add(tid_b, 0_o, 9_o, 2000_t, 100, 100 + data_size_b)
                       .build());
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
     auto add_res
       = m.add_objects(
            os,

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -166,8 +166,20 @@ protected:
 
     std::expected<std::monostate, stm_update_error>
     apply_add_objects(add_objects_update update) {
+        chunked_vector<object_id> oids;
+        for (const auto& o : update.new_objects) {
+            oids.push_back(o.oid);
+        }
         if (GetParam() == state_backend::simple) {
+            auto prereg = preregister_for_simple(oids);
+            if (!prereg.has_value()) {
+                return prereg;
+            }
             return update.apply(state_);
+        }
+        auto prereg = preregister_for_lsm(oids);
+        if (!prereg.has_value()) {
+            return prereg;
         }
         add_objects_db_update db_update{
           .new_objects = std::move(update.new_objects),
@@ -186,8 +198,20 @@ protected:
 
     std::expected<std::monostate, stm_update_error>
     apply_replace_objects(replace_objects_update update) {
+        chunked_vector<object_id> oids;
+        for (const auto& o : update.new_objects) {
+            oids.push_back(o.oid);
+        }
         if (GetParam() == state_backend::simple) {
+            auto prereg = preregister_for_simple(oids);
+            if (!prereg.has_value()) {
+                return prereg;
+            }
             return update.apply(state_);
+        }
+        auto prereg = preregister_for_lsm(oids);
+        if (!prereg.has_value()) {
+            return prereg;
         }
         replace_objects_db_update db_update{
           .new_objects = std::move(update.new_objects),
@@ -363,7 +387,47 @@ protected:
         return state_;
     }
 
+    std::expected<std::monostate, stm_update_error>
+    apply_preregister_objects(std::initializer_list<object_id> ids) {
+        chunked_vector<object_id> id_vec(ids.begin(), ids.end());
+        if (GetParam() == state_backend::simple) {
+            return preregister_for_simple(id_vec);
+        }
+        return preregister_for_lsm(id_vec);
+    }
+
 private:
+    std::expected<std::monostate, stm_update_error>
+    preregister_for_simple(const chunked_vector<object_id>& ids) {
+        preregister_objects_update u;
+        u.registered_at = model::timestamp::now();
+        for (const auto& oid : ids) {
+            u.object_ids.push_back(oid);
+        }
+        if (u.object_ids.empty()) {
+            return std::monostate{};
+        }
+        return u.apply(state_);
+    }
+
+    std::expected<std::monostate, stm_update_error>
+    preregister_for_lsm(const chunked_vector<object_id>& ids) {
+        preregister_objects_db_update update;
+        update.registered_at = model::timestamp::now();
+        for (const auto& oid : ids) {
+            update.object_ids.push_back(oid);
+        }
+        auto reader = state_reader(db_->create_snapshot());
+        chunked_vector<write_batch_row> rows;
+        auto result = update.build_rows(reader, rows).get();
+        if (!result.has_value()) {
+            return std::unexpected(
+              stm_update_error{fmt::format("{}", result.error())});
+        }
+        apply_rows_to_db(rows);
+        return std::monostate{};
+    }
+
     void apply_rows_to_db(const chunked_vector<write_batch_row>& rows) {
         auto wb = db_->create_write_batch();
         auto seqno = next_seqno();
@@ -435,6 +499,7 @@ TEST_P(StateUpdateParamTest, TestAddBasic) {
 }
 
 TEST_P(StateUpdateParamTest, TestDuplicateAddSingleUpdate) {
+    ASSERT_TRUE(apply_preregister_objects({oid1, oid2}).has_value());
     auto update = add_objects_builder()
                     .add(new_obj_builder(oid1, 100, 1100)
                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
@@ -1524,6 +1589,7 @@ TEST_P(StateUpdateParamTest, TestAddSameSubsequentTerm) {
 }
 
 TEST_P(StateUpdateParamTest, TestAddNoTerms) {
+    ASSERT_TRUE(apply_preregister_objects({oid1}).has_value());
     auto update = add_objects_builder()
                     .add(new_obj_builder(oid1, 100, 1100)
                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
@@ -1535,6 +1601,7 @@ TEST_P(StateUpdateParamTest, TestAddNoTerms) {
 }
 
 TEST_P(StateUpdateParamTest, TestAddMissingTermsForPartition) {
+    ASSERT_TRUE(apply_preregister_objects({oid1}).has_value());
     auto update = add_objects_builder()
                     .add(new_obj_builder(oid1, 100, 1100)
                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
@@ -1569,6 +1636,7 @@ TEST_P(StateUpdateParamTest, TestAddDecreasingTerm) {
     auto res = apply_add_objects(std::move(update));
     EXPECT_TRUE(res.has_value());
 
+    ASSERT_TRUE(apply_preregister_objects({oid2}).has_value());
     update = add_objects_builder()
                .add(new_obj_builder(oid2, 100, 1100)
                       .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
@@ -1594,6 +1662,7 @@ TEST_P(StateUpdateParamTest, TestRejectBogusTermWithBogusExtent) {
 }
 
 TEST_P(StateUpdateParamTest, TestTermsWithNoExtent) {
+    ASSERT_TRUE(apply_preregister_objects({oid1}).has_value());
     auto update = add_objects_builder()
                     .add(new_obj_builder(oid1, 100, 1100)
                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
@@ -1617,6 +1686,7 @@ TEST_P(StateUpdateParamTest, TestAddMismatchedStartOffset) {
     EXPECT_TRUE(res.has_value());
 
     // Add an update where the term's start offset doesn't match the extent.
+    ASSERT_TRUE(apply_preregister_objects({oid2}).has_value());
     update = add_objects_builder()
                .add(new_obj_builder(oid2, 100, 1100)
                       .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
@@ -2179,4 +2249,19 @@ TEST_P(StateUpdateParamTest, TestExpirePreregisteredObjectsClearsFlag) {
     // oid2 untouched
     ASSERT_TRUE(s.objects.contains(oid2));
     EXPECT_TRUE(s.objects.at(oid2).is_preregistration);
+}
+
+TEST(AddObjectsUpdateTest, RejectsUnregisteredObject) {
+    state s;
+    // oid1 is NOT in objects (not preregistered).
+    // add_objects_update::build() should fail.
+    chunked_vector<new_object> objs;
+    new_object obj;
+    obj.oid = oid1;
+    obj.footer_pos = 0;
+    obj.object_size = 100;
+    objs.push_back(std::move(obj));
+
+    auto result = add_objects_update::build(s, std::move(objs), {});
+    EXPECT_FALSE(result.has_value());
 }

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -312,6 +312,50 @@ protected:
         return std::monostate{};
     }
 
+    std::expected<std::monostate, stm_update_error> apply_preregister_objects(
+      chunked_vector<object_id> ids, model::timestamp ts) {
+        if (GetParam() == state_backend::simple) {
+            preregister_objects_update update;
+            update.object_ids = std::move(ids);
+            update.registered_at = ts;
+            return update.apply(state_);
+        }
+        preregister_objects_db_update db_update{
+          .object_ids = std::move(ids),
+          .registered_at = ts,
+        };
+        auto reader = state_reader(db_->create_snapshot());
+        chunked_vector<write_batch_row> rows;
+        auto result = db_update.build_rows(reader, rows).get();
+        if (!result.has_value()) {
+            return std::unexpected(
+              stm_update_error{fmt::format("{}", result.error())});
+        }
+        apply_rows_to_db(rows);
+        return std::monostate{};
+    }
+
+    std::expected<std::monostate, stm_update_error>
+    apply_expire_preregistered_objects(chunked_vector<object_id> ids) {
+        if (GetParam() == state_backend::simple) {
+            expire_preregistered_objects_update update;
+            update.object_ids = std::move(ids);
+            return update.apply(state_);
+        }
+        expire_preregistered_objects_db_update db_update{
+          .object_ids = std::move(ids),
+        };
+        auto reader = state_reader(db_->create_snapshot());
+        chunked_vector<write_batch_row> rows;
+        auto result = db_update.build_rows(reader, rows).get();
+        if (!result.has_value()) {
+            return std::unexpected(
+              stm_update_error{fmt::format("{}", result.error())});
+        }
+        apply_rows_to_db(rows);
+        return std::monostate{};
+    }
+
     state& get_state() {
         if (GetParam() == state_backend::lsm) {
             state_ = snapshot_to_state(*db_);
@@ -2067,7 +2111,7 @@ TEST_P(StateUpdateParamTest, TestCompactionValidatesEpoch) {
         // Fix the expected epoch and see state increment its internal
         // compaction_epoch.
         auto replace = replace_objects_builder()
-                         .add(new_obj_builder(oid2, 100, 1100)
+                         .add(new_obj_builder(oid3, 100, 1100)
                                 .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                                 .build())
                          .clean(
@@ -2092,4 +2136,47 @@ TEST_P(StateUpdateParamTest, TestCompactionValidatesEpoch) {
           p_state->get().compaction_epoch,
           partition_state::compaction_epoch_t{1});
     }
+}
+
+// --- preregistration tests ---
+
+TEST_P(StateUpdateParamTest, TestPreregisterObjectsInsertsThenApply) {
+    auto now = model::timestamp::now();
+    chunked_vector<object_id> ids;
+    ids.push_back(oid1);
+    ids.push_back(oid2);
+
+    auto res = apply_preregister_objects(std::move(ids), now);
+    ASSERT_TRUE(res.has_value());
+
+    auto& s = get_state();
+    EXPECT_EQ(s.objects.size(), 2u);
+    ASSERT_TRUE(s.objects.contains(oid1));
+    ASSERT_TRUE(s.objects.contains(oid2));
+    EXPECT_TRUE(s.objects.at(oid1).is_preregistration);
+    EXPECT_EQ(s.objects.at(oid1).last_updated, now);
+}
+
+TEST_P(StateUpdateParamTest, TestExpirePreregisteredObjectsClearsFlag) {
+    auto now = model::timestamp{1000};
+    chunked_vector<object_id> prereg_ids;
+    prereg_ids.push_back(oid1);
+    prereg_ids.push_back(oid2);
+    ASSERT_TRUE(
+      apply_preregister_objects(std::move(prereg_ids), now).has_value());
+
+    chunked_vector<object_id> expire_ids;
+    expire_ids.push_back(oid1);
+    ASSERT_TRUE(
+      apply_expire_preregistered_objects(std::move(expire_ids)).has_value());
+
+    auto& s = get_state();
+    // oid1 should have is_preregistration cleared (zero-sized, GC-eligible)
+    ASSERT_TRUE(s.objects.contains(oid1));
+    EXPECT_FALSE(s.objects.at(oid1).is_preregistration);
+    EXPECT_EQ(s.objects.at(oid1).total_data_size, 0u);
+
+    // oid2 untouched
+    ASSERT_TRUE(s.objects.contains(oid2));
+    EXPECT_TRUE(s.objects.at(oid2).is_preregistration);
 }

--- a/src/v/cloud_topics/level_one/metastore/tests/topic_purger_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/topic_purger_test.cc
@@ -126,7 +126,7 @@ public:
             auto tp = model::topic_id_partition(
               make_tid(i), model::partition_id{0});
 
-            auto oid_res = builder->get_or_create_object_for(tp);
+            auto oid_res = co_await builder->get_or_create_object_for(tp);
             ASSERT_TRUE_CORO(oid_res.has_value());
 
             auto add_res = builder->add(

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -441,7 +441,7 @@ ss::future<size_t> reconciler<Clock>::reconcile_source_set(
     chunked_hash_map<l1::object_id, chunked_vector<ss::shared_ptr<source>>>
       oid_to_sources;
     for (const auto& src : sources) {
-        auto oid = metadata_builder->get_or_create_object_for(
+        auto oid = co_await metadata_builder->get_or_create_object_for(
           src->topic_id_partition());
         if (!oid.has_value()) {
             vlog(lg.warn, "Could not get object: {}", oid.error());

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4715,6 +4715,12 @@ configuration::configuration()
       "performance and lowering the cost.",
       {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       true)
+  , cloud_topics_preregistered_object_ttl(
+      *this,
+      "cloud_topics_preregistered_object_ttl",
+      "Time-to-live for pre-registered L1 objects before they are expired.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      1h)
   , development_feature_property_testing_only(
       *this,
       "development_feature_property_testing_only",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -815,6 +815,8 @@ public:
 
     property<bool> cloud_topics_fetch_debounce_enabled;
 
+    property<std::chrono::milliseconds> cloud_topics_preregistered_object_ttl;
+
     development_feature_property<int> development_feature_property_testing_only;
 
 private:


### PR DESCRIPTION
The L1 reconciler and compaction worker upload objects to object storage before committing metadata to the metastore. A crash in that window orphans the object: it exists in object storage but the metastore has no record of it, so GC can never find it.

This PR closes that gap by preregistering object IDs with the metastore before uploading. The metastore then knows about every object that may exist, and a background expiry process cleans up any that were never committed within a TTL.

`object_entry` gains `is_preregistration` and `last_updated` fields to track registration state alongside committed objects. A new preregister_objects RPC lets `replicated_object_builder` pre-allocate IDs from the domain leader before upload, with `add_objects`, `replace_objects`, and `compact_objects` validating that every committed object was preregistered first. The GC loop is extended to expire stale preregistrations, re-validating candidates under the writer lock to stay race-free with concurrent commits.

`simple_metastore` and `simple_stm` aren't used in production, but receive the same updates for consistency with the rest of the STM logic.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
