### PR TITLE
cluster: remove copy of partition map when beginning a txn

### DIFF
--- a/src/v/cluster/rm_partition_frontend.cc
+++ b/src/v/cluster/rm_partition_frontend.cc
@@ -300,13 +300,13 @@ rm_partition_frontend::do_begin_tx_on_partition_shard(
         co_return begin_tx_reply{std::move(ntp), tx::errc::stm_not_found};
     }
 
-    auto topic_md = _metadata_cache.local().get_topic_metadata(
+    auto topic_md = _metadata_cache.local().get_topic_metadata_ref(
       model::topic_namespace_view(ntp));
     if (!topic_md) {
         co_return begin_tx_reply{
           std::move(ntp), tx::errc::partition_not_exists};
     }
-    auto topic_revision = topic_md->get_revision();
+    auto topic_revision = topic_md->get().get_revision();
 
     auto etag = co_await stm->begin_tx(pid, tx_seq, transaction_timeout_ms, tm);
     if (!etag.has_value()) {


### PR DESCRIPTION


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [x] v25.2.x
- [ ] v25.1.x

## Release Notes

### Improvements

* Remove a copy of a potentially large datastructure when starting a transaction


