### PR TITLE
http: show Host header as primary URL in log prefix

### DIFF
--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -130,14 +130,24 @@ ss::future<client::request_response_t> client::make_request(
     constexpr unsigned http_version = 11;
     header.version(http_version);
 
-    // The default host is derived from the transport configuration
-    if (header.find(boost::beast::http::field::host) == header.end()) {
-        header.insert(boost::beast::http::field::host, _host_with_port);
-    }
-
     auto verb = header.method();
     auto target = header.target();
     ss::sstring target_str(target.data(), target.size());
+
+    bool host_matches = false;
+    std::string_view host_hdr;
+    const auto host_header_it = header.find(boost::beast::http::field::host);
+    if (host_header_it == header.end()) {
+        header.insert(boost::beast::http::field::host, _host_with_port);
+        host_hdr = std::string_view{_host_with_port};
+        host_matches = true;
+    } else {
+        host_hdr = host_header_it->value();
+        host_matches
+          = host_hdr == _host_with_port
+            || (host_hdr == server_address().host()
+                && is_default_port(server_address().port(), has_tls()));
+    }
 
     _ctxlog = prefix_logger{
       http_log,
@@ -145,9 +155,14 @@ ss::future<client::request_response_t> client::make_request(
         "{} {}{}{}{}",
         verb,
         has_tls() ? "https://" : "http://",
-        server_address().host(),
-        port_display_string(server_address().port(), has_tls()),
-        target_str)};
+        host_hdr,
+        target_str,
+        host_matches
+          ? ""
+          : ssx::sformat(
+              " (via {}{})",
+              server_address().host(),
+              port_display_string(server_address().port(), has_tls())))};
     vlog(_ctxlog.trace, "client.make_request {}", header);
 
     auto req = ss::make_shared<request_stream>(this, std::move(header));

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -46,15 +46,18 @@ namespace http {
 
 namespace {
 
-ss::sstring port_display_string(uint16_t port, bool has_tls) {
+bool is_default_port(uint16_t port, bool has_tls) {
     static constexpr uint16_t https_default_port = 443;
     static constexpr uint16_t http_default_port = 80;
-
     return (has_tls && port == https_default_port)
-               || (!has_tls && port == http_default_port)
+           || (!has_tls && port == http_default_port);
+}
+
+ss::sstring port_display_string(uint16_t port, bool has_tls) {
+    return is_default_port(port, has_tls)
              ? ss::sstring{}
              : ss::sstring{fmt::format(":{}", port)};
-};
+}
 
 } // namespace
 

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -160,9 +160,9 @@ started_client_and_server(const net::base_transport::configuration& conf) {
     };
 }
 
-template<typename Header, typename Host>
-static void header_set_host(Header& header, Host& h) {
-    auto host = fmt::format("{}", h);
+template<typename Header>
+static void header_set_host(Header& header, const net::unresolved_address& h) {
+    auto host = fmt::format("{}:{}", h.host(), h.port());
     header.insert(boost::beast::http::field::host, host);
 }
 


### PR DESCRIPTION
The HTTP client log prefix is built using the TCP server address, but
the Host header (which determines virtual-host routing) can differ —
e.g. S3 virtual-hosted style connects to `s3.amazonaws.com` while Host
is `mybucket.s3.us-east-1.amazonaws.com`. The log prefix hides this,
making debugging confusing.

Use the Host header as the URL in the prefix. When it differs from the
server address, append the server address as supplementary info:
`GET https://mybucket.s3.us-east-1.amazonaws.com/key (via s3.amazonaws.com)`.
No change when they match (the common case).

Also fixes the test helper `header_set_host` which produced
`{host: foo, port: 101}` instead of `foo:101` — this didn't affect
test results as the test server does not inspect the header.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none