### PR TITLE
[CORE-15643] ct/l1: fix deadlock in db_domain_manager shutdown

### DIFF
--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -136,8 +136,8 @@ ss::future<> db_domain_manager::stop_and_wait() {
     vlog(cd_log.debug, "DB domain manager stopping...");
     as_.request_abort();
     sem_.broken();
-    auto gate_fut = gate_.close();
     writer_lock_.broken();
+    co_await gate_.close();
     auto wlock_res = co_await exclusive_db_lock();
     if (wlock_res.has_value()) {
         if (db_) {
@@ -148,8 +148,6 @@ ss::future<> db_domain_manager::stop_and_wait() {
             }
         }
     }
-
-    co_await std::move(gate_fut);
     vlog(cd_log.debug, "DB domain manager stopped...");
 }
 


### PR DESCRIPTION
stop_and_wait() previously started gate_.close() and then awaited the db_instance_lock_ write lock before awaiting the gate future. This deadlocks with gc_loop() when the gc_loop is still in its first iteration (e.g. inside gate_and_open_reads -> maybe_open_db): gc_loop holds a gate holder for its entire lifetime and needs the db_instance_lock_ to make progress, while stop_and_wait holds the write lock and needs the gate to close. Neither can proceed.

Fix by awaiting gate_.close() before acquiring the write lock. The abort source, broken semaphore, and broken writer lock all fire first, so gc_loop and in-flight RPCs can fail out and release their gate holders promptly. Once the gate is closed, no concurrent access remains and the write lock acquisition is uncontested.

Fixes CORE-15643

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
