### PR TITLE
testing/gbac: add stub OIDC provider and group claim integration tests

### DIFF
--- a/tests/rptest/remote_scripts/stub_oidc_provider.py
+++ b/tests/rptest/remote_scripts/stub_oidc_provider.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import base64
+import http.server
+import json
+import signal
+import socketserver
+import time
+from types import FrameType
+from typing import Any
+from urllib.parse import parse_qs
+
+from cryptography.hazmat.primitives.asymmetric.rsa import (
+    RSAPrivateKey,
+    RSAPublicKey,
+    generate_private_key,
+)
+import jwt as pyjwt
+
+
+KID = "stub-key-1"
+AUDIENCE = "redpanda"
+
+
+def base64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def generate_rsa_keypair() -> tuple[RSAPrivateKey, RSAPublicKey]:
+    private_key = generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+    return private_key, public_key
+
+
+def public_key_to_jwk(public_key: RSAPublicKey, kid: str) -> dict[str, str]:
+    public_numbers = public_key.public_numbers()
+    n_bytes = public_numbers.n.to_bytes((public_numbers.n.bit_length() + 7) // 8, "big")
+    e_bytes = public_numbers.e.to_bytes((public_numbers.e.bit_length() + 7) // 8, "big")
+    return {
+        "kty": "RSA",
+        "alg": "RS256",
+        "use": "sig",
+        "kid": kid,
+        "n": base64url_encode(n_bytes),
+        "e": base64url_encode(e_bytes),
+    }
+
+
+class BaseHandler(http.server.BaseHTTPRequestHandler):
+    def log_request(self, *args: Any, **kwargs: Any) -> None:
+        return
+
+    def json_log(self, response_code: int) -> None:
+        log_item = {
+            "path": self.path,
+            "method": self.command,
+            "response_code": response_code,
+        }
+        print(json.dumps(log_item), flush=True)
+
+    def send_json(self, data: dict[str, Any], status: int = 200) -> None:
+        body = json.dumps(data).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+        self.json_log(status)
+
+
+def make_handler(
+    private_key: RSAPrivateKey,
+    public_key: RSAPublicKey,
+    issuer: str,
+    token_lifetime: int,
+) -> type[BaseHandler]:
+    jwk = public_key_to_jwk(public_key, KID)
+    jwks_doc: dict[str, list[dict[str, str]]] = {"keys": [jwk]}
+    clients: dict[str, dict[str, Any]] = {}
+
+    class OIDCHandler(BaseHandler):
+        def do_GET(self) -> None:
+            if self.path == "/.well-known/openid-configuration":
+                self.send_json(
+                    {
+                        "issuer": issuer,
+                        "jwks_uri": f"{issuer}/jwks",
+                        "token_endpoint": f"{issuer}/token",
+                    }
+                )
+            elif self.path == "/jwks":
+                self.send_json(jwks_doc)
+            else:
+                self.send_response(404)
+                self.end_headers()
+                self.json_log(404)
+
+        def do_POST(self) -> None:
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length).decode("utf-8")
+
+            if self.path == "/register":
+                data = json.loads(body)
+                client_id = data["client_id"]
+                clients[client_id] = {
+                    "secret": data.get("client_secret", "stub-secret"),
+                    "claims": data.get("claims", {}),
+                }
+                self.send_json({"status": "registered", "client_id": client_id})
+
+            elif self.path == "/token":
+                params = parse_qs(body)
+                client_id = params.get("client_id", [None])[0]
+
+                if client_id is None or client_id not in clients:
+                    self.send_json({"error": "invalid_client"}, status=400)
+                    return
+
+                now = time.time()
+                payload = {
+                    "iss": issuer,
+                    "aud": AUDIENCE,
+                    "iat": int(now),
+                    "exp": int(now) + token_lifetime,
+                }
+                # Merge registered claims as-is — no validation
+                payload.update(clients[client_id]["claims"])
+
+                token = pyjwt.encode(
+                    payload,
+                    private_key,
+                    algorithm="RS256",
+                    headers={"kid": KID},
+                )
+
+                self.send_json(
+                    {
+                        "access_token": token,
+                        "token_type": "bearer",
+                        "expires_in": token_lifetime,
+                    }
+                )
+            else:
+                self.send_response(404)
+                self.end_headers()
+                self.json_log(404)
+
+    return OIDCHandler
+
+
+def main() -> None:
+    import argparse
+    import socket
+
+    parser = argparse.ArgumentParser(description="Stub OIDC Provider")
+    parser.add_argument("--port", type=int, default=8090)
+    parser.add_argument("--issuer", type=str, default=None)
+    parser.add_argument("--token-lifetime", type=int, default=3600)
+    options = parser.parse_args()
+
+    if options.issuer is None:
+        hostname = socket.getfqdn()
+        options.issuer = f"http://{hostname}:{options.port}"
+
+    private_key, public_key = generate_rsa_keypair()
+    handler = make_handler(
+        private_key, public_key, options.issuer, options.token_lifetime
+    )
+
+    class ReuseAddressTcpServer(socketserver.TCPServer):
+        allow_reuse_address = True
+
+    with ReuseAddressTcpServer(("", options.port), handler) as httpd:
+
+        def _stop(_signum: int, _frame: FrameType | None) -> None:
+            httpd.server_close()
+            exit(0)
+
+        signal.signal(signal.SIGTERM, _stop)
+        print(
+            json.dumps(
+                {"status": "ready", "port": options.port, "issuer": options.issuer}
+            ),
+            flush=True,
+        )
+        httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/rptest/services/stub_oidc_provider.py
+++ b/tests/rptest/services/stub_oidc_provider.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import requests
+from ducktape.cluster.cluster import ClusterNode
+from ducktape.cluster.remoteaccount import RemoteCommandError
+from ducktape.tests.test import TestContext
+from ducktape.utils.util import wait_until
+
+from rptest.services.http_server import HttpServer
+from rptest.services.keycloak import OAuthConfig
+from rptest.util import inject_remote_script
+
+
+SCRIPT_NAME = "stub_oidc_provider.py"
+
+
+class StubOIDCProvider(HttpServer):
+    LOG_DIR = "/tmp/stub_oidc_provider"
+    STDOUT_CAPTURE = os.path.join(LOG_DIR, "stub_oidc_provider.stdout")
+
+    logs: dict[str, dict[str, Any]] = {
+        "stub_oidc_provider_stdout": {
+            "path": STDOUT_CAPTURE,
+            "collect_default": True,
+        },
+    }
+
+    def __init__(
+        self, context: TestContext, port: int = 8090, token_lifetime: int = 3600
+    ) -> None:
+        super(HttpServer, self).__init__(context, 1)
+        self.port = port
+        self.token_lifetime = token_lifetime
+        self.stop_timeout_sec = 5
+        self.requests: list[dict[str, Any]] = []
+        self.hostname: str = self.nodes[0].account.hostname
+        self.address = f"{self.hostname}:{self.port}"
+        self.url = f"http://{self.address}"
+        self.remote_script_path: str | None = None
+
+    def _worker(self, idx: int, node: ClusterNode) -> None:
+        node.account.ssh(f"mkdir -p {self.LOG_DIR}", allow_fail=False)
+        self.remote_script_path = inject_remote_script(node, SCRIPT_NAME)
+        cmd = (
+            f"python3 -u {self.remote_script_path} "
+            f"--port {self.port} "
+            f"--token-lifetime {self.token_lifetime} 2>&1"
+        )
+        cmd += f" | tee -a {self.STDOUT_CAPTURE} &"
+
+        self.logger.debug(f"Starting stub OIDC provider {self.url}")
+        for line in node.account.ssh_capture(cmd):
+            self.logger.debug(f"stub_oidc: {line}")
+            parsed: dict[str, Any] | None = self.try_parse_json(node, line.strip())  # type: ignore[assignment]
+            if parsed is not None:
+                if "response_code" in parsed:
+                    self.requests.append(parsed)
+
+    def pids(self, node: ClusterNode) -> list[int]:
+        try:
+            cmd = f"ps ax | grep {SCRIPT_NAME} | grep -v grep | awk '{{print $1}}'"
+            pid_arr: list[int] = [
+                pid  # type: ignore[misc]
+                for pid in node.account.ssh_capture(cmd, allow_fail=True, callback=int)
+            ]
+            return pid_arr
+        except (RemoteCommandError, ValueError):
+            return []
+
+    def wait_ready(self, timeout_sec: int = 30) -> None:
+        wait_until(
+            lambda: self._is_ready(),
+            timeout_sec=timeout_sec,
+            backoff_sec=1,
+            err_msg="Stub OIDC provider did not become ready",
+        )
+
+    def _is_ready(self) -> bool:
+        try:
+            resp = requests.get(
+                f"{self.url}/.well-known/openid-configuration", timeout=2
+            )
+            return resp.status_code == 200
+        except Exception:
+            return False
+
+    def register_client(
+        self, client_id: str, claims: dict[str, Any], client_secret: str = "stub-secret"
+    ) -> Any:
+        resp = requests.post(
+            f"{self.url}/register",
+            json={
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "claims": claims,
+            },
+            timeout=5,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def generate_oauth_config(
+        self, node: ClusterNode, client_id: str, client_secret: str = "stub-secret"
+    ) -> OAuthConfig:
+        return OAuthConfig(
+            client_id=client_id,
+            client_secret=client_secret,
+            token_endpoint=f"http://{node.account.hostname}:{self.port}/token",
+        )
+
+    def get_access_token(
+        self, client_id: str, client_secret: str = "stub-secret"
+    ) -> str:
+        """Request an access token for a registered client."""
+        resp = requests.post(
+            f"{self.url}/token",
+            data={"client_id": client_id, "client_secret": client_secret},
+            timeout=5,
+        )
+        resp.raise_for_status()
+        return resp.json()["access_token"]
+
+    def get_discovery_url(self, node: ClusterNode) -> str:
+        return f"http://{node.account.hostname}:{self.port}/.well-known/openid-configuration"

--- a/tests/rptest/tests/gbac_claim_test.py
+++ b/tests/rptest/tests/gbac_claim_test.py
@@ -1,0 +1,1016 @@
+from __future__ import annotations
+
+from typing import Any
+
+from confluent_kafka import KafkaError, Message, Producer
+from confluent_kafka.error import KafkaException
+from ducktape.tests.test import Test, TestContext
+from ducktape.utils.util import wait_until
+
+from rptest.clients.admin.proto.redpanda.core.admin.v2 import security_pb2
+from rptest.clients.admin.v2 import Admin as AdminV2
+from rptest.clients.python_librdkafka import PythonLibrdkafka
+from confluent_kafka.admin import (
+    AclBinding,
+    AclOperation,
+    AclPermissionType,
+    ResourcePatternType,
+    ResourceType,
+)
+from rptest.clients.rpk import RpkTool
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import (
+    LoggingConfig,
+    SecurityConfig,
+    make_redpanda_service,
+)
+from rptest.services.stub_oidc_provider import StubOIDCProvider
+
+
+class StubOIDCTestBase(Test):
+    """Base class for GBAC tests using StubOIDCProvider instead of Keycloak."""
+
+    def __init__(
+        self, test_context: TestContext, num_nodes: int = 4, **kwargs: Any
+    ) -> None:
+        super().__init__(test_context, **kwargs)
+        num_brokers = num_nodes - 1
+        self.stub_idp = StubOIDCProvider(test_context)
+
+        security = SecurityConfig()
+        security.enable_sasl = True
+        security.sasl_mechanisms = ["SCRAM", "OAUTHBEARER"]
+        security.http_authentication = ["BASIC", "OIDC"]
+
+        stub_node = self.stub_idp.nodes[0]
+
+        self.redpanda = make_redpanda_service(
+            test_context,
+            num_brokers,
+            extra_rp_conf={
+                "oidc_discovery_url": self.stub_idp.get_discovery_url(stub_node),
+                "oidc_token_audience": "redpanda",
+            },
+            security=security,
+            log_config=LoggingConfig(
+                "info",
+                logger_levels={
+                    "security": "trace",
+                    "kafka/client": "trace",
+                    "kafka": "debug",
+                },
+            ),
+        )
+
+        self.su_username, self.su_password, self.su_algorithm = (
+            self.redpanda.SUPERUSER_CREDENTIALS
+        )
+
+        self.rpk = RpkTool(
+            self.redpanda,
+            username=self.su_username,
+            password=self.su_password,
+            sasl_mechanism=self.su_algorithm,
+        )
+
+    def setUp(self) -> None:
+        self.stub_idp.start()
+        self.stub_idp.wait_ready()
+        self.redpanda.start()
+
+    def make_producer(
+        self, client_id: str, client_secret: str = "stub-secret"
+    ) -> Producer:
+        """Create a Kafka producer authenticated via the stub OIDC provider."""
+        stub_node = self.stub_idp.nodes[0]
+        cfg = self.stub_idp.generate_oauth_config(stub_node, client_id, client_secret)
+        k_client = PythonLibrdkafka(
+            self.redpanda,
+            algorithm="OAUTHBEARER",
+            oauth_config=cfg,
+        )
+        producer = k_client.get_producer()
+        producer.poll(0.0)
+        return producer
+
+    def _try_produce(self, producer: Producer, topic: str) -> KafkaError | None:
+        """Produce a message and return the delivery error, or None on success."""
+        errors: list[KafkaError | None] = []
+
+        def _on_delivery(err: KafkaError | None, _msg: Message) -> None:
+            errors.append(err)
+
+        producer.produce(
+            topic,
+            b"test",
+            on_delivery=_on_delivery,
+        )
+        producer.flush(timeout=10)
+        assert len(errors) > 0, "Expected delivery callback but got none"
+        return errors[0]
+
+    def wait_until_produce_succeeds(
+        self, producer: Producer, topic: str, err_msg: str
+    ) -> None:
+        """Retry producing until it succeeds (ACL propagation may be delayed)."""
+        wait_until(
+            lambda: self._try_produce(producer, topic) is None,
+            timeout_sec=10,
+            backoff_sec=1,
+            err_msg=err_msg,
+        )
+
+    def assert_produce_denied(self, producer: Producer, topic: str) -> None:
+        """Assert that producing to the topic fails with TOPIC_AUTHORIZATION_FAILED."""
+        err = self._try_produce(producer, topic)
+        assert err is not None, (
+            f"Expected produce to {topic} to be denied, but it succeeded"
+        )
+        assert err.code() == KafkaError.TOPIC_AUTHORIZATION_FAILED, (
+            f"Expected TOPIC_AUTHORIZATION_FAILED, got {err}"
+        )
+
+    def resolve_oidc_identity(
+        self, client_id: str, client_secret: str = "stub-secret"
+    ) -> security_pb2.ResolveOidcIdentityResponse:
+        """Get a token and resolve the OIDC identity via Admin API v2."""
+        token = self.stub_idp.get_access_token(client_id, client_secret)
+        admin_v2 = AdminV2(self.redpanda)
+        req = security_pb2.ResolveOidcIdentityRequest()
+        return admin_v2.security().resolve_oidc_identity(
+            req,
+            extra_headers={"Authorization": f"Bearer {token}"},
+        )
+
+
+class GbacGroupClaimFormatTest(StubOIDCTestBase):
+    """Tests for various group claim formats in OIDC tokens."""
+
+    @cluster(num_nodes=4)
+    def test_json_array_groups(self) -> None:
+        """Groups as JSON array. Each element becomes a group."""
+        client_id = "array-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "array-user",
+                "groups": ["eng", "fin"],
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert sorted(resp.groups) == ["eng", "fin"]
+
+        topic = "array-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:eng", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.wait_until_produce_succeeds(
+            producer,
+            topic,
+            "JSON array group should grant topic access",
+        )
+
+    @cluster(num_nodes=4)
+    def test_csv_groups(self) -> None:
+        """Groups as CSV string. Split into individual groups."""
+        client_id = "csv-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "csv-user",
+                "groups": "eng,fin",
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert sorted(resp.groups) == ["eng", "fin"]
+
+        topic = "csv-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:eng", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.wait_until_produce_succeeds(
+            producer,
+            topic,
+            "CSV group string should grant topic access",
+        )
+
+    @cluster(num_nodes=4)
+    def test_csv_groups_with_whitespace(self) -> None:
+        """CSV string with whitespace around entries. Whitespace is
+        trimmed."""
+        client_id = "csv-ws-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "csv-ws-user",
+                "groups": "eng , fin",
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert sorted(resp.groups) == ["eng", "fin"]
+
+        topic = "csv-ws-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:eng", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.wait_until_produce_succeeds(
+            producer,
+            topic,
+            "CSV with whitespace should be trimmed and grant access",
+        )
+
+    @cluster(num_nodes=4)
+    def test_csv_groups_with_empty_entries(self) -> None:
+        """CSV string with consecutive commas. Empty entries produce empty
+        group strings, but valid groups still match."""
+        client_id = "csv-empty-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "csv-empty-user",
+                "groups": "eng,,,fin",
+            },
+        )
+
+        expected_groups = ["", "", "eng", "fin"]
+        resp = self.resolve_oidc_identity(client_id)
+        assert sorted(resp.groups) == expected_groups
+
+        topic = "csv-empty-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:eng", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.wait_until_produce_succeeds(
+            producer,
+            topic,
+            "CSV with empty entries should still parse valid groups",
+        )
+
+    @cluster(num_nodes=4)
+    def test_empty_array_groups(self) -> None:
+        """Empty group array. No groups extracted."""
+        client_id = "empty-array-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "empty-user",
+                "groups": [],
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert len(resp.groups) == 0
+
+        topic = "empty-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:eng", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.assert_produce_denied(producer, topic)
+
+    @cluster(num_nodes=4)
+    def test_very_long_group_name(self) -> None:
+        """Very long group name (1000+ chars)."""
+        long_group = "a" * 1000
+        client_id = "long-name-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "long-user",
+                "groups": [long_group],
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert list(resp.groups) == [long_group]
+
+        topic = "long-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal(f"Group:{long_group}", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.wait_until_produce_succeeds(
+            producer,
+            topic,
+            "Very long group name should work",
+        )
+
+    @cluster(num_nodes=4)
+    def test_groups_as_objects(self) -> None:
+        """Groups as array of objects. Entire group claim discarded."""
+        client_id = "obj-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "obj-user",
+                "groups": [{"name": "eng"}],
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert len(resp.groups) == 0
+
+        topic = "obj-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:eng", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.assert_produce_denied(producer, topic)
+
+
+class GbacGroupClaimPathTest(StubOIDCTestBase):
+    """Tests for group claim path resolution with various oidc_group_claim_path configs."""
+
+    @cluster(num_nodes=4)
+    def test_nested_claim_path(self) -> None:
+        """Nested claim path set. Groups extracted successfully."""
+        self.redpanda.set_cluster_config(
+            {
+                "oidc_group_claim_path": "$.realm_access.groups",
+            }
+        )
+
+        client_id = "nested-path-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "nested-user",
+                "realm_access": {"groups": ["admin"]},
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert list(resp.groups) == ["admin"]
+
+        topic = "nested-path-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:admin", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.wait_until_produce_succeeds(
+            producer,
+            topic,
+            "Nested claim path should extract groups",
+        )
+
+    @cluster(num_nodes=4)
+    def test_claim_path_missing(self) -> None:
+        """Claim path missing from token. No groups extracted."""
+        client_id = "no-groups-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "no-groups-user",
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert len(resp.groups) == 0
+
+        topic = "no-groups-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:eng", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.assert_produce_denied(producer, topic)
+
+
+class GbacMalformedGroupClaimTest(StubOIDCTestBase):
+    """Tests for invalid or malformed group claims (fail-safe behavior)."""
+
+    @cluster(num_nodes=4)
+    def test_arbitrary_string(self) -> None:
+        """Groups as non-CSV string with semicolon. Treated as single
+        literal group, not split."""
+        client_id = "arb-str-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "arb-str-user",
+                "groups": "eng;fin",
+            },
+        )
+
+        # Not CSV (no comma), so treated as single group "eng;fin".
+        resp = self.resolve_oidc_identity(client_id)
+        assert "eng" not in resp.groups
+
+        topic = "arb-str-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:eng", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.assert_produce_denied(producer, topic)
+
+        topic = "arb-str-topic2"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:eng;fin", ["all"], "topic", topic)
+        self.wait_until_produce_succeeds(
+            producer,
+            topic,
+            "Group name with semicolon should match literally",
+        )
+
+    @cluster(num_nodes=4)
+    def test_groups_as_number(self) -> None:
+        """Groups claim is a number. No groups extracted."""
+        client_id = "num-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "num-user",
+                "groups": 42,
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert len(resp.groups) == 0
+
+        topic = "num-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:42", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.assert_produce_denied(producer, topic)
+
+    @cluster(num_nodes=4)
+    def test_groups_as_object(self) -> None:
+        """Groups claim is an object. No groups extracted."""
+        client_id = "obj-bad-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "obj-bad-user",
+                "groups": {"key": "val"},
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert len(resp.groups) == 0
+
+        topic = "obj-bad-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:val", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.assert_produce_denied(producer, topic)
+
+    @cluster(num_nodes=4)
+    def test_mixed_type_array(self) -> None:
+        """Mixed-type group array with strings, numbers, and nulls. Entire
+        array rejected."""
+        client_id = "mixed-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "mixed-user",
+                "groups": ["eng", 42, None],
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert len(resp.groups) == 0
+
+        topic = "mixed-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:eng", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.assert_produce_denied(producer, topic)
+
+    @cluster(num_nodes=4)
+    def test_very_large_group_list(self) -> None:
+        """Very large group list (1050 groups). Stable parsing, access
+        granted for matching group."""
+        groups = [f"g{i}" for i in range(1050)]
+        client_id = "large-list-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "large-user",
+                "groups": groups,
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert len(resp.groups) == 1050
+        assert "g500" in resp.groups
+
+        topic = "large-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:g500", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.wait_until_produce_succeeds(
+            producer,
+            topic,
+            "Large group list should still grant access for matching group",
+        )
+
+
+class GbacGroupNameEdgeCaseTest(StubOIDCTestBase):
+    """Tests for group name edge cases (case, unicode, special chars, etc)."""
+
+    @cluster(num_nodes=4)
+    def test_case_mismatch(self) -> None:
+        """Case mismatch between token group and ACL. Exact match required."""
+        client_id = "case-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "case-user",
+                "groups": ["Eng"],
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert list(resp.groups) == ["Eng"]
+
+        topic = "case-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:eng", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.assert_produce_denied(producer, topic)
+
+    @cluster(num_nodes=4)
+    def test_unicode_group_name(self) -> None:
+        """Unicode group name supported."""
+        group = "ingeniería"
+        client_id = "unicode-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "unicode-user",
+                "groups": [group],
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert list(resp.groups) == [group]
+
+        topic = "unicode-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal(f"Group:{group}", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.wait_until_produce_succeeds(
+            producer,
+            topic,
+            "Unicode group name should match correctly",
+        )
+
+    @cluster(num_nodes=4)
+    def test_special_characters(self) -> None:
+        """Special characters in group name supported."""
+        group = "eng@dev#1"
+        client_id = "special-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "special-user",
+                "groups": [group],
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert list(resp.groups) == [group]
+
+        topic = "special-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal(f"Group:{group}", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.wait_until_produce_succeeds(
+            producer,
+            topic,
+            "Special character group name should match correctly",
+        )
+
+    @cluster(num_nodes=4)
+    def test_comma_in_group_name_array(self) -> None:
+        """Group name with comma in JSON array form. Comma preserved as
+        part of group name."""
+        group = "eng,fin"
+        client_id = "comma-array-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "comma-array-user",
+                "groups": [group],
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert list(resp.groups) == [group]
+
+        topic = "comma-array-topic"
+        self.rpk.create_topic(topic)
+        # rpk's --allow-principal flag treats commas as delimiters between
+        # multiple principals. Without quoting, "Group:eng,fin" would be
+        # split into two ACL entries: Group:eng and User:fin (the second
+        # defaulting to User type since it lacks a prefix). This is
+        # rpk-specific behavior — the underlying Kafka protocol handles
+        # commas in principal names without issue. CSV-style double quotes
+        # prevent rpk from splitting on the comma.
+        self.rpk.sasl_allow_principal(f'"Group:{group}"', ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.wait_until_produce_succeeds(
+            producer,
+            topic,
+            "Comma in group name (array form) should be supported",
+        )
+
+    @cluster(num_nodes=4)
+    def test_newline_tab_in_group_name(self) -> None:
+        """Group names with newline/tab characters. Parsed without crashing,
+        but access denied because the broker rejects ACL creation for
+        principals containing control characters."""
+        nl_group = "eng\nfin"
+        tab_group = "admin\tstaff"
+        client_id = "ctrl-char-test"
+        groups = [nl_group, tab_group]
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "ctrl-char-user",
+                "groups": groups,
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert sorted(resp.groups) == sorted(groups), (
+            f"Expected groups {groups}, got {list(resp.groups)}"
+        )
+
+        # The broker rejects ACL creation for principals with control characters,
+        # so no matching ACL can exist and access is denied. Instead, create an
+        # ACL for the literal group name to verify it doesn't match the control chars
+        # and grant access.
+        topic = "ctrl-char-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:eng", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.assert_produce_denied(producer, topic)
+
+    @cluster(num_nodes=4)
+    def test_empty_string_group(self) -> None:
+        """Empty string group. Passed through as-is, but access denied
+        because the broker rejects ACL creation for empty principal names."""
+        client_id = "empty-str-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "empty-str-user",
+                "groups": [""],
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert resp.groups == [""]
+
+        topic = "empty-str-topic"
+        self.rpk.create_topic(topic)
+
+        # Use the Kafka API directly to verify the broker rejects an ACL with
+        # an empty principal name. Using Kafka API instead of rpk because rpk
+        # silently exits 0 for this case, but the Kafka protocol returns INVALID_REQUEST.
+        su_client = PythonLibrdkafka(
+            self.redpanda,
+            username=self.su_username,
+            password=self.su_password,
+            algorithm=self.su_algorithm,
+        )
+        admin = su_client.get_client()
+        binding = AclBinding(
+            restype=ResourceType.TOPIC,
+            name=topic,
+            resource_pattern_type=ResourcePatternType.LITERAL,
+            principal="Group:",
+            host="*",
+            operation=AclOperation.ALL,
+            permission_type=AclPermissionType.ALLOW,
+        )
+        results = admin.create_acls([binding])  # type: ignore[reportUnknownMemberType]
+        for _, fut in results.items():
+            try:
+                fut.result()
+                assert False, "Expected KafkaException for empty principal name"
+            except KafkaException as e:
+                assert "INVALID_REQUEST" in str(e)
+
+        # No ACL was created, so produce is denied.
+        producer = self.make_producer(client_id)
+        self.assert_produce_denied(producer, topic)
+
+    @cluster(num_nodes=4)
+    def test_duplicate_groups(self) -> None:
+        """Duplicate groups in array are not deduplicated."""
+        client_id = "dup-test"
+        groups = ["admin", "admin"]
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "dup-user",
+                "groups": groups,
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert list(resp.groups) == groups
+
+        allowed_topic = "allowed-topic"
+        self.rpk.create_topic(allowed_topic)
+        self.rpk.sasl_allow_principal("Group:admin", ["all"], "topic", allowed_topic)
+
+        producer = self.make_producer(client_id)
+        self.wait_until_produce_succeeds(
+            producer,
+            allowed_topic,
+            "Produce should succeed.",
+        )
+
+
+class GbacNestedGroupTest(StubOIDCTestBase):
+    """Tests for nested_group_behavior config (none vs suffix modes)."""
+
+    @cluster(num_nodes=4)
+    def test_none_mode_full_path_match(self) -> None:
+        """Nested path with nested_group_behavior set to none. Full path is the literal group name."""
+        self.redpanda.set_cluster_config({"nested_group_behavior": "none"})
+
+        client_id = "none-full-path-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "none-full-path-user",
+                "groups": ["a/b/c"],
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert list(resp.groups) == ["a/b/c"]
+
+        topic = "none-full-path-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:a/b/c", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.wait_until_produce_succeeds(
+            producer,
+            topic,
+            "Full path group 'a/b/c' should match ACL on Group:a/b/c in none mode",
+        )
+
+    @cluster(num_nodes=4)
+    def test_none_mode_suffix_no_match(self) -> None:
+        """Nested path with nested_group_behavior set to none. ACL on suffix only.
+        Suffix extraction does not happen."""
+        self.redpanda.set_cluster_config({"nested_group_behavior": "none"})
+
+        client_id = "none-suffix-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "none-suffix-user",
+                "groups": ["a/b/c"],
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert list(resp.groups) == ["a/b/c"]
+
+        topic = "none-suffix-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:c", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.assert_produce_denied(producer, topic)
+
+    @cluster(num_nodes=4)
+    def test_suffix_mode_extracts_last_segment(self) -> None:
+        """Nested path with nested_group_behavior set to suffix. Last segment is extracted."""
+        self.redpanda.set_cluster_config({"nested_group_behavior": "suffix"})
+
+        client_id = "sfx-extract-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "sfx-extract-user",
+                "groups": ["a/b/c"],
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert list(resp.groups) == ["c"]
+
+        topic = "sfx-extract-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:c", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.wait_until_produce_succeeds(
+            producer,
+            topic,
+            "Suffix mode should extract last segment 'c' from 'a/b/c' and grant access",
+        )
+
+    @cluster(num_nodes=4)
+    def test_suffix_mode_trailing_slash(self) -> None:
+        """Trailing slash in suffix mode. Last segment is empty."""
+        self.redpanda.set_cluster_config({"nested_group_behavior": "suffix"})
+
+        client_id = "sfx-trailing-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "sfx-trailing-user",
+                "groups": ["a/b/"],
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert list(resp.groups) == [""]
+
+        topic = "sfx-trailing-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:b", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.assert_produce_denied(producer, topic)
+
+    @cluster(num_nodes=4)
+    def test_suffix_mode_collision(self) -> None:
+        """Multiple nested paths with same suffix in suffix mode. Both
+        collapse to same group (duplicated)."""
+        self.redpanda.set_cluster_config({"nested_group_behavior": "suffix"})
+
+        client_id = "sfx-collide-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "sfx-collide-user",
+                "groups": ["deptA/admin", "deptB/admin"],
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert list(resp.groups) == ["admin", "admin"]
+
+        topic = "sfx-collide-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:admin", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.wait_until_produce_succeeds(
+            producer,
+            topic,
+            "Suffix 'admin' from both 'deptA/admin' and 'deptB/admin' should grant access",
+        )
+
+
+class GbacMultiGroupTest(StubOIDCTestBase):
+    """Tests for multiple group membership and ACL union behavior."""
+
+    @cluster(num_nodes=4)
+    def test_union_of_group_permissions(self) -> None:
+        """Two groups with ACLs on different topics. Union of permissions
+        grants access to both."""
+        client_id = "union-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "union-user",
+                "groups": ["eng", "fin"],
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert sorted(resp.groups) == ["eng", "fin"]
+
+        topic_eng = "union-eng-topic"
+        self.rpk.create_topic(topic_eng)
+        self.rpk.sasl_allow_principal("Group:eng", ["all"], "topic", topic_eng)
+
+        topic_fin = "union-fin-topic"
+        self.rpk.create_topic(topic_fin)
+        self.rpk.sasl_allow_principal("Group:fin", ["all"], "topic", topic_fin)
+
+        producer = self.make_producer(client_id)
+        self.wait_until_produce_succeeds(
+            producer,
+            topic_eng,
+            "eng group ACL should grant access to eng topic",
+        )
+        self.wait_until_produce_succeeds(
+            producer,
+            topic_fin,
+            "fin group ACL should grant access to fin topic",
+        )
+
+    @cluster(num_nodes=4)
+    def test_one_matching_group_grants_access(self) -> None:
+        """Two groups, only one has an ACL. One matching group is sufficient
+        for access."""
+        client_id = "one-match-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "one-match-user",
+                "groups": ["eng", "noacl"],
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert sorted(resp.groups) == ["eng", "noacl"]
+
+        topic = "one-match-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:eng", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.wait_until_produce_succeeds(
+            producer,
+            topic,
+            "One matching group should be sufficient for access",
+        )
+
+    @cluster(num_nodes=4)
+    def test_group_without_acl_no_access(self) -> None:
+        """Group with no matching ACL. Access denied."""
+        client_id = "no-acl-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "no-acl-user",
+                "groups": ["noacl"],
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert list(resp.groups) == ["noacl"]
+
+        topic = "no-acl-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:eng", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.assert_produce_denied(producer, topic)
+
+    @cluster(num_nodes=4)
+    def test_wildcard_group_acl_rejected(self) -> None:
+        """Wildcard Group:* ACL creation. Rejected by broker, only User:*
+        wildcards are allowed."""
+        client_id = "wildcard-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "wildcard-user",
+                "groups": ["eng"],
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert list(resp.groups) == ["eng"]
+
+        topic = "wildcard-topic"
+        self.rpk.create_topic(topic)
+
+        # Use the Kafka admin API directly to verify the broker rejects
+        # Group:* ACL creation. rpk does not surface this error clearly.
+        su_client = PythonLibrdkafka(
+            self.redpanda,
+            username=self.su_username,
+            password=self.su_password,
+            algorithm=self.su_algorithm,
+        )
+        admin = su_client.get_client()
+        binding = AclBinding(
+            restype=ResourceType.TOPIC,
+            name=topic,
+            resource_pattern_type=ResourcePatternType.LITERAL,
+            principal="Group:*",
+            host="*",
+            operation=AclOperation.ALL,
+            permission_type=AclPermissionType.ALLOW,
+        )
+        results = admin.create_acls([binding])  # type: ignore[reportUnknownMemberType]
+        for _, fut in results.items():
+            try:
+                fut.result()
+                assert False, "Expected KafkaException for wildcard Group:*"
+            except KafkaException as e:
+                assert "INVALID_REQUEST" in str(e)
+
+        # No ACL was created, so produce is denied.
+        producer = self.make_producer(client_id)
+        self.assert_produce_denied(producer, topic)


### PR DESCRIPTION
Adds a lightweight stub OIDC provider and a comprehensive suite of ducktape integration tests for GBAC's OIDC group claim parsing.

The existing GBAC tests use Keycloak, which is limits the ability to test arbitrary claim shapes (malformed types, edge-case group names, unusual nesting). The stub OIDC provider is a minimal HTTP server that generates RSA-signed JWTs with caller-specified claims, making it possible to inject any claim structure.

### Stub OIDC Provider

The provider implements three OIDC endpoints (discovery, JWKS, token) plus a `/register` endpoint for dynamic client registration with arbitrary claims. Claims are merged into the JWT payload as-is. The ducktape service wrapper manages remote deployment, lifecycle, and provides helpers for client registration and token retrieval.

### Integration Tests (30 tests across 6 classes)
These tests correspond to [scenarios listed here](https://redpandadata.atlassian.net/wiki/spaces/QE/pages/1613103105/GBAC+Test+cases+results+and+automation+info).

All tests follow the same pattern: register a client with specific claims, call the Admin v2 `resolve_oidc_identity` API to assert parsed groups, then verify access via a Kafka producer against Group ACLs.

- **GbacGroupClaimFormatTest**: JSON arrays, CSV strings (whitespace trimming, empty entries), empty arrays, long names, objects.
- **GbacGroupClaimPathTest**: nested JSONPath resolution and missing paths.
- **GbacMalformedGroupClaimTest**: numbers, objects, mixed-type arrays, non-comma delimiters, very large group lists.
- **GbacGroupNameEdgeCaseTest**: case sensitivity, unicode, special chars, commas in names, control characters, empty strings, duplicates.
- **GbacNestedGroupTest**: `nested_group_behavior` none vs suffix modes, trailing slash, suffix collision.
- **GbacMultiGroupTest**: multi-group ACL union, single match sufficiency, wildcard `Group:*` rejection.

## Backports Required
- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none