### PR TITLE
[CORE-15674] `rptest`: change `num_objects_deleted` condition in `l0_gc_test`

### DIFF
--- a/tests/rptest/tests/cloud_topics/l0_gc_test.py
+++ b/tests/rptest/tests/cloud_topics/l0_gc_test.py
@@ -1195,13 +1195,9 @@ class CloudTopicsL0GCNodeFailureTest(CloudTopicsL0GCTestBase):
         self.logger.info(f"Restarting node {kill_node.name} (id={kill_node_id})")
         self.redpanda.start_node(kill_node, timeout=30, node_id_override=kill_node_id)
 
-        deleted_after_restart = self.get_num_objects_deleted(nodes=[kill_node])
-        self.logger.info(
-            f"Waiting for restarted node GC to resume (currently {deleted_after_restart})"
-        )
+        self.logger.info("Waiting for restarted node GC to resume")
         wait_until(
-            lambda: self.get_num_objects_deleted(nodes=[kill_node])
-            > deleted_after_restart,
+            lambda: self.get_num_objects_deleted(nodes=[kill_node]) > 0,
             timeout_sec=30,
             backoff_sec=3,
             retry_on_exc=True,


### PR DESCRIPTION
After restarting a killed node, L0 GC can complete its initial burst of deletes before the test samples the baseline metric, making the "counter increased" assertion impossible to satisfy.

Simply check that the restarted node deletes anything from L0 instead, since metrics reset on restart of the node anyways.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
