### PR TITLE
`misc`: rename `cloud_topics_compaction` logger

### DIFF
--- a/src/go/rpk/pkg/cli/redpanda/admin/config/config.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/config/config.go
@@ -350,7 +350,7 @@ var defaultLoggers = []string{
 	"cloud_roles",
 	"cloud_storage",
 	"cloud_topics",
-	"cloud_topics-compaction",
+	"cloud_topics_compaction",
 	"cluster",
 	"compaction_ctrl",
 	"compression",

--- a/src/v/cloud_topics/level_one/compaction/logger.h
+++ b/src/v/cloud_topics/level_one/compaction/logger.h
@@ -16,6 +16,6 @@
 
 namespace cloud_topics::l1 {
 
-inline ss::logger compaction_log("cloud_topics-compaction");
+inline ss::logger compaction_log("cloud_topics_compaction");
 
 } // namespace cloud_topics::l1

--- a/tests/rptest/fuzz/random_node_operations_test.py
+++ b/tests/rptest/fuzz/random_node_operations_test.py
@@ -50,7 +50,7 @@ class RandomNodeOperationsTest(RandomNodeOperationsBase):
                     "kafka": "debug",
                     "reconciler": "debug",
                     "cloud_topics": "debug",
-                    "cloud_topics-compaction": "debug",
+                    "cloud_topics_compaction": "debug",
                 },
             ),
         )

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1136,7 +1136,7 @@ class LoggingConfig:
     # assumed it was always supported/does not require special handling.
     LOGGER_GENESIS: dict[str, RedpandaVersionTriple] = {
         "datalake": (24, 3, 1),
-        "cloud_topics-compaction": (26, 1, 1),
+        "cloud_topics_compaction": (26, 1, 1),
     }
 
     def __init__(self, default_level: str, logger_levels: dict[str, str] = {}) -> None:

--- a/tests/rptest/tests/random_node_operations_smoke_test.py
+++ b/tests/rptest/tests/random_node_operations_smoke_test.py
@@ -911,7 +911,7 @@ class RedpandaNodeOperationsSmokeTest(RandomNodeOperationsBase):
                     "kafka": "debug",
                     "reconciler": "debug",
                     "cloud_topics": "debug",
-                    "cloud_topics-compaction": "debug",
+                    "cloud_topics_compaction": "debug",
                     "offset_translator": "trace",
                 },
             ),


### PR DESCRIPTION
The `-` symbol seemed to cause our external toolings grief.

Rename the logger.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
