### PR TITLE
shadowing/mux_consumer: fix per partition max partition buffered bytes

### DIFF
--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -251,10 +251,12 @@ make_remote_consumer_configuration(const model::connection_config& conn_cfg) {
     dc_configuration.partition_max_bytes
       = conn_cfg.get_fetch_partition_max_bytes();
 
+    const size_t partition_max_buffered
+      = 2 * conn_cfg.get_fetch_partition_max_bytes();
     return replication::mux_remote_consumer::configuration{
       .client_id = conn_cfg.client_id,
       .direct_consumer_configuration = dc_configuration,
-      .partition_max_buffered = max_buffered_bytes,
+      .partition_max_buffered = partition_max_buffered,
       .fetch_max_wait = max_wait_time,
     };
 }


### PR DESCRIPTION
Seems like a copy-pasta error. New logic sets it twice of max of what can be fetched per partition in a single fetch request. Earlier default was much higher.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
