### PR TITLE
[CORE-15767] `rptest`: retry on exception for `all_partitions_scrubbed`

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -6242,7 +6242,12 @@ class RedpandaService(Service, RedpandaServiceABC):
 
         n_partitions = len(cloud_storage_partitions)
         timeout = (n_partitions // 100) * 60 + 120
-        wait_until(all_partitions_scrubbed, timeout_sec=timeout, backoff_sec=5)
+        wait_until(
+            all_partitions_scrubbed,
+            timeout_sec=timeout,
+            backoff_sec=5,
+            retry_on_exc=True,
+        )
 
         return all_anomalies
 


### PR DESCRIPTION
The `all_partitions_scrubbed()` check in `_post_test_anomaly_check` calls `get_cloud_storage_anomalies()`, which can raise a 404 error when racing with a partition move. This is a transient failure.

Pass `retry_on_exc=True` so the scrub check retries on transient errors instead of immediately failing the test.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
