### PR TITLE
ct: Demote ctp_stm sync log messages

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -626,15 +626,24 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
     auto fence_fut = co_await ss::coroutine::as_future(
       ctp_stm_api->fence_epoch(upload_res.value().front().id.epoch));
     if (fence_fut.failed()) {
+        auto not_leader = !partition->is_leader();
         auto e = fence_fut.get_exception();
-        vlogl(
-          cd_log,
-          ssx::is_shutdown_exception(e) ? ss::log_level::debug
-                                        : ss::log_level::warn,
-          "Failed to fence epoch {} for ntp {}, error: {}",
-          upload_res.value().front().id.epoch,
-          ntp,
-          e);
+        if (not_leader) {
+            vlog(
+              cd_log.debug,
+              "Failed to fence epoch {} for ntp {}, not a leader",
+              upload_res.value().front().id.epoch,
+              ntp);
+        } else {
+            vlogl(
+              cd_log,
+              ssx::is_shutdown_exception(e) ? ss::log_level::debug
+                                            : ss::log_level::warn,
+              "Failed to fence epoch {} for ntp {}, error: {}",
+              upload_res.value().front().id.epoch,
+              ntp,
+              e);
+        }
         co_return default_errc;
     }
     auto fence = std::move(fence_fut.get());
@@ -760,15 +769,24 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
     auto fence_fut = co_await ss::coroutine::as_future(
       _ctp_stm_api->fence_epoch(res.value().front().id.epoch));
     if (fence_fut.failed()) {
+        auto not_leader = !_partition->is_leader();
         auto e = fence_fut.get_exception();
-        vlogl(
-          cd_log,
-          ssx::is_shutdown_exception(e) ? ss::log_level::debug
-                                        : ss::log_level::warn,
-          "Failed to fence epoch {} for ntp {}, error: {}",
-          res.value().front().id.epoch,
-          ntp(),
-          fence_fut.get_exception());
+        if (not_leader) {
+            vlog(
+              cd_log.debug,
+              "Failed to fence epoch {} for ntp {}, not a leader",
+              res.value().front().id.epoch,
+              ntp());
+        } else {
+            vlogl(
+              cd_log,
+              ssx::is_shutdown_exception(e) ? ss::log_level::debug
+                                            : ss::log_level::warn,
+              "Failed to fence epoch {} for ntp {}, error: {}",
+              res.value().front().id.epoch,
+              ntp(),
+              e);
+        }
         std::rethrow_exception(e);
     }
     auto fence = std::move(fence_fut.get());

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -417,7 +417,11 @@ ctp_stm::fence_epoch(cluster_epoch e) {
     if (!co_await sync(sync_timeout, _as)) {
         // Prevent the below log spam if we are shutting down.
         _as.check();
-        vlog(_log.warn, "ctp_stm::fence_epoch sync timeout");
+        if (_raft->is_leader()) {
+            vlog(_log.warn, "ctp_stm::fence_epoch sync timeout");
+        } else {
+            vlog(_log.debug, "ctp_stm::fence_epoch sync timeout (not leader)");
+        }
         throw std::runtime_error(fmt_with_ctx(fmt::format, "Sync timeout"));
     }
     auto term = _raft->confirmed_term();


### PR DESCRIPTION
Demote sync timeout errors from WARN to DEBUG when they're caused by the leadership transfer.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none