### PR TITLE
[CORE-15748] `cluster`: fix use-after-free in `check_ntp_states_locally()`

### DIFF
--- a/src/v/cluster/data_migration_backend.cc
+++ b/src/v/cluster/data_migration_backend.cc
@@ -1548,7 +1548,7 @@ void backend::handle_shard_update(
 }
 
 ss::future<check_ntp_states_reply>
-backend::check_ntp_states_locally(check_ntp_states_request&& req) {
+backend::check_ntp_states_locally(check_ntp_states_request req) {
     vlog(dm_log.debug, "processing node request {}", req);
     check_ntp_states_reply reply;
     co_await ssx::async_for_each(

--- a/src/v/cluster/data_migration_backend.h
+++ b/src/v/cluster/data_migration_backend.h
@@ -235,7 +235,7 @@ private:
     /* RPC and raft0 actions */
     ss::future<> send_rpc(model::node_id node_id);
     ss::future<check_ntp_states_reply>
-    check_ntp_states_locally(check_ntp_states_request&& req);
+    check_ntp_states_locally(check_ntp_states_request req);
     void to_advance_if_done(mrstate_cit_t it);
     ss::future<> advance(id migration_id, state sought_state);
     void spawn_advances();


### PR DESCRIPTION
Taking an r-value reference to `req` in `check_ntp_states_locally()` could result in a heap-use-after-free due to the fact `req` is not `std::move()`'d within the function, and `check_ntp_states_locally()` is being called via continuation in `backend::send_rpc()`.

Change `check_ntp_states_locally()` to take `req` by value instead.

```
#0 0xaaaad89d8a18 in chunked_vector<cluster::data_migrations::data_migration_ntp_state>::iter<false>::check_generation() const bazel-out/aarch64-dbg/bin/src/v/container/_virtual_includes/chunked_vector/container/chunked_vector.h:474:13
#1 0xaaaad89d8a18 in chunked_vector<cluster::data_migrations::data_migration_ntp_state>::iter<false>::operator==(chunked_vector<cluster::data_migrations::data_migration_ntp_state>::iter<false> const&) const bazel-out/aarch64-dbg/bin/src/v/container/_virtual_includes/chunked_vector/container/chunked_vector.h:439:13
#2 0xaaaad88ff614 in seastar::future<void> ssx::detail::async_for_each_coro<ssx::async_algo_traits, ssx::detail::internal_counter, cluster::data_migrations::backend::check_ntp_states_locally(cluster::data_migrations::check_ntp_states_request&&)::$_0, chunked_vector<cluster::data_migrations::data_migration_ntp_state>::iter<false>, chunked_vector<cluster::data_migrations::data_migration_ntp_state>::iter<false>>(ssx::detail::internal_counter, T2, chunked_vector<cluster::data_migrations::data_migration_ntp_state>::iter<false>, cluster::data_migrations::backend::check_ntp_states_locally(cluster::data_migrations::check_ntp_states_request&&)::$_0) (.resume) bazel-out/aarch64-dbg/bin/src/v/ssx/_virtual_includes/async_algorithm/ssx/async_algorithm.h:148:20
#3 0xaaaace22a4dc in std::__1::coroutine_handle<seastar::internal::coroutine_traits_base<void>::promise_type>::resume[abi:se200100]() const external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__coroutine/coroutine_handle.h:144:5
#4 0xaaaace22a4dc in seastar::internal::coroutine_traits_base<void>::promise_type::run_and_dispose() external/+non_module_dependencies+seastar/include/seastar/core/coroutine.hh:171:20
#5 0xaaaadde45c2c in seastar::reactor::task_queue::run_tasks() external/+non_module_dependencies+seastar/src/core/reactor.cc:2747:14
#6 0xaaaadde4c594 in seastar::reactor::task_queue_group::run_tasks() external/+non_module_dependencies+seastar/src/core/reactor.cc:3251:27
#7 0xaaaadde4c034 in seastar::reactor::task_queue_group::run_some_tasks() external/+non_module_dependencies+seastar/src/core/reactor.cc:3235:5
#8 0xaaaadde4dcac in seastar::reactor::do_run() external/+non_module_dependencies+seastar/src/core/reactor.cc:3418:20
#9 0xaaaadde4cc44 in seastar::reactor::run() external/+non_module_dependencies+seastar/src/core/reactor.cc:3295:16
#10 0xaaaaddc381d4 in seastar::app_template::run_deprecated(int, char**, std::__1::function<void ()>&&) external/+non_module_dependencies+seastar/src/core/app-template.cc:266:31
#11 0xaaaaddc36a4c in seastar::app_template::run(int, char**, std::__1::function<seastar::future<int> ()>&&) external/+non_module_dependencies+seastar/src/core/app-template.cc:160:12
#12 0xaaaace07c3b8 in application::run(int, char**) src/v/redpanda/application.cc:312:16
#13 0xaaaace034788 in main src/v/redpanda/main.cc:22:16
#14 0xffffaf0073f8  (/opt/redpanda_installs/ci/lib/libc.so.6+0x273f8) (BuildId: 2a450fe74d1b79a321cc1b12337fc31a2c3fb834)
#15 0xffffaf0074c8 in __libc_start_main (/opt/redpanda_installs/ci/lib/libc.so.6+0x274c8) (BuildId: 2a450fe74d1b79a321cc1b12337fc31a2c3fb834)
#16 0xaaaacdf503ec in _start (/opt/redpanda_installs/ci/libexec/redpanda+0x1a3e03ec) (BuildId: 52528f0683dceb3bfb7940a4869a87f6)
```


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
