### PR TITLE
bazel: add clang-22 toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,6 +8,9 @@ build --linkopt -stdlib=libc++
 
 common:clang-21 --extra_toolchains=@next_llvm_toolchain//:all
 
+# llvm 22.1.0
+common:clang-22 --extra_toolchains=@clang-22_llvm_toolchain//:all
+
 # Use Bash instead of system python for finding the hermetic interpreter
 # within Bazel due to the `python3` binary not being present on CI
 # (it has `python` version 3 but Bazel uses the `python3` executable).

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -174,6 +174,19 @@ COMPILERS = {
         },
         "version": "21.1.6",
     },
+    "clang-22": {
+        "tars": {
+            "aarch64": {
+                "build_date": "2026-03-02",
+                "sha": "4fcc2b9cc39b98f63e63739a5229e0b73a2bc9b26d1f4681f12c2cf55ddcab6e",
+            },
+            "x86_64": {
+                "build_date": "2026-03-02",
+                "sha": "46eacaffa999ea1d0fcb83f28d3f1089363fbb389dfbcf043e6c5de7329dc0b3",
+            },
+        },
+        "version": "22.1.0",
+    },
 }
 
 [

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -4460,7 +4460,7 @@
     "@@toolchains_llvm+//toolchain/extensions:llvm.bzl%llvm": {
       "general": {
         "bzlTransitiveDigest": "c1HwgmsVfl3HQfJp5j/lYNFyGkE5EiG6RookiyKG0oM=",
-        "usagesDigest": "OXxJAxR1mn/Pqehud4kY2dgNEDreduIrM+5001WyCKE=",
+        "usagesDigest": "RyrGkIFp3swLydAVOUytW/zr4jpgLj3Af+cQ8J7aW3Y=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -4628,6 +4628,94 @@
               "link_libs": {},
               "llvm_versions": {
                 "": "21.1.6"
+              },
+              "opt_compile_flags": {},
+              "opt_link_flags": {},
+              "stdlib": {},
+              "target_settings": {},
+              "unfiltered_compile_flags": {},
+              "toolchain_roots": {},
+              "sysroot": {
+                "linux-x86_64": "'@@+non_module_dependencies+x86_64_sysroot//:sysroot'",
+                "linux-aarch64": "'@@+non_module_dependencies+aarch64_sysroot//:sysroot'"
+              }
+            }
+          },
+          "clang-22_llvm_toolchain_llvm": {
+            "repoRuleId": "@@toolchains_llvm+//toolchain:rules.bzl%llvm",
+            "attributes": {
+              "alternative_llvm_sources": [],
+              "auth_patterns": {},
+              "distribution": "auto",
+              "exec_arch": "",
+              "exec_os": "",
+              "extra_llvm_distributions": {},
+              "libclang_rt": {},
+              "llvm_mirror": "",
+              "llvm_version": "22.1.0",
+              "llvm_versions": {},
+              "netrc": "",
+              "sha256": {
+                "linux-aarch64": "4fcc2b9cc39b98f63e63739a5229e0b73a2bc9b26d1f4681f12c2cf55ddcab6e",
+                "linux-x86_64": "46eacaffa999ea1d0fcb83f28d3f1089363fbb389dfbcf043e6c5de7329dc0b3"
+              },
+              "strip_prefix": {},
+              "urls": {
+                "linux-aarch64": [
+                  "https://github.com/redpanda-data/llvm-project/releases/download/llvmorg-22.1.0/llvm-22.1.0-debian-11-aarch64-2026-03-02.tar.zst"
+                ],
+                "linux-x86_64": [
+                  "https://github.com/redpanda-data/llvm-project/releases/download/llvmorg-22.1.0/llvm-22.1.0-debian-11-x86_64-2026-03-02.tar.zst"
+                ]
+              }
+            }
+          },
+          "clang-22_llvm_toolchain": {
+            "repoRuleId": "@@toolchains_llvm+//toolchain:rules.bzl%toolchain",
+            "attributes": {
+              "absolute_paths": false,
+              "archive_flags": {},
+              "compile_flags": {
+                "linux-aarch64": [
+                  "--target=aarch64-unknown-linux-gnu",
+                  "-march=armv8-a+crc+crypto",
+                  "-U_FORTIFY_SOURCE",
+                  "-fstack-protector",
+                  "-fno-omit-frame-pointer",
+                  "-fcolor-diagnostics",
+                  "-Wall",
+                  "-Wthread-safety",
+                  "-Wself-assign"
+                ],
+                "linux-x86_64": [
+                  "--target=x86_64-unknown-linux-gnu",
+                  "-march=westmere",
+                  "-U_FORTIFY_SOURCE",
+                  "-fstack-protector",
+                  "-fno-omit-frame-pointer",
+                  "-fcolor-diagnostics",
+                  "-Wall",
+                  "-Wthread-safety",
+                  "-Wself-assign"
+                ]
+              },
+              "conly_flags": {},
+              "coverage_compile_flags": {},
+              "coverage_link_flags": {},
+              "cxx_builtin_include_directories": {},
+              "cxx_flags": {},
+              "cxx_standard": {
+                "": "c++23"
+              },
+              "dbg_compile_flags": {},
+              "exec_arch": "",
+              "exec_os": "",
+              "extra_exec_compatible_with": {},
+              "extra_target_compatible_with": {},
+              "link_flags": {},
+              "link_libs": {},
+              "llvm_versions": {
+                "": "22.1.0"
               },
               "opt_compile_flags": {},
               "opt_link_flags": {},

--- a/bazel/toolchain/Dockerfile.llvm
+++ b/bazel/toolchain/Dockerfile.llvm
@@ -25,6 +25,7 @@ RUN echo "deb http://archive.debian.org/debian bullseye-backports main" > /etc/a
       pkg-config
 
 ARG LLVM_VERSION=21
+ARG LLVM_REF=release/${LLVM_VERSION}.x
 
 RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && /llvm.sh ${LLVM_VERSION} all
 
@@ -41,7 +42,7 @@ WORKDIR /src
 # Clone LLVM project (includes Clang, clang-tidy, clangd, and BOLT)
 # We use the latest version of the release branch to pick up fixes quicker rather than waiting for a full
 # release to happen
-RUN git clone --depth 1 --branch release/${LLVM_VERSION}.x https://github.com/llvm/llvm-project.git
+RUN git clone --depth 1 --branch ${LLVM_REF} https://github.com/llvm/llvm-project.git
 
 # LTO builds take a bunch of RAM, limit them to a low number by default
 ARG MAX_LINK_JOBS=4

--- a/bazel/toolchain/README.md
+++ b/bazel/toolchain/README.md
@@ -37,6 +37,20 @@ docker run --rm --platform linux/arm64 debian:bullseye uname -a
 docker buildx build --platform=linux/arm64 --build-arg LLVM_VERSION=$LLVM_VERSION --file Dockerfile.llvm --output type=tar,dest=- . | zstd -o "$OUTPUT_FILE"
 ```
 
+### Building from a specific tag
+
+By default the Dockerfile builds from the `release/${LLVM_VERSION}.x` branch (latest on that release branch). To pin a specific LLVM tag instead, use the `LLVM_REF` build arg:
+
+```
+LLVM_VERSION=22
+LLVM_REF="llvmorg-22.1.0"
+OUTPUT_FILE="llvm-22.1.0-debian-11-x86_64-$(date --rfc-3339=date -u).tar.zst"
+echo "Building $OUTPUT_FILE"
+docker build --file Dockerfile.llvm --build-arg LLVM_VERSION=$LLVM_VERSION --build-arg LLVM_REF=$LLVM_REF --output type=tar,dest=- . | zstd -o "$OUTPUT_FILE"
+```
+
+`LLVM_VERSION` is still required to install the bootstrap compiler from apt.llvm.org. `LLVM_REF` can be a tag (`llvmorg-22.1.0`) or branch (`main`).
+
 ### LTO Builds
 
 By default we build with PGO+LTO, but if PGO is causing issues (like on AArch64), we can choose a different build (resulting

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -10,6 +10,8 @@
  */
 
 #pragma once
+#include "base/compiler_utils.h"
+
 #include <system_error>
 
 namespace cluster {
@@ -294,6 +296,12 @@ struct errc_category final : public std::error_category {
             return "A topic with the given id already exists";
         case errc::feature_sanctioned:
             return "Unable to use requested feature - license is invalid";
+            REDPANDA_BEGIN_IGNORE_DEPRECATIONS
+            // unused in the codebase but still in the enum, include it here
+            // since clang wants switches to be exhaustive
+        case errc::inconsistent_stm_update:
+            return "inconsistent_stm_update";
+            REDPANDA_END_IGNORE_DEPRECATIONS
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/errors.cc
+++ b/src/v/cluster/errors.cc
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
+#include "base/compiler_utils.h"
 #include "cluster/errc.h"
 
 #include <iostream>
@@ -186,6 +187,10 @@ std::ostream& operator<<(std::ostream& o, cluster::errc err) {
         return o << "cluster::errc::topic_id_already_exists";
     case errc::feature_sanctioned:
         return o << "cluster::errc::feature_sanctioned";
+        REDPANDA_BEGIN_IGNORE_DEPRECATIONS
+    case errc::inconsistent_stm_update:
+        return o << "cluster::errc::inconsistent_stm_update (deprecated)";
+        REDPANDA_END_IGNORE_DEPRECATIONS
     }
 
     // fallback path: we don't expect it, but this is better than just falling

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 #pragma once
+#include "base/compiler_utils.h"
 #include "cluster/cluster_link/errc.h"
 #include "cluster/errc.h"
 #include "cluster/tx_errc.h"
@@ -121,6 +122,10 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::topic_id_already_exists:
     case cluster::errc::feature_sanctioned:
         break;
+        REDPANDA_BEGIN_IGNORE_DEPRECATIONS
+    case cluster::errc::inconsistent_stm_update:
+        break;
+        REDPANDA_END_IGNORE_DEPRECATIONS
     }
     return error_code::unknown_server_error;
 }


### PR DESCRIPTION
Add clang-22 (LLVM 22.1.0) as a Bazel toolchain option. This lets us
start testing builds against the next LLVM release to catch issues early.

Also adds a `LLVM_REF` build arg to the toolchain Dockerfile so we can
pin builds to a specific tag rather than always tracking the release
branch tip.

The second commit handles the deprecated `inconsistent_stm_update` enum
value in switch statements — clang-22 enforces exhaustive switches more
strictly and warns on the missing case.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none