### PR TITLE
rptest: Use new args to openssl pkcs12 command

### DIFF
--- a/tests/rptest/services/tls.py
+++ b/tests/rptest/services/tls.py
@@ -504,7 +504,7 @@ class TLSCertManager:
         """
         p12_password = self.generate_password(length=pw_length)
         self._exec(
-            f"openssl pkcs12 -export -inkey {key} -in {crt} -certfile {ca} -passout pass:{p12_password} -out {p12_file}"
+            f"openssl pkcs12 -export -inkey {key} -in {crt} -certfile {ca} -passout pass:{p12_password} -out {p12_file} -certpbe AES-256-CBC -keypbe AES-256-CBC -macalg SHA256"
         )
         return p12_password
 


### PR DESCRIPTION
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

### Bug Fixes

Should fix DEVPROD-1907 if Claude is to be believed.