### PR TITLE
ct: miscellaneous improvements following preregistration

### DIFF
--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -949,7 +949,7 @@ db_domain_manager::get_extent_metadata(rpc::get_extent_metadata_request req) {
 
 ss::future<rpc::preregister_objects_reply>
 db_domain_manager::preregister_objects(rpc::preregister_objects_request req) {
-    auto gl_res = co_await gate_and_open_writes();
+    auto gl_res = co_await gate_and_open_reads();
     if (!gl_res.has_value()) {
         co_return rpc::preregister_objects_reply{
           .ec = gl_res.error(),
@@ -973,7 +973,11 @@ db_domain_manager::preregister_objects(rpc::preregister_objects_request req) {
         };
     }
 
-    auto apply_res = co_await write_rows(gl_res.value(), std::move(rows));
+    // NOTE: we aren't holding the write lock, and we're not using
+    // db_domain_manager::write() to avoid some locking here. This is only safe
+    // because if this fails, these preregistrations won't be touched by
+    // anything else anyway.
+    auto apply_res = co_await write_rows_no_lock(std::move(rows));
     if (!apply_res.has_value()) {
         co_return rpc::preregister_objects_reply{
           .ec = apply_res.error(),
@@ -1047,6 +1051,11 @@ db_domain_manager::gate_and_open_writes() {
 
 ss::future<std::expected<void, rpc::errc>> db_domain_manager::write_rows(
   const gate_writer_locks&, chunked_vector<write_batch_row> rows) {
+    co_return co_await write_rows_no_lock(std::move(rows));
+}
+
+ss::future<std::expected<void, rpc::errc>>
+db_domain_manager::write_rows_no_lock(chunked_vector<write_batch_row> rows) {
     // TODO: it's probably worth pushing some retries into replicated_database
     // while locks are still held, rather than stepping down immediately.
     auto apply_res = co_await db_->write(std::move(rows));

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.h
@@ -141,6 +141,9 @@ private:
     ss::future<std::expected<void, rpc::errc>>
     write_rows(const gate_writer_locks&, chunked_vector<write_batch_row>);
 
+    ss::future<std::expected<void, rpc::errc>>
+      write_rows_no_lock(chunked_vector<write_batch_row>);
+
     ss::future<rpc::get_compaction_info_reply> do_get_compaction_info(
       const gate_read_lock&, state_reader&, rpc::get_compaction_info_request);
 

--- a/src/v/cloud_topics/level_one/metastore/leader_router.cc
+++ b/src/v/cloud_topics/level_one/metastore/leader_router.cc
@@ -831,6 +831,7 @@ leader_router::preregister_objects_locally(
   rpc::preregister_objects_request request,
   const model::ntp& metastore_ntp,
   ss::shard_id shard) {
+    auto m = _probe.auto_measure_preregister_objects();
     co_return co_await container().invoke_on(
       shard,
       [metastore_ntp, req = std::move(request)](leader_router& fe) mutable {

--- a/src/v/cloud_topics/level_one/metastore/leader_router_probe.cc
+++ b/src/v/cloud_topics/level_one/metastore/leader_router_probe.cc
@@ -96,6 +96,10 @@ void leader_router_probe::setup_metrics() {
           "restore_domain_duration_microseconds",
           [this] { return _restore_domain.internal_histogram_logform(); },
           sm::description("Latency of local restore_domain requests")),
+        sm::make_histogram(
+          "preregister_objects_duration_microseconds",
+          [this] { return _preregister_objects.internal_histogram_logform(); },
+          sm::description("Latency of local preregister_objects requests")),
       });
 }
 

--- a/src/v/cloud_topics/level_one/metastore/leader_router_probe.h
+++ b/src/v/cloud_topics/level_one/metastore/leader_router_probe.h
@@ -98,6 +98,10 @@ public:
         return _restore_domain.auto_measure();
     }
 
+    std::unique_ptr<hist_t::measurement> auto_measure_preregister_objects() {
+        return _preregister_objects.auto_measure();
+    }
+
 private:
     hist_t _add_objects;
     hist_t _replace_objects;
@@ -115,6 +119,7 @@ private:
     hist_t _get_extent_metadata;
     hist_t _flush_domain;
     hist_t _restore_domain;
+    hist_t _preregister_objects;
 
     metrics::internal_metric_groups _metrics;
 };

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -412,6 +412,20 @@ ss::future<size_t> reconciler<Clock>::reconcile_source_set(
         co_return 0;
     }
 
+    // Don't do any work when no source has pending data.
+    {
+        chunked_vector<ss::shared_ptr<source>> pending;
+        for (auto& src : sources) {
+            if (src->has_pending_data()) {
+                pending.push_back(std::move(src));
+            }
+        }
+        sources = std::move(pending);
+    }
+    if (sources.empty()) {
+        co_return 0;
+    }
+
     // Begin by creating the set of objects to be built.
     retry_chain_node rtc = l1::make_default_metastore_rtc(_as);
     auto metadata_builder_res = co_await l1::retry_metastore_op(

--- a/src/v/cloud_topics/reconciler/reconciliation_source.cc
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.cc
@@ -60,6 +60,16 @@ public:
       , _fe(ss::make_lw_shared<frontend>(partition, dp_api))
       , _partition(std::move(partition)) {}
 
+    bool has_pending_data() override {
+        auto lro = last_reconciled_offset();
+        auto lso = _fe->last_stable_offset();
+        if (!lso.has_value()) {
+            // LSO is invalid.
+            return false;
+        }
+        return lso.value() > kafka::next_offset(lro);
+    }
+
     kafka::offset last_reconciled_offset() override {
         ctp_stm_api api(_partition->raft()->stm_manager()->get<ctp_stm>());
         return api.get_last_reconciled_offset();

--- a/src/v/cloud_topics/reconciler/reconciliation_source.h
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.h
@@ -52,6 +52,9 @@ public:
         return _tidp;
     }
 
+    // Returns true if there may be new data to reconcile (LSO > LRO).
+    virtual bool has_pending_data() = 0;
+
     // Get the last reconciled offset for this source, or kafka::offset::min()
     // if none.
     virtual kafka::offset last_reconciled_offset() = 0;

--- a/src/v/cloud_topics/reconciler/tests/test_utils.h
+++ b/src/v/cloud_topics/reconciler/tests/test_utils.h
@@ -48,6 +48,8 @@ public:
         _source_log.push_back(std::move(batch));
     }
 
+    bool has_pending_data() override { return true; }
+
     kafka::offset last_reconciled_offset() override { return _lro; }
 
     ss::future<std::expected<void, errc>>

--- a/tools/dashboards/cloud_topics.json
+++ b/tools/dashboards/cloud_topics.json
@@ -3396,6 +3396,210 @@
       ],
       "title": "leader_router: Restore Domain (p99)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Latency of local preregister_objects requests (p50)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "µs"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 136
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum(rate(vectorized_cloud_topics_l1_leader_router_preregister_objects_duration_microseconds_bucket[$__rate_interval])) by (le, instance))",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "leader_router: Preregister Objects (p50)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Latency of local preregister_objects requests (p99)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "µs"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 136
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(vectorized_cloud_topics_l1_leader_router_preregister_objects_duration_microseconds_bucket[$__rate_interval])) by (le, instance))",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "leader_router: Preregister Objects (p99)",
+      "type": "timeseries"
     }
   ],
   "preload": false,


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
- noticed that we would preregister objects when there's no data to reconcile, so my idle cluster would continue to grow slowly with a trickle of preregistration RPCs
- adds a metric for preregistration
- removes write locking for preregistration to improve concurrency

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
