### PR TITLE
lsm: support parallel compaction

### DIFF
--- a/src/v/lsm/db/BUILD
+++ b/src/v/lsm/db/BUILD
@@ -60,6 +60,7 @@ redpanda_cc_library(
         "//src/v/lsm/core/internal:logger",
         "//src/v/lsm/core/internal:merging_iterator",
         "//src/v/lsm/sst:builder",
+        "//src/v/ssx:future_util",
         "@fmt",
     ],
     deps = [

--- a/src/v/lsm/db/BUILD
+++ b/src/v/lsm/db/BUILD
@@ -296,6 +296,7 @@ redpanda_cc_library(
         "//src/v/lsm/core:exceptions",
         "//src/v/lsm/core/internal:logger",
         "//src/v/lsm/sst:builder",
+        "//src/v/ssx:when_all",
     ],
     deps = [
         ":snapshot",

--- a/src/v/lsm/db/compaction_task.cc
+++ b/src/v/lsm/db/compaction_task.cc
@@ -107,30 +107,30 @@ ss::future<ss::lw_shared_ptr<version_edit>> do_run_compaction_task(
   snapshot_list* snapshots,
   version_set* versions,
   ss::lw_shared_ptr<internal::options> opts,
-  compaction compaction,
+  compaction* compaction,
   ss::abort_source* as) {
-    auto input_level = compaction.level();
+    auto input_level = compaction->level();
     auto output_level = input_level + 1_level;
     auto num_input_files
-      = compaction.num_input_files(compaction::which::input_level)
-        + compaction.num_input_files(compaction::which::output_level);
+      = compaction->num_input_files(compaction::which::input_level)
+        + compaction->num_input_files(compaction::which::output_level);
     vlog(
       log.trace,
       "compaction_start input_level={} output_level={} input_files={}",
       input_level,
       output_level,
       num_input_files);
-    if (compaction.is_trivial_move()) {
-        auto input_level_files = compaction.num_input_files(
+    if (compaction->is_trivial_move()) {
+        auto input_level_files = compaction->num_input_files(
           compaction::which::input_level);
         vassert(
           input_level_files == 1,
           "trivial compactions should only be for a single input file: {}",
           input_level_files);
-        auto file = compaction.input(compaction::which::input_level, 0);
-        compaction.edit()->remove_file(compaction.level(), file->handle);
-        compaction.edit()->add_file({
-          .level = compaction.level() + 1_level,
+        auto file = compaction->input(compaction::which::input_level, 0);
+        compaction->edit()->remove_file(compaction->level(), file->handle);
+        compaction->edit()->add_file({
+          .level = compaction->level() + 1_level,
           .file_handle = file->handle,
           .file_size = file->file_size,
           .smallest = file->smallest,
@@ -145,7 +145,7 @@ ss::future<ss::lw_shared_ptr<version_edit>> do_run_compaction_task(
           input_level,
           output_level,
           file->file_size);
-        co_return compaction.edit();
+        co_return compaction->edit();
     }
     compaction_state state{
       // We need to preserve intermediate data between snapshots so we can
@@ -164,14 +164,14 @@ ss::future<ss::lw_shared_ptr<version_edit>> do_run_compaction_task(
       .compression = opts->levels[output_level].compression,
     };
     try {
-        auto input = co_await versions->make_input_iterator(&compaction);
+        auto input = co_await versions->make_input_iterator(compaction);
         std::optional<internal::key> current_key;
         internal::sequence_number last_seqno_for_key
           = internal::sequence_number::max();
         co_await input->seek_to_first();
         while (input->valid() && !as->abort_requested()) {
             auto key = input->key();
-            if (compaction.should_stop_before(key) && state.builder) {
+            if (compaction->should_stop_before(key) && state.builder) {
                 co_await state.finish_current_builder();
             }
             bool drop = false;
@@ -187,7 +187,7 @@ ss::future<ss::lw_shared_ptr<version_edit>> do_run_compaction_task(
                 drop = true;
             } else if (
               key.is_tombstone() && key_seqno <= state.smallest_snapshot
-              && compaction.is_base_level_for_key(key)) {
+              && compaction->is_base_level_for_key(key)) {
                 // For this user key:
                 // (1) there is no data in higher levels
                 // (2) data in lower levels will have larger sequence numbers
@@ -201,7 +201,7 @@ ss::future<ss::lw_shared_ptr<version_edit>> do_run_compaction_task(
             last_seqno_for_key = key_seqno;
             if (!drop) {
                 if (!state.builder) {
-                    auto id = compaction.edit()->allocate_id();
+                    auto id = compaction->edit()->allocate_id();
                     vlog(log.trace, "compaction_start_new_file file_id={}", id);
                     co_await state.open_current_builder(
                       {
@@ -232,11 +232,11 @@ ss::future<ss::lw_shared_ptr<version_edit>> do_run_compaction_task(
         state.err = std::make_exception_ptr(ex);
     }
     co_await state.finish();
-    auto edit = compaction.edit();
-    compaction.add_input_deletions(edit.get());
+    auto edit = compaction->edit();
+    compaction->add_input_deletions(edit.get());
     for (auto& output : state.outputs) {
         edit->add_file({
-          .level = compaction.level() + 1_level,
+          .level = compaction->level() + 1_level,
           .file_handle = output.handle,
           .file_size = output.file_size,
           .smallest = std::move(output.smallest),
@@ -263,7 +263,7 @@ ss::future<ss::lw_shared_ptr<version_edit>> run_compaction_task(
   snapshot_list* snapshots,
   version_set* versions,
   ss::lw_shared_ptr<internal::options> opts,
-  compaction compaction,
+  compaction* compaction,
   ss::abort_source* as) {
     try {
         co_return co_await do_run_compaction_task(

--- a/src/v/lsm/db/compaction_task.cc
+++ b/src/v/lsm/db/compaction_task.cc
@@ -12,8 +12,9 @@
 #include "lsm/core/exceptions.h"
 #include "lsm/core/internal/logger.h"
 #include "lsm/sst/builder.h"
+#include "ssx/when_all.h"
 
-#include <seastar/core/coroutine.hh>
+#include <exception>
 
 namespace lsm::db {
 
@@ -37,14 +38,56 @@ struct compaction_state {
         auto w = co_await p->open_sequential_writer(h);
         builder.emplace(std::move(w), opts);
     }
+
+    struct closing_builder {
+        sst::builder builder;
+        ss::future<> close_fut;
+
+        explicit closing_builder(sst::builder b)
+          : builder(std::move(b))
+          , close_fut(builder.close()) {}
+    };
+
     ss::future<> finish_current_builder() {
+        if (!builder) {
+            co_return;
+        }
         auto b = std::exchange(builder, std::nullopt);
-        co_await b->finish().finally([&b] { return b->close(); });
+        auto finish_fut = co_await ss::coroutine::as_future(b->finish());
         uint64_t current_bytes = b->file_size();
+        closes.emplace_back(std::move(*b));
+        if (finish_fut.failed()) {
+            std::rethrow_exception(finish_fut.get_exception());
+        }
         current_output().file_size = current_bytes;
         total_bytes += current_bytes;
     }
 
+    ss::future<> finish() {
+        if (builder) {
+            auto ready_future = co_await ss::coroutine::as_future(
+              finish_current_builder());
+            if (err) {
+                ready_future.ignore_ready_future();
+            } else if (ready_future.failed()) {
+                err = ready_future.get_exception();
+            }
+        }
+        for (auto& c : closes) {
+            auto ready_future = co_await ss::coroutine::as_future(
+              std::move(c.close_fut));
+            if (err) {
+                ready_future.ignore_ready_future();
+            } else if (ready_future.failed()) {
+                err = ready_future.get_exception();
+            }
+        }
+        if (err) {
+            std::rethrow_exception(err);
+        }
+    }
+
+    chunked_vector<closing_builder> closes;
     std::exception_ptr err;
     chunked_vector<output> outputs;
     // Sequence numbers < smallest_snapshot are not significant since we
@@ -188,13 +231,7 @@ ss::future<ss::lw_shared_ptr<version_edit>> do_run_compaction_task(
     } catch (const base_exception& ex) {
         state.err = std::make_exception_ptr(ex);
     }
-    if (state.builder) {
-        co_await state.finish_current_builder();
-    }
-    as->check(); // Do this after we clean up the builder
-    if (state.err) {
-        std::rethrow_exception(state.err);
-    }
+    co_await state.finish();
     auto edit = compaction.edit();
     compaction.add_input_deletions(edit.get());
     for (auto& output : state.outputs) {
@@ -230,12 +267,7 @@ ss::future<ss::lw_shared_ptr<version_edit>> run_compaction_task(
   ss::abort_source* as) {
     try {
         co_return co_await do_run_compaction_task(
-          persistence,
-          snapshots,
-          versions,
-          std::move(opts),
-          std::move(compaction),
-          as);
+          persistence, snapshots, versions, std::move(opts), compaction, as);
     } catch (...) {
         vlog(log.warn, "compaction_end error=\"{}\"", std::current_exception());
         throw;

--- a/src/v/lsm/db/compaction_task.h
+++ b/src/v/lsm/db/compaction_task.h
@@ -21,7 +21,7 @@ ss::future<ss::lw_shared_ptr<version_edit>> run_compaction_task(
   snapshot_list* snapshots,
   version_set* versions,
   ss::lw_shared_ptr<internal::options> opts,
-  compaction compaction,
+  compaction* compaction,
   ss::abort_source* as);
 
 } // namespace lsm::db

--- a/src/v/lsm/db/impl.cc
+++ b/src/v/lsm/db/impl.cc
@@ -440,7 +440,7 @@ ss::future<> impl::do_compaction() {
       &_snapshots,
       _versions.get(),
       _opts,
-      std::move(compact.value()),
+      compact->get(),
       &_as);
     m->stop();
     co_await apply_edits(std::move(edit));

--- a/src/v/lsm/db/impl.cc
+++ b/src/v/lsm/db/impl.cc
@@ -21,12 +21,11 @@
 #include "lsm/io/persistence.h"
 #include "lsm/sst/block_cache.h"
 #include "ssx/clock.h"
+#include "ssx/future-util.h"
 
 #include <seastar/core/sleep.hh>
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/switch_to.hh>
-
-#include <fmt/format.h>
 
 #include <chrono>
 #include <exception>
@@ -257,8 +256,7 @@ ss::future<> impl::close() {
     vlog(log.trace, "close_start");
     _as.request_abort_ex(abort_requested_exception("database closing"));
     co_await _gc_actor.stop();
-    co_await std::exchange(_compaction_task, std::nullopt).value_or(ss::now());
-    co_await std::exchange(_flush_task, std::nullopt).value_or(ss::now());
+    co_await _gate.close();
     co_await _table_cache->close();
     co_await _persistence.data->close();
     co_await _persistence.metadata->close();
@@ -324,9 +322,11 @@ void impl::maybe_schedule_compaction() {
     if (_as.abort_requested() || _opts->readonly) {
         return;
     }
-    if (!_flush_task && _imm) {
+    if (!_is_flushing && _imm) {
         vlog(log.trace, "flush_task_start");
-        auto task = do_flush().then_wrapped([this](ss::future<> f) {
+        _is_flushing = true;
+        auto h = _gate.hold();
+        ssx::background = do_flush().then_wrapped([this, h](ss::future<> f) {
             if (f.failed()) {
                 auto ex = f.get_exception();
                 bool is_abort = is_abort_exception(ex);
@@ -336,7 +336,7 @@ void impl::maybe_schedule_compaction() {
                   is_abort,
                   ex);
                 if (is_abort) {
-                    _flush_task = std::nullopt;
+                    _is_flushing = false;
                     _background_work_finished_signal.broken(ex);
                     return;
                 }
@@ -347,46 +347,38 @@ void impl::maybe_schedule_compaction() {
             }
             // Check and see if the new manifest we wrote requires compaction
             // due to number files in L0 (or retry if there was an error).
-            _flush_task = std::nullopt;
+            _is_flushing = false;
             maybe_schedule_compaction();
         });
-        // It is possible in release mode tests that the above closure has
-        // executed already (because it's using in0memory IO). In this case we
-        // don't want to assign the flush task otherwise nothing would be able
-        // to remove it.
-        if (!task.available()) {
-            _flush_task = std::move(task);
-        }
     }
-    if (!_compaction_task && _versions->needs_compaction()) {
+    while (auto c = _versions->pick_compaction()) {
         vlog(log.trace, "compaction_task_start");
-        auto task = do_compaction().then_wrapped([this](ss::future<> f) {
-            if (f.failed()) {
-                auto ex = f.get_exception();
-                bool is_abort = is_abort_exception(ex);
-                vlog(
-                  log.warn,
-                  "compaction_task_end is_abort={} error=\"{}\"",
-                  is_abort,
-                  ex);
-                if (is_abort) {
-                    _compaction_task = std::nullopt;
-                    _background_work_finished_signal.broken(ex);
-                    return;
-                }
-            } else {
-                // Notify all waiters that work has been finished.
-                _background_work_finished_signal.broadcast();
-                vlog(log.trace, "compaction_task_end");
-            }
-            // Check and see if the new manifest we wrote requires compaction
-            // due to level size limits (or retry if there was an error).
-            _compaction_task = std::nullopt;
-            maybe_schedule_compaction();
-        });
-        if (!task.available()) {
-            _compaction_task = std::move(task);
-        }
+        auto h = _gate.hold();
+        ssx::background
+          = do_compaction(std::move(*c))
+              .then_wrapped([this, h](ss::future<> f) {
+                  if (f.failed()) {
+                      auto ex = f.get_exception();
+                      bool is_abort = is_abort_exception(ex);
+                      vlog(
+                        log.warn,
+                        "compaction_task_end is_abort={} error=\"{}\"",
+                        is_abort,
+                        ex);
+                      if (is_abort) {
+                          _background_work_finished_signal.broken(ex);
+                          return;
+                      }
+                  } else {
+                      // Notify all waiters that work has been finished.
+                      _background_work_finished_signal.broadcast();
+                      vlog(log.trace, "compaction_task_end");
+                  }
+                  // Check and see if the new manifest we wrote requires
+                  // compaction due to level size limits (or retry if there was
+                  // an error).
+                  maybe_schedule_compaction();
+              });
     }
 }
 
@@ -428,11 +420,7 @@ ss::future<> impl::do_flush() {
     _imm = std::nullopt;
 }
 
-ss::future<> impl::do_compaction() {
-    auto compact = _versions->pick_compaction();
-    if (!compact) {
-        co_return;
-    }
+ss::future<> impl::do_compaction(std::unique_ptr<compaction> compact) {
     co_await ss::coroutine::switch_to(_opts->compaction_scheduling_group);
     auto m = _opts->probe->compaction_latency.auto_measure();
     auto edit = co_await run_compaction_task(
@@ -440,7 +428,7 @@ ss::future<> impl::do_compaction() {
       &_snapshots,
       _versions.get(),
       _opts,
-      compact->get(),
+      compact.get(),
       &_as);
     m->stop();
     co_await apply_edits(std::move(edit));

--- a/src/v/lsm/db/impl.h
+++ b/src/v/lsm/db/impl.h
@@ -115,7 +115,7 @@ private:
     void maybe_schedule_compaction();
 
     ss::future<> do_flush();
-    ss::future<> do_compaction();
+    ss::future<> do_compaction(std::unique_ptr<compaction>);
     ss::future<> apply_edits(ss::lw_shared_ptr<version_edit>);
 
     io::persistence _persistence;
@@ -131,8 +131,8 @@ private:
     snapshot_list _snapshots;
     gc_actor _gc_actor;
     ssx::mutex _manifest_write_mu;
-    std::optional<ss::future<>> _compaction_task;
-    std::optional<ss::future<>> _flush_task;
+    bool _is_flushing = false;
+    ss::gate _gate;
 };
 
 } // namespace lsm::db

--- a/src/v/lsm/db/tests/version_set_test.cc
+++ b/src/v/lsm/db/tests/version_set_test.cc
@@ -806,3 +806,361 @@ TEST_F(CompactionTest, CompactionPointerRespected) {
     EXPECT_THAT(input_file_ids(*c), ElementsAre(3_file_id));
     EXPECT_THAT(output_file_ids(*c), ElementsAre(101_file_id));
 }
+
+TEST_F(CompactionTest, HighestScoringLevelIsPickedL1OverL0) {
+    // When both L0 and L1 have score >= 1, the level with the higher score
+    // should be picked. Here L1 has a higher score than L0.
+    //
+    // L0 score: 4 files / 4 trigger = 1.0
+    add_file(0_level, 1_file_id, "a"_key, "b"_key);
+    add_file(0_level, 2_file_id, "c"_key, "d"_key);
+    add_file(0_level, 3_file_id, "e"_key, "f"_key);
+    add_file(0_level, 4_file_id, "g"_key, "h"_key);
+
+    // L1 score: 20KB / 10KB = 2.0 (higher than L0's 1.0)
+    add_file(1_level, 10_file_id, "aa"_key, "ab"_key, 2000);
+    add_file(1_level, 11_file_id, "ac"_key, "ad"_key, 2000);
+    add_file(1_level, 12_file_id, "ae"_key, "af"_key, 2000);
+    add_file(1_level, 13_file_id, "ag"_key, "ah"_key, 2000);
+    add_file(1_level, 14_file_id, "ai"_key, "aj"_key, 2000);
+    add_file(1_level, 15_file_id, "ak"_key, "al"_key, 2000);
+    add_file(1_level, 16_file_id, "am"_key, "an"_key, 2000);
+    add_file(1_level, 17_file_id, "ao"_key, "ap"_key, 2000);
+    add_file(1_level, 18_file_id, "aq"_key, "ar"_key, 2000);
+    add_file(1_level, 19_file_id, "as"_key, "at"_key, 2000);
+
+    auto maybe_c = version_set().pick_compaction();
+
+    ASSERT_TRUE(maybe_c);
+    auto& c = *maybe_c;
+    // L1 score (2.0) > L0 score (1.0), so L1→L2 compaction is picked
+    EXPECT_EQ(c->level(), 1_level);
+}
+
+TEST_F(CompactionTest, HighestScoringLevelIsPickedL0OverL1) {
+    // When both L0 and L1 have score >= 1, the level with the higher score
+    // should be picked. Here L0 has a higher score than L1.
+    //
+    // L0 score: 8 files / 4 trigger = 2.0
+    add_file(0_level, 1_file_id, "a"_key, "b"_key);
+    add_file(0_level, 2_file_id, "c"_key, "d"_key);
+    add_file(0_level, 3_file_id, "e"_key, "f"_key);
+    add_file(0_level, 4_file_id, "g"_key, "h"_key);
+    add_file(0_level, 5_file_id, "i"_key, "j"_key);
+    add_file(0_level, 6_file_id, "k"_key, "l"_key);
+    add_file(0_level, 7_file_id, "m"_key, "n"_key);
+    add_file(0_level, 8_file_id, "o"_key, "p"_key);
+
+    // L1 score: 11KB / 10KB = 1.1 (lower than L0's 2.0)
+    add_file(1_level, 10_file_id, "aa"_key, "ab"_key, 1000);
+    add_file(1_level, 11_file_id, "ac"_key, "ad"_key, 1000);
+    add_file(1_level, 12_file_id, "ae"_key, "af"_key, 1000);
+    add_file(1_level, 13_file_id, "ag"_key, "ah"_key, 1000);
+    add_file(1_level, 14_file_id, "ai"_key, "aj"_key, 1000);
+    add_file(1_level, 15_file_id, "ak"_key, "al"_key, 1000);
+    add_file(1_level, 16_file_id, "am"_key, "an"_key, 1000);
+    add_file(1_level, 17_file_id, "ao"_key, "ap"_key, 1000);
+    add_file(1_level, 18_file_id, "aq"_key, "ar"_key, 1000);
+    add_file(1_level, 19_file_id, "as"_key, "at"_key, 1000);
+    add_file(1_level, 20_file_id, "au"_key, "av"_key, 1000);
+
+    auto maybe_c = version_set().pick_compaction();
+
+    ASSERT_TRUE(maybe_c);
+    auto& c = *maybe_c;
+    // L0 score (2.0) > L1 score (1.1), so L0→L1 compaction is picked
+    EXPECT_EQ(c->level(), 0_level);
+}
+
+TEST_F(CompactionTest, NeedsCompactionChecksAllLevels) {
+    // needs_compaction should return true when any level exceeds the threshold,
+    // even if L0 is below its threshold.
+    EXPECT_FALSE(version_set().needs_compaction());
+
+    // L0 has only 1 file (below trigger of 4)
+    add_file(0_level, 1_file_id, "a"_key, "z"_key);
+    EXPECT_FALSE(version_set().needs_compaction());
+
+    // Fill L1 above its 10KB threshold to trigger needs_compaction
+    add_file(1_level, 10_file_id, "aa"_key, "ab"_key, 1000);
+    add_file(1_level, 11_file_id, "ac"_key, "ad"_key, 1000);
+    add_file(1_level, 12_file_id, "ae"_key, "af"_key, 1000);
+    add_file(1_level, 13_file_id, "ag"_key, "ah"_key, 1000);
+    add_file(1_level, 14_file_id, "ai"_key, "aj"_key, 1000);
+    add_file(1_level, 15_file_id, "ak"_key, "al"_key, 1000);
+    add_file(1_level, 16_file_id, "am"_key, "an"_key, 1000);
+    add_file(1_level, 17_file_id, "ao"_key, "ap"_key, 1000);
+    add_file(1_level, 18_file_id, "aq"_key, "ar"_key, 1000);
+    add_file(1_level, 19_file_id, "as"_key, "at"_key, 1000);
+    add_file(1_level, 20_file_id, "au"_key, "av"_key, 1000);
+
+    EXPECT_TRUE(version_set().needs_compaction());
+}
+
+TEST_F(CompactionTest, CompactingLevelSkippedByPick) {
+    // When a compaction is in progress on a level, that level (and its output
+    // level) should be skipped by pick_compaction. A second call should pick
+    // the next best level.
+
+    // L0 score: 4/4 = 1.0
+    add_file(0_level, 1_file_id, "a"_key, "b"_key);
+    add_file(0_level, 2_file_id, "c"_key, "d"_key);
+    add_file(0_level, 3_file_id, "e"_key, "f"_key);
+    add_file(0_level, 4_file_id, "g"_key, "h"_key);
+
+    // L2 score: 120KB / 100KB = 1.2 (L2 max = 10KB * 10 = 100KB)
+    add_file(2_level, 30_file_id, "aa"_key, "ab"_key, 10000);
+    add_file(2_level, 31_file_id, "ac"_key, "ad"_key, 10000);
+    add_file(2_level, 32_file_id, "ae"_key, "af"_key, 10000);
+    add_file(2_level, 33_file_id, "ag"_key, "ah"_key, 10000);
+    add_file(2_level, 34_file_id, "ai"_key, "aj"_key, 10000);
+    add_file(2_level, 35_file_id, "ak"_key, "al"_key, 10000);
+    add_file(2_level, 36_file_id, "am"_key, "an"_key, 10000);
+    add_file(2_level, 37_file_id, "ao"_key, "ap"_key, 10000);
+    add_file(2_level, 38_file_id, "aq"_key, "ar"_key, 10000);
+    add_file(2_level, 39_file_id, "as"_key, "at"_key, 10000);
+    add_file(2_level, 40_file_id, "au"_key, "av"_key, 10000);
+    add_file(2_level, 41_file_id, "aw"_key, "ax"_key, 10000);
+
+    EXPECT_TRUE(version_set().needs_compaction());
+
+    // L2 score (1.2) > L0 score (1.0), so first pick should be L2
+    auto c1 = version_set().pick_compaction();
+    ASSERT_TRUE(c1);
+    EXPECT_EQ((*c1)->level(), 2_level);
+
+    // While L2→L3 compaction is held, L2 and L3 are locked out.
+    // Second pick should fall back to L0→L1.
+    EXPECT_TRUE(version_set().needs_compaction());
+    auto c2 = version_set().pick_compaction();
+    ASSERT_TRUE(c2);
+    EXPECT_EQ((*c2)->level(), 0_level);
+
+    // Now both L0→L1 and L2→L3 are in progress. No more compactions.
+    EXPECT_FALSE(version_set().needs_compaction());
+    auto c3 = version_set().pick_compaction();
+    EXPECT_FALSE(c3);
+}
+
+TEST_F(CompactionTest, CompactingLevelUnlockedOnDestruction) {
+    // Verifies that dropping a compaction object unlocks the levels.
+    add_file(0_level, 1_file_id, "a"_key, "b"_key);
+    add_file(0_level, 2_file_id, "c"_key, "d"_key);
+    add_file(0_level, 3_file_id, "e"_key, "f"_key);
+    add_file(0_level, 4_file_id, "g"_key, "h"_key);
+
+    EXPECT_TRUE(version_set().needs_compaction());
+
+    {
+        auto c = version_set().pick_compaction();
+        ASSERT_TRUE(c);
+        EXPECT_EQ((*c)->level(), 0_level);
+        // L0 and L1 are locked
+        EXPECT_FALSE(version_set().needs_compaction());
+    }
+    // compaction destroyed, levels unlocked
+    EXPECT_TRUE(version_set().needs_compaction());
+}
+
+TEST_F(CompactionTest, L2ToL3Compaction) {
+    // Deeper levels should also trigger compaction when they exceed their
+    // byte threshold. L2 max = 10KB * 10 = 100KB with multiplier=10.
+    add_file(2_level, 1_file_id, "aa"_key, "ab"_key, 10000);
+    add_file(2_level, 2_file_id, "ac"_key, "ad"_key, 10000);
+    add_file(2_level, 3_file_id, "ae"_key, "af"_key, 10000);
+    add_file(2_level, 4_file_id, "ag"_key, "ah"_key, 10000);
+    add_file(2_level, 5_file_id, "ai"_key, "aj"_key, 10000);
+    add_file(2_level, 6_file_id, "ak"_key, "al"_key, 10000);
+    add_file(2_level, 7_file_id, "am"_key, "an"_key, 10000);
+    add_file(2_level, 8_file_id, "ao"_key, "ap"_key, 10000);
+    add_file(2_level, 9_file_id, "aq"_key, "ar"_key, 10000);
+    add_file(2_level, 10_file_id, "as"_key, "at"_key, 10000);
+    add_file(2_level, 11_file_id, "au"_key, "av"_key, 10000);
+
+    // Add an L3 file to verify correct output level
+    add_file(3_level, 100_file_id, "aa"_key, "ac"_key);
+
+    EXPECT_TRUE(version_set().needs_compaction());
+
+    auto maybe_c = version_set().pick_compaction();
+    ASSERT_TRUE(maybe_c);
+    auto& c = *maybe_c;
+    EXPECT_EQ(c->level(), 2_level);
+    EXPECT_THAT(output_file_ids(*c), ElementsAre(100_file_id));
+}
+
+TEST_F(CompactionTest, NeedsCompactionFalseWhenLevelLocked) {
+    // If the only level needing compaction is currently locked,
+    // needs_compaction should return false.
+    add_file(0_level, 1_file_id, "a"_key, "b"_key);
+    add_file(0_level, 2_file_id, "c"_key, "d"_key);
+    add_file(0_level, 3_file_id, "e"_key, "f"_key);
+    add_file(0_level, 4_file_id, "g"_key, "h"_key);
+
+    EXPECT_TRUE(version_set().needs_compaction());
+
+    auto c = version_set().pick_compaction();
+    ASSERT_TRUE(c);
+
+    // L0→L1 is in progress, both levels locked. Since L0 was the only level
+    // above threshold, needs_compaction should now be false.
+    EXPECT_FALSE(version_set().needs_compaction());
+}
+
+TEST_F(CompactionTest, NeedsCompactionFalseWhenOutputLevelLocked) {
+    // If a level needs compaction but its output level is locked by another
+    // compaction, needs_compaction should return false.
+
+    // Fill L1 above its 10KB threshold so L1→L2 is needed.
+    add_file(1_level, 10_file_id, "aa"_key, "ab"_key, 1000);
+    add_file(1_level, 11_file_id, "ac"_key, "ad"_key, 1000);
+    add_file(1_level, 12_file_id, "ae"_key, "af"_key, 1000);
+    add_file(1_level, 13_file_id, "ag"_key, "ah"_key, 1000);
+    add_file(1_level, 14_file_id, "ai"_key, "aj"_key, 1000);
+    add_file(1_level, 15_file_id, "ak"_key, "al"_key, 1000);
+    add_file(1_level, 16_file_id, "am"_key, "an"_key, 1000);
+    add_file(1_level, 17_file_id, "ao"_key, "ap"_key, 1000);
+    add_file(1_level, 18_file_id, "aq"_key, "ar"_key, 1000);
+    add_file(1_level, 19_file_id, "as"_key, "at"_key, 1000);
+    add_file(1_level, 20_file_id, "au"_key, "av"_key, 1000);
+
+    EXPECT_TRUE(version_set().needs_compaction());
+
+    // Pick the L1→L2 compaction, locking both L1 and L2.
+    auto c1 = version_set().pick_compaction();
+    ASSERT_TRUE(c1);
+    EXPECT_EQ((*c1)->level(), 1_level);
+
+    // Now fill L2 above its 100KB threshold so L2→L3 would be needed, but
+    // L2 is already locked as the output of the L1→L2 compaction.
+    add_file(2_level, 30_file_id, "ba"_key, "bb"_key, 10000);
+    add_file(2_level, 31_file_id, "bc"_key, "bd"_key, 10000);
+    add_file(2_level, 32_file_id, "be"_key, "bf"_key, 10000);
+    add_file(2_level, 33_file_id, "bg"_key, "bh"_key, 10000);
+    add_file(2_level, 34_file_id, "bi"_key, "bj"_key, 10000);
+    add_file(2_level, 35_file_id, "bk"_key, "bl"_key, 10000);
+    add_file(2_level, 36_file_id, "bm"_key, "bn"_key, 10000);
+    add_file(2_level, 37_file_id, "bo"_key, "bp"_key, 10000);
+    add_file(2_level, 38_file_id, "bq"_key, "br"_key, 10000);
+    add_file(2_level, 39_file_id, "bs"_key, "bt"_key, 10000);
+    add_file(2_level, 40_file_id, "bu"_key, "bv"_key, 10000);
+
+    // L2 is the input level for the would-be L2→L3, but it's locked.
+    EXPECT_FALSE(version_set().needs_compaction());
+    auto c2 = version_set().pick_compaction();
+    EXPECT_FALSE(c2);
+}
+
+TEST_F(CompactionTest, PickCompactionSkipsWhenOutputLevelLocked) {
+    // When L1→L2 compaction is in progress (locking L1 and L2), an L0→L1
+    // compaction must not be picked because L1 is locked as an output level.
+
+    // L0 score: 4/4 = 1.0 (exactly at threshold)
+    add_file(0_level, 1_file_id, "a"_key, "b"_key);
+    add_file(0_level, 2_file_id, "c"_key, "d"_key);
+    add_file(0_level, 3_file_id, "e"_key, "f"_key);
+    add_file(0_level, 4_file_id, "g"_key, "h"_key);
+
+    // Fill L1 above its 10KB threshold so L1→L2 scores >= 1.
+    add_file(1_level, 10_file_id, "aa"_key, "ab"_key, 1000);
+    add_file(1_level, 11_file_id, "ac"_key, "ad"_key, 1000);
+    add_file(1_level, 12_file_id, "ae"_key, "af"_key, 1000);
+    add_file(1_level, 13_file_id, "ag"_key, "ah"_key, 1000);
+    add_file(1_level, 14_file_id, "ai"_key, "aj"_key, 1000);
+    add_file(1_level, 15_file_id, "ak"_key, "al"_key, 1000);
+    add_file(1_level, 16_file_id, "am"_key, "an"_key, 1000);
+    add_file(1_level, 17_file_id, "ao"_key, "ap"_key, 1000);
+    add_file(1_level, 18_file_id, "aq"_key, "ar"_key, 1000);
+    add_file(1_level, 19_file_id, "as"_key, "at"_key, 1000);
+    add_file(1_level, 20_file_id, "au"_key, "av"_key, 1000);
+
+    EXPECT_TRUE(version_set().needs_compaction());
+
+    // Pick L1→L2 first (higher score). This locks L1 and L2.
+    auto c1 = version_set().pick_compaction();
+    ASSERT_TRUE(c1);
+    EXPECT_EQ((*c1)->level(), 1_level);
+
+    // L0→L1 should NOT be picked because L1 (the output level) is locked.
+    EXPECT_FALSE(version_set().needs_compaction());
+    auto c2 = version_set().pick_compaction();
+    EXPECT_FALSE(c2);
+
+    // After L1→L2 completes, compactions become available again.
+    c1 = {};
+    EXPECT_TRUE(version_set().needs_compaction());
+    auto c3 = version_set().pick_compaction();
+    ASSERT_TRUE(c3);
+}
+
+TEST_F(CompactionTest, SeekCompactionSkippedWhenLevelLocked) {
+    // Seek-triggered compaction on L1 should be skipped when L1 is locked by
+    // an in-progress compaction.
+
+    // Add a single file to L1 (below score threshold).
+    add_file(1_level, 10_file_id, "aa"_key, "az"_key);
+
+    // Set _file_to_compact on the current version by forcing allowed_seeks to
+    // 0 and calling update_stats.
+    auto current = version_set().current();
+    auto l1_files = current->get_overlapping_inputs(
+      1_level, std::nullopt, std::nullopt);
+    ASSERT_EQ(l1_files.size(), 1);
+    l1_files[0]->allowed_seeks = 0;
+    EXPECT_TRUE(current->update_stats(
+      {.seek_file = l1_files[0], .seek_file_level = 1_level}));
+
+    // Seek compaction is pending on L1, so needs_compaction should be true.
+    EXPECT_TRUE(version_set().needs_compaction());
+
+    // Pick the seek compaction — this locks L1 and L2.
+    auto c = version_set().pick_compaction();
+    ASSERT_TRUE(c);
+    EXPECT_EQ((*c)->level(), 1_level);
+
+    // L1 and L2 are now locked. No more compactions.
+    EXPECT_FALSE(version_set().needs_compaction());
+}
+
+TEST_F(CompactionTest, SeekCompactionSkippedWhenOutputLevelLocked) {
+    // Seek compaction on L1 should be blocked when L2 (its output level) is
+    // already locked by a L1→L2 compaction.
+
+    // Fill L1 above threshold to trigger score-based compaction, and also add
+    // a file on which we'll trigger seek compaction.
+    add_file(1_level, 10_file_id, "aa"_key, "ab"_key, 1000);
+    add_file(1_level, 11_file_id, "ac"_key, "ad"_key, 1000);
+    add_file(1_level, 12_file_id, "ae"_key, "af"_key, 1000);
+    add_file(1_level, 13_file_id, "ag"_key, "ah"_key, 1000);
+    add_file(1_level, 14_file_id, "ai"_key, "aj"_key, 1000);
+    add_file(1_level, 15_file_id, "ak"_key, "al"_key, 1000);
+    add_file(1_level, 16_file_id, "am"_key, "an"_key, 1000);
+    add_file(1_level, 17_file_id, "ao"_key, "ap"_key, 1000);
+    add_file(1_level, 18_file_id, "aq"_key, "ar"_key, 1000);
+    add_file(1_level, 19_file_id, "as"_key, "at"_key, 1000);
+    add_file(1_level, 20_file_id, "au"_key, "av"_key, 1000);
+    // Add a separate L2 file for seek compaction target.
+    add_file(2_level, 50_file_id, "ba"_key, "bz"_key);
+
+    // Set _file_to_compact for L2 on the current version.
+    auto current = version_set().current();
+    auto l2_files = current->get_overlapping_inputs(
+      2_level, std::nullopt, std::nullopt);
+    ASSERT_EQ(l2_files.size(), 1);
+    l2_files[0]->allowed_seeks = 0;
+    EXPECT_TRUE(current->update_stats(
+      {.seek_file = l2_files[0], .seek_file_level = 2_level}));
+
+    EXPECT_TRUE(version_set().needs_compaction());
+
+    // Pick L1→L2 compaction (score-based, preferred over seek). Locks L1, L2.
+    auto c = version_set().pick_compaction();
+    ASSERT_TRUE(c);
+    EXPECT_EQ((*c)->level(), 1_level);
+
+    // Seek compaction on L2 should be blocked because L2 is locked as the
+    // output of L1→L2, and L3 would be the output of a L2→L3 compaction.
+    EXPECT_FALSE(version_set().needs_compaction());
+    auto c2 = version_set().pick_compaction();
+    EXPECT_FALSE(c2);
+}

--- a/src/v/lsm/db/tests/version_set_test.cc
+++ b/src/v/lsm/db/tests/version_set_test.cc
@@ -528,9 +528,10 @@ TEST_F(CompactionTest, PickCompactionLevel0ToLevel1) {
     add_file(1_level, 10_file_id, "b"_key, "f"_key);
     add_file(1_level, 11_file_id, "g"_key, "k"_key);
 
-    auto c = version_set().pick_compaction();
+    auto maybe_c = version_set().pick_compaction();
 
-    ASSERT_TRUE(c.has_value());
+    ASSERT_TRUE(maybe_c);
+    auto& c = *maybe_c;
     EXPECT_EQ(c->level(), 0_level);
     // L0 compaction includes all overlapping files
     EXPECT_THAT(input_file_ids(*c), ElementsAre(1_file_id));
@@ -546,9 +547,10 @@ TEST_F(CompactionTest, TrivialMove) {
     add_file(0_level, 4_file_id, "n"_key, "z"_key);
 
     // L1 has no files - first file can be trivially moved
-    auto c = version_set().pick_compaction();
+    auto maybe_c = version_set().pick_compaction();
 
-    ASSERT_TRUE(c.has_value());
+    ASSERT_TRUE(maybe_c);
+    auto& c = *maybe_c;
     EXPECT_EQ(c->level(), 0_level);
     EXPECT_THAT(input_file_ids(*c), ElementsAre(1_file_id));
     EXPECT_THAT(output_file_ids(*c), IsEmpty());
@@ -567,9 +569,10 @@ TEST_F(CompactionTest, OverlappingL0Files) {
     // Add overlapping file in L1
     add_file(1_level, 10_file_id, "d"_key, "h"_key);
 
-    auto c = version_set().pick_compaction();
+    auto maybe_c = version_set().pick_compaction();
 
-    ASSERT_TRUE(c.has_value());
+    ASSERT_TRUE(maybe_c);
+    auto& c = *maybe_c;
     EXPECT_EQ(c->level(), 0_level);
     // Should include all overlapping L0 files: starts with file 1, which
     // overlaps with file 2, which overlaps with file 3
@@ -599,9 +602,10 @@ TEST_F(CompactionTest, Level1ToLevel2Compaction) {
     // Add overlapping file in L2
     add_file(2_level, 100_file_id, "aa"_key, "ac"_key);
 
-    auto c = version_set().pick_compaction();
+    auto maybe_c = version_set().pick_compaction();
 
-    ASSERT_TRUE(c.has_value());
+    ASSERT_TRUE(maybe_c);
+    auto& c = *maybe_c;
     EXPECT_EQ(c->level(), 1_level); // L1→L2 compaction
     // Expansion picks both file 1 and 2 since they both overlap with
     // the same L2 file and fit within the expansion byte limit
@@ -623,9 +627,10 @@ TEST_F(CompactionTest, GrandparentOverlapTracking) {
     add_file(2_level, 20_file_id, "a"_key, "c"_key);
     add_file(2_level, 21_file_id, "d"_key, "e"_key);
 
-    auto c = version_set().pick_compaction();
+    auto maybe_c = version_set().pick_compaction();
 
-    ASSERT_TRUE(c.has_value());
+    ASSERT_TRUE(maybe_c);
+    auto& c = *maybe_c;
     EXPECT_EQ(c->level(), 0_level);
     // Expansion picks both file 1 and 2 since they both overlap with
     // the same L1 file and fit within the expansion byte limit.
@@ -647,9 +652,10 @@ TEST_F(CompactionTest, InputExpansion) {
     // L1 file that covers both file 1 and file 2
     add_file(1_level, 10_file_id, "a"_key, "g"_key, 100);
 
-    auto c = version_set().pick_compaction();
+    auto maybe_c = version_set().pick_compaction();
 
-    ASSERT_TRUE(c.has_value());
+    ASSERT_TRUE(maybe_c);
+    auto& c = *maybe_c;
     EXPECT_EQ(c->level(), 0_level);
     // Expansion should pick both files 1 and 2 since they both overlap with
     // the same L1 file and fit within the expansion limit
@@ -671,9 +677,10 @@ TEST_F(CompactionTest, NoExpansionWhenOutputLevelGrows) {
     add_file(1_level, 10_file_id, "a"_key, "c"_key, 100);
     add_file(1_level, 11_file_id, "d"_key, "f"_key, 100);
 
-    auto c = version_set().pick_compaction();
+    auto maybe_c = version_set().pick_compaction();
 
-    ASSERT_TRUE(c.has_value());
+    ASSERT_TRUE(maybe_c);
+    auto& c = *maybe_c;
     EXPECT_EQ(c->level(), 0_level);
     // Only file 1 should be selected; expansion would add file 2 but also
     // require adding L1 file 11, so it's rejected
@@ -693,9 +700,10 @@ TEST_F(CompactionTest, BoundaryKeyHandling) {
     add_file(
       1_level, 11_file_id, "e"_key, "g"_key); // Starts at 'e' like file 2
 
-    auto c = version_set().pick_compaction();
+    auto maybe_c = version_set().pick_compaction();
 
-    ASSERT_TRUE(c.has_value());
+    ASSERT_TRUE(maybe_c);
+    auto& c = *maybe_c;
     EXPECT_EQ(c->level(), 0_level);
     // Should include file 1 from L0
     EXPECT_THAT(input_file_ids(*c), ElementsAre(1_file_id));
@@ -712,7 +720,7 @@ TEST_F(CompactionTest, NoCompactionBelowThreshold) {
     auto c = version_set().pick_compaction();
 
     // No compaction should be triggered
-    EXPECT_FALSE(c.has_value());
+    EXPECT_FALSE(c);
 }
 
 TEST_F(CompactionTest, SameUserKeyDifferentSeqnosOverlap) {
@@ -739,9 +747,10 @@ TEST_F(CompactionTest, SameUserKeyDifferentSeqnosOverlap) {
     // File 11: "apple" at seqno 50 (could be a tombstone)
     add_file(1_level, 11_file_id, "apple@50"_key, "apple@50"_key);
 
-    auto c = version_set().pick_compaction();
+    auto maybe_c = version_set().pick_compaction();
 
-    ASSERT_TRUE(c.has_value());
+    ASSERT_TRUE(maybe_c);
+    auto& c = *maybe_c;
     EXPECT_EQ(c->level(), 0_level);
     // File 1 from L0 should be selected
     EXPECT_THAT(input_file_ids(*c), ElementsAre(1_file_id));
@@ -789,8 +798,9 @@ TEST_F(CompactionTest, CompactionPointerRespected) {
     version_set().log_and_apply(std::move(edit)).get();
 
     // Next compaction should pick file 3 or later, not file 1 or 2
-    auto c = version_set().pick_compaction();
-    ASSERT_TRUE(c.has_value());
+    auto maybe_c = version_set().pick_compaction();
+    ASSERT_TRUE(maybe_c);
+    auto& c = *maybe_c;
     EXPECT_EQ(c->level(), 1_level);
     // Should pick file 3 (first file after the compact pointer at "d")
     EXPECT_THAT(input_file_ids(*c), ElementsAre(3_file_id));

--- a/src/v/lsm/db/version_set.cc
+++ b/src/v/lsm/db/version_set.cc
@@ -264,7 +264,8 @@ private:
 
 version::version(ctor, version_set* vset)
   : _vset(vset)
-  , _files(_vset->_options->levels.size()) {}
+  , _files(_vset->_options->levels.size())
+  , _compaction_scores(_vset->_options->levels.size(), 0.0) {}
 
 ss::future<> version::add_iterators(
   chunked_vector<std::unique_ptr<internal::iterator>>* iters) {
@@ -764,9 +765,10 @@ bool version_set::needs_compaction() const {
     return _current->_compaction_score >= 1 || _current->_file_to_compact;
 }
 
-std::optional<compaction> version_set::pick_compaction() {
+ss::optimized_optional<std::unique_ptr<compaction>>
+version_set::pick_compaction() {
     internal::level level;
-    std::optional<compaction> c;
+    std::unique_ptr<compaction> c;
     using which = compaction::which;
     // We prefer compactions triggered by too much data in a level over
     // compactions triggered by seeks.
@@ -777,7 +779,8 @@ std::optional<compaction> version_set::pick_compaction() {
         vassert(
           level() + 1 < _options->levels.size(),
           "cannot compact the bottom-most level");
-        c.emplace(compaction(_options, new_edit(), level));
+        c = std::make_unique<compaction>(
+          compaction::ctor{}, _options, new_edit(), level);
         // Pick the first file that comes after _compact_pointer[level]
         for (const auto& f : _current->_files[level]) {
             const auto& key = _compact_pointer[level];
@@ -793,7 +796,8 @@ std::optional<compaction> version_set::pick_compaction() {
         }
     } else if (seek_compaction) {
         level = _current->_file_to_compact_level;
-        c.emplace(compaction(_options, new_edit(), level));
+        c = std::make_unique<compaction>(
+          compaction::ctor{}, _options, new_edit(), level);
         c->_inputs[which::input_level].push_back(*_current->_file_to_compact);
     } else {
         return std::nullopt;

--- a/src/v/lsm/db/version_set.cc
+++ b/src/v/lsm/db/version_set.cc
@@ -24,6 +24,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/as_future.hh>
 
+#include <algorithm>
 #include <exception>
 #include <memory>
 
@@ -570,6 +571,7 @@ version_set::version_set(
   : _persistence(persistence)
   , _table_cache(table_cache)
   , _options(std::move(opts))
+  , _compacting_levels(_options->levels.size(), false)
   , _compact_pointer(_options->levels.size()) {
     set_current(ss::make_lw_shared<version>(version::ctor{}, this));
 }
@@ -665,30 +667,18 @@ void version_set::finalize(version* v) {
         return;
     }
     // Precompute the best level for the next compaction
-    internal::level best_level = 0_level;
-    double best_score = static_cast<double>(v->_files[0_level].size())
-                        / static_cast<double>(
-                          _options->level_one_compaction_trigger);
-    // If L0 is at or above the slowdown threshold, prioritize it
-    // unconditionally so that lower-level compactions cannot starve L0.
-    bool l0_urgent = v->_files[0_level].size()
-                     >= _options->level_zero_slowdown_writes_trigger;
-    if (!l0_urgent) {
-        // While level 0 compaction score is based on number of files, other
-        // levels are based on number of bytes in the level.
-        for (auto level = 1_level; level < _options->max_level(); ++level) {
-            size_t level_bytes = total_file_size(v->_files[level]);
-            double score = static_cast<double>(level_bytes)
-                           / static_cast<double>(
-                             _options->levels[level].max_total_bytes);
-            if (score > best_score) {
-                best_level = level;
-                best_score = score;
-            }
-        }
+    v->_compaction_scores[0_level]
+      = static_cast<double>(v->_files[0_level].size())
+        / static_cast<double>(_options->level_one_compaction_trigger);
+    // While level 0 compaction score is based on number of files, other levels
+    // are based on number of bytes in the level.
+    for (auto level = 1_level; level < _options->max_level(); ++level) {
+        size_t level_bytes = total_file_size(v->_files[level]);
+        double score = static_cast<double>(level_bytes)
+                       / static_cast<double>(
+                         _options->levels[level].max_total_bytes);
+        v->_compaction_scores[level] = score;
     }
-    v->_compaction_level = best_level;
-    v->_compaction_score = best_score;
 }
 
 ss::future<> version_set::write_manifest(manifest m) {
@@ -762,7 +752,22 @@ ss::future<std::optional<version_set::manifest>> version_set::read_manifest() {
 }
 
 bool version_set::needs_compaction() const {
-    return _current->_compaction_score >= 1 || _current->_file_to_compact;
+    if (
+      _current->_file_to_compact
+      && !_compacting_levels[_current->_file_to_compact_level]
+      && !_compacting_levels[_current->_file_to_compact_level + 1_level]) {
+        return true;
+    }
+    const auto& scores = _current->_compaction_scores;
+    for (auto lvl = 0_level; lvl < _options->max_level(); ++lvl) {
+        if (_compacting_levels[lvl] || _compacting_levels[lvl + 1_level]) {
+            continue;
+        }
+        if (scores[lvl] >= 1) {
+            return true;
+        }
+    }
+    return false;
 }
 
 ss::optimized_optional<std::unique_ptr<compaction>>
@@ -772,15 +777,30 @@ version_set::pick_compaction() {
     using which = compaction::which;
     // We prefer compactions triggered by too much data in a level over
     // compactions triggered by seeks.
-    bool size_compaction = _current->_compaction_score >= 1;
-    bool seek_compaction = _current->_file_to_compact != std::nullopt;
+    std::optional<internal::level> size_compaction;
+    const auto& scores = _current->_compaction_scores;
+    for (auto lvl = 0_level; lvl < _options->max_level(); ++lvl) {
+        if (_compacting_levels[lvl] || _compacting_levels[lvl + 1_level]) {
+            continue;
+        }
+        double score = scores[lvl];
+        if (!size_compaction && score >= 1) { // NOLINT(*-branch-clone)
+            size_compaction.emplace(lvl);
+        } else if (size_compaction && score > scores[*size_compaction]) {
+            size_compaction.emplace(lvl);
+        }
+    }
+    bool seek_compaction
+      = _current->_file_to_compact != std::nullopt
+        && !_compacting_levels[_current->_file_to_compact_level]
+        && !_compacting_levels[_current->_file_to_compact_level + 1_level];
     if (size_compaction) {
-        level = _current->_compaction_level;
+        level = size_compaction.value();
         vassert(
           level() + 1 < _options->levels.size(),
           "cannot compact the bottom-most level");
         c = std::make_unique<compaction>(
-          compaction::ctor{}, _options, new_edit(), level);
+          compaction::ctor{}, _options, _current, new_edit(), level);
         // Pick the first file that comes after _compact_pointer[level]
         for (const auto& f : _current->_files[level]) {
             const auto& key = _compact_pointer[level];
@@ -797,12 +817,11 @@ version_set::pick_compaction() {
     } else if (seek_compaction) {
         level = _current->_file_to_compact_level;
         c = std::make_unique<compaction>(
-          compaction::ctor{}, _options, new_edit(), level);
+          compaction::ctor{}, _options, _current, new_edit(), level);
         c->_inputs[which::input_level].push_back(*_current->_file_to_compact);
     } else {
         return std::nullopt;
     }
-    c->_input_version = _current;
 
     // files in level 0 may overlap each other, so pick up all overlapping ones.
     if (level == 0_level) {
@@ -925,6 +944,29 @@ internal::file_id version_set::min_uncommitted_file_id() const {
         min = std::min(min, e._min_allocated_id);
     }
     return min;
+}
+
+compaction::compaction(
+  ctor,
+  ss::lw_shared_ptr<internal::options> options,
+  ss::lw_shared_ptr<version> version,
+  ss::lw_shared_ptr<version_edit> edit,
+  internal::level level)
+  : _level(level)
+  , _input_version(std::move(version))
+  , _edit(std::move(edit))
+  , _level_ptrs(/*n=*/options->levels.size(), /*val=*/0) {
+    // Mark the input and output levels as having compaction running so we don't
+    // try and schedule anything that could conflict.
+    auto* vset = _input_version->_vset;
+    vset->_compacting_levels[_level] = true;
+    vset->_compacting_levels[_level + 1_level] = true;
+}
+
+compaction::~compaction() {
+    auto* vset = _input_version->_vset;
+    vset->_compacting_levels[_level] = false;
+    vset->_compacting_levels[_level + 1_level] = false;
 }
 
 bool compaction::is_trivial_move() const {

--- a/src/v/lsm/db/version_set.h
+++ b/src/v/lsm/db/version_set.h
@@ -179,7 +179,7 @@ public:
 
     // Pick level and inputs for a new compaction run.
     // Returns std::nullopt if there is no compaction.
-    std::optional<compaction> pick_compaction();
+    ss::optimized_optional<std::unique_ptr<compaction>> pick_compaction();
 
     // Create an iterator that reads over the compaction inputs.
     ss::future<std::unique_ptr<internal::iterator>>
@@ -221,7 +221,20 @@ private:
 
 // Encapulate information about a compaction event.
 class compaction {
+    // A private struct so that the constructor can only be used
+    // internal to version (or friended classes).
+    struct ctor {};
+
 public:
+    compaction(
+      ctor,
+      ss::lw_shared_ptr<internal::options> options,
+      ss::lw_shared_ptr<version_edit> edit,
+      internal::level level)
+      : _level(level)
+      , _edit(std::move(edit))
+      , _level_ptrs(/*n=*/options->levels.size(), /*val=*/0) {}
+
     // Return the level that is being compacted.  Inputs from "level"
     // and "level+1" will be merged to produce a set of "level+1" files.
     internal::level level() const { return _level; }
@@ -266,14 +279,6 @@ public:
 private:
     friend class version;
     friend class version_set;
-
-    compaction(
-      ss::lw_shared_ptr<internal::options> options,
-      ss::lw_shared_ptr<version_edit> edit,
-      internal::level level)
-      : _level(level)
-      , _edit(std::move(edit))
-      , _level_ptrs(/*n=*/options->levels.size(), /*val=*/0) {}
 
     internal::level _level;
     uint64_t _max_output_file_size = 0;

--- a/src/v/lsm/db/version_set.h
+++ b/src/v/lsm/db/version_set.h
@@ -120,10 +120,9 @@ private:
     ss::optimized_optional<ss::lw_shared_ptr<file_meta_data>> _file_to_compact;
     internal::level _file_to_compact_level;
 
-    // The level that should be compacted next and it's compaction score.
-    // Score < 1 means that compaction is not strictly needed.
-    double _compaction_score = 0;
-    internal::level _compaction_level;
+    // The compaction score for each level.
+    // Scores < 1 means that compaction is not strictly needed.
+    absl::FixedArray<double> _compaction_scores;
 };
 
 // The representation of a database is a set of versions. The newest version is
@@ -213,6 +212,7 @@ private:
     ss::lw_shared_ptr<internal::options> _options;
     ss::lw_shared_ptr<version> _current;
     intrusive_list<version_edit, &version_edit::_list_hook> _live_edits;
+    absl::FixedArray<bool> _compacting_levels;
     internal::file_id _next_file_id = internal::file_id{2};
     internal::file_id _current_manifest_id;
     std::optional<internal::sequence_number> _last_seqno;
@@ -229,11 +229,11 @@ public:
     compaction(
       ctor,
       ss::lw_shared_ptr<internal::options> options,
+      ss::lw_shared_ptr<version> version,
       ss::lw_shared_ptr<version_edit> edit,
-      internal::level level)
-      : _level(level)
-      , _edit(std::move(edit))
-      , _level_ptrs(/*n=*/options->levels.size(), /*val=*/0) {}
+      internal::level level);
+
+    ~compaction();
 
     // Return the level that is being compacted.  Inputs from "level"
     // and "level+1" will be merged to produce a set of "level+1" files.


### PR DESCRIPTION
- **lsm: make compaction closing async**
- **lsm: track all compaction scores**
- **lsm: make compaction have stable memory location**
- **lsm: support parallel compactions**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.3.x
- [ ] v25.2.x
- [ ] v25.1.x

## Release Notes

* none
