### PR TITLE
cluster: Remove ctp_stm dependency from partition

### DIFF
--- a/src/v/cloud_topics/housekeeper/BUILD
+++ b/src/v/cloud_topics/housekeeper/BUILD
@@ -30,6 +30,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics:state_accessors",
         "//src/v/cloud_topics/frontend",
         "//src/v/cloud_topics/level_one/metastore",
+        "//src/v/cloud_topics/level_zero/stm:ctp_stm",
         "//src/v/cloud_topics/level_zero/stm:ctp_stm_api",
         "//src/v/cluster",
         "//src/v/config",

--- a/src/v/cloud_topics/housekeeper/manager.cc
+++ b/src/v/cloud_topics/housekeeper/manager.cc
@@ -12,6 +12,7 @@
 
 #include "cloud_topics/frontend/frontend.h"
 #include "cloud_topics/housekeeper/housekeeper.h"
+#include "cloud_topics/level_zero/stm/ctp_stm.h"
 #include "cloud_topics/level_zero/stm/ctp_stm_api.h"
 #include "cloud_topics/logger.h"
 #include "cloud_topics/state_accessors.h"

--- a/src/v/cloud_topics/reconciler/BUILD
+++ b/src/v/cloud_topics/reconciler/BUILD
@@ -64,6 +64,7 @@ redpanda_cc_library(
     implementation_deps = [
         "//src/v/cloud_topics:logger",
         "//src/v/cloud_topics/frontend",
+        "//src/v/cloud_topics/level_zero/stm:ctp_stm",
         "//src/v/cloud_topics/level_zero/stm:ctp_stm_api",
         "//src/v/config",
         "//src/v/kafka/utils:txn_reader",

--- a/src/v/cloud_topics/reconciler/reconciliation_source.cc
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.cc
@@ -12,6 +12,7 @@
 
 #include "cloud_topics/data_plane_api.h"
 #include "cloud_topics/frontend/frontend.h"
+#include "cloud_topics/level_zero/stm/ctp_stm.h"
 #include "cloud_topics/level_zero/stm/ctp_stm_api.h"
 #include "cloud_topics/log_reader_config.h"
 #include "cloud_topics/logger.h"

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -12,6 +12,7 @@
 
 #include "absl/container/node_hash_map.h"
 #include "absl/container/node_hash_set.h"
+#include "cloud_topics/level_zero/stm/ctp_stm.h"
 #include "cluster/cloud_storage_size_reducer.h"
 #include "cluster/controller_service.h"
 #include "cluster/errc.h"
@@ -961,8 +962,11 @@ partition_status build_partition_status(const partition& p) {
     status.revision_id = p.get_revision_id();
     status.size_bytes = p.size_bytes() + p.non_log_disk_size_bytes();
     status.reclaimable_size_bytes = p.reclaimable_size_bytes();
-    status.cloud_topic_max_gc_eligible_epoch
-      = p.cloud_topic_max_gc_eligible_epoch();
+    auto ctp_stm = p.raft()->stm_manager()->get<cloud_topics::ctp_stm>();
+    if (ctp_stm) {
+        status.cloud_topic_max_gc_eligible_epoch
+          = ctp_stm->estimate_inactive_epoch();
+    }
     status.shard = ss::this_shard_id();
 
     if (p.ntp().ns == model::kafka_namespace && p.started()) {

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -474,11 +474,6 @@ ss::future<> partition::start(
     _partition_properties_stm
       = _raft->stm_manager()->get<cluster::partition_properties_stm>();
 
-    // the cloud topics stm provides access to garbage collection metadata. this
-    // metadata is collected into cluster health reports as a way to disseminate
-    // this information to the garbage collection process.
-    _ctp_stm = _raft->stm_manager()->get<cloud_topics::ctp_stm>();
-
     // Start the probe after the partition is fully initialised
     _probe.setup_metrics(ntp);
 
@@ -1843,13 +1838,6 @@ ss::future<result<ss::rwlock::holder>> partition::hold_writes_enabled() {
     }
 
     co_return *std::move(maybe_units);
-}
-
-std::optional<int64_t> partition::cloud_topic_max_gc_eligible_epoch() const {
-    if (_ctp_stm) {
-        return _ctp_stm->estimate_inactive_epoch();
-    }
-    return std::nullopt;
 }
 
 ss::sharded<cloud_topics::state_accessors>*

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include "cloud_storage/fwd.h"
-#include "cloud_topics/level_zero/stm/ctp_stm.h"
 #include "cluster/archival/archival_metadata_stm.h"
 #include "cluster/archival/fwd.h"
 #include "cluster/fwd.h"
@@ -402,10 +401,6 @@ public:
     ss::sharded<cloud_topics::state_accessors>*
     get_cloud_topics_state() noexcept;
 
-    // If this is a cloud topics partition then the max GC eligible epoch (if
-    // any) is returned.
-    std::optional<int64_t> cloud_topic_max_gc_eligible_epoch() const;
-
 private:
     ss::future<>
     replicate_unsafe_reset(cloud_storage::partition_manifest manifest);
@@ -432,7 +427,6 @@ private:
     ss::shared_ptr<archival_metadata_stm> _archival_meta_stm;
     ss::shared_ptr<partition_properties_stm> _partition_properties_stm;
     ss::sharded<cloud_topics::state_accessors>* _cloud_topics_state;
-    ss::shared_ptr<cloud_topics::ctp_stm> _ctp_stm;
     ss::abort_source _as;
     partition_probe _probe;
     ss::sharded<features::feature_table>& _feature_table;


### PR DESCRIPTION
The partition.h header no longer includes ctp_stm.h header. The header was needed to store the pointer to the stm directly in the partition. The stm was used to implement
cloud_topic_max_gc_eligible_epoch method. The method was only used in the health_monitor_backend. This commit removes this and fetches the STM directly from the stm_manager in the health_monitor_backend.

This improves the situation with dependencies a bit. The partitin.h header is included in a lot of places. If the ctp_stm.h header is included there huge part of redpana depends on it implicitly. After this change the ctp_stm header is included in the health_monitor_backend.cc

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none