### PR TITLE
[v25.3.x] cluster/feature_manager: use insert_or_assign for version updates

### DIFF
--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -525,7 +525,7 @@ void feature_manager::update_node_version(
       update_node,
       v);
 
-    _updates.emplace(update_node, v);
+    _updates.insert_or_assign(update_node, v);
     _update_wait.signal();
 }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/29824

The second commit (dt: increase alter_cluster_quotas timeout during upgrade) was
dropped because the `QuotaManagementUtils` mixin and `QuotaManagementUpgradeTest`
it modifies do not exist on v25.3.x.

Fixes https://github.com/redpanda-data/redpanda/issues/29855