### PR TITLE
[CORE-15532] data-migration: fix use-after-free

### DIFF
--- a/src/v/cluster/data_migration_backend.cc
+++ b/src/v/cluster/data_migration_backend.cc
@@ -1548,7 +1548,7 @@ void backend::handle_shard_update(
 }
 
 ss::future<check_ntp_states_reply>
-backend::check_ntp_states_locally(check_ntp_states_request&& req) {
+backend::check_ntp_states_locally(check_ntp_states_request req) {
     vlog(dm_log.debug, "processing node request {}", req);
     check_ntp_states_reply reply;
     co_await ssx::async_for_each(

--- a/src/v/cluster/data_migration_backend.h
+++ b/src/v/cluster/data_migration_backend.h
@@ -235,7 +235,7 @@ private:
     /* RPC and raft0 actions */
     ss::future<> send_rpc(model::node_id node_id);
     ss::future<check_ntp_states_reply>
-    check_ntp_states_locally(check_ntp_states_request&& req);
+    check_ntp_states_locally(check_ntp_states_request req);
     void to_advance_if_done(mrstate_cit_t it);
     ss::future<> advance(id migration_id, state sought_state);
     void spawn_advances();


### PR DESCRIPTION
check_ntp_states_locally takes its request parameter by rvalue reference (&&). For a coroutine, only the reference is stored in the coroutine frame, not the object. Before 7fbd86f41e, check_ntp_states_locally was not a coroutine — it used a synchronous for-loop and returned a ready future via ssx::now(). The && parameter was safe because the function ran to completion within the caller's stack frame. That commit converted it to use co_await ssx::async_for_each and co_return, making it a coroutine with a suspension point.

The use-after-free sequence:
1. Coroutine send_rpc builds a request and moves it into a lambda.
2. ssx::spawn_with_gate calls the lambda, which calls check_ntp_states_locally(std::move(req)). Because the parameter is &&, the coroutine frame stores a reference back into the lambda's captured req.
3. check_ntp_states_locally suspends at co_await async_for_each (via maybe_yield). Control returns up the stack.
4. spawn_with_gate returns, send_rpc falls off the end, and its coroutine frame is destroyed — taking the lambda and its captured req with it.
5. check_ntp_states_locally resumes and accesses the destroyed req through iterators into req.sought_states.

Fix by taking the parameter by value so that req is move-constructed into check_ntp_states_locally's own coroutine frame, decoupling its lifetime from the caller.

Taking a `T&&` rvalue reference (not perfect forwarding) seems generally dangerous in coroutines. I wrote a little clang-tidy check to look for it and we have it in a lot of places in the codebase. Worth auditing?

Fixes CORE-15532

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

