### PR TITLE
lsm: tweaks to get out of L0 throttling

### DIFF
--- a/src/v/lsm/db/impl.cc
+++ b/src/v/lsm/db/impl.cc
@@ -72,6 +72,7 @@ ss::future<std::unique_ptr<impl>> impl::open(
         co_return db;
     }
     co_await db->_gc_actor.start();
+    db->maybe_schedule_compaction();
     vlog(log.trace, "open_end readonly=false");
     co_return db;
 }

--- a/src/v/lsm/db/version_set.cc
+++ b/src/v/lsm/db/version_set.cc
@@ -668,16 +668,22 @@ void version_set::finalize(version* v) {
     double best_score = static_cast<double>(v->_files[0_level].size())
                         / static_cast<double>(
                           _options->level_one_compaction_trigger);
-    // While level 0 compaction score is based on number of files, other levels
-    // are based on number of bytes in the level.
-    for (auto level = 1_level; level < _options->max_level(); ++level) {
-        size_t level_bytes = total_file_size(v->_files[level]);
-        double score = static_cast<double>(level_bytes)
-                       / static_cast<double>(
-                         _options->levels[level].max_total_bytes);
-        if (score > best_score) {
-            best_level = level;
-            best_score = score;
+    // If L0 is at or above the slowdown threshold, prioritize it
+    // unconditionally so that lower-level compactions cannot starve L0.
+    bool l0_urgent = v->_files[0_level].size()
+                     >= _options->level_zero_slowdown_writes_trigger;
+    if (!l0_urgent) {
+        // While level 0 compaction score is based on number of files, other
+        // levels are based on number of bytes in the level.
+        for (auto level = 1_level; level < _options->max_level(); ++level) {
+            size_t level_bytes = total_file_size(v->_files[level]);
+            double score = static_cast<double>(level_bytes)
+                           / static_cast<double>(
+                             _options->levels[level].max_total_bytes);
+            if (score > best_score) {
+                best_level = level;
+                best_score = score;
+            }
         }
     }
     v->_compaction_level = best_level;

--- a/src/v/lsm/db/version_set.cc
+++ b/src/v/lsm/db/version_set.cc
@@ -667,7 +667,7 @@ void version_set::finalize(version* v) {
     internal::level best_level = 0_level;
     double best_score = static_cast<double>(v->_files[0_level].size())
                         / static_cast<double>(
-                          _options->default_level_one_compaction_trigger);
+                          _options->level_one_compaction_trigger);
     // While level 0 compaction score is based on number of files, other levels
     // are based on number of bytes in the level.
     for (auto level = 1_level; level < _options->max_level(); ++level) {


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
On my cluster I found a metastore database instance being throttled because the LSM's L0 had too many files in it. This ultimately led to the metastore being unstable, because the throttling caused write timeouts, which were treated requiring stepdown. I didn't see any mention of compaction being scheduled around this time. This PR tries to address this:
- fix a bug where we use the default instead of configured number of L0 files
- schedule compaction after throttling due to L0 fullness
- prioritize L0 compaction when in throttling territory

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
