### PR TITLE
rptest: allow cloud_storage_url_style override via globals

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -805,6 +805,25 @@ class SISettings:
         elif self.cloud_storage_type == CloudStorageType.ABS:
             self._load_abs_context(logger, test_context)
 
+        cloud_storage_url_style = test_context.globals.get(
+            "cloud_storage_url_style", None
+        )
+        if cloud_storage_url_style is not None:
+            if cloud_storage_url_style not in ("path", "virtual_host"):
+                raise ValueError(
+                    f"Invalid cloud_storage_url_style: {cloud_storage_url_style!r}, "
+                    f"expected 'path' or 'virtual_host'"
+                )
+            logger.info(
+                f"Overriding cloud_storage_url_style from globals: "
+                f"{cloud_storage_url_style}"
+            )
+            self.cloud_storage_url_style = cloud_storage_url_style
+            if cloud_storage_url_style == "path":
+                self.addressing_style = S3AddressingStyle.PATH
+            else:
+                self.addressing_style = S3AddressingStyle.VIRTUAL
+
     def _load_abs_context(self, logger: Logger, test_context: TestContext) -> None:
         storage_account = test_context.globals.get(
             self.GLOBAL_ABS_STORAGE_ACCOUNT, None


### PR DESCRIPTION
Allow test environments to override the S3 URL style (path vs virtual-hosted) through the ducktape globals config. Using the path style allows for simpler Minio deployments in tests.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
