### PR TITLE
rpk/benchmark: disable producer compression

### DIFF
--- a/src/go/rpk/pkg/cli/benchmark/benchmark.go
+++ b/src/go/rpk/pkg/cli/benchmark/benchmark.go
@@ -374,6 +374,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				kgo.RequiredAcks(kgo.AllISRAcks()),
 				kgo.RecordPartitioner(kgo.RoundRobinPartitioner()),
 				kgo.ProducerLinger(0),
+				kgo.ProducerBatchCompression(kgo.NoCompression()),
 			}
 
 			producerClients := make([]*kgo.Client, 0, clients)


### PR DESCRIPTION
franz-go uses snappy compression by default, which means the MB/s rate
reported by the benchmark tool doesn't match the ingress rate Redpanda
actually sees. Disabling compression makes the reported throughput align
with the broker's view and makes benchmark results more predictable.

This is probably only noticeable at higher payload sizes as small payloads 
don't compress well or at all.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none