### PR TITLE
gbac/tests: add ducktape tests for configuration edge cases

### DIFF
--- a/tests/rptest/tests/gbac_claim_test.py
+++ b/tests/rptest/tests/gbac_claim_test.py
@@ -1098,3 +1098,55 @@ class GbacConfigEdgeCaseTest(StubOIDCTestBase):
             topic,
             "Phase 2: client-B should have access via groups2 claim path",
         )
+
+    @cluster(num_nodes=4)
+    def test_change_nested_group_behavior_at_runtime(self) -> None:
+        """Changing nested_group_behavior at runtime applies the new behavior
+        to subsequent tokens."""
+        client_id = "behavior-change-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "behavior-user",
+                "groups": ["a/b/c"],
+            },
+        )
+
+        # Phase 1: none mode — full path is the group name.
+        self.redpanda.set_cluster_config({"nested_group_behavior": "none"})
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert list(resp.groups) == ["a/b/c"]
+
+        topic_full = "full-path-topic"
+        topic_suffix = "suffix-topic"
+        self.rpk.create_topic(topic_full)
+        self.rpk.create_topic(topic_suffix)
+        self.rpk.sasl_allow_principal("Group:a/b/c", ["all"], "topic", topic_full)
+        self.rpk.sasl_allow_principal("Group:c", ["all"], "topic", topic_suffix)
+
+        producer = self.make_producer(client_id)
+        self.wait_until_produce_succeeds(
+            producer,
+            topic_full,
+            "Phase 1: full path group should grant access in none mode",
+        )
+
+        self.assert_produce_denied(producer, topic_suffix)
+
+        # Switch to suffix mode.
+        self.redpanda.set_cluster_config({"nested_group_behavior": "suffix"})
+
+        # Phase 2: suffix mode — only last segment is the group name.
+        resp = self.resolve_oidc_identity(client_id)
+        assert list(resp.groups) == ["c"]
+
+        self.revoke_oidc_sessions()
+
+        self.assert_produce_denied(producer, topic_full)
+
+        self.wait_until_produce_succeeds(
+            producer,
+            topic_suffix,
+            "Phase 2: suffix group should grant access in suffix mode",
+        )

--- a/tests/rptest/tests/gbac_claim_test.py
+++ b/tests/rptest/tests/gbac_claim_test.py
@@ -1150,3 +1150,37 @@ class GbacConfigEdgeCaseTest(StubOIDCTestBase):
             topic_suffix,
             "Phase 2: suffix group should grant access in suffix mode",
         )
+
+    @cluster(num_nodes=4)
+    def test_invalid_group_claim_path(self) -> None:
+        """Invalid oidc_group_claim_path values are handled gracefully."""
+        # Sub-scenario 1: Syntactically invalid path is rejected.
+        try:
+            self.redpanda.set_cluster_config({"oidc_group_claim_path": "$[invalid"})
+            assert False, "Expected HTTPError for syntactically invalid claim path"
+        except requests.exceptions.HTTPError as e:
+            assert e.response.status_code == 400
+
+        # Sub-scenario 2: Valid syntax but nonexistent path — no groups.
+        self.redpanda.set_cluster_config(
+            {"oidc_group_claim_path": "$.nonexistent.claim"}
+        )
+
+        client_id = "invalid-path-test"
+        self.stub_idp.register_client(
+            client_id,
+            claims={
+                "sub": "invalid-path-user",
+                "groups": ["eng"],
+            },
+        )
+
+        resp = self.resolve_oidc_identity(client_id)
+        assert len(resp.groups) == 0
+
+        topic = "topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:eng", ["all"], "topic", topic)
+
+        producer = self.make_producer(client_id)
+        self.assert_produce_denied(producer, topic)

--- a/tests/rptest/tests/gbac_claim_test.py
+++ b/tests/rptest/tests/gbac_claim_test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import requests
 from confluent_kafka import KafkaError, Message, Producer
 from confluent_kafka.error import KafkaException
 from ducktape.tests.test import Test, TestContext
@@ -100,11 +101,16 @@ class StubOIDCTestBase(Test):
         def _on_delivery(err: KafkaError | None, _msg: Message) -> None:
             errors.append(err)
 
-        producer.produce(
-            topic,
-            b"test",
-            on_delivery=_on_delivery,
-        )
+        try:
+            producer.produce(
+                topic,
+                b"test",
+                on_delivery=_on_delivery,
+            )
+        except KafkaException as e:
+            err = e.args[0]
+            assert isinstance(err, KafkaError)
+            return err
         producer.flush(timeout=10)
         assert len(errors) > 0, "Expected delivery callback but got none"
         return errors[0]
@@ -1014,3 +1020,81 @@ class GbacMultiGroupTest(StubOIDCTestBase):
         # No ACL was created, so produce is denied.
         producer = self.make_producer(client_id)
         self.assert_produce_denied(producer, topic)
+
+
+class GbacConfigEdgeCaseTest(StubOIDCTestBase):
+    """Tests for runtime configuration changes affecting GBAC behavior."""
+
+    def revoke_oidc_sessions(self) -> None:
+        """Revoke existing OIDC sessions so that producers must
+        re-authenticate. Without this, the already-connected producers
+        keep their old SASL sessions and the config change has no
+        effect on them until the token naturally expires."""
+        admin_v2 = AdminV2(self.redpanda)
+        admin_v2.security().revoke_oidc_sessions(
+            security_pb2.RevokeOidcSessionsRequest()
+        )
+
+    @cluster(num_nodes=4)
+    def test_change_group_claim_path_at_runtime(self) -> None:
+        """Changing oidc_group_claim_path at runtime causes subsequent tokens
+        to be evaluated against the new path."""
+        client_a = "client-a"
+        self.stub_idp.register_client(
+            client_a,
+            claims={
+                "sub": "user-a",
+                "groups1": ["test-group"],
+            },
+        )
+
+        client_b = "client-b"
+        self.stub_idp.register_client(
+            client_b,
+            claims={
+                "sub": "user-b",
+                "groups2": ["test-group"],
+            },
+        )
+
+        # Phase 1: setting group claim path to $.groups1 — client-A resolves groups.
+        self.redpanda.set_cluster_config({"oidc_group_claim_path": "$.groups1"})
+
+        resp = self.resolve_oidc_identity(client_a)
+        assert list(resp.groups) == ["test-group"]
+        resp = self.resolve_oidc_identity(client_b)
+        assert len(resp.groups) == 0
+
+        topic = "claim-path-topic"
+        self.rpk.create_topic(topic)
+        self.rpk.sasl_allow_principal("Group:test-group", ["all"], "topic", topic)
+
+        producer_a = self.make_producer(client_a)
+        producer_b = self.make_producer(client_b)
+
+        self.wait_until_produce_succeeds(
+            producer_a,
+            topic,
+            "Phase 1: client-A should have access via groups1 claim path",
+        )
+
+        self.assert_produce_denied(producer_b, topic)
+
+        # Change group claim path to $.groups2 at runtime — client-B should now resolve groups, client-A should not.
+        self.redpanda.set_cluster_config({"oidc_group_claim_path": "$.groups2"})
+
+        # Phase 2: new path — client-B resolves groups.
+        resp = self.resolve_oidc_identity(client_a)
+        assert len(resp.groups) == 0
+        resp = self.resolve_oidc_identity(client_b)
+        assert list(resp.groups) == ["test-group"]
+
+        self.revoke_oidc_sessions()
+
+        self.assert_produce_denied(producer_a, topic)
+
+        self.wait_until_produce_succeeds(
+            producer_b,
+            topic,
+            "Phase 2: client-B should have access via groups2 claim path",
+        )


### PR DESCRIPTION
Add ducktape tests for section V (Configuration Edge Cases) of the [GBAC test plan](https://redpandadata.atlassian.net/wiki/spaces/QE/pages/1613103105/GBAC+Test+cases+results+and+automation+info). These tests verify that runtime changes to GBAC configuration properties take effect on subsequent token evaluations.

Tests added:
- GBAC-CFG-010: Changing `oidc_group_claim_path` at runtime causes subsequent tokens to resolve groups using the new path
- GBAC-CFG-020: Changing `nested_group_behavior` at runtime applies the new behavior (none vs suffix) to subsequent tokens
- GBAC-CFG-030: Invalid `oidc_group_claim_path` values are handled gracefully — syntactically invalid paths are rejected, and valid but nonexistent paths result in no groups

Related to [CORE-15420](https://redpandadata.atlassian.net/browse/CORE-15420)
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
- none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-15420]: https://redpandadata.atlassian.net/browse/CORE-15420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ