### PR TITLE
security/tests: add GBAC group claim edge case and nested group tests

### DIFF
--- a/src/v/security/tests/authorizer_test.cc
+++ b/src/v/security/tests/authorizer_test.cc
@@ -3128,6 +3128,81 @@ TEST(AUTHORIZER_TEST, group_role_authz_implied_operations) {
     EXPECT_EQ(result.role, role_name1);
 }
 
+// Case-sensitive group matching
+TEST(AUTHORIZER_TEST, group_authz_case_sensitive) {
+    acl_principal user1(principal_type::user, "user1");
+    acl_principal group_lower(principal_type::group, "eng");
+    acl_principal group_upper(principal_type::group, "Eng");
+
+    acl_entry allow_lower(
+      group_lower,
+      acl_host::wildcard_host(),
+      acl_operation::read,
+      acl_permission::allow);
+
+    chunked_vector<acl_binding> bindings;
+    resource_pattern resource(
+      resource_type::topic, default_topic(), pattern_type::literal);
+    bindings.emplace_back(resource, allow_lower);
+
+    role_store roles;
+    auto auth = make_test_instance(authorizer::allow_empty_matches::no, &roles);
+    auth.add_bindings(bindings);
+
+    // User in group "Eng" (uppercase) should NOT match ACL for "eng"
+    auto result = auth.authorized(
+      default_topic,
+      acl_operation::read,
+      user1,
+      acl_host("192.168.1.1"),
+      security::superuser_required::no,
+      {group_upper});
+
+    EXPECT_FALSE(bool(result));
+
+    // User in group "eng" (matching case) should match
+    auto result2 = auth.authorized(
+      default_topic,
+      acl_operation::read,
+      user1,
+      acl_host("192.168.1.1"),
+      security::superuser_required::no,
+      {group_lower});
+
+    EXPECT_TRUE(bool(result2));
+}
+
+// Authorization with whitespace control chars in group name
+TEST(AUTHORIZER_TEST, group_authz_whitespace_chars_in_name) {
+    acl_principal user1(principal_type::user, "user1");
+    acl_principal group_tab(principal_type::group, "group\twith\ttabs");
+
+    acl_entry allow_tab(
+      group_tab,
+      acl_host::wildcard_host(),
+      acl_operation::read,
+      acl_permission::allow);
+
+    chunked_vector<acl_binding> bindings;
+    resource_pattern resource(
+      resource_type::topic, default_topic(), pattern_type::literal);
+    bindings.emplace_back(resource, allow_tab);
+
+    role_store roles;
+    auto auth = make_test_instance(authorizer::allow_empty_matches::no, &roles);
+    auth.add_bindings(bindings);
+
+    auto result = auth.authorized(
+      default_topic,
+      acl_operation::read,
+      user1,
+      acl_host("192.168.1.1"),
+      security::superuser_required::no,
+      {group_tab});
+
+    EXPECT_TRUE(bool(result));
+}
+
 // Test ACL pattern types (prefix, literal, wildcard) for context subjects.
 TEST(AUTHORIZER_TEST, authz_sr_context_subject_patterns) {
     namespace ppsr = pandaproxy::schema_registry;

--- a/src/v/security/tests/oidc_principal_mapping_test.cc
+++ b/src/v/security/tests/oidc_principal_mapping_test.cc
@@ -445,3 +445,205 @@ BOOST_AUTO_TEST_CASE(test_apply_nested_group_policy_suffix_empty) {
     BOOST_CHECK_EQUAL(principal.type(), security::principal_type::group);
     BOOST_CHECK_EQUAL(principal.name(), "");
 }
+
+// Claim resolves to JSON object
+BOOST_AUTO_TEST_CASE(test_get_group_claim_object_type) {
+    auto jwt = make_test_jwt(R"({
+        "iss": "http://example.com",
+        "sub": "user123",
+        "groups": {"team": "admin", "dept": "engineering"}
+    })");
+    BOOST_REQUIRE(jwt.has_value());
+
+    json::Pointer group_pointer("/groups");
+    auto result = security::oidc::detail::get_group_claim(
+      group_pointer, jwt.assume_value());
+
+    BOOST_REQUIRE(!result.has_value());
+    BOOST_CHECK_EQUAL(
+      result.error(), security::oidc::errc::group_claim_not_found);
+}
+
+// Groups as arbitrary non-comma-delimited string
+BOOST_AUTO_TEST_CASE(test_get_group_claim_semicolon_delimited) {
+    auto jwt = make_test_jwt(R"({
+        "iss": "http://example.com",
+        "sub": "user123",
+        "groups": "eng;fin"
+    })");
+    BOOST_REQUIRE(jwt.has_value());
+
+    json::Pointer group_pointer("/groups");
+    auto result = security::oidc::detail::get_group_claim(
+      group_pointer, jwt.assume_value());
+
+    BOOST_REQUIRE(result.has_value());
+    auto groups = std::move(result).value();
+    // Semicolons are not a delimiter — treated as single group name
+    BOOST_REQUIRE_EQUAL(groups.size(), 1);
+    BOOST_CHECK_EQUAL(groups[0], "eng;fin");
+}
+
+// CSV with empty entries between commas
+BOOST_AUTO_TEST_CASE(test_get_group_claim_csv_empty_entries) {
+    auto jwt = make_test_jwt(R"({
+        "iss": "http://example.com",
+        "sub": "user123",
+        "groups": "admin,,users"
+    })");
+    BOOST_REQUIRE(jwt.has_value());
+
+    json::Pointer group_pointer("/groups");
+    auto result = security::oidc::detail::get_group_claim(
+      group_pointer, jwt.assume_value());
+
+    BOOST_REQUIRE(result.has_value());
+    auto groups = std::move(result).value();
+    // absl::StrSplit keeps empty entries — "admin,,users" produces
+    // ["admin", "", "users"]. Empty group names are not filtered.
+    BOOST_REQUIRE_EQUAL(groups.size(), 3);
+    BOOST_CHECK_EQUAL(groups[0], "admin");
+    BOOST_CHECK_EQUAL(groups[1], "");
+    BOOST_CHECK_EQUAL(groups[2], "users");
+}
+
+// Unicode group names
+BOOST_AUTO_TEST_CASE(test_get_group_claim_unicode) {
+    auto jwt = make_test_jwt(R"({
+        "iss": "http://example.com",
+        "sub": "user123",
+        "groups": ["équipe", "中文组", "グループ"]
+    })");
+    BOOST_REQUIRE(jwt.has_value());
+
+    json::Pointer group_pointer("/groups");
+    auto result = security::oidc::detail::get_group_claim(
+      group_pointer, jwt.assume_value());
+
+    BOOST_REQUIRE(result.has_value());
+    auto groups = std::move(result).value();
+    BOOST_REQUIRE_EQUAL(groups.size(), 3);
+    BOOST_CHECK_EQUAL(groups[0], "équipe");
+    BOOST_CHECK_EQUAL(groups[1], "中文组");
+    BOOST_CHECK_EQUAL(groups[2], "グループ");
+}
+
+// Special characters in group names
+BOOST_AUTO_TEST_CASE(test_get_group_claim_special_chars) {
+    auto jwt = make_test_jwt(R"({
+        "iss": "http://example.com",
+        "sub": "user123",
+        "groups": ["admin@corp.com", "dev.team", "my group", "role=admin"]
+    })");
+    BOOST_REQUIRE(jwt.has_value());
+
+    json::Pointer group_pointer("/groups");
+    auto result = security::oidc::detail::get_group_claim(
+      group_pointer, jwt.assume_value());
+
+    BOOST_REQUIRE(result.has_value());
+    auto groups = std::move(result).value();
+    BOOST_REQUIRE_EQUAL(groups.size(), 4);
+    BOOST_CHECK_EQUAL(groups[0], "admin@corp.com");
+    BOOST_CHECK_EQUAL(groups[1], "dev.team");
+    BOOST_CHECK_EQUAL(groups[2], "my group");
+    BOOST_CHECK_EQUAL(groups[3], "role=admin");
+}
+
+// Group name containing comma in JSON array form
+BOOST_AUTO_TEST_CASE(test_get_group_claim_comma_in_array_element) {
+    auto jwt = make_test_jwt(R"({
+        "iss": "http://example.com",
+        "sub": "user123",
+        "groups": ["admin,role", "users"]
+    })");
+    BOOST_REQUIRE(jwt.has_value());
+
+    json::Pointer group_pointer("/groups");
+    auto result = security::oidc::detail::get_group_claim(
+      group_pointer, jwt.assume_value());
+
+    BOOST_REQUIRE(result.has_value());
+    auto groups = std::move(result).value();
+    // Array path: comma is part of the name, not a delimiter
+    BOOST_REQUIRE_EQUAL(groups.size(), 2);
+    BOOST_CHECK_EQUAL(groups[0], "admin,role");
+    BOOST_CHECK_EQUAL(groups[1], "users");
+}
+
+// Group name containing comma in CSV form
+BOOST_AUTO_TEST_CASE(test_get_group_claim_comma_in_csv_is_split) {
+    auto jwt = make_test_jwt(R"({
+        "iss": "http://example.com",
+        "sub": "user123",
+        "groups": "admin,role,users"
+    })");
+    BOOST_REQUIRE(jwt.has_value());
+
+    json::Pointer group_pointer("/groups");
+    auto result = security::oidc::detail::get_group_claim(
+      group_pointer, jwt.assume_value());
+
+    BOOST_REQUIRE(result.has_value());
+    auto groups = std::move(result).value();
+    // CSV form: commas always split — cannot embed commas in names
+    BOOST_REQUIRE_EQUAL(groups.size(), 3);
+    BOOST_CHECK_EQUAL(groups[0], "admin");
+    BOOST_CHECK_EQUAL(groups[1], "role");
+    BOOST_CHECK_EQUAL(groups[2], "users");
+}
+
+// Duplicate group names in array
+BOOST_AUTO_TEST_CASE(test_get_group_claim_duplicates) {
+    auto jwt = make_test_jwt(R"({
+        "iss": "http://example.com",
+        "sub": "user123",
+        "groups": ["admin", "admin", "users"]
+    })");
+    BOOST_REQUIRE(jwt.has_value());
+
+    json::Pointer group_pointer("/groups");
+    auto result = security::oidc::detail::get_group_claim(
+      group_pointer, jwt.assume_value());
+
+    BOOST_REQUIRE(result.has_value());
+    auto groups = std::move(result).value();
+    // Implementation does not deduplicate
+    BOOST_REQUIRE_EQUAL(groups.size(), 3);
+    BOOST_CHECK_EQUAL(groups[0], "admin");
+    BOOST_CHECK_EQUAL(groups[1], "admin");
+    BOOST_CHECK_EQUAL(groups[2], "users");
+}
+
+// Group names with newline/tab characters.
+BOOST_AUTO_TEST_CASE(test_get_group_claim_whitespace_chars) {
+    auto jwt = make_test_jwt(R"({
+        "iss": "http://example.com",
+        "sub": "user123",
+        "groups": ["group\twith\ttabs", "group\nwith\nnewlines"]
+    })");
+    BOOST_REQUIRE(jwt.has_value());
+
+    json::Pointer group_pointer("/groups");
+    auto result = security::oidc::detail::get_group_claim(
+      group_pointer, jwt.assume_value());
+
+    BOOST_REQUIRE(result.has_value());
+    auto groups = std::move(result).value();
+    BOOST_REQUIRE_EQUAL(groups.size(), 2);
+    BOOST_CHECK_EQUAL(groups[0], "group\twith\ttabs");
+    BOOST_CHECK_EQUAL(groups[1], "group\nwith\nnewlines");
+}
+
+// Multiple nested groups collide to same suffix
+BOOST_AUTO_TEST_CASE(test_apply_nested_group_policy_suffix_collision) {
+    auto p1 = security::oidc::detail::apply_nested_group_policy(
+      "deptA/admin", security::oidc::nested_group_behavior::suffix);
+    auto p2 = security::oidc::detail::apply_nested_group_policy(
+      "deptB/admin", security::oidc::nested_group_behavior::suffix);
+
+    // Both resolve to "admin"
+    BOOST_CHECK_EQUAL(p1.name(), "admin");
+    BOOST_CHECK_EQUAL(p2.name(), "admin");
+    BOOST_CHECK_EQUAL(p1.name(), p2.name());
+}

--- a/tests/rptest/services/keycloak.py
+++ b/tests/rptest/services/keycloak.py
@@ -220,6 +220,12 @@ class KeycloakAdminClient:
         assert group_id is not None, f"Group {group_name} not found"
         self._add_user_to_group(user_id=account_id, group_id=group_id)
 
+    def add_service_user_to_group_by_id(self, client_id: str, group_id: str):
+        id = self.kc_admin.get_client_id(client_id)
+        assert id is not None, f"Client {client_id} not found"
+        service_account_user = self.kc_admin.get_client_service_account_user(id)
+        self._add_user_to_group(user_id=service_account_user["id"], group_id=group_id)
+
     def remove_service_user_from_group(self, client_id: str, group_name: str):
         id = self.kc_admin.get_client_id(client_id)
         assert id is not None, f"Client {client_id} not found"

--- a/tests/rptest/tests/redpanda_oauth_test.py
+++ b/tests/rptest/tests/redpanda_oauth_test.py
@@ -187,6 +187,31 @@ class RedpandaOIDCTestBase(Test):
             tls_enabled=use_ssl,
         )
 
+    def _wait_for_acl_on_all_nodes(self, principal, timeout_sec=10, backoff_sec=1):
+        """Wait until the given principal appears in the ACL list on all nodes."""
+        self.logger.debug(f"Waiting for ACL '{principal}' to propagate to all nodes...")
+
+        def propagated():
+            for node in self.redpanda.nodes:
+                acls = self.rpk.acl_list(node=node, format="json")
+                principals = {m["principal"] for m in acls.get("matches", [])}
+                if principal not in principals:
+                    self.logger.debug(
+                        f"ACL '{principal}' not yet on {node.account.hostname}, "
+                        f"found: {principals}"
+                    )
+                    return False
+            self.logger.debug(f"ACL '{principal}' propagated to all nodes")
+            return True
+
+        wait_until(
+            propagated,
+            timeout_sec=timeout_sec,
+            backoff_sec=backoff_sec,
+            retry_on_exc=True,
+            err_msg=f"Timeout waiting for ACL '{principal}' to propagate to all nodes",
+        )
+
     def setUp(self):
         self.redpanda.logger.info("Starting Redpanda")
         self.redpanda.start()
@@ -1963,6 +1988,116 @@ class RedpandaOIDCTestMethods(RedpandaOIDCTestBase):
         )
         self.logger.info(
             f"Read from denied subject denied: {res.status_code} {res.text}"
+        )
+
+    @cluster(num_nodes=4)
+    def test_nested_group_behavior_none_requires_full_path(self):
+        """
+        GBAC-NEST-NONE-020: With nested_group_behavior=none, Redpanda uses the
+        full group path from the token verbatim. An ACL for only the leaf group
+        name (e.g. Group:child) must NOT match a token that contains the full
+        path (e.g. /parent/child).
+
+        Setup: Keycloak group mapper with use_full_path=True, so the token
+        contains the full group path including leading slash
+        (e.g. "/nested-none-parent/nested-none-child").
+
+        Test flow:
+        1. Create a nested group hierarchy in Keycloak (parent -> child)
+        2. Configure the group mapper with use_full_path=True
+        3. Set nested_group_behavior=none
+        4. Grant ACL for Group:nested-none-child (leaf only) — verify access
+           is DENIED (token has full path, leaf ACL does not match)
+        5. Grant ACL for Group:/nested-none-parent/nested-none-child (full path)
+           — verify access is GRANTED
+        """
+        kc_node = self.keycloak.nodes[0]
+        client_id = CLIENT_ID
+
+        parent_group = "nested-none-parent"
+        child_group = "nested-none-child"
+        topic_name = "nested-none-topic"
+        full_path = f"/{parent_group}/{child_group}"
+
+        self.redpanda.set_cluster_config(
+            {"nested_group_behavior": NestedGroupType.NONE.value}
+        )
+
+        self.create_service_user()
+
+        # use_full_path=True: token contains the full path, e.g. "/nested-none-parent/nested-none-child"
+        self.keycloak.admin.create_group_mapper(client_id, use_full_path=True)
+
+        parent_id = self.keycloak.admin.create_group(parent_group)
+        child_id = self.keycloak.admin.create_group(child_group, parent=parent_id)
+        self.keycloak.admin.add_service_user_to_group_by_id(client_id, child_id)
+
+        self.rpk.create_topic(topic_name)
+
+        cfg = self.keycloak.generate_oauth_config(kc_node, client_id)
+
+        def get_visible_topics() -> set[str]:
+            k_client = PythonLibrdkafka(
+                self.redpanda,
+                algorithm="OAUTHBEARER",
+                oauth_config=cfg,
+                tls_cert=self.client_cert,
+            )
+            producer = k_client.get_producer()
+            producer.poll(0.0)
+            return set(producer.list_topics(timeout=5).topics.keys())
+
+        # ACL for leaf name only — token has full path, so this must NOT match
+        leaf_principal = f"Group:{child_group}"
+        self.rpk.sasl_allow_principal(
+            leaf_principal,
+            ["all"],
+            "topic",
+            topic_name,
+            self.su_username,
+            self.su_password,
+            self.su_algorithm,
+        )
+
+        # Wait for leaf ACL to propagate before asserting denial
+        self._wait_for_acl_on_all_nodes(leaf_principal)
+        assert topic_name not in get_visible_topics(), (
+            f"Expected topic '{topic_name}' to NOT be visible: "
+            f"leaf ACL '{leaf_principal}' should not match full path '{full_path}' "
+            f"when nested_group_behavior=none"
+        )
+        self.logger.info(
+            f"Verified: leaf ACL '{leaf_principal}' does not match full group "
+            f"path '{full_path}' with nested_group_behavior=none"
+        )
+
+        # ACL for full path — this must match
+        full_path_principal = f"Group:{full_path}"
+        self.rpk.sasl_allow_principal(
+            full_path_principal,
+            ["all"],
+            "topic",
+            topic_name,
+            self.su_username,
+            self.su_password,
+            self.su_algorithm,
+        )
+
+        # Wait for full path ACL to propagate before asserting access
+        self._wait_for_acl_on_all_nodes(full_path_principal)
+
+        wait_until(
+            lambda: topic_name in get_visible_topics(),
+            timeout_sec=10,
+            backoff_sec=1,
+            err_msg=(
+                f"Expected topic '{topic_name}' to be visible via full path "
+                f"ACL '{full_path_principal}' with nested_group_behavior=none"
+            ),
+        )
+        self.logger.info(
+            f"Verified: full path ACL '{full_path_principal}' grants access "
+            f"when nested_group_behavior=none"
         )
 
 


### PR DESCRIPTION
This PR adds automated test coverage for GBAC (Group-Based Access Control) scenarios that were previously only manually verified. It covers edge cases in OIDC group claim parsing, group name ACL matching, and nested group path behavior.

The [scenarios](https://redpandadata.atlassian.net/wiki/spaces/QE/pages/1613103105/GBAC+Test+cases+results+and+automation+info) that these cover include:

| Test ID              | File                                                                 |
|----------------------|----------------------------------------------------------------------|
| GBAC-GRP-PATH-040    | oidc_principal_mapping_test.cc (test_get_group_claim_object_type)   |
| GBAC-GRP-BAD-010     | oidc_principal_mapping_test.cc (test_get_group_claim_semicolon_delimited) |
| GBAC-GRP-BAD-030     | Covered by same test as GRP-PATH-040                                 |
| GBAC-GRP-FMT-040     | oidc_principal_mapping_test.cc (test_get_group_claim_csv_empty_entries) |
| GBAC-GRP-NAME-020    | oidc_principal_mapping_test.cc (test_get_group_claim_unicode)       |
| GBAC-GRP-NAME-030    | oidc_principal_mapping_test.cc (test_get_group_claim_special_chars) |
| GBAC-GRP-NAME-040    | oidc_principal_mapping_test.cc (test_get_group_claim_comma_in_array_element) |
| GBAC-GRP-NAME-050    | oidc_principal_mapping_test.cc (test_get_group_claim_comma_in_csv_is_split) |
| GBAC-GRP-NAME-070    | oidc_principal_mapping_test.cc (test_get_group_claim_duplicates)    |
| GBAC-GRP-NAME-080    | oidc_principal_mapping_test.cc (test_get_group_claim_whitespace_chars) + authorizer_test.cc (group_authz_whitespace_chars_in_name) |
| GBAC-GRP-NAME-010    | authorizer_test.cc (group_authz_case_sensitive)                     |
| GBAC-NEST-SFX-030    | oidc_principal_mapping_test.cc (test_apply_nested_group_policy_suffix_collision) |
| GBAC-NEST-NONE-020   | redpanda_oauth_test.py (test_nested_group_behavior_none_requires_full_path) |

  ## Backports Required

  - [x] none - not a bug fix

  ## Release Notes

  * none