### PR TITLE
bazel: add Antithesis coverage instrumentation build config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -307,6 +307,20 @@ build:coverage --instrumentation_filter="^//src/v[/:]"
 build:sanitizer --config=debug
 
 # =================================
+# Antithesis
+# =================================
+# Build mode for Antithesis testing. Enables coverage instrumentation
+# that Antithesis uses for guided exploration. Debug symbols are included
+# for symbolization (placed in /symbols in the container image).
+build:antithesis --//bazel:antithesis=True
+build:antithesis --compilation_mode=opt
+build:antithesis --per_file_copt=src/v/.*@-fsanitize-coverage=trace-pc-guard
+build:antithesis --linkopt=-Wl,--build-id
+build:antithesis --linkopt=-Wl,--allow-shlib-undefined
+build:antithesis --copt=-g --strip=never
+build:antithesis --@seastar//:stack_guards=False --@seastar//:debug=False
+
+# =================================
 # Testing
 # =================================
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -478,3 +478,11 @@ http_archive(
     strip_prefix = "openmessaging-benchmark-0.0.1-SNAPSHOT",
     urls = ["https://vectorized-public.s3.amazonaws.com/dependencies/omb/omb_minimal_3c624daad47f16ae7036b67142c384d3e59150bf.tar.gz"],
 )
+
+http_archive(
+    name = "antithesis_sdk_cpp",
+    build_file = "//bazel/thirdparty:antithesis_sdk.BUILD",
+    sha256 = "e083cec08b4e173df23e0b07beda5509eddebc1f11d9adc71a8a39d0a229da97",
+    strip_prefix = "antithesis-sdk-cpp-0.4.7",
+    urls = ["https://github.com/antithesishq/antithesis-sdk-cpp/archive/refs/tags/0.4.7.tar.gz"],
+)

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -70,3 +70,15 @@ filegroup(
     srcs = ["bench_wrapper.py"],
     visibility = ["//visibility:public"],
 )
+
+bool_flag(
+    name = "antithesis",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "antithesis_enabled",
+    flag_values = {
+        ":antithesis": "true",
+    },
+)

--- a/bazel/antithesis/BUILD
+++ b/bazel/antithesis/BUILD
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "instrumentation",
+    srcs = ["antithesis_instrumentation.cc"],
+    visibility = ["//visibility:public"],
+    deps = ["@antithesis_sdk_cpp//:antithesis_sdk"],
+    alwayslink = True,
+)

--- a/bazel/antithesis/antithesis_instrumentation.cc
+++ b/bazel/antithesis/antithesis_instrumentation.cc
@@ -1,0 +1,11 @@
+// Antithesis coverage instrumentation hooks.
+//
+// This translation unit provides the __sanitizer_cov_trace_pc_guard and
+// __sanitizer_cov_trace_pc_guard_init symbols required when building with
+// -fsanitize-coverage=trace-pc-guard. The antithesis_instrumentation.h
+// header forwards these to libvoidstar.so (loaded via dlopen) when running
+// inside the Antithesis environment, and provides no-op fallbacks otherwise.
+//
+// This must be linked into any binary built with --config=antithesis.
+
+#include "antithesis_instrumentation.h"

--- a/bazel/build.bzl
+++ b/bazel/build.bzl
@@ -7,7 +7,7 @@ making behavior changes across the entire build.
 
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
-load(":internal.bzl", "redpanda_copts")
+load(":internal.bzl", "antithesis_deps", "redpanda_copts")
 
 # buildifier: disable=function-docstring-args
 def redpanda_cc_library(
@@ -64,7 +64,7 @@ def redpanda_cc_binary(
         defines = defines,
         local_defines = local_defines,
         visibility = visibility,
-        deps = deps,
+        deps = deps + antithesis_deps(),
         testonly = testonly,
         copts = redpanda_copts() + copts,
         linkopts = linkopts,

--- a/bazel/internal.bzl
+++ b/bazel/internal.bzl
@@ -25,3 +25,10 @@ def redpanda_copts():
     copts.append("-DFMT_DEPRECATED_OSTREAM")
 
     return copts
+
+def antithesis_deps():
+    """Conditional deps for Antithesis coverage instrumentation."""
+    return select({
+        "//bazel:antithesis_enabled": ["//bazel/antithesis:instrumentation"],
+        "//conditions:default": [],
+    })

--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -10,7 +10,7 @@ load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
-load(":internal.bzl", "redpanda_copts")
+load(":internal.bzl", "antithesis_deps", "redpanda_copts")
 
 def _has_flags(args, *flags):
     """
@@ -153,7 +153,7 @@ def _redpanda_cc_test(
         timeout = timeout,
         srcs = srcs,
         defines = defines,
-        deps = deps,
+        deps = deps + antithesis_deps(),
         copts = redpanda_copts(),
         args = args,
         features = [
@@ -456,7 +456,7 @@ def redpanda_cc_bench(
         name = binary_name,
         srcs = srcs,
         defines = defines,
-        deps = deps,
+        deps = deps + antithesis_deps(),
         testonly = True,
         copts = redpanda_copts(),
         features = [

--- a/bazel/thirdparty/antithesis_sdk.BUILD
+++ b/bazel/thirdparty/antithesis_sdk.BUILD
@@ -1,0 +1,12 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "antithesis_sdk",
+    hdrs = [
+        "antithesis_instrumentation.h",
+        "antithesis_sdk.h",
+    ],
+    includes = ["."],
+    linkopts = ["-ldl"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Adds `--config=antithesis` which enables LLVM coverage callbacks and links the Antithesis SDK's instrumentation hooks into all redpanda_cc_binary, cc_test, and cc_bench targets. At runtime the hooks attempt to dlopen libvoidstar.so, which Antithesis injects in their environment. Outside Antithesis they are no-ops.

 `--allow-shlib-undefined` is needed because shared libraries reference the coverage guard symbols that are only defined in the final binary.

Future PRs will build on this to:
- Automatically package test binaries into docker images that are designed to run on the Antithesis platform.
- Provide a properties/invariants header with always/sometimes/never assertions that map to Antithesis SDK assertions when this configuration is enabled. These will also similarly map to libFuzzer-specifc asserts when that mode is enabled.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
