### PR TITLE
[CORE 15747] Partial solution to feature gating cloud topics

### DIFF
--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -132,6 +132,8 @@ std::string_view to_string_view(feature f) {
         return "group_based_authorization";
     case feature::user_based_client_quota:
         return "user_based_client_quota";
+    case feature::cloud_topics:
+        return "cloud_topics";
 
     /*
      * testing features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -53,6 +53,7 @@ enum class feature : std::uint64_t {
     coordinated_compaction = 1ULL << 10U,
     cloud_retention = 1ULL << 11U,
     group_based_authorization = 1ULL << 12U,
+    cloud_topics = 1ULL << 13U,
     node_isolation = 1ULL << 19U,
     group_offset_retention = 1ULL << 20U,
     membership_change_controller_cmds = 1ULL << 22U,
@@ -539,6 +540,12 @@ inline constexpr std::array feature_schema{
     release_version::v26_1_1,
     "ordered_leaders_pinning",
     feature::ordered_leaders_pinning,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    release_version::v26_1_1,
+    "cloud_topics",
+    feature::cloud_topics,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 };

--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -48,6 +48,7 @@ redpanda_cc_library(
         "//src/v/config",
         "//src/v/container:chunked_vector",
         "//src/v/datalake:partition_spec_parser",
+        "//src/v/features",
         "//src/v/kafka/protocol",
         "//src/v/kafka/protocol:describe_configs",
         "//src/v/kafka/protocol:logger",

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -318,7 +318,9 @@ ss::future<response_ptr> create_topics_handler::handle(
       begin,
       valid_range_end,
       std::back_inserter(response.data.topics),
-      validators{});
+      validators{},
+      ctx.feature_table().local_is_initialized() ? &ctx.feature_table().local()
+                                                 : nullptr);
 
     // Print log if not supported configuration options are present
     for (auto& r : boost::make_iterator_range(begin, valid_range_end)) {

--- a/src/v/kafka/server/handlers/topics/topic_utils.h
+++ b/src/v/kafka/server/handlers/topics/topic_utils.h
@@ -14,6 +14,7 @@
 #include "cluster/fwd.h"
 #include "cluster/types.h"
 #include "container/chunked_vector.h"
+#include "features/feature_table.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/logger.h"
 #include "kafka/server/handlers/topics/types.h"
@@ -69,7 +70,7 @@ creatable_topic_result generate_successfull_result(const T& item) {
 template<typename Iter, typename ErrIter, typename Predicate>
     requires TopicRequestItem<typename Iter::value_type> &&
     TopicResultIterator<ErrIter> &&
-    std::predicate<Predicate, std::iter_reference_t<Iter>>
+    std::predicate<Predicate, std::iter_reference_t<Iter>, features::feature_table*>
 // clang-format on
 Iter validate_requests_range(
   Iter begin,
@@ -77,8 +78,12 @@ Iter validate_requests_range(
   ErrIter out_it,
   error_code code,
   const ss::sstring& error_msg,
-  Predicate&& p) {
-    auto valid_range_end = std::partition(begin, end, p);
+  Predicate&& p,
+  features::feature_table* ft = nullptr) {
+    auto valid_range_end = std::partition(
+      begin, end, [p = std::forward<Predicate>(p), ft](const auto& c) {
+          return p(c, ft);
+      });
     std::transform(
       valid_range_end,
       end,
@@ -97,14 +102,16 @@ Iter validate_requests_range(
   Iter begin,
   Iter end,
   ErrIter err_it,
-  validator_type_list<typename Iter::value_type, ValidatorTypes...>) {
+  validator_type_list<typename Iter::value_type, ValidatorTypes...>,
+  features::feature_table* ft = nullptr) {
     ((end = validate_requests_range(
         begin,
         end,
         err_it,
         ValidatorTypes::ec,
         ValidatorTypes::error_message,
-        ValidatorTypes::is_valid)),
+        ValidatorTypes::is_valid,
+        ft)),
      ...);
     return end;
 }

--- a/src/v/kafka/server/handlers/topics/validators.h
+++ b/src/v/kafka/server/handlers/topics/validators.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "config/configuration.h"
 #include "datalake/partition_spec_parser.h"
+#include "features/feature_table.h"
 #include "kafka/protocol/schemata/create_topics_request.h"
 #include "kafka/protocol/schemata/create_topics_response.h"
 #include "kafka/server/handlers/topics/types.h"
@@ -21,8 +22,9 @@
 
 namespace kafka {
 template<typename Request, typename T>
-concept RequestValidator = requires(T validator, const Request& request) {
-    { T::is_valid(request) } -> std::same_as<bool>;
+concept RequestValidator = requires(
+  T validator, const Request& request, features::feature_table* ft) {
+    { T::is_valid(request, ft) } -> std::same_as<bool>;
     { T::ec } -> std::convertible_to<const error_code&>;
     { T::error_message } -> std::convertible_to<const char*>;
 };
@@ -40,7 +42,7 @@ struct custom_partition_assignment_negative_partition_count {
       = "For custom partition assignment, partition count and replication "
         "factor must be equal to -1";
 
-    static bool is_valid(const creatable_topic& c) {
+    static bool is_valid(const creatable_topic& c, features::feature_table*) {
         if (!c.assignments.empty()) {
             return c.num_partitions == -1 && c.replication_factor == -1;
         }
@@ -54,7 +56,7 @@ struct replicas_diversity {
     static constexpr const char* error_message
       = "Topic partition replica set must contain unique nodes";
 
-    static bool is_valid(const creatable_topic& c) {
+    static bool is_valid(const creatable_topic& c, features::feature_table*) {
         if (c.assignments.empty()) {
             return true;
         }
@@ -75,7 +77,7 @@ struct all_replication_factors_are_the_same {
     static constexpr const char* error_message
       = "All custom assigned partitions must have the same number of replicas";
 
-    static bool is_valid(const creatable_topic& c) {
+    static bool is_valid(const creatable_topic& c, features::feature_table*) {
         if (c.assignments.empty()) {
             return true;
         }
@@ -94,7 +96,7 @@ struct partition_count_must_be_positive {
     static constexpr const char* error_message
       = "Partitions count must be greater than 0";
 
-    static bool is_valid(const creatable_topic& c) {
+    static bool is_valid(const creatable_topic& c, features::feature_table*) {
         if (!c.assignments.empty()) {
             return true;
         }
@@ -108,7 +110,7 @@ struct replication_factor_must_be_odd {
     static constexpr const char* error_message
       = "Replication factor must be an odd number - 1,3,5,7,9,11...";
 
-    static bool is_valid(const creatable_topic& c) {
+    static bool is_valid(const creatable_topic& c, features::feature_table*) {
         if (!c.assignments.empty()) {
             return true;
         }
@@ -122,7 +124,7 @@ struct replication_factor_must_be_positive {
     static constexpr const char* error_message
       = "Replication factor must be greater than 0";
 
-    static bool is_valid(const creatable_topic& c) {
+    static bool is_valid(const creatable_topic& c, features::feature_table*) {
         if (!c.assignments.empty()) {
             return true;
         }
@@ -137,7 +139,7 @@ struct replication_factor_must_be_greater_or_equal_to_minimum {
       = "Replication factor must be greater than or equal to specified minimum "
         "value";
 
-    static bool is_valid(const creatable_topic& c) {
+    static bool is_valid(const creatable_topic& c, features::feature_table*) {
         // All topics being validated as this level will be created in the kafka
         // namespace
         if (model::is_user_topic(
@@ -161,7 +163,7 @@ struct remote_read_and_write_are_not_supported_for_read_replica {
     static constexpr const char* error_message
       = "remote read and write are not supported for read replicas";
 
-    static bool is_valid(const creatable_topic& c) {
+    static bool is_valid(const creatable_topic& c, features::feature_table*) {
         auto config_entries = config_map(c.configs);
         auto end = config_entries.end();
         bool is_recovery
@@ -187,7 +189,7 @@ struct batch_max_bytes_limits {
         "equal to the `kafka_max_message_size_upper_limit` broker "
         "configuration";
 
-    static bool is_valid(const creatable_topic& c) {
+    static bool is_valid(const creatable_topic& c, features::feature_table*) {
         auto it = std::find_if(
           c.configs.begin(),
           c.configs.end(),
@@ -242,7 +244,7 @@ struct subject_name_strategy_validator {
       = "Unsupported subject name strategy ";
     static constexpr error_code ec = error_code::invalid_config;
 
-    static bool is_valid(const creatable_topic& c) {
+    static bool is_valid(const creatable_topic& c, features::feature_table*) {
         return std::all_of(
           c.configs.begin(),
           c.configs.end(),
@@ -282,7 +284,7 @@ struct iceberg_config_validator {
         "level.";
     static constexpr error_code ec = error_code::invalid_config;
 
-    static bool is_valid(const creatable_topic& c) {
+    static bool is_valid(const creatable_topic& c, features::feature_table*) {
         model::iceberg_mode parsed_mode = model::iceberg_mode::disabled;
 
         auto mode_it = std::find_if(
@@ -345,7 +347,7 @@ struct iceberg_invalid_record_action_validator {
 
     static constexpr error_code ec = error_code::invalid_config;
 
-    static bool is_valid(const creatable_topic& c) {
+    static bool is_valid(const creatable_topic& c, features::feature_table*) {
         auto it = std::find_if(
           c.configs.begin(),
           c.configs.end(),
@@ -436,7 +438,7 @@ struct write_caching_configs_validator {
         return false;
     }
 
-    static bool is_valid(const creatable_topic& c) {
+    static bool is_valid(const creatable_topic& c, features::feature_table*) {
         return validate_write_caching(c) && validate_flush_ms(c)
                && validate_flush_bytes(c);
     }
@@ -449,7 +451,7 @@ struct iceberg_target_lag_ms_validator {
       = topic_property_iceberg_target_lag_ms;
     static constexpr error_code ec = error_code::invalid_config;
 
-    static bool is_valid(const creatable_topic& c) {
+    static bool is_valid(const creatable_topic& c, features::feature_table*) {
         if (auto it = std::ranges::find(
               c.configs,
               topic_property_iceberg_target_lag_ms,
@@ -474,7 +476,7 @@ struct configuration_value_validator {
     static constexpr const char* error_message = T::error_message;
     static constexpr error_code ec = error_code::invalid_config;
 
-    static bool is_valid(const creatable_topic& c) {
+    static bool is_valid(const creatable_topic& c, features::feature_table*) {
         auto config_entries = config_map(c.configs);
         auto end = config_entries.end();
 
@@ -496,7 +498,7 @@ struct vcluster_id_validator {
     static constexpr const char* error_message = "invalid virtual cluster id";
     static constexpr error_code ec = error_code::invalid_config;
 
-    static bool is_valid(const creatable_topic& c) {
+    static bool is_valid(const creatable_topic& c, features::feature_table*) {
         if (!config::shard_local_cfg().enable_mpx_extensions()) {
             return true;
         }
@@ -522,7 +524,7 @@ struct min_max_compaction_lag_ms_validator {
       = "max.compaction.lag.ms must be at least min.compaction.lag.ms";
     static constexpr error_code ec = error_code::invalid_config;
 
-    static bool is_valid(const creatable_topic& c) {
+    static bool is_valid(const creatable_topic& c, features::feature_table*) {
         const auto entries = config_map(c.configs);
         const auto min_lag = get_config_value<int64_t>(
           entries, topic_property_min_compaction_lag_ms);
@@ -544,7 +546,7 @@ struct storage_mode_config_validator {
         "'tiered' requires cloud storage to be enabled.";
     static constexpr error_code ec = error_code::invalid_config;
 
-    static bool is_valid(const creatable_topic& c) {
+    static bool is_valid(const creatable_topic& c, features::feature_table*) {
         auto it = std::find_if(
           c.configs.begin(),
           c.configs.end(),

--- a/src/v/kafka/server/handlers/topics/validators.h
+++ b/src/v/kafka/server/handlers/topics/validators.h
@@ -542,11 +542,13 @@ struct min_max_compaction_lag_ms_validator {
  */
 struct storage_mode_config_validator {
     static constexpr const char* error_message
-      = "Invalid storage mode: 'cloud' requires cloud topics to be enabled, "
+      = "Invalid storage mode: 'cloud' requires cloud topics to be enabled and "
+        "the cluster to be fully upgraded to at least v26.1.1, "
         "'tiered' requires cloud storage to be enabled.";
     static constexpr error_code ec = error_code::invalid_config;
 
-    static bool is_valid(const creatable_topic& c, features::feature_table*) {
+    static bool
+    is_valid(const creatable_topic& c, features::feature_table* ft) {
         auto it = std::find_if(
           c.configs.begin(),
           c.configs.end(),
@@ -566,6 +568,11 @@ struct storage_mode_config_validator {
         case model::redpanda_storage_mode::tiered:
             return config::shard_local_cfg().cloud_storage_enabled();
         case model::redpanda_storage_mode::cloud:
+            if (
+              ft == nullptr
+              || !ft->is_active(features::feature::cloud_topics)) {
+                return false;
+            }
             return config::shard_local_cfg().cloud_topics_enabled();
         case model::redpanda_storage_mode::unset:
             // unset is always valid - actual behavior depends on

--- a/src/v/kafka/server/tests/topic_utils_test.cc
+++ b/src/v/kafka/server/tests/topic_utils_test.cc
@@ -100,7 +100,7 @@ struct partitions_validator {
       = kafka::error_code::invalid_partitions;
     static constexpr const char* error_message = "Partitions count is invalid";
 
-    static bool is_valid(const test_request& r) {
+    static bool is_valid(const test_request& r, features::feature_table*) {
         return r.num_partitions > 0 && r.num_partitions < 10;
     }
 };
@@ -110,7 +110,7 @@ struct r_factor_validator {
       = kafka::error_code::invalid_replication_factor;
     static constexpr const char* error_message = "RF is invalid";
 
-    static bool is_valid(const test_request& r) {
+    static bool is_valid(const test_request& r, features::feature_table*) {
         return r.replication_factor > 0 && r.replication_factor <= 5;
     }
 };

--- a/src/v/kafka/server/tests/validator_tests.cc
+++ b/src/v/kafka/server/tests/validator_tests.cc
@@ -76,5 +76,6 @@ BOOST_DATA_TEST_CASE(
       .replication_factor = 1,
       .configs = data.configs};
     BOOST_REQUIRE_EQUAL(
-      subject_name_strategy_validator::is_valid(no_options), data.is_valid);
+      subject_name_strategy_validator::is_valid(no_options, nullptr),
+      data.is_valid);
 }

--- a/tests/rptest/tests/cloud_topics/upgrade_test.py
+++ b/tests/rptest/tests/cloud_topics/upgrade_test.py
@@ -1,0 +1,167 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.tests.test import TestContext
+from ducktape.utils.util import wait_until
+
+from rptest.clients.rpk import RpkException, RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import (
+    CLOUD_TOPICS_CONFIG_STR,
+    PREV_VERSION_LOG_ALLOW_LIST,
+    RESTART_LOG_ALLOW_LIST,
+    SISettings,
+)
+from rptest.services.redpanda_installer import RedpandaInstaller
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class CloudTopicsUpgradeTest(RedpandaTest):
+    """
+    Verify that cloud topics topic creation is rejected when the cluster
+    is not fully upgraded to v26.1.1, and succeeds after the upgrade
+    completes.
+    """
+
+    # The cloud_topics feature is gated at v26.1.1, so we start the cluster
+    # on v25.3.x and upgrade to HEAD.
+    OLD_VERSION = (25, 3)
+
+    def __init__(self, test_context: TestContext):
+        si_settings = SISettings(
+            test_context,
+            cloud_storage_max_connections=10,
+            cloud_storage_enable_remote_read=False,
+            cloud_storage_enable_remote_write=False,
+            fast_uploads=True,
+        )
+
+        extra_rp_conf = {
+            CLOUD_TOPICS_CONFIG_STR: True,
+            "enable_cluster_metadata_upload_loop": False,
+        }
+
+        super().__init__(
+            test_context=test_context,
+            num_brokers=3,
+            si_settings=si_settings,
+            extra_rp_conf=extra_rp_conf,
+        )
+
+        self.installer = self.redpanda._installer
+        self.admin = Admin(self.redpanda)
+        self.rpk = RpkTool(self.redpanda)
+
+    def setUp(self):
+        self.installer.install(self.redpanda.nodes, self.OLD_VERSION)
+        self.redpanda.start()
+
+    def _try_create_cloud_topic(self, topic_name: str) -> bool:
+        """Attempt to create a cloud-mode topic. Returns True on success."""
+        try:
+            self.rpk.create_topic(
+                topic=topic_name,
+                partitions=1,
+                replicas=3,
+                config={
+                    TopicSpec.PROPERTY_STORAGE_MODE: TopicSpec.STORAGE_MODE_CLOUD,
+                    "cleanup.policy": TopicSpec.CLEANUP_DELETE,
+                },
+            )
+            return True
+        except RpkException as e:
+            self.logger.info(f"Topic creation failed as expected: {e}")
+            return False
+
+    def _cloud_topics_feature_active(self):
+        features = self.admin.get_features()
+        features_map = {f["name"]: f for f in features["features"]}
+        feat = features_map.get("cloud_topics")
+        return feat is not None and feat["state"] == "active"
+
+    def _wait_for_feature_active(self, feature_name: str) -> None:
+        def check():
+            features = self.admin.get_features()
+            features_map = {f["name"]: f for f in features["features"]}
+            feat = features_map.get(feature_name)
+            return feat is not None and feat["state"] == "active"
+
+        wait_until(
+            check,
+            timeout_sec=30,
+            backoff_sec=2,
+            err_msg=f"Feature {feature_name} did not become active",
+        )
+
+    @cluster(
+        num_nodes=3,
+        log_allow_list=RESTART_LOG_ALLOW_LIST + PREV_VERSION_LOG_ALLOW_LIST,
+    )
+    def test_cloud_topic_create_rejected_during_upgrade(self):
+        """
+        Start a cluster on v25.3.x, upgrade all nodes to HEAD, and confirm
+        that cloud topic creation is rejected while the cloud_topics feature
+        has not yet activated. After the feature activates, topic creation
+        should succeed.
+        """
+        initial_version = self.admin.get_features()["cluster_version"]
+        self.logger.info(
+            f"Starting upgrade test: initial_version={initial_version}, "
+            f"old_version={self.OLD_VERSION}"
+        )
+
+        # Upgrade all nodes to HEAD one at a time.
+        self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
+        for node in self.redpanda.nodes:
+            self.redpanda.restart_nodes([node])
+
+        # All nodes are now on HEAD. The cloud_topics feature should not be
+        # active immediately — it requires the cluster version to bump via
+        # health monitor ticks first.
+        if not self._cloud_topics_feature_active():
+            self.logger.info(
+                "cloud_topics feature not yet active, confirming topic "
+                "creation is rejected"
+            )
+            assert not self._try_create_cloud_topic("should-fail-pre-activation"), (
+                "Cloud topic creation should fail before cloud_topics feature is active"
+            )
+        else:
+            self.logger.info(
+                "cloud_topics feature already active (race), skipping "
+                "pre-activation check"
+            )
+
+        # Wait for the cloud_topics feature to become active.
+        self._wait_for_feature_active("cloud_topics")
+
+        # The cloud_topics_enabled config was set in extra_rp_conf, but
+        # v25.3.x doesn't know this property so it was never propagated to
+        # the cluster config store. Explicitly set it now that all nodes
+        # are on a version that recognizes the property. This is a
+        # restart-required property, so restart after setting it.
+        self.redpanda.set_cluster_config(
+            {CLOUD_TOPICS_CONFIG_STR: True}, expect_restart=True
+        )
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        # Now cloud topic creation should succeed.
+        assert self._try_create_cloud_topic("should-succeed-after-upgrade"), (
+            "Cloud topic creation should succeed after full upgrade"
+        )
+
+        # Verify the topic has the expected storage mode.
+        topic_configs = self.rpk.describe_topic_configs("should-succeed-after-upgrade")
+        storage_mode = topic_configs.get("redpanda.storage.mode", None)
+        assert storage_mode is not None, "storage mode config not found"
+        assert storage_mode[0] == "cloud", (
+            f"Expected storage mode 'cloud', got '{storage_mode[0]}'"
+        )


### PR DESCRIPTION
- Feature gates cloud topics at the Kafka create topic API boundary
- Gating the subsystem startup is a bit more complicated (follow up)
- Gating at create time catches 99% of the cases we care about

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
