### PR TITLE
cluster/rm_stm: do not apply raft snapshot after stopping

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -2332,6 +2332,7 @@ rm_stm::take_raft_snapshot(model::offset last_included_offset) {
 }
 
 ss::future<> rm_stm::apply_raft_snapshot(const iobuf& buf) {
+    auto holder = _gate.hold();
     auto local_buf = buf.copy();
     auto units = co_await _state_lock.hold_write_lock();
     vlog(


### PR DESCRIPTION
Fixes crashes introduced in #29623.

Without the fix, applying a snapshot can race with shutdown and can add producers _after_ stop() executes fully. These producers are just destroyed in ~rm_stm().

This can manifest as two different crashes.

In debug builds: safe link hook triggers an assert because we are destroying a producer_state that has an active link to manager.

In release builds: the producer state is silently destroyed but when producer state manager loops though the list of producers, it will encounter the destroyed producer and an immediate sigsegv. This results in a cryptic stack.

Hard to reproduce a race particularly with shutdown but I managed to reproduce both variants with some well placed sleeps.

It was an oversight not to hold the gate.

Fixes: https://redpandadata.atlassian.net/browse/CORE-15117
Fixes: https://redpandadata.atlassian.net/browse/CORE-15679

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
