### PR TITLE
Improve memory estimates in cloud storage

### DIFF
--- a/src/v/cloud_storage/materialized_resources.cc
+++ b/src/v/cloud_storage/materialized_resources.cc
@@ -190,8 +190,23 @@ inline ssize_t projected_remote_segment_memory_usage() {
     // This is an estimate. When the reader is created it's size should be
     // checked and if it's larger units should be acquired. If it's smaller
     // some units should be released.
-    static constexpr size_t segment_index_projected_size = 0x1000;
-    return sizeof(remote_segment) + segment_index_projected_size;
+
+    // index ~4KB + coarse index ~256B + segment_chunks base ~1KB
+    // + heap paths ~512B + chunk map entries (assumes small segment) ~512B
+    static constexpr size_t subobject_overhead = 0x2800; // ~10KB
+
+    // run_hydrate_bg (640B) + hydration_loop_state::hydrate (232B)
+    // + do_hydrate_index (1112B) + do_hydrate_txrange (512B)
+    // + 2x download_object (2x1368B) + segment_chunks::run_hydrate_bg (392B)
+    // + heap allocations for hydration state (~1100B)
+    static constexpr size_t coroutine_overhead = 0x1A00; // ~6.5KB
+
+    // Cached free chunks in the hydration and chunk waiter expiring_fifos.
+    static size_t waiter_overhead
+      = remote_segment::estimate_wait_list_overhead(); // ~40KB
+
+    return sizeof(remote_segment) + subobject_overhead + coroutine_overhead
+           + waiter_overhead;
 }
 
 materialized_manifest_cache&

--- a/src/v/cloud_storage/materialized_resources.cc
+++ b/src/v/cloud_storage/materialized_resources.cc
@@ -253,14 +253,14 @@ void materialized_resources::register_segment(materialized_segment_state& s) {
     if (units > estimate) {
         vlog(
           cst_log.debug,
-          "Returning extra units. Current: {}, extimate: {}",
+          "Returning extra units. Current: {}, estimate: {}",
           units,
           estimate);
         s._units.return_units(units - estimate);
     } else {
         vlog(
           cst_log.debug,
-          "Adopting extra units. Current: {}, extimate: {}",
+          "Adopting extra units. Current: {}, estimate: {}",
           units,
           estimate);
         auto tr = _mem_units.take(estimate - units);

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -86,13 +86,12 @@ remote_partition::iterator remote_partition::get_or_materialize_segment(
       "Segment with base offset {} is already materialized",
       meta.base_offset);
 
-    _ts_probe.segment_materialized();
-
     vlog(
       _ctxlog.debug,
       "Materialized new segment for meta {} with path {}",
       meta,
       path);
+
     _ts_probe.segment_materialized();
 
     return new_iter;

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -343,13 +343,45 @@ remote_segment::maybe_get_offsets(kafka::offset kafka_offset) {
     return pos;
 }
 
+/// Per-segment overhead from chunked_fifo's save_free_chunks=1 policy. The
+/// average case of 1 active chunked_fifo for segment hydration and 1 active
+/// segment chunk fifo is assumed.
+size_t remote_segment::estimate_wait_list_overhead() {
+    // Each expiring_fifo entry is ~160 bytes, chunked_fifo stores 128 per
+    // chunk plus a pointer and two indices of bookkeeping.
+    static constexpr size_t waiter_fifo_size_bytes = 160 * 128 + sizeof(void*)
+                                                     + 2 * sizeof(unsigned);
+    return 2 * waiter_fifo_size_bytes;
+}
+
 size_t remote_segment::estimate_memory_use() const {
-    // NOTE: this is imprecise and doesn't account for certain
-    // things (e.g. chunks api)
     size_t res = sizeof(remote_segment);
+
+    // Heap-allocated filesystem paths
+    res += _path().native().capacity();
+    res += _index_path.native().capacity();
+    res += _chunk_root.native().capacity();
+
     if (_index) {
         res += _index->estimate_memory_use();
     }
+
+    if (_coarse_index) {
+        // absl::btree_map base overhead + per-entry cost
+        res += 256 + _coarse_index->size() * 24;
+    }
+
+    if (_chunks_api) {
+        // segment_chunks owns a btree_map of segment_chunk entries plus
+        // background loop infrastructure (gate, abort_source, cvar, timers,
+        // retry chain, etc.)
+        res += sizeof(segment_chunks);
+        res += _chunks_in_segment * sizeof(segment_chunk);
+    }
+
+    // Cached free chunks in the hydration and chunk waiter expiring_fifos.
+    res += estimate_wait_list_overhead();
+
     return res;
 }
 

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -132,6 +132,11 @@ public:
     /// Return memory occupied by the object
     size_t estimate_memory_use() const;
 
+    /// Estimated memory overhead from the hydration wait lists in the segment
+    /// and its chunks. Each expiring_fifo retains one free chunk after draining
+    /// concurrent waiters.
+    static size_t estimate_wait_list_overhead();
+
     retry_chain_node* get_retry_chain_node() { return &_rtc; }
 
     bool download_in_progress() const noexcept {


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Previously the per-segment memory estimate used was `sizeof(remote_segment) + 4KB`. This significantly underestimated actual usage. The biggest missing contributor was the hydration wait lists in both the segment and chunks. Each can cache one free chunk(~20KB) even when empty. Assuming that there is likely to be at least one segment wait list and one chunked wait list this results in ~40KB of memory usage unaccounted for. In workloads with many small segments this allowed RP to materialize far more segments than memory allowed resulting in an OOM.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
