### PR TITLE
bazel/test: add test_regex option to redpanda_cc_bench

### DIFF
--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -497,7 +497,7 @@ def redpanda_cc_bench(
     # we write a wrapper to test the benchmark, which tries to
     # run it as quickly as possible in order to smoke test it
     test_data, test_env = _test_options()
-    test_args = args + ["--iterations=1 --runs=1 --duration=0 --overprovisioned"]
+    test_args = args + ["--iterations=1 --runs=1 --duration=0 --no-stdout --overprovisioned"]
     if test_regex != None:
         test_args = test_args + ["-t {}".format(test_regex)]
     py_test(

--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -390,7 +390,8 @@ def redpanda_cc_bench(
         duration = None,
         data = [],
         tags = [],
-        redirect_stderr = False):
+        redirect_stderr = False,
+        test_regex = None):
     """
     Create a seastar benchmark target
 
@@ -410,6 +411,8 @@ def redpanda_cc_bench(
       timeout: the timeout for smoke testing the benchmark
       redirect_stderr: if True, redirects stdout (seastar logging, mostly) to a file
                        so that it does not overwhelm the result output
+      test_regex: optional regex passed as `-t <regex>` to the smoke test to select
+                  a subset of benchmarks to run
     """
 
     # We require this naming convention as we do things like extract
@@ -494,6 +497,9 @@ def redpanda_cc_bench(
     # we write a wrapper to test the benchmark, which tries to
     # run it as quickly as possible in order to smoke test it
     test_data, test_env = _test_options()
+    test_args = args + ["--iterations=1 --runs=1 --duration=0 --overprovisioned"]
+    if test_regex != None:
+        test_args = test_args + ["-t {}".format(test_regex)]
     py_test(
         name = name + "_test",
         timeout = timeout,
@@ -501,6 +507,6 @@ def redpanda_cc_bench(
         tags = resource_tags + tags,
         srcs = ["//bazel:bench_wrapper"],
         env = test_env | env,
-        args = args + ["--iterations=1 --runs=1 --duration=0 --no-stdout --overprovisioned"],
+        args = test_args,
         data = [":" + binary_name] + data + test_data,
     )

--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -409,7 +409,7 @@ def redpanda_cc_bench(
       data: any data files available to the benchmark as runfiles
       tags: custom tags for the test
       timeout: the timeout for smoke testing the benchmark
-      redirect_stderr: if True, redirects stdout (seastar logging, mostly) to a file
+      redirect_stderr: if True, redirects stderr (seastar logging, mostly) to a file
                        so that it does not overwhelm the result output
       test_regex: optional regex passed as `-t <regex>` to the smoke test to select
                   a subset of benchmarks to run

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -274,6 +274,7 @@ redpanda_cc_bench(
     srcs = [
         "record_multiplexer_bench.cc",
     ],
+    test_regex = ".*_linear_1_field_small",
     deps = [
         ":catalog_and_registry_fixture",
         ":record_generator",

--- a/src/v/pandaproxy/schema_registry/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/test/BUILD
@@ -492,6 +492,9 @@ redpanda_cc_bench(
     srcs = [
         "api_bench.cc",
     ],
+    # this bench is very slow, because posting many versions & subjects
+    # in setup_bench is slow, so in test mode, run only the 1, 1 test
+    test_regex = ".*(lookup|post)_x1_1",
     deps = [
         ":client_utils",
         ":protobuf_utils",


### PR DESCRIPTION
Add an optional `test_regex` parameter to `redpanda_cc_bench` that passes
`-t <regex>` to the smoke test target only, allowing BUILD files to select
a subset of benchmarks to run during testing.

Use it for `record_multiplexer_rpbench` and `api_rpbench` to skip slow
benchmark variants during smoke testing, reducing runtime from ~4 minutes
to ~12 seconds.

## Backports Required

- [x] none - not a bug fix

## Release Notes

* none