### PR TITLE
`ct/l1`: add `batches_processed` as metric in `worker_probe`

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/scheduler_probe.cc
+++ b/src/v/cloud_topics/level_one/compaction/scheduler_probe.cc
@@ -38,8 +38,8 @@ void compaction_scheduler_probe::setup_metrics() {
           [this] { return _compaction_queue_length; },
           sm::description(
             "Length of the compaction queue for this compaction scheduler")),
-        sm::make_gauge(
-          "log_compactions",
+        sm::make_counter(
+          "log_compactions_total",
           [this] { return _log_compactions; },
           sm::description(
             "Number of compaction rounds performed across all shards")),

--- a/src/v/cloud_topics/level_one/compaction/worker_probe.cc
+++ b/src/v/cloud_topics/level_one/compaction/worker_probe.cc
@@ -34,20 +34,20 @@ void compaction_worker_probe::setup_metrics() {
           sm::description(
             "Number of batches processed across all cloud topic partitions on "
             "this shard")),
-        sm::make_gauge(
-          "batches_removed",
+        sm::make_counter(
+          "batches_removed_total",
           [this] { return _batches_removed; },
           sm::description(
             "Number of batches removed across all cloud topic partitions on "
             "this shard")),
-        sm::make_gauge(
-          "records_removed",
+        sm::make_counter(
+          "records_removed_total",
           [this] { return _records_removed; },
           sm::description(
             "Number of records removed across all cloud topic partitions on "
             "this shard")),
-        sm::make_gauge(
-          "tombstones_removed",
+        sm::make_counter(
+          "tombstones_removed_total",
           [this] { return _tombstones_removed; },
           sm::description(
             "Number of tombstone records removed across all cloud topic "

--- a/src/v/cloud_topics/level_one/compaction/worker_probe.cc
+++ b/src/v/cloud_topics/level_one/compaction/worker_probe.cc
@@ -28,6 +28,12 @@ void compaction_worker_probe::setup_metrics() {
     _metrics.add_group(
       prometheus_sanitize::metrics_name("cloud_topics:compaction_worker"),
       {
+        sm::make_counter(
+          "batches_processed_total",
+          [this] { return _batches_processed; },
+          sm::description(
+            "Number of batches processed across all cloud topic partitions on "
+            "this shard")),
         sm::make_gauge(
           "batches_removed",
           [this] { return _batches_removed; },

--- a/src/v/cloud_topics/level_one/compaction/worker_probe.h
+++ b/src/v/cloud_topics/level_one/compaction/worker_probe.h
@@ -39,6 +39,7 @@ public:
     }
 
     void add_stats(const compaction::stats& stats) {
+        _batches_processed += stats.batches_processed;
         _batches_removed += stats.batches_discarded;
         _records_removed += stats.records_discarded;
         _tombstones_removed += stats.expired_tombstones_discarded;
@@ -47,6 +48,7 @@ public:
 private:
     hist_t _compaction_runs;
 
+    uint64_t _batches_processed{0};
     uint64_t _batches_removed{0};
     uint64_t _records_removed{0};
     uint64_t _tombstones_removed{0};

--- a/tests/rptest/tests/cloud_topics/e2e_test.py
+++ b/tests/rptest/tests/cloud_topics/e2e_test.py
@@ -359,12 +359,12 @@ class EndToEndCloudTopicsCompactionTest(EndToEndCloudTopicsBase):
 
     def get_removed_records(self):
         return self._metric_sum(
-            "vectorized_cloud_topics_compaction_worker_records_removed"
+            "vectorized_cloud_topics_compaction_worker_records_removed_total"
         )
 
     def get_log_compactions(self):
         return self._metric_sum(
-            "vectorized_cloud_topics_compaction_scheduler_log_compactions"
+            "vectorized_cloud_topics_compaction_scheduler_log_compactions_total"
         )
 
     def get_managed_logs(self):

--- a/tests/rptest/tests/cloud_topics/iceberg_test.py
+++ b/tests/rptest/tests/cloud_topics/iceberg_test.py
@@ -174,7 +174,7 @@ class EndToEndCloudTopicsIcebergCompactionTest(EndToEndCloudTopicsIcebergTestBas
                 assert self.redpanda
                 return (
                     self.redpanda.metric_sum(
-                        metric_name="vectorized_cloud_topics_compaction_scheduler_log_compactions",
+                        metric_name="vectorized_cloud_topics_compaction_scheduler_log_compactions_total",
                         metrics_endpoint=MetricsEndpoint.METRICS,
                         expect_metric=True,
                     )


### PR DESCRIPTION
This could serve clearly as an indicator for in progress compactions.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
