### PR TITLE
[v25.2.x] cluster/feature_manager: use insert_or_assign for version updates

### DIFF
--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -518,7 +518,7 @@ void feature_manager::update_node_version(
       update_node,
       v);
 
-    _updates.emplace(update_node, v);
+    _updates.insert_or_assign(update_node, v);
     _update_wait.signal();
 }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/29824
Resolves https://github.com/redpanda-data/redpanda/issues/29856

Dropped commit c77c86edde ("dt: increase alter_cluster_quotas timeout during upgrade") — it increases a timeout in `QuotaManagementUtils.alter(with_retries=True)`, but the `QuotaManagementUtils` mixin and `with_retries` code path don't exist on v25.2.x.