### PR TITLE
`ct`: `describe-storage` impl for cloud topics

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -2,7 +2,7 @@ version: v2
 managed:
   enabled: false
 inputs:
-  - module: buf.build/redpandadata/core:ddc363cdd034
+  - module: buf.build/redpandadata/core:ddc363cdd034400c82feaf6544928665
     paths:
       - redpanda/core/admin/v2/shadow_link.proto
       - redpanda/core/common/v1/acl.proto

--- a/src/go/rpk/pkg/cli/topic/describe_storage.go
+++ b/src/go/rpk/pkg/cli/topic/describe_storage.go
@@ -145,10 +145,13 @@ func newDescribeStorageCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				// We can safely pick the value of the first partition since
 				// the cloud storage mode doesn't change between partitions of
 				// the same topic.
-				tw.PrintColumn("CLOUD-STORAGE-MODE", report[0].CloudStatus.CloudStorageMode)
+				mode := report[0].CloudStatus.CloudStorageMode
+				tw.PrintColumn("CLOUD-STORAGE-MODE", mode)
 
-				lastUpload := getLastUpload(report)
-				tw.PrintColumn("LAST-UPLOAD", humanReadable(lastUpload, human, humanTime))
+				if mode != "cloud_topic" && mode != "cloud_topic_read_replica" {
+					lastUpload := getLastUpload(report)
+					tw.PrintColumn("LAST-UPLOAD", humanReadable(lastUpload, human, humanTime))
+				}
 			})
 
 			sections.Add(secOffsets, func() {
@@ -166,17 +169,36 @@ func newDescribeStorageCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			})
 
 			sections.Add(secSize, func() {
-				tw := out.NewTable("PARTITION", "CLOUD-BYTES", "LOCAL-BYTES", "TOTAL-BYTES", "CLOUD-SEGMENTS", "LOCAL-SEGMENTS")
-				defer tw.Flush()
-				for _, r := range report {
-					tw.Print(
-						r.Partition,
-						humanReadable(r.CloudStatus.CloudLogBytes, human, humanSize),
-						humanReadable(r.CloudStatus.LocalLogBytes, human, humanSize),
-						humanReadable(r.CloudStatus.TotalLogBytes, human, humanSize),
-						r.CloudStatus.CloudLogSegmentCount,
-						r.CloudStatus.LocalLogSegmentCount,
-					)
+				mode := report[0].CloudStatus.CloudStorageMode
+				isCloudTopic := mode == "cloud_topic" || mode == "cloud_topic_read_replica"
+				if isCloudTopic {
+					tw := out.NewTable("PARTITION", "LOCAL-BYTES", "L0-BYTES", "L1-BYTES", "TOTAL-BYTES", "L1-EXTENTS")
+					defer tw.Flush()
+					for _, r := range report {
+						l1 := r.CloudStatus.CloudLogBytes
+						l0 := r.CloudStatus.TotalLogBytes - l1
+						tw.Print(
+							r.Partition,
+							humanReadable(r.CloudStatus.LocalLogBytes, human, humanSize),
+							humanReadable(l0, human, humanSize),
+							humanReadable(l1, human, humanSize),
+							humanReadable(r.CloudStatus.TotalLogBytes, human, humanSize),
+							r.CloudStatus.CloudLogSegmentCount,
+						)
+					}
+				} else {
+					tw := out.NewTable("PARTITION", "CLOUD-BYTES", "LOCAL-BYTES", "TOTAL-BYTES", "CLOUD-SEGMENTS", "LOCAL-SEGMENTS")
+					defer tw.Flush()
+					for _, r := range report {
+						tw.Print(
+							r.Partition,
+							humanReadable(r.CloudStatus.CloudLogBytes, human, humanSize),
+							humanReadable(r.CloudStatus.LocalLogBytes, human, humanSize),
+							humanReadable(r.CloudStatus.TotalLogBytes, human, humanSize),
+							r.CloudStatus.CloudLogSegmentCount,
+							r.CloudStatus.LocalLogSegmentCount,
+						)
+					}
 				}
 			})
 
@@ -254,7 +276,8 @@ given topic, the information is divided in 4 sections:
 SUMMARY
 
 The summary section contains general information about the topic, the cloud
-storage mode (one of disabled, write_only, read_only, full, and read_replica),
+storage mode (one of disabled, write_only, read_only, full, read_replica,
+cloud_topic, and cloud_topic_read_replica),
 and the delta in milliseconds since the last upload of either the partition
 manifest or a segment.
 
@@ -265,10 +288,14 @@ partition of data available in both the cloud and on local disk.
 
 SIZE
 
-The size section contains the total bytes per partition in the cloud and on
-local disk, the total size of the log of each partition (excluding cloud and
-local overlap), and the number of segments in the cloud and on local disk. The
-cloud segment count does not include segments queued for deletion.
+For tiered storage topics, the size section contains the total bytes per
+partition in the cloud and on local disk, the total size of the log of each
+partition (excluding cloud and local overlap), and the number of segments in
+the cloud and on local disk. The cloud segment count does not include segments
+queued for deletion.
+
+For cloud topics, the size section shows the L0 (level zero) and L1 (level
+one) byte breakdown, the total bytes, and the number of L1 extents.
 
 SYNC
 

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -338,13 +338,11 @@ frontend::make_l0_reader(const cloud_topic_log_reader_config& cfg) const {
       cfg, _partition, _data_plane);
 }
 
-ss::future<size_t> frontend::size_bytes() {
-    auto l0_size = _ctp_stm_api->estimated_data_size();
-
+ss::future<std::optional<l1::metastore::size_response>> frontend::l1_size() {
     // If we have never reconciled there is no L1 data to query.
     auto lro = _ctp_stm_api->get_last_reconciled_offset();
     if (lro < kafka::offset{0}) {
-        co_return l0_size;
+        co_return std::nullopt;
     }
 
     auto ct_state = _partition->get_cloud_topics_state();
@@ -352,7 +350,7 @@ ss::future<size_t> frontend::size_bytes() {
 
     auto tidp = topic_id_partition();
     if (!tidp) {
-        co_return 0;
+        co_return std::nullopt;
     }
     auto size_res = co_await l1_metastore->get_size(*tidp);
     if (!size_res.has_value()) {
@@ -361,6 +359,23 @@ ss::future<size_t> frontend::size_bytes() {
           "Could not fetch L1 partition size for {}: {}",
           tidp,
           size_res.error());
+        co_return std::nullopt;
+    }
+
+    co_return size_res.value();
+}
+
+ss::future<size_t> frontend::size_bytes() {
+    auto l0_size = get_l0_size_estimate();
+
+    // If we have never reconciled there is no L1 data to query.
+    auto lro = _ctp_stm_api->get_last_reconciled_offset();
+    if (lro < kafka::offset{0}) {
+        co_return l0_size;
+    }
+
+    auto l1_size_res = co_await l1_size();
+    if (!l1_size_res) {
         /*
          * If we can't get an estimate of L1 we return 0 without reporting L0.
          * The rationale here is that if we are going to have size estimates
@@ -370,7 +385,7 @@ ss::future<size_t> frontend::size_bytes() {
         co_return 0;
     }
 
-    co_return size_res.value().size + l0_size;
+    co_return l0_size + l1_size_res.value().size;
 }
 
 std::unique_ptr<model::record_batch_reader::impl> frontend::make_l1_reader(

--- a/src/v/cloud_topics/frontend/frontend.h
+++ b/src/v/cloud_topics/frontend/frontend.h
@@ -11,6 +11,7 @@
 
 #include "base/format_to.h"
 #include "cloud_topics/frontend/errc.h"
+#include "cloud_topics/level_one/metastore/metastore.h"
 #include "cloud_topics/level_zero/stm/ctp_stm_api.h"
 #include "cloud_topics/log_reader_config.h"
 #include "cloud_topics/types.h"
@@ -151,6 +152,7 @@ public:
 
     ss::future<std::error_code> linearizable_barrier();
 
+    ss::future<std::optional<l1::metastore::size_response>> l1_size();
     ss::future<size_t> size_bytes();
 
     /// Get the current cluster epoch

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -592,6 +592,7 @@ db_domain_manager::get_size(rpc::get_size_request req) {
     co_return rpc::get_size_reply{
       .ec = rpc::errc::ok,
       .size = metadata.size,
+      .num_extents = metadata.num_extents,
     };
 }
 

--- a/src/v/cloud_topics/level_one/domain/simple_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/simple_domain_manager.cc
@@ -388,6 +388,7 @@ simple_domain_manager::get_size(rpc::get_size_request req) {
     co_return rpc::get_size_reply{
       .ec = rpc::errc::ok,
       .size = get_res->size,
+      .num_extents = get_res->num_extents,
     };
 }
 

--- a/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/state_update.cc
@@ -404,6 +404,7 @@ add_objects_db_update::build_rows(
           .compaction_epoch = opt ? opt->compaction_epoch
                                   : partition_state::compaction_epoch_t{0},
           .size = (opt ? opt->size : 0) + extent_size_sum,
+          .num_extents = (opt ? opt->num_extents : 0) + extents.size(),
         };
     }
     // Now that we've validated the offsets of our extents, validate the terms
@@ -674,6 +675,8 @@ replace_objects_db_update::build_rows(
         auto prev_size = static_cast<ssize_t>(meta_res.value()->size);
         meta_res.value()->size = std::max(
           ssize_t(0), prev_size - removed_for_tidp);
+        meta_res.value()->num_extents -= std::min(
+          meta_res.value()->num_extents, extent_keys_to_delete[tidp].size());
     }
 
     // Update existing object entries to indicate the removal of data from
@@ -738,6 +741,7 @@ replace_objects_db_update::build_rows(
                               ? start_it->second
                               : kafka::offset{0};
         size_t added_for_tidp = 0;
+        size_t added_extents_for_tidp = 0;
         for (const auto& extent : extents) {
             // Skip extents fully below start_offset. These are stale
             // replacements for extents that have been truncated.
@@ -748,6 +752,7 @@ replace_objects_db_update::build_rows(
             auto key = extent_row_key::encode(tidp, extent.base_offset);
             added_extent_keys.emplace(key);
             added_for_tidp += extent.len;
+            ++added_extents_for_tidp;
             out.emplace_back(
               write_batch_row{
                 .key = extent_row_key::encode(tidp, extent.base_offset),
@@ -768,6 +773,7 @@ replace_objects_db_update::build_rows(
             co_return std::unexpected(std::move(meta_res.error()));
         }
         meta_res.value()->size += added_for_tidp;
+        meta_res.value()->num_extents += added_extents_for_tidp;
     }
     if (added_extent_keys.empty()) {
         // No extents, e.g. because all replacements are below the current
@@ -1038,6 +1044,9 @@ set_start_offset_db_update::build_rows(
             .next_offset = metadata.next_offset,
             .compaction_epoch = metadata.compaction_epoch,
             .size = metadata.size - std::min(metadata.size, total_removed_size),
+            .num_extents
+            = metadata.num_extents
+              - std::min(metadata.num_extents, extent_keys_to_delete.size()),
           }),
       });
 

--- a/src/v/cloud_topics/level_one/metastore/lsm/values.h
+++ b/src/v/cloud_topics/level_one/metastore/lsm/values.h
@@ -20,10 +20,11 @@ namespace cloud_topics::l1 {
 struct metadata_row_value
   : public serde::envelope<
       metadata_row_value,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     auto serde_fields() {
-        return std::tie(start_offset, next_offset, compaction_epoch, size);
+        return std::tie(
+          start_offset, next_offset, compaction_epoch, size, num_extents);
     }
     kafka::offset start_offset{};
     kafka::offset next_offset{};
@@ -31,6 +32,8 @@ struct metadata_row_value
     // Partition's size in bytes, updated incrementally as extents are
     // added/removed.
     size_t size{0};
+    // Number of extents in the partition, updated incrementally.
+    size_t num_extents{0};
 };
 
 struct extent_row_value

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -180,7 +180,9 @@ public:
 
     struct size_response {
         // The total size of the partition in bytes.
-        size_t size;
+        size_t size{0};
+        // The number of extents in the partition.
+        size_t num_extents{0};
     };
     // Returns the size of the partition in bytes.
     virtual ss::future<std::expected<size_response, errc>>

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -369,6 +369,7 @@ replicated_metastore::get_size(const model::topic_id_partition& tidp) {
 
     metastore::size_response resp;
     resp.size = reply.size;
+    resp.num_extents = reply.num_extents;
     co_return resp;
 }
 

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -195,11 +195,12 @@ struct get_offsets_request
 
 struct get_size_reply
   : serde::
-      envelope<get_size_reply, serde::version<0>, serde::compat_version<0>> {
-    auto serde_fields() { return std::tie(ec, size); }
+      envelope<get_size_reply, serde::version<1>, serde::compat_version<0>> {
+    auto serde_fields() { return std::tie(ec, size, num_extents); }
 
     errc ec;
     size_t size{0};
+    size_t num_extents{0};
 };
 struct get_size_request
   : serde::

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -199,6 +199,7 @@ simple_metastore::get_size(
     const auto& prt = prt_ref->get();
     return size_response{
       .size = prt.calculate_size(),
+      .num_extents = prt.extents.size(),
     };
 }
 

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -799,6 +799,10 @@ std::ostream& operator<<(std::ostream& o, const cloud_storage_mode& mode) {
         return o << "full";
     case cloud_storage_mode::read_replica:
         return o << "read_replica";
+    case cloud_storage_mode::cloud_topic:
+        return o << "cloud_topic";
+    case cloud_storage_mode::cloud_topic_read_replica:
+        return o << "cloud_topic_read_replica";
     }
     __builtin_unreachable();
 }

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3260,7 +3260,9 @@ enum class cloud_storage_mode : uint8_t {
     write_only = 1,
     read_only = 2,
     full = 3,
-    read_replica = 4
+    read_replica = 4,
+    cloud_topic = 5,
+    cloud_topic_read_replica = 6
 };
 
 std::ostream& operator<<(std::ostream&, const cloud_storage_mode&);

--- a/src/v/kafka/data/BUILD
+++ b/src/v/kafka/data/BUILD
@@ -48,6 +48,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics:state_accessors",
         "//src/v/cloud_topics/frontend",
         "//src/v/cloud_topics/frontend:errc",
+        "//src/v/cloud_topics/level_one/metastore",
         "//src/v/cloud_topics/level_zero/frontend_reader",
         "//src/v/kafka/data:log_reader_config",
         "//src/v/kafka/protocol",

--- a/src/v/kafka/data/cloud_topic_partition.cc
+++ b/src/v/kafka/data/cloud_topic_partition.cc
@@ -239,4 +239,22 @@ model::offset cloud_topic_partition::offset_lag() const {
     return _partition->high_watermark() - _partition->dirty_offset();
 }
 
+ss::future<cluster::partition_cloud_storage_status>
+cloud_topic_partition::get_cloud_storage_status() const {
+    cluster::partition_cloud_storage_status status{};
+    auto local_size = local_size_bytes();
+    auto l0_size = _fe->get_l0_size_estimate();
+    auto l1_size = (co_await _fe->l1_size())
+                     .value_or(cloud_topics::l1::metastore::size_response{});
+    status.mode = cluster::cloud_storage_mode::cloud_topic;
+    status.local_log_size_bytes = local_size;
+    // Report the L1 size via "cloud" size bytes and the sum of L0 and L1 sizes
+    // via "total" log size bytes. Users can derive the L0 size through total -
+    // cloud.
+    status.cloud_log_size_bytes = l1_size.size;
+    status.total_log_size_bytes = l0_size + l1_size.size;
+    status.stm_region_segment_count = l1_size.num_extents;
+    co_return status;
+}
+
 } // namespace kafka

--- a/src/v/kafka/data/cloud_topic_partition.h
+++ b/src/v/kafka/data/cloud_topic_partition.h
@@ -97,6 +97,8 @@ public:
     size_t local_size_bytes() const override;
     ss::future<std::optional<size_t>> cloud_size_bytes() const override;
     model::offset offset_lag() const override;
+    ss::future<cluster::partition_cloud_storage_status>
+    get_cloud_storage_status() const override;
 
 private:
     ss::lw_shared_ptr<cluster::partition> _partition;

--- a/src/v/kafka/data/cloud_topic_read_replica.cc
+++ b/src/v/kafka/data/cloud_topic_read_replica.cc
@@ -314,7 +314,8 @@ size_t partition_proxy::local_size_bytes() const {
     return partition_->size_bytes();
 };
 
-ss::future<std::optional<size_t>> partition_proxy::cloud_size_bytes() const {
+ss::future<std::optional<cloud_topics::l1::metastore::size_response>>
+partition_proxy::get_metastore_size() const {
     auto snap_res = co_await get_snapshot();
     if (!snap_res.has_value()) {
         co_return std::nullopt;
@@ -324,10 +325,31 @@ ss::future<std::optional<size_t>> partition_proxy::cloud_size_bytes() const {
     if (!size_res.has_value()) {
         co_return std::nullopt;
     }
+    co_return size_res.value();
+}
+
+ss::future<std::optional<size_t>> partition_proxy::cloud_size_bytes() const {
+    auto size_res = co_await get_metastore_size();
     co_return size_res.value().size;
 }
 
 model::offset partition_proxy::offset_lag() const { return model::offset(0); }
+
+ss::future<cluster::partition_cloud_storage_status>
+partition_proxy::get_cloud_storage_status() const {
+    cluster::partition_cloud_storage_status status{};
+    auto local_size = local_size_bytes();
+    auto cloud_size = (co_await get_metastore_size())
+                        .value_or(cloud_topics::l1::metastore::size_response{});
+    status.mode = cluster::cloud_storage_mode::cloud_topic_read_replica;
+    status.local_log_size_bytes = local_size;
+    // A cloud topic read replica only has access to L1 data, and therefore only
+    // reports L1 data size for both "cloud" and "total" log size bytes.
+    status.cloud_log_size_bytes = cloud_size.size;
+    status.total_log_size_bytes = cloud_size.size;
+    status.stm_region_segment_count = cloud_size.num_extents;
+    co_return status;
+}
 
 ss::future<std::expected<partition_proxy::snapshot, ss::sstring>>
 partition_proxy::get_snapshot() const {

--- a/src/v/kafka/data/cloud_topic_read_replica.h
+++ b/src/v/kafka/data/cloud_topic_read_replica.h
@@ -9,6 +9,7 @@
  */
 #pragma once
 
+#include "cloud_topics/level_one/metastore/metastore.h"
 #include "cloud_topics/read_replica/partition_metadata.h"
 #include "kafka/data/partition_proxy.h"
 #include "kafka/protocol/errors.h"
@@ -132,8 +133,13 @@ public:
     size_t local_size_bytes() const final;
     ss::future<std::optional<size_t>> cloud_size_bytes() const final;
     model::offset offset_lag() const final;
+    ss::future<cluster::partition_cloud_storage_status>
+    get_cloud_storage_status() const final;
 
 private:
+    ss::future<std::optional<cloud_topics::l1::metastore::size_response>>
+    get_metastore_size() const;
+
     struct snapshot {
         partition_metadata metadata;
         std::unique_ptr<snapshot_metastore> metastore;

--- a/src/v/kafka/data/partition_proxy.h
+++ b/src/v/kafka/data/partition_proxy.h
@@ -12,6 +12,7 @@
 
 #include "base/outcome.h"
 #include "cluster/fwd.h"
+#include "cluster/types.h"
 #include "kafka/data/log_reader_config.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/types.h"
@@ -99,6 +100,8 @@ public:
         virtual size_t local_size_bytes() const = 0;
         virtual ss::future<std::optional<size_t>> cloud_size_bytes() const = 0;
         virtual model::offset offset_lag() const = 0;
+        virtual ss::future<cluster::partition_cloud_storage_status>
+        get_cloud_storage_status() const = 0;
     };
 
     explicit partition_proxy(std::unique_ptr<impl> impl) noexcept
@@ -211,6 +214,11 @@ public:
      * zero. It's calculated as the highwater mark minus the dirty offset.
      */
     model::offset offset_lag() const { return _impl->offset_lag(); }
+
+    ss::future<cluster::partition_cloud_storage_status>
+    get_cloud_storage_status() const {
+        return _impl->get_cloud_storage_status();
+    }
 
 private:
     std::unique_ptr<impl> _impl;

--- a/src/v/kafka/data/replicated_partition.cc
+++ b/src/v/kafka/data/replicated_partition.cc
@@ -766,4 +766,9 @@ model::offset replicated_partition::offset_lag() const {
     return _partition->high_watermark() - _partition->dirty_offset();
 }
 
+ss::future<cluster::partition_cloud_storage_status>
+replicated_partition::get_cloud_storage_status() const {
+    co_return _partition->get_cloud_storage_status();
+}
+
 } // namespace kafka

--- a/src/v/kafka/data/replicated_partition.h
+++ b/src/v/kafka/data/replicated_partition.h
@@ -104,6 +104,8 @@ public:
     size_t local_size_bytes() const override;
     ss::future<std::optional<size_t>> cloud_size_bytes() const override;
     model::offset offset_lag() const override;
+    ss::future<cluster::partition_cloud_storage_status>
+    get_cloud_storage_status() const override;
 
 private:
     // Returns the Kafka offset corresponding to the lowest offset in the

--- a/src/v/kafka/data/rpc/test/deps.h
+++ b/src/v/kafka/data/rpc/test/deps.h
@@ -185,6 +185,10 @@ public:
     model::offset offset_lag() const override {
         throw std::runtime_error("unimplemented");
     }
+    ss::future<cluster::partition_cloud_storage_status>
+    get_cloud_storage_status() const override {
+        throw std::runtime_error("unimplemented");
+    }
 
 private:
     model::offset latest_offset() {

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -59,6 +59,7 @@
 #include "json/stringbuffer.h"
 #include "json/validator.h"
 #include "json/writer.h"
+#include "kafka/data/partition_proxy.h"
 #include "metrics/metrics.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -4668,16 +4669,16 @@ admin_server::get_partition_cloud_storage_status(
 
     auto status = co_await _partition_manager.invoke_on(
       *shard,
-      [&ntp](const auto& pm)
-        -> std::optional<cluster::partition_cloud_storage_status> {
+      [&ntp](this auto, const auto& pm)
+        -> ss::future<std::optional<cluster::partition_cloud_storage_status>> {
           const auto& partitions = pm.partitions();
           auto partition_iter = partitions.find(ntp);
 
           if (partition_iter == partitions.end()) {
-              return std::nullopt;
+              co_return std::nullopt;
           }
-
-          return partition_iter->second->get_cloud_storage_status();
+          auto pp = kafka::make_partition_proxy(partition_iter->second);
+          co_return co_await pp.get_cloud_storage_status();
       });
 
     if (!status) {


### PR DESCRIPTION
Enables `rpk topic describe-storage topic` to print a more accurate & user friendly summary of storage for cloud topics. Sample output is:

```
willem@bloom:~/redpanda$ rpk topic describe-storage my_cloud_topic
SUMMARY
=======
NAME                my_cloud_topic
PARTITIONS          1
REPLICAS            1
CLOUD-STORAGE-MODE  cloud_topic

SIZE
====
PARTITION  LOCAL-BYTES  L0-BYTES  L1-BYTES  TOTAL-BYTES  L1-EXTENTS
0          24.89kB      0B        123.9kB   123.9kB      1

```

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
