### PR TITLE
ct: Improve tailing read latency

### DIFF
--- a/src/v/cloud_topics/batch_cache/batch_cache.cc
+++ b/src/v/cloud_topics/batch_cache/batch_cache.cc
@@ -10,6 +10,7 @@
 
 #include "cloud_topics/batch_cache/batch_cache.h"
 
+#include "cloud_topics/logger.h"
 #include "config/configuration.h"
 #include "ssx/future-util.h"
 #include "storage/batch_cache.h"
@@ -72,10 +73,16 @@ void batch_cache::put(
     }
     entry.index->put(b, storage::batch_cache::is_dirty_entry::no);
     _probe.register_put(b.size_bytes());
-
-    // Notify any readers waiting for this offset.
     if (entry.monitor) {
         entry.monitor->notify(b.last_offset());
+    }
+}
+
+void batch_cache::notify(
+  const model::topic_id_partition& tidp, model::offset last_offset) {
+    auto it = _entries.find(tidp);
+    if (it != _entries.end() && it->second.monitor) {
+        it->second.monitor->notify(last_offset);
     }
 }
 
@@ -87,7 +94,8 @@ batch_cache::get(const model::topic_id_partition& tidp, model::offset o) {
     _gate.check();
     if (auto it = _entries.find(tidp);
         it != _entries.end() && it->second.index) {
-        auto rb = it->second.index->get(o);
+        auto& index = *it->second.index;
+        auto rb = index.get(o);
         if (rb.has_value()) {
             vassert(
               rb->term() > model::term_id{-1},
@@ -102,11 +110,11 @@ batch_cache::get(const model::topic_id_partition& tidp, model::offset o) {
               o);
             _probe.register_get(rb->size_bytes());
         } else {
+            // Offset was within the cached range but got evicted.
             _probe.register_miss();
         }
         return rb;
     }
-    _probe.register_miss();
     return std::nullopt;
 }
 
@@ -122,6 +130,55 @@ ss::future<> batch_cache::wait_for_offset(
         entry.monitor->notify(last_known);
     }
     return entry.monitor->wait(offset, deadline, as);
+}
+
+void batch_cache::put_ordered(
+  const model::topic_id_partition& tidp,
+  chunked_vector<model::record_batch> batches) {
+    if (batches.empty() || _lm == nullptr) {
+        return;
+    }
+    _gate.check();
+
+    auto first_base = batches.front().base_offset();
+    auto last = batches.back().last_offset();
+
+    // Insert all batches into the cache without notifying the monitor.
+    auto& entry = _entries[tidp];
+    if (!entry.index) {
+        auto cache_ix = _lm->create_cache(storage::with_cache::yes);
+        if (!cache_ix.has_value()) {
+            return;
+        }
+        entry.index = std::make_unique<storage::batch_cache_index>(
+          std::move(*cache_ix));
+    }
+    for (const auto& b : batches) {
+        vassert(
+          b.term() > model::term_id{-1},
+          "Batch without term in the cache: {}",
+          b.header());
+        entry.index->put(b, storage::batch_cache::is_dirty_entry::no);
+        _probe.register_put(b.size_bytes());
+    }
+
+    if (!entry.monitor) {
+        return;
+    }
+
+    auto prev = model::prev_offset(first_base);
+    if (prev <= entry.monitor->last_applied()) {
+        // The batch is contiguous with what the monitor has already seen.
+        entry.monitor->notify(last);
+        return;
+    }
+
+    // Check whether the index covers the gap between the monitor's position
+    // and this batch.
+    auto gap_start = model::next_offset(entry.monitor->last_applied());
+    if (entry.index->has_contiguous_coverage(gap_start, prev)) {
+        entry.monitor->notify(last);
+    }
 }
 
 ss::future<> batch_cache::cleanup_index_entries() {

--- a/src/v/cloud_topics/batch_cache/batch_cache.h
+++ b/src/v/cloud_topics/batch_cache/batch_cache.h
@@ -58,9 +58,7 @@ public:
     ss::future<> start();
     ss::future<> stop();
 
-    // Put element into the batch cache. The element shouldn't be dirty.
-    // The code that uses this class should only use this to cache committed
-    // entries.
+    // Put element into the batch cache.
     void
     put(const model::topic_id_partition& tidp, const model::record_batch& b);
 
@@ -78,7 +76,17 @@ public:
       model::timeout_clock::time_point deadline,
       std::optional<std::reference_wrapper<ss::abort_source>> as);
 
+    /// Put batches into the cache and notify the offset monitor when the
+    /// inserted batches extend the contiguous range tracked by the monitor.
+    void put_ordered(
+      const model::topic_id_partition& tidp,
+      chunked_vector<model::record_batch> batches);
+
 private:
+    /// Signal that batches up to \p last_offset have been inserted for \p tidp.
+    /// Wakes readers blocked in wait_for_offset.
+    void
+    notify(const model::topic_id_partition& tidp, model::offset last_offset);
     // Remove dead index entries
     ss::future<> cleanup_index_entries();
 

--- a/src/v/cloud_topics/batch_cache/tests/batch_cache_test.cc
+++ b/src/v/cloud_topics/batch_cache/tests/batch_cache_test.cc
@@ -143,6 +143,175 @@ TEST_F(batch_cache_test_fixture, test_batch_cache_eviction) {
     _cache.stop().get();
 }
 
+// Verify that put_ordered inserts batches into the cache and notifies
+// waiters blocked in wait_for_offset.
+TEST_F(batch_cache_test_fixture, test_put_ordered_sequential) {
+    auto tidp = model::topic_id_partition{
+      model::topic_id::create(), model::partition_id(0)};
+
+    // Create 3 batches: [0,9], [10,19], [20,29]
+    chunked_vector<model::record_batch> batches;
+    batches.push_back(
+      model::test::make_random_batch(model::offset(0), 10, false));
+    batches.push_back(
+      model::test::make_random_batch(model::offset(10), 10, false));
+    batches.push_back(
+      model::test::make_random_batch(model::offset(20), 10, false));
+
+    _cache.start().get();
+
+    // Seed the offset monitor so put_ordered can check alignment.
+    _cache
+      .wait_for_offset(
+        tidp,
+        model::offset{},
+        model::offset{},
+        model::timeout_clock::now(),
+        std::nullopt)
+      .get();
+
+    _cache.put_ordered(tidp, std::move(batches));
+
+    // All batches should be retrievable immediately.
+    auto b0 = _cache.get(tidp, model::offset(0));
+    auto b1 = _cache.get(tidp, model::offset(10));
+    auto b2 = _cache.get(tidp, model::offset(20));
+    ASSERT_TRUE(b0.has_value());
+    ASSERT_TRUE(b1.has_value());
+    ASSERT_TRUE(b2.has_value());
+    ASSERT_EQ(b0->base_offset(), model::offset(0));
+    ASSERT_EQ(b1->base_offset(), model::offset(10));
+    ASSERT_EQ(b2->base_offset(), model::offset(20));
+
+    // The monitor should have been notified up to offset 29.
+    auto wait_fut = _cache.wait_for_offset(
+      tidp,
+      model::offset(29),
+      model::offset{},
+      model::timeout_clock::now(),
+      std::nullopt);
+    ASSERT_TRUE(wait_fut.available());
+    ASSERT_NO_THROW(wait_fut.get());
+
+    _cache.stop().get();
+}
+
+// Verify that put_ordered wakes a concurrent wait_for_offset.
+TEST_F(batch_cache_test_fixture, test_put_ordered_wakes_waiter) {
+    auto tidp = model::topic_id_partition{
+      model::topic_id::create(), model::partition_id(0)};
+
+    _cache.start().get();
+
+    // Start waiting for offset 9 (last offset of a 10-record batch at 0).
+    auto wait_fut = _cache.wait_for_offset(
+      tidp,
+      model::offset(9),
+      model::offset{},
+      model::timeout_clock::now() + 5s,
+      std::nullopt);
+
+    ASSERT_FALSE(wait_fut.available())
+      << "wait_for_offset should block before put_ordered";
+
+    // Insert the batch that covers offset 9.
+    chunked_vector<model::record_batch> batches;
+    batches.push_back(
+      model::test::make_random_batch(model::offset(0), 10, false));
+    _cache.put_ordered(tidp, std::move(batches));
+
+    // The waiter should now be resolved.
+    ASSERT_NO_THROW(wait_fut.get());
+
+    _cache.stop().get();
+}
+
+// Verify that out-of-order put_ordered calls notify correctly:
+// inserting [10,19] first puts the data in cache but doesn't notify the
+// monitor.  When [0,9] arrives the index has contiguous coverage and
+// the monitor is notified for both batches.
+TEST_F(batch_cache_test_fixture, test_put_ordered_out_of_order) {
+    auto tidp = model::topic_id_partition{
+      model::topic_id::create(), model::partition_id(0)};
+
+    _cache.start().get();
+
+    // Set up a waiter for offset 19 so the monitor exists.
+    auto wait_fut = _cache.wait_for_offset(
+      tidp,
+      model::offset(19),
+      model::offset{},
+      model::timeout_clock::now() + 5s,
+      std::nullopt);
+    ASSERT_FALSE(wait_fut.available());
+
+    // Insert batch [10,19] first — it goes into cache but the monitor
+    // is not notified because there is no contiguous coverage from
+    // the monitor's position.
+    chunked_vector<model::record_batch> second_batch;
+    second_batch.push_back(
+      model::test::make_random_batch(model::offset(10), 10, false));
+    _cache.put_ordered(tidp, std::move(second_batch));
+
+    // The batch is in cache but the monitor hasn't been notified.
+    ASSERT_TRUE(_cache.get(tidp, model::offset(10)).has_value());
+    ASSERT_FALSE(wait_fut.available());
+
+    // Now insert batch [0,9] — the index now has contiguous coverage
+    // from 0 through 9, which fills the gap, so the monitor is notified
+    // with offset 9 (the last offset of [0,9]).
+    chunked_vector<model::record_batch> first_batch;
+    first_batch.push_back(
+      model::test::make_random_batch(model::offset(0), 10, false));
+    _cache.put_ordered(tidp, std::move(first_batch));
+
+    // The waiter for offset 19 should NOT be resolved yet because
+    // put_ordered for [0,9] only notifies with offset 9.
+    // We need to verify both batches are in cache though.
+    auto b0 = _cache.get(tidp, model::offset(0));
+    auto b1 = _cache.get(tidp, model::offset(10));
+    ASSERT_TRUE(b0.has_value());
+    ASSERT_TRUE(b1.has_value());
+
+    _cache.stop().get();
+
+    // Consume the waiter future — stop() sent it abort_requested_exception.
+    ASSERT_THROW(wait_fut.get(), ss::abort_requested_exception);
+}
+
+// Verify that put_ordered inserts the batch even when the predecessor
+// never arrives — the data is still cached, just no monitor notification.
+TEST_F(
+  batch_cache_test_fixture, test_put_ordered_no_predecessor_still_inserts) {
+    auto tidp = model::topic_id_partition{
+      model::topic_id::create(), model::partition_id(0)};
+
+    _cache.start().get();
+
+    // Seed the monitor.
+    _cache
+      .wait_for_offset(
+        tidp,
+        model::offset{},
+        model::offset{},
+        model::timeout_clock::now(),
+        std::nullopt)
+      .get();
+
+    // Insert batch [10,19] without [0,9] — no contiguous coverage so
+    // the monitor is not notified, but the batch is still in cache.
+    chunked_vector<model::record_batch> batches;
+    batches.push_back(
+      model::test::make_random_batch(model::offset(10), 10, false));
+    _cache.put_ordered(tidp, std::move(batches));
+
+    auto b = _cache.get(tidp, model::offset(10));
+    ASSERT_TRUE(b.has_value());
+    ASSERT_EQ(b->base_offset(), model::offset(10));
+
+    _cache.stop().get();
+}
+
 TEST_F(batch_cache_test_fixture, test_batch_cache_topic_recreation) {
     // Test that recreating a topic with the same name doesn't resurrect batches
     auto topic_id_1 = model::topic_id::create();

--- a/src/v/cloud_topics/data_plane_api.h
+++ b/src/v/cloud_topics/data_plane_api.h
@@ -96,6 +96,13 @@ public:
     virtual std::optional<model::record_batch>
     cache_get(const model::topic_id_partition&, model::offset o) = 0;
 
+    /// Put batches into the cache and notify the offset monitor when the
+    /// inserted batches extend the contiguous range tracked by the monitor.
+    virtual void cache_put_ordered(
+      const model::topic_id_partition&,
+      chunked_vector<model::record_batch> batches)
+      = 0;
+
     /// Retrieve current cluster epoch
     virtual ss::future<std::optional<cloud_topics::cluster_epoch>>
     get_current_epoch(ss::abort_source* as) = 0;

--- a/src/v/cloud_topics/data_plane_impl.cc
+++ b/src/v/cloud_topics/data_plane_impl.cc
@@ -203,6 +203,12 @@ public:
         return _batch_cache.local().get(tidp, o);
     }
 
+    void cache_put_ordered(
+      const model::topic_id_partition& tidp,
+      chunked_vector<model::record_batch> batches) final {
+        _batch_cache.local().put_ordered(tidp, std::move(batches));
+    }
+
     ss::future<> cache_wait(
       const model::topic_id_partition& tidp,
       model::offset offset,

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -691,22 +691,13 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
         // which case it's not stored) or from the log replay. The
         // simplest solution in this case is to skip caching.
         if (res.value().last_term >= model::term_id{0}) {
-            // Topic config may already be gone if the topic is being
-            // deleted; skip caching in that case.
             auto tidp = get_topic_id_partition(partition);
             if (tidp) {
                 update_batches(
                   cache_batches,
                   kafka::offset_cast(res.value().last_offset),
                   res.value().last_term);
-                for (const auto& b : cache_batches) {
-                    vlog(
-                      cd_log.trace,
-                      "Putting batch to cache: {}, term: {}",
-                      b.base_offset(),
-                      b.term());
-                    api->cache_put(*tidp, b);
-                }
+                api->cache_put_ordered(*tidp, std::move(cache_batches));
             }
         } else {
             vlog(
@@ -810,20 +801,10 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
     }
     auto ret_offset = model::offset(result.value().last_offset());
     if (!rb_copy.empty()) {
-        // Topic config may already be gone if the topic is being
-        // deleted; skip caching in that case.
         auto tidp = topic_id_partition();
         if (tidp) {
             update_batches(rb_copy, ret_offset, result.value().last_term);
-            for (const auto& b : rb_copy) {
-                vlog(
-                  cd_log.trace,
-                  "Putting batch for {} to cache: {}, term: {}",
-                  ntp(),
-                  b.base_offset(),
-                  b.term());
-                _data_plane->cache_put(*tidp, b);
-            }
+            _data_plane->cache_put_ordered(*tidp, std::move(rb_copy));
         }
     }
     co_return ret_offset;

--- a/src/v/cloud_topics/frontend/tests/frontend_test.cc
+++ b/src/v/cloud_topics/frontend/tests/frontend_test.cc
@@ -79,6 +79,12 @@ public:
       (override));
 
     MOCK_METHOD(
+      void,
+      cache_put_ordered,
+      (const model::topic_id_partition&, chunked_vector<model::record_batch>),
+      (override));
+
+    MOCK_METHOD(
       ss::future<>,
       cache_wait,
       (const model::topic_id_partition&,
@@ -151,7 +157,9 @@ TEST_F(frontend_fixture, test_replicate_epoch) {
 
     cloud_topics::frontend frontend(std::move(partition), _data_plane.get());
 
-    EXPECT_CALL(*_data_plane, cache_put(_, _)).Times(2);
+    ON_CALL(*_data_plane, cache_put_ordered(_, _))
+      .WillByDefault([](const auto&, auto) {});
+    EXPECT_CALL(*_data_plane, cache_put_ordered(_, _)).Times(2);
     using stage_result = std::expected<staged_write, std::error_code>;
     EXPECT_CALL(*_data_plane, stage_write(_))
       .WillOnce(Return(ss::as_ready_future(stage_result{})))

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -79,13 +79,32 @@ level_zero_log_reader_impl::read_some(
         co_return chunked_circular_buffer<model::record_batch>{};
     }
 
+    // Like the storage layer log reader, stop when we've consumed all
+    // committed data. The Kafka fetch handler owns the waiting policy
+    // via the visible_offset_monitor / max_wait_ms.
+    {
+        auto ot_state = _ctp->get_offset_translator_state();
+        auto translated = ot_state->from_log_offset(
+          _ctp->raft()->committed_offset());
+        if (_next_offset > model::offset_cast(translated)) {
+            vlog(
+              _log.debug,
+              "next offset {} beyond committed kafka offset {}, "
+              "end of stream",
+              _next_offset,
+              translated);
+            set_end_of_stream();
+            co_return chunked_circular_buffer<model::record_batch>{};
+        }
+    }
+
     // Wait briefly for the write path to cache the batch we need.
     // This closes the race window between replicate() completing (HWM
     // advance) and cache_put() running on the write continuation.
     if (cache_enabled() && _ctp->is_leader()) {
         auto tidp = require_topic_id_partition();
         auto wait_deadline = model::timeout_clock::now()
-                             + std::chrono::milliseconds(25);
+                             + std::chrono::milliseconds(500);
         try {
             // Translate committed_offset from raft-space to kafka-space.
             // The batch cache monitor tracks kafka offsets (put() notifies
@@ -192,13 +211,6 @@ level_zero_log_reader_impl::maybe_read_batches_from_cache() {
         if (!batch.has_value()) {
             break;
         }
-
-        vlog(
-          _log.trace,
-          "Loaded batch from cache for {}: {} @ term {}",
-          _next_offset,
-          batch.value().base_offset(),
-          batch.value().term());
 
         auto batch_size = batch.value().size_bytes();
         if (is_over_limit_with_bytes(batch_size)) {
@@ -351,11 +363,6 @@ level_zero_log_reader_impl::materialize_batches(
                 auto cached = _ct_api->cache_get(
                   tidp, kafka::offset_cast(meta->base_offset));
                 if (cached.has_value()) {
-                    vlog(
-                      _log.trace,
-                      "Cache hit for extent at offset {} during "
-                      "materialize",
-                      meta->base_offset);
                     unhydrated_it->data = local_log_batch::cached_batch{
                       .batch = std::move(cached.value())};
                     continue;

--- a/src/v/storage/batch_cache.cc
+++ b/src/v/storage/batch_cache.cc
@@ -429,6 +429,37 @@ batch_cache_index::read_result batch_cache_index::read(
     return ret;
 }
 
+bool batch_cache_index::has_contiguous_coverage(
+  model::offset from, model::offset to) const {
+    if (from > to) {
+        return true;
+    }
+    // Find the first entry whose base_offset may contain 'from'.
+    auto it = _index.upper_bound(from);
+    if (it != _index.begin()) {
+        --it;
+    }
+    model::offset expected = from;
+    while (it != _index.end() && expected <= to) {
+        const auto& range = it->second.range();
+        if (!range || !range->valid()) {
+            return false;
+        }
+        auto hdr = it->second.header();
+        if (hdr.base_offset > expected) {
+            return false;
+        }
+        auto next = model::next_offset(hdr.last_offset());
+        if (next <= expected) {
+            ++it;
+            continue;
+        }
+        expected = next;
+        ++it;
+    }
+    return expected > to;
+}
+
 void batch_cache_index::truncate(model::offset offset) {
     lock_guard lk(*this);
 

--- a/src/v/storage/batch_cache.h
+++ b/src/v/storage/batch_cache.h
@@ -592,6 +592,11 @@ public:
       size_t max_bytes,
       bool skip_lru_promote);
 
+    /// Check whether the index contains valid (non-evicted) entries that cover
+    /// every offset in the closed range [from, to] without gaps.  Returns true
+    /// when from > to (empty range).
+    bool has_contiguous_coverage(model::offset from, model::offset to) const;
+
     /**
      * Removes all batches that _may_ contain the specified offset.
      */

--- a/src/v/utils/offset_monitor.h
+++ b/src/v/utils/offset_monitor.h
@@ -64,6 +64,9 @@ public:
     /// Returns true if there are no waiters.
     bool empty() const { return _waiters.empty(); }
 
+    /// Returns the last notified offset.
+    Offset last_applied() const { return _last_applied; }
+
     /// Notify waiters of an offset.
     void notify(Offset offset) {
         _last_applied = std::max(offset, _last_applied);


### PR DESCRIPTION
Fix cache put race condition (details in the commit message).
Also, fix an excessive cache wait in situation when the reader tries to read past HWM.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none