### PR TITLE
[CORE-15659] cloud_storage/multipart: Allow put after finalize

### DIFF
--- a/src/v/cloud_storage_clients/multipart_upload.cc
+++ b/src/v/cloud_storage_clients/multipart_upload.cc
@@ -82,7 +82,9 @@ multipart_upload::~multipart_upload() {
 
 ss::future<> multipart_upload::put(iobuf data) {
     if (_finalized) {
-        throw std::logic_error("Cannot put() on finalized multipart upload");
+        // May occur if a multipart upload is aborted with pending data and then
+        // its stream is closed.
+        co_return;
     }
 
     // Append data to buffer

--- a/src/v/cloud_storage_clients/multipart_upload.h
+++ b/src/v/cloud_storage_clients/multipart_upload.h
@@ -136,6 +136,10 @@ public:
     /// reaches part_size. This method may upload multiple parts if data size
     /// exceeds part_size.
     ///
+    /// No-op if the upload has already been finalized. This can occur when an
+    /// upload is aborted with pending data and its stream is subsequently
+    /// closed.
+    ///
     /// \param data Data to write
     [[nodiscard]] virtual ss::future<> put(iobuf data);
 
@@ -148,15 +152,13 @@ public:
     /// no parts have been uploaded yet, uses regular put_object instead of
     /// multipart upload for efficiency.
     ///
-    /// \throws std::logic_error if already finalized
+    /// No-op if the upload has already been finalized.
     [[nodiscard]] virtual ss::future<> complete();
 
     /// Abort the multipart upload (cancel without committing)
     ///
     /// Cancels the multipart upload and attempts to clean up any uploaded
-    /// parts. Safe to call multiple times.
-    ///
-    /// \throws std::logic_error if already finalized with complete()
+    /// parts. No-op if the upload has already been finalized.
     [[nodiscard]] virtual ss::future<> abort();
 
     /// Check if the upload has been finalized (completed or aborted)

--- a/src/v/cloud_storage_clients/tests/multipart_upload_test.cc
+++ b/src/v/cloud_storage_clients/tests/multipart_upload_test.cc
@@ -290,3 +290,115 @@ SEASTAR_THREAD_TEST_CASE(test_multipart_upload_complete_error_in_body) {
                       == "We encountered an internal error. Please try again.";
       });
 }
+
+SEASTAR_THREAD_TEST_CASE(test_multipart_upload_put_after_abort_is_noop) {
+    s3_imposter_fixture imposter;
+
+    imposter.set_expectations_and_listen({
+      // CreateMultipartUpload
+      {.url = "abort-put-key?uploads", .body = R"xml(<?xml version="1.0"?>
+<InitiateMultipartUploadResult>
+    <UploadId>test-upload-id-ap</UploadId>
+</InitiateMultipartUploadResult>)xml"},
+
+      // UploadPart 1
+      {.url = "abort-put-key?partNumber=1&uploadId=test-upload-id-ap",
+       .body = std::nullopt},
+
+      // AbortMultipartUpload
+      {.url = "abort-put-key?uploadId=test-upload-id-ap", .body = ""},
+    });
+
+    auto conf = imposter.get_configuration();
+    const client_pool_builder pool_builder{conf};
+
+    ss::sharded<client_pool> pool;
+    auto stop_guard = pool_builder.connections_per_shard(1).build(pool).get();
+
+    const auto test_bucket = bucket_name_parts{
+      .name = plain_bucket_name(imposter.bucket_name)};
+    const auto key = object_key("abort-put-key");
+    auto timeout = std::chrono::seconds(30);
+
+    ss::abort_source as;
+    auto lease = pool.local().acquire(test_bucket, as).get();
+
+    auto state_result = lease.client
+                          ->initiate_multipart_upload(
+                            test_bucket.name, key, test_part_size, timeout)
+                          .get();
+
+    BOOST_REQUIRE(state_result.has_value());
+    auto upload = ss::make_shared<multipart_upload>(
+      std::move(state_result.value()), test_part_size, test_log);
+
+    // Write enough data to trigger multipart initialization
+    auto data = ::tests::random_iobuf(6_MiB);
+    upload->put(std::move(data)).get();
+
+    // Abort the upload
+    upload->abort().get();
+
+    const auto requests_after_abort = imposter.get_requests().size();
+
+    // put() after abort should be a no-op: no exception, no extra requests
+    data = ::tests::random_iobuf(1_MiB);
+    upload->put(std::move(data)).get();
+
+    BOOST_CHECK_EQUAL(imposter.get_requests().size(), requests_after_abort);
+
+    // complete() after abort should also be a no-op
+    upload->complete().get();
+
+    BOOST_CHECK_EQUAL(imposter.get_requests().size(), requests_after_abort);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_multipart_upload_put_after_complete_is_noop) {
+    s3_imposter_fixture imposter;
+
+    // Use the small file path for a simpler setup
+    imposter.set_expectations_and_listen({
+      {.url = "complete-put-key", .body = std::nullopt},
+    });
+
+    auto conf = imposter.get_configuration();
+    const client_pool_builder pool_builder{conf};
+
+    ss::sharded<client_pool> pool;
+    auto stop_guard = pool_builder.connections_per_shard(1).build(pool).get();
+
+    const auto test_bucket = bucket_name_parts{
+      .name = plain_bucket_name(imposter.bucket_name)};
+    const auto key = object_key("complete-put-key");
+    auto timeout = std::chrono::seconds(30);
+
+    ss::abort_source as;
+    auto lease = pool.local().acquire(test_bucket, as).get();
+
+    auto state_result = lease.client
+                          ->initiate_multipart_upload(
+                            test_bucket.name, key, test_part_size, timeout)
+                          .get();
+
+    BOOST_REQUIRE(state_result.has_value());
+    auto upload = ss::make_shared<multipart_upload>(
+      std::move(state_result.value()), test_part_size, test_log);
+
+    // Write small data and complete
+    auto data = ::tests::random_iobuf(1_MiB);
+    upload->put(std::move(data)).get();
+    upload->complete().get();
+
+    const auto requests_after_complete = imposter.get_requests().size();
+
+    // put() after complete should be a no-op: no exception, no extra requests
+    data = ::tests::random_iobuf(1_MiB);
+    upload->put(std::move(data)).get();
+
+    BOOST_CHECK_EQUAL(imposter.get_requests().size(), requests_after_complete);
+
+    // abort() after complete should also be a no-op
+    upload->abort().get();
+
+    BOOST_CHECK_EQUAL(imposter.get_requests().size(), requests_after_complete);
+}


### PR DESCRIPTION
When the reconciler fails building an object for some reason, it aborts the multipart upload and cleans up its object builder. The object builder holds the multipart stream, and closes the stream as part of its cleanup. This can cause the stream to attempt to put data to the multipart upload, even though it has been aborted. Downgrade the sequence put-after-finalize from a logic error to a no-op, so the reconciler doesn't trigger exceptions from this expected behavior.

Fixes CORE-15659

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

