### PR TITLE
ct/reconciler: Use HDR histogram for object size

### DIFF
--- a/src/v/cloud_topics/reconciler/BUILD
+++ b/src/v/cloud_topics/reconciler/BUILD
@@ -46,6 +46,7 @@ redpanda_cc_library(
     deps = [
         "//src/v/config",
         "//src/v/metrics",
+        "//src/v/utils:hdr_hist",
         "//src/v/utils:log_hist",
         "@seastar",
     ],

--- a/src/v/cloud_topics/reconciler/reconciler_probe.cc
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.cc
@@ -75,7 +75,7 @@ void reconciler_probe::setup_metrics() {
           sm::description("Duration of add_objects to metastore")),
         sm::make_histogram(
           "object_size_bytes",
-          [this] { return _object_size_bytes.internal_histogram_logform(); },
+          [this] { return _object_size_bytes.seastar_histogram_logform(); },
           sm::description("Distribution of built L1 object sizes in bytes")),
       });
 }

--- a/src/v/cloud_topics/reconciler/reconciler_probe.h
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "metrics/metrics.h"
+#include "utils/hdr_hist.h"
 #include "utils/log_hist.h"
 
 #include <seastar/core/metrics_registration.hh>
@@ -62,7 +63,7 @@ public:
         return _metastore_add_objects_duration.internal_histogram_logform();
     }
     auto get_object_size_bytes_for_tests() const {
-        return _object_size_bytes.internal_histogram_logform();
+        return _object_size_bytes.seastar_histogram_logform();
     }
 
 private:
@@ -79,7 +80,7 @@ private:
     hist_t _l0_read_duration;
     hist_t _object_build_duration;
     hist_t _metastore_add_objects_duration;
-    hist_t _object_size_bytes;
+    hdr_hist _object_size_bytes;
 };
 
 } // namespace cloud_topics::reconciler


### PR DESCRIPTION
The reconciler was using a histogram tuned for microsecond latencies that was inappropriate for object byte sizes. Change the metric to use an HDR histogram, like the L0 object size metric.

The bad histogram type was making it appear as if the reconciler was producing a p95 object size that was 50% too big.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none

