### PR TITLE
ct/reconciler: Downgrade error logs to warn

### DIFF
--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -55,7 +55,7 @@ void log_error(
   const reconcile_error& err,
   vlog::file_line file_line = vlog::file_line::current()) {
     lg.log(
-      err.benign ? ss::log_level::debug : ss::log_level::error,
+      err.benign ? ss::log_level::debug : ss::log_level::warn,
       "{} - {}",
       file_line,
       err.message);


### PR DESCRIPTION
The reconciler catches exceptions that bubble up from its dependencies. Especially because a cloud storage client is a dependency, this leads to a large amount of different exception that can be caught, and that are difficult for the reconciler to do anything with. The reconciler will always retry, so none of these exceptions are fatal, though on rare cases they may indicate non-transient problems. Typically, however, the exceptions are transient cloud conditions, which means that logging them at error level creates unnecessary noise that fails tests that validate logs and will cause headaches for operators wondering if the error logs require action. This change proposes reducing the logging of non-benign reconcile_errors to warn. This will get rid of the error log noise. The tradeoff is that some non-transient problems could be less visible at warn level than at error level, but in practice I think this is minor because a non-transient problem is likely a general cloud storage problem or a general metastore problem, and it will have a blast radius much larger than just the reconciler.

Future work should try to catch and analyze more exception types, and ideally minimize the use of exceptions to communicate error conditions.

Fixes CORE-15781
Fixes CORE-15782

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
