### PR TITLE
dev_cluster: Add option to delete data dir on startup

### DIFF
--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -536,6 +536,12 @@ async def main() -> None:
     parser.add_argument(
         "-d", "--directory", type=Path, help="data directory", default=None
     )
+    parser.add_argument(
+        "--delete-data-dir",
+        action=argparse.BooleanOptionalAction,
+        help="delete the data directory before starting",
+        default=False,
+    )
     parser.add_argument("--base-rpc-port", type=int, help="rpc port", default=33145)
     parser.add_argument("--base-kafka-port", type=int, help="kafka port", default=9092)
     parser.add_argument("--base-admin-port", type=int, help="admin port", default=9644)
@@ -622,6 +628,15 @@ async def main() -> None:
 
     if args.directory is None:
         args.directory = Path(os.environ.get("BUILD_WORKSPACE_DIRECTORY", ".")) / "data"
+
+    if (
+        args.delete_data_dir
+        and args.directory.exists()
+        # safety check that we are dealing with a dev cluster data dir
+        and (args.directory / "node0/config.yaml").exists()
+    ):
+        print(f"Deleting existing data directory: {args.directory}")
+        shutil.rmtree(args.directory)
 
     # Apply port offset to all base ports
     if args.port_offset:


### PR DESCRIPTION
Adds a flag to wipe the data dir on startup and start fresh.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


* none
