### PR TITLE
ct/l1: clarify L1 metastore paths

### DIFF
--- a/src/v/cloud_topics/level_one/domain/BUILD
+++ b/src/v/cloud_topics/level_one/domain/BUILD
@@ -82,6 +82,7 @@ redpanda_cc_library(
     implementation_deps = [
         "//src/v/cloud_topics:logger",
         "//src/v/cloud_topics/level_one/common:object_id",
+        "//src/v/cloud_topics/level_one/metastore:domain_uuid",
         "//src/v/cloud_topics/level_one/metastore/lsm:garbage_collector",
         "//src/v/cloud_topics/level_one/metastore/lsm:keys",
         "//src/v/cloud_topics/level_one/metastore/lsm:state_reader",

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -10,6 +10,7 @@
 #include "cloud_topics/level_one/domain/db_domain_manager.h"
 
 #include "cloud_topics/level_one/common/object_id.h"
+#include "cloud_topics/level_one/metastore/domain_uuid.h"
 #include "cloud_topics/level_one/metastore/lsm/garbage_collector.h"
 #include "cloud_topics/level_one/metastore/lsm/keys.h"
 #include "cloud_topics/level_one/metastore/lsm/state_reader.h"
@@ -1508,7 +1509,7 @@ db_domain_manager::restore_domain(rpc::restore_domain_request req) {
     }
 
     cloud_storage_clients::object_key domain_prefix{
-      fmt::format("{}", req.new_uuid)};
+      domain_cloud_prefix(req.new_uuid)};
     auto meta_persist = co_await lsm::io::open_cloud_metadata_persistence(
       remote_, bucket_, domain_prefix);
 

--- a/src/v/cloud_topics/level_one/domain/tests/BUILD
+++ b/src/v/cloud_topics/level_one/domain/tests/BUILD
@@ -17,6 +17,7 @@ redpanda_cc_gtest(
         "//src/v/cloud_topics/level_one/common:object_id",
         "//src/v/cloud_topics/level_one/common:object_utils",
         "//src/v/cloud_topics/level_one/domain:db_domain_manager",
+        "//src/v/cloud_topics/level_one/metastore:domain_uuid",
         "//src/v/cloud_topics/level_one/metastore:rpc_types",
         "//src/v/cloud_topics/level_one/metastore:state_update",
         "//src/v/cloud_topics/level_one/metastore/lsm:state_reader",

--- a/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
+++ b/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
@@ -15,6 +15,7 @@
 #include "cloud_topics/level_one/common/object_id.h"
 #include "cloud_topics/level_one/common/object_utils.h"
 #include "cloud_topics/level_one/domain/db_domain_manager.h"
+#include "cloud_topics/level_one/metastore/domain_uuid.h"
 #include "cloud_topics/level_one/metastore/lsm/state_reader.h"
 #include "cloud_topics/level_one/metastore/lsm/state_update.h"
 #include "cloud_topics/level_one/metastore/lsm/stm.h"
@@ -222,13 +223,17 @@ void flush_as_manifest(
   chunked_vector<new_object> new_objects,
   term_state_update_t new_terms) {
     auto domain_prefix = cloud_storage_clients::object_key{
-      fmt::format("{}", uuid)};
+      domain_cloud_prefix(uuid)};
     temporary_dir tmp("test");
     auto cloud_db = lsm::database::open(
                       {.database_epoch = db_epoch},
                       lsm::io::persistence{
                         .data = lsm::io::open_cloud_data_persistence(
-                                  tmp.get_path(), remote, bucket, domain_prefix)
+                                  tmp.get_path(),
+                                  remote,
+                                  bucket,
+                                  domain_prefix,
+                                  ss::sstring(uuid()))
                                   .get(),
                         .metadata = lsm::io::open_cloud_metadata_persistence(
                                       remote, bucket, domain_prefix)

--- a/src/v/cloud_topics/level_one/metastore/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/BUILD
@@ -17,6 +17,8 @@ redpanda_cc_library(
     deps = [
         "//src/v/utils:named_type",
         "//src/v/utils:uuid",
+        "@fmt",
+        "@seastar",
     ],
 )
 

--- a/src/v/cloud_topics/level_one/metastore/domain_uuid.h
+++ b/src/v/cloud_topics/level_one/metastore/domain_uuid.h
@@ -12,8 +12,17 @@
 #include "utils/named_type.h"
 #include "utils/uuid.h"
 
+#include <seastar/core/sstring.hh>
+
+#include <fmt/format.h>
+
 namespace cloud_topics::l1 {
 
 using domain_uuid = named_type<uuid_t, struct domain_uuid_tag>;
+
+/// Cloud storage path prefix for a domain's LSM data.
+inline ss::sstring domain_cloud_prefix(const domain_uuid& id) {
+    return fmt::format("level_one/meta/domain/{}", id());
+}
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/lsm/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/lsm/BUILD
@@ -155,6 +155,7 @@ redpanda_cc_library(
     implementation_deps = [
         ":replicated_persistence",
         "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics/level_one/metastore:domain_uuid",
         "//src/v/config",
         "//src/v/lsm/io:cloud_persistence",
         "//src/v/model:batch_builder",

--- a/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.cc
@@ -10,6 +10,7 @@
 
 #include "cloud_topics/level_one/metastore/lsm/replicated_db.h"
 
+#include "cloud_topics/level_one/metastore/domain_uuid.h"
 #include "cloud_topics/level_one/metastore/lsm/lsm_update.h"
 #include "cloud_topics/level_one/metastore/lsm/replicated_persistence.h"
 #include "cloud_topics/level_one/metastore/lsm/stm.h"
@@ -110,11 +111,15 @@ replicated_database::open(
     }
     auto domain_uuid = s->state().domain_uuid;
     cloud_storage_clients::object_key domain_prefix{
-      fmt::format("{}", domain_uuid())};
+      domain_cloud_prefix(domain_uuid)};
 
     auto data_persist_fut = co_await ss::coroutine::as_future(
       lsm::io::open_cloud_data_persistence(
-        staging_directory, remote, bucket, domain_prefix));
+        staging_directory,
+        remote,
+        bucket,
+        domain_prefix,
+        ss::sstring(domain_uuid())));
     if (data_persist_fut.failed()) {
         co_return std::unexpected(wrap_failed_future(
           data_persist_fut.get_exception(), "Failed to open data persistence"));

--- a/src/v/cloud_topics/level_one/metastore/lsm/tests/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/lsm/tests/BUILD
@@ -68,6 +68,7 @@ redpanda_cc_gtest(
         "//src/v/cloud_io/tests:s3_imposter",
         "//src/v/cloud_io/tests:scoped_remote",
         "//src/v/cloud_storage_clients",
+        "//src/v/cloud_topics/level_one/metastore:domain_uuid",
         "//src/v/cloud_topics/level_one/metastore/lsm:replicated_db",
         "//src/v/cloud_topics/level_one/metastore/lsm:stm",
         "//src/v/cloud_topics/level_one/metastore/lsm:write_batch_row",

--- a/src/v/cloud_topics/level_one/metastore/lsm/tests/replicated_db_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/tests/replicated_db_test.cc
@@ -12,6 +12,7 @@
 #include "cloud_io/tests/s3_imposter.h"
 #include "cloud_io/tests/scoped_remote.h"
 #include "cloud_storage_clients/types.h"
+#include "cloud_topics/level_one/metastore/domain_uuid.h"
 #include "cloud_topics/level_one/metastore/lsm/replicated_db.h"
 #include "cloud_topics/level_one/metastore/lsm/stm.h"
 #include "cloud_topics/level_one/metastore/lsm/write_batch_row.h"
@@ -211,7 +212,7 @@ public:
       domain_uuid domain_uuid,
       chunked_vector<volatile_row> rows) {
         auto domain_prefix = cloud_storage_clients::object_key{
-          fmt::format("{}", domain_uuid)};
+          domain_cloud_prefix(domain_uuid)};
         temporary_dir tmp("lsm_staging_scratch");
         auto cloud_db
           = lsm::database::open(
@@ -221,7 +222,8 @@ public:
                           tmp.get_path(),
                           &sr->remote.local(),
                           bucket_name,
-                          domain_prefix)
+                          domain_prefix,
+                          ss::sstring(domain_uuid()))
                           .get(),
                 .metadata = lsm::io::open_cloud_metadata_persistence(
                               &sr->remote.local(), bucket_name, domain_prefix)

--- a/src/v/cloud_topics/level_one/metastore/manifest_io.cc
+++ b/src/v/cloud_topics/level_one/metastore/manifest_io.cc
@@ -25,8 +25,8 @@ namespace cloud_topics::l1 {
 namespace {
 cloud_storage_clients::object_key
 manifest_path(const cloud_storage::remote_label& remote_label) {
-    return cloud_storage_clients::object_key{
-      fmt::format("{}/level_one/metastore.bin", remote_label.cluster_uuid)};
+    return cloud_storage_clients::object_key{fmt::format(
+      "level_one/meta/metastore/{}/manifest.bin", remote_label.cluster_uuid)};
 }
 } // namespace
 

--- a/src/v/cloud_topics/level_one/metastore/manifest_io.h
+++ b/src/v/cloud_topics/level_one/metastore/manifest_io.h
@@ -34,13 +34,15 @@ public:
     manifest_io(
       cloud_io::remote& io, cloud_storage_clients::bucket_name bucket);
 
-    // Uploads manifest to: {cluster_uuid}/level_one/metastore.bin
+    // Uploads manifest to:
+    // level_one/meta/metastore/{cluster_uuid}/manifest.bin
     // Uses the local cluster's UUID from storage::api.
     ss::future<std::expected<size_t, error>> upload_metastore_manifest(
       const cloud_storage::remote_label& remote_label,
       metastore_manifest manifest);
 
-    // Downloads manifest from: {cluster_uuid}/level_one/metastore.bin
+    // Downloads manifest from:
+    // level_one/meta/metastore/{cluster_uuid}/manifest.bin
     ss::future<std::expected<metastore_manifest, error>>
     download_metastore_manifest(
       const cloud_storage::remote_label& remote_label);

--- a/src/v/cloud_topics/level_one/metastore/tests/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/tests/BUILD
@@ -81,6 +81,7 @@ redpanda_cc_gtest(
     deps = [
         "//src/v/cloud_storage:remote_label",
         "//src/v/cloud_topics:app",
+        "//src/v/cloud_topics/level_one/metastore:domain_uuid",
         "//src/v/cloud_topics/level_one/metastore:manifest_io",
         "//src/v/cloud_topics/level_one/metastore:metastore_manifest",
         "//src/v/cloud_topics/level_one/metastore:replicated_metastore",

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -9,6 +9,7 @@
  */
 
 #include "cloud_storage/remote_label.h"
+#include "cloud_topics/level_one/metastore/domain_uuid.h"
 #include "cloud_topics/level_one/metastore/manifest_io.h"
 #include "cloud_topics/level_one/metastore/metastore_manifest.h"
 #include "cloud_topics/level_one/metastore/replicated_metastore.h"
@@ -86,7 +87,7 @@ private:
         // Create a database using cloud metadata persistence pointing at the
         // LSM state's domain prefix in the bucket.
         auto domain_prefix = cloud_storage_clients::object_key{
-          fmt::format("{}", lsm_st.domain_uuid)};
+          domain_cloud_prefix(lsm_st.domain_uuid)};
         auto meta_persist = lsm::io::open_cloud_metadata_persistence(
                               remote, bucket_name, domain_prefix)
                               .get();

--- a/src/v/lsm/io/cloud_persistence.cc
+++ b/src/v/lsm/io/cloud_persistence.cc
@@ -24,6 +24,7 @@
 #include <seastar/core/fstream.hh>
 #include <seastar/core/reactor.hh>
 
+#include <algorithm>
 #include <exception>
 #include <memory>
 
@@ -189,11 +190,13 @@ public:
       std::filesystem::path staging,
       cloud_io::remote* remote,
       cloud_storage_clients::bucket_name bucket,
-      cloud_storage_clients::object_key prefix)
+      cloud_storage_clients::object_key prefix,
+      ss::sstring staging_prefix)
       : _staging(std::move(staging))
       , _remote(remote)
       , _bucket(std::move(bucket))
-      , _prefix(std::move(prefix)) {}
+      , _prefix(std::move(prefix))
+      , _staging_prefix(std::move(staging_prefix)) {}
 
     ss::future<optional_pointer<random_access_file_reader>>
     open_random_access_reader(internal::file_handle h) override {
@@ -427,7 +430,7 @@ private:
     }
 
     std::filesystem::path staging_path(std::string_view name) {
-        return _staging / fmt::format("{}-{}", _prefix(), name);
+        return _staging / fmt::format("{}-{}", _staging_prefix, name);
     }
 
     cloud_storage_clients::object_key cloud_key(std::string_view name) {
@@ -438,6 +441,7 @@ private:
     cloud_io::remote* _remote;
     cloud_storage_clients::bucket_name _bucket;
     cloud_storage_clients::object_key _prefix;
+    ss::sstring _staging_prefix;
     ss::abort_source _as;
     ss::gate _gate;
 };
@@ -568,7 +572,8 @@ ss::future<std::unique_ptr<data_persistence>> open_cloud_data_persistence(
   std::filesystem::path staging_directory,
   cloud_io::remote* remote,
   cloud_storage_clients::bucket_name bucket,
-  cloud_storage_clients::object_key prefix) {
+  cloud_storage_clients::object_key prefix,
+  ss::sstring staging_prefix) {
     try {
         co_await ss::recursive_touch_directory(staging_directory.native());
     } catch (const std::system_error& e) {
@@ -581,7 +586,8 @@ ss::future<std::unique_ptr<data_persistence>> open_cloud_data_persistence(
       std::move(staging_directory),
       remote,
       std::move(bucket),
-      std::move(prefix));
+      std::move(prefix),
+      std::move(staging_prefix));
 }
 
 ss::future<std::unique_ptr<metadata_persistence>>

--- a/src/v/lsm/io/cloud_persistence.h
+++ b/src/v/lsm/io/cloud_persistence.h
@@ -22,7 +22,8 @@ ss::future<std::unique_ptr<data_persistence>> open_cloud_data_persistence(
   std::filesystem::path staging_directory,
   cloud_io::remote* remote,
   cloud_storage_clients::bucket_name bucket,
-  cloud_storage_clients::object_key prefix);
+  cloud_storage_clients::object_key prefix,
+  ss::sstring staging_prefix);
 
 // Open a metadata persistence object in the given bucket at the prefix.
 ss::future<std::unique_ptr<metadata_persistence>>

--- a/src/v/lsm/io/tests/persistence_test.cc
+++ b/src/v/lsm/io/tests/persistence_test.cc
@@ -319,7 +319,8 @@ INSTANTIATE_TEST_SUITE_P(
           staging,
           &sr->remote.local(),
           fixture->bucket_name,
-          cloud_storage_clients::object_key("test-prefix"));
+          cloud_storage_clients::object_key("test-prefix"),
+          "test-prefix");
 
         co_return std::make_unique<mock_cloud_data_persistence>(
           std::move(fixture), std::move(sr), std::move(impl));


### PR DESCRIPTION
Previously the metastore topic manifest and domain manifests were
prefixed by cluster UUID and domain UUIDs respectively. This made it
somewhat unwieldy to know what these were when inspecting a bucket. This
changes the paths as follows:
- metastore topic manifest: {cluster_uuid}/level_one/metastore.bin
  - now level_one/meta/metastore/{cluster_uuid}/...
- domain LSM files: {domain_uuid}/{SST/MANIFEST}
  - now level_one/meta/domain/{domain_uuid}/...

This way, the metadata for L1 metastore is entirely in level_one, while
still being uniquely identified by their respective UUIDs.

As a part of this, now that LSM metastore files has / in the name,
updates the local staging paths for cloud_persistence to be flattened,
rather than having an unnecessary nested hierarchy.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
