### PR TITLE
tests/cloud: migrate ducktape cloud tests from cloud-api to public-api v1

### DIFF
--- a/tests/rp_cloud_cleanup.py
+++ b/tests/rp_cloud_cleanup.py
@@ -144,19 +144,38 @@ class CloudCleanup:
             self.log.info(msg)
 
         # Function detects cluster type and deletes it
-        cluster = self.cloudv2.get_resource(handle)
-        if cluster is None:
+        _resp = self.cloudv2.get_resource(handle)
+        if _resp is None:
             self.log.warning(f"# Cluster '{handle}' was already deleted")
             return
+        cluster = _resp.get("cluster", _resp)
         id = cluster["id"]
-        cluster_type = cluster["spec"]["clusterType"]
-        state = cluster["state"]
-        createdDate = datetime.strptime(cluster["createdAt"], "%Y-%m-%dT%H:%M:%S.%fZ")
+        cluster_type = cluster.get("type", cluster.get("spec", {}).get("clusterType", ""))
+        # Normalize v1 type enum to short form (e.g. TYPE_DEDICATED -> FMC, TYPE_BYOC -> BYOC)
+        if cluster_type == "TYPE_DEDICATED":
+            cluster_type = "FMC"
+        elif cluster_type == "TYPE_BYOC":
+            cluster_type = "BYOC"
+        state = cluster.get("state", "")
+        created_at = cluster.get("created_at", cluster.get("createdAt", ""))
+        name = cluster.get("name", "")
+        # v1 uses RFC3339 with timezone, legacy uses %Y-%m-%dT%H:%M:%S.%fZ
+        try:
+            createdDate = datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%S.%fZ")
+        except ValueError:
+            createdDate = datetime.strptime(created_at[:19], "%Y-%m-%dT%H:%M:%S")
         message = (
-            f"-> cluster '{cluster['name']}', {cluster['createdAt']}, {cluster_type} "
+            f"-> cluster '{name}', {created_at}, {cluster_type} "
         )
+        # Normalize v1 state enums for comparison
+        if state == "STATE_READY":
+            state = "ready"
+        elif state == "STATE_DELETING_AGENT":
+            state = "deleting_agent"
+        elif state == "STATE_CREATING_AGENT":
+            state = "creating_agent"
         if cluster_type in ["FMC"]:
-            message += f"| status: '{cluster['state']}' "
+            message += f"| status: '{state}' "
             if state in ["ready"]:
                 if not _ensure_date(createdDate):
                     _log_skip(message)
@@ -173,11 +192,18 @@ class CloudCleanup:
             # Check if provider is the same
             # This is relevant only for BYOC as
             # rpk will not be able to delete it anyway
-            if cluster["spec"]["provider"].lower() != self.config.provider.lower():
+            # v1 uses cloud_provider (e.g. CLOUD_PROVIDER_AWS), legacy uses spec.provider
+            _cluster_provider = cluster.get(
+                "cloud_provider",
+                cluster.get("spec", {}).get("provider", ""),
+            )
+            # Normalize v1 enum to short form for comparison
+            _cluster_provider_short = _cluster_provider.replace("CLOUD_PROVIDER_", "")
+            if _cluster_provider_short.lower() != self.config.provider.lower():
                 # Wrong provider, can't delete right now
                 message += (
                     "| SKIP: Can't delete "
-                    f"'{cluster['spec']['provider']}' "
+                    f"'{_cluster_provider_short}' "
                     f"cluster using '{self.config.provider}' creds"
                 )
                 self.log.info(message)
@@ -191,8 +217,8 @@ class CloudCleanup:
 
             # If the cluster in deleleting_agent, we should clean it
             # regardless of time or anything else to clean up quota
-            message += f"| status: '{cluster['state']}' "
-            if cluster["state"] in ["deleting_agent"]:
+            message += f"| status: '{state}' "
+            if state in ["deleting_agent"]:
                 # Login
                 try:
                     message += "| cloud login "
@@ -336,7 +362,8 @@ class CloudCleanup:
                         # Add peerings delete handle to own list
                         npr_queue += [
                             self.cloudv2.network_peering_endpoint(
-                                id=peernet["networkId"], peering_id=peernet["id"]
+                                id=peernet.get("network_id", peernet.get("networkId")),
+                                peering_id=peernet["id"],
                             )
                         ]
                 # TODO: Prepare needed data for clusters

--- a/tests/rptest/services/provider_clients/rpcloud_client.py
+++ b/tests/rptest/services/provider_clients/rpcloud_client.py
@@ -159,14 +159,14 @@ class RpCloudApiClient(object):
 
     @staticmethod
     def namespace_endpoint(uuid=None):
-        _e = "/v1beta2/resource-groups"
+        _e = "/v1/resource-groups"
         if uuid:
             _e += f"/{uuid}"
         return _e
 
     @staticmethod
     def cluster_endpoint(id=None):
-        _e = "/v1beta2/clusters"
+        _e = "/v1/clusters"
         if id:
             _e += f"/{id}"
         return _e
@@ -178,7 +178,8 @@ class RpCloudApiClient(object):
             _e += f"/{id}"
         return _e
 
-    # delete for DEVPROD-2525
+    # TODO: DEVPROD-2525 - keep legacy endpoint for install pack version
+    # and prometheus credentials which have no public-api v1 equivalent
     @staticmethod
     def legacy_cluster_endpoint(id=None):
         _e = "/api/v1/clusters"
@@ -186,19 +187,16 @@ class RpCloudApiClient(object):
             _e += f"/{id}"
         return _e
 
-    # try converting to /v1beta2/networks again for DEVPROD-2525
     @staticmethod
     def network_endpoint(id=None):
-        _e = "/api/v1/networks"
+        _e = "/v1/networks"
         if id:
             _e += f"/{id}"
         return _e
 
     @staticmethod
     def network_peering_endpoint(id=None, peering_id=None):
-        # the network_peerings API has no public API replacement yet.
-        # revisit for DEVPROD-2525
-        _e = "/api/v1/networks"
+        _e = "/v1/networks"
         if id:
             _e += f"/{id}/network-peerings"
             if peering_id:
@@ -227,21 +225,20 @@ class RpCloudApiClient(object):
         )["resource_groups"]
 
     def list_networks(self, ns_uuid=None):
-        # get networks for a namespace
         _ret = self._http_get(
-            self.network_endpoint(), params=self._prepare_params(ns_uuid)
+            self.network_endpoint(),
+            base_url=self._config.public_api_url,
+            params=self._prepare_params(ns_uuid),
         )
-        # return it
-        return _ret
+        return _ret.get("networks", [])
 
-    # the network_peerings API has no public API replacement yet.
-    # revisit for DEVPROD-2525
     def list_network_peerings(self, network_id, ns_uuid=None):
         _ret = self._http_get(
             self.network_peering_endpoint(id=network_id),
+            base_url=self._config.public_api_url,
             params=self._prepare_params(ns_uuid=ns_uuid),
         )
-        return _ret
+        return _ret.get("network_peerings", [])
 
     def get_cluster(self, cluster_id: str):
         _cluster = self._http_get(
@@ -256,20 +253,24 @@ class RpCloudApiClient(object):
         )
         return _cluster["serverless_cluster"]
 
-    # delete for DEVPROD-2525
+    # TODO: DEVPROD-2525 - keep for install pack version and prometheus
+    # credentials which have no public-api v1 equivalent
     def get_legacy_cluster(self, cluster_id: str):
         _cluster = self._http_get(self.legacy_cluster_endpoint(id=cluster_id))
         return _cluster
 
-    # not porting this endpoint until DEVPROD-2525
     def get_network(self, network_id):
-        _network = self._http_get(self.network_endpoint(id=network_id))
-        return _network
+        _network = self._http_get(
+            self.network_endpoint(id=network_id),
+            base_url=self._config.public_api_url,
+        )
+        return _network.get("network", _network)
 
     def get_resource(self, resource_handle) -> Union[None, dict, str]:
         _r = None
+        base = self._config.public_api_url if resource_handle.startswith("/v1/") else None
         try:
-            _r = self._http_get(endpoint=resource_handle)
+            _r = self._http_get(endpoint=resource_handle, base_url=base)
             self._logger.debug(f"...resource requested with '{resource_handle}'")
         except Exception as e:
             self._logger.warning(f"# Warning failed to get resource: {e}")
@@ -285,8 +286,9 @@ class RpCloudApiClient(object):
 
     def delete_resource(self, resource_handle):
         _r = None
+        base = self._config.public_api_url if resource_handle.startswith("/v1/") else None
         try:
-            _r = self._http_delete(endpoint=resource_handle)
+            _r = self._http_delete(endpoint=resource_handle, base_url=base)
             self._logger.debug(f"...delete requested for '{resource_handle}'")
         except Exception as e:
             self._logger.warning(f"# Warning deletion failed: {e}")

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -178,7 +178,7 @@ class LiveClusterParams:
 
     @property
     def network_endpoint(self):
-        return f"/api/v1/networks/{self.network_id}/network-peerings"
+        return f"/v1/networks/{self.network_id}/network-peerings"
 
 
 @dataclass
@@ -445,7 +445,7 @@ class CloudCluster:
         self._logger.debug(f"creating namespace name {name}")
         body = {"name": name}
         # namespace, resource-group… totally the same thing
-        r = self.public_api._http_post(endpoint="/v1beta2/resource-groups", json=body)
+        r = self.public_api._http_post(endpoint="/v1/resource-groups", json=body)
         _id = r["resource_group"]["id"]
         self._logger.debug(f"created namespaceUuid {_id}")
         # save namespace name
@@ -493,6 +493,7 @@ class CloudCluster:
             return None
         return self.rpcloud.get_network(self.current.network_id)
 
+    # TODO: DEVPROD-2525 - install pack versions only available via legacy API
     def _get_latest_install_pack_ver(self):
         """Get latest certified install pack ver by searching list of avail.
 
@@ -519,11 +520,9 @@ class CloudCluster:
         """
 
         provider = f"CLOUD_PROVIDER_{self.config.provider}"
-        body = {"cloudProvider": provider, "name": self.current.region}
-        regions = self.public_api._http_post(
-            endpoint="/redpanda.api.ui.v1alpha1.RegionService/ListRegions",
-            override_headers={"connect-protocol-version": "1"},
-            json=body,
+        regions = self.public_api._http_get(
+            endpoint=f"/v1/regions/{provider}",
+            base_url=self.config.public_api_url,
         )
 
         return next(
@@ -531,6 +530,7 @@ class CloudCluster:
             {"id": None},
         )["id"]
 
+    # TODO: DEVPROD-2525 - migrate to v1 when tiers endpoint is available
     def _get_tier_name(self, config_profile_name):
         """Get the product name for the first matching config
         profile name using filter parameters.
@@ -610,18 +610,21 @@ class CloudCluster:
         """
         Update info from existing cluster (BYOC)
         """
-        # get cluster data (needs legacy data, revisit for DEVPROD-2525)
-        _c = self._get_legacy_cluster(self.current.cluster_id)
-        # Fill in immediate configuration
-        self.current._isAlive = True if _c["status"]["health"] == "healthy" else False
+        _c = self._get_cluster(self.current.cluster_id)
+        self.current._isAlive = _c["state"] == "STATE_READY"
         self.current.name = _c["name"]
-        self.current.namespace_uuid = _c["namespaceUuid"]
-        self.current.install_pack_ver = _c["spec"]["installPackVersion"]
-        self.current.region = _c["spec"]["region"]
+        self.current.namespace_uuid = _c["resource_group_id"]
+        self.current.region = _c["region"]
         self.current.region_id = self._get_region_id()
-        self.current.zones = _c["spec"]["zones"]
-        self.current.network_id = _c["spec"]["networkId"]
-        self.current.network_cidr = _c["spec"]["network"]["networkCidr"]
+        self.current.zones = _c["zones"]
+        self.current.network_id = _c["network_id"]
+        # Get network CIDR from network endpoint
+        _net = self._get_network()
+        if _net is not None:
+            self.current.network_cidr = _net.get("cidr_block", "")
+        # TODO: DEVPROD-2525 - install pack version only available via legacy API
+        _legacy = self._get_legacy_cluster(self.current.cluster_id)
+        self.current.install_pack_ver = _legacy["spec"]["installPackVersion"]
         if self.current.region != self.config.region:
             raise RuntimeError(
                 "BYOC Cluster is in different region: "
@@ -638,8 +641,7 @@ class CloudCluster:
         """
 
         base_url = self._get_cluster_console_url()
-        # revisit when there's a public API endpoint for prometheus
-        # credentials (DEVPROD-2525)
+        # TODO: DEVPROD-2525 - prometheus credentials only available via legacy API
         legacy = self._get_legacy_cluster(self.current.cluster_id)
         username = legacy["spec"]["consolePrometheusCredentials"]["username"]
         password = legacy["spec"]["consolePrometheusCredentials"]["password"]
@@ -695,7 +697,7 @@ class CloudCluster:
         return _id
 
     def _netop_complete(self, netop_id: str, target: str) -> bool:
-        n = self.public_api._http_get(endpoint=f"/v1beta2/operations/{netop_id}")
+        n = self.public_api._http_get(endpoint=f"/v1/operations/{netop_id}")
         if n is None:
             return False
         if "operation" not in n or "state" not in n["operation"]:
@@ -706,14 +708,14 @@ class CloudCluster:
     def _wait_for_netop_id(
         self, netop_id, timeout=300, target="STATE_COMPLETED"
     ) -> str:
-        self._logger.debug(f"polling /v1beta2/operations/{netop_id}")
+        self._logger.debug(f"polling /v1/operations/{netop_id}")
         wait_until(
             lambda: self._netop_complete(netop_id, target) == True,
             timeout_sec=timeout,
             backoff_sec=10,
             err_msg=f"Failed to get proper id of cloud cluster {self.current.name}",
         )
-        n = self.public_api._http_get(endpoint=f"/v1beta2/operations/{netop_id}")
+        n = self.public_api._http_get(endpoint=f"/v1/operations/{netop_id}")
         if n is None or "operation" not in n or "resource_id" not in n["operation"]:
             return ""
         return n["operation"]["resource_id"]
@@ -749,9 +751,9 @@ class CloudCluster:
         self._logger.warning(f'creating network name "{self.current.name}-network"')
         # Prepare network payload block
         _body = self._create_network_payload()
-        self._logger.debug(f"POST to /v1beta2/networks body: {json.dumps(_body)}")
+        self._logger.debug(f"POST to /v1/networks body: {json.dumps(_body)}")
         # Send API request to create network
-        n = self.public_api._http_post(endpoint="/v1beta2/networks", json=_body)
+        n = self.public_api._http_post(endpoint="/v1/networks", json={"network": _body})
         if n is None:
             raise RuntimeError(self.rpcloud.lasterror)
         netop_id = n["operation"]["id"]
@@ -761,9 +763,9 @@ class CloudCluster:
         self._logger.warning(f"creating cluster name {self.current.name}")
         # Prepare cluster payload block
         _body = self._create_cluster_payload()
-        self._logger.debug(f"POST to /v1beta2/clusters body: {json.dumps(_body)}")
+        self._logger.debug(f"POST to /v1/clusters body: {json.dumps(_body)}")
         # Send API request to create cluster
-        r = self.public_api._http_post(endpoint="/v1beta2/clusters", json=_body)
+        r = self.public_api._http_post(endpoint="/v1/clusters", json={"cluster": _body})
         # handle error on CloudV2 side
         if r is None:
             raise RuntimeError(self.rpcloud.lasterror)
@@ -1077,8 +1079,9 @@ class CloudCluster:
         # 2. Wait for status "delete agent"
         # 3. Use rpk to delete agent
 
-        resp = self.rpcloud._http_delete(
-            endpoint=self.rpcloud.cluster_endpoint(self.current.cluster_id)
+        resp = self.public_api._http_delete(
+            endpoint=self.rpcloud.cluster_endpoint(self.current.cluster_id),
+            base_url=self.config.public_api_url,
         )
         self._logger.debug(f"resp: {json.dumps(resp)}")
 
@@ -1099,7 +1102,7 @@ class CloudCluster:
         # skip namespace deletion to avoid error because cluster delete not complete yet
         if self._delete_namespace:
             resp = self.public_api._http_delete(
-                endpoint=f"/v1beta2/resource-groups/{namespace_uuid}"
+                endpoint=f"/v1/resource-groups/{namespace_uuid}"
             )
             self._logger.debug(f"resp: {json.dumps(resp)}")
 
@@ -1152,6 +1155,7 @@ class CloudCluster:
         cluster = self.rpcloud.get_serverless_cluster(self.current.cluster_id)
         return cluster["kafka_api"]["seed_brokers"][0]
 
+    # TODO: DEVPROD-2525 - install pack version only available via legacy API
     def get_install_pack_version(self):
         cluster = self.rpcloud._http_get(
             endpoint=f"/api/v1/clusters/{self.current.cluster_id}"
@@ -1243,7 +1247,11 @@ class CloudCluster:
         Get VPC peering connection from CloudV2
         """
         _endpoint = f"{endpoint}/{self.vpc_peering['id']}"
-        return self.rpcloud._http_get(endpoint=_endpoint)
+        _ret = self.public_api._http_get(
+            endpoint=_endpoint,
+            base_url=self.config.public_api_url,
+        )
+        return _ret.get("network_peering", _ret)
 
     def _check_peering_status_cluster(self, endpoint, state):
         """
@@ -1362,16 +1370,19 @@ class CloudCluster:
             self._logger.debug(f"body: '{_body}'")
 
             # Create peering
-            resp = self.rpcloud._http_post(
-                endpoint=self.current.network_endpoint, json=_body
+            resp = self.public_api._http_post(
+                endpoint=self.current.network_endpoint,
+                base_url=self.config.public_api_url,
+                json=_body,
             )
             if resp is None:
                 # Check if such peering exists
-                # self._logger.warning(self.cloudv2.lasterror)
-                if "network peering already exists" in self.rpcloud.lasterror:
-                    self.vpc_peering = self.rpcloud._http_get(
-                        endpoint=self.current.network_endpoint
-                    )[0]
+                if "network peering already exists" in self.public_api.lasterror:
+                    _peerings = self.public_api._http_get(
+                        endpoint=self.current.network_endpoint,
+                        base_url=self.config.public_api_url,
+                    )
+                    self.vpc_peering = _peerings.get("network_peerings", [_peerings])[0]
                     # State should be ready at this point
                     self._logger.warning(
                         "Found Cloud VPC peering connection "
@@ -1395,10 +1406,10 @@ class CloudCluster:
                             )
                         )
                 else:
-                    raise RuntimeError(self.rpcloud.lasterror)
+                    raise RuntimeError(self.public_api.lasterror)
             else:
                 self._logger.debug(f"Created VPC peering: '{resp}'")
-                self.vpc_peering = resp
+                self.vpc_peering = resp.get("network_peering", resp)
 
                 # 3.
                 # Wait for "pending acceptance"
@@ -1432,11 +1443,13 @@ class CloudCluster:
             self._logger.debug(f"body: '{_body}'")
 
             # Create peering
-            resp = self.rpcloud._http_post(
-                endpoint=self.current.network_endpoint, json=_body
+            resp = self.public_api._http_post(
+                endpoint=self.current.network_endpoint,
+                base_url=self.config.public_api_url,
+                json=_body,
             )
             self._logger.debug(f"Created VPC peering: '{resp}'")
-            self.vpc_peering = resp
+            self.vpc_peering = resp.get("network_peering", resp)
 
             # Ducktape -> RP
             # facing_vpcs=False turns off RP peering creation
@@ -1451,15 +1464,19 @@ class CloudCluster:
             self._logger.debug(f"body: '{_body}'")
 
             # Create peering
-            resp = self.rpcloud._http_post(
-                endpoint=self.current.network_endpoint, json=_body
+            resp = self.public_api._http_post(
+                endpoint=self.current.network_endpoint,
+                base_url=self.config.public_api_url,
+                json=_body,
             )
             if resp is None:
                 # Check if such peering exists
-                if "network peering already exists" in self.rpcloud.lasterror:
-                    self.vpc_peering = self.rpcloud._http_get(
-                        endpoint=self.current.network_endpoint
-                    )[0]
+                if "network peering already exists" in self.public_api.lasterror:
+                    _peerings = self.public_api._http_get(
+                        endpoint=self.current.network_endpoint,
+                        base_url=self.config.public_api_url,
+                    )
+                    self.vpc_peering = _peerings.get("network_peerings", [_peerings])[0]
                     self._logger.warning(
                         "Found Cloud VPC peering connection "
                         f"'{self.vpc_peering['displayName']}', "
@@ -1481,10 +1498,10 @@ class CloudCluster:
                             )
                         )
                 else:
-                    raise RuntimeError(self.rpcloud.lasterror)
+                    raise RuntimeError(self.public_api.lasterror)
             else:
                 self._logger.debug(f"Created VPC peering: '{resp}'")
-                self.vpc_peering = resp
+                self.vpc_peering = resp.get("network_peering", resp)
 
                 # 3. Wait for "pending acceptance"
                 self._wait_peering_status_cluster("pending acceptance")
@@ -1586,6 +1603,7 @@ class CloudCluster:
 
         return
 
+    # TODO: DEVPROD-2525 - migrate to v1 when tiers endpoint is available
     def get_tier(self) -> ThroughputTierInfo | None:
         """Get throughput tier information.
 
@@ -1865,6 +1883,7 @@ class CloudCluster:
             self._logger.error(f"Error getting cluster {cluster_id}: {e}")
             raise
 
+    # TODO: DEVPROD-2525 - migrate to v1 when tiers endpoint is available
     def list_throughput_tiers(
         self,
         cloud_provider: str | None = None,


### PR DESCRIPTION
## Summary
- Migrate cluster CRUD, networks, resource groups, operations, and network peerings from legacy cloud-api (`/api/v1/`) and v1beta2 (`/v1beta2/`) endpoints to public-api v1 (`/v1/`) endpoints
- Update `rpcloud_client.py` endpoint definitions and HTTP methods to route through `public_api_url`
- Update `redpanda_cloud.py` cluster creation/deletion, operation polling, region lookup, and peering flows to use v1 endpoints
- Update `rp_cloud_cleanup.py` to handle v1 response format (type/state enum normalization, field name changes)
- Preserve legacy endpoints only where no v1 equivalent exists: tiers (`/v1beta2/tiers`), install pack versions, and prometheus credentials

## Endpoints migrated
| From | To |
|---|---|
| `POST /v1beta2/resource-groups` | `POST /v1/resource-groups` |
| `DELETE /v1beta2/resource-groups/{id}` | `DELETE /v1/resource-groups/{id}` |
| `GET /v1beta2/clusters`, `GET /v1beta2/clusters/{id}` | `GET /v1/clusters`, `GET /v1/clusters/{id}` |
| `POST /v1beta2/clusters` | `POST /v1/clusters` |
| `POST /v1beta2/networks` | `POST /v1/networks` |
| `GET /v1beta2/operations/{id}` | `GET /v1/operations/{id}` |
| `GET /api/v1/clusters/{id}` (most uses) | `GET /v1/clusters/{id}` |
| `DELETE /api/v1/clusters/{id}` | `DELETE /v1/clusters/{id}` |
| `GET /api/v1/networks/{id}`, `GET /api/v1/networks` | `GET /v1/networks/{id}`, `GET /v1/networks` |
| `POST /api/v1/networks/{id}/network-peerings` | `POST /v1/networks/{id}/network-peerings` |
| `GET /api/v1/networks/{id}/network-peerings` | `GET /v1/networks/{id}/network-peerings` |
| `POST ListRegions` (ConnectRPC) | `GET /v1/regions/{cloud_provider}` |

## Intentionally unchanged
- `/v1beta2/tiers` — no v1 equivalent yet
- `/api/v1/clusters-resources/install-pack-versions` — no v1 equivalent
- `/api/v1/clusters/{id}` for install pack version and prometheus credentials — no v1 equivalent
- Console API calls (`/api/users`, `/api/acls`) — out of scope

All remaining legacy/beta references are marked with `TODO: DEVPROD-2525` comments.

## Test plan
- [ ] Run FMC cluster creation/deletion lifecycle test
- [ ] Run BYOC cluster creation/deletion lifecycle test
- [ ] Run private-network cluster test with VPC peering flow
- [ ] Run `rp_cloud_cleanup.py` against test environment
- [ ] Grep for remaining `/api/v1/` and `/v1beta2/` — verify all are intentional