### PR TITLE
cluster/feature_manager: use insert_or_assign for version updates

### DIFF
--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -528,7 +528,7 @@ void feature_manager::update_node_version(
       update_node,
       v);
 
-    _updates.emplace(update_node, v);
+    _updates.insert_or_assign(update_node, v);
     _update_wait.signal();
 }
 

--- a/tests/rptest/tests/quota_management_test.py
+++ b/tests/rptest/tests/quota_management_test.py
@@ -198,7 +198,7 @@ class QuotaManagementUtils:
             wait_until(
                 lambda: self.rpk.alter_cluster_quotas(*args, **kwargs)["status"]
                 == "OK",
-                timeout_sec=10,
+                timeout_sec=30,
                 backoff_sec=1,
                 err_msg="failed to run rpk.alter_cluster_quotas",
             )


### PR DESCRIPTION
`QuotaManagementUpgradeTest.test_quotas_during_upgrade` was flaky because it can take longer than 10s for the logical version to update after the restart and for the user quotas feature to activate – which is then surfacing as a timeout for this test.

There are 2 issues here that are addressed by this PR:

1. The 10s timeout is generally fairly low because the health reports are collected on a 10s interval, so there is a non-0 chance of hitting this 10s timeout.

2. There was a bug in the feature_manager’s handling of node version updates where the logic was using emplace instead of insert_or_assign which meant that node version updates could be delayed further if there was a stale update earlier.

```
INFO  2026-03-09 06:21:03,170 [shard 0:clus] cluster - feature_manager.cc:103 - Starting...
DEBUG 2026-03-09 06:21:03,170 [shard 0:clus] cluster - feature_manager.cc:143 - Controller leader notification term 1
DEBUG 2026-03-09 06:21:03,170 [shard 0:clus] cluster - feature_manager.cc:413 - Waiting for enterprise license to be verified before checking for active version updates...
DEBUG 2026-03-09 06:21:03,174 [shard 0:main] cluster - feature_manager.cc:356 - Verifying enterprise license...
INFO  2026-03-09 06:21:03,174 [shard 0:main] cluster - feature_manager.cc:395 - Verifying enterprise license: active_version=17, latest_version=18, enterprise_features=[core_balancing_continuous, cloud_storage, partition_auto_balancing_continuous], license_missing_or_expired=false
DEBUG 2026-03-09 06:21:03,174 [shard 0:clus] cluster - feature_manager.cc:420 - Checking for active version update...
DEBUG 2026-03-09 06:21:03,400 [shard 0:admi] cluster - feature_manager.cc:529 - update_node_version: enqueuing update node=2 version=17 *** <- inserted into _updates
DEBUG 2026-03-09 06:21:03,400 [shard 0:admi] cluster - feature_manager.cc:529 - update_node_version: enqueuing update node=1 version=18
DEBUG 2026-03-09 06:21:06,787 [shard 0:rr  ] cluster - feature_manager.cc:143 - Controller leader notification term 3
DEBUG 2026-03-09 06:21:13,446 [shard 0:admi] cluster - feature_manager.cc:529 - update_node_version: enqueuing update node=2 version=18 *** <- this is ignored by .emplace
DEBUG 2026-03-09 06:21:13,446 [shard 0:admi] cluster - feature_manager.cc:529 - update_node_version: enqueuing update node=1 version=18
DEBUG 2026-03-09 06:21:13,912 [shard 0:rs  ] cluster - feature_manager.cc:143 - Controller leader notification term 3
DEBUG 2026-03-09 06:21:15,545 [shard 0:rs  ] cluster - feature_manager.cc:143 - Controller leader notification term 5
DEBUG 2026-03-09 06:21:15,545 [shard 0:rs  ] cluster - feature_manager.cc:161 - generating version update for controller leader 1 (18)
DEBUG 2026-03-09 06:21:15,545 [shard 0:rs  ] cluster - feature_manager.cc:529 - update_node_version: enqueuing update node=1 version=18
DEBUG 2026-03-09 06:21:15,546 [shard 0:clus] cluster - feature_manager.cc:413 - Waiting for enterprise license to be verified before checking for active version updates...
DEBUG 2026-03-09 06:21:15,546 [shard 0:clus] cluster - feature_manager.cc:420 - Checking for active version update...
DEBUG 2026-03-09 06:21:15,546 [shard 0:clus] cluster - feature_manager.cc:557 - Processing update node=1 version=18
DEBUG 2026-03-09 06:21:15,546 [shard 0:clus] cluster - feature_manager.cc:557 - Processing update node=2 version=17
DEBUG 2026-03-09 06:21:15,546 [shard 0:clus] cluster - feature_manager.cc:602 - Can't update active version to 18 because node 2 version is too low (17)
```

Fixes https://redpandadata.atlassian.net/browse/CORE-15478

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [x] v25.1.x

## Release Notes
### Improvements

* Minor improvement to speed up feature activation after major version upgrades.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
