### PR TITLE
tests: reduce measurement overhead in microbenchmarks

### DIFF
--- a/src/v/cloud_io/tests/cache_bench.cc
+++ b/src/v/cloud_io/tests/cache_bench.cc
@@ -26,11 +26,12 @@ static void run_test(int test_scale) {
         names.push_back(ssx::sformat("name-{}", i));
     }
 
+    perf_tests::start_measuring_time();
     for (int i = 0; i < test_scale; i++) {
-        perf_tests::start_measuring_time();
         tracker.add(names[i % test_scale], make_ts(i), 0);
-        perf_tests::stop_measuring_time();
     }
+    perf_tests::stop_measuring_time();
+    perf_tests::do_not_optimize(tracker);
 }
 
 PERF_TEST(cache_utils, cm_sketch_1000) { run_test(1000); }

--- a/src/v/cloud_topics/level_zero/read_debounce/tests/read_debounce_bench.cc
+++ b/src/v/cloud_topics/level_zero/read_debounce/tests/read_debounce_bench.cc
@@ -138,6 +138,7 @@ public:
 
     // Run requests serially
     ss::future<> test_run(int num_requests) {
+        perf_tests::start_measuring_time();
         for (int i = 0; i < num_requests; i++) {
             l0::dataplane_query query;
             query.output_size_estimate = 1_KiB;
@@ -153,14 +154,13 @@ public:
             // latency is expected to be in the ballpark of 10 microseconds end
             // to end. The actual I/O (either cache or cloud) will take
             // longer.
-            perf_tests::start_measuring_time();
             perf_tests::do_not_optimize(
               co_await pipeline.local().make_reader(
                 model::controller_ntp,
                 std::move(query),
                 ss::lowres_clock::now() + 10s));
-            perf_tests::stop_measuring_time();
         }
+        perf_tests::stop_measuring_time();
     }
 
     // Fire N concurrent requests all targeting the same object_id.
@@ -255,6 +255,7 @@ public:
 
     // Run requests serially, each with a unique object_id
     ss::future<> test_run_unique(int num_requests) {
+        perf_tests::start_measuring_time();
         for (int i = 0; i < num_requests; i++) {
             l0::dataplane_query query;
             query.output_size_estimate = 1_KiB;
@@ -263,14 +264,13 @@ public:
                 .id = object_id{.name = uuid_t::create()},
                 .byte_range_size = byte_range_size_t{1_KiB}});
 
-            perf_tests::start_measuring_time();
             perf_tests::do_not_optimize(
               co_await pipeline.local().make_reader(
                 model::controller_ntp,
                 std::move(query),
                 ss::lowres_clock::now() + 10s));
-            perf_tests::stop_measuring_time();
         }
+        perf_tests::stop_measuring_time();
     }
 
     // Fire N concurrent requests all targeting the same object_id.

--- a/src/v/container/tests/map_bench.cc
+++ b/src/v/container/tests/map_bench.cc
@@ -74,6 +74,9 @@ public:
         return KeySetSize * (FillPercent / 100.0);
     }
 
+    static constexpr size_t lookup_inner_iters = std::max<size_t>(
+      1, 10000 / std::max<size_t>(1, KeySetSize));
+
     size_t run_look_up_test() {
         MapT map = make_filled();
         std::vector<key_t> to_query;
@@ -81,22 +84,29 @@ public:
             return random_generators::get_int<key_t>(KeySetSize);
         });
         perf_tests::start_measuring_time();
-        for (const auto& i : to_query) {
-            perf_tests::do_not_optimize(map.find(i));
+        for (size_t iter = 0; iter < lookup_inner_iters; ++iter) {
+            for (const auto& i : to_query) {
+                perf_tests::do_not_optimize(map.find(i));
+            }
         }
         perf_tests::stop_measuring_time();
-        return 1000;
+        return 1000 * lookup_inner_iters;
     }
+
+    static constexpr size_t iterate_inner_iters = std::max<size_t>(
+      1, 10000 / std::max<size_t>(1, KeySetSize));
 
     size_t run_iterate_test() {
         MapT map = make_filled();
 
         perf_tests::start_measuring_time();
-        for (const auto& p : map) {
-            perf_tests::do_not_optimize(p);
+        for (size_t iter = 0; iter < iterate_inner_iters; ++iter) {
+            for (const auto& p : map) {
+                perf_tests::do_not_optimize(p);
+            }
         }
         perf_tests::stop_measuring_time();
-        return KeySetSize * (FillPercent / 100.0);
+        return iterate_inner_iters;
     }
 };
 

--- a/src/v/container/tests/priority_queue_bench.cc
+++ b/src/v/container/tests/priority_queue_bench.cc
@@ -20,10 +20,17 @@
 #include <cstddef>
 #include <queue>
 #include <type_traits>
+#include <vector>
+
+constexpr size_t inner_iters_for(size_t size) {
+    return std::max<size_t>(1, 10000 / std::max<size_t>(1, size));
+}
 
 template<typename PriorityQueue, size_t Size>
 struct PriorityQueueBenchTest {
     using value_type = typename PriorityQueue::value_type;
+    static constexpr size_t inner_iters = inner_iters_for(Size);
+    const chunked_vector<value_type> test_data = make_test_data();
 
     static auto make_random_value() {
         if constexpr (std::is_integral_v<value_type>) {
@@ -63,106 +70,150 @@ struct PriorityQueueBenchTest {
         return pq;
     }
 
+    // No start/stop — trivial setup only, framework handles timing.
     [[gnu::noinline]]
     void run_push_test() {
-        auto test_data = make_test_data();
         PriorityQueue pq;
-        perf_tests::start_measuring_time();
         for (const auto& val : test_data) {
             pq.push(val);
         }
-        perf_tests::stop_measuring_time();
         perf_tests::do_not_optimize(pq);
     }
 
     [[gnu::noinline]]
-    void run_push_rvalue_test() {
-        auto test_data = make_test_data();
-        PriorityQueue pq;
+    size_t run_push_rvalue_test() {
+        std::vector<chunked_vector<value_type>> inputs;
+        inputs.reserve(inner_iters);
+        for (size_t i = 0; i < inner_iters; ++i) {
+            inputs.push_back(make_test_data());
+        }
         perf_tests::start_measuring_time();
-        for (auto& val : std::move(test_data)) {
-            pq.push(std::move(val));
+        for (auto& td : inputs) {
+            PriorityQueue pq;
+            for (auto& val : std::move(td)) {
+                pq.push(std::move(val));
+            }
+            perf_tests::do_not_optimize(pq);
         }
         perf_tests::stop_measuring_time();
-        perf_tests::do_not_optimize(pq);
+        return inner_iters;
     }
 
+    // No start/stop — trivial setup only, framework handles timing.
     [[gnu::noinline]]
     void run_push_range_test() {
-        auto test_data = make_test_data();
         PriorityQueue pq;
-        perf_tests::start_measuring_time();
         pq.push_range(test_data);
-        perf_tests::stop_measuring_time();
         perf_tests::do_not_optimize(pq);
     }
 
     [[gnu::noinline]]
-    void run_push_rvalue_range_test() {
-        auto test_data = make_test_data();
-        PriorityQueue pq;
+    size_t run_push_rvalue_range_test() {
+        std::vector<chunked_vector<value_type>> inputs;
+        inputs.reserve(inner_iters);
+        for (size_t i = 0; i < inner_iters; ++i) {
+            inputs.push_back(make_test_data());
+        }
         perf_tests::start_measuring_time();
-        pq.push_range(std::move(test_data));
+        for (auto& td : inputs) {
+            PriorityQueue pq;
+            pq.push_range(std::move(td));
+            perf_tests::do_not_optimize(pq);
+        }
         perf_tests::stop_measuring_time();
-        perf_tests::do_not_optimize(pq);
+        return inner_iters;
     }
 
     [[gnu::noinline]]
-    ss::future<> run_async_push_rvalue_range_test() {
-        auto test_data = make_test_data();
-        PriorityQueue pq;
+    ss::future<size_t> run_async_push_rvalue_range_test() {
+        std::vector<chunked_vector<value_type>> inputs;
+        inputs.reserve(inner_iters);
+        for (size_t i = 0; i < inner_iters; ++i) {
+            inputs.push_back(make_test_data());
+        }
         perf_tests::start_measuring_time();
-        co_await pq.async_push_range(std::move(test_data));
+        for (auto& td : inputs) {
+            PriorityQueue pq;
+            co_await pq.async_push_range(std::move(td));
+            perf_tests::do_not_optimize(pq);
+        }
         perf_tests::stop_measuring_time();
-        perf_tests::do_not_optimize(pq);
+        co_return inner_iters;
     }
 
     [[gnu::noinline]]
-    void run_pop_test() {
-        PriorityQueue pq = make_filled();
+    size_t run_pop_test() {
+        std::vector<PriorityQueue> inputs;
+        inputs.reserve(inner_iters);
+        for (size_t i = 0; i < inner_iters; ++i) {
+            inputs.push_back(make_filled());
+        }
         perf_tests::start_measuring_time();
-        while (!pq.empty()) {
-            if constexpr (!std::is_void_v<decltype(pq.pop())>) {
-                // bounded_priority_queue::pop() returns a value
-                auto x = pq.pop();
-                perf_tests::do_not_optimize(x);
-            } else {
-                // std::priority_queue::pop() returns void
-                auto x = pq.top();
-                pq.pop();
-                perf_tests::do_not_optimize(x);
+        for (auto& pq : inputs) {
+            while (!pq.empty()) {
+                if constexpr (!std::is_void_v<decltype(pq.pop())>) {
+                    auto x = pq.pop();
+                    perf_tests::do_not_optimize(x);
+                } else {
+                    auto x = pq.top();
+                    pq.pop();
+                    perf_tests::do_not_optimize(x);
+                }
             }
         }
         perf_tests::stop_measuring_time();
+        return inner_iters;
     }
 
     [[gnu::noinline]]
-    void run_extract_sorted_test() {
-        PriorityQueue pq = make_filled();
+    size_t run_extract_sorted_test() {
+        std::vector<PriorityQueue> inputs;
+        inputs.reserve(inner_iters);
+        for (size_t i = 0; i < inner_iters; ++i) {
+            inputs.push_back(make_filled());
+        }
         perf_tests::start_measuring_time();
-        auto x = std::move(pq).extract_sorted();
+        for (auto& pq : inputs) {
+            auto x = std::move(pq).extract_sorted();
+            perf_tests::do_not_optimize(x);
+        }
         perf_tests::stop_measuring_time();
-        perf_tests::do_not_optimize(x);
+        return inner_iters;
     }
 
     [[gnu::noinline]]
-    ss::future<> run_async_extract_sorted_test() {
-        PriorityQueue pq;
-        co_await pq.async_push_range(make_test_data());
+    ss::future<size_t> run_async_extract_sorted_test() {
+        std::vector<PriorityQueue> inputs;
+        inputs.reserve(inner_iters);
+        for (size_t i = 0; i < inner_iters; ++i) {
+            PriorityQueue pq;
+            pq.push_range(make_test_data());
+            inputs.push_back(std::move(pq));
+        }
         perf_tests::start_measuring_time();
-        auto x = co_await std::move(pq).async_extract_sorted();
+        for (auto& pq : inputs) {
+            auto x = co_await std::move(pq).async_extract_sorted();
+            perf_tests::do_not_optimize(x);
+        }
         perf_tests::stop_measuring_time();
-        perf_tests::do_not_optimize(x);
+        co_return inner_iters;
     }
 
     [[gnu::noinline]]
-    void run_sort_extract_heap_test() {
-        PriorityQueue pq = make_filled();
+    size_t run_sort_extract_heap_test() {
+        std::vector<PriorityQueue> inputs;
+        inputs.reserve(inner_iters);
+        for (size_t i = 0; i < inner_iters; ++i) {
+            inputs.push_back(make_filled());
+        }
         perf_tests::start_measuring_time();
-        auto x = std::move(pq).extract_heap();
-        std::ranges::sort(x);
+        for (auto& pq : inputs) {
+            auto x = std::move(pq).extract_heap();
+            std::ranges::sort(x);
+            perf_tests::do_not_optimize(x);
+        }
         perf_tests::stop_measuring_time();
-        perf_tests::do_not_optimize(x);
+        return inner_iters;
     }
 };
 
@@ -170,23 +221,37 @@ template<typename PriorityQueue, size_t InputSize, size_t Cap>
 struct BoundedPriorityQueueBenchTest
   : PriorityQueueBenchTest<PriorityQueue, InputSize> {
     [[gnu::noinline]]
-    void run_push_rvalue_range_test() {
-        auto test_data = this->make_test_data();
-        PriorityQueue pq{Cap};
+    size_t run_push_rvalue_range_test() {
+        std::vector<chunked_vector<typename PriorityQueue::value_type>> inputs;
+        inputs.reserve(this->inner_iters);
+        for (size_t i = 0; i < this->inner_iters; ++i) {
+            inputs.push_back(this->make_test_data());
+        }
         perf_tests::start_measuring_time();
-        pq.push_range(std::move(test_data));
+        for (auto& td : inputs) {
+            PriorityQueue pq{Cap};
+            pq.push_range(std::move(td));
+            perf_tests::do_not_optimize(pq);
+        }
         perf_tests::stop_measuring_time();
-        perf_tests::do_not_optimize(pq);
+        return this->inner_iters;
     }
 
     [[gnu::noinline]]
-    ss::future<> run_async_push_rvalue_range_test() {
-        auto test_data = this->make_test_data();
-        PriorityQueue pq{Cap};
+    ss::future<size_t> run_async_push_rvalue_range_test() {
+        std::vector<chunked_vector<typename PriorityQueue::value_type>> inputs;
+        inputs.reserve(this->inner_iters);
+        for (size_t i = 0; i < this->inner_iters; ++i) {
+            inputs.push_back(this->make_test_data());
+        }
         perf_tests::start_measuring_time();
-        co_await pq.async_push_range(std::move(test_data));
+        for (auto& td : inputs) {
+            PriorityQueue pq{Cap};
+            co_await pq.async_push_range(std::move(td));
+            perf_tests::do_not_optimize(pq);
+        }
         perf_tests::stop_measuring_time();
-        perf_tests::do_not_optimize(pq);
+        co_return this->inner_iters;
     }
 };
 
@@ -204,7 +269,7 @@ struct BoundedPriorityQueueBenchTest
     }                                                                          \
     PERF_TEST_F(                                                               \
       PriorityQueueBenchTest_##container##_##element##_##size, Pop) {          \
-        run_pop_test();                                                        \
+        return run_pop_test();                                                 \
     }
 
 #define PRIORITY_QUEUE_MOVE_TEST(container, element, size)                     \
@@ -212,12 +277,12 @@ struct BoundedPriorityQueueBenchTest
       : public PriorityQueueBenchTest<container<element>, size> {};            \
     PERF_TEST_F(                                                               \
       PriorityQueueRValueBenchTest_##container##_##element##_##size, Push) {   \
-        run_push_rvalue_test();                                                \
+        return run_push_rvalue_test();                                         \
     }                                                                          \
     PERF_TEST_F(                                                               \
       PriorityQueueRValueBenchTest_##container##_##element##_##size,           \
       PushRange) {                                                             \
-        run_push_rvalue_range_test();                                          \
+        return run_push_rvalue_range_test();                                   \
     }                                                                          \
     PERF_TEST_F(                                                               \
       PriorityQueueRValueBenchTest_##container##_##element##_##size,           \
@@ -231,12 +296,12 @@ struct BoundedPriorityQueueBenchTest
     PERF_TEST_F(                                                               \
       PriorityQueueSortBenchTest_##container##_##element##_##size,             \
       ExtractSorted) {                                                         \
-        run_extract_sorted_test();                                             \
+        return run_extract_sorted_test();                                      \
     }                                                                          \
     PERF_TEST_F(                                                               \
       PriorityQueueSortBenchTest_##container##_##element##_##size,             \
       SortExtractHeap) {                                                       \
-        run_sort_extract_heap_test();                                          \
+        return run_sort_extract_heap_test();                                   \
     }                                                                          \
     PERF_TEST_F(                                                               \
       PriorityQueueSortBenchTest_##container##_##element##_##size,             \
@@ -256,7 +321,7 @@ struct BoundedPriorityQueueBenchTest
     PERF_TEST_F(                                                                         \
       BoundedPriorityQueueBenchTest_##container##_##element##_##input_size##_##capacity, \
       PushRange) {                                                                       \
-        run_push_rvalue_range_test();                                                    \
+        return run_push_rvalue_range_test();                                             \
     }                                                                                    \
     PERF_TEST_F(                                                                         \
       BoundedPriorityQueueBenchTest_##container##_##element##_##input_size##_##capacity, \

--- a/src/v/container/tests/vector_bench.cc
+++ b/src/v/container/tests/vector_bench.cc
@@ -24,6 +24,10 @@ template<typename Vector, size_t Size>
 struct VectorBenchTest {
     using value_type = typename Vector::value_type;
 
+    static constexpr size_t inner_iters = std::max<size_t>(
+      1, 10000 / std::max<size_t>(1, Size));
+    static constexpr size_t access_inner_iters = 100;
+
     const value_type val = make_value();
     const Vector filled = make_filled();
 
@@ -57,43 +61,59 @@ struct VectorBenchTest {
     }();
 
     [[gnu::noinline]]
-    void run_sort_test() {
-        auto v = copy(filled);
-        std::sort(v.begin(), v.end());
+    size_t run_sort_test() {
+        for (size_t iter = 0; iter < inner_iters; ++iter) {
+            auto v = copy(filled);
+            std::sort(v.begin(), v.end());
+            perf_tests::do_not_optimize(v);
+        }
+        return inner_iters;
     }
 
     [[gnu::noinline]]
-    void run_fifo_test() {
-        Vector v;
-        for (size_t i = 0; i < Size; ++i) {
-            // NOLINTNEXTLINE(performance-inefficient-vector-operation)
-            v.push_back(val);
+    size_t run_fifo_test() {
+        for (size_t iter = 0; iter < inner_iters; ++iter) {
+            Vector v;
+            for (size_t i = 0; i < Size; ++i) {
+                // NOLINTNEXTLINE(performance-inefficient-vector-operation)
+                v.push_back(val);
+            }
+            perf_tests::do_not_optimize(v);
         }
-        perf_tests::do_not_optimize(v);
+        return inner_iters;
     }
 
     [[gnu::noinline]]
-    void run_lifo_test() {
-        Vector v;
-        for (size_t i = 0; i < Size; ++i) {
-            v.push_back(val);
+    size_t run_lifo_test() {
+        for (size_t iter = 0; iter < inner_iters; ++iter) {
+            Vector v;
+            for (size_t i = 0; i < Size; ++i) {
+                v.push_back(val);
+            }
+            while (!v.empty()) {
+                v.pop_back();
+            }
         }
-        while (!v.empty()) {
-            v.pop_back();
-        }
+        return inner_iters;
     }
 
     [[gnu::noinline]]
-    void run_fill_test() {
-        Vector v = make_filled();
-        perf_tests::do_not_optimize(v);
+    size_t run_fill_test() {
+        for (size_t iter = 0; iter < inner_iters; ++iter) {
+            Vector v = make_filled();
+            perf_tests::do_not_optimize(v);
+        }
+        return inner_iters;
     }
 
     [[gnu::noinline]]
-    void run_random_access_test() {
-        for (size_t index : indexes) {
-            perf_tests::do_not_optimize(filled[index]);
+    size_t run_random_access_test() {
+        for (size_t iter = 0; iter < access_inner_iters; ++iter) {
+            for (size_t index : indexes) {
+                perf_tests::do_not_optimize(filled[index]);
+            }
         }
+        return access_inner_iters;
     }
 };
 
@@ -102,20 +122,20 @@ struct VectorBenchTest {
     class VectorBenchTest_##container##_##element##_##size                     \
       : public VectorBenchTest<container<element>, size> {};                   \
     PERF_TEST_F(VectorBenchTest_##container##_##element##_##size, Sort) {      \
-        run_sort_test();                                                       \
+        return run_sort_test();                                                \
     }                                                                          \
     PERF_TEST_F(VectorBenchTest_##container##_##element##_##size, Fifo) {      \
-        run_fifo_test();                                                       \
+        return run_fifo_test();                                                \
     }                                                                          \
     PERF_TEST_F(VectorBenchTest_##container##_##element##_##size, Lifo) {      \
-        run_lifo_test();                                                       \
+        return run_lifo_test();                                                \
     }                                                                          \
     PERF_TEST_F(VectorBenchTest_##container##_##element##_##size, Fill) {      \
-        run_fill_test();                                                       \
+        return run_fill_test();                                                \
     }                                                                          \
     PERF_TEST_F(                                                               \
       VectorBenchTest_##container##_##element##_##size, RandomAccess) {        \
-        run_random_access_test();                                              \
+        return run_random_access_test();                                       \
     }
 // NOLINTEND(*-macro-*)
 

--- a/src/v/hashing/tests/hash_bench.cc
+++ b/src/v/hashing/tests/hash_bench.cc
@@ -31,7 +31,7 @@
 
 static constexpr size_t step_bytes = 57;
 
-static constexpr size_t inner_iters = 1000;
+static constexpr size_t inner_iters = 100000;
 
 template<typename F>
 static size_t header_body(F n) {

--- a/src/v/rpc/test/rpc_bench.cc
+++ b/src/v/rpc/test/rpc_bench.cc
@@ -9,9 +9,34 @@
 
 #include "reflection/adl.h"
 
-#include <seastar/core/reactor.hh>
-#include <seastar/core/sharded.hh>
 #include <seastar/testing/perf_tests.hh>
+
+#include <vector>
+
+namespace {
+
+/// Pre-generate N inputs via factory(), then time only the work() loop.
+/// Results from work() are collected and destroyed after
+/// stop_measuring_time() so that destruction cost is excluded.
+template<size_t N, typename Factory, typename Work>
+size_t bench_with_setup(Factory factory, Work work) {
+    using input_t = decltype(factory());
+    using result_t = decltype(work(std::declval<input_t>()));
+    std::vector<input_t> inputs;
+    inputs.reserve(N);
+    for (size_t i = 0; i < N; ++i) {
+        inputs.push_back(factory());
+    }
+    std::vector<result_t> results;
+    results.reserve(N);
+    perf_tests::start_measuring_time();
+    for (auto& input : inputs) {
+        results.emplace_back(work(std::move(input)));
+    }
+    perf_tests::stop_measuring_time();
+    perf_tests::do_not_optimize(results);
+    return N;
+}
 
 struct small_t {
     int8_t a = 1;
@@ -22,18 +47,20 @@ struct small_t {
 };
 static_assert(sizeof(small_t) == 16, "one more byte for padding");
 
+static constexpr size_t small_inner_iters = 10000;
+
+} // namespace
+
 PERF_TEST(small, serialize) {
-    perf_tests::start_measuring_time();
-    auto o = reflection::to_iobuf(small_t{});
-    perf_tests::do_not_optimize(o);
-    perf_tests::stop_measuring_time();
+    return bench_with_setup<small_inner_iters>(
+      [] { return small_t{}; },
+      [](small_t s) { return reflection::to_iobuf(s); });
 }
+
 PERF_TEST(small, deserialize) {
-    auto b = reflection::to_iobuf(small_t{});
-    perf_tests::start_measuring_time();
-    auto result = reflection::adl<small_t>().from(std::move(b));
-    perf_tests::do_not_optimize(result);
-    perf_tests::stop_measuring_time();
+    return bench_with_setup<small_inner_iters>(
+      [] { return reflection::to_iobuf(small_t{}); },
+      [](iobuf&& b) { return reflection::adl<small_t>().from(std::move(b)); });
 }
 
 struct big_t {
@@ -51,37 +78,43 @@ inline big_t gen_big(size_t data_size, size_t chunk_size) {
     return ret;
 }
 
-inline void serialize_big(size_t data_size, size_t chunk_size) {
-    big_t b = gen_big(data_size, chunk_size);
-    auto o = iobuf();
-    perf_tests::start_measuring_time();
-    reflection::serialize(o, std::move(b));
-    perf_tests::do_not_optimize(o);
-    perf_tests::stop_measuring_time();
+static constexpr size_t big_1mb_inner_iters = 100;
+static constexpr size_t big_10mb_inner_iters = 10;
+
+template<size_t N>
+size_t serialize_big(size_t data_size, size_t chunk_size) {
+    return bench_with_setup<N>(
+      [=] { return gen_big(data_size, chunk_size); },
+      [](big_t&& b) {
+          auto o = iobuf();
+          reflection::serialize(o, std::move(b));
+          return o;
+      });
 }
 
-inline void deserialize_big(size_t data_size, size_t chunk_size) {
-    big_t b = gen_big(data_size, chunk_size);
-    auto o = iobuf();
-    reflection::serialize(o, std::move(b));
-    perf_tests::start_measuring_time();
-    auto result = reflection::adl<big_t>().from(std::move(o));
-    perf_tests::do_not_optimize(result);
-    perf_tests::stop_measuring_time();
+template<size_t N>
+size_t deserialize_big(size_t data_size, size_t chunk_size) {
+    return bench_with_setup<N>(
+      [=] {
+          auto o = iobuf();
+          reflection::serialize(o, gen_big(data_size, chunk_size));
+          return o;
+      },
+      [](iobuf&& o) { return reflection::adl<big_t>().from(std::move(o)); });
 }
 
 PERF_TEST(big_1mb, serialize) {
-    serialize_big(1 << 20 /*1MB*/, 1 << 15 /*32KB*/);
+    return serialize_big<big_1mb_inner_iters>(1 << 20, 1 << 15);
 }
 
 PERF_TEST(big_1mb, deserialize) {
-    return deserialize_big(1 << 20 /*1MB*/, 1 << 15 /*32KB*/);
+    return deserialize_big<big_1mb_inner_iters>(1 << 20, 1 << 15);
 }
 
 PERF_TEST(big_10mb, serialize) {
-    serialize_big(10 << 20 /*10MB*/, 1 << 15 /*32KB*/);
+    return serialize_big<big_10mb_inner_iters>(10 << 20, 1 << 15);
 }
 
 PERF_TEST(big_10mb, deserialize) {
-    return deserialize_big(10 << 20 /*10MB*/, 1 << 15 /*32KB*/);
+    return deserialize_big<big_10mb_inner_iters>(10 << 20, 1 << 15);
 }

--- a/src/v/security/tests/role_store_bench.cc
+++ b/src/v/security/tests/role_store_bench.cc
@@ -114,51 +114,59 @@ const role_store mixed_store_64_r_512_m_data = make_store(
 const role_store mixed_store_8_r_1Ki_m_data = make_store(
   generate_role_names(8ul), mixed_members_data);
 
+static constexpr size_t query_inner_iters = 1000;
+
 template<bool materialize>
-void run_get_member_roles(
+size_t run_get_member_roles(
   const std::vector<role_member>& members, const role_store& store) {
-    const auto& m = members[random_generators::get_int(members.size() - 1)];
     perf_tests::start_measuring_time();
-    auto rng = store.roles_for_member(m);
-    perf_tests::do_not_optimize(rng);
-    if constexpr (materialize) {
-        bool is_empty = rng.empty();
-        perf_tests::do_not_optimize(is_empty);
+    for (size_t i = 0; i < query_inner_iters; ++i) {
+        const auto& m = members[random_generators::get_int(members.size() - 1)];
+        auto rng = store.roles_for_member(m);
+        perf_tests::do_not_optimize(rng);
+        if constexpr (materialize) {
+            bool is_empty = rng.empty();
+            perf_tests::do_not_optimize(is_empty);
+        }
     }
     perf_tests::stop_measuring_time();
+    return query_inner_iters;
 }
 
 template<bool materialize>
-void run_range_queries(
+size_t run_range_queries(
   const std::vector<role_member>& members, const role_store& store) {
-    const auto& m = members[random_generators::get_int(members.size() - 1)];
     perf_tests::start_measuring_time();
-    auto rng = store.range(
-      [&m](const auto& e) { return role_store::has_member(e, m); });
-    perf_tests::do_not_optimize(rng);
-    if constexpr (materialize) {
-        bool is_empty = rng.empty();
-        perf_tests::do_not_optimize(is_empty);
+    for (size_t i = 0; i < query_inner_iters; ++i) {
+        const auto& m = members[random_generators::get_int(members.size() - 1)];
+        auto rng = store.range(
+          [&m](const auto& e) { return role_store::has_member(e, m); });
+        perf_tests::do_not_optimize(rng);
+        if constexpr (materialize) {
+            bool is_empty = rng.empty();
+            perf_tests::do_not_optimize(is_empty);
+        }
     }
     perf_tests::stop_measuring_time();
+    return query_inner_iters;
 }
 
 } // namespace
 
 PERF_TEST(role_store_bench, get_member_roles) {
-    run_get_member_roles<true>(members_data, store_512_r_1Ki_m_data);
+    return run_get_member_roles<true>(members_data, store_512_r_1Ki_m_data);
 }
 
 PERF_TEST(role_store_bench, get_member_roles_bare_query) {
-    run_get_member_roles<false>(members_data, store_512_r_1Ki_m_data);
+    return run_get_member_roles<false>(members_data, store_512_r_1Ki_m_data);
 }
 
 PERF_TEST(role_store_bench, user_range_query) {
-    run_range_queries<true>(members_data, store_512_r_1Ki_m_data);
+    return run_range_queries<true>(members_data, store_512_r_1Ki_m_data);
 }
 
 PERF_TEST(role_store_bench, user_range_query_bare_query) {
-    run_range_queries<false>(members_data, store_512_r_1Ki_m_data);
+    return run_range_queries<false>(members_data, store_512_r_1Ki_m_data);
 }
 
 PERF_TEST(role_store_bench, remove_role) {
@@ -202,21 +210,23 @@ PERF_TEST(role_store_bench, put_role) {
 }
 
 PERF_TEST(role_store_bench, get_member_roles_mixed) {
-    run_get_member_roles<true>(
+    return run_get_member_roles<true>(
       mixed_members_data, mixed_store_512_r_1Ki_m_data);
 }
 
 PERF_TEST(role_store_bench, get_member_roles_bare_query_mixed) {
-    run_get_member_roles<false>(
+    return run_get_member_roles<false>(
       mixed_members_data, mixed_store_512_r_1Ki_m_data);
 }
 
 PERF_TEST(role_store_bench, range_query_mixed) {
-    run_range_queries<true>(mixed_members_data, mixed_store_512_r_1Ki_m_data);
+    return run_range_queries<true>(
+      mixed_members_data, mixed_store_512_r_1Ki_m_data);
 }
 
 PERF_TEST(role_store_bench, range_query_bare_query_mixed) {
-    run_range_queries<false>(mixed_members_data, mixed_store_512_r_1Ki_m_data);
+    return run_range_queries<false>(
+      mixed_members_data, mixed_store_512_r_1Ki_m_data);
 }
 
 PERF_TEST(role_store_bench, remove_role_mixed) {
@@ -274,7 +284,7 @@ make_test_authorizer(std::optional<const role_store*> roles = std::nullopt) {
       roles.value_or(&_roles)};
 }
 
-void run_authz(
+size_t run_authz(
   const role_store& store,
   const std::vector<role_member>& members,
   acl_permission perm = acl_permission::allow,
@@ -327,83 +337,89 @@ void run_authz(
     auto auth = make_test_authorizer(&store);
     auth.add_bindings(bindings);
 
-    const auto& m = members[random_generators::get_int(members.size() - 1)];
-    acl_principal p{
-      principal_type_for_member_type(m.type()), ss::sstring{m.name()}};
-
     perf_tests::start_measuring_time();
-    auto result = auth.authorized(
-      topic1,
-      acl_operation::read,
-      p,
-      host1,
-      security::superuser_required::no,
-      {});
-    perf_tests::do_not_optimize(result);
+    for (size_t i = 0; i < query_inner_iters; ++i) {
+        const auto& m = members[random_generators::get_int(members.size() - 1)];
+        acl_principal p{
+          principal_type_for_member_type(m.type()), ss::sstring{m.name()}};
+        auto result = auth.authorized(
+          topic1,
+          acl_operation::read,
+          p,
+          host1,
+          security::superuser_required::no,
+          {});
+        perf_tests::do_not_optimize(result);
+    }
     perf_tests::stop_measuring_time();
+    return query_inner_iters;
 }
 
 } // namespace
 
 PERF_TEST(role_store_bench, role_authz_512_roles_1Ki_members) {
-    run_authz(store_512_r_1Ki_m_data, members_data);
+    return run_authz(store_512_r_1Ki_m_data, members_data);
 }
 
 PERF_TEST(role_store_bench, role_authz_256_roles_1Ki_members) {
-    run_authz(store_256_r_1Ki_m_data, members_data);
+    return run_authz(store_256_r_1Ki_m_data, members_data);
 }
 
 PERF_TEST(role_store_bench, role_authz_128_roles_1Ki_members) {
-    run_authz(store_128_r_1Ki_m_data, members_data);
+    return run_authz(store_128_r_1Ki_m_data, members_data);
 }
 
 PERF_TEST(role_store_bench, role_authz_64_roles_1Ki_members) {
-    run_authz(store_64_r_1Ki_m_data, members_data);
+    return run_authz(store_64_r_1Ki_m_data, members_data);
 }
 
 PERF_TEST(role_store_bench, role_authz_64_roles_1Ki_members_4_extra_bindings) {
-    run_authz(store_64_r_1Ki_m_data, members_data, acl_permission::allow, 4);
+    return run_authz(
+      store_64_r_1Ki_m_data, members_data, acl_permission::allow, 4);
 }
 
 PERF_TEST(role_store_bench, role_authz_64_roles_1Ki_members_8_extra_bindings) {
-    run_authz(store_64_r_1Ki_m_data, members_data, acl_permission::allow, 8);
+    return run_authz(
+      store_64_r_1Ki_m_data, members_data, acl_permission::allow, 8);
 }
 
 PERF_TEST(role_store_bench, role_authz_64_roles_1Ki_members_16_extra_bindings) {
-    run_authz(store_64_r_1Ki_m_data, members_data, acl_permission::allow, 16);
+    return run_authz(
+      store_64_r_1Ki_m_data, members_data, acl_permission::allow, 16);
 }
 
 PERF_TEST(role_store_bench, role_authz_64_roles_512_members) {
-    run_authz(store_64_r_512_m_data, members_512_data);
+    return run_authz(store_64_r_512_m_data, members_512_data);
 }
 
 PERF_TEST(role_store_bench, role_authz_64_roles_512_members_deny) {
-    run_authz(store_64_r_512_m_data, members_512_data, acl_permission::deny);
+    return run_authz(
+      store_64_r_512_m_data, members_512_data, acl_permission::deny);
 }
 
 PERF_TEST(role_store_bench, role_authz_8_roles_1Ki_members) {
-    run_authz(store_8_r_1Ki_m_data, members_data);
+    return run_authz(store_8_r_1Ki_m_data, members_data);
 }
 
 PERF_TEST(role_store_bench, role_authz_512_roles_1Ki_members_mixed) {
-    run_authz(mixed_store_512_r_1Ki_m_data, mixed_members_data);
+    return run_authz(mixed_store_512_r_1Ki_m_data, mixed_members_data);
 }
 
 PERF_TEST(role_store_bench, role_authz_256_roles_1Ki_members_mixed) {
-    run_authz(mixed_store_256_r_1Ki_m_data, mixed_members_data);
+    return run_authz(mixed_store_256_r_1Ki_m_data, mixed_members_data);
 }
 
 PERF_TEST(role_store_bench, role_authz_128_roles_1Ki_members_mixed) {
-    run_authz(mixed_store_128_r_1Ki_m_data, mixed_members_data);
+    return run_authz(mixed_store_128_r_1Ki_m_data, mixed_members_data);
 }
 
 PERF_TEST(role_store_bench, role_authz_64_roles_1Ki_members_mixed) {
-    run_authz(mixed_store_64_r_1Ki_m_data, mixed_members_data);
+    return run_authz(mixed_store_64_r_1Ki_m_data, mixed_members_data);
 }
 
 PERF_TEST(
   role_store_bench, role_authz_64_roles_1Ki_members_4_extra_bindings_mixed) {
-    run_authz(
+    return run_authz(
       mixed_store_64_r_1Ki_m_data,
       mixed_members_data,
       acl_permission::allow,
@@ -412,7 +428,7 @@ PERF_TEST(
 
 PERF_TEST(
   role_store_bench, role_authz_64_roles_1Ki_members_8_extra_bindings_mixed) {
-    run_authz(
+    return run_authz(
       mixed_store_64_r_1Ki_m_data,
       mixed_members_data,
       acl_permission::allow,
@@ -421,7 +437,7 @@ PERF_TEST(
 
 PERF_TEST(
   role_store_bench, role_authz_64_roles_1Ki_members_16_extra_bindings_mixed) {
-    run_authz(
+    return run_authz(
       mixed_store_64_r_1Ki_m_data,
       mixed_members_data,
       acl_permission::allow,
@@ -429,18 +445,18 @@ PERF_TEST(
 }
 
 PERF_TEST(role_store_bench, role_authz_64_roles_512_members_mixed) {
-    run_authz(mixed_store_64_r_512_m_data, mixed_members_512_data);
+    return run_authz(mixed_store_64_r_512_m_data, mixed_members_512_data);
 }
 
 PERF_TEST(role_store_bench, role_authz_64_roles_512_members_deny_mixed) {
-    run_authz(
+    return run_authz(
       mixed_store_64_r_512_m_data,
       mixed_members_512_data,
       acl_permission::deny);
 }
 
 PERF_TEST(role_store_bench, role_authz_8_roles_1Ki_members_mixed) {
-    run_authz(mixed_store_8_r_1Ki_m_data, mixed_members_data);
+    return run_authz(mixed_store_8_r_1Ki_m_data, mixed_members_data);
 }
 
 PERF_TEST(role_store_bench, role_authz_empty_store) {
@@ -470,13 +486,16 @@ PERF_TEST(role_store_bench, role_authz_empty_store) {
     auth.add_bindings(bindings);
 
     perf_tests::start_measuring_time();
-    auto result = auth.authorized(
-      topic1,
-      acl_operation::read,
-      user1,
-      host1,
-      security::superuser_required::no,
-      {});
-    perf_tests::do_not_optimize(result);
+    for (size_t i = 0; i < query_inner_iters; ++i) {
+        auto result = auth.authorized(
+          topic1,
+          acl_operation::read,
+          user1,
+          host1,
+          security::superuser_required::no,
+          {});
+        perf_tests::do_not_optimize(result);
+    }
     perf_tests::stop_measuring_time();
+    return query_inner_iters;
 }

--- a/src/v/serde/test/bench.cc
+++ b/src/v/serde/test/bench.cc
@@ -7,14 +7,38 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-#include "bytes/iobuf.h"
 #include "serde/envelope.h"
 #include "serde/rw/envelope.h"
 #include "serde/rw/iobuf.h"
 
-#include <seastar/core/reactor.hh>
-#include <seastar/core/sharded.hh>
 #include <seastar/testing/perf_tests.hh>
+
+#include <vector>
+
+namespace {
+
+/// Pre-generate N inputs via factory(), then time only the work() loop.
+/// Results from work() are collected and destroyed after
+/// stop_measuring_time() so that destruction cost is excluded.
+template<size_t N, typename Factory, typename Work>
+size_t bench_with_setup(Factory factory, Work work) {
+    using input_t = decltype(factory());
+    using result_t = decltype(work(std::declval<input_t>()));
+    std::vector<input_t> inputs;
+    inputs.reserve(N);
+    for (size_t i = 0; i < N; ++i) {
+        inputs.push_back(factory());
+    }
+    std::vector<result_t> results;
+    results.reserve(N);
+    perf_tests::start_measuring_time();
+    for (auto& input : inputs) {
+        results.emplace_back(work(std::move(input)));
+    }
+    perf_tests::stop_measuring_time();
+    perf_tests::do_not_optimize(results);
+    return N;
+}
 
 struct small_t
   : public serde::
@@ -29,18 +53,19 @@ struct small_t
 };
 static_assert(sizeof(small_t) == 16, "one more byte for padding");
 
+static constexpr size_t small_inner_iters = 10000;
+
+} // namespace
+
 PERF_TEST(small, serialize) {
-    perf_tests::start_measuring_time();
-    auto o = serde::to_iobuf(small_t{});
-    perf_tests::do_not_optimize(o);
-    perf_tests::stop_measuring_time();
+    return bench_with_setup<small_inner_iters>(
+      [] { return small_t{}; }, [](small_t s) { return serde::to_iobuf(s); });
 }
+
 PERF_TEST(small, deserialize) {
-    auto b = serde::to_iobuf(small_t{});
-    perf_tests::start_measuring_time();
-    auto result = serde::from_iobuf<small_t>(std::move(b));
-    perf_tests::do_not_optimize(result);
-    perf_tests::stop_measuring_time();
+    return bench_with_setup<small_inner_iters>(
+      [] { return serde::to_iobuf(small_t{}); },
+      [](iobuf&& b) { return serde::from_iobuf<small_t>(std::move(b)); });
 }
 
 struct big_t
@@ -60,37 +85,43 @@ inline big_t gen_big(size_t data_size, size_t chunk_size) {
     return ret;
 }
 
-inline void serialize_big(size_t data_size, size_t chunk_size) {
-    big_t b = gen_big(data_size, chunk_size);
-    auto o = iobuf();
-    perf_tests::start_measuring_time();
-    serde::write(o, std::move(b));
-    perf_tests::do_not_optimize(o);
-    perf_tests::stop_measuring_time();
+static constexpr size_t big_1mb_inner_iters = 100;
+static constexpr size_t big_10mb_inner_iters = 10;
+
+template<size_t N>
+size_t serialize_big(size_t data_size, size_t chunk_size) {
+    return bench_with_setup<N>(
+      [=] { return gen_big(data_size, chunk_size); },
+      [](big_t&& b) {
+          auto o = iobuf();
+          serde::write(o, std::move(b));
+          return o;
+      });
 }
 
-inline void deserialize_big(size_t data_size, size_t chunk_size) {
-    big_t b = gen_big(data_size, chunk_size);
-    auto o = iobuf();
-    serde::write(o, std::move(b));
-    perf_tests::start_measuring_time();
-    auto result = serde::from_iobuf<big_t>(std::move(o));
-    perf_tests::do_not_optimize(result);
-    perf_tests::stop_measuring_time();
+template<size_t N>
+size_t deserialize_big(size_t data_size, size_t chunk_size) {
+    return bench_with_setup<N>(
+      [=] {
+          auto o = iobuf();
+          serde::write(o, gen_big(data_size, chunk_size));
+          return o;
+      },
+      [](iobuf&& o) { return serde::from_iobuf<big_t>(std::move(o)); });
 }
 
 PERF_TEST(big_1mb, serialize) {
-    serialize_big(1 << 20 /*1MB*/, 1 << 15 /*32KB*/);
+    return serialize_big<big_1mb_inner_iters>(1 << 20, 1 << 15);
 }
 
 PERF_TEST(big_1mb, deserialize) {
-    return deserialize_big(1 << 20 /*1MB*/, 1 << 15 /*32KB*/);
+    return deserialize_big<big_1mb_inner_iters>(1 << 20, 1 << 15);
 }
 
 PERF_TEST(big_10mb, serialize) {
-    serialize_big(10 << 20 /*10MB*/, 1 << 15 /*32KB*/);
+    return serialize_big<big_10mb_inner_iters>(10 << 20, 1 << 15);
 }
 
 PERF_TEST(big_10mb, deserialize) {
-    return deserialize_big(10 << 20 /*10MB*/, 1 << 15 /*32KB*/);
+    return deserialize_big<big_10mb_inner_iters>(10 << 20, 1 << 15);
 }

--- a/src/v/ssx/tests/async_algorithm_bench.cc
+++ b/src/v/ssx/tests/async_algorithm_bench.cc
@@ -22,7 +22,13 @@ using std::ranges::generate_n;
 
 constexpr size_t BIG_ELEM_COUNT = 1000;
 constexpr size_t SMALL_ELEM_COUNT = 1;
-constexpr size_t ITERATIONS = 1000;
+
+// Scale iterations inversely with element count so that
+// even small-element tests do enough work per start/stop
+// timing pair to avoid excessive measurement overhead.
+constexpr size_t iterations_for(size_t elem_count) {
+    return std::max<size_t>(1000, 1000000 / std::max<size_t>(1, elem_count));
+}
 
 namespace {
 using vec_t = std::vector<int>;
@@ -46,14 +52,14 @@ struct sum {
 
 // split up the inner loop into two variations so that
 // the "sync" version doesn't have a co_await in the loop
-ss::future<> coro_inner(vec_t& data, auto fn, sum& s) {
-    for (size_t i = 0; i < ITERATIONS; i++) {
+ss::future<> coro_inner(vec_t& data, auto fn, sum& s, size_t iters) {
+    for (size_t i = 0; i < iters; i++) {
         co_await fn(data, s);
     }
 }
 
-ss::future<> sync_inner(vec_t& data, auto fn, sum& s) {
-    for (size_t i = 0; i < ITERATIONS; i++) {
+ss::future<> sync_inner(vec_t& data, auto fn, sum& s, size_t iters) {
+    for (size_t i = 0; i < iters; i++) {
         fn(data, s);
     }
     return ss::now();
@@ -61,19 +67,20 @@ ss::future<> sync_inner(vec_t& data, auto fn, sum& s) {
 
 template<size_t elem_count, bool async_inner = true>
 ss::future<size_t> run_test_coro(auto fn) {
+    constexpr auto iters = iterations_for(elem_count);
     auto data = rand_vec(elem_count);
     sum s;
 
     perf_tests::start_measuring_time();
     if constexpr (async_inner) {
-        co_await coro_inner(data, fn, s);
+        co_await coro_inner(data, fn, s, iters);
     } else {
-        co_await sync_inner(data, fn, s);
+        co_await sync_inner(data, fn, s, iters);
     }
     perf_tests::stop_measuring_time();
 
     perf_tests::do_not_optimize(s);
-    co_return ITERATIONS;
+    co_return iters;
 }
 
 template<typename Fn>


### PR DESCRIPTION
## Summary

- Reduce timing overhead in 10 microbenchmark files by restructuring how
  `start_measuring_time()` / `stop_measuring_time()` are used
- Main approaches: removing redundant start/stop calls, adding inner iteration
  loops, moving setup to fixtures, and pre-generating inputs for mutating operations
- Before these changes many benchmarks had 70–100% measurement overhead,
  making their results unreliable; after, overhead drops to 0%

See the [Microbenchmarks wiki](https://redpandadata.atlassian.net/wiki/spaces/CORE/pages/1175453697/Microbenchmarks#Avoid-excess-timing-overhead) for background on the approaches used.

## Test plan

- Each commit message includes before/after benchmark results showing overhead
  drops to 0% while allocs/tasks stay constant
- `bazel test //src/v/.../tests:*_rpbench_test` passes for all affected benchmarks