### PR TITLE
[CORE-14786] `rptest`: bump number of concurrent partition moves in `many_topics_test`

### DIFF
--- a/tests/rptest/scale_tests/many_topics_test.py
+++ b/tests/rptest/scale_tests/many_topics_test.py
@@ -100,6 +100,10 @@ class ManyTopicsTest(RedpandaTest):
             "topic_partitions_memory_allocation_percent": self.PARTITIONS_MEMORY_ALLOCATION_PERCENT,
             "log_segment_size": 8000000,
             "log_segment_size_min": 8000000,
+            # With 40k topics the default of 50 concurrent moves means decommissioning
+            # a single node can take upwards of ~40 min, exceeding the test timeout.
+            # Bump it to avoid timeouts and shorten runs.
+            "partition_autobalancing_concurrent_moves": 500,
         }
 
         # Reduce per-partition log spam


### PR DESCRIPTION
This decommission test occasionally times out because draining a single node of all its replicas (with `40k` topics present) at the default limit of 50 concurrent moves can take upwards of 40 min, putting the test over the 45 minute timeout.

Set `partition_autobalancing_concurrent_moves` to 500 to reduce the drain time for this test.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
