### PR TITLE
ct/frontend: clamp aborted txn ranges to log start

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -159,12 +159,17 @@ get_aborted_transactions_local(
     auto source = co_await p.aborted_transactions(
       offsets.begin_rp, offsets.end_rp);
 
+    // We trim beginning of aborted ranges to raft_start_offset because we
+    // don't have offset translation info for earlier offsets. This mirrors
+    // the logic in replicated_partition::aborted_transactions_local().
+    auto trim_at = p.raft_start_offset();
+
     std::vector<cluster::tx::tx_range> target;
     target.reserve(source.size());
     for (const auto& range : source) {
         target.emplace_back(
           range.pid,
-          ot_state->from_log_offset(range.first),
+          ot_state->from_log_offset(std::max(trim_at, range.first)),
           ot_state->from_log_offset(range.last));
     }
 


### PR DESCRIPTION
The cloud topics frontend was missing this trimming step. It meant that aborted transaction ranges before the start of the log could attempt to be offset-translated, leading to boom which could stall reconciliation.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
