### PR TITLE
ct: Fix L0 object size distribution

### DIFF
--- a/src/v/cloud_topics/level_zero/batcher/batcher.cc
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.cc
@@ -28,6 +28,7 @@
 
 #include <chrono>
 #include <exception>
+#include <limits>
 #include <variant>
 
 using namespace std::chrono_literals;
@@ -237,72 +238,128 @@ ss::future<std::expected<std::monostate, errc>> batcher<Clock>::run_once(
 template<class Clock>
 ss::future<> batcher<Clock>::bg_controller_loop() {
     auto h = _gate.hold();
-    bool more_work = false;
     while (!_as.abort_requested()) {
-        if (!more_work) {
-            auto wait_res = co_await _stage.wait_next(&_as);
-            if (!wait_res.has_value()) {
-                // Shutting down
-                vlog(
-                  _logger.info,
-                  "Batcher upload loop is shutting down {}",
-                  wait_res.error());
-                co_return;
-            }
+        auto wait_res = co_await _stage.wait_next(&_as);
+        if (!wait_res.has_value()) {
+            vlog(
+              _logger.info,
+              "Batcher upload loop is shutting down {}",
+              wait_res.error());
+            co_return;
         }
         if (_as.abort_requested()) {
             vlog(_logger.info, "Batcher upload loop is shutting down");
             co_return;
         }
 
-        // Acquire semaphore units to limit concurrent background fibers.
-        // This blocks until a slot is available.
-        auto units_fut = co_await ss::coroutine::as_future(
-          ss::get_units(_upload_sem, 1, _as));
+        // Pull all available write requests at once.
+        auto all = _stage.pull_write_requests(
+          std::numeric_limits<size_t>::max(),
+          std::numeric_limits<size_t>::max());
 
-        auto list = _stage.pull_write_requests(
-          config::shard_local_cfg()
-            .cloud_topics_produce_batching_size_threshold(),
-          config::shard_local_cfg()
-            .cloud_topics_produce_cardinality_threshold());
-
-        bool complete = list.complete;
-
-        if (units_fut.failed()) {
-            auto ex = units_fut.get_exception();
-            vlog(_logger.info, "Batcher upload loop is shutting down: {}", ex);
-            co_return;
+        if (all.requests.empty()) {
+            continue;
         }
-        auto units = std::move(units_fut.get());
 
-        // We can spawn the work in the background without worrying about memory
-        // usage because the background fibers is holding units acquired above.
-        ssx::spawn_with_gate(
-          _gate,
-          [this, list = std::move(list), units = std::move(units)]() mutable {
-              return run_once(std::move(list))
-                .then([this](std::expected<std::monostate, errc> res) {
-                    if (!res.has_value()) {
-                        if (res.error() == errc::shutting_down) {
-                            vlog(
-                              _logger.info,
-                              "Batcher upload loop is shutting down");
-                        } else {
-                            vlog(
-                              _logger.info,
-                              "Batcher upload loop error: {}",
-                              res.error());
+        // Calculate total size and split into evenly-sized chunks,
+        // each close to the configured threshold.
+        size_t total_size = 0;
+        for (const auto& wr : all.requests) {
+            total_size += wr.size_bytes();
+        }
+
+        auto threshold = config::shard_local_cfg()
+                           .cloud_topics_produce_batching_size_threshold();
+
+        // If we will allow every chunk to be 'threshold' size
+        // then the last chunk in the list has an opportunity to be
+        // much smaller than the rest. Consider a case when the threshold
+        // is 4MiB and we got 8MiB + 1KiB in one iteration. If we will
+        // upload two 4MiB objects we will have to upload 1KiB object next.
+        // The solution is to allow upload size to deviate more if it allows
+        // us to avoid overly small objects (which will impact TCO).
+        //
+        // The computation below can yield small target_chunk_size in case
+        // if total_size is below the threshold. If the total_size exceeds
+        // the threshold the target_chunk_size can either overshoot the
+        // threshold or undershoot. In both cases the error is bounded by
+        // about 50%. The largest error is an overshoot in case if
+        // the total_size is 6MiB - 1 byte and the threshold is 4MiB. The
+        // num_chunks in this case is 1 and the target_chunk_size is approx.
+        // 6MiB which is 2MiB over the threshold (50% of 4MiB threshold).
+        // If the total_size is 6MiB the num_chunks will be 2 and the
+        // target_chunk_size will be 3MiB which is 1MiB below the threshold
+        // (or 25% of 4MiB).
+        size_t num_chunks = std::max(
+          size_t{1}, (total_size + threshold / 2) / threshold);
+        size_t target_chunk_size = total_size / num_chunks;
+
+        vlog(
+          _logger.trace,
+          "Splitting {} ({} bytes) into {} chunks, target chunk size: {} "
+          "({})",
+          human::bytes(total_size),
+          total_size,
+          num_chunks,
+          human::bytes(target_chunk_size),
+          target_chunk_size);
+
+        for (size_t i = 0; i < num_chunks && !all.requests.empty(); ++i) {
+            auto units_fut = co_await ss::coroutine::as_future(
+              ss::get_units(_upload_sem, 1, _as));
+
+            if (units_fut.failed()) {
+                auto ex = units_fut.get_exception();
+                vlog(
+                  _logger.info, "Batcher upload loop is shutting down: {}", ex);
+                co_return;
+            }
+            auto units = std::move(units_fut.get());
+
+            // Build a chunk by moving requests from the pulled list
+            // until we reach the target size (unless it's the last
+            // chunk, upload everything in this case).
+            typename write_pipeline<Clock>::write_requests_list chunk(
+              all._parent, all._ps);
+
+            size_t chunk_size = 0;
+            bool is_last = (i == num_chunks - 1);
+            while (!all.requests.empty()) {
+                auto& wr = all.requests.front();
+                auto sz = wr.size_bytes();
+                chunk_size += sz;
+                wr._hook.unlink();
+                chunk.requests.push_back(wr);
+                // Allow the last chunk to be larger than the target
+                // to avoid small objects.
+                if (!is_last && chunk_size >= target_chunk_size) {
+                    break;
+                }
+            }
+
+            ssx::spawn_with_gate(
+              _gate,
+              [this,
+               chunk = std::move(chunk),
+               units = std::move(units)]() mutable {
+                  return run_once(std::move(chunk))
+                    .then([this](std::expected<std::monostate, errc> res) {
+                        if (!res.has_value()) {
+                            if (res.error() == errc::shutting_down) {
+                                vlog(
+                                  _logger.info,
+                                  "Batcher upload loop is shutting down");
+                            } else {
+                                vlog(
+                                  _logger.info,
+                                  "Batcher upload loop error: {}",
+                                  res.error());
+                            }
                         }
-                    }
-                })
-                .finally([u = std::move(units)] {});
-          });
-
-        // The work is spawned in the background so we can grab data for the
-        // next L0 object. If complete==true, all pending requests were pulled,
-        // so wait for more. If complete==false, there are more pending
-        // requests.
-        more_work = !complete;
+                    })
+                    .finally([u = std::move(units)] {});
+              });
+        }
     }
 }
 

--- a/src/v/cloud_topics/level_zero/batcher/tests/BUILD
+++ b/src/v/cloud_topics/level_zero/batcher/tests/BUILD
@@ -51,6 +51,7 @@ redpanda_cc_gtest(
         "//src/v/storage:record_batch_utils",
         "//src/v/test_utils:gtest",
         "//src/v/test_utils:random_bytes",
+        "//src/v/test_utils:scoped_config",
         "@googletest//:gtest",
         "@seastar",
     ],

--- a/src/v/cloud_topics/level_zero/batcher/tests/batcher_test.cc
+++ b/src/v/cloud_topics/level_zero/batcher/tests/batcher_test.cc
@@ -27,6 +27,7 @@
 #include "remote_mock.h"
 #include "storage/record_batch_builder.h"
 #include "test_utils/random_bytes.h"
+#include "test_utils/scoped_config.h"
 #include "test_utils/test.h"
 
 #include <seastar/core/abort_source.hh>
@@ -352,6 +353,80 @@ TEST_CORO(batcher_test, expired_write_request) {
     }
 }
 
-// TODO: add more tests
-// - behaviour in case if pending write request sizes exceed L0 object size
-// limit
+TEST_CORO(batcher_test, chunk_splitting_balances_upload_sizes) {
+    scoped_config cfg;
+    // Use a small threshold so test data splits into multiple chunks.
+    cfg.get("cloud_topics_produce_batching_size_threshold")
+      .set_value(size_t{4096});
+
+    remote_mock mock;
+    mock.expect_upload_object_repeatedly();
+
+    cloud_storage_clients::bucket_name bucket("foo");
+    cloud_topics::l0::write_pipeline<ss::manual_clock> pipeline;
+    static_cluster_services cluster_services;
+    cloud_topics::l0::batcher<ss::manual_clock> batcher(
+      pipeline.register_write_pipeline_stage(),
+      bucket,
+      mock,
+      &cluster_services);
+    cloud_topics::l0::write_pipeline_accessor pipeline_accessor{
+      .pipeline = &pipeline,
+    };
+
+    // Push several write requests. Each has 1 batch with 10 records
+    // (~3KB serialized), so 6 requests total ~18KB. With threshold=4096
+    // this should produce multiple balanced chunks.
+    const int num_requests = 6;
+    std::vector<ss::future<std::expected<
+      chunked_vector<cloud_topics::extent_meta>,
+      std::error_code>>>
+      futures;
+
+    const auto timeout = 10s;
+    auto deadline = ss::manual_clock::now() + timeout;
+
+    for (int i = 0; i < num_requests; i++) {
+        auto [_, records, batches] = get_random_batches(1, 10);
+        futures.push_back(pipeline.write_and_debounce(
+          model::controller_ntp, min_epoch, std::move(batches), deadline));
+    }
+
+    // Wait for all write requests to be staged in the pipeline
+    // before starting the batcher. subscribe() checks pre-existing
+    // pending data, so bg_controller_loop's wait_next will return
+    // immediately seeing all requests at once.
+    co_await sleep_until(10ms, [&] {
+        return pipeline_accessor.write_requests_pending(num_requests);
+    });
+
+    // Start the batcher — bg_controller_loop will pull all 6 requests
+    // in one batch and split them into balanced chunks.
+    co_await batcher.start();
+
+    // Wait for all write request futures to resolve (the batcher
+    // loop processes chunks via spawn_with_gate, which sets the
+    // promises on each write request).
+    auto results = co_await ss::when_all_succeed(std::move(futures));
+    for (auto& res : results) {
+        ASSERT_TRUE_CORO(res.has_value());
+    }
+
+    co_await batcher.stop();
+
+    // Multiple uploads should happen since total data exceeds threshold.
+    ASSERT_GT_CORO(mock.payloads.size(), size_t{1});
+
+    // Verify uploads are balanced: no upload should be excessively small
+    // compared to the average.
+    size_t total_payload = 0;
+    for (const auto& p : mock.payloads) {
+        total_payload += p.size();
+    }
+    size_t avg_size = total_payload / mock.payloads.size();
+    for (size_t i = 0; i < mock.payloads.size(); i++) {
+        EXPECT_GE(mock.payloads[i].size(), avg_size / 3)
+          << "Upload " << i << " size " << mock.payloads[i].size()
+          << " is too small relative to average " << avg_size;
+    }
+}

--- a/src/v/cloud_topics/level_zero/batcher/tests/remote_mock.h
+++ b/src/v/cloud_topics/level_zero/batcher/tests/remote_mock.h
@@ -88,6 +88,19 @@ public:
               ss::make_ready_future<cloud_io::upload_result>(res)));
     }
 
+    /// Accept any number of upload_object calls, recording keys and payloads.
+    void expect_upload_object_repeatedly(
+      cloud_io::upload_result res = cloud_io::upload_result::success) {
+        EXPECT_CALL(*this, upload_object(::testing::_))
+          .WillRepeatedly(
+            [this,
+             res](const cloud_io::basic_upload_request<ss::manual_clock>& req) {
+                keys.push_back(req.transfer_details.key);
+                payloads.push_back(iobuf_to_bytes(req.payload));
+                return ss::make_ready_future<cloud_io::upload_result>(res);
+            });
+    }
+
     static std::deque<ss::sstring>
     convert_bytes_to_string(const chunked_vector<bytes>& expected) {
         std::deque<ss::sstring> result;

--- a/src/v/cloud_topics/level_zero/common/level_zero_probe.cc
+++ b/src/v/cloud_topics/level_zero/common/level_zero_probe.cc
@@ -252,6 +252,14 @@ void write_request_scheduler_probe::setup_internal_metrics(bool disable) {
          "active_groups",
          [this] { return _active_groups; },
          sm::description("Number of active upload groups in the scheduler."),
+         labels),
+
+       sm::make_gauge(
+         "next_stage_bytes",
+         [this] { return _next_stage_bytes; },
+         sm::description(
+           "Bytes buffered in the next pipeline stage, used for "
+           "group split/merge decisions."),
          labels)});
 }
 read_merge_probe::read_merge_probe(bool disable) {

--- a/src/v/cloud_topics/level_zero/common/level_zero_probe.h
+++ b/src/v/cloud_topics/level_zero/common/level_zero_probe.h
@@ -114,6 +114,8 @@ public:
 
     void set_active_groups(uint64_t count) { _active_groups = count; }
 
+    void set_next_stage_bytes(uint64_t bytes) { _next_stage_bytes = bytes; }
+
 private:
     void setup_internal_metrics(bool disable);
 
@@ -128,6 +130,8 @@ private:
     uint64_t _rx_bytes_xshard{0};
     /// Number of active upload groups
     uint64_t _active_groups{0};
+    /// Bytes buffered in the next pipeline stage
+    uint64_t _next_stage_bytes{0};
 
     metrics::internal_metric_groups _metrics;
 };

--- a/src/v/cloud_topics/level_zero/pipeline/read_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/read_pipeline.cc
@@ -204,7 +204,8 @@ read_pipeline<Clock>::get_fetch_requests(
         el._hook.unlink();
         result.requests.push_back(el);
     }
-    result.complete = pending.empty();
+    result.complete = std::none_of(
+      it, pending.end(), [stage](const auto& r) { return r.stage == stage; });
     vlog(
       logger.debug,
       "get_fetch_requests returned {} requests which are querying {} ({}B)",

--- a/src/v/cloud_topics/level_zero/pipeline/tests/write_pipeline_test.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/tests/write_pipeline_test.cc
@@ -516,3 +516,44 @@ TEST_CORO(write_pipeline_test, max_requests_limit) {
 
     ASSERT_TRUE_CORO(accessor.write_requests_pending(0));
 }
+
+TEST_CORO(write_pipeline_test, enqueue_foreign_request_accounts_bytes) {
+    // Verify that enqueue_foreign_request updates _stage_bytes for
+    // the destination stage. This was previously missing, causing
+    // the scheduler to underreport cross-shard work.
+    cloud_topics::l0::write_pipeline<ss::manual_clock> pipeline;
+
+    auto stage1 = pipeline.register_write_pipeline_stage();
+    auto stage2 = pipeline.register_write_pipeline_stage();
+
+    ASSERT_EQ_CORO(pipeline.stage_bytes(stage2.id()), 0);
+
+    const auto timeout = ss::manual_clock::now() + 10s;
+
+    auto make_chunk = [&]() -> ss::future<cloud_topics::l0::serialized_chunk> {
+        chunked_vector<model::record_batch> batches;
+        auto data = co_await model::test::make_random_batches(
+          {.count = 1, .records = 5});
+        std::ranges::move(std::move(data), std::back_inserter(batches));
+        co_return co_await cloud_topics::l0::serialize_batches(
+          std::move(batches));
+    };
+
+    auto chunk = co_await make_chunk();
+    auto req
+      = std::make_unique<cloud_topics::l0::write_request<ss::manual_clock>>(
+        model::controller_ntp, min_epoch, std::move(chunk), timeout);
+    auto expected_size = req->size_bytes();
+
+    // enqueue_foreign_request should account bytes at the next stage
+    stage1.enqueue_foreign_request(*req, false);
+
+    ASSERT_EQ_CORO(pipeline.stage_bytes(stage2.id()), expected_size);
+
+    // Pull from stage2 — bytes should be released
+    auto res = stage2.pull_write_requests(std::numeric_limits<size_t>::max());
+    ASSERT_EQ_CORO(res.requests.size(), 1);
+    ASSERT_EQ_CORO(pipeline.stage_bytes(stage2.id()), 0);
+
+    res.requests.front().set_value(chunked_vector<cloud_topics::extent_meta>{});
+}

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -273,11 +273,12 @@ void write_pipeline<Clock>::stage::signal_next_stage() {
 template<class Clock>
 void write_pipeline<Clock>::stage::enqueue_foreign_request(
   write_request<Clock>& req, bool signal) {
-    // Foreign requests are proxied from another shard where their bytes
-    // were already accounted for. We place them directly at the next stage
-    // without any byte accounting.
     auto next = _parent->next_stage(_ps);
     req.stage = next;
+    if (next != unassigned_pipeline_stage) {
+        auto idx = static_cast<size_t>(next()->get_numeric_id());
+        _parent->_stage_bytes.at(idx) += req.size_bytes();
+    }
     _parent->get_pending().push_back(req);
     if (signal) {
         _parent->signal(next);

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -221,7 +221,8 @@ write_pipeline<Clock>::get_write_requests(
         }
         result.requests.push_back(el);
     }
-    result.complete = pending.empty();
+    result.complete = std::none_of(
+      it, pending.end(), [stage](const auto& r) { return r.stage == stage; });
     vlog(
       cd_log.trace,
       "get_write_requests returned {} elements, containing {} ({}B)",

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_test.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_test.cc
@@ -549,6 +549,8 @@ public:
     void set_next_stage_backlog(size_t shard, size_t bytes) {
         next_stage_counters[shard]->store(bytes);
     }
+
+    l0::write_request_scheduler_probe probe{true};
 };
 
 TEST_F(scheduler_context_test, test_initial_state) {
@@ -767,9 +769,10 @@ TEST_F(scheduler_context_test, test_try_schedule_upload_triggers_split) {
     auto ctx = make_context(4);
 
     // Group has 4 shards, max_buffer_size = 4 MiB
-    // Split threshold = 4 MiB × 4 = 16 MiB
-    constexpr size_t max_buffer_size = 4 * 1024 * 1024;              // 4 MiB
-    constexpr size_t expected_split_threshold = max_buffer_size * 4; // 16 MiB
+    // Split threshold = 2 × 4 MiB × 4 = 32 MiB
+    constexpr size_t max_buffer_size = 4 * 1024 * 1024; // 4 MiB
+    constexpr size_t expected_split_threshold = 2 * max_buffer_size
+                                                * 4; // 32 MiB
 
     // Set high next stage backlog to trigger split
     set_next_stage_backlog(0, expected_split_threshold + 1);
@@ -785,7 +788,7 @@ TEST_F(scheduler_context_test, test_try_schedule_upload_triggers_split) {
 
     // Shard 0 is first in group, should evaluate and trigger split
     auto result = ctx->try_schedule_upload(
-      ss::shard_id(0), max_buffer_size, 100ms, clock_type::now());
+      ss::shard_id(0), max_buffer_size, 100ms, clock_type::now(), probe);
 
     // After split, shards 0,1 should be in group 0, shards 2,3 in group 2
     EXPECT_EQ(ctx->shard_to_group[0].load(), l0::group_id{0});
@@ -818,7 +821,8 @@ TEST_F(scheduler_context_test, test_try_schedule_upload_triggers_merge) {
       ss::shard_id(0),
       500, // max_buffer_size
       100ms,
-      clock_type::now());
+      clock_type::now(),
+      probe);
 
     // After merge, all shards should be in group 0
     EXPECT_EQ(ctx->shard_to_group[0].load(), l0::group_id{0});
@@ -840,7 +844,7 @@ TEST_F(scheduler_context_test, test_round_robin_within_group) {
 
     // Round-robin counter starts at 0, so shard 0 should be selected first
     auto result0 = ctx->try_schedule_upload(
-      ss::shard_id(0), 500, 100ms, clock_type::now());
+      ss::shard_id(0), 500, 100ms, clock_type::now(), probe);
     EXPECT_EQ(result0.action, l0::schedule_action::upload);
 
     // Release the lock before checking next shard (simulates upload completion)
@@ -848,11 +852,11 @@ TEST_F(scheduler_context_test, test_round_robin_within_group) {
 
     // After upload, ix is incremented, so shard 1 should be selected next
     auto result1_skip = ctx->try_schedule_upload(
-      ss::shard_id(0), 500, 100ms, clock_type::now());
+      ss::shard_id(0), 500, 100ms, clock_type::now(), probe);
     EXPECT_EQ(result1_skip.action, l0::schedule_action::skip);
 
     auto result1 = ctx->try_schedule_upload(
-      ss::shard_id(1), 500, 100ms, clock_type::now());
+      ss::shard_id(1), 500, 100ms, clock_type::now(), probe);
     EXPECT_EQ(result1.action, l0::schedule_action::upload);
 }
 
@@ -933,6 +937,8 @@ public:
     void add_next_stage_backlog(size_t shard, size_t bytes) {
         next_stage_counters[shard]->fetch_add(bytes);
     }
+
+    l0::write_request_scheduler_probe probe{true};
 
     // Simulate ingestion: add random bytes to current stage backlog
     void simulate_ingestion() {
@@ -1050,7 +1056,8 @@ TEST_F(scheduler_context_fuzz_test, test_random_workload) {
               ss::shard_id(shard),
               max_buffer_size,
               scheduling_interval,
-              simulated_time);
+              simulated_time,
+              probe);
 
             if (result.action == l0::schedule_action::upload) {
                 // Deposit bytes from current stage to next stage
@@ -1105,7 +1112,8 @@ TEST_F(scheduler_context_fuzz_test, test_high_load_causes_splits) {
               ss::shard_id(shard),
               max_buffer_size,
               scheduling_interval,
-              simulated_time);
+              simulated_time,
+              probe);
 
             if (result.action == l0::schedule_action::upload) {
                 deposit_to_next_stage(*ctx, result.gid);
@@ -1187,7 +1195,8 @@ TEST_F(scheduler_context_fuzz_test, test_low_load_causes_merges) {
               ss::shard_id(shard),
               max_buffer_size,
               scheduling_interval,
-              simulated_time);
+              simulated_time,
+              probe);
 
             if (result.action == l0::schedule_action::upload) {
                 deposit_to_next_stage(*ctx, result.gid);

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
@@ -12,6 +12,7 @@
 
 #include "base/vassert.h"
 #include "cloud_topics/level_zero/common/extent_meta.h"
+#include "cloud_topics/level_zero/common/level_zero_probe.h"
 #include "cloud_topics/level_zero/pipeline/base_pipeline.h"
 #include "cloud_topics/level_zero/pipeline/write_pipeline.h"
 #include "cloud_topics/level_zero/pipeline/write_request.h"
@@ -215,7 +216,8 @@ schedule_result<Clock> scheduler_context<Clock>::try_schedule_upload(
   ss::shard_id shard,
   size_t max_buffer_size,
   std::chrono::milliseconds scheduling_interval,
-  time_point now) {
+  time_point now,
+  write_request_scheduler_probe& probe) {
     // Get group info for this shard
     auto gid = shard_to_group[shard].load();
     auto& group = groups[static_cast<size_t>(gid)];
@@ -241,8 +243,9 @@ schedule_result<Clock> scheduler_context<Clock>::try_schedule_upload(
 
         if (can_modify) {
             auto next_stage_bytes = get_group_next_stage_bytes(gid);
+            probe.set_next_stage_bytes(next_stage_bytes);
             // Calculate dynamic split threshold based on group size
-            size_t group_split_threshold = max_buffer_size * grp_size;
+            size_t group_split_threshold = 2 * max_buffer_size * grp_size;
             if (grp_size > 1 && next_stage_bytes > group_split_threshold) {
                 // Split: next stage is overloaded, work more independently
                 if (try_split_group(gid)) {
@@ -421,7 +424,7 @@ write_request_scheduler<Clock>::run_once() {
 
     // Let scheduler_context make the scheduling decision
     auto result = _context->try_schedule_upload(
-      this_shard, _max_buffer_size(), _scheduling_interval(), now);
+      this_shard, _max_buffer_size(), _scheduling_interval(), now, _probe);
 
     switch (result.action) {
     case schedule_action::skip:

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.h
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.h
@@ -296,12 +296,14 @@ struct scheduler_context {
     /// \param max_buffer_size Data threshold for triggering upload
     /// \param scheduling_interval Time threshold for triggering upload
     /// \param now Current time
+    /// \param probe Is a metrics probe
     /// \return schedule_result with action and optional lock
     schedule_result<Clock> try_schedule_upload(
       ss::shard_id shard,
       size_t max_buffer_size,
       std::chrono::milliseconds scheduling_interval,
-      time_point now);
+      time_point now,
+      write_request_scheduler_probe& probe);
 
     /// Update last upload time for a group after successful upload
     void record_upload_time(group_id gid, time_point upload_time);

--- a/tests/rptest/tests/cloud_topics/l0_gc_test.py
+++ b/tests/rptest/tests/cloud_topics/l0_gc_test.py
@@ -136,7 +136,7 @@ class CloudTopicsL0GCTestBase(RedpandaTest):
             workers=1,
         ) as repeater:
             repeater.await_group_ready()
-            repeater.await_progress(n, timeout_sec=90)
+            repeater.await_progress(n, timeout_sec=120)
 
 
 class CloudTopicsL0GCTest(CloudTopicsL0GCTestBase):


### PR DESCRIPTION
Tweak the batcher a bit. Currently, the batcher uploads a lot of small objects. There are few reasons for that.
- The 'complete' flag returned by the `pull_write_request` method is not computed correctly. The method doesn't take the stage into account. So the batcher always tries to pull iterate one more time even if there is no work or the request are not deposited fully (`write_request_scheduler` started to send requests but not finished yet).
- There is a work accounting bug in the `write_request_scheduler`. When the scheduler proxies the request it subtracts the byte count from the current shard but doesn't add bytes to the target shard. In some cases it trigger an overflow which looks as a very large batcher backlog. This causes the scheduler to aggressively split groups. With more groups than needed the batcher uploads small objects.
- Finally, the batcher itself may upload small objects depending on the workload. E.g. if the total size of all requests sent to the batcher is 4.1MiB it will upload 4MiB object (target size) + 100KiB object (the remaining part). The the last commit fixes this by forcing batcher to group data more so there is no small uploads unless the batcher is given very little data.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none