### PR TITLE
cpd: Add Go/rpk based throughput benchmark

### DIFF
--- a/src/go/rpk/pkg/cli/BUILD
+++ b/src/go/rpk/pkg/cli/BUILD
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/go/rpk/pkg/cli/acl",
+        "//src/go/rpk/pkg/cli/benchmark",
         "//src/go/rpk/pkg/cli/cloud",
         "//src/go/rpk/pkg/cli/cluster",
         "//src/go/rpk/pkg/cli/connect",

--- a/src/go/rpk/pkg/cli/benchmark/BUILD
+++ b/src/go/rpk/pkg/cli/benchmark/BUILD
@@ -1,0 +1,17 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "benchmark",
+    srcs = ["benchmark.go"],
+    importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/benchmark",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/go/rpk/pkg/config",
+        "//src/go/rpk/pkg/kafka",
+        "@com_github_spf13_afero//:afero",
+        "@com_github_spf13_cobra//:cobra",
+        "@com_github_twmb_franz_go//pkg/kerr",
+        "@com_github_twmb_franz_go//pkg/kgo",
+        "@com_github_twmb_franz_go_pkg_kadm//:kadm",
+    ],
+)

--- a/src/go/rpk/pkg/cli/benchmark/BUILD
+++ b/src/go/rpk/pkg/cli/benchmark/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//src/go/rpk/pkg/config",
         "//src/go/rpk/pkg/kafka",
+        "//src/go/rpk/pkg/out",
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_twmb_franz_go//pkg/kerr",

--- a/src/go/rpk/pkg/cli/benchmark/benchmark.go
+++ b/src/go/rpk/pkg/cli/benchmark/benchmark.go
@@ -1,0 +1,434 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package benchmark
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+type stats struct {
+	requests atomic.Uint64
+	bytes    atomic.Uint64
+	errors   atomic.Uint64
+}
+
+type finalMetrics struct {
+	RequestsPerSec float64 `json:"requests_per_sec"`
+	MBPerSec       float64 `json:"mb_per_sec"`
+	Errors         uint64  `json:"errors"`
+}
+
+func computeMetrics(s *stats, now, measureStart time.Time) finalMetrics {
+	elapsed := now.Sub(measureStart).Seconds()
+	if elapsed <= 0 {
+		elapsed = 1e-9
+	}
+	return finalMetrics{
+		RequestsPerSec: float64(s.requests.Load()) / elapsed,
+		MBPerSec:       (float64(s.bytes.Load()) / (1024 * 1024)) / elapsed,
+		Errors:         s.errors.Load(),
+	}
+}
+
+func printStats(s *stats, now, measureStart time.Time, final bool) {
+	if now.Before(measureStart) {
+		remaining := measureStart.Sub(now).Round(time.Second)
+		fmt.Printf("warmup in progress, %s remaining\n", remaining)
+		return
+	}
+	m := computeMetrics(s, now, measureStart)
+
+	prefix := ""
+	if final {
+		prefix = "final "
+	}
+	fmt.Printf("%srequests/s=%.2f MB/s=%.2f errors=%d\n", prefix, m.RequestsPerSec, m.MBPerSec, m.Errors)
+}
+
+func createBenchmarkTopic(ctx context.Context, adm *kadm.Client, topic string, partitions int32, replicas int16) error {
+	resps, err := adm.CreateTopics(ctx, partitions, replicas, nil, topic)
+	if err != nil {
+		return err
+	}
+	resp, ok := resps[topic]
+	if !ok {
+		return fmt.Errorf("missing create topic response for %q", topic)
+	}
+	if errors.Is(resp.Err, kerr.TopicAlreadyExists) {
+		return fmt.Errorf("benchmark topic %q already exists; choose a unique --topic", topic)
+	}
+	if resp.Err != nil {
+		return resp.Err
+	}
+	return nil
+}
+
+func deleteBenchmarkTopic(adm *kadm.Client, topic string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	resps, err := adm.DeleteTopics(ctx, topic)
+	if err != nil {
+		return err
+	}
+	resp, ok := resps[topic]
+	if !ok {
+		return fmt.Errorf("missing delete topic response for %q", topic)
+	}
+	if resp.Err != nil {
+		return resp.Err
+	}
+	return nil
+}
+
+// checks whether leadership is balanced, aka:
+// - all brokers have equal amount of leadership.
+// - The above but some are leader for one more partition.
+func leadershipBalanced(md kadm.Metadata, topic string, expectedPartitions int32) (bool, string) {
+	td, ok := md.Topics[topic]
+	if !ok {
+		return false, "topic metadata not found"
+	}
+	if td.Err != nil {
+		return false, td.Err.Error()
+	}
+	if int32(len(td.Partitions)) != expectedPartitions {
+		return false, fmt.Sprintf(
+			"partition count is %d, expected %d",
+			len(td.Partitions),
+			expectedPartitions,
+		)
+	}
+
+	replicaNodes := make(map[int32]struct{})
+	leaderCounts := make(map[int32]int)
+	for _, p := range td.Partitions {
+		if p.Err != nil {
+			return false, p.Err.Error()
+		}
+		if p.Leader < 0 {
+			return false, fmt.Sprintf("partition %d has no leader", p.Partition)
+		}
+		leaderCounts[p.Leader]++
+		for _, replica := range p.Replicas {
+			replicaNodes[replica] = struct{}{}
+		}
+	}
+
+	if len(replicaNodes) == 0 {
+		return false, "no replicas in topic metadata"
+	}
+
+	brokerCount := len(replicaNodes)
+	basePartitionLeadersPerBroker := int(expectedPartitions) / brokerCount
+	moduloLeaderCount := int(expectedPartitions) % brokerCount
+
+	brokersAtBase := 0
+	brokersAtBasePlusOne := 0
+	for replica := range replicaNodes {
+		count := leaderCounts[replica]
+		switch count {
+		case basePartitionLeadersPerBroker:
+			brokersAtBase++
+		case basePartitionLeadersPerBroker + 1:
+			brokersAtBasePlusOne++
+		default:
+			return false, fmt.Sprintf(
+				"leader distribution invalid: broker %d has %d leaders (expected %d or %d)",
+				replica,
+				count,
+				basePartitionLeadersPerBroker,
+				basePartitionLeadersPerBroker+1,
+			)
+		}
+	}
+
+	if brokersAtBasePlusOne != moduloLeaderCount {
+		return false, fmt.Sprintf(
+			"leader distribution invalid: expected %d brokers with %d leaders, got %d",
+			moduloLeaderCount,
+			basePartitionLeadersPerBroker+1,
+			brokersAtBasePlusOne,
+		)
+	}
+	if brokersAtBase != brokerCount-moduloLeaderCount {
+		return false, fmt.Sprintf(
+			"leader distribution invalid: expected %d brokers with %d leaders, got %d",
+			brokerCount-moduloLeaderCount,
+			basePartitionLeadersPerBroker,
+			brokersAtBase,
+		)
+	}
+
+	return true, ""
+}
+
+func waitForBalancedLeadership(
+	ctx context.Context,
+	adm *kadm.Client,
+	topic string,
+	expectedPartitions int32,
+) error {
+	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	var lastReason string
+	for {
+		md, err := adm.Metadata(ctx, topic)
+		if err == nil {
+			if ok, reason := leadershipBalanced(md, topic, expectedPartitions); ok {
+				return nil
+			} else {
+				lastReason = reason
+			}
+		} else {
+			lastReason = err.Error()
+		}
+
+		select {
+		case <-ctx.Done():
+			if lastReason == "" {
+				lastReason = ctx.Err().Error()
+			}
+			return fmt.Errorf(
+				"timed out waiting for balanced leadership on topic %q: %s",
+				topic,
+				lastReason,
+			)
+		case <-ticker.C:
+		}
+	}
+}
+
+func runProducerLoop(
+	ctx context.Context,
+	cl *kgo.Client,
+	topic string,
+	payload []byte,
+	measureStart time.Time,
+	stats *stats,
+) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		rec := &kgo.Record{Topic: topic, Value: payload}
+
+		// We use sync produce. Like this we can guarantee single record per batch per request.
+		// To increase inflight it's easy to just bump clients/connections (this is cheap in franz-go)
+		err := cl.ProduceSync(ctx, rec).FirstErr()
+		now := time.Now()
+		if now.Before(measureStart) {
+			continue
+		}
+		if err != nil {
+			if ctx.Err() == nil {
+				stats.requests.Add(1)
+				stats.errors.Add(1)
+			}
+			continue
+		}
+
+		stats.requests.Add(1)
+		stats.bytes.Add(uint64(len(payload)))
+	}
+}
+
+func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var (
+		topic                  string
+		partitions             int32
+		replicas               int16
+		clients                int
+		recordSize             int
+		warmupS                int
+		durationS              int
+		metricsJSON            string
+		waitLeadershipBalanced bool
+	)
+
+	cmd := &cobra.Command{
+		Use:    "benchmark",
+		Short:  "Run a Kafka benchmark",
+		Long:   "Load testing tool which stresses the broker by sending small batches with high request rate",
+		Args:   cobra.NoArgs,
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if partitions <= 0 {
+				return fmt.Errorf("invalid --partitions %d, must be > 0", partitions)
+			}
+			if replicas <= 0 {
+				return fmt.Errorf("invalid --replicas %d, must be > 0", replicas)
+			}
+			if clients <= 0 {
+				return fmt.Errorf("invalid --clients %d, must be > 0", clients)
+			}
+			if recordSize <= 0 {
+				return fmt.Errorf("invalid --record-size %d, must be > 0", recordSize)
+			}
+			if warmupS < 0 {
+				return fmt.Errorf("invalid --warmup %d, must be >= 0", warmupS)
+			}
+			if durationS <= 0 {
+				return fmt.Errorf("invalid --duration %d, must be > 0", durationS)
+			}
+
+			profile, err := p.LoadVirtualProfile(fs)
+			if err != nil {
+				return fmt.Errorf("rpk unable to load config: %w", err)
+			}
+
+			adm, err := kafka.NewAdmin(fs, profile)
+			if err != nil {
+				return fmt.Errorf("unable to initialize admin kafka client: %w", err)
+			}
+			defer adm.Close()
+
+			ctx, cancel := context.WithCancel(cmd.Context())
+			defer cancel()
+
+			sigCh := make(chan os.Signal, 1)
+			signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+			defer signal.Stop(sigCh)
+			go func() {
+				select {
+				case <-sigCh:
+					cancel()
+				case <-ctx.Done():
+				}
+			}()
+
+			err = createBenchmarkTopic(ctx, adm, topic, partitions, replicas)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err := deleteBenchmarkTopic(adm, topic); err != nil {
+					fmt.Printf("cleanup warning: unable to delete topic %q: %v\n", topic, err)
+				}
+			}()
+
+			if waitLeadershipBalanced {
+				fmt.Printf("waiting for balanced leadership on topic=%s\n", topic)
+				err = waitForBalancedLeadership(ctx, adm, topic, partitions)
+				if err != nil {
+					return err
+				}
+			}
+
+			warmup := time.Duration(warmupS) * time.Second
+			duration := time.Duration(durationS) * time.Second
+			measureStart := time.Now().Add(warmup)
+			measureEnd := measureStart.Add(duration)
+
+			runCtx, runCancel := context.WithDeadline(ctx, measureEnd)
+			defer runCancel()
+
+			payload := make([]byte, recordSize)
+			for i := range payload {
+				payload[i] = 'x'
+			}
+			stats := &stats{}
+
+			producerOpts := []kgo.Opt{
+				kgo.DefaultProduceTopic(topic),
+				kgo.RequiredAcks(kgo.AllISRAcks()),
+				kgo.RecordPartitioner(kgo.RoundRobinPartitioner()),
+				kgo.ProducerLinger(0),
+			}
+
+			producerClients := make([]*kgo.Client, 0, clients)
+			for i := 0; i < clients; i++ {
+				cl, err := kafka.NewFranzClient(fs, profile, producerOpts...)
+				if err != nil {
+					for _, started := range producerClients {
+						started.Close()
+					}
+					return fmt.Errorf("unable to initialize producer client %d: %w", i, err)
+				}
+				producerClients = append(producerClients, cl)
+			}
+			defer func() {
+				for _, cl := range producerClients {
+					cl.Close()
+				}
+			}()
+
+			fmt.Printf("topic=%s clients=%d partitions=%d record_size=%d replication_factor=%d\n", topic, clients, partitions, recordSize, replicas)
+
+			var wg sync.WaitGroup
+			for _, cl := range producerClients {
+				wg.Add(1)
+				go func(cl *kgo.Client) {
+					defer wg.Done()
+					runProducerLoop(runCtx, cl, topic, payload, measureStart, stats)
+				}(cl)
+			}
+
+			ticker := time.NewTicker(time.Second)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-runCtx.Done():
+					wg.Wait()
+					if ctx.Err() == nil {
+						printStats(stats, measureEnd, measureStart, true)
+					}
+					if metricsJSON != "" {
+						metrics := computeMetrics(stats, measureEnd, measureStart)
+						b, err := json.MarshalIndent(metrics, "", "  ")
+						if err != nil {
+							return fmt.Errorf("unable to marshal metrics json: %w", err)
+						}
+						err = os.WriteFile(metricsJSON, append(b, '\n'), 0o644)
+						if err != nil {
+							return fmt.Errorf("unable to write metrics json to %q: %w", metricsJSON, err)
+						}
+					}
+					return nil
+				case <-ticker.C:
+					printStats(stats, time.Now(), measureStart, false)
+				}
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&topic, "topic", "rpk-benchmark-topic", "Benchmark topic name")
+	cmd.Flags().Int32VarP(&partitions, "partitions", "p", 18, "Number of partitions for benchmark topic creation")
+	cmd.Flags().Int16VarP(&replicas, "replicas", "r", 3, "Replication factor for benchmark topic creation")
+	cmd.Flags().IntVar(&clients, "clients", 16, "Number of producer client connections")
+	cmd.Flags().IntVar(&recordSize, "record-size", 100, "Record payload size in bytes")
+	cmd.Flags().IntVar(&warmupS, "warmup", 10, "Warmup duration in seconds")
+	cmd.Flags().IntVar(&durationS, "duration", 60, "Measurement duration in seconds")
+	cmd.Flags().StringVar(&metricsJSON, "metrics-json", "", "Optional path to write final metrics JSON")
+	cmd.Flags().BoolVar(&waitLeadershipBalanced, "wait-leadership-balanced", true, "Wait for topic leadership to become balanced before producing")
+
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/benchmark/benchmark.go
+++ b/src/go/rpk/pkg/cli/benchmark/benchmark.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/twmb/franz-go/pkg/kadm"
@@ -42,6 +43,12 @@ type finalMetrics struct {
 	Errors         uint64  `json:"errors"`
 }
 
+const (
+	statsReqWidth = 12
+	statsMBWidth  = 8
+	statsErrWidth = 8
+)
+
 func computeMetrics(s *stats, now, measureStart time.Time) finalMetrics {
 	elapsed := now.Sub(measureStart).Seconds()
 	if elapsed <= 0 {
@@ -54,19 +61,24 @@ func computeMetrics(s *stats, now, measureStart time.Time) finalMetrics {
 	}
 }
 
-func printStats(s *stats, now, measureStart time.Time, final bool) {
-	if now.Before(measureStart) {
-		remaining := measureStart.Sub(now).Round(time.Second)
-		fmt.Printf("warmup in progress, %s remaining\n", remaining)
-		return
-	}
+func printStatsHeader(tw *out.TabWriter) {
+	tw.Print(
+		fmt.Sprintf("%*s", statsReqWidth, "REQUESTS/S"),
+		fmt.Sprintf("%*s", statsMBWidth, "MB/S"),
+		fmt.Sprintf("%*s", statsErrWidth, "ERRORS"),
+	)
+	_ = tw.Flush()
+}
+
+func printStats(tw *out.TabWriter, s *stats, now, measureStart time.Time) {
 	m := computeMetrics(s, now, measureStart)
 
-	prefix := ""
-	if final {
-		prefix = "final "
-	}
-	fmt.Printf("%srequests/s=%.2f MB/s=%.2f errors=%d\n", prefix, m.RequestsPerSec, m.MBPerSec, m.Errors)
+	tw.Print(
+		fmt.Sprintf("%12.2f", m.RequestsPerSec),
+		fmt.Sprintf("%8.2f", m.MBPerSec),
+		fmt.Sprintf("%8d", m.Errors),
+	)
+	_ = tw.Flush()
 }
 
 func createBenchmarkTopic(ctx context.Context, adm *kadm.Client, topic string, partitions int32, replicas int16) error {
@@ -382,6 +394,11 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			}()
 
 			fmt.Printf("topic=%s clients=%d partitions=%d record_size=%d replication_factor=%d\n", topic, clients, partitions, recordSize, replicas)
+			if warmup > 0 {
+				fmt.Printf("warming up for %ds...\n", warmupS)
+			}
+
+			statsTable := out.NewTable()
 
 			var wg sync.WaitGroup
 			for _, cl := range producerClients {
@@ -392,6 +409,13 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				}(cl)
 			}
 
+			select {
+			case <-runCtx.Done():
+			case <-time.After(warmup):
+			}
+
+			printStatsHeader(statsTable)
+
 			ticker := time.NewTicker(time.Second)
 			defer ticker.Stop()
 			for {
@@ -399,7 +423,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				case <-runCtx.Done():
 					wg.Wait()
 					if ctx.Err() == nil {
-						printStats(stats, measureEnd, measureStart, true)
+						printStats(statsTable, stats, measureEnd, measureStart)
 					}
 					if metricsJSON != "" {
 						metrics := computeMetrics(stats, measureEnd, measureStart)
@@ -414,7 +438,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 					}
 					return nil
 				case <-ticker.C:
-					printStats(stats, time.Now(), measureStart, false)
+					printStats(statsTable, stats, time.Now(), measureStart)
 				}
 			}
 		},

--- a/src/go/rpk/pkg/cli/root.go
+++ b/src/go/rpk/pkg/cli/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/fatih/color"
 	mTerm "github.com/moby/term"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/acl"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/benchmark"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cloud"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/connect"
@@ -114,6 +115,7 @@ func Execute() {
 
 	root.AddCommand(
 		acl.NewCommand(fs, p),
+		benchmark.NewCommand(fs, p),
 		cloud.NewCommand(fs, p, osExec),
 		cluster.NewCommand(fs, p),
 		container.NewCommand(fs, p),

--- a/tests/rptest/perf/rpk_benchmark_test.py
+++ b/tests/rptest/perf/rpk_benchmark_test.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from typing import Any
+
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import ResourceSettings
+from rptest.services.rpk_benchmark_service import RpkBenchmarkService
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class RpkBenchmarkPerf(RedpandaTest):
+    PARTITIONS = 18
+    REPLICAS = 3
+    CLIENTS = 60
+    MSG_SIZE = 100
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        # drop shards to two to reduce noise
+        resource_settings = ResourceSettings(num_cpus=2)
+        super().__init__(
+            *args, num_brokers=3, resource_settings=resource_settings, **kwargs
+        )
+
+    def run_workload(self) -> None:
+        svc = RpkBenchmarkService(
+            self.test_context,
+            self.redpanda,
+            topic="rpk-bench-topic",
+            partitions=self.PARTITIONS,
+            replicas=self.REPLICAS,
+            clients=self.CLIENTS,
+            record_size=self.MSG_SIZE,
+            warmup_s=20,
+            duration_s=60,
+        )
+        svc.start()
+        svc.wait(timeout_sec=300)
+
+        metrics = svc.metrics()
+        assert metrics.errors == 0, f"Unexpected benchmark errors: {metrics.errors}"
+        assert metrics.requests_per_sec > 0, "Expected requests/s > 0"
+        assert metrics.mb_per_sec > 0, "Expected MB/s > 0"
+
+        svc.write_metrics_result(metrics)
+
+    @cluster(num_nodes=6)
+    def test_produce(self) -> None:
+        self.run_workload()

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -4716,7 +4716,7 @@ class RedpandaService(Service, RedpandaServiceABC):
             return "/opt/redpanda"
         return self._context.globals["rp_install_path_root"]
 
-    def find_binary(self, name: str):
+    def find_binary(self, name: str) -> str:
         rp_install_path_root = self.rp_install_path()
         return f"{rp_install_path_root}/bin/{name}"
 

--- a/tests/rptest/services/rpk_benchmark_service.py
+++ b/tests/rptest/services/rpk_benchmark_service.py
@@ -1,0 +1,144 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from ducktape.cluster.cluster import ClusterNode
+from ducktape.cluster.remoteaccount import RemoteCommandError
+from ducktape.services.service import Service
+from ducktape.tests.test import TestContext
+from ducktape.utils.util import wait_until
+
+from rptest.services.redpanda import RedpandaService
+
+
+@dataclass
+class RpkBenchmarkMetrics:
+    requests_per_sec: float
+    mb_per_sec: float
+    errors: int
+
+
+class RpkBenchmarkService(Service):
+    PROCESS_NAME = "rpk"
+    LOG_PATH = "/tmp/rpk_benchmark.log"
+    METRICS_PATH = "/tmp/rpk_benchmark_metrics.json"
+    RESULT_FILE_NAME = "result.json"
+
+    logs = {
+        "rpk_benchmark_output": {
+            "path": LOG_PATH,
+            "collect_default": True,
+        }
+    }
+
+    def __init__(
+        self,
+        context: TestContext,
+        redpanda: RedpandaService,
+        topic: str,
+        *,
+        partitions: int = 18,
+        replicas: int = 3,
+        clients: int = 1,
+        record_size: int = 100,
+        warmup_s: int = 5,
+        duration_s: int = 30,
+        wait_for_stable_leadership: bool = True,
+    ):
+        super().__init__(context, num_nodes=1)
+        self._redpanda = redpanda
+        self._topic = topic
+        self._partitions = partitions
+        self._replicas = replicas
+        self._clients = clients
+        self._record_size = record_size
+        self._warmup_s = warmup_s
+        self._duration_s = duration_s
+        self._wait_for_stable_leadership = wait_for_stable_leadership
+        self._pids: dict[str, int] = {}
+
+    def _build_cmd(self) -> str:
+        return (
+            f"{self._redpanda.find_binary('rpk')} -X brokers={self._redpanda.brokers()} benchmark "
+            f"--topic {self._topic} --partitions {self._partitions} --replicas {self._replicas} "
+            f"--clients {self._clients} --record-size {self._record_size} "
+            f"--warmup {self._warmup_s} --duration {self._duration_s} "
+            f"--metrics-json {self.METRICS_PATH} --wait-leadership-balanced={str(self._wait_for_stable_leadership).lower()}"
+        )
+
+    def start_node(self, node: ClusterNode, **kwargs: Any) -> None:
+        self.clean_node(node, **kwargs)
+        wrapped_cmd = f"nohup {self._build_cmd()} >> {self.LOG_PATH} 2>&1 & echo $!"
+        pid = int(node.account.ssh_output(wrapped_cmd, timeout_sec=10).strip())
+        self._pids[node.name] = pid
+        self.logger.debug(f"Spawned rpk benchmark node={node.name} pid={pid}")
+
+    def wait_node(self, node: ClusterNode, timeout_sec: float | None = None) -> bool:
+        pid = self._pids[node.name]
+        timeout = timeout_sec or 600
+        wait_until(
+            lambda: not node.account.exists(f"/proc/{pid}"),
+            timeout_sec=timeout,
+            backoff_sec=2,
+            err_msg=f"rpk benchmark did not finish in {timeout}s (pid={pid})",
+        )
+
+        return True
+
+    def stop_node(self, node: ClusterNode, **kwargs: Any) -> None:
+        pid = self._pids.get(node.name)
+        if pid is None:
+            return
+        try:
+            node.account.signal(pid, signal.SIGKILL, allow_fail=False)
+        except RemoteCommandError as e:
+            if "No such process" not in str(e.msg):
+                raise
+
+    def clean_node(self, node: ClusterNode, **kwargs: Any) -> None:
+        node.account.kill_process(self.PROCESS_NAME, clean_shutdown=False)
+        node.account.remove(self.LOG_PATH, allow_fail=True)
+        node.account.remove(self.METRICS_PATH, allow_fail=True)
+
+    def _result_file_path(self) -> str:
+        result_dir = TestContext.results_dir(self.context, self.context.test_index)
+        os.makedirs(result_dir, exist_ok=True)
+        return os.path.join(result_dir, self.RESULT_FILE_NAME)
+
+    def write_metrics_result(self, metrics: RpkBenchmarkMetrics) -> None:
+        with open(self._result_file_path(), "w", encoding="utf-8") as result_file:
+            json.dump(asdict(metrics), result_file, indent=2, sort_keys=True)
+            result_file.write("\n")
+
+    def metrics(self) -> RpkBenchmarkMetrics:
+        # We could just make rpk write the result.json directly. This way we
+        # support checking the metrics though and we will need this if we ever
+        # add multi node support for this service.
+        if not self.nodes[0].account.exists(self.METRICS_PATH):
+            raise RuntimeError(f"metrics json not found at {self.METRICS_PATH}")
+
+        output = (
+            self.nodes[0]
+            .account.ssh_output(f"cat {self.METRICS_PATH}", timeout_sec=10)
+            .decode("utf-8")
+        )
+        metrics = json.loads(output)
+
+        return RpkBenchmarkMetrics(
+            requests_per_sec=float(metrics["requests_per_sec"]),
+            mb_per_sec=float(metrics["mb_per_sec"]),
+            errors=int(metrics["errors"]),
+        )

--- a/tests/rptest/tests/rpk_benchmark_service_test.py
+++ b/tests/rptest/tests/rpk_benchmark_service_test.py
@@ -1,0 +1,49 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from typing import Any
+from uuid import uuid4
+
+from rptest.services.cluster import cluster
+from rptest.services.rpk_benchmark_service import RpkBenchmarkService
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class RpkBenchmarkServiceSelfTest(RedpandaTest):
+    """Smoke test for the RpkBenchmarkService wrapper."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, num_brokers=1, **kwargs)
+
+    @cluster(num_nodes=2)
+    def test_smoke(self) -> None:
+        topic = f"rpk-bench-smoke-{uuid4().hex[:8]}"
+        svc = RpkBenchmarkService(
+            self.test_context,
+            self.redpanda,
+            topic=topic,
+            partitions=6,
+            replicas=1,
+            clients=5,
+            record_size=100,
+            warmup_s=5,
+            duration_s=5,
+        )
+
+        svc.start()
+        svc.wait(timeout_sec=120)
+
+        metrics = svc.metrics()
+        self.logger.debug(f"Rpk benchmark service metrics: {metrics}")
+
+        assert metrics.errors == 0, f"Unexpected benchmark errors: {metrics.errors}"
+        assert metrics.requests_per_sec > 0, "Expected requests/s > 0"
+        assert metrics.mb_per_sec > 0, "Expected MB/s > 0"
+
+        svc.write_metrics_result(metrics)


### PR DESCRIPTION
Adds a produce throughput benchmark to rpk and adds a CPD test for it.

Note this still uses two shards (which introduces some inherent noise due to unlucky connection  shard placement). To fix that we might need to add a custom load balancer thingy to redpanda (to shuffle produce/consume connections correctly).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

