### PR TITLE
ct/l1: add configurable deletion delay

### DIFF
--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -1144,12 +1144,17 @@ ss::future<> db_domain_manager::gc_loop() {
         }
         // TODO: make batch size configurable.
         vlog(cd_log.debug, "Running garbage collection now...");
+        auto now = model::timestamp::now();
         auto ttl
           = config::shard_local_cfg().cloud_topics_preregistered_object_ttl();
         auto prereg_expiry_cutoff = model::timestamp{
-          model::timestamp::now()() - static_cast<int64_t>(ttl.count())};
+          now() - static_cast<int64_t>(ttl.count())};
+        auto deletion_delay = config::shard_local_cfg()
+                                .cloud_topics_long_term_file_deletion_delay();
+        auto deletion_delay_cutoff = model::timestamp{
+          now() - static_cast<int64_t>(deletion_delay.count())};
         auto gc_res = co_await gc.remove_unreferenced_objects(
-          db_.get(), &as_, 1000, prereg_expiry_cutoff);
+          db_.get(), &as_, 1000, prereg_expiry_cutoff, deletion_delay_cutoff);
         if (!gc_res.has_value()) {
             using enum db_garbage_collector::errc;
             switch (gc_res.error().e) {

--- a/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
+++ b/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
@@ -954,6 +954,7 @@ chunked_vector<object_id> put_dummy_objects(
 TEST_F(DbDomainManagerTest, TestGarbageCollectionAfterRemoveTopic) {
     cfg.get("cloud_topics_long_term_garbage_collection_interval")
       .set_value(100ms);
+    cfg.get("cloud_topics_long_term_file_deletion_delay").set_value(0ms);
 
     auto tp = make_tp();
 
@@ -1003,6 +1004,61 @@ TEST_F(DbDomainManagerTest, TestGarbageCollectionAfterRemoveTopic) {
 
     // Start running GC and wait for all the objects to be removed.
     initial_manager->start();
+    RPTEST_REQUIRE_EVENTUALLY(
+      30s, [&] { return all_objects_missing(object_ids); });
+}
+
+TEST_F(DbDomainManagerTest, TestGarbageCollectionDeletionDelay) {
+    cfg.get("cloud_topics_long_term_garbage_collection_interval")
+      .set_value(100ms);
+    cfg.get("cloud_topics_long_term_file_deletion_delay").set_value(5000ms);
+
+    auto tp = make_tp();
+
+    auto prereg_reply = initial_manager
+                          ->preregister_objects({
+                            .metastore_partition = model::partition_id(0),
+                            .count = 3,
+                          })
+                          .get();
+    ASSERT_EQ(prereg_reply.ec, l1_rpc::errc::ok);
+    auto new_objects = make_new_objects_with_ids(
+      tp, kafka::offset(0), 10, prereg_reply.object_ids);
+    auto object_ids = put_dummy_objects(initial_leader->object_io, new_objects);
+
+    for (const auto& oid : object_ids) {
+        ASSERT_TRUE(object_exists(oid).get());
+    }
+
+    // Add and remove objects so the metastore thinks they are eligible for
+    // removal.
+    {
+        l1_rpc::add_objects_request req;
+        req.new_objects = std::move(new_objects);
+        req.new_terms = make_terms(tp, kafka::offset(0), model::term_id(1));
+        auto reply = initial_manager->add_objects(std::move(req)).get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+    }
+    {
+        l1_rpc::remove_topics_request req;
+        req.topics.push_back(tp.topic_id);
+        auto reply = initial_manager->remove_topics(std::move(req)).get();
+        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+        ASSERT_TRUE(reply.not_removed.empty());
+    }
+
+    ASSERT_EQ(initial_manager->flush_domain({}).get().ec, l1_rpc::errc::ok);
+
+    // Start GC. The deletion delay should prevent immediate removal.
+    initial_manager->start();
+
+    // Verify objects survive several GC cycles while the delay hasn't elapsed.
+    ss::sleep(1s).get();
+    for (const auto& oid : object_ids) {
+        EXPECT_TRUE(object_exists(oid).get());
+    }
+
+    // Objects should eventually be deleted once the delay elapses.
     RPTEST_REQUIRE_EVENTUALLY(
       30s, [&] { return all_objects_missing(object_ids); });
 }
@@ -1099,6 +1155,7 @@ TEST_F(DbDomainManagerTest, TestPreregisteredObjectExpiry) {
     cfg.get("cloud_topics_preregistered_object_ttl").set_value(1ms);
     cfg.get("cloud_topics_long_term_garbage_collection_interval")
       .set_value(100ms);
+    cfg.get("cloud_topics_long_term_file_deletion_delay").set_value(0ms);
 
     auto tp = make_tp();
     auto prereg_reply = initial_manager

--- a/src/v/cloud_topics/level_one/metastore/lsm/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/lsm/BUILD
@@ -155,6 +155,7 @@ redpanda_cc_library(
     implementation_deps = [
         ":replicated_persistence",
         "//src/v/cloud_topics:logger",
+        "//src/v/config",
         "//src/v/lsm/io:cloud_persistence",
         "//src/v/model:batch_builder",
         "//src/v/serde",

--- a/src/v/cloud_topics/level_one/metastore/lsm/garbage_collector.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/garbage_collector.cc
@@ -91,6 +91,7 @@ db_garbage_collector::remove_unreferenced_batch(
   size_t batch_size,
   std::optional<object_id> start_point,
   model::timestamp prereg_expiry_cutoff,
+  model::timestamp deletion_delay_cutoff,
   chunked_vector<object_id>& to_expire_out) {
     auto persisted_seqno = db->db().max_persisted_seqno();
     if (!persisted_seqno.has_value()) {
@@ -171,7 +172,9 @@ db_garbage_collector::remove_unreferenced_batch(
             // but don't block the rest of GC.
             continue;
         }
-        if (obj_entry.removed_data_size == obj_entry.total_data_size) {
+        if (
+          obj_entry.removed_data_size == obj_entry.total_data_size
+          && obj_entry.last_updated <= deletion_delay_cutoff) {
             vlog(cd_log.debug, "Deleting L1 object: {}", oid);
             to_remove.emplace_back(oid);
             if (to_remove.size() + batch_expire_count == batch_size) {
@@ -224,12 +227,19 @@ db_garbage_collector::remove_unreferenced_objects(
   replicated_database* db,
   ss::abort_source* as,
   size_t batch_size,
-  model::timestamp prereg_expiry_cutoff) {
+  model::timestamp prereg_expiry_cutoff,
+  model::timestamp deletion_delay_cutoff) {
     chunked_vector<object_id> to_expire;
     std::optional<object_id> next_start;
     while (!as->abort_requested()) {
         auto batch_res = co_await remove_unreferenced_batch(
-          db, as, batch_size, next_start, prereg_expiry_cutoff, to_expire);
+          db,
+          as,
+          batch_size,
+          next_start,
+          prereg_expiry_cutoff,
+          deletion_delay_cutoff,
+          to_expire);
         if (!batch_res.has_value()) {
             co_return std::unexpected(batch_res.error());
         }

--- a/src/v/cloud_topics/level_one/metastore/lsm/garbage_collector.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/garbage_collector.h
@@ -57,7 +57,8 @@ public:
       replicated_database*,
       ss::abort_source*,
       size_t batch_size,
-      model::timestamp prereg_expiry_cutoff);
+      model::timestamp prereg_expiry_cutoff,
+      model::timestamp deletion_delay_cutoff);
 
 private:
     // Removes the given batch size worth of objects, evaluating objects
@@ -71,6 +72,7 @@ private:
       size_t batch_size,
       std::optional<object_id>,
       model::timestamp prereg_expiry_cutoff,
+      model::timestamp deletion_delay_cutoff,
       chunked_vector<object_id>& to_expire_out);
 
     io* io_;

--- a/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.cc
@@ -14,6 +14,7 @@
 #include "cloud_topics/level_one/metastore/lsm/replicated_persistence.h"
 #include "cloud_topics/level_one/metastore/lsm/stm.h"
 #include "cloud_topics/logger.h"
+#include "config/configuration.h"
 #include "lsm/io/cloud_persistence.h"
 #include "lsm/io/persistence.h"
 #include "lsm/proto/manifest.proto.h"
@@ -136,7 +137,9 @@ replicated_database::open(
       lsm::database::open(
         lsm::options{
           .database_epoch = epoch(),
-          // TODO: tuning.
+          .file_deletion_delay = absl::FromChrono(
+            config::shard_local_cfg()
+              .cloud_topics_long_term_file_deletion_delay()),
         },
         std::move(io)));
     if (db_fut.failed()) {

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4745,6 +4745,14 @@ configuration::configuration()
       "Time-to-live for pre-registered L1 objects before they are expired.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1h)
+  , cloud_topics_long_term_file_deletion_delay(
+      *this,
+      "cloud_topics_long_term_file_deletion_delay",
+      "Delay before deleting stale long term files, allowing concurrent "
+      "readers (e.g. read replica topics) to finish reading them before "
+      "removal.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      1h)
   , development_feature_property_testing_only(
       *this,
       "development_feature_property_testing_only",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -819,6 +819,9 @@ public:
 
     property<std::chrono::milliseconds> cloud_topics_preregistered_object_ttl;
 
+    property<std::chrono::milliseconds>
+      cloud_topics_long_term_file_deletion_delay;
+
     development_feature_property<int> development_feature_property_testing_only;
 
 private:


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Adds a new config to delay deletion of metastore SSTs and L1 objects. This will mostly be important when we support read replicas on cloud topics, since their view of the world will be slightly stale. But otherwise it can just be nice to have some wiggle room for emergency investigation, rather than these files get deleted immediately.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
