### PR TITLE
ct/l0: track active readers

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -334,8 +334,10 @@ std::optional<model::topic_id_partition> frontend::topic_id_partition() const {
 
 std::unique_ptr<model::record_batch_reader::impl>
 frontend::make_l0_reader(const cloud_topic_log_reader_config& cfg) const {
-    return std::make_unique<level_zero_log_reader_impl>(
+    auto rdr = std::make_unique<level_zero_log_reader_impl>(
       cfg, _partition, _data_plane);
+    rdr->register_with_stm(_ctp_stm_api.get());
+    return rdr;
 }
 
 ss::future<std::optional<l1::metastore::size_response>> frontend::l1_size() {

--- a/src/v/cloud_topics/level_zero/frontend_reader/BUILD
+++ b/src/v/cloud_topics/level_zero/frontend_reader/BUILD
@@ -20,6 +20,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics:state_accessors",
         "//src/v/cloud_topics:topic_id_partition",
         "//src/v/cloud_topics:types",
+        "//src/v/cloud_topics/level_zero/stm:ctp_stm_api",
         "//src/v/cloud_topics/level_zero/stm:placeholder",
         "//src/v/cluster",
         "//src/v/config",

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.cc
@@ -519,6 +519,10 @@ void level_zero_log_reader_impl::print(std::ostream& o) {
     o << "cloud_topics_reader";
 }
 
+void level_zero_log_reader_impl::register_with_stm(ctp_stm_api* api) {
+    api->register_reader(&_state);
+}
+
 void level_zero_log_reader_impl::set_end_of_stream() { _end_of_stream = true; }
 
 bool level_zero_log_reader_impl::is_end_of_stream() const {

--- a/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/level_zero_reader.h
@@ -11,6 +11,7 @@
 
 #include "cloud_topics/errc.h"
 #include "cloud_topics/level_zero/common/extent_meta.h"
+#include "cloud_topics/level_zero/stm/ctp_stm_api.h"
 #include "cloud_topics/log_reader_config.h"
 #include "model/record_batch_reader.h"
 #include "utils/prefix_logger.h"
@@ -81,6 +82,10 @@ public:
       do_load_slice(model::timeout_clock::time_point) final;
 
     void print(std::ostream& o) final;
+
+    // Register this reader with the STM - this is needed so that L0 doesn't GC
+    // any active data during reads.
+    void register_with_stm(ctp_stm_api*);
 
 private:
     // A batch read from the local log, these can be either placeholder batches
@@ -155,6 +160,8 @@ private:
     data_plane_api* _ct_api;
     prefix_logger _log;
     size_t _bytes_consumed{0};
+    // state that the STM tracks as to hold back prefix truncation and GC
+    active_reader_state _state;
 };
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/stm/BUILD
+++ b/src/v/cloud_topics/level_zero/stm/BUILD
@@ -64,6 +64,7 @@ redpanda_cc_library(
     visibility = [":__subpackages__"],
     deps = [
         "//src/v/cloud_topics:types",
+        "//src/v/container:intrusive",
         "//src/v/model",
         "@fmt",
         "@seastar",

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -14,6 +14,7 @@
 #include "cloud_topics/level_zero/stm/ctp_stm_commands.h"
 #include "cloud_topics/level_zero/stm/ctp_stm_state.h"
 #include "cloud_topics/level_zero/stm/placeholder.h"
+#include "cloud_topics/level_zero/stm/types.h"
 #include "cloud_topics/types.h"
 #include "raft/consensus.h"
 #include "raft/persisted_stm.h"
@@ -115,12 +116,14 @@ ss::future<> ctp_stm::prefix_truncate_below_lro() {
         vlog(
           _log.trace,
           "Waiting for LRO to advance past {}, current snapshot index: {}",
-          _state.get_max_collectible_offset(),
+          max_removable_local_log_offset(),
           _raft->last_snapshot_index());
         try {
             if (
-              _raft->last_snapshot_index()
-              >= _state.get_max_collectible_offset()) {
+              _raft->last_snapshot_index() >= max_removable_local_log_offset()
+              && _active_readers.empty()) {
+                // Only wait without a timeout if there are no active readers
+                // that could be holding us back.
                 co_await _lro_advanced.wait();
             } else {
                 co_await _lro_advanced.wait(retry_backoff_time);
@@ -137,12 +140,12 @@ ss::future<> ctp_stm::prefix_truncate_below_lro() {
               "error waiting for LRO to advance in ctp stm background loop: {}",
               std::current_exception());
         }
-        auto lro = _state.get_max_collectible_offset();
+        auto lro = max_removable_local_log_offset();
         auto snapshot_index = _raft->last_snapshot_index();
         vlog(
           _log.trace,
           "Attempting to snapshot ctp at {}, last snapshot at {}",
-          _state.get_max_collectible_offset(),
+          max_removable_local_log_offset(),
           _raft->last_snapshot_index());
         try {
             co_await _raft->snapshot_and_truncate_log(lro);
@@ -202,6 +205,10 @@ ss::future<bool> ctp_stm::sync_in_term(
 }
 
 std::optional<cluster_epoch> ctp_stm::estimate_inactive_epoch() const noexcept {
+    // If there is an active reader, it holds back the inactive_epoch.
+    if (!_active_readers.empty()) {
+        return _active_readers.front().inactive_epoch;
+    }
     return _state.estimate_inactive_epoch();
 }
 
@@ -488,10 +495,20 @@ ctp_stm::fence_epoch(cluster_epoch e) {
 }
 
 model::offset ctp_stm::max_removable_local_log_offset() {
+    // If there is an active reader, it holds back prefix truncation.
+    if (!_active_readers.empty()) {
+        return _active_readers.front().lrlo;
+    }
     return _state.get_max_collectible_offset();
 }
 
 l0::producer_queue& ctp_stm::producer_queue() { return _producer_queue; }
+
+void ctp_stm::register_reader(active_reader_state* state) {
+    state->inactive_epoch = _state.estimate_inactive_epoch();
+    state->lrlo = _state.get_max_collectible_offset();
+    _active_readers.push_back(*state);
+}
 
 void epoch_window_checker::check_epoch(
   const model::ntp& ntp, cluster_epoch epoch, model::offset offset) {

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -112,6 +112,14 @@ public:
     // This is used to preserve ordering of concurrently uploading requests.
     l0::producer_queue& producer_queue();
 
+    // Register this reader with the STM.
+    //
+    // By registering this reader, it's ensured that we don't GC any of the
+    // data at the time this method is called. The state here will be filled in
+    // by the STM for bookkeeping. The pointer to `state` must be kept stable
+    // for it's entire lifetime.
+    void register_reader(active_reader_state* state);
+
 private:
     ss::future<> do_apply(const model::record_batch&) override;
     void apply_placeholder(const model::record_batch&);
@@ -135,6 +143,8 @@ private:
 
 private:
     l0::producer_queue _producer_queue;
+    intrusive_list<active_reader_state, &active_reader_state::hook>
+      _active_readers;
     /// Lock to protect the state from concurrent access.
     /// When the new epoch is applied we need to acquire a write lock.
     /// Otherwise, we need to acquire a read lock.

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
@@ -321,4 +321,8 @@ uint64_t ctp_stm_api::estimated_data_size() const noexcept {
     return _stm->state().estimated_data_size();
 }
 
+void ctp_stm_api::register_reader(active_reader_state* state) {
+    return _stm->register_reader(state);
+}
+
 }; // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
@@ -118,6 +118,11 @@ public:
 
     l0::producer_queue& producer_queue();
 
+    // Register this reader with the STM so that it's state isn't GC'd.
+    //
+    // The provided pointer must be kept *stable* during it's entire lifetime.
+    void register_reader(active_reader_state*);
+
     /// Estimate the total bytes of cloud data addressable by the level-zero
     /// log for this partition.
     uint64_t estimated_data_size() const noexcept;

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -50,6 +50,10 @@ struct ctp_stm_accessor {
     bool epoch_cv_has_waiters(ctp_stm& stm) {
         return stm._epoch_updated_cv.has_waiters();
     }
+
+    model::offset max_removable_local_log_offset(ctp_stm& stm) {
+        return stm.max_removable_local_log_offset();
+    }
 };
 } // namespace cloud_topics
 
@@ -1131,4 +1135,126 @@ TEST_F_CORO(
     // wasn't actually idle - it had unreconciled data that blocked LRLO from
     // reaching the epoch_window_offset
     ASSERT_EQ_CORO(estimate_after_sync.value(), estimate_before_sync.value());
+}
+
+TEST_F_CORO(ctp_stm_fixture, test_active_reader_holds_back_gc) {
+    // An active reader registered with the STM should hold back both
+    // estimate_inactive_epoch() and max_removable_local_log_offset() to
+    // the values captured at registration time. This prevents prefix
+    // truncation from removing data a reader still needs.
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+
+    auto& leader = node(*get_leader());
+    auto leader_api = api(leader);
+    auto stm = get_stm<0>(leader);
+    ct::ctp_stm_accessor accessor;
+
+    // Replicate epoch 5 placeholder and reconcile it.
+    auto b1 = make_record_batch(ct::cluster_epoch{5}, model::offset{0}, 0);
+    co_await replicate_record_batch(leader, std::move(b1));
+    co_await leader_api.advance_reconciled_offset(
+      kafka::offset{0}, model::no_timeout, as);
+
+    // Advance epoch to 10 and sync LRLO past the advance_epoch batch.
+    co_await leader_api.advance_epoch(
+      ct::cluster_epoch{10}, model::no_timeout, as);
+    co_await leader_api.sync_to_next_placeholder(model::no_timeout, as);
+
+    // Capture baseline: epoch estimate=4, lrlo from state.
+    auto baseline_epoch = leader_api.estimate_inactive_epoch();
+    ASSERT_TRUE_CORO(baseline_epoch.has_value());
+    ASSERT_EQ_CORO(baseline_epoch.value(), ct::cluster_epoch{4});
+    auto baseline_lrlo = accessor.max_removable_local_log_offset(*stm);
+
+    // Register a reader - captures the current state.
+    auto reader1 = std::make_unique<ct::active_reader_state>();
+    leader_api.register_reader(reader1.get());
+    ASSERT_EQ_CORO(reader1->inactive_epoch, baseline_epoch);
+    ASSERT_EQ_CORO(reader1->lrlo, baseline_lrlo);
+
+    // Advance the state: new epoch 15, replicate + reconcile more data.
+    auto b2 = make_record_batch(ct::cluster_epoch{15}, model::offset{1}, 1);
+    co_await replicate_record_batch(leader, std::move(b2));
+    co_await leader_api.advance_reconciled_offset(
+      kafka::offset{1}, model::no_timeout, as);
+    co_await leader_api.advance_epoch(
+      ct::cluster_epoch{20}, model::no_timeout, as);
+    co_await leader_api.sync_to_next_placeholder(model::no_timeout, as);
+
+    // The reader should hold back both values to the captured state.
+    ASSERT_EQ_CORO(leader_api.estimate_inactive_epoch(), ct::cluster_epoch{4});
+    ASSERT_EQ_CORO(
+      accessor.max_removable_local_log_offset(*stm), baseline_lrlo);
+
+    // Destroy reader1 to unlink it from the tracking list.
+    reader1 = nullptr;
+
+    // Without any readers, both values should reflect the advanced state.
+    auto advanced_epoch = leader_api.estimate_inactive_epoch();
+    ASSERT_TRUE_CORO(advanced_epoch.has_value());
+    ASSERT_GT_CORO(advanced_epoch.value(), ct::cluster_epoch{4});
+    ASSERT_GT_CORO(
+      accessor.max_removable_local_log_offset(*stm), baseline_lrlo);
+}
+
+TEST_F_CORO(ctp_stm_fixture, test_multiple_active_readers) {
+    // With multiple readers, the first registered reader (front of list)
+    // determines the holdback point. When it's removed, the next reader
+    // takes over.
+    co_await start();
+    co_await wait_for_leader(raft::default_timeout());
+
+    auto& leader = node(*get_leader());
+    auto leader_api = api(leader);
+    auto stm = get_stm<0>(leader);
+    ct::ctp_stm_accessor accessor;
+
+    // Replicate epoch 5 placeholder and reconcile.
+    auto b1 = make_record_batch(ct::cluster_epoch{5}, model::offset{0}, 0);
+    co_await replicate_record_batch(leader, std::move(b1));
+    co_await leader_api.advance_reconciled_offset(
+      kafka::offset{0}, model::no_timeout, as);
+    co_await leader_api.advance_epoch(
+      ct::cluster_epoch{10}, model::no_timeout, as);
+    co_await leader_api.sync_to_next_placeholder(model::no_timeout, as);
+
+    // Register reader1 at state A.
+    auto reader1 = std::make_unique<ct::active_reader_state>();
+    leader_api.register_reader(reader1.get());
+    auto reader1_epoch = reader1->inactive_epoch;
+    auto reader1_lrlo = reader1->lrlo;
+    ASSERT_EQ_CORO(reader1_epoch, ct::cluster_epoch{4});
+
+    // Advance state: new epoch 15, replicate + reconcile.
+    auto b2 = make_record_batch(ct::cluster_epoch{15}, model::offset{1}, 1);
+    co_await replicate_record_batch(leader, std::move(b2));
+    co_await leader_api.advance_reconciled_offset(
+      kafka::offset{1}, model::no_timeout, as);
+    co_await leader_api.advance_epoch(
+      ct::cluster_epoch{20}, model::no_timeout, as);
+    co_await leader_api.sync_to_next_placeholder(model::no_timeout, as);
+
+    // Register reader2 at state B (more advanced).
+    auto reader2 = std::make_unique<ct::active_reader_state>();
+    leader_api.register_reader(reader2.get());
+    auto reader2_epoch = reader2->inactive_epoch;
+    auto reader2_lrlo = reader2->lrlo;
+    ASSERT_GT_CORO(reader2_epoch, reader1_epoch);
+    ASSERT_GE_CORO(reader2_lrlo, reader1_lrlo);
+
+    // reader1 (front) determines the holdback.
+    ASSERT_EQ_CORO(leader_api.estimate_inactive_epoch(), reader1_epoch);
+    ASSERT_EQ_CORO(accessor.max_removable_local_log_offset(*stm), reader1_lrlo);
+
+    // Remove reader1 - reader2 (now front) takes over.
+    reader1.reset();
+    ASSERT_EQ_CORO(leader_api.estimate_inactive_epoch(), reader2_epoch);
+    ASSERT_EQ_CORO(accessor.max_removable_local_log_offset(*stm), reader2_lrlo);
+
+    // Remove reader2 - live state values returned.
+    reader2.reset();
+    auto live_epoch = leader_api.estimate_inactive_epoch();
+    ASSERT_TRUE_CORO(live_epoch.has_value());
+    ASSERT_GE_CORO(live_epoch.value(), reader2_epoch.value());
 }

--- a/src/v/cloud_topics/level_zero/stm/types.h
+++ b/src/v/cloud_topics/level_zero/stm/types.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_topics/types.h"
+#include "container/intrusive_list_helpers.h"
 #include "model/fundamental.h"
 
 #include <seastar/core/rwlock.hh>
@@ -37,6 +38,15 @@ struct [[nodiscard]] stale_cluster_epoch {
     cluster_epoch window_min;
     // The highest epoch we accept
     cluster_epoch window_max;
+};
+
+// The state captured when an l0 reader was started.
+struct active_reader_state {
+    intrusive_list_hook hook;
+    // The epoch that this reader could read.
+    std::optional<cluster_epoch> inactive_epoch;
+    // The last reconciled log offset when the reader runs.
+    model::offset lrlo;
 };
 
 } // namespace cloud_topics


### PR DESCRIPTION
This prevents a scenario where L0 readers (and reading aborted txns) run
into errors with cloud topics as prefix truncation can be run
aggressively.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
