### PR TITLE
bazel: update openssl to 3.5.5

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -302,7 +302,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "KpoPHfz3cH8M0fTJ+YQYTm6QqMRtrMoIw1+4UUjQcfY=",
+        "bzlTransitiveDigest": "IlG6diwV0jQMUPkw8yUHR3dFbHoNZDCnRXun6k6ZNNg=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -446,9 +446,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:openssl.BUILD",
-              "sha256": "fa5a4143b8aae18be53ef2f3caf29a2e0747430b8bc74d32d88335b94ab63072",
-              "strip_prefix": "openssl-3.0.19",
-              "url": "https://github.com/openssl/openssl/releases/download/openssl-3.0.19/openssl-3.0.19.tar.gz"
+              "sha256": "b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89",
+              "strip_prefix": "openssl-3.5.5",
+              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/openssl-3.5.5.tar.gz"
             }
           },
           "openssl-fips": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -138,9 +138,9 @@ def data_dependency():
     http_archive(
         name = "openssl",
         build_file = "//bazel/thirdparty:openssl.BUILD",
-        sha256 = "fa5a4143b8aae18be53ef2f3caf29a2e0747430b8bc74d32d88335b94ab63072",
-        strip_prefix = "openssl-3.0.19",
-        url = "https://github.com/openssl/openssl/releases/download/openssl-3.0.19/openssl-3.0.19.tar.gz",
+        sha256 = "b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89",
+        strip_prefix = "openssl-3.5.5",
+        url = "https://vectorized-public.s3.amazonaws.com/dependencies/openssl-3.5.5.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
This pulls in a bug fix for openssl where `SSL_CTX_new` could corrupt the openssl error queue after a partially successful call.

This can happen if the machine redpanda is running on has an `openssl.cnf` file that our current version of the openssl library (openssl-3.0.18) fails to parse. The call stack during the failure is:
```
  SSL_CTX_new_ex()
    -> ssl_ctx_system_config(ctx)            // ssl_mcnf.c
      -> ssl_do_config(ctx, "system_default")
        -> SSL_CONF_cmd("Groups", value)
          -> gid_cb()                        // t1_lib.c
            -> ERR_raise_data(ERR_LIB_SSL, ERR_R_PASSED_INVALID_ARGUMENT,
                              "group '%s' cannot be set", ...)
    // ssl_ctx_system_config is void — ignores the return value
```

During this call chain, openssl attempts to pre-populate the context with Groups settings from the openssl provider, but that fails as the parsing of the groups string fails. However, this failure is silently ignored (only observable through the error on the error queue) while the `SSL_CTX_new_ex` method returns a partially-populated ssl context.

This has been indirectly addressed since openssl-3.4.0, so we can get the fix by upgrading to the 3.5.5 version we have been using for the 26.1 RCs.

Ref: https://github.com/openssl/openssl/commit/21819f78b057c254254646a7854bfad0cd40ed83

Note: this does not yet fix the issue for FIPS builds. We are separately working on a seastar patch to address this for FIPS builds as well.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
### Bug Fixes

* Upgraded OpenSSL to 3.5.5 to fix TLS initialization error handling. Fixed an issue where OpenSSL could leave spurious errors on its internal error queue during TLS context initialization. This could cause subsequent TLS operations to incorrectly report errors or fail unexpectedly.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
