### PR TITLE
bazel: Remove duration/runs from produce bench

### DIFF
--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -887,10 +887,8 @@ redpanda_cc_bench(
     srcs = [
         "produce_partition_bench.cc",
     ],
-    duration = 1,
     memory = "4GiB",
     redirect_stderr = True,
-    runs = 1,
     deps = [
         "//src/v/container:chunked_vector",
         "//src/v/kafka/protocol/schemata:produce_request",


### PR DESCRIPTION
Unclear why we added this in the first place.

Remove

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


* none
