### PR TITLE
dt: deflake test_upgrade controller leadership race

### DIFF
--- a/tests/rptest/tests/quota_management_test.py
+++ b/tests/rptest/tests/quota_management_test.py
@@ -10,30 +10,30 @@
 import json
 from enum import Enum
 from functools import total_ordering
-from typing import NamedTuple, Any
-from typing_extensions import Self
+from typing import Any, NamedTuple
 
 from ducktape.mark import parametrize
 from ducktape.utils.util import wait_until
+from typing_extensions import Self
 
 from rptest.clients.kafka_cli_tools import KafkaCliTools, KafkaCliToolsError
-from rptest.services.redpanda_installer import (
-    wait_for_num_versions,
-    InstallOptions,
-    RedpandaVersionTriple,
-    RedpandaInstaller,
-)
-from rptest.tests.end_to_end import EndToEndTest
 from rptest.clients.kcl import RawKCL
 from rptest.clients.rpk import RpkException, RpkTool
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import (
-    LoggingConfig,
     RESTART_LOG_ALLOW_LIST,
-    SISettings,
     ClusterNode,
+    LoggingConfig,
+    SISettings,
 )
+from rptest.services.redpanda_installer import (
+    InstallOptions,
+    RedpandaInstaller,
+    RedpandaVersionTriple,
+    wait_for_num_versions,
+)
+from rptest.tests.end_to_end import EndToEndTest
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import expect_exception, wait_until_result
 
@@ -851,6 +851,10 @@ class QuotaManagementUpgradeTest(EndToEndTest, QuotaManagementUtils):
         self.redpanda._installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
         self.redpanda.restart_nodes([first_node])
         wait_for_num_versions(self.redpanda, 2)
+
+        # Ensure the controller is on the upgraded node so that we can verify
+        # the behavior of user quotas during the upgrade
+        self.transfer_leadership(first_node)
 
         self.logger.debug("Verify that during upgrade user quotas are disabled")
         res = self.alter_quotas(alter_user_quota_body)


### PR DESCRIPTION
Transfer controller leadership to the upgraded node before verifying user quota behavior during mixed-version state. Without this, the request may land on the old v25.3 node which returns a different error message, causing a flaky assertion.

Fixes https://redpandadata.atlassian.net/browse/CORE-15511

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
