### PR TITLE
CORE-13741: Scale Tests: Enable ManyPartitionsTest.test_many_partitions_cloud_topics_tiered_storage

### DIFF
--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -15,7 +15,7 @@ from collections import Counter
 from typing import Any, Callable
 from ducktape.cluster.cluster import ClusterNode
 import numpy
-from ducktape.mark import ignore, parametrize  # type: ignore[reportUnknownVariableType]
+from ducktape.mark import parametrize
 from ducktape.utils.util import TimeoutError, wait_until
 
 from rptest.clients.rpk import RpkException, RpkTool
@@ -75,9 +75,13 @@ STRESS_DATA_SIZE = 1024 * 1024 * 1024 * 100
 STOP_TIMEOUT = 60 * 5
 CLOUD_TOPICS_STOP_TIMEOUT = 60 * 10
 
-# TODO: suppress this log in the reconciler
-METASTORE_TRANSPORT_LOG_ALLOW_LIST = [
+# TODO: these transient S3/metastore errors should not be logged at ERROR
+RECONCILER_TRANSIENT_ERROR_LOG_ALLOW_LIST = [
     re.compile(r"reconciler - .*std::runtime_error .*metastore::errc::transport_error"),
+    re.compile(r"reconciler - .*cloud_storage_clients::rest_error_response"),
+    re.compile(
+        r"cloud_io - .*Multipart upload.*cloud_storage_clients::rest_error_response"
+    ),
 ]
 
 
@@ -521,7 +525,12 @@ class ManyPartitionsTest(PreallocNodesTest):
                 str(scale.local_retention_after_warmup),
             )
 
-    def _write_and_random_read(self, scale: ScaleParameters, topic_names: list[str]):
+    def _write_and_random_read(
+        self,
+        scale: ScaleParameters,
+        topic_names: list[str],
+        skip_rand_reads: bool = False,
+    ):
         """
         This is a relatively low intensity test, that covers random
         and sequential reads & validates correctness of offsets in the
@@ -646,22 +655,23 @@ class ManyPartitionsTest(PreallocNodesTest):
             err_msg="Waiting for producer checkpoints",
         )
 
-        rand_ios = 100
-        rand_parallel = 100
-        if self.redpanda.dedicated_nodes:
-            rand_parallel = 10
-            rand_ios = 10
+        if not skip_rand_reads:
+            rand_ios = 100
+            rand_parallel = 100
+            if self.redpanda.dedicated_nodes:
+                rand_parallel = 10
+                rand_ios = 10
 
-        rand_consumer = KgoVerifierMultiRandomConsumer(
-            self.test_context,
-            self.redpanda,
-            stress_params,
-            rand_read_msgs=rand_ios,
-            parallel=rand_parallel,
-            custom_node=[self.preallocated_nodes[1]],
-        )
-        rand_consumer.start(clean=False)
-        rand_consumer.wait()
+            rand_consumer = KgoVerifierMultiRandomConsumer(
+                self.test_context,
+                self.redpanda,
+                stress_params,
+                rand_read_msgs=rand_ios,
+                parallel=rand_parallel,
+                custom_node=[self.preallocated_nodes[1]],
+            )
+            rand_consumer.start(clean=False)
+            rand_consumer.wait()
 
         fast_producer.stop()
         self.logger.info("Write+randread stress test complete, verifying sequentially")
@@ -851,7 +861,8 @@ class ManyPartitionsTest(PreallocNodesTest):
 
     @cluster(
         num_nodes=12,
-        log_allow_list=RESTART_LOG_ALLOW_LIST + METASTORE_TRANSPORT_LOG_ALLOW_LIST,
+        log_allow_list=RESTART_LOG_ALLOW_LIST
+        + RECONCILER_TRANSIENT_ERROR_LOG_ALLOW_LIST,
     )
     @parametrize(
         mib_per_partition=DEFAULT_MIB_PER_PARTITION,
@@ -867,10 +878,10 @@ class ManyPartitionsTest(PreallocNodesTest):
             topic_partitions_per_shard=topic_partitions_per_shard,
         )
 
-    @ignore  # TODO: Evaluate parameters and turn this back on
     @cluster(
         num_nodes=12,
-        log_allow_list=RESTART_LOG_ALLOW_LIST + METASTORE_TRANSPORT_LOG_ALLOW_LIST,
+        log_allow_list=RESTART_LOG_ALLOW_LIST
+        + RECONCILER_TRANSIENT_ERROR_LOG_ALLOW_LIST,
     )
     @parametrize(
         mib_per_partition=DEFAULT_MIB_PER_PARTITION,
@@ -1093,13 +1104,23 @@ class ManyPartitionsTest(PreallocNodesTest):
                 f"Open files after initial elections on {node_name}: {file_count}"
             )
 
-        if scale.tiered_storage_enabled:
+        if scale.tiered_storage_enabled and not cloud_topics_enabled:
+            # Skip warmup when cloud topics are also enabled: the goal of the
+            # combo test is mixed-mode coexistence under load, not re-proving
+            # tiered storage handles millions of segments (already covered by
+            # test_many_partitions_tiered_storage).  Skipping saves ~25 min.
             self.logger.info("Entering tiered storage warmup")
             for tn in regular_topic_names:
                 self._tiered_storage_warmup(scale, tn)
 
         self.logger.info("Entering initial traffic test, writes + random reads")
-        self._write_and_random_read(scale, topic_names)
+        # When both tiered storage and cloud topics are enabled, skip random
+        # reads entirely: cloud topic random reads hit object store with high
+        # latency at this partition scale, and each path is already covered by
+        # its dedicated test.  The sequential consumer group verify still
+        # validates both read paths.
+        skip_rand_reads = cloud_topics_enabled and scale.tiered_storage_enabled
+        self._write_and_random_read(scale, topic_names, skip_rand_reads)
 
         # Start kgo-repeater
 
@@ -1181,6 +1202,11 @@ class ManyPartitionsTest(PreallocNodesTest):
 
             soak_time_seconds = 60
             soak_await_bytes = soak_time_seconds * scale.expect_bandwidth
+            if cloud_topics_enabled and tiered_storage_enabled:
+                # Cloud topics and tiered storage compete for things like
+                # cloud storage clients and overall bucket request limits,
+                # so dial back the soak time.
+                soak_await_bytes = int(soak_await_bytes * 0.5)
             soak_await_msgs = int(soak_await_bytes / repeater_msg_size)
             # Add some leeway to avoid flakiness
             soak_timeout = int(soak_time_seconds * 1.25)


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Notably had to add a couple more transient errors to the log allow list.
These need addressing at first opportunity but do appear to be
straightforwardly the result of pessimistic categorization of retryable
errors.

As expected, cloud topics and tiered storage do compete for things like
cloud storage clients. For this reason, some parameters are adjusted down
or activities totally skipped to make the test practical:

- decrease soak time (bytes awaited)
- skip random reads
- skip tiered storage warmup

These aspects should be covered already by dedicated tests for each feature.

### PROOF 

https://buildkite.com/redpanda/redpanda/builds/81369#019cb6d7-4e8c-4d5f-bc7a-86b56d9f2137

```
test_id:    rptest.scale_tests.many_partitions_test.ManyPartitionsTest.test_many_partitions_cloud_topics_tiered_storage.mib_per_partition=0.1953125.topic_partitions_per_shard=3000
status:     PASS
run time:   12 minutes 20.337 seconds
{"result": null, "usage_stats": {"RedpandaService-0-278068469366400": {"disk_bytes_read": 297655934976, "disk_bytes_written": 92440285184, "batches_read": 0, "batches_written": 0, "internal_rpc_bytes_recv": 0, "internal_rpc_bytes_sent": 0, "cloud_storage_puts": 0, "cloud_storage_gets": 0}}}
----------------------------------------------------------------------------------------------------
test_id:    rptest.scale_tests.many_partitions_test.ManyPartitionsTest.test_many_partitions_cloud_topics_tiered_storage.mib_per_partition=0.1953125.topic_partitions_per_shard=3000
status:     PASS
run time:   12 minutes 57.588 seconds
{"result": null, "usage_stats": {"RedpandaService-0-278068469361744": {"disk_bytes_read": 276119581696, "disk_bytes_written": 99590094848, "batches_read": 0, "batches_written": 0, "internal_rpc_bytes_recv": 0, "internal_rpc_bytes_sent": 0, "cloud_storage_puts": 0, "cloud_storage_gets": 0}}}
----------------------------------------------------------------------------------------------------
test_id:    rptest.scale_tests.many_partitions_test.ManyPartitionsTest.test_many_partitions_cloud_topics_tiered_storage.mib_per_partition=0.1953125.topic_partitions_per_shard=3000
status:     PASS
run time:   13 minutes 0.899 seconds
{"result": null, "usage_stats": {"RedpandaService-0-278068469366544": {"disk_bytes_read": 310644791296, "disk_bytes_written": 98551308288, "batches_read": 0, "batches_written": 0, "internal_rpc_bytes_recv": 0, "internal_rpc_bytes_sent": 0, "cloud_storage_puts": 0, "cloud_storage_gets": 0}}}
----------------------------------------------------------------------------------------------------
test_id:    rptest.scale_tests.many_partitions_test.ManyPartitionsTest.test_many_partitions_cloud_topics_tiered_storage.mib_per_partition=0.1953125.topic_partitions_per_shard=3000
status:     PASS
run time:   13 minutes 20.495 seconds
{"result": null, "usage_stats": {"RedpandaService-0-278068471562096": {"disk_bytes_read": 335073334272, "disk_bytes_written": 98122305536, "batches_read": 0, "batches_written": 0, "internal_rpc_bytes_recv": 0, "internal_rpc_bytes_sent": 0, "cloud_storage_puts": 0, "cloud_storage_gets": 0}}}
----------------------------------------------------------------------------------------------------
====================================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2026-03-04--001
run time:         51 minutes 39.867 seconds
tests run:        4
passed:           4
flaky:            0
failed:           0
ignored:          0
====================================================================================================
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
