### PR TITLE
ct/l1: Limit object readahead to 1

### DIFF
--- a/src/v/cloud_topics/level_one/common/file_io.cc
+++ b/src/v/cloud_topics/level_one/common/file_io.cc
@@ -184,8 +184,10 @@ file_io::read_object(object_extent extent, ss::abort_source* as) {
       extent.size);
     while (true) {
         auto stream_fut = co_await ss::coroutine::as_future<
-          std::optional<cloud_io::cache_item_stream>>(
-          _cache->get_stream(cache_key));
+          std::optional<cloud_io::cache_item_stream>>(_cache->get_stream(
+          cache_key,
+          config::shard_local_cfg().storage_read_buffer_size(),
+          config::shard_local_cfg().storage_read_readahead_count()));
         if (stream_fut.failed()) {
             auto ex = stream_fut.get_exception();
             vlog(


### PR DESCRIPTION
This reduces the readahead of on-disk cached L1 objects from the cloud_io default of 10 to 1. A large readahead isn't necessary to saturate fast storage with a 128KiB buffer (the cloud_io default, preserved here), and a readahead of 10 is often more data than is desired in one fetch (1MiB).

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
