### PR TITLE
ct/reconciler: Add/remove schedulers only in attach/detach

### DIFF
--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -331,12 +331,23 @@ ss::future<> reconciler<Clock>::reconcile() {
     auto now = Clock::now();
     chunked_vector<chunked_vector<ss::shared_ptr<source>>> due_topics;
 
+    // No yield points between the source copy and here, so the scheduler
+    // map must be in sync with sources: one scheduler per distinct topic.
+    vassert(
+      topics.size() == _topic_schedulers.size(),
+      "Topic scheduler count ({}) doesn't match source topic count ({})",
+      _topic_schedulers.size(),
+      topics.size());
+
     for (auto& topic_sources : topics) {
         vassert(!topic_sources.empty(), "Empty topic source set");
         auto topic_id = topic_sources.front()->topic_id_partition().topic_id;
-        auto& scheduler_state = get_or_create_topic_scheduler(topic_id);
-        auto next_due = scheduler_state.last_reconciled
-                        + scheduler_state.scheduler.current_interval();
+        auto sched_it = _topic_schedulers.find(topic_id);
+        if (sched_it == _topic_schedulers.end()) {
+            continue;
+        }
+        auto next_due = sched_it->second.last_reconciled
+                        + sched_it->second.scheduler.current_interval();
 
         if (now >= next_due) {
             due_topics.push_back(std::move(topic_sources));
@@ -374,10 +385,13 @@ ss::future<> reconciler<Clock>::reconcile() {
           // Update the topic's scheduler state. Adapt based on max object
           // size produced. Note that we slow down if there's nothing to
           // reconcile or if all objects failed. This is a sort of retry
-          // with backoff mechanism.
-          auto& scheduler_state = get_or_create_topic_scheduler(topic_id);
-          scheduler_state.scheduler.adapt(bytes);
-          scheduler_state.last_reconciled = now;
+          // with backoff mechanism. The scheduler may have been removed
+          // if sources were detached during reconciliation.
+          auto sched_it = _topic_schedulers.find(topic_id);
+          if (sched_it != _topic_schedulers.end()) {
+              sched_it->second.scheduler.adapt(bytes);
+              sched_it->second.last_reconciled = now;
+          }
       });
 }
 

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -103,6 +103,9 @@ public:
 
     void setup_metrics_for_tests() { _probe.setup_metrics(); }
     const reconciler_probe& get_probe_for_tests() const { return _probe; }
+    size_t topic_scheduler_count_for_tests() const {
+        return _topic_schedulers.size();
+    }
 
     void attach_partition(
       const model::ntp&,

--- a/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
@@ -720,3 +720,30 @@ TEST_F(ReconcilerTest, OnlyDueTopicIsReconciled) {
     reconcile();
     EXPECT_EQ(src1->last_reconciled_offset(), kafka::offset{19});
 }
+
+// Regression test: detaching a source during reconciliation (e.g. due to a
+// leadership change) must not leave an orphaned topic scheduler. Before the
+// fix, get_or_create_topic_scheduler in the post-reconciliation path would
+// recreate the scheduler with partition_count=0 after detach had removed it,
+// causing compute_next_wait to see it as perpetually due and busy-loop.
+TEST_F(ReconcilerTest, DetachDuringReconcileDoesNotOrphanScheduler) {
+    // Two topics: src1 will be detached mid-reconciliation, src2 stays.
+    auto src1 = add_source();
+    src1->add_batch({.count = 10});
+    auto src2 = add_source();
+    src2->add_batch({.count = 10});
+
+    // Detach src1 when it's read during reconciliation. This simulates
+    // a leadership change firing during an async reconciliation pass.
+    auto ntp1 = src1->ntp();
+    src1->set_on_make_reader([this, ntp1] { _reconciler.detach(ntp1); });
+
+    reconcile();
+
+    // The scheduler for the detached topic must not survive. With the bug,
+    // it would be recreated with partition_count=0 and never cleaned up.
+    // A second reconcile() would then hit the vassert in reconcile() because
+    // the orphaned scheduler has no matching sources.
+    reconcile();
+    EXPECT_EQ(_reconciler.topic_scheduler_count_for_tests(), 1);
+}

--- a/src/v/cloud_topics/reconciler/tests/test_utils.h
+++ b/src/v/cloud_topics/reconciler/tests/test_utils.h
@@ -23,6 +23,7 @@
 #include <seastar/util/log.hh>
 
 #include <expected>
+#include <functional>
 #include <optional>
 #include <stdexcept>
 
@@ -63,6 +64,9 @@ public:
 
     ss::future<model::record_batch_reader>
     make_reader(source::reader_config cfg) override {
+        if (_on_make_reader) {
+            _on_make_reader();
+        }
         if (_fail_make_reader) {
             throw std::runtime_error("Failed to make reader");
         }
@@ -87,12 +91,16 @@ public:
 
     void fail_set_lro(bool fail) { _fail_set_lro = fail; }
     void fail_make_reader(bool fail) { _fail_make_reader = fail; }
+    void set_on_make_reader(std::function<void()> cb) {
+        _on_make_reader = std::move(cb);
+    }
 
 private:
     kafka::offset _lro;
     chunked_vector<model::record_batch> _source_log;
     bool _fail_set_lro = false;
     bool _fail_make_reader = false;
+    std::function<void()> _on_make_reader;
 };
 
 class unreliable_metastore : public l1::simple_metastore {


### PR DESCRIPTION
1. Reconciler runs with source A from topic T. It copies A into its round-local sources.
2. Reconciliation yields somewhere.
3. Topic T is deleted, or leadership of A moves, and A is detached from the reconciler. It's the last source for its topic, so the topic's scheduler is removed from the scheduler map.
4. Reconciliation of A continues and finishes. The reconciler uses the bytes produced to update T's scheduler state.
5. BUG: the reconciler creates a new scheduler state for T instead of noticing there's no state for it and making the update a no-op.
6. If no other sources for T are attached, once T's scheduler comes due, it causes reconciliation to spin in a tight loop.

Adding or removing topic scheduler state should happen only in attach/detach. The reconciler should no-op if it doesn't find scheduler state for a topic whose sources were reconciled.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
