### PR TITLE
[CORE-15580] ct/compaction: Reduce some compaction logging to WARN

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/sink.cc
+++ b/src/v/cloud_topics/level_one/compaction/sink.cc
@@ -145,7 +145,7 @@ compaction_sink::initialize_builder(kafka::offset object_base_offset) {
     auto oid_res = co_await _metadata_builder->create_object_for(_tp);
     if (!oid_res.has_value()) {
         vlog(
-          compaction_log.error,
+          compaction_log.warn,
           "Failed to create object for tidp {}: {}",
           _tp,
           oid_res.error());
@@ -159,7 +159,7 @@ compaction_sink::initialize_builder(kafka::offset object_base_offset) {
     if (!upload_res.has_value()) {
         std::ignore = _metadata_builder->remove_pending_object(oid);
         vlog(
-          compaction_log.error,
+          compaction_log.warn,
           "Failed to create multipart upload for object {}, tidp {}: {}",
           oid,
           _tp,


### PR DESCRIPTION
When creating an object in the metastore or when beginning a multipart upload, a failure caused a compaction ERROR log. These operations can fail due to transient problems, and calling code catches and handles exceptions, retrying in a later compaction loop. Reduce the severity to WARN, which will make these logs stop failing some tests.

Fixes CORE-15580

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
