### PR TITLE
dev_cluster: Add --cpuset-stride flag

### DIFF
--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -419,6 +419,10 @@ class Redpanda:
         self.extra_args = extra_args
         self.env = env
 
+    def cpuset(self) -> str:
+        base_core = self.cores * self.node_meta.index
+        return ",".join(str(base_core + core) for core in range(self.cores))
+
     def stop(self) -> None:
         print(f"node-{self.node_meta.index}: dev_cluster stop requested")
         assert self.process
@@ -435,9 +439,7 @@ class Redpanda:
         if not has_arg("-c", "--smp"):
             # Caller is required to pass a finite core count
             assert self.cores > 0
-            base_core = self.cores * self.node_meta.index
-
-            cores_args = f"--cpuset {base_core}-{base_core + self.cores - 1}"
+            cores_args = f"--cpuset {self.cpuset()}"
         else:
             cores_args = ""
 

--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -24,6 +24,7 @@ import pathlib
 from pathlib import Path
 import shutil
 import signal
+import subprocess
 import time
 from typing import Optional, Any
 
@@ -114,6 +115,47 @@ class NodeMetadata:
 
     # Dictionary of node config properties.
     config_dict: dict[str, Any]
+
+
+def cpuset_cpu(
+    hardware_core_count: int, stride: int, smp: int, node_index: int, core_index: int
+) -> int:
+    # Map a (node_index, core_index) pair to a physical CPU index using an
+    # interleaved layout that spaces assigned CPUs `stride` apart. This is
+    # useful for spreading nodes across physical cores so that co-located
+    # hyper-thread siblings or NUMA-adjacent cores are left unused between them.
+    #
+    # Example: 12 CPUs, stride=2, 3 nodes with smp=2
+    #
+    #   slot: 0  1 | 2  3 | 4  5
+    #    cpu: 0  2 | 4  6 | 8 10
+    #         n0   | n1   | n2
+    #
+    # With stride=1 the layout is contiguous, matching the default.
+    # Global slot for this node/core pair.
+    slot = (node_index * smp) + core_index
+    # Number of CPUs available per interleave group. With stride=16 on a
+    # 32-CPU machine there are 2 CPUs per group (0,16 / 1,17 / 2,18 / ...).
+    slots_per_group = hardware_core_count // stride
+    # Which interleave group this slot falls into.
+    group = slot // slots_per_group
+    # Position within that group.
+    index_in_group = slot % slots_per_group
+    return group + (index_in_group * stride)
+
+
+def cpuset_hardware_core_count() -> int:
+    try:
+        # this will also include offline CPUs (SMT etc.)
+        configured_count = int(subprocess.check_output(["nproc", "--all"]))
+        if configured_count > 0:
+            return int(configured_count)
+    except Exception:
+        pass
+
+    fallback_count = psutil.cpu_count(logical=True)
+    assert fallback_count
+    return fallback_count
 
 
 async def stream_until_eof(
@@ -408,20 +450,33 @@ class Redpanda:
         self,
         binary: Path,
         cores: int,
+        cpuset_stride: int,
         node_meta: NodeMetadata,
         extra_args: list[str],
         env: dict[str, str],
     ) -> None:
         self.binary = binary
         self.cores = cores
+        self.cpuset_stride = cpuset_stride
         self.node_meta = node_meta
         self.process: asyncio.subprocess.Process | None = None
         self.extra_args = extra_args
         self.env = env
 
     def cpuset(self) -> str:
-        base_core = self.cores * self.node_meta.index
-        return ",".join(str(base_core + core) for core in range(self.cores))
+        hardware_core_count = cpuset_hardware_core_count()
+        return ",".join(
+            str(
+                cpuset_cpu(
+                    hardware_core_count,
+                    self.cpuset_stride,
+                    self.cores,
+                    self.node_meta.index,
+                    core,
+                )
+            )
+            for core in range(self.cores)
+        )
 
     def stop(self) -> None:
         print(f"node-{self.node_meta.index}: dev_cluster stop requested")
@@ -534,6 +589,12 @@ async def main() -> None:
     parser.add_argument("--nodes", type=int, help="number of nodes", default=3)
     parser.add_argument(
         "--cores", type=int, help="number of cores per node", default=None
+    )
+    parser.add_argument(
+        "--cpuset-stride",
+        type=int,
+        help="stride between assigned cpuset CPUs. 1 means no gaps",
+        default=1,
     )
     parser.add_argument(
         "-d", "--directory", type=Path, help="data directory", default=None
@@ -794,7 +855,17 @@ async def main() -> None:
             env["UBSAN_OPTIONS"] += f":suppressions={args.ubsan_suppression_file}"
     if args.lsan_suppression_file and "LSAN_OPTIONS" not in env:
         env["LSAN_OPTIONS"] = f"suppressions={args.lsan_suppression_file}"
-    nodes = [Redpanda(args.executable, cores, m, extra_args, env) for m in node_metas]
+    nodes = [
+        Redpanda(
+            args.executable,
+            cores,
+            args.cpuset_stride,
+            m,
+            extra_args,
+            env,
+        )
+        for m in node_metas
+    ]
 
     all_coros = [r.run() for r in nodes]
 


### PR DESCRIPTION
Make dev_cluster cpuset generation optionally use a stride.

This is useful for SMT systems or SMT specific testing:

 - --cpuset-stride=2 on a 32 core system will generate 0,2 , 4,6 and
   8,10
 - --cpuset-stride=16 on a 32 core system will generate 0,16, 1,17 and
   2,18

Both are a valid scenarios depending on the SMT sibling core assignment
id of the system.

Note flag validation is not very detailed as it's generally hard to
validate the different valid scenarios (e.g.: as per above).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes


* none
