### PR TITLE
ct: Conditionally demote fencing log message

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -639,8 +639,15 @@ ss::future<result<raft::replicate_result>> do_upload_and_replicate(
     }
     auto fence = std::move(fence_fut.get());
     if (!fence.has_value()) {
-        vlog(
-          cd_log.warn,
+        auto no_window = fence.error().window_min == fence.error().window_max;
+        // NOTE: we might see the error when the partition is just created
+        // or right after the leadership transfer. This is transient state
+        // and is expected so we're logging this on DEBUG level. If the
+        // fence is not acquired during the steady state operation the log
+        // message is more useful and is logged on WARN level.
+        vlogl(
+          cd_log,
+          no_window ? ss::log_level::debug : ss::log_level::warn,
           "Failed to fence epoch {} for ntp {}, ctp window is [{}, {}]",
           upload_res.value().front().id.epoch,
           ntp,


### PR DESCRIPTION
The fencing error is expected in some cases (right after the leadership transfer or when the partition is empty). The log message on WARN level is not very useful in this case because we already expect this to happen.

The error is logged on WARN level in all other cases.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none