### PR TITLE
ct/l1: make LSM apply waits configurable

### DIFF
--- a/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
+++ b/src/v/cloud_topics/level_one/domain/tests/db_domain_manager_test.cc
@@ -688,6 +688,10 @@ TEST_P(DbDomainManagerTestWithParams, TestConcurrentUpdates) {
 }
 
 TEST_P(DbDomainManagerTestWithParams, TestUpdatesWithDroppedAppends) {
+    cfg.get("cloud_topics_metastore_replication_timeout_ms")
+      .set_value(std::chrono::milliseconds(10s));
+    cfg.get("cloud_topics_metastore_lsm_apply_timeout_ms")
+      .set_value(std::chrono::milliseconds(30s));
     auto args = params();
     auto tp = make_tp();
     bool done = false;

--- a/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/replicated_db.cc
@@ -259,7 +259,9 @@ replicated_database::write(chunked_vector<write_batch_row> rows) {
     // NOTE: at this point, since we waited for STM apply after replication,
     // the write should have been added to the volatile buffer.
     needs_apply_cv_.signal();
-    auto deadline = ss::lowres_clock::now() + 30s;
+    auto lsm_apply_timeout
+      = config::shard_local_cfg().cloud_topics_metastore_lsm_apply_timeout_ms();
+    auto deadline = ss::lowres_clock::now() + lsm_apply_timeout;
     auto wait_fut = co_await ss::coroutine::as_future(finished_apply_cv_.wait(
       deadline, as_, [this, o = replicate_result.value()] {
           return applied_offset_.has_value() && applied_offset_.value() >= o;

--- a/src/v/cloud_topics/level_one/metastore/lsm/stm.cc
+++ b/src/v/cloud_topics/level_one/metastore/lsm/stm.cc
@@ -13,6 +13,7 @@
 #include "cloud_topics/level_one/metastore/lsm/lsm_update.h"
 #include "cloud_topics/level_one/metastore/lsm/state.h"
 #include "cloud_topics/logger.h"
+#include "config/configuration.h"
 #include "model/record_batch_types.h"
 #include "serde/async.h"
 #include "ssx/future-util.h"
@@ -99,12 +100,10 @@ ss::future<std::expected<model::offset, stm::errc>> stm::replicate_and_wait(
     if (!gh) {
         co_return std::unexpected(errc::shutting_down);
     }
-    constexpr auto replicate_timeout = 10s;
+    auto timeout = config::shard_local_cfg()
+                     .cloud_topics_metastore_replication_timeout_ms();
     auto opts = raft::replicate_options(
-      raft::consistency_level::quorum_ack,
-      term,
-      replicate_timeout,
-      std::ref(as));
+      raft::consistency_level::quorum_ack, term, timeout, std::ref(as));
     opts.set_force_flush();
     const auto offsets_delta = batch.header().last_offset_delta;
     const auto res = co_await _raft->replicate(std::move(batch), opts);
@@ -115,7 +114,7 @@ ss::future<std::expected<model::offset, stm::errc>> stm::replicate_and_wait(
     auto base_offset = model::offset(last_offset() - offsets_delta);
     auto replicated_offset = res.value().last_offset;
     auto success = co_await wait_no_throw(
-      replicated_offset, ss::lowres_clock::now() + 30s, as);
+      replicated_offset, ss::lowres_clock::now() + timeout, as);
     if (!success || _raft->term() != term) {
         vlog(
           cd_log.debug,

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4740,6 +4740,21 @@ configuration::configuration()
       "GC will not proceed while the cluster is unhealthy.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10s)
+  , cloud_topics_metastore_replication_timeout_ms(
+      *this,
+      "cloud_topics_metastore_replication_timeout_ms",
+      "Timeout for L1 metastore Raft replication and waiting for the STM to "
+      "apply the replicated write batch.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      30s)
+  , cloud_topics_metastore_lsm_apply_timeout_ms(
+      *this,
+      "cloud_topics_metastore_lsm_apply_timeout_ms",
+      "Timeout for applying a replicated write batch to the local LSM "
+      "database. This may take longer than usual when L0 compaction is "
+      "behind and writes are being throttled.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      5min)
   , cloud_topics_parallel_fetch_enabled(
       *this,
       "cloud_topics_parallel_fetch_enabled",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -815,6 +815,11 @@ public:
       cloud_topics_short_term_gc_backoff_interval;
     property<std::chrono::milliseconds> cloud_topics_gc_health_check_interval;
 
+    property<std::chrono::milliseconds>
+      cloud_topics_metastore_replication_timeout_ms;
+    property<std::chrono::milliseconds>
+      cloud_topics_metastore_lsm_apply_timeout_ms;
+
     property<bool> cloud_topics_parallel_fetch_enabled;
 
     property<bool> cloud_topics_fetch_debounce_enabled;


### PR DESCRIPTION
Saw that when the LSM is being throttled, the replicated_db fails to apply the LSM batches in 30s, and then it steps down for safety. Make this configurable to be less sensitive.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
