### PR TITLE
rptest/datalake/verifier: skip assertions in stop() on wait() failure

### DIFF
--- a/tests/rptest/tests/datalake/datalake_verifier.py
+++ b/tests/rptest/tests/datalake/datalake_verifier.py
@@ -363,6 +363,7 @@ class DatalakeVerifier:
         return progress
 
     def wait(self, progress_timeout_sec=30):
+        check = True
         try:
             while not self._all_offsets_translated():
                 wait_until(
@@ -377,30 +378,32 @@ class DatalakeVerifier:
             self.logger.debug("No errors around waiting")
         except Exception as e:
             self.logger.error(f"Error around waiting: {e}")
+            check = False
             raise
         finally:
-            self.stop()
+            self.stop(check=check)
 
-    def stop(self):
+    def stop(self, check=True):
         self.logger.debug("stopping")
         try:
             self._stop.set()
             self._msg_semaphore.release()
             self._executor.shutdown(wait=False)
-            assert len(self._errors) == 0, (
-                f"Topic {self.topic} validation errors: {self._errors}"
-            )
+            if check:
+                assert len(self._errors) == 0, (
+                    f"Topic {self.topic} validation errors: {self._errors}"
+                )
 
-            self.logger.debug(f"consumed offsets: {self.max_consumed_offsets}")
-            self.logger.debug(f"queried offsets: {self._max_queried_offsets}")
+                self.logger.debug(f"consumed offsets: {self.max_consumed_offsets}")
+                self.logger.debug(f"queried offsets: {self._max_queried_offsets}")
 
-            assert self._max_queried_offsets == self.max_consumed_offsets, (
-                "Mismatch between maximum offsets in topic vs iceberg table"
-            )
+                assert self._max_queried_offsets == self.max_consumed_offsets, (
+                    "Mismatch between maximum offsets in topic vs iceberg table"
+                )
 
-            assert len(self._expected_compacted_keys) == 0, (
-                "Some keys which were compacted away were not seen later in the consumer's log"
-            )
+                assert len(self._expected_compacted_keys) == 0, (
+                    "Some keys which were compacted away were not seen later in the consumer's log"
+                )
         finally:
             if self._consumer:
                 self._consumer.close()


### PR DESCRIPTION
When wait() fails (e.g. timeout or assertion), stop() still runs assertions that either mask the original error or produce confusing secondary failures. Separate teardown from validation by adding a check parameter to stop(). wait() passes check=False on the failure path so only teardown (stop event, executor shutdown, consumer close) runs, letting the original exception propagate cleanly.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
