### PR TITLE
archival: repair misaligned archive offsets

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -1152,6 +1152,11 @@ void partition_manifest::spillover(const segment_meta& spillover_meta) {
 }
 
 segment_meta partition_manifest::make_manifest_metadata() const {
+    if (empty()) {
+        throw std::runtime_error(
+          "can't make manifest metadata for empty manifest");
+    }
+
     return segment_meta{
       .size_bytes = cloud_log_size(),
       .base_offset = get_start_offset().value(),

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -2816,6 +2816,69 @@ void partition_manifest::process_anomalies(
       _last_scrubbed_offset);
 }
 
+std::optional<partition_manifest> partition_manifest::repair_state() const {
+    auto repaired = do_repair_state();
+
+    // Guard against "infinite repair loop" scenario, where the manifest is
+    // repaired but the repaired manifest is still inconsistent and needs to be
+    // repaired again.
+    if (repaired.has_value() && repaired->do_repair_state().has_value()) {
+        throw std::runtime_error(
+          fmt::format(
+            "[{}] Manifest repair failed: repaired manifest is still "
+            "inconsistent, this should never happen",
+            display_name()));
+    }
+
+    return repaired;
+}
+
+std::optional<partition_manifest> partition_manifest::do_repair_state() const {
+    if (!get_spillover_map().empty()) {
+        const auto first_spill = get_spillover_map().begin();
+        if (
+          _archive_start_offset < first_spill->base_offset
+          || _archive_clean_offset < first_spill->base_offset) {
+            auto cloned = clone();
+
+            // Old versions of redpanda (pre v25.3) could have a manifest with
+            // incorrect `archive_start_offset` and `archive_clean_offset`
+            // values—below the offset of the first spillover manifest. To avoid
+            // issues with such manifests, we need to detect this case and fix
+            // the offsets by bumping them up to the offset of the first
+            // spillover manifest.
+
+            if (_archive_start_offset < first_spill->base_offset) {
+                vlog(
+                  cst_log.warn,
+                  "[{}] archive_start_offset {} is below the first spillover "
+                  "manifest offset {}, advancing it to align with the first "
+                  "spillover manifest offset.",
+                  display_name(),
+                  _archive_start_offset,
+                  first_spill->base_offset);
+                cloned.set_archive_start_offset(
+                  first_spill->base_offset, first_spill->delta_offset);
+            }
+            if (_archive_clean_offset < first_spill->base_offset) {
+                vlog(
+                  cst_log.warn,
+                  "[{}] archive_clean_offset {} is below the first spillover "
+                  "manifest offset {}, advancing it to align with the first "
+                  "spillover manifest offset.",
+                  display_name(),
+                  _archive_clean_offset,
+                  first_spill->base_offset);
+                cloned.set_archive_clean_offset(first_spill->base_offset, 0);
+            }
+
+            return cloned;
+        }
+    }
+
+    return std::nullopt;
+}
+
 std::ostream& operator<<(std::ostream& o, const partition_manifest& pm) {
     o << "{manifest: ";
     pm.serialize_json(o, false);

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -381,6 +381,8 @@ public:
     /// This mechanism is used by the 'spillover' mechanism. The 'segment_meta'
     /// instances that describe spillover manifests are stored using this
     /// format.
+    ///
+    /// \pre The manifest must not be empty.
     segment_meta make_manifest_metadata() const;
 
     /// Return 'true' if the spillover manifest can be added to

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -596,6 +596,10 @@ public:
       scrub_status status,
       anomalies detected);
 
+    /// Returns a repaired copy of the manifest if the manifest has known
+    /// defects. Returns `std::nullopt` otherwise.
+    std::optional<partition_manifest> repair_state() const;
+
 private:
     ss::sstring display_name() const;
     std::optional<kafka::offset> compute_start_kafka_offset_local() const;
@@ -644,6 +648,8 @@ private:
     /// Serialize removed manifest entry
     void serialize_removed_segment_meta(
       const lw_segment_meta& meta, serialization_cursor_ptr cursor) const;
+
+    std::optional<partition_manifest> do_repair_state() const;
 
     model::ntp _ntp;
     model::initial_revision_id _rev;

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -2840,3 +2840,96 @@ SEASTAR_THREAD_TEST_CASE(
     BOOST_REQUIRE(restored == m);
     BOOST_REQUIRE(m.get_applied_offset() == model::offset{100});
 }
+
+SEASTAR_THREAD_TEST_CASE(test_repair_state_no_spillovers) {
+    partition_manifest m;
+    m.add(make_segment({10, 99}, 1234));
+    m.add(make_segment({100, 199}, 1000));
+
+    BOOST_REQUIRE(!m.repair_state().has_value());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_repair_state_aligned) {
+    partition_manifest m;
+    m.add(make_segment({10, 199}, 2234, 0));
+    m.add(make_segment({200, 299}, 2000, 0));
+    m.add(make_segment({300, 399}, 500, 0));
+    {
+        auto spill_manifest = partition_manifest{
+          m.get_ntp(), m.get_revision_id()};
+        spill_manifest.add(*m.begin());
+        m.spillover(spill_manifest.make_manifest_metadata());
+        m.set_archive_start_offset(model::offset{10}, model::offset_delta{0});
+        m.set_archive_clean_offset(model::offset{10}, 0);
+    }
+
+    auto first_spill_base = m.get_spillover_map().begin()->base_offset;
+    BOOST_REQUIRE_EQUAL(first_spill_base, model::offset{10});
+    BOOST_REQUIRE(!m.repair_state().has_value());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_repair_state_misaligned) {
+    partition_manifest m;
+    m.add(make_segment({10, 199}, 2234, 0));
+    m.add(make_segment({200, 299}, 2000, 0));
+    m.add(make_segment({300, 399}, 500, 0));
+
+    {
+        auto spill_manifest = partition_manifest{
+          m.get_ntp(), m.get_revision_id()};
+        spill_manifest.add(*m.begin());
+        m.spillover(spill_manifest.make_manifest_metadata());
+        m.set_archive_start_offset(model::offset{5}, model::offset_delta{0});
+        m.set_archive_clean_offset(model::offset{5}, 0);
+    }
+
+    auto first_spill = *m.get_spillover_map().begin();
+    BOOST_REQUIRE(m.get_archive_start_offset() < first_spill.base_offset);
+
+    auto repaired = m.repair_state();
+    BOOST_REQUIRE(repaired.has_value());
+    BOOST_REQUIRE_EQUAL(
+      repaired->get_archive_start_offset(), first_spill.base_offset);
+    BOOST_REQUIRE_EQUAL(
+      repaired->get_archive_clean_offset(), first_spill.base_offset);
+
+    // Original manifest is unchanged.
+    BOOST_REQUIRE_EQUAL(m.get_archive_start_offset(), model::offset{5});
+    BOOST_REQUIRE_EQUAL(m.get_archive_clean_offset(), model::offset{5});
+
+    // Repaired manifest no longer needs repair.
+    BOOST_REQUIRE(!repaired->repair_state().has_value());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_repair_state_misaligned_clean_offset) {
+    partition_manifest m;
+    m.add(make_segment({10, 199}, 2234, 0));
+    m.add(make_segment({200, 299}, 2000, 0));
+    m.add(make_segment({300, 399}, 500, 0));
+
+    {
+        auto spill_manifest = partition_manifest{
+          m.get_ntp(), m.get_revision_id()};
+        spill_manifest.add(*m.begin());
+        m.spillover(spill_manifest.make_manifest_metadata());
+        m.set_archive_start_offset(model::offset{200}, model::offset_delta{0});
+        m.set_archive_clean_offset(model::offset{5}, 0);
+    }
+
+    auto first_spill = *m.get_spillover_map().begin();
+    BOOST_REQUIRE(m.get_archive_clean_offset() < first_spill.base_offset);
+
+    auto repaired = m.repair_state();
+    BOOST_REQUIRE(repaired.has_value());
+    BOOST_REQUIRE_EQUAL(
+      repaired->get_archive_start_offset(), model::offset{200});
+    BOOST_REQUIRE_EQUAL(
+      repaired->get_archive_clean_offset(), first_spill.base_offset);
+
+    // Original manifest is unchanged.
+    BOOST_REQUIRE_EQUAL(m.get_archive_start_offset(), model::offset{200});
+    BOOST_REQUIRE_EQUAL(m.get_archive_clean_offset(), model::offset{5});
+
+    // Repaired manifest no longer needs repair.
+    BOOST_REQUIRE(!repaired->repair_state().has_value());
+}

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -418,6 +418,40 @@ archival_stm_fence ntp_archiver::emit_rw_fence() {
     };
 }
 
+ss::future<std::error_code>
+ntp_archiver::maybe_repair_manifest(ss::lowres_clock::time_point deadline) {
+    auto repaired_copy = _parent.archival_meta_stm()->manifest().repair_state();
+    if (!repaired_copy) {
+        co_return std::error_code{};
+    }
+
+    vlog(
+      _rtclog.warn, "Manifest repair created a new manifest. Replicating it.");
+    auto batch = _parent.archival_meta_stm()->batch_start(deadline, _as);
+    auto fence = emit_rw_fence();
+    if (fence.emit_rw_fence_cmd) {
+        vlog(
+          _rtclog.debug,
+          "replace manifest with repair, read-write fence: {}",
+          fence.read_write_fence);
+        batch.read_write_fence(fence.read_write_fence);
+    }
+
+    batch.replace_manifest(repaired_copy->to_iobuf());
+    auto ec = co_await batch.replicate();
+    if (ec) {
+        vlog(
+          _rtclog.error,
+          "Failed to replace manifest with repaired version: {}",
+          ec);
+    } else {
+        vlog(
+          _rtclog.debug, "Finished replacing manifest with repaired version");
+    }
+
+    co_return ec;
+}
+
 void ntp_archiver::log_collected_traces() noexcept {
     try {
         _rtclog.bypass_tracing([this] {
@@ -696,6 +730,13 @@ ss::future<> ntp_archiver::upload_until_abort() {
                   checks_disabled,
                   ok_to_skip);
             }
+        }
+
+        if (auto ec = co_await maybe_repair_manifest(
+              ss::lowres_clock::now() + sync_timeout);
+            ec) {
+            vlog(_rtclog.warn, "Failed to repair manifest: {}, retrying", ec);
+            continue;
         }
 
         vlog(_rtclog.debug, "upload loop synced in term {}", _start_term);

--- a/src/v/cluster/archival/ntp_archiver_service.h
+++ b/src/v/cluster/archival/ntp_archiver_service.h
@@ -471,6 +471,9 @@ private:
     /// Create a fence value for the next STM operation
     archival_stm_fence emit_rw_fence();
 
+    ss::future<std::error_code>
+    maybe_repair_manifest(ss::lowres_clock::time_point deadline);
+
     /// Delete objects, return true on success and false otherwise
     ss::future<bool>
     batch_delete(std::vector<cloud_storage_clients::object_key> paths);

--- a/src/v/cluster/archival/tests/ntp_archiver_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_test.cc
@@ -2402,4 +2402,22 @@ FIXTURE_TEST(test_repair_archive_start_before_spillover, archiver_fixture) {
     BOOST_REQUIRE(res.has_value());
     BOOST_REQUIRE_EQUAL(res.value().offset, model::offset{});
     BOOST_REQUIRE_EQUAL(res.value().delta, model::offset_delta{});
+
+    // Enable the upload loop. The archiver should detect the misalignment
+    // and replicate a repaired manifest.
+    cfg.get("cloud_storage_disable_upload_loop_for_tests").set_value(false);
+    archiver.start().get();
+
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+        return manifest.get_archive_start_offset() >= first_spill_base;
+    });
+
+    BOOST_REQUIRE_EQUAL(manifest.get_archive_start_offset(), first_spill_base);
+    BOOST_REQUIRE_EQUAL(manifest.get_archive_clean_offset(), first_spill_base);
+
+    // After repair: retention correctly identifies the old segment for removal.
+    res = amv->compute_retention(std::nullopt, 1h).get();
+    BOOST_REQUIRE(res.has_value());
+    BOOST_REQUIRE_EQUAL(res.value().offset, model::offset{30});
+    BOOST_REQUIRE_EQUAL(res.value().delta, model::offset_delta{0});
 }

--- a/src/v/cluster/archival/tests/ntp_archiver_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_test.cc
@@ -2265,3 +2265,141 @@ FIXTURE_TEST(
         return get_requests().size() - initial_request > 4;
     });
 }
+
+// Regression test: archive_start_offset before the first spillover manifest's
+// base_offset creates a gap that causes time-based retention to give up. Such a
+// manifest could be created only by previous versions of the code (pre v25.3).
+// The archiver should detect and repair this on leader start.
+FIXTURE_TEST(test_repair_archive_start_before_spillover, archiver_fixture) {
+    auto cfg = scoped_config{};
+    cfg.get("cloud_storage_disable_upload_loop_for_tests").set_value(true);
+
+    std::vector<segment_desc> segments = {
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(0),
+       .term = model::term_id(1),
+       .num_records = 1000}};
+
+    init_storage_api_local(segments);
+    wait_for_partition_leadership(manifest_ntp);
+
+    auto part = app.partition_manager.local().get(manifest_ntp);
+    tests::cooperative_spin_wait_with_timeout(10s, [part]() mutable {
+        return part->last_stable_offset() >= model::offset(1);
+    }).get();
+
+    listen();
+
+    auto [arch_conf, remote_conf] = get_configurations();
+    auto amv = ss::make_shared<cloud_storage::async_manifest_view>(
+      remote,
+      app.shadow_index_cache,
+      part->archival_meta_stm()->manifest(),
+      arch_conf->bucket_name,
+      path_provider);
+    archival::ntp_archiver archiver(
+      get_ntp_conf(),
+      arch_conf,
+      remote.local(),
+      app.shadow_index_cache.local(),
+      *part,
+      amv);
+    archiver.initialize_probe();
+    amv->start().get();
+    auto action = ss::defer([&archiver, &amv] {
+        archiver.stop().get();
+        amv->stop().get();
+    });
+
+    // Build a bogus manifest with archive_start_offset below the first
+    // spillover entry, reproducing a pre-v25.3 bug.
+    //
+    //  archive_start=10    spillover[20..49]    stm[50..60]
+    //  archive_clean=10    (3 segments)         (1 segment)
+    //       ^--- gap ---^
+    //
+    // The first spillover segment [20..29] has an old timestamp so that
+    // time-based retention wants to remove it.
+    auto now = model::timestamp::now();
+    auto old_ts = model::timestamp{1000};
+    std::vector<cloud_storage::segment_meta> segs;
+    segs.push_back(
+      cloud_storage::segment_meta{
+        .size_bytes = 4097,
+        .base_offset = model::offset{20},
+        .committed_offset = model::offset{29},
+        .base_timestamp = old_ts,
+        .max_timestamp = old_ts,
+        .delta_offset = model::offset_delta{0},
+        .ntp_revision = manifest_revision,
+        .archiver_term = model::term_id{1},
+        .segment_term = model::term_id{1},
+        .delta_offset_end = model::offset_delta{0},
+        .sname_format = cloud_storage::segment_name_format::v3,
+      });
+    for (auto [base, committed] :
+         std::vector<std::pair<int, int>>{{30, 39}, {40, 49}, {50, 60}}) {
+        segs.push_back(
+          cloud_storage::segment_meta{
+            .size_bytes = 4097,
+            .base_offset = model::offset{base},
+            .committed_offset = model::offset{committed},
+            .base_timestamp = now,
+            .max_timestamp = now,
+            .delta_offset = model::offset_delta{0},
+            .ntp_revision = manifest_revision,
+            .archiver_term = model::term_id{1},
+            .segment_term = model::term_id{1},
+            .delta_offset_end = model::offset_delta{0},
+            .sname_format = cloud_storage::segment_name_format::v3,
+          });
+    }
+
+    // Build the spillover manifest from the first 3 segments and put it
+    // in the cache so async_manifest_view can materialize it.
+    cloud_storage::spillover_manifest spm(manifest_ntp, manifest_revision);
+    for (int i = 0; i < 3; ++i) {
+        spm.add(segs[i]);
+    }
+    auto spill_meta = spm.make_manifest_metadata();
+    {
+        auto spill_path = spm.get_manifest_path(path_provider);
+        auto [stream, size] = spm.serialize().get();
+        auto reservation
+          = app.shadow_index_cache.local().reserve_space(size, 1).get();
+        app.shadow_index_cache.local()
+          .put(spill_path, stream, reservation)
+          .get();
+        stream.close().get();
+    }
+
+    cloud_storage::partition_manifest bogus(manifest_ntp, manifest_revision);
+    for (int i = 0; i < 3; ++i) {
+        bogus.add(segs[i]);
+    }
+    bogus.add(segs[3]);
+    bogus.spillover(spill_meta);
+
+    bogus.set_archive_start_offset(model::offset{10}, model::offset_delta{0});
+    bogus.set_archive_clean_offset(model::offset{10}, 0);
+
+    auto first_spill_base = bogus.get_spillover_map().begin()->base_offset;
+    BOOST_REQUIRE_EQUAL(first_spill_base, model::offset{20});
+    BOOST_REQUIRE(bogus.get_archive_start_offset() < first_spill_base);
+
+    // Replicate the bogus manifest through the STM.
+    auto b = part->archival_meta_stm()->batch_start(
+      ss::lowres_clock::now() + 10s, never_abort);
+    b.replace_manifest(bogus.to_iobuf());
+    auto errc = b.replicate().get();
+    BOOST_REQUIRE(!errc);
+
+    const auto& manifest = part->archival_meta_stm()->manifest();
+    BOOST_REQUIRE(manifest.get_archive_start_offset() < first_spill_base);
+
+    // Before repair: the gap causes time-based retention to give up.
+    auto res = amv->compute_retention(std::nullopt, 1h).get();
+    BOOST_REQUIRE(res.has_value());
+    BOOST_REQUIRE_EQUAL(res.value().offset, model::offset{});
+    BOOST_REQUIRE_EQUAL(res.value().delta, model::offset_delta{});
+}


### PR DESCRIPTION
Old versions of Redpanda (pre v25.3) could produce manifests where
`archive_start_offset` and `archive_clean_offset` sit below the first
spillover manifest's base offset. This gap causes time-based retention to
silently give up, leaving unreachable segments in the archive indefinitely.

Add `partition_manifest::repair_state()` which detects this condition and
returns a corrected copy of the manifest. The upload loop calls it on
every iteration and, when a defect is found, replicates the repaired
manifest through the archival STM so that all replicas converge.

Fixes [CORE-15656](https://redpandadata.atlassian.net/browse/CORE-15656)

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Bug Fixes

* Repair tiered-storage manifests with misaligned archive offsets during archiver startup. This unblocks retention when such a manifest was present.

[CORE-15656]: https://redpandadata.atlassian.net/browse/CORE-15656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ