### PR TITLE
ct/l1/lsm: fix reactor stall in snapshot serialization

### DIFF
--- a/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
+++ b/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
@@ -81,6 +81,10 @@ struct domain_manager_node {
         }
         auto* ptr = mgr.get();
         managers.push_back(std::move(mgr));
+        if (managers.size() > 3) {
+            inactive_managers.push_back(std::move(managers.front()));
+            managers.pop_front();
+        }
         return ptr;
     }
 
@@ -91,6 +95,18 @@ struct domain_manager_node {
                 co_await mgr->stop_and_wait();
             } catch (...) {
                 // Ignore errors during teardown.
+                auto ex = std::current_exception();
+                vlog(dm_test_log.info, "Manager shutdown error: {}", ex);
+            }
+        }
+        for (auto& mgr : inactive_managers) {
+            try {
+                co_await mgr->stop_and_wait();
+            } catch (...) {
+                // Ignore errors during teardown.
+                auto ex = std::current_exception();
+                vlog(
+                  dm_test_log.info, "Inactive manager shutdown error: {}", ex);
             }
         }
     }
@@ -100,7 +116,19 @@ struct domain_manager_node {
     const cloud_storage_clients::bucket_name& bucket;
     temporary_dir staging_directory;
     file_io object_io;
+
+    // Active managers on this node. These managers may be operated on by
+    // callers. Not all of these managers are expected to actually work, e.g.
+    // managers from previous terms likely won't work. We keep around multiple
+    // to validate concurrency, but not too many (hence inactive_managers) to
+    // not make these tests too stressful.
+    //
+    // It is expected that the last manager in this list is typically
+    // functional.
     std::list<std::unique_ptr<db_domain_manager>> managers;
+
+    // Inactive managers, left around to destruct at the end of the test.
+    std::list<std::unique_ptr<db_domain_manager>> inactive_managers;
 };
 
 model::topic_id_partition
@@ -490,7 +518,7 @@ public:
                 co_await ss::maybe_yield();
             }
             co_await ss::when_all_succeed(std::move(futs));
-            co_await random_sleep_ms(100);
+            co_await random_sleep_ms(1000);
         }
     }
 
@@ -596,7 +624,9 @@ TEST_P(DbDomainManagerTestWithParams, TestConcurrentUpdates) {
             futs.emplace_back(extent_validator_loop(*node, tp, done));
             futs.emplace_back(
               replacer_loop(*node, tp, expected_add_next, done));
-            if (args.with_flush_loop) {
+        }
+        if (args.with_flush_loop) {
+            for (int i = 0; i < 2; ++i) {
                 futs.emplace_back(flusher_loop(*node, done));
             }
         }

--- a/src/v/cloud_topics/level_one/metastore/lsm/state.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state.cc
@@ -9,6 +9,7 @@
  */
 #include "cloud_topics/level_one/metastore/lsm/state.h"
 
+#include "serde/async.h"
 #include "serde/rw/envelope.h"
 #include "serde/rw/iobuf.h"
 #include "serde/rw/named_type.h"
@@ -18,6 +19,8 @@
 #include "serde/rw/vector.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 
 namespace cloud_topics::l1 {
 
@@ -32,6 +35,21 @@ std::deque<volatile_row> share_rows(std::deque<volatile_row>& rows) {
               .key = r.row.key, .value = r.row.value.share()}});
     }
     return copy;
+}
+
+template<typename Vec>
+ss::future<> write_vector_async(iobuf& out, Vec t) {
+    if (unlikely(t.size() > std::numeric_limits<serde::serde_size_t>::max())) {
+        throw serde::serde_exception(fmt_with_ctx(
+          ssx::sformat,
+          "serde: vector size {} exceeds serde_size_t",
+          t.size()));
+    }
+    serde::write(out, static_cast<serde::serde_size_t>(t.size()));
+    for (auto& el : t) {
+        serde::write(out, std::move(el));
+        co_await ss::coroutine::maybe_yield();
+    }
 }
 } // namespace
 
@@ -71,6 +89,18 @@ model::offset lsm_state::to_offset(lsm::sequence_number s) const {
 
 lsm::sequence_number lsm_state::to_seqno(model::offset o) const {
     return lsm::sequence_number(o() + seqno_delta);
+}
+
+ss::future<> lsm_state::serde_async_write(iobuf& out) {
+    serde::write(out, domain_uuid);
+    serde::write(out, seqno_delta);
+    serde::write(out, db_epoch_delta);
+    co_await write_vector_async(out, std::move(volatile_buffer));
+    serde::write(out, std::move(persisted_manifest));
+}
+
+ss::future<> lsm_stm_snapshot::serde_async_write(iobuf& out) {
+    return serde::write_async(out, std::move(state));
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/lsm/state.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state.h
@@ -16,6 +16,8 @@
 #include "model/fundamental.h"
 #include "serde/envelope.h"
 
+#include <seastar/core/future.hh>
+
 #include <deque>
 
 namespace cloud_topics::l1 {
@@ -58,6 +60,7 @@ struct lsm_state
           persisted_manifest);
     }
     lsm_state share();
+    ss::future<> serde_async_write(iobuf& out);
 
     // Conversion between Redpanda space and LSM DB space.
     model::term_id to_term(lsm::internal::database_epoch) const;
@@ -129,6 +132,7 @@ struct lsm_stm_snapshot
       envelope<lsm_stm_snapshot, serde::version<0>, serde::compat_version<0>> {
     auto serde_fields() { return std::tie(state); }
     lsm_state state;
+    ss::future<> serde_async_write(iobuf& out);
 };
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/lsm/tests/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/lsm/tests/BUILD
@@ -12,6 +12,7 @@ redpanda_cc_gtest(
         "//src/v/cloud_topics/level_one/metastore/lsm:write_batch_row",
         "//src/v/container:chunked_vector",
         "//src/v/model",
+        "//src/v/serde",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
     ],

--- a/src/v/cloud_topics/level_one/metastore/lsm/tests/lsm_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/tests/lsm_update_test.cc
@@ -11,10 +11,16 @@
 #include "cloud_topics/level_one/metastore/lsm/lsm_update.h"
 #include "cloud_topics/level_one/metastore/lsm/state.h"
 #include "cloud_topics/level_one/metastore/lsm/write_batch_row.h"
+#include "serde/async.h"
 
 #include <gtest/gtest.h>
 
 using namespace cloud_topics::l1;
+
+// Verify that lsm_state and lsm_stm_snapshot use async serde writes to avoid
+// reactor stalls when serializing a large volatile_buffer.
+static_assert(serde::has_serde_async_write<lsm_state>);
+static_assert(serde::has_serde_async_write<lsm_stm_snapshot>);
 
 namespace {
 


### PR DESCRIPTION
serde::write_async<lsm_stm_snapshot> was falling through to the synchronous else-branch since neither it nor the lsm_state type had serde_async_write.

Adds serde_async_write calls with appropriate yields.

Also included is a fix for CORE-15709, which seemed to get flakier with this change.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
