### PR TITLE
archival: add incremental batching to archive GC

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -2851,7 +2851,7 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
         co_return;
     }
 
-    model::offset new_clean_offset;
+    model::offset new_clean_offset{clean_offset};
     // Value includes segments but doesn't include manifests
     size_t bytes_to_remove = 0;
     size_t segments_to_remove_count = 0;

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -369,6 +369,8 @@ ntp_archiver::ntp_archiver(
   , _max_segments_pending_deletion(
       config::shard_local_cfg()
         .cloud_storage_max_segments_pending_deletion_per_partition.bind())
+  , _gc_max_segments(
+      config::shard_local_cfg().cloud_storage_gc_max_segments_per_run.bind())
   , _housekeeping_interval(
       config::shard_local_cfg().cloud_storage_housekeeping_interval_ms.bind())
   , _housekeeping_jitter(_housekeeping_interval(), housekeeping_jit)
@@ -1117,8 +1119,16 @@ ss::future<> ntp_archiver::upload_until_term_change_legacy() {
         }
 
         if (ss::lowres_clock::now() >= _next_housekeeping) {
-            co_await housekeeping();
-            _next_housekeeping = _housekeeping_jitter();
+            if (co_await housekeeping() == housekeeping_result::partial) {
+                // Only apply the very short jitter if there is more pending
+                // housekeeping work to do.
+                // NB: The actual duration between housekeeping runs is
+                // bounded by upload loop scheduling. Here we establish a lower
+                // bound on duration between housekeeping runs.
+                _next_housekeeping = ss::lowres_clock::now() + housekeeping_jit;
+            } else {
+                _next_housekeeping = _housekeeping_jitter();
+            }
         }
 
         if (!may_begin_uploads()) {
@@ -2692,7 +2702,8 @@ std::ostream& operator<<(std::ostream& os, wait_result fr) {
     return os;
 }
 
-ss::future<> ntp_archiver::housekeeping() {
+ss::future<ntp_archiver::housekeeping_result> ntp_archiver::housekeeping() {
+    auto result = housekeeping_result::complete;
     try {
         if (may_begin_uploads()) {
             // Acquire mutex to prevent concurrency between
@@ -2704,7 +2715,7 @@ ss::future<> ntp_archiver::housekeeping() {
                 co_await garbage_collect();
             } else {
                 co_await apply_archive_retention();
-                co_await garbage_collect_archive();
+                result = co_await garbage_collect_archive();
                 co_await garbage_collect();
             }
             co_await apply_spillover();
@@ -2719,8 +2730,11 @@ ss::future<> ntp_archiver::housekeeping() {
     } catch (const std::exception& e) {
         // Unexpected exceptions are logged, and suppressed: we do not
         // want to stop who upload loop because of issues in housekeeping
+        result = housekeeping_result::error;
         vlog(_rtclog.warn, "Error occurred during housekeeping: {}", e.what());
     }
+
+    co_return result;
 }
 
 ss::future<> ntp_archiver::apply_archive_retention() {
@@ -2801,9 +2815,10 @@ ss::future<> ntp_archiver::apply_archive_retention() {
     }
 }
 
-ss::future<> ntp_archiver::garbage_collect_archive() {
+ss::future<ntp_archiver::housekeeping_result>
+ntp_archiver::garbage_collect_archive() {
     if (!may_begin_uploads()) {
-        co_return;
+        co_return housekeeping_result::complete;
     }
     auto fence = emit_rw_fence();
     auto backlog = co_await _manifest_view->get_retention_backlog();
@@ -2812,7 +2827,7 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
             vlog(
               _rtclog.debug,
               "Skipping archive GC as Redpanda is shutting down");
-            co_return;
+            co_return housekeeping_result::complete;
         }
 
         vlog(
@@ -2827,12 +2842,15 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
 
     const auto clean_offset = manifest().get_archive_clean_offset();
     const auto start_offset = manifest().get_archive_start_offset();
+    const size_t max_segments = _gc_max_segments();
 
     vlog(
       _rtclog.info,
-      "Garbage collecting archive segments in offest range [{}, {})",
+      "Garbage collecting archive segments in offset range [{}, {}) with batch "
+      "limit {}",
       clean_offset,
-      start_offset);
+      start_offset,
+      max_segments);
 
     if (clean_offset == start_offset) {
         vlog(
@@ -2840,7 +2858,7 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
           "Garbage collection in the archive not required as clean offset "
           "equals the start offset ({})",
           clean_offset);
-        co_return;
+        co_return housekeeping_result::complete;
     } else if (clean_offset > start_offset) {
         vlog(
           _rtclog.error,
@@ -2848,7 +2866,7 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
           "at {}. Skipping garbage collection.",
           clean_offset,
           start_offset);
-        co_return;
+        co_return housekeeping_result::error;
     }
 
     model::offset new_clean_offset{clean_offset};
@@ -2874,6 +2892,9 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
                       continue;
                   }
                   if (meta.committed_offset < start_offset) {
+                      if (segments_to_remove_count >= max_segments) {
+                          return true;
+                      }
                       const auto path = manifest.generate_segment_path(
                         meta, remote_path_provider());
                       vlog(
@@ -2919,13 +2940,17 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
           path);
         manifests_to_remove.emplace_back(path);
 
+        if (segments_to_remove_count >= max_segments) {
+            break;
+        }
+
         auto res = co_await cursor->next();
         if (res.has_failure()) {
             if (res.error() == cloud_storage::error_outcome::shutting_down) {
                 vlog(
                   _rtclog.debug,
                   "Stopping archive GC as Redpanda is shutting down");
-                co_return;
+                co_return housekeeping_result::complete;
             }
 
             vlog(
@@ -2939,12 +2964,23 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
         }
     }
 
+    if (segments_to_remove_count >= max_segments) {
+        vlog(
+          _rtclog.trace,
+          "Archive GC batch limit reached, initial clean offset {}, new clean "
+          "offset {}, start offset {}, segments to remove {}",
+          clean_offset,
+          new_clean_offset,
+          start_offset,
+          segments_to_remove_count);
+    }
+
     // Drop out if we have no work to do, avoid doing things like the following
     // manifest flushing unnecessarily. This is problematic since, we've already
     // checked that the clean offset is greater than the start offset.
     if (objects_to_remove.empty() && manifests_to_remove.empty()) {
         vlog(_rtclog.error, "Nothing to remove in archive GC");
-        co_return;
+        co_return housekeeping_result::error;
     }
 
     if (
@@ -2952,7 +2988,7 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
       != cluster::archival_metadata_stm::state_dirty::clean) {
         auto result = co_await upload_manifest("pre-garbage-collect-archive");
         if (result != cloud_storage::upload_result::success) {
-            co_return;
+            co_return housekeeping_result::error;
         }
     }
 
@@ -2962,29 +2998,16 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
       &_rtcnode);
     const auto delete_result = co_await _remote.delete_objects(
       get_bucket_name(), objects_to_remove, fib);
-    const auto backlog_size_exceeded = segments_to_remove_count
-                                       > _max_segments_pending_deletion();
     const auto all_deletes_succeeded = delete_result
                                        == cloud_storage::upload_result::success;
 
-    if (!all_deletes_succeeded && backlog_size_exceeded) {
-        vlog(
-          _rtclog.warn,
-          "The current number of spillover segments pending deletion has "
-          "exceeded the configurable limit ({} > {}) and deletion of some "
-          "segments failed. Metadata for all remaining segments pending "
-          "deletion will be removed and these segments will have to be removed "
-          "manually.",
-          objects_to_remove.size(),
-          _max_segments_pending_deletion());
-    }
-    if (!all_deletes_succeeded && !backlog_size_exceeded) {
+    if (!all_deletes_succeeded) {
         vlog(
           _rtclog.info,
           "Failed to delete all selected segments from cloud storage. Will "
           "retry on the next housekeeping run.");
-    }
-    if (all_deletes_succeeded || backlog_size_exceeded) {
+        co_return housekeeping_result::error;
+    } else {
         auto sync_timeout = config::shard_local_cfg()
                               .cloud_storage_metadata_sync_timeout_ms.value();
         auto deadline = ss::lowres_clock::now() + sync_timeout;
@@ -3012,15 +3035,20 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
             std::ignore = co_await _remote.delete_objects(
               get_bucket_name(), manifests_to_remove, fib);
         }
-    }
 
-    _probe.value().segments_deleted(
-      static_cast<int64_t>(
-        all_deletes_succeeded ? segments_to_remove_count : 0));
-    vlog(
-      _rtclog.debug,
-      "Deleted {} spillover segments from the cloud",
-      all_deletes_succeeded ? segments_to_remove_count : 0);
+        _probe.value().segments_deleted(
+          static_cast<int64_t>(segments_to_remove_count));
+        vlog(
+          _rtclog.info,
+          "Archive GC deleted {} segments, clean offset {}, start offset {}",
+          segments_to_remove_count,
+          new_clean_offset,
+          start_offset);
+
+        co_return new_clean_offset < start_offset
+          ? housekeeping_result::partial
+          : housekeeping_result::complete;
+    }
 }
 
 ss::future<> ntp_archiver::apply_spillover() {

--- a/src/v/cluster/archival/ntp_archiver_service.h
+++ b/src/v/cluster/archival/ntp_archiver_service.h
@@ -216,6 +216,17 @@ public:
         auto operator<=>(const batch_result&) const = default;
     };
 
+    enum class [[nodiscard]] housekeeping_result : uint8_t {
+        /// The run completed some work and should be scheduled again soon.
+        /// Return `error` instead if the run failed before committing progress.
+        partial,
+        /// The run finished all available work and should be retried after a
+        /// longer delay.
+        complete,
+        /// The run failed and should fall back to the normal cadence.
+        error
+    };
+
     /// Compute the maximum offset that is safe to be uploaded to the cloud.
     ///
     /// It must be guaranteed that this offset is monotonically increasing/
@@ -248,7 +259,7 @@ public:
     maybe_truncate_manifest();
 
     /// \brief Perform housekeeping operations.
-    ss::future<> housekeeping();
+    ss::future<housekeeping_result> housekeeping();
 
     /// \brief Advance the start offest for the remote partition
     /// according to the retention policy specified by the partition
@@ -266,7 +277,7 @@ public:
     ss::future<> apply_archive_retention();
 
     /// \brief Remove segments and manifests below the archive_start_offset.
-    ss::future<> garbage_collect_archive();
+    ss::future<housekeeping_result> garbage_collect_archive();
 
     /// \brief If the size of the manifest exceeds the limit
     /// move some segments into a separate immutable manifest and
@@ -736,6 +747,7 @@ private:
     ss::lw_shared_ptr<const configuration> _conf;
     config::binding<std::chrono::milliseconds> _sync_manifest_timeout;
     config::binding<size_t> _max_segments_pending_deletion;
+    config::binding<size_t> _gc_max_segments;
     simple_time_jitter<ss::lowres_clock> _backoff_jitter{100ms};
     size_t _concurrency{4};
 

--- a/src/v/cluster/archival/probe.cc
+++ b/src/v/cluster/archival/probe.cc
@@ -17,7 +17,6 @@
 #include "ssx/rate_limited_function.h"
 
 #include <seastar/core/metrics.hh>
-#include <seastar/core/smp.hh>
 
 namespace archival {
 
@@ -126,7 +125,8 @@ void ntp_level_probe::setup_public_metrics(const model::ntp& ntp) {
          "segments",
          [this] { return _stm->manifest().size(); },
          sm::description(
-           "Total number of accounted segments in the cloud for the topic"),
+           "Number of segments tracked in the STM region (excludes "
+           "spillover)."),
          labels)
          .aggregate(aggregate_labels),
        sm::make_gauge(
@@ -149,8 +149,8 @@ void ntp_level_probe::setup_public_metrics(const model::ntp& ntp) {
            },
            segments_pending_deletion_refresh_rate),
          sm::description(
-           "Total number of segments pending deletion from the "
-           "cloud for the topic"),
+           "Number of segments pending deletion tracked in the STM region "
+           "(excludes spillover)."),
          labels)
          .aggregate(aggregate_labels),
        sm::make_gauge(

--- a/src/v/cluster/archival/tests/BUILD
+++ b/src/v/cluster/archival/tests/BUILD
@@ -142,6 +142,7 @@ redpanda_cc_btest(
         "//src/v/cluster",
         "//src/v/config",
         "//src/v/model",
+        "//src/v/random:generators",
         "//src/v/ssx:sformat",
         "//src/v/storage",
         "//src/v/test_utils:scoped_config",

--- a/src/v/cluster/archival/tests/ntp_archiver_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_test.cc
@@ -22,6 +22,7 @@
 #include "config/property.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "random/generators.h"
 #include "ssx/sformat.h"
 #include "storage/parser.h"
 #include "storage/types.h"
@@ -654,7 +655,10 @@ FIXTURE_TEST(test_archive_retention, archiver_fixture) {
         return archive_clean_offset_reset && archive_start_offset_reset
                && deletes_sent;
     }).get();
-    fut.get();
+    auto archive_gc_result = fut.get();
+    BOOST_REQUIRE(
+      archive_gc_result
+      == archival::ntp_archiver::housekeeping_result::complete);
 
     BOOST_REQUIRE_EQUAL(
       part->archival_meta_stm()->manifest().get_spillover_map().size(), 0);
@@ -685,6 +689,430 @@ FIXTURE_TEST(test_archive_retention, archiver_fixture) {
     bool spill_manifest_deleted = delete_payloads.find(spill_path().string())
                                   != ss::sstring::npos;
     BOOST_REQUIRE_EQUAL(true, spill_manifest_deleted);
+}
+
+FIXTURE_TEST(test_archive_retention_incremental, archiver_fixture) {
+    // Constants chosen deliberately to cover all possible edge cases (partial
+    // spillover gc, multiple spillover gc, boundary gc, full archive gc).
+    const size_t num_segments = 12;
+    const size_t num_segments_pending_gc = 9;
+    const size_t num_segments_per_spill = 3;
+    const size_t gc_max_segments_per_run = 2;
+
+    auto cfg = scoped_config{};
+    cfg.get("cloud_storage_spillover_manifest_max_segments")
+      .set_value(std::make_optional(num_segments_per_spill));
+    cfg.get("cloud_storage_spillover_manifest_size")
+      .set_value(std::optional<size_t>{std::nullopt});
+    cfg.get("cloud_storage_gc_max_segments_per_run")
+      .set_value(gc_max_segments_per_run);
+
+    auto old_stamp = model::timestamp{
+      model::timestamp::now().value()
+      - std::chrono::milliseconds{10min}.count()};
+
+    std::vector<segment_desc> segments;
+    segments.reserve(num_segments);
+    for (size_t i = 0; i < num_segments; i++) {
+        segments.push_back(
+          {.ntp = manifest_ntp,
+           .base_offset = model::offset(i * 1000),
+           .term = model::term_id(i + 1),
+           .num_records = 1000,
+           .timestamp = i < num_segments_pending_gc
+                          ? old_stamp
+                          : std::optional<model::timestamp>{}});
+    }
+
+    init_storage_api_local(segments);
+    vlog(test_log.info, "Initialized, start waiting for partition leadership");
+
+    wait_for_partition_leadership(manifest_ntp);
+    auto part = app.partition_manager.local().get(manifest_ntp);
+    tests::cooperative_spin_wait_with_timeout(10s, [part]() mutable {
+        return part->last_stable_offset() >= model::offset(1);
+    }).get();
+
+    vlog(
+      test_log.info,
+      "Partition is a leader, HW {}, CO {}, partition: {}",
+      part->high_watermark(),
+      part->committed_offset(),
+      *part);
+
+    listen();
+
+    auto [arch_conf, remote_conf] = get_configurations();
+    auto amv = ss::make_shared<cloud_storage::async_manifest_view>(
+      remote,
+      app.shadow_index_cache,
+      part->archival_meta_stm()->manifest(),
+      arch_conf->bucket_name,
+      path_provider);
+    archival::ntp_archiver archiver(
+      get_ntp_conf(),
+      arch_conf,
+      remote.local(),
+      app.shadow_index_cache.local(),
+      *part,
+      amv);
+    archiver.initialize_probe();
+    amv->start().get();
+    auto action = ss::defer([&archiver, &amv] {
+        archiver.stop().get();
+        amv->stop().get();
+    });
+
+    size_t total_uploaded = 0;
+    while (total_uploaded < num_segments) {
+        auto res = upload_next_with_retries(archiver).get();
+        total_uploaded += res.non_compacted_upload_result.num_succeeded;
+        BOOST_REQUIRE_EQUAL(res.non_compacted_upload_result.num_failed, 0);
+    }
+    BOOST_REQUIRE_EQUAL(total_uploaded, num_segments);
+
+    std::vector<std::pair<remote_segment_path, bool>> segment_urls;
+    for (const auto& seg : segments) {
+        auto name = cloud_storage::generate_local_segment_name(
+          seg.base_offset, seg.term);
+        auto path = get_segment_path(
+          part->archival_meta_stm()->manifest(), name);
+        bool deletion_expected = seg.timestamp == old_stamp;
+        segment_urls.emplace_back(path, deletion_expected);
+    }
+
+    archiver.apply_spillover().get();
+
+    const auto& manifest = part->archival_meta_stm()->manifest();
+    BOOST_REQUIRE_EQUAL(manifest.get_archive_start_offset(), model::offset{0});
+    BOOST_REQUIRE_EQUAL(manifest.get_archive_clean_offset(), model::offset{0});
+    BOOST_REQUIRE_EQUAL(manifest.get_start_offset(), model::offset(9000));
+
+    const auto& spills = manifest.get_spillover_map();
+    BOOST_REQUIRE_EQUAL(spills.size(), 3);
+
+    auto it = spills.begin();
+    BOOST_REQUIRE_EQUAL(it->base_offset, model::offset{0});
+    BOOST_REQUIRE_EQUAL(it->committed_offset, model::offset{2999});
+    auto spill_path_a = generate_spill_manifest_path(manifest, *it);
+
+    ++it;
+    BOOST_REQUIRE_EQUAL(it->base_offset, model::offset{3000});
+    BOOST_REQUIRE_EQUAL(it->committed_offset, model::offset{5999});
+    auto spill_path_b = generate_spill_manifest_path(manifest, *it);
+
+    ++it;
+    BOOST_REQUIRE_EQUAL(it->base_offset, model::offset{6000});
+    BOOST_REQUIRE_EQUAL(it->committed_offset, model::offset{8999});
+    auto spill_path_c = generate_spill_manifest_path(manifest, *it);
+
+    config::shard_local_cfg().log_retention_ms.set_value(
+      std::chrono::milliseconds{5min});
+    auto reset_cfg = ss::defer(
+      [] { config::shard_local_cfg().log_retention_ms.reset(); });
+
+    archiver.apply_archive_retention().get();
+    BOOST_REQUIRE_EQUAL(
+      manifest.get_archive_start_offset(), model::offset{9000});
+    BOOST_REQUIRE_EQUAL(manifest.get_archive_clean_offset(), model::offset{0});
+
+    // Expected cumulative state after each GC round (batch_size=2).
+
+    using hk_result = archival::ntp_archiver::housekeeping_result;
+    struct round {
+        hk_result result;
+        model::offset clean;
+        size_t spill_map_sz;
+        size_t num_deleted_segments;
+        std::array<bool, 3> manifest_deleted;
+    };
+
+    constexpr std::array<round, 5> rounds = {{
+      // Round 1: partial cleanup of spillover manifest A, B and C remain
+      // unaffected.
+      {
+        .result = hk_result::partial,
+        .clean = model::offset{2000},
+        .spill_map_sz = 3,
+        .num_deleted_segments = 2,
+        .manifest_deleted = {false, false, false},
+      },
+      // Round 2: complete cleanup of spillover manifest A, partial cleanup of
+      // B, C remains unaffected.
+      {
+        .result = hk_result::partial,
+        .clean = model::offset{4000},
+        .spill_map_sz = 2,
+        .num_deleted_segments = 4,
+        .manifest_deleted = {true, false, false},
+      },
+      // Round 3: all segments in B are cleaned.
+      {
+        .result = hk_result::partial,
+        .clean = model::offset{6000},
+        .spill_map_sz = 2,
+        .num_deleted_segments = 6,
+        .manifest_deleted = {true, true, false},
+      },
+      // Round 4: partial cleanup of spillover manifest C
+      {
+        .result = hk_result::partial,
+        .clean = model::offset{8000},
+        .spill_map_sz = 1,
+        .num_deleted_segments = 8,
+        .manifest_deleted = {true, true, false},
+      },
+      // Round 5: complete cleanup of spillover manifest C, archive is empty.
+      {.result = hk_result::complete,
+       .clean = model::offset{},
+       .spill_map_sz = 0,
+       .num_deleted_segments = 9,
+       .manifest_deleted = {true, true, true}},
+    }};
+
+    std::array<ss::sstring, 3> spill_urls = {
+      spill_path_a().string(),
+      spill_path_b().string(),
+      spill_path_c().string()};
+
+    // Count how many times a key appears in multi-delete XML payloads.
+    auto count_key = [&](const ss::sstring& path) -> size_t {
+        auto needle = ssx::sformat("<Key>{}</Key>", path);
+        ss::sstring payloads;
+        for (const auto& [url, req] : get_targets()) {
+            if (req.has_q_delete) {
+                payloads += req.content;
+            }
+        }
+        size_t count = 0;
+        size_t pos = 0;
+        while ((pos = payloads.find(needle, pos)) != ss::sstring::npos) {
+            ++count;
+            pos += needle.size();
+        }
+        return count;
+    };
+
+    for (size_t r = 0; r < rounds.size(); r++) {
+        const auto& e = rounds[r];
+        vlog(test_log.info, "GC round {}", r + 1);
+
+        auto result = archiver.garbage_collect_archive().get();
+        BOOST_REQUIRE(result == e.result);
+        BOOST_REQUIRE_EQUAL(manifest.get_archive_clean_offset(), e.clean);
+        BOOST_REQUIRE_EQUAL(spills.size(), e.spill_map_sz);
+
+        for (size_t i = 0; i < num_segments_pending_gc; i++) {
+            BOOST_REQUIRE_EQUAL(
+              count_key(segment_urls.at(i).first().string()),
+              i < e.num_deleted_segments ? 1 : 0);
+        }
+        for (size_t i = 0; i < 3; i++) {
+            BOOST_REQUIRE_EQUAL(
+              count_key(spill_urls.at(i)), e.manifest_deleted.at(i) ? 1 : 0);
+        }
+    }
+
+    // Entire archive GCd.
+    BOOST_REQUIRE_EQUAL(manifest.get_archive_start_offset(), model::offset{});
+    BOOST_REQUIRE_EQUAL(manifest.get_archive_clean_offset(), model::offset{});
+
+    // STM segments still present.
+    for (size_t i = num_segments_pending_gc; i < num_segments; i++) {
+        BOOST_REQUIRE_EQUAL(count_key(segment_urls[i].first().string()), 0);
+    }
+}
+
+FIXTURE_TEST(
+  test_archive_retention_incremental_with_http_failures, archiver_fixture) {
+    // Constants chosen deliberately to cover all possible edge cases (partial
+    // spillover gc, multiple spillover gc, boundary gc, full archive gc).
+    const size_t num_segments = 12;
+    const size_t num_segments_pending_gc = 9;
+    const size_t num_segments_per_spill = 3;
+    const size_t gc_max_segments_per_run = 2;
+
+    auto cfg = scoped_config{};
+    cfg.get("cloud_storage_spillover_manifest_max_segments")
+      .set_value(std::make_optional(num_segments_per_spill));
+    cfg.get("cloud_storage_spillover_manifest_size")
+      .set_value(std::optional<size_t>{std::nullopt});
+    cfg.get("cloud_storage_gc_max_segments_per_run")
+      .set_value(gc_max_segments_per_run);
+
+    auto old_stamp = model::timestamp{
+      model::timestamp::now().value()
+      - std::chrono::milliseconds{10min}.count()};
+
+    std::vector<segment_desc> segments;
+    segments.reserve(num_segments);
+    for (size_t i = 0; i < num_segments; i++) {
+        segments.push_back(
+          {.ntp = manifest_ntp,
+           .base_offset = model::offset(i * 1000),
+           .term = model::term_id(i + 1),
+           .num_records = 1000,
+           .timestamp = i < num_segments_pending_gc
+                          ? old_stamp
+                          : std::optional<model::timestamp>{}});
+    }
+
+    init_storage_api_local(segments);
+    wait_for_partition_leadership(manifest_ntp);
+    auto part = app.partition_manager.local().get(manifest_ntp);
+    tests::cooperative_spin_wait_with_timeout(10s, [part]() mutable {
+        return part->last_stable_offset() >= model::offset(1);
+    }).get();
+
+    listen();
+
+    auto [arch_conf, remote_conf] = get_configurations();
+    auto amv = ss::make_shared<cloud_storage::async_manifest_view>(
+      remote,
+      app.shadow_index_cache,
+      part->archival_meta_stm()->manifest(),
+      arch_conf->bucket_name,
+      path_provider);
+    archival::ntp_archiver archiver(
+      get_ntp_conf(),
+      arch_conf,
+      remote.local(),
+      app.shadow_index_cache.local(),
+      *part,
+      amv);
+    archiver.initialize_probe();
+    amv->start().get();
+    auto action = ss::defer([&archiver, &amv] {
+        archiver.stop().get();
+        amv->stop().get();
+    });
+
+    size_t total_uploaded = 0;
+    while (total_uploaded < num_segments) {
+        auto res = upload_next_with_retries(archiver).get();
+        total_uploaded += res.non_compacted_upload_result.num_succeeded;
+        BOOST_REQUIRE_EQUAL(res.non_compacted_upload_result.num_failed, 0);
+    }
+    BOOST_REQUIRE_EQUAL(total_uploaded, num_segments);
+
+    std::vector<std::pair<remote_segment_path, bool>> segment_urls;
+    for (const auto& seg : segments) {
+        auto name = cloud_storage::generate_local_segment_name(
+          seg.base_offset, seg.term);
+        auto path = get_segment_path(
+          part->archival_meta_stm()->manifest(), name);
+        bool deletion_expected = seg.timestamp == old_stamp;
+        segment_urls.emplace_back(path, deletion_expected);
+    }
+
+    archiver.apply_spillover().get();
+
+    const auto& manifest = part->archival_meta_stm()->manifest();
+    BOOST_REQUIRE_EQUAL(manifest.get_archive_start_offset(), model::offset{0});
+    BOOST_REQUIRE_EQUAL(manifest.get_archive_clean_offset(), model::offset{0});
+    BOOST_REQUIRE_EQUAL(manifest.get_start_offset(), model::offset(9000));
+
+    const auto& spills = manifest.get_spillover_map();
+    BOOST_REQUIRE_EQUAL(spills.size(), 3);
+
+    std::vector<ss::sstring> spill_urls;
+    for (const auto& s : spills) {
+        spill_urls.push_back(
+          generate_spill_manifest_path(manifest, s)().string());
+    }
+
+    config::shard_local_cfg().log_retention_ms.set_value(
+      std::chrono::milliseconds{5min});
+    auto reset_cfg = ss::defer(
+      [] { config::shard_local_cfg().log_retention_ms.reset(); });
+
+    archiver.apply_archive_retention().get();
+    BOOST_REQUIRE_EQUAL(
+      manifest.get_archive_start_offset(), model::offset{9000});
+    BOOST_REQUIRE_EQUAL(manifest.get_archive_clean_offset(), model::offset{0});
+
+    size_t injected_failures = 0;
+    fail_request_if(
+      [&injected_failures](const ss::http::request& req) {
+          if (
+            req._method == "POST" && req.has_query_param("delete")
+            && random_generators::get_int(3) > 0) {
+              ++injected_failures;
+              return true;
+          }
+          return false;
+      },
+      {.body = "",
+       .status = ss::http::reply::status_type::internal_server_error});
+
+    using hk_result = archival::ntp_archiver::housekeeping_result;
+
+    size_t iteration_ix = 0;
+    size_t errors = 0;
+
+    for (;; iteration_ix++) {
+        std::optional<hk_result> result;
+        try {
+            result = archiver.garbage_collect_archive().get();
+        } catch (...) {
+            vlog(
+              test_log.info,
+              "GC iteration {} failed with exception: {}",
+              iteration_ix,
+              std::current_exception());
+            result = hk_result::error;
+        }
+        if (result == hk_result::error) {
+            ++errors;
+        }
+        if (result == hk_result::complete) {
+            break;
+        }
+    }
+
+    vlog(
+      test_log.info,
+      "GC finished after {} iterations ({} errors, {} injected failures)",
+      iteration_ix,
+      errors,
+      injected_failures);
+
+    BOOST_REQUIRE_GT(injected_failures, 0);
+    BOOST_REQUIRE_EQUAL(manifest.get_archive_start_offset(), model::offset{});
+    BOOST_REQUIRE_EQUAL(manifest.get_archive_clean_offset(), model::offset{});
+    BOOST_REQUIRE_EQUAL(spills.size(), 0);
+
+    auto count_key = [&](const ss::sstring& path) -> size_t {
+        auto needle = ssx::sformat("<Key>{}</Key>", path);
+        ss::sstring payloads;
+        for (const auto& [url, req] : get_targets()) {
+            if (req.has_q_delete) {
+                payloads += req.content;
+            }
+        }
+        size_t count = 0;
+        size_t pos = 0;
+        while ((pos = payloads.find(needle, pos)) != ss::sstring::npos) {
+            ++count;
+            pos += needle.size();
+        }
+        return count;
+    };
+
+    for (size_t i = 0; i < num_segments; i++) {
+        auto key = segment_urls[i].first().string();
+        if (i < num_segments_pending_gc) {
+            BOOST_REQUIRE_GE(count_key(key), 1);
+        } else {
+            BOOST_REQUIRE_EQUAL(count_key(key), 0);
+        }
+    }
+
+    for (const auto& sp : spill_urls) {
+        // At most one delete request for each spill manifest. We are optimistic
+        // with this delete.
+        BOOST_REQUIRE_GE(count_key(sp), 1);
+    }
 }
 
 FIXTURE_TEST(test_segments_pending_deletion_limit, archiver_fixture) {

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2418,9 +2418,20 @@ configuration::configuration()
       "The per-partition limit for the number of segments pending deletion "
       "from the cloud. Segments can be deleted due to retention or compaction. "
       "If this limit is breached and deletion fails, then segments will be "
-      "orphaned in the cloud and will have to be removed manually",
+      "orphaned in the cloud and will have to be removed manually. Applies "
+      "only the the in-memory manifest. Spillover manifests are not affected "
+      "by this limit.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5000)
+  , cloud_storage_gc_max_segments_per_run(
+      *this,
+      "cloud_storage_gc_max_segments_per_run",
+      "Maximum number of segments to delete per housekeeping run. Each segment "
+      "maps to up to three object keys (data, index, tx manifest), so a value "
+      "of 300 produces 600 to 900 deletes plus one per spillover manifest.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      300,
+      {.min = 1})
   , cloud_storage_enable_compacted_topic_reupload(
       *this,
       "cloud_storage_enable_compacted_topic_reupload",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -438,6 +438,7 @@ struct configuration final : public config_store {
     property<bool> enable_cluster_metadata_upload_loop;
     property<std::optional<ss::sstring>> cloud_storage_cluster_name;
     property<size_t> cloud_storage_max_segments_pending_deletion_per_partition;
+    bounded_property<size_t> cloud_storage_gc_max_segments_per_run;
     property<bool> cloud_storage_enable_compacted_topic_reupload;
     property<size_t> cloud_storage_recovery_temporary_retention_bytes_default;
     // validation of topic manifest during recovery

--- a/tests/rptest/tests/tiered_storage_model.py
+++ b/tests/rptest/tests/tiered_storage_model.py
@@ -1494,7 +1494,7 @@ class TS_Spillover_GarbageCollect(Expression):
         return [
             LogBasedValidator(
                 "TS_Spillover_GarbageCollect_log",
-                "ntp_archiver_service.*Deleted .* spillover segments from the cloud",
+                "ntp_archiver_service.*Archive GC deleted .* segments",
                 confidence_threshold=LOW_THRESHOLD,
                 execution_stage=TestRunStage.Intermediate,
             ),


### PR DESCRIPTION
See last commit in the chain for cover letter.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

### Improvements

- Archive garbage collection now deletes segments in bounded batches (controlled by `cloud_storage_gc_max_segments_per_run`, default `300`) instead of attempting to delete the entire backlog in a single housekeeping run. This prevents unbounded object storage delete requests on partitions with large expired archives, ensures each run commits incremental progress, and automatically schedules fast follow-up runs until the backlog is fully drained.
