### PR TITLE
dev_cluster: add --scrape-interval flag for prometheus

### DIFF
--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -337,12 +337,14 @@ class Grafana:
         directory: Path,
         port: int,
         prometheus_url: str | None = None,
+        scrape_interval: str = "5s",
     ) -> None:
         self.binary = binary
         self.directory = directory
         self.stopped = False
         self.port = port
         self.prometheus_url = prometheus_url
+        self.scrape_interval = scrape_interval
         self.process: asyncio.subprocess.Process
 
     def stop(self) -> None:
@@ -383,6 +385,9 @@ class Grafana:
                         "url": self.prometheus_url,
                         "isDefault": True,
                         "editable": True,
+                        "jsonData": {
+                            "timeInterval": self.scrape_interval,
+                        },
                     }
                 ],
             }
@@ -845,6 +850,7 @@ async def main() -> None:
             grafana_dir,
             port=args.grafana_port,
             prometheus_url=prometheus_url,
+            scrape_interval=args.scrape_interval,
         )
         grafana_task = asyncio.create_task(grafana.run())
 

--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -245,6 +245,7 @@ class Prometheus:
         listen_address: str = "127.0.0.1",
         port: int = 3001,
         redpanda_admin_ports: list[int] = [],
+        scrape_interval: str = "5s",
     ) -> None:
         self.binary = binary
         self.directory = directory
@@ -252,6 +253,7 @@ class Prometheus:
         self.listen_address = listen_address
         self.port = port
         self.redpanda_admin_ports = redpanda_admin_ports
+        self.scrape_interval = scrape_interval
         self.process: asyncio.subprocess.Process
 
     def stop(self) -> None:
@@ -267,10 +269,10 @@ class Prometheus:
         data_dir.mkdir(parents=True, exist_ok=True)
 
         # Create a basic Prometheus configuration
-        config = {
+        config: dict[str, Any] = {
             "global": {
-                "scrape_interval": "5s",
-                "evaluation_interval": "5s",
+                "scrape_interval": self.scrape_interval,
+                "evaluation_interval": self.scrape_interval,
             },
             "scrape_configs": [
                 {
@@ -664,6 +666,12 @@ async def main() -> None:
         default=True,
     )
     parser.add_argument(
+        "--scrape-interval",
+        type=str,
+        help="prometheus scrape interval (e.g. '1s', '5s', '15s')",
+        default="5s",
+    )
+    parser.add_argument(
         "--grafana",
         type=Path,
         help="path to grafana executable",
@@ -817,6 +825,7 @@ async def main() -> None:
             prometheus_dir,
             args.listen_address,
             redpanda_admin_ports=[args.base_admin_port + i for i in range(args.nodes)],
+            scrape_interval=args.scrape_interval,
         )
         prometheus_task = asyncio.create_task(prometheus.run())
 


### PR DESCRIPTION
The Prometheus scrape interval in dev_cluster was hardcoded to 5s. This
adds a `--scrape-interval` CLI argument to make it configurable, which is
useful when testing metrics that update at sub-5s intervals.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none