### PR TITLE
cloud_topics/l1: re-land lookahead buffer for object lookup

### DIFF
--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -905,12 +905,37 @@ db_domain_manager::get_extent_metadata(rpc::get_extent_metadata_request req) {
         }
         const auto& extent = row.value();
         auto key = extent_row_key::decode(extent.key);
-        extents.push_back(
-          rpc::extent_metadata{
-            .base_offset = key->base_offset,
-            .last_offset = extent.val.last_offset,
-            .max_timestamp = extent.val.max_timestamp,
-          });
+        rpc::extent_metadata em{
+          .base_offset = key->base_offset,
+          .last_offset = extent.val.last_offset,
+          .max_timestamp = extent.val.max_timestamp,
+        };
+        if (req.include_object_metadata) {
+            auto object_res = co_await reader.get_object(extent.val.oid);
+            if (!object_res.has_value()) {
+                co_return rpc::get_extent_metadata_reply{
+                  .ec = log_and_convert(
+                    object_res.error(),
+                    fmt::format(
+                      "Error getting object {} in extent ({}~{}): ",
+                      extent.val.oid,
+                      key->base_offset,
+                      extent.val.last_offset)),
+                };
+            }
+            if (!object_res->has_value()) {
+                co_return rpc::get_extent_metadata_reply{
+                  .ec = rpc::errc::out_of_range,
+                };
+            }
+            const auto& object = object_res.value().value();
+            em.object_info = rpc::extent_object_info{
+              .oid = extent.val.oid,
+              .footer_pos = object.footer_pos,
+              .object_size = object.object_size,
+            };
+        }
+        extents.push_back(std::move(em));
         if (extents.size() >= req.max_num_extents) {
             end_of_stream = false;
             break;

--- a/src/v/cloud_topics/level_one/domain/simple_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/simple_domain_manager.cc
@@ -56,11 +56,20 @@ meta_to_rpc_extent_metadata(metastore::extent_metadata_vec v) {
     chunked_vector<rpc::extent_metadata> res;
     res.reserve(v.size());
     for (auto& e : v) {
+        std::optional<rpc::extent_object_info> obj_info;
+        if (e.object_info.has_value()) {
+            obj_info = rpc::extent_object_info{
+              .oid = e.object_info->oid,
+              .footer_pos = e.object_info->footer_pos,
+              .object_size = e.object_info->object_size,
+            };
+        }
         res.push_back(
           rpc::extent_metadata{
             .base_offset = e.base_offset,
             .last_offset = e.last_offset,
-            .max_timestamp = e.max_timestamp});
+            .max_timestamp = e.max_timestamp,
+            .object_info = std::move(obj_info)});
     }
     return res;
 }
@@ -649,7 +658,8 @@ simple_domain_manager::get_extent_metadata(
               req.tp,
               req.min_offset,
               req.max_offset,
-              req.max_num_extents);
+              req.max_num_extents,
+              metastore::include_object_metadata(req.include_object_metadata));
         case rpc::get_extent_metadata_request::order::backwards:
             return simple_metastore::get_extent_metadata_backwards(
               stm_state,

--- a/src/v/cloud_topics/level_one/frontend_reader/l1_reader_cache.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/l1_reader_cache.cc
@@ -83,19 +83,26 @@ ss::future<> l1_reader_cache::stop() {
 
 ss::future<> l1_reader_cache::evict_stale() {
     auto now = ss::lowres_clock::now();
+    // Collect all stale readers without yielding. Yielding mid-iteration
+    // would let take_reader() or return_reader() erase entries from the
+    // list, invalidating our iterator (use-after-free).
+    std::vector<std::unique_ptr<l1::object_reader>> to_close;
     auto it = _entries.begin();
     while (it != _entries.end()) {
         if (now - it->atime > ttl) {
-            auto reader_to_close = std::move(it->reader.reader);
+            to_close.push_back(std::move(it->reader.reader));
             vlog(cd_log.debug, "TTL evicted cached L1 reader for {}", it->tidp);
             it = _entries.erase_and_dispose(
               it, [](cache_entry* e) { delete e; }); // NOLINT
-            co_await close_reader_safe(std::move(reader_to_close));
         } else {
             ++it;
         }
     }
     arm_timer();
+    co_await ss::max_concurrent_for_each(
+      to_close, 16, [](std::unique_ptr<l1::object_reader>& r) {
+          return close_reader_safe(std::move(r));
+      });
 }
 
 void l1_reader_cache::arm_timer() {

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.cc
@@ -207,19 +207,39 @@ level_one_log_reader_impl::read_some(
     }
 }
 
-ss::future<std::optional<level_one_log_reader_impl::object_info>>
-level_one_log_reader_impl::lookup_object_for_offset(
-  kafka::offset offset, model::timeout_clock::time_point /*deadline*/) {
+std::optional<l1::metastore::object_response>
+level_one_log_reader_impl::consume_lookahead_buffer(kafka::offset offset) {
+    // Discard stale entries whose data is entirely before the requested
+    // offset.
+    while (!_lookahead_buffer.empty()
+           && _lookahead_buffer.front().last_offset < offset) {
+        _lookahead_buffer.pop_front();
+    }
+    if (_lookahead_buffer.empty()) {
+        return std::nullopt;
+    }
+    auto entry = std::move(_lookahead_buffer.front());
+    _lookahead_buffer.pop_front();
+    return entry;
+}
+
+ss::future<> level_one_log_reader_impl::fill_lookahead_buffer(
+  kafka::offset offset, size_t num_objects) {
     ss::abort_source default_abort_source;
     auto* abort_source = _config.abort_source
                            ? &_config.abort_source.value().get()
                            : &default_abort_source;
     retry_chain_node rtc = l1::make_default_metastore_rtc(*abort_source);
     auto response = co_await l1::retry_metastore_op(
-      [this, offset]
-      -> ss::future<
-        std::expected<l1::metastore::object_response, l1::metastore::errc>> {
-          return _metastore->get_first_ge(_tidp, offset);
+      [this, offset, num_objects] -> ss::future<std::expected<
+                                    l1::metastore::extent_metadata_response,
+                                    l1::metastore::errc>> {
+          return _metastore->get_extent_metadata_forwards(
+            _tidp,
+            offset,
+            kafka::offset::max(),
+            num_objects,
+            l1::metastore::include_object_metadata::yes);
       },
       rtc);
     if (!response.has_value()) {
@@ -227,12 +247,10 @@ level_one_log_reader_impl::lookup_object_for_offset(
         case l1::metastore::errc::out_of_range:
             vlog(
               _log.debug, "No L1 objects found at offset {} or later", offset);
-            co_return std::nullopt;
-
+            co_return;
         case l1::metastore::errc::missing_ntp:
             vlog(_log.debug, "Partition not tracked in metastore");
-            co_return std::nullopt;
-
+            co_return;
         default:
             throw std::runtime_error(_log.format(
               "Metastore query failed offset {}: {}",
@@ -241,7 +259,36 @@ level_one_log_reader_impl::lookup_object_for_offset(
         }
     }
 
-    auto& obj = response.value();
+    for (auto& em : response.value().extents) {
+        vassert(
+          em.object_info.has_value(),
+          "extent metadata missing object_info for offsets ({}~{})",
+          em.base_offset,
+          em.last_offset);
+        _lookahead_buffer.push_back(
+          l1::metastore::object_response{
+            .oid = em.object_info->oid,
+            .footer_pos = em.object_info->footer_pos,
+            .object_size = em.object_info->object_size,
+            .first_offset = em.base_offset,
+            .last_offset = em.last_offset,
+          });
+    }
+}
+
+ss::future<std::optional<level_one_log_reader_impl::object_info>>
+level_one_log_reader_impl::lookup_object_for_offset(
+  kafka::offset offset, model::timeout_clock::time_point /*deadline*/) {
+    if (_lookahead_buffer.empty()) {
+        auto num_objects = std::max<size_t>(1, _config.lookahead_objects);
+        co_await fill_lookahead_buffer(offset, num_objects);
+    }
+    auto obj_resp = consume_lookahead_buffer(offset);
+    if (!obj_resp.has_value()) {
+        co_return std::nullopt;
+    }
+
+    auto& obj = obj_resp.value();
     vlog(_log.debug, "Found L1 object {} at offset {}", obj.oid, offset);
 
     auto footer = co_await read_footer(

--- a/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/level_one_reader.h
@@ -18,6 +18,7 @@
 #include "model/record_batch_reader.h"
 #include "utils/prefix_logger.h"
 
+#include <deque>
 #include <expected>
 
 namespace cloud_topics {
@@ -97,10 +98,27 @@ private:
 
     /*
      * Contacts the L1 metastore to retrieve metadata for an L1 object that
-     * contains the target offset.
+     * contains the target offset. Uses a lookahead buffer populated via
+     * get_extent_metadata_forwards — when lookahead_objects > 1, multiple
+     * objects are fetched at once; otherwise exactly one is fetched.
      */
     ss::future<std::optional<object_info>> lookup_object_for_offset(
       kafka::offset, model::timeout_clock::time_point deadline);
+
+    /*
+     * Fills the lookahead buffer by fetching up to num_objects extents
+     * from the metastore starting at the given offset.
+     */
+    ss::future<>
+    fill_lookahead_buffer(kafka::offset offset, size_t num_objects);
+
+    /*
+     * Consumes the front entry of the lookahead buffer that covers the
+     * given offset, discarding any stale entries. Returns nullopt if the
+     * buffer is empty or has no applicable entry.
+     */
+    std::optional<l1::metastore::object_response>
+    consume_lookahead_buffer(kafka::offset offset);
 
     /*
      * Materialize batches from the L1 object starting from the given offset.
@@ -161,6 +179,11 @@ private:
     l1_reader_cache* _cache;
     prefix_logger _log;
     size_t _bytes_consumed{0};
+
+    // Lookahead buffer of object metadata, ordered by ascending offset.
+    // Consumed front-to-back as the reader advances through objects.
+    // Populated with 1 entry (no prefetch) or N entries (prefetch).
+    std::deque<l1::metastore::object_response> _lookahead_buffer;
 };
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_one/frontend_reader/tests/l1_reader_fixture.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/tests/l1_reader_fixture.h
@@ -137,7 +137,8 @@ protected:
       kafka::offset start_offset = kafka::offset{0},
       kafka::offset max_offset = kafka::offset::max(),
       size_t max_bytes = std::numeric_limits<size_t>::max(),
-      bool strict_max_bytes = false) {
+      bool strict_max_bytes = false,
+      size_t lookahead_objects = 0) {
         cloud_topic_log_reader_config config(
           start_offset,
           max_offset,
@@ -148,6 +149,7 @@ protected:
           /*abort_source=*/std::nullopt,
           /*client_addr=*/std::nullopt,
           /*strict_max_bytes=*/strict_max_bytes);
+        config.lookahead_objects = lookahead_objects;
         return model::record_batch_reader(
           std::make_unique<level_one_log_reader_impl>(
             config, ntp, tidp, &_metastore, &_io, nullptr, _cache_ptr));

--- a/src/v/cloud_topics/level_one/frontend_reader/tests/reader_test.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/tests/reader_test.cc
@@ -826,3 +826,85 @@ TEST_F(l1_reader_cache_test, cache_strict_max_bytes_resume) {
     }
     EXPECT_EQ(combined, expected);
 }
+
+// Lookahead tests: verify that lookahead_objects > 1 produces the same results
+// as the default single-object lookup path.
+TEST_P(l1_reader_test, lookahead_single_object) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+
+    auto batches = model::test::make_random_batches(model::offset{0}, 10).get();
+    auto expected = copy(batches);
+
+    std::vector<tidp_batches_t> tidp_batches;
+    tidp_batches.emplace_back(tidp, std::move(batches));
+    make_l1_objects(std::move(tidp_batches)).get();
+
+    // Read with lookahead enabled — should produce identical results.
+    auto reader = make_reader(
+      ntp,
+      tidp,
+      kafka::offset{0},
+      kafka::offset::max(),
+      std::numeric_limits<size_t>::max(),
+      /*strict_max_bytes=*/false,
+      /*lookahead_objects=*/10);
+    auto result = read_all(std::move(reader));
+    EXPECT_EQ(result, expected);
+}
+
+TEST_P(l1_reader_test, lookahead_multiple_objects) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+
+    // Create 3 separate objects with batches at increasing offsets.
+    auto batches1 = model::test::make_random_batches(model::offset{0}, 5).get();
+    auto next_offset = batches1.back().last_offset() + model::offset{1};
+    auto batches2 = model::test::make_random_batches(next_offset, 5).get();
+    next_offset = batches2.back().last_offset() + model::offset{1};
+    auto batches3 = model::test::make_random_batches(next_offset, 5).get();
+
+    // Collect expected batches.
+    chunked_circular_buffer<model::record_batch> expected;
+    for (auto& b : batches1) {
+        expected.push_back(b.share());
+    }
+    for (auto& b : batches2) {
+        expected.push_back(b.share());
+    }
+    for (auto& b : batches3) {
+        expected.push_back(b.share());
+    }
+
+    // Create three separate L1 objects.
+    {
+        std::vector<tidp_batches_t> tb;
+        tb.emplace_back(tidp, std::move(batches1));
+        make_l1_objects(std::move(tb)).get();
+    }
+    {
+        std::vector<tidp_batches_t> tb;
+        tb.emplace_back(tidp, std::move(batches2));
+        make_l1_objects(std::move(tb)).get();
+    }
+    {
+        std::vector<tidp_batches_t> tb;
+        tb.emplace_back(tidp, std::move(batches3));
+        make_l1_objects(std::move(tb)).get();
+    }
+
+    // Read with lookahead=10, which should batch-lookup all 3 objects.
+    auto reader = make_reader(
+      ntp,
+      tidp,
+      kafka::offset{0},
+      kafka::offset::max(),
+      std::numeric_limits<size_t>::max(),
+      /*strict_max_bytes=*/false,
+      /*lookahead_objects=*/10);
+    auto result = read_all(std::move(reader));
+    EXPECT_EQ(result, expected);
+
+    // Also verify without lookahead (regression test).
+    auto reader_no_prefetch = make_reader(ntp, tidp);
+    auto result_no_prefetch = read_all(std::move(reader_no_prefetch));
+    EXPECT_EQ(result_no_prefetch, expected);
+}

--- a/src/v/cloud_topics/level_one/metastore/extent_metadata_reader.cc
+++ b/src/v/cloud_topics/level_one/metastore/extent_metadata_reader.cc
@@ -50,7 +50,11 @@ extent_metadata_reader::forward_generator() {
         auto extent_md_res = co_await retry_metastore_op_with_default_rtc(
           [this, next_offset] {
               return _metastore->get_extent_metadata_forwards(
-                _tp, next_offset, _max_offset, _num_extents_per_request);
+                _tp,
+                next_offset,
+                _max_offset,
+                _num_extents_per_request,
+                metastore::include_object_metadata::no);
           },
           _as);
 

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -22,6 +22,7 @@
 #include <seastar/core/future.hh>
 
 #include <expected>
+#include <optional>
 
 namespace cloud_storage {
 struct remote_label;
@@ -443,12 +444,32 @@ public:
     virtual ss::future<std::expected<compaction_info_map, errc>>
     get_compaction_infos(const chunked_vector<compaction_info_spec>&) = 0;
 
+    struct extent_object_info {
+        object_id oid;
+        size_t footer_pos{0};
+        size_t object_size{0};
+    };
+
     struct extent_metadata {
         kafka::offset base_offset;
         kafka::offset last_offset;
         model::timestamp max_timestamp;
+        // Only populated when include_object_metadata is set.
+        std::optional<extent_object_info> object_info;
 
         fmt::iterator format_to(fmt::iterator it) const {
+            if (object_info.has_value()) {
+                return fmt::format_to(
+                  it,
+                  "{{offsets:({}~{}), max_timestamp:{}, oid:{}, "
+                  "footer_pos:{}, object_size:{}}}",
+                  base_offset,
+                  last_offset,
+                  max_timestamp,
+                  object_info->oid,
+                  object_info->footer_pos,
+                  object_info->object_size);
+            }
             return fmt::format_to(
               it,
               "{{offsets:({}~{}), max_timestamp:{}}}",
@@ -468,15 +489,25 @@ public:
         bool end_of_stream{true};
     };
 
+    using include_object_metadata
+      = ss::bool_class<struct include_object_metadata_tag>;
+
     // Returns a number of extents in the offset range `[start, end]`
     // inclusively, and in ascending offset order. Useful for forward
     // iteration over an extent-aligned offset range- that is, for an extent
     // metastore state of `[[0, 9],[10,19],[20,29]]`, and a request like
     // `get_extent_metadata_ge([0, 15])`, the returned extents will be `[[0, 9],
     // [10, 19]]`.
+    //
+    // When include_object_metadata is yes, each extent_metadata in the
+    // response will also have oid, footer_pos, and object_size populated.
     virtual ss::future<std::expected<extent_metadata_response, errc>>
     get_extent_metadata_forwards(
-      const model::topic_id_partition&, kafka::offset, kafka::offset, size_t)
+      const model::topic_id_partition&,
+      kafka::offset,
+      kafka::offset,
+      size_t,
+      include_object_metadata)
       = 0;
 
     // Returns a number of extents in the offset range `[start, end]`
@@ -485,6 +516,9 @@ public:
     // metastore state of `[[0, 9],[10,19],[20,29]]`, and a request like
     // `get_extent_metadata_le([0, 15])`, the returned extents will be `[[10,
     // 19], [0, 9]]`.
+    //
+    // NOTE: unlike get_extent_metadata_forwards, this method does not
+    // support include_object_metadata. Add it here if needed.
     virtual ss::future<std::expected<extent_metadata_response, errc>>
     get_extent_metadata_backwards(
       const model::topic_id_partition&, kafka::offset, kafka::offset, size_t)

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -280,7 +280,21 @@ rpc_to_meta_extent_metadata(chunked_vector<rpc::extent_metadata> v) {
     metastore::extent_metadata_vec res;
     res.reserve(v.size());
     for (auto& e : v) {
-        res.emplace_back(e.base_offset, e.last_offset, e.max_timestamp);
+        std::optional<metastore::extent_object_info> obj_info;
+        if (e.object_info.has_value()) {
+            obj_info = metastore::extent_object_info{
+              .oid = e.object_info->oid,
+              .footer_pos = e.object_info->footer_pos,
+              .object_size = e.object_info->object_size,
+            };
+        }
+        res.push_back(
+          metastore::extent_metadata{
+            .base_offset = e.base_offset,
+            .last_offset = e.last_offset,
+            .max_timestamp = e.max_timestamp,
+            .object_info = std::move(obj_info),
+          });
     }
     return res;
 }
@@ -866,7 +880,8 @@ replicated_metastore::get_extent_metadata_forwards(
   const model::topic_id_partition& tidp,
   kafka::offset min_offset,
   kafka::offset max_offset,
-  size_t max_num_extents) {
+  size_t max_num_extents,
+  include_object_metadata include_object_metadata) {
     static constexpr auto o = rpc::get_extent_metadata_request::order::forwards;
 
     rpc::get_extent_metadata_request req;
@@ -875,6 +890,7 @@ replicated_metastore::get_extent_metadata_forwards(
     req.max_offset = max_offset;
     req.max_num_extents = max_num_extents;
     req.o = o;
+    req.include_object_metadata = bool(include_object_metadata);
 
     auto reply_fut = co_await ss::coroutine::as_future(
       fe_.get_extent_metadata(std::move(req)));

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
@@ -89,7 +89,8 @@ public:
       const model::topic_id_partition&,
       kafka::offset,
       kafka::offset,
-      size_t) override;
+      size_t,
+      include_object_metadata) override;
 
     ss::future<std::expected<extent_metadata_response, errc>>
     get_extent_metadata_backwards(

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -17,8 +17,11 @@
 #include "serde/envelope.h"
 #include "serde/rw/enum.h"
 #include "serde/rw/envelope.h"
+#include "serde/rw/optional.h"
 
 #include <fmt/format.h>
+
+#include <optional>
 
 namespace cloud_topics::l1::rpc {
 
@@ -207,16 +210,30 @@ struct get_size_request
     model::topic_id_partition tp;
 };
 
+struct extent_object_info
+  : serde::envelope<
+      extent_object_info,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    auto serde_fields() { return std::tie(oid, footer_pos, object_size); }
+
+    object_id oid;
+    size_t footer_pos{0};
+    size_t object_size{0};
+};
+
 struct extent_metadata
   : serde::
       envelope<extent_metadata, serde::version<0>, serde::compat_version<0>> {
     auto serde_fields() {
-        return std::tie(base_offset, last_offset, max_timestamp);
+        return std::tie(base_offset, last_offset, max_timestamp, object_info);
     }
 
     kafka::offset base_offset;
     kafka::offset last_offset;
     model::timestamp max_timestamp;
+    // Only populated when include_object_metadata is set on the request.
+    std::optional<extent_object_info> object_info;
 };
 
 struct get_compaction_info_reply
@@ -395,7 +412,13 @@ struct get_extent_metadata_request
     enum class order { forwards, backwards };
 
     auto serde_fields() {
-        return std::tie(tp, min_offset, max_offset, o, max_num_extents);
+        return std::tie(
+          tp,
+          min_offset,
+          max_offset,
+          o,
+          max_num_extents,
+          include_object_metadata);
     }
 
     model::topic_id_partition tp;
@@ -403,6 +426,7 @@ struct get_extent_metadata_request
     kafka::offset max_offset;
     order o;
     size_t max_num_extents;
+    bool include_object_metadata{false};
 };
 
 struct restore_domain_reply

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -782,9 +782,15 @@ simple_metastore::get_extent_metadata_forwards(
   const model::topic_id_partition& tp,
   kafka::offset min_offset,
   kafka::offset max_offset,
-  size_t max_num_extents) {
+  size_t max_num_extents,
+  include_object_metadata include_object_metadata) {
     co_return get_extent_metadata_forwards(
-      state_, tp, min_offset, max_offset, max_num_extents);
+      state_,
+      tp,
+      min_offset,
+      max_offset,
+      max_num_extents,
+      include_object_metadata);
 }
 
 std::expected<metastore::extent_metadata_response, metastore::errc>
@@ -793,7 +799,8 @@ simple_metastore::get_extent_metadata_forwards(
   const model::topic_id_partition& tp,
   kafka::offset min_offset,
   kafka::offset max_offset,
-  size_t max_num_extents) {
+  size_t max_num_extents,
+  include_object_metadata include_object_metadata) {
     auto prt_ref = state.partition_state(tp);
 
     if (!prt_ref.has_value()) {
@@ -809,15 +816,36 @@ simple_metastore::get_extent_metadata_forwards(
     auto min_it = std::ranges::lower_bound(
       prt.extents, min_offset, std::less<>{}, &extent::last_offset);
     for (auto it = min_it; it != prt.extents.end(); ++it) {
-        auto& extent = *it;
-        if (extent.base_offset > max_offset) {
+        auto& ext = *it;
+        if (ext.base_offset > max_offset) {
             break;
         }
 
-        extents.push_back(
-          {.base_offset = extent.base_offset,
-           .last_offset = extent.last_offset,
-           .max_timestamp = extent.max_timestamp});
+        extent_metadata em{
+          .base_offset = ext.base_offset,
+          .last_offset = ext.last_offset,
+          .max_timestamp = ext.max_timestamp};
+
+        if (include_object_metadata) {
+            auto object_it = state.objects.find(ext.oid);
+            if (object_it == state.objects.end()) {
+                vlog(
+                  cd_log.error,
+                  "Missing object metadata for oid {} in extent "
+                  "({}~{})",
+                  ext.oid,
+                  ext.base_offset,
+                  ext.last_offset);
+                return std::unexpected(errc::out_of_range);
+            }
+            em.object_info = extent_object_info{
+              .oid = ext.oid,
+              .footer_pos = object_it->second.footer_pos,
+              .object_size = object_it->second.object_size,
+            };
+        }
+
+        extents.push_back(std::move(em));
 
         if (extents.size() >= max_num_extents) {
             end_of_stream = false;
@@ -872,15 +900,15 @@ simple_metastore::get_extent_metadata_backwards(
                      ? std::make_reverse_iterator(prt.extents.end())
                      : std::make_reverse_iterator(std::next(max_it));
     for (auto it = max_rit; it != prt.extents.rend(); ++it) {
-        auto& extent = *it;
-        if (extent.last_offset < min_offset) {
+        auto& ext = *it;
+        if (ext.last_offset < min_offset) {
             break;
         }
 
         extents.push_back(
-          {.base_offset = extent.base_offset,
-           .last_offset = extent.last_offset,
-           .max_timestamp = extent.max_timestamp});
+          {.base_offset = ext.base_offset,
+           .last_offset = ext.last_offset,
+           .max_timestamp = ext.max_timestamp});
 
         if (extents.size() >= max_num_extents) {
             end_of_stream = false;

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -119,7 +119,8 @@ public:
       const model::topic_id_partition&,
       kafka::offset,
       kafka::offset,
-      size_t) override;
+      size_t,
+      include_object_metadata) override;
 
     ss::future<std::expected<extent_metadata_response, errc>>
     get_extent_metadata_backwards(
@@ -173,7 +174,8 @@ private:
       const model::topic_id_partition&,
       kafka::offset,
       kafka::offset,
-      size_t);
+      size_t,
+      include_object_metadata);
     static std::expected<extent_metadata_response, errc>
     get_extent_metadata_backwards(
       const state&,

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -2021,7 +2021,11 @@ TEST(SimpleMetastoreTest, TestGetExtentMetadataForwards) {
         auto min_offset = kafka::offset{0};
         auto max_offset = kafka::offset{9};
         auto extent_metadata_res = m.get_extent_metadata_forwards(
-                                      tp, min_offset, max_offset, 10)
+                                      tp,
+                                      min_offset,
+                                      max_offset,
+                                      10,
+                                      metastore::include_object_metadata::no)
                                      .get();
         ASSERT_TRUE(extent_metadata_res.has_value());
         EXPECT_THAT(
@@ -2033,7 +2037,11 @@ TEST(SimpleMetastoreTest, TestGetExtentMetadataForwards) {
         auto min_offset = kafka::offset{0};
         auto max_offset = kafka::offset{15};
         auto extent_metadata_res = m.get_extent_metadata_forwards(
-                                      tp, min_offset, max_offset, 10)
+                                      tp,
+                                      min_offset,
+                                      max_offset,
+                                      10,
+                                      metastore::include_object_metadata::no)
                                      .get();
         ASSERT_TRUE(extent_metadata_res.has_value());
         EXPECT_THAT(
@@ -2046,7 +2054,11 @@ TEST(SimpleMetastoreTest, TestGetExtentMetadataForwards) {
         auto min_offset = kafka::offset{0};
         auto max_offset = kafka::offset{19};
         auto extent_metadata_res = m.get_extent_metadata_forwards(
-                                      tp, min_offset, max_offset, 10)
+                                      tp,
+                                      min_offset,
+                                      max_offset,
+                                      10,
+                                      metastore::include_object_metadata::no)
                                      .get();
         ASSERT_TRUE(extent_metadata_res.has_value());
         EXPECT_THAT(
@@ -2059,7 +2071,11 @@ TEST(SimpleMetastoreTest, TestGetExtentMetadataForwards) {
         auto min_offset = kafka::offset{0};
         auto max_offset = kafka::offset{20};
         auto extent_metadata_res = m.get_extent_metadata_forwards(
-                                      tp, min_offset, max_offset, 10)
+                                      tp,
+                                      min_offset,
+                                      max_offset,
+                                      10,
+                                      metastore::include_object_metadata::no)
                                      .get();
         ASSERT_TRUE(extent_metadata_res.has_value());
         EXPECT_THAT(
@@ -2074,7 +2090,11 @@ TEST(SimpleMetastoreTest, TestGetExtentMetadataForwards) {
         auto min_offset = kafka::offset{0};
         auto max_offset = kafka::offset{100};
         auto extent_metadata_res = m.get_extent_metadata_forwards(
-                                      tp, min_offset, max_offset, 10)
+                                      tp,
+                                      min_offset,
+                                      max_offset,
+                                      10,
+                                      metastore::include_object_metadata::no)
                                      .get();
         ASSERT_TRUE(extent_metadata_res.has_value());
         EXPECT_THAT(
@@ -2090,8 +2110,13 @@ TEST(SimpleMetastoreTest, TestGetExtentMetadataForwards) {
     {
         auto min_offset = kafka::offset{0};
         auto max_offset = kafka::offset{9};
-        auto extent_metadata_res
-          = m.get_extent_metadata_forwards(tp, min_offset, max_offset, 0).get();
+        auto extent_metadata_res = m.get_extent_metadata_forwards(
+                                      tp,
+                                      min_offset,
+                                      max_offset,
+                                      0,
+                                      metastore::include_object_metadata::no)
+                                     .get();
         // Requesting 0 extents still results in a single extent being returned.
         ASSERT_TRUE(extent_metadata_res.has_value());
         ASSERT_EQ(extent_metadata_res->extents.size(), 1);
@@ -2100,8 +2125,13 @@ TEST(SimpleMetastoreTest, TestGetExtentMetadataForwards) {
     {
         auto min_offset = kafka::offset{0};
         auto max_offset = kafka::offset{15};
-        auto extent_metadata_res
-          = m.get_extent_metadata_forwards(tp, min_offset, max_offset, 1).get();
+        auto extent_metadata_res = m.get_extent_metadata_forwards(
+                                      tp,
+                                      min_offset,
+                                      max_offset,
+                                      1,
+                                      metastore::include_object_metadata::no)
+                                     .get();
         ASSERT_TRUE(extent_metadata_res.has_value());
         EXPECT_THAT(
           extent_metadata_res->extents,
@@ -2111,8 +2141,13 @@ TEST(SimpleMetastoreTest, TestGetExtentMetadataForwards) {
     {
         auto min_offset = kafka::offset{0};
         auto max_offset = kafka::offset{20};
-        auto extent_metadata_res
-          = m.get_extent_metadata_forwards(tp, min_offset, max_offset, 2).get();
+        auto extent_metadata_res = m.get_extent_metadata_forwards(
+                                      tp,
+                                      min_offset,
+                                      max_offset,
+                                      2,
+                                      metastore::include_object_metadata::no)
+                                     .get();
         ASSERT_TRUE(extent_metadata_res.has_value());
         EXPECT_THAT(
           extent_metadata_res->extents,
@@ -2126,7 +2161,11 @@ TEST(SimpleMetastoreTest, TestGetExtentMetadataForwards) {
         auto min_offset = kafka::offset{5};
         auto max_offset = kafka::offset{9};
         auto extent_metadata_res = m.get_extent_metadata_forwards(
-                                      tp, min_offset, max_offset, 10)
+                                      tp,
+                                      min_offset,
+                                      max_offset,
+                                      10,
+                                      metastore::include_object_metadata::no)
                                      .get();
         ASSERT_TRUE(extent_metadata_res.has_value());
         EXPECT_THAT(
@@ -2138,7 +2177,11 @@ TEST(SimpleMetastoreTest, TestGetExtentMetadataForwards) {
         auto min_offset = kafka::offset{9};
         auto max_offset = kafka::offset{29};
         auto extent_metadata_res = m.get_extent_metadata_forwards(
-                                      tp, min_offset, max_offset, 10)
+                                      tp,
+                                      min_offset,
+                                      max_offset,
+                                      10,
+                                      metastore::include_object_metadata::no)
                                      .get();
         ASSERT_TRUE(extent_metadata_res.has_value());
         EXPECT_THAT(
@@ -2360,7 +2403,11 @@ TEST(SimpleMetastoreTest, TestGetExtentMetadataEmpty) {
         auto min_offset = kafka::offset{0};
         auto max_offset = kafka::offset{100};
         auto extent_metadata_ge_res = m.get_extent_metadata_forwards(
-                                         tp, min_offset, max_offset, 10)
+                                         tp,
+                                         min_offset,
+                                         max_offset,
+                                         10,
+                                         metastore::include_object_metadata::no)
                                         .get();
         ASSERT_TRUE(extent_metadata_ge_res.has_value());
         ASSERT_TRUE(extent_metadata_ge_res->extents.empty());
@@ -2508,4 +2555,87 @@ TEST(SimpleMetastoreTest, TestGetSizeMultiplePartitions) {
     auto size_res_b = m.get_size(tp_b).get();
     ASSERT_TRUE(size_res_b.has_value());
     ASSERT_EQ(data_size_b, size_res_b->size);
+}
+
+TEST(SimpleMetastoreTest, TestGetExtentMetadataForwardsWithObjectMetadata) {
+    simple_metastore m;
+    om_list_t os;
+    os.emplace_back(
+      om_builder(oid1, 100, 1100).add(tid_a, 0_o, 9_o, 2000_t, 0, 500).build());
+    os.emplace_back(om_builder(oid2, 200, 2200)
+                      .add(tid_a, 10_o, 19_o, 3000_t, 0, 500)
+                      .build());
+    os.emplace_back(om_builder(oid3, 300, 3300)
+                      .add(tid_a, 20_o, 29_o, 4000_t, 0, 500)
+                      .build());
+    m.preregister_objects(chunked_vector<object_id>::single(oid1));
+    m.preregister_objects(chunked_vector<object_id>::single(oid2));
+    m.preregister_objects(chunked_vector<object_id>::single(oid3));
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    auto tp = model::topic_id_partition::from(tid_a);
+
+    // Without include_object_metadata, object_info should be nullopt.
+    {
+        auto res
+          = m.get_extent_metadata_forwards(
+               tp, 0_o, 100_o, 10, metastore::include_object_metadata::no)
+              .get();
+        ASSERT_TRUE(res.has_value());
+        ASSERT_EQ(res->extents.size(), 3);
+        EXPECT_FALSE(res->extents[0].object_info.has_value());
+        EXPECT_FALSE(res->extents[1].object_info.has_value());
+        EXPECT_FALSE(res->extents[2].object_info.has_value());
+    }
+
+    // With include_object_metadata, object_info should be populated from
+    // the object store.
+    {
+        auto res
+          = m.get_extent_metadata_forwards(
+               tp, 0_o, 100_o, 10, metastore::include_object_metadata::yes)
+              .get();
+        ASSERT_TRUE(res.has_value());
+        ASSERT_EQ(res->extents.size(), 3);
+
+        EXPECT_EQ(res->extents[0].base_offset, 0_o);
+        EXPECT_EQ(res->extents[0].last_offset, 9_o);
+        ASSERT_TRUE(res->extents[0].object_info.has_value());
+        EXPECT_EQ(res->extents[0].object_info->oid, oid1);
+        EXPECT_EQ(res->extents[0].object_info->footer_pos, 100);
+        EXPECT_EQ(res->extents[0].object_info->object_size, 1100);
+
+        EXPECT_EQ(res->extents[1].base_offset, 10_o);
+        EXPECT_EQ(res->extents[1].last_offset, 19_o);
+        ASSERT_TRUE(res->extents[1].object_info.has_value());
+        EXPECT_EQ(res->extents[1].object_info->oid, oid2);
+        EXPECT_EQ(res->extents[1].object_info->footer_pos, 200);
+        EXPECT_EQ(res->extents[1].object_info->object_size, 2200);
+
+        EXPECT_EQ(res->extents[2].base_offset, 20_o);
+        EXPECT_EQ(res->extents[2].last_offset, 29_o);
+        ASSERT_TRUE(res->extents[2].object_info.has_value());
+        EXPECT_EQ(res->extents[2].object_info->oid, oid3);
+        EXPECT_EQ(res->extents[2].object_info->footer_pos, 300);
+        EXPECT_EQ(res->extents[2].object_info->object_size, 3300);
+
+        EXPECT_TRUE(res->end_of_stream);
+    }
+
+    // With max_num_extents limit.
+    {
+        auto res
+          = m.get_extent_metadata_forwards(
+               tp, 0_o, 100_o, 2, metastore::include_object_metadata::yes)
+              .get();
+        ASSERT_TRUE(res.has_value());
+        ASSERT_EQ(res->extents.size(), 2);
+        ASSERT_TRUE(res->extents[0].object_info.has_value());
+        EXPECT_EQ(res->extents[0].object_info->oid, oid1);
+        ASSERT_TRUE(res->extents[1].object_info.has_value());
+        EXPECT_EQ(res->extents[1].object_info->oid, oid2);
+        EXPECT_FALSE(res->end_of_stream);
+    }
 }

--- a/src/v/cloud_topics/log_reader_config.h
+++ b/src/v/cloud_topics/log_reader_config.h
@@ -86,6 +86,14 @@ struct cloud_topic_log_reader_config {
 
     bool skip_cache{false};
 
+    // Number of objects to look ahead when fetching object metadata from
+    // the metastore. 0 (default) means no lookahead and is equivalent to 1:
+    // fetch one object's metadata at a time. Values > 1 batch-fetch multiple
+    // objects' metadata in a single metastore RPC.
+    //
+    // NB: Applies to the L1 reader only.
+    size_t lookahead_objects{0};
+
     fmt::iterator format_to(fmt::iterator it) const;
 };
 


### PR DESCRIPTION
Re-applies the changes from #29673 (reverted in #29757) with a fix for the TestGetExtentMetadataForwardsWithObjectMetadata test, which needed preregister_objects calls after #29739 made preregistration mandatory.

No non-test updates were needed.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
