### PR TITLE
rm_stm improvements around LSO and aborted xacts

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1290,6 +1290,7 @@ model::offset rm_stm::last_stable_offset() {
     // We optimize for the case where there are no inflight transactional
     // batch to return the high water mark.
     auto last_applied = last_applied_offset();
+    auto next_to_apply = model::next_offset(last_applied);
 
     // scenario 1: still bootstrapping
     if (unlikely(
@@ -1324,31 +1325,38 @@ model::offset rm_stm::last_stable_offset() {
           last_applied);
         return _last_known_lso;
     }
+
     // Check for any in-flight transactions.
     auto first_tx_start = model::offset::max();
     if (_is_tx_enabled && !_active_tx_producers.empty()) {
         const auto& earliest_open_tx_producer = _active_tx_producers.begin();
         const auto& tx_state = earliest_open_tx_producer->transaction_state();
-        if (tx_state) {
-            first_tx_start = tx_state->first;
-        } else {
+        if (!tx_state) {
             vlog(
               _ctx_log.error,
-              "[{}] Invalid transaction state for transactional producer, lso "
-              "may be incorrect",
+              "No transaction state for transactional producer: {}, lso may be "
+              "incorrect",
               *earliest_open_tx_producer);
+            return model::invalid_lso;
+        }
+        first_tx_start = tx_state->first;
+        if (first_tx_start > _apply_watermark) {
+            vlog(
+              _ctx_log.error,
+              "An in-flight transaction for producer [{}] found above "
+              "apply watermark [{}], lso may be incorrect",
+              *earliest_open_tx_producer,
+              _apply_watermark);
+            return model::invalid_lso;
         }
     }
 
     auto synced_leader = _raft->is_leader() && _raft->term() == _insync_term;
     model::offset lso{model::invalid_lso};
     auto last_visible_index = _raft->last_visible_index();
-    auto next_to_apply = model::next_offset(last_applied);
-    if (first_tx_start <= last_visible_index) {
-        // There are in flight transactions < high water mark that may
-        // not be applied yet. We still need to consider only applied
-        // transactions.
-        lso = std::min(first_tx_start, next_to_apply);
+    if (first_tx_start != model::offset::max()) {
+        // There is an open transaction
+        lso = first_tx_start;
     } else if (synced_leader) {
         ////////////////  WARNING ///////////
         // there is a real bug lurking here that overestimates the LSO beyond

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -259,7 +259,7 @@ ss::future<checked<model::term_id, tx::errc>> rm_stm::begin_tx(
   std::chrono::milliseconds transaction_timeout_ms,
   model::partition_id tm) {
     auto holder = _gate.hold();
-    auto state_lock = co_await _state_lock.hold_read_lock();
+    auto state_lock_holder = co_await _state_lock.hold_read_lock();
     auto lso_lock_holder = co_await _lso_lock.hold_write_lock();
     if (!co_await sync(_sync_timeout())) {
         vlog(
@@ -326,8 +326,7 @@ ss::future<checked<model::term_id, tx::errc>> rm_stm::do_begin_tx(
         vlog(
           _ctx_log.trace,
           "processing name:begin_tx pid:{}, tx_seq:{}, "
-          "timeout:{}, coordinator:{} => not "
-          "a leader",
+          "timeout:{}, coordinator:{} => not a leader",
           pid,
           tx_seq,
           transaction_timeout_ms,
@@ -1282,13 +1281,14 @@ model::offset rm_stm::last_stable_offset() {
     //
     // We distinguish between (1) and (2) based on the offset
     // we save during first apply (_bootstrap_committed_offset).
-
-    // We always want to return only the `applied` state as it
-    // contains aborted transactions metadata that is consumed by
-    // the client to distinguish aborted data batch.
+    //
+    // If there are in-flight transactions we base our calculation on applied
+    // state. `_lso_lock` prevents LSO calculation when there is a transaction
+    // is open from STM ingestion point of view, but not yet in STM applied
+    // state.
     //
     // We optimize for the case where there are no inflight transactional
-    // batch to return the high water mark.
+    // batches to return the high water mark.
     auto last_applied = last_applied_offset();
     auto next_to_apply = model::next_offset(last_applied);
 
@@ -1358,40 +1358,11 @@ model::offset rm_stm::last_stable_offset() {
         // There is an open transaction
         lso = first_tx_start;
     } else if (synced_leader) {
-        ////////////////  WARNING ///////////
-        // there is a real bug lurking here that overestimates the LSO beyond
-        // an open transaction.
-        //
-
-        // The problem manifests when the LSO is requested after successful
-        // replication of begin_tx batch but before the stm has applied it.
-        // In this case the LSO may be advanced beyond the begin_tx batch offset
-        // because the leader doesn't yet 'know' about the begin_tx batch and
-        // may not consider it in LSO calculation.
-
-        // Another problem is we do not let lso move backwards once
-        // computed (see _last_known_lso update below), So even if the
-        // stm has applied the begin_tx later, we will not correct
-        // the LSO to reflect the begin_tx presence.
-
-        // There is a test that caught this issue in rm_stm_tests which
-        // is disabled for now until we can fix the underlying problem.
-
-        // The impact of this overestimation is that compaction may compact
-        // away open transaction begin marker as it relies on LSO. The
-        // chances are rare but not impossible :(. if at that point the replica
-        // restarts and there are no further updates in the transaction, the
-        // transaction has no record of ever beginning.
-
-        // We need a better way to track in-flight transactions for the purposes
-        // of LSO calculation.
-
-        // An obvious solution is to clamp LSO to next_to_apply in all cases
-        // but it was tried in the past and caused performance regressions
-        // in non transaction workloads like write_caching, acks=0/1. So that
-        // is not a viable solution.
-
-        // no inflight transactions in (last_applied, last_visible_index]
+        // Thanks to _lso_lock held for write there's no transaction that has
+        // been opened in log, but its begin_tx batch hasn't been applied yet.
+        // Additionally, it means there's no unapplied abort batches, which
+        // guarantees that aborted_transactions() will return complete data for
+        // interval up to LSO
         lso = model::next_offset(last_visible_index);
     } else {
         // a follower or hasn't synced yet leader doesn't know about the

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -260,7 +260,7 @@ ss::future<checked<model::term_id, tx::errc>> rm_stm::begin_tx(
   model::partition_id tm) {
     auto holder = _gate.hold();
     auto state_lock_holder = co_await _state_lock.hold_read_lock();
-    auto lso_lock_holder = co_await _lso_lock.hold_write_lock();
+    auto lso_lock_holder = co_await _lso_lock.hold_read_lock();
     if (!co_await sync(_sync_timeout())) {
         vlog(
           _ctx_log.trace,
@@ -1315,8 +1315,8 @@ model::offset rm_stm::last_stable_offset() {
           last_applied);
         return _last_known_lso;
     }
-    auto lso_read_units = _lso_lock.try_hold_read_lock();
-    if (!lso_read_units) {
+    auto lso_recalc_holder = _lso_lock.try_hold_write_lock();
+    if (!lso_recalc_holder) {
         // LSO calculation is in progress, return last known LSO
         vlog(
           _ctx_log.trace,

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -40,6 +40,7 @@
 #include <iterator>
 #include <optional>
 #include <ranges>
+#include <stdexcept>
 #include <utility>
 
 namespace cluster {
@@ -1412,6 +1413,27 @@ static void filter_intersecting(
 
 ss::future<chunked_vector<tx_range>>
 rm_stm::aborted_transactions(model::offset from, model::offset to) {
+    auto lso = last_stable_offset();
+    if (lso == model::invalid_lso) {
+        auto lvi = _raft->last_visible_index();
+        if (to > lvi) {
+            throw std::runtime_error(
+              fmt::format(
+                "to: {} should be <= last_visible_index: {} when lso is "
+                "invalid",
+                to,
+                lvi));
+        }
+    } else {
+        if (to >= lso && to > last_applied()) {
+            throw std::runtime_error(
+              fmt::format(
+                "to: {} should be < lso: {} or <= last_applied: {}",
+                to,
+                lso,
+                last_applied()));
+        }
+    }
     auto gate_holder = _gate.hold();
     auto lock_holder = co_await _state_lock.hold_read_lock();
     co_return co_await do_aborted_transactions(from, to);

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -2035,6 +2035,8 @@ ss::future<raft::stm_snapshot> rm_stm::do_take_local_snapshot(
       "Unsupported snapshot version requested: {}",
       version);
 
+    auto units = co_await _state_lock.hold_read_lock();
+
     auto start_offset = _raft->start_offset();
     vlog(
       _ctx_log.trace,
@@ -2300,6 +2302,9 @@ rm_stm::take_raft_snapshot(model::offset last_included_offset) {
     // this is always called under apply lock, so we can be sure
     // that no concurrent modifications to the state are happening via apply
     // path.
+
+    // write lock is probably excessive here because the loop below is
+    // synchronous
     auto units = co_await _state_lock.hold_write_lock();
     tx::raft_snapshot snapshot;
     auto kafka_offset = from_log_offset(last_included_offset);

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1777,6 +1777,7 @@ void rm_stm::apply_fence(model::producer_identity pid, model::record_batch b) {
 
 ss::future<> rm_stm::do_apply(const model::record_batch& b) {
     auto holder = _gate.hold();
+    _apply_watermark = b.last_offset();
     const auto& hdr = b.header();
     const auto bid = model::batch_identity::from(hdr);
 
@@ -2335,6 +2336,7 @@ ss::future<> rm_stm::apply_raft_snapshot(const iobuf& buf) {
     auto holder = _gate.hold();
     auto local_buf = buf.copy();
     auto units = co_await _state_lock.hold_write_lock();
+    _apply_watermark = model::prev_offset(_raft->start_offset());
     vlog(
       _ctx_log.info,
       "Resetting all state, reason: log eviction, offset: {}",

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -439,12 +439,19 @@ private:
     // for monotonicity of computed LSO.
     model::offset _last_known_lso{model::invalid_lso};
     /**
-     * LSO lock protects the LSO from being exposed before transaction begin
-     * batch is applied.
+     * LSO lock protects from incorrect LSO calculation based on applied data
+     * when transaction begin batch has been accepted but not yet applied.
      *
-     * The lock is acquired in write mode when a begin transaction batch is
-     * being handled protecting exposure of potentially invalid LSO until the
-     * begin batch is applied.
+     * The lock is acquired in write mode during LSO calculation. The lock is
+     * acquired in read mode when a begin transaction batch is being replicated.
+     *
+     * This lock mode choice does not reflect any entity being written into or
+     * read from, but purely to enforce necessary isolation:
+     * - concurrent begin batch processing is allowed;
+     * - but no LSO recalculation is allowed during this.
+     *
+     * Write lock contention is not an issue, as calculation is done in a
+     * synchronous function. Should this change, a bimodal lock should be used.
      */
     ss::rwlock _lso_lock;
 

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -432,6 +432,10 @@ private:
     ss::gate _gate;
     // Highest producer ID applied to this stm.
     model::producer_id _highest_producer_id;
+    // Tracks the last offset of the batch/snapshot being applied. Updated
+    // inside do_apply/apply_raft_snapshot before set_next runs, so it is
+    // always >= last_applied_offset() during the apply window.
+    model::offset _apply_watermark;
     // for monotonicity of computed LSO.
     model::offset _last_known_lso{model::invalid_lso};
     /**

--- a/src/v/cluster/tests/rm_stm_test_fixture.h
+++ b/src/v/cluster/tests/rm_stm_test_fixture.h
@@ -129,6 +129,11 @@ struct rm_stm_test_fixture : simple_raft_fixture {
           .get();
     }
 
+    auto get_aborted_txs() {
+        return _stm->aborted_transactions(
+          model::offset::min(), _stm->last_applied_offset());
+    }
+
     ss::sharded<config::mock_property<size_t>> max_concurent_producers;
     ss::sharded<config::mock_property<std::chrono::milliseconds>>
       producer_expiration_ms;

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -134,9 +134,6 @@ FIXTURE_TEST(test_tx_happy_tx, rm_stm_test_fixture) {
     wait_for_confirmed_leader();
     wait_for_meta_initialized();
 
-    auto min_offset = model::offset(0);
-    auto max_offset = model::offset(std::numeric_limits<int64_t>::max());
-
     auto pid1 = model::producer_identity{1, 0};
     auto rreader = make_batches(pid1, 0, 5, false);
     auto offset_r = replicate_all(stm, std::move(rreader)).get();
@@ -144,7 +141,7 @@ FIXTURE_TEST(test_tx_happy_tx, rm_stm_test_fixture) {
     RPTEST_REQUIRE_EVENTUALLY(
       1s, [&] { return stm.highest_producer_id() == pid1.get_id(); });
     BOOST_REQUIRE((bool)offset_r);
-    auto aborted_txs = stm.aborted_transactions(min_offset, max_offset).get();
+    auto aborted_txs = get_aborted_txs().get();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
     auto first_offset = offset_r.value().last_offset();
     tests::cooperative_spin_wait_with_timeout(10s, [&stm, first_offset]() {
@@ -167,12 +164,12 @@ FIXTURE_TEST(test_tx_happy_tx, rm_stm_test_fixture) {
     }).get();
     BOOST_REQUIRE_LE(stm.last_stable_offset(), tx_offset);
 
-    aborted_txs = stm.aborted_transactions(min_offset, max_offset).get();
+    aborted_txs = get_aborted_txs().get();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
 
     auto op = stm.commit_tx(pid2, tx_seq, 2'000ms).get();
     BOOST_REQUIRE_EQUAL(op, cluster::tx::errc::none);
-    aborted_txs = stm.aborted_transactions(min_offset, max_offset).get();
+    aborted_txs = get_aborted_txs().get();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
     tests::cooperative_spin_wait_with_timeout(10s, [&stm, tx_offset]() {
         return tx_offset < stm.last_stable_offset();
@@ -189,8 +186,6 @@ FIXTURE_TEST(test_tx_aborted_tx_1, rm_stm_test_fixture) {
     auto& stm = start_and_disable_auto_abort();
 
     auto tx_seq = model::tx_seq(0);
-    auto min_offset = model::offset(0);
-    auto max_offset = model::offset(std::numeric_limits<int64_t>::max());
 
     auto pid1 = model::producer_identity{1, 0};
     auto rreader = make_batches(pid1, 0, 5, false);
@@ -198,7 +193,7 @@ FIXTURE_TEST(test_tx_aborted_tx_1, rm_stm_test_fixture) {
     RPTEST_REQUIRE_EVENTUALLY(
       1s, [&] { return stm.highest_producer_id() == pid1.get_id(); });
     BOOST_REQUIRE((bool)offset_r);
-    auto aborted_txs = stm.aborted_transactions(min_offset, max_offset).get();
+    auto aborted_txs = get_aborted_txs().get();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
     auto first_offset = offset_r.value().last_offset();
     tests::cooperative_spin_wait_with_timeout(10s, [&stm, first_offset]() {
@@ -219,7 +214,7 @@ FIXTURE_TEST(test_tx_aborted_tx_1, rm_stm_test_fixture) {
         return first_offset < stm.last_stable_offset();
     }).get();
     BOOST_REQUIRE_LE(stm.last_stable_offset(), tx_offset);
-    aborted_txs = stm.aborted_transactions(min_offset, max_offset).get();
+    aborted_txs = get_aborted_txs().get();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
 
     auto op = stm.abort_tx(pid2, tx_seq, 2'000ms).get();
@@ -229,7 +224,7 @@ FIXTURE_TEST(test_tx_aborted_tx_1, rm_stm_test_fixture) {
                       _raft.get()->committed_offset(),
                       model::timeout_clock::now() + 2'000ms)
                     .get());
-    aborted_txs = stm.aborted_transactions(min_offset, max_offset).get();
+    aborted_txs = get_aborted_txs().get();
 
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 1);
     BOOST_REQUIRE(
@@ -251,16 +246,13 @@ FIXTURE_TEST(test_tx_aborted_tx_2, rm_stm_test_fixture) {
     auto& stm = start_and_disable_auto_abort();
     auto tx_seq = model::tx_seq(0);
 
-    auto min_offset = model::offset(0);
-    auto max_offset = model::offset(std::numeric_limits<int64_t>::max());
-
     auto pid1 = model::producer_identity{1, 0};
     auto rreader = make_batches(pid1, 0, 5, false);
     auto offset_r = replicate_all(stm, std::move(rreader)).get();
     RPTEST_REQUIRE_EVENTUALLY(
       1s, [&] { return stm.highest_producer_id() == pid1.get_id(); });
     BOOST_REQUIRE((bool)offset_r);
-    auto aborted_txs = stm.aborted_transactions(min_offset, max_offset).get();
+    auto aborted_txs = get_aborted_txs().get();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
     auto first_offset = offset_r.value().last_offset();
     tests::cooperative_spin_wait_with_timeout(10s, [&stm, first_offset]() {
@@ -282,7 +274,7 @@ FIXTURE_TEST(test_tx_aborted_tx_2, rm_stm_test_fixture) {
         return first_offset < stm.last_stable_offset();
     }).get();
     BOOST_REQUIRE_LE(stm.last_stable_offset(), tx_offset);
-    aborted_txs = stm.aborted_transactions(min_offset, max_offset).get();
+    aborted_txs = get_aborted_txs().get();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
 
     auto op = stm.abort_tx(pid2, tx_seq, 2'000ms).get();
@@ -292,7 +284,7 @@ FIXTURE_TEST(test_tx_aborted_tx_2, rm_stm_test_fixture) {
                       _raft.get()->committed_offset(),
                       model::timeout_clock::now() + 2'000ms)
                     .get());
-    aborted_txs = stm.aborted_transactions(min_offset, max_offset).get();
+    aborted_txs = get_aborted_txs().get();
 
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 1);
     BOOST_REQUIRE(
@@ -437,12 +429,6 @@ FIXTURE_TEST(test_aborted_transactions, rm_stm_test_fixture) {
 
     auto& segments = disk_log->segments();
 
-    // Few helpers to avoid repeated boiler plate code.
-
-    auto aborted_txs = [&](auto begin, auto end) {
-        return stm.aborted_transactions(begin, end).get();
-    };
-
     // Aborted transactions in a given segment index.
     auto aborted_txes_seg = [&](auto segment_index) {
         BOOST_REQUIRE_GE(segment_index, 0);
@@ -454,12 +440,13 @@ FIXTURE_TEST(test_aborted_transactions, rm_stm_test_fixture) {
           segment_index,
           offsets.get_base_offset(),
           offsets.get_dirty_offset());
-        return aborted_txs(
-          offsets.get_base_offset(), offsets.get_dirty_offset());
+        return stm
+          .aborted_transactions(
+            offsets.get_base_offset(), offsets.get_dirty_offset())
+          .get();
     };
 
-    BOOST_REQUIRE_EQUAL(
-      aborted_txs(model::offset::min(), model::offset::max()).size(), 0);
+    BOOST_REQUIRE_EQUAL(get_aborted_txs().get().size(), 0);
 
     // Begins a tx with random pid and writes a data batch.
     // Returns the associated pid.

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -653,13 +653,15 @@ void async_ser_verify(T type) {
 }
 
 cluster::tx::tx_snapshot_v4 make_tx_snapshot_v4() {
+    auto offset = model::random_offset_above(model::offset(1));
     return {
       .fenced = tests::random_frag_vector(model::random_producer_identity),
-      .ongoing = tests::random_frag_vector(model::random_tx_range),
+      .ongoing = tests::random_frag_vector(
+        model::random_tx_range_below, 20, offset),
       .prepared = tests::random_frag_vector(cluster::random_prepare_marker),
       .aborted = tests::random_frag_vector(model::random_tx_range),
       .abort_indexes = tests::random_frag_vector(cluster::random_abort_index),
-      .offset = model::random_offset(),
+      .offset = offset,
       .seqs = tests::random_frag_vector(cluster::random_seq_entry),
       .tx_data = tests::random_frag_vector(cluster::random_tx_data_snapshot),
       .expiration = tests::random_frag_vector(
@@ -685,14 +687,15 @@ cluster::tx::tx_snapshot_v5 make_tx_snapshot_v5() {
         snapshots.push_back(std::move(old_snapshot));
     }
     cluster::tx::tx_snapshot_v5 snap;
-    snap.offset = model::random_offset();
-    snap.producers = std::move(snapshots),
-    snap.fenced = tests::random_frag_vector(model::random_producer_identity),
-    snap.ongoing = tests::random_frag_vector(model::random_tx_range),
-    snap.prepared = tests::random_frag_vector(cluster::random_prepare_marker),
-    snap.aborted = tests::random_frag_vector(model::random_tx_range),
-    snap.abort_indexes = tests::random_frag_vector(cluster::random_abort_index),
-    snap.tx_data = tests::random_frag_vector(cluster::random_tx_data_snapshot),
+    snap.offset = model::random_offset_above(model::offset(1));
+    snap.producers = std::move(snapshots);
+    snap.fenced = tests::random_frag_vector(model::random_producer_identity);
+    snap.ongoing = tests::random_frag_vector(
+      model::random_tx_range_below, 20, snap.offset);
+    snap.prepared = tests::random_frag_vector(cluster::random_prepare_marker);
+    snap.aborted = tests::random_frag_vector(model::random_tx_range);
+    snap.abort_indexes = tests::random_frag_vector(cluster::random_abort_index);
+    snap.tx_data = tests::random_frag_vector(cluster::random_tx_data_snapshot);
     snap.expiration = tests::random_frag_vector(
       cluster::random_expiration_snapshot);
     snap.highest_producer_id = model::random_producer_identity().get_id();

--- a/src/v/model/tests/randoms.h
+++ b/src/v/model/tests/randoms.h
@@ -175,8 +175,25 @@ inline model::offset random_offset() {
     return tests::random_named_int<model::offset>();
 }
 
+inline model::offset random_offset_above(model::offset strict_lower_bound) {
+    return model::offset(
+      random_generators::get_int<int64_t>(
+        strict_lower_bound() + 1, std::numeric_limits<int64_t>::max()));
+}
+
 inline model::tx_range random_tx_range() {
     return {random_producer_identity(), random_offset(), random_offset()};
+}
+
+/// Generates a tx_range with first < last < max_offset.
+/// max_offset must be >= 2.
+inline model::tx_range random_tx_range_below(model::offset max_offset) {
+    vassert(max_offset >= model::offset(2), "max_offset must be >= 2");
+    auto first = model::offset(
+      random_generators::get_int<int64_t>(0, max_offset() - 2));
+    auto last = model::offset(
+      random_generators::get_int<int64_t>(first() + 1, max_offset() - 1));
+    return {random_producer_identity(), first, last};
 }
 
 inline model::broker_shard random_broker_shard() {


### PR DESCRIPTION
- throw if `aborted_transactions()` requested for an interval rm_stm doesn't have data for
- log an error and return `model::invalid_lso` if transaction state is incorrect
- reduce lock contention

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
