### PR TITLE
[CORE-15790] ct: Tailing workload fixes

### DIFF
--- a/src/v/cloud_topics/batch_cache/batch_cache.cc
+++ b/src/v/cloud_topics/batch_cache/batch_cache.cc
@@ -169,7 +169,10 @@ void batch_cache::put_ordered(
     auto prev = model::prev_offset(first_base);
     if (prev <= entry.monitor->last_applied()) {
         // The batch is contiguous with what the monitor has already seen.
-        entry.monitor->notify(last);
+        // Scan forward past `last` in case earlier out-of-order puts left
+        // batches beyond this range that are now reachable.
+        auto end = entry.index->contiguous_end(model::next_offset(last));
+        entry.monitor->notify(std::max(last, end));
         return;
     }
 
@@ -177,7 +180,10 @@ void batch_cache::put_ordered(
     // and this batch.
     auto gap_start = model::next_offset(entry.monitor->last_applied());
     if (entry.index->has_contiguous_coverage(gap_start, prev)) {
-        entry.monitor->notify(last);
+        // The gap is closed. Scan forward past the inserted range to
+        // pick up any batches that arrived out of order earlier.
+        auto end = entry.index->contiguous_end(model::next_offset(last));
+        entry.monitor->notify(std::max(last, end));
     }
 }
 

--- a/src/v/cloud_topics/batch_cache/tests/batch_cache_test.cc
+++ b/src/v/cloud_topics/batch_cache/tests/batch_cache_test.cc
@@ -258,25 +258,24 @@ TEST_F(batch_cache_test_fixture, test_put_ordered_out_of_order) {
     ASSERT_FALSE(wait_fut.available());
 
     // Now insert batch [0,9] — the index now has contiguous coverage
-    // from 0 through 9, which fills the gap, so the monitor is notified
-    // with offset 9 (the last offset of [0,9]).
+    // from 0 through 19, which fills the gap. put_ordered scans forward
+    // past the inserted range and discovers [10,19] is already cached,
+    // so the monitor is notified with offset 19.
     chunked_vector<model::record_batch> first_batch;
     first_batch.push_back(
       model::test::make_random_batch(model::offset(0), 10, false));
     _cache.put_ordered(tidp, std::move(first_batch));
 
-    // The waiter for offset 19 should NOT be resolved yet because
-    // put_ordered for [0,9] only notifies with offset 9.
-    // We need to verify both batches are in cache though.
+    // Both batches are in cache and the waiter for offset 19 is resolved
+    // because the gap-closing put discovers the full contiguous range.
     auto b0 = _cache.get(tidp, model::offset(0));
     auto b1 = _cache.get(tidp, model::offset(10));
     ASSERT_TRUE(b0.has_value());
     ASSERT_TRUE(b1.has_value());
+    ASSERT_TRUE(wait_fut.available());
+    wait_fut.get();
 
     _cache.stop().get();
-
-    // Consume the waiter future — stop() sent it abort_requested_exception.
-    ASSERT_THROW(wait_fut.get(), ss::abort_requested_exception);
 }
 
 // Verify that put_ordered inserts the batch even when the predecessor

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -82,20 +82,18 @@ level_zero_log_reader_impl::read_some(
     // Like the storage layer log reader, stop when we've consumed all
     // committed data. The Kafka fetch handler owns the waiting policy
     // via the visible_offset_monitor / max_wait_ms.
-    {
-        auto ot_state = _ctp->get_offset_translator_state();
-        auto translated = ot_state->from_log_offset(
-          _ctp->raft()->committed_offset());
-        if (_next_offset > model::offset_cast(translated)) {
-            vlog(
-              _log.debug,
-              "next offset {} beyond committed kafka offset {}, "
-              "end of stream",
-              _next_offset,
-              translated);
-            set_end_of_stream();
-            co_return chunked_circular_buffer<model::record_batch>{};
-        }
+    auto ot_state = _ctp->get_offset_translator_state();
+    auto committed_kafka = ot_state->from_log_offset(
+      _ctp->raft()->committed_offset());
+    if (_next_offset > model::offset_cast(committed_kafka)) {
+        vlog(
+          _log.debug,
+          "next offset {} beyond committed kafka offset {}, "
+          "end of stream",
+          _next_offset,
+          committed_kafka);
+        set_end_of_stream();
+        co_return chunked_circular_buffer<model::record_batch>{};
     }
 
     // Wait briefly for the write path to cache the batch we need.
@@ -106,14 +104,6 @@ level_zero_log_reader_impl::read_some(
         auto wait_deadline = model::timeout_clock::now()
                              + std::chrono::milliseconds(500);
         try {
-            // Translate committed_offset from raft-space to kafka-space.
-            // The batch cache monitor tracks kafka offsets (put() notifies
-            // with kafka offsets), so the seed must also be in kafka-space.
-            // Using a raft offset here would over-seed the monitor by the
-            // offset delta, causing the wait to resolve immediately.
-            auto ot_state = _ctp->get_offset_translator_state();
-            auto committed_kafka = ot_state->from_log_offset(
-              _ctp->raft()->committed_offset());
             co_await _ct_api->cache_wait(
               tidp,
               kafka::offset_cast(_next_offset),
@@ -131,7 +121,9 @@ level_zero_log_reader_impl::read_some(
     // the 'empty' state. It doesn't make any difference if the reader is in
     // the 'materialized' state. If we're in 'ready' state we risk to go out
     // of sync with cached metadata so it's safer to hydrate.
-    if (auto cached = maybe_read_batches_from_cache(); !cached.empty()) {
+    if (auto cached = maybe_read_batches_from_cache(
+          model::offset_cast(committed_kafka));
+        !cached.empty()) {
         co_return cached;
     }
 
@@ -194,7 +186,8 @@ level_zero_log_reader_impl::read_some(
 }
 
 chunked_circular_buffer<model::record_batch>
-level_zero_log_reader_impl::maybe_read_batches_from_cache() {
+level_zero_log_reader_impl::maybe_read_batches_from_cache(
+  kafka::offset committed_kafka) {
     chunked_circular_buffer<model::record_batch> ret;
     if (!cache_enabled()) {
         return ret;
@@ -206,7 +199,8 @@ level_zero_log_reader_impl::maybe_read_batches_from_cache() {
      * Fetch batches from the cache starting at `_next_offset` until we hit a
      * gap or a control batch and must then fetch the data from object storage.
      */
-    while (_next_offset <= _config.max_offset) {
+    auto max_offset = std::min(_config.max_offset, committed_kafka);
+    while (_next_offset <= max_offset) {
         auto batch = _ct_api->cache_get(tidp, kafka::offset_cast(_next_offset));
         if (!batch.has_value()) {
             break;

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
@@ -133,7 +133,7 @@ private:
     // This method could change state of the reader to end_of_stream_state
     // when it reaches committed offset.
     chunked_circular_buffer<model::record_batch>
-    maybe_read_batches_from_cache();
+    maybe_read_batches_from_cache(kafka::offset committed_kafka);
 
     // If adding a batch of `size` would cause this to go over the bytes limit.
     bool is_over_limit_with_bytes(size_t size) const;

--- a/src/v/storage/batch_cache.cc
+++ b/src/v/storage/batch_cache.cc
@@ -460,6 +460,32 @@ bool batch_cache_index::has_contiguous_coverage(
     return expected > to;
 }
 
+model::offset batch_cache_index::contiguous_end(model::offset from) const {
+    auto it = _index.upper_bound(from);
+    if (it != _index.begin()) {
+        --it;
+    }
+    model::offset expected = from;
+    while (it != _index.end()) {
+        const auto& range = it->second.range();
+        if (!range || !range->valid()) {
+            break;
+        }
+        auto hdr = it->second.header();
+        if (hdr.base_offset > expected) {
+            break;
+        }
+        auto next = model::next_offset(hdr.last_offset());
+        if (next <= expected) {
+            ++it;
+            continue;
+        }
+        expected = next;
+        ++it;
+    }
+    return model::prev_offset(expected);
+}
+
 void batch_cache_index::truncate(model::offset offset) {
     lock_guard lk(*this);
 

--- a/src/v/storage/batch_cache.h
+++ b/src/v/storage/batch_cache.h
@@ -597,6 +597,11 @@ public:
     /// when from > to (empty range).
     bool has_contiguous_coverage(model::offset from, model::offset to) const;
 
+    /// Return the last offset of the contiguous range starting at \p from.
+    /// If \p from is not covered by the index, returns the offset before
+    /// \p from (i.e. no coverage).
+    model::offset contiguous_end(model::offset from) const;
+
     /**
      * Removes all batches that _may_ contain the specified offset.
      */


### PR DESCRIPTION
This PR has two followups for the prev. PR that improved tailing workloads.
* fix the metric to avoid registration of spurious cache misses
* fix the cache wait mechanism for tailing consumers to avoid missing notifications

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none