### PR TITLE
kafka/tests: fix flaky unlicensed enterprise tests

### DIFF
--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -544,16 +544,16 @@ FIXTURE_TEST(unlicensed_rejected, create_topic_fixture) {
     // NOTE(oren): w/o schema validation enabled at the cluster level, related
     // properties will be ignored on the topic create path. stick to COMPAT here
     // because it's a superset of REDPANDA.
-    lconf().enable_schema_id_validation.set_value(
-      pandaproxy::schema_registry::schema_id_validation_mode::compat);
-    lconf().cloud_storage_enabled.set_value(true);
+    update_cluster_config(lconf().enable_schema_id_validation.name(), "compat");
+    update_cluster_config(lconf().cloud_storage_enabled.name(), "true");
 
-    auto unset_cloud_storage = ss::defer([&] {
-        lconf().enable_schema_id_validation.set_value(
-          pandaproxy::schema_registry::schema_id_validation_mode::none);
-        lconf().cloud_storage_enabled.set_value(false);
+    auto unset_cluster_config = ss::defer([&] {
+        update_cluster_config(
+          lconf().enable_schema_id_validation.name(), "none");
+        update_cluster_config(lconf().cloud_storage_enabled.name(), "false");
     });
 
+    wait_for_license_init();
     revoke_license();
     using prop_t = std::map<ss::sstring, ss::sstring>;
     const auto with = [](const std::string_view prop, const auto value) {
@@ -603,9 +603,11 @@ FIXTURE_TEST(unlicensed_rejected, create_topic_fixture) {
 }
 
 FIXTURE_TEST(unlicensed_reject_defaults, create_topic_fixture) {
-    lconf().cloud_storage_enabled.set_value(true);
-    auto unset_cloud_storage = ss::defer(
-      [&] { lconf().cloud_storage_enabled.set_value(false); });
+    update_cluster_config(lconf().cloud_storage_enabled.name(), "true");
+    auto unset_cluster_config = ss::defer([&] {
+        update_cluster_config(lconf().cloud_storage_enabled.name(), "false");
+    });
+    wait_for_license_init();
     revoke_license();
 
     const std::initializer_list<std::string_view> si_configs{

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -502,10 +502,10 @@ FIXTURE_TEST(case_insensitive_boolean_property, create_topic_fixture) {
 }
 
 FIXTURE_TEST(unlicensed_permit_if_config_disabled, create_topic_fixture) {
-    lconf().enable_schema_id_validation.set_value(
-      pandaproxy::schema_registry::schema_id_validation_mode::none);
-    lconf().cloud_storage_enabled.set_value(false);
+    update_cluster_config(lconf().enable_schema_id_validation.name(), "none");
+    update_cluster_config(lconf().cloud_storage_enabled.name(), "false");
 
+    wait_for_license_init();
     revoke_license();
 
     using prop_t = std::map<ss::sstring, ss::sstring>;

--- a/src/v/kafka/server/tests/topic_properties_helpers.h
+++ b/src/v/kafka/server/tests/topic_properties_helpers.h
@@ -13,10 +13,20 @@
 #include "kafka/protocol/create_partitions.h"
 #include "kafka/protocol/create_topics.h"
 #include "redpanda/tests/fixture.h"
+#include "test_utils/async.h"
 
 class topic_properties_test_fixture : public redpanda_thread_fixture {
 public:
     topic_properties_test_fixture() { wait_for_controller_leadership().get(); }
+
+    void wait_for_license_init() {
+        tests::cooperative_spin_wait_with_timeout(5s, [this] {
+            return app.controller->get_feature_table()
+              .local()
+              .get_license()
+              .has_value();
+        }).get();
+    }
 
     void revoke_license() {
         app.controller->get_feature_table()


### PR DESCRIPTION
The `unlicensed_reject_defaults` and `unlicensed_rejected` tests in `create_topics_test.cc` are flaky in CI. Two issues cause the tests to intermittently pass when they should enforce enterprise license checks:
  1. A race between `revoke_license()` and the async trial license init `metrics_reporter::try_initialize_cluster_info()`. If the init completed before revoke, `should_sanction()` is permissive.
  2. `lconf().cloud_storage_enabled.set_value(true)` only sets the config shard 0. If the Kafka handler runs on another shard, `is_restricted()` returns false.

This adds a `wait_for_license_init()` helper that waits for the async trial license to be initialized before revoking, and switches config mutations to `update_cluster_config()` to propagate to all shards.

Fixes [CORE-15319](https://redpandadata.atlassian.net/browse/CORE-15319)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.3.x
- [X] v25.2.x
- [ ] v25.1.x

## Release Notes
- none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-15319]: https://redpandadata.atlassian.net/browse/CORE-15319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ