### PR TITLE
[v25.3.x] kafka/tests: fix flaky unlicensed enterprise tests

### DIFF
--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -544,16 +544,16 @@ FIXTURE_TEST(unlicensed_rejected, create_topic_fixture) {
     // NOTE(oren): w/o schema validation enabled at the cluster level, related
     // properties will be ignored on the topic create path. stick to COMPAT here
     // because it's a superset of REDPANDA.
-    lconf().enable_schema_id_validation.set_value(
-      pandaproxy::schema_registry::schema_id_validation_mode::compat);
-    lconf().cloud_storage_enabled.set_value(true);
+    update_cluster_config(lconf().enable_schema_id_validation.name(), "compat");
+    update_cluster_config(lconf().cloud_storage_enabled.name(), "true");
 
-    auto unset_cloud_storage = ss::defer([&] {
-        lconf().enable_schema_id_validation.set_value(
-          pandaproxy::schema_registry::schema_id_validation_mode::none);
-        lconf().cloud_storage_enabled.set_value(false);
+    auto unset_cluster_config = ss::defer([&] {
+        update_cluster_config(
+          lconf().enable_schema_id_validation.name(), "none");
+        update_cluster_config(lconf().cloud_storage_enabled.name(), "false");
     });
 
+    wait_for_license_init();
     revoke_license();
     using prop_t = std::map<ss::sstring, ss::sstring>;
     const auto with = [](const std::string_view prop, const auto value) {
@@ -603,9 +603,11 @@ FIXTURE_TEST(unlicensed_rejected, create_topic_fixture) {
 }
 
 FIXTURE_TEST(unlicensed_reject_defaults, create_topic_fixture) {
-    lconf().cloud_storage_enabled.set_value(true);
-    auto unset_cloud_storage = ss::defer(
-      [&] { lconf().cloud_storage_enabled.set_value(false); });
+    update_cluster_config(lconf().cloud_storage_enabled.name(), "true");
+    auto unset_cluster_config = ss::defer([&] {
+        update_cluster_config(lconf().cloud_storage_enabled.name(), "false");
+    });
+    wait_for_license_init();
     revoke_license();
 
     const std::initializer_list<std::string_view> si_configs{

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -502,10 +502,10 @@ FIXTURE_TEST(case_insensitive_boolean_property, create_topic_fixture) {
 }
 
 FIXTURE_TEST(unlicensed_permit_if_config_disabled, create_topic_fixture) {
-    lconf().enable_schema_id_validation.set_value(
-      pandaproxy::schema_registry::schema_id_validation_mode::none);
-    lconf().cloud_storage_enabled.set_value(false);
+    update_cluster_config(lconf().enable_schema_id_validation.name(), "none");
+    update_cluster_config(lconf().cloud_storage_enabled.name(), "false");
 
+    wait_for_license_init();
     revoke_license();
 
     using prop_t = std::map<ss::sstring, ss::sstring>;

--- a/src/v/kafka/server/tests/topic_properties_helpers.h
+++ b/src/v/kafka/server/tests/topic_properties_helpers.h
@@ -13,10 +13,20 @@
 #include "kafka/protocol/create_partitions.h"
 #include "kafka/protocol/create_topics.h"
 #include "redpanda/tests/fixture.h"
+#include "test_utils/async.h"
 
 class topic_properties_test_fixture : public redpanda_thread_fixture {
 public:
     topic_properties_test_fixture() { wait_for_controller_leadership().get(); }
+
+    void wait_for_license_init() {
+        tests::cooperative_spin_wait_with_timeout(5s, [this] {
+            return app.controller->get_feature_table()
+              .local()
+              .get_license()
+              .has_value();
+        }).get();
+    }
 
     void revoke_license() {
         app.controller->get_feature_table()


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/29740
