### PR TITLE
ct: be more permissive about having topic config

### DIFF
--- a/src/v/cloud_topics/topic_manifest_upload_manager.cc
+++ b/src/v/cloud_topics/topic_manifest_upload_manager.cc
@@ -73,10 +73,15 @@ private:
     ss::future<std::expected<void, topic_manifest_uploader::error>>
     upload_once() {
         auto topic_cfg_opt = _partition->get_topic_config();
-        vassert(
-          topic_cfg_opt.has_value(),
-          "Expected topic config to be set on partition 0: {}",
-          _tidp);
+        if (!topic_cfg_opt.has_value()) {
+            // Topic config may not yet be set if we raced with partition
+            // creation. Retry after backoff.
+            co_return std::unexpected(
+              topic_manifest_uploader::error{
+                topic_manifest_uploader::errc::io_error,
+                fmt::format(
+                  "topic config not yet set on partition 0: {}", _tidp)});
+        }
 
         // Tweak the replication factor based on the current number of
         // replicas, matching the behavior in tiered storage.


### PR DESCRIPTION
Ran into this when running on a dev_cluster.

assert - Assert failure: (src/v/cloud_topics/topic_manifest_upload_manager.cc:79) 'topic_cfg_opt.has_value()' Expected topic config to be set on partition 0: {d2b296d3-4d52-43ea-bb87-7a6131f88b05/0}

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
