### PR TITLE
Claude md improvements

### DIFF
--- a/.claude/rules/cpp.md
+++ b/.claude/rules/cpp.md
@@ -26,7 +26,7 @@ the coroutine frame. Required for memory safety, not just style.
 - Don't call `.get_exception()` inside log/assert args — assign to a variable first
 
 ## Naming & style
-- snake_case for identifiers, CamelCase for concepts
+- snake_case uniformly — identifiers, class names, namespaces, file names
 - `/// \brief` Doxygen on public types
 - Map strings to values with `string_switch` (`src/v/strings/string_switch.h`), not if-else chains
 

--- a/.claude/rules/cpp.md
+++ b/.claude/rules/cpp.md
@@ -1,0 +1,41 @@
+---
+paths:
+  - "src/v/**/*.{h,cc}"
+  - "src/transform-sdk/cpp/**/*.{h,cc}"
+---
+
+# C++ Conventions
+
+## Seastar patterns
+- Prefix Seastar types with `ss::` (e.g. `ss::future`, `ss::promise`, `ss::logger`)
+- Assertions: `vassert(cond, msg, args...)` — always enabled, logs message. Use `dassert` for debug-only.
+- Logging: `vlog(logger.level, fmt, args...)` e.g. `vlog(stlog.info, "msg {}", val)` where `stlog` is `ss::logger stlog("storage")`
+
+## Coroutine / lambda capture safety
+Lambda coroutines passed to `seastar::future::then()` risk use-after-free: the lambda object is
+freed when the continuation returns, but the coroutine frame may still reference its captures.
+
+Fix: use C++23 "deducing this" — `[captures...](this auto, args...)` — which moves captures into
+the coroutine frame. Required for memory safety, not just style.
+
+## Don't
+- Don't use `std::vector` for large containers — use `chunked_vector`
+- Don't use `std::unordered_map` for large containers — use `chunked_hash_map`
+- Don't declare `operator<<(ostream&, T)` — use a `format_to` member (see `src/v/base/format_to.h`)
+- Don't use `ss::parallel_for_each` on large ranges (partitions, topics, segments) — use `ss::max_concurrent_for_each`
+- Don't call `.get_exception()` inside log/assert args — assign to a variable first
+
+## Naming & style
+- snake_case for identifiers, CamelCase for concepts
+- `/// \brief` Doxygen on public types
+- Map strings to values with `string_switch` (`src/v/strings/string_switch.h`), not if-else chains
+
+## Comments
+Default to no comments. Add for: non-obvious algorithms, gotchas, wire protocol mappings,
+ASCII state diagrams, and links to external specs. Don't restate what the code says.
+
+## Benchmarks
+```bash
+bazel run --config=release //src/v/utils/tests:coro_rpbench -- --help
+```
+See also: `external/+non_module_dependencies+seastar/tests/perf/perf-tests.md`

--- a/.claude/rules/go.md
+++ b/.claude/rules/go.md
@@ -1,0 +1,22 @@
+---
+paths:
+  - "src/go/**/*.go"
+---
+
+# Go Conventions (rpk)
+
+## Error handling
+- Define sentinel errors as package-level vars: `var ErrFoo = errors.New("...")`
+- Wrap errors with context: `fmt.Errorf("unable to do X %q: %w", val, err)`
+- Check wrapped errors with `errors.Is()`, not string comparison
+- Return early; avoid deeply nested error checks
+
+## Logging
+- No logging in utility/library functions — log only in command handlers
+- Structured logging via `zap.L().Sugar()` or the config logger `p.Logger()`
+- CLI output (tables, JSON, YAML) goes through the `out` package, not fmt/log
+
+## Structure
+- One package per feature area (e.g. `oauth/`, `schemaregistry/`, `adminapi/`)
+- Config flows through `*config.Params` passed to command handlers
+- Constructor pattern: `NewClient(fs afero.Fs, p *config.Params) (*Client, error)`

--- a/.claude/rules/proto.md
+++ b/.claude/rules/proto.md
@@ -1,0 +1,10 @@
+---
+paths:
+  - "proto/**/*.proto"
+---
+
+# Protobuf Conventions
+
+Follow `proto/redpanda/README.md` for coding standards.
+
+Formatting is enforced by `.clang-format` — run `bazel run //tools:clang_format` before committing.

--- a/.claude/rules/python.md
+++ b/.claude/rules/python.md
@@ -6,5 +6,17 @@ paths:
 
 # Python Conventions
 
+## Style
 - Use `except Exception:` not bare `except:` — bare except swallows signals used for test timeouts
 - Use `|` for type unions, not `Union`/`Optional`
+
+## Integration tests (tests/rptest/)
+Tests run against a live cluster via the ducktape framework — there are no mocks.
+
+Test structure:
+- Inherit from `RedpandaTest`; cluster starts in `setUp()` automatically
+- Declare cluster size with `@cluster(num_nodes=N)` on each test method
+- Use `wait_until(fn, timeout_sec=N, backoff_sec=N)` for async assertions — never sleep
+- Access the broker via `self.redpanda` (service) and `self.client()` (Kafka client)
+- Use `self.logger.info()` for test logging
+- Parameterize with `@parametrize(key=value)` rather than duplicating test methods

--- a/.claude/rules/python.md
+++ b/.claude/rules/python.md
@@ -1,0 +1,10 @@
+---
+paths:
+  - "tests/**/*.py"
+  - "tools/**/*.py"
+---
+
+# Python Conventions
+
+- Use `except Exception:` not bare `except:` — bare except swallows signals used for test timeouts
+- Use `|` for type unions, not `Union`/`Optional`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,31 @@ Before marking any task done, run in order:
 2. `bazel test <relevant targets>`
 3. `bazel run //tools:clang_format` — must produce no diff
 
+## Architecture
+
+Redpanda is sharded and thread-per-core. Each CPU core runs one Seastar reactor
+shard. Cross-shard calls use `peering_sharded_service::invoke_on(shard, fn)` —
+never shared memory.
+
+Write path:
+```
+Kafka client → src/v/kafka/   (protocol parsing, request routing)
+             → src/v/raft/    (consensus, replication to followers)
+             → src/v/storage/ (log segment append, fsync)
+```
+
+Key subsystems:
+```
+src/v/raft/          HIGH RISK — consensus; bugs cause data loss or split-brain
+src/v/storage/       HIGH RISK — log segments; bugs corrupt persistent data
+src/v/cluster/       partition leadership, membership, metadata coordination
+src/v/kafka/         Kafka protocol translation; no persistent state of its own
+src/v/cloud_storage/ tiered storage (S3/GCS offload)
+src/v/ssx/           Seastar extensions (futures, semaphores, background tasks)
+src/v/container/     chunked_vector, chunked_hash_map
+src/go/rpk/          CLI; no broker-side state
+```
+
 ## Don't
 - Don't open PRs against `main` — always target `dev`
 - Don't manually install C++ deps — Bazel manages them via `MODULE.bazel`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,260 +1,41 @@
-# Copilot Coding Agent Onboarding Guide for `redpanda-data/redpanda`
+# Redpanda
 
-## High-Level Overview
+High-performance, Kafka-compatible streaming platform. Core in C++23 (Seastar, thread-per-core), CLI in Go (`rpk`), integration tests in Python.
 
-**What is Redpanda?**
+## Stack
+- Core: `src/v/` (C++23, Seastar, Bazel)
+- CLI: `src/go/rpk/`
+- Tests: `tests/rptest/` (Python), plus Bazel unit tests
+- Protos: `proto/`
+- Build: Bazel via Bazelisk — never use a plain `bazel` binary
 
-Redpanda is a high-performance, Apache Kafka®-compatible streaming data platform. It is written primarily in C++ for the core, with Go for CLI tooling (`rpk`), and some Python for auxiliary scripts and tests. Redpanda is designed to be lightweight, fast, and simple to operate, omitting ZooKeeper and the JVM.
-
-It uses extensively the thread-per-core model and asynchronous (coroutines, futures) programming model.
-
-**Repository Characteristics:**
-- **Large multi-language codebase:** C++ (core), Go (CLI/tools), Python (testing/scripts), Bash and Bazel for builds.
-- **Build System:** Bazel (with Bazelisk) for core.
-- **Target Platforms:** Linux (primary), some support for macOS and Windows.
-- **Key Directories:**
-  - `src/v/`: Core C++ source code
-  - `src/go/`: Go CLI and tools
-  - `bazel/`, `BUILD`, `MODULE.bazel`: Bazel scripts and definitions
-  - `tools/`: Development and helper scripts
-  - `tests/`: Test suites
-  - `conf/`: Configuration files
-  - `proto/`: Protobuf definitions for Redpanda services and APIs
-  - `.github/`, `.buildkite/`: CI/workflow automation
-- **Documentation:** [Docs site](https://redpanda.com/documentation) and `docs/`.
-
-## Build, Test, and Validation Instructions
-
-### Prerequisites (Always Perform)
-
-1. **Install Bazelisk** (the required Bazel wrapper):
-   ```bash
-   wget -O ~/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64
-   chmod +x ~/bin/bazel
-   export PATH="$HOME/bin:$PATH"
-   ```
-2. **Install system dependencies**:
-   ```bash
-   sudo ./bazel/install-deps.sh
-   ```
-   _This must always be run before any Bazel build, especially on a fresh system or after dependency updates._
-
-### Core Build Steps
-
-- **Build all (fastbuild):**
-  ```bash
-  bazel build //...
-  ```
-- **Test all:**
-  ```bash
-  bazel test //...
-  ```
-- **Lint (C++):**
-  - Formatting and linting are enforced. Use:
-    ```bash
-    bazel run //tools:clang_format
-    ```
-  - Configs: `.clang-format`, `.clang-tidy`, etc.
-
-- **Go CLI (`rpk`) Build:**
-  ```bash
-  bazel build //:rpk
-  ```
-
-See `.bazelrc` for more details on build settings and config modes
-
-### Validation and CI
-
-- **Pre-push/merge:** All changes are validated by CI (GitHub Actions, Buildkite) for build, test, and lint.
-- **Formatting and lint checks are enforced; run locally before PRs.**
-- **Target branch:** Always open PRs against `dev`.
-
-## Project Layout & Architectural Notes
-
-- **Main C++ source:** `src/v/`
-- **Go CLI:** `src/go/rpk/`
-- **Build configuration:** `.bazelrc`, `.bazelversion`, `BUILD`, `MODULE.bazel`, and `bazel/`
-- **CI configuration:** `.github/workflows/`, `.buildkite/`
-- **Testing:** `tests/`
-- **Config:** `conf/`
-- **Docker:** `tools/docker/`
-
-### Lint/Formatting Configs:
-- `.clang-format`, `.clang-tidy*`: C++ style
-- `.style.yapf`, `.yapfignore`: Python formatting
-
-### CI/CD Checks
-
-- **Build, test, and lint are enforced by CI.** Use the same steps as above locally before PRs.
-
-### File Index (Root Level)
-- `.bazelignore`, `.bazelrc`, `.bazelversion`, `BUILD`, `MODULE.bazel`, `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `LICENSES/`, `bazel/`, `src/`, `tests/`, `conf/`, `tools/`, `.github/`, `.buildkite/`, etc.
-
----
-
-## Protobuf-Specific Instructions
-
-### Protobuf Coding Guidelines
-
-Follow the guidelines provided in `proto/redpanda/README.md` for basic Protobuf standards.
-
-### Protobuf Build & Environment
-- **Primary Protobuf code lives in `proto/`.**
-- **Formatting:** `.clang-format` in the root directory is enforced. Always run `clang-format` before committing changes or submitting a PR:
-  ```bash
-  bazel run //tools:clang_format
-  ```
-
-## C++-Specific Instructions
-
-### C++ Build & Environment
-
-- **Primary C++ code lives in `src/v/`.**
-- **C++ build is managed by Bazel.** All dependencies and toolchains are configured via Bazel rules and the `MODULE.bazel` file. Do not manually install C++ dependencies unless explicitly instructed in documentation.
-- **Compiler Standard:** C++23 is required. Some SDK components (e.g., `src/transform-sdk/cpp/`) use C++23 and specific flags like `-Wall`, `-fno-exceptions`, and for some targets, `-stdlib=libc++`.
-- **Sanitizers:** Some components and test builds use sanitizers (address, leak, undefined) via `-fsanitize=address,leak,undefined` for both compile and link.
-- **Suppression Files:** Leak, undefined, and other sanitizer suppressions can be found in the root as `lsan_suppressions.txt`, `ubsan_suppressions.txt`.
-- **C++ Linting:** `.clang-format` and `.clang-tidy` in the root directory are enforced. Always run `clang-format` before committing changes or submitting a PR:
-  ```bash
-  bazel run //tools:clang_format
-  ```
-- **C++ Libraries:** Bazel dependencies are managed in `MODULE.bazel` (e.g., Boost, Abseil, fmt, protobuf, googletest, yaml-cpp, etc.).
-- **Testing:** C++ unit tests are run via Bazel.
-
-### Common C++ Pitfalls & Workarounds
-
-- **Always use Bazelisk and Bazel for building the core.** Using a plain Bazel binary may result in missing dependencies or incompatible flags.
-- **If you encounter build issues related to missing system libraries, rerun `sudo ./bazel/install-deps.sh`.**
-- **Do not attempt to manually install or update C++ dependencies unless specifically instructed.**
-- **Always run lint and formatter before pushing. CI will fail on formatting/lint discrepancies.**
-- **If building in CI or a containerized environment, ensure the correct toolchain is available as specified in `tools/docker/README.md` or CI scripts.**
-- **Check for additional build and compile flags in `BUILD`, `MODULE.bazel` and related files.**
-
-### C++ coding guidelines
-
-Check that these guidelines are followed for new code.
-
-- Do not declare new `operator<<(ostream& os, type)` overloads, instead prefer to use a `format_to` member function inside `type` as described in
-src/v/base/format_to.h.
-- Prefer using latest C++ features (C++23).
-- Use `ss` namespace as a prefix for Seastar types (e.g. `ss::future`, `ss::promise`).
-- Use `vassert(cond, msg, msg_args...)` macro for assertions. It is
-  similar to `assert(cond)` but it is always enabled and it prints the message
-  to the log. Use `dassert` for assertions that are only enabled in debug mode.
-- Use `vlog(method, fmt, args...)` for logging. `method` is the method reference
-  for the logger to use. I.e. `vlog(stlog.info, "Hello world");`. Where `stlog`
-  is defined as `ss::logger stlog("storage");`.
-- Do not use `std::vector` for containers that may grow very large, instead use `chunked_vector`.
-- Do not use `std::unordered_map` for containers that may grow very large, instead use `chunked_hash_map`.
-- Instead of long if-else chains for mapping string to values, use
-  `string_switch` mechanism defined in
-  [string_switch.h](./src/v/strings/string_switch.h).
-- Don't use `ss::parallel_for_each` with ranges that can grow large such as
-  partitions, topics or segments. Instead prefer `ss::max_concurrent_for_each` to
-  limit concurrency. Think about how much concurrency is needed to adequately hide
-  latency. See our
-  [docs](https://redpandadata.atlassian.net/wiki/x/AQBZTw#Managing-Concurrency-in-the-system)
-  for more background.
-- Do not call the `get_exception` method on a future within a logging or
-  assertion statement (e.g. `vlog(..., fut.get_exception(), ...)`). Instead,
-  assign the return value of `get_exception` in a variable and pass the variable.
-
-#### Lambda coroutines, coroutine argument capture, and deducing this
-
-When a lambda coroutine is passed to APIs like `seastar::future::then()`,
-the lambda object is stored in managed memory that gets freed once the
-continuation returns—but the coroutine may still be suspended and later
-access its captures, causing use-after-free. This happens because the
-coroutine frame holds a reference to the lambda's capture storage, which
-becomes dangling. The C++23 "deducing this" syntax
-`([captures...](this auto, args...))` solves this by moving the captures
-directly into the coroutine frame rather than referencing them through the
-lambda object, decoupling capture lifetime from the lambda's lifetime.
-This is distinct from the recursive-lambda use case—here this auto is required
-for memory safety in coroutines, not self-reference.
-
-### C++ coding style
-
-- Use snake_case for identifiers. Use CamelCase for concepts.
-- Use Doxygen comments with 3-slashes (///) for public APIs
-
-### Code comments
-
-- **Default to no comments** - clear code and good names are better
-- **Avoid comments that restate the code** - they become stale
-- **Prefer alternatives:**
-  - Better variable/function names
-  - Log lines (serve as documentation and debugging)
-- **Do add comments for:**
-  - Doc comments (`/// \brief`) on public types explaining purpose/usage
-  - Complex algorithms or non-obvious "gotchas"
-  - Test comments explaining input format or test intent
-  - Links to external resources (specs, docs, issues)
-  - Mapping internal types/concepts to external formats (e.g., wire protocols, APIs)
-  - ASCII diagrams for complex state machines or data flows
-- **Avoid obvious branching comments** - `if (x)` rarely needs `// when x is true`
-
-### Benchmarking
-
-  - Run benchmarks like `bazel run --config=release //src/v/utils/tests:coro_rpbench`
-  - Get --help like: `bazel run --config=release //src/v/utils/tests:coro_rpbench -- --help`
-  - If running/writing benchmarks read this also: external/+non_module_dependencies+seastar/tests/perf/perf-tests.md
-
-### More C++-Specific References
-
-- [MODULE.bazel](https://github.com/redpanda-data/redpanda/blob/dev/MODULE.bazel)
-- [BUILD](https://github.com/redpanda-data/redpanda/blob/dev/BUILD)
-
----
-
-## Python specific instructions
-
-### Instructions for python test code under tests/rptest
-
-- Avoid catching bare `except:` as this can hide system exceptions, including exceptions
-  raised by a signal when a test is being forcibly timed out. Instead use `except Exception:`.
-
-### Instructions for type hints
-
-- Use modern style with `|` instead of `Union` or `Optional`
-
-For further details, consult:
-- [README.md](https://github.com/redpanda-data/redpanda/blob/dev/README.md)
-- [CONTRIBUTING.md](https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md)
-- [Redpanda Documentation](https://redpanda.com/documentation)
-- CI/CD configs in `.github/workflows/` and `.buildkite/`
-
----
-
-## Commit message instructions
-
-When writing or critiquing commit messages, follow these guidelines:
-
-**Format:**
-```
-area[/detail]: short description
-
-<optional body>
-```
-
-- Title: ≤72 chars
-- Body: wrapped at 72 chars
-
-**Check git history first** to match the style of the area you're changing:
+## Commands
 ```bash
-git log --oneline --no-merges -- path/to/changed/files | head -20
+# Build
+bazel build //...
+bazel build //:rpk          # Go CLI only
+
+# Test
+bazel test //...
+
+# Lint/format — MUST pass before any PR
+bazel run //tools:clang_format
 ```
 
-**Goal:** Make the commit easy to review and provide context for future readers (via `git blame`/`git log`)
+## Verification
+Before marking any task done, run in order:
+1. `bazel build //...` (or the specific target)
+2. `bazel test <relevant targets>`
+3. `bazel run //tools:clang_format` — must produce no diff
 
-**Rules:**
-- Title: imperative mood, lowercase after colon, no period
-- Keep bodies concise (1-2 lines typical, trivial changes need only a title)
-- Don't reference GitHub issues/PRs or Jira tickets
-- Use the body to help reviewers and future readers understand:
-  - The "why": motivation, design choices, preparation for future work
-  - The "what": new abstractions introduced, non-obvious changes
-  - Integration tests: briefly note what behaviors are covered
-- Don't restate what's obvious from the diff, but duplicating a doc comment is fine if it helps reviewers understand the change faster.
+## Don't
+- Don't open PRs against `main` — always target `dev`
+- Don't manually install C++ deps — Bazel manages them via `MODULE.bazel`
 
-_Results from code search may be incomplete. For more C++ details, see the [repository code search](https://github.com/redpanda-data/redpanda/search?q=c%2B%2B)._
+## Commit messages
+Format: `area[/detail]: short description` (≤72 chars, imperative mood, lowercase after colon, no period)
+
+Check area style first: `git log --oneline --no-merges -- <path> | head -20`
+
+Body: explain the "why" and non-obvious "what" in 1–2 lines. Don't reference GitHub issues or Jira tickets.
+


### PR DESCRIPTION
Restructures Claude Code context files to improve instruction adherence. The root CLAUDE.md had grown to ~260 lines — well past the point where Claude reliably follows all instructions.                                                                                                                          
                                                                                                                                                                
  Changes:                                                                                                                                                      
  - Rewrote root CLAUDE.md as a lean ~65-line brief covering stack, commands, verification loop, architecture, and commit format                              
  - Moved C++, proto, Python, and Go conventions into .claude/rules/ with path-scoped frontmatter so they only load when relevant files are opened              
  - Added architecture diagram and subsystem risk map (verified against source)                                                                               
  - Added rptest test infrastructure patterns and rpk Go conventions (both verified by reading actual source files)                                             
  - Fixed an incorrect naming convention (CamelCase for concepts — not evidenced in the codebase; uniformly snake_case) 
 
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
