### PR TITLE
treewide: fix compilation errors with clang-22

### DIFF
--- a/src/v/cloud_topics/level_one/frontend_reader/tests/reader_test.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/tests/reader_test.cc
@@ -304,7 +304,7 @@ TEST_F(l1_reader_test, missing_object) {
         .first_offset = kafka::offset{0},
       });
 
-    _metastore.add_objects(*builder, term_map).get().value();
+    std::ignore = _metastore.add_objects(*builder, term_map).get().value();
 
     auto reader = make_reader(ntp, tidp);
     EXPECT_THROW(read_all(std::move(reader)), std::runtime_error);
@@ -364,7 +364,7 @@ TEST_F(l1_reader_test, empty_offset_range) {
         .term = model::term_id{1},
         .first_offset = high_watermark,
       });
-    _metastore.add_objects(*meta_builder, term_map).get().value();
+    std::ignore = _metastore.add_objects(*meta_builder, term_map).get().value();
 
     // Write some objects after the empty object.
     auto final_batches

--- a/src/v/cluster/errors.cc
+++ b/src/v/cluster/errors.cc
@@ -187,5 +187,9 @@ std::ostream& operator<<(std::ostream& o, cluster::errc err) {
     case errc::feature_sanctioned:
         return o << "cluster::errc::feature_sanctioned";
     }
+
+    // fallback path: we don't expect it, but this is better than just falling
+    // off the end without returning anything
+    return o << "cluster::errc::unknown(" << static_cast<int>(err) << ")";
 }
 } // namespace cluster

--- a/src/v/crypto/ossl_context_service.cc
+++ b/src/v/crypto/ossl_context_service.cc
@@ -39,14 +39,16 @@ using initialize_result = result<R, std::string>;
 
 ss::logger lg("ossl-library-context-service");
 
-using OSSL_PROVIDER_ptr = internal::handle<OSSL_PROVIDER, [](OSSL_PROVIDER* p) {
+void unload_ossl_provider(OSSL_PROVIDER* p) {
     if (1 != OSSL_PROVIDER_unload(p)) {
         vlog(
           lg.warn,
           "Failed to unload OSSL provider: {}",
           internal::ossl_error::build_error());
     }
-}>;
+}
+
+using OSSL_PROVIDER_ptr = internal::handle<OSSL_PROVIDER, unload_ossl_provider>;
 
 struct initialize_return {
     // Only loaded when in FIPS mode

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -883,7 +883,7 @@ public:
 
         const auto all_deleted = is_deleted(
           std::all_of(versions.begin(), versions.end(), [](const auto& v) {
-              return v.deleted;
+              return static_cast<bool>(v.deleted);
           }));
 
         if (deleted == all_deleted) {


### PR DESCRIPTION
Fix four compilation errors encountered when building with the clang-22
toolchain. These are minimal targeted fixes to satisfy new/stricter
diagnostics in clang 22.1.0.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none