### PR TITLE
ct/l0/gc: Improve prefix range assignment algorithm

### DIFF
--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -901,17 +901,30 @@ level_zero_gc::do_try_to_collect(std::optional<cluster_epoch>& max_gc_epoch) {
 
 std::optional<prefix_range_inclusive>
 compute_prefix_range(size_t shard_idx, size_t total_shards) {
-    auto total_prefixes = object_id::prefix_max + 1;
-    total_shards = std::min(total_shards, static_cast<size_t>(total_prefixes));
-    if (shard_idx >= total_shards) {
+    constexpr size_t total_prefixes = object_id::prefix_max + 1;
+    total_shards = std::min(total_shards, total_prefixes);
+    if (total_shards == 0 || shard_idx >= total_shards) {
         return std::nullopt;
     }
+
+    // Divide prefixes evenly, distributing the remainder one-per-shard across
+    // the first `remainder` shards. E.g. 1000 prefixes / 32 shards:
+    //   stride=31, remainder=8
+    //   shards 0-7:  32 prefixes each (31 + 1 extra)
+    //   shards 8-31: 31 prefixes each
     auto stride = total_prefixes / total_shards;
-    auto min = static_cast<object_id::prefix_t>(shard_idx * stride);
-    auto max = static_cast<object_id::prefix_t>(min + stride - 1);
-    if (shard_idx == total_shards - 1) {
-        max = object_id::prefix_max;
-    }
+    auto remainder = total_prefixes % total_shards;
+
+    auto has_extra = shard_idx < remainder;
+    auto width = stride + (has_extra ? 1 : 0);
+
+    // Each shard before us consumed `stride` prefixes, plus one extra for each
+    // of the first `remainder` shards. The number of extra prefixes already
+    // handed out is min(shard_idx, remainder).
+    auto extras_before = std::min(shard_idx, remainder);
+    auto min = static_cast<object_id::prefix_t>(
+      shard_idx * stride + extras_before);
+    auto max = static_cast<object_id::prefix_t>(min + width - 1);
 
     return prefix_range_inclusive{min, max};
 }

--- a/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
+++ b/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
@@ -593,6 +593,50 @@ TEST_F(PrefixRangeComputationTest, HeterogeneousCompleteCoverage) {
 }
 
 /*
+ * Verify that prefix ranges are balanced: no shard gets more than one extra
+ * prefix compared to any other. Also checks complete, non-overlapping coverage
+ * for several shard counts including 32 (the case that exposed the original
+ * imbalance where the last shard received all leftover prefixes).
+ */
+TEST_F(PrefixRangeComputationTest, BalancedDistribution) {
+    for (size_t total : std::vector<size_t>{
+           2, 3, 7, 10, 24, 32, 41, 64, 128, prefix_max, n_prefixes}) {
+        SCOPED_TRACE(fmt::format("total_shards={}", total));
+
+        std::vector<int> coverage_count(n_prefixes, 0);
+        size_t min_width = std::numeric_limits<size_t>::max();
+        size_t max_width = 0;
+
+        for (size_t shard = 0; shard < total; ++shard) {
+            auto r = cloud_topics::compute_prefix_range(shard, total);
+            ASSERT_TRUE(r.has_value());
+            ASSERT_LE(r->min, r->max);
+            ASSERT_LE(r->max, prefix_max);
+            size_t width = r->max - r->min + 1;
+            min_width = std::min(min_width, width);
+            max_width = std::max(max_width, width);
+
+            for (auto pfx = r->min; pfx <= r->max; ++pfx) {
+                coverage_count[pfx]++;
+            }
+        }
+
+        EXPECT_LE(max_width - min_width, 1) << fmt::format(
+          "Imbalance too large: min_width={}, max_width={}",
+          min_width,
+          max_width);
+
+        for (size_t pfx = 0; pfx < n_prefixes; ++pfx) {
+            EXPECT_EQ(coverage_count[pfx], 1) << fmt::format(
+              "Prefix {} covered {} times (total_shards={})",
+              pfx,
+              coverage_count[pfx],
+              total);
+        }
+    }
+}
+
+/*
  * Base test fixture for prefix-based partitioning tests.
  * Creates a single GC instance per test - do NOT create multiple GC instances.
  */

--- a/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
+++ b/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
@@ -23,6 +23,8 @@ struct gc_test_config {
     std::chrono::milliseconds list_cost{0ms};
     std::chrono::milliseconds delete_cost{0ms};
 };
+constexpr size_t prefix_max = cloud_topics::object_id::prefix_max;
+constexpr size_t n_prefixes = prefix_max + 1;
 } // namespace
 
 class object_storage_test_impl
@@ -481,7 +483,7 @@ void check_range_contents(
 } // namespace
 
 /*
- * With a single shard, it should handle all prefixes [0, 999].
+ * With a single shard, it should handle all prefixes [0, prefix_max].
  */
 TEST_F(PrefixRangeComputationTest, SingleShardCoversAllPrefixes) {
     auto range = cloud_topics::compute_prefix_range(
@@ -509,7 +511,7 @@ TEST_F(PrefixRangeComputationTest, TwoShardsPartitionSpace) {
         auto range = cloud_topics::compute_prefix_range(
           1 /* shard_idx */, 2 /* total_shards */);
         check_range_contents(range);
-        // Second shard: [500, 999]
+        // Second shard: [500, prefix_max]
         EXPECT_EQ(range->min, 500);
         EXPECT_EQ(range->max, cloud_topics::object_id::prefix_max);
     }
@@ -519,7 +521,7 @@ TEST_F(PrefixRangeComputationTest, TwoShardsPartitionSpace) {
  * With 1000 shards (one per prefix), each shard handles exactly one prefix.
  */
 TEST_F(PrefixRangeComputationTest, ThousandShardsOnePerPrefix) {
-    constexpr size_t total = 1000;
+    constexpr size_t total = n_prefixes;
 
     for (size_t i = 0; i < total; ++i) {
         auto range = cloud_topics::compute_prefix_range(
@@ -568,7 +570,7 @@ TEST_F(PrefixRangeComputationTest, MoreShardsThanPrefixes) {
 TEST_F(PrefixRangeComputationTest, HeterogeneousCompleteCoverage) {
     constexpr size_t total = 41;
 
-    std::vector<int> coverage_count(1000, 0);
+    std::vector<int> coverage_count(n_prefixes, 0);
 
     for (size_t shard = 0; shard < total; ++shard) {
         auto r = cloud_topics::compute_prefix_range(
@@ -577,13 +579,14 @@ TEST_F(PrefixRangeComputationTest, HeterogeneousCompleteCoverage) {
         auto [min, max] = r.value();
         EXPECT_GE(min, 0);
         EXPECT_LE(max, cloud_topics::object_id::prefix_max);
-        for (auto prefix = min; prefix <= max && prefix < 1000; ++prefix) {
+        for (auto prefix = min; prefix <= max && prefix < n_prefixes;
+             ++prefix) {
             coverage_count[prefix]++;
         }
     }
 
-    // Verify all prefixes are covered exactlye
-    for (int prefix = 0; prefix < 1000; ++prefix) {
+    // Verify all prefixes are covered exactly once
+    for (size_t prefix = 0; prefix < n_prefixes; ++prefix) {
         EXPECT_EQ(coverage_count[prefix], 1) << fmt::format(
           "Prefix {} covered {} times", prefix, coverage_count[prefix]);
     }
@@ -706,7 +709,7 @@ TEST_P(LevelZeroGCPartitioningTest, ShardOnlyDeletesObjectsInRange) {
     auto [min, max] = range.value();
 
     // Add objects across the full prefix range (every 50th prefix)
-    for (int prefix = 0; prefix <= 999; prefix += 50) {
+    for (size_t prefix = 0; prefix <= prefix_max; prefix += 50) {
         add_listed_with_prefix(prefix, 1);
     }
     sort_listed();
@@ -741,7 +744,7 @@ TEST_P(LevelZeroGCPartitioningTest, PaginationWithinRange) {
     cfg_.list_page_size = 5;
 
     // Add several objects within this shard's range
-    for (auto prefix = min; prefix <= max && prefix < 1000; prefix += 5) {
+    for (auto prefix = min; prefix <= max && prefix < n_prefixes; prefix += 5) {
         for (int i = 0; i < 10; ++i) {
             add_listed_with_prefix(prefix, 1);
         }
@@ -770,7 +773,7 @@ TEST_P(LevelZeroGCPartitioningTest, EpochFilteringWithPartitioning) {
     auto [min, max] = range.value();
 
     // Add objects with various epochs, using prefixes in our range
-    if (min < 1000) {
+    if (min < n_prefixes) {
         add_listed_with_prefix(min, 50);  // epoch 50, eligible
         add_listed_with_prefix(min, 100); // epoch 100, boundary
         add_listed_with_prefix(min, 150); // epoch 150, not eligible
@@ -796,7 +799,7 @@ TEST_P(LevelZeroGCPartitioningTest, AgeFilteringWithPartitioning) {
     ASSERT_TRUE(range.has_value());
     auto [min, max] = range.value();
 
-    if (min < 1000) {
+    if (min < n_prefixes) {
         add_listed_with_prefix(min, 1, 24h); // old enough
         add_listed_with_prefix(
           min + 1 > max ? min : min + 1, 1, 24h); // old enough
@@ -829,9 +832,9 @@ TEST_P(LevelZeroGCPartitioningTest, NoObjectsInRange) {
         // Add objects before our range
         add_listed_with_prefix(0, 1);
     }
-    if (max < 999) {
+    if (max < prefix_max) {
         // Add objects after our range
-        add_listed_with_prefix(999, 1);
+        add_listed_with_prefix(prefix_max, 1);
     }
     sort_listed();
 
@@ -855,7 +858,7 @@ TEST_P(LevelZeroGCPartitioningTest, ObjectsAtBoundaries) {
     // Add object at min boundary
     add_listed_with_prefix(min, 1);
     // Add object at max boundary
-    if (max < 1000) {
+    if (max < n_prefixes) {
         add_listed_with_prefix(max, 1);
     }
     sort_listed();
@@ -877,7 +880,7 @@ INSTANTIATE_TEST_SUITE_P(
   testing::Values(
     std::make_tuple(0, 1),  // Single shard covering all prefixes
     std::make_tuple(0, 2),  // First half [0, 500)
-    std::make_tuple(1, 2),  // Second half [500, 999]
+    std::make_tuple(1, 2),  // Second half [500, prefix_max]
     std::make_tuple(0, 10), // First range [0, 100)
     std::make_tuple(4, 10), // Middle range [400, 500)
     std::make_tuple(23, 24) // Last shard (handles remainder)


### PR DESCRIPTION
The number of shards in a cluster is not guaranteed to divide the total number of object prefixes, so we should make an effort to distribute the remainder (total_prefixes % total_shards) across the shards. Previously we would assign the entire remainder to the highest-indexed shard, creating an imbalance of GC work.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
