### PR TITLE
`config`: validate `cloud_storage_enabled` when setting `cloud_topics_enabled`

### DIFF
--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -477,6 +477,16 @@ validate_default_redpanda_storage_mode(const configuration& config) {
 }
 
 std::optional<ss::sstring>
+validate_cloud_topics_enabled(const configuration& config) {
+    if (config.cloud_topics_enabled() && !config.cloud_storage_enabled()) {
+        return fmt::format(
+          "cloud_topics_enabled requires cloud_storage_enabled to be set to "
+          "true");
+    }
+    return std::nullopt;
+}
+
+std::optional<ss::sstring>
 validate_sane_partition_balancer_timeouts(const configuration& config) {
     // how often node status sends an rpc
     auto node_status = config.node_status_interval();

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -90,4 +90,7 @@ validate_sane_partition_balancer_timeouts(const configuration& config);
 std::optional<ss::sstring>
 validate_default_redpanda_storage_mode(const configuration& config);
 
+std::optional<ss::sstring>
+validate_cloud_topics_enabled(const configuration& config);
+
 }; // namespace config

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -2063,6 +2063,13 @@ void config_multi_property_validation(
         errors[ss::sstring{updated_config.default_redpanda_storage_mode.name()}]
           = storage_mode_err.value();
     }
+
+    // Validate cloud_topics_enabled dependencies
+    auto ct_err = config::validate_cloud_topics_enabled(updated_config);
+    if (ct_err.has_value()) {
+        errors[ss::sstring{updated_config.cloud_topics_enabled.name()}]
+          = ct_err.value();
+    }
 }
 } // namespace
 


### PR DESCRIPTION
In `server.cc`. This will hopefully prevent users from misconfiguring and hitting a `vassert` within `application_services` at start-up time.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
