### PR TITLE
dt: deflake test_enabling_consumer_offsets_cache_test cache hit ratio

### DIFF
--- a/tests/rptest/tests/consumer_offsets_batch_cache_test.py
+++ b/tests/rptest/tests/consumer_offsets_batch_cache_test.py
@@ -84,4 +84,4 @@ class ConsumerOffsetsCacheTest(RedpandaTest):
         hit_ratio = self._consumer_offsets_cache_hit_ratio()
         # hit ratio is not exactly 1.0 as the topic is read once during the
         # startup, the cache is cold during that operation
-        assert hit_ratio > 0.8, "Consumer offsets topic should use cache now"
+        assert hit_ratio > 0.75, "Consumer offsets topic should use cache now"


### PR DESCRIPTION
This test has flaked a couple of times with the hit_ratio being just below the 0.8 limit (~0.78) a few times. Since the cache hit ratio is a complex metric which depends on a number of factors, some variance here seems expected and it doesn't change the correctness of the test if we relax the limit to 0.75 to avoid this flakiness.

Fixes https://redpandadata.atlassian.net/browse/CORE-14993

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
