### PR TITLE
dt: deflake test_replication_timestamps_match retention race

### DIFF
--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -2217,6 +2217,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             partition_count=partition_count,
             replication_factor=3,
             message_timestamp_type=timestamp_type,
+            retention_ms=-1,
         )
 
         self.source_default_client().create_topic(topic)
@@ -2229,7 +2230,7 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
             err_msg=f"Topic {topic.name} not found in target cluster",
         )
         msg_cnt = 100
-        base_ts = 1664453149000
+        base_ts = 1664453149000  # Thu Sep 29 2022 12:05:49 GMT
         with self.producer_consumer(
             topic=topic.name,
             msg_size=128,


### PR DESCRIPTION
The test produces messages with fake timestamps from 2022. With timestamp_type=CreateTime, Kafka's log cleaner treats these as past the 7-day retention period and deletes the segment before rpk can consume, causing a timeout. Set retention_ms=-1 on the topic to prevent this.

Fixes https://redpandadata.atlassian.net/browse/CORE-6999

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
