### PR TITLE
admin/broker: restore build_info in ListBrokers response

### DIFF
--- a/src/go/rpk/pkg/adminapi/version.go
+++ b/src/go/rpk/pkg/adminapi/version.go
@@ -26,10 +26,11 @@ func HasMinimumVersion(ctx context.Context, cl *rpadmin.AdminAPI, version redpan
 		return false
 	}
 	for _, broker := range brokers.Msg.Brokers {
-		if broker.BuildInfo == nil {
+		brokerResp, err := cl.BrokerService().GetBroker(ctx, &connect.Request[adminv2.GetBrokerRequest]{Msg: &adminv2.GetBrokerRequest{NodeId: &broker.NodeId}})
+		if err != nil || brokerResp.Msg.Broker.BuildInfo == nil {
 			return false
 		}
-		v, err := redpanda.VersionFromString(broker.BuildInfo.Version)
+		v, err := redpanda.VersionFromString(brokerResp.Msg.Broker.BuildInfo.Version)
 		if err != nil || !v.IsAtLeast(version) {
 			return false
 		}

--- a/src/v/redpanda/admin/services/broker.cc
+++ b/src/v/redpanda/admin/services/broker.cc
@@ -61,6 +61,11 @@ broker_service_impl::list_brokers(
     for (auto& [node_id, _] : clients) {
         auto& broker = list_resp.get_brokers().emplace_back();
         broker.set_node_id(node_id());
+
+        // Populate build_info for all brokers with this broker's version for
+        // backwards compatibility with rpk's cluster connections list version
+        // compatibility check.
+        broker.set_build_info(std::move(self_broker().get_build_info()));
     }
     co_return list_resp;
 }

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1628,7 +1628,9 @@ class RpkTool:
         output = self._execute(cmd)
         return list(filter(None, map(parse, output.splitlines())))
 
-    def cluster_connections_list(self, limit: int, filter_raw=None, order_by=None):
+    def cluster_connections_list(
+        self, limit: int, filter_raw: str | None = None, order_by: str | None = None
+    ) -> str:
         cmd = [
             self._rpk_binary(),
             "-X",

--- a/tests/rptest/tests/list_kafka_connections_test.py
+++ b/tests/rptest/tests/list_kafka_connections_test.py
@@ -6,6 +6,7 @@
 #
 # https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
 
+import json
 from datetime import datetime
 from typing import Any
 
@@ -225,6 +226,41 @@ class AdminV2ListKafkaConnectionsTest(RedpandaTest):
                 retry_on_exc=True,
                 err_msg="Pagination validation failed",
             )
+
+        self.consumer.stop()
+
+    @cluster(num_nodes=4)
+    def test_list_kafka_connections_rpk(self):
+        """
+        Tests that rpk cluster connections list works correctly.
+
+        This specifically exercises the code path where rpk calls ListBrokers
+        to check version compatibility before listing connections.
+        """
+
+        self.logger.debug("Start a consumer to open some kafka connections")
+        self.consumer.start()
+
+        def valid_response() -> bool:
+            raw_resp = self.super_rpk.cluster_connections_list(
+                limit=100,
+                filter_raw="state = KAFKA_CONNECTION_STATE_OPEN",
+            )
+            resp = json.loads(raw_resp)
+            conns = resp.get("connections", [])
+
+            self.logger.info(
+                f"rpk cluster connections list returned {len(conns)} connections"
+            )
+
+            return len(conns) >= 2
+
+        wait_until(
+            valid_response,
+            timeout_sec=30,
+            retry_on_exc=True,
+            err_msg="rpk cluster connections list failed",
+        )
 
         self.consumer.stop()
 

--- a/tools/type-checking/type-check-strictness.json
+++ b/tools/type-checking/type-check-strictness.json
@@ -33,7 +33,6 @@
         "rptest/scale_tests/datalake_scale_test.py",
         "rptest/scale_tests/franzgo_bench.py",
         "rptest/scale_tests/large_controller_snapshot_test.py",
-        "rptest/scale_tests/list_kafka_connections_scale_test.py",
         "rptest/scale_tests/log_storage_target_size_test.py",
         "rptest/scale_tests/many_clients_test.py",
         "rptest/scale_tests/partition_balancer_scale_test.py",


### PR DESCRIPTION
https://github.com/redpanda-data/redpanda/commit/bf9fe02068d6a07244bfa10869d873b4e228e315 earlier removed build_info from
ListBrokers responses to avoid requiring all brokers to be reachable.
However, this broke rpk cluster connections list, which checks
build_info to validate version compatibility.

Populate build_info for all brokers in ListBrokers using the responding
broker's version. This fixes rpk cluster connections list which checks
build_info to validate version compatibility.

Fixes https://redpandadata.atlassian.net/browse/CORE-15134

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
