### PR TITLE
ct/l1: bound extent removal work per RPC

### DIFF
--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.cc
@@ -869,50 +869,55 @@ ss::future<rpc::set_start_offset_reply> db_domain_manager::do_set_start_offset(
         current_start_offset = meta.start_offset;
     }
 
-    // Advance start_offset in batches until reaching final target.
-    while (current_start_offset < target_offset) {
-        auto reader = state_reader(db_->db().create_snapshot());
-
-        // Scan through extents to find an intermediate offset in case there
-        // are a ton of extents.
-        auto new_start_res = co_await scan_extents_below(
-          reader, req.tp, target_offset, max_extents_per_batch);
-        if (!new_start_res.has_value()) {
-            co_return rpc::set_start_offset_reply{
-              .ec = log_and_convert(
-                new_start_res.error(), "Error scanning extents: "),
-            };
-        }
-
-        auto update = set_start_offset_db_update{
-          .tp = req.tp,
-          .new_start_offset = new_start_res.value(),
+    if (current_start_offset >= target_offset) {
+        co_return rpc::set_start_offset_reply{
+          .ec = rpc::errc::ok,
         };
+    }
 
-        chunked_vector<write_batch_row> rows;
-        bool is_no_op = false;
-        auto build_res = co_await update.build_rows(reader, rows, &is_no_op);
-        if (!build_res.has_value()) {
-            co_return rpc::set_start_offset_reply{
-              .ec = log_and_convert(
-                build_res.error(), "Rejecting request to set start offset: "),
-            };
-        }
-        if (is_no_op) {
-            current_start_offset = new_start_res.value();
-            continue;
-        }
-        auto apply_res = co_await write_rows(locks, std::move(rows));
-        if (!apply_res.has_value()) {
-            co_return rpc::set_start_offset_reply{
-              .ec = apply_res.error(),
-            };
-        }
-        current_start_offset = new_start_res.value();
+    auto reader = state_reader(db_->db().create_snapshot());
+
+    // Scan through extents to find an intermediate offset bounded by
+    // max_extents_per_batch.
+    auto new_start_res = co_await scan_extents_below(
+      reader, req.tp, target_offset, max_extents_per_batch);
+    if (!new_start_res.has_value()) {
+        co_return rpc::set_start_offset_reply{
+          .ec = log_and_convert(
+            new_start_res.error(), "Error scanning extents: "),
+        };
+    }
+
+    auto update = set_start_offset_db_update{
+      .tp = req.tp,
+      .new_start_offset = new_start_res.value(),
+    };
+
+    chunked_vector<write_batch_row> rows;
+    bool is_no_op = false;
+    auto build_res = co_await update.build_rows(reader, rows, &is_no_op);
+    if (!build_res.has_value()) {
+        co_return rpc::set_start_offset_reply{
+          .ec = log_and_convert(
+            build_res.error(), "Rejecting request to set start offset: "),
+        };
+    }
+    if (is_no_op) {
+        co_return rpc::set_start_offset_reply{
+          .ec = rpc::errc::ok,
+          .has_more = new_start_res.value() < target_offset,
+        };
+    }
+    auto apply_res = co_await write_rows(locks, std::move(rows));
+    if (!apply_res.has_value()) {
+        co_return rpc::set_start_offset_reply{
+          .ec = apply_res.error(),
+        };
     }
 
     co_return rpc::set_start_offset_reply{
       .ec = rpc::errc::ok,
+      .has_more = new_start_res.value() < target_offset,
     };
 }
 
@@ -927,7 +932,8 @@ db_domain_manager::set_start_offset(rpc::set_start_offset_request req) {
     co_return co_await do_set_start_offset(gl_res.value(), req);
 }
 
-ss::future<std::expected<void, rpc::errc>>
+ss::future<
+  std::expected<db_domain_manager::set_partitions_empty_result, rpc::errc>>
 db_domain_manager::set_partitions_empty(
   const gate_writer_locks& locks, const model::topic_id& tid) {
     auto reader = state_reader(db_->db().create_snapshot());
@@ -937,20 +943,20 @@ db_domain_manager::set_partitions_empty(
           partitions_res.error(), "Error getting partitions for topic: "));
     }
     if (partitions_res.value().empty()) {
-        // No partitions, all done!
-        co_return std::expected<void, rpc::errc>{};
+        co_return set_partitions_empty_result{.has_more = false};
     }
 
-    // Truncate all partitions that have data.
-    for (const auto& pid : partitions_res.value()) {
+    // Process one batch of work for the first non-empty partition, then
+    // return so the caller can bound work per RPC.
+    for (size_t i = 0; i < partitions_res.value().size(); ++i) {
+        const auto& pid = partitions_res.value()[i];
         model::topic_id_partition tidp(tid, pid);
         auto meta_res = co_await reader.get_metadata(tidp);
         if (!meta_res.has_value()) {
             co_return std::unexpected(
               log_and_convert(meta_res.error(), "Error getting metadata: "));
         }
-        if (!meta_res->has_value()) {
-            // Partition doesn't exist, skip.
+        if (!meta_res.value().has_value()) {
             continue;
         }
         const auto& metadata = (*meta_res).value();
@@ -964,10 +970,11 @@ db_domain_manager::set_partitions_empty(
             if (set_offset_reply.ec != rpc::errc::ok) {
                 co_return std::unexpected(set_offset_reply.ec);
             }
+            co_return set_partitions_empty_result{.has_more = true};
         }
     }
 
-    co_return std::expected<void, rpc::errc>{};
+    co_return set_partitions_empty_result{.has_more = false};
 }
 
 ss::future<std::expected<void, rpc::errc>> db_domain_manager::do_remove_topics(
@@ -1027,9 +1034,8 @@ db_domain_manager::remove_topics(rpc::remove_topics_request req) {
         if (
           to_delete_so_far.empty() && topic_extents >= max_extents_per_batch) {
             // This topic is big and it's the first one (we don't have any
-            // other topics accumulated). Delete it on its own by iteratively
-            // emptying its partitions (via set_partitions_empty) and then
-            // removing the remaining topic metadata.
+            // other topics accumulated). Do one batch of partition emptying
+            // and return, expecting callers to retry.
             auto empty_res = co_await set_partitions_empty(gl_res.value(), tid);
             if (!empty_res.has_value()) {
                 co_return rpc::remove_topics_reply{
@@ -1037,6 +1043,15 @@ db_domain_manager::remove_topics(rpc::remove_topics_request req) {
                   .not_removed = {},
                 };
             }
+            if (empty_res.value().has_more) {
+                // More emptying to do — return this topic (and the rest)
+                // as not_removed so the caller retries.
+                co_return rpc::remove_topics_reply{
+                  .ec = rpc::errc::ok,
+                  .not_removed = copy_req_topics_from(i),
+                };
+            }
+            // Partitions are fully emptied. Remove the remaining metadata.
             auto rm_res = co_await do_remove_topics(
               gl_res.value(), chunked_vector<model::topic_id>::single(tid));
             if (!rm_res.has_value()) {
@@ -1047,7 +1062,7 @@ db_domain_manager::remove_topics(rpc::remove_topics_request req) {
             }
             co_return rpc::remove_topics_reply{
               .ec = rpc::errc::ok,
-              .not_removed = copy_req_topics_from(1),
+              .not_removed = copy_req_topics_from(i + 1),
             };
         }
 

--- a/src/v/cloud_topics/level_one/domain/db_domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/db_domain_manager.h
@@ -152,9 +152,13 @@ private:
     ss::future<rpc::set_start_offset_reply> do_set_start_offset(
       const gate_writer_locks&, rpc::set_start_offset_request);
 
-    // Ensures all partitions for a topic have start_offset == next_offset by
-    // advancing start_offset where needed.
-    ss::future<std::expected<void, rpc::errc>>
+    struct set_partitions_empty_result {
+        bool has_more{false};
+    };
+
+    // Advances start_offset toward next_offset for one partition at a time.
+    // Returns has_more=true if more work remains (more batches or partitions).
+    ss::future<std::expected<set_partitions_empty_result, rpc::errc>>
     set_partitions_empty(const gate_writer_locks&, const model::topic_id&);
 
     // Removes all metadata rows for the given topics. Callers are expected to

--- a/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
+++ b/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
@@ -990,7 +990,7 @@ TEST_F(DbDomainManagerTest, TestGarbageCollectionAfterRemoveTopic) {
     auto prereg_reply = initial_manager
                           ->preregister_objects({
                             .metastore_partition = model::partition_id(0),
-                            .count = 4321,
+                            .count = 1234,
                           })
                           .get();
     ASSERT_EQ(prereg_reply.ec, l1_rpc::errc::ok);
@@ -1012,13 +1012,18 @@ TEST_F(DbDomainManagerTest, TestGarbageCollectionAfterRemoveTopic) {
         ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
     }
 
-    // Remove the topic, marking the objects as removable.
+    // Remove the topic, retrying as needed since batching may return
+    // not_removed when extent counts exceed the batch limit.
     {
-        l1_rpc::remove_topics_request req;
-        req.topics.push_back(tp.topic_id);
-        auto reply = initial_manager->remove_topics(std::move(req)).get();
-        ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
-        ASSERT_TRUE(reply.not_removed.empty());
+        chunked_vector<model::topic_id> remaining;
+        remaining.push_back(tp.topic_id);
+        while (!remaining.empty()) {
+            l1_rpc::remove_topics_request req;
+            req.topics = std::move(remaining);
+            auto reply = initial_manager->remove_topics(std::move(req)).get();
+            ASSERT_EQ(reply.ec, l1_rpc::errc::ok);
+            remaining = std::move(reply.not_removed);
+        }
     }
 
     // Allow for some time to GC, but no GC should happen until we flush.
@@ -1220,14 +1225,23 @@ TEST_F(DbDomainManagerTest, TestSetStartOffsetBatchedExtentRemoval) {
     ASSERT_NO_FATAL_FAILURE(add_preregistered_objects(
       tp, kafka::offset(0), 2500, 1, model::term_id(1)));
 
-    // Truncate everything in one call.
-    l1_rpc::set_start_offset_request set_req{
-      .tp = tp,
-      .start_offset = kafka::offset(2500),
-    };
-    auto set_reply
-      = initial_manager->set_start_offset(std::move(set_req)).get();
-    ASSERT_EQ(set_reply.ec, l1_rpc::errc::ok);
+    // Each call does one batch. The first calls should return has_more=true,
+    // and the final call has_more=false once the target is reached.
+    int rounds = 0;
+    bool has_more = true;
+    while (has_more) {
+        l1_rpc::set_start_offset_request set_req{
+          .tp = tp,
+          .start_offset = kafka::offset(2500),
+        };
+        auto set_reply
+          = initial_manager->set_start_offset(std::move(set_req)).get();
+        ASSERT_EQ(set_reply.ec, l1_rpc::errc::ok);
+        has_more = set_reply.has_more;
+        ++rounds;
+    }
+    // 2500 extents at 1000 per batch = 3 rounds.
+    ASSERT_EQ(rounds, 3);
 
     l1_rpc::get_offsets_request verify_req{.tp = tp};
     auto verify_reply
@@ -1266,13 +1280,18 @@ TEST_F(DbDomainManagerTest, TestSetStartOffsetMidExtent) {
     // The batch scans 1000 extents, ending at [9990,9999]. Without
     // clamping, the intermediate offset would be next_offset(9999)=10000,
     // which would incorrectly delete extent [9990,9999].
-    l1_rpc::set_start_offset_request set_req{
-      .tp = tp,
-      .start_offset = kafka::offset(9995),
-    };
-    auto set_reply
-      = initial_manager->set_start_offset(std::move(set_req)).get();
-    ASSERT_EQ(set_reply.ec, l1_rpc::errc::ok);
+    // Retry until all batches are processed.
+    bool has_more = true;
+    while (has_more) {
+        l1_rpc::set_start_offset_request set_req{
+          .tp = tp,
+          .start_offset = kafka::offset(9995),
+        };
+        auto set_reply
+          = initial_manager->set_start_offset(std::move(set_req)).get();
+        ASSERT_EQ(set_reply.ec, l1_rpc::errc::ok);
+        has_more = set_reply.has_more;
+    }
 
     l1_rpc::get_offsets_request verify_req{.tp = tp};
     auto verify_reply

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -491,23 +491,26 @@ replicated_metastore::replace_objects(
 ss::future<std::expected<void, metastore::errc>>
 replicated_metastore::set_start_offset(
   const model::topic_id_partition& tidp, kafka::offset offset) {
-    rpc::set_start_offset_request req;
-    req.tp = tidp;
-    req.start_offset = offset;
+    while (true) {
+        rpc::set_start_offset_request req;
+        req.tp = tidp;
+        req.start_offset = offset;
 
-    auto reply_fut = co_await ss::coroutine::as_future(
-      fe_.set_start_offset(std::move(req)));
-    if (reply_fut.failed()) {
-        auto ex = reply_fut.get_exception();
-        vlog(cd_log.warn, "Error while sending request: {}", ex);
-        co_return std::unexpected(metastore::errc::transport_error);
+        auto reply_fut = co_await ss::coroutine::as_future(
+          fe_.set_start_offset(std::move(req)));
+        if (reply_fut.failed()) {
+            auto ex = reply_fut.get_exception();
+            vlog(cd_log.warn, "Error while sending request: {}", ex);
+            co_return std::unexpected(metastore::errc::transport_error);
+        }
+        auto reply = reply_fut.get();
+        if (reply.ec != rpc::errc::ok) {
+            co_return std::unexpected(rpc_to_meta_errc(reply.ec));
+        }
+        if (!reply.has_more) {
+            co_return std::expected<void, metastore::errc>{};
+        }
     }
-    auto reply = reply_fut.get();
-    if (reply.ec != rpc::errc::ok) {
-        co_return std::unexpected(rpc_to_meta_errc(reply.ec));
-    }
-
-    co_return std::expected<void, metastore::errc>{};
 }
 
 ss::future<std::expected<metastore::topic_removal_response, metastore::errc>>

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -326,11 +326,12 @@ struct get_end_offset_for_term_request
 struct set_start_offset_reply
   : serde::envelope<
       set_start_offset_reply,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
-    auto serde_fields() { return std::tie(ec); }
+    auto serde_fields() { return std::tie(ec, has_more); }
 
     errc ec;
+    bool has_more{false};
 };
 struct set_start_offset_request
   : serde::envelope<


### PR DESCRIPTION
do_set_start_offset, set_partitions_empty, and remove_topics could each do unbounded work in a single RPC, risking timeouts on large topics. Limit each to one batch of up to 1000 extents per call and signal remaining work via has_more / not_removed so callers retry.

This is follow-up to https://github.com/redpanda-data/redpanda/pull/29727

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
