### PR TITLE
sr: fix delete mode/config deadlock on context-only subjects

### DIFF
--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -476,7 +476,10 @@ ss::future<server::reply_t> delete_config_subject(
         }
     }
 
-    co_await rq.service().writer().delete_config(ctx_sub);
+    auto deleted = co_await rq.service().writer().delete_config(ctx_sub);
+    if (!deleted) {
+        throw as_exception(not_found(ctx_sub));
+    }
 
     auto resp = ppj::rjson_serialize_iobuf(get_config_req_rep{.compat = lvl});
     log_response(*rq.req, resp);
@@ -615,7 +618,10 @@ ss::future<server::reply_t> delete_mode_subject(
         throw;
     }
 
-    co_await rq.service().writer().delete_mode(ctx_sub);
+    auto deleted = co_await rq.service().writer().delete_mode(ctx_sub);
+    if (!deleted) {
+        throw as_exception(not_found(ctx_sub));
+    }
 
     auto resp = ppj::rjson_serialize_iobuf(mode_req_rep{.mode = m});
     log_response(*rq.req, resp);

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -361,26 +361,22 @@ seq_writer::do_delete_config(context_subject ctx_sub) {
                                              : std::make_optional(ctx_sub.sub);
     co_await check_mutable(ctx_sub.ctx, sub_opt);
 
+    chunked_vector<seq_marker> sequences;
     try {
-        if (ctx_sub.is_context_only()) {
-            co_await _store.get_compatibility(ctx_sub.ctx);
-        } else {
-            co_await _store.get_compatibility(ctx_sub, default_to_global::no);
-        }
-
+        sequences = ctx_sub.is_context_only()
+                      ? co_await _store.get_context_config_written_at(
+                          ctx_sub.ctx)
+                      : co_await _store.get_subject_config_written_at(ctx_sub);
     } catch (const exception&) {
-        // subject config already blank
+        co_return false;
+    }
+
+    if (sequences.empty()) {
         co_return false;
     }
 
     batch_builder rb{model::offset{0}};
-    if (ctx_sub.is_context_only()) {
-        rb.add_tombstones(
-          ctx_sub, co_await _store.get_context_config_written_at(ctx_sub.ctx));
-    } else {
-        rb.add_tombstones(
-          ctx_sub, co_await _store.get_subject_config_written_at(ctx_sub));
-    }
+    rb.add_tombstones(ctx_sub, sequences);
 
     if (co_await produce_and_apply(std::nullopt, std::move(rb).build())) {
         co_return true;
@@ -484,22 +480,23 @@ seq_writer::write_mode(context_subject ctx_sub, mode mode, force f) {
 ss::future<std::optional<bool>>
 seq_writer::do_delete_mode(context_subject ctx_sub, model::offset write_at) {
     vlog(srlog.debug, "delete mode sub={} offset={}", ctx_sub, write_at);
-    // Report an error if the mode isn't registered
-    if (ctx_sub.is_context_only()) {
-        co_await _store.get_mode(ctx_sub.ctx);
-    } else {
-        co_await _store.get_mode(ctx_sub, default_to_global::no);
-    }
     _store.check_mode_mutability(force::no);
 
-    batch_builder rb{write_at};
-    if (ctx_sub.is_context_only()) {
-        rb.add_tombstones(
-          ctx_sub, co_await _store.get_context_mode_written_at(ctx_sub.ctx));
-    } else {
-        rb.add_tombstones(
-          ctx_sub, co_await _store.get_subject_mode_written_at(ctx_sub));
+    chunked_vector<seq_marker> sequences;
+    try {
+        sequences = ctx_sub.is_context_only()
+                      ? co_await _store.get_context_mode_written_at(ctx_sub.ctx)
+                      : co_await _store.get_subject_mode_written_at(ctx_sub);
+    } catch (const exception&) {
+        co_return false;
     }
+
+    if (sequences.empty()) {
+        co_return false;
+    }
+
+    batch_builder rb{write_at};
+    rb.add_tombstones(ctx_sub, sequences);
 
     if (co_await produce_and_apply(std::nullopt, std::move(rb).build())) {
         co_return true;

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -667,9 +667,11 @@ public:
     result<chunked_vector<seq_marker>>
     get_context_mode_written_at(const context& ctx) const {
         auto it = _context_stores.find(ctx);
-        if (it == _context_stores.end()) {
-            return chunked_vector<seq_marker>{};
+        if (
+          it == _context_stores.end() || it->second._mode_written_at.empty()) {
+            return not_found({ctx, subject{""}});
         }
+
         return it->second._mode_written_at.copy();
     }
 
@@ -747,9 +749,12 @@ public:
     result<chunked_vector<seq_marker>>
     get_context_config_written_at(const context& ctx) const {
         auto it = _context_stores.find(ctx);
-        if (it == _context_stores.end()) {
-            return chunked_vector<seq_marker>{};
+        if (
+          it == _context_stores.end()
+          || it->second._config_written_at.empty()) {
+            return not_found({ctx, subject{""}});
         }
+
         return it->second._config_written_at.copy();
     }
 

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -1058,11 +1058,10 @@ BOOST_AUTO_TEST_CASE(test_store_context_mode_written_at) {
     auto test_ctx = pps::context{".test"};
     auto s = pps::store{pps::is_mutable::yes};
 
-    // Initially no write markers
-    auto markers = s.get_context_mode_written_at(test_ctx).value();
-    BOOST_REQUIRE(markers.empty());
-    markers = s.get_context_mode_written_at(pps::default_context).value();
-    BOOST_REQUIRE(markers.empty());
+    // Initially context doesn't exist
+    BOOST_REQUIRE(s.get_context_mode_written_at(test_ctx).has_error());
+    BOOST_REQUIRE(
+      s.get_context_mode_written_at(pps::default_context).has_error());
 
     // Create distinct markers
     auto marker1 = pps::seq_marker{
@@ -1080,7 +1079,7 @@ BOOST_AUTO_TEST_CASE(test_store_context_mode_written_at) {
     BOOST_REQUIRE(
       s.set_mode(marker1, test_ctx, pps::mode::read_only, pps::force::no)
         .value());
-    markers = s.get_context_mode_written_at(test_ctx).value();
+    auto markers = s.get_context_mode_written_at(test_ctx).value();
     BOOST_REQUIRE_EQUAL(markers.size(), 1);
     BOOST_REQUIRE_EQUAL(markers[0], marker1);
 
@@ -1092,14 +1091,13 @@ BOOST_AUTO_TEST_CASE(test_store_context_mode_written_at) {
     BOOST_REQUIRE_EQUAL(markers[0], marker1);
     BOOST_REQUIRE_EQUAL(markers[1], marker2);
 
-    // Default context should still have no markers
-    markers = s.get_context_mode_written_at(pps::default_context).value();
-    BOOST_REQUIRE(markers.empty());
+    // Default context should still not exist
+    BOOST_REQUIRE(
+      s.get_context_mode_written_at(pps::default_context).has_error());
 
     // Clear mode clears all markers
     BOOST_REQUIRE(s.clear_mode(test_ctx, pps::force::no).value());
-    markers = s.get_context_mode_written_at(test_ctx).value();
-    BOOST_REQUIRE(markers.empty());
+    BOOST_REQUIRE(s.get_context_mode_written_at(test_ctx).has_error());
 }
 
 BOOST_AUTO_TEST_CASE(test_store_context_config) {
@@ -1150,9 +1148,8 @@ BOOST_AUTO_TEST_CASE(test_store_context_config_written_at) {
     auto test_ctx = pps::context{".test"};
     pps::store s;
 
-    // Initially no write markers
-    auto markers = s.get_context_config_written_at(test_ctx).value();
-    BOOST_REQUIRE(markers.empty());
+    // Initially context doesn't exist
+    BOOST_REQUIRE(s.get_context_config_written_at(test_ctx).has_error());
 
     // Create distinct markers
     auto marker1 = pps::seq_marker{
@@ -1170,7 +1167,7 @@ BOOST_AUTO_TEST_CASE(test_store_context_config_written_at) {
     BOOST_REQUIRE(
       s.set_compatibility(marker1, test_ctx, pps::compatibility_level::full)
         .value());
-    markers = s.get_context_config_written_at(test_ctx).value();
+    auto markers = s.get_context_config_written_at(test_ctx).value();
     BOOST_REQUIRE_EQUAL(markers.size(), 1);
     BOOST_REQUIRE_EQUAL(markers[0], marker1);
 
@@ -1183,14 +1180,13 @@ BOOST_AUTO_TEST_CASE(test_store_context_config_written_at) {
     BOOST_REQUIRE_EQUAL(markers[0], marker1);
     BOOST_REQUIRE_EQUAL(markers[1], marker2);
 
-    // Default context should still have no markers
-    markers = s.get_context_config_written_at(pps::default_context).value();
-    BOOST_REQUIRE(markers.empty());
+    // Default context should still not exist
+    BOOST_REQUIRE(
+      s.get_context_config_written_at(pps::default_context).has_error());
 
     // Clear compatibility clears all markers
     BOOST_REQUIRE(s.clear_compatibility(test_ctx).value());
-    markers = s.get_context_config_written_at(test_ctx).value();
-    BOOST_REQUIRE(markers.empty());
+    BOOST_REQUIRE(s.get_context_config_written_at(test_ctx).has_error());
 }
 
 BOOST_AUTO_TEST_CASE(test_store_context_materialized) {

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -17,7 +17,7 @@ import time
 import urllib.parse
 import uuid
 from enum import Enum
-from typing import Any, Literal, NamedTuple, Optional, TypeAlias
+from typing import Any, NamedTuple, Optional, TypeAlias
 
 import requests
 from confluent_kafka.schema_registry import (
@@ -30,7 +30,6 @@ from confluent_kafka.schema_registry import (
     topic_subject_name_strategy,
 )
 from confluent_kafka.serialization import MessageField, SerializationContext
-from ducktape.errors import TimeoutError as DucktapeTimeoutError
 from ducktape.mark import matrix, parametrize
 from ducktape.services.background_thread import BackgroundThreadService
 from ducktape.tests.test import TestContext
@@ -5477,6 +5476,20 @@ class SchemaRegistryContextTest(SchemaRegistryEndpoints):
         self.assert_equal(result.json()["mode"], "READWRITE")
 
     @cluster(num_nodes=1)
+    def test_delete_context_config_and_mode_before_set(self):
+        """Deleting context-level config or mode when neither has been set
+        should return 404. This is a regression test to protect against a
+        bug where deleting /config/{subject} and /mode/{subject} with a
+        context-only qualifier (e.g. ":.ctx:") would deadlock because the
+        handler built tombstones from empty written_at sequences."""
+
+        result = self.sr_client.delete_config_subject(subject=":.test-ctx:")
+        self.assert_equal(result.status_code, requests.codes.not_found)
+
+        result = self.sr_client.delete_mode_subject(subject=":.test-ctx:")
+        self.assert_equal(result.status_code, requests.codes.not_found)
+
+    @cluster(num_nodes=1)
     def test_context_record_persistence(self):
         # First, register a schema in the default context (no CONTEXT record)
         result = self.sr_client.post_subjects_subject_versions(
@@ -10604,169 +10617,3 @@ class SchemaRegistryContextAuthzTest(SchemaRegistryAclAuthzTestBase):
             99999, subject="sub1", auth=self.user_auth
         )
         self.assert_equal(result.status_code, 403)
-
-
-class SchemaRegistryDeadlockTest(SchemaRegistryEndpoints):
-    """
-    Reproduces a bug where DELETE /mode/{subject} or DELETE /config/{subject}
-    with a context-only qualifier (e.g., ":.:" or ":.ctx:") puts schema
-    registry into a deadlocked state: the request never completes and the
-    broker cannot shut down gracefully.
-
-    Only context-only qualifiers trigger the deadlock. Fully qualified
-    subjects (":.ctx:subject") and non-qualified subjects ("my-subject")
-    behave normally.
-    """
-
-    def __init__(self, context: TestContext, **kwargs: Any):
-        schema_registry_config = SchemaRegistryConfig()
-        schema_registry_config.mode_mutability = True
-        super().__init__(
-            context,
-            schema_registry_config=schema_registry_config,
-            extra_rp_conf={"schema_registry_enable_qualified_subjects": True},
-            **kwargs,
-        )
-
-    def _call_delete_endpoint(
-        self,
-        endpoint: Literal["mode", "config"],
-        subject: str,
-        expect_timeout: bool = True,
-    ):
-        """
-        Send a DELETE to /mode/{subject} or /config/{subject}.
-
-        If expect_timeout is True, assert the request never completes
-        (times out or connection error). If False, assert it succeeds.
-        """
-        delete_fn = {
-            "mode": self.sr_client.delete_mode_subject,
-            "config": self.sr_client.delete_config_subject,
-        }[endpoint]
-
-        node = self.redpanda.nodes[0]
-        hostname = node.account.hostname
-
-        try:
-            result = delete_fn(subject=subject, timeout=10, hostname=hostname)
-            assert not expect_timeout, (
-                f"Expected DELETE /{endpoint}/{subject} to hang, but it returned."
-            )
-            return result
-        except (requests.exceptions.ReadTimeout, requests.exceptions.ConnectionError):
-            assert expect_timeout, (
-                f"DELETE /{endpoint}/{subject} timed out or connection error "
-                "unexpectedly."
-            )
-
-    def _call_get_endpoint(
-        self,
-        endpoint: Literal["mode", "config"],
-        subject: str,
-    ):
-        """
-        Send a GET to /mode/{subject} or /config/{subject}.
-        Assert the request succeeds. This is used to confirm that the deadlock
-        only affects WRITE requests, not GETs.
-        """
-        get_fn = {
-            "mode": self.sr_client.get_mode_subject,
-            "config": self.sr_client.get_config_subject,
-        }[endpoint]
-
-        node = self.redpanda.nodes[0]
-        hostname = node.account.hostname
-
-        get_fn(subject=subject, timeout=10, hostname=hostname)
-
-    def _post_schema(self, expect_timeout: bool = True):
-        """
-        Post a schema to an unrelated subject to verify whether writes to
-        schema registry are blocked by the deadlock.
-        """
-        schema = '{"type": "string"}'
-        node = self.redpanda.nodes[0]
-        hostname = node.account.hostname
-        subject = "deadlock-test-unrelated"
-
-        try:
-            result = self.sr_client.post_subjects_subject_versions(
-                subject=subject,
-                data=json.dumps({"schema": schema}),
-                timeout=10,
-                hostname=hostname,
-            )
-            assert not expect_timeout, (
-                f"Expected POST /subjects/{subject}/versions to hang, but it returned."
-            )
-            return result
-        except (requests.exceptions.ReadTimeout, requests.exceptions.ConnectionError):
-            assert expect_timeout, (
-                f"POST /subjects/{subject}/versions timed out or connection "
-                "error unexpectedly."
-            )
-
-    def _stop_node(self, node, expect_timeout: bool = True):
-        """
-        Attempt to stop a node gracefully.
-
-        If expect_timeout is True, assert the shutdown times out (confirming
-        a deadlocked state). If False, assert clean shutdown succeeds.
-        stop_node sends SIGKILL after timeout before re-raising TimeoutError.
-        """
-        try:
-            self.redpanda.stop_node(node, timeout=15)
-            assert not expect_timeout, (
-                "Expected broker shutdown to time out, but it completed."
-            )
-        except DucktapeTimeoutError:
-            assert expect_timeout, "Broker shutdown timed out unexpectedly."
-            self.logger.info("Broker shutdown timed out as expected.")
-
-    @cluster(num_nodes=3)
-    @parametrize(subject=":.:", expect_deadlock=False)
-    @parametrize(subject=":.ctx:", expect_deadlock=False)
-    @parametrize(subject=":.:subject", expect_deadlock=False)
-    @parametrize(subject=":.ctx:subject", expect_deadlock=False)
-    @parametrize(subject="subject", expect_deadlock=False)
-    def test_delete_mode_context_only_subject_causes_deadlock(
-        self, subject: str, expect_deadlock: bool
-    ):
-        """
-        DELETE /mode/{subject} with a context-only qualifier deadlocks schema
-        registry when schema_registry_enable_qualified_subjects is enabled.
-
-        When the bug is fixed, this test should be updated to assert that the
-        DELETE succeeds and shutdown is clean.
-        """
-        self._call_delete_endpoint("mode", subject, expect_timeout=expect_deadlock)
-        self._call_get_endpoint(
-            "mode", subject
-        )  # GET should still work even if DELETE deadlocks
-        self._post_schema(expect_timeout=expect_deadlock)
-        self._stop_node(self.redpanda.nodes[0], expect_timeout=expect_deadlock)
-
-    @cluster(num_nodes=3)
-    @parametrize(subject=":.:", expect_deadlock=False)
-    @parametrize(subject=":.ctx:", expect_deadlock=False)
-    @parametrize(subject=":.:subject", expect_deadlock=False)
-    @parametrize(subject=":.ctx:subject", expect_deadlock=False)
-    @parametrize(subject="subject", expect_deadlock=False)
-    def test_delete_config_context_only_subject_causes_deadlock(
-        self, subject: str, expect_deadlock: bool
-    ):
-        """
-        DELETE /config/{subject} with a context-only qualifier deadlocks
-        schema registry when schema_registry_enable_qualified_subjects is
-        enabled.
-
-        When the bug is fixed, this test should be updated to assert that the
-        DELETE succeeds and shutdown is clean.
-        """
-        self._call_delete_endpoint("config", subject, expect_timeout=expect_deadlock)
-        self._call_get_endpoint(
-            "config", subject
-        )  # GET should still work even if DELETE deadlocks
-        self._post_schema(expect_timeout=expect_deadlock)
-        self._stop_node(self.redpanda.nodes[0], expect_timeout=expect_deadlock)

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -17,7 +17,7 @@ import time
 import urllib.parse
 import uuid
 from enum import Enum
-from typing import Any, NamedTuple, Optional, TypeAlias
+from typing import Any, Literal, NamedTuple, Optional, TypeAlias
 
 import requests
 from confluent_kafka.schema_registry import (
@@ -30,6 +30,7 @@ from confluent_kafka.schema_registry import (
     topic_subject_name_strategy,
 )
 from confluent_kafka.serialization import MessageField, SerializationContext
+from ducktape.errors import TimeoutError as DucktapeTimeoutError
 from ducktape.mark import matrix, parametrize
 from ducktape.services.background_thread import BackgroundThreadService
 from ducktape.tests.test import TestContext
@@ -10603,3 +10604,171 @@ class SchemaRegistryContextAuthzTest(SchemaRegistryAclAuthzTestBase):
             99999, subject="sub1", auth=self.user_auth
         )
         self.assert_equal(result.status_code, 403)
+
+
+class SchemaRegistryDeadlockTest(SchemaRegistryEndpoints):
+    """
+    Reproduces a bug where DELETE /mode/{subject} or DELETE /config/{subject}
+    with a context-only qualifier (e.g., ":.:" or ":.ctx:") puts schema
+    registry into a deadlocked state: the request never completes and the
+    broker cannot shut down gracefully.
+
+    Only context-only qualifiers trigger the deadlock. Fully qualified
+    subjects (":.ctx:subject") and non-qualified subjects ("my-subject")
+    behave normally.
+    """
+
+    def __init__(self, context: TestContext, **kwargs: Any):
+        schema_registry_config = SchemaRegistryConfig()
+        schema_registry_config.mode_mutability = True
+        super().__init__(
+            context,
+            schema_registry_config=schema_registry_config,
+            extra_rp_conf={"schema_registry_enable_qualified_subjects": True},
+            **kwargs,
+        )
+
+    def _call_delete_endpoint(
+        self,
+        endpoint: Literal["mode", "config"],
+        subject: str,
+        expect_timeout: bool = True,
+    ):
+        """
+        Send a DELETE to /mode/{subject} or /config/{subject}.
+
+        If expect_timeout is True, assert the request never completes
+        (times out or connection error). If False, assert it succeeds.
+        """
+        delete_fn = {
+            "mode": self.sr_client.delete_mode_subject,
+            "config": self.sr_client.delete_config_subject,
+        }[endpoint]
+
+        node = self.redpanda.nodes[0]
+        hostname = node.account.hostname
+
+        try:
+            result = delete_fn(subject=subject, timeout=10, hostname=hostname)
+            assert not expect_timeout, (
+                f"Expected DELETE /{endpoint}/{subject} to hang, but it returned."
+            )
+            return result
+        except (requests.exceptions.ReadTimeout, requests.exceptions.ConnectionError):
+            assert expect_timeout, (
+                f"DELETE /{endpoint}/{subject} timed out or connection error "
+                "unexpectedly."
+            )
+
+    def _call_get_endpoint(
+        self,
+        endpoint: Literal["mode", "config"],
+        subject: str,
+    ):
+        """
+        Send a GET to /mode/{subject} or /config/{subject}.
+        Assert the request succeeds. This is used to confirm that the deadlock
+        only affects WRITE requests, not GETs.
+        """
+        get_fn = {
+            "mode": self.sr_client.get_mode_subject,
+            "config": self.sr_client.get_config_subject,
+        }[endpoint]
+
+        node = self.redpanda.nodes[0]
+        hostname = node.account.hostname
+
+        get_fn(subject=subject, timeout=10, hostname=hostname)
+
+    def _post_schema(self, expect_timeout: bool = True):
+        """
+        Post a schema to an unrelated subject to verify whether writes to
+        schema registry are blocked by the deadlock.
+        """
+        schema = '{"type": "string"}'
+        node = self.redpanda.nodes[0]
+        hostname = node.account.hostname
+        subject = "deadlock-test-unrelated"
+
+        try:
+            result = self.sr_client.post_subjects_subject_versions(
+                subject=subject,
+                data=json.dumps({"schema": schema}),
+                timeout=10,
+                hostname=hostname,
+            )
+            assert not expect_timeout, (
+                f"Expected POST /subjects/{subject}/versions to hang, but it returned."
+            )
+            return result
+        except (requests.exceptions.ReadTimeout, requests.exceptions.ConnectionError):
+            assert expect_timeout, (
+                f"POST /subjects/{subject}/versions timed out or connection "
+                "error unexpectedly."
+            )
+
+    def _stop_node(self, node, expect_timeout: bool = True):
+        """
+        Attempt to stop a node gracefully.
+
+        If expect_timeout is True, assert the shutdown times out (confirming
+        a deadlocked state). If False, assert clean shutdown succeeds.
+        stop_node sends SIGKILL after timeout before re-raising TimeoutError.
+        """
+        try:
+            self.redpanda.stop_node(node, timeout=15)
+            assert not expect_timeout, (
+                "Expected broker shutdown to time out, but it completed."
+            )
+        except DucktapeTimeoutError:
+            assert expect_timeout, "Broker shutdown timed out unexpectedly."
+            self.logger.info("Broker shutdown timed out as expected.")
+
+    @cluster(num_nodes=3)
+    @parametrize(subject=":.:", expect_deadlock=True)
+    @parametrize(subject=":.ctx:", expect_deadlock=True)
+    # These do not trigger the deadlock — only context-only qualifiers do:
+    @parametrize(subject=":.:subject", expect_deadlock=False)
+    @parametrize(subject=":.ctx:subject", expect_deadlock=False)
+    @parametrize(subject="subject", expect_deadlock=False)
+    def test_delete_mode_context_only_subject_causes_deadlock(
+        self, subject: str, expect_deadlock: bool
+    ):
+        """
+        DELETE /mode/{subject} with a context-only qualifier deadlocks schema
+        registry when schema_registry_enable_qualified_subjects is enabled.
+
+        When the bug is fixed, this test should be updated to assert that the
+        DELETE succeeds and shutdown is clean.
+        """
+        self._call_delete_endpoint("mode", subject, expect_timeout=expect_deadlock)
+        self._call_get_endpoint(
+            "mode", subject
+        )  # GET should still work even if DELETE deadlocks
+        self._post_schema(expect_timeout=expect_deadlock)
+        self._stop_node(self.redpanda.nodes[0], expect_timeout=expect_deadlock)
+
+    @cluster(num_nodes=3)
+    @parametrize(subject=":.:", expect_deadlock=True)
+    @parametrize(subject=":.ctx:", expect_deadlock=True)
+    # These do not trigger the deadlock — only context-only qualifiers do:
+    @parametrize(subject=":.:subject", expect_deadlock=False)
+    @parametrize(subject=":.ctx:subject", expect_deadlock=False)
+    @parametrize(subject="subject", expect_deadlock=False)
+    def test_delete_config_context_only_subject_causes_deadlock(
+        self, subject: str, expect_deadlock: bool
+    ):
+        """
+        DELETE /config/{subject} with a context-only qualifier deadlocks
+        schema registry when schema_registry_enable_qualified_subjects is
+        enabled.
+
+        When the bug is fixed, this test should be updated to assert that the
+        DELETE succeeds and shutdown is clean.
+        """
+        self._call_delete_endpoint("config", subject, expect_timeout=expect_deadlock)
+        self._call_get_endpoint(
+            "config", subject
+        )  # GET should still work even if DELETE deadlocks
+        self._post_schema(expect_timeout=expect_deadlock)
+        self._stop_node(self.redpanda.nodes[0], expect_timeout=expect_deadlock)

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -10725,9 +10725,8 @@ class SchemaRegistryDeadlockTest(SchemaRegistryEndpoints):
             self.logger.info("Broker shutdown timed out as expected.")
 
     @cluster(num_nodes=3)
-    @parametrize(subject=":.:", expect_deadlock=True)
-    @parametrize(subject=":.ctx:", expect_deadlock=True)
-    # These do not trigger the deadlock — only context-only qualifiers do:
+    @parametrize(subject=":.:", expect_deadlock=False)
+    @parametrize(subject=":.ctx:", expect_deadlock=False)
     @parametrize(subject=":.:subject", expect_deadlock=False)
     @parametrize(subject=":.ctx:subject", expect_deadlock=False)
     @parametrize(subject="subject", expect_deadlock=False)
@@ -10749,9 +10748,8 @@ class SchemaRegistryDeadlockTest(SchemaRegistryEndpoints):
         self._stop_node(self.redpanda.nodes[0], expect_timeout=expect_deadlock)
 
     @cluster(num_nodes=3)
-    @parametrize(subject=":.:", expect_deadlock=True)
-    @parametrize(subject=":.ctx:", expect_deadlock=True)
-    # These do not trigger the deadlock — only context-only qualifiers do:
+    @parametrize(subject=":.:", expect_deadlock=False)
+    @parametrize(subject=":.ctx:", expect_deadlock=False)
     @parametrize(subject=":.:subject", expect_deadlock=False)
     @parametrize(subject=":.ctx:subject", expect_deadlock=False)
     @parametrize(subject="subject", expect_deadlock=False)


### PR DESCRIPTION
`DELETE /mode/{subject}` and `DELETE /config/{subject}` deadlock schema registry when invoked with a context-only qualifier (e.g., `":.:"` or `":.ctx:"`) and `schema_registry_enable_qualified_subjects` is enabled.

`do_delete_mode` and `do_delete_config` used `get_mode`/`get_compatibility` for existence checking before deleting. These always return a default value for context-only subjects, so the writer proceeded to build tombstones from
empty `written_at` sequences, causing a deadlock. Replace existence checks with `written_at` sequence lookups as the source of truth for whether a mode or config is actually stored. If empty or context not found, return false instead of attempting to produce an empty record batch (which would trigger the deadlock).

Also make `get_context_mode_written_at` and `get_context_config_written_at` consistently return `not_found` when the context doesn't exist, with a guard for empty `written_at` vectors matching the subject variants.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
