### PR TITLE
[CORE-15564] `rptest`: wait for manifest upload before asserting cloud usage

### DIFF
--- a/tests/rptest/tests/cloud_storage_timing_stress_test.py
+++ b/tests/rptest/tests/cloud_storage_timing_stress_test.py
@@ -53,6 +53,20 @@ class CloudStorageCheck:
 
 
 def assert_cloud_storage_usage(test):
+    # Wait for the partition manifest to be fully uploaded to S3 before
+    # comparing. Without this, a compacted segment reupload may have
+    # updated the in-memory manifest (via the STM) while the S3 manifest
+    # still reflects the old, larger segment sizes.
+    wait_until(
+        lambda: not test.admin.get_partition_cloud_storage_status(test.topic, 0)[
+            "metadata_update_pending"
+        ],
+        timeout_sec=60,
+        backoff_sec=1,
+        err_msg="Timed out waiting for partition manifest upload to S3",
+        retry_on_exc=True,
+    )
+
     bucket_view = BucketView(test.redpanda)
     manifest_usage = bucket_view.cloud_log_size_for_ntp(test.topic, 0)
     test.logger.debug(f"Cloud log usage inferred from manifests: {manifest_usage}")


### PR DESCRIPTION
`assert_cloud_storage_usage` reads the partition manifest from S3 and compares it against the usage reported by the admin API (which reflects in-memory STM state). With a `compact`-enabled cleanup policy, a compacted segment reupload can update the STM before the manifest is re-uploaded to S3, causing the S3 manifest to report a larger size than the in-memory state and causing the size equivalence assertion to fail.

Wait for `metadata_update_pending` to return `false` before reading the S3 manifest, ensuring the manifest reflects the in-memory state.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
